### PR TITLE
fix: simplify application interface webhook methods

### DIFF
--- a/pkg/applications/github/github.go
+++ b/pkg/applications/github/github.go
@@ -294,32 +294,21 @@ type WebhookConfiguration struct {
 	Repository string `json:"repository"`
 }
 
-func (g *GitHub) RequestWebhook(ctx core.AppInstallationContext, configuration any) error {
-	config := WebhookConfiguration{}
-	err := mapstructure.Decode(configuration, &config)
+func (g *GitHub) CompareWebhookConfig(a, b any) (bool, error) {
+	configA := WebhookConfiguration{}
+	configB := WebhookConfiguration{}
+
+	err := mapstructure.Decode(a, &configA)
 	if err != nil {
-		return fmt.Errorf("Failed to decode configuration: %v", err)
+		return false, err
 	}
 
-	hooks, err := ctx.ListWebhooks()
+	err = mapstructure.Decode(b, &configB)
 	if err != nil {
-		return fmt.Errorf("Failed to list webhooks: %v", err)
+		return false, err
 	}
 
-	for _, hook := range hooks {
-		c := WebhookConfiguration{}
-		err := mapstructure.Decode(hook.Configuration, &c)
-		if err != nil {
-			return err
-		}
-
-		if c.Repository == config.Repository && c.EventType == config.EventType {
-			ctx.AssociateWebhook(hook.ID)
-			return nil
-		}
-	}
-
-	return ctx.CreateWebhook(configuration)
+	return configA.Repository == configB.Repository && configA.EventType == configB.EventType, nil
 }
 
 type Webhook struct {

--- a/pkg/applications/github/github_test.go
+++ b/pkg/applications/github/github_test.go
@@ -57,3 +57,115 @@ func Test__GitHub__Setup(t *testing.T) {
 		assert.NotEmpty(t, metadata.State)
 	})
 }
+
+func Test__GitHub__CompareWebhookConfig(t *testing.T) {
+	g := &GitHub{}
+
+	testCases := []struct {
+		name        string
+		configA     any
+		configB     any
+		expectEqual bool
+		expectError bool
+	}{
+		{
+			name: "identical configurations",
+			configA: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			configB: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			expectEqual: true,
+			expectError: false,
+		},
+		{
+			name: "different event types",
+			configA: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			configB: WebhookConfiguration{
+				EventType:  "pull_request",
+				Repository: "superplane",
+			},
+			expectEqual: false,
+			expectError: false,
+		},
+		{
+			name: "different repositories",
+			configA: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			configB: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "other-repo",
+			},
+			expectEqual: false,
+			expectError: false,
+		},
+		{
+			name: "both fields different",
+			configA: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			configB: WebhookConfiguration{
+				EventType:  "issues",
+				Repository: "other-repo",
+			},
+			expectEqual: false,
+			expectError: false,
+		},
+		{
+			name: "comparing map representations",
+			configA: map[string]any{
+				"eventType":  "push",
+				"repository": "superplane",
+			},
+			configB: map[string]any{
+				"eventType":  "push",
+				"repository": "superplane",
+			},
+			expectEqual: true,
+			expectError: false,
+		},
+		{
+			name:    "invalid first configuration",
+			configA: "invalid",
+			configB: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			expectEqual: false,
+			expectError: true,
+		},
+		{
+			name: "invalid second configuration",
+			configA: WebhookConfiguration{
+				EventType:  "push",
+				Repository: "superplane",
+			},
+			configB:     "invalid",
+			expectEqual: false,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			equal, err := g.CompareWebhookConfig(tc.configA, tc.configB)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectEqual, equal)
+		})
+	}
+}

--- a/pkg/applications/semaphore/semaphore.go
+++ b/pkg/applications/semaphore/semaphore.go
@@ -101,32 +101,18 @@ type WebhookConfiguration struct {
 	Project string `json:"project"`
 }
 
