### PR TITLE
feat: unify history event queue and run components

### DIFF
--- a/api/swagger/superplane.swagger.json
+++ b/api/swagger/superplane.swagger.json
@@ -4092,6 +4092,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "eventId": {
+          "type": "string"
         }
       }
     },

--- a/pkg/grpc/actions/stage_events/list_stage_events.go
+++ b/pkg/grpc/actions/stage_events/list_stage_events.go
@@ -117,6 +117,7 @@ func serializeStageEvent(in models.StageEvent) (*pb.StageEvent, error) {
 		Approvals:   []*pb.StageEventApproval{},
 		Inputs:      []*pb.KeyValuePair{},
 		Name:        in.Name,
+		EventId:     in.EventID.String(),
 	}
 
 	//

--- a/pkg/openapi_client/model_superplane_stage_event.go
+++ b/pkg/openapi_client/model_superplane_stage_event.go
@@ -31,6 +31,7 @@ type SuperplaneStageEvent struct {
 	Execution *SuperplaneExecution `json:"execution,omitempty"`
 	Inputs []SuperplaneKeyValuePair `json:"inputs,omitempty"`
 	Name *string `json:"name,omitempty"`
+	EventId *string `json:"eventId,omitempty"`
 }
 
 // NewSuperplaneStageEvent instantiates a new SuperplaneStageEvent object
@@ -382,6 +383,38 @@ func (o *SuperplaneStageEvent) SetName(v string) {
 	o.Name = &v
 }
 
+// GetEventId returns the EventId field value if set, zero value otherwise.
+func (o *SuperplaneStageEvent) GetEventId() string {
+	if o == nil || IsNil(o.EventId) {
+		var ret string
+		return ret
+	}
+	return *o.EventId
+}
+
+// GetEventIdOk returns a tuple with the EventId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SuperplaneStageEvent) GetEventIdOk() (*string, bool) {
+	if o == nil || IsNil(o.EventId) {
+		return nil, false
+	}
+	return o.EventId, true
+}
+
+// HasEventId returns a boolean if a field has been set.
+func (o *SuperplaneStageEvent) HasEventId() bool {
+	if o != nil && !IsNil(o.EventId) {
+		return true
+	}
+
+	return false
+}
+
+// SetEventId gets a reference to the given string and assigns it to the EventId field.
+func (o *SuperplaneStageEvent) SetEventId(v string) {
+	o.EventId = &v
+}
+
 func (o SuperplaneStageEvent) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -421,6 +454,9 @@ func (o SuperplaneStageEvent) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.Name) {
 		toSerialize["name"] = o.Name
+	}
+	if !IsNil(o.EventId) {
+		toSerialize["eventId"] = o.EventId
 	}
 	return toSerialize, nil
 }

