### PR TITLE
fix: payload missing from loaded events

### DIFF
--- a/web_src/src/stores/nodeExecutionStore.ts
+++ b/web_src/src/stores/nodeExecutionStore.ts
@@ -204,7 +204,7 @@ export const useNodeExecutionStore = create<NodeExecutionStore>((set, get) => ({
           ? queryClient.fetchQuery(nodeQueueItemsQueryOptions(workflowId, nodeId))
           : Promise.resolve({ items: [] }),
         nodeType === "TYPE_TRIGGER"
-          ? queryClient.fetchQuery(nodeEventsQueryOptions(workflowId, nodeId, { limit: 10 }))
+          ? queryClient.fetchQuery(nodeEventsQueryOptions(workflowId, nodeId))
           : Promise.resolve({ events: [] }),
       ]);
 
@@ -267,7 +267,7 @@ export const useNodeExecutionStore = create<NodeExecutionStore>((set, get) => ({
           ? queryClient.fetchQuery(nodeQueueItemsQueryOptions(workflowId, nodeId))
           : Promise.resolve({ items: [] }),
         nodeType === "TYPE_TRIGGER"
-          ? queryClient.fetchQuery(nodeEventsQueryOptions(workflowId, nodeId, { limit: 10 }))
+          ? queryClient.fetchQuery(nodeEventsQueryOptions(workflowId, nodeId))
           : Promise.resolve({ events: [] }),
       ]);
 


### PR DESCRIPTION
This issue was only happening for events because of limit parameter only set for events in a very specific function. Removing that, all sidebar events that were loaded, even if paginated, were added to the nodeEventsMap.

Closes: https://github.com/superplanehq/superplane/issues/1101