-func (s *Semaphore) RequestWebhook(ctx core.AppInstallationContext, configuration any) error {
-	config := WebhookConfiguration{}
-	err := mapstructure.Decode(configuration, &config)
-	if err != nil {
-		return fmt.Errorf("Failed to decode configuration: %v", err)
+func (s *Semaphore) CompareWebhookConfig(a, b any) (bool, error) {
+	configA := WebhookConfiguration{}
+	if err := mapstructure.Decode(a, &configA); err != nil {
+		return false, err
 	}
 
-	hooks, err := ctx.ListWebhooks()
-	if err != nil {
-		return fmt.Errorf("Failed to list webhooks: %v", err)
+	configB := WebhookConfiguration{}
+	if err := mapstructure.Decode(b, &configB); err != nil {
+		return false, err
 	}
 
-	for _, hook := range hooks {
-		c := WebhookConfiguration{}
-		err := mapstructure.Decode(hook.Configuration, &c)
-		if err != nil {
-			return err
-		}
-
-		if c.Project == config.Project {
-			ctx.AssociateWebhook(hook.ID)
-			return nil
-		}
-	}
-
-	return ctx.CreateWebhook(configuration)
+	return configA.Project == configB.Project, nil
 }
 
 type WebhookMetadata struct {

--- a/pkg/applications/semaphore/semaphore_test.go
+++ b/pkg/applications/semaphore/semaphore_test.go
@@ -1,0 +1,86 @@
+package semaphore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__Semaphore__CompareWebhookConfig(t *testing.T) {
+	s := &Semaphore{}
+
+	testCases := []struct {
+		name        string
+		configA     any
+		configB     any
+		expectEqual bool
+		expectError bool
+	}{
+		{
+			name: "identical configurations",
+			configA: WebhookConfiguration{
+				Project: "my-project",
+			},
+			configB: WebhookConfiguration{
+				Project: "my-project",
+			},
+			expectEqual: true,
+			expectError: false,
+		},
+		{
+			name: "different projects",
+			configA: WebhookConfiguration{
+				Project: "my-project",
+			},
+			configB: WebhookConfiguration{
+				Project: "other-project",
+			},
+			expectEqual: false,
+			expectError: false,
+		},
+		{
+			name: "comparing map representations",
+			configA: map[string]any{
+				"project": "my-project",
+			},
+			configB: map[string]any{
+				"project": "my-project",
+			},
+			expectEqual: true,
+			expectError: false,
+		},
+		{
+			name:    "invalid first configuration",
+			configA: "invalid",
+			configB: WebhookConfiguration{
+				Project: "my-project",
+			},
+			expectEqual: false,
+			expectError: true,
+		},
+		{
+			name: "invalid second configuration",
+			configA: WebhookConfiguration{
+				Project: "my-project",
+			},
+			configB:     "invalid",
+			expectEqual: false,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			equal, err := s.CompareWebhookConfig(tc.configA, tc.configB)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectEqual, equal)
+		})
+	}
+}

--- a/pkg/core/application.go
+++ b/pkg/core/application.go
@@ -55,10 +55,11 @@ type Application interface {
 	HandleRequest(ctx HTTPRequestContext)
 
 	/*
-	 * Request a webhook from the app installation.
-	 * Used by components/triggers that need access to application webhooks.
+	 * Used to compare webhook configurations.
+	 * If the configuration is the same,
+	 * the system will reuse the existing webhook.
 	 */
-	RequestWebhook(ctx AppInstallationContext, configuration any) error
+	CompareWebhookConfig(a, b any) (bool, error)
 
 	/*
 	 * Set up webhooks through the app installation, in the external system.
@@ -121,27 +122,10 @@ type AppInstallationContext interface {
 	GetSecrets() ([]InstallationSecret, error)
 
 	/*
-	 * List the webhooks associated with the app installation.
-	 */
-	ListWebhooks() ([]Webhook, error)
-
-	/*
-	 * Create a new webhook for the app installation,
-	 * and associate it with the current node.
-	 */
-	CreateWebhook(configuration any) error
-
-	/*
 	 * Request a new webhook from the app installation.
 	 * Called from the components/triggers Setup().
 	 */
 	RequestWebhook(configuration any) error
-
-	/*
-	 * Associate the current node with this webhook ID.
-	 * TODO: not happy about this method at all.
-	 */
-	AssociateWebhook(webhookID uuid.UUID)
 }
 
 type InstallationSecret struct {

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -149,11 +149,6 @@ type IntegrationContext interface {
 	GetIntegration(ID string) (integrations.ResourceManager, error)
 }
 
-type Webhook struct {
-	ID            uuid.UUID
-	Configuration any
-}
-
 /*
  * MetadataContext allows components to store/retrieve
  * component-specific information about each execution.

--- a/test/support/application.go
+++ b/test/support/application.go
@@ -54,8 +54,8 @@ func (t *DummyApplication) Sync(ctx core.SyncContext) error {
 func (t *DummyApplication) HandleRequest(ctx core.HTTPRequestContext) {
 }
 
-func (t *DummyApplication) RequestWebhook(ctx core.AppInstallationContext, configuration any) error {
-	return nil
+func (t *DummyApplication) CompareWebhookConfig(a, b any) (bool, error) {
+	return false, nil
 }
 
 func (t *DummyApplication) SetupWebhook(ctx core.AppInstallationContext, options core.WebhookOptions) (any, error) {

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -51,7 +51,6 @@ type AppInstallationContext struct {
 	State            string
 	StateDescription string
 	BrowserAction    *core.BrowserAction
-	Webhooks         []core.Webhook
 	Secrets          map[string]core.InstallationSecret
 	WebhookRequests  []any
 }
@@ -102,22 +101,9 @@ func (c *AppInstallationContext) GetSecrets() ([]core.InstallationSecret, error)
 	return secrets, nil
 }
 
-func (c *AppInstallationContext) ListWebhooks() ([]core.Webhook, error) {
-	return []core.Webhook{}, nil
-}
-
-func (c *AppInstallationContext) CreateWebhook(configuration any) error {
-	c.Webhooks = append(c.Webhooks, core.Webhook{ID: uuid.New(), Configuration: configuration})
-	return nil
-}
-
 func (c *AppInstallationContext) RequestWebhook(configuration any) error {
 	c.WebhookRequests = append(c.WebhookRequests, configuration)
 	return nil
-}
-
-func (c *AppInstallationContext) AssociateWebhook(webhookID uuid.UUID) {
-	// TODO: I don't like this method
 }
 
 type ExecutionStateContext struct {


### PR DESCRIPTION
The logic of searching for an existing web hook that matches the requested configuration is the same for all Application implementations. The only thing that is different is the logic for comparing web hook configurations. Due to that, we simplify the webhook-related methods by doing the following:
- The RequestWebhook() methods lives only on the AppInstallationContext - not on the Application interface - and it's how application components/triggers implementations request a webhook from the the app installation.
- No more ListWebhooks(), CreateWebhook() and AssociateWebhook() methods in AppInstallationContext. That could be confusing to the user implementing the component/trigger. Now, they only see a RequestWebhook().
- A new CompareWebhookConfig() was added to the Application interface, and it's how application implementations determine when to reuse web hooks or not.