--- a/pkg/protos/canvases/canvases.pb.go
+++ b/pkg/protos/canvases/canvases.pb.go
@@ -3794,6 +3794,7 @@ type StageEvent struct {
 	Execution     *Execution             `protobuf:"bytes,8,opt,name=execution,proto3" json:"execution,omitempty"`
 	Inputs        []*KeyValuePair        `protobuf:"bytes,9,rep,name=inputs,proto3" json:"inputs,omitempty"`
 	Name          string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	EventId       string                 `protobuf:"bytes,11,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3894,6 +3895,13 @@ func (x *StageEvent) GetInputs() []*KeyValuePair {
 func (x *StageEvent) GetName() string {
 	if x != nil {
 		return x.Name
+	}
+	return ""
+}
+
+func (x *StageEvent) GetEventId() string {
+	if x != nil {
+		return x.EventId
 	}
 	return ""
 }
@@ -6847,7 +6855,7 @@ const file_canvases_proto_rawDesc = "" +
 	"\x06states\x18\x03 \x03(\x0e2\x1c.Superplane.StageEvent.StateR\x06states\x12G\n" +
 	"\rstate_reasons\x18\x04 \x03(\x0e2\".Superplane.StageEvent.StateReasonR\fstateReasons\"I\n" +
 	"\x17ListStageEventsResponse\x12.\n" +
-	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\x91\x06\n" +
+	"\x06events\x18\x01 \x03(\v2\x16.Superplane.StageEventR\x06events\"\xac\x06\n" +
 	"\n" +
 	"StageEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
@@ -6862,7 +6870,8 @@ const file_canvases_proto_rawDesc = "" +
 	"\texecution\x18\b \x01(\v2\x15.Superplane.ExecutionR\texecution\x120\n" +
 	"\x06inputs\x18\t \x03(\v2\x18.Superplane.KeyValuePairR\x06inputs\x12\x12\n" +
 	"\x04name\x18\n" +
-	" \x01(\tR\x04name\"U\n" +
+	" \x01(\tR\x04name\x12\x19\n" +
+	"\bevent_id\x18\v \x01(\tR\aeventId\"U\n" +
 	"\x05State\x12\x11\n" +
 	"\rSTATE_UNKNOWN\x10\x00\x12\x11\n" +
 	"\rSTATE_PENDING\x10\x01\x12\x11\n" +

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -778,6 +778,7 @@ message StageEvent {
   Execution execution = 8;
   repeated KeyValuePair inputs = 9;
   string name = 10;
+  string event_id = 11;
 }
 
 message KeyValuePair {

--- a/web_src/src/api-client/types.gen.ts
+++ b/web_src/src/api-client/types.gen.ts
@@ -709,6 +709,7 @@ export type SuperplaneStageEvent = {
     execution?: SuperplaneExecution;
     inputs?: Array<SuperplaneKeyValuePair>;
     name?: string;
+    eventId?: string;
 };
 
 export type SuperplaneStageEventApproval = {

--- a/web_src/src/pages/canvas/components/EventItem.tsx
+++ b/web_src/src/pages/canvas/components/EventItem.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
 import { SuperplaneEventState } from '@/api-client';
 import { formatRelativeTime } from '../utils/stageEventUtils';
+import { PayloadDisplay } from './PayloadDisplay';
 
 interface EventItemProps {
   eventId: string;
@@ -13,8 +14,6 @@ interface EventItemProps {
   payload?: { [key: string]: unknown };
 }
 
-type TabType = 'details' | 'headers' | 'payload';
-
 export const EventItem: React.FC<EventItemProps> = React.memo(({
   eventId,
   timestamp,
@@ -25,16 +24,12 @@ export const EventItem: React.FC<EventItemProps> = React.memo(({
   payload,
 }) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
-  const [activeTab, setActiveTab] = useState<TabType>('details');
 
   const toggleExpand = (): void => {
     setIsExpanded(!isExpanded);
   };
 
-  const displayHeaders = headers || {};
-  const displayPayload = payload || {};
-
-  // Map SuperplaneEventState to EventStateItem format
+  // Map SuperplaneEventState to EventStateItem format for the header display
   const getEventStateType = () => {
     switch (state) {
       case 'STATE_PROCESSED':
@@ -78,24 +73,6 @@ export const EventItem: React.FC<EventItemProps> = React.memo(({
 
   const stateConfig = getStateConfig();
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text).catch(err => {
-      console.error('Failed to copy: ', err);
-    });
-  };
-
-  const formatTimestamp = () => {
-    return new Date(timestamp).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric'
-    }) + ', ' + new Date(timestamp).toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: true
-    });
-  };
 
   const getTruncatedUrl = () => {
     // Create a truncated version of the event ID to simulate a URL
@@ -105,116 +82,6 @@ export const EventItem: React.FC<EventItemProps> = React.memo(({
     return eventId;
   };
 
-  const renderTabButton = (tabKey: TabType, label: string) => {
-    const isActive = activeTab === tabKey;
-    return (
-      <button
-        type="button"
-        className={`relative flex items-center gap-2 font-medium transition-all duration-200 ease-in-out focus:outline-hidden text-xs px-3 py-2 relative ${isActive
-          ? 'text-blue-600 dark:text-blue-400 cursor-pointer'
-          : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300 cursor-pointer'
-          }`}
-        onClick={() => setActiveTab(tabKey)}
-        data-testid={`tab-${tabKey}`}
-      >
-        <span className="leading-none whitespace-nowrap">{label}</span>
-        <div className={`absolute inset-x-0 bottom-0 h-0.5 bg-blue-500 transition-all duration-200 ease-in-out ${isActive ? 'scale-x-100' : 'scale-x-0'
-          }`}></div>
-      </button>
-    );
-  };
-
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case 'details':
-        return (
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-6 text-sm">
-              <div>
-                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">STATE</div>
-                <div className="text-blue-600 dark:text-blue-400 text-xs font-medium">
-                  <div className="flex items-center gap-2">
-                    <div className={`w-2 h-2 ${stateConfig.dotColor} ${stateConfig.animate ? 'animate-pulse' : ''} rounded-full flex-shrink-0`}></div>
-                    <span className={`text-xs font-medium ${stateConfig.textColor}`}>{stateConfig.label}</span>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">RECEIVED ON</div>
-                <div className="text-xs text-gray-900 dark:text-zinc-200">{formatTimestamp()}</div>
-              </div>
-              <div>
-                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">SOURCE</div>
-                <div className="text-xs text-gray-900 dark:text-zinc-200">{sourceName || 'External Webhook'}</div>
-              </div>
-              <div>
-                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">TYPE</div>
-                <div className="text-xs font-medium">{eventType || 'webhook'}</div>
-              </div>
-              <div className="col-span-2">
-                <div>
-                  <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">EVENT ID</div>
-                  <div className="font-mono text-xs text-gray-900 dark:text-zinc-200 break-all">{eventId}</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      case 'headers':
-        return (
-          <div>
-            <div className="space-y-2">
-              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
-                {Object.keys(displayHeaders).length > 0 ? (
-                  <div className="space-y-2">
-                    {Object.entries(displayHeaders).map(([key, value]) => (
-                      <div key={key} className="flex justify-between">
-                        <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium pr-2 flex-shrink-0">{key}</span>
-                        <span className="text-xs font-mono text-gray-900 dark:text-zinc-200 break-all">{String(value)}</span>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-xs text-gray-500 dark:text-zinc-400 italic">No headers available</div>
-                )}
-              </div>
-            </div>
-          </div>
-        );
-      case 'payload':
-        return (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs font-medium text-gray-500 dark:text-zinc-400">Request Body</span>
-              <div className="flex items-center">
-                <a
-                  className="!text-xs flex items-center cursor-pointer"
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    copyToClipboard(JSON.stringify(displayPayload, null, 2));
-                  }}
-                >
-                  <MaterialSymbol name="content_copy" size="sm" className="mr-1" />
-                  Copy
-                </a>
-              </div>
-            </div>
-            <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
-              {Object.keys(displayPayload).length > 0 ? (
-                <pre className="text-xs font-mono text-gray-900 dark:text-zinc-200 whitespace-pre-wrap">
-                  {JSON.stringify(displayPayload, null, 2)}
-                </pre>
-              ) : (
-                <div className="text-xs text-gray-500 dark:text-zinc-400 italic">No payload available</div>
-              )}
-            </div>
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
     <div className="border bg-zinc-50 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 rounded-lg text-left">
@@ -235,22 +102,16 @@ export const EventItem: React.FC<EventItemProps> = React.memo(({
         </div>
 
         {isExpanded && (
-          <div className="mt-3 space-y-4">
-            <div className="border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-900">
-              <div className="border-b border-gray-200 dark:border-zinc-700">
-                <div className="w-full border-b border-zinc-200 dark:border-zinc-700">
-                  <nav className="flex gap-0">
-                    {renderTabButton('details', 'Details')}
-                    {renderTabButton('headers', 'Headers')}
-                    {renderTabButton('payload', 'Payload')}
-                  </nav>
-                </div>
-              </div>
-              <div className="px-4 py-3">
-                {renderTabContent()}
-              </div>
-            </div>
-          </div>
+          <PayloadDisplay 
+            headers={headers}
+            payload={payload}
+            eventId={eventId}
+            timestamp={timestamp}
+            state={state}
+            eventType={eventType}
+            sourceName={sourceName}
+            showDetailsTab={true}
+          />
         )}
       </div>
     </div>

--- a/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
+++ b/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
@@ -45,7 +45,7 @@ export const ExecutionTimeline = ({
           const relatedPlainEvent = allPlainEventsById[execution.event.eventId || ''];
           const plainEventPayload = relatedPlainEvent?.raw;
           const plainEventHeaders = relatedPlainEvent?.headers;
-          
+
           return (
             <RunItem
               key={execution.id!}
@@ -60,7 +60,7 @@ export const ExecutionTimeline = ({
               approvedOn={getMinApprovedAt(execution)}
               approvedBy={getApprovalsNames(execution, userDisplayNames)}
               queuedOn={execution.event.createdAt}
-              eventId={execution.event.id}
+              eventId={relatedPlainEvent?.id}
               relatedPlainEvent={relatedPlainEvent}
               plainEventPayload={plainEventPayload}
               plainEventHeaders={plainEventHeaders}

--- a/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
+++ b/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
@@ -15,13 +15,15 @@ import {
 interface ExecutionTimelineProps {
   executions: ExecutionWithEvent[];
   organizationId: string;
-  allPlainEventsById: Record<string, SuperplaneEvent>;
+  connectionEventsById: Record<string, SuperplaneEvent>;
+  eventsByExecutionId: Record<string, SuperplaneEvent>;
 }
 
 export const ExecutionTimeline = ({
   executions,
   organizationId,
-  allPlainEventsById,
+  connectionEventsById,
+  eventsByExecutionId,
 }: ExecutionTimelineProps) => {
   // Fetch organization users to resolve user IDs to names
   const { data: orgUsers = [] } = useOrganizationUsersForCanvas(organizationId);
@@ -42,9 +44,8 @@ export const ExecutionTimeline = ({
     <div className="space-y-3">
       {
         executions.map((execution) => {
-          const relatedPlainEvent = allPlainEventsById[execution.event.eventId || ''];
-          const plainEventPayload = relatedPlainEvent?.raw;
-          const plainEventHeaders = relatedPlainEvent?.headers;
+          const sourceEvent = connectionEventsById[execution.event.eventId || ''];
+          const emmitedEvent = eventsByExecutionId[execution.id || ''];
 
           return (
             <RunItem
@@ -60,10 +61,9 @@ export const ExecutionTimeline = ({
               approvedOn={getMinApprovedAt(execution)}
               approvedBy={getApprovalsNames(execution, userDisplayNames)}
               queuedOn={execution.event.createdAt}
-              eventId={relatedPlainEvent?.id}
-              relatedPlainEvent={relatedPlainEvent}
-              plainEventPayload={plainEventPayload}
-              plainEventHeaders={plainEventHeaders}
+              eventId={sourceEvent?.id}
+              sourceEvent={sourceEvent}
+              emmitedEvent={emmitedEvent}
             />
           );
         })

--- a/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
+++ b/web_src/src/pages/canvas/components/ExecutionTimeline.tsx
@@ -2,6 +2,14 @@ import { ExecutionWithEvent } from "../store/types";
 import { RunItem } from "./tabs/RunItem";
 import { useOrganizationUsersForCanvas } from "../../../hooks/useCanvasData";
 import { useMemo } from "react";
+import {
+  formatDuration,
+  getMinApprovedAt,
+  getApprovalsNames,
+  mapExecutionOutputs,
+  mapExecutionEventInputs,
+  createUserDisplayNames
+} from "../utils/stageEventUtils";
 
 interface ExecutionTimelineProps {
   executions: ExecutionWithEvent[];
@@ -15,39 +23,7 @@ export const ExecutionTimeline = ({
   // Fetch organization users to resolve user IDs to names
   const { data: orgUsers = [] } = useOrganizationUsersForCanvas(organizationId);
 
-  // Create a lookup map for user IDs to display names
-  const userDisplayNames = useMemo(() => {
-    const map: Record<string, string> = {};
-    orgUsers.forEach(user => {
-      if (user.metadata?.id) {
-        map[user.metadata.id] = user.spec?.displayName || user.metadata?.email || user.metadata.id;
-      }
-    });
-    return map;
-  }, [orgUsers]);
-
-  const getMinApprovedAt = (execution: ExecutionWithEvent) => {
-    if (!execution.event.approvals?.length)
-      return undefined;
-
-    return execution.event.approvals.reduce((min, approval) => {
-      if (approval.approvedAt && new Date(approval.approvedAt).getTime() < new Date(min).getTime()) {
-        return approval.approvedAt;
-      }
-      return min;
-    }, execution.event.approvals[0].approvedAt!);
-  }
-
-
-  const getApprovalsNames = (execution: ExecutionWithEvent) => {
-    const names: string[] = [];
-    execution.event.approvals?.forEach(approval => {
-      if (approval.approvedBy) {
-        names.push(userDisplayNames[approval.approvedBy]);
-      }
-    });
-    return names.join(', ');
-  };
+  const userDisplayNames = useMemo(() => createUserDisplayNames(orgUsers), [orgUsers]);
 
 
   if (executions.length === 0) {
@@ -58,49 +34,6 @@ export const ExecutionTimeline = ({
       </div>
     );
   }
-
-
-
-
-  const formatDuration = (startedAt?: string, finishedAt?: string) => {
-    if (!startedAt || !finishedAt) {
-      return "-";
-    }
-    const duration = new Date(finishedAt).getTime() - new Date(startedAt).getTime();
-    const hours = Math.floor(duration / (1000 * 60 * 60));
-    const prefixHours = hours >= 10 ? `${hours}h ` : `0${hours}h`;
-    const minutes = Math.floor((duration % (1000 * 60 * 60)) / (1000 * 60));
-    const prefixMinutes = minutes >= 10 ? `${minutes}m ` : `0${minutes}m`;
-    const seconds = Math.floor((duration % (1000 * 60)) / 1000);
-    const prefixSeconds = seconds >= 10 ? `${seconds}s` : `0${seconds}s`;
-    return `${prefixHours} ${prefixMinutes} ${prefixSeconds}`;
-  };
-
-  const mapExecutionOutputs = (execution: ExecutionWithEvent) => {
-    const map: Record<string, string> = {};
-    execution.outputs?.forEach((output) => {
-      if (!output.name) {
-        return;
-      }
-
-      map[output.name!] = output.value!;
-    });
-
-    return map;
-  };
-
-  const mapExecutionEventInputs = (execution: ExecutionWithEvent) => {
-    const map: Record<string, string> = {};
-    execution.event.inputs?.forEach((input) => {
-      if (!input.name) {
-        return;
-      }
-
-      map[input.name!] = input.value!;
-    });
-
-    return map;
-  };
 
   return (
     <div className="space-y-3">
@@ -115,9 +48,9 @@ export const ExecutionTimeline = ({
             state={execution.state || 'STATE_UNKNOWN'}
             result={execution.result || 'RESULT_UNKNOWN'}
             timestamp={execution.createdAt || new Date().toISOString()}
-            executionDuration={formatDuration(execution.startedAt, execution.finishedAt)}
+            executionDuration={formatDuration(execution.startedAt || execution.createdAt, execution.finishedAt)}
             approvedOn={getMinApprovedAt(execution)}
-            approvedBy={getApprovalsNames(execution)}
+            approvedBy={getApprovalsNames(execution, userDisplayNames)}
             queuedOn={execution.event.createdAt}
             eventId={execution.event.id}
           />

--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -81,16 +81,6 @@ const MessageItem = React.memo(({
       ?.find(condition => condition.type === "CONDITION_TYPE_TIME_WINDOW"),
     [selectedStage]);
 
-  const getStatusLabel = useCallback(() => {
-    if (event.state === 'STATE_WAITING' && event.stateReason === 'STATE_REASON_APPROVAL') {
-      return 'Waiting';
-    } else if (event.state === 'STATE_WAITING' && event.stateReason === 'STATE_REASON_TIME_WINDOW') {
-      return 'Waiting';
-    } else if (event.state === 'STATE_PENDING') {
-      return 'Pending';
-    }
-    return 'Pending';
-  }, [event.state, event.stateReason]);
 
   const formatTimeWindow = useCallback(() => {
     if (timeWindowCondition?.timeWindow?.start && timeWindowCondition?.timeWindow?.end) {
@@ -110,10 +100,22 @@ const MessageItem = React.memo(({
       <div className="p-3 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 cursor-pointer" onClick={toggleExpand}>
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 truncate">
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full flex-shrink-0 bg-amber-600 dark:bg-amber-500 animate-pulse"></div>
-              <span className="text-xs font-medium text-amber-700 dark:text-amber-500">{getStatusLabel()}</span>
-            </div>
+            {event.state === 'STATE_WAITING' && event.stateReason === 'STATE_REASON_APPROVAL' ? (
+              <span className="inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-amber-400/20 text-amber-700 group-data-hover:bg-amber-400/30 dark:bg-amber-400/10 dark:text-amber-400 dark:group-data-hover:bg-amber-400/15">
+                <span className="material-symbols-outlined select-none inline-flex items-center justify-center !text-base animate-pulse" aria-hidden="true">how_to_reg</span>
+                <span className="uppercase">Approval</span>
+              </span>
+            ) : event.state === 'STATE_WAITING' && event.stateReason === 'STATE_REASON_TIME_WINDOW' ? (
+              <span className="inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10">
+                <span className="material-symbols-outlined select-none inline-flex items-center justify-center !text-base animate-pulse" aria-hidden="true">schedule</span>
+                <span className="uppercase">Scheduled</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10">
+                <span className="material-symbols-outlined select-none inline-flex items-center justify-center !text-base animate-pulse" aria-hidden="true">pending</span>
+                <span className="uppercase">Pending</span>
+              </span>
+            )}
             <span className="font-medium truncate text-sm dark:text-white">
               {event.name || event.id || 'Unknown'}
             </span>

--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -151,7 +151,7 @@ const MessageItem = React.memo(({
               </span>
             )}
             <span className="font-medium truncate text-sm dark:text-white">
-              {isStageEvent(event) ? (event.name || event.id || 'Unknown') : (event.sourceName || event.id || 'Discarded Event')}
+              {isStageEvent(event) ? (event.name || event.id || 'Unknown') : (event.id || 'Discarded Event')}
             </span>
           </div>
           <div className="flex items-center gap-3">

--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -6,7 +6,7 @@ import { PayloadDisplay } from './PayloadDisplay';
 
 interface MessageItemProps {
   event: SuperplaneStageEvent | SuperplaneEvent;
-  relatedPlainEvent?: SuperplaneEvent;
+  sourceEvent?: SuperplaneEvent;
   selectedStage?: SuperplaneStage;
   onApprove?: (eventId: string) => void;
   onRemove?: (eventId: string) => void;
@@ -22,7 +22,7 @@ const MessageItem = React.memo(({
   onRemove,
   plainEventPayload,
   plainEventHeaders,
-  relatedPlainEvent
+  sourceEvent
 }: MessageItemProps) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -226,14 +226,14 @@ const MessageItem = React.memo(({
               )}
 
               {/* Show payload/headers for plain events */}
-              {isStageEvent(event) && relatedPlainEvent && (plainEventPayload || plainEventHeaders) && (
+              {isStageEvent(event) && sourceEvent && (plainEventPayload || plainEventHeaders) && (
                 <PayloadDisplay
                   showDetailsTab={true}
-                  eventId={relatedPlainEvent.id}
-                  timestamp={relatedPlainEvent.receivedAt}
-                  state={relatedPlainEvent.state}
-                  eventType={relatedPlainEvent.type}
-                  sourceName={relatedPlainEvent.sourceName}
+                  eventId={sourceEvent.id}
+                  timestamp={sourceEvent.receivedAt}
+                  state={sourceEvent.state}
+                  eventType={sourceEvent.type}
+                  sourceName={sourceEvent.sourceName}
                   headers={plainEventHeaders}
                   payload={plainEventPayload}
                 />

--- a/web_src/src/pages/canvas/components/PayloadDisplay.tsx
+++ b/web_src/src/pages/canvas/components/PayloadDisplay.tsx
@@ -25,10 +25,20 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
   sourceName,
   showDetailsTab = false
 }) => {
-  const [activeTab, setActiveTab] = useState<TabType>(showDetailsTab ? 'details' : 'headers');
-
   const displayHeaders = headers || {};
   const displayPayload = payload || {};
+
+  const hasHeaders = Object.keys(displayHeaders).length > 0;
+  const hasPayload = Object.keys(displayPayload).length > 0;
+  
+  const getDefaultTab = (): TabType => {
+    if (showDetailsTab) return 'details';
+    if (hasHeaders) return 'headers';
+    if (hasPayload) return 'payload';
+    return 'details';
+  };
+
+  const [activeTab, setActiveTab] = useState<TabType>(getDefaultTab());
 
   // State configuration for details tab
   const getStateConfig = () => {
@@ -212,7 +222,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
   };
 
   // Don't render if no data to display
-  if (Object.keys(displayHeaders).length === 0 && Object.keys(displayPayload).length === 0 && !showDetailsTab) {
+  if (!hasHeaders && !hasPayload && !showDetailsTab) {
     return null;
   }
 
@@ -223,8 +233,8 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
           <div className="w-full border-b border-zinc-200 dark:border-zinc-700">
             <nav className="flex gap-0">
               {showDetailsTab && renderTabButton('details', 'Details')}
-              {renderTabButton('headers', 'Headers')}
-              {renderTabButton('payload', 'Payload')}
+              {hasHeaders && renderTabButton('headers', 'Headers')}
+              {hasPayload && renderTabButton('payload', 'Payload')}
             </nav>
           </div>
         </div>

--- a/web_src/src/pages/canvas/components/PayloadDisplay.tsx
+++ b/web_src/src/pages/canvas/components/PayloadDisplay.tsx
@@ -1,0 +1,235 @@
+import React, { useState } from 'react';
+import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+
+interface PayloadDisplayProps {
+  headers?: { [key: string]: unknown };
+  payload?: { [key: string]: unknown };
+  // Details tab props
+  eventId?: string;
+  timestamp?: string;
+  state?: string;
+  eventType?: string;
+  sourceName?: string;
+  showDetailsTab?: boolean;
+}
+
+type TabType = 'details' | 'headers' | 'payload';
+
+export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
+  headers,
+  payload,
+  eventId,
+  timestamp,
+  state,
+  eventType,
+  sourceName,
+  showDetailsTab = false
+}) => {
+  const [activeTab, setActiveTab] = useState<TabType>(showDetailsTab ? 'details' : 'headers');
+
+  const displayHeaders = headers || {};
+  const displayPayload = payload || {};
+
+  // State configuration for details tab
+  const getStateConfig = () => {
+    switch (state) {
+      case 'STATE_PENDING':
+        return {
+          dotColor: 'bg-yellow-500',
+          textColor: 'text-yellow-700 dark:text-yellow-400',
+          label: 'Pending',
+          animate: true,
+        };
+      case 'STATE_DISCARDED':
+        return {
+          dotColor: 'bg-zinc-500',
+          textColor: 'text-zinc-600 dark:text-zinc-400',
+          label: 'Discarded',
+          animate: false,
+        };
+      case 'STATE_PROCESSED':
+        return {
+          dotColor: 'bg-green-500',
+          textColor: 'text-green-600 dark:text-green-400',
+          label: 'Forwarded',
+          animate: false,
+        };
+      default:
+        return {
+          dotColor: 'bg-gray-500',
+          textColor: 'text-gray-600 dark:text-gray-400',
+          label: 'Unknown',
+          animate: false,
+        };
+    }
+  };
+
+  const stateConfig = getStateConfig();
+
+  const formatTimestamp = () => {
+    if (!timestamp) return 'N/A';
+    return new Date(timestamp).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }) + ', ' + new Date(timestamp).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: true
+    });
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text).catch(err => {
+      console.error('Failed to copy: ', err);
+    });
+  };
+
+  const renderTabButton = (tabKey: TabType, label: string) => {
+    const isActive = activeTab === tabKey;
+    return (
+      <button
+        type="button"
+        className={`relative flex items-center gap-2 font-medium transition-all duration-200 ease-in-out focus:outline-hidden text-xs px-3 py-2 relative ${isActive
+          ? 'text-blue-600 dark:text-blue-400 cursor-pointer'
+          : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300 cursor-pointer'
+          }`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setActiveTab(tabKey);
+        }}
+        data-testid={`tab-${tabKey}`}
+      >
+        <span className="leading-none whitespace-nowrap">{label}</span>
+        <div
+          className={`absolute inset-x-0 bottom-0 h-0.5 bg-blue-500 transition-all duration-200 ease-in-out ${isActive ? 'scale-x-100' : 'scale-x-0'
+            }`}
+        ></div>
+      </button>
+    );
+  };
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'details':
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-6 text-sm">
+              <div>
+                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">STATE</div>
+                <div className="text-blue-600 dark:text-blue-400 text-xs font-medium">
+                  <div className="flex items-center gap-2">
+                    <div className={`w-2 h-2 ${stateConfig.dotColor} ${stateConfig.animate ? 'animate-pulse' : ''} rounded-full flex-shrink-0`}></div>
+                    <span className={`text-xs font-medium ${stateConfig.textColor}`}>{stateConfig.label}</span>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">RECEIVED ON</div>
+                <div className="text-xs text-gray-900 dark:text-zinc-200">{formatTimestamp()}</div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">SOURCE</div>
+                <div className="text-xs text-gray-900 dark:text-zinc-200">{sourceName || 'External Webhook'}</div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">TYPE</div>
+                <div className="text-xs font-medium">{eventType || 'webhook'}</div>
+              </div>
+              <div className="col-span-2">
+                <div>
+                  <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">EVENT ID</div>
+                  <div className="font-mono text-xs text-gray-900 dark:text-zinc-200 break-all">{eventId}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      case 'headers':
+        return (
+          <div>
+            <div className="space-y-2">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+                {Object.keys(displayHeaders).length > 0 ? (
+                  <div className="space-y-2">
+                    {Object.entries(displayHeaders).map(([key, value]) => (
+                      <div key={key} className="flex justify-between">
+                        <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium pr-2 flex-shrink-0">
+                          {key}
+                        </span>
+                        <span className="text-xs font-mono text-gray-900 dark:text-zinc-200 break-all">
+                          {String(value)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-xs text-gray-500 dark:text-zinc-400 italic">
+                    No headers available
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      case 'payload':
+        return (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-gray-500 dark:text-zinc-400">Event Data</span>
+              <div className="flex items-center">
+                <a
+                  className="!text-xs flex items-center cursor-pointer"
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    copyToClipboard(JSON.stringify(displayPayload, null, 2));
+                  }}
+                >
+                  <MaterialSymbol name="content_copy" size="sm" className="mr-1" />
+                  Copy
+                </a>
+              </div>
+            </div>
+            <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+              {Object.keys(displayPayload).length > 0 ? (
+                <pre className="text-xs font-mono text-gray-900 dark:text-zinc-200 whitespace-pre-wrap">
+                  {JSON.stringify(displayPayload, null, 2)}
+                </pre>
+              ) : (
+                <div className="text-xs text-gray-500 dark:text-zinc-400 italic">
+                  No payload available
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  // Don't render if no data to display
+  if (Object.keys(displayHeaders).length === 0 && Object.keys(displayPayload).length === 0 && !showDetailsTab) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+      <div className="border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-900">
+        <div className="border-b border-gray-200 dark:border-zinc-700">
+          <div className="w-full border-b border-zinc-200 dark:border-zinc-700">
+            <nav className="flex gap-0">
+              {showDetailsTab && renderTabButton('details', 'Details')}
+              {renderTabButton('headers', 'Headers')}
+              {renderTabButton('payload', 'Payload')}
+            </nav>
+          </div>
+        </div>
+        <div className="px-4 py-3">{renderTabContent()}</div>
+      </div>
+    </div>
+  );
+};

--- a/web_src/src/pages/canvas/components/SideBar.tsx
+++ b/web_src/src/pages/canvas/components/SideBar.tsx
@@ -80,7 +80,7 @@ export const Sidebar = ({ selectedStage, onClose, approveStageEvent }: SidebarPr
         );
 
       case 'history':
-        return <HistoryTab allExecutions={allExecutions} organizationId={organizationId!} />;
+        return <HistoryTab approveStageEvent={approveStageEvent} allExecutions={allExecutions} organizationId={organizationId!} selectedStage={selectedStage} allStageEvents={selectedStage.queue || []} />;
 
       case 'settings':
         return <SettingsTab selectedStage={selectedStage} />;

--- a/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
@@ -65,15 +65,24 @@ export const ActivityTab = ({
           ) : (
             [...pendingEvents, ...waitingEvents]
               .sort((a, b) => new Date(b.createdAt || '').getTime() - new Date(a.createdAt || '').getTime())
-              .map((event) => (
-                <MessageItem
-                  key={event.id}
-                  event={event}
-                  selectedStage={selectedStage}
-                  onApprove={event.state === 'STATE_WAITING' ? (eventId) => approveStageEvent(eventId, selectedStage.metadata!.id!) : undefined}
-                  executionRunning={executionRunning}
-                />
-              ))
+              .map((event) => {
+                const relatedPlainEvent = allPlainEventsById[event.eventId || ''];
+                const plainEventPayload = relatedPlainEvent?.raw;
+                const plainEventHeaders = relatedPlainEvent?.headers;
+                
+                return (
+                  <MessageItem
+                    key={event.id}
+                    event={event}
+                    selectedStage={selectedStage}
+                    onApprove={event.state === 'STATE_WAITING' ? (eventId) => approveStageEvent(eventId, selectedStage.metadata!.id!) : undefined}
+                    executionRunning={executionRunning}
+                    relatedPlainEvent={relatedPlainEvent}
+                    plainEventPayload={plainEventPayload}
+                    plainEventHeaders={plainEventHeaders}
+                  />
+                );
+              })
           )}
         </div>
       </div>

--- a/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
@@ -1,6 +1,6 @@
 import { ExecutionWithEvent, StageWithEventQueue } from "../../store/types";
 import { ExecutionTimeline } from '../ExecutionTimeline';
-import { SuperplaneStageEvent } from "@/api-client";
+import { SuperplaneStageEvent, SuperplaneEvent } from "@/api-client";
 import MessageItem from '../MessageItem';
 
 interface ActivityTabProps {
@@ -12,6 +12,7 @@ interface ActivityTabProps {
   executionRunning: boolean;
   onChangeTab: (tab: string) => void;
   organizationId: string;
+  allPlainEventsById: Record<string, SuperplaneEvent>;
 }
 
 export const ActivityTab = ({
@@ -22,7 +23,8 @@ export const ActivityTab = ({
   approveStageEvent,
   executionRunning,
   onChangeTab,
-  organizationId
+  organizationId,
+  allPlainEventsById
 }: ActivityTabProps) => {
   const queueCount = pendingEvents.length + waitingEvents.length;
 
@@ -41,6 +43,7 @@ export const ActivityTab = ({
         <ExecutionTimeline
           executions={allExecutions.slice(0, 3)}
           organizationId={organizationId}
+          allPlainEventsById={allPlainEventsById}
         />
       </div>
 

--- a/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/ActivityTab.tsx
@@ -12,7 +12,8 @@ interface ActivityTabProps {
   executionRunning: boolean;
   onChangeTab: (tab: string) => void;
   organizationId: string;
-  allPlainEventsById: Record<string, SuperplaneEvent>;
+  connectionEventsById: Record<string, SuperplaneEvent>;
+  eventsByExecutionId: Record<string, SuperplaneEvent>;
 }
 
 export const ActivityTab = ({
@@ -24,7 +25,8 @@ export const ActivityTab = ({
   executionRunning,
   onChangeTab,
   organizationId,
-  allPlainEventsById
+  connectionEventsById,
+  eventsByExecutionId
 }: ActivityTabProps) => {
   const queueCount = pendingEvents.length + waitingEvents.length;
 
@@ -43,7 +45,8 @@ export const ActivityTab = ({
         <ExecutionTimeline
           executions={allExecutions.slice(0, 3)}
           organizationId={organizationId}
-          allPlainEventsById={allPlainEventsById}
+          connectionEventsById={connectionEventsById}
+          eventsByExecutionId={eventsByExecutionId}
         />
       </div>
 
@@ -66,10 +69,10 @@ export const ActivityTab = ({
             [...pendingEvents, ...waitingEvents]
               .sort((a, b) => new Date(b.createdAt || '').getTime() - new Date(a.createdAt || '').getTime())
               .map((event) => {
-                const relatedPlainEvent = allPlainEventsById[event.eventId || ''];
-                const plainEventPayload = relatedPlainEvent?.raw;
-                const plainEventHeaders = relatedPlainEvent?.headers;
-                
+                const sourceEvent = connectionEventsById[event.eventId || ''];
+                const plainEventPayload = sourceEvent?.raw;
+                const plainEventHeaders = sourceEvent?.headers;
+
                 return (
                   <MessageItem
                     key={event.id}
@@ -77,7 +80,7 @@ export const ActivityTab = ({
                     selectedStage={selectedStage}
                     onApprove={event.state === 'STATE_WAITING' ? (eventId) => approveStageEvent(eventId, selectedStage.metadata!.id!) : undefined}
                     executionRunning={executionRunning}
-                    relatedPlainEvent={relatedPlainEvent}
+                    sourceEvent={sourceEvent}
                     plainEventPayload={plainEventPayload}
                     plainEventHeaders={plainEventHeaders}
                   />

--- a/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
@@ -101,7 +101,7 @@ export const HistoryTab = ({ allExecutions, selectedStage, allStageEvents, organ
               const relatedPlainEvent = allPlainEventsById?.[execution.event.eventId || ''];
               const plainEventPayload = relatedPlainEvent?.raw;
               const plainEventHeaders = relatedPlainEvent?.headers;
-              
+
               return (
                 <RunItem
                   key={execution.id!}
@@ -116,7 +116,7 @@ export const HistoryTab = ({ allExecutions, selectedStage, allStageEvents, organ
                   approvedOn={getMinApprovedAt(execution)}
                   approvedBy={getApprovalsNames(execution, userDisplayNames)}
                   queuedOn={execution.event.createdAt}
-                  eventId={execution.event.id}
+                  eventId={relatedPlainEvent?.id}
                   relatedPlainEvent={relatedPlainEvent}
                   plainEventPayload={plainEventPayload}
                   plainEventHeaders={plainEventHeaders}

--- a/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
@@ -1,21 +1,118 @@
-import { ExecutionTimeline } from '../ExecutionTimeline';
-import { ExecutionWithEvent } from "../../store/types";
+import { ExecutionWithEvent, StageWithEventQueue } from "../../store/types";
+import { SuperplaneStageEvent } from "@/api-client";
+import MessageItem from '../MessageItem';
+import { RunItem } from './RunItem';
+import { useMemo } from 'react';
+import { useOrganizationUsersForCanvas } from '@/hooks/useCanvasData';
+import {
+  formatDuration,
+  getMinApprovedAt,
+  getApprovalsNames,
+  mapExecutionOutputs,
+  mapExecutionEventInputs,
+  createUserDisplayNames
+} from '../../utils/stageEventUtils';
 
 interface HistoryTabProps {
   allExecutions: ExecutionWithEvent[];
+  selectedStage: StageWithEventQueue;
+  allStageEvents: SuperplaneStageEvent[];
   organizationId: string;
+  approveStageEvent: (stageEventId: string, stageId: string) => void;
 }
 
-export const HistoryTab = ({ allExecutions, organizationId }: HistoryTabProps) => {
+export const HistoryTab = ({ allExecutions, selectedStage, allStageEvents, organizationId, approveStageEvent }: HistoryTabProps) => {
+  // Create a unified timeline by merging executions and stage events
+  type TimelineItem = {
+    type: 'execution' | 'event';
+    timestamp: string;
+    data: ExecutionWithEvent | SuperplaneStageEvent;
+  };
+
+  const { data: orgUsers = [] } = useOrganizationUsersForCanvas(organizationId);
+
+
+  const createTimeline = (): TimelineItem[] => {
+    const items: TimelineItem[] = [];
+
+    // Add executions
+    allExecutions.forEach(execution => {
+      if (execution?.createdAt) {
+        items.push({
+          type: 'execution',
+          timestamp: execution.createdAt,
+          data: execution
+        });
+      }
+    });
+
+    const executionEventIds = new Set(allExecutions.map(exec => exec.event?.id).filter(Boolean));
+    const orphanedEvents = allStageEvents.filter(event => !executionEventIds.has(event.id));
+
+    orphanedEvents.forEach(event => {
+      if (event?.createdAt) {
+        items.push({
+          type: 'event',
+          timestamp: event.createdAt,
+          data: event
+        });
+      }
+    });
+
+    return items.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  };
+
+  const userDisplayNames = useMemo(() => createUserDisplayNames(orgUsers), [orgUsers]);
+
+
+  const timeline = createTimeline();
+
   return (
     <div className="p-6">
-      <h3 className="font-bold text-left text-sm text-gray-500 dark:text-gray-400 uppercase tracking-wide">Historical Runs ({allExecutions.length})</h3>
+      <h3 className="font-bold text-left text-sm text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+        History ({timeline.length} items)
+      </h3>
 
-      <div className="mb-8 mt-5">
-        <ExecutionTimeline
-          executions={allExecutions}
-          organizationId={organizationId}
-        />
+      <div className="mb-8 mt-5 space-y-3">
+        {timeline.length === 0 ? (
+          <div className="text-center py-8 bg-gray-50 dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700">
+            <span className="material-symbols-outlined select-none inline-flex items-center justify-center !w-16 !h-16 !text-[64px] !leading-16 mx-auto text-zinc-400 dark:text-zinc-500 mb-3" aria-hidden="true" style={{ fontVariationSettings: "FILL 0, wght 400, GRAD 0, opsz 24" }}>history</span>
+            <p className="text-zinc-600 dark:text-zinc-400 max-w-md mx-auto mb-6 !text-sm text-base/6 text-zinc-500 sm:text-sm/6 dark:text-zinc-400">No history available</p>
+          </div>
+        ) : (
+          timeline.map((item) => {
+            if (item.type === 'execution') {
+              const execution = item.data as ExecutionWithEvent;
+              return (
+                <RunItem
+                  key={execution.id!}
+                  title={execution.event.name || execution.id || 'Execution'}
+                  runId={execution.id}
+                  inputs={mapExecutionEventInputs(execution)}
+                  outputs={mapExecutionOutputs(execution)}
+                  state={execution.state || 'STATE_UNKNOWN'}
+                  result={execution.result || 'RESULT_UNKNOWN'}
+                  timestamp={execution.createdAt || new Date().toISOString()}
+                  executionDuration={formatDuration(execution.startedAt || execution.createdAt, execution.finishedAt)}
+                  approvedOn={getMinApprovedAt(execution)}
+                  approvedBy={getApprovalsNames(execution, userDisplayNames)}
+                  queuedOn={execution.event.createdAt}
+                  eventId={execution.event.id}
+                />
+              );
+            }
+            return (
+              <MessageItem
+                key={item.data.id}
+                event={item.data as SuperplaneStageEvent}
+                selectedStage={selectedStage}
+                executionRunning={false}
+                onApprove={item.data.state === 'STATE_WAITING' ? (eventId) => approveStageEvent(eventId, selectedStage.metadata!.id!) : undefined}
+
+              />
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
+++ b/web_src/src/pages/canvas/components/tabs/HistoryTab.tsx
@@ -2,8 +2,9 @@ import { ExecutionWithEvent, StageWithEventQueue } from "../../store/types";
 import { SuperplaneStageEvent, SuperplaneEvent } from "@/api-client";
 import MessageItem from '../MessageItem';
 import { RunItem } from './RunItem';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useOrganizationUsersForCanvas } from '@/hooks/useCanvasData';
+import { ControlledTabs, Tab } from '@/components/Tabs/tabs';
 import {
   formatDuration,
   getMinApprovedAt,
@@ -32,6 +33,8 @@ export const HistoryTab = ({ allExecutions, selectedStage, allStageEvents, organ
   };
 
   const { data: orgUsers = [] } = useOrganizationUsersForCanvas(organizationId);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeFilter, setActiveFilter] = useState('all');
 
 
   const createTimeline = (): TimelineItem[] => {
@@ -80,23 +83,104 @@ export const HistoryTab = ({ allExecutions, selectedStage, allStageEvents, organ
 
   const userDisplayNames = useMemo(() => createUserDisplayNames(orgUsers), [orgUsers]);
 
+  const filterTabs: Tab[] = [
+    { id: 'all', label: 'All' },
+    { id: 'runs', label: 'Runs' },
+    { id: 'queue', label: 'Queue' },
+    { id: 'events', label: 'Events' }
+  ];
 
   const timeline = createTimeline();
+
+  const filteredTimeline = useMemo(() => {
+    let filtered = timeline;
+
+    // Filter by type
+    if (activeFilter !== 'all') {
+      if (activeFilter === 'runs') {
+        filtered = filtered.filter(item => item.type === 'execution');
+      } else if (activeFilter === 'queue') {
+        filtered = filtered.filter(item => item.type === 'stage_event');
+      } else if (activeFilter === 'events') {
+        filtered = filtered.filter(item => item.type === 'discarded_event');
+      }
+    }
+
+    // Filter by search query
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter(item => {
+        if (item.type === 'execution') {
+          const execution = item.data as ExecutionWithEvent;
+          return (
+            execution.event?.name?.toLowerCase().includes(query) ||
+            execution.id?.toLowerCase().includes(query) ||
+            execution.state?.toLowerCase().includes(query) ||
+            execution.result?.toLowerCase().includes(query)
+          );
+        } else if (item.type === 'stage_event') {
+          const stageEvent = item.data as SuperplaneStageEvent;
+          return (
+            stageEvent.name?.toLowerCase().includes(query) ||
+            stageEvent.id?.toLowerCase().includes(query) ||
+            stageEvent.state?.toLowerCase().includes(query)
+          );
+        } else if (item.type === 'discarded_event') {
+          const plainEvent = item.data as SuperplaneEvent;
+          return (
+            plainEvent.id?.toLowerCase().includes(query) ||
+            plainEvent.state?.toLowerCase().includes(query)
+          );
+        }
+        return false;
+      });
+    }
+
+    return filtered;
+  }, [timeline, activeFilter, searchQuery]);
 
   return (
     <div className="p-6">
       <h3 className="font-bold text-left text-sm text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-        History ({timeline.length} items)
+        History ({filteredTimeline.length} items)
       </h3>
 
-      <div className="mb-8 mt-5 space-y-3">
-        {timeline.length === 0 ? (
+      <div className="mt-5 mb-6">
+        <div className="flex items-center gap-2">
+          <div className="flex-grow">
+            <div className="relative">
+              <span className="material-symbols-outlined absolute left-3 top-1/2 transform -translate-y-1/2 text-zinc-500 dark:text-zinc-400 text-base pointer-events-none text-base!">
+                search
+              </span>
+              <input
+                type="search"
+                placeholder="Search history..."
+                className="w-full pl-8 pr-4 py-2 text-sm border border-zinc-300 dark:border-zinc-600 rounded-lg bg-white dark:bg-zinc-800 text-zinc-900 dark:text-white placeholder:text-zinc-500 dark:placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex-shrink-0">
+            <ControlledTabs
+              tabs={filterTabs}
+              activeTab={activeFilter}
+              onTabChange={setActiveFilter}
+              variant="pills"
+              buttonClasses="text-xs"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-8 space-y-3">
+        {filteredTimeline.length === 0 ? (
           <div className="text-center py-8 bg-gray-50 dark:bg-zinc-900 border border-gray-200 dark:border-zinc-700">
             <span className="material-symbols-outlined select-none inline-flex items-center justify-center !w-16 !h-16 !text-[64px] !leading-16 mx-auto text-zinc-400 dark:text-zinc-500 mb-3" aria-hidden="true" style={{ fontVariationSettings: "FILL 0, wght 400, GRAD 0, opsz 24" }}>history</span>
             <p className="text-zinc-600 dark:text-zinc-400 max-w-md mx-auto mb-6 !text-sm text-base/6 text-zinc-500 sm:text-sm/6 dark:text-zinc-400">No history available</p>
           </div>
         ) : (
-          timeline.map((item) => {
+          filteredTimeline.map((item) => {
             if (item.type === 'execution') {
               const execution = item.data as ExecutionWithEvent;
               const sourceEvent = connectionEventsById?.[execution.event.eventId || ''];

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -202,7 +202,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
                   Run Details
                 </div>
-                
+
                 {Object.keys(inputs).length > 0 && (
                   <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
                     <div className="flex items-start gap-3">
@@ -249,7 +249,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
 
                 {emmitedEvent && (emmitedEventPayload || emmitedEventHeaders) && (
                   <div>
-                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-2 font-bold">Payload Emitted</div>
+                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-2 font-bold">Emitted Event</div>
                     <PayloadDisplay
                       showDetailsTab={true}
                       eventId={emmitedEvent.id}
@@ -271,7 +271,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
                   Queue Details
                 </div>
-                
+
                 <div className="bg-zinc-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 p-4 text-xs">
                   <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-2">Queue Metadata</div>
                   <div className="space-y-1">
@@ -328,7 +328,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
                   Event Details
                 </div>
-                
+
                 <PayloadDisplay
                   showDetailsTab={true}
                   eventId={sourceEvent.id}

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -1,6 +1,7 @@
 import React, { JSX } from 'react';
-import { ExecutionResult, SuperplaneExecutionState } from '@/api-client';
+import { ExecutionResult, SuperplaneExecutionState, SuperplaneEvent } from '@/api-client';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+import { PayloadDisplay } from '../PayloadDisplay';
 
 interface RunItemProps {
   state: SuperplaneExecutionState;
@@ -15,6 +16,9 @@ interface RunItemProps {
   queuedOn?: string;
   approvedOn?: string;
   approvedBy?: string;
+  relatedPlainEvent?: SuperplaneEvent;
+  plainEventPayload?: { [key: string]: unknown };
+  plainEventHeaders?: { [key: string]: unknown };
 }
 
 export const RunItem: React.FC<RunItemProps> = React.memo(({
@@ -30,6 +34,9 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
   queuedOn,
   approvedOn,
   approvedBy,
+  relatedPlainEvent,
+  plainEventPayload,
+  plainEventHeaders,
 }) => {
   const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
 
@@ -278,6 +285,20 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                   )}
                 </div>
               </div>
+            )}
+
+            {/* Show payload/headers for related plain event */}
+            {relatedPlainEvent && (plainEventPayload || plainEventHeaders) && (
+              <PayloadDisplay
+                showDetailsTab={true}
+                eventId={relatedPlainEvent.id}
+                timestamp={relatedPlainEvent.receivedAt}
+                state={relatedPlainEvent.state}
+                eventType={relatedPlainEvent.type}
+                sourceName={relatedPlainEvent.sourceName}
+                headers={plainEventHeaders}
+                payload={plainEventPayload}
+              />
             )}
           </div>
         )}

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -1,4 +1,4 @@
-import React, { JSX } from 'react';
+import React, { JSX, useMemo } from 'react';
 import { ExecutionResult, SuperplaneExecutionState, SuperplaneEvent } from '@/api-client';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
 import { PayloadDisplay } from '../PayloadDisplay';
@@ -16,9 +16,8 @@ interface RunItemProps {
   queuedOn?: string;
   approvedOn?: string;
   approvedBy?: string;
-  relatedPlainEvent?: SuperplaneEvent;
-  plainEventPayload?: { [key: string]: unknown };
-  plainEventHeaders?: { [key: string]: unknown };
+  sourceEvent?: SuperplaneEvent;
+  emmitedEvent?: SuperplaneEvent;
 }
 
 export const RunItem: React.FC<RunItemProps> = React.memo(({
@@ -34,15 +33,19 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
   queuedOn,
   approvedOn,
   approvedBy,
-  relatedPlainEvent,
-  plainEventPayload,
-  plainEventHeaders,
+  sourceEvent,
+  emmitedEvent,
 }) => {
   const [isExpanded, setIsExpanded] = React.useState<boolean>(false);
 
   const toggleExpand = (): void => {
     setIsExpanded(!isExpanded);
   };
+
+  const sourceEventPayload = useMemo(() => sourceEvent?.raw, [sourceEvent]);
+  const sourceEventHeaders = useMemo(() => sourceEvent?.headers, [sourceEvent]);
+  const emmitedEventPayload = useMemo(() => emmitedEvent?.raw, [emmitedEvent]);
+  const emmitedEventHeaders = useMemo(() => emmitedEvent?.headers, [emmitedEvent]);
 
   const renderStatusBadge = (): JSX.Element => {
     switch (state) {
@@ -192,113 +195,151 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
 
         {/* Expanded content */}
         {isExpanded && (
-          <div className="mt-3 space-y-3 text-left">
-            {Object.keys(inputs).length > 0 && (
-              <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                <div className="flex items-start gap-3">
-                  <div className="flex-1">
-                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Inputs</div>
-                    <div className="space-y-1">
-                      {Object.entries(inputs).map(([key, value]) => (
-                        <div key={key} className="flex items-center justify-between gap-2 min-w-0">
-                          <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
-                          <div className="flex items-center gap-2 flex-shrink-0">
-                            <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
-                              {value || '-'}
-                            </span>
-                          </div>
+          <div className="mt-3 space-y-4 text-left">
+            {/* Run Details Section */}
+            {(Object.keys(inputs).length > 0 || Object.keys(outputs).length > 0 || (emmitedEvent && (emmitedEventPayload || emmitedEventHeaders))) && (
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
+                  Run Details
+                </div>
+                
+                {Object.keys(inputs).length > 0 && (
+                  <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1">
+                        <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Inputs</div>
+                        <div className="space-y-1">
+                          {Object.entries(inputs).map(([key, value]) => (
+                            <div key={key} className="flex items-center justify-between gap-2 min-w-0">
+                              <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
+                              <div className="flex items-center gap-2 flex-shrink-0">
+                                <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
+                                  {value || '-'}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
                         </div>
-                      ))}
+                      </div>
                     </div>
                   </div>
-                </div>
+                )}
+
+                {Object.keys(outputs).length > 0 && (
+                  <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1">
+                        <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Outputs</div>
+                        <div className="space-y-1">
+                          {Object.entries(outputs).map(([key, value]) => (
+                            <div key={key} className="flex items-center justify-between gap-2 min-w-0">
+                              <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
+                              <div className="flex items-center gap-2 flex-shrink-0">
+                                <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
+                                  {value || '-'}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {emmitedEvent && (emmitedEventPayload || emmitedEventHeaders) && (
+                  <div>
+                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-2 font-bold">Payload Emitted</div>
+                    <PayloadDisplay
+                      showDetailsTab={true}
+                      eventId={emmitedEvent.id}
+                      timestamp={emmitedEvent.receivedAt}
+                      state={emmitedEvent.state}
+                      eventType={emmitedEvent.type}
+                      sourceName={emmitedEvent.sourceName}
+                      headers={emmitedEventHeaders}
+                      payload={emmitedEventPayload}
+                    />
+                  </div>
+                )}
               </div>
             )}
 
-            {Object.keys(outputs).length > 0 && (
-              <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                <div className="flex items-start gap-3">
-                  <div className="flex-1">
-                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Outputs</div>
-                    <div className="space-y-1">
-                      {Object.entries(outputs).map(([key, value]) => (
-                        <div key={key} className="flex items-center justify-between gap-2 min-w-0">
-                          <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
-                          <div className="flex items-center gap-2 flex-shrink-0">
-                            <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
-                              {value || '-'}
-                            </span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
+            {/* Queue Details Section */}
             {(queuedOn || approvedOn || approvedBy) && (
-              <div className="bg-zinc-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 p-4 text-xs">
-                <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-2">Queue Information</div>
-                <div className="space-y-1">
-                  {queuedOn && (
-                    <div className="flex items-center gap-1">
-                      <MaterialSymbol name="schedule" size="md" className="text-gray-600 dark:text-zinc-400" />
-                      <span className="text-xs text-gray-500 dark:text-zinc-400">
-                        Added to queue on {new Date(queuedOn).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric'
-                        })} {new Date(queuedOn).toLocaleTimeString('en-US', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          second: '2-digit',
-                          hour12: false
-                        })}
-                      </span>
-                    </div>
-                  )}
-                  {approvedOn && (
-                    <div className="flex items-center gap-1">
-                      <MaterialSymbol name="check_circle" size="md" className="text-gray-600 dark:text-zinc-400" />
-                      <span className="text-xs text-gray-500 dark:text-zinc-400">
-                        Approved on {new Date(approvedOn).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric'
-                        })} {new Date(approvedOn).toLocaleTimeString('en-US', {
-                          hour: '2-digit',
-                          minute: '2-digit',
-                          second: '2-digit',
-                          hour12: false
-                        })}
-                      </span>
-                    </div>
-                  )}
-                  {approvedBy && (
-                    <div className="flex items-center gap-1">
-                      <MaterialSymbol name="person" size="md" className="text-gray-600 dark:text-zinc-400" />
-                      <span className="text-xs text-gray-500 dark:text-zinc-400 truncate">
-                        Approved by <span className="text-blue-600 dark:text-blue-400 truncate">{approvedBy}</span>
-                      </span>
-                    </div>
-                  )}
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
+                  Queue Details
+                </div>
+                
+                <div className="bg-zinc-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 p-4 text-xs">
+                  <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-2">Queue Metadata</div>
+                  <div className="space-y-1">
+                    {queuedOn && (
+                      <div className="flex items-center gap-1">
+                        <MaterialSymbol name="schedule" size="md" className="text-gray-600 dark:text-zinc-400" />
+                        <span className="text-xs text-gray-500 dark:text-zinc-400">
+                          Added to queue on {new Date(queuedOn).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric'
+                          })} {new Date(queuedOn).toLocaleTimeString('en-US', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit',
+                            hour12: false
+                          })}
+                        </span>
+                      </div>
+                    )}
+                    {approvedOn && (
+                      <div className="flex items-center gap-1">
+                        <MaterialSymbol name="check_circle" size="md" className="text-gray-600 dark:text-zinc-400" />
+                        <span className="text-xs text-gray-500 dark:text-zinc-400">
+                          Approved on {new Date(approvedOn).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric'
+                          })} {new Date(approvedOn).toLocaleTimeString('en-US', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit',
+                            hour12: false
+                          })}
+                        </span>
+                      </div>
+                    )}
+                    {approvedBy && (
+                      <div className="flex items-center gap-1">
+                        <MaterialSymbol name="person" size="md" className="text-gray-600 dark:text-zinc-400" />
+                        <span className="text-xs text-gray-500 dark:text-zinc-400 truncate">
+                          Approved by <span className="text-blue-600 dark:text-blue-400 truncate">{approvedBy}</span>
+                        </span>
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
             )}
 
-            {/* Show payload/headers for related plain event */}
-            {relatedPlainEvent && (plainEventPayload || plainEventHeaders) && (
-              <PayloadDisplay
-                showDetailsTab={true}
-                eventId={relatedPlainEvent.id}
-                timestamp={relatedPlainEvent.receivedAt}
-                state={relatedPlainEvent.state}
-                eventType={relatedPlainEvent.type}
-                sourceName={relatedPlainEvent.sourceName}
-                headers={plainEventHeaders}
-                payload={plainEventPayload}
-              />
+            {/* Event Details Section */}
+            {sourceEvent && (sourceEventPayload || sourceEventHeaders) && (
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
+                  Event Details
+                </div>
+                
+                <PayloadDisplay
+                  showDetailsTab={true}
+                  eventId={sourceEvent.id}
+                  timestamp={sourceEvent.receivedAt}
+                  state={sourceEvent.state}
+                  eventType={sourceEvent.type}
+                  sourceName={sourceEvent.sourceName}
+                  headers={sourceEventHeaders}
+                  payload={sourceEventPayload}
+                />
+              </div>
             )}
           </div>
         )}

--- a/web_src/src/pages/canvas/store/types.ts
+++ b/web_src/src/pages/canvas/store/types.ts
@@ -10,7 +10,7 @@ export interface CanvasState {
   canvasId: string;
   stages: StageWithEventQueue[];
   eventSources: EventSourceWithEvents[];
-  connectionGroups: SuperplaneConnectionGroup[];
+  connectionGroups: ConnectionGroupWithEvents[];
   nodePositions: Record<string, { x: number, y: number }>;
   selectedStageId: string | null;
   selectedEventSourceId: string | null;
@@ -23,12 +23,12 @@ export interface CanvasState {
   
   // Actions
   initialize: (data: CanvasData) => void;
-  addStage: (stage: SuperplaneStage, draft?: boolean, autoLayout?: boolean) => void;
+  addStage: (stage: StageWithEventQueue, draft?: boolean, autoLayout?: boolean) => void;
   removeStage: (stageId: string) => void;
-  addConnectionGroup: (connectionGroup: SuperplaneConnectionGroup) => void;
+  addConnectionGroup: (connectionGroup: ConnectionGroupWithEvents) => void;
   removeConnectionGroup: (connectionGroupId: string) => void;
-  updateConnectionGroup: (connectionGroup: SuperplaneConnectionGroup) => void;
-  updateStage: (stage: SuperplaneStage) => void;
+  updateConnectionGroup: (connectionGroup: ConnectionGroupWithEvents) => void;
+  updateStage: (stage: StageWithEventQueue) => void;
   addEventSource: (eventSource: EventSourceWithEvents, autoLayout?: boolean) => void;
   removeEventSource: (eventSourceId: string) => void;
   updateEventSource: (eventSource: EventSourceWithEvents) => void;
@@ -47,6 +47,8 @@ export interface CanvasState {
   updateWebSocketConnectionStatus: (status: ReadyState) => void;
   syncStageEvents: (canvasId: string, stageId: string) => Promise<void>;
   syncEventSourceEvents: (canvasId: string, eventSourceId: string) => Promise<void>;
+  syncStagePlainEvents: (canvasId: string, stageId: string) => Promise<void>;
+  syncConnectionGroupPlainEvents: (canvasId: string, connectionGroupId: string) => Promise<void>;
 
   // flow fields
   nodes: AllNodeType[];
@@ -89,6 +91,7 @@ export interface CanvasState {
   setLockedNodes: (locked: boolean) => void;
 }
 
-export type StageWithEventQueue = SuperplaneStage & {queue: Array<SuperplaneStageEvent>; isDraft?: boolean}
+export type StageWithEventQueue = SuperplaneStage & {queue: Array<SuperplaneStageEvent>; events: Array<SuperplaneEvent>; isDraft?: boolean}
 export type EventSourceWithEvents = SuperplaneEventSource & {events: Array<SuperplaneEvent>; eventSourceType?: string; eventFilters?: Array<EventSourceEventType>}
+export type ConnectionGroupWithEvents = SuperplaneConnectionGroup & {events: Array<SuperplaneEvent>}
 export type ExecutionWithEvent = SuperplaneExecution & {event: SuperplaneStageEvent}

--- a/web_src/src/pages/canvas/types/events/index.ts
+++ b/web_src/src/pages/canvas/types/events/index.ts
@@ -1,5 +1,5 @@
-import { SuperplaneStage, SuperplaneCanvas, SuperplaneConnectionGroup } from "@/api-client";
-import { EventSourceWithEvents } from "../../store/types";
+import { SuperplaneCanvas } from "@/api-client";
+import { ConnectionGroupWithEvents, EventSourceWithEvents, StageWithEventQueue } from "../../store/types";
 
 export type ExecutionPayload = { id: string; stage_id: string; canvas_id: string; result: string; timestamp: string }
 export type StageEventPayload = { stage_id: string; source_id: string, timestamp: string };
@@ -7,9 +7,9 @@ export type EventPayload = { id: string; stage_id: string; source_id: string, so
 
 // event_name: payload_type
 export type EventMap = {
-    stage_added: SuperplaneStage;
-    connection_group_added: SuperplaneConnectionGroup;
-    stage_updated: SuperplaneStage;
+    stage_added: StageWithEventQueue;
+    connection_group_added: ConnectionGroupWithEvents;
+    stage_updated: StageWithEventQueue;
     event_source_added: EventSourceWithEvents;
     canvas_updated: SuperplaneCanvas;
     new_stage_event: StageEventPayload;

--- a/web_src/src/pages/canvas/types/index.ts
+++ b/web_src/src/pages/canvas/types/index.ts
@@ -1,9 +1,9 @@
-import { SuperplaneCanvas, SuperplaneConnectionGroup } from "@/api-client";
-import { EventSourceWithEvents, StageWithEventQueue } from "@/canvas/store/types";
+import { SuperplaneCanvas } from "@/api-client";
+import { ConnectionGroupWithEvents, EventSourceWithEvents, StageWithEventQueue } from "@/canvas/store/types";
 
 export interface CanvasData {
   canvas: SuperplaneCanvas;
   stages: StageWithEventQueue[];
   eventSources: EventSourceWithEvents[];
-  connectionGroups: SuperplaneConnectionGroup[];
+  connectionGroups: ConnectionGroupWithEvents[];
 }

--- a/web_src/src/pages/canvas/utils/nodeHandlers.ts
+++ b/web_src/src/pages/canvas/utils/nodeHandlers.ts
@@ -1,6 +1,6 @@
 import { useCanvasStore } from '../store/canvasStore';
 import { NodeType, createEmptyNode, CreateNodeParams } from './nodeFactories';
-import { EventSourceWithEvents } from '../store/types';
+import { ConnectionGroupWithEvents, EventSourceWithEvents, StageWithEventQueue } from '../store/types';
 
 /**
  * Hook that provides modular node handling functionality
@@ -21,7 +21,13 @@ export const useNodeHandlers = (canvasId: string) => {
       switch (nodeType) {
         case 'stage': {
           const stage = createEmptyNode('stage', params);
-          addStage(stage, true); // true = draft mode
+          const stageWithEventQueue: StageWithEventQueue = {
+            ...stage,
+            queue: [],
+            events: [],
+            isDraft: true
+          };
+          addStage(stageWithEventQueue, true); // true = draft mode
           return stage.metadata?.id || '';
         }
         
@@ -39,7 +45,11 @@ export const useNodeHandlers = (canvasId: string) => {
         
         case 'connection_group': {
           const connectionGroup = createEmptyNode('connection_group', params);
-          addConnectionGroup(connectionGroup);
+          const connectionGroupWithEvents: ConnectionGroupWithEvents = {
+            ...connectionGroup,
+            events: [],
+          };
+          addConnectionGroup(connectionGroupWithEvents);
           return connectionGroup.metadata?.id || '';
         }
         

--- a/web_src/src/pages/canvas/utils/stageUpdateQueue.ts
+++ b/web_src/src/pages/canvas/utils/stageUpdateQueue.ts
@@ -1,0 +1,88 @@
+/**
+ * Stage Update Queue System
+ * 
+ * Prevents race conditions between syncStageEvents and pollStageUntilNoPending
+ * by queuing operations per stage ID and executing them serially.
+ */
+
+type StageUpdateOperation = {
+  stageId: string;
+  operation: () => Promise<void>;
+  priority: 'high' | 'normal';
+};
+
+class StageUpdateQueue {
+  private queues: Map<string, StageUpdateOperation[]> = new Map();
+  private processing: Set<string> = new Set();
+
+  /**
+   * Add an operation to the queue for a specific stage
+   */
+  async enqueue(stageId: string, operation: () => Promise<void>, priority: 'high' | 'normal' = 'normal'): Promise<void> {
+    const op: StageUpdateOperation = { stageId, operation, priority };
+    
+    if (!this.queues.has(stageId)) {
+      this.queues.set(stageId, []);
+    }
+    
+    const queue = this.queues.get(stageId)!;
+    
+    if (priority === 'high') {
+      // Insert high priority operations at the front
+      queue.unshift(op);
+    } else {
+      queue.push(op);
+    }
+    
+    // Start processing if not already running
+    if (!this.processing.has(stageId)) {
+      this.processQueue(stageId);
+    }
+  }
+
+  private async processQueue(stageId: string): Promise<void> {
+    if (this.processing.has(stageId)) {
+      return;
+    }
+
+    this.processing.add(stageId);
+    const queue = this.queues.get(stageId);
+    
+    if (!queue) {
+      this.processing.delete(stageId);
+      return;
+    }
+
+    while (queue.length > 0) {
+      const operation = queue.shift()!;
+      
+      try {
+        await operation.operation();
+      } catch (error) {
+        console.error(`Stage update operation failed for stage ${stageId}:`, error);
+      }
+    }
+    
+    this.processing.delete(stageId);
+    this.queues.delete(stageId);
+  }
+
+  /**
+   * Check if a stage has pending operations
+   */
+  hasPendingOperations(stageId: string): boolean {
+    const queue = this.queues.get(stageId);
+    return (queue && queue.length > 0) || this.processing.has(stageId);
+  }
+
+  /**
+   * Get the number of pending operations for a stage
+   */
+  getPendingCount(stageId: string): number {
+    const queue = this.queues.get(stageId);
+    return queue ? queue.length : 0;
+  }
+}
+
+// Global singleton instance
+export const stageUpdateQueue = new StageUpdateQueue();


### PR DESCRIPTION
- unify history event queue and run components at history Tab
- Add stage update queue to avoid racing conditions while updating stage, since we were having events inconsistencies
- Add both emmited and source event in run item

<img width="436" height="807" alt="image" src="https://github.com/user-attachments/assets/6a6441bd-e86e-4833-8dc1-1f4490ee36c2" />
<img width="486" height="802" alt="image" src="https://github.com/user-attachments/assets/888e5c41-0dcb-4752-941d-bec7d0ce55d4" />

