### PR TITLE
refactor(ui): provide event templates in EmitEventModal when no events has been emitted by node

### DIFF
--- a/web_src/src/components/EmitEventModal/EmitEventModal.stories.tsx
+++ b/web_src/src/components/EmitEventModal/EmitEventModal.stories.tsx
@@ -8,6 +8,7 @@ import { SuperplaneEvent } from '@/api-client'
 function ModalWrapper({
   isOpen: initialIsOpen = false,
   sourceName = 'Test Event Source',
+  nodeType = 'event_source',
   loadLastEvent,
   simulateLoading = false
 }: Partial<React.ComponentProps<typeof EmitEventModal>> & {
@@ -30,6 +31,7 @@ function ModalWrapper({
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         sourceName={sourceName}
+        nodeType={nodeType}
         loadLastEvent={loadLastEvent || defaultLoadLastEvent}
         onCancel={() => {}}
         onSubmit={async (eventType, eventData) => {
@@ -51,6 +53,10 @@ const meta: Meta<typeof ModalWrapper> = {
     sourceName: {
       control: 'text',
     },
+    nodeType: {
+      control: 'select',
+      options: ['event_source', 'stage'],
+    },
     isOpen: {
       control: 'boolean',
     },
@@ -66,6 +72,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     sourceName: 'GitHub Webhook',
+    nodeType: 'event_source',
     isOpen: false,
   },
 }
@@ -73,6 +80,7 @@ export const Default: Story = {
 export const WithLastEvent: Story = {
   args: {
     sourceName: 'Slack Webhook',
+    nodeType: 'event_source',
     isOpen: false,
     loadLastEvent: async () => ({
       id: 'event-123',
@@ -95,6 +103,7 @@ export const WithLastEvent: Story = {
 export const LoadingState: Story = {
   args: {
     sourceName: 'API Webhook',
+    nodeType: 'event_source',
     isOpen: false,
     simulateLoading: true,
   },
@@ -103,6 +112,15 @@ export const LoadingState: Story = {
 export const OpenedModal: Story = {
   args: {
     sourceName: 'GitHub Push',
+    nodeType: 'event_source',
+    isOpen: true,
+  },
+}
+
+export const StageTemplates: Story = {
+  args: {
+    sourceName: 'SuperPlane Stage',
+    nodeType: 'stage',
     isOpen: true,
   },
 }

--- a/web_src/src/components/EmitEventModal/EmitEventModal.tsx
+++ b/web_src/src/components/EmitEventModal/EmitEventModal.tsx
@@ -4,19 +4,313 @@ import Editor from '@monaco-editor/react';
 import { Input } from '@/components/Input/input';
 import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
 import { Button } from '@/components/Button/button';
+import { Select } from '@/components/Select';
 import { SuperplaneEvent } from '@/api-client';
+import GithubLogo from '@/assets/github-mark.svg';
+import SemaphoreLogo from '@/assets/semaphore-logo-sign-black.svg';
+
+interface EventTemplate {
+  name: string;
+  description?: string;
+  icon?: string;
+  image?: string;
+  eventType: string;
+  nodeType: 'event_source' | 'stage';
+  eventData: any;
+}
+
+const EVENT_TEMPLATES: EventTemplate[] = [
+  {
+    name: 'GitHub - Push Event',
+    description: 'Event emitted when code is pushed to a GitHub repository',
+    image: GithubLogo,
+    eventType: 'push',
+    nodeType: 'event_source' as const,
+    eventData: {
+      ref: "refs/heads/main",
+      before: "2364960799e343f8cb594a81b1f34e7219f8254a",
+      after: "7fcca06c1b2b2c482df382248610d46cfd789837",
+      repository: {
+        name: "superplane",
+        full_name: "superplanehq/superplane",
+        private: false,
+        owner: {
+          name: "superplanehq",
+          email: null,
+          login: "superplanehq",
+          avatar_url: "https://avatars.githubusercontent.com/u/210748804?v=4",
+          gravatar_id: "",
+          url: "https://api.github.com/users/superplanehq",
+          html_url: "https://github.com/superplanehq",
+          type: "Organization",
+          user_view_type: "public",
+          site_admin: false
+        },
+        html_url: "https://github.com/superplanehq/superplane",
+        description: null,
+        fork: false,
+        url: "https://api.github.com/repos/superplanehq/superplane",
+        created_at: 1746640119,
+        updated_at: "2025-09-24T18:47:53Z",
+        pushed_at: 1758745245,
+        git_url: "git://github.com/superplanehq/superplane.git",
+        ssh_url: "git@github.com:superplanehq/superplane.git",
+        clone_url: "https://github.com/superplanehq/superplane.git",
+        visibility: "public",
+        default_branch: "main",
+        master_branch: "main",
+        organization: "superplanehq",
+      },
+      pusher: {
+        name: "lucaspin",
+        email: "pinheiro.lucasaugusto@gmail.com"
+      },
+      organization: {
+        login: "superplanehq",
+        url: "https://api.github.com/orgs/superplanehq",
+        avatar_url: "https://avatars.githubusercontent.com/u/210748804?v=4",
+        description: null
+      },
+      sender: {
+        login: "lucaspin",
+        avatar_url: "https://avatars.githubusercontent.com/u/12387728?v=4",
+        gravatar_id: "",
+        url: "https://api.github.com/users/lucaspin",
+        html_url: "https://github.com/lucaspin",
+        type: "User",
+        user_view_type: "public",
+        site_admin: false
+      },
+      created: false,
+      deleted: false,
+      forced: false,
+      base_ref: null,
+      compare: "https://github.com/superplanehq/superplane/compare/2364960799e3...7fcca06c1b2b",
+      commits: [
+        {
+          id: "7fcca06c1b2b2c482df382248610d46cfd789837",
+          tree_id: "fb692ac9149f575c86374f7cd54e0ba703b03609",
+          distinct: true,
+          message: "refactor(ui): display only last processed event in event source node (#315)",
+          timestamp: "2025-09-24T17:20:44-03:00",
+          url: "https://github.com/superplanehq/superplane/commit/7fcca06c1b2b2c482df382248610d46cfd789837",
+          author: {
+            name: "Lucas Pinheiro",
+            email: "lpinheiro@semaphore.io",
+            username: "lucaspin"
+          },
+          committer: {
+            name: "GitHub",
+            email: "noreply@github.com",
+            username: "web-flow"
+          },
+          added: [],
+          removed: [
+            "pkg/openapi_client/model_status_history.go"
+          ],
+          modified: [
+            "api/swagger/superplane.swagger.json",
+            "pkg/grpc/actions/event_sources/create_event_source.go",
+            "pkg/grpc/actions/event_sources/describe_event_source.go",
+            "pkg/grpc/actions/event_sources/list_event_sources.go",
+            "pkg/grpc/actions/events/list_events.go",
+            "pkg/grpc/actions/events/list_events_test.go",
+            "pkg/grpc/canvas_service.go",
+            "pkg/models/event.go",
+            "pkg/models/event_source.go",
+            "pkg/openapi_client/.openapi-generator/FILES",
+            "pkg/openapi_client/api_event.go",
+            "pkg/openapi_client/model_superplane_event_source_status.go",
+            "pkg/protos/canvases/canvases.pb.go",
+            "protos/canvases.proto",
+            "web_src/src/api-client/types.gen.ts",
+            "web_src/src/hooks/useCanvasData.ts",
+            "web_src/src/pages/canvas/components/EventSourceSidebar.tsx",
+            "web_src/src/pages/canvas/components/EventStateItem.tsx",
+            "web_src/src/pages/canvas/components/nodes/event_source.tsx",
+            "web_src/src/pages/canvas/index.tsx"
+          ]
+        }
+      ],
+      head_commit: {
+        id: "7fcca06c1b2b2c482df382248610d46cfd789837",
+        tree_id: "fb692ac9149f575c86374f7cd54e0ba703b03609",
+        distinct: true,
+        message: "refactor(ui): display only last processed event in event source node (#315)",
+        timestamp: "2025-09-24T17:20:44-03:00",
+        url: "https://github.com/superplanehq/superplane/commit/7fcca06c1b2b2c482df382248610d46cfd789837",
+        author: {
+          name: "Lucas Pinheiro",
+          email: "lpinheiro@semaphore.io",
+          username: "lucaspin"
+        },
+        committer: {
+          name: "GitHub",
+          email: "noreply@github.com",
+          username: "web-flow"
+        },
+        added: [],
+        removed: [
+          "pkg/openapi_client/model_status_history.go"
+        ],
+        modified: [
+          "api/swagger/superplane.swagger.json",
+          "pkg/grpc/actions/event_sources/create_event_source.go",
+          "pkg/grpc/actions/event_sources/describe_event_source.go",
+          "pkg/grpc/actions/event_sources/list_event_sources.go",
+          "pkg/grpc/actions/events/list_events.go",
+          "pkg/grpc/actions/events/list_events_test.go",
+          "pkg/grpc/canvas_service.go",
+          "pkg/models/event.go",
+          "pkg/models/event_source.go",
+          "pkg/openapi_client/.openapi-generator/FILES",
+          "pkg/openapi_client/api_event.go",
+          "pkg/openapi_client/model_superplane_event_source_status.go",
+          "pkg/protos/canvases/canvases.pb.go",
+          "protos/canvases.proto",
+          "web_src/src/api-client/types.gen.ts",
+          "web_src/src/hooks/useCanvasData.ts",
+          "web_src/src/pages/canvas/components/EventSourceSidebar.tsx",
+          "web_src/src/pages/canvas/components/EventStateItem.tsx",
+          "web_src/src/pages/canvas/components/nodes/event_source.tsx",
+          "web_src/src/pages/canvas/index.tsx"
+        ]
+      }
+    }
+  },
+  {
+    name: 'Semaphore - Pipeline Done Event',
+    description: 'Event emitted when a Semaphore CI/CD pipeline completes',
+    image: SemaphoreLogo,
+    eventType: 'pipeline_done',
+    nodeType: 'event_source' as const,
+    eventData: {
+      version: "1.0.0",
+      organization: {
+        name: "test",
+        id: crypto.randomUUID()
+      },
+      project: {
+        name: "test",
+        id: crypto.randomUUID()
+      },
+      repository: {
+        url: "https://github.com/test/test",
+        slug: "test/test"
+      },
+      revision: {
+        sender: {
+          login: "testuser",
+          email: "1234567890+testuser@users.noreply.github.com",
+          avatar_url: "https://avatars2.githubusercontent.com/u/1234567890?v=4"
+        },
+        reference_type: "branch",
+        reference: "refs/heads/my-branch",
+        pull_request: null,
+        commit_sha: "2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563",
+        commit_message: "empty",
+        branch: {
+          name: "my-branch",
+          commit_range: "36ebdf6e906cf3491391442d2f779b512ca49485...2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563"
+        }
+      },
+      workflow: {
+        initial_pipeline_id: crypto.randomUUID(),
+        id: crypto.randomUUID(),
+        created_at: new Date().toISOString()
+      },
+      pipeline: {
+        yaml_file_name: "semaphore.yml",
+        working_directory: ".semaphore",
+        stopping_at: new Date().toISOString(),
+        state: "done",
+        running_at: new Date().toISOString(),
+        result_reason: "user",
+        result: "stopped",
+        queuing_at: new Date().toISOString(),
+        pending_at: new Date().toISOString(),
+        name: "Pipeline",
+        id: crypto.randomUUID(),
+        error_description: "",
+        done_at: new Date().toISOString(),
+        created_at: new Date().toISOString()
+      },
+      blocks: [
+        {
+          state: "done",
+          result_reason: "user",
+          result: "stopped",
+          name: "List & Test & Build",
+          jobs: [
+            {
+              status: "finished",
+              result: "stopped",
+              name: "Test",
+              index: 1,
+              id: crypto.randomUUID()
+            },
+            {
+              status: "finished",
+              result: "stopped",
+              name: "Build",
+              index: 2,
+              id: crypto.randomUUID()
+            },
+            {
+              status: "finished",
+              result: "passed",
+              name: "Lint",
+              index: 0,
+              id: crypto.randomUUID()
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name: 'Custom WebHook',
+    description: 'Create your own custom webhook event with custom data',
+    icon: 'webhook',
+    eventType: 'custom',
+    nodeType: 'event_source' as const,
+    eventData: {}
+  },
+  {
+    name: 'SuperPlane - Execution Finished Event',
+    description: 'Event emitted when a SuperPlane stage execution completes',
+    icon: 'task_alt',
+    eventType: 'execution_finished',
+    nodeType: 'stage' as const,
+    eventData: {
+      type: "execution_finished",
+      stage: {
+        id: crypto.randomUUID()
+      },
+      execution: {
+        created_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+        id: crypto.randomUUID(),
+        result: "passed",
+        result_message: "",
+        result_reason: ""
+      },
+    }
+  }
+];
 
 interface EmitEventModalProps {
   isOpen: boolean;
   onClose: () => void;
   sourceName: string;
+  nodeType: 'event_source' | 'stage';
   loadLastEvent: () => Promise<SuperplaneEvent | null>;
   onCancel?: () => void;
   onSubmit: (eventType: string, eventData: any) => Promise<void>;
 }
 
 
-export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onCancel, onSubmit }: EmitEventModalProps) {
+export function EmitEventModal({ isOpen, onClose, sourceName, nodeType, loadLastEvent, onCancel, onSubmit }: EmitEventModalProps) {
   const [eventType, setEventType] = useState('');
   const [rawEventData, setRawEventData] = useState('{}');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -24,6 +318,9 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
   const [jsonError, setJsonError] = useState<string | null>(null);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [isLoadingLastEvent, setIsLoadingLastEvent] = useState(false);
+  const [hasLastEvent, setHasLastEvent] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const availableTemplates = EVENT_TEMPLATES.filter(template => template.nodeType === nodeType);
 
   // Detect dark mode
   useEffect(() => {
@@ -46,6 +343,8 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
   useEffect(() => {
     if (isOpen) {
       setIsLoadingLastEvent(true);
+      setHasLastEvent(false);
+      setSelectedTemplate('');
       loadLastEvent()
         .then((event) => {
           if (event) {
@@ -53,10 +352,14 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
             if (event.raw) {
               setRawEventData(JSON.stringify(event.raw, null, 2));
             }
+            setHasLastEvent(true);
+          } else {
+            setHasLastEvent(false);
           }
         })
         .catch((error) => {
           console.error('Failed to load last event:', error);
+          setHasLastEvent(false);
         })
         .finally(() => {
           setIsLoadingLastEvent(false);
@@ -83,6 +386,14 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
     } else {
       setJsonError(null);
     }
+  };
+
+  const handleTemplateSelect = (template: EventTemplate) => {
+    setEventType(template.eventType);
+    setRawEventData(JSON.stringify(template.eventData, null, 2));
+    setSelectedTemplate(template.name);
+    setJsonError(null);
+    setError(null);
   };
 
   const handleSubmit = async () => {
@@ -122,6 +433,8 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
       setRawEventData('{}');
       setError(null);
       setJsonError(null);
+      setHasLastEvent(false);
+      setSelectedTemplate('');
       if (onCancel) {
         onCancel();
       }
@@ -134,96 +447,117 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-50/55 dark:bg-zinc-900/55">
       <div className="bg-white dark:bg-zinc-800 rounded-lg shadow-xl w-[85vw] h-[80vh] max-w-5xl flex flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-zinc-700">
-          <div className="flex items-center gap-3">
-            <MaterialSymbol name="send" size="lg" className="text-gray-700 dark:text-gray-300" />
-            <div>
-              <div className="text-xl font-semibold text-gray-900 dark:text-zinc-100">
-                Emit Event
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                Manually emit an event for "{sourceName}"
-              </div>
-            </div>
-          </div>
-          <button
-            onClick={handleClose}
-            disabled={isSubmitting}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-zinc-700 rounded-md transition-colors text-gray-600 dark:text-zinc-400"
-            title="Close"
-          >
-            <MaterialSymbol name="close" size="md" />
-          </button>
-        </div>
-
         {/* Body */}
-        <div className="flex-1 p-6 overflow-hidden flex flex-col">
+        <div className="flex-1 px-6 py-6 overflow-hidden flex flex-col">
           {isLoadingLastEvent ? (
             <div className="flex-1 flex items-center justify-center">
-              <div className="flex items-center gap-3 text-gray-600 dark:text-gray-400">
-                <MaterialSymbol name="hourglass_empty" className="animate-spin" size="lg" />
-                <span className="text-lg">Loading last event...</span>
+              <div className="text-center py-8">
+                <div className="inline-flex items-center justify-center w-16 h-16 mb-3">
+                  <div className="animate-spin rounded-full h-8 w-8 border-2 border-blue-600 border-t-transparent"></div>
+                </div>
+                <p className="text-zinc-600 dark:text-zinc-400 text-sm">Loading last emitted event...</p>
               </div>
             </div>
           ) : (
             <div className="flex-1 flex flex-col space-y-4">
-              <div>
-                <label htmlFor="eventType" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Event Type
-                </label>
-                <Input
-                  id="eventType"
-                  value={eventType}
-                  onChange={(e) => setEventType(e.target.value)}
-                  placeholder="e.g., webhook, push, deployment_complete"
-                  disabled={isSubmitting}
-                  className="w-full"
+              <div className="flex items-center gap-2 mb-4">
+                <MaterialSymbol
+                  name={hasLastEvent ? "history" : "info"}
+                  size="md"
+                  className={hasLastEvent ? "text-green-600 dark:text-green-400" : "text-blue-600 dark:text-blue-400"}
                 />
+                <div className="text-sm text-gray-900 dark:text-zinc-100">
+                  {hasLastEvent
+                    ? `Last event loaded. Modify it as needed before emitting a new event for "${sourceName}"`
+                    : `No events emitted yet. Choose a template to emit your first event for "${sourceName}"`
+                  }
+                </div>
               </div>
 
-              <div className="flex-1 flex flex-col">
-                <label htmlFor="rawData" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Event Data (JSON)
-                </label>
-                <div className="flex-1 border border-gray-300 dark:border-gray-600 rounded-md overflow-hidden">
-                  <Editor
-                    height="100%"
-                    defaultLanguage="json"
-                    value={rawEventData}
-                    onChange={handleRawDataChange}
-                    theme={isDarkMode ? 'vs-dark' : 'vs'}
-                    options={{
-                      minimap: { enabled: false },
-                      fontSize: 14,
-                      lineNumbers: 'on',
-                      rulers: [],
-                      wordWrap: 'on',
-                      folding: true,
-                      bracketPairColorization: {
-                        enabled: true
-                      },
-                      autoIndent: 'advanced',
-                      formatOnPaste: true,
-                      formatOnType: true,
-                      tabSize: 2,
-                      insertSpaces: true,
-                      scrollBeyondLastLine: false,
-                      renderWhitespace: 'boundary',
-                      smoothScrolling: true,
-                      cursorBlinking: 'smooth',
-                      readOnly: isSubmitting,
-                      contextmenu: true,
-                      selectOnLineNumbers: true
-                    }}
-                  />
+              {!hasLastEvent && (
+                <div className="flex items-center gap-3">
+                  <MaterialSymbol name="library_add" size="sm" className="text-gray-600 dark:text-gray-400" />
+                  <label className="text-xs font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap w-18">
+                    Template
+                  </label>
+                  <div className="flex-1">
+                    <Select
+                      options={availableTemplates.map(template => ({
+                        value: template.name,
+                        label: template.name,
+                        description: template.description,
+                        icon: template.icon,
+                        image: template.image
+                      }))}
+                      value={selectedTemplate}
+                      onChange={(templateName) => {
+                        const template = availableTemplates.find(t => t.name === templateName);
+                        if (template) handleTemplateSelect(template);
+                      }}
+                      placeholder="Select a template..."
+                    />
+                  </div>
                 </div>
-                {jsonError && (
-                  <p className="text-red-600 dark:text-red-400 text-sm mt-1">
-                    {jsonError}
-                  </p>
-                )}
-              </div>
+              )}
+
+              {(!hasLastEvent && selectedTemplate) || hasLastEvent ? (
+                <>
+                  <div className="flex items-center gap-3">
+                    <MaterialSymbol name="label" size="sm" className="text-gray-600 dark:text-gray-400" />
+                    <label htmlFor="eventType" className="text-xs font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap w-18">
+                      Event Type
+                    </label>
+                    <Input
+                      id="eventType"
+                      value={eventType}
+                      onChange={(e) => setEventType(e.target.value)}
+                      placeholder="e.g., webhook, push, deployment_complete"
+                      disabled={isSubmitting}
+                      className="flex-1"
+                    />
+                  </div>
+
+                  <div className="flex-1 flex flex-col">
+                    <div className="flex-1 border border-gray-300 dark:border-gray-600 rounded-md overflow-hidden">
+                      <Editor
+                        height="100%"
+                        defaultLanguage="json"
+                        value={rawEventData}
+                        onChange={handleRawDataChange}
+                        theme={isDarkMode ? 'vs-dark' : 'vs'}
+                        options={{
+                          minimap: { enabled: false },
+                          fontSize: 14,
+                          lineNumbers: 'on',
+                          rulers: [],
+                          wordWrap: 'on',
+                          folding: true,
+                          bracketPairColorization: {
+                            enabled: true
+                          },
+                          autoIndent: 'advanced',
+                          formatOnPaste: true,
+                          formatOnType: true,
+                          tabSize: 2,
+                          insertSpaces: true,
+                          scrollBeyondLastLine: false,
+                          renderWhitespace: 'boundary',
+                          smoothScrolling: true,
+                          cursorBlinking: 'smooth',
+                          readOnly: isSubmitting,
+                          contextmenu: true,
+                          selectOnLineNumbers: true
+                        }}
+                      />
+                    </div>
+                    {jsonError && (
+                      <p className="text-red-600 dark:text-red-400 text-sm mt-1">
+                        {jsonError}
+                      </p>
+                    )}
+                  </div>
+                </>
+              ) : null}
 
               {error && (
                 <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-3">
@@ -238,7 +572,7 @@ export function EmitEventModal({ isOpen, onClose, sourceName, loadLastEvent, onC
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800">
+        <div className="flex items-center justify-end gap-3 px-6 py-5 border-t border-gray-200 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-800">
           <Button onClick={handleClose} disabled={isSubmitting} outline>
             Cancel
           </Button>

--- a/web_src/src/components/EmitEventModal/EmitEventModal.tsx
+++ b/web_src/src/components/EmitEventModal/EmitEventModal.tsx
@@ -96,7 +96,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
           url: "https://github.com/superplanehq/superplane/commit/7fcca06c1b2b2c482df382248610d46cfd789837",
           author: {
             name: "Lucas Pinheiro",
-            email: "lpinheiro@semaphore.io",
+            email: "lucas@superplane.com",
             username: "lucaspin"
           },
           committer: {
@@ -141,7 +141,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
         url: "https://github.com/superplanehq/superplane/commit/7fcca06c1b2b2c482df382248610d46cfd789837",
         author: {
           name: "Lucas Pinheiro",
-          email: "lpinheiro@semaphore.io",
+          email: "lucas@superplane.com",
           username: "lucaspin"
         },
         committer: {
@@ -187,31 +187,30 @@ const EVENT_TEMPLATES: EventTemplate[] = [
     getEventData: () => ({
       version: "1.0.0",
       organization: {
-        name: "test",
+        name: "superplanehq",
         id: crypto.randomUUID()
       },
       project: {
-        name: "test",
+        name: "superplane",
         id: crypto.randomUUID()
       },
       repository: {
-        url: "https://github.com/test/test",
-        slug: "test/test"
+        url: "https://github.com/superplanehq/superplane",
+        slug: "superplanehq/superplane"
       },
       revision: {
         sender: {
-          login: "testuser",
-          email: "1234567890+testuser@users.noreply.github.com",
-          avatar_url: "https://avatars2.githubusercontent.com/u/1234567890?v=4"
+          login: "lucaspin",
+          email: "lucas@superplane.com",
         },
         reference_type: "branch",
-        reference: "refs/heads/my-branch",
+        reference: "refs/heads/main",
         pull_request: null,
-        commit_sha: "2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563",
-        commit_message: "empty",
+        commit_sha: "7fcca06c1b2b2c482df382248610d46cfd789837",
+        commit_message: "refactor(ui): display only last processed event in event source node (#315)",
         branch: {
-          name: "my-branch",
-          commit_range: "36ebdf6e906cf3491391442d2f779b512ca49485...2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563"
+          name: "main",
+          commit_range: "2364960799e343f8cb594a81b1f34e7219f8254a...7fcca06c1b2b2c482df382248610d46cfd789837"
         }
       },
       workflow: {
@@ -225,8 +224,8 @@ const EVENT_TEMPLATES: EventTemplate[] = [
         stopping_at: new Date().toISOString(),
         state: "done",
         running_at: new Date().toISOString(),
-        result_reason: "user",
-        result: "stopped",
+        result_reason: "",
+        result: "passed",
         queuing_at: new Date().toISOString(),
         pending_at: new Date().toISOString(),
         name: "Pipeline",
@@ -238,20 +237,20 @@ const EVENT_TEMPLATES: EventTemplate[] = [
       blocks: [
         {
           state: "done",
-          result_reason: "user",
-          result: "stopped",
+          result_reason: "",
+          result: "passed",
           name: "List & Test & Build",
           jobs: [
             {
               status: "finished",
-              result: "stopped",
+              result: "passed",
               name: "Test",
               index: 1,
               id: crypto.randomUUID()
             },
             {
               status: "finished",
-              result: "stopped",
+              result: "passed",
               name: "Build",
               index: 2,
               id: crypto.randomUUID()
@@ -468,8 +467,8 @@ export function EmitEventModal({ isOpen, onClose, sourceName, nodeType, loadLast
                 />
                 <div className="text-sm text-gray-900 dark:text-zinc-100">
                   {hasLastEvent
-                    ? `Last event loaded. Modify it as needed before emitting a new event for "${sourceName}"`
-                    : `No events emitted yet. Choose a template to emit your first event for "${sourceName}"`
+                    ? <>{`Last event loaded. Modify it as needed before emitting a new event for ${nodeType === 'event_source' ? 'event source' : 'stage'} `}<span className="font-mono bg-yellow-50 dark:bg-yellow-900/20 px-2 py-1 rounded">{sourceName}</span></>
+                    : <>{`No events emitted yet. Choose a template to emit your first event for ${nodeType === 'event_source' ? 'event source' : 'stage'} `}<span className="font-mono bg-yellow-50 dark:bg-yellow-900/20 px-2 py-1 rounded">{sourceName}</span></>
                   }
                 </div>
               </div>

--- a/web_src/src/components/EmitEventModal/EmitEventModal.tsx
+++ b/web_src/src/components/EmitEventModal/EmitEventModal.tsx
@@ -16,7 +16,7 @@ interface EventTemplate {
   image?: string;
   eventType: string;
   nodeType: 'event_source' | 'stage';
-  eventData: any;
+  getEventData: () => any;
 }
 
 const EVENT_TEMPLATES: EventTemplate[] = [
@@ -26,7 +26,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
     image: GithubLogo,
     eventType: 'push',
     nodeType: 'event_source' as const,
-    eventData: {
+    getEventData: () => ({
       ref: "refs/heads/main",
       before: "2364960799e343f8cb594a81b1f34e7219f8254a",
       after: "7fcca06c1b2b2c482df382248610d46cfd789837",
@@ -176,7 +176,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
           "web_src/src/pages/canvas/index.tsx"
         ]
       }
-    }
+    })
   },
   {
     name: 'Semaphore - Pipeline Done Event',
@@ -184,7 +184,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
     image: SemaphoreLogo,
     eventType: 'pipeline_done',
     nodeType: 'event_source' as const,
-    eventData: {
+    getEventData: () => ({
       version: "1.0.0",
       organization: {
         name: "test",
@@ -266,7 +266,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
           ]
         }
       ]
-    }
+    })
   },
   {
     name: 'Custom WebHook',
@@ -274,7 +274,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
     icon: 'webhook',
     eventType: 'custom',
     nodeType: 'event_source' as const,
-    eventData: {}
+    getEventData: () => ({})
   },
   {
     name: 'SuperPlane - Execution Finished Event',
@@ -282,7 +282,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
     icon: 'task_alt',
     eventType: 'execution_finished',
     nodeType: 'stage' as const,
-    eventData: {
+    getEventData: () => ({
       type: "execution_finished",
       stage: {
         id: crypto.randomUUID()
@@ -295,7 +295,7 @@ const EVENT_TEMPLATES: EventTemplate[] = [
         result_message: "",
         result_reason: ""
       },
-    }
+    })
   }
 ];
 
@@ -390,7 +390,7 @@ export function EmitEventModal({ isOpen, onClose, sourceName, nodeType, loadLast
 
   const handleTemplateSelect = (template: EventTemplate) => {
     setEventType(template.eventType);
-    setRawEventData(JSON.stringify(template.eventData, null, 2));
+    setRawEventData(JSON.stringify(template.getEventData(), null, 2));
     setSelectedTemplate(template.name);
     setJsonError(null);
     setError(null);

--- a/web_src/src/components/ScheduleConfiguration/index.tsx
+++ b/web_src/src/components/ScheduleConfiguration/index.tsx
@@ -11,9 +11,9 @@ interface ScheduleConfigurationProps {
 }
 
 const SCHEDULE_TYPE_OPTIONS = [
-  { value: 'TYPE_HOURLY', label: 'Hourly' },
-  { value: 'TYPE_DAILY', label: 'Daily' },
-  { value: 'TYPE_WEEKLY', label: 'Weekly' },
+  { value: 'TYPE_HOURLY', label: 'Hourly', icon: 'schedule' },
+  { value: 'TYPE_DAILY', label: 'Daily', icon: 'today' },
+  { value: 'TYPE_WEEKLY', label: 'Weekly', icon: 'calendar_view_week' },
 ];
 
 const WEEKDAY_OPTIONS = [

--- a/web_src/src/components/Select/index.tsx
+++ b/web_src/src/components/Select/index.tsx
@@ -6,6 +6,9 @@ import { twMerge } from 'tailwind-merge'
 export interface SelectOption {
   value: string
   label: string
+  description?: string
+  icon?: string
+  image?: string
 }
 
 export interface SelectProps {
@@ -145,12 +148,31 @@ export function Select({
           className
         )}
       >
-        <span className={twMerge(
-          'block truncate',
-          !selectedOption && 'text-zinc-500 dark:text-zinc-400'
-        )}>
-          {selectedOption ? selectedOption.label : placeholder}
-        </span>
+        <div className="flex items-center min-w-0 flex-1">
+          {(selectedOption?.image || selectedOption?.icon) && (
+            <div className="w-4 h-4 mr-2 flex-shrink-0 flex items-center justify-center">
+              {selectedOption?.image && (
+                <img
+                  src={selectedOption.image}
+                  alt=""
+                  className="w-4 h-4 dark:bg-white dark:rounded-sm dark:p-0.5"
+                />
+              )}
+              {selectedOption?.icon && !selectedOption?.image && (
+                <MaterialSymbol
+                  name={selectedOption.icon}
+                  size="sm"
+                />
+              )}
+            </div>
+          )}
+          <span className={twMerge(
+            'block truncate',
+            !selectedOption && 'text-zinc-500 dark:text-zinc-400'
+          )}>
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+        </div>
         <MaterialSymbol
           name={isOpen ? "expand_less" : "expand_more"}
           size="sm"
@@ -178,24 +200,50 @@ export function Select({
                     key={option.value}
                     role="option"
                     aria-selected={isSelected}
-                    className="relative cursor-pointer select-none px-3 py-2 text-sm hover:bg-blue-500 hover:text-white text-zinc-900 dark:text-zinc-100"
+                    className="relative cursor-pointer select-none px-3 py-2 text-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 text-zinc-900 dark:text-zinc-100 transition-colors duration-150"
                     onClick={(e) => {
                       e.preventDefault()
                       handleOptionSelect(option.value)
                     }}
                   >
                     <div className="flex items-center justify-between">
-                      <span className={twMerge(
-                        'block truncate',
-                        isSelected ? 'font-medium' : 'font-normal'
-                      )}>
-                        {option.label}
-                      </span>
+                      <div className="flex items-center min-w-0 flex-1">
+                        {(option.image || option.icon) && (
+                          <div className="w-4 h-4 mr-2 flex-shrink-0 flex items-center justify-center">
+                            {option.image && (
+                              <img
+                                src={option.image}
+                                alt=""
+                                className="w-4 h-4 dark:bg-white dark:rounded-sm dark:p-0.5"
+                              />
+                            )}
+                            {option.icon && !option.image && (
+                              <MaterialSymbol
+                                name={option.icon}
+                                size="sm"
+                              />
+                            )}
+                          </div>
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <span className={twMerge(
+                            'block truncate',
+                            isSelected ? 'font-medium' : 'font-normal'
+                          )}>
+                            {option.label}
+                          </span>
+                          {option.description && (
+                            <span className="block truncate text-xs text-zinc-500 dark:text-zinc-400">
+                              {option.description}
+                            </span>
+                          )}
+                        </div>
+                      </div>
                       {isSelected && (
                         <MaterialSymbol
                           name="check"
                           size="sm"
-                          className="text-blue-500"
+                          className="text-blue-500 ml-2 flex-shrink-0"
                         />
                       )}
                     </div>

--- a/web_src/src/pages/canvas/components/nodes/event_source.tsx
+++ b/web_src/src/pages/canvas/components/nodes/event_source.tsx
@@ -611,6 +611,7 @@ export default function EventSourceNode(props: NodeProps<EventSourceNodeType>) {
           isOpen={showEmitEventModal}
           onClose={() => setShowEmitEventModal(false)}
           sourceName={currentEventSource.metadata.name || ''}
+          nodeType="event_source"
           loadLastEvent={async () => {
             // For event sources, return the latest event immediately
             return currentEventSource.events?.[0] || null;

--- a/web_src/src/pages/canvas/components/nodes/stage.tsx
+++ b/web_src/src/pages/canvas/components/nodes/stage.tsx
@@ -786,6 +786,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
             isOpen={showEmitEventModal}
             onClose={() => setShowEmitEventModal(false)}
             sourceName={currentStage.metadata.name || ''}
+            nodeType="stage"
             loadLastEvent={async () => {
               try {
                 const response = await superplaneListEvents(withOrganizationHeader({


### PR DESCRIPTION
This makes it easy to get started and play around when your manual trigger has no events yet.

#### Modal with last event

Same as before, just the styling changed to have more space for the actual event data

<img width="1304" height="691" alt="Screenshot 2025-09-25 at 08 11 20" src="https://github.com/user-attachments/assets/7c892a99-4f6e-4197-b900-706c8a080edc" />

#### Modal without last event

And if the node hasn't emitted anything yet, we should this:

<img width="1302" height="688" alt="Screenshot 2025-09-25 at 08 11 38" src="https://github.com/user-attachments/assets/e39f07cd-cc78-4759-9cfa-876d64c29cbe" />
