### PR TITLE
fix: open rejected events tab when the sidebar is already open

### DIFF
--- a/web_src/src/pages/canvas/components/SideBar.tsx
+++ b/web_src/src/pages/canvas/components/SideBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Stage } from "../store/types";
@@ -36,6 +36,7 @@ interface SidebarProps {
 
 export const Sidebar = ({ selectedStage, onClose, approveStageEvent, discardStageEvent, cancelStageExecution, initialWidth = DEFAULT_SIDEBAR_WIDTH }: SidebarProps) => {
   const sidebarTab = useCanvasStore(state => state.sidebarTab);
+  const setSidebarTab = useCanvasStore(state => state.setSidebarTab)
   const sidebarEventFilter = useCanvasStore(state => state.sidebarEventFilter);
   const [activeTab, setActiveTab] = useState(sidebarTab || 'activity');
   const { organizationId, canvasId } = useParams<{ organizationId: string, canvasId: string }>();
@@ -46,7 +47,7 @@ export const Sidebar = ({ selectedStage, onClose, approveStageEvent, discardStag
   const handleApproveStageEvent = async (stageEventId: string, stageId: string) => {
     try {
       await approveStageEvent(stageEventId, stageId);
-      
+
       // Invalidate queries to refresh both stage events and executions data
       await queryClient.invalidateQueries({
         queryKey: canvasKeys.stageEvents(canvasId || '', stageId, ['STATE_PENDING', 'STATE_WAITING'])
@@ -63,7 +64,7 @@ export const Sidebar = ({ selectedStage, onClose, approveStageEvent, discardStag
   const handleDiscardStageEvent = async (stageEventId: string, stageId: string) => {
     try {
       await discardStageEvent(stageEventId, stageId);
-      
+
       // Invalidate queries to refresh the data
       await queryClient.invalidateQueries({
         queryKey: canvasKeys.stageEvents(canvasId || '', stageId, ['STATE_PENDING', 'STATE_WAITING'])
@@ -77,7 +78,7 @@ export const Sidebar = ({ selectedStage, onClose, approveStageEvent, discardStag
   const handleCancelStageExecution = async (executionId: string, stageId: string) => {
     try {
       await cancelStageExecution(executionId, stageId);
-      
+
       // Invalidate queries to refresh the data
       await queryClient.invalidateQueries({
         queryKey: canvasKeys.stageExecutions(canvasId || '', stageId)
@@ -141,6 +142,12 @@ export const Sidebar = ({ selectedStage, onClose, approveStageEvent, discardStag
     [allQueueEvents]
   );
 
+  useEffect(() => {
+    if (sidebarTab) {
+      setActiveTab(sidebarTab);
+      setSidebarTab('');
+    }
+  }, [sidebarTab, setSidebarTab]);
 
   // Render the appropriate content based on the active tab
   const renderTabContent = () => {

--- a/web_src/src/pages/canvas/store/canvasStore.ts
+++ b/web_src/src/pages/canvas/store/canvasStore.ts
@@ -198,6 +198,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     });
   },
 
+  setSidebarTab: (tab: string) => {
+    set({
+      sidebarTab: tab
+    })
+  },
+
   cleanSelectedStageId: () => {
     set({ selectedStageId: null, sidebarTab: null, sidebarEventFilter: null });
   },

--- a/web_src/src/pages/canvas/store/types.ts
+++ b/web_src/src/pages/canvas/store/types.ts
@@ -41,6 +41,7 @@ export interface CanvasState {
   discardStageEvent: (stageEventId: string, stageId: string) => Promise<void>;
   cancelStageExecution: (executionId: string, stageId: string) => Promise<void>;
   selectStageId: (stageId: string, options?: { tab?: string; eventFilter?: string }) => void;
+  setSidebarTab: (tab: string) => void;
   cleanSelectedStageId: () => void;
   selectEventSourceId: (eventSourceId: string) => void;
   cleanSelectedEventSourceId: () => void;


### PR DESCRIPTION
Fix related to: https://github.com/superplanehq/superplane/issues/334#issuecomment-3376806773

- open rejected events tab when the sidebar is already open