### PR TITLE
refactor: Update Connections, Labels and event source

### DIFF
--- a/web_src/src/pages/canvas/components/nodes/event_source.tsx
+++ b/web_src/src/pages/canvas/components/nodes/event_source.tsx
@@ -5,33 +5,20 @@ import { EventSourceNodeType } from '@/canvas/types/flow';
 
 export default function EventSourceNode( props : NodeProps<EventSourceNodeType>) {
   return (
-    <div className={`bg-white roundedg shadow-md border ${props.selected ? 'ring-2 ring-blue-500' : 'border-gray-200'}`}>
+    <div className={`bg-white min-w-70 roundedg shadow-md border ${props.selected ? 'ring-2 ring-blue-500' : 'border-gray-200'}`}>
       <div className="flex items-center p-3 bg-[#24292e] text-white rounded-tg">
-        <span className="mr-2">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-            <path fillRule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
-          </svg>
-        </span>
-        <span className="font-semibold">{props.data.repoName}</span>
+        <span className="font-semibold">Event Source</span>
         {props.selected && <div className="absolute top-0 right-0 w-3 h-3 bg-blue-500 rounded-full m-1"></div>}
       </div>
       <div className="p-4">
         <div className="mb-3">
-          <a href={props.data.repoUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 break-all">
-            {props.data.repoUrl}
+          <a href={props.data.name} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 break-all">
+            {props.data.name}
           </a>
         </div>
         <div>
           <h4 className="text-sm font-medium text-gray-700 mb-2">Last Event</h4>
           <div className="bg-gray-50 border border-gray-200 rounded p-3">
-            <div className="flex justify-between mb-1">
-              <span className="text-sm text-gray-600">Event Type:</span>
-              <span className="text-sm font-medium">{props.data.eventType}</span>
-            </div>
-            <div className="flex justify-between mb-1">
-              <span className="text-sm text-gray-600">Release:</span>
-              <span className="text-sm font-medium">{props.data.release}</span>
-            </div>
             <div className="flex justify-between">
               <span className="text-sm text-gray-600">Timestamp:</span>
               <span className="text-sm font-medium">{props.data.timestamp}</span>

--- a/web_src/src/pages/canvas/store/canvasStore.ts
+++ b/web_src/src/pages/canvas/store/canvasStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { CanvasData } from "../types";
-import { CanvasState } from './types';
-import { SuperplaneCanvas, SuperplaneEventSource, SuperplaneStage } from "@/api-client/types.gen";
+import { CanvasState, EventSourceWithEvents } from './types';
+import { SuperplaneCanvas, SuperplaneStage } from "@/api-client/types.gen";
 import { superplaneApproveStageEvent } from '@/api-client';
 import { ReadyState } from 'react-use-websocket';
 
@@ -53,14 +53,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     }));
   },
   
