### PR TITLE
fix: show no example object text only when it is null

### DIFF
--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -13,14 +13,14 @@ export interface AutoCompleteInputProps extends Omit<React.ComponentPropsWithout
   suffix?: string;
   startWord?: string;
   inputSize?: 'xs' | 'sm' | 'md' | 'lg';
-  noSuggestionsText?: string;
+  noExampleObjectText?: string;
   showValuePreview?: boolean;
 }
 
 let blurTimeout: NodeJS.Timeout;
 
 export const AutoCompleteInput = forwardRef<HTMLInputElement, AutoCompleteInputProps>(
-  ({ exampleObj, value = '', onChange, className, placeholder = 'Type to search...', disabled, prefix = '', suffix = '', startWord, inputSize = 'md', noSuggestionsText = 'No suggestions found', showValuePreview = false, ...props }) => {
+  ({ exampleObj, value = '', onChange, className, placeholder = 'Type to search...', disabled, prefix = '', suffix = '', startWord, inputSize = 'md', noExampleObjectText = 'No suggestions found', showValuePreview = false, ...props }) => {
     const [inputValue, setInputValue] = useState(value);
     const [suggestions, setSuggestions] = useState<Array<{ suggestion: string; type: string }>>([]);
     const [isOpen, setIsOpen] = useState(false);
@@ -354,7 +354,7 @@ export const AutoCompleteInput = forwardRef<HTMLInputElement, AutoCompleteInputP
             'dark:bg-zinc-800 dark:border-zinc-700'
           ])}>
             <div className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">
-              {noSuggestionsText}
+              {!exampleObj ? noExampleObjectText : 'No suggestions found'}
             </div>
           </div>
         )}

--- a/web_src/src/pages/canvas/components/StageEditModeContent.tsx
+++ b/web_src/src/pages/canvas/components/StageEditModeContent.tsx
@@ -1553,7 +1553,7 @@ export function StageEditModeContent({ data, currentStageId, canvasId, organizat
                                                     startWord="$"
                                                     prefix='$.'
                                                     showValuePreview
-                                                    noSuggestionsText="This component hasn't received any events from this connection. Send events to this connection to enable autocomplete suggestions."
+                                                    noExampleObjectText="This component hasn't received any events from this connection. Send events to this connection to enable autocomplete suggestions."
                                                   />
                                                   <div className="mt-2">
                                                     <ProTip show message="Pro tip: Type $ to select data from event payload" />

--- a/web_src/src/pages/canvas/components/shared/ConnectionSelector.tsx
+++ b/web_src/src/pages/canvas/components/shared/ConnectionSelector.tsx
@@ -137,7 +137,7 @@ export function ConnectionSelector({
                       startWord='$'
                       prefix='$.'
                       showValuePreview
-                      noSuggestionsText="This component hasn't received any events from this connection. Send events to this connection to enable autocomplete suggestions."
+                      noExampleObjectText="This component hasn't received any events from this connection. Send events to this connection to enable autocomplete suggestions."
                     />
                     <button
                       onClick={() => onFilterRemove(index, filterIndex)}


### PR DESCRIPTION
### Changes
Only show no example object text if the exampleObj variable is null. This prevents the ambiguity of no suggestions and non existing object as template