### PR TITLE
fix: remove *Context suffix from context fields

### DIFF
--- a/docs/contributing/applications.md
+++ b/docs/contributing/applications.md
@@ -228,7 +228,7 @@ func (t *OnEvent) Configuration() []configuration.Field {
 
 func (t *OnEvent) Setup(ctx core.TriggerContext) error {
 	var metadata OnEventMetadata
-	err := mapstructure.Decode(ctx.MetadataContext.Get(), &metadata)
+	err := mapstructure.Decode(ctx.Metadata.Get(), &metadata)
 	if err != nil {
 		return fmt.Errorf("failed to parse metadata: %w", err)
 	}
@@ -251,13 +251,13 @@ func (t *OnEvent) Setup(ctx core.TriggerContext) error {
 
 	// Store metadata
 	metadata.Resource = config.Resource
-	err = ctx.MetadataContext.Set(metadata)
+	err = ctx.Metadata.Set(metadata)
 	if err != nil {
 		return fmt.Errorf("failed to set metadata: %w", err)
 	}
 
 	// Request webhook if needed
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType: "event",
 		Resource:  config.Resource,
 	})
@@ -279,7 +279,7 @@ func (t *OnEvent) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 	}
 
 	// Verify the signature
-	secret, err := ctx.WebhookContext.GetSecret()
+	secret, err := ctx.Webhook.GetSecret()
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error authenticating request")
 	}
@@ -312,7 +312,7 @@ func (t *OnEvent) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 	}
 
 	// Emit the event to trigger workflow execution
-	err = ctx.EventContext.Emit(data)
+	err = ctx.Events.Emit(data)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)
 	}

--- a/pkg/applications/github/common.go
+++ b/pkg/applications/github/common.go
@@ -108,7 +108,7 @@ func verifySignature(ctx core.WebhookRequestContext, expectedType string) (int, 
 		return http.StatusForbidden, fmt.Errorf("invalid signature")
 	}
 
-	secret, err := ctx.WebhookContext.GetSecret()
+	secret, err := ctx.Webhook.GetSecret()
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error authenticating request")
 	}

--- a/pkg/applications/github/create_issue.go
+++ b/pkg/applications/github/create_issue.go
@@ -98,8 +98,8 @@ func (c *CreateIssue) Configuration() []configuration.Field {
 
 func (c *CreateIssue) Setup(ctx core.SetupContext) error {
 	return ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 }
@@ -111,16 +111,16 @@ func (c *CreateIssue) Execute(ctx core.ExecutionContext) error {
 	}
 
 	var nodeMetadata NodeMetadata
-	if err := mapstructure.Decode(ctx.NodeMetadataContext.Get(), &nodeMetadata); err != nil {
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &nodeMetadata); err != nil {
 		return fmt.Errorf("failed to decode node metadata: %w", err)
 	}
 
 	var appMetadata Metadata
-	if err := mapstructure.Decode(ctx.AppInstallationContext.GetMetadata(), &appMetadata); err != nil {
+	if err := mapstructure.Decode(ctx.AppInstallation.GetMetadata(), &appMetadata); err != nil {
 		return fmt.Errorf("failed to decode application metadata: %w", err)
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	client, err := NewClient(ctx.AppInstallation, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
 	if err != nil {
 		return fmt.Errorf("failed to initialize GitHub client: %w", err)
 	}
@@ -156,7 +156,7 @@ func (c *CreateIssue) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create issue: %w", err)
 	}
 
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"github.issue",
 		[]any{issue},

--- a/pkg/applications/github/get_issue.go
+++ b/pkg/applications/github/get_issue.go
@@ -71,8 +71,8 @@ func (c *GetIssue) Setup(ctx core.SetupContext) error {
 	}
 
 	return ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 }
@@ -89,12 +89,12 @@ func (c *GetIssue) Execute(ctx core.ExecutionContext) error {
 	}
 
 	var appMetadata Metadata
-	if err := mapstructure.Decode(ctx.AppInstallationContext.GetMetadata(), &appMetadata); err != nil {
+	if err := mapstructure.Decode(ctx.AppInstallation.GetMetadata(), &appMetadata); err != nil {
 		return fmt.Errorf("failed to decode application metadata: %w", err)
 	}
 
 	// Initialize GitHub client
-	client, err := NewClient(ctx.AppInstallationContext, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	client, err := NewClient(ctx.AppInstallation, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
 	if err != nil {
 		return fmt.Errorf("failed to initialize GitHub client: %w", err)
 	}
@@ -111,7 +111,7 @@ func (c *GetIssue) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to get issue: %w", err)
 	}
 
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"github.issue",
 		[]any{issue},

--- a/pkg/applications/github/on_branch_created.go
+++ b/pkg/applications/github/on_branch_created.go
@@ -67,8 +67,8 @@ func (t *OnBranchCreated) Configuration() []configuration.Field {
 
 func (t *OnBranchCreated) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -81,7 +81,7 @@ func (t *OnBranchCreated) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "create",
 		Repository: config.Repository,
 	})
@@ -144,7 +144,7 @@ func (t *OnBranchCreated) HandleWebhook(ctx core.WebhookRequestContext) (int, er
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.branchCreated", data)
+	err = ctx.Events.Emit("github.branchCreated", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_branch_created_test.go
+++ b/pkg/applications/github/on_branch_created_test.go
@@ -31,9 +31,9 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -56,8 +56,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "feature-branch"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -86,8 +86,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: ".*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -117,8 +117,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "feature-branch"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -148,8 +148,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeNotEquals, Value: "main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -179,8 +179,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: "feature/.*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -210,8 +210,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "feature-branch"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -241,8 +241,8 @@ func Test__OnBranchCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: ".*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -258,9 +258,9 @@ func Test__OnBranchCreated__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -273,9 +273,9 @@ func Test__OnBranchCreated__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -290,9 +290,9 @@ func Test__OnBranchCreated__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/on_issue.go
+++ b/pkg/applications/github/on_issue.go
@@ -79,8 +79,8 @@ func (i *OnIssue) Configuration() []configuration.Field {
 
 func (i *OnIssue) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -93,7 +93,7 @@ func (i *OnIssue) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "issues",
 		Repository: config.Repository,
 	})
@@ -129,7 +129,7 @@ func (i *OnIssue) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.issue", data)
+	err = ctx.Events.Emit("github.issue", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_issue_test.go
+++ b/pkg/applications/github/on_issue_test.go
@@ -31,9 +31,9 @@ func Test__OnIssue__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -54,8 +54,8 @@ func Test__OnIssue__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -82,8 +82,8 @@ func Test__OnIssue__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -111,8 +111,8 @@ func Test__OnIssue__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -128,9 +128,9 @@ func Test__OnIssue__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -143,9 +143,9 @@ func Test__OnIssue__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -160,9 +160,9 @@ func Test__OnIssue__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/on_pull_request.go
+++ b/pkg/applications/github/on_pull_request.go
@@ -73,8 +73,8 @@ func (p *OnPullRequest) Configuration() []configuration.Field {
 
 func (p *OnPullRequest) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -87,7 +87,7 @@ func (p *OnPullRequest) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "pull_request",
 		Repository: config.Repository,
 	})
@@ -123,7 +123,7 @@ func (p *OnPullRequest) HandleWebhook(ctx core.WebhookRequestContext) (int, erro
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.pullRequest", data)
+	err = ctx.Events.Emit("github.pullRequest", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_pull_request_test.go
+++ b/pkg/applications/github/on_pull_request_test.go
@@ -31,9 +31,9 @@ func Test__OnPullRequest__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -54,8 +54,8 @@ func Test__OnPullRequest__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -82,8 +82,8 @@ func Test__OnPullRequest__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -111,8 +111,8 @@ func Test__OnPullRequest__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"opened"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -128,9 +128,9 @@ func Test__OnPullRequest__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -143,9 +143,9 @@ func Test__OnPullRequest__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -160,9 +160,9 @@ func Test__OnPullRequest__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/on_push.go
+++ b/pkg/applications/github/on_push.go
@@ -67,8 +67,8 @@ func (p *OnPush) Configuration() []configuration.Field {
 
 func (p *OnPush) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -81,7 +81,7 @@ func (p *OnPush) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "push",
 		Repository: config.Repository,
 	})
@@ -134,7 +134,7 @@ func (p *OnPush) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.push", data)
+	err = ctx.Events.Emit("github.push", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_push_test.go
+++ b/pkg/applications/github/on_push_test.go
@@ -31,9 +31,9 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -56,8 +56,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "refs/heads/main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -86,8 +86,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "refs/heads/main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -117,8 +117,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "refs/heads/main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -148,8 +148,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeNotEquals, Value: "refs/heads/main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -179,8 +179,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: "refs/heads/feat/*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -210,8 +210,8 @@ func Test__OnPush__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "refs/heads/main"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -227,9 +227,9 @@ func Test__OnPush__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -242,9 +242,9 @@ func Test__OnPush__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -259,9 +259,9 @@ func Test__OnPush__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/on_release.go
+++ b/pkg/applications/github/on_release.go
@@ -70,8 +70,8 @@ func (r *OnRelease) Configuration() []configuration.Field {
 
 func (r *OnRelease) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -84,7 +84,7 @@ func (r *OnRelease) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "release",
 		Repository: config.Repository,
 	})
@@ -120,7 +120,7 @@ func (r *OnRelease) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.release", data)
+	err = ctx.Events.Emit("github.release", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_release_test.go
+++ b/pkg/applications/github/on_release_test.go
@@ -31,9 +31,9 @@ func Test__OnRelease__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -54,8 +54,8 @@ func Test__OnRelease__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"created"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -82,8 +82,8 @@ func Test__OnRelease__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"created"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -111,8 +111,8 @@ func Test__OnRelease__HandleWebhook(t *testing.T) {
 				"repository": "test",
 				"actions":    []string{"created"},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -128,9 +128,9 @@ func Test__OnRelease__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -143,9 +143,9 @@ func Test__OnRelease__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -160,9 +160,9 @@ func Test__OnRelease__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/on_tag_created.go
+++ b/pkg/applications/github/on_tag_created.go
@@ -67,8 +67,8 @@ func (t *OnTagCreated) Configuration() []configuration.Field {
 
 func (t *OnTagCreated) Setup(ctx core.TriggerContext) error {
 	err := ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 
@@ -81,7 +81,7 @@ func (t *OnTagCreated) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		EventType:  "create",
 		Repository: config.Repository,
 	})
@@ -144,7 +144,7 @@ func (t *OnTagCreated) HandleWebhook(ctx core.WebhookRequestContext) (int, error
 		return http.StatusOK, nil
 	}
 
-	err = ctx.EventContext.Emit("github.tagCreated", data)
+	err = ctx.Events.Emit("github.tagCreated", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/github/on_tag_created_test.go
+++ b/pkg/applications/github/on_tag_created_test.go
@@ -31,9 +31,9 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -56,8 +56,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "v1.0.0"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -86,8 +86,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: ".*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -117,8 +117,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "v1.0.0"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -148,8 +148,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeNotEquals, Value: "v1.0.0"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -179,8 +179,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: "v.*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -210,8 +210,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeEquals, Value: "v1.0.0"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -241,8 +241,8 @@ func Test__OnTagCreated__HandleWebhook(t *testing.T) {
 					{Type: configuration.PredicateTypeMatches, Value: ".*"},
 				},
 			},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -258,9 +258,9 @@ func Test__OnTagCreated__Setup(t *testing.T) {
 	t.Run("repository is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
 		})
 
 		require.ErrorContains(t, err, "repository is required")
@@ -273,9 +273,9 @@ func Test__OnTagCreated__Setup(t *testing.T) {
 			},
 		}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          map[string]any{"repository": "world"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
 		})
 
 		require.ErrorContains(t, err, "repository world is not accessible to app installation")
@@ -290,9 +290,9 @@ func Test__OnTagCreated__Setup(t *testing.T) {
 
 		nodeMetadataCtx := contexts.MetadataContext{}
 		require.NoError(t, trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &nodeMetadataCtx,
-			Configuration:          map[string]any{"repository": "hello"},
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
 		}))
 
 		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})

--- a/pkg/applications/github/update_issue.go
+++ b/pkg/applications/github/update_issue.go
@@ -127,8 +127,8 @@ func (c *UpdateIssue) Configuration() []configuration.Field {
 
 func (c *UpdateIssue) Setup(ctx core.SetupContext) error {
 	return ensureRepoInMetadata(
-		ctx.MetadataContext,
-		ctx.AppInstallationContext,
+		ctx.Metadata,
+		ctx.AppInstallation,
 		ctx.Configuration,
 	)
 }
@@ -140,16 +140,16 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 	}
 
 	var nodeMetadata NodeMetadata
-	if err := mapstructure.Decode(ctx.NodeMetadataContext.Get(), &nodeMetadata); err != nil {
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &nodeMetadata); err != nil {
 		return fmt.Errorf("failed to decode node metadata: %w", err)
 	}
 
 	var appMetadata Metadata
-	if err := mapstructure.Decode(ctx.AppInstallationContext.GetMetadata(), &appMetadata); err != nil {
+	if err := mapstructure.Decode(ctx.AppInstallation.GetMetadata(), &appMetadata); err != nil {
 		return fmt.Errorf("failed to decode application metadata: %w", err)
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	client, err := NewClient(ctx.AppInstallation, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
 	if err != nil {
 		return fmt.Errorf("failed to initialize GitHub client: %w", err)
 	}
@@ -192,7 +192,7 @@ func (c *UpdateIssue) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to update issue: %w", err)
 	}
 
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"github.issue",
 		[]any{issue},

--- a/pkg/applications/pagerduty/create_incident.go
+++ b/pkg/applications/pagerduty/create_incident.go
@@ -105,7 +105,7 @@ func (c *CreateIncident) Setup(ctx core.SetupContext) error {
 		return errors.New("service is required")
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return fmt.Errorf("error creating client: %v", err)
 	}
@@ -115,7 +115,7 @@ func (c *CreateIncident) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error finding service: %v", err)
 	}
 
-	return ctx.MetadataContext.Set(NodeMetadata{Service: service})
+	return ctx.Metadata.Set(NodeMetadata{Service: service})
 }
 
 func (c *CreateIncident) Execute(ctx core.ExecutionContext) error {
@@ -125,7 +125,7 @@ func (c *CreateIncident) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return fmt.Errorf("error creating client: %v", err)
 	}
@@ -135,7 +135,7 @@ func (c *CreateIncident) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create incident: %v", err)
 	}
 
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"pagerduty.incident",
 		[]any{incident},

--- a/pkg/applications/pagerduty/on_incident_test.go
+++ b/pkg/applications/pagerduty/on_incident_test.go
@@ -41,9 +41,9 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 		headers.Set("X-PagerDuty-Signature", "invalid")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -56,11 +56,11 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 		headers.Set("X-PagerDuty-Signature", "v1=invalid")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  validConfig,
-			WebhookContext: &contexts.WebhookContext{Secret: "test-secret"},
-			EventContext:   &contexts.EventContext{},
+			Body:          body,
+			Headers:       headers,
+			Configuration: validConfig,
+			Webhook:       &contexts.WebhookContext{Secret: "test-secret"},
+			Events:        &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -75,11 +75,11 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 		headers.Set("X-PagerDuty-Signature", "v1="+signatureFor(secret, body))
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  validConfig,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Body:          body,
+			Headers:       headers,
+			Configuration: validConfig,
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -95,11 +95,11 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  validConfig,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:          body,
+			Headers:       headers,
+			Configuration: validConfig,
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -116,11 +116,11 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  map[string]any{"events": []string{"incident.triggered"}, "urgencies": []string{"high"}},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:          body,
+			Headers:       headers,
+			Configuration: map[string]any{"events": []string{"incident.triggered"}, "urgencies": []string{"high"}},
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -137,11 +137,11 @@ func Test__OnIncident__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  validConfig,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:          body,
+			Headers:       headers,
+			Configuration: validConfig,
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        eventContext,
 		})
 
 		require.Equal(t, http.StatusOK, code)
