### PR TITLE
fix: request worker handles requests for child/parent the same way

### DIFF
--- a/pkg/grpc/workflow_service.go
+++ b/pkg/grpc/workflow_service.go
@@ -126,6 +126,7 @@ func (s *WorkflowService) InvokeNodeExecutionAction(ctx context.Context, req *pb
 		ctx,
 		s.authService,
 		s.registry,
+		s.encryptor,
 		uuid.MustParse(organizationID),
 		workflowID,
 		executionID,

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -45,7 +45,7 @@ func WithNode(logger *log.Entry, node models.WorkflowNode) *log.Entry {
 	if node.ParentNodeID != nil {
 		return logger.WithFields(log.Fields{
 			"node_id": node.NodeID,
-			"parent":  node.ParentNodeID,
+			"parent":  *node.ParentNodeID,
 		})
 	}
 


### PR DESCRIPTION
Now that we have workflow_node records for all nodes in workflow, we don't need to treat nodes differently in WorkflowNodeRequestWorker