### PR TITLE
fix: assign viewer role when accepting invitation for user

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
--- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg130+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1076,7 +1076,7 @@ ALTER TABLE ONLY public.users
 --
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
--- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg130+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/pkg/grpc/actions/organizations/create_invitation.go
+++ b/pkg/grpc/actions/organizations/create_invitation.go
@@ -5,14 +5,17 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/organizations"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
-func CreateInvitation(ctx context.Context, orgID string, email string) (*pb.CreateInvitationResponse, error) {
+func CreateInvitation(ctx context.Context, authService authorization.Authorization, orgID string, email string) (*pb.CreateInvitationResponse, error) {
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
@@ -30,9 +33,51 @@ func CreateInvitation(ctx context.Context, orgID string, email string) (*pb.Crea
 		return nil, status.Error(codes.AlreadyExists, "user is already a member of the organization")
 	}
 
-	invitation, err := models.CreateInvitation(uuid.MustParse(orgID), uuid.MustParse(userID), email)
+	org := uuid.MustParse(orgID)
+	user := uuid.MustParse(userID)
+
+	//
+	// Check if account already exists.
+	// If it doesn't, we will create a pending invitation,
+	// which will be fullfilled once the account signs in for the first time.
+	//
+	account, err := models.FindAccountByEmail(email)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "Failed to create invitation: %v", err)
+		invitation, err := models.CreateInvitation(org, user, email, models.InvitationStatusPending)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "Failed to create invitation: %v", err)
+		}
+
+		return &pb.CreateInvitationResponse{
+			Invitation: serializeInvitation(invitation),
+		}, nil
+	}
+
+	//
+	// If an account already exists,
+	// we add a new user for it to the organization immediately.
+	//
+	var invitation *models.OrganizationInvitation
+	err = database.Conn().Transaction(func(tx *gorm.DB) error {
+		i, err := models.CreateInvitationInTransaction(tx, org, user, email, models.InvitationStatusAccepted)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "Failed to create invitation: %v", err)
+		}
+
+		invitation = i
+		user, err := models.CreateUserInTransaction(tx, invitation.OrganizationID, account.ID, account.Email, account.Name)
+		if err != nil {
+			return err
+		}
+
+		//
+		// TODO: this is not using the transaction properly
+		//
+		return authService.AssignRole(user.ID.String(), models.RoleOrgViewer, orgID, models.DomainTypeOrganization)
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
 	return &pb.CreateInvitationResponse{

--- a/pkg/grpc/actions/organizations/create_invitation_test.go
+++ b/pkg/grpc/actions/organizations/create_invitation_test.go
@@ -1,0 +1,101 @@
+package organizations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+func Test__CreateInvitation(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+	t.Run("unauthenticated user -> error", func(t *testing.T) {
+		_, err := CreateInvitation(context.Background(), r.AuthService, r.Organization.ID.String(), "new@example.com")
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, s.Code())
+		assert.Equal(t, "user not authenticated", s.Message())
+	})
+
+	t.Run("empty email -> error", func(t *testing.T) {
+		_, err := CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), "")
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "email is required", s.Message())
+	})
+
+	t.Run("user already exists in organization -> error", func(t *testing.T) {
+		_, err := CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), r.Account.Email)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, s.Code())
+		assert.Equal(t, "user is already a member of the organization", s.Message())
+	})
+
+	t.Run("account does not exist -> creates pending invitation", func(t *testing.T) {
+		email := "does-not-exist@example.com"
+		response, err := CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), email)
+		require.NoError(t, err)
+		assert.Equal(t, r.Organization.ID.String(), response.Invitation.OrganizationId)
+		assert.Equal(t, email, response.Invitation.Email)
+		assert.Equal(t, models.InvitationStatusPending, response.Invitation.Status)
+
+		// Verify user for this account is not added to organization
+		_, err = models.FindUserByEmail(r.Organization.ID.String(), email)
+		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+	})
+
+	t.Run("account exists -> creates accepted invitation and adds user immediately", func(t *testing.T) {
+		//
+		// Create a separate account that is not yet in the organization
+		//
+		account, err := models.CreateAccount("existing@example.com", "Existing User")
+		require.NoError(t, err)
+
+		response, err := CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), account.Email)
+		require.NoError(t, err)
+		assert.Equal(t, r.Organization.ID.String(), response.Invitation.OrganizationId)
+		assert.Equal(t, account.Email, response.Invitation.Email)
+		assert.Equal(t, models.InvitationStatusAccepted, response.Invitation.Status)
+
+		//
+		// Verify the user was created in the organization and assigned the viewer role
+		//
+		user, err := models.FindUserByEmail(r.Organization.ID.String(), account.Email)
+		require.NoError(t, err)
+		assert.Equal(t, account.ID, user.AccountID)
+		assert.Equal(t, account.Email, user.Email)
+		assert.Equal(t, account.Name, user.Name)
+		assert.Equal(t, r.Organization.ID, user.OrganizationID)
+
+		roles, err := r.AuthService.GetUserRolesForOrg(user.ID.String(), r.Organization.ID.String())
+		require.NoError(t, err)
+		assert.Contains(t, roles[0].Name, models.RoleOrgViewer)
+	})
+
+	t.Run("duplicate invitation for non-existent account -> error", func(t *testing.T) {
+		email := "duplicate@example.com"
+
+		// Create first invitation
+		_, err := CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), email)
+		require.NoError(t, err)
+
+		// Try to create second invitation for same email
+		_, err = CreateInvitation(ctx, r.AuthService, r.Organization.ID.String(), email)
+		assert.Error(t, err)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Contains(t, s.Message(), "Failed to create invitation")
+	})
+}

