### PR TITLE
feat: links to component resources

### DIFF
--- a/web_src/src/components/ClickableBadge/ClickableBadge.tsx
+++ b/web_src/src/components/ClickableBadge/ClickableBadge.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Badge } from '@/components/Badge/badge';
+import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+import { ResourceLinkConfig } from '@/utils/resourceLinks';
+
+interface ClickableBadgeProps {
+  icon: string;
+  color?: 'zinc' | 'blue' | 'green' | 'yellow' | 'red' | 'indigo' | 'gray';
+  truncate?: boolean;
+  className?: string;
+  title?: string;
+  children: React.ReactNode;
+  resourceLinks?: ResourceLinkConfig[];
+  badgeText?: string;
+}
+
+export function ClickableBadge({
+  icon,
+  color = 'zinc',
+  truncate = false,
+  className = '',
+  title,
+  children,
+  resourceLinks = [],
+  badgeText
+}: ClickableBadgeProps) {
+  const getRelevantLink = (): ResourceLinkConfig | null => {
+    if (resourceLinks.length === 0) return null;
+
+    const text = badgeText || children?.toString() || '';
+
+
+    if (icon === 'assignment') {
+      const repoLink = resourceLinks.find(link =>
+        link.tooltip.includes('repository') || link.tooltip.includes('project')
+      );
+      return repoLink || resourceLinks[0];
+    }
+
+
+    if (icon === 'code') {
+      const fileLink = resourceLinks.find(link =>
+        link.tooltip.includes('pipeline file') ||
+        link.tooltip.includes('workflow file') ||
+        link.tooltip.includes(text)
+      );
+      return fileLink || null;
+    }
+
+
+    if (icon === 'graph_1') {
+      const branchLink = resourceLinks.find(link =>
+        link.tooltip.includes('at') && link.tooltip.includes(text)
+      );
+      return branchLink || resourceLinks[0];
+    }
+
+
+    return resourceLinks[0];
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    const relevantLink = getRelevantLink();
+    if (relevantLink) {
+      window.open(relevantLink.url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  const relevantLink = getRelevantLink();
+  const hasClickableLink = relevantLink !== null;
+  const badgeTitle = relevantLink?.tooltip || title;
+
+  return (
+    <div
+      className={`inline-flex items-center ${hasClickableLink ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''} ${className}`}
+      onClick={hasClickableLink ? handleClick : undefined}
+      title={badgeTitle}
+    >
+      <Badge
+        color={color}
+        icon={icon}
+        truncate={truncate}
+        className="relative max-w-full"
+      >
+        <div className="flex items-center gap-1 min-w-0">
+          <span className={truncate ? 'truncate' : ''}>{children}</span>
+          {hasClickableLink && (
+            <MaterialSymbol
+              name="open_in_new"
+              size="sm"
+              className="text-zinc-500 dark:text-zinc-400 flex-shrink-0"
+            />
+          )}
+        </div>
+      </Badge>
+    </div>
+  );
+}

--- a/web_src/src/components/ResourceLink/ResourceLink.tsx
+++ b/web_src/src/components/ResourceLink/ResourceLink.tsx
@@ -1,0 +1,47 @@
+import { MaterialSymbol } from '@/components/MaterialSymbol/material-symbol';
+import { ResourceLinkConfig } from '@/utils/resourceLinks';
+
+interface ResourceLinkProps {
+  config: ResourceLinkConfig;
+  className?: string;
+  variant?: 'standalone' | 'badge';
+}
+
+export function ResourceLink({ config, className = '', variant = 'standalone' }: ResourceLinkProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.open(config.url, '_blank', 'noopener,noreferrer');
+  };
+
+  const iconColorClass = variant === 'badge'
+    ? 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200'
+    : 'text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300';
+
+  return (
+    <button
+      onClick={handleClick}
+      title={config.tooltip}
+      className={`inline-flex items-center gap-1 transition-colors ${iconColorClass} ${className}`}
+    >
+      <MaterialSymbol name="open_in_new" size="sm" />
+    </button>
+  );
+}
+
+interface ResourceLinksProps {
+  links: ResourceLinkConfig[];
+  className?: string;
+  variant?: 'standalone' | 'badge';
+}
+
+export function ResourceLinks({ links, className = '', variant = 'standalone' }: ResourceLinksProps) {
+  if (links.length === 0) return null;
+
+  return (
+    <div className={`inline-flex items-center gap-1 ${className}`}>
+      {links.map((link, index) => (
+        <ResourceLink key={index} config={link} variant={variant} />
+      ))}
+    </div>
+  );
+}

--- a/web_src/src/components/SettingsPage/components/CanvasIntegrations.tsx
+++ b/web_src/src/components/SettingsPage/components/CanvasIntegrations.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../IntegrationForm'
 import { ApiTokenForm } from '../../IntegrationForm/ApiTokenForm'
 import { showErrorToast, showSuccessToast } from '../../../utils/toast'
+import { getResourceLinks } from '@/utils/resourceLinks'
 
 interface CanvasIntegrationsProps {
   canvasId: string
@@ -353,9 +354,45 @@ export function CanvasIntegrations({ canvasId, organizationId }: CanvasIntegrati
                         <div className="w-8 h-8 bg-gray-200 rounded flex items-center justify-center">
                           <img className="w-8 h-8 p-2 object-contain" src={INTEGRATION_TYPES[integration.spec?.type || '']?.icon as string} alt={integration.metadata?.name} />
                         </div>
-                        <Heading level={3} className="max-w-50 truncate">
-                          {integration.metadata?.name}
-                        </Heading>
+                        <div className="flex items-center gap-2 min-w-0 flex-1">
+                          {getResourceLinks(
+                            integration.spec?.type as string,
+                            integration.spec?.url,
+                            integration.metadata?.name,
+                            {}
+                          ).length > 0 ? (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                const links = getResourceLinks(
+                                  integration.spec?.type as string,
+                                  integration.spec?.url,
+                                  '',
+                                  {}
+                                );
+                                if (links.length > 0) {
+                                  window.open(links[0].url, '_blank', 'noopener,noreferrer');
+                                }
+                              }}
+                              className="flex items-center gap-2 min-w-0 flex-1 text-left hover:opacity-80 transition-opacity"
+                              title={getResourceLinks(
+                                integration.spec?.type as string,
+                                integration.spec?.url,
+                                '',
+                                {}
+                              )[0]?.tooltip}
+                            >
+                              <Heading level={3} className="truncate flex-1 min-w-0 max-w-40">
+                                {integration.metadata?.name}
+                              </Heading>
+                              <MaterialSymbol name="open_in_new" size="sm" className="text-zinc-500 dark:text-zinc-400 flex-shrink-0" />
+                            </button>
+                          ) : (
+                            <Heading level={3} className="truncate flex-1 min-w-0 max-w-50">
+                              {integration.metadata?.name}
+                            </Heading>
+                          )}
+                        </div>
                       </div>
 
                     </div>

--- a/web_src/src/pages/canvas/components/EventSourceBadges.tsx
+++ b/web_src/src/pages/canvas/components/EventSourceBadges.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useCallback } from 'react';
-import { Badge } from '@/components/Badge/badge';
 import { SuperplaneEventSource, IntegrationsIntegration, SuperplaneFilter } from '@/api-client';
 import Tippy from '@tippyjs/react/headless';
 import { getResourceLabel } from '@/utils/components';
+import { getResourceLinks } from '@/utils/resourceLinks';
+import { ClickableBadge } from '@/components/ClickableBadge/ClickableBadge';
 
 interface EventSourceBadgesProps {
   resourceName?: string;
@@ -38,13 +39,23 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
 
   const cleanResourceName = resourceName?.replace('.semaphore/', '') || '';
 
+  const resourceLinks = useMemo(() => {
+    return getResourceLinks(
+      sourceType as string,
+      integration?.spec?.url,
+      resourceName,
+      {}
+    );
+  }, [sourceType, integration?.spec?.url, resourceName]);
+
   const badgeItems = useMemo(() => {
-    const badges: Array<{ icon: string; text: string; tooltip: React.ReactNode }> = [];
+    const badges: Array<{ icon: string; text: string; tooltip: React.ReactNode; resourceLinks: typeof resourceLinks }> = [];
 
     if (resourceName) {
       badges.push({
         icon: 'assignment',
         text: cleanResourceName,
+        resourceLinks: resourceLinks,
         tooltip: (
           <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-4 min-w-[250px]">
             <div className="text-sm font-medium text-zinc-900 dark:text-white mb-3">{getResourceLabel(sourceType)} Configuration</div>
@@ -73,6 +84,7 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
       badges.push({
         icon: 'filter_list',
         text: filterText,
+        resourceLinks: [],
         tooltip: (
           <div className="bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-4 min-w-[280px]">
             <div className="space-y-3">
@@ -108,7 +120,7 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
     }
 
     return badges;
-  }, [resourceName, cleanResourceName, totalFilters, totalEventTypes, currentEventSource, integration, getFilterTypeLabel, getFilterExpression]);
+  }, [resourceName, cleanResourceName, totalFilters, totalEventTypes, currentEventSource, integration, sourceType, getFilterTypeLabel, getFilterExpression, resourceLinks]);
 
   if (badgeItems.length === 0) return null;
 
@@ -121,13 +133,14 @@ export const EventSourceBadges: React.FC<EventSourceBadgesProps> = ({
           placement="top"
         >
           <div className="flex-shrink min-w-0 max-w-full">
-            <Badge
+            <ClickableBadge
               color="zinc"
               icon={badge.icon}
               truncate
+              resourceLinks={badge.resourceLinks}
             >
               {badge.text}
-            </Badge>
+            </ClickableBadge>
           </div>
         </Tippy>
       ))}

--- a/web_src/src/pages/canvas/components/nodes/stage.tsx
+++ b/web_src/src/pages/canvas/components/nodes/stage.tsx
@@ -25,6 +25,8 @@ import { createStageDuplicate, focusAndEditNode } from '../../utils/nodeDuplicat
 import { showErrorToast } from '@/utils/toast';
 import { EmitEventModal } from '@/components/EmitEventModal/EmitEventModal';
 import { withOrganizationHeader } from '@/utils/withOrganizationHeader';
+import { getResourceLinks } from '@/utils/resourceLinks';
+import { ClickableBadge } from '@/components/ClickableBadge/ClickableBadge';
 
 const StageImageMap = {
   'http': <MaterialSymbol className='-mt-1 -mb-1 text-gray-700 dark:text-gray-300' name="rocket_launch" size="xl" />,
@@ -723,18 +725,28 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
                   )}
                   {executorBadges.length > 0 && !props.data.dryRun && (
                     <div className="flex items-center gap-2 min-w-0 overflow-hidden">
-                      {executorBadges.map((badge, index) => (
-                        <Badge
-                          key={`${badge.icon}-${index}`}
-                          color="zinc"
-                          icon={badge.icon}
-                          truncate
-                          className="flex-shrink min-w-0 max-w-full"
-                          title={badge.text}
-                        >
-                          {badge.text}
-                        </Badge>
-                      ))}
+                      {executorBadges.map((badge, index) => {
+                        const resourceLinks = getResourceLinks(
+                          props.data.executor?.type as string,
+                          availableIntegrations.find(int => int.metadata?.name === props.data.executor?.integration?.name)?.spec?.url,
+                          props.data.executor?.resource?.name,
+                          props.data.executor?.spec || {}
+                        );
+                        return (
+                          <ClickableBadge
+                            key={`${currentStage?.metadata?.id}-badge-${index}`}
+                            color="zinc"
+                            icon={badge.icon}
+                            truncate
+                            className="flex-shrink min-w-0 max-w-full"
+                            title={badge.text}
+                            resourceLinks={resourceLinks}
+                            badgeText={badge.text}
+                          >
+                            {badge.text}
+                          </ClickableBadge>
+                        );
+                      })}
                     </div>
                   )}
                 </div>
@@ -845,7 +857,7 @@ export default function StageNode(props: NodeProps<StageNodeType>) {
                   return null;
                 }
               }}
-              onSubmit={async (eventType: string, eventData: any) => {
+              onSubmit={async (eventType: string, eventData: unknown) => {
                 await superplaneCreateEvent(withOrganizationHeader({
                   path: { canvasIdOrName: canvasId! },
                   body: {

--- a/web_src/src/utils/resourceLinks.ts
+++ b/web_src/src/utils/resourceLinks.ts
@@ -1,0 +1,158 @@
+/**
+ * Utility functions for generating external resource links for integrations
+ */
+
+export interface ResourceLinkConfig {
+  url: string;
+  tooltip: string;
+}
+
+/**
+ * Generate link to Semaphore project
+ */
+export function getSemaphoreProjectLink(integrationUrl: string, projectName: string, ref?: string): ResourceLinkConfig | null {
+  if (!integrationUrl || !projectName) return null;
+
+  const cleanProjectName = projectName.replace('.semaphore/', '');
+  const baseUrl = integrationUrl.endsWith('/') ? integrationUrl.slice(0, -1) : integrationUrl;
+
+  let url = `${baseUrl}/projects/${cleanProjectName}`;
+  if (ref) {
+    if (ref.startsWith('refs/tags/')) {
+      url += `?type=tag`;
+    } else {
+      url += `?type=branch`;
+    }
+  }
+  const tooltip = ref
+    ? `Open ${cleanProjectName} project at ${ref} in Semaphore`
+    : `Open ${cleanProjectName} project in Semaphore`;
+
+  return {
+    url,
+    tooltip
+  };
+}
+
+/**
+ * Generate link to Semaphore pipeline file on GitHub
+ */
+export function getSemaphorePipelineLink(
+  integrationUrl: string,
+  projectName: string,
+): ResourceLinkConfig | null {
+  if (!integrationUrl || !projectName) return null;
+
+  const githubUrl = `${integrationUrl}/projects/${projectName}/edit_workflow`;
+
+  return {
+    url: githubUrl,
+    tooltip: `View ${projectName} pipeline file`
+  };
+}
+
+/**
+ * Generate link to GitHub repository
+ */
+export function getGitHubRepositoryLink(integrationUrl: string, repositoryName: string, ref?: string): ResourceLinkConfig | null {
+  if (!integrationUrl || !repositoryName) return null;
+
+  const baseUrl = `${integrationUrl}/${repositoryName}`;
+  const url = ref ? `${baseUrl}/tree/${ref}` : baseUrl;
+  const tooltip = ref
+    ? `Open ${repositoryName} repository at ${ref} on GitHub`
+    : `Open ${repositoryName} repository on GitHub`;
+
+  return {
+    url,
+    tooltip
+  };
+}
+
+/**
+ * Generate link to GitHub Actions workflow file
+ */
+export function getGitHubWorkflowLink(
+  integrationUrl: string,
+  repositoryName: string,
+  workflowFile: string,
+  ref?: string
+): ResourceLinkConfig | null {
+  if (!integrationUrl || !repositoryName || !workflowFile) return null;
+
+  const cleanWorkflowFile = workflowFile.replace('.github/workflows/', '');
+  const gitRef = ref || 'main';
+
+  return {
+    url: `${integrationUrl}/${repositoryName}/blob/${gitRef}/.github/workflows/${cleanWorkflowFile}`,
+    tooltip: `View ${cleanWorkflowFile} workflow file on GitHub`
+  };
+}
+
+/**
+ * Generic function to get resource links based on integration type and executor spec
+ */
+export function getResourceLinks(
+  integrationType: string,
+  integrationUrl?: string,
+  resourceName?: string,
+  executorSpec?: Record<string, unknown>
+): ResourceLinkConfig[] {
+  const links: ResourceLinkConfig[] = [];
+
+  if (!integrationType || !integrationUrl) return links;
+
+  if (!resourceName) {
+    const pureIntegrationUrlLink = {
+      url: integrationUrl,
+      tooltip: `Open ${integrationUrl}`
+    }
+    links.push(pureIntegrationUrlLink);
+    return links;
+  }
+
+  switch (integrationType) {
+    case 'semaphore': {
+      const ref = executorSpec?.ref as string | undefined;
+
+      if (integrationUrl) {
+        const projectLink = getSemaphoreProjectLink(integrationUrl, resourceName);
+        if (projectLink) links.push(projectLink);
+
+        const pipelineLink = getSemaphorePipelineLink(integrationUrl, resourceName);
+        if (pipelineLink) links.push(pipelineLink);
+
+        if (ref) {
+          const projectLink = getSemaphoreProjectLink(integrationUrl, resourceName, ref);
+          if (projectLink) links.push(projectLink);
+        }
+      }
+      break;
+    }
+
+    case 'github': {
+      const repoLink = getGitHubRepositoryLink(integrationUrl, resourceName);
+      if (repoLink) links.push(repoLink);
+
+      if (executorSpec?.workflow) {
+        const workflowLink = getGitHubWorkflowLink(
+          integrationUrl,
+          resourceName,
+          executorSpec.workflow as string,
+          executorSpec.ref as string | undefined
+        );
+        if (workflowLink) links.push(workflowLink);
+
+      }
+
+      if (executorSpec?.ref) {
+        const branchLink = getGitHubRepositoryLink(integrationUrl, resourceName, executorSpec.ref as string );
+        if (branchLink) links.push(branchLink);
+      }
+      
+      break;
+    }
+  }
+
+  return links;
+}


### PR DESCRIPTION
### Changes
Added links to badges using the click event.
Added integration url link to the integrations page.
Note: not all resources are possible to link directly to the resource. For example, for the semaphore pipeline File, it is not possible to know its repository link, so it redirects to the edit workflow page of the project.

<img width="829" height="378" alt="image" src="https://github.com/user-attachments/assets/ea5ec781-9aa8-4209-bd6e-16a11831e23a" />
<img width="871" height="717" alt="image" src="https://github.com/user-attachments/assets/0945a33f-d243-4d62-8452-acd8f9fa1aad" />
