### PR TITLE
fix: missing nil verification in queue worker

### DIFF
--- a/pkg/workers/workflow_node_queue_worker.go
+++ b/pkg/workers/workflow_node_queue_worker.go
@@ -90,6 +90,10 @@ func (w *WorkflowNodeQueueWorker) LockAndProcessNode(logger *log.Entry, node mod
 	if err == nil {
 		if len(executions) > 0 {
 			for _, execution := range executions {
+				if execution == nil {
+					continue
+				}
+
 				messages.NewWorkflowExecutionMessage(
 					execution.WorkflowID.String(),
 					execution.ID.String(),


### PR DESCRIPTION
Added missing verification for nil execution. Since some components like `merge` might return nil for execution and error after `ProcessQueueItem ` execution.