@@ -166,9 +166,9 @@ func Test__OnIncident__Setup(t *testing.T) {
 	t.Run("invalid configuration -> decode error", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          "invalid-config",
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   "invalid-config",
 		})
 
 		require.ErrorContains(t, err, "failed to decode configuration")
@@ -177,9 +177,9 @@ func Test__OnIncident__Setup(t *testing.T) {
 	t.Run("at least one event required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          OnIncidentConfiguration{Events: []string{}, Service: "svc-1"},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   OnIncidentConfiguration{Events: []string{}, Service: "svc-1"},
 		})
 
 		require.ErrorContains(t, err, "at least one event type must be chosen")
@@ -188,9 +188,9 @@ func Test__OnIncident__Setup(t *testing.T) {
 	t.Run("service is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          OnIncidentConfiguration{Events: []string{"incident.triggered"}},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   OnIncidentConfiguration{Events: []string{"incident.triggered"}},
 		})
 
 		require.ErrorContains(t, err, "service is required")
@@ -204,9 +204,9 @@ func Test__OnIncident__Setup(t *testing.T) {
 		}
 
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        metadataCtx,
-			Configuration:          OnIncidentConfiguration{Events: []string{"incident.triggered"}, Service: "svc-1"},
+			AppInstallation: appCtx,
+			Metadata:        metadataCtx,
+			Configuration:   OnIncidentConfiguration{Events: []string{"incident.triggered"}, Service: "svc-1"},
 		})
 
 		require.NoError(t, err)

