### PR TITLE
feat: pass workflow info as URL parameters in navigation

### DIFF
--- a/web_src/src/pages/custom-component/index.tsx
+++ b/web_src/src/pages/custom-component/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   Node,
   Edge,
@@ -162,6 +162,7 @@ const createBlockData = (node: any, component: ComponentsComponent | undefined):
 export const CustomComponent = () => {
   const { organizationId, blueprintId } = useParams<{ organizationId: string; blueprintId: string }>()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const [blueprintConfiguration, setBlueprintConfiguration] = useState<any[]>([])
   const [blueprintOutputChannels, setBlueprintOutputChannels] = useState<any[]>([])
   const [blueprintName, setBlueprintName] = useState('')
@@ -504,10 +505,19 @@ export const CustomComponent = () => {
     )
   }
 
-  const breadcrumbs: BreadcrumbItem[] = [
-    { label: 'Components', href: `/${organizationId}` },
-    { label: blueprintName, iconSlug: blueprintIcon, iconColor: `text-${blueprintColor}-600` },
-  ]
+  // Get workflow info from URL parameters
+  const fromWorkflowId = searchParams.get('fromWorkflow')
+  const workflowName = searchParams.get('workflowName')
+
+  const breadcrumbs: BreadcrumbItem[] = fromWorkflowId && workflowName
+    ? [
+        { label: workflowName, href: `/${organizationId}/workflows/${fromWorkflowId}` },
+        { label: blueprintName, iconSlug: blueprintIcon, iconColor: `text-${blueprintColor}-600` },
+      ]
+    : [
+        { label: 'Components', href: `/${organizationId}` },
+        { label: blueprintName, iconSlug: blueprintIcon, iconColor: `text-${blueprintColor}-600` },
+      ]
 
   return (
     <>

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -504,11 +504,16 @@ export function WorkflowPageV2() {
     (nodeId: string) => {
       const node = workflow?.nodes?.find((n) => n.id === nodeId);
       if (!node) return;
-      if (node.type === "TYPE_BLUEPRINT" && node.blueprint?.id && organizationId) {
-        navigate(`/${organizationId}/custom-components/${node.blueprint.id}`);
+      if (node.type === "TYPE_BLUEPRINT" && node.blueprint?.id && organizationId && workflow) {
+        // Pass workflow info as URL parameters
+        const params = new URLSearchParams({
+          fromWorkflow: workflowId!,
+          workflowName: workflow.name || 'Workflow',
+        });
+        navigate(`/${organizationId}/custom-components/${node.blueprint.id}?${params.toString()}`);
       }
     },
-    [workflow, organizationId, navigate],
+    [workflow, organizationId, workflowId, navigate],
   );
 
   const handleRun = useCallback(


### PR DESCRIPTION
When selecting "Configure" from custom component action menu, we store info on Canvas you came from and display it in breadcrumb.