### PR TITLE
fix: multi select with the mouse should include annotations

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -3056,7 +3056,7 @@ function prepareAnnotationNode(node: ComponentsNode): CanvasNode {
   return {
     id: node.id!,
     position: { x: node.position?.x!, y: node.position?.y! },
-    selectable: false,
+    selectable: true,
     style: { width, height },
     data: {
       type: "annotation",


### PR DESCRIPTION
<img width="1018" height="763" alt="image" src="https://github.com/user-attachments/assets/17fd1cba-152c-43d1-8c3d-31bd864a487d" />

Closes: https://github.com/superplanehq/superplane/issues/1812