### PR TITLE
fix: stage deletion not working when stage event approvals exist

### DIFF
--- a/db/migrations/20250916194326_add-cascade-delete-to-stage-event-approvals.up.sql
+++ b/db/migrations/20250916194326_add-cascade-delete-to-stage-event-approvals.up.sql
@@ -1,0 +1,12 @@
+begin;
+
+-- Drop the existing foreign key constraint
+ALTER TABLE stage_event_approvals
+DROP CONSTRAINT stage_event_approvals_stage_event_id_fkey;
+
+-- Add the foreign key constraint with CASCADE deletion
+ALTER TABLE stage_event_approvals
+ADD CONSTRAINT stage_event_approvals_stage_event_id_fkey
+FOREIGN KEY (stage_event_id) REFERENCES stage_events(id) ON DELETE CASCADE;
+
+commit;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict fKYlVLv4VZuIzQRaR1gFhzQCJQUYPCi0kIAZPzb96QeeHnbhNn1MqFiMvwC6SMo
+\restrict d0wjNX1MTbwtllrvNXn4uVKAa0cPGce3cyEprUVaCnrOeXgAIvtHvVLtStg9jUd
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
@@ -836,6 +836,13 @@ CREATE INDEX idx_canvases_deleted_at ON public.canvases USING btree (deleted_at)
 
 
 --
+-- Name: idx_casbin_rule; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_casbin_rule ON public.casbin_rule USING btree (ptype, v0, v1, v2, v3, v4, v5);
+
+
+--
 -- Name: idx_casbin_rule_ptype; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1091,7 +1098,7 @@ ALTER TABLE ONLY public.connections
 --
 
 ALTER TABLE ONLY public.stage_event_approvals
-    ADD CONSTRAINT stage_event_approvals_stage_event_id_fkey FOREIGN KEY (stage_event_id) REFERENCES public.stage_events(id);
+    ADD CONSTRAINT stage_event_approvals_stage_event_id_fkey FOREIGN KEY (stage_event_id) REFERENCES public.stage_events(id) ON DELETE CASCADE;
 
 
 --
@@ -1154,13 +1161,13 @@ ALTER TABLE ONLY public.users
 -- PostgreSQL database dump complete
 --
 
-\unrestrict fKYlVLv4VZuIzQRaR1gFhzQCJQUYPCi0kIAZPzb96QeeHnbhNn1MqFiMvwC6SMo
+\unrestrict d0wjNX1MTbwtllrvNXn4uVKAa0cPGce3cyEprUVaCnrOeXgAIvtHvVLtStg9jUd
 
 --
 -- PostgreSQL database dump
 --
 
-\restrict zoDaMqcoofd39OdHE5Hqyw4YsEjFAbb0wr9ouklidjJD5mwbHdESgPc5CHCBe51
+\restrict okP7aQ2YZfoS11J0CyWJiCxKtih5NNeClLZslnSuGD2FWY6zKEcp9jAUtdm2aaM
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
 -- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg13+1)
@@ -1182,7 +1189,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20250915181443	f
+20250916194326	f
 \.
 
 
@@ -1190,5 +1197,5 @@ COPY public.schema_migrations (version, dirty) FROM stdin;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict zoDaMqcoofd39OdHE5Hqyw4YsEjFAbb0wr9ouklidjJD5mwbHdESgPc5CHCBe51
+\unrestrict okP7aQ2YZfoS11J0CyWJiCxKtih5NNeClLZslnSuGD2FWY6zKEcp9jAUtdm2aaM
 


### PR DESCRIPTION
### Issue

Worker is failing due to delete stage that has stage event approvals. It fails with:

```text
Failed to hard delete stage: failed to delete stage events: ERROR: update or delete on table "stage_events" violates foreign key constraint "stage_event_approvals_stage_event_id_fkey" on table "stage_event_approvals”
```

### Solution

Delete stage_event_approvals in cascade in the database, by updating the foreign key for that table.