### PR TITLE
fix: add healthcheck and connection retry for consumers

### DIFF
--- a/docker-compose.vm.yml
+++ b/docker-compose.vm.yml
@@ -41,6 +41,12 @@ services:
     links:
       - db:db
       - rabbitmq:rabbitmq
+    
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 
   db:
     image: postgres:9.6
@@ -48,12 +54,26 @@ services:
       - postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: "the-cake-is-a-lie"
+    restart: "on-failure"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
+
   rabbitmq:
     image: rabbitmq:3.8.17-management-alpine
     container_name: "rabbitmq"
     ports:
       - 5672:5672
       - 15672:15672
+    restart: "on-failure"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 3s
+      timeout: 3s
+      retries: 5
+
 volumes:
   postgres-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,12 @@ services:
       - db:db
       - rabbitmq:rabbitmq
 
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+
     volumes:
       - go-pkg-cache:/go
       - .:/app
@@ -50,6 +56,12 @@ services:
       - postgres-data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: "the-cake-is-a-lie"
+    restart: "on-failure"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
   
   pgweb:
     image: sosedoff/pgweb
@@ -59,6 +71,9 @@ services:
       - 8081:8081
     links:
       - db:db
+    depends_on:
+      db:
+        condition: service_healthy
 
   rabbitmq:
     image: rabbitmq:3.8.17-management-alpine
@@ -66,6 +81,13 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+    restart: "on-failure"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 3s
+      timeout: 3s
+      retries: 5
+
 volumes:
   repo-data:
     driver: local


### PR DESCRIPTION
### Changes

Add an eternal connection retry for the worker consumer. It was dying before the rabbit MQ was available.
The Websocket consumer already had a retry that did not end.
Added healthchecks for docker compose
![image](https://github.com/user-attachments/assets/65ad2934-9237-44db-ab70-eadbd0a8af57)

