### PR TITLE
feat: intuitive run names

### DIFF
--- a/api/swagger/superplane.swagger.json
+++ b/api/swagger/superplane.swagger.json
@@ -3624,6 +3624,9 @@
         },
         "spec": {
           "type": "object"
+        },
+        "label": {
+          "type": "string"
         }
       }
     },
@@ -3925,6 +3928,9 @@
             "type": "object",
             "$ref": "#/definitions/SuperplaneKeyValuePair"
           }
+        },
+        "label": {
+          "type": "string"
         }
       }
     },

--- a/api/swagger/superplane.swagger.json
+++ b/api/swagger/superplane.swagger.json
@@ -3625,7 +3625,7 @@
         "spec": {
           "type": "object"
         },
-        "label": {
+        "name": {
           "type": "string"
         }
       }
@@ -3929,7 +3929,7 @@
             "$ref": "#/definitions/SuperplaneKeyValuePair"
           }
         },
-        "label": {
+        "name": {
           "type": "string"
         }
       }

--- a/db/migrations/20250821200205_add-executor-label-fields.down.sql
+++ b/db/migrations/20250821200205_add-executor-label-fields.down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE stages DROP COLUMN executor_label;
-ALTER TABLE stage_events DROP COLUMN executor_label;

--- a/db/migrations/20250821200205_add-executor-label-fields.down.sql
+++ b/db/migrations/20250821200205_add-executor-label-fields.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stages DROP COLUMN executor_label;
+ALTER TABLE stage_events DROP COLUMN executor_label;

--- a/db/migrations/20250821200205_add-executor-label-fields.up.sql
+++ b/db/migrations/20250821200205_add-executor-label-fields.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stages ADD COLUMN executor_label text;
+ALTER TABLE stage_events ADD COLUMN executor_label text;

--- a/db/migrations/20250821200205_add-executor-label-fields.up.sql
+++ b/db/migrations/20250821200205_add-executor-label-fields.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE stages ADD COLUMN executor_label text;
-ALTER TABLE stage_events ADD COLUMN executor_label text;
+ALTER TABLE stages ADD COLUMN executor_name text;
+ALTER TABLE stage_events ADD COLUMN name text;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,9 +2,9 @@
 -- PostgreSQL database dump
 --
 
-\restrict HgwL9cehz8gA1JiuMUhC8deOrcvkCtf5RfRLqKbsKj4jP129YqkgERCk8lZXKdb
+\restrict IadZUhKpc0SeXoqDTxhP4hDLytPZHxDGcZxBKNV2Rfc2MUWgCPC350Pid4TvZA2
 
--- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
 
 SET statement_timeout = 0;
@@ -395,7 +395,8 @@ CREATE TABLE public.stage_events (
     state character varying(64) NOT NULL,
     state_reason character varying(64),
     created_at timestamp without time zone NOT NULL,
-    inputs jsonb DEFAULT '{}'::jsonb NOT NULL
+    inputs jsonb DEFAULT '{}'::jsonb NOT NULL,
+    executor_label text
 );
 
 
@@ -438,7 +439,8 @@ CREATE TABLE public.stages (
     secrets jsonb DEFAULT '[]'::jsonb NOT NULL,
     executor_type character varying(64) NOT NULL,
     resource_id uuid,
-    description text
+    description text,
+    executor_label text
 );
 
 
@@ -1075,15 +1077,15 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict HgwL9cehz8gA1JiuMUhC8deOrcvkCtf5RfRLqKbsKj4jP129YqkgERCk8lZXKdb
+\unrestrict IadZUhKpc0SeXoqDTxhP4hDLytPZHxDGcZxBKNV2Rfc2MUWgCPC350Pid4TvZA2
 
 --
 -- PostgreSQL database dump
 --
 
-\restrict 5DoteuaSQTfujuqsGCa61ber016id0Nt1VO4kQkZcf7LgKv35s8BGDtjTTeaga3
+\restrict T3gXV6BUWxK80M1VdENSx5o9cVyzME0cEaXqAVx7GkaSiiQjy6eZxyDHiCWRXuX
 
--- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
 
 SET statement_timeout = 0;
@@ -1103,7 +1105,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20250813203041	f
+20250821200205	f
 \.
 
 
@@ -1111,5 +1113,5 @@ COPY public.schema_migrations (version, dirty) FROM stdin;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 5DoteuaSQTfujuqsGCa61ber016id0Nt1VO4kQkZcf7LgKv35s8BGDtjTTeaga3
+\unrestrict T3gXV6BUWxK80M1VdENSx5o9cVyzME0cEaXqAVx7GkaSiiQjy6eZxyDHiCWRXuX
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict IadZUhKpc0SeXoqDTxhP4hDLytPZHxDGcZxBKNV2Rfc2MUWgCPC350Pid4TvZA2
+\restrict lx7SBo9hwCG2FMbbYbYYbRVCkmM9WfefZzzsjXnblsTdVZ3Nh7gK2sO8uhxWtru
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
@@ -396,7 +396,7 @@ CREATE TABLE public.stage_events (
     state_reason character varying(64),
     created_at timestamp without time zone NOT NULL,
     inputs jsonb DEFAULT '{}'::jsonb NOT NULL,
-    executor_label text
+    name text
 );
 
 
@@ -440,7 +440,7 @@ CREATE TABLE public.stages (
     executor_type character varying(64) NOT NULL,
     resource_id uuid,
     description text,
-    executor_label text
+    executor_name text
 );
 
 
@@ -1077,13 +1077,13 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict IadZUhKpc0SeXoqDTxhP4hDLytPZHxDGcZxBKNV2Rfc2MUWgCPC350Pid4TvZA2
+\unrestrict lx7SBo9hwCG2FMbbYbYYbRVCkmM9WfefZzzsjXnblsTdVZ3Nh7gK2sO8uhxWtru
 
 --
 -- PostgreSQL database dump
 --
 
-\restrict T3gXV6BUWxK80M1VdENSx5o9cVyzME0cEaXqAVx7GkaSiiQjy6eZxyDHiCWRXuX
+\restrict mJM5mKREsvlOGDGHORt7dGZ2NSx67NNcNSSp3aZYsPIuTWCyh1bcrbmO6L4mYXa
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
@@ -1113,5 +1113,5 @@ COPY public.schema_migrations (version, dirty) FROM stdin;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict T3gXV6BUWxK80M1VdENSx5o9cVyzME0cEaXqAVx7GkaSiiQjy6eZxyDHiCWRXuX
+\unrestrict mJM5mKREsvlOGDGHORt7dGZ2NSx67NNcNSSp3aZYsPIuTWCyh1bcrbmO6L4mYXa
 

--- a/pkg/builders/stage.go
+++ b/pkg/builders/stage.go
@@ -132,6 +132,11 @@ func (b *StageBuilder) WithExecutorSpec(spec []byte) *StageBuilder {
 	return b
 }
 
