### PR TITLE
feat: GitHub Delete Release

### DIFF
--- a/pkg/applications/github/delete_release.go
+++ b/pkg/applications/github/delete_release.go
@@ -1,0 +1,225 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteRelease struct{}
+
+type DeleteReleaseConfiguration struct {
+	Repository      string `mapstructure:"repository"`
+	ReleaseStrategy string `mapstructure:"releaseStrategy"`
+	TagName         string `mapstructure:"tagName"`
+	DeleteTag       bool   `mapstructure:"deleteTag"`
+}
+
+func (c *DeleteRelease) Name() string {
+	return "github.deleteRelease"
+}
+
+func (c *DeleteRelease) Label() string {
+	return "Delete Release"
+}
+
+func (c *DeleteRelease) Description() string {
+	return "Delete a release from a GitHub repository"
+}
+
+func (c *DeleteRelease) Icon() string {
+	return "github"
+}
+
+func (c *DeleteRelease) Color() string {
+	return "gray"
+}
+
+func (c *DeleteRelease) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteRelease) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeString,
+			Required: true,
+		},
+		{
+			Name:     "releaseStrategy",
+			Label:    "Release to Delete",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "specific",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{
+							Label: "Specific tag",
+							Value: "specific",
+						},
+						{
+							Label: "Latest release",
+							Value: "latest",
+						},
+						{
+							Label: "Latest draft",
+							Value: "latestDraft",
+						},
+						{
+							Label: "Latest prerelease",
+							Value: "latestPrerelease",
+						},
+					},
+				},
+			},
+			Description: "How to identify which release to delete",
+		},
+		{
+			Name:        "tagName",
+			Label:       "Tag Name",
+			Type:        configuration.FieldTypeString,
+			Placeholder: "e.g., v1.0.0 or {{$.data.tag_name}}",
+			Description: "Git tag identifying the release to delete. Supports template variables from previous steps.",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{
+					Field:  "releaseStrategy",
+					Values: []string{"specific"},
+				},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{
+					Field:  "releaseStrategy",
+					Values: []string{"specific"},
+				},
+			},
+		},
+		{
+			Name:        "deleteTag",
+			Label:       "Also delete Git tag",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "When enabled, also deletes the associated Git tag from the repository",
+		},
+	}
+}
+
+func (c *DeleteRelease) Setup(ctx core.SetupContext) error {
+	return ensureRepoInMetadata(
+		ctx.Metadata,
+		ctx.AppInstallation,
+		ctx.Configuration,
+	)
+}
+
+func (c *DeleteRelease) Execute(ctx core.ExecutionContext) error {
+	var config DeleteReleaseConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	var nodeMetadata NodeMetadata
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &nodeMetadata); err != nil {
+		return fmt.Errorf("failed to decode node metadata: %w", err)
+	}
+
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.AppInstallation.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode application metadata: %w", err)
+	}
+
+	client, err := NewClient(ctx.AppInstallation, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	//
+	// Fetch the release based on the selected strategy
+	//
+	release, err := fetchReleaseByStrategy(client, appMetadata.Owner, config.Repository, config.ReleaseStrategy, config.TagName)
+	if err != nil {
+		return err
+	}
+
+	//
+	// Store pre-deletion state for output
+	//
+	deletedReleaseData := map[string]any{
+		"id":          release.GetID(),
+		"tag_name":    release.GetTagName(),
+		"name":        release.GetName(),
+		"html_url":    release.GetHTMLURL(),
+		"draft":       release.GetDraft(),
+		"prerelease":  release.GetPrerelease(),
+		"deleted_at":  time.Now().Format(time.RFC3339),
+		"tag_deleted": false,
+	}
+
+	//
+	// Delete the release
+	//
+	_, err = client.Repositories.DeleteRelease(
+		context.Background(),
+		appMetadata.Owner,
+		config.Repository,
+		release.GetID(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete release: %w", err)
+	}
+
+	//
+	// Optionally delete the Git tag
+	//
+	if config.DeleteTag {
+		_, err = client.Git.DeleteRef(
+			context.Background(),
+			appMetadata.Owner,
+			config.Repository,
+			fmt.Sprintf("tags/%s", release.GetTagName()),
+		)
+		if err != nil {
+			// Log warning but don't fail the operation since release deletion succeeded
+			ctx.Logger.Warnf("Release deleted successfully, but failed to delete Git tag %s: %v", release.GetTagName(), err)
+		} else {
+			deletedReleaseData["tag_deleted"] = true
+		}
+	}
+
+	//
+	// Emit output with deleted release data
+	//
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.release",
+		[]any{deletedReleaseData},
+	)
+}
+
+func (c *DeleteRelease) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteRelease) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *DeleteRelease) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *DeleteRelease) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *DeleteRelease) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}

