### PR TITLE
fix: no need for HTTP configuration field type for now

### DIFF
--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -165,7 +165,6 @@ const (
 	FieldTypeMultiSelect         = "multi-select"
 	FieldTypeIntegration         = "integration"
 	FieldTypeIntegrationResource = "integration-resource"
-	FieldTypeURL                 = "url"
 	FieldTypeList                = "list"
 	FieldTypeObject              = "object"
 	FieldTypeTime                = "time"

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -59,7 +59,7 @@ func (e *HTTP) Configuration() []components.ConfigurationField {
 		{
 			Name:     "url",
 			Label:    "URL",
-			Type:     components.FieldTypeURL,
+			Type:     components.FieldTypeString,
 			Required: true,
 		},
 		{

--- a/pkg/components/validation.go
+++ b/pkg/components/validation.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"slices"
@@ -54,20 +53,6 @@ func validateNumber(field ConfigurationField, value any) error {
 
 	if options.Max != nil && num > float64(*options.Max) {
 		return fmt.Errorf("must be at most %d", *options.Max)
-	}
-
-	return nil
-}
-
-func validateURL(value any) error {
-	URL, ok := value.(string)
-	if !ok {
-		return fmt.Errorf("must be a string")
-	}
-
-	_, err := url.ParseRequestURI(URL)
-	if err != nil {
-		return fmt.Errorf("%s is not a valid URL", URL)
 	}
 
 	return nil
@@ -209,9 +194,6 @@ func validateFieldValue(field ConfigurationField, value any) error {
 		if _, ok := value.(bool); !ok {
 			return fmt.Errorf("must be a boolean")
 		}
-
-	case FieldTypeURL:
-		return validateURL(value)
 
 	case FieldTypeSelect:
 		return validateSelect(field, value)


### PR DESCRIPTION
Validating the HTTP url field as a URL blocks us from using configuration to build it. For now, let's just make that field a string. If the URL is not properly built, the request will fail, which is a better behavior for now.