### PR TITLE
feat: add get/list CLI commands for integrations

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -200,7 +200,7 @@ func getDomainTypeAndId(domainID string, domainType pbAuth.DomainType) (string, 
 			return models.DomainTypeCanvas, domainID, nil
 		}
 
-		canvas, err := models.FindCanvasByID(domainID)
+		canvas, err := models.FindCanvasByName(domainID)
 		if err != nil {
 			return "", "", fmt.Errorf("canvas %s not found", domainID)
 		}

--- a/pkg/cli/approve.go
+++ b/pkg/cli/approve.go
@@ -17,8 +17,8 @@ var approveEventCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		eventID := args[0]
 
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
-		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
+		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name", true)
 
 		c := DefaultClient()
 

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -19,7 +19,7 @@ var listCanvasesCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		c := DefaultClient()
-		organizationId := getOneOrAnotherFlag(cmd, "organization-id", "organization-name")
+		organizationId := getOneOrAnotherFlag(cmd, "organization-id", "organization-name", true)
 		response, _, err := c.CanvasAPI.SuperplaneListCanvases(context.Background()).OrganizationId(organizationId).Execute()
 		Check(err)
 
@@ -48,7 +48,7 @@ var listEventSourcesCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
 
 		c := DefaultClient()
 		response, _, err := c.EventSourceAPI.SuperplaneListEventSources(context.Background(), canvasIDOrName).Execute()
@@ -80,7 +80,7 @@ var listStagesCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
 
 		c := DefaultClient()
 		response, _, err := c.StageAPI.SuperplaneListStages(context.Background(), canvasIDOrName).Execute()
@@ -112,7 +112,7 @@ var listConnectionGroupsCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
 
 		c := DefaultClient()
 		response, _, err := c.ConnectionGroupAPI.SuperplaneListConnectionGroups(context.Background(), canvasIDOrName).Execute()