-  addEventSource: (eventSource: SuperplaneEventSource) => {
+  addEventSource: (eventSource: EventSourceWithEvents) => {
     console.log("Adding event source:", eventSource);
     set((state) => ({
       event_sources: [...state.event_sources, eventSource]
     }));
   },
   
-  updateEventSource: (eventSource: SuperplaneEventSource) => {
+  updateEventSource: (eventSource: EventSourceWithEvents) => {
     console.log("Updating event source:", eventSource);
     set((state) => ({
       event_sources: state.event_sources.map(es => 

--- a/web_src/src/pages/canvas/store/flowStore.ts
+++ b/web_src/src/pages/canvas/store/flowStore.ts
@@ -2,7 +2,7 @@
 // and manages the state of the displayed flow
 
 import { create } from 'zustand';
-import { applyNodeChanges, applyEdgeChanges, Connection, Viewport } from '@xyflow/react';
+import { applyNodeChanges, applyEdgeChanges, Connection, Viewport, ConnectionLineType, MarkerType } from '@xyflow/react';
 import { FlowStoreType } from '../types/zustand';
 import { AllNodeType, EdgeType } from '../types/flow';
 
@@ -87,8 +87,10 @@ export const useFlowStore = create<FlowStoreType>((set, get) => ({
       target: connection.target || '',
       sourceHandle: connection.sourceHandle,
       targetHandle: connection.targetHandle,
-      type: 'smoothstep',
-      animated: true
+      type: ConnectionLineType.Bezier,
+      animated: true,
+      style: { stroke: '#000000', strokeWidth: 4 },
+      markerEnd: { type: MarkerType.Arrow, color: '#000000', strokeWidth: 2 }
     };
     
     set({

--- a/web_src/src/pages/canvas/store/types.ts
+++ b/web_src/src/pages/canvas/store/types.ts
@@ -1,12 +1,12 @@
 import { CanvasData } from "../types";
-import { SuperplaneCanvas, SuperplaneStage, SuperplaneEventSource, SuperplaneStageEvent } from "@/api-client/types.gen";
+import { SuperplaneCanvas, SuperplaneStage, SuperplaneStageEvent } from "@/api-client/types.gen";
 import { ReadyState } from "react-use-websocket";
 
 // Define the store state type
 export interface CanvasState {
   canvas: SuperplaneCanvas;
   stages: StageWithEventQueue[];
-  event_sources: SuperplaneEventSource[];
+  event_sources: EventSourceWithEvents[];
   nodePositions: Record<string, { x: number, y: number }>;
   selectedStage: StageWithEventQueue | null;
   webSocketConnectionStatus: ReadyState;
@@ -15,8 +15,8 @@ export interface CanvasState {
   initialize: (data: CanvasData) => void;
   addStage: (stage: SuperplaneStage) => void;
   updateStage: (stage: SuperplaneStage) => void;
-  addEventSource: (eventSource: SuperplaneEventSource) => void;
-  updateEventSource: (eventSource: SuperplaneEventSource) => void;
+  addEventSource: (eventSource: EventSourceWithEvents) => void;
+  updateEventSource: (eventSource: EventSourceWithEvents) => void;
   updateCanvas: (canvas: SuperplaneCanvas) => void;
   updateNodePosition: (nodeId: string, position: { x: number, y: number }) => void;
   approveStageEvent: (stageEventId: string, stageId: string) => void;
@@ -30,3 +30,4 @@ export interface CanvasState {
 }
 
 export type StageWithEventQueue = SuperplaneStage & {queue: Array<SuperplaneStageEvent>}
+export type EventSourceWithEvents = SuperplaneStage & {events: Array<SuperplaneStageEvent>}

--- a/web_src/src/pages/canvas/types/flow/index.ts
+++ b/web_src/src/pages/canvas/types/flow/index.ts
@@ -16,10 +16,7 @@ export type EdgeType = Edge;
 // Event source node
 export type EventSourceNodeData = {
   id: string;
-  repoName: string;
-  repoUrl: string;
-  eventType: string;
-  release: string;
+  name: string;
   timestamp: string;
 }
 

--- a/web_src/src/pages/canvas/types/flow/index.ts
+++ b/web_src/src/pages/canvas/types/flow/index.ts
@@ -7,7 +7,9 @@ import {
   SuperplaneConnection,
   ConnectionFilterOperator,
   SuperplaneCondition,
-  SuperplaneConditionType
+  SuperplaneConditionType,
+  SuperplaneInputDefinition,
+  SuperplaneOutputDefinition
 } from "@/api-client/types.gen";
 
 export type AllNodeType = EventSourceNodeType | StageNodeType;
@@ -32,6 +34,8 @@ export type StageData = {
   queues: SuperplaneStageEvent[];
   connections: SuperplaneConnection[];
   conditions: SuperplaneCondition[];
+  inputs: SuperplaneInputDefinition[];
+  outputs: SuperplaneOutputDefinition[];
   executorSpec: SuperplaneExecutorSpec;
   approveStageEvent: (event: SuperplaneStageEvent) => void;
 }

--- a/web_src/src/pages/canvas/types/index.ts
+++ b/web_src/src/pages/canvas/types/index.ts
@@ -1,8 +1,8 @@
-import { SuperplaneCanvas, SuperplaneEventSource } from "@/api-client";
-import { StageWithEventQueue } from "@/canvas/store/types";
+import { SuperplaneCanvas } from "@/api-client";
+import { EventSourceWithEvents, StageWithEventQueue } from "@/canvas/store/types";
 
 export interface CanvasData {
   canvas: SuperplaneCanvas;
   stages: StageWithEventQueue[];
-  event_sources: SuperplaneEventSource[];
+  event_sources: EventSourceWithEvents[];
 }

--- a/web_src/src/pages/canvas/utils/flowTransformers.ts
+++ b/web_src/src/pages/canvas/utils/flowTransformers.ts
@@ -22,7 +22,7 @@ export const transformEventSourcesToNodes = (
         })[0]
       : null;
     
-    const lastEventTimestamp = lastEvent?.createdAt || 'n/a';
+    const lastEventTimestamp = new Date(lastEvent?.createdAt || '').toLocaleString() || 'n/a';
     
     return ({
       id: es.metadata?.id || '',

--- a/web_src/src/pages/canvas/utils/flowTransformers.ts
+++ b/web_src/src/pages/canvas/utils/flowTransformers.ts
@@ -1,7 +1,7 @@
 import { SuperplaneEventSource, SuperplaneStageEvent } from "@/api-client/types.gen";
 import { DEFAULT_WIDTH, DEFAULT_HEIGHT, LAYOUT_SPACING } from "./constants";
 import { AllNodeType, EdgeType } from "../types/flow";
-import { StageWithEventQueue } from "../store/types";
+import { EventSourceWithEvents, StageWithEventQueue } from "../store/types";
 
 
 interface NodePositions {
@@ -9,23 +9,32 @@ interface NodePositions {
 }
 
 export const transformEventSourcesToNodes = (
-  eventSources: SuperplaneEventSource[],
+  eventSources: EventSourceWithEvents[],
   nodePositions: NodePositions
 ): AllNodeType[] => {
-  return eventSources.map((es, idx) => ({
-    id: es.metadata?.id || '',
-    type: 'githubIntegration',
-    data: {
-      id: es.metadata?.name || '',
-      repoName: "repo/name",
-      repoUrl: "repo/url",
-      eventType: 'push',
-      release: 'v1.0.0',
-      timestamp: '2023-01-01T00:00:00'
-    },
-    position: nodePositions[es.metadata?.id || ''] || { x: 0, y: idx * 320 },
-    draggable: true
-  }) as unknown as AllNodeType);
+  return eventSources.map((es, idx) => {
+    const lastEvent = es.events && es.events.length > 0 
+      ? es.events.sort((a, b) => {
+          const timeA = new Date(a.createdAt || 0).getTime();
+          const timeB = new Date(b.createdAt || 0).getTime();
+          return timeB - timeA;
+        })[0]
+      : null;
+    
+    const lastEventTimestamp = lastEvent?.createdAt || 'n/a';
+    
+    return ({
+      id: es.metadata?.id || '',
+      type: 'githubIntegration',
+      data: {
+        id: es.metadata?.name || '',
+        name: es.metadata?.name,
+        timestamp: lastEventTimestamp
+      },
+      position: nodePositions[es.metadata?.id || ''] || { x: 0, y: idx * 320 },
+      draggable: true
+    }) as unknown as AllNodeType;
+  });
 };
 
 export const transformStagesToNodes = (

--- a/web_src/src/pages/canvas/utils/flowTransformers.ts
+++ b/web_src/src/pages/canvas/utils/flowTransformers.ts
@@ -2,6 +2,7 @@ import { SuperplaneEventSource, SuperplaneStageEvent } from "@/api-client/types.
 import { DEFAULT_WIDTH, DEFAULT_HEIGHT, LAYOUT_SPACING } from "./constants";
 import { AllNodeType, EdgeType } from "../types/flow";
 import { EventSourceWithEvents, StageWithEventQueue } from "../store/types";
+import { ConnectionLineType, MarkerType } from "@xyflow/react";
 
 
 interface NodePositions {
@@ -77,14 +78,15 @@ export const transformToEdges = (
         eventSources.find((es) => es.metadata?.name === conn.name) ||
         stages.find((s) => s.metadata?.name === conn.name);
       const sourceId = sourceObj?.metadata?.id ?? conn.name;
-      
+      const strokeColor = isEvent ? '#FF0000' : '#000000';
       return { 
         id: `e-${conn.name}-${st.metadata?.id}`, 
         source: sourceId, 
         target: st.metadata?.id || '', 
-        type: "smoothstep", 
+        type: ConnectionLineType.Bezier, 
         animated: true, 
-        style: isEvent ? { stroke: '#FF0000', strokeWidth: 2 } : undefined 
+        style: { stroke: strokeColor, strokeWidth: 4 },
+        markerEnd: { type: MarkerType.Arrow, color: strokeColor, strokeWidth: 2 }
       } as EdgeType;
     })
   );

--- a/web_src/src/pages/canvas/utils/flowTransformers.ts
+++ b/web_src/src/pages/canvas/utils/flowTransformers.ts
@@ -54,6 +54,8 @@ export const transformStagesToNodes = (
           queues: st.queue || [],
         connections: st.spec?.connections || [],
         conditions: st.spec?.conditions || [],
+        outputs: st.spec?.outputs || [],
+        inputs: st.spec?.inputs || [],
         executor: st.spec?.executor,
           approveStageEvent: (event: SuperplaneStageEvent) => {
             approveStageEvent(event.id!, st.metadata?.id || '');

--- a/web_src/src/pages/canvas/utils/layoutConfig.ts
+++ b/web_src/src/pages/canvas/utils/layoutConfig.ts
@@ -9,7 +9,7 @@ export const elk = new Elk({
     "elk.spacing": "80",
     "elk.spacing.individual": "80",
     "elk.edgeRouting": "SPLINES",
-    "elk.layered.spacing.nodeNodeBetweenLayers": "100",
+    "elk.layered.spacing.nodeNodeBetweenLayers": "250",
     "elk.spacing.nodeNode": "100",
     "elk.separateConnectedComponents": "true",
     "elk.spacing.componentComponent": "50",


### PR DESCRIPTION
### Changes
- Removed github icon + all bogus data from source box. Now we just have name + last event timestamp for now
- Stage box now displays the latest finished execution outputs instead of placeholder labels
- Updated Connection Types to be curved with an arrow pointing to its target.
![image](https://github.com/user-attachments/assets/151b33f1-1fd5-429f-baa8-db037e507a68)