--- a/pkg/applications/semaphore/on_pipeline_done.go
+++ b/pkg/applications/semaphore/on_pipeline_done.go
@@ -55,7 +55,7 @@ func (p *OnPipelineDone) Configuration() []configuration.Field {
 
 func (p *OnPipelineDone) Setup(ctx core.TriggerContext) error {
 	var metadata OnPipelineDoneMetadata
-	err := mapstructure.Decode(ctx.MetadataContext.Get(), &metadata)
+	err := mapstructure.Decode(ctx.Metadata.Get(), &metadata)
 	if err != nil {
 		return fmt.Errorf("failed to parse metadata: %w", err)
 	}
@@ -84,7 +84,7 @@ func (p *OnPipelineDone) Setup(ctx core.TriggerContext) error {
 		return nil
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (p *OnPipelineDone) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("error finding project %s: %v", config.Project, err)
 	}
 
-	err = ctx.MetadataContext.Set(OnPipelineDoneMetadata{
+	err = ctx.Metadata.Set(OnPipelineDoneMetadata{
 		Project: &Project{
 			ID:   project.Metadata.ProjectID,
 			Name: project.Metadata.ProjectName,
@@ -106,7 +106,7 @@ func (p *OnPipelineDone) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("error setting metadata: %v", err)
 	}
 
-	return ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	return ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		Project: project.Metadata.ProjectName,
 	})
 }
@@ -130,7 +130,7 @@ func (p *OnPipelineDone) HandleWebhook(ctx core.WebhookRequestContext) (int, err
 		return http.StatusForbidden, fmt.Errorf("invalid signature")
 	}
 
-	secret, err := ctx.WebhookContext.GetSecret()
+	secret, err := ctx.Webhook.GetSecret()
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error authenticating request")
 	}
@@ -145,7 +145,7 @@ func (p *OnPipelineDone) HandleWebhook(ctx core.WebhookRequestContext) (int, err
 		return http.StatusBadRequest, fmt.Errorf("error parsing request body: %v", err)
 	}
 
-	err = ctx.EventContext.Emit("semaphore.pipelineDone", data)
+	err = ctx.Events.Emit("semaphore.pipelineDone", data)
 
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)

--- a/pkg/applications/semaphore/on_pipeline_done_test.go
+++ b/pkg/applications/semaphore/on_pipeline_done_test.go
@@ -30,9 +30,9 @@ func Test__OnPipelineDone__HandleWebhook(t *testing.T) {
 		headers.Set("X-Semaphore-Signature-256", "invalidsignature")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -46,10 +46,10 @@ func Test__OnPipelineDone__HandleWebhook(t *testing.T) {
 		headers.Set("X-Semaphore-Signature-256", "sha256=invalidsignature")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           []byte(`{"pipeline":{"state":"done"}}`),
-			Headers:        headers,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Body:    []byte(`{"pipeline":{"state":"done"}}`),
+			Headers: headers,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -69,10 +69,10 @@ func Test__OnPipelineDone__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:    body,
+			Headers: headers,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -94,10 +94,10 @@ func Test__OnPipelineDone__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:    body,
+			Headers: headers,
+			Webhook: &contexts.WebhookContext{Secret: secret},
+			Events:  eventContext,
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -111,9 +111,9 @@ func Test__OnPipelineDone__Setup(t *testing.T) {
 	t.Run("project is required", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          OnPipelineDoneConfiguration{Project: ""},
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   OnPipelineDoneConfiguration{Project: ""},
 		})
 
 		require.ErrorContains(t, err, "project is required")
@@ -129,9 +129,9 @@ func Test__OnPipelineDone__Setup(t *testing.T) {
 		}
 
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: &contexts.AppInstallationContext{},
-			MetadataContext:        metadataCtx,
-			Configuration:          OnPipelineDoneConfiguration{Project: "test-project"},
+			AppInstallation: &contexts.AppInstallationContext{},
+			Metadata:        metadataCtx,
+			Configuration:   OnPipelineDoneConfiguration{Project: "test-project"},
 		})
 
 		require.NoError(t, err)
@@ -142,9 +142,9 @@ func Test__OnPipelineDone__Setup(t *testing.T) {
 	t.Run("invalid configuration -> decode error", func(t *testing.T) {
 		appCtx := &contexts.AppInstallationContext{}
 		err := trigger.Setup(core.TriggerContext{
-			AppInstallationContext: appCtx,
-			MetadataContext:        &contexts.MetadataContext{},
-			Configuration:          "invalid-config",
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   "invalid-config",
 		})
 
 		require.ErrorContains(t, err, "failed to decode configuration")

--- a/pkg/applications/semaphore/run_workflow.go
+++ b/pkg/applications/semaphore/run_workflow.go
@@ -169,7 +169,7 @@ func (r *RunWorkflow) Setup(ctx core.SetupContext) error {
 	}
 
 	metadata := RunWorkflowNodeMetadata{}
-	err = mapstructure.Decode(ctx.MetadataContext.Get(), &metadata)
+	err = mapstructure.Decode(ctx.Metadata.Get(), &metadata)
 	if err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
@@ -181,7 +181,7 @@ func (r *RunWorkflow) Setup(ctx core.SetupContext) error {
 		return nil
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (r *RunWorkflow) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error finding project %s: %v", config.Project, err)
 	}
 
-	err = ctx.MetadataContext.Set(RunWorkflowNodeMetadata{
+	err = ctx.Metadata.Set(RunWorkflowNodeMetadata{
 		Project: &Project{
 			ID:   project.Metadata.ProjectID,
 			Name: project.Metadata.ProjectName,
@@ -203,7 +203,7 @@ func (r *RunWorkflow) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error setting metadata: %v", err)
 	}
 
-	ctx.AppInstallationContext.RequestWebhook(WebhookConfiguration{
+	ctx.AppInstallation.RequestWebhook(WebhookConfiguration{
 		Project: project.Metadata.ProjectName,
 	})
 
@@ -218,12 +218,12 @@ func (r *RunWorkflow) Execute(ctx core.ExecutionContext) error {
 	}
 
 	metadata := RunWorkflowNodeMetadata{}
-	err = mapstructure.Decode(ctx.NodeMetadataContext.Get(), &metadata)
+	err = mapstructure.Decode(ctx.NodeMetadata.Get(), &metadata)
 	if err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return err
 	}
@@ -241,12 +241,12 @@ func (r *RunWorkflow) Execute(ctx core.ExecutionContext) error {
 
 	response, err := client.RunWorkflow(params)
 	if err != nil {
-		return ctx.ExecutionStateContext.Fail(models.WorkflowNodeExecutionResultReasonError, err.Error())
+		return ctx.ExecutionState.Fail(models.WorkflowNodeExecutionResultReasonError, err.Error())
 	}
 
 	ctx.Logger.Infof("New workflow created - workflow=%s, pipeline=%s", response.WorkflowID, response.PipelineID)
 
-	ctx.MetadataContext.Set(RunWorkflowExecutionMetadata{
+	ctx.Metadata.Set(RunWorkflowExecutionMetadata{
 		Workflow: &WorkflowMetadata{
 			ID:  response.WorkflowID,
 			URL: fmt.Sprintf("%s/workflows/%s", string(client.OrgURL), response.WorkflowID),
@@ -260,7 +260,7 @@ func (r *RunWorkflow) Execute(ctx core.ExecutionContext) error {
 	// This is what allows the component to associate a semaphore webhook
 	// for a pipeline finishing to a SuperPlane execution.
 	//
-	err = ctx.ExecutionStateContext.SetKV("pipeline", response.PipelineID)
+	err = ctx.ExecutionState.SetKV("pipeline", response.PipelineID)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (r *RunWorkflow) Execute(ctx core.ExecutionContext) error {
 	// We still set up the poller to check for pipeline finishing,
 	// just in case something wrong happens with the update through the webhook.
 	//
-	return ctx.RequestContext.ScheduleActionCall("poll", map[string]any{}, PollInterval)
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 }
 
 func (r *RunWorkflow) Cancel(ctx core.ExecutionContext) error {
@@ -287,7 +287,7 @@ func (r *RunWorkflow) HandleWebhook(ctx core.WebhookRequestContext) (int, error)
 		return http.StatusForbidden, fmt.Errorf("invalid signature")
 	}
 
-	secret, err := ctx.WebhookContext.GetSecret()
+	secret, err := ctx.Webhook.GetSecret()
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error authenticating request")
 	}
@@ -321,7 +321,7 @@ func (r *RunWorkflow) HandleWebhook(ctx core.WebhookRequestContext) (int, error)
 	}
 
 	metadata := RunWorkflowExecutionMetadata{}
-	err = mapstructure.Decode(executionCtx.MetadataContext.Get(), &metadata)
+	err = mapstructure.Decode(executionCtx.Metadata.Get(), &metadata)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error decoding metadata: %v", err)
 	}
@@ -335,15 +335,15 @@ func (r *RunWorkflow) HandleWebhook(ctx core.WebhookRequestContext) (int, error)
 
 	metadata.Pipeline.State = hook.Pipeline.State
 	metadata.Pipeline.Result = hook.Pipeline.Result
-	err = executionCtx.MetadataContext.Set(metadata)
+	err = executionCtx.Metadata.Set(metadata)
 	if err != nil {
 		return http.StatusInternalServerError, fmt.Errorf("error setting metadata: %v", err)
 	}
 
 	if metadata.Pipeline.Result == PipelineResultPassed {
-		err = executionCtx.ExecutionStateContext.Emit(PassedOutputChannel, PayloadType, []any{metadata})
+		err = executionCtx.ExecutionState.Emit(PassedOutputChannel, PayloadType, []any{metadata})
 	} else {
-		err = executionCtx.ExecutionStateContext.Emit(FailedOutputChannel, PayloadType, []any{metadata})
+		err = executionCtx.ExecutionState.Emit(FailedOutputChannel, PayloadType, []any{metadata})
 	}
 
 	if err != nil {
@@ -392,12 +392,12 @@ func (r *RunWorkflow) poll(ctx core.ActionContext) error {
 		return err
 	}
 
-	if ctx.ExecutionStateContext.IsFinished() {
+	if ctx.ExecutionState.IsFinished() {
 		return nil
 	}
 
 	metadata := RunWorkflowExecutionMetadata{}
-	err = mapstructure.Decode(ctx.MetadataContext.Get(), &metadata)
+	err = mapstructure.Decode(ctx.Metadata.Get(), &metadata)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ func (r *RunWorkflow) poll(ctx core.ActionContext) error {
 		return nil
 	}
 
-	client, err := NewClient(ctx.AppInstallationContext)
+	client, err := NewClient(ctx.AppInstallation)
 	if err != nil {
 		return err
 	}
@@ -423,26 +423,26 @@ func (r *RunWorkflow) poll(ctx core.ActionContext) error {
 	// If not finished, poll again in 1min.
 	//
 	if pipeline.State != PipelineStateDone {
-		return ctx.RequestContext.ScheduleActionCall("poll", map[string]any{}, PollInterval)
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, PollInterval)
 	}
 
 	metadata.Pipeline.State = pipeline.State
 	metadata.Pipeline.Result = pipeline.Result
-	err = ctx.MetadataContext.Set(metadata)
+	err = ctx.Metadata.Set(metadata)
 	if err != nil {
 		return err
 	}
 
 	if pipeline.Result == PipelineResultPassed {
-		return ctx.ExecutionStateContext.Emit(PassedOutputChannel, PayloadType, []any{metadata})
+		return ctx.ExecutionState.Emit(PassedOutputChannel, PayloadType, []any{metadata})
 	}
 
-	return ctx.ExecutionStateContext.Emit(FailedOutputChannel, PayloadType, []any{metadata})
+	return ctx.ExecutionState.Emit(FailedOutputChannel, PayloadType, []any{metadata})
 }
 
 func (r *RunWorkflow) finish(ctx core.ActionContext) error {
 	metadata := RunWorkflowExecutionMetadata{}
-	err := mapstructure.Decode(ctx.MetadataContext.Get(), &metadata)
+	err := mapstructure.Decode(ctx.Metadata.Get(), &metadata)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func (r *RunWorkflow) finish(ctx core.ActionContext) error {
 	}
 
 	metadata.Extra = dataMap
-	err = ctx.MetadataContext.Set(metadata)
+	err = ctx.Metadata.Set(metadata)
 	if err != nil {
 		return err
 	}

--- a/pkg/components/approval/approval_test.go
+++ b/pkg/components/approval/approval_test.go
@@ -50,9 +50,9 @@ func TestApproval_HandleAction_Approved_UsesCorrectChannel(t *testing.T) {
 		Parameters: map[string]any{
 			"index": float64(0),
 		},
-		MetadataContext:       metadataCtx,
-		ExecutionStateContext: stateCtx,
-		AuthContext:           authCtx,
+		Metadata:       metadataCtx,
+		ExecutionState: stateCtx,
+		Auth:           authCtx,
 	}
 
 	err := approval.HandleAction(ctx)
@@ -89,9 +89,9 @@ func TestApproval_HandleAction_Rejected_UsesCorrectChannel(t *testing.T) {
 			"index":  float64(0),
 			"reason": "Not approved",
 		},
-		MetadataContext:       metadataCtx,
-		ExecutionStateContext: stateCtx,
-		AuthContext:           authCtx,
+		Metadata:       metadataCtx,
+		ExecutionState: stateCtx,
+		Auth:           authCtx,
 	}
 
 	err := approval.HandleAction(ctx)
@@ -129,9 +129,9 @@ func TestApproval_HandleAction_StillPending_DoesNotCallPass(t *testing.T) {
 		Parameters: map[string]any{
 			"index": float64(0),
 		},
-		MetadataContext:       metadataCtx,
-		ExecutionStateContext: stateCtx,
-		AuthContext:           authCtx,
+		Metadata:       metadataCtx,
+		ExecutionState: stateCtx,
+		Auth:           authCtx,
 	}
 
 	err := approval.HandleAction(ctx)
@@ -254,9 +254,9 @@ func TestApproval_Execute(t *testing.T) {
 			Configuration: map[string]any{
 				"items": []any{},
 			},
-			MetadataContext:       metadataCtx,
-			ExecutionStateContext: stateCtx,
-			AuthContext:           authCtx,
+			Metadata:       metadataCtx,
+			ExecutionState: stateCtx,
+			Auth:           authCtx,
 		}
 
 		err := approval.Execute(ctx)
@@ -291,9 +291,9 @@ func TestApproval_Execute(t *testing.T) {
 					},
 				},
 			},
-			MetadataContext:       metadataCtx,
-			ExecutionStateContext: stateCtx,
-			AuthContext:           authCtx,
+			Metadata:       metadataCtx,
+			ExecutionState: stateCtx,
+			Auth:           authCtx,
 		}
 
 		err := approval.Execute(ctx)

--- a/pkg/components/filter/filter.go
+++ b/pkg/components/filter/filter.go
@@ -94,14 +94,14 @@ func (f *Filter) Execute(ctx core.ExecutionContext) error {
 	}
 
 	if matches {
-		return ctx.ExecutionStateContext.Emit(
+		return ctx.ExecutionState.Emit(
 			core.DefaultOutputChannel.Name,
 			"filter.executed",
 			[]any{map[string]any{}},
 		)
 	}
 
-	return ctx.ExecutionStateContext.Pass()
+	return ctx.ExecutionState.Pass()
 }
 
 func (f *Filter) Actions() []core.Action {

--- a/pkg/components/filter/filter_test.go
+++ b/pkg/components/filter/filter_test.go
@@ -55,9 +55,9 @@ func TestFilter_Execute_EmitsEmptyEvents(t *testing.T) {
 			stateCtx := &contexts.ExecutionStateContext{}
 
 			ctx := core.ExecutionContext{
-				Data:                  tt.inputData,
-				Configuration:         tt.configuration,
-				ExecutionStateContext: stateCtx,
+				Data:           tt.inputData,
+				Configuration:  tt.configuration,
+				ExecutionState: stateCtx,
 			}
 
 			err := filter.Execute(ctx)
@@ -85,9 +85,9 @@ func TestFilter_Execute_InvalidExpression_ShouldReturnError(t *testing.T) {
 	stateCtx := &contexts.ExecutionStateContext{}
 
 	ctx := core.ExecutionContext{
-		Data:                  map[string]any{"test": "value"},
-		Configuration:         map[string]any{"expression": "invalid expression syntax +++"},
-		ExecutionStateContext: stateCtx,
+		Data:           map[string]any{"test": "value"},
+		Configuration:  map[string]any{"expression": "invalid expression syntax +++"},
+		ExecutionState: stateCtx,
 	}
 
 	err := filter.Execute(ctx)
@@ -101,9 +101,9 @@ func TestFilter_Execute_NonBooleanResult_ShouldReturnError(t *testing.T) {
 	stateCtx := &contexts.ExecutionStateContext{}
 
 	ctx := core.ExecutionContext{
-		Data:                  map[string]any{"test": "value"},
-		Configuration:         map[string]any{"expression": "$.test"},
-		ExecutionStateContext: stateCtx,
+		Data:           map[string]any{"test": "value"},
+		Configuration:  map[string]any{"expression": "$.test"},
+		ExecutionState: stateCtx,
 	}
 
 	err := filter.Execute(ctx)

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -398,7 +398,7 @@ func (e *HTTP) Execute(ctx core.ExecutionContext) error {
 		retryMetadata.MaxRetries = *spec.Retries
 	}
 
-	err = ctx.MetadataContext.Set(retryMetadata)
+	err = ctx.Metadata.Set(retryMetadata)
 	if err != nil {
 		return err
 	}
@@ -438,20 +438,20 @@ func (e *HTTP) scheduleRetry(ctx core.ExecutionContext, lastError string, retryM
 	retryMetadata.TotalRetries++
 	retryMetadata.LastError = lastError
 
-	err := ctx.MetadataContext.Set(retryMetadata)
+	err := ctx.Metadata.Set(retryMetadata)
 	if err != nil {
 		return err
 	}
 
-	return ctx.RequestContext.ScheduleActionCall("retryRequest", map[string]any{}, 1*time.Second)
+	return ctx.Requests.ScheduleActionCall("retryRequest", map[string]any{}, 1*time.Second)
 }
 
 func (e *HTTP) handleRetryRequest(ctx core.ActionContext) error {
-	if ctx.ExecutionStateContext.IsFinished() {
+	if ctx.ExecutionState.IsFinished() {
 		return nil
 	}
 
-	metadata := ctx.MetadataContext.Get()
+	metadata := ctx.Metadata.Get()
 
 	var retryMetadata RetryMetadata
 	err := mapstructure.Decode(metadata, &retryMetadata)
@@ -466,11 +466,11 @@ func (e *HTTP) handleRetryRequest(ctx core.ActionContext) error {
 	}
 
 	execCtx := core.ExecutionContext{
-		Configuration:         ctx.Configuration,
-		ExecutionStateContext: ctx.ExecutionStateContext,
-		MetadataContext:       ctx.MetadataContext,
-		RequestContext:        ctx.RequestContext,
-		AuthContext:           ctx.AuthContext,
+		Configuration:  ctx.Configuration,
+		ExecutionState: ctx.ExecutionState,
+		Metadata:       ctx.Metadata,
+		Requests:       ctx.Requests,
+		Auth:           ctx.Auth,
 	}
 
 	return e.executeHTTPRequest(execCtx, spec, retryMetadata)
@@ -531,22 +531,22 @@ func (e *HTTP) executeRequest(spec Spec, timeout time.Duration) (*http.Response,
 
 func (e *HTTP) handleRequestError(ctx core.ExecutionContext, err error, totalAttempts int) error {
 	// Get current metadata and update with final result
-	metadata := ctx.MetadataContext.Get()
+	metadata := ctx.Metadata.Get()
 	var retryMetadata RetryMetadata
 	mapstructure.Decode(metadata, &retryMetadata)
 
 	retryMetadata.Result = "error"
 	retryMetadata.LastError = err.Error()
 
-	if ctx.MetadataContext != nil {
-		ctx.MetadataContext.Set(retryMetadata)
+	if ctx.Metadata != nil {
+		ctx.Metadata.Set(retryMetadata)
 	}
 
 	errorResponse := map[string]any{
 		"error":    err.Error(),
 		"attempts": totalAttempts,
 	}
-	emitErr := ctx.ExecutionStateContext.Emit(
+	emitErr := ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"http.request.error",
 		[]any{errorResponse},
@@ -555,7 +555,7 @@ func (e *HTTP) handleRequestError(ctx core.ExecutionContext, err error, totalAtt
 		return fmt.Errorf("request failed after %d attempts: %w (and failed to emit event: %v)", totalAttempts, err, emitErr)
 	}
 
-	err = ctx.ExecutionStateContext.Fail(models.WorkflowNodeExecutionResultReasonError, fmt.Sprintf("Request failed after %d attempts: %v", totalAttempts, err))
+	err = ctx.ExecutionState.Fail(models.WorkflowNodeExecutionResultReasonError, fmt.Sprintf("Request failed after %d attempts: %v", totalAttempts, err))
 	if err != nil {
 		return fmt.Errorf("request failed after %d attempts: %w (and failed to mark execution as failed: %v)", totalAttempts, err, err)
 	}
@@ -569,7 +569,7 @@ func (e *HTTP) processResponse(ctx core.ExecutionContext, resp *http.Response, s
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// Get current metadata and update with final result
-		metadata := ctx.MetadataContext.Get()
+		metadata := ctx.Metadata.Get()
 		var retryMetadata RetryMetadata
 		mapstructure.Decode(metadata, &retryMetadata)
 
@@ -577,15 +577,15 @@ func (e *HTTP) processResponse(ctx core.ExecutionContext, resp *http.Response, s
 		retryMetadata.FinalStatus = resp.StatusCode
 		retryMetadata.LastError = fmt.Sprintf("failed to read response body: %v", err)
 
-		if ctx.MetadataContext != nil {
-			ctx.MetadataContext.Set(retryMetadata)
+		if ctx.Metadata != nil {
+			ctx.Metadata.Set(retryMetadata)
 		}
 
 		errorResponse := map[string]any{
 			"status": resp.StatusCode,
 			"error":  fmt.Sprintf("failed to read response body: %v", err),
 		}
-		emitErr := ctx.ExecutionStateContext.Emit(
+		emitErr := ctx.ExecutionState.Emit(
 			core.DefaultOutputChannel.Name,
 			"http.request.error",
 			[]any{errorResponse},
@@ -620,7 +620,7 @@ func (e *HTTP) processResponse(ctx core.ExecutionContext, resp *http.Response, s
 	}
 
 	// Get current metadata and update with final result
-	metadata := ctx.MetadataContext.Get()
+	metadata := ctx.Metadata.Get()
 	var retryMetadata RetryMetadata
 	mapstructure.Decode(metadata, &retryMetadata)
 
@@ -631,8 +631,8 @@ func (e *HTTP) processResponse(ctx core.ExecutionContext, resp *http.Response, s
 		retryMetadata.Result = "failed"
 	}
 
-	if ctx.MetadataContext != nil {
-		ctx.MetadataContext.Set(retryMetadata)
+	if ctx.Metadata != nil {
+		ctx.Metadata.Set(retryMetadata)
 	}
 
 	eventType := "http.request.finished"
@@ -641,11 +641,11 @@ func (e *HTTP) processResponse(ctx core.ExecutionContext, resp *http.Response, s
 	}
 
 	if !isSuccess {
-		ctx.ExecutionStateContext.Fail(models.WorkflowNodeExecutionResultReasonError, fmt.Sprintf("HTTP request failed with status %d", resp.StatusCode))
+		ctx.ExecutionState.Fail(models.WorkflowNodeExecutionResultReasonError, fmt.Sprintf("HTTP request failed with status %d", resp.StatusCode))
 		return nil
 	}
 
-	err = ctx.ExecutionStateContext.Emit(
+	err = ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		eventType,
 		[]any{response},

--- a/pkg/components/http/http_test.go
+++ b/pkg/components/http/http_test.go
@@ -21,9 +21,9 @@ func createExecutionContext(config map[string]any) (core.ExecutionContext, *cont
 	stateCtx := &contexts.ExecutionStateContext{}
 	metadataCtx := &contexts.MetadataContext{}
 	return core.ExecutionContext{
-		Configuration:         config,
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
+		Configuration:  config,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
 	}, stateCtx, metadataCtx
 }
 
@@ -628,8 +628,8 @@ func TestHTTP__Execute__WithoutRetryStrategy(t *testing.T) {
 			"method": "GET",
 			"url":    server.URL,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
 	}
 
 	err := h.Execute(ctx)
@@ -675,8 +675,8 @@ func TestHTTP__Execute__FixedTimeoutStrategy_Success(t *testing.T) {
 			"timeoutSeconds":  5,
 			"retries":         2,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
 	}
 
 	err := h.Execute(ctx)
@@ -719,8 +719,8 @@ func TestHTTP__Execute__ExponentialTimeoutStrategy_Success(t *testing.T) {
 			"timeoutSeconds":  2,
 			"retries":         3,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
 	}
 
 	err := h.Execute(ctx)
@@ -766,9 +766,9 @@ func TestHTTP__HandleAction__RetryRequest_SuccessOnRetry(t *testing.T) {
 			"timeoutSeconds":  1,
 			"retries":         1,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx,
 	}
 
 	err := h.Execute(ctx)
@@ -779,11 +779,11 @@ func TestHTTP__HandleAction__RetryRequest_SuccessOnRetry(t *testing.T) {
 	assert.Equal(t, 1*time.Second, requestCtx.Duration)
 
 	actionCtx := core.ActionContext{
-		Name:                  "retryRequest",
-		Configuration:         ctx.Configuration,
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx,
+		Name:           "retryRequest",
+		Configuration:  ctx.Configuration,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx,
 	}
 
 	err = h.HandleAction(actionCtx)
@@ -829,26 +829,26 @@ func TestHTTP__HandleAction__RetryRequest_ExhaustedRetries(t *testing.T) {
 			"timeoutSeconds":  1,
 			"retries":         2,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx,
 	}
 
 	err := h.Execute(ctx)
 	assert.NoError(t, err)
 
 	actionCtx := core.ActionContext{
-		Name:                  "retryRequest",
-		Configuration:         ctx.Configuration,
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        &contexts.RequestContext{},
+		Name:           "retryRequest",
+		Configuration:  ctx.Configuration,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       &contexts.RequestContext{},
 	}
 
 	err = h.HandleAction(actionCtx)
 	assert.NoError(t, err)
 
-	actionCtx.RequestContext = &contexts.RequestContext{}
+	actionCtx.Requests = &contexts.RequestContext{}
 	err = h.HandleAction(actionCtx)
 	assert.NoError(t, err)
 	assert.False(t, stateCtx.Passed)
@@ -954,9 +954,9 @@ func TestHTTP__RetryProgression_ExponentialStrategy(t *testing.T) {
 			"timeoutSeconds":  2,
 			"retries":         3,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx,
 	}
 
 	// Execute initial request (should fail and schedule retry)
@@ -967,11 +967,11 @@ func TestHTTP__RetryProgression_ExponentialStrategy(t *testing.T) {
 
 	requestCtx1 := &contexts.RequestContext{}
 	actionCtx := core.ActionContext{
-		Name:                  "retryRequest",
-		Configuration:         ctx.Configuration,
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx1,
+		Name:           "retryRequest",
+		Configuration:  ctx.Configuration,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx1,
 	}
 
 	err = h.HandleAction(actionCtx)
@@ -979,14 +979,14 @@ func TestHTTP__RetryProgression_ExponentialStrategy(t *testing.T) {
 	assert.Equal(t, "retryRequest", requestCtx1.Action)
 
 	requestCtx2 := &contexts.RequestContext{}
-	actionCtx.RequestContext = requestCtx2
+	actionCtx.Requests = requestCtx2
 	err = h.HandleAction(actionCtx)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "retryRequest", requestCtx2.Action)
 
 	requestCtx3 := &contexts.RequestContext{}
-	actionCtx.RequestContext = requestCtx3
+	actionCtx.Requests = requestCtx3
 	err = h.HandleAction(actionCtx)
 	assert.NoError(t, err)
 	assert.True(t, stateCtx.Passed)
@@ -1027,9 +1027,9 @@ func TestHTTP__RetryProgression_NetworkError(t *testing.T) {
 			"timeoutSeconds":  1,
 			"retries":         2,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        requestCtx,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       requestCtx,
 	}
 
 	// Execute initial request (should fail with network error and schedule retry)
@@ -1043,11 +1043,11 @@ func TestHTTP__RetryProgression_NetworkError(t *testing.T) {
 	// Simulate retries until exhaustion
 	for i := 0; i < 2; i++ {
 		actionCtx := core.ActionContext{
-			Name:                  "retryRequest",
-			Configuration:         ctx.Configuration,
-			ExecutionStateContext: stateCtx,
-			MetadataContext:       metadataCtx,
-			RequestContext:        &contexts.RequestContext{},
+			Name:           "retryRequest",
+			Configuration:  ctx.Configuration,
+			ExecutionState: stateCtx,
+			Metadata:       metadataCtx,
+			Requests:       &contexts.RequestContext{},
 		}
 
 		if i == 1 {
@@ -1087,9 +1087,9 @@ func TestHTTP__RetryMetadata_Progression(t *testing.T) {
 			"timeoutSeconds":  1,
 			"retries":         2,
 		},
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        &contexts.RequestContext{},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       &contexts.RequestContext{},
 	}
 
 	// Execute initial request (attempt 0)
@@ -1109,11 +1109,11 @@ func TestHTTP__RetryMetadata_Progression(t *testing.T) {
 
 	// Simulate first retry (attempt 1)
 	actionCtx := core.ActionContext{
-		Name:                  "retryRequest",
-		Configuration:         ctx.Configuration,
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       metadataCtx,
-		RequestContext:        &contexts.RequestContext{},
+		Name:           "retryRequest",
+		Configuration:  ctx.Configuration,
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+		Requests:       &contexts.RequestContext{},
 	}
 
 	err = h.HandleAction(actionCtx)
@@ -1126,7 +1126,7 @@ func TestHTTP__RetryMetadata_Progression(t *testing.T) {
 	assert.Equal(t, 2, retryMeta.TotalRetries)
 	assert.Equal(t, "HTTP status 500", retryMeta.LastError)
 
-	actionCtx.RequestContext = &contexts.RequestContext{}
+	actionCtx.Requests = &contexts.RequestContext{}
 	err = h.HandleAction(actionCtx)
 	assert.NoError(t, err)
 	assert.False(t, stateCtx.Passed)

--- a/pkg/components/if/if.go
+++ b/pkg/components/if/if.go
@@ -98,14 +98,14 @@ func (f *If) Execute(ctx core.ExecutionContext) error {
 	}
 
 	if matches {
-		return ctx.ExecutionStateContext.Emit(
+		return ctx.ExecutionState.Emit(
 			ChannelNameTrue,
 			"if.executed",
 			[]any{map[string]any{}},
 		)
 	}
 
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		ChannelNameFalse,
 		"if.executed",
 		[]any{map[string]any{}},

--- a/pkg/components/if/if_test.go
+++ b/pkg/components/if/if_test.go
@@ -50,9 +50,9 @@ func TestIf_Execute_EmitsEmptyEvents(t *testing.T) {
 			stateCtx := &contexts.ExecutionStateContext{}
 
 			ctx := core.ExecutionContext{
-				Data:                  tt.inputData,
-				Configuration:         tt.configuration,
-				ExecutionStateContext: stateCtx,
+				Data:           tt.inputData,
+				Configuration:  tt.configuration,
+				ExecutionState: stateCtx,
 			}
 
 			err := ifComponent.Execute(ctx)
@@ -74,9 +74,9 @@ func TestIf_Execute_InvalidExpression_ShouldReturnError(t *testing.T) {
 	stateCtx := &contexts.ExecutionStateContext{}
 
 	ctx := core.ExecutionContext{
-		Data:                  map[string]any{"test": "value"},
-		Configuration:         map[string]any{"expression": "invalid expression syntax +++"},
-		ExecutionStateContext: stateCtx,
+		Data:           map[string]any{"test": "value"},
+		Configuration:  map[string]any{"expression": "invalid expression syntax +++"},
+		ExecutionState: stateCtx,
 	}
 
 	err := ifComponent.Execute(ctx)
@@ -90,9 +90,9 @@ func TestIf_Execute_NonBooleanResult_ShouldReturnError(t *testing.T) {
 	stateCtx := &contexts.ExecutionStateContext{}
 
 	ctx := core.ExecutionContext{
-		Data:                  map[string]any{"test": "value"},
-		Configuration:         map[string]any{"expression": "$.test"},
-		ExecutionStateContext: stateCtx,
+		Data:           map[string]any{"test": "value"},
+		Configuration:  map[string]any{"expression": "$.test"},
+		ExecutionState: stateCtx,
 	}
 
 	err := ifComponent.Execute(ctx)
@@ -125,9 +125,9 @@ func TestIf_Execute_BothTrueAndFalsePathsEmitEmpty(t *testing.T) {
 			stateCtx := &contexts.ExecutionStateContext{}
 
 			ctx := core.ExecutionContext{
-				Data:                  map[string]any{"test": "value"},
-				Configuration:         tt.configuration,
-				ExecutionStateContext: stateCtx,
+				Data:           map[string]any{"test": "value"},
+				Configuration:  tt.configuration,
+				ExecutionState: stateCtx,
 			}
 
 			err := ifComponent.Execute(ctx)

--- a/pkg/components/noop/noop.go
+++ b/pkg/components/noop/noop.go
@@ -48,7 +48,7 @@ func (c *NoOp) Configuration() []configuration.Field {
 }
 
 func (c *NoOp) Execute(ctx core.ExecutionContext) error {
-	return ctx.ExecutionStateContext.Emit(
+	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		PayloadType,
 		[]any{map[string]any{}},

--- a/pkg/components/noop/noop_test.go
+++ b/pkg/components/noop/noop_test.go
@@ -43,8 +43,8 @@ func TestNoop_Execute_EmitsEmptyEvents(t *testing.T) {
 			stateCtx := &contexts.ExecutionStateContext{}
 
 			ctx := core.ExecutionContext{
-				Data:                  tt.inputData,
-				ExecutionStateContext: stateCtx,
+				Data:           tt.inputData,
+				ExecutionState: stateCtx,
 			}
 
 			err := noop.Execute(ctx)
@@ -71,8 +71,8 @@ func TestNoop_Execute_AlwaysEmitsEmpty(t *testing.T) {
 		}
 
 		ctx := core.ExecutionContext{
-			Data:                  originalData,
-			ExecutionStateContext: stateCtx,
+			Data:           originalData,
+			ExecutionState: stateCtx,
 		}
 
 		err := noop.Execute(ctx)

--- a/pkg/components/timegate/time_gate_test.go
+++ b/pkg/components/timegate/time_gate_test.go
@@ -107,9 +107,9 @@ func TestTimeGate_HandleAction_PushThrough_Finishes(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "pushThrough",
-		ExecutionStateContext: stateCtx,
-		Parameters:            map[string]any{},
+		Name:           "pushThrough",
+		ExecutionState: stateCtx,
+		Parameters:     map[string]any{},
 	}
 
 	err := tg.HandleAction(ctx)

--- a/pkg/components/wait/wait_test.go
+++ b/pkg/components/wait/wait_test.go
@@ -15,12 +15,12 @@ func TestWait_HandleAction_PushThrough(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "pushThrough",
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       &contexts.MetadataContext{},
-		AuthContext:           &contexts.AuthContext{},
-		Configuration:         nil,
-		Parameters:            map[string]any{},
+		Name:           "pushThrough",
+		ExecutionState: stateCtx,
+		Metadata:       &contexts.MetadataContext{},
+		Auth:           &contexts.AuthContext{},
+		Configuration:  nil,
+		Parameters:     map[string]any{},
 	}
 
 	err := w.HandleAction(ctx)
@@ -34,10 +34,10 @@ func TestWait_HandleAction_TimeReached(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "timeReached",
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       &contexts.MetadataContext{},
-		Parameters:            map[string]any{},
+		Name:           "timeReached",
+		ExecutionState: stateCtx,
+		Metadata:       &contexts.MetadataContext{},
+		Parameters:     map[string]any{},
 	}
 
 	err := w.HandleAction(ctx)
@@ -51,10 +51,10 @@ func TestWait_HandleAction_Unknown(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "unknown",
-		ExecutionStateContext: stateCtx,
-		MetadataContext:       &contexts.MetadataContext{},
-		Parameters:            map[string]any{},
+		Name:           "unknown",
+		ExecutionState: stateCtx,
+		Metadata:       &contexts.MetadataContext{},
+		Parameters:     map[string]any{},
 	}
 
 	err := w.HandleAction(ctx)
@@ -307,11 +307,11 @@ func TestWait_Execute_IntervalMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			requestCtx := &contexts.RequestContext{}
 			ctx := core.ExecutionContext{
-				Configuration:         tt.config,
-				Data:                  tt.data,
-				RequestContext:        requestCtx,
-				MetadataContext:       &contexts.MetadataContext{},
-				ExecutionStateContext: &contexts.ExecutionStateContext{},
+				Configuration:  tt.config,
+				Data:           tt.data,
+				Requests:       requestCtx,
+				Metadata:       &contexts.MetadataContext{},
+				ExecutionState: &contexts.ExecutionStateContext{},
 			}
 
 			err := w.Execute(ctx)
@@ -383,11 +383,11 @@ func TestWait_Execute_CountdownMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			requestCtx := &contexts.RequestContext{}
 			ctx := core.ExecutionContext{
-				Configuration:         tt.config,
-				Data:                  tt.data,
-				RequestContext:        requestCtx,
-				MetadataContext:       &contexts.MetadataContext{},
-				ExecutionStateContext: &contexts.ExecutionStateContext{},
+				Configuration:  tt.config,
+				Data:           tt.data,
+				Requests:       requestCtx,
+				Metadata:       &contexts.MetadataContext{},
+				ExecutionState: &contexts.ExecutionStateContext{},
 			}
 
 			err := w.Execute(ctx)
@@ -447,10 +447,10 @@ func TestWait_Execute_InvalidConfiguration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := core.ExecutionContext{
-				Configuration:         tt.config,
-				RequestContext:        &contexts.RequestContext{},
-				MetadataContext:       &contexts.MetadataContext{},
-				ExecutionStateContext: &contexts.ExecutionStateContext{},
+				Configuration:  tt.config,
+				Requests:       &contexts.RequestContext{},
+				Metadata:       &contexts.MetadataContext{},
+				ExecutionState: &contexts.ExecutionStateContext{},
 			}
 
 			err := w.Execute(ctx)
@@ -465,9 +465,9 @@ func TestWait_HandleTimeReached_CompletionOutput(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "timeReached",
-		ExecutionStateContext: stateCtx,
-		MetadataContext: &contexts.MetadataContext{
+		Name:           "timeReached",
+		ExecutionState: stateCtx,
+		Metadata: &contexts.MetadataContext{
 			Metadata: ExecutionMetadata{StartTime: "2025-12-10T09:02:43.651Z"},
 		},
 	}
@@ -494,15 +494,15 @@ func TestWait_HandlePushThrough_CompletionOutput(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ActionContext{
-		Name:                  "pushThrough",
-		ExecutionStateContext: stateCtx,
-		AuthContext: &contexts.AuthContext{
+		Name:           "pushThrough",
+		ExecutionState: stateCtx,
+		Auth: &contexts.AuthContext{
 			User: &core.User{
 				Email: "alex@company.com",
 				Name:  "Aleksandar Mitrović",
 			},
 		},
-		MetadataContext: &contexts.MetadataContext{
+		Metadata: &contexts.MetadataContext{
 			Metadata: ExecutionMetadata{StartTime: "2025-12-10T09:02:43.651Z"},
 		},
 	}
@@ -579,10 +579,10 @@ func TestWait_Execute_CountdownMode_ResolvedValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := core.ExecutionContext{
-				Configuration:         tt.config,
-				RequestContext:        &contexts.RequestContext{},
-				MetadataContext:       &contexts.MetadataContext{},
-				ExecutionStateContext: &contexts.ExecutionStateContext{},
+				Configuration:  tt.config,
+				Requests:       &contexts.RequestContext{},
+				Metadata:       &contexts.MetadataContext{},
+				ExecutionState: &contexts.ExecutionStateContext{},
 			}
 
 			err := w.Execute(ctx)
@@ -608,11 +608,11 @@ func TestWait_Cancel_CompletionOutput(t *testing.T) {
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	ctx := core.ExecutionContext{
-		ExecutionStateContext: stateCtx,
-		MetadataContext: &contexts.MetadataContext{
+		ExecutionState: stateCtx,
+		Metadata: &contexts.MetadataContext{
 			Metadata: ExecutionMetadata{StartTime: "2025-12-10T09:02:43.651Z"},
 		},
-		AuthContext: &contexts.AuthContext{
+		Auth: &contexts.AuthContext{
 			User: &core.User{
 				Email: "alex@company.com",
 				Name:  "Aleksandar Mitrović",

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -113,18 +113,18 @@ type OutputChannel struct {
  * to control the state and metadata of each execution of it.
  */
 type ExecutionContext struct {
-	ID                     uuid.UUID
-	WorkflowID             string
-	Data                   any
-	Configuration          any
-	Logger                 *log.Entry
-	MetadataContext        MetadataContext
-	NodeMetadataContext    MetadataContext
-	ExecutionStateContext  ExecutionStateContext
-	RequestContext         RequestContext
-	AuthContext            AuthContext
-	IntegrationContext     IntegrationContext
-	AppInstallationContext AppInstallationContext
+	ID              uuid.UUID
+	WorkflowID      string
+	Data            any
+	Configuration   any
+	Logger          *log.Entry
+	Metadata        MetadataContext
+	NodeMetadata    MetadataContext
+	ExecutionState  ExecutionStateContext
+	Requests        RequestContext
+	Auth            AuthContext
+	Integration     IntegrationContext
+	AppInstallation AppInstallationContext
 }
 
 /*
@@ -132,13 +132,13 @@ type ExecutionContext struct {
  * to control the state and metadata of each execution of it.
  */
 type SetupContext struct {
-	Logger                 *log.Entry
-	Configuration          any
-	MetadataContext        MetadataContext
-	RequestContext         RequestContext
-	AuthContext            AuthContext
-	IntegrationContext     IntegrationContext
-	AppInstallationContext AppInstallationContext
+	Logger          *log.Entry
+	Configuration   any
+	Metadata        MetadataContext
+	Requests        RequestContext
+	Auth            AuthContext
+	Integration     IntegrationContext
+	AppInstallation AppInstallationContext
 }
 
 /*
@@ -208,16 +208,16 @@ type Action struct {
  * and control the state and metadata of each execution of it.
  */
 type ActionContext struct {
-	Name                   string
-	Configuration          any
-	Parameters             map[string]any
-	Logger                 *log.Entry
-	MetadataContext        MetadataContext
-	ExecutionStateContext  ExecutionStateContext
-	AuthContext            AuthContext
-	RequestContext         RequestContext
-	IntegrationContext     IntegrationContext
-	AppInstallationContext AppInstallationContext
+	Name            string
+	Configuration   any
+	Parameters      map[string]any
+	Logger          *log.Entry
+	Metadata        MetadataContext
+	ExecutionState  ExecutionStateContext
+	Auth            AuthContext
+	Requests        RequestContext
+	Integration     IntegrationContext
+	AppInstallation AppInstallationContext
 }
 
 /*

--- a/pkg/core/trigger.go
+++ b/pkg/core/trigger.go
@@ -66,14 +66,14 @@ type Trigger interface {
 }
 
 type TriggerContext struct {
-	Logger                 *log.Entry
-	Configuration          any
-	MetadataContext        MetadataContext
-	RequestContext         RequestContext
-	EventContext           EventContext
-	WebhookContext         NodeWebhookContext
-	IntegrationContext     IntegrationContext
-	AppInstallationContext AppInstallationContext
+	Logger          *log.Entry
+	Configuration   any
+	Metadata        MetadataContext
+	Requests        RequestContext
+	Events          EventContext
+	Webhook         NodeWebhookContext
+	Integration     IntegrationContext
+	AppInstallation AppInstallationContext
 }
 
 type WebhookSetupOptions struct {
@@ -88,25 +88,25 @@ type EventContext interface {
 }
 
 type TriggerActionContext struct {
-	Name                   string
-	Parameters             map[string]any
-	Configuration          any
-	Logger                 *log.Entry
-	MetadataContext        MetadataContext
-	RequestContext         RequestContext
-	EventContext           EventContext
-	WebhookContext         NodeWebhookContext
-	AppInstallationContext AppInstallationContext
+	Name            string
+	Parameters      map[string]any
+	Configuration   any
+	Logger          *log.Entry
+	Metadata        MetadataContext
+	Requests        RequestContext
+	Events          EventContext
+	Webhook         NodeWebhookContext
+	AppInstallation AppInstallationContext
 }
 
 type WebhookRequestContext struct {
-	Body           []byte
-	Headers        http.Header
-	WorkflowID     string
-	NodeID         string
-	Configuration  any
-	WebhookContext NodeWebhookContext
-	EventContext   EventContext
+	Body          []byte
+	Headers       http.Header
+	WorkflowID    string
+	NodeID        string
+	Configuration any
+	Webhook       NodeWebhookContext
+	Events        EventContext
 
 	//
 	// Return an execution context for a given execution,

--- a/pkg/grpc/actions/workflows/cancel_execution.go
+++ b/pkg/grpc/actions/workflows/cancel_execution.go
@@ -84,14 +84,14 @@ func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authori
 
 			logger := logging.ForExecution(execution, nil)
 			ctx := core.ExecutionContext{
-				ID:                    execution.ID,
-				WorkflowID:            execution.WorkflowID.String(),
-				Configuration:         execution.Configuration.Data(),
-				MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-				ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-				RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-				AuthContext:           contexts.NewAuthContext(tx, uuid.MustParse(organizationID), authService, user),
-				IntegrationContext:    contexts.NewIntegrationContext(tx, registry),
+				ID:             execution.ID,
+				WorkflowID:     execution.WorkflowID.String(),
+				Configuration:  execution.Configuration.Data(),
+				Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+				ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+				Requests:       contexts.NewExecutionRequestContext(tx, execution),
+				Auth:           contexts.NewAuthContext(tx, uuid.MustParse(organizationID), authService, user),
+				Integration:    contexts.NewIntegrationContext(tx, registry),
 			}
 
 			if node.AppInstallationID != nil {
@@ -102,7 +102,7 @@ func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authori
 				}
 
 				logger = logging.WithAppInstallation(logger, *appInstallation)
-				ctx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
+				ctx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
 			}
 
 			ctx.Logger = logger

--- a/pkg/grpc/actions/workflows/invoke_node_execution_action.go
+++ b/pkg/grpc/actions/workflows/invoke_node_execution_action.go
@@ -82,14 +82,14 @@ func InvokeNodeExecutionAction(
 	tx := database.Conn()
 	logger := logging.ForExecution(execution, nil)
 	actionCtx := core.ActionContext{
-		Name:                  actionName,
-		Parameters:            parameters,
-		Configuration:         node.Configuration.Data(),
-		MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-		ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-		AuthContext:           contexts.NewAuthContext(tx, orgID, authService, user),
-		RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-		IntegrationContext:    contexts.NewIntegrationContext(tx, registry),
+		Name:           actionName,
+		Parameters:     parameters,
+		Configuration:  node.Configuration.Data(),
+		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+		ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+		Auth:           contexts.NewAuthContext(tx, orgID, authService, user),
+		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Integration:    contexts.NewIntegrationContext(tx, registry),
 	}
 
 	if node.AppInstallationID != nil {
@@ -100,7 +100,7 @@ func InvokeNodeExecutionAction(
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		actionCtx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
+		actionCtx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
 	}
 
 	actionCtx.Logger = logger

--- a/pkg/grpc/actions/workflows/invoke_node_trigger_action.go
+++ b/pkg/grpc/actions/workflows/invoke_node_trigger_action.go
@@ -80,12 +80,12 @@ func InvokeNodeTriggerAction(
 	logger := logging.ForNode(*node)
 
 	actionCtx := core.TriggerActionContext{
-		Name:            actionName,
-		Parameters:      parameters,
-		Configuration:   node.Configuration.Data(),
-		MetadataContext: contexts.NewNodeMetadataContext(tx, node),
-		RequestContext:  contexts.NewNodeRequestContext(tx, node),
-		WebhookContext:  contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
+		Name:          actionName,
+		Parameters:    parameters,
+		Configuration: node.Configuration.Data(),
+		Metadata:      contexts.NewNodeMetadataContext(tx, node),
+		Requests:      contexts.NewNodeRequestContext(tx, node),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
 	}
 
 	if node.AppInstallationID != nil {
@@ -96,7 +96,7 @@ func InvokeNodeTriggerAction(
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		actionCtx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
+		actionCtx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, encryptor, registry)
 	}
 
 	actionCtx.Logger = logger

--- a/pkg/grpc/actions/workflows/update_workflow.go
+++ b/pkg/grpc/actions/workflows/update_workflow.go
@@ -253,12 +253,12 @@ func setupTrigger(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor, 
 
 	logger := logging.ForNode(*node)
 	triggerCtx := core.TriggerContext{
-		Configuration:      node.Configuration.Data(),
-		MetadataContext:    contexts.NewNodeMetadataContext(tx, node),
-		RequestContext:     contexts.NewNodeRequestContext(tx, node),
-		IntegrationContext: contexts.NewIntegrationContext(tx, registry),
-		EventContext:       contexts.NewEventContext(tx, node),
-		WebhookContext:     contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
+		Configuration: node.Configuration.Data(),
+		Metadata:      contexts.NewNodeMetadataContext(tx, node),
+		Requests:      contexts.NewNodeRequestContext(tx, node),
+		Integration:   contexts.NewIntegrationContext(tx, registry),
+		Events:        contexts.NewEventContext(tx, node),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
 	}
 
 	if node.AppInstallationID != nil {
@@ -268,7 +268,7 @@ func setupTrigger(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor, 
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		triggerCtx.AppInstallationContext = contexts.NewAppInstallationContext(
+		triggerCtx.AppInstallation = contexts.NewAppInstallationContext(
 			tx,
 			node,
 			appInstallation,
@@ -295,10 +295,10 @@ func setupComponent(tx *gorm.DB, encryptor crypto.Encryptor, registry *registry.
 
 	logger := logging.ForNode(*node)
 	setupCtx := core.SetupContext{
-		Configuration:      node.Configuration.Data(),
-		MetadataContext:    contexts.NewNodeMetadataContext(tx, node),
-		RequestContext:     contexts.NewNodeRequestContext(tx, node),
-		IntegrationContext: contexts.NewIntegrationContext(tx, registry),
+		Configuration: node.Configuration.Data(),
+		Metadata:      contexts.NewNodeMetadataContext(tx, node),
+		Requests:      contexts.NewNodeRequestContext(tx, node),
+		Integration:   contexts.NewIntegrationContext(tx, registry),
 	}
 
 	if node.AppInstallationID != nil {
@@ -308,7 +308,7 @@ func setupComponent(tx *gorm.DB, encryptor crypto.Encryptor, registry *registry.
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		setupCtx.AppInstallationContext = contexts.NewAppInstallationContext(
+		setupCtx.AppInstallation = contexts.NewAppInstallationContext(
 			tx,
 			node,
 			appInstallation,

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -731,13 +731,13 @@ func (s *Server) executeTriggerNode(ctx context.Context, body []byte, headers ht
 
 	tx := database.Conn()
 	return trigger.HandleWebhook(core.WebhookRequestContext{
-		Body:           body,
-		Headers:        headers,
-		WorkflowID:     node.WorkflowID.String(),
-		NodeID:         node.NodeID,
-		Configuration:  node.Configuration.Data(),
-		WebhookContext: contexts.NewNodeWebhookContext(ctx, tx, s.encryptor, &node, s.BaseURL+s.BasePath),
-		EventContext:   contexts.NewEventContext(tx, &node),
+		Body:          body,
+		Headers:       headers,
+		WorkflowID:    node.WorkflowID.String(),
+		NodeID:        node.NodeID,
+		Configuration: node.Configuration.Data(),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, s.encryptor, &node, s.BaseURL+s.BasePath),
+		Events:        contexts.NewEventContext(tx, &node),
 	})
 }
 
@@ -750,13 +750,13 @@ func (s *Server) executeComponentNode(ctx context.Context, body []byte, headers 
 
 	tx := database.Conn()
 	return component.HandleWebhook(core.WebhookRequestContext{
-		Body:           body,
-		Headers:        headers,
-		WorkflowID:     node.WorkflowID.String(),
-		NodeID:         node.NodeID,
-		Configuration:  node.Configuration.Data(),
-		WebhookContext: contexts.NewNodeWebhookContext(ctx, tx, s.encryptor, &node, s.BaseURL+s.BasePath),
-		EventContext:   contexts.NewEventContext(tx, &node),
+		Body:          body,
+		Headers:       headers,
+		WorkflowID:    node.WorkflowID.String(),
+		NodeID:        node.NodeID,
+		Configuration: node.Configuration.Data(),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, s.encryptor, &node, s.BaseURL+s.BasePath),
+		Events:        contexts.NewEventContext(tx, &node),
 		FindExecutionByKV: func(key string, value string) (*core.ExecutionContext, error) {
 			execution, err := models.FirstNodeExecutionByKVInTransaction(tx, node.WorkflowID, node.NodeID, key, value)
 			if err != nil {
@@ -764,14 +764,14 @@ func (s *Server) executeComponentNode(ctx context.Context, body []byte, headers 
 			}
 
 			return &core.ExecutionContext{
-				ID:                    execution.ID,
-				WorkflowID:            execution.WorkflowID.String(),
-				Configuration:         execution.Configuration.Data(),
-				MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-				NodeMetadataContext:   contexts.NewNodeMetadataContext(tx, &node),
-				ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-				RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-				Logger:                logging.ForExecution(execution, nil),
+				ID:             execution.ID,
+				WorkflowID:     execution.WorkflowID.String(),
+				Configuration:  execution.Configuration.Data(),
+				Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+				NodeMetadata:   contexts.NewNodeMetadataContext(tx, &node),
+				ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+				Requests:       contexts.NewExecutionRequestContext(tx, execution),
+				Logger:         logging.ForExecution(execution, nil),
 			}, nil
 		},
 	})

--- a/pkg/triggers/github/github_test.go
+++ b/pkg/triggers/github/github_test.go
@@ -29,9 +29,9 @@ func Test__HandleWebhook(t *testing.T) {
 		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			EventContext:   &contexts.EventContext{},
-			WebhookContext: &contexts.WebhookContext{},
+			Headers: headers,
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusBadRequest, code)
@@ -45,10 +45,10 @@ func Test__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Headers:        headers,
-			Configuration:  Configuration{EventType: "push"},
-			EventContext:   eventContext,
-			WebhookContext: &contexts.WebhookContext{},
+			Headers:       headers,
+			Configuration: Configuration{EventType: "push"},
+			Events:        eventContext,
+			Webhook:       &contexts.WebhookContext{},
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -64,11 +64,11 @@ func Test__HandleWebhook(t *testing.T) {
 		headers.Set("X-GitHub-Event", "push")
 
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           []byte(`{"ref":"refs/heads/main"}`),
-			Headers:        headers,
-			Configuration:  Configuration{EventType: "push"},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   &contexts.EventContext{},
+			Body:          []byte(`{"ref":"refs/heads/main"}`),
+			Headers:       headers,
+			Configuration: Configuration{EventType: "push"},
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        &contexts.EventContext{},
 		})
 
 		assert.Equal(t, http.StatusForbidden, code)
@@ -89,11 +89,11 @@ func Test__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  Configuration{EventType: "push"},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:          body,
+			Headers:       headers,
+			Configuration: Configuration{EventType: "push"},
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)
@@ -115,11 +115,11 @@ func Test__HandleWebhook(t *testing.T) {
 
 		eventContext := &contexts.EventContext{}
 		code, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:           body,
-			Headers:        headers,
-			Configuration:  Configuration{EventType: "push"},
-			WebhookContext: &contexts.WebhookContext{Secret: secret},
-			EventContext:   eventContext,
+			Body:          body,
+			Headers:       headers,
+			Configuration: Configuration{EventType: "push"},
+			Webhook:       &contexts.WebhookContext{Secret: secret},
+			Events:        eventContext,
 		})
 
 		assert.Equal(t, http.StatusOK, code)

--- a/pkg/triggers/schedule/schedule_test.go
+++ b/pkg/triggers/schedule/schedule_test.go
@@ -490,12 +490,12 @@ func TestEmitEvent(t *testing.T) {
 			eventCtx := &contexts.EventContext{}
 
 			ctx := core.TriggerActionContext{
-				Name:            "emitEvent",
-				Configuration:   tt.config,
-				Logger:          log.NewEntry(log.StandardLogger()),
-				EventContext:    eventCtx,
-				MetadataContext: &contexts.MetadataContext{},
-				RequestContext:  &contexts.RequestContext{},
+				Name:          "emitEvent",
+				Configuration: tt.config,
+				Logger:        log.NewEntry(log.StandardLogger()),
+				Events:        eventCtx,
+				Metadata:      &contexts.MetadataContext{},
+				Requests:      &contexts.RequestContext{},
 			}
 
 			err := schedule.emitEvent(ctx)

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -236,13 +236,13 @@ func TestWebhook_Setup(t *testing.T) {
 			}
 
 			ctx := core.TriggerContext{
-				Configuration:   tt.config,
-				MetadataContext: metadataCtx,
-				RequestContext: &mockRequestContext{
+				Configuration: tt.config,
+				Metadata:      metadataCtx,
+				Requests: &mockRequestContext{
 					workflowID: "test-workflow",
 					nodeID:     "test-node",
 				},
-				WebhookContext: webhookCtx,
+				Webhook: webhookCtx,
 			}
 
 			err := webhook.Setup(ctx)
@@ -323,9 +323,9 @@ func TestWebhook_Setup_AuthenticationMethodChange(t *testing.T) {
 			}
 
 			ctx := core.TriggerContext{
-				Configuration:   config,
-				MetadataContext: metadataCtx,
-				WebhookContext:  webhookCtx,
+				Configuration: config,
+				Metadata:      metadataCtx,
+				Webhook:       webhookCtx,
 			}
 
 			err := webhook.Setup(ctx)
@@ -402,9 +402,9 @@ func TestWebhook_HandleAction_ResetAuth(t *testing.T) {
 			webhookCtx := &mockWebhookContext{}
 
 			ctx := core.TriggerActionContext{
-				Name:            "resetAuthentication",
-				MetadataContext: metadataCtx,
-				WebhookContext:  webhookCtx,
+				Name:     "resetAuthentication",
+				Metadata: metadataCtx,
+				Webhook:  webhookCtx,
 			}
 
 			_, err := webhook.HandleAction(ctx)
@@ -584,11 +584,11 @@ func TestWebhook_HandleWebhook(t *testing.T) {
 			webhookCtx := &mockWebhookContext{}
 
 			ctx := core.WebhookRequestContext{
-				Body:           tt.body,
-				Headers:        headers,
-				Configuration:  tt.config,
-				EventContext:   eventCtx,
-				WebhookContext: webhookCtx,
+				Body:          tt.body,
+				Headers:       headers,
+				Configuration: tt.config,
+				Events:        eventCtx,
+				Webhook:       webhookCtx,
 			}
 
 			code, err := webhook.HandleWebhook(ctx)
@@ -671,8 +671,8 @@ func TestWebhook_HandleWebhook_SignatureVerification(t *testing.T) {
 				Configuration: Metadata{
 					Authentication: "signature",
 				},
-				EventContext:   eventCtx,
-				WebhookContext: webhookCtx,
+				Events:  eventCtx,
+				Webhook: webhookCtx,
 			}
 
 			code, err := webhook.HandleWebhook(ctx)
@@ -712,12 +712,12 @@ func TestWebhook_URLGeneration_WithTrailingSlash(t *testing.T) {
 		Configuration: Configuration{
 			Authentication: "none",
 		},
-		MetadataContext: metadataCtx,
-		RequestContext: &mockRequestContext{
+		Metadata: metadataCtx,
+		Requests: &mockRequestContext{
 			workflowID: "test-workflow",
 			nodeID:     "test-node",
 		},
-		WebhookContext: webhookCtx,
+		Webhook: webhookCtx,
 	}
 
 	err := webhook.Setup(ctx)

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -101,14 +101,14 @@ func BuildProcessQueueContext(tx *gorm.DB, node *models.WorkflowNode, queueItem 
 		}
 
 		return &core.ExecutionContext{
-			ID:                    execution.ID,
-			WorkflowID:            execution.WorkflowID.String(),
-			Configuration:         execution.Configuration.Data(),
-			MetadataContext:       NewExecutionMetadataContext(tx, &execution),
-			NodeMetadataContext:   NewNodeMetadataContext(tx, node),
-			ExecutionStateContext: NewExecutionStateContext(tx, &execution),
-			RequestContext:        NewExecutionRequestContext(tx, &execution),
-			Logger:                logging.WithExecution(logging.ForNode(*node), &execution, nil),
+			ID:             execution.ID,
+			WorkflowID:     execution.WorkflowID.String(),
+			Configuration:  execution.Configuration.Data(),
+			Metadata:       NewExecutionMetadataContext(tx, &execution),
+			NodeMetadata:   NewNodeMetadataContext(tx, node),
+			ExecutionState: NewExecutionStateContext(tx, &execution),
+			Requests:       NewExecutionRequestContext(tx, &execution),
+			Logger:         logging.WithExecution(logging.ForNode(*node), &execution, nil),
 		}, nil
 	}
 
@@ -194,14 +194,14 @@ func BuildProcessQueueContext(tx *gorm.DB, node *models.WorkflowNode, queueItem 
 		}
 
 		return &core.ExecutionContext{
-			ID:                    execution.ID,
-			WorkflowID:            execution.WorkflowID.String(),
-			Configuration:         execution.Configuration.Data(),
-			MetadataContext:       NewExecutionMetadataContext(tx, execution),
-			NodeMetadataContext:   NewNodeMetadataContext(tx, node),
-			ExecutionStateContext: NewExecutionStateContext(tx, execution),
-			RequestContext:        NewExecutionRequestContext(tx, execution),
-			Logger:                logging.WithExecution(logging.ForNode(*node), execution, nil),
+			ID:             execution.ID,
+			WorkflowID:     execution.WorkflowID.String(),
+			Configuration:  execution.Configuration.Data(),
+			Metadata:       NewExecutionMetadataContext(tx, execution),
+			NodeMetadata:   NewNodeMetadataContext(tx, node),
+			ExecutionState: NewExecutionStateContext(tx, execution),
+			Requests:       NewExecutionRequestContext(tx, execution),
+			Logger:         logging.WithExecution(logging.ForNode(*node), execution, nil),
 		}, nil
 	}
 

--- a/pkg/workers/workflow_node_executor.go
+++ b/pkg/workers/workflow_node_executor.go
@@ -224,16 +224,16 @@ func (w *WorkflowNodeExecutor) executeComponentNode(tx *gorm.DB, execution *mode
 	}
 
 	ctx := core.ExecutionContext{
-		ID:                    execution.ID,
-		WorkflowID:            execution.WorkflowID.String(),
-		Configuration:         execution.Configuration.Data(),
-		Data:                  input,
-		MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-		NodeMetadataContext:   contexts.NewNodeMetadataContext(tx, node),
-		ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-		RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-		AuthContext:           contexts.NewAuthContext(tx, workflow.OrganizationID, nil, nil),
-		IntegrationContext:    contexts.NewIntegrationContext(tx, w.registry),
+		ID:             execution.ID,
+		WorkflowID:     execution.WorkflowID.String(),
+		Configuration:  execution.Configuration.Data(),
+		Data:           input,
+		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+		NodeMetadata:   contexts.NewNodeMetadataContext(tx, node),
+		ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Auth:           contexts.NewAuthContext(tx, workflow.OrganizationID, nil, nil),
+		Integration:    contexts.NewIntegrationContext(tx, w.registry),
 	}
 
 	if node.AppInstallationID != nil {
@@ -249,7 +249,7 @@ func (w *WorkflowNodeExecutor) executeComponentNode(tx *gorm.DB, execution *mode
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		ctx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
+		ctx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
 	}
 
 	ctx.Logger = logger

--- a/pkg/workers/workflow_node_request_worker.go
+++ b/pkg/workers/workflow_node_request_worker.go
@@ -130,13 +130,13 @@ func (w *NodeRequestWorker) invokeTriggerAction(tx *gorm.DB, request *models.Wor
 	}
 
 	actionCtx := core.TriggerActionContext{
-		Name:            actionName,
-		Parameters:      spec.InvokeAction.Parameters,
-		Configuration:   node.Configuration.Data(),
-		Logger:          logging.ForNode(*node),
-		MetadataContext: contexts.NewNodeMetadataContext(tx, node),
-		EventContext:    contexts.NewEventContext(tx, node),
-		RequestContext:  contexts.NewNodeRequestContext(tx, node),
+		Name:          actionName,
+		Parameters:    spec.InvokeAction.Parameters,
+		Configuration: node.Configuration.Data(),
+		Logger:        logging.ForNode(*node),
+		Metadata:      contexts.NewNodeMetadataContext(tx, node),
+		Events:        contexts.NewEventContext(tx, node),
+		Requests:      contexts.NewNodeRequestContext(tx, node),
 	}
 
 	if node.AppInstallationID != nil {
@@ -150,7 +150,7 @@ func (w *NodeRequestWorker) invokeTriggerAction(tx *gorm.DB, request *models.Wor
 			return fmt.Errorf("failed to find app installation: %v", err)
 		}
 
-		actionCtx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
+		actionCtx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
 	}
 
 	_, err = trigger.HandleAction(actionCtx)
@@ -203,13 +203,13 @@ func (w *NodeRequestWorker) invokeParentNodeComponentAction(tx *gorm.DB, request
 
 	logger := logging.ForExecution(execution, nil)
 	actionCtx := core.ActionContext{
-		Name:                  actionName,
-		Configuration:         node.Configuration.Data(),
-		Parameters:            spec.InvokeAction.Parameters,
-		MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-		ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-		RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-		IntegrationContext:    contexts.NewIntegrationContext(tx, w.registry),
+		Name:           actionName,
+		Configuration:  node.Configuration.Data(),
+		Parameters:     spec.InvokeAction.Parameters,
+		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+		ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Integration:    contexts.NewIntegrationContext(tx, w.registry),
 	}
 
 	if node.AppInstallationID != nil {
@@ -219,7 +219,7 @@ func (w *NodeRequestWorker) invokeParentNodeComponentAction(tx *gorm.DB, request
 		}
 
 		logger = logging.WithAppInstallation(logger, *appInstallation)
-		actionCtx.AppInstallationContext = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
+		actionCtx.AppInstallation = contexts.NewAppInstallationContext(tx, node, appInstallation, w.encryptor, w.registry)
 	}
 
 	actionCtx.Logger = logger
@@ -275,14 +275,14 @@ func (w *NodeRequestWorker) invokeChildNodeComponentAction(tx *gorm.DB, request 
 	}
 
 	actionCtx := core.ActionContext{
-		Name:                  actionName,
-		Configuration:         childNode.Configuration,
-		Parameters:            spec.InvokeAction.Parameters,
-		Logger:                logging.ForExecution(execution, parentExecution),
-		MetadataContext:       contexts.NewExecutionMetadataContext(tx, execution),
-		ExecutionStateContext: contexts.NewExecutionStateContext(tx, execution),
-		RequestContext:        contexts.NewExecutionRequestContext(tx, execution),
-		IntegrationContext:    contexts.NewIntegrationContext(tx, w.registry),
+		Name:           actionName,
+		Configuration:  childNode.Configuration,
+		Parameters:     spec.InvokeAction.Parameters,
+		Logger:         logging.ForExecution(execution, parentExecution),
+		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
+		ExecutionState: contexts.NewExecutionStateContext(tx, execution),
+		Requests:       contexts.NewExecutionRequestContext(tx, execution),
+		Integration:    contexts.NewIntegrationContext(tx, w.registry),
 	}
 
 	err = component.HandleAction(actionCtx)


### PR DESCRIPTION
This was really annoying me. We don't need *Context suffixes everywhere, it just makes the code more verbose.