### PR TITLE
chore: No need to explicitly set the name of the rabbitmq docker container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -126,7 +126,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:3.8.17-management-alpine
-    container_name: "rabbitmq"
     ports:
       - 5672:5672
       - 15672:15672


### PR DESCRIPTION
Noticed this while setting up dev env with @e-todorovski-bm.
Needless friction in the dev setup process.