### PR TITLE
refactor: redesign of close and confirm buttons

### DIFF
--- a/web_src/src/pages/canvas/components/shared/CloseAndCheckButtons.tsx
+++ b/web_src/src/pages/canvas/components/shared/CloseAndCheckButtons.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@/components/Button/button";
+
+const CloseAndCheckButtons = ({
+  onCancel,
+  onConfirm
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+}) => {
+  return (
+    <div className="flex justify-end gap-1 pt-2 pb-3">
+      <Button
+        className="flex items-center border-0"
+        outline
+        onClick={onCancel}
+      >
+        <span className="material-symbols-outlined select-none inline-flex items-center justify-center !text-sm" aria-hidden="true">close</span>
+      </Button>
+      <Button
+        className="flex items-center justify-center"
+        color="white"
+        onClick={onConfirm}
+      >
+        <span className="material-symbols-outlined select-none inline-flex items-center justify-center !text-sm" aria-hidden="true">check</span>
+      </Button>
+    </div>
+  );
+};
+
+export default CloseAndCheckButtons;

--- a/web_src/src/pages/canvas/components/shared/InlineEditor.tsx
+++ b/web_src/src/pages/canvas/components/shared/InlineEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button } from '@/components/Button/button';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+import CloseAndCheckButtons from './CloseAndCheckButtons';
 
 interface InlineEditorProps {
   isEditing: boolean;
@@ -29,15 +29,7 @@ export function InlineEditor({
     return (
       <div className={`border border-zinc-200 dark:border-zinc-700 rounded-lg p-3 space-y-3 ${className}`}>
         {editForm}
-        <div className="flex justify-end gap-2 pt-2">
-          <Button outline onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button color="blue" onClick={onSave}>
-            <MaterialSymbol name="save" size="sm" data-slot="icon" />
-            Save
-          </Button>
-        </div>
+        <CloseAndCheckButtons onCancel={onCancel} onConfirm={onSave} />
       </div>
     );
   }


### PR DESCRIPTION
### Changes

Update design of close and confirm buttons to only use icons buttons:
<img width="854" height="508" alt="image" src="https://github.com/user-attachments/assets/ac3c3eeb-14a5-4907-a3a7-c224882cca5a" />
