### PR TITLE
Waiting style matching running

### DIFF
--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -152,13 +152,15 @@ export const ComponentSidebar = ({
         iconSize = 8;
         break;
       case "waiting":
-        EventIcon = resolveIcon("circle-dashed");
-        EventColor = "text-orange-700";
-        EventBackground = "bg-orange-200";
+        EventIcon = resolveIcon("refresh-cw");
+        EventColor = "text-blue-700";
+        EventBackground = "bg-blue-100";
         iconBorderColor = "";
         iconSize = 17;
         iconContainerSize = 5;
         iconStrokeWidth = 2;
+        animation = "animate-spin";
+        break;
         break;
       case "running":
         EventIcon = resolveIcon("refresh-cw");


### PR DESCRIPTION
We have this `waiting` state which seems to be different than `running`. 
Until we design this state properly, I will match the running style in sidebar.

Change waiting state style to match running in order to avoid orange elements in sidebar