### PR TITLE
fix: do not specify GitHub scope

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -53,7 +53,7 @@ func (a *Handler) InitializeProviders(providers map[string]ProviderConfig) {
 
 		switch providerName {
 		case models.ProviderGitHub:
-			gothProviders = append(gothProviders, github.New(config.Key, config.Secret, config.CallbackURL, models.ScopeUser))
+			gothProviders = append(gothProviders, github.New(config.Key, config.Secret, config.CallbackURL))
 			log.Infof("GitHub OAuth provider initialized")
 		default:
 			log.Warnf("Unknown provider: %s", providerName)

--- a/pkg/models/constants.go
+++ b/pkg/models/constants.go
@@ -4,7 +4,6 @@ import "fmt"
 
 const (
 	ProviderGitHub = "github"
-	ScopeUser      = "user"
 
 	DomainTypeOrganization = "org"
 	DomainTypeCanvas       = "canvas"


### PR DESCRIPTION
Fixes https://github.com/superplanehq/superplane/issues/239

Not using a scope grants read-only access to public information only (including user profile info, repository info, and gists). See https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps