### PR TITLE
fix(cli): do not log configuration when setting it

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -55,8 +55,6 @@ var configSetCmd = &cobra.Command{
 		viper.Set(key, value)
 		err := viper.WriteConfig()
 		CheckWithMessage(err, "Failed to write configuration")
-
-		fmt.Printf("Configuration '%s' set to '%s'\n", key, value)
 	},
 }
 


### PR DESCRIPTION
Logging the values passed to `./cli config set` can lead someone to have their API token leaked somewhere.