### PR TITLE
feat: implement simple hearbeat

### DIFF
--- a/pkg/public/ws/ws_hub.go
+++ b/pkg/public/ws/ws_hub.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-    writeWait = 10 * time.Second       // Time allowed to write a message
-    pongWait  = 20 * time.Second       // Must receive pong within 20s
-    pingPeriod = 10 * time.Second      // Ping every 10s
+	writeWait  = 10 * time.Second // Time allowed to write a message
+	pongWait   = 20 * time.Second // Must receive pong within 20s
+	pingPeriod = 10 * time.Second // Ping every 10s
 )
 
 // Client represents a connected websocket client
@@ -208,11 +208,6 @@ func (c *Client) readPump() {
 
 	c.conn.SetReadLimit(1024 * 1024) // 1MB max message size
 	c.conn.SetReadDeadline(time.Now().Add(pongWait))
-	c.conn.SetPongHandler(func(string) error {
-		c.conn.SetReadDeadline(time.Now().Add(pongWait))
-		return nil
-	})
-
 	// Process incoming messages
 	for {
 		_, message, err := c.conn.ReadMessage()
@@ -240,9 +235,20 @@ func (c *Client) readPump() {
 	}
 }
 
+func (c *Client) handlePing() {
+	select {
+	case c.send <- []byte("pong"):
+	default:
+	}
+}
+
 // handleMessage processes incoming messages from clients
 func (c *Client) handleMessage(message []byte) {
-	// Handle client messages
-	log.Infof("Received message: %s", string(message))
-	return
+	msgStr := string(message)
+
+	// Handle application-level ping (since browsers can't send WebSocket ping frames)
+	if msgStr == "ping" {
+		c.handlePing()
+		return
+	}
 }

--- a/web_src/src/pages/canvas/hooks/useWebsocketEvents.ts
+++ b/web_src/src/pages/canvas/hooks/useWebsocketEvents.ts
@@ -26,13 +26,16 @@ export function useWebsocketEvents(canvasId: string, organizationId: string): vo
   const syncToReactFlow = useCanvasStore((s) => s.syncToReactFlow);
   const lockedNodes = useCanvasStore((s) => s.lockedNodes);
 
-  // WebSocket setup
+  // WebSocket setup  
   const { lastJsonMessage, readyState } = useWebSocket<ServerEvent>(
     `${SOCKET_SERVER_URL}${canvasId}?organization_id=${organizationId}`,
     {
       shouldReconnect: () => true,
       reconnectAttempts: 10,
-      heartbeat: false,
+      heartbeat: {
+        interval: 5000,
+        message: 'ping',
+      },
       reconnectInterval: 3000,
       onOpen: () => {},
       onError: () => {},


### PR DESCRIPTION
Implement simple heartbeat for the browser. Since the current library can't send WebSocket ping frames