### PR TITLE
fix: metadata not updating for github + webhook replacement on setup

### DIFF
--- a/pkg/integrations/github/common.go
+++ b/pkg/integrations/github/common.go
@@ -30,13 +30,6 @@ func ensureRepoInMetadata(ctx core.MetadataContext, app core.IntegrationContext,
 		return fmt.Errorf("failed to decode node metadata: %w", err)
 	}
 
-	//
-	// If metadata is already set, skip setup
-	//
-	if nodeMetadata.Repository != nil {
-		return nil
-	}
-
 	repository := getRepositoryFromConfiguration(configuration)
 	if repository == "" {
 		return fmt.Errorf("repository is required")
@@ -56,6 +49,10 @@ func ensureRepoInMetadata(ctx core.MetadataContext, app core.IntegrationContext,
 
 	if repoIndex == -1 {
 		return fmt.Errorf("repository %s is not accessible to app installation", repository)
+	}
+
+	if nodeMetadata.Repository != nil && nodeMetadata.Repository.Name == repository {
+		return nil
 	}
 
 	return ctx.Set(NodeMetadata{

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -46,6 +46,10 @@ func (c *IntegrationContext) RequestWebhook(configuration any) error {
 		return err
 	}
 
+	if err := c.replaceMismatchedWebhook(configuration, integration); err != nil {
+		return err
+	}
+
 	webhooks, err := models.ListAppInstallationWebhooks(c.tx, c.appInstallation.ID)
 	if err != nil {
 		return fmt.Errorf("Failed to list webhooks: %v", err)
@@ -64,6 +68,39 @@ func (c *IntegrationContext) RequestWebhook(configuration any) error {
 	}
 
 	return c.createWebhook(configuration)
+}
+
+func (c *IntegrationContext) replaceMismatchedWebhook(configuration any, integration core.Integration) error {
+	if c.node == nil || c.node.WebhookID == nil {
+		return nil
+	}
+
+	webhook, err := models.FindWebhookInTransaction(c.tx, *c.node.WebhookID)
+	if err != nil {
+		return err
+	}
+
+	matches, err := integration.CompareWebhookConfig(webhook.Configuration.Data(), configuration)
+	if err != nil {
+		return err
+	}
+
+	if matches {
+		return nil
+	}
+
+	c.node.WebhookID = nil
+
+	nodes, err := models.FindWebhookNodesInTransaction(c.tx, webhook.ID)
+	if err != nil {
+		return err
+	}
+
+	if len(nodes) > 1 {
+		return nil
+	}
+
+	return c.tx.Delete(webhook).Error
 }
 
 func (c *IntegrationContext) createWebhook(configuration any) error {

--- a/pkg/workers/contexts/integration_context_test.go
+++ b/pkg/workers/contexts/integration_context_test.go
@@ -1,6 +1,8 @@
 package contexts
 
 import (
+	"context"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -8,10 +10,50 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
 )
+
+type testIntegration struct {
+	compare func(a, b any) (bool, error)
+}
+
+func (t *testIntegration) Name() string { return "dummy" }
+
+func (t *testIntegration) Label() string { return "test integration" }
+
+func (t *testIntegration) Icon() string { return "test" }
+
+func (t *testIntegration) Description() string { return "test integration" }
+
+func (t *testIntegration) Instructions() string { return "test integration" }
+
+func (t *testIntegration) Configuration() []configuration.Field { return nil }
+
+func (t *testIntegration) Components() []core.Component { return nil }
+
+func (t *testIntegration) Triggers() []core.Trigger { return nil }
+
+func (t *testIntegration) Sync(ctx core.SyncContext) error { return nil }
+
+func (t *testIntegration) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return nil, nil
+}
+
+func (t *testIntegration) HandleRequest(ctx core.HTTPRequestContext) {}
+
+func (t *testIntegration) CompareWebhookConfig(a, b any) (bool, error) {
+	return t.compare(a, b)
+}
+
+func (t *testIntegration) SetupWebhook(ctx core.SetupWebhookContext) (any, error) { return nil, nil }
+
+func (t *testIntegration) CleanupWebhook(ctx core.CleanupWebhookContext) error { return nil }
 
 func Test__IntegrationContext_ScheduleResync(t *testing.T) {
 	r := support.Setup(t)
@@ -70,4 +112,77 @@ func Test__IntegrationContext_ScheduleResync(t *testing.T) {
 		newRequest := requests[newRequestIndex]
 		require.Equal(t, models.AppInstallationRequestStatePending, newRequest.State)
 	})
+}
+
+func Test__IntegrationContext_RequestWebhook_ReplacesWebhookOnConfigChange(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	r.Registry.Integrations["dummy"] = &testIntegration{
+		compare: func(a, b any) (bool, error) {
+			return reflect.DeepEqual(a, b), nil
+		},
+	}
+
+	installation, err := models.CreateAppInstallation(
+		uuid.New(),
+		r.Organization.ID,
+		"dummy",
+		support.RandomName("installation"),
+		map[string]any{},
+	)
+	require.NoError(t, err)
+
+	oldConfig := map[string]any{"repository": "old"}
+	newConfig := map[string]any{"repository": "new"}
+
+	webhookID := uuid.New()
+	_, encryptedKey, err := crypto.NewRandomKey(context.Background(), r.Encryptor, webhookID.String())
+	require.NoError(t, err)
+
+	now := time.Now()
+	webhook := models.Webhook{
+		ID:                webhookID,
+		State:             models.WebhookStateReady,
+		Secret:            encryptedKey,
+		Configuration:     datatypes.NewJSONType[any](oldConfig),
+		Metadata:          datatypes.NewJSONType[any](map[string]any{}),
+		AppInstallationID: &installation.ID,
+		CreatedAt:         &now,
+	}
+	require.NoError(t, database.Conn().Create(&webhook).Error)
+
+	inputNode := models.WorkflowNode{
+		NodeID:        "node-1",
+		Name:          "Node 1",
+		Type:          models.NodeTypeTrigger,
+		Ref:           datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+		Configuration: datatypes.NewJSONType(map[string]any{}),
+		Metadata:      datatypes.NewJSONType(map[string]any{}),
+		Position:      datatypes.NewJSONType(models.Position{}),
+	}
+
+	workflow, nodes := support.CreateWorkflow(t, r.Organization.ID, r.User, []models.WorkflowNode{inputNode}, nil)
+	require.NotNil(t, workflow)
+	require.Len(t, nodes, 1)
+
+	node := nodes[0]
+	node.AppInstallationID = &installation.ID
+	node.WebhookID = &webhookID
+	require.NoError(t, database.Conn().Save(&node).Error)
+
+	ctx := NewIntegrationContext(database.Conn(), &node, installation, r.Encryptor, r.Registry)
+	require.NoError(t, ctx.RequestWebhook(newConfig))
+
+	require.NotNil(t, node.WebhookID)
+	require.NotEqual(t, webhookID, *node.WebhookID)
+
+	var deletedWebhook models.Webhook
+	require.NoError(t, database.Conn().Unscoped().First(&deletedWebhook, webhookID).Error)
+	require.True(t, deletedWebhook.DeletedAt.Valid)
+
+	newWebhook, err := models.FindWebhookInTransaction(database.Conn(), *node.WebhookID)
+	require.NoError(t, err)
+	require.False(t, newWebhook.DeletedAt.Valid)
+	assert.Equal(t, newConfig, newWebhook.Configuration.Data())
 }


### PR DESCRIPTION
## Summary
- Update GitHub trigger metadata when the configured repository changes (not only on first setup).
- Replace mismatched webhooks by detaching the node and soft-deleting the old webhook when it’s no longer shared.
- Add a unit test to verify webhook replacement behavior.

## Problem
- Re-running GitHub `onRelease` setup did not update repository metadata when the repository changed.
- Changing repository/configuration left old webhooks behind.

## Solution
- `ensureRepoInMetadata` now updates metadata when the repository differs.
- `RequestWebhook()` verifies an existing webhook’s configuration, detaches the node on mismatch, and soft-deletes the webhook if it’s not shared.
- Added unit coverage for the replacement behavior.


Closes: https://github.com/superplanehq/superplane/issues/1801
