### PR TITLE
fix: owner setup e2e test

### DIFF
--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -51,7 +51,6 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.assertRedirectedToOrganizationHome()
 		steps.clearCookies()
 		steps.visitLoginPage()
-		steps.clickEmailPasswordLogin()
 		steps.fillInEmailAndPassword("owner@example.com", "Password1")
 		steps.submitLoginForm()
 		steps.assertRedirectedToOrganizationHome()
@@ -197,17 +196,12 @@ func (s *ownerSetupSteps) visitLoginPage() {
 	s.session.Sleep(500) // wait for page load
 }
 
-func (s *ownerSetupSteps) clickEmailPasswordLogin() {
-	s.session.Click(q.Text("Email & Password"))
-	s.session.Sleep(500) // wait for navigation
-}
-
 func (s *ownerSetupSteps) fillInEmailAndPassword(email, password string) {
 	s.session.FillIn(q.Locator(`input[type="email"]`), email)
 	s.session.FillIn(q.Locator(`input[type="password"]`), password)
 }
 
 func (s *ownerSetupSteps) submitLoginForm() {
-	s.session.Click(q.Text("Sign in"))
+	s.session.Click(q.Text("Login"))
 	s.session.Sleep(1000) // wait for redirect
 }


### PR DESCRIPTION
fix: owner setup e2e test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the owner setup E2E login flow to match current UI.
> 
> - Removes `clickEmailPasswordLogin` step and its usage in the login test
> - Updates `submitLoginForm` to click `"Login"` instead of `"Sign in"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e94c6a63369f5d5b9263c73132721b5fabf1718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->