### PR TITLE
chore: Switch base image to Ubuntu to support playwright

### DIFF
--- a/scripts/docker/install-go.sh
+++ b/scripts/docker/install-go.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+GO_VERSION=$1
+ARCH=$(dpkg --print-architecture)
+
+echo "Installing Go version: ${GO_VERSION} for architecture: ${ARCH}"
+
+apt-get update
+apt-get install -y wget ca-certificates
+
+if [ "$ARCH" = "arm64" ]; then
+  wget https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz -O go.tar.gz;
+else
+  wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O go.tar.gz;
+fi
+
+tar -C /usr/local -xzf go.tar.gz
+rm go.tar.gz

--- a/scripts/docker/install-gomigrate.sh
+++ b/scripts/docker/install-gomigrate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+echo "Installing Go Migrate v4.18.2"
+
+ARCH=$(dpkg --print-architecture)
+
+if [ "$ARCH" = "arm64" ]; then
+  curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.linux-arm64.tar.gz | tar xvz;
+else
+  curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.linux-amd64.tar.gz | tar xvz;
+fi
+
+mv /tmp/migrate /usr/bin/migrate
+chmod +x /usr/bin/migrate

--- a/scripts/docker/install-nodejs.sh
+++ b/scripts/docker/install-nodejs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+echo "Installing Node.js 22.x from NodeSource repository"
+
+apt-get update -y
+apt-get install --no-install-recommends -y curl gnupg
+
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+
+apt-get update -y
+apt-get install -y nodejs
+apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+node -v
+npm -v

--- a/scripts/docker/install-postgresql-client.sh
+++ b/scripts/docker/install-postgresql-client.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+echo "Installing PostgreSQL Client 17"
+
+apt-get update -y
+apt-get install --no-install-recommends -y ca-certificates unzip curl gnupg lsb-release libc-bin libc6
+
+sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+
+apt-get update -y
+apt-get install --no-install-recommends -y postgresql-client-17
+apt-get clean && rm -f /var/lib/apt/lists/*_*

--- a/scripts/docker/install-protoc.sh
+++ b/scripts/docker/install-protoc.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+echo "Installing Protobuf Compiler (protoc) 3.15.8"
+
+ARCH=$(dpkg --print-architecture)
+
+if [ "$ARCH" = "arm64" ]; then
+  curl -sL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-aarch_64.zip -o protoc.zip;
+else
+  curl -sL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip -o protoc.zip;
+fi
+
+unzip protoc.zip
+mv bin/protoc /usr/local/bin/protoc
+rm -rf protoc.zip


### PR DESCRIPTION
This is a more drastic change so I feel the need to justify it.

- Playwright (cypress also partially) only really support Ubuntu
- Official golang images are based on Debian or Alpine

To support this:

- I started from the official Ubuntu image, the same one we use for the release
- Manually installed Golang in the base

---

At some point in development, I was struggling to understand why things are not working, so I extracted long install steps into dedicated files where I can more easily add debug messages.

If you feel this is not nice for the future, I can inline them back into the Dockerfile.