+func (b *StageBuilder) WithExecutorLabel(label string) *StageBuilder {
+	b.newStage.ExecutorLabel = label
+	return b
+}
+
 func (b *StageBuilder) Create() (*models.Stage, error) {
 	err := b.validateExecutorSpec()
 	if err != nil {
@@ -152,6 +157,7 @@ func (b *StageBuilder) Create() (*models.Stage, error) {
 		Secrets:       b.newStage.Secrets,
 		ExecutorType:  b.executorType,
 		ExecutorSpec:  datatypes.JSON(b.executorSpec),
+		ExecutorLabel: b.newStage.ExecutorLabel,
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
@@ -292,6 +298,7 @@ func (b *StageBuilder) Update() (*models.Stage, error) {
 			Update("secrets", b.newStage.Secrets).
 			Update("executor_type", b.executorType).
 			Update("executor_spec", datatypes.JSON(b.executorSpec)).
+			Update("executor_label", b.newStage.ExecutorLabel).
 			Update("resource_id", resourceID).
 			Error
 

--- a/pkg/builders/stage.go
+++ b/pkg/builders/stage.go
@@ -132,8 +132,8 @@ func (b *StageBuilder) WithExecutorSpec(spec []byte) *StageBuilder {
 	return b
 }
 
-func (b *StageBuilder) WithExecutorLabel(label string) *StageBuilder {
-	b.newStage.ExecutorLabel = label
+func (b *StageBuilder) WithExecutorName(name string) *StageBuilder {
+	b.newStage.ExecutorName = name
 	return b
 }
 
@@ -157,7 +157,7 @@ func (b *StageBuilder) Create() (*models.Stage, error) {
 		Secrets:       b.newStage.Secrets,
 		ExecutorType:  b.executorType,
 		ExecutorSpec:  datatypes.JSON(b.executorSpec),
-		ExecutorLabel: b.newStage.ExecutorLabel,
+		ExecutorName:  b.newStage.ExecutorName,
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
@@ -298,7 +298,7 @@ func (b *StageBuilder) Update() (*models.Stage, error) {
 			Update("secrets", b.newStage.Secrets).
 			Update("executor_type", b.executorType).
 			Update("executor_spec", datatypes.JSON(b.executorSpec)).
-			Update("executor_label", b.newStage.ExecutorLabel).
+			Update("executor_name", b.newStage.ExecutorName).
 			Update("resource_id", resourceID).
 			Error
 

--- a/pkg/grpc/actions/stage_events/list_stage_events.go
+++ b/pkg/grpc/actions/stage_events/list_stage_events.go
@@ -116,7 +116,7 @@ func serializeStageEvent(in models.StageEvent) (*pb.StageEvent, error) {
 		SourceType:  pb.Connection_TYPE_EVENT_SOURCE,
 		Approvals:   []*pb.StageEventApproval{},
 		Inputs:      []*pb.KeyValuePair{},
-		Label:       in.ExecutorLabel,
+		Name:        in.Name,
 	}
 
 	//

--- a/pkg/grpc/actions/stage_events/list_stage_events.go
+++ b/pkg/grpc/actions/stage_events/list_stage_events.go
@@ -116,6 +116,7 @@ func serializeStageEvent(in models.StageEvent) (*pb.StageEvent, error) {
 		SourceType:  pb.Connection_TYPE_EVENT_SOURCE,
 		Approvals:   []*pb.StageEventApproval{},
 		Inputs:      []*pb.KeyValuePair{},
+		Label:       in.ExecutorLabel,
 	}
 
 	//

--- a/pkg/grpc/actions/stage_events/list_stage_events_test.go
+++ b/pkg/grpc/actions/stage_events/list_stage_events_test.go
@@ -97,7 +97,7 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Execution.Outputs, 2)
 		assert.Contains(t, e.Execution.Outputs, &protos.OutputValue{Name: "VERSION", Value: "v1"})
 		assert.Contains(t, e.Execution.Outputs, &protos.OutputValue{Name: "VALUE_1", Value: "value1"})
-		assert.Equal(t, "", e.Label)
+		assert.Equal(t, "", e.Name)
 
 		// event with approvals
 		e = res.Events[1]
@@ -114,7 +114,7 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Inputs, 1)
 		assert.Equal(t, "VERSION", e.Inputs[0].Name)
 		assert.Equal(t, "v1", e.Inputs[0].Value)
-		assert.Equal(t, "", e.Label)
+		assert.Equal(t, "", e.Name)
 
 		// event with no approvals
 		e = res.Events[2]
@@ -127,6 +127,6 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Approvals, 0)
 		require.Nil(t, e.Execution)
 		require.Len(t, e.Inputs, 0)
-		assert.Equal(t, "", e.Label)
+		assert.Equal(t, "", e.Name)
 	})
 }

--- a/pkg/grpc/actions/stage_events/list_stage_events_test.go
+++ b/pkg/grpc/actions/stage_events/list_stage_events_test.go
@@ -97,6 +97,7 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Execution.Outputs, 2)
 		assert.Contains(t, e.Execution.Outputs, &protos.OutputValue{Name: "VERSION", Value: "v1"})
 		assert.Contains(t, e.Execution.Outputs, &protos.OutputValue{Name: "VALUE_1", Value: "value1"})
+		assert.Equal(t, "", e.Label)
 
 		// event with approvals
 		e = res.Events[1]
@@ -113,6 +114,7 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Inputs, 1)
 		assert.Equal(t, "VERSION", e.Inputs[0].Name)
 		assert.Equal(t, "v1", e.Inputs[0].Value)
+		assert.Equal(t, "", e.Label)
 
 		// event with no approvals
 		e = res.Events[2]
@@ -125,5 +127,6 @@ func Test__ListStageEvents(t *testing.T) {
 		require.Len(t, e.Approvals, 0)
 		require.Nil(t, e.Execution)
 		require.Len(t, e.Inputs, 0)
+		assert.Equal(t, "", e.Label)
 	})
 }