--- a/pkg/grpc/organization_service.go
+++ b/pkg/grpc/organization_service.go
@@ -35,7 +35,7 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, req *pb.De
 
 func (s *OrganizationService) CreateInvitation(ctx context.Context, req *pb.CreateInvitationRequest) (*pb.CreateInvitationResponse, error) {
 	orgID := ctx.Value(authorization.DomainIdContextKey).(string)
-	return organizations.CreateInvitation(ctx, orgID, req.Email)
+	return organizations.CreateInvitation(ctx, s.authorizationService, orgID, req.Email)
 }
 
 func (s *OrganizationService) ListInvitations(ctx context.Context, req *pb.ListInvitationsRequest) (*pb.ListInvitationsResponse, error) {

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
+	"gorm.io/gorm"
 )
 
 type User struct {
@@ -18,6 +19,10 @@ type User struct {
 }
 
 func CreateUser(orgID, accountID uuid.UUID, email, name string) (*User, error) {
+	return CreateUserInTransaction(database.Conn(), orgID, accountID, email, name)
+}
+
+func CreateUserInTransaction(tx *gorm.DB, orgID, accountID uuid.UUID, email, name string) (*User, error) {
 	user := &User{
 		OrganizationID: orgID,
 		AccountID:      accountID,
@@ -25,7 +30,7 @@ func CreateUser(orgID, accountID uuid.UUID, email, name string) (*User, error) {
 		Name:           name,
 	}
 
-	err := database.Conn().Create(user).Error
+	err := tx.Create(user).Error
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -82,7 +82,7 @@ func NewServer(
 ) (*Server, error) {
 
 	// Initialize OAuth providers from environment variables
-	authHandler := authentication.NewHandler(jwtSigner, encryptor, appEnv)
+	authHandler := authentication.NewHandler(jwtSigner, encryptor, authorizationService, appEnv)
 	providers := getOAuthProviders()
 	authHandler.InitializeProviders(providers)
 


### PR DESCRIPTION
There are two issues with the current invitation system:
- When the invitation is accepted, we are not assigning any roles to the new organization user created. We should assign the viewer role.
- We are currently only accepting invitation after the authentication flow completes, so if I am creating an invitation for an email that is associated with an existing account, that account will have to log out and log in again to be added to the organization, which is not ideal. Instead, when creating invitations, if an account for the email being already exists, we add a new user for it to the organization.