--- a/pkg/applications/github/delete_release_test.go
+++ b/pkg/applications/github/delete_release_test.go
@@ -1,0 +1,185 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteRelease__Setup(t *testing.T) {
+	helloRepo := Repository{ID: 123456, Name: "hello", URL: "https://github.com/testhq/hello"}
+	component := DeleteRelease{}
+
+	t.Run("repository is required", func(t *testing.T) {
+		appCtx := &contexts.AppInstallationContext{}
+		err := component.Setup(core.SetupContext{
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": ""},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("repository is not accessible", func(t *testing.T) {
+		appCtx := &contexts.AppInstallationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			AppInstallation: appCtx,
+			Metadata:        &contexts.MetadataContext{},
+			Configuration:   map[string]any{"repository": "world"},
+		})
+
+		require.ErrorContains(t, err, "repository world is not accessible to app installation")
+	})
+
+	t.Run("metadata is set successfully", func(t *testing.T) {
+		appCtx := &contexts.AppInstallationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			AppInstallation: appCtx,
+			Metadata:        &nodeMetadataCtx,
+			Configuration:   map[string]any{"repository": "hello"},
+		}))
+
+		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})
+	})
+}
+
+func Test__DeleteRelease__Configuration(t *testing.T) {
+	component := DeleteRelease{}
+	config := component.Configuration()
+
+	t.Run("has required fields", func(t *testing.T) {
+		fieldNames := make(map[string]bool)
+		for _, field := range config {
+			fieldNames[field.Name] = field.Required
+		}
+
+		assert.True(t, fieldNames["repository"], "repository should be required")
+		assert.True(t, fieldNames["releaseStrategy"], "releaseStrategy should be required")
+		assert.False(t, fieldNames["tagName"], "tagName should be optional (conditionally required)")
+		assert.False(t, fieldNames["deleteTag"], "deleteTag should be optional")
+	})
+
+	t.Run("has correct field types", func(t *testing.T) {
+		fieldTypes := make(map[string]string)
+		for _, field := range config {
+			fieldTypes[field.Name] = field.Type
+		}
+
+		assert.Equal(t, "string", fieldTypes["repository"])
+		assert.Equal(t, "select", fieldTypes["releaseStrategy"])
+		assert.Equal(t, "string", fieldTypes["tagName"])
+		assert.Equal(t, "boolean", fieldTypes["deleteTag"])
+	})
+
+	t.Run("releaseStrategy has correct options", func(t *testing.T) {
+		var foundField bool
+
+		for _, field := range config {
+			if field.Name == "releaseStrategy" {
+				foundField = true
+				assert.Equal(t, "select", field.Type)
+				assert.NotNil(t, field.TypeOptions)
+				assert.NotNil(t, field.TypeOptions.Select)
+
+				options := field.TypeOptions.Select.Options
+				assert.Len(t, options, 4, "should have 4 release strategy options")
+
+				values := make([]string, len(options))
+				for i, opt := range options {
+					values[i] = opt.Value
+				}
+
+				assert.Contains(t, values, "specific")
+				assert.Contains(t, values, "latest")
+				assert.Contains(t, values, "latestDraft")
+				assert.Contains(t, values, "latestPrerelease")
+				break
+			}
+		}
+
+		assert.True(t, foundField, "releaseStrategy field should exist in configuration")
+	})
+
+	t.Run("tagName has visibility conditions", func(t *testing.T) {
+		var foundField bool
+
+		for _, field := range config {
+			if field.Name == "tagName" {
+				foundField = true
+				assert.Len(t, field.VisibilityConditions, 1, "should have 1 visibility condition")
+				assert.Equal(t, "releaseStrategy", field.VisibilityConditions[0].Field)
+				assert.Equal(t, []string{"specific"}, field.VisibilityConditions[0].Values)
+
+				assert.Len(t, field.RequiredConditions, 1, "should have 1 required condition")
+				assert.Equal(t, "releaseStrategy", field.RequiredConditions[0].Field)
+				assert.Equal(t, []string{"specific"}, field.RequiredConditions[0].Values)
+				break
+			}
+		}
+
+		assert.True(t, foundField, "tagName field should exist in configuration")
+	})
+
+	t.Run("deleteTag has default value true", func(t *testing.T) {
+		var foundField bool
+
+		for _, field := range config {
+			if field.Name == "deleteTag" {
+				foundField = true
+				assert.Equal(t, true, field.Default)
+				break
+			}
+		}
+
+		assert.True(t, foundField, "deleteTag field should exist in configuration")
+	})
+}
+
+func Test__DeleteRelease__Component_Interface(t *testing.T) {
+	component := DeleteRelease{}
+
+	t.Run("Name returns correct value", func(t *testing.T) {
+		assert.Equal(t, "github.deleteRelease", component.Name())
+	})
+
+	t.Run("Label returns correct value", func(t *testing.T) {
+		assert.Equal(t, "Delete Release", component.Label())
+	})
+
+	t.Run("Description returns correct value", func(t *testing.T) {
+		assert.Equal(t, "Delete a release from a GitHub repository", component.Description())
+	})
+
+	t.Run("Icon returns correct value", func(t *testing.T) {
+		assert.Equal(t, "github", component.Icon())
+	})
+
+	t.Run("Color returns correct value", func(t *testing.T) {
+		assert.Equal(t, "gray", component.Color())
+	})
+
+	t.Run("OutputChannels returns default channel", func(t *testing.T) {
+		channels := component.OutputChannels(nil)
+		assert.Len(t, channels, 1)
+		assert.Equal(t, core.DefaultOutputChannel, channels[0])
+	})
+
+	t.Run("Actions returns empty slice", func(t *testing.T) {
+		actions := component.Actions()
+		assert.Empty(t, actions)
+	})
+}

