### PR TITLE
docs: Update README with demo container instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A few concrete things teams build with SuperPlane:
 Run the latest demo container:
 
 ```
+docker pull ghcr.io/superplanehq/superplane-demo:stable
 docker run --rm -p 3000:3000 -v spdata:/app/data -ti ghcr.io/superplanehq/superplane-demo:stable
 ```
 


### PR DESCRIPTION
Technically, a single docker run is enough, but it has a major flow:
It will never pull newer versions. If you try it out once, you are stuck on that version forever.

Adding an explicit `docker pull`.