### PR TITLE
patch(ui): Improve error messages Added note for GH integration modal.

### DIFF
--- a/web_src/src/components/IntegrationZeroState/GitHubIntegrationForm.tsx
+++ b/web_src/src/components/IntegrationZeroState/GitHubIntegrationForm.tsx
@@ -52,6 +52,9 @@ export function GitHubIntegrationForm({
           className="w-full"
         />
         {errors.orgUrl && <ErrorMessage>{errors.orgUrl}</ErrorMessage>}
+        <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-2">
+          <span className="font-semibold">Note:</span> The organization or user profile you enter here must match the owner of the Personal Access Token (PAT) you provide below.
+        </div>
       </Field>
 
       <Field>

--- a/web_src/src/pages/canvas/components/EventSourceEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/EventSourceEditModeContent.tsx
@@ -176,7 +176,7 @@ export function EventSourceEditModeContent({
       if (errorMessage.includes('project')) {
         errors.resourceName = 'Project not found. Please check the project name and ensure it exists in Semaphore.';
       } else if (errorMessage.includes('repository')) {
-        errors.resourceName = 'Repository not found. Please check the repository name and ensure it exists.';
+        errors.resourceName = 'Repository not found. Please check the repository name and ensure your Personal Access Token (PAT) has access to it.';
       }
     }
 

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -166,7 +166,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
     if (repositoryNotFoundMatch) {
       return {
         field: 'repository',
-        message: `Repository "${repositoryNotFoundMatch[1]}" not found`
+        message: `Repository "${repositoryNotFoundMatch[1]}" not found. Please check that the repository exists and that your Personal Access Token (PAT) has access to it.`
       };
     }
 


### PR DESCRIPTION
- **Clearer GitHub Integration**: Added a warning to the GitHub integration form to ensure the PAT owner matches the specified organization/user, preventing common setup errors.
- **Actionable Error Messages**: The "repository not found" error now prompts users to check their PAT access, providing a clear next step for troubleshooting.