--- a/pkg/applications/github/github.go
+++ b/pkg/applications/github/github.go
@@ -100,6 +100,7 @@ func (g *GitHub) Components() []core.Component {
 		&PublishCommitStatus{},
 		&CreateRelease{},
 		&UpdateRelease{},
+		&DeleteRelease{},
 	}
 }
 

--- a/pkg/applications/github/update_release.go
+++ b/pkg/applications/github/update_release.go
@@ -156,76 +156,6 @@ func (c *UpdateRelease) Setup(ctx core.SetupContext) error {
 	)
 }
 
-func (c *UpdateRelease) fetchReleaseByStrategy(client *github.Client, owner, repo, strategy, tagName string) (*github.RepositoryRelease, error) {
-	switch strategy {
-	case "specific":
-		// Fetch by specific tag name
-		release, _, err := client.Repositories.GetReleaseByTag(
-			context.Background(),
-			owner,
-			repo,
-			tagName,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find release with tag %s: %w", tagName, err)
-		}
-		return release, nil
-
-	case "latest":
-		// Fetch latest published release
-		release, _, err := client.Repositories.GetLatestRelease(
-			context.Background(),
-			owner,
-			repo,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch latest release: %w", err)
-		}
-		return release, nil
-
-	case "latestDraft":
-		// List releases and find the latest draft
-		releases, _, err := client.Repositories.ListReleases(
-			context.Background(),
-			owner,
-			repo,
-			&github.ListOptions{PerPage: 100},
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list releases: %w", err)
-		}
-
-		for _, release := range releases {
-			if release.GetDraft() {
-				return release, nil
-			}
-		}
-		return nil, fmt.Errorf("no draft releases found")
-
-	case "latestPrerelease":
-		// List releases and find the latest prerelease
-		releases, _, err := client.Repositories.ListReleases(
-			context.Background(),
-			owner,
-			repo,
-			&github.ListOptions{PerPage: 100},
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list releases: %w", err)
-		}
-
-		for _, release := range releases {
-			if release.GetPrerelease() && !release.GetDraft() {
-				return release, nil
-			}
-		}
-		return nil, fmt.Errorf("no prerelease releases found")
-
-	default:
-		return nil, fmt.Errorf("invalid release strategy: %s", strategy)
-	}
-}
-
 func (c *UpdateRelease) Execute(ctx core.ExecutionContext) error {
 	var config UpdateReleaseConfiguration
 	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
@@ -250,7 +180,7 @@ func (c *UpdateRelease) Execute(ctx core.ExecutionContext) error {
 	//
 	// Fetch the existing release based on the selected strategy
 	//
-	release, err := c.fetchReleaseByStrategy(client, appMetadata.Owner, config.Repository, config.ReleaseStrategy, config.TagName)
+	release, err := fetchReleaseByStrategy(client, appMetadata.Owner, config.Repository, config.ReleaseStrategy, config.TagName)
 	if err != nil {
 		return err
 	}

--- a/web_src/src/pages/workflowv2/mappers/github/delete_release.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/delete_release.ts
@@ -1,0 +1,70 @@
+import {
+  ComponentsNode,
+  ComponentsComponent,
+  WorkflowsWorkflowNodeExecution,
+  WorkflowsWorkflowNodeQueueItem,
+} from "@/api-client";
+import { ComponentBaseProps } from "@/ui/componentBase";
+import { ComponentBaseMapper, OutputPayload } from "../types";
+import { baseProps } from "./base";
+
+interface DeletedReleaseOutput {
+  id?: number;
+  tag_name?: string;
+  name?: string;
+  html_url?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  deleted_at?: string;
+  tag_deleted?: boolean;
+}
+
+export const deleteReleaseMapper: ComponentBaseMapper = {
+  props(
+    nodes: ComponentsNode[],
+    node: ComponentsNode,
+    componentDefinition: ComponentsComponent,
+    lastExecutions: WorkflowsWorkflowNodeExecution[],
+    queueItems: WorkflowsWorkflowNodeQueueItem[],
+  ): ComponentBaseProps {
+    return baseProps(nodes, node, componentDefinition, lastExecutions, queueItems);
+  },
+
+  getExecutionDetails(execution: WorkflowsWorkflowNodeExecution, _node: ComponentsNode): Record<string, string> {
+    const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+
+    // If no outputs (e.g., execution failed), return empty details
+    if (!outputs || !outputs.default || outputs.default.length === 0) {
+      return {};
+    }
+
+    const deletedRelease = outputs.default[0].data as DeletedReleaseOutput;
+
+    const details: Record<string, string> = {
+      "Release ID": deletedRelease?.id?.toString() || "-",
+      "Tag Name": deletedRelease?.tag_name || "-",
+    };
+
+    if (deletedRelease?.name) {
+      details["Release Name"] = deletedRelease.name;
+    }
+
+    if (deletedRelease?.deleted_at) {
+      details["Deleted At"] = deletedRelease.deleted_at;
+    }
+
+    if (deletedRelease?.tag_deleted !== undefined) {
+      details["Tag Deleted"] = deletedRelease.tag_deleted ? "Yes" : "No";
+    }
+
+    if (deletedRelease?.draft) {
+      details["Was Draft"] = "Yes";
+    }
+
+    if (deletedRelease?.prerelease) {
+      details["Was Prerelease"] = "Yes";
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -12,6 +12,7 @@ import { RUN_WORKFLOW_STATE_REGISTRY, runWorkflowMapper } from "./run_workflow";
 import { publishCommitStatusMapper } from "./publish_commit_status";
 import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
+import { deleteReleaseMapper } from "./delete_release";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   runWorkflow: RUN_WORKFLOW_STATE_REGISTRY,
@@ -25,6 +26,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   publishCommitStatus: publishCommitStatusMapper,
   createRelease: createReleaseMapper,
   updateRelease: updateReleaseMapper,
+  deleteRelease: deleteReleaseMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {


### PR DESCRIPTION
Note: The PR has still the changes of https://github.com/superplanehq/superplane/pull/1629 because it reuses components. Ignore those for now


Similar to Update, regarding how the tag to be deleted is chosen

UI:
<img width="464" height="220" alt="Screenshot 2026-01-14 at 15 16 34" src="https://github.com/user-attachments/assets/4e532362-1fcf-41cb-b528-90f6e2ff6a26" />
<img width="464" height="837" alt="Screenshot 2026-01-14 at 15 16 06" src="https://github.com/user-attachments/assets/f66ebcad-d530-4d7f-afe2-d629a402e1e5" />
