### PR TITLE
refactor: update design of message item and runitem do display inputs within payload display

### DIFF
--- a/web_src/src/pages/canvas/components/MessageItem.tsx
+++ b/web_src/src/pages/canvas/components/MessageItem.tsx
@@ -171,46 +171,6 @@ const MessageItem = React.memo(({
         {isExpanded && (
           <div className="text-left mt-3 space-y-3">
             <div className="mt-3 space-y-3">
-              {/* Show inputs for stage events */}
-              {isStageEvent(event) && (
-                <>
-                  {Object.keys(inputsRecord).length > 0 ? (
-                    <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                      <div className="flex items-start gap-3">
-                        <div className="flex-1">
-                          <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Inputs</div>
-                          <div className="space-y-1">
-                            {Object.entries(inputsRecord).map(([key, value]) => (
-                              <div key={key} className="flex items-center justify-between gap-2 min-w-0">
-                                <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
-                                <div className="flex items-center gap-2 flex-shrink-0">
-                                  <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
-                                    {value}
-                                  </span>
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                      <div className="flex items-start gap-3">
-                        <div className="flex-1">
-                          <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Inputs</div>
-                          <div className="space-y-1">
-                            <div className="flex items-center justify-between">
-                              <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium">No inputs</span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-
               {/* Show payload/headers for plain events */}
               {isPlainEvent(event) && (plainEventPayload || plainEventHeaders) && (
                 <PayloadDisplay
@@ -222,10 +182,12 @@ const MessageItem = React.memo(({
                   sourceName={event.sourceName}
                   headers={plainEventHeaders}
                   payload={plainEventPayload}
+                  inputs={inputsRecord}
+                  rounded={false}
                 />
               )}
 
-              {/* Show payload/headers for plain events */}
+              {/* Show payload/headers for stage events */}
               {isStageEvent(event) && sourceEvent && (plainEventPayload || plainEventHeaders) && (
                 <PayloadDisplay
                   showDetailsTab={true}
@@ -236,6 +198,8 @@ const MessageItem = React.memo(({
                   sourceName={sourceEvent.sourceName}
                   headers={plainEventHeaders}
                   payload={plainEventPayload}
+                  inputs={inputsRecord}
+                  rounded={false}
                 />
               )}
             </div>

--- a/web_src/src/pages/canvas/components/PayloadDisplay.tsx
+++ b/web_src/src/pages/canvas/components/PayloadDisplay.tsx
@@ -44,9 +44,9 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
   const hasOutputs = Object.keys(displayOutputs).length > 0;
 
   const getDefaultTab = (): TabType => {
-    if (showDetailsTab) return 'details';
     if (hasInputs) return 'inputs';
     if (hasOutputs) return 'outputs';
+    if (showDetailsTab) return 'details';
     if (hasHeaders) return 'headers';
     if (hasPayload) return 'payload';
     return 'details';
@@ -174,7 +174,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
         return (
           <div>
             <div className="space-y-2">
-              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 max-h-60 overflow-y-auto">
                 {Object.keys(displayHeaders).length > 0 ? (
                   <div className="space-y-2">
                     {Object.entries(displayHeaders).map(([key, value]) => (
@@ -217,7 +217,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
                 </a>
               </div>
             </div>
-            <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+            <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 max-h-60 overflow-y-auto">
               {Object.keys(displayPayload).length > 0 ? (
                 <pre className="text-xs font-mono text-gray-900 dark:text-zinc-200 whitespace-pre-wrap">
                   {JSON.stringify(displayPayload, null, 2)}
@@ -234,7 +234,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
         return (
           <div>
             <div className="space-y-2">
-              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 max-h-60 overflow-y-auto">
                 {Object.keys(displayInputs).length > 0 ? (
                   <div className="space-y-2">
                     {Object.entries(displayInputs).map(([key, value]) => (
@@ -261,7 +261,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
         return (
           <div>
             <div className="space-y-2">
-              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 max-h-60 overflow-y-auto">
                 {Object.keys(displayOutputs).length > 0 ? (
                   <div className="space-y-2">
                     {Object.entries(displayOutputs).map(([key, value]) => (
@@ -300,9 +300,9 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
         <div className="border-b border-gray-200 dark:border-zinc-700">
           <div className="w-full border-b border-zinc-200 dark:border-zinc-700">
             <nav className="flex gap-0">
-              {showDetailsTab && renderTabButton('details', 'Details')}
               {hasInputs && renderTabButton('inputs', 'Inputs')}
               {hasOutputs && renderTabButton('outputs', 'Outputs')}
+              {showDetailsTab && renderTabButton('details', 'Details')}
               {hasHeaders && renderTabButton('headers', 'Headers')}
               {hasPayload && renderTabButton('payload', 'Payload')}
             </nav>

--- a/web_src/src/pages/canvas/components/PayloadDisplay.tsx
+++ b/web_src/src/pages/canvas/components/PayloadDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+import { twMerge } from 'tailwind-merge';
 
 interface PayloadDisplayProps {
   headers?: { [key: string]: unknown };
@@ -11,9 +12,13 @@ interface PayloadDisplayProps {
   eventType?: string;
   sourceName?: string;
   showDetailsTab?: boolean;
+  // Inputs/Outputs props
+  inputs?: Record<string, string>;
+  outputs?: Record<string, string>;
+  rounded?: boolean;
 }
 
-type TabType = 'details' | 'headers' | 'payload';
+type TabType = 'details' | 'headers' | 'payload' | 'inputs' | 'outputs';
 
 export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
   headers,
@@ -23,16 +28,25 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
   state,
   eventType,
   sourceName,
-  showDetailsTab = false
+  showDetailsTab = false,
+  inputs,
+  outputs,
+  rounded = true,
 }) => {
   const displayHeaders = headers || {};
   const displayPayload = payload || {};
+  const displayInputs = inputs || {};
+  const displayOutputs = outputs || {};
 
   const hasHeaders = Object.keys(displayHeaders).length > 0;
   const hasPayload = Object.keys(displayPayload).length > 0;
-  
+  const hasInputs = Object.keys(displayInputs).length > 0;
+  const hasOutputs = Object.keys(displayOutputs).length > 0;
+
   const getDefaultTab = (): TabType => {
     if (showDetailsTab) return 'details';
+    if (hasInputs) return 'inputs';
+    if (hasOutputs) return 'outputs';
     if (hasHeaders) return 'headers';
     if (hasPayload) return 'payload';
     return 'details';
@@ -130,7 +144,7 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
                 <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-1">STATE</div>
                 <div className="text-blue-600 dark:text-blue-400 text-xs font-medium">
                   <div className="flex items-center gap-2">
-                    <div className={`w-2 h-2 ${stateConfig.dotColor} ${stateConfig.animate ? 'animate-pulse' : ''} rounded-full flex-shrink-0`}></div>
+                    <div className={`w-2 h-2 ${stateConfig.dotColor} ${stateConfig.animate ? 'animate-pulse' : ''} ${rounded ? 'rounded-full' : 'rounded'} flex-shrink-0`}></div>
                     <span className={`text-xs font-medium ${stateConfig.textColor}`}>{stateConfig.label}</span>
                   </div>
                 </div>
@@ -216,23 +230,79 @@ export const PayloadDisplay: React.FC<PayloadDisplayProps> = ({
             </div>
           </div>
         );
+      case 'inputs':
+        return (
+          <div>
+            <div className="space-y-2">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+                {Object.keys(displayInputs).length > 0 ? (
+                  <div className="space-y-2">
+                    {Object.entries(displayInputs).map(([key, value]) => (
+                      <div key={key} className="flex justify-between">
+                        <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium pr-2 flex-shrink-0">
+                          {key}
+                        </span>
+                        <span className="text-xs font-mono text-gray-900 dark:text-zinc-200 break-all">
+                          {value || '-'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-xs text-gray-500 dark:text-zinc-400 italic">
+                    No inputs available
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      case 'outputs':
+        return (
+          <div>
+            <div className="space-y-2">
+              <div className="bg-zinc-50 dark:bg-zinc-800 rounded border border-gray-200 dark:border-zinc-700 p-3 h-60 max-h-60 overflow-y-auto">
+                {Object.keys(displayOutputs).length > 0 ? (
+                  <div className="space-y-2">
+                    {Object.entries(displayOutputs).map(([key, value]) => (
+                      <div key={key} className="flex justify-between">
+                        <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium pr-2 flex-shrink-0">
+                          {key}
+                        </span>
+                        <span className="text-xs font-mono text-gray-900 dark:text-zinc-200 break-all">
+                          {value || '-'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-xs text-gray-500 dark:text-zinc-400 italic">
+                    No outputs available
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
       default:
         return null;
     }
   };
 
   // Don't render if no data to display
-  if (!hasHeaders && !hasPayload && !showDetailsTab) {
+  if (!hasHeaders && !hasPayload && !hasInputs && !hasOutputs && !showDetailsTab) {
     return null;
   }
 
   return (
     <div className="mt-3" onClick={(e) => e.stopPropagation()}>
-      <div className="border border-gray-200 dark:border-zinc-700 rounded-lg bg-white dark:bg-zinc-900">
+      <div className={twMerge(`border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900`, rounded ? 'rounded-lg' : '')}>
         <div className="border-b border-gray-200 dark:border-zinc-700">
           <div className="w-full border-b border-zinc-200 dark:border-zinc-700">
             <nav className="flex gap-0">
               {showDetailsTab && renderTabButton('details', 'Details')}
+              {hasInputs && renderTabButton('inputs', 'Inputs')}
+              {hasOutputs && renderTabButton('outputs', 'Outputs')}
               {hasHeaders && renderTabButton('headers', 'Headers')}
               {hasPayload && renderTabButton('payload', 'Payload')}
             </nav>

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -200,7 +200,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
             {(Object.keys(inputs).length > 0 || Object.keys(outputs).length > 0 || (emmitedEvent && (emmitedEventPayload || emmitedEventHeaders))) && (
               <div className="space-y-3">
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
-                  Run Details
+                  Run
                 </div>
                 <div>
                   <PayloadDisplay
@@ -224,7 +224,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
             {(queuedOn || approvedOn || approvedBy) && (
               <div className="space-y-3">
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
-                  Queue Details
+                  Queue
                 </div>
 
                 <div className="bg-zinc-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 p-4 text-xs">
@@ -280,7 +280,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
             {sourceEvent && (sourceEventPayload || sourceEventHeaders) && (
               <div className="space-y-3">
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
-                  Trigger Details
+                  Trigger Event
                 </div>
 
                 <PayloadDisplay

--- a/web_src/src/pages/canvas/components/tabs/RunItem.tsx
+++ b/web_src/src/pages/canvas/components/tabs/RunItem.tsx
@@ -202,66 +202,21 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
                   Run Details
                 </div>
-
-                {Object.keys(inputs).length > 0 && (
-                  <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                    <div className="flex items-start gap-3">
-                      <div className="flex-1">
-                        <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Inputs</div>
-                        <div className="space-y-1">
-                          {Object.entries(inputs).map(([key, value]) => (
-                            <div key={key} className="flex items-center justify-between gap-2 min-w-0">
-                              <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
-                              <div className="flex items-center gap-2 flex-shrink-0">
-                                <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
-                                  {value || '-'}
-                                </span>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {Object.keys(outputs).length > 0 && (
-                  <div className="border border-gray-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50 dark:bg-zinc-800">
-                    <div className="flex items-start gap-3">
-                      <div className="flex-1">
-                        <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-1 font-bold">Outputs</div>
-                        <div className="space-y-1">
-                          {Object.entries(outputs).map(([key, value]) => (
-                            <div key={key} className="flex items-center justify-between gap-2 min-w-0">
-                              <span className="text-xs text-gray-600 dark:text-zinc-400 font-medium font-mono truncate">{key}</span>
-                              <div className="flex items-center gap-2 flex-shrink-0">
-                                <span className="font-mono !text-xs truncate inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10 max-w-32">
-                                  {value || '-'}
-                                </span>
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {emmitedEvent && (emmitedEventPayload || emmitedEventHeaders) && (
-                  <div>
-                    <div className="text-xs text-gray-700 dark:text-zinc-400 uppercase tracking-wide mb-2 font-bold">Emitted Event</div>
-                    <PayloadDisplay
-                      showDetailsTab={true}
-                      eventId={emmitedEvent.id}
-                      timestamp={emmitedEvent.receivedAt}
-                      state={emmitedEvent.state}
-                      eventType={emmitedEvent.type}
-                      sourceName={emmitedEvent.sourceName}
-                      headers={emmitedEventHeaders}
-                      payload={emmitedEventPayload}
-                    />
-                  </div>
-                )}
+                <div>
+                  <PayloadDisplay
+                    showDetailsTab={false}
+                    eventId={emmitedEvent?.id}
+                    timestamp={emmitedEvent?.receivedAt}
+                    state={emmitedEvent?.state}
+                    eventType={emmitedEvent?.type}
+                    sourceName={emmitedEvent?.sourceName}
+                    headers={emmitedEventHeaders}
+                    payload={emmitedEventPayload}
+                    inputs={inputs}
+                    outputs={outputs}
+                    rounded={false}
+                  />
+                </div>
               </div>
             )}
 
@@ -273,7 +228,6 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                 </div>
 
                 <div className="bg-zinc-50 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 p-4 text-xs">
-                  <div className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-2">Queue Metadata</div>
                   <div className="space-y-1">
                     {queuedOn && (
                       <div className="flex items-center gap-1">
@@ -322,11 +276,11 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
               </div>
             )}
 
-            {/* Event Details Section */}
+            {/* Trigger Event Details Section */}
             {sourceEvent && (sourceEventPayload || sourceEventHeaders) && (
               <div className="space-y-3">
                 <div className="text-sm font-semibold text-gray-700 dark:text-zinc-300 uppercase tracking-wide border-b border-gray-200 dark:border-zinc-700 pb-1">
-                  Event Details
+                  Trigger Details
                 </div>
 
                 <PayloadDisplay
@@ -338,6 +292,7 @@ export const RunItem: React.FC<RunItemProps> = React.memo(({
                   sourceName={sourceEvent.sourceName}
                   headers={sourceEventHeaders}
                   payload={sourceEventPayload}
+                  rounded={false}
                 />
               </div>
             )}


### PR DESCRIPTION
### Changes
Updated runitem and message item design to display inputs in the same tab view an payload display.
Also, removed some repetitive information
<img width="890" height="1216" alt="image" src="https://github.com/user-attachments/assets/9b6d5cd0-1e78-4fef-b89e-929d71943698" />
