### PR TITLE
fix: add default value option for configuration field modal

### DIFF
--- a/web_src/src/ui/CustomComponentBuilderPage/ConfigurationFieldModal.tsx
+++ b/web_src/src/ui/CustomComponentBuilderPage/ConfigurationFieldModal.tsx
@@ -143,7 +143,7 @@ export function ConfigurationFieldModal({ isOpen, onClose, field, onSave }: Conf
           <DialogTitle>{field ? "Edit Configuration Field" : "Add Configuration Field"}</DialogTitle>
           <DialogDescription>Configure the blueprint configuration field</DialogDescription>
         </VisuallyHidden>
-        <div className="p-6">
+        <div className="p-1 max-h-[calc(100vh-5rem)] overflow-y-auto">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-zinc-100 mb-6">
             {field ? "Edit Configuration Field" : "Add Configuration Field"}
           </h3>


### PR DESCRIPTION
<img width="1064" height="1438" alt="image" src="https://github.com/user-attachments/assets/c3ff02ae-b7bd-4ec6-9fa7-7fb81ce48e46" />
<img width="1006" height="1494" alt="image" src="https://github.com/user-attachments/assets/7ae518c8-2670-4c26-8ff3-ed0b85f28254" />

Resolves: https://github.com/superplanehq/superplane/issues/709