### PR TITLE
refactor: Inputs mappings validation and implicit creation

### DIFF
--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -1237,7 +1237,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
                                                     onChange={() => handleValueModeChange('lastExecution', actualMappingIndex, input)}
                                                     className="w-4 h-4"
                                                   />
-                                                  From Last Execution
+                                                  Inherit value from last execution
                                                 </label>
                                               </div>
                                             </div>

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -496,6 +496,11 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
       sectionsToOpen.push('connections');
     }
 
+    const inputErrors = Object.keys(validationErrors).some(key => key.startsWith('input_'));
+    if (inputErrors && !sectionsToOpen.includes('inputs')) {
+      sectionsToOpen.push('inputs');
+    }
+
     const executorErrors = validateExecutor(executor);
     if (Object.keys(executorErrors).length > 0 || hasFieldErrors) {
       if (!sectionsToOpen.includes('executor')) {
@@ -508,7 +513,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
     }
 
     setOpenSections(sectionsToOpen);
-  }, [connections.length, executor, openSections, setOpenSections, setValidationErrors, validateExecutor]);
+  }, [connections.length, executor, openSections, setOpenSections, setValidationErrors, validateExecutor, validationErrors]);
 
   // Expose the trigger function to parent
   useEffect(() => {
@@ -524,6 +529,11 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
     const connectionsNeedConfiguration = connections.length === 0;
     if (connectionsNeedConfiguration) {
       sectionsToOpen.push('connections');
+    }
+
+    const inputErrors = Object.keys(validationErrors).some(key => key.startsWith('input_'));
+    if (inputErrors) {
+      sectionsToOpen.push('inputs');
     }
 
     const executorErrors = validateExecutor(executor);
@@ -1109,6 +1119,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
               onRevert={revertSection}
               count={inputs.length}
               countLabel="inputs"
+              hasError={Object.keys(validationErrors).some(key => key.startsWith('input_'))}
             >
               {inputs.map((input, index) => {
                 // Get mappings for this specific input


### PR DESCRIPTION
### This PR fixes the following issues related to Inputs specifically:

- When creating input, I should already have mappings created equal to amount of connections - P2/E2
- Mappings should not be removable as long as they are mandatory - P2/E2
- Each mapping should have Connection preselected - P2/E3
- If I add new connection and new mapping is added - make sure you're validating INPUTS when I try to Save - P1/E2
- When using "From Event Data" remove "Data Source Connection" from UI and always set it in the background to same value as Triggered By - P2/E2
- "From Event Source" placeholder eg. $.commit[0].message - P3/E3
- "From Last Execution" > "Inherit value from last execution" - passed and failed preselected - P3/E3

<img width="424" height="1268" alt="image" src="https://github.com/user-attachments/assets/a0ebe177-f9d6-49fe-b979-fd4f395703bc" />
