### PR TITLE
fix: update path imports and add dirname in Storybook

### DIFF
--- a/web_src/.storybook/main.ts
+++ b/web_src/.storybook/main.ts
@@ -1,5 +1,9 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import * as path from 'path';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const config: StorybookConfig = {
   "stories": [


### PR DESCRIPTION
I wasn't able to run storybook due to the following error:

``` bash
info Using tsconfig paths for react-docgen
=> Failed to build the preview
ReferenceError: __dirname is not defined
    at Object.viteFinal (./.storybook/main.ts:35:34)
    at ./node_modules/storybook/dist/common/index.cjs:23650:18
    at async createViteServer (./node_modules/@storybook/builder-vite/dist/index.js:92:25)
    at async Module.start (./node_modules/@storybook/builder-vite/dist/index.js:92:658)
    at async storybookDevServer (./node_modules/storybook/dist/core-server/index.cjs:42917:79)
    at async buildOrThrow (./node_modules/storybook/dist/core-server/index.cjs:39285:12)
    at async buildDevStandalone (./node_modules/storybook/dist/core-server/index.cjs:44170:78)
    at async withTelemetry (./node_modules/storybook/dist/core-server/index.cjs:42279:12)
    at async dev (./node_modules/storybook/dist/cli/bin/index.cjs:5905:3)
    at async r.<anonymous> (./node_modules/storybook/dist/cli/bin/index.cjs:6015:74)

Broken build, fix the error above.
```

This PR updates path imports and add dirname resolution for ES modules in Storybook config.