### PR TITLE
fix: always initialize resource and integration from source

### DIFF
--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -54,7 +54,12 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
   const [connections, setConnections] = useState<SuperplaneConnection[]>(data.connections || []);
   const [secrets, setSecrets] = useState<SuperplaneValueDefinition[]>(data.secrets || []);
   const [conditions, setConditions] = useState<SuperplaneCondition[]>(data.conditions || []);
-  const [executor, setExecutor] = useState<SuperplaneExecutor>({ type: data.executor?.type || '', spec: data.executor?.spec || {} });
+  const [executor, setExecutor] = useState<SuperplaneExecutor>({
+    type: data.executor?.type || '',
+    spec: data.executor?.spec || {},
+    resource: data.executor?.resource || {},
+    integration: data.executor?.integration || {},
+  });
   const [inputMappings, setInputMappings] = useState<SuperplaneInputMapping[]>(data.inputMappings || []);
   const [responsePolicyStatusCodesDisplay, setResponsePolicyStatusCodesDisplay] = useState(
     ((executor.spec?.responsePolicy as Record<string, unknown>)?.statusCodes as number[] || []).join(', ')


### PR DESCRIPTION
fix: always initialize resource and integration from source, unless issues like this happen at first render:
<img width="446" height="478" alt="image" src="https://github.com/user-attachments/assets/e82827d4-5232-405f-a06b-7f664c5e99d7" />
