### PR TITLE
 feat: create event deletion worker

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -123,6 +123,13 @@ func startWorkers(jwtSigner *jwt.Signer, encryptor crypto.Encryptor, registry *r
 
 		go w.Start()
 	}
+
+	if os.Getenv("START_EVENT_DELETION_WORKER") == "yes" {
+		log.Println("Starting Event Deletion Worker")
+
+		w := workers.NewEventDeletionWorker()
+		go w.Start()
+	}
 }
 
 func startInternalAPI(encryptor crypto.Encryptor, authService authorization.Authorization, registry *registry.Registry) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,7 @@ services:
       START_PENDING_EVENT_SOURCES_WORKER: "yes"
       START_HARD_DELETION_WORKER: "yes"
       START_EVENT_SOURCE_SCHEDULE_WORKER: "yes"
+      START_EVENT_DELETION_WORKER: "yes"
       WEB_BASE_PATH: ""
       ENCRYPTION_KEY: 1234567890abcdefghijklmnopqrstuv
       JWT_SECRET: 1234567890abcdefghijklmnopqrstuv

--- a/pkg/workers/event_deletion_worker.go
+++ b/pkg/workers/event_deletion_worker.go
@@ -1,0 +1,55 @@
+package workers
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const (
+	WorkerDefaultInterval         = 24 * time.Hour
+	DefaultEventRetentionDuration = 3 * 30 * 24 * time.Hour // ~3 months
+)
+
+type EventDeletionWorker struct {
+	RetentionDuration time.Duration
+}
+
+func NewEventDeletionWorker() *EventDeletionWorker {
+	return &EventDeletionWorker{
+		RetentionDuration: DefaultEventRetentionDuration,
+	}
+}
+
+func (w *EventDeletionWorker) Start() {
+	for {
+		err := w.Tick()
+		if err != nil {
+			log.Errorf("Error processing event deletion: %v", err)
+		}
+
+		// Run once per day
+		time.Sleep(WorkerDefaultInterval)
+	}
+}
+
+func (w *EventDeletionWorker) Tick() error {
+	log.Info("Starting event deletion worker")
+
+	states := []string{models.EventStateRejected}
+
+	deletedCount, err := models.DeleteOldEvents(w.RetentionDuration, states)
+	if err != nil {
+		log.Errorf("Error deleting old events: %v", err)
+		return err
+	}
+
+	if deletedCount > 0 {
+		log.Infof("Successfully deleted %d old rejected events older than %v", deletedCount, w.RetentionDuration)
+	} else {
+		log.Info("No old rejected events to delete")
+	}
+
+	return nil
+}

--- a/pkg/workers/event_deletion_worker_test.go
+++ b/pkg/workers/event_deletion_worker_test.go
@@ -1,0 +1,140 @@
+package workers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func TestEventDeletionWorker_Tick(t *testing.T) {
+	r := support.SetupWithOptions(t, support.SetupOptions{})
+	defer r.Close()
+
+	canvasID := uuid.New()
+	sourceID := uuid.New()
+
+	oldTime := time.Now().Add(-4 * 30 * 24 * time.Hour)
+	oldRejectedEvent := models.Event{
+		SourceID:     sourceID,
+		CanvasID:     canvasID,
+		SourceName:   "test-source",
+		SourceType:   models.SourceTypeEventSource,
+		Type:         "test",
+		State:        models.EventStateRejected,
+		StateReason:  models.EventStateReasonFiltered,
+		StateMessage: "",
+		ReceivedAt:   &oldTime,
+		Raw:          datatypes.JSON([]byte(`{"test": "data"}`)),
+		Headers:      datatypes.JSON([]byte(`{}`)),
+	}
+
+	err := database.Conn().Create(&oldRejectedEvent).Error
+	require.NoError(t, err)
+
+	recentTime := time.Now().Add(-1 * 24 * time.Hour)
+	recentRejectedEvent := models.Event{
+		SourceID:     sourceID,
+		CanvasID:     canvasID,
+		SourceName:   "test-source",
+		SourceType:   models.SourceTypeEventSource,
+		Type:         "test",
+		State:        models.EventStateRejected,
+		StateReason:  models.EventStateReasonFiltered,
+		StateMessage: "",
+		ReceivedAt:   &recentTime,
+		Raw:          datatypes.JSON([]byte(`{"test": "data"}`)),
+		Headers:      datatypes.JSON([]byte(`{}`)),
+	}
+
+	err = database.Conn().Create(&recentRejectedEvent).Error
+	require.NoError(t, err)
+
+	oldProcessedEvent := models.Event{
+		SourceID:     sourceID,
+		CanvasID:     canvasID,
+		SourceName:   "test-source",
+		SourceType:   models.SourceTypeEventSource,
+		Type:         "test",
+		State:        models.EventStateProcessed,
+		StateReason:  models.EventStateReasonOk,
+		StateMessage: "",
+		ReceivedAt:   &oldTime,
+		Raw:          datatypes.JSON([]byte(`{"test": "data"}`)),
+		Headers:      datatypes.JSON([]byte(`{}`)),
+	}
+
+	err = database.Conn().Create(&oldProcessedEvent).Error
+	require.NoError(t, err)
+
+	var eventCount int64
+	err = database.Conn().Model(&models.Event{}).Count(&eventCount).Error
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), eventCount)
+
+	worker := NewEventDeletionWorker()
+	err = worker.Tick()
+	assert.NoError(t, err)
+
+	err = database.Conn().Model(&models.Event{}).Count(&eventCount).Error
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), eventCount)
+
+	var remainingEvents []models.Event
+	err = database.Conn().Find(&remainingEvents).Error
+	assert.NoError(t, err)
+	assert.Len(t, remainingEvents, 2)
+
+	eventIDs := make([]uuid.UUID, len(remainingEvents))
+	for i, event := range remainingEvents {
+		eventIDs[i] = event.ID
+	}
+
+	assert.Contains(t, eventIDs, recentRejectedEvent.ID)
+	assert.Contains(t, eventIDs, oldProcessedEvent.ID)
+	assert.NotContains(t, eventIDs, oldRejectedEvent.ID)
+}
+
+func TestEventDeletionWorker_CustomRetention(t *testing.T) {
+	r := support.SetupWithOptions(t, support.SetupOptions{})
+	defer r.Close()
+
+	canvasID := uuid.New()
+	sourceID := uuid.New()
+
+	oldTime := time.Now().Add(-2 * 24 * time.Hour)
+	rejectedEvent := models.Event{
+		SourceID:     sourceID,
+		CanvasID:     canvasID,
+		SourceName:   "test-source",
+		SourceType:   models.SourceTypeEventSource,
+		Type:         "test",
+		State:        models.EventStateRejected,
+		StateReason:  models.EventStateReasonFiltered,
+		StateMessage: "",
+		ReceivedAt:   &oldTime,
+		Raw:          datatypes.JSON([]byte(`{"test": "data"}`)),
+		Headers:      datatypes.JSON([]byte(`{}`)),
+	}
+
+	err := database.Conn().Create(&rejectedEvent).Error
+	require.NoError(t, err)
+
+	worker := &EventDeletionWorker{
+		RetentionDuration: 24 * time.Hour,
+	}
+
+	err = worker.Tick()
+	assert.NoError(t, err)
+
+	var eventCount int64
+	err = database.Conn().Model(&models.Event{}).Count(&eventCount).Error
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), eventCount)
+}


### PR DESCRIPTION
Issue: https://github.com/superplanehq/superplane/issues/163

Created Event Deletion worker with a default retention policy of 3 months.
The worker just deleted rejected events (filtered, or not accepted by any connections).