### PR TITLE
feat: Efficient multi-tenant RBAC rule enforcer

### DIFF
--- a/pkg/authorization2/auth.go
+++ b/pkg/authorization2/auth.go
@@ -1,0 +1,38 @@
+package authorization2
+
+import (
+	org "github.com/superplanehq/superplane/pkg/authorization2/org"
+	"gorm.io/gorm"
+)
+
+//
+// Exposed functions for organization-level authorization.
+//
+
+func OrgProvision(tx *gorm.DB, orgID string, ownerID string) error {
+	return org.Provision(tx, orgID, ownerID)
+}
+
+func OrgVerifier(orgID string, userID string) (*org.Verifier, error) {
+	return org.NewVerifier(orgID, userID)
+}
+
+func OrgUpdater(orgID string) error {
+	panic("not implemented")
+}
+
+//
+// Exposed functions for canvas-level authorization.
+//
+
+func CanvasProvision(tx *gorm.DB, canvasID string, orgID string) error {
+	panic("not implemented")
+}
+
+func CanvasVerifier(canvasID string, userID string) (any, error) {
+	panic("not implemented")
+}
+
+func CanvasUpdater(canvasID string) error {
+	panic("not implemented")
+}

--- a/pkg/authorization2/base/enforcer.go
+++ b/pkg/authorization2/base/enforcer.go
@@ -1,4 +1,4 @@
-package authorization2
+package base
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 )
 
-func enforcer() (*casbin.TransactionalEnforcer, error) {
+func Enforcer() (*casbin.TransactionalEnforcer, error) {
 	modelPath := os.Getenv("RBAC_MODEL_PATH")
 
 	adapter, err := gormadapter.NewTransactionalAdapterByDB(database.Conn())

--- a/pkg/authorization2/org/provision.go
+++ b/pkg/authorization2/org/provision.go
@@ -1,4 +1,4 @@
-package authorization2
+package org
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/casbin/casbin/v2"
+	"github.com/superplanehq/superplane/pkg/authorization2/base"
 	"github.com/superplanehq/superplane/pkg/models"
 	"gorm.io/gorm"
 )
@@ -73,7 +74,7 @@ func newProvisioner(tx *gorm.DB, orgID string, ownerID string) *provisioner {
 func (p *provisioner) initializeEnforcer() error {
 	var err error
 
-	p.enforcer, err = enforcer()
+	p.enforcer, err = base.Enforcer()
 	if err != nil {
 		return fmt.Errorf("failed to create enforcer: %w", err)
 	}

--- a/pkg/authorization2/org/provision_test.go
+++ b/pkg/authorization2/org/provision_test.go
@@ -1,4 +1,4 @@
-package authorization2_test
+package org
 
 import (
 	"testing"
@@ -7,8 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
-
-	auth "github.com/superplanehq/superplane/pkg/authorization2"
 )
 
 func TestProvision(t *testing.T) {
@@ -26,7 +24,7 @@ func TestProvision(t *testing.T) {
 	user, err := models.CreateUser(org.ID, account.ID, "user1@example.com", "Peter Parker")
 	require.NoError(t, err)
 
-	err = auth.Provision(database.Conn(), org.ID.String(), user.ID.String())
+	err = Provision(database.Conn(), org.ID.String(), user.ID.String())
 	require.NoError(t, err)
 
 	t.Run("creates default roles", func(t *testing.T) {
@@ -48,7 +46,7 @@ func TestProvision(t *testing.T) {
 	})
 
 	t.Run("verify that the org owner has correct permissions", func(t *testing.T) {
-		verifier, err := auth.OrgVerifier(org.ID.String(), user.ID.String())
+		verifier, err := NewVerifier(org.ID.String(), user.ID.String())
 		require.NoError(t, err)
 
 		can, err = verifier.CanReadCanvas()

--- a/pkg/authorization2/org/verify.go
+++ b/pkg/authorization2/org/verify.go
@@ -1,25 +1,31 @@
-package authorization2
+package org
 
 import (
 	"fmt"
 
 	"github.com/casbin/casbin/v2"
-	gormadapter "github.com/casbin/gorm-adapter/v3"
+	"github.com/superplanehq/superplane/pkg/authorization2/base"
 	"github.com/superplanehq/superplane/pkg/models"
+
+	gormadapter "github.com/casbin/gorm-adapter/v3"
 )
 
-type orgverifier struct {
+//
+// Verifier for organization-level permissions.
+//
+
+type Verifier struct {
 	enforcer *casbin.TransactionalEnforcer
 
 	domain string
 	user   string
 }
 
-func OrgVerifier(orgID string, userID string) (*orgverifier, error) {
+func NewVerifier(orgID string, userID string) (*Verifier, error) {
 	domain := fmt.Sprintf("%s:%s", models.DomainTypeOrganization, orgID)
 	user := fmt.Sprintf("user:%s", userID)
 
-	enforcer, err := enforcer()
+	enforcer, err := base.Enforcer()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create enforcer: %w", err)
 	}
@@ -40,49 +46,49 @@ func OrgVerifier(orgID string, userID string) (*orgverifier, error) {
 		return nil, fmt.Errorf("failed to load filtered policies: %w", err)
 	}
 
-	return &orgverifier{
+	return &Verifier{
 		enforcer: enforcer,
 		domain:   domain,
 		user:     user,
 	}, nil
 }
 
-func (v *orgverifier) CanReadCanvas() (bool, error) {
+func (v *Verifier) CanReadCanvas() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "canvas", "read")
 }
 
-func (v *orgverifier) CanCreateCanvas() (bool, error) {
+func (v *Verifier) CanCreateCanvas() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "canvas", "create")
 }
 
-func (v *orgverifier) CanUpdateCanvas() (bool, error) {
+func (v *Verifier) CanUpdateCanvas() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "canvas", "update")
 }
 
-func (v *orgverifier) CanDeleteCanvas() (bool, error) {
+func (v *Verifier) CanDeleteCanvas() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "canvas", "delete")
 }
 
-func (v *orgverifier) CanCreateMember() (bool, error) {
+func (v *Verifier) CanCreateMember() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "member", "create")
 }
 
-func (v *orgverifier) CanDeleteMember() (bool, error) {
+func (v *Verifier) CanDeleteMember() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "member", "delete")
 }
 
-func (v *orgverifier) CanUpdateMember() (bool, error) {
+func (v *Verifier) CanUpdateMember() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "member", "update")
 }
 
-func (v *orgverifier) CanReadMember() (bool, error) {
+func (v *Verifier) CanReadMember() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "member", "read")
 }
 
-func (v *orgverifier) CanUpdateOrg() (bool, error) {
+func (v *Verifier) CanUpdateOrg() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "org", "update")
 }
 
-func (v *orgverifier) CanDeleteOrg() (bool, error) {
+func (v *Verifier) CanDeleteOrg() (bool, error) {
 	return v.enforcer.Enforce(v.user, v.domain, "org", "delete")
 }


### PR DESCRIPTION
SUPER WIP

No service, just exposesing three things:

```
auth.Provision(orgID) // Provision auth rules for a new org
auth.Verify(orgID, userID, resource, action) // Verify rule
auth.Update(orgID, func(tx) error) // Transactionally update rules
```