### PR TITLE
chore: remove .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ wget-log*
 .env.docker
 vendor/bundle
 .claude/settings.local.json
+.env


### PR DESCRIPTION
My .env file was added in git by misake. This PR deletes it. 