### PR TITLE
fix: JS build failing due to unused function

### DIFF
--- a/web_src/src/pages/canvas/store/canvasStore.ts
+++ b/web_src/src/pages/canvas/store/canvasStore.ts
@@ -8,14 +8,6 @@ import { Connection, Viewport, applyNodeChanges, applyEdgeChanges } from '@xyflo
 import { AllNodeType, EdgeType } from '../types/flow';
 import { autoLayoutNodes, transformConnectionGroupsToNodes, transformEventSourcesToNodes, transformStagesToNodes, transformToEdges } from '../utils/flowTransformers';
 
-function generateFakeUUID() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = Math.random() * 16 | 0;
-    const v = c == 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
-}
-
 // Create the store
 export const useCanvasStore = create<CanvasState>((set, get) => ({
   // Initial state


### PR DESCRIPTION
https://github.com/superplanehq/superplane/pull/57 removed requester ID field from the approve stage event request, but we forgot to remove the `generateFakeUUID` function from the JS, which fails the [image build job](https://superplanehq.semaphoreci.com/jobs/27cf6836-79a4-48df-8af2-8f86ba85e929#L863).