### PR TITLE
fix: use source ID for encrypting key

### DIFF
--- a/pkg/models/canvas.go
+++ b/pkg/models/canvas.go
@@ -32,12 +32,13 @@ func (Canvas) TableName() string {
 }
 
 func (c *Canvas) CreateEventSource(name string, description string, key []byte, scope string, eventTypes []EventType, resourceId *uuid.UUID) (*EventSource, error) {
-	return c.CreateEventSourceInTransaction(database.Conn(), name, description, key, scope, eventTypes, resourceId)
+	return c.CreateEventSourceInTransaction(database.Conn(), uuid.New(), name, description, key, scope, eventTypes, resourceId)
 }
 
 // NOTE: caller must encrypt the key before calling this method.
 func (c *Canvas) CreateEventSourceInTransaction(
 	tx *gorm.DB,
+	id uuid.UUID,
 	name string,
 	description string,
 	key []byte,
@@ -48,6 +49,7 @@ func (c *Canvas) CreateEventSourceInTransaction(
 	now := time.Now()
 
 	eventSource := EventSource{
+		ID:          id,
 		Name:        name,
 		CanvasID:    c.ID,
 		Description: description,

--- a/pkg/models/event_source.go
+++ b/pkg/models/event_source.go
@@ -1,12 +1,10 @@
 package models
 
 import (
-	"context"
 	"slices"
 	"time"
 
 	uuid "github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -45,23 +43,6 @@ func (s *EventSource) UpdateKey(key []byte) error {
 	s.Key = key
 	s.UpdatedAt = &now
 	return database.Conn().Save(s).Error
-}
-
-func (s *EventSource) GetDecryptedKey(ctx context.Context, encryptor crypto.Encryptor) ([]byte, error) {
-	return s.GetDecryptedKeyInTransaction(ctx, database.Conn(), encryptor)
-}
-
-func (s *EventSource) GetDecryptedKeyInTransaction(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor) ([]byte, error) {
-	if s.ResourceID == nil {
-		return encryptor.Decrypt(ctx, s.Key, []byte(s.Name))
-	}
-
-	resource, err := FindResourceByIDInTransaction(tx, *s.ResourceID)
-	if err != nil {
-		return nil, err
-	}
-
-	return encryptor.Decrypt(ctx, s.Key, []byte(resource.Id()))
 }
 
 func (s *EventSource) UpdateState(state string) error {

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -630,7 +630,7 @@ func (s *Server) HandleCustomWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key, err := source.GetDecryptedKey(r.Context(), s.encryptor)
+	key, err := s.encryptor.Decrypt(r.Context(), source.Key, []byte(source.ID.String()))
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
@@ -726,7 +726,7 @@ func (s *Server) HandleIntegrationWebhook(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	key, err := source.GetDecryptedKey(r.Context(), s.encryptor)
+	key, err := s.encryptor.Decrypt(r.Context(), source.Key, []byte(source.ID.String()))
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -188,7 +188,7 @@ func Test__ReceiveCustomWebhook(t *testing.T) {
 	server, err := NewServer(&crypto.NoOpEncryptor{}, r.Registry, signer, crypto.NewOIDCVerifier(), "", "")
 	require.NoError(t, err)
 
-	key, err := r.Source.GetDecryptedKey(context.Background(), r.Encryptor)
+	key, err := r.Encryptor.Decrypt(context.Background(), r.Source.Key, []byte(r.Source.ID.String()))
 	require.NoError(t, err)
 
 	validEvent := []byte(`{"foo": "bar"}`)

--- a/pkg/workers/pending_event_sources_worker.go
+++ b/pkg/workers/pending_event_sources_worker.go
@@ -76,7 +76,7 @@ func (w *PendingEventSourcesWorker) ProcessEventSource(eventSource models.EventS
 		return fmt.Errorf("error creating integration: %v", err)
 	}
 
-	key, err := w.Encryptor.Decrypt(context.Background(), eventSource.Key, []byte(eventSource.Name))
+	key, err := w.Encryptor.Decrypt(context.Background(), eventSource.Key, []byte(eventSource.ID.String()))
 	if err != nil {
 		return fmt.Errorf("error decrypting event source key: %v", err)
 	}


### PR DESCRIPTION
This saves us one additional query on the HTTP endpoint for receiving hooks from integrations, which is a very hot path.