### PR TITLE
fix: Don't remount the canvas after a save

### DIFF
--- a/web_src/src/hooks/useWorkflowData.ts
+++ b/web_src/src/hooks/useWorkflowData.ts
@@ -125,7 +125,6 @@ export const useUpdateWorkflow = (organizationId: string, workflowId: string) =>
       )
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: workflowKeys.detail(organizationId, workflowId) })
       queryClient.invalidateQueries({ queryKey: workflowKeys.list(organizationId) })
     },
   })


### PR DESCRIPTION
Fixes #646.

The page wasn't really refreshing but the canvas was being "remounted" so it appeared like a refresh.