### PR TITLE
Added hover effect for edge delete button

### DIFF
--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -68,11 +68,13 @@ export function CustomEdge({
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
               pointerEvents: 'all',
+              width: '40px',
+              height: '40px',
             }}
-            className="nodrag nopan"
+            className="nodrag nopan group flex items-center justify-center"
           >
             <button
-              className="flex items-center justify-center bg-white rounded-full shadow-lg hover:bg-red-50 transition-colors cursor-pointer"
+              className="flex items-center justify-center bg-red-100 rounded-full shadow-lg group-hover:bg-red-50 transition-all cursor-pointer group-hover:scale-[2]"
               onClick={onDeleteClick}
               aria-label="Delete edge"
             >


### PR DESCRIPTION
When edge is select, getting cursor close to delete button will increase it's size making it easier to select.