### PR TITLE
fix: installation issues with OIDC keys

### DIFF
--- a/release/superplane-demo-image/gen-superplane-env.sh
+++ b/release/superplane-demo-image/gen-superplane-env.sh
@@ -79,7 +79,13 @@ if [ -z "$(find "${OIDC_KEYS_PATH}" -type f 2>/dev/null | head -n 1)" ]; then
     exit 1
   fi
   oidc_key_file="${OIDC_KEYS_PATH}/$(date -u +%s).pem"
-  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out "${oidc_key_file}"
+  openssl_err_file="$(mktemp)"
+  if ! openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out "${oidc_key_file}" 2>"${openssl_err_file}"; then
+    cat "${openssl_err_file}"
+    rm -f "${openssl_err_file}"
+    exit 1
+  fi
+  rm -f "${openssl_err_file}"
   chmod 600 "${oidc_key_file}"
 fi
 

--- a/release/superplane-single-host-tarball/templates/docker-compose.yml
+++ b/release/superplane-single-host-tarball/templates/docker-compose.yml
@@ -9,6 +9,8 @@ services:
         condition: service_healthy
     env_file:
       - superplane.env
+    volumes:
+      - ${OIDC_KEYS_HOST_PATH:-./oidc}:${OIDC_KEYS_CONTAINER_PATH:-/app/oidc-keys}
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/health || exit 1"]
       interval: 10s


### PR DESCRIPTION
A few issues with the OIDC keys generation during installation scripts:
- Hide the output of the openssl command used to generate the keys
- Path to the OIDC keys in the host and in the container were wrong in the single host installation script