### PR TITLE
refactor: event source UI fixes

### DIFF
--- a/web_src/src/pages/canvas/components/EventSourceBadges.tsx
+++ b/web_src/src/pages/canvas/components/EventSourceBadges.tsx
@@ -21,6 +21,8 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
     0
   ) || 0;
 
+  const totalEventTypes = currentEventSource?.spec?.events?.length || 0;
+
   const getResourceTypeLabel = useCallback(() => {
     if (eventSourceType === 'github') return 'Repository';
     if (eventSourceType === 'semaphore') return 'Project';
@@ -68,10 +70,14 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
       });
     }
 
-    if (totalFilters > 0) {
+    if (totalFilters > 0 || totalEventTypes > 0) {
+      const filterText = totalFilters > 0
+        ? `${totalFilters} Event ${totalFilters === 1 ? 'filter' : 'filters'}`
+        : `${totalEventTypes} Event ${totalEventTypes === 1 ? 'type' : 'types'}`;
+
       badges.push({
         icon: 'filter_list',
-        text: `${totalFilters} Event ${totalFilters === 1 ? 'filter' : 'filters'}`,
+        text: filterText,
         tooltip: (
           <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-4 min-w-[280px]">
             <div className="space-y-3">
@@ -107,7 +113,7 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
     }
 
     return badges;
-  }, [resourceName, cleanResourceName, totalFilters, currentEventSource, integration, getResourceTypeLabel, getFilterTypeLabel, getFilterExpression]);
+  }, [resourceName, cleanResourceName, totalFilters, totalEventTypes, currentEventSource, integration, getResourceTypeLabel, getFilterTypeLabel, getFilterExpression]);
 
   if (badgeItems.length === 0) return null;
 

--- a/web_src/src/pages/canvas/components/FilterTooltip.tsx
+++ b/web_src/src/pages/canvas/components/FilterTooltip.tsx
@@ -1,0 +1,70 @@
+import Tippy from '@tippyjs/react/headless';
+import { ReactElement } from 'react';
+
+interface FilterTooltipProps {
+  children: React.ReactNode;
+}
+
+export function FilterTooltip({ children }: FilterTooltipProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Tippy
+        render={() => (
+          <div className="min-w-[300px] max-w-sm">
+            <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-4 text-sm z-50">
+              <div className="font-semibold mb-3 text-zinc-900 dark:text-zinc-100">Filter Examples</div>
+              <div className="space-y-2">
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">$.type == "push"</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">Match specific event type</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">$.ref == "refs/heads/main"</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">GitHub branch filter</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">$.action in ["opened", "closed"]</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">Multiple values</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">$.payload.size {'>'}  100</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">Numeric comparison</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">has($.repository.private)</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">Check field exists</div>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2">
+                  <span className="text-zinc-500 text-base leading-none mt-1">•</span>
+                  <div>
+                    <code className="bg-zinc-100 dark:bg-zinc-700 px-2 py-1 rounded text-xs font-mono text-zinc-800 dark:text-zinc-200">$.branch matches "^feature/"</code>
+                    <div className="text-xs text-zinc-600 dark:text-zinc-400 mt-1">Regex pattern</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        placement="top"
+        interactive={true}
+      >
+        {children as ReactElement}
+      </Tippy>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes
This PR fixes:

- For event type use default instead of placeholder (GH: push, Semaphore:pipeline_done) - P3/E3
- If only event type is configured - filter tag should still appear in View mode - P2/E2
- If you add a filter - use $.ref=="heads/refs/main" as default for GH and $.pipeline.state=="done" for Semaphore (confirm/test if syntax is correct) - P3/E3
- Add question mark with tooltip for filters (give few examples in tooltip) - P2/E3
- Filters description - Pro tip: You can use [Expr](https://expr-lang.org/docs/language-definition) expressions to parse the payload data. - P2/E3