### PR TITLE
chore: use dummy restrict-key for pg_dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ db.migrate:
 	rm -f db/structure.sql
 	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) app migrate -source file://db/migrations -database postgres://postgres:$(DB_PASSWORD)@db:5432/$(DB_NAME)?sslmode=disable up
 	# echo dump schema to db/structure.sql
-	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) -e PGPASSWORD=$(DB_PASSWORD) app bash -c "pg_dump --schema-only --no-privileges --no-owner -h db -p 5432 -U postgres -d $(DB_NAME)" > db/structure.sql
-	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) -e PGPASSWORD=$(DB_PASSWORD) app bash -c "pg_dump --data-only --table schema_migrations -h db -p 5432 -U postgres -d $(DB_NAME)" >> db/structure.sql
+	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) -e PGPASSWORD=$(DB_PASSWORD) app bash -c "pg_dump --schema-only --no-privileges --restrict-key abcdef123 --no-owner -h db -p 5432 -U postgres -d $(DB_NAME)" > db/structure.sql
+	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) -e PGPASSWORD=$(DB_PASSWORD) app bash -c "pg_dump --data-only --restrict-key abcdef123 --table schema_migrations -h db -p 5432 -U postgres -d $(DB_NAME)" >> db/structure.sql
 
 db.console:
 	docker compose $(DOCKER_COMPOSE_OPTS) run --rm --user $$(id -u):$$(id -g) -e PGPASSWORD=the-cake-is-a-lie app psql -h db -p 5432 -U postgres $(DB_NAME)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict gbqGdgEYXe37grMJaf8JF8idcvfsEABIte9aRxhCvXi2nGKO3htjUCahVPpLIMj
+\restrict abcdef123
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Ubuntu 17.6-2.pgdg22.04+1)
@@ -1638,13 +1638,13 @@ ALTER TABLE ONLY public.workflow_nodes
 -- PostgreSQL database dump complete
 --
 
-\unrestrict gbqGdgEYXe37grMJaf8JF8idcvfsEABIte9aRxhCvXi2nGKO3htjUCahVPpLIMj
+\unrestrict abcdef123
 
 --
 -- PostgreSQL database dump
 --
 
-\restrict loAVm7cRG67bIOIKSGxGjGBv63NpnzMboT26wHkS0iQzUJU2vrwIkJHXBNJeTcI
+\restrict abcdef123
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
 -- Dumped by pg_dump version 17.6 (Ubuntu 17.6-2.pgdg22.04+1)
@@ -1674,5 +1674,5 @@ COPY public.schema_migrations (version, dirty) FROM stdin;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict loAVm7cRG67bIOIKSGxGjGBv63NpnzMboT26wHkS0iQzUJU2vrwIkJHXBNJeTcI
+\unrestrict abcdef123
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -102,7 +102,7 @@ services:
   pgweb:
     image: sosedoff/pgweb
     environment:
-      DATABASE_URL: "postgres://postgres:the-cake-is-a-lie@db:5432/superplane?sslmode=disable"
+      DATABASE_URL: "postgres://postgres:the-cake-is-a-lie@db:5432/superplane_dev?sslmode=disable"
     ports:
       - 8081:8081
     links:

--- a/pkg/workers/webhook_cleanup_worker.go
+++ b/pkg/workers/webhook_cleanup_worker.go
@@ -40,8 +40,6 @@ func (w *WebhookCleanupWorker) Start(ctx context.Context) {
 				w.log("Error finding workflow nodes ready to be processed: %v", err)
 			}
 
-			w.log("Found %d deleted webhooks", len(webhooks))
-
 			for _, webhook := range webhooks {
 				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)


### PR DESCRIPTION
To avoid changing db/structure.sql after every make `dev.setup`