### PR TITLE
refactor(backend): create approved and rejected output channels

### DIFF
--- a/pkg/components/approval/approval.go
+++ b/pkg/components/approval/approval.go
@@ -20,6 +20,9 @@ const (
 	ItemTypeUser  = "user"
 	ItemTypeRole  = "role"
 	ItemTypeGroup = "group"
+
+	ChannelApproved = "approved"
+	ChannelRejected = "rejected"
 )
 
 func init() {
@@ -255,7 +258,10 @@ func (a *Approval) Color() string {
 }
 
 func (a *Approval) OutputChannels(configuration any) []components.OutputChannel {
-	return []components.OutputChannel{components.DefaultOutputChannel}
+	return []components.OutputChannel{
+		{Name: ChannelApproved, Label: "Approved", Description: "All required actors approved"},
+		{Name: ChannelRejected, Label: "Rejected", Description: "At least one actor rejected (after everyone responded)"},
+	}
 }
 
 func (a *Approval) Configuration() []configuration.Field {
@@ -430,8 +436,15 @@ func (a *Approval) HandleAction(ctx components.ActionContext) error {
 	metadata.UpdateResult()
 	ctx.MetadataContext.Set(metadata)
 
+	var outputChannel string
+	if metadata.Result == StateApproved {
+		outputChannel = ChannelApproved
+	} else if metadata.Result == StateRejected {
+		outputChannel = ChannelRejected
+	}
+
 	return ctx.ExecutionStateContext.Pass(map[string][]any{
-		components.DefaultOutputChannel.Name: {metadata},
+		outputChannel: {metadata},
 	})
 }
 

--- a/pkg/components/approval/approval_test.go
+++ b/pkg/components/approval/approval_test.go
@@ -1,0 +1,203 @@
+package approval
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/superplanehq/superplane/pkg/components"
+)
+
+type MockExecutionStateContext struct {
+	mock.Mock
+}
+
+func (m *MockExecutionStateContext) Pass(outputs map[string][]any) error {
+	args := m.Called(outputs)
+	return args.Error(0)
+}
+
+func (m *MockExecutionStateContext) Fail(reason, message string) error {
+	args := m.Called(reason, message)
+	return args.Error(0)
+}
+
+func (m *MockExecutionStateContext) IsFinished() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+type MockMetadataContext struct {
+	mock.Mock
+}
+
+func (m *MockMetadataContext) Set(data any) {
+	m.Called(data)
+}
+
+func (m *MockMetadataContext) Get() any {
+	args := m.Called()
+	return args.Get(0)
+}
+
+type MockAuthContext struct {
+	mock.Mock
+}
+
+func (m *MockAuthContext) AuthenticatedUser() *components.User {
+	args := m.Called()
+	return args.Get(0).(*components.User)
+}
+
+func (m *MockAuthContext) HasRole(role string) (bool, error) {
+	args := m.Called(role)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockAuthContext) InGroup(group string) (bool, error) {
+	args := m.Called(group)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockAuthContext) GetUser(userID uuid.UUID) (*components.User, error) {
+	args := m.Called(userID)
+	return args.Get(0).(*components.User), args.Error(1)
+}
+
+func TestApproval_OutputChannels(t *testing.T) {
+	approval := &Approval{}
+	channels := approval.OutputChannels(nil)
+
+	assert.Len(t, channels, 2)
+	assert.Equal(t, ChannelApproved, channels[0].Name)
+	assert.Equal(t, "Approved", channels[0].Label)
+	assert.Equal(t, "All required actors approved", channels[0].Description)
+
+	assert.Equal(t, ChannelRejected, channels[1].Name)
+	assert.Equal(t, "Rejected", channels[1].Label)
+	assert.Equal(t, "At least one actor rejected (after everyone responded)", channels[1].Description)
+}
+
+func TestApproval_HandleAction_Approved_UsesCorrectChannel(t *testing.T) {
+	approval := &Approval{}
+
+	user := &components.User{ID: "test-user"}
+	metadata := &Metadata{
+		Result: StatePending,
+		Records: []Record{
+			{Index: 0, State: StatePending, Type: ItemTypeUser, User: user},
+		},
+	}
+
+	mockExecStateCtx := &MockExecutionStateContext{}
+	mockMetadataCtx := &MockMetadataContext{}
+	mockAuthCtx := &MockAuthContext{}
+
+	mockMetadataCtx.On("Get").Return(metadata)
+	mockMetadataCtx.On("Set", mock.Anything)
+
+	mockAuthCtx.On("AuthenticatedUser").Return(user)
+
+	mockExecStateCtx.On("Pass", mock.MatchedBy(func(outputs map[string][]any) bool {
+		_, hasApproved := outputs[ChannelApproved]
+		return hasApproved
+	})).Return(nil)
+
+	ctx := components.ActionContext{
+		Name: "approve",
+		Parameters: map[string]any{
+			"index": float64(0),
+		},
+		MetadataContext:       mockMetadataCtx,
+		ExecutionStateContext: mockExecStateCtx,
+		AuthContext:           mockAuthCtx,
+	}
+
+	err := approval.HandleAction(ctx)
+
+	assert.NoError(t, err)
+	mockExecStateCtx.AssertExpectations(t)
+}
+
+func TestApproval_HandleAction_Rejected_UsesCorrectChannel(t *testing.T) {
+	approval := &Approval{}
+
+	user := &components.User{ID: "test-user"}
+	metadata := &Metadata{
+		Result: StatePending,
+		Records: []Record{
+			{Index: 0, State: StatePending, Type: ItemTypeUser, User: user},
+		},
+	}
+
+	mockExecStateCtx := &MockExecutionStateContext{}
+	mockMetadataCtx := &MockMetadataContext{}
+	mockAuthCtx := &MockAuthContext{}
+
+	mockMetadataCtx.On("Get").Return(metadata)
+	mockMetadataCtx.On("Set", mock.Anything)
+
+	mockAuthCtx.On("AuthenticatedUser").Return(user)
+
+	mockExecStateCtx.On("Pass", mock.MatchedBy(func(outputs map[string][]any) bool {
+		_, hasRejected := outputs[ChannelRejected]
+		return hasRejected
+	})).Return(nil)
+
+	ctx := components.ActionContext{
+		Name: "reject",
+		Parameters: map[string]any{
+			"index":  float64(0),
+			"reason": "Not approved",
+		},
+		MetadataContext:       mockMetadataCtx,
+		ExecutionStateContext: mockExecStateCtx,
+		AuthContext:           mockAuthCtx,
+	}
+
+	err := approval.HandleAction(ctx)
+
+	assert.NoError(t, err)
+	mockExecStateCtx.AssertExpectations(t)
+}
+
+func TestApproval_HandleAction_StillPending_DoesNotCallPass(t *testing.T) {
+	approval := &Approval{}
+
+	user1 := &components.User{ID: "test-user-1"}
+	user2 := &components.User{ID: "test-user-2"}
+	metadata := &Metadata{
+		Result: StatePending,
+		Records: []Record{
+			{Index: 0, State: StatePending, Type: ItemTypeUser, User: user1},
+			{Index: 1, State: StatePending, Type: ItemTypeUser, User: user2},
+		},
+	}
+
+	mockExecStateCtx := &MockExecutionStateContext{}
+	mockMetadataCtx := &MockMetadataContext{}
+	mockAuthCtx := &MockAuthContext{}
+
+	mockMetadataCtx.On("Get").Return(metadata)
+	mockMetadataCtx.On("Set", mock.Anything)
+
+	mockAuthCtx.On("AuthenticatedUser").Return(user1)
+
+	ctx := components.ActionContext{
+		Name: "approve",
+		Parameters: map[string]any{
+			"index": float64(0),
+		},
+		MetadataContext:       mockMetadataCtx,
+		ExecutionStateContext: mockExecStateCtx,
+		AuthContext:           mockAuthCtx,
+	}
+
+	err := approval.HandleAction(ctx)
+
+	assert.NoError(t, err)
+
+	mockExecStateCtx.AssertNotCalled(t, "Pass")
+}


### PR DESCRIPTION
<img width="755" height="359" alt="image" src="https://github.com/user-attachments/assets/e59b0b38-ca95-4813-a471-eb25b3214bef" />

- create approved and rejected output channels
- It will be required a DB update for existing approval components output channels
Resolves: https://github.com/superplanehq/superplane/issues/1230