### PR TITLE
refactor: reduce execution poller internval to 1 minute

### DIFF
--- a/pkg/workers/execution_poller.go
+++ b/pkg/workers/execution_poller.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DefaultExecutionTimeout          = 3 * time.Hour
-	ExecutionResourcePollingInterval = 5 * time.Minute
+	ExecutionResourcePollingInterval = 1 * time.Minute
 )
 
 type ExecutionPoller struct {


### PR DESCRIPTION
refactor: reduce execution poller internval to 1 minute until we fix https://github.com/superplanehq/superplane/issues/337 