### PR TITLE
fix: Use REL_VERSION instead of VERSION

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: "Release ${{parameters.VERSION}}"
+name: "Release ${{parameters.REL_VERSION}}"
 agent:
   machine:
     type: f1-standard-2
@@ -17,8 +17,8 @@ blocks:
       jobs:
         - name: "Demo"
           commands:
-            - bash release/demo/build.sh $VERSION
+            - bash release/demo/build.sh $REL_VERSION
 
         - name: "Single Host"
           commands:
-            - bash release/single-host/build.sh $VERSION
+            - bash release/single-host/build.sh $REL_VERSION


### PR DESCRIPTION
no idea what is happening on CI:

<img width="3002" height="1606" alt="CleanShot 2025-12-21 at 19 51 48@2x" src="https://github.com/user-attachments/assets/4ea8be68-90f9-4e67-b23b-81eff5a53743" />

---

Switching from REL_VERSION -> VERSION to try to fix it.