### PR TITLE
fix: Disable template seeding in production

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -322,11 +322,13 @@ func Start() {
 	oidcVerifier := crypto.NewOIDCVerifier()
 	registry := registry.NewRegistry(encryptorInstance)
 
-	if err := templates.SeedTemplates(registry); err != nil {
-		log.Warnf("Failed to seed templates: %v", err)
-	}
+	if os.Getenv("APP_ENV") == "development" {
+		if err := templates.SeedTemplates(registry); err != nil {
+			log.Warnf("Failed to seed templates: %v", err)
+		}
 
-	templates.StartTemplateReloader(registry)
+		templates.StartTemplateReloader(registry)
+	}
 
 	if os.Getenv("START_PUBLIC_API") == "yes" {
 		go startPublicAPI(baseURL, basePath, encryptorInstance, registry, jwtSigner, oidcVerifier, authService)


### PR DESCRIPTION
Disabling it for now in non-development environments.
Will re-enable once I figure out why it lock server startup.