### PR TITLE
chore: Optimized Google fonts loading

### DIFF
--- a/web_src/index.html
+++ b/web_src/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     
     <!-- Material Icons Fonts -->
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
 
     <script>
       window.SUPERPLANE_SENTRY_DSN = "{{ .SentryDSN }}";


### PR DESCRIPTION
## Problem/Motivation

The frontend part is using Google Fonts:

```html
<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
```

Google Fonts are loaded from two origins:
- fonts.googleapis.com - CSS
- fonts.gstatic.com - font files

There could be corresponding render delay and even FOIT/FOUT (flash or blink).

## Proposed Resolution

Add `rel=preconnect` to reduce the render delay for Google fonts, which is a best practice.

## References

- [MDN: rel="preconnect"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preconnect)