### PR TITLE
refactor: expand connections and executor config if they are not configured

### DIFF
--- a/web_src/src/pages/canvas/components/AccordionItem.tsx
+++ b/web_src/src/pages/canvas/components/AccordionItem.tsx
@@ -11,7 +11,7 @@ interface AccordionItemProps {
 
 export const AccordionItem = memo(function AccordionItem({ id, title, children, isOpen, onToggle, className }: AccordionItemProps) {
   return (
-    <div className="border-b border-zinc-200 dark:border-zinc-700">
+    <div className="border-b border-zinc-200 dark:border-zinc-700 last:border-b-0">
       <button
         className={`w-full px-4 py-3 text-left flex justify-between items-center hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors ${className || ''}`}
         onClick={() => onToggle(id)}

--- a/web_src/src/pages/canvas/components/AccordionItem.tsx
+++ b/web_src/src/pages/canvas/components/AccordionItem.tsx
@@ -6,13 +6,14 @@ interface AccordionItemProps {
   children: React.ReactNode;
   isOpen: boolean;
   onToggle: (id: string) => void;
+  className?: string;
 }
 
-export const AccordionItem = memo(function AccordionItem({ id, title, children, isOpen, onToggle }: AccordionItemProps) {
+export const AccordionItem = memo(function AccordionItem({ id, title, children, isOpen, onToggle, className }: AccordionItemProps) {
   return (
     <div className="border-b border-zinc-200 dark:border-zinc-700">
       <button
-        className="w-full px-4 py-3 text-left flex justify-between items-center hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
+        className={`w-full px-4 py-3 text-left flex justify-between items-center hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors ${className || ''}`}
         onClick={() => onToggle(id)}
       >
         <div className={`${isOpen ? 'font-bold' : 'font-normal'} text-zinc-900 dark:text-zinc-100 w-full`}>{title}</div>

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -1727,7 +1727,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
               isModified={isSectionModified(executor, 'executor')}
               onRevert={revertSection}
               countLabel="executor"
-              className="rounded-lg"
+              className={!openSections.includes('executor') ? 'rounded-b-2xl border-b-0' : ''}
             >
               <div className="space-y-4">
                 {/* Executor Label - Universal field for all executor types */}

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -325,7 +325,8 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
         errors.executorRef = 'Ref (branch/tag) is required';
       }
     } else if (executor.type === 'http') {
-      if (!executor.spec.url || !/^https?:\/\//.test(executor.spec.url as string)) {
+      const urlRegex = /^https?:\/\/(www\.)?([-a-zA-Z0-9@:%._+~#=]{1,256}(\.[a-zA-Z0-9()]{1,6})?|(\d{1,3}\.){3}\d{1,3})(:\d+)?([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/;
+      if (!executor.spec.url || !urlRegex.test(executor.spec.url as string)) {
         errors.executorUrl = 'Valid URL is required';
       }
     }

--- a/web_src/src/pages/canvas/components/nodes/stage.tsx
+++ b/web_src/src/pages/canvas/components/nodes/stage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import type { NodeProps } from '@xyflow/react';
 import CustomBarHandle from './handle';
@@ -36,6 +36,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
   const [stageName, setStageName] = useState(props.data.name || '');
   const [stageDescription, setStageDescription] = useState(props.data.description || '');
   const [nameError, setNameError] = useState<string | null>(null);
+  const triggerSectionValidationRef = useRef<(() => void) | null>(null);
   const { selectStageId, updateStage, setEditingStage, removeStage, approveStageEvent } = useCanvasStore();
   const allStages = useCanvasStore(state => state.stages);
   const nodes = useCanvasStore(state => state.nodes);
@@ -189,6 +190,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
     }
 
     if (!currentFormData.isValid) {
+      triggerSectionValidationRef?.current?.();
       return;
     }
 
@@ -541,6 +543,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
             canvasId={canvasId}
             organizationId={organizationId!}
             onDataChange={handleDataChange}
+            onTriggerSectionValidation={triggerSectionValidationRef}
           />
         ) : (
           <>

--- a/web_src/src/pages/canvas/components/shared/EditableAccordionSection.tsx
+++ b/web_src/src/pages/canvas/components/shared/EditableAccordionSection.tsx
@@ -15,6 +15,7 @@ interface EditableAccordionSectionProps {
   children: React.ReactNode;
   validationError?: string;
   className?: string;
+  hasError?: boolean;
 }
 
 export function EditableAccordionSection({
@@ -29,12 +30,13 @@ export function EditableAccordionSection({
   requiredBadge = false,
   children,
   validationError,
-  className
+  className,
+  hasError = false
 }: EditableAccordionSectionProps) {
   const titleContent = (
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-2">
-        <span className="text-sm text-zinc-600 dark:text-zinc-100">{title}</span>
+        <span className={`text-sm ${hasError ? 'text-red-600 dark:text-red-400' : 'text-zinc-600 dark:text-zinc-100'}`}>{title}</span>
         <RevertButton
           sectionId={id}
           isModified={isModified}

--- a/web_src/src/pages/canvas/components/shared/EditableAccordionSection.tsx
+++ b/web_src/src/pages/canvas/components/shared/EditableAccordionSection.tsx
@@ -14,6 +14,7 @@ interface EditableAccordionSectionProps {
   requiredBadge?: boolean;
   children: React.ReactNode;
   validationError?: string;
+  className?: string;
 }
 
 export function EditableAccordionSection({
@@ -27,7 +28,8 @@ export function EditableAccordionSection({
   countLabel,
   requiredBadge = false,
   children,
-  validationError
+  validationError,
+  className
 }: EditableAccordionSectionProps) {
   const titleContent = (
     <div className="flex items-center justify-between w-full">
@@ -58,6 +60,7 @@ export function EditableAccordionSection({
       title={titleContent}
       isOpen={isOpen}
       onToggle={onToggle}
+      className={className}
     >
       <div className="space-y-2">
         {validationError && (

--- a/web_src/src/pages/canvas/utils/nodeFactories.ts
+++ b/web_src/src/pages/canvas/utils/nodeFactories.ts
@@ -45,6 +45,9 @@ export const createEmptyStage = ({ canvasId, name = 'New Stage', executorType, c
       case 'http':
         return {
           type: 'http',
+          spec: {
+            url: '',
+          },
         };
       default:
         return { type: '', spec: {} };

--- a/web_src/src/pages/canvas/utils/nodeFactories.ts
+++ b/web_src/src/pages/canvas/utils/nodeFactories.ts
@@ -24,7 +24,7 @@ export const createEmptyStage = ({ canvasId, name = 'New Stage', executorType, c
         return {
           type: 'semaphore',
           integration: {
-            name: 'semaphore',
+            name: '',
           },
           resource: {
             type: 'project',
@@ -35,7 +35,7 @@ export const createEmptyStage = ({ canvasId, name = 'New Stage', executorType, c
         return {
           type: 'github',
           integration: {
-            name: 'github',
+            name: '',
           },
           resource: {
             type: 'repository',


### PR DESCRIPTION
## Changes

This PR applies changes in 'StageEditModeContent.tsx'. More specifically to the validation of the stage and and executor.

Including: 
- When creating - Connections is expanded (if not configured), Executor is expanded (both are showing red text that they have to be configured) 
- There's no Add executor button you can have only one executor
- When executor is saved, it's collapsed, no need to have that "semaphore executor" minimised item
- On Api errors it should also open the executor config. The error fallback with a toast will be added in another pr.
- Added to open sections on Stage Actions "Save" validation


<img width="287" height="672" alt="image" src="https://github.com/user-attachments/assets/f59d6825-a476-4b5f-a03e-d7fd3c49a4eb" />
<img width="338" height="700" alt="image" src="https://github.com/user-attachments/assets/5b12464a-a233-418b-8913-4c526715ac9a" />
