### PR TITLE
fix: Include parallel upstream executions in message chain resolution (merge fan-in)

### DIFF
--- a/pkg/grpc/actions/workflows/emit_node_event.go
+++ b/pkg/grpc/actions/workflows/emit_node_event.go
@@ -87,6 +87,7 @@ func resolveCustomName(node *models.WorkflowNode, payload map[string]any) (*stri
 	}
 
 	builder := contexts.NewNodeConfigurationBuilder(database.Conn(), node.WorkflowID).
+		WithNodeID(node.NodeID).
 		WithInput(map[string]any{node.NodeID: payload})
 	resolved, err := builder.ResolveExpression(template)
 	if err != nil {

--- a/pkg/workers/contexts/event_context.go
+++ b/pkg/workers/contexts/event_context.go
@@ -75,6 +75,7 @@ func (s *EventContext) resolveCustomName(payload any) (*string, error) {
 	}
 
 	builder := NewNodeConfigurationBuilder(s.tx, s.workflowNode.WorkflowID).
+		WithNodeID(s.workflowNode.NodeID).
 		WithInput(map[string]any{s.workflowNode.NodeID: payload})
 	resolved, err := builder.ResolveExpression(template)
 	if err != nil {

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -37,6 +37,7 @@ func BuildProcessQueueContext(httpClient *http.Client, tx *gorm.DB, node *models
 	}
 
 	configBuilder := NewNodeConfigurationBuilder(tx, queueItem.WorkflowID).
+		WithNodeID(node.NodeID).
 		WithRootEvent(&queueItem.RootEventID).
 		WithPreviousExecution(event.ExecutionID).
 		WithInput(map[string]any{event.NodeID: event.Data.Data()})
@@ -75,6 +76,7 @@ func BuildProcessQueueContext(httpClient *http.Client, tx *gorm.DB, node *models
 	}
 	ctx.ExpressionEnv = func(expression string) (map[string]any, error) {
 		builder := NewNodeConfigurationBuilder(tx, queueItem.WorkflowID).
+			WithNodeID(node.NodeID).
 			WithRootEvent(&queueItem.RootEventID).
 			WithInput(map[string]any{event.NodeID: event.Data.Data()})
 		if event.ExecutionID != nil {

--- a/pkg/workers/workflow_node_executor.go
+++ b/pkg/workers/workflow_node_executor.go
@@ -173,6 +173,7 @@ func (w *WorkflowNodeExecutor) executeBlueprintNode(tx *gorm.DB, execution *mode
 	// and the user should be aware of this.
 	//
 	configBuilder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).
+		WithNodeID(node.NodeID).
 		WithRootEvent(&execution.RootEventID).
 		WithPreviousExecution(&execution.ID).
 		ForBlueprintNode(node).
@@ -291,6 +292,7 @@ func (w *WorkflowNodeExecutor) executeComponentNode(tx *gorm.DB, execution *mode
 	}
 	ctx.ExpressionEnv = func(expression string) (map[string]any, error) {
 		builder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).
+			WithNodeID(node.NodeID).
 			WithRootEvent(&execution.RootEventID).
 			WithInput(map[string]any{inputEvent.NodeID: input})
 		if execution.PreviousExecutionID != nil {


### PR DESCRIPTION
## Summary
- Expands execution chain resolution to include all upstream branch executions that feed into the current node, not just the linear `previous_execution_id` chain.
- Preserves `previous()` semantics by keeping depth lookups on the linear chain only.
- Adds a regression test for fan-in (action1/action2/action3 -> merge) and wires node ID through builder call sites.

## Why
When multiple upstream executions converge into a merge, expression resolution should be able to reference each upstream node’s outputs. Previously, `listExecutionsInChain` only followed a single `previous_execution_id` path, so only one branch was visible.

## Key Changes
- `NodeConfigurationBuilder`:
  - Added `WithNodeID` and `listUpstreamNodeIDs` to collect all upstream nodes via workflow edges.
  - `listExecutionsInChain` now unions the linear chain with all upstream executions for the same root event.
  - `previous()` uses the linear chain only via `listLinearExecutionsInChain` (no behavioral regression).
- Contexts now pass `WithNodeID` to the builder:
  - `pkg/workers/contexts/process_queue_context.go`
  - `pkg/workers/workflow_node_executor.go`
  - `pkg/grpc/actions/workflows/emit_node_event.go`
  - `pkg/workers/contexts/event_context.go`
- New test:
  - `Test_NodeConfigurationBuilder_Chain_IncludesParallelUpstreamExecutions`


## Notes
- No DB schema changes.
- `previous()` behavior remains linear and unchanged.

Closes: https://github.com/superplanehq/superplane/issues/1832
