### PR TITLE
fix: put overflow ellipsis in IO tooltip value

### DIFF
--- a/web_src/src/pages/canvas/components/nodes/IOTooltip.tsx
+++ b/web_src/src/pages/canvas/components/nodes/IOTooltip.tsx
@@ -23,7 +23,7 @@ export function IOTooltip({ type, data, children }: IOTooltipProps) {
                     <div key={index} className="flex items-center justify-between">
                       <span className="text-xs text-gray-600 dark:text-zinc-300 font-medium">{item.name || 'Unknown'}</span>
                       <div className="flex items-center gap-2">
-                        <span className="font-mono !text-xs inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10">{item.value || 'N/A'}</span>
+                        <span className="font-mono !text-xs rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 truncate max-w-40 inline-block">{item.value || 'N/A'}</span>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
fix: put overflow ellipsis in IO tooltip value

<img width="647" height="594" alt="image" src="https://github.com/user-attachments/assets/5e99cd85-d5f7-4886-91b7-29e832df7dc8" />
