### PR TITLE
fix: merge component live updates

### DIFF
--- a/pkg/components/approval/approval.go
+++ b/pkg/components/approval/approval.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -328,7 +329,7 @@ func (a *Approval) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (a *Approval) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (a *Approval) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/integrations"
+	"github.com/superplanehq/superplane/pkg/models"
 )
 
 var DefaultOutputChannel = OutputChannel{Name: "default", Label: "Default"}
@@ -63,7 +64,7 @@ type Component interface {
 	 * is ready to be processed. Implementations should create the appropriate
 	 * execution or handle the item synchronously using the provided context.
 	 */
-	ProcessQueueItem(ctx ProcessQueueContext) error
+	ProcessQueueItem(ctx ProcessQueueContext) (*models.WorkflowNodeExecution, error)
 
 	/*
 	 * Passes full execution control to the component.
@@ -212,7 +213,7 @@ type ProcessQueueContext struct {
 	// DefaultProcessing performs the default processing for the queue item.
 	// Convenience method to avoid boilerplate in components that just want default behavior,
 	// where an execution is created and the item is dequeued.
-	DefaultProcessing func() error
+	DefaultProcessing func() (*models.WorkflowNodeExecution, error)
 
 	// GetExecutionMetadata retrieves the execution metadata for a given execution ID.
 	GetExecutionMetadata func(uuid.UUID) (map[string]any, error)
@@ -222,7 +223,7 @@ type ProcessQueueContext struct {
 	CountIncomingEdges func() (int, error)
 
 	// FinishExecution marks the execution as finished with the provided outputs.
-	FinishExecution func(execID uuid.UUID, outputs map[string][]any) error
+	FinishExecution func(execID uuid.UUID, outputs map[string][]any) (*models.WorkflowNodeExecution, error)
 
 	FindExecutionIDByKV func(key string, value string) (uuid.UUID, bool, error)
 	SetExecutionKV      func(execID uuid.UUID, key string, value string) error

--- a/pkg/components/filter/filter.go
+++ b/pkg/components/filter/filter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -111,6 +112,6 @@ func (f *Filter) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (f *Filter) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (f *Filter) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -132,7 +133,7 @@ func (e *HTTP) HandleAction(ctx components.ActionContext) error {
 	return fmt.Errorf("http does not support actions")
 }
 
-func (e *HTTP) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (e *HTTP) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/if/if.go
+++ b/pkg/components/if/if.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -121,6 +122,6 @@ func (f *If) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (f *If) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (f *If) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }

--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -87,30 +87,30 @@ func (m *Merge) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (m *Merge) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (m *Merge) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	mergeGroup := ctx.RootEventID
 
 	execID, err := m.findOrCreateExecution(ctx, mergeGroup)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := ctx.DequeueItem(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := ctx.UpdateNodeState(models.WorkflowNodeStateReady); err != nil {
-		return err
+		return nil, err
 	}
 
 	incoming, err := ctx.CountIncomingEdges()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	md, err := m.addEventToMetadata(ctx, execID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(md.EventIDs) >= incoming {
@@ -119,7 +119,7 @@ func (m *Merge) ProcessQueueItem(ctx components.ProcessQueueContext) error {
 		})
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (m *Merge) findOrCreateExecution(ctx components.ProcessQueueContext, mergeGroup string) (uuid.UUID, error) {

--- a/pkg/components/merge/merge_test.go
+++ b/pkg/components/merge/merge_test.go
@@ -194,8 +194,9 @@ func (s *MergeTestSteps) ProcessFirstEvent(m *Merge) {
 	ctx1, err := contexts.BuildProcessQueueContext(s.Tx, s.MergeNode, s.QueureItem1)
 	assert.NoError(s.t, err)
 
-	err = m.ProcessQueueItem(*ctx1)
+	execution, err := m.ProcessQueueItem(*ctx1)
 	require.NoError(s.t, err)
+	require.Nil(s.t, execution)
 }
 
 func (s *MergeTestSteps) ProcessSecondEvent(m *Merge) {
@@ -204,8 +205,9 @@ func (s *MergeTestSteps) ProcessSecondEvent(m *Merge) {
 	ctx2, err := contexts.BuildProcessQueueContext(s.Tx, s.MergeNode, s.QueureItem2)
 	assert.NoError(s.t, err)
 
-	err = m.ProcessQueueItem(*ctx2)
+	execution, err := m.ProcessQueueItem(*ctx2)
 	require.NoError(s.t, err)
+	require.NotNil(s.t, execution)
 }
 
 func (s *MergeTestSteps) AssertNodeExecutionCount(expectedCount int) {

--- a/pkg/components/noop/noop.go
+++ b/pkg/components/noop/noop.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -50,7 +51,7 @@ func (c *NoOp) Execute(ctx components.ExecutionContext) error {
 	})
 }
 
-func (c *NoOp) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (c *NoOp) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/semaphore/semaphore.go
+++ b/pkg/components/semaphore/semaphore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/integrations/semaphore"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -156,7 +157,7 @@ func (s *Semaphore) Configuration() []configuration.Field {
 	}
 }
 
-func (s *Semaphore) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (s *Semaphore) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/timegate/time_gate.go
+++ b/pkg/components/timegate/time_gate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -240,7 +241,7 @@ func (tg *TimeGate) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (tg *TimeGate) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (tg *TimeGate) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/wait/wait.go
+++ b/pkg/components/wait/wait.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/components"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -144,7 +145,7 @@ func (w *Wait) Setup(ctx components.SetupContext) error {
 	return nil
 }
 
-func (w *Wait) ProcessQueueItem(ctx components.ProcessQueueContext) error {
+func (w *Wait) ProcessQueueItem(ctx components.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
 	return ctx.DefaultProcessing()
 }
 


### PR DESCRIPTION
Since the merge component has a different queue processing compared to other components, It was required to add message handling after the transaction in [workflow_node_queue_worker.go](https://github.com/superplanehq/superplane/compare/fix/merge-component-not-live-updating?expand=1#diff-895a8ced7d92708594d9c9805384d7f7c392f808fa903e500048156970913787)

Also, it was required to change the interface of the default processing to return or not the created execution