### PR TITLE
feat: allow using secrets/integrations on different domain type

### DIFF
--- a/api/swagger/superplane.swagger.json
+++ b/api/swagger/superplane.swagger.json
@@ -3912,6 +3912,9 @@
     "SuperplaneValueFromSecret": {
       "type": "object",
       "properties": {
+        "domainType": {
+          "$ref": "#/definitions/AuthorizationDomainType"
+        },
         "name": {
           "type": "string"
         },

--- a/api/swagger/superplane.swagger.json
+++ b/api/swagger/superplane.swagger.json
@@ -3539,6 +3539,9 @@
     "SuperplaneIntegrationsValueFromSecret": {
       "type": "object",
       "properties": {
+        "domainType": {
+          "$ref": "#/definitions/AuthorizationDomainType"
+        },
         "name": {
           "type": "string"
         },

--- a/pkg/builders/stage.go
+++ b/pkg/builders/stage.go
@@ -202,7 +202,7 @@ func (b *StageBuilder) findOrCreateEventSourceForExecutor(tx *gorm.DB) (*models.
 		WithTransaction(tx).
 		WithContext(b.ctx).
 		InCanvas(b.canvas).
-		WithName(b.resource.Name()).
+		WithName(b.integration.Name + "-" + b.resource.Name()).
 		WithScope(models.EventSourceScopeInternal).
 		ForIntegration(b.integration).
 		ForResource(b.resource).

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pbAuth "github.com/superplanehq/superplane/pkg/protos/authorization"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	integrationpb "github.com/superplanehq/superplane/pkg/protos/integrations"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -287,15 +288,29 @@ func DomainTypeToProto(domainType string) pbAuth.DomainType {
 	}
 }
 
-func ValidateIntegration(canvas *models.Canvas, integrationName string) (*models.Integration, error) {
-	if integrationName == "" {
+func ValidateIntegration(canvas *models.Canvas, integrationRef *integrationpb.IntegrationRef) (*models.Integration, error) {
+	if integrationRef.Name == "" {
 		return nil, status.Error(codes.InvalidArgument, "integration name is required")
 	}
 
-	// TODO: support for organization level integration
-	integration, err := models.FindIntegrationByName(models.DomainTypeCanvas, canvas.ID, integrationName)
+	//
+	// If the integration used is on the organization level, we need to find it there.
+	//
+	if integrationRef.DomainType == pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION {
+		integration, err := models.FindIntegrationByName(models.DomainTypeOrganization, canvas.OrganizationID, integrationRef.Name)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "integration %s not found", integrationRef.Name)
+		}
+
+		return integration, nil
+	}
+
+	//
+	// Otherwise, we look for it on the canvas level.
+	//
+	integration, err := models.FindIntegrationByName(models.DomainTypeCanvas, canvas.ID, integrationRef.Name)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "integration %s not found", integrationName)
+		return nil, status.Errorf(codes.InvalidArgument, "integration %s not found", integrationRef.Name)
 	}
 
 	return integration, nil

--- a/pkg/grpc/actions/event_sources/create_event_source.go
+++ b/pkg/grpc/actions/event_sources/create_event_source.go
@@ -47,7 +47,7 @@ func CreateEventSource(ctx context.Context, encryptor crypto.Encryptor, req *pb.
 	//
 	var integration *models.Integration
 	if req.EventSource.Spec != nil && req.EventSource.Spec.Integration != nil {
-		integration, err = actions.ValidateIntegration(canvas, req.EventSource.Spec.Integration.Name)
+		integration, err = actions.ValidateIntegration(canvas, req.EventSource.Spec.Integration)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,10 @@ func serializeEventSource(eventSource models.EventSource) (*pb.EventSource, erro
 			return nil, fmt.Errorf("integration not found: %v", err)
 		}
 
-		spec.Integration = &integrationPb.IntegrationRef{Name: integration.Name}
+		spec.Integration = &integrationPb.IntegrationRef{
+			Name:       integration.Name,
+			DomainType: actions.DomainTypeToProto(integration.DomainType),
+		}
 
 		switch integration.Type {
 		case models.IntegrationTypeSemaphore:

--- a/pkg/grpc/actions/event_sources/create_event_source_test.go
+++ b/pkg/grpc/actions/event_sources/create_event_source_test.go
@@ -192,8 +192,9 @@ func Test__CreateEventSource(t *testing.T) {
 				Token: &models.IntegrationAuthToken{
 					ValueFrom: models.ValueDefinitionFrom{
 						Secret: &models.ValueDefinitionFromSecret{
-							Name: secret.Name,
-							Key:  "key",
+							DomainType: models.DomainTypeOrganization,
+							Name:       secret.Name,
+							Key:        "key",
 						},
 					},
 				},

--- a/pkg/grpc/actions/integrations/create_integration_test.go
+++ b/pkg/grpc/actions/integrations/create_integration_test.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/models"
 
+	authpb "github.com/superplanehq/superplane/pkg/protos/authorization"
 	protos "github.com/superplanehq/superplane/pkg/protos/integrations"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -20,7 +22,10 @@ func Test__CreateIntegration(t *testing.T) {
 	defer r.Close()
 
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
-	secret, err := support.CreateSecret(t, r, map[string]string{"key": "value"})
+	canvasSecret, err := support.CreateCanvasSecret(t, r, map[string]string{"key": "value"})
+	require.NoError(t, err)
+
+	orgSecret, err := support.CreateOrganizationSecret(t, r, map[string]string{"key": "value"})
 	require.NoError(t, err)
 
 	t.Run("unauthenticated -> error", func(t *testing.T) {
@@ -100,7 +105,7 @@ func Test__CreateIntegration(t *testing.T) {
 					Token: &protos.Integration_Auth_Token{
 						ValueFrom: &protos.ValueFrom{
 							Secret: &protos.ValueFromSecret{
-								Name: secret.Name,
+								Name: canvasSecret.Name,
 								Key:  "nope",
 							},
 						},
@@ -113,13 +118,14 @@ func Test__CreateIntegration(t *testing.T) {
 		s, ok := status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, s.Code())
-		assert.Equal(t, "key nope not found in secret "+secret.Name, s.Message())
+		assert.Equal(t, "key nope not found in secret "+canvasSecret.Name, s.Message())
 	})
 
-	t.Run("integration is created", func(t *testing.T) {
+	t.Run("canvas integration using canvas secret is created", func(t *testing.T) {
+		name := support.RandomName("integration")
 		integration := &protos.Integration{
 			Metadata: &protos.Integration_Metadata{
-				Name: "test",
+				Name: name,
 			},
 			Spec: &protos.Integration_Spec{
 				Type: protos.Integration_TYPE_SEMAPHORE,
@@ -128,7 +134,7 @@ func Test__CreateIntegration(t *testing.T) {
 					Token: &protos.Integration_Auth_Token{
 						ValueFrom: &protos.ValueFrom{
 							Secret: &protos.ValueFromSecret{
-								Name: secret.Name,
+								Name: canvasSecret.Name,
 								Key:  "key",
 							},
 						},
@@ -139,13 +145,19 @@ func Test__CreateIntegration(t *testing.T) {
 
 		response, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), integration)
 		require.NoError(t, err)
-		assert.Equal(t, "test", response.Integration.Metadata.Name)
+		require.NotNil(t, response)
+		assert.Equal(t, name, response.Integration.Metadata.Name)
+		assert.NotEmpty(t, response.Integration.Metadata.Id)
+		assert.NotEmpty(t, response.Integration.Metadata.CreatedAt)
+		assert.Equal(t, authpb.DomainType_DOMAIN_TYPE_CANVAS, response.Integration.Metadata.DomainType)
+		assert.Equal(t, r.Canvas.ID.String(), response.Integration.Metadata.DomainId)
 	})
 
-	t.Run("name already used -> error", func(t *testing.T) {
+	t.Run("canvas integration using organization secret is created", func(t *testing.T) {
+		name := support.RandomName("integration")
 		integration := &protos.Integration{
 			Metadata: &protos.Integration_Metadata{
-				Name: "test",
+				Name: name,
 			},
 			Spec: &protos.Integration_Spec{
 				Type: protos.Integration_TYPE_SEMAPHORE,
@@ -154,7 +166,68 @@ func Test__CreateIntegration(t *testing.T) {
 					Token: &protos.Integration_Auth_Token{
 						ValueFrom: &protos.ValueFrom{
 							Secret: &protos.ValueFromSecret{
-								Name: secret.Name,
+								DomainType: authpb.DomainType_DOMAIN_TYPE_ORGANIZATION,
+								Name:       orgSecret.Name,
+								Key:        "key",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		response, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), integration)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Equal(t, name, response.Integration.Metadata.Name)
+		assert.NotEmpty(t, response.Integration.Metadata.Id)
+		assert.NotEmpty(t, response.Integration.Metadata.CreatedAt)
+		assert.Equal(t, authpb.DomainType_DOMAIN_TYPE_CANVAS, response.Integration.Metadata.DomainType)
+		assert.Equal(t, r.Canvas.ID.String(), response.Integration.Metadata.DomainId)
+	})
+
+	t.Run("organization integration using canvas secret -> error", func(t *testing.T) {
+		integration := &protos.Integration{
+			Metadata: &protos.Integration_Metadata{
+				Name: support.RandomName("integration"),
+			},
+			Spec: &protos.Integration_Spec{
+				Type: protos.Integration_TYPE_SEMAPHORE,
+				Auth: &protos.Integration_Auth{
+					Use: protos.Integration_AUTH_TYPE_TOKEN,
+					Token: &protos.Integration_Auth_Token{
+						ValueFrom: &protos.ValueFrom{
+							Secret: &protos.ValueFromSecret{
+								DomainType: authpb.DomainType_DOMAIN_TYPE_CANVAS,
+								Name:       canvasSecret.Name,
+								Key:        "key",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), integration)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "integration on organization level must use organization-level secret", s.Message())
+	})
+
+	t.Run("organization integration using existing canvas secret -> error", func(t *testing.T) {
+		integration := &protos.Integration{
+			Metadata: &protos.Integration_Metadata{
+				Name: support.RandomName("integration"),
+			},
+			Spec: &protos.Integration_Spec{
+				Type: protos.Integration_TYPE_SEMAPHORE,
+				Auth: &protos.Integration_Auth{
+					Use: protos.Integration_AUTH_TYPE_TOKEN,
+					Token: &protos.Integration_Auth_Token{
+						ValueFrom: &protos.ValueFrom{
+							Secret: &protos.ValueFromSecret{
+								Name: canvasSecret.Name,
 								Key:  "key",
 							},
 						},
@@ -163,8 +236,96 @@ func Test__CreateIntegration(t *testing.T) {
 			},
 		}
 
-		_, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), integration)
+		_, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), integration)
 		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, fmt.Sprintf("error finding secret %s: record not found", canvasSecret.Name), s.Message())
+	})
+
+	t.Run("organization integration using organization secret is created", func(t *testing.T) {
+		name := support.RandomName("integration")
+		integration := &protos.Integration{
+			Metadata: &protos.Integration_Metadata{
+				Name: name,
+			},
+			Spec: &protos.Integration_Spec{
+				Type: protos.Integration_TYPE_SEMAPHORE,
+				Auth: &protos.Integration_Auth{
+					Use: protos.Integration_AUTH_TYPE_TOKEN,
+					Token: &protos.Integration_Auth_Token{
+						ValueFrom: &protos.ValueFrom{
+							Secret: &protos.ValueFromSecret{
+								Name: orgSecret.Name,
+								Key:  "key",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		response, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), integration)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Equal(t, name, response.Integration.Metadata.Name)
+		assert.NotEmpty(t, response.Integration.Metadata.Id)
+		assert.NotEmpty(t, response.Integration.Metadata.CreatedAt)
+		assert.Equal(t, authpb.DomainType_DOMAIN_TYPE_ORGANIZATION, response.Integration.Metadata.DomainType)
+		assert.Equal(t, r.Organization.ID.String(), response.Integration.Metadata.DomainId)
+	})
+
+	t.Run("name already used -> error", func(t *testing.T) {
+		name := support.RandomName("integration")
+		integration := &protos.Integration{
+			Metadata: &protos.Integration_Metadata{
+				Name: name,
+			},
+			Spec: &protos.Integration_Spec{
+				Type: protos.Integration_TYPE_SEMAPHORE,
+				Auth: &protos.Integration_Auth{
+					Use: protos.Integration_AUTH_TYPE_TOKEN,
+					Token: &protos.Integration_Auth_Token{
+						ValueFrom: &protos.ValueFrom{
+							Secret: &protos.ValueFromSecret{
+								Name: canvasSecret.Name,
+								Key:  "key",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		//
+		// No canvas integration with this name yet, so this works.
+		//
+		_, err := CreateIntegration(ctx, r.Encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), integration)
+		require.NoError(t, err)
+
+		//
+		// No organization integration with this name yet, so this works.
+		//
+		integration.Spec.Auth.Token.ValueFrom.Secret.Name = orgSecret.Name
+		_, err = CreateIntegration(ctx, r.Encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), integration)
+		require.NoError(t, err)
+
+		//
+		// Name already taken, so canvas integration with this name fails now.
+		//
+		integration.Spec.Auth.Token.ValueFrom.Secret.Name = canvasSecret.Name
+		_, err = CreateIntegration(ctx, r.Encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), integration)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "name already used", s.Message())
+
+		//
+		// Same thing on the organization level.
+		//
+		integration.Spec.Auth.Token.ValueFrom.Secret.Name = orgSecret.Name
+		_, err = CreateIntegration(ctx, r.Encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), integration)
+		s, ok = status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, s.Code())
 		assert.Equal(t, "name already used", s.Message())

--- a/pkg/grpc/actions/secrets/create_secret_test.go
+++ b/pkg/grpc/actions/secrets/create_secret_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/models"
+	authpb "github.com/superplanehq/superplane/pkg/protos/authorization"
 	protos "github.com/superplanehq/superplane/pkg/protos/secrets"
 	"github.com/superplanehq/superplane/test/support"
 	"google.golang.org/grpc/codes"
@@ -44,10 +45,10 @@ func Test__CreateSecret(t *testing.T) {
 		assert.Equal(t, "user not authenticated", s.Message())
 	})
 
-	t.Run("name still not used -> secret is created", func(t *testing.T) {
+	t.Run("canvas secret is created", func(t *testing.T) {
 		secret := &protos.Secret{
 			Metadata: &protos.Secret_Metadata{
-				Name: "test",
+				Name: support.RandomName("secret"),
 			},
 			Spec: &protos.Secret_Spec{
 				Provider: protos.Secret_PROVIDER_LOCAL,
@@ -65,16 +66,17 @@ func Test__CreateSecret(t *testing.T) {
 		require.NotNil(t, response.Secret)
 		assert.NotEmpty(t, response.Secret.Metadata.Id)
 		assert.NotEmpty(t, response.Secret.Metadata.CreatedAt)
+		assert.Equal(t, authpb.DomainType_DOMAIN_TYPE_CANVAS, response.Secret.Metadata.DomainType)
+		assert.Equal(t, r.Canvas.ID.String(), response.Secret.Metadata.DomainId)
 		assert.Equal(t, protos.Secret_PROVIDER_LOCAL, response.Secret.Spec.Provider)
 		require.NotNil(t, response.Secret.Spec.Local)
 		require.Equal(t, map[string]string{"test": "***"}, response.Secret.Spec.Local.Data)
 	})
 
-	t.Run("name already used", func(t *testing.T) {
-		ctx := authentication.SetUserIdInMetadata(context.Background(), uuid.NewString())
+	t.Run("organization secret is created", func(t *testing.T) {
 		secret := &protos.Secret{
 			Metadata: &protos.Secret_Metadata{
-				Name: "test",
+				Name: support.RandomName("secret"),
 			},
 			Spec: &protos.Secret_Spec{
 				Provider: protos.Secret_PROVIDER_LOCAL,
@@ -86,8 +88,62 @@ func Test__CreateSecret(t *testing.T) {
 			},
 		}
 
+		response, err := CreateSecret(ctx, encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), secret)
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotNil(t, response.Secret)
+		assert.NotEmpty(t, response.Secret.Metadata.Id)
+		assert.NotEmpty(t, response.Secret.Metadata.CreatedAt)
+		assert.Equal(t, authpb.DomainType_DOMAIN_TYPE_ORGANIZATION, response.Secret.Metadata.DomainType)
+		assert.Equal(t, r.Organization.ID.String(), response.Secret.Metadata.DomainId)
+		assert.Equal(t, protos.Secret_PROVIDER_LOCAL, response.Secret.Spec.Provider)
+		require.NotNil(t, response.Secret.Spec.Local)
+		require.Equal(t, map[string]string{"test": "***"}, response.Secret.Spec.Local.Data)
+	})
+
+	t.Run("name already used", func(t *testing.T) {
+		name := support.RandomName("secret")
+		ctx := authentication.SetUserIdInMetadata(context.Background(), uuid.NewString())
+		secret := &protos.Secret{
+			Metadata: &protos.Secret_Metadata{
+				Name: name,
+			},
+			Spec: &protos.Secret_Spec{
+				Provider: protos.Secret_PROVIDER_LOCAL,
+				Local: &protos.Secret_Local{
+					Data: map[string]string{
+						"test": "test",
+					},
+				},
+			},
+		}
+
+		//
+		// This works since there's no canvas secret with this name
+		//
 		_, err := CreateSecret(ctx, encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), secret)
+		require.NoError(t, err)
+
+		//
+		// This also works since there's no organization secret with this name too.
+		//
+		_, err = CreateSecret(ctx, encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), secret)
+		require.NoError(t, err)
+
+		//
+		// Name is already taken, so we cannot create another canvas secret with it.
+		//
+		_, err = CreateSecret(ctx, encryptor, models.DomainTypeCanvas, r.Canvas.ID.String(), secret)
 		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "name already used", s.Message())
+
+		//
+		// Same thing on the organization level.
+		//
+		_, err = CreateSecret(ctx, encryptor, models.DomainTypeOrganization, r.Organization.ID.String(), secret)
+		s, ok = status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, s.Code())
 		assert.Equal(t, "name already used", s.Message())

--- a/pkg/grpc/actions/secrets/update_secret.go
+++ b/pkg/grpc/actions/secrets/update_secret.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func UpdateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType string, domainID string, idOrName string, spec *pb.Secret) (*pb.UpdateSecretResponse, error) {
+func UpdateSecret(ctx context.Context, encryptor crypto.Encryptor, domainType, domainID, idOrName string, spec *pb.Secret) (*pb.UpdateSecretResponse, error) {
 	err := actions.ValidateUUIDs(idOrName)
 	var secret *models.Secret
 	if err != nil {

--- a/pkg/grpc/actions/stages/create_stage.go
+++ b/pkg/grpc/actions/stages/create_stage.go
@@ -85,7 +85,7 @@ func CreateStage(ctx context.Context, encryptor crypto.Encryptor, specValidator 
 	//
 	var integration *models.Integration
 	if req.Stage.Spec != nil && req.Stage.Spec.Executor != nil && req.Stage.Spec.Executor.Integration != nil {
-		integration, err = actions.ValidateIntegration(canvas, req.Stage.Spec.Executor.Integration.Name)
+		integration, err = actions.ValidateIntegration(canvas, req.Stage.Spec.Executor.Integration)
 		if err != nil {
 			return nil, err
 		}
@@ -471,7 +471,8 @@ func serializeExecutor(executor *models.StageExecutor) (*pb.ExecutorSpec, error)
 			Type:      pb.ExecutorSpec_TYPE_SEMAPHORE,
 			Semaphore: spec,
 			Integration: &integrationPb.IntegrationRef{
-				Name: resource.IntegrationName,
+				Name:       resource.IntegrationName,
+				DomainType: actions.DomainTypeToProto(resource.DomainType),
 			},
 		}, nil
 

--- a/pkg/grpc/actions/stages/create_stage_test.go
+++ b/pkg/grpc/actions/stages/create_stage_test.go
@@ -479,8 +479,9 @@ func Test__CreateStage(t *testing.T) {
 				Token: &models.IntegrationAuthToken{
 					ValueFrom: models.ValueDefinitionFrom{
 						Secret: &models.ValueDefinitionFromSecret{
-							Name: secret.Name,
-							Key:  "key",
+							DomainType: models.DomainTypeOrganization,
+							Name:       secret.Name,
+							Key:        "key",
 						},
 					},
 				},

--- a/pkg/grpc/actions/stages/update_stage.go
+++ b/pkg/grpc/actions/stages/update_stage.go
@@ -64,7 +64,7 @@ func UpdateStage(ctx context.Context, encryptor crypto.Encryptor, specValidator 
 	//
 	var integration *models.Integration
 	if req.Stage.Spec != nil && req.Stage.Spec.Executor != nil && req.Stage.Spec.Executor.Integration != nil {
-		integration, err = actions.ValidateIntegration(canvas, req.Stage.Spec.Executor.Integration.Name)
+		integration, err = actions.ValidateIntegration(canvas, req.Stage.Spec.Executor.Integration)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/grpc/actions/stages/update_stage.go
+++ b/pkg/grpc/actions/stages/update_stage.go
@@ -113,7 +113,7 @@ func UpdateStage(ctx context.Context, encryptor crypto.Encryptor, specValidator 
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	secrets, err := validateSecrets(req.Stage.Spec.Secrets)
+	secrets, err := validateSecrets(ctx, encryptor, canvas, req.Stage.Spec.Secrets)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/pkg/integrations/integration.go
+++ b/pkg/integrations/integration.go
@@ -36,7 +36,7 @@ func NewIntegration(ctx context.Context, integration *models.Integration, encryp
 	switch integration.Type {
 	case models.IntegrationTypeSemaphore:
 		secretInfo := integration.Auth.Data().Token.ValueFrom.Secret
-		provider, err := secrets.NewProvider(encryptor, secretInfo.Name, integration.DomainType, integration.DomainID)
+		provider, err := secretProvider(encryptor, secretInfo, integration)
 		if err != nil {
 			return nil, fmt.Errorf("error creating secret provider: %v", err)
 		}
@@ -55,4 +55,32 @@ func NewIntegration(ctx context.Context, integration *models.Integration, encryp
 	default:
 		return nil, fmt.Errorf("unsupported integration type %s", integration.Type)
 	}
+}
+
+func secretProvider(encryptor crypto.Encryptor, secretDef *models.ValueDefinitionFromSecret, integration *models.Integration) (secrets.Provider, error) {
+	//
+	// If the integration is scoped to an organization, the secret must also be scoped there.
+	//
+	if integration.DomainType == models.DomainTypeOrganization {
+		return secrets.NewProvider(encryptor, secretDef.Name, secretDef.DomainType, integration.DomainID)
+	}
+
+	//
+	// Here, we know the integration is on the canvas level.
+	// If the secret is also on the canvas level, we use the same domain type and ID.
+	//
+	if secretDef.DomainType == models.DomainTypeCanvas {
+		return secrets.NewProvider(encryptor, secretDef.Name, secretDef.DomainType, integration.DomainID)
+	}
+
+	//
+	// Otherwise, the integration is on the canvas level, but the secret is on the organization level,
+	// so we need to get the organization ID for the canvas where the integration is.
+	//
+	canvas, err := models.FindCanvasByID(integration.DomainID.String())
+	if err != nil {
+		return nil, fmt.Errorf("error finding canvas %s: %v", integration.DomainID, err)
+	}
+
+	return secrets.NewProvider(encryptor, secretDef.Name, secretDef.DomainType, canvas.OrganizationID)
 }

--- a/pkg/models/integration.go
+++ b/pkg/models/integration.go
@@ -174,4 +174,5 @@ func ListIntegrations(domainType string, domainID uuid.UUID) ([]*Integration, er
 type IntegrationResource struct {
 	Name            string
 	IntegrationName string
+	DomainType      string
 }

--- a/pkg/models/stage.go
+++ b/pkg/models/stage.go
@@ -81,8 +81,9 @@ type ValueDefinitionFromLastExecution struct {
 }
 
 type ValueDefinitionFromSecret struct {
-	Name string `json:"name"`
-	Key  string `json:"key"`
+	DomainType string `json:"domain_type"`
+	Name       string `json:"name"`
+	Key        string `json:"key"`
 }
 
 type StageCondition struct {

--- a/pkg/models/stage_executor.go
+++ b/pkg/models/stage_executor.go
@@ -62,7 +62,7 @@ func (e *StageExecutor) GetIntegrationResource() (*IntegrationResource, error) {
 	err := database.Conn().
 		Table("resources").
 		Joins("INNER JOIN integrations ON integrations.id = resources.integration_id").
-		Select("resources.name as name, integrations.name as integration_name").
+		Select("resources.name as name, integrations.name as integration_name, integrations.domain_type as domain_type").
 		Where("resources.id = ?", e.ResourceID).
 		First(&r).
 		Error

--- a/pkg/openapi_client/model_superplane_integrations_value_from_secret.go
+++ b/pkg/openapi_client/model_superplane_integrations_value_from_secret.go
@@ -20,6 +20,7 @@ var _ MappedNullable = &SuperplaneIntegrationsValueFromSecret{}
 
 // SuperplaneIntegrationsValueFromSecret struct for SuperplaneIntegrationsValueFromSecret
 type SuperplaneIntegrationsValueFromSecret struct {
+	DomainType *AuthorizationDomainType `json:"domainType,omitempty"`
 	Name *string `json:"name,omitempty"`
 	Key *string `json:"key,omitempty"`
 }
@@ -30,6 +31,8 @@ type SuperplaneIntegrationsValueFromSecret struct {
 // will change when the set of required properties is changed
 func NewSuperplaneIntegrationsValueFromSecret() *SuperplaneIntegrationsValueFromSecret {
 	this := SuperplaneIntegrationsValueFromSecret{}
+	var domainType AuthorizationDomainType = AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_UNSPECIFIED
+	this.DomainType = &domainType
 	return &this
 }
 
@@ -38,7 +41,41 @@ func NewSuperplaneIntegrationsValueFromSecret() *SuperplaneIntegrationsValueFrom
 // but it doesn't guarantee that properties required by API are set
 func NewSuperplaneIntegrationsValueFromSecretWithDefaults() *SuperplaneIntegrationsValueFromSecret {
 	this := SuperplaneIntegrationsValueFromSecret{}
+	var domainType AuthorizationDomainType = AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_UNSPECIFIED
+	this.DomainType = &domainType
 	return &this
+}
+
+// GetDomainType returns the DomainType field value if set, zero value otherwise.
+func (o *SuperplaneIntegrationsValueFromSecret) GetDomainType() AuthorizationDomainType {
+	if o == nil || IsNil(o.DomainType) {
+		var ret AuthorizationDomainType
+		return ret
+	}
+	return *o.DomainType
+}
+
+// GetDomainTypeOk returns a tuple with the DomainType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SuperplaneIntegrationsValueFromSecret) GetDomainTypeOk() (*AuthorizationDomainType, bool) {
+	if o == nil || IsNil(o.DomainType) {
+		return nil, false
+	}
+	return o.DomainType, true
+}
+
+// HasDomainType returns a boolean if a field has been set.
+func (o *SuperplaneIntegrationsValueFromSecret) HasDomainType() bool {
+	if o != nil && !IsNil(o.DomainType) {
+		return true
+	}
+
+	return false
+}
+
+// SetDomainType gets a reference to the given AuthorizationDomainType and assigns it to the DomainType field.
+func (o *SuperplaneIntegrationsValueFromSecret) SetDomainType(v AuthorizationDomainType) {
+	o.DomainType = &v
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -115,6 +152,9 @@ func (o SuperplaneIntegrationsValueFromSecret) MarshalJSON() ([]byte, error) {
 
 func (o SuperplaneIntegrationsValueFromSecret) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.DomainType) {
+		toSerialize["domainType"] = o.DomainType
+	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}

--- a/pkg/openapi_client/model_superplane_value_from_secret.go
+++ b/pkg/openapi_client/model_superplane_value_from_secret.go
@@ -20,6 +20,7 @@ var _ MappedNullable = &SuperplaneValueFromSecret{}
 
 // SuperplaneValueFromSecret struct for SuperplaneValueFromSecret
 type SuperplaneValueFromSecret struct {
+	DomainType *AuthorizationDomainType `json:"domainType,omitempty"`
 	Name *string `json:"name,omitempty"`
 	Key *string `json:"key,omitempty"`
 }
@@ -30,6 +31,8 @@ type SuperplaneValueFromSecret struct {
 // will change when the set of required properties is changed
 func NewSuperplaneValueFromSecret() *SuperplaneValueFromSecret {
 	this := SuperplaneValueFromSecret{}
+	var domainType AuthorizationDomainType = AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_UNSPECIFIED
+	this.DomainType = &domainType
 	return &this
 }
 
@@ -38,7 +41,41 @@ func NewSuperplaneValueFromSecret() *SuperplaneValueFromSecret {
 // but it doesn't guarantee that properties required by API are set
 func NewSuperplaneValueFromSecretWithDefaults() *SuperplaneValueFromSecret {
 	this := SuperplaneValueFromSecret{}
+	var domainType AuthorizationDomainType = AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_UNSPECIFIED
+	this.DomainType = &domainType
 	return &this
+}
+
+// GetDomainType returns the DomainType field value if set, zero value otherwise.
+func (o *SuperplaneValueFromSecret) GetDomainType() AuthorizationDomainType {
+	if o == nil || IsNil(o.DomainType) {
+		var ret AuthorizationDomainType
+		return ret
+	}
+	return *o.DomainType
+}
+
+// GetDomainTypeOk returns a tuple with the DomainType field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SuperplaneValueFromSecret) GetDomainTypeOk() (*AuthorizationDomainType, bool) {
+	if o == nil || IsNil(o.DomainType) {
+		return nil, false
+	}
+	return o.DomainType, true
+}
+
+// HasDomainType returns a boolean if a field has been set.
+func (o *SuperplaneValueFromSecret) HasDomainType() bool {
+	if o != nil && !IsNil(o.DomainType) {
+		return true
+	}
+
+	return false
+}
+
+// SetDomainType gets a reference to the given AuthorizationDomainType and assigns it to the DomainType field.
+func (o *SuperplaneValueFromSecret) SetDomainType(v AuthorizationDomainType) {
+	o.DomainType = &v
 }
 
 // GetName returns the Name field value if set, zero value otherwise.
@@ -115,6 +152,9 @@ func (o SuperplaneValueFromSecret) MarshalJSON() ([]byte, error) {
 
 func (o SuperplaneValueFromSecret) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.DomainType) {
+		toSerialize["domainType"] = o.DomainType
+	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
 	}

--- a/pkg/protos/canvases/canvases.pb.go
+++ b/pkg/protos/canvases/canvases.pb.go
@@ -9,6 +9,7 @@ package canvases
 import (
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	authorization "github.com/superplanehq/superplane/pkg/protos/authorization"
 	integrations "github.com/superplanehq/superplane/pkg/protos/integrations"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -2522,9 +2523,10 @@ func (x *ValueFromLastExecution) GetResults() []Execution_Result {
 }
 
 type ValueFromSecret struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Key           string                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	DomainType    authorization.DomainType `protobuf:"varint,1,opt,name=domain_type,json=domainType,proto3,enum=Superplane.Authorization.DomainType" json:"domain_type,omitempty"`
+	Name          string                   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Key           string                   `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2557,6 +2559,13 @@ func (x *ValueFromSecret) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ValueFromSecret.ProtoReflect.Descriptor instead.
 func (*ValueFromSecret) Descriptor() ([]byte, []int) {
 	return file_canvases_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *ValueFromSecret) GetDomainType() authorization.DomainType {
+	if x != nil {
+		return x.DomainType
+	}
+	return authorization.DomainType(0)
 }
 
 func (x *ValueFromSecret) GetName() string {
@@ -5626,7 +5635,7 @@ var File_canvases_proto protoreflect.FileDescriptor
 const file_canvases_proto_rawDesc = "" +
 	"\n" +
 	"\x0ecanvases.proto\x12\n" +
-	"Superplane\x1a\x12integrations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\">\n" +
+	"Superplane\x1a\x13authorization.proto\x1a\x12integrations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\">\n" +
 	"\x13ListCanvasesRequest\x12'\n" +
 	"\x0forganization_id\x18\x01 \x01(\tR\x0eorganizationId\"F\n" +
 	"\x14ListCanvasesResponse\x12.\n" +
@@ -5823,10 +5832,12 @@ const file_canvases_proto_rawDesc = "" +
 	"expression\x18\x02 \x01(\tR\n" +
 	"expression\"P\n" +
 	"\x16ValueFromLastExecution\x126\n" +
-	"\aresults\x18\x01 \x03(\x0e2\x1c.Superplane.Execution.ResultR\aresults\"7\n" +
-	"\x0fValueFromSecret\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
-	"\x03key\x18\x02 \x01(\tR\x03key\"\x99\x02\n" +
+	"\aresults\x18\x01 \x03(\x0e2\x1c.Superplane.Execution.ResultR\aresults\"~\n" +
+	"\x0fValueFromSecret\x12E\n" +
+	"\vdomain_type\x18\x01 \x01(\x0e2$.Superplane.Authorization.DomainTypeR\n" +
+	"domainType\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
+	"\x03key\x18\x03 \x01(\tR\x03key\"\x99\x02\n" +
 	"\tCondition\x12.\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1a.Superplane.Condition.TypeR\x04type\x129\n" +
 	"\bapproval\x18\x02 \x01(\v2\x1d.Superplane.ConditionApprovalR\bapproval\x12@\n" +
@@ -6216,8 +6227,9 @@ var file_canvases_proto_goTypes = []any{
 	nil,                                          // 100: Superplane.ExecutorSpec.Semaphore.ParametersEntry
 	nil,                                          // 101: Superplane.ExecutorSpec.HTTP.HeadersEntry
 	nil,                                          // 102: Superplane.ExecutorSpec.HTTP.PayloadEntry
-	(*integrations.IntegrationRef)(nil),          // 103: Superplane.Integrations.IntegrationRef
-	(*timestamp.Timestamp)(nil),                  // 104: google.protobuf.Timestamp
+	(authorization.DomainType)(0),                // 103: Superplane.Authorization.DomainType
+	(*integrations.IntegrationRef)(nil),          // 104: Superplane.Integrations.IntegrationRef
+	(*timestamp.Timestamp)(nil),                  // 105: google.protobuf.Timestamp
 }
 var file_canvases_proto_depIdxs = []int32{
 	14,  // 0: Superplane.ListCanvasesResponse.canvases:type_name -> Superplane.Canvas
@@ -6255,120 +6267,121 @@ var file_canvases_proto_depIdxs = []int32{
 	48,  // 32: Superplane.ValueFrom.last_execution:type_name -> Superplane.ValueFromLastExecution
 	49,  // 33: Superplane.ValueFrom.secret:type_name -> Superplane.ValueFromSecret
 	11,  // 34: Superplane.ValueFromLastExecution.results:type_name -> Superplane.Execution.Result
-	4,   // 35: Superplane.Condition.type:type_name -> Superplane.Condition.Type
-	51,  // 36: Superplane.Condition.approval:type_name -> Superplane.ConditionApproval
-	52,  // 37: Superplane.Condition.time_window:type_name -> Superplane.ConditionTimeWindow
-	41,  // 38: Superplane.CreateStageRequest.stage:type_name -> Superplane.Stage
-	5,   // 39: Superplane.ExecutorSpec.type:type_name -> Superplane.ExecutorSpec.Type
-	103, // 40: Superplane.ExecutorSpec.integration:type_name -> Superplane.Integrations.IntegrationRef
-	97,  // 41: Superplane.ExecutorSpec.semaphore:type_name -> Superplane.ExecutorSpec.Semaphore
-	98,  // 42: Superplane.ExecutorSpec.http:type_name -> Superplane.ExecutorSpec.HTTP
-	41,  // 43: Superplane.CreateStageResponse.stage:type_name -> Superplane.Stage
-	41,  // 44: Superplane.UpdateStageRequest.stage:type_name -> Superplane.Stage
-	41,  // 45: Superplane.UpdateStageResponse.stage:type_name -> Superplane.Stage
-	41,  // 46: Superplane.ListStagesResponse.stages:type_name -> Superplane.Stage
-	19,  // 47: Superplane.ListEventSourcesResponse.event_sources:type_name -> Superplane.EventSource
-	64,  // 48: Superplane.ListConnectionGroupFieldSetsResponse.field_sets:type_name -> Superplane.ConnectionGroupFieldSet
-	69,  // 49: Superplane.ConnectionGroupFieldSet.fields:type_name -> Superplane.KeyValuePair
-	6,   // 50: Superplane.ConnectionGroupFieldSet.state:type_name -> Superplane.ConnectionGroupFieldSet.State
-	7,   // 51: Superplane.ConnectionGroupFieldSet.state_reason:type_name -> Superplane.ConnectionGroupFieldSet.StateReason
-	65,  // 52: Superplane.ConnectionGroupFieldSet.events:type_name -> Superplane.ConnectionGroupEvent
-	104, // 53: Superplane.ConnectionGroupFieldSet.created_at:type_name -> google.protobuf.Timestamp
-	3,   // 54: Superplane.ConnectionGroupEvent.source_type:type_name -> Superplane.Connection.Type
-	104, // 55: Superplane.ConnectionGroupEvent.received_at:type_name -> google.protobuf.Timestamp
-	8,   // 56: Superplane.ListStageEventsRequest.states:type_name -> Superplane.StageEvent.State
-	9,   // 57: Superplane.ListStageEventsRequest.state_reasons:type_name -> Superplane.StageEvent.StateReason
-	68,  // 58: Superplane.ListStageEventsResponse.events:type_name -> Superplane.StageEvent
-	3,   // 59: Superplane.StageEvent.source_type:type_name -> Superplane.Connection.Type
-	8,   // 60: Superplane.StageEvent.state:type_name -> Superplane.StageEvent.State
-	9,   // 61: Superplane.StageEvent.state_reason:type_name -> Superplane.StageEvent.StateReason
-	104, // 62: Superplane.StageEvent.created_at:type_name -> google.protobuf.Timestamp
-	73,  // 63: Superplane.StageEvent.approvals:type_name -> Superplane.StageEventApproval
-	71,  // 64: Superplane.StageEvent.execution:type_name -> Superplane.Execution
-	69,  // 65: Superplane.StageEvent.inputs:type_name -> Superplane.KeyValuePair
-	10,  // 66: Superplane.Execution.state:type_name -> Superplane.Execution.State
-	11,  // 67: Superplane.Execution.result:type_name -> Superplane.Execution.Result
-	104, // 68: Superplane.Execution.created_at:type_name -> google.protobuf.Timestamp
-	104, // 69: Superplane.Execution.started_at:type_name -> google.protobuf.Timestamp
-	104, // 70: Superplane.Execution.finished_at:type_name -> google.protobuf.Timestamp
-	70,  // 71: Superplane.Execution.outputs:type_name -> Superplane.OutputValue
-	72,  // 72: Superplane.Execution.resources:type_name -> Superplane.ExecutionResource
-	104, // 73: Superplane.StageEventApproval.approved_at:type_name -> google.protobuf.Timestamp
-	68,  // 74: Superplane.ApproveStageEventResponse.event:type_name -> Superplane.StageEvent
-	104, // 75: Superplane.StageCreated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 76: Superplane.ConnectionGroupCreated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 77: Superplane.StageUpdated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 78: Superplane.EventSourceCreated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 79: Superplane.StageEventCreated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 80: Superplane.StageEventApproved.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 81: Superplane.StageExecutionCreated.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 82: Superplane.StageExecutionStarted.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 83: Superplane.StageExecutionFinished.timestamp:type_name -> google.protobuf.Timestamp
-	104, // 84: Superplane.Canvas.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	104, // 85: Superplane.EventSource.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	104, // 86: Superplane.EventSource.Metadata.updated_at:type_name -> google.protobuf.Timestamp
-	103, // 87: Superplane.EventSource.Spec.integration:type_name -> Superplane.Integrations.IntegrationRef
-	88,  // 88: Superplane.EventSource.Spec.semaphore:type_name -> Superplane.EventSource.Spec.Semaphore
-	104, // 89: Superplane.ConnectionGroup.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	104, // 90: Superplane.ConnectionGroup.Metadata.updated_at:type_name -> google.protobuf.Timestamp
-	40,  // 91: Superplane.ConnectionGroup.Spec.connections:type_name -> Superplane.Connection
-	91,  // 92: Superplane.ConnectionGroup.Spec.group_by:type_name -> Superplane.ConnectionGroup.Spec.GroupBy
-	2,   // 93: Superplane.ConnectionGroup.Spec.timeout_behavior:type_name -> Superplane.ConnectionGroup.Spec.TimeoutBehavior
-	92,  // 94: Superplane.ConnectionGroup.Spec.GroupBy.fields:type_name -> Superplane.ConnectionGroup.Spec.GroupBy.Field
-	104, // 95: Superplane.Stage.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	40,  // 96: Superplane.Stage.Spec.connections:type_name -> Superplane.Connection
-	50,  // 97: Superplane.Stage.Spec.conditions:type_name -> Superplane.Condition
-	54,  // 98: Superplane.Stage.Spec.executor:type_name -> Superplane.ExecutorSpec
-	43,  // 99: Superplane.Stage.Spec.inputs:type_name -> Superplane.InputDefinition
-	44,  // 100: Superplane.Stage.Spec.input_mappings:type_name -> Superplane.InputMapping
-	42,  // 101: Superplane.Stage.Spec.outputs:type_name -> Superplane.OutputDefinition
-	45,  // 102: Superplane.Stage.Spec.secrets:type_name -> Superplane.ValueDefinition
-	96,  // 103: Superplane.InputMapping.When.triggered_by:type_name -> Superplane.InputMapping.WhenTriggeredBy
-	100, // 104: Superplane.ExecutorSpec.Semaphore.parameters:type_name -> Superplane.ExecutorSpec.Semaphore.ParametersEntry
-	101, // 105: Superplane.ExecutorSpec.HTTP.headers:type_name -> Superplane.ExecutorSpec.HTTP.HeadersEntry
-	102, // 106: Superplane.ExecutorSpec.HTTP.payload:type_name -> Superplane.ExecutorSpec.HTTP.PayloadEntry
-	99,  // 107: Superplane.ExecutorSpec.HTTP.response_policy:type_name -> Superplane.ExecutorSpec.HTTPResponsePolicy
-	12,  // 108: Superplane.Superplane.ListCanvases:input_type -> Superplane.ListCanvasesRequest
-	15,  // 109: Superplane.Superplane.CreateCanvas:input_type -> Superplane.CreateCanvasRequest
-	28,  // 110: Superplane.Superplane.CreateConnectionGroup:input_type -> Superplane.CreateConnectionGroupRequest
-	22,  // 111: Superplane.Superplane.CreateEventSource:input_type -> Superplane.CreateEventSourceRequest
-	24,  // 112: Superplane.Superplane.ResetEventSourceKey:input_type -> Superplane.ResetEventSourceKeyRequest
-	53,  // 113: Superplane.Superplane.CreateStage:input_type -> Superplane.CreateStageRequest
-	17,  // 114: Superplane.Superplane.DescribeCanvas:input_type -> Superplane.DescribeCanvasRequest
-	20,  // 115: Superplane.Superplane.DescribeStage:input_type -> Superplane.DescribeStageRequest
-	26,  // 116: Superplane.Superplane.DescribeEventSource:input_type -> Superplane.DescribeEventSourceRequest
-	32,  // 117: Superplane.Superplane.DescribeConnectionGroup:input_type -> Superplane.DescribeConnectionGroupRequest
-	58,  // 118: Superplane.Superplane.ListStages:input_type -> Superplane.ListStagesRequest
-	60,  // 119: Superplane.Superplane.ListEventSources:input_type -> Superplane.ListEventSourcesRequest
-	34,  // 120: Superplane.Superplane.ListConnectionGroups:input_type -> Superplane.ListConnectionGroupsRequest
-	66,  // 121: Superplane.Superplane.ListStageEvents:input_type -> Superplane.ListStageEventsRequest
-	62,  // 122: Superplane.Superplane.ListConnectionGroupFieldSets:input_type -> Superplane.ListConnectionGroupFieldSetsRequest
-	56,  // 123: Superplane.Superplane.UpdateStage:input_type -> Superplane.UpdateStageRequest
-	30,  // 124: Superplane.Superplane.UpdateConnectionGroup:input_type -> Superplane.UpdateConnectionGroupRequest
-	74,  // 125: Superplane.Superplane.ApproveStageEvent:input_type -> Superplane.ApproveStageEventRequest
-	13,  // 126: Superplane.Superplane.ListCanvases:output_type -> Superplane.ListCanvasesResponse
-	16,  // 127: Superplane.Superplane.CreateCanvas:output_type -> Superplane.CreateCanvasResponse
-	29,  // 128: Superplane.Superplane.CreateConnectionGroup:output_type -> Superplane.CreateConnectionGroupResponse
-	23,  // 129: Superplane.Superplane.CreateEventSource:output_type -> Superplane.CreateEventSourceResponse
-	25,  // 130: Superplane.Superplane.ResetEventSourceKey:output_type -> Superplane.ResetEventSourceKeyResponse
-	55,  // 131: Superplane.Superplane.CreateStage:output_type -> Superplane.CreateStageResponse
-	18,  // 132: Superplane.Superplane.DescribeCanvas:output_type -> Superplane.DescribeCanvasResponse
-	21,  // 133: Superplane.Superplane.DescribeStage:output_type -> Superplane.DescribeStageResponse
-	27,  // 134: Superplane.Superplane.DescribeEventSource:output_type -> Superplane.DescribeEventSourceResponse
-	33,  // 135: Superplane.Superplane.DescribeConnectionGroup:output_type -> Superplane.DescribeConnectionGroupResponse
-	59,  // 136: Superplane.Superplane.ListStages:output_type -> Superplane.ListStagesResponse
-	61,  // 137: Superplane.Superplane.ListEventSources:output_type -> Superplane.ListEventSourcesResponse
-	35,  // 138: Superplane.Superplane.ListConnectionGroups:output_type -> Superplane.ListConnectionGroupsResponse
-	67,  // 139: Superplane.Superplane.ListStageEvents:output_type -> Superplane.ListStageEventsResponse
-	63,  // 140: Superplane.Superplane.ListConnectionGroupFieldSets:output_type -> Superplane.ListConnectionGroupFieldSetsResponse
-	57,  // 141: Superplane.Superplane.UpdateStage:output_type -> Superplane.UpdateStageResponse
-	31,  // 142: Superplane.Superplane.UpdateConnectionGroup:output_type -> Superplane.UpdateConnectionGroupResponse
-	75,  // 143: Superplane.Superplane.ApproveStageEvent:output_type -> Superplane.ApproveStageEventResponse
-	126, // [126:144] is the sub-list for method output_type
-	108, // [108:126] is the sub-list for method input_type
-	108, // [108:108] is the sub-list for extension type_name
-	108, // [108:108] is the sub-list for extension extendee
-	0,   // [0:108] is the sub-list for field type_name
+	103, // 35: Superplane.ValueFromSecret.domain_type:type_name -> Superplane.Authorization.DomainType
+	4,   // 36: Superplane.Condition.type:type_name -> Superplane.Condition.Type
+	51,  // 37: Superplane.Condition.approval:type_name -> Superplane.ConditionApproval
+	52,  // 38: Superplane.Condition.time_window:type_name -> Superplane.ConditionTimeWindow
+	41,  // 39: Superplane.CreateStageRequest.stage:type_name -> Superplane.Stage
+	5,   // 40: Superplane.ExecutorSpec.type:type_name -> Superplane.ExecutorSpec.Type
+	104, // 41: Superplane.ExecutorSpec.integration:type_name -> Superplane.Integrations.IntegrationRef
+	97,  // 42: Superplane.ExecutorSpec.semaphore:type_name -> Superplane.ExecutorSpec.Semaphore
+	98,  // 43: Superplane.ExecutorSpec.http:type_name -> Superplane.ExecutorSpec.HTTP
+	41,  // 44: Superplane.CreateStageResponse.stage:type_name -> Superplane.Stage
+	41,  // 45: Superplane.UpdateStageRequest.stage:type_name -> Superplane.Stage
+	41,  // 46: Superplane.UpdateStageResponse.stage:type_name -> Superplane.Stage
+	41,  // 47: Superplane.ListStagesResponse.stages:type_name -> Superplane.Stage
+	19,  // 48: Superplane.ListEventSourcesResponse.event_sources:type_name -> Superplane.EventSource
+	64,  // 49: Superplane.ListConnectionGroupFieldSetsResponse.field_sets:type_name -> Superplane.ConnectionGroupFieldSet
+	69,  // 50: Superplane.ConnectionGroupFieldSet.fields:type_name -> Superplane.KeyValuePair
+	6,   // 51: Superplane.ConnectionGroupFieldSet.state:type_name -> Superplane.ConnectionGroupFieldSet.State
+	7,   // 52: Superplane.ConnectionGroupFieldSet.state_reason:type_name -> Superplane.ConnectionGroupFieldSet.StateReason
+	65,  // 53: Superplane.ConnectionGroupFieldSet.events:type_name -> Superplane.ConnectionGroupEvent
+	105, // 54: Superplane.ConnectionGroupFieldSet.created_at:type_name -> google.protobuf.Timestamp
+	3,   // 55: Superplane.ConnectionGroupEvent.source_type:type_name -> Superplane.Connection.Type
+	105, // 56: Superplane.ConnectionGroupEvent.received_at:type_name -> google.protobuf.Timestamp
+	8,   // 57: Superplane.ListStageEventsRequest.states:type_name -> Superplane.StageEvent.State
+	9,   // 58: Superplane.ListStageEventsRequest.state_reasons:type_name -> Superplane.StageEvent.StateReason
+	68,  // 59: Superplane.ListStageEventsResponse.events:type_name -> Superplane.StageEvent
+	3,   // 60: Superplane.StageEvent.source_type:type_name -> Superplane.Connection.Type
+	8,   // 61: Superplane.StageEvent.state:type_name -> Superplane.StageEvent.State
+	9,   // 62: Superplane.StageEvent.state_reason:type_name -> Superplane.StageEvent.StateReason
+	105, // 63: Superplane.StageEvent.created_at:type_name -> google.protobuf.Timestamp
+	73,  // 64: Superplane.StageEvent.approvals:type_name -> Superplane.StageEventApproval
+	71,  // 65: Superplane.StageEvent.execution:type_name -> Superplane.Execution
+	69,  // 66: Superplane.StageEvent.inputs:type_name -> Superplane.KeyValuePair
+	10,  // 67: Superplane.Execution.state:type_name -> Superplane.Execution.State
+	11,  // 68: Superplane.Execution.result:type_name -> Superplane.Execution.Result
+	105, // 69: Superplane.Execution.created_at:type_name -> google.protobuf.Timestamp
+	105, // 70: Superplane.Execution.started_at:type_name -> google.protobuf.Timestamp
+	105, // 71: Superplane.Execution.finished_at:type_name -> google.protobuf.Timestamp
+	70,  // 72: Superplane.Execution.outputs:type_name -> Superplane.OutputValue
+	72,  // 73: Superplane.Execution.resources:type_name -> Superplane.ExecutionResource
+	105, // 74: Superplane.StageEventApproval.approved_at:type_name -> google.protobuf.Timestamp
+	68,  // 75: Superplane.ApproveStageEventResponse.event:type_name -> Superplane.StageEvent
+	105, // 76: Superplane.StageCreated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 77: Superplane.ConnectionGroupCreated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 78: Superplane.StageUpdated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 79: Superplane.EventSourceCreated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 80: Superplane.StageEventCreated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 81: Superplane.StageEventApproved.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 82: Superplane.StageExecutionCreated.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 83: Superplane.StageExecutionStarted.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 84: Superplane.StageExecutionFinished.timestamp:type_name -> google.protobuf.Timestamp
+	105, // 85: Superplane.Canvas.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	105, // 86: Superplane.EventSource.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	105, // 87: Superplane.EventSource.Metadata.updated_at:type_name -> google.protobuf.Timestamp
+	104, // 88: Superplane.EventSource.Spec.integration:type_name -> Superplane.Integrations.IntegrationRef
+	88,  // 89: Superplane.EventSource.Spec.semaphore:type_name -> Superplane.EventSource.Spec.Semaphore
+	105, // 90: Superplane.ConnectionGroup.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	105, // 91: Superplane.ConnectionGroup.Metadata.updated_at:type_name -> google.protobuf.Timestamp
+	40,  // 92: Superplane.ConnectionGroup.Spec.connections:type_name -> Superplane.Connection
+	91,  // 93: Superplane.ConnectionGroup.Spec.group_by:type_name -> Superplane.ConnectionGroup.Spec.GroupBy
+	2,   // 94: Superplane.ConnectionGroup.Spec.timeout_behavior:type_name -> Superplane.ConnectionGroup.Spec.TimeoutBehavior
+	92,  // 95: Superplane.ConnectionGroup.Spec.GroupBy.fields:type_name -> Superplane.ConnectionGroup.Spec.GroupBy.Field
+	105, // 96: Superplane.Stage.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	40,  // 97: Superplane.Stage.Spec.connections:type_name -> Superplane.Connection
+	50,  // 98: Superplane.Stage.Spec.conditions:type_name -> Superplane.Condition
+	54,  // 99: Superplane.Stage.Spec.executor:type_name -> Superplane.ExecutorSpec
+	43,  // 100: Superplane.Stage.Spec.inputs:type_name -> Superplane.InputDefinition
+	44,  // 101: Superplane.Stage.Spec.input_mappings:type_name -> Superplane.InputMapping
+	42,  // 102: Superplane.Stage.Spec.outputs:type_name -> Superplane.OutputDefinition
+	45,  // 103: Superplane.Stage.Spec.secrets:type_name -> Superplane.ValueDefinition
+	96,  // 104: Superplane.InputMapping.When.triggered_by:type_name -> Superplane.InputMapping.WhenTriggeredBy
+	100, // 105: Superplane.ExecutorSpec.Semaphore.parameters:type_name -> Superplane.ExecutorSpec.Semaphore.ParametersEntry
+	101, // 106: Superplane.ExecutorSpec.HTTP.headers:type_name -> Superplane.ExecutorSpec.HTTP.HeadersEntry
+	102, // 107: Superplane.ExecutorSpec.HTTP.payload:type_name -> Superplane.ExecutorSpec.HTTP.PayloadEntry
+	99,  // 108: Superplane.ExecutorSpec.HTTP.response_policy:type_name -> Superplane.ExecutorSpec.HTTPResponsePolicy
+	12,  // 109: Superplane.Superplane.ListCanvases:input_type -> Superplane.ListCanvasesRequest
+	15,  // 110: Superplane.Superplane.CreateCanvas:input_type -> Superplane.CreateCanvasRequest
+	28,  // 111: Superplane.Superplane.CreateConnectionGroup:input_type -> Superplane.CreateConnectionGroupRequest
+	22,  // 112: Superplane.Superplane.CreateEventSource:input_type -> Superplane.CreateEventSourceRequest
+	24,  // 113: Superplane.Superplane.ResetEventSourceKey:input_type -> Superplane.ResetEventSourceKeyRequest
+	53,  // 114: Superplane.Superplane.CreateStage:input_type -> Superplane.CreateStageRequest
+	17,  // 115: Superplane.Superplane.DescribeCanvas:input_type -> Superplane.DescribeCanvasRequest
+	20,  // 116: Superplane.Superplane.DescribeStage:input_type -> Superplane.DescribeStageRequest
+	26,  // 117: Superplane.Superplane.DescribeEventSource:input_type -> Superplane.DescribeEventSourceRequest
+	32,  // 118: Superplane.Superplane.DescribeConnectionGroup:input_type -> Superplane.DescribeConnectionGroupRequest
+	58,  // 119: Superplane.Superplane.ListStages:input_type -> Superplane.ListStagesRequest
+	60,  // 120: Superplane.Superplane.ListEventSources:input_type -> Superplane.ListEventSourcesRequest
+	34,  // 121: Superplane.Superplane.ListConnectionGroups:input_type -> Superplane.ListConnectionGroupsRequest
+	66,  // 122: Superplane.Superplane.ListStageEvents:input_type -> Superplane.ListStageEventsRequest
+	62,  // 123: Superplane.Superplane.ListConnectionGroupFieldSets:input_type -> Superplane.ListConnectionGroupFieldSetsRequest
+	56,  // 124: Superplane.Superplane.UpdateStage:input_type -> Superplane.UpdateStageRequest
+	30,  // 125: Superplane.Superplane.UpdateConnectionGroup:input_type -> Superplane.UpdateConnectionGroupRequest
+	74,  // 126: Superplane.Superplane.ApproveStageEvent:input_type -> Superplane.ApproveStageEventRequest
+	13,  // 127: Superplane.Superplane.ListCanvases:output_type -> Superplane.ListCanvasesResponse
+	16,  // 128: Superplane.Superplane.CreateCanvas:output_type -> Superplane.CreateCanvasResponse
+	29,  // 129: Superplane.Superplane.CreateConnectionGroup:output_type -> Superplane.CreateConnectionGroupResponse
+	23,  // 130: Superplane.Superplane.CreateEventSource:output_type -> Superplane.CreateEventSourceResponse
+	25,  // 131: Superplane.Superplane.ResetEventSourceKey:output_type -> Superplane.ResetEventSourceKeyResponse
+	55,  // 132: Superplane.Superplane.CreateStage:output_type -> Superplane.CreateStageResponse
+	18,  // 133: Superplane.Superplane.DescribeCanvas:output_type -> Superplane.DescribeCanvasResponse
+	21,  // 134: Superplane.Superplane.DescribeStage:output_type -> Superplane.DescribeStageResponse
+	27,  // 135: Superplane.Superplane.DescribeEventSource:output_type -> Superplane.DescribeEventSourceResponse
+	33,  // 136: Superplane.Superplane.DescribeConnectionGroup:output_type -> Superplane.DescribeConnectionGroupResponse
+	59,  // 137: Superplane.Superplane.ListStages:output_type -> Superplane.ListStagesResponse
+	61,  // 138: Superplane.Superplane.ListEventSources:output_type -> Superplane.ListEventSourcesResponse
+	35,  // 139: Superplane.Superplane.ListConnectionGroups:output_type -> Superplane.ListConnectionGroupsResponse
+	67,  // 140: Superplane.Superplane.ListStageEvents:output_type -> Superplane.ListStageEventsResponse
+	63,  // 141: Superplane.Superplane.ListConnectionGroupFieldSets:output_type -> Superplane.ListConnectionGroupFieldSetsResponse
+	57,  // 142: Superplane.Superplane.UpdateStage:output_type -> Superplane.UpdateStageResponse
+	31,  // 143: Superplane.Superplane.UpdateConnectionGroup:output_type -> Superplane.UpdateConnectionGroupResponse
+	75,  // 144: Superplane.Superplane.ApproveStageEvent:output_type -> Superplane.ApproveStageEventResponse
+	127, // [127:145] is the sub-list for method output_type
+	109, // [109:127] is the sub-list for method input_type
+	109, // [109:109] is the sub-list for extension type_name
+	109, // [109:109] is the sub-list for extension extendee
+	0,   // [0:109] is the sub-list for field type_name
 }
 
 func init() { file_canvases_proto_init() }

--- a/pkg/protos/integrations/integrations.pb.go
+++ b/pkg/protos/integrations/integrations.pb.go
@@ -576,9 +576,10 @@ func (x *ValueFrom) GetSecret() *ValueFromSecret {
 }
 
 type ValueFromSecret struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Key           string                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	DomainType    authorization.DomainType `protobuf:"varint,1,opt,name=domain_type,json=domainType,proto3,enum=Superplane.Authorization.DomainType" json:"domain_type,omitempty"`
+	Name          string                   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Key           string                   `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -611,6 +612,13 @@ func (x *ValueFromSecret) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ValueFromSecret.ProtoReflect.Descriptor instead.
 func (*ValueFromSecret) Descriptor() ([]byte, []int) {
 	return file_integrations_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ValueFromSecret) GetDomainType() authorization.DomainType {
+	if x != nil {
+		return x.DomainType
+	}
+	return authorization.DomainType(0)
 }
 
 func (x *ValueFromSecret) GetName() string {
@@ -984,10 +992,12 @@ const file_integrations_proto_rawDesc = "" +
 	"domainType\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\"M\n" +
 	"\tValueFrom\x12@\n" +
-	"\x06secret\x18\x03 \x01(\v2(.Superplane.Integrations.ValueFromSecretR\x06secret\"7\n" +
-	"\x0fValueFromSecret\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x10\n" +
-	"\x03key\x18\x02 \x01(\tR\x03key2\xbd\x05\n" +
+	"\x06secret\x18\x03 \x01(\v2(.Superplane.Integrations.ValueFromSecretR\x06secret\"~\n" +
+	"\x0fValueFromSecret\x12E\n" +
+	"\vdomain_type\x18\x01 \x01(\x0e2$.Superplane.Authorization.DomainTypeR\n" +
+	"domainType\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
+	"\x03key\x18\x03 \x01(\tR\x03key2\xbd\x05\n" +
 	"\fIntegrations\x12\xcb\x01\n" +
 	"\x10ListIntegrations\x120.Superplane.Integrations.ListIntegrationsRequest\x1a1.Superplane.Integrations.ListIntegrationsResponse\"R\x92A3\n" +
 	"\vIntegration\x12\x11List integrations\x1a\x11List integrations\x82\xd3\xe4\x93\x02\x16\x12\x14/api/v1/integrations\x12\xed\x01\n" +
@@ -1045,25 +1055,26 @@ var file_integrations_proto_depIdxs = []int32{
 	15, // 8: Superplane.Integrations.Integration.spec:type_name -> Superplane.Integrations.Integration.Spec
 	17, // 9: Superplane.Integrations.IntegrationRef.domain_type:type_name -> Superplane.Authorization.DomainType
 	11, // 10: Superplane.Integrations.ValueFrom.secret:type_name -> Superplane.Integrations.ValueFromSecret
-	18, // 11: Superplane.Integrations.Integration.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	17, // 12: Superplane.Integrations.Integration.Metadata.domain_type:type_name -> Superplane.Authorization.DomainType
-	1,  // 13: Superplane.Integrations.Integration.Auth.use:type_name -> Superplane.Integrations.Integration.AuthType
-	16, // 14: Superplane.Integrations.Integration.Auth.token:type_name -> Superplane.Integrations.Integration.Auth.Token
-	0,  // 15: Superplane.Integrations.Integration.Spec.type:type_name -> Superplane.Integrations.Integration.Type
-	13, // 16: Superplane.Integrations.Integration.Spec.auth:type_name -> Superplane.Integrations.Integration.Auth
-	14, // 17: Superplane.Integrations.Integration.Spec.oidc:type_name -> Superplane.Integrations.Integration.OIDC
-	10, // 18: Superplane.Integrations.Integration.Auth.Token.value_from:type_name -> Superplane.Integrations.ValueFrom
-	4,  // 19: Superplane.Integrations.Integrations.ListIntegrations:input_type -> Superplane.Integrations.ListIntegrationsRequest
-	6,  // 20: Superplane.Integrations.Integrations.DescribeIntegration:input_type -> Superplane.Integrations.DescribeIntegrationRequest
-	2,  // 21: Superplane.Integrations.Integrations.CreateIntegration:input_type -> Superplane.Integrations.CreateIntegrationRequest
-	5,  // 22: Superplane.Integrations.Integrations.ListIntegrations:output_type -> Superplane.Integrations.ListIntegrationsResponse
-	7,  // 23: Superplane.Integrations.Integrations.DescribeIntegration:output_type -> Superplane.Integrations.DescribeIntegrationResponse
-	3,  // 24: Superplane.Integrations.Integrations.CreateIntegration:output_type -> Superplane.Integrations.CreateIntegrationResponse
-	22, // [22:25] is the sub-list for method output_type
-	19, // [19:22] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	17, // 11: Superplane.Integrations.ValueFromSecret.domain_type:type_name -> Superplane.Authorization.DomainType
+	18, // 12: Superplane.Integrations.Integration.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	17, // 13: Superplane.Integrations.Integration.Metadata.domain_type:type_name -> Superplane.Authorization.DomainType
+	1,  // 14: Superplane.Integrations.Integration.Auth.use:type_name -> Superplane.Integrations.Integration.AuthType
+	16, // 15: Superplane.Integrations.Integration.Auth.token:type_name -> Superplane.Integrations.Integration.Auth.Token
+	0,  // 16: Superplane.Integrations.Integration.Spec.type:type_name -> Superplane.Integrations.Integration.Type
+	13, // 17: Superplane.Integrations.Integration.Spec.auth:type_name -> Superplane.Integrations.Integration.Auth
+	14, // 18: Superplane.Integrations.Integration.Spec.oidc:type_name -> Superplane.Integrations.Integration.OIDC
+	10, // 19: Superplane.Integrations.Integration.Auth.Token.value_from:type_name -> Superplane.Integrations.ValueFrom
+	4,  // 20: Superplane.Integrations.Integrations.ListIntegrations:input_type -> Superplane.Integrations.ListIntegrationsRequest
+	6,  // 21: Superplane.Integrations.Integrations.DescribeIntegration:input_type -> Superplane.Integrations.DescribeIntegrationRequest
+	2,  // 22: Superplane.Integrations.Integrations.CreateIntegration:input_type -> Superplane.Integrations.CreateIntegrationRequest
+	5,  // 23: Superplane.Integrations.Integrations.ListIntegrations:output_type -> Superplane.Integrations.ListIntegrationsResponse
+	7,  // 24: Superplane.Integrations.Integrations.DescribeIntegration:output_type -> Superplane.Integrations.DescribeIntegrationResponse
+	3,  // 25: Superplane.Integrations.Integrations.CreateIntegration:output_type -> Superplane.Integrations.CreateIntegrationResponse
+	23, // [23:26] is the sub-list for method output_type
+	20, // [20:23] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_integrations_proto_init() }

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package Superplane;
 
+import "authorization.proto";
 import "integrations.proto";
 import "google/protobuf/timestamp.proto";
 import "google/api/annotations.proto";
@@ -519,8 +520,9 @@ message ValueFromLastExecution {
 }
 
 message ValueFromSecret {
-  string name = 1;
-  string key = 2;
+  Authorization.DomainType domain_type = 1;
+  string name = 2;
+  string key = 3;
 }
 
 message Condition {

--- a/protos/integrations.proto
+++ b/protos/integrations.proto
@@ -147,6 +147,7 @@ message ValueFrom {
 }
 
 message ValueFromSecret {
-  string name = 1;
-  string key = 2;
+  Authorization.DomainType domain_type = 1;
+  string name = 2;
+  string key = 3;
 }

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -78,7 +78,7 @@ func SetupWithOptions(t *testing.T, options SetupOptions) *ResourceRegistry {
 	log.Infof("Semaphore API mock started at %s", r.SemaphoreAPIMock.Server.URL)
 
 	if options.Integration {
-		secret, err := CreateSecret(t, &r, map[string]string{"key": "test"})
+		secret, err := CreateCanvasSecret(t, &r, map[string]string{"key": "test"})
 		require.NoError(t, err)
 		integration, err := models.CreateIntegration(&models.Integration{
 			Name:       RandomName("integration"),
@@ -258,10 +258,18 @@ func ProtoExecutor(r *ResourceRegistry) *pb.ExecutorSpec {
 	}
 }
 
-func CreateSecret(t *testing.T, r *ResourceRegistry, secretData map[string]string) (*models.Secret, error) {
+func CreateCanvasSecret(t *testing.T, r *ResourceRegistry, secretData map[string]string) (*models.Secret, error) {
 	data, err := json.Marshal(secretData)
 	require.NoError(t, err)
 	secret, err := models.CreateSecret(RandomName("secret"), secrets.ProviderLocal, r.User.String(), models.DomainTypeCanvas, r.Canvas.ID, data)
+	require.NoError(t, err)
+	return secret, nil
+}
+
+func CreateOrganizationSecret(t *testing.T, r *ResourceRegistry, secretData map[string]string) (*models.Secret, error) {
+	data, err := json.Marshal(secretData)
+	require.NoError(t, err)
+	secret, err := models.CreateSecret(RandomName("secret"), secrets.ProviderLocal, r.User.String(), models.DomainTypeOrganization, r.Organization.ID, data)
 	require.NoError(t, err)
 	return secret, nil
 }

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -92,8 +92,9 @@ func SetupWithOptions(t *testing.T, options SetupOptions) *ResourceRegistry {
 				Token: &models.IntegrationAuthToken{
 					ValueFrom: models.ValueDefinitionFrom{
 						Secret: &models.ValueDefinitionFromSecret{
-							Name: secret.Name,
-							Key:  "key",
+							DomainType: models.DomainTypeCanvas,
+							Name:       secret.Name,
+							Key:        "key",
 						},
 					},
 				},


### PR DESCRIPTION
When creating an integration, it should be possible to:
- Create it on the organization level using an organization secret
- Create it on the canvas level using a canvas secret
- Create it on the canvas level using an organization secret

When creating an event source or stage that points to an integration, it should be possible to create it using an organization or canvas level integration.