### PR TITLE
chore: Add make targets for starting storybooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ check.build.app:
 storybook:
 	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --service-ports app /bin/bash -c "cd web_src && npm install && npm run storybook"
 
+ui.setup:
+	npm install
+
+ui.start:
+	npm run storybook
+
 #
 # Database target helpers
 #


### PR DESCRIPTION
Analoguous to dev.setup, dev.start, we now have ui.setup, ui.start.