### PR TITLE
chore: Add sanity check for execution state transitions

### DIFF
--- a/pkg/models/workflow_node_execution.go
+++ b/pkg/models/workflow_node_execution.go
@@ -258,6 +258,11 @@ func (e *WorkflowNodeExecution) Start() error {
 }
 
 func (e *WorkflowNodeExecution) StartInTransaction(tx *gorm.DB) error {
+	// Just a sanity check that we are not trying to start and already started execution.
+	if e.State != WorkflowNodeExecutionStatePending {
+		return fmt.Errorf("cannot start execution %s in state %s", e.ID, e.State)
+	}
+
 	//
 	// Update the execution state to started.
 	//


### PR DESCRIPTION
If it is a race condition in the executor, this will point it out:

<img width="1818" height="328" alt="CleanShot 2025-11-10 at 21 23 28@2x" src="https://github.com/user-attachments/assets/bc4a8354-902e-469b-b143-77e0d9f75e9e" />