--- a/pkg/grpc/actions/stages/create_stage.go
+++ b/pkg/grpc/actions/stages/create_stage.go
@@ -118,7 +118,7 @@ func CreateStage(ctx context.Context, encryptor crypto.Encryptor, registry *regi
 		WithSecrets(secrets).
 		WithExecutorType(stage.Spec.Executor.Type).
 		WithExecutorSpec(executorSpec).
-		WithExecutorLabel(stage.Spec.Executor.Label).
+		WithExecutorName(stage.Spec.Executor.Name).
 		ForIntegration(integration).
 		ForResource(resource).
 		Create()
@@ -460,9 +460,9 @@ func serializeExecutor(stage models.Stage) (*pb.Executor, error) {
 
 	if stage.ResourceID == nil {
 		return &pb.Executor{
-			Type:  stage.ExecutorType,
-			Spec:  spec,
-			Label: stage.ExecutorLabel,
+			Type: stage.ExecutorType,
+			Spec: spec,
+			Name: stage.ExecutorName,
 		}, nil
 	}
 
@@ -472,9 +472,9 @@ func serializeExecutor(stage models.Stage) (*pb.Executor, error) {
 	}
 
 	return &pb.Executor{
-		Type:  stage.ExecutorType,
-		Spec:  spec,
-		Label: stage.ExecutorLabel,
+		Type: stage.ExecutorType,
+		Spec: spec,
+		Name: stage.ExecutorName,
 		Integration: &integrationpb.IntegrationRef{
 			Name:       integrationResource.IntegrationName,
 			DomainType: actions.DomainTypeToProto(integrationResource.DomainType),

--- a/pkg/grpc/actions/stages/create_stage.go
+++ b/pkg/grpc/actions/stages/create_stage.go
@@ -118,6 +118,7 @@ func CreateStage(ctx context.Context, encryptor crypto.Encryptor, registry *regi
 		WithSecrets(secrets).
 		WithExecutorType(stage.Spec.Executor.Type).
 		WithExecutorSpec(executorSpec).
+		WithExecutorLabel(stage.Spec.Executor.Label).
 		ForIntegration(integration).
 		ForResource(resource).
 		Create()
@@ -459,8 +460,9 @@ func serializeExecutor(stage models.Stage) (*pb.Executor, error) {
 
 	if stage.ResourceID == nil {
 		return &pb.Executor{
-			Type: stage.ExecutorType,
-			Spec: spec,
+			Type:  stage.ExecutorType,
+			Spec:  spec,
+			Label: stage.ExecutorLabel,
 		}, nil
 	}
 
@@ -470,8 +472,9 @@ func serializeExecutor(stage models.Stage) (*pb.Executor, error) {
 	}
 
 	return &pb.Executor{
-		Type: stage.ExecutorType,
-		Spec: spec,
+		Type:  stage.ExecutorType,
+		Spec:  spec,
+		Label: stage.ExecutorLabel,
 		Integration: &integrationpb.IntegrationRef{
 			Name:       integrationResource.IntegrationName,
 			DomainType: actions.DomainTypeToProto(integrationResource.DomainType),

--- a/pkg/grpc/actions/stages/update_stage.go
+++ b/pkg/grpc/actions/stages/update_stage.go
@@ -134,7 +134,7 @@ func UpdateStage(ctx context.Context, encryptor crypto.Encryptor, registry *regi
 		WithSecrets(secrets).
 		WithExecutorType(newStage.Spec.Executor.Type).
 		WithExecutorSpec(executorSpec).
-		WithExecutorLabel(newStage.Spec.Executor.Label).
+		WithExecutorName(newStage.Spec.Executor.Name).
 		ForResource(resource).
 		ForIntegration(integration).
 		Update()

--- a/pkg/grpc/actions/stages/update_stage.go
+++ b/pkg/grpc/actions/stages/update_stage.go
@@ -134,6 +134,7 @@ func UpdateStage(ctx context.Context, encryptor crypto.Encryptor, registry *regi
 		WithSecrets(secrets).
 		WithExecutorType(newStage.Spec.Executor.Type).
 		WithExecutorSpec(executorSpec).
+		WithExecutorLabel(newStage.Spec.Executor.Label).
 		ForResource(resource).
 		ForIntegration(integration).
 		Update()

--- a/pkg/models/stage.go
+++ b/pkg/models/stage.go
@@ -29,9 +29,10 @@ type Stage struct {
 	CreatedBy   uuid.UUID
 	UpdatedBy   uuid.UUID
 
-	ExecutorType string
-	ExecutorSpec datatypes.JSON
-	ResourceID   *uuid.UUID
+	ExecutorType  string
+	ExecutorSpec  datatypes.JSON
+	ExecutorLabel string
+	ResourceID    *uuid.UUID
 
 	Conditions    datatypes.JSONSlice[StageCondition]
 	Inputs        datatypes.JSONSlice[InputDefinition]

--- a/pkg/models/stage.go
+++ b/pkg/models/stage.go
@@ -29,10 +29,10 @@ type Stage struct {
 	CreatedBy   uuid.UUID
 	UpdatedBy   uuid.UUID
 
-	ExecutorType  string
-	ExecutorSpec  datatypes.JSON
-	ExecutorLabel string
-	ResourceID    *uuid.UUID
+	ExecutorType string
+	ExecutorSpec datatypes.JSON
+	ExecutorName string
+	ResourceID   *uuid.UUID
 
 	Conditions    datatypes.JSONSlice[StageCondition]
 	Inputs        datatypes.JSONSlice[InputDefinition]

--- a/pkg/models/stage_event.go
+++ b/pkg/models/stage_event.go
@@ -31,16 +31,16 @@ var (
 
 type StageEvent struct {
 	ID          uuid.UUID `gorm:"primary_key;default:uuid_generate_v4()"`
+	Name        string
 	StageID     uuid.UUID
 	EventID     uuid.UUID
 	SourceID    uuid.UUID
 	SourceName  string
 	SourceType  string
-	State         string
-	StateReason   string
-	CreatedAt     *time.Time
-	Inputs        datatypes.JSONType[map[string]any]
-	ExecutorLabel string
+	State       string
+	StateReason string
+	CreatedAt   *time.Time
+	Inputs      datatypes.JSONType[map[string]any]
 }
 
 func (e *StageEvent) UpdateState(state, reason string) error {
@@ -114,23 +114,23 @@ func FindStageEventByID(id, stageID string) (*StageEvent, error) {
 	return &event, nil
 }
 
-func CreateStageEvent(stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, executorLabel string) (*StageEvent, error) {
-	return CreateStageEventInTransaction(database.Conn(), stageID, event, state, stateReason, inputs, executorLabel)
+func CreateStageEvent(stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, name string) (*StageEvent, error) {
+	return CreateStageEventInTransaction(database.Conn(), stageID, event, state, stateReason, inputs, name)
 }
 
-func CreateStageEventInTransaction(tx *gorm.DB, stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, executorLabel string) (*StageEvent, error) {
+func CreateStageEventInTransaction(tx *gorm.DB, stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, name string) (*StageEvent, error) {
 	now := time.Now()
 	stageEvent := StageEvent{
-		StageID:       stageID,
-		EventID:       event.ID,
-		SourceID:      event.SourceID,
-		SourceName:    event.SourceName,
-		SourceType:    event.SourceType,
-		State:         state,
-		StateReason:   stateReason,
-		CreatedAt:     &now,
-		Inputs:        datatypes.NewJSONType(inputs),
-		ExecutorLabel: executorLabel,
+		StageID:     stageID,
+		EventID:     event.ID,
+		SourceID:    event.SourceID,
+		SourceName:  event.SourceName,
+		SourceType:  event.SourceType,
+		State:       state,
+		StateReason: stateReason,
+		CreatedAt:   &now,
+		Inputs:      datatypes.NewJSONType(inputs),
+		Name:        name,
 	}
 
 	err := tx.Create(&stageEvent).

--- a/pkg/models/stage_event.go
+++ b/pkg/models/stage_event.go
@@ -36,10 +36,11 @@ type StageEvent struct {
 	SourceID    uuid.UUID
 	SourceName  string
 	SourceType  string
-	State       string
-	StateReason string
-	CreatedAt   *time.Time
-	Inputs      datatypes.JSONType[map[string]any]
+	State         string
+	StateReason   string
+	CreatedAt     *time.Time
+	Inputs        datatypes.JSONType[map[string]any]
+	ExecutorLabel string
 }
 
 func (e *StageEvent) UpdateState(state, reason string) error {
@@ -113,22 +114,23 @@ func FindStageEventByID(id, stageID string) (*StageEvent, error) {
 	return &event, nil
 }
 
-func CreateStageEvent(stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any) (*StageEvent, error) {
-	return CreateStageEventInTransaction(database.Conn(), stageID, event, state, stateReason, inputs)
+func CreateStageEvent(stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, executorLabel string) (*StageEvent, error) {
+	return CreateStageEventInTransaction(database.Conn(), stageID, event, state, stateReason, inputs, executorLabel)
 }
 
-func CreateStageEventInTransaction(tx *gorm.DB, stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any) (*StageEvent, error) {
+func CreateStageEventInTransaction(tx *gorm.DB, stageID uuid.UUID, event *Event, state, stateReason string, inputs map[string]any, executorLabel string) (*StageEvent, error) {
 	now := time.Now()
 	stageEvent := StageEvent{
-		StageID:     stageID,
-		EventID:     event.ID,
-		SourceID:    event.SourceID,
-		SourceName:  event.SourceName,
-		SourceType:  event.SourceType,
-		State:       state,
-		StateReason: stateReason,
-		CreatedAt:   &now,
-		Inputs:      datatypes.NewJSONType(inputs),
+		StageID:       stageID,
+		EventID:       event.ID,
+		SourceID:      event.SourceID,
+		SourceName:    event.SourceName,
+		SourceType:    event.SourceType,
+		State:         state,
+		StateReason:   stateReason,
+		CreatedAt:     &now,
+		Inputs:        datatypes.NewJSONType(inputs),
+		ExecutorLabel: executorLabel,
 	}
 
 	err := tx.Create(&stageEvent).

--- a/pkg/openapi_client/model_superplane_executor.go
+++ b/pkg/openapi_client/model_superplane_executor.go
@@ -24,6 +24,7 @@ type SuperplaneExecutor struct {
 	Integration *IntegrationsIntegrationRef `json:"integration,omitempty"`
 	Resource *IntegrationsResourceRef `json:"resource,omitempty"`
 	Spec map[string]interface{} `json:"spec,omitempty"`
+	Label *string `json:"label,omitempty"`
 }
 
 // NewSuperplaneExecutor instantiates a new SuperplaneExecutor object
@@ -171,6 +172,38 @@ func (o *SuperplaneExecutor) SetSpec(v map[string]interface{}) {
 	o.Spec = v
 }
 
+// GetLabel returns the Label field value if set, zero value otherwise.
+func (o *SuperplaneExecutor) GetLabel() string {
+	if o == nil || IsNil(o.Label) {
+		var ret string
+		return ret
+	}
+	return *o.Label
+}
+
+// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SuperplaneExecutor) GetLabelOk() (*string, bool) {
+	if o == nil || IsNil(o.Label) {
+		return nil, false
+	}
+	return o.Label, true
+}
+
+// HasLabel returns a boolean if a field has been set.
+func (o *SuperplaneExecutor) HasLabel() bool {
+	if o != nil && !IsNil(o.Label) {
+		return true
+	}
+
+	return false
+}
+
+// SetLabel gets a reference to the given string and assigns it to the Label field.
+func (o *SuperplaneExecutor) SetLabel(v string) {
+	o.Label = &v
+}
+
 func (o SuperplaneExecutor) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -192,6 +225,9 @@ func (o SuperplaneExecutor) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Spec) {
 		toSerialize["spec"] = o.Spec
+	}
+	if !IsNil(o.Label) {
+		toSerialize["label"] = o.Label
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi_client/model_superplane_executor.go
+++ b/pkg/openapi_client/model_superplane_executor.go
@@ -24,7 +24,7 @@ type SuperplaneExecutor struct {
 	Integration *IntegrationsIntegrationRef `json:"integration,omitempty"`
 	Resource *IntegrationsResourceRef `json:"resource,omitempty"`
 	Spec map[string]interface{} `json:"spec,omitempty"`
-	Label *string `json:"label,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // NewSuperplaneExecutor instantiates a new SuperplaneExecutor object
@@ -172,36 +172,36 @@ func (o *SuperplaneExecutor) SetSpec(v map[string]interface{}) {
 	o.Spec = v
 }
 
-// GetLabel returns the Label field value if set, zero value otherwise.
-func (o *SuperplaneExecutor) GetLabel() string {
-	if o == nil || IsNil(o.Label) {
+// GetName returns the Name field value if set, zero value otherwise.
+func (o *SuperplaneExecutor) GetName() string {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-	return *o.Label
+	return *o.Name
 }
 
-// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SuperplaneExecutor) GetLabelOk() (*string, bool) {
-	if o == nil || IsNil(o.Label) {
+func (o *SuperplaneExecutor) GetNameOk() (*string, bool) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return o.Label, true
+	return o.Name, true
 }
 
-// HasLabel returns a boolean if a field has been set.
-func (o *SuperplaneExecutor) HasLabel() bool {
-	if o != nil && !IsNil(o.Label) {
+// HasName returns a boolean if a field has been set.
+func (o *SuperplaneExecutor) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
 	return false
 }
 
-// SetLabel gets a reference to the given string and assigns it to the Label field.
-func (o *SuperplaneExecutor) SetLabel(v string) {
-	o.Label = &v
+// SetName gets a reference to the given string and assigns it to the Name field.
+func (o *SuperplaneExecutor) SetName(v string) {
+	o.Name = &v
 }
 
 func (o SuperplaneExecutor) MarshalJSON() ([]byte, error) {
@@ -226,8 +226,8 @@ func (o SuperplaneExecutor) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Spec) {
 		toSerialize["spec"] = o.Spec
 	}
-	if !IsNil(o.Label) {
-		toSerialize["label"] = o.Label
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi_client/model_superplane_stage_event.go
+++ b/pkg/openapi_client/model_superplane_stage_event.go
@@ -30,7 +30,7 @@ type SuperplaneStageEvent struct {
 	Approvals []SuperplaneStageEventApproval `json:"approvals,omitempty"`
 	Execution *SuperplaneExecution `json:"execution,omitempty"`
 	Inputs []SuperplaneKeyValuePair `json:"inputs,omitempty"`
-	Label *string `json:"label,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // NewSuperplaneStageEvent instantiates a new SuperplaneStageEvent object
@@ -350,36 +350,36 @@ func (o *SuperplaneStageEvent) SetInputs(v []SuperplaneKeyValuePair) {
 	o.Inputs = v
 }
 
-// GetLabel returns the Label field value if set, zero value otherwise.
-func (o *SuperplaneStageEvent) GetLabel() string {
-	if o == nil || IsNil(o.Label) {
+// GetName returns the Name field value if set, zero value otherwise.
+func (o *SuperplaneStageEvent) GetName() string {
+	if o == nil || IsNil(o.Name) {
 		var ret string
 		return ret
 	}
-	return *o.Label
+	return *o.Name
 }
 
-// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *SuperplaneStageEvent) GetLabelOk() (*string, bool) {
-	if o == nil || IsNil(o.Label) {
+func (o *SuperplaneStageEvent) GetNameOk() (*string, bool) {
+	if o == nil || IsNil(o.Name) {
 		return nil, false
 	}
-	return o.Label, true
+	return o.Name, true
 }
 
-// HasLabel returns a boolean if a field has been set.
-func (o *SuperplaneStageEvent) HasLabel() bool {
-	if o != nil && !IsNil(o.Label) {
+// HasName returns a boolean if a field has been set.
+func (o *SuperplaneStageEvent) HasName() bool {
+	if o != nil && !IsNil(o.Name) {
 		return true
 	}
 
 	return false
 }
 
-// SetLabel gets a reference to the given string and assigns it to the Label field.
-func (o *SuperplaneStageEvent) SetLabel(v string) {
-	o.Label = &v
+// SetName gets a reference to the given string and assigns it to the Name field.
+func (o *SuperplaneStageEvent) SetName(v string) {
+	o.Name = &v
 }
 
 func (o SuperplaneStageEvent) MarshalJSON() ([]byte, error) {
@@ -419,8 +419,8 @@ func (o SuperplaneStageEvent) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Inputs) {
 		toSerialize["inputs"] = o.Inputs
 	}
-	if !IsNil(o.Label) {
-		toSerialize["label"] = o.Label
+	if !IsNil(o.Name) {
+		toSerialize["name"] = o.Name
 	}
 	return toSerialize, nil
 }

--- a/pkg/openapi_client/model_superplane_stage_event.go
+++ b/pkg/openapi_client/model_superplane_stage_event.go
@@ -30,6 +30,7 @@ type SuperplaneStageEvent struct {
 	Approvals []SuperplaneStageEventApproval `json:"approvals,omitempty"`
 	Execution *SuperplaneExecution `json:"execution,omitempty"`
 	Inputs []SuperplaneKeyValuePair `json:"inputs,omitempty"`
+	Label *string `json:"label,omitempty"`
 }
 
 // NewSuperplaneStageEvent instantiates a new SuperplaneStageEvent object
@@ -349,6 +350,38 @@ func (o *SuperplaneStageEvent) SetInputs(v []SuperplaneKeyValuePair) {
 	o.Inputs = v
 }
 
+// GetLabel returns the Label field value if set, zero value otherwise.
+func (o *SuperplaneStageEvent) GetLabel() string {
+	if o == nil || IsNil(o.Label) {
+		var ret string
+		return ret
+	}
+	return *o.Label
+}
+
+// GetLabelOk returns a tuple with the Label field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SuperplaneStageEvent) GetLabelOk() (*string, bool) {
+	if o == nil || IsNil(o.Label) {
+		return nil, false
+	}
+	return o.Label, true
+}
+
+// HasLabel returns a boolean if a field has been set.
+func (o *SuperplaneStageEvent) HasLabel() bool {
+	if o != nil && !IsNil(o.Label) {
+		return true
+	}
+
+	return false
+}
+
+// SetLabel gets a reference to the given string and assigns it to the Label field.
+func (o *SuperplaneStageEvent) SetLabel(v string) {
+	o.Label = &v
+}
+
 func (o SuperplaneStageEvent) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -385,6 +418,9 @@ func (o SuperplaneStageEvent) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Inputs) {
 		toSerialize["inputs"] = o.Inputs
+	}
+	if !IsNil(o.Label) {
+		toSerialize["label"] = o.Label
 	}
 	return toSerialize, nil
 }

--- a/pkg/protos/canvases/canvases.pb.go
+++ b/pkg/protos/canvases/canvases.pb.go
@@ -2900,7 +2900,7 @@ type Executor struct {
 	Integration   *integrations.IntegrationRef `protobuf:"bytes,2,opt,name=integration,proto3" json:"integration,omitempty"`
 	Resource      *integrations.ResourceRef    `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	Spec          *_struct.Struct              `protobuf:"bytes,4,opt,name=spec,proto3" json:"spec,omitempty"`
-	Label         string                       `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	Name          string                       `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2963,9 +2963,9 @@ func (x *Executor) GetSpec() *_struct.Struct {
 	return nil
 }
 
-func (x *Executor) GetLabel() string {
+func (x *Executor) GetName() string {
 	if x != nil {
-		return x.Label
+		return x.Name
 	}
 	return ""
 }
@@ -3681,7 +3681,7 @@ type StageEvent struct {
 	Approvals     []*StageEventApproval  `protobuf:"bytes,7,rep,name=approvals,proto3" json:"approvals,omitempty"`
 	Execution     *Execution             `protobuf:"bytes,8,opt,name=execution,proto3" json:"execution,omitempty"`
 	Inputs        []*KeyValuePair        `protobuf:"bytes,9,rep,name=inputs,proto3" json:"inputs,omitempty"`
-	Label         string                 `protobuf:"bytes,10,opt,name=label,proto3" json:"label,omitempty"`
+	Name          string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3779,9 +3779,9 @@ func (x *StageEvent) GetInputs() []*KeyValuePair {
 	return nil
 }
 
-func (x *StageEvent) GetLabel() string {
+func (x *StageEvent) GetName() string {
 	if x != nil {
-		return x.Label
+		return x.Name
 	}
 	return ""
 }
@@ -6307,13 +6307,13 @@ const file_canvases_proto_rawDesc = "" +
 	"\tweek_days\x18\x03 \x03(\tR\bweekDays\"h\n" +
 	"\x12CreateStageRequest\x12'\n" +
 	"\x05stage\x18\x01 \x01(\v2\x11.Superplane.StageR\x05stage\x12)\n" +
-	"\x11canvas_id_or_name\x18\x02 \x01(\tR\x0ecanvasIdOrName\"\xee\x01\n" +
+	"\x11canvas_id_or_name\x18\x02 \x01(\tR\x0ecanvasIdOrName\"\xec\x01\n" +
 	"\bExecutor\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12I\n" +
 	"\vintegration\x18\x02 \x01(\v2'.Superplane.Integrations.IntegrationRefR\vintegration\x12@\n" +
 	"\bresource\x18\x03 \x01(\v2$.Superplane.Integrations.ResourceRefR\bresource\x12+\n" +
-	"\x04spec\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x04spec\x12\x14\n" +
-	"\x05label\x18\x05 \x01(\tR\x05label\">\n" +
+	"\x04spec\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x04spec\x12\x12\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\">\n" +
 	"\x13CreateStageResponse\x12'\n" +
 	"\x05stage\x18\x01 \x01(\v2\x11.Superplane.StageR\x05stage\"\x86\x01\n" +
 	"\x12UpdateStageRequest\x12'\n" +
@@ -6371,7 +6371,7 @@ const file_canvases_proto_rawDesc = "" +
 	"\x06states\x18\x03 \x03(\x0e2\x1c.Superplane.StageEvent.StateR\x06states\x12G\n" +
 	"\rstate_reasons\x18\x04 \x03(\x0e2\".Superplane.StageEvent.StateReasonR\fstateReasons\"I\n" +
 	"\x17ListStageEventsResponse\x12.\n" +
-	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\x93\x06\n" +
+	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\x91\x06\n" +
 	"\n" +
 	"StageEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
@@ -6384,9 +6384,9 @@ const file_canvases_proto_rawDesc = "" +
 	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
 	"\tapprovals\x18\a \x03(\v2\x1e.Superplane.StageEventApprovalR\tapprovals\x123\n" +
 	"\texecution\x18\b \x01(\v2\x15.Superplane.ExecutionR\texecution\x120\n" +
-	"\x06inputs\x18\t \x03(\v2\x18.Superplane.KeyValuePairR\x06inputs\x12\x14\n" +
-	"\x05label\x18\n" +
-	" \x01(\tR\x05label\"U\n" +
+	"\x06inputs\x18\t \x03(\v2\x18.Superplane.KeyValuePairR\x06inputs\x12\x12\n" +
+	"\x04name\x18\n" +
+	" \x01(\tR\x04name\"U\n" +
 	"\x05State\x12\x11\n" +
 	"\rSTATE_UNKNOWN\x10\x00\x12\x11\n" +
 	"\rSTATE_PENDING\x10\x01\x12\x11\n" +

--- a/pkg/protos/canvases/canvases.pb.go
+++ b/pkg/protos/canvases/canvases.pb.go
@@ -2900,6 +2900,7 @@ type Executor struct {
 	Integration   *integrations.IntegrationRef `protobuf:"bytes,2,opt,name=integration,proto3" json:"integration,omitempty"`
 	Resource      *integrations.ResourceRef    `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	Spec          *_struct.Struct              `protobuf:"bytes,4,opt,name=spec,proto3" json:"spec,omitempty"`
+	Label         string                       `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2960,6 +2961,13 @@ func (x *Executor) GetSpec() *_struct.Struct {
 		return x.Spec
 	}
 	return nil
+}
+
+func (x *Executor) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
 }
 
 type CreateStageResponse struct {
@@ -3673,6 +3681,7 @@ type StageEvent struct {
 	Approvals     []*StageEventApproval  `protobuf:"bytes,7,rep,name=approvals,proto3" json:"approvals,omitempty"`
 	Execution     *Execution             `protobuf:"bytes,8,opt,name=execution,proto3" json:"execution,omitempty"`
 	Inputs        []*KeyValuePair        `protobuf:"bytes,9,rep,name=inputs,proto3" json:"inputs,omitempty"`
+	Label         string                 `protobuf:"bytes,10,opt,name=label,proto3" json:"label,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3768,6 +3777,13 @@ func (x *StageEvent) GetInputs() []*KeyValuePair {
 		return x.Inputs
 	}
 	return nil
+}
+
+func (x *StageEvent) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
 }
 
 type KeyValuePair struct {
@@ -6291,12 +6307,13 @@ const file_canvases_proto_rawDesc = "" +
 	"\tweek_days\x18\x03 \x03(\tR\bweekDays\"h\n" +
 	"\x12CreateStageRequest\x12'\n" +
 	"\x05stage\x18\x01 \x01(\v2\x11.Superplane.StageR\x05stage\x12)\n" +
-	"\x11canvas_id_or_name\x18\x02 \x01(\tR\x0ecanvasIdOrName\"\xd8\x01\n" +
+	"\x11canvas_id_or_name\x18\x02 \x01(\tR\x0ecanvasIdOrName\"\xee\x01\n" +
 	"\bExecutor\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12I\n" +
 	"\vintegration\x18\x02 \x01(\v2'.Superplane.Integrations.IntegrationRefR\vintegration\x12@\n" +
 	"\bresource\x18\x03 \x01(\v2$.Superplane.Integrations.ResourceRefR\bresource\x12+\n" +
-	"\x04spec\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x04spec\">\n" +
+	"\x04spec\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x04spec\x12\x14\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\">\n" +
 	"\x13CreateStageResponse\x12'\n" +
 	"\x05stage\x18\x01 \x01(\v2\x11.Superplane.StageR\x05stage\"\x86\x01\n" +
 	"\x12UpdateStageRequest\x12'\n" +
@@ -6354,7 +6371,7 @@ const file_canvases_proto_rawDesc = "" +
 	"\x06states\x18\x03 \x03(\x0e2\x1c.Superplane.StageEvent.StateR\x06states\x12G\n" +
 	"\rstate_reasons\x18\x04 \x03(\x0e2\".Superplane.StageEvent.StateReasonR\fstateReasons\"I\n" +
 	"\x17ListStageEventsResponse\x12.\n" +
-	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\xfd\x05\n" +
+	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\x93\x06\n" +
 	"\n" +
 	"StageEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
@@ -6367,7 +6384,9 @@ const file_canvases_proto_rawDesc = "" +
 	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
 	"\tapprovals\x18\a \x03(\v2\x1e.Superplane.StageEventApprovalR\tapprovals\x123\n" +
 	"\texecution\x18\b \x01(\v2\x15.Superplane.ExecutionR\texecution\x120\n" +
-	"\x06inputs\x18\t \x03(\v2\x18.Superplane.KeyValuePairR\x06inputs\"U\n" +
+	"\x06inputs\x18\t \x03(\v2\x18.Superplane.KeyValuePairR\x06inputs\x12\x14\n" +
+	"\x05label\x18\n" +
+	" \x01(\tR\x05label\"U\n" +
 	"\x05State\x12\x11\n" +
 	"\rSTATE_UNKNOWN\x10\x00\x12\x11\n" +
 	"\rSTATE_PENDING\x10\x01\x12\x11\n" +

--- a/pkg/workers/pending_events_worker.go
+++ b/pkg/workers/pending_events_worker.go
@@ -277,12 +277,12 @@ func (w *PendingEventsWorker) handleEventForStage(tx *gorm.DB, event *models.Eve
 		return err
 	}
 
-	executorLabel, err := w.buildExecutorLabel(inputs, *stage)
+	executorName, err := w.buildExecutorName(inputs, *stage)
 	if err != nil {
 		return err
 	}
 
-	stageEvent, err := models.CreateStageEventInTransaction(tx, stage.ID, event, models.StageEventStatePending, "", inputs, executorLabel)
+	stageEvent, err := models.CreateStageEventInTransaction(tx, stage.ID, event, models.StageEventStatePending, "", inputs, executorName)
 	if err != nil {
 		return err
 	}
@@ -367,13 +367,13 @@ func (w *PendingEventsWorker) buildInputs(tx *gorm.DB, event *models.Event, stag
 	return inputs, nil
 }
 
-func (w *PendingEventsWorker) buildExecutorLabel(inputs map[string]any, stage models.Stage) (string, error) {
-	if stage.ExecutorLabel == "" {
+func (w *PendingEventsWorker) buildExecutorName(inputs map[string]any, stage models.Stage) (string, error) {
+	if stage.ExecutorName == "" {
 		return "", nil
 	}
 
 	specBuilder := &executors.SpecBuilder{}
-	resolvedLabel, err := specBuilder.ResolveExpression(stage.ExecutorLabel, inputs, map[string]string{})
+	resolvedLabel, err := specBuilder.ResolveExpression(stage.ExecutorName, inputs, map[string]string{})
 	if err != nil {
 		return "", fmt.Errorf("error resolving executor label template: %v", err)
 	}

--- a/pkg/workers/pending_events_worker_test.go
+++ b/pkg/workers/pending_events_worker_test.go
@@ -580,52 +580,52 @@ func Test__PendingEventsWorker(t *testing.T) {
 	})
 }
 
-func Test__PendingEventsWorker__buildExecutorLabel(t *testing.T) {
+func Test__PendingEventsWorker__buildExecutorName(t *testing.T) {
 	w := &PendingEventsWorker{}
 
 	t.Run("empty label returns empty string", func(t *testing.T) {
 		stage := models.Stage{
-			ExecutorLabel: "",
+			ExecutorName: "",
 		}
 		inputs := map[string]any{}
-		
-		result, err := w.buildExecutorLabel(inputs, stage)
+
+		result, err := w.buildExecutorName(inputs, stage)
 		require.NoError(t, err)
 		assert.Equal(t, "", result)
 	})
 
 	t.Run("static label returns static string", func(t *testing.T) {
 		stage := models.Stage{
-			ExecutorLabel: "Deploy to production",
+			ExecutorName: "Deploy to production",
 		}
 		inputs := map[string]any{}
-		
-		result, err := w.buildExecutorLabel(inputs, stage)
+
+		result, err := w.buildExecutorName(inputs, stage)
 		require.NoError(t, err)
 		assert.Equal(t, "Deploy to production", result)
 	})
 
 	t.Run("template with inputs resolves correctly", func(t *testing.T) {
 		stage := models.Stage{
-			ExecutorLabel: "Deploy ${{ inputs.VERSION }} to ${{ inputs.ENVIRONMENT }}",
+			ExecutorName: "Deploy ${{ inputs.VERSION }} to ${{ inputs.ENVIRONMENT }}",
 		}
 		inputs := map[string]any{
 			"VERSION":     "v1.2.3",
 			"ENVIRONMENT": "production",
 		}
-		
-		result, err := w.buildExecutorLabel(inputs, stage)
+
+		result, err := w.buildExecutorName(inputs, stage)
 		require.NoError(t, err)
 		assert.Equal(t, "Deploy v1.2.3 to production", result)
 	})
 
 	t.Run("template with missing input returns error", func(t *testing.T) {
 		stage := models.Stage{
-			ExecutorLabel: "Deploy ${{ inputs.VERSION }} to production",
+			ExecutorName: "Deploy ${{ inputs.VERSION }} to production",
 		}
 		inputs := map[string]any{}
-		
-		result, err := w.buildExecutorLabel(inputs, stage)
+
+		result, err := w.buildExecutorName(inputs, stage)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "input VERSION not found")
 		assert.Equal(t, "", result)
@@ -633,14 +633,14 @@ func Test__PendingEventsWorker__buildExecutorLabel(t *testing.T) {
 
 	t.Run("complex template with concatenation", func(t *testing.T) {
 		stage := models.Stage{
-			ExecutorLabel: "Release ${{ inputs.VERSION_A }}.0 + hotfix ${{ inputs.VERSION_B }}",
+			ExecutorName: "Release ${{ inputs.VERSION_A }}.0 + hotfix ${{ inputs.VERSION_B }}",
 		}
 		inputs := map[string]any{
 			"VERSION_A": "2",
 			"VERSION_B": "1",
 		}
-		
-		result, err := w.buildExecutorLabel(inputs, stage)
+
+		result, err := w.buildExecutorName(inputs, stage)
 		require.NoError(t, err)
 		assert.Equal(t, "Release 2.0 + hotfix 1", result)
 	})

--- a/pkg/workers/pending_events_worker_test.go
+++ b/pkg/workers/pending_events_worker_test.go
@@ -579,3 +579,69 @@ func Test__PendingEventsWorker(t *testing.T) {
 		assert.Equal(t, models.ResultPassed, executionResource.Result)
 	})
 }
+
+func Test__PendingEventsWorker__buildExecutorLabel(t *testing.T) {
+	w := &PendingEventsWorker{}
+
+	t.Run("empty label returns empty string", func(t *testing.T) {
+		stage := models.Stage{
+			ExecutorLabel: "",
+		}
+		inputs := map[string]any{}
+		
+		result, err := w.buildExecutorLabel(inputs, stage)
+		require.NoError(t, err)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("static label returns static string", func(t *testing.T) {
+		stage := models.Stage{
+			ExecutorLabel: "Deploy to production",
+		}
+		inputs := map[string]any{}
+		
+		result, err := w.buildExecutorLabel(inputs, stage)
+		require.NoError(t, err)
+		assert.Equal(t, "Deploy to production", result)
+	})
+
+	t.Run("template with inputs resolves correctly", func(t *testing.T) {
+		stage := models.Stage{
+			ExecutorLabel: "Deploy ${{ inputs.VERSION }} to ${{ inputs.ENVIRONMENT }}",
+		}
+		inputs := map[string]any{
+			"VERSION":     "v1.2.3",
+			"ENVIRONMENT": "production",
+		}
+		
+		result, err := w.buildExecutorLabel(inputs, stage)
+		require.NoError(t, err)
+		assert.Equal(t, "Deploy v1.2.3 to production", result)
+	})
+
+	t.Run("template with missing input returns error", func(t *testing.T) {
+		stage := models.Stage{
+			ExecutorLabel: "Deploy ${{ inputs.VERSION }} to production",
+		}
+		inputs := map[string]any{}
+		
+		result, err := w.buildExecutorLabel(inputs, stage)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "input VERSION not found")
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("complex template with concatenation", func(t *testing.T) {
+		stage := models.Stage{
+			ExecutorLabel: "Release ${{ inputs.VERSION_A }}.0 + hotfix ${{ inputs.VERSION_B }}",
+		}
+		inputs := map[string]any{
+			"VERSION_A": "2",
+			"VERSION_B": "1",
+		}
+		
+		result, err := w.buildExecutorLabel(inputs, stage)
+		require.NoError(t, err)
+		assert.Equal(t, "Release 2.0 + hotfix 1", result)
+	})
+}

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -610,6 +610,7 @@ message Executor {
   Integrations.IntegrationRef integration = 2;
   Integrations.ResourceRef resource = 3;
   google.protobuf.Struct spec = 4;
+  string label = 5;
 }
 
 message CreateStageResponse {
@@ -720,6 +721,7 @@ message StageEvent {
   repeated StageEventApproval approvals = 7;
   Execution execution = 8;
   repeated KeyValuePair inputs = 9;
+  string label = 10;
 }
 
 message KeyValuePair {

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -610,7 +610,7 @@ message Executor {
   Integrations.IntegrationRef integration = 2;
   Integrations.ResourceRef resource = 3;
   google.protobuf.Struct spec = 4;
-  string label = 5;
+  string name = 5;
 }
 
 message CreateStageResponse {
@@ -721,7 +721,7 @@ message StageEvent {
   repeated StageEventApproval approvals = 7;
   Execution execution = 8;
   repeated KeyValuePair inputs = 9;
-  string label = 10;
+  string name = 10;
 }
 
 message KeyValuePair {

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -247,7 +247,7 @@ func CreateStageEventWithData(t *testing.T,
 ) *models.StageEvent {
 	event, err := models.CreateEvent(source.ID, source.CanvasID, source.Name, models.SourceTypeEventSource, "push", data, headers)
 	require.NoError(t, err)
-	stageEvent, err := models.CreateStageEvent(stage.ID, event, models.StageEventStatePending, "", inputs)
+	stageEvent, err := models.CreateStageEvent(stage.ID, event, models.StageEventStatePending, "", inputs, "")
 	require.NoError(t, err)
 	return stageEvent
 }

--- a/web_src/src/api-client/types.gen.ts
+++ b/web_src/src/api-client/types.gen.ts
@@ -575,7 +575,7 @@ export type SuperplaneExecutor = {
     spec?: {
         [key: string]: unknown;
     };
-    label?: string;
+    name?: string;
 };
 
 export type SuperplaneFilter = {
@@ -696,7 +696,7 @@ export type SuperplaneStageEvent = {
     approvals?: Array<SuperplaneStageEventApproval>;
     execution?: SuperplaneExecution;
     inputs?: Array<SuperplaneKeyValuePair>;
-    label?: string;
+    name?: string;
 };
 
 export type SuperplaneStageEventApproval = {

--- a/web_src/src/api-client/types.gen.ts
+++ b/web_src/src/api-client/types.gen.ts
@@ -575,6 +575,7 @@ export type SuperplaneExecutor = {
     spec?: {
         [key: string]: unknown;
     };
+    label?: string;
 };
 
 export type SuperplaneFilter = {
@@ -695,6 +696,7 @@ export type SuperplaneStageEvent = {
     approvals?: Array<SuperplaneStageEventApproval>;
     execution?: SuperplaneExecution;
     inputs?: Array<SuperplaneKeyValuePair>;
+    label?: string;
 };
 
 export type SuperplaneStageEventApproval = {

--- a/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
+++ b/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
@@ -108,7 +108,7 @@ export const ExecutionTimeline = ({
         executions.map((execution) => (
           <RunItem
             key={execution.id!}
-            title={execution.event.label || execution.id || 'Execution'}
+            title={execution.event.name || execution.id || 'Execution'}
             runId={execution.id}
             inputs={mapExecutionEventInputs(execution)}
             outputs={mapExecutionOutputs(execution)}

--- a/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
+++ b/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
@@ -108,7 +108,8 @@ export const ExecutionTimeline = ({
         executions.map((execution) => (
           <RunItem
             key={execution.id!}
-            title={execution.id || 'Execution'}
+            title={execution.event.label || execution.id || 'Execution'}
+            runId={execution.id}
             inputs={mapExecutionEventInputs(execution)}
             outputs={mapExecutionOutputs(execution)}
             state={execution.state || 'STATE_UNKNOWN'}

--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -115,7 +115,7 @@ const MessageItem = React.memo(({
               <span className="text-xs font-medium text-amber-700 dark:text-amber-500">{getStatusLabel()}</span>
             </div>
             <span className="font-medium truncate text-sm dark:text-white">
-              {event.label || event.id || 'Unknown'}
+              {event.name || event.id || 'Unknown'}
             </span>
           </div>
           <div className="flex items-center gap-3">

--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -115,7 +115,7 @@ const MessageItem = React.memo(({
               <span className="text-xs font-medium text-amber-700 dark:text-amber-500">{getStatusLabel()}</span>
             </div>
             <span className="font-medium truncate text-sm dark:text-white">
-              {event.id || 'Unknown'}
+              {event.label || event.id || 'Unknown'}
             </span>
           </div>
           <div className="flex items-center gap-3">
@@ -133,7 +133,7 @@ const MessageItem = React.memo(({
         </div>
 
         {isExpanded && (
-          <div className="mt-3 space-y-3">
+          <div className="text-left mt-3 space-y-3">
             <div className="mt-3 space-y-3">
               {Object.keys(inputsRecord).length > 0 ? (
                 <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">

--- a/web_src/src/pages/canvas/components/QueueItems.tsx
+++ b/web_src/src/pages/canvas/components/QueueItems.tsx
@@ -17,7 +17,7 @@ export const ApprovalQueueItem: React.FC<ApprovalQueueItemProps> = ({ event, onA
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">Action required</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
         </div>
         <div className="flex items-center gap-1">
           {/*
@@ -65,7 +65,7 @@ export const WaitingQueueItem: React.FC<WaitingQueueItemProps> = ({ event, label
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">{label}</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
         </div>
         <div className="flex items-center">
           <MaterialSymbol name="timer" size="lg" className="text-orange-700 dark:text-orange-600 px-2" />
@@ -88,7 +88,7 @@ export const PendingQueueItem: React.FC<PendingQueueItemProps> = ({ event }) => 
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">Pending</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
         </div>
         <div className="flex items-center">
           <MaterialSymbol name="timer" size="lg" className="text-orange-700 dark:text-orange-600 px-2" />

--- a/web_src/src/pages/canvas/components/QueueItems.tsx
+++ b/web_src/src/pages/canvas/components/QueueItems.tsx
@@ -17,7 +17,7 @@ export const ApprovalQueueItem: React.FC<ApprovalQueueItemProps> = ({ event, onA
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">Action required</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.name || event.id}</span>
         </div>
         <div className="flex items-center gap-1">
           {/*
@@ -65,7 +65,7 @@ export const WaitingQueueItem: React.FC<WaitingQueueItemProps> = ({ event, label
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">{label}</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.name || event.id}</span>
         </div>
         <div className="flex items-center">
           <MaterialSymbol name="timer" size="lg" className="text-orange-700 dark:text-orange-600 px-2" />
@@ -88,7 +88,7 @@ export const PendingQueueItem: React.FC<PendingQueueItemProps> = ({ event }) => 
             <div className="w-2 h-2 rounded-full flex-shrink-0 bg-orange-600 dark:bg-orange-500 animate-pulse"></div>
             <span className="text-xs font-medium text-orange-700 dark:text-orange-500">Pending</span>
           </div>
-          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.label || event.id}</span>
+          <span className="text-sm text-gray-700 dark:text-gray-200 truncate font-medium">{event.name || event.id}</span>
         </div>
         <div className="flex items-center">
           <MaterialSymbol name="timer" size="lg" className="text-orange-700 dark:text-orange-600 px-2" />

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -1683,6 +1683,18 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
                   )}
                   editForm={
                     <div className="space-y-4">
+                      {/* Executor Label - Universal field for all executor types */}
+                      <ValidationField label="Executor Label">
+                        <input
+                          type="text"
+                          value={executor.label || ''}
+                          onChange={(e) => setExecutor(prev => ({ ...prev, label: e.target.value }))}
+                          placeholder="${{ inputs.VERSION }} deployment"
+                          className="w-full px-3 py-2 border rounded-md bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 border-zinc-300 dark:border-zinc-600 focus:ring-blue-500"
+                        />
+
+                      </ValidationField>
+
                       {executor.type === 'semaphore' && (
                         <div className="space-y-4">
                           <ValidationField label="Integration">
@@ -1736,7 +1748,9 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
                           </ValidationField>
 
                           <ValidationField label="Execution Type">
-                            <ControlledTabs className="text-left m-0 max-w-48"
+                            <ControlledTabs
+                              className="text-left m-0 w-full"
+                              buttonClasses='w-full'
                               tabs={[
                                 { id: 'workflow', label: 'Workflow' },
                                 { id: 'task', label: 'Task' },

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -1685,11 +1685,11 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
                   editForm={
                     <div className="space-y-4">
                       {/* Executor Label - Universal field for all executor types */}
-                      <ValidationField label="Executor Label">
+                      <ValidationField label="Executor name">
                         <input
                           type="text"
-                          value={executor.label || ''}
-                          onChange={(e) => setExecutor(prev => ({ ...prev, label: e.target.value }))}
+                          value={executor.name || ''}
+                          onChange={(e) => setExecutor(prev => ({ ...prev, name: e.target.value }))}
                           placeholder="${{ inputs.VERSION }} deployment"
                           className="w-full px-3 py-2 border rounded-md bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 border-zinc-300 dark:border-zinc-600 focus:ring-blue-500"
                         />

--- a/web_src/src/pages/canvas/components/nodes/stage.tsx
+++ b/web_src/src/pages/canvas/components/nodes/stage.tsx
@@ -536,7 +536,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
                     className="text-left w-full font-semibold text-sm hover:underline truncate text-gray-900 dark:text-gray-100"
                     onClick={() => selectStageId(props.id)}
                   >
-                    {lastExecution?.id || 'No recent runs'}
+                    {lastExecutionEvent?.name || lastExecution?.id || 'No recent runs'}
                   </span>
                 </div>
                 <div className="flex items-center gap-2 font-semibold">

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -6,6 +6,7 @@ interface RunItemProps {
   state: SuperplaneExecutionState;
   result: ExecutionResult;
   title: string;
+  runId?: string;
   inputs: Record<string, string>;
   outputs: Record<string, string>;
   timestamp: string;
@@ -20,6 +21,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
   state,
   result,
   title,
+  runId,
   timestamp,
   executionDuration,
   inputs,
@@ -162,7 +164,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
             <div className="flex items-center gap-1 min-w-0">
               <MaterialSymbol name="bolt" size="md" className="text-gray-600 dark:text-zinc-400 flex-shrink-0" />
               <span className="text-xs text-gray-500 dark:text-zinc-400 min-w-0 flex items-center">
-                <div className="text-blue-600 dark:text-blue-400 truncate">{title}</div>
+                <div className="text-blue-600 dark:text-blue-400 truncate">{runId}</div>
                 {eventId && (
                   <>
                     <span className="mx-1 flex-shrink-0"> • Event ID: </span>


### PR DESCRIPTION
### Changes
- Implement Intuitive Run Names in Backend and Frontend
- Now, there is a new option under executor called "label". This label can be configured to  manage how the executions text will be displayed in UI:

<img width="897" height="762" alt="image" src="https://github.com/user-attachments/assets/f9805f09-d134-4d98-801f-7e48d5781786" />
<img width="421" height="171" alt="image" src="https://github.com/user-attachments/assets/30fb87e2-6aa9-4b45-a78c-db1daf38f0cd" />
<img width="443" height="264" alt="image" src="https://github.com/user-attachments/assets/b7faeee1-5ba6-4720-9a6f-efe6ef9db9d4" />
