### PR TITLE
build: push image on every main commit

### DIFF
--- a/.semaphore/build-image.yml
+++ b/.semaphore/build-image.yml
@@ -1,0 +1,16 @@
+version: v1.0
+name: Build Image
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+blocks:
+  - name: "Build & Push"
+    task:
+      jobs:
+        - name: "Build and push image"
+          commands:
+            - checkout
+            - make image.auth
+            - make image.build
+            - make image.push

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: Initial Pipeline
+name: CI
 agent:
   machine:
     type: f1-standard-2
@@ -23,3 +23,23 @@ blocks:
         - name: "\U0001F9EA Lint"
           commands:
             - make lint
+      epilogue:
+        always:
+          commands:
+            - test-results publish junit-report.xml
+
+after_pipeline:
+  task:
+    jobs:
+      - name: Submit Reports
+        commands:
+          - test-results gen-pipeline-report
+
+promotions:
+  - name: Build Image
+    pipeline_file: build-image.yml
+    deployment_target: ghcr
+    auto_promote_on:
+      - result: passed
+        branch:
+          - "main"


### PR DESCRIPTION
Having to manually build/push the images is tedious after a merge, and slow/impossible since we mostly work on Mac, and we need to cross build it to linux/amd64 right now. To help, this pull request adds a new auto promotion that runs on every commit on main branch, and builds and pushes the image to GHCR.