### PR TITLE
feat: add new instrucitons for Required permissions in SemaphoreInteg…

### DIFF
--- a/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
+++ b/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
@@ -79,7 +79,7 @@ export function SemaphoreIntegrationForm({
           <div className="flex-1">
             <div className="text-sm font-medium text-gray-900 dark:text-white">Connect Semaphore with your API Token</div>
             <p className="text-sm text-zinc-700 dark:text-zinc-300 mt-1">
-              To connect Semaphore, create an API Token in your account page and paste it below.
+              To connect Semaphore, create an API Token in your account settings and paste it below.
             </p>
             <button
               type="button"

--- a/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
+++ b/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
@@ -77,7 +77,7 @@ export function SemaphoreIntegrationForm({
             <MaterialSymbol name="info" size="md" />
           </div>
           <div className="flex-1">
-            <div className="text-sm font-medium text-gray-900 dark:text-white">Connect Semaphore with your Semaphore API Token</div>
+            <div className="text-sm font-medium text-gray-900 dark:text-white">Connect Semaphore with your API Token</div>
             <p className="text-sm text-zinc-700 dark:text-zinc-300 mt-1">
               To connect Semaphore, create an API Token in your Semaphore settings and paste it below.
             </p>

--- a/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
+++ b/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
@@ -79,7 +79,7 @@ export function SemaphoreIntegrationForm({
           <div className="flex-1">
             <div className="text-sm font-medium text-gray-900 dark:text-white">Connect Semaphore with your API Token</div>
             <p className="text-sm text-zinc-700 dark:text-zinc-300 mt-1">
-              To connect Semaphore, create an API Token in your Semaphore settings and paste it below.
+              To connect Semaphore, create an API Token in your account page and paste it below.
             </p>
             <button
               type="button"

--- a/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
+++ b/web_src/src/components/IntegrationZeroState/SemaphoreIntegrationForm.tsx
@@ -3,6 +3,7 @@ import { Field, Label, ErrorMessage } from '../Fieldset/fieldset';
 import { Input } from '../Input/input';
 import { semaphoreConfig } from './integrationConfigs';
 import type { BaseIntegrationFormProps } from './types';
+import { MaterialSymbol } from '../MaterialSymbol/material-symbol';
 
 export function SemaphoreIntegrationForm({
   integrationData,
@@ -11,6 +12,7 @@ export function SemaphoreIntegrationForm({
   setErrors,
   orgUrlRef
 }: BaseIntegrationFormProps) {
+  const [showSemaphoreTokenInfo, setShowSemaphoreTokenInfo] = useState(false);
   const [dirtyByUser, setDirtyByUser] = useState(false);
 
   const handleOrgUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -69,6 +71,46 @@ export function SemaphoreIntegrationForm({
         />
         {errors.name && <ErrorMessage>{errors.name}</ErrorMessage>}
       </Field>
+      <div className="rounded-md border border-gray-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 p-4">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 text-zinc-600 dark:text-zinc-300">
+            <MaterialSymbol name="info" size="md" />
+          </div>
+          <div className="flex-1">
+            <div className="text-sm font-medium text-gray-900 dark:text-white">Connect Semaphore with your Semaphore API Token</div>
+            <p className="text-sm text-zinc-700 dark:text-zinc-300 mt-1">
+              To connect Semaphore, create an API Token in your Semaphore settings and paste it below.
+            </p>
+            <button
+              type="button"
+              className="mt-2 text-sm text-blue-600 dark:text-blue-300 hover:underline"
+              aria-expanded={showSemaphoreTokenInfo}
+              onClick={() => setShowSemaphoreTokenInfo(v => !v)}
+            >
+              {showSemaphoreTokenInfo ? 'Hide steps' : 'Show steps to create your token'}
+            </button>
+            {showSemaphoreTokenInfo && (
+              <div className="mt-3 space-y-2 text-sm text-zinc-700 dark:text-zinc-300">
+                <ol className="list-decimal ml-5 mt-1 space-y-1">
+                  <li>
+                    You can find your token by visiting your <a className="text-blue-600 dark:text-blue-400 underline!" href="https://me.semaphoreci.com/account" target="_blank" rel="noopener noreferrer">account settings</a>.
+                  </li>
+                  <li>Click on <strong>Regenerate API Token</strong></li>
+                  <li>Check if your Role has the <a className="text-blue-600 dark:text-blue-400 underline!" href="https://docs.semaphore.io/using-semaphore/rbac#org-member" target="_blank" rel="noopener noreferrer">required permissions</a> in the organization:</li>
+                  <ul className="list-disc ml-5 mt-1 space-y-1">
+                    <li><strong>Secrets</strong> → View and Manage</li>
+                    <li><strong>Notifications</strong> → View and Manage</li>
+                  </ul>
+                  <li>Copy and paste the token here</li>
+                </ol>
+                <p className="text-xs text-zinc-600 dark:text-zinc-400 mt-2">
+                  Tip: You can check your current organization role at the People page of your organization. Check the <a className="text-blue-600 dark:text-blue-400 underline!" href="https://docs.semaphore.io/using-semaphore/rbac" target="_blank" rel="noopener noreferrer">Role Based Access Control (RBAC)</a> documentation for more information.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Add new instructions for the semaphore integration modal just like we have for GitHub PAT:

<img width="438" height="828" alt="image" src="https://github.com/user-attachments/assets/704df029-9e7e-4edd-a758-e289ce5a33c6" />

