### PR TITLE
fix: merge component uses new payload structure

### DIFF
--- a/pkg/applications/semaphore/run_workflow.go
+++ b/pkg/applications/semaphore/run_workflow.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
-	"github.com/superplanehq/superplane/pkg/models"
 )
 
 const PayloadType = "semaphore.workflow.finished"
@@ -152,7 +152,7 @@ func (r *RunWorkflow) Configuration() []configuration.Field {
 	}
 }
 
-func (r *RunWorkflow) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (r *RunWorkflow) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/approval/approval.go
+++ b/pkg/components/approval/approval.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -351,7 +350,7 @@ func (a *Approval) Setup(ctx core.SetupContext) error {
 	return nil
 }
 
-func (a *Approval) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (a *Approval) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/filter/filter.go
+++ b/pkg/components/filter/filter.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr"
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -116,7 +116,7 @@ func (f *Filter) Setup(ctx core.SetupContext) error {
 	return nil
 }
 
-func (f *Filter) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (f *Filter) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -9,10 +9,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -312,7 +312,7 @@ func (e *HTTP) HandleAction(ctx core.ActionContext) error {
 	return fmt.Errorf("http does not support actions")
 }
 
-func (e *HTTP) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (e *HTTP) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/if/if.go
+++ b/pkg/components/if/if.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr"
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -124,7 +124,7 @@ func (f *If) Setup(ctx core.SetupContext) error {
 	return nil
 }
 
-func (f *If) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (f *If) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/noop/noop.go
+++ b/pkg/components/noop/noop.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -55,7 +55,7 @@ func (c *NoOp) Execute(ctx core.ExecutionContext) error {
 	)
 }
 
-func (c *NoOp) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (c *NoOp) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/semaphore/semaphore.go
+++ b/pkg/components/semaphore/semaphore.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/semaphore"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -166,7 +165,7 @@ func (s *Semaphore) Configuration() []configuration.Field {
 	}
 }
 
-func (s *Semaphore) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (s *Semaphore) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/timegate/time_gate.go
+++ b/pkg/components/timegate/time_gate.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -242,7 +242,7 @@ func (tg *TimeGate) Setup(ctx core.SetupContext) error {
 	return nil
 }
 
-func (tg *TimeGate) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (tg *TimeGate) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/components/wait/wait.go
+++ b/pkg/components/wait/wait.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -388,7 +388,7 @@ func (w *Wait) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 	return http.StatusOK, nil
 }
 
-func (w *Wait) ProcessQueueItem(ctx core.ProcessQueueContext) (*models.WorkflowNodeExecution, error) {
+func (w *Wait) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
 	return ctx.DefaultProcessing()
 }
 

--- a/pkg/grpc/actions/workflows/cancel_execution.go
+++ b/pkg/grpc/actions/workflows/cancel_execution.go
@@ -82,7 +82,7 @@ func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authori
 			}
 
 			ctx := core.ExecutionContext{
-				ID:                    execution.ID.String(),
+				ID:                    execution.ID,
 				WorkflowID:            execution.WorkflowID.String(),
 				Configuration:         execution.Configuration.Data(),
 				MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -730,7 +730,7 @@ func (s *Server) executeComponentNode(ctx context.Context, body []byte, headers 
 			}
 
 			return &core.ExecutionContext{
-				ID:                    execution.ID.String(),
+				ID:                    execution.ID,
 				WorkflowID:            execution.WorkflowID.String(),
 				Configuration:         execution.Configuration.Data(),
 				MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),

--- a/pkg/workers/workflow_node_executor.go
+++ b/pkg/workers/workflow_node_executor.go
@@ -224,7 +224,7 @@ func (w *WorkflowNodeExecutor) executeComponentNode(tx *gorm.DB, execution *mode
 	}
 
 	ctx := core.ExecutionContext{
-		ID:                    execution.ID.String(),
+		ID:                    execution.ID,
 		WorkflowID:            execution.WorkflowID.String(),
 		Configuration:         execution.Configuration.Data(),
 		Data:                  input,


### PR DESCRIPTION
Executions for the merge component are handled mostly as part of ProcessQueueItem(), and ProcessQueueContext does not provide an interface that forces the component to emit events with the new base payload structure. To address that, we:
- Simplify the ProcessQueueContext by returning `core.ExecutionContext` from methods that get/create executions. With that, the interface for managing state/metadata/kv for executions is the same across all methods.
- We should not have a dependency between pkg/core and pkg/models, so the models.WorkflowNodeExecution references were removed. The only reason we need them is so the queue worker can send updates to the UI, and we can achieve through IDs only.