### PR TITLE
chore: Limit test reruns to only flaky tests, not to real problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test.e2e.setup:
 	docker compose $(DOCKER_COMPOSE_OPTS) exec app bash -c "cd web_src && npm ci"
 
 test.e2e:
-	docker compose $(DOCKER_COMPOSE_OPTS) exec app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --packages="$(E2E_TEST_PACKAGES)" -- -p 1
+	docker compose $(DOCKER_COMPOSE_OPTS) exec app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1
 
 test.e2e.single:
 	bash ./scripts/vscode_run_tests.sh line $(FILE) $(LINE)


### PR DESCRIPTION
> To avoid re-running tests when there are real failures, the re-run will be skipped when there are too many test failures. By default this value is 10, and can be changed with --rerun-fails-max-failures=n.