@@ -138,18 +138,13 @@ var listConnectionGroupsCmd = &cobra.Command{
 
 var listSecretsCmd = &cobra.Command{
 	Use:     "secrets",
-	Short:   "List all secrets for a canvas",
-	Long:    `Retrieve a list of all secrets for the specified canvas`,
-	Aliases: []string{"secrets"},
+	Short:   "List secrets for an organization or canvas",
+	Long:    `Retrieve a list of all secrets for the specified organization or canvas`,
+	Aliases: []string{"secret"},
 	Args:    cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		domainType, _ := cmd.Flags().GetString("domain-type")
-		domainID, _ := cmd.Flags().GetString("domain-id")
-		if domainID == "" {
-			fmt.Println("Domain ID not provided")
-			os.Exit(1)
-		}
+		domainType, domainID := getDomainOrExit(cmd)
 
 		c := DefaultClient()
 		response, httpResponse, err := c.SecretAPI.
@@ -191,6 +186,51 @@ var listSecretsCmd = &cobra.Command{
 	},
 }
 
+var listIntegrationsCmd = &cobra.Command{
+	Use:     "integrations",
+	Short:   "List all integrations for an organization or canvas",
+	Long:    `Retrieve a list of integrations for the specified organization or canvas`,
+	Aliases: []string{"integration"},
+	Args:    cobra.ExactArgs(0),
+
+	Run: func(cmd *cobra.Command, args []string) {
+		domainType, domainID := getDomainOrExit(cmd)
+
+		c := DefaultClient()
+		response, httpResponse, err := c.IntegrationAPI.
+			IntegrationsListIntegrations(context.Background()).
+			DomainId(domainID).
+			DomainType(domainType).
+			Execute()
+
+		if err != nil {
+			b, _ := io.ReadAll(httpResponse.Body)
+			fmt.Printf("%s\n", string(b))
+			os.Exit(1)
+		}
+
+		if len(response.Integrations) == 0 {
+			fmt.Println("No integrations found.")
+			return
+		}
+
+		fmt.Printf("Found %d integrations:\n\n", len(response.Integrations))
+		for i, integration := range response.Integrations {
+			metadata := integration.GetMetadata()
+			spec := integration.GetSpec()
+			fmt.Printf("%d. %s (ID: %s)\n", i+1, *metadata.Name, *metadata.Id)
+			fmt.Printf("   Domain Type: %s\n", *metadata.DomainType)
+			fmt.Printf("   Domain ID: %s\n", *metadata.DomainId)
+			fmt.Printf("   Type: %s\n", string(*spec.Type))
+			fmt.Printf("   URL: %s\n", spec.GetUrl())
+
+			if i < len(response.Integrations)-1 {
+				fmt.Println()
+			}
+		}
+	},
+}
+
 var listStageEventsCmd = &cobra.Command{
 	Use:   "stage-events",
 	Short: "List stage events",
@@ -198,8 +238,8 @@ var listStageEventsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
-		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
+		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name", true)
 
 		states, _ := cmd.Flags().GetStringSlice("states")
 		stateReasons, _ := cmd.Flags().GetStringSlice("state-reasons")
@@ -281,8 +321,8 @@ var listConnectionGroupFieldSetsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
-		connGroupIdOrName := getOneOrAnotherFlag(cmd, "connection-group-id", "connection-group-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
+		connGroupIdOrName := getOneOrAnotherFlag(cmd, "connection-group-id", "connection-group-name", true)
 
 		c := DefaultClient()
 		listRequest := c.ConnectionGroupAPI.SuperplaneListConnectionGroupFieldSets(context.Background(), canvasIDOrName, connGroupIdOrName)
@@ -352,8 +392,15 @@ func init() {
 
 	// Secrets command
 	listCmd.AddCommand(listSecretsCmd)
-	listSecretsCmd.Flags().String("domain-type", "DOMAIN_TYPE_ORGANIZATION", "Domain to list secrets from (organization, canvas)")
-	listSecretsCmd.Flags().String("domain-id", "", "ID of the domain (organization ID, canvas ID)")
+	listSecretsCmd.Flags().String("organization-id", "", "Organization ID")
+	listSecretsCmd.Flags().String("canvas-id", "", "Canvas ID")
+	listSecretsCmd.Flags().String("canvas-name", "", "Canvas name")
+
+	// Integrations command
+	listCmd.AddCommand(listIntegrationsCmd)
+	listIntegrationsCmd.Flags().String("organization-id", "", "Organization ID")
+	listIntegrationsCmd.Flags().String("canvas-id", "", "Canvas ID")
+	listIntegrationsCmd.Flags().String("canvas-name", "", "Canvas name")
 
 	// Stage events command
 	listCmd.AddCommand(listStageEventsCmd)

--- a/pkg/cli/reset.go
+++ b/pkg/cli/reset.go
@@ -14,7 +14,7 @@ var resetEventSourceKeyCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		idOrName := args[0]
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
 
 		c := DefaultClient()
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -134,8 +134,8 @@ var updateStageCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 
 	Run: func(cmd *cobra.Command, args []string) {
-		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name")
-		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name")
+		canvasIDOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", true)
+		stageIDOrName := getOneOrAnotherFlag(cmd, "stage-id", "stage-name", true)
 		yamlFile, _ := cmd.Flags().GetString("file")
 
 		if yamlFile == "" {

--- a/pkg/cli/utils.go
+++ b/pkg/cli/utils.go
@@ -5,9 +5,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
-func getOneOrAnotherFlag(cmd *cobra.Command, flag1, flag2 string) string {
+func getOneOrAnotherFlag(cmd *cobra.Command, flag1, flag2 string, required bool) string {
 	flag1Value, _ := cmd.Flags().GetString(flag1)
 	flag2Value, _ := cmd.Flags().GetString(flag2)
 
@@ -24,8 +25,27 @@ func getOneOrAnotherFlag(cmd *cobra.Command, flag1, flag2 string) string {
 		return flag2Value
 	}
 
-	fmt.Fprintf(os.Stderr, "Error: must specify either --%s or --%s\n", flag1, flag2)
-	os.Exit(1)
+	if required {
+		fmt.Fprintf(os.Stderr, "Error: must specify either --%s or --%s\n", flag1, flag2)
+		os.Exit(1)
+	}
 
 	return ""
+}
+
+func getDomainOrExit(cmd *cobra.Command) (string, string) {
+	organizationId, _ := cmd.Flags().GetString("organization-id")
+	canvasIdOrName := getOneOrAnotherFlag(cmd, "canvas-id", "canvas-name", false)
+
+	if organizationId != "" {
+		return string(openapi_client.AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_ORGANIZATION), organizationId
+	}
+
+	if canvasIdOrName != "" {
+		return string(openapi_client.AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_CANVAS), canvasIdOrName
+	}
+
+	fmt.Println("Either organization-id or canvas-id / canvas-name flags must be provided")
+	os.Exit(1)
+	return "", ""
 }

--- a/pkg/grpc/actions/integrations/create_integration.go
+++ b/pkg/grpc/actions/integrations/create_integration.go
@@ -182,8 +182,9 @@ func serializeIntegrationAuth(authType string, auth models.IntegrationAuth) *pb.
 			Token: &pb.Integration_Auth_Token{
 				ValueFrom: &pb.ValueFrom{
 					Secret: &pb.ValueFromSecret{
-						Name: auth.Token.ValueFrom.Secret.Name,
-						Key:  auth.Token.ValueFrom.Secret.Key,
+						DomainType: actions.DomainTypeToProto(auth.Token.ValueFrom.Secret.DomainType),
+						Name:       auth.Token.ValueFrom.Secret.Name,
+						Key:        auth.Token.ValueFrom.Secret.Key,
 					},
 				},
 			},

--- a/pkg/grpc/actions/stages/create_stage.go
+++ b/pkg/grpc/actions/stages/create_stage.go
@@ -409,8 +409,9 @@ func serializeValueFrom(in models.ValueDefinitionFrom) *pb.ValueFrom {
 	if in.Secret != nil {
 		return &pb.ValueFrom{
 			Secret: &pb.ValueFromSecret{
-				Name: in.Secret.Name,
-				Key:  in.Secret.Key,
+				DomainType: actions.DomainTypeToProto(in.Secret.DomainType),
+				Name:       in.Secret.Name,
+				Key:        in.Secret.Key,
 			},
 		}
 	}


### PR DESCRIPTION
- Add get/list CLI commands for integrations
- Update get/list commands for secrets/integrations to not use `--domain-id` and `--domain-type` flags, and instead use the same `--canvas-id`, `--canvas-name` and `--organization-id` flags we have for other commands