### PR TITLE
fix: sidebar id mismatch

### DIFF
--- a/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
+++ b/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
@@ -372,7 +372,9 @@ export const SidebarEventItem: React.FC<SidebarEventItemProps> = ({
       {/* Second row: Event ID and title with actions */}
       <div className="flex items-center mt-1 gap-2">
         <div className="flex items-center gap-2 min-w-0 flex-1 cursor-pointer">
-          {event.id && <span className="text-[13px] text-gray-950/50 font-mono">#{event.id?.slice(0, 4)}</span>}
+          {tabData?.root?.["Event ID"] && (
+            <span className="text-[13px] text-gray-950/50 font-mono">#{tabData.root["Event ID"]?.slice(0, 4)}</span>
+          )}
           <span className="text-sm text-gray-800 font-inter truncate text-md min-w-0 font-medium">{event.title}</span>
         </div>
       </div>


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/1417

<img width="1341" height="447" alt="image" src="https://github.com/user-attachments/assets/aeb15373-0301-47a6-8157-620c71394045" />
