### PR TITLE
fix: Always use junit-report.xml to expose the real failure

### DIFF
--- a/scripts/test_e2e_autoparallel.sh
+++ b/scripts/test_e2e_autoparallel.sh
@@ -83,10 +83,7 @@ echo ""
 regex="^($(printf '%s\n' "${selected_tests[@]}" | paste -sd '|' -))$"
 
 # Use a per-shard JUnit file so CI can aggregate results.
-junit_file="junit-report.e2e.${INDEX}.xml"
-
-echo "Running gotestsum with -run '${regex}'"
-echo "JUnit report (shard): ${junit_file}"
+junit_file="junit-report.xml"
 
 gotestsum \
   --format short \
@@ -97,6 +94,3 @@ gotestsum \
   -- \
   -p 1 \
   -run "${regex}"
-
-# Keep backward compatibility with CI that expects junit-report.xml
-cp "${junit_file}" junit-report.xml


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies JUnit reporting for e2e shards.
> 
> - In `scripts/test_e2e_autoparallel.sh`, set `junit_file` to `junit-report.xml` and remove per-shard naming (`junit-report.e2e.${INDEX}.xml`) and the compatibility `cp` step
> - Keeps test selection and `gotestsum` invocation the same, only changing the JUnit output target
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595cab32bd31c61094c6c7ac415b2facef13602c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->