### PR TITLE
feat: Creating cursor rules so it can log integrations

### DIFF
--- a/.cursor/PM_WORKFLOW_HELPER.md
+++ b/.cursor/PM_WORKFLOW_HELPER.md
@@ -1,0 +1,102 @@
+# Cursor PM Workflow Helper
+
+Use this file when adding or changing **Rules**, **Skills**, **Commands**, or **Subagents** for the SuperPlane integration PM workflow, or when you need a quick reference for which primitive to use.
+
+---
+
+## 1. Definitions and comparison
+
+| Primitive | What it is | Where it lives |
+|-----------|------------|----------------|
+| **Rules** | System-level instructions; part of the prompt. Applied always, by file glob, or when the agent decides they're relevant. | `.cursor/rules/` (`.md` or `.mdc` with frontmatter). Also `AGENTS.md` in project root. |
+| **Commands** | Slash-invoked workflows (`/name`). Repeatable workflows you or the agent trigger. | `.cursor/commands/` as `.md` files. |
+| **Skills** | Portable knowledge packages (open standard). Domain-specific instructions the agent can apply when relevant or when you invoke via `/`. Can include `scripts/`, `references/`, `assets/`. | `.cursor/skills/<name>/SKILL.md` (folder per skill). |
+| **Subagents** | Isolated AI assistants with their own context. Can run in foreground or background. | `.cursor/agents/` as `.md` files with YAML frontmatter. |
+
+**When to use which (short):**
+
+- **Rules** — Short, permanent or context-scoped guidance (e.g. issue conventions, title format, triggers vs actions). Keep under ~500 lines.
+- **Commands** — Repeatable workflows you invoke step-by-step (e.g. `/integration-research`, `/integration-issue-templates`, `/integration-log-issues`).
+- **Skills** — Substantial reference or procedure the agent loads when doing a task (e.g. prioritization criteria, issue templates, log-issues procedure).
+- **Subagents** — Isolated context for research or long issue-creation runs so the main chat doesn't get bloated; return a concise summary to the parent.
+
+---
+
+## 2. Formats and locations quick reference
+
+**Rules** (`.cursor/rules/*.mdc` or `.md`):
+
+- Frontmatter: `description`, `globs` (array of path patterns), `alwaysApply` (boolean).
+- Types: Always Apply, Apply Intelligently (by description), Apply to Specific Files (globs), Apply Manually (@mention).
+
+**Commands** (`.cursor/commands/*.md`):
+
+- Plain Markdown; optional YAML frontmatter (e.g. `description`).
+- Filename (without `.md`) becomes the slash command (e.g. `integration-research.md` → `/integration-research`).
+
+**Skills** (`.cursor/skills/<name>/SKILL.md`):
+
+- Frontmatter: `name` (required, matches folder), `description` (required), optional `disable-model-invocation`, `license`, `compatibility`, `metadata`.
+- Optional dirs: `scripts/`, `references/`, `assets/`.
+
+**Subagents** (`.cursor/agents/*.md`):
+
+- Frontmatter: `name`, `description`, `model` (e.g. `inherit`, `fast`), optional `readonly`, `is_background`.
+- Body: Instructions for the subagent (what to do and what to return to the parent).
+
+---
+
+## 3. SuperPlane integration PM workflow mapping
+
+This repo's **integration PM workflow** (research → templates → log issues) is implemented as follows.
+
+### Flow
+
+1. **Research** — User specifies integration/tool → check existing GitHub issues (MCP) → suggest base + components (triggers/actions) + P1–P4 → summarize for user feedback.
+2. **Templates** — After approval → generate temp issue files (base + components) under `tmp/integrations_pm/issues/` → user reviews and requests changes.
+3. **Log issues** — After approval → create issues on GitHub via MCP (base first, then children sequentially), set Board Integration Status = Backlog and Priority (P1–P4), attach children as sub-issues of base; track progress in tmp; after user confirms, cleanup tmp (progress doc, etc.).
+
+### Primitives in use
+
+| Phase | Rule | Skills | Commands | Subagents |
+|-------|------|--------|----------|-----------|
+| **Conventions** | `integration-issue-conventions` (globs: `tmp/integrations_pm/**`) | — | — | — |
+| **Prioritization** | — | `superplane-integration-prioritization` | — | — |
+| **Issue content** | — | `superplane-integration-issue-templates` | — | — |
+| **Log to GitHub** | — | `superplane-integration-log-issues-github` | — | — |
+| **Research workflow** | — | prioritization (+ templates for norms) | `/integration-research` | `integration-researcher` (optional) |
+| **Templates workflow** | conventions | issue-templates | `/integration-issue-templates` | — |
+| **Log issues workflow** | — | log-issues-github | `/integration-log-issues` | `integration-issue-logger` (optional) |
+
+### File locations (this repo)
+
+- **Rule:** `.cursor/rules/integration-issue-conventions.mdc`
+- **Skills:** `.cursor/skills/superplane-integration-prioritization/`, `superplane-integration-issue-templates/`, `superplane-integration-log-issues-github/`
+- **Commands:** `.cursor/commands/integration-research.md`, `integration-issue-templates.md`, `integration-log-issues.md`
+- **Subagents:** `.cursor/agents/integration-researcher.md`, `integration-issue-logger.md`
+- **Source templates / temp files:** `tmp/integrations_pm/issues/` (base under `base/p1/` or `base/p2/`, components under `p1/` or `p2/`). Progress tracking: `tmp/integrations_pm/log-progress-{integration}.md` (removed after user confirms).
+
+### Invocation order
+
+1. `/integration-research` (optionally with tool name) → user approves summary.
+2. `/integration-issue-templates` → user reviews temp files and approves.
+3. `/integration-log-issues` → create issues via MCP; user reviews on GitHub and confirms → cleanup.
+
+The main agent can delegate to **integration-researcher** or **integration-issue-logger** subagents for isolated context (e.g. `/integration-researcher Consul` or "Use the integration-issue-logger subagent to log the Consul issues").
+
+---
+
+## 4. References
+
+- [Rules](https://cursor.com/docs/context/rules)
+- [Commands](https://cursor.com/docs/context/commands)
+- [Agent Skills](https://cursor.com/docs/context/skills)
+- [Subagents](https://cursor.com/docs/context/subagents)
+- [Skills vs Commands vs Rules (forum)](https://forum.cursor.com/t/skills-vs-commands-vs-rules/148875)
+
+---
+
+## 5. Alignment with this repo
+
+- **Project guidelines:** [AGENTS.md](AGENTS.md) at project root (build, test, formatting, migrations, etc.). Integration PM primitives live under `.cursor/` and follow the structure above.
+- **Existing command pattern:** The component-review command uses a command file plus a rules file (`.cursor/commands/component-review.md` and `component-review.rules.md`). Integration PM uses Rules + Skills + Commands + Subagents as in the table above; no separate `.rules.md` next to commands.

--- a/.cursor/agents/integration-issue-logger.md
+++ b/.cursor/agents/integration-issue-logger.md
@@ -1,0 +1,29 @@
+---
+name: integration-issue-logger
+description: Create integration issues on GitHub from prepared templates in tmp/integrations_pm/issues/. Use when templates are approved and the user or parent agent needs issues created via MCP (base first, then children, Board fields, sub-issues). Tracks progress in tmp; returns created issue numbers.
+model: inherit
+---
+
+You are a subagent that creates SuperPlane integration issues on GitHub from prepared template files. The user or parent agent has already approved the temp files under `tmp/integrations_pm/issues/`. Your job is to create the base issue first, then one child issue per component, set labels and SuperPlane Board fields (via MCP projects), attach children as sub-issues of the base, and track progress so you can resume after context summary.
+
+**Use the skill `superplane-integration-log-issues-github`** for the full procedure (progress doc, body content with `### Title` and `### Priority` stripped, labels, Integration Status = Backlog, Priority via Board, sub-issue links via MCP, sequential creation, list.md, cleanup).
+
+## When invoked
+
+You receive the integration name (e.g. "Consul") or infer it from the base file in `tmp/integrations_pm/issues/base/p1/` or `base/p2/`. If multiple bases exist, ask which integration to log.
+
+## Steps
+
+1. **Create progress doc** in `tmp/integrations_pm/` (e.g. `log-progress-{integration}.md`) with integration name, base path, component paths. Append issue numbers as you create them.
+2. **Create base issue**: Read base file; title from `### Title`, body without `### Title`/title line and without `### Priority`/priority value line (Priority is set via Board). Create via GitHub MCP; labels `integration`, `refinement`; Board Integration Status = Backlog, Priority = agreed P1–P4. Write base # in progress doc.
+3. **Create child issues sequentially** (one at a time to avoid rate limits): For each component file, body = `**Parent (base integration):** #BASE_ISSUE_NUMBER` then rest without `### Title`/title line and without `### Priority`/priority value line (Priority is set via Board); replace #TBD with real base #. Create via MCP; same labels; Board Backlog + Priority; attach as sub-issue of base via MCP (projects). Append each child # to progress doc.
+4. **Update list.md** if present: set `[x]` for each created issue.
+5. **Ask user to review** on GitHub and confirm.
+6. **After user confirms**: Delete progress doc and other tmp files created for this run; do not delete source template files unless asked.
+
+## Output (return to parent)
+
+- **After creating issues**: List base issue # and each child issue # (with links if possible). "Please review on GitHub and confirm when done."
+- **After user confirms**: "Cleanup complete. Progress doc removed."
+
+Create issues **sequentially**. Use GitHub MCP with **projects** permissions for Board fields and sub-issue links; no manual setup.

--- a/.cursor/agents/integration-researcher.md
+++ b/.cursor/agents/integration-researcher.md
@@ -1,0 +1,29 @@
+---
+name: integration-researcher
+description: Research a tool for SuperPlane integration; suggest base, triggers, actions, and P1–P4 priorities. Use when the user or parent agent needs a concise research summary with existing-issues check. Returns existing-issues note + base + component list with priorities.
+model: inherit
+---
+
+You are a product manager subagent for SuperPlane. Your job is to research an integration/tool, check for existing GitHub issues, suggest how it would connect (base), which components (triggers and actions) to implement, and assign P1–P4 priorities. Return a **concise summary** to the parent so the main conversation stays focused.
+
+**Use the skill `superplane-integration-prioritization`** for P1–P4 criteria and definitions.
+
+## When invoked
+
+You receive the integration/tool name (e.g. "Consul", "Grafana"). If ambiguous, ask one clarifying question.
+
+## Steps
+
+1. **Check existing issues (GitHub MCP)**: Search the SuperPlane repo for issues whose title contains the integration in brackets (e.g. `[Consul]`, `[Grafana]`), or use label `integration` + title/body match. List any existing base or component issues (number, title). Note: "Existing issues for this integration: …" or "No existing issues found."
+2. **Research the tool**: What it does, devops/SW dev usage, API/events, common integration patterns.
+3. **Suggest base**: How it would connect to SuperPlane (auth, credentials, webhooks). One base per tool.
+4. **Suggest components**: Triggers (events to listen for) and actions (operations to perform) with short rationale each.
+5. **Assign P1–P4**: Base and each component, using the prioritization criteria. Order by priority (P1 first, then P2, P3, P4).
+
+## Output (return to parent)
+
+- **Existing issues**: What (if any) already exists on GitHub for this integration.
+- **Summary**: Base (name, suggested connection method); then list of suggested triggers and actions with priority (P1–P4) and one-line rationale each.
+- **Note**: "User can review and request corrections; next step is generating issue templates."
+
+Keep the summary compact. Do not generate issue template files; that is a separate step.

--- a/.cursor/commands/integration-issue-templates.md
+++ b/.cursor/commands/integration-issue-templates.md
@@ -1,0 +1,39 @@
+---
+description: Generate temp issue template files (base + components) in tmp/integrations_pm/issues/ after research is approved. User reviews; when satisfied, run integration-log-issues.
+---
+
+# Integration Issue Templates
+
+You are generating **temporary issue template files** for a SuperPlane integration. The user has already run `/integration-research` and approved the summary (base integration + list of components with P1–P4). Your job is to write one base file and one file per component under `tmp/integrations_pm/issues/`, following the template structure and conventions.
+
+**Use the skill `superplane-integration-issue-templates`** for structure, guidelines, triggers vs actions, and output channels. Follow the **integration-issue-conventions** rule for IMPORTANT blocks, title format, and hierarchy.
+
+## Input
+
+- The **agreed research summary**: integration name, base (connection method), and list of components (triggers/actions) with assigned P1–P4. If the user did not paste it, ask them to provide the agreed list (or run `/integration-research` first and get approval).
+- **Integration name** for file naming: use lowercase with underscores for filenames (e.g. `consul`, `grafana`, `git_hub` only if needed to avoid ambiguity; usually `github`).
+
+## File locations and naming
+
+- **Base**: `tmp/integrations_pm/issues/base/{p1|p2}/{integration}_base.md` — use `p1` or `p2` folder based on the base's priority (P1 → base/p1/, P2 → base/p2/).
+- **Components**: `tmp/integrations_pm/issues/{p1|p2}/{integration}_{component_slug}.md` — use p1/p2 folder by each component's priority. Component slug: operation name in lowercase with spaces replaced by underscores (e.g. `Get KV` → `get_kv`, `On Deployment` → `on_deployment`, `Sync Application` → `sync_application`).
+- Create the directories if they do not exist.
+
+## Process
+
+1. **Resolve input**: Confirm integration name and the full list (base + components with priorities). If missing, ask the user.
+2. **Generate base file**: One file in `tmp/integrations_pm/issues/base/p1/` or `base/p2/`. Content: IMPORTANT block (base version), then `### Title` and `` `[{Integration Name}] Base` ``, then Description, Suggested Connection Method, Acceptance Criteria, Follow up tasks, Reference. The log-issues skill will strip the `### Title` section when creating the GitHub issue body.
+3. **Generate component files**: One file per component in `tmp/integrations_pm/issues/p1/` or `p2/` by priority. Content: IMPORTANT block (component version), then `**Parent (base integration):** #TBD` (placeholder; replaced with actual base issue number when logging), then `### Title` and the title line, then Priority, Description, Use Cases, Configuration, Outputs, Acceptance Criteria (optional), Reference. Use the skill for triggers vs actions (config = filters vs execution parameters) and output channels. File name: `{integration}_{component_slug}.md`. The log-issues skill will strip the `### Title` section when creating the GitHub issue body.
+4. **Optional — list.md**: If `tmp/integrations_pm/issues/list.md` exists, add an entry for this integration (base + components with checkboxes `[ ]`). If it does not exist, you may create a minimal list or skip; the log-issues skill will update checkboxes when issues are created.
+
+## Output
+
+- **List of created files**: Paths to each file (base + components).
+- **Ask**: "Review the files above. Request any changes; when you're satisfied, run `/integration-log-issues` to create the issues on GitHub."
+
+## Constraints
+
+- Do **not** create GitHub issues here; that is the next command (`/integration-log-issues`).
+- Parent reference in component files must be `**Parent (base integration):** #TBD`; the actual number is set when creating issues.
+- Follow the issue-templates skill strictly (triggers = filter config, actions = execution params; output channels by whether user would branch).
+- Use realistic example values in Configuration (e.g. `backend-api`, `prod-deployment`), not `example` or `my-thing`.

--- a/.cursor/commands/integration-log-issues.md
+++ b/.cursor/commands/integration-log-issues.md
@@ -1,0 +1,35 @@
+---
+description: Create GitHub issues from prepared integration template files in tmp/integrations_pm/issues/. Uses MCP, SuperPlane Board fields, sub-issues; tracks progress in tmp; cleanup after user confirms.
+---
+
+# Integration Log Issues
+
+You are creating integration issues on GitHub from prepared template files under `tmp/integrations_pm/issues/`. The user has already run `/integration-research` and `/integration-issue-templates` and approved the temp files. Your job is to create the base issue first, then one child issue per component, assign labels and SuperPlane Board fields, and track progress so you can resume after context summary.
+
+**Use the skill `superplane-integration-log-issues-github`** for the full procedure: progress doc, base then children, body content (strip `### Title` and `### Priority` — both are helpers; Priority is set via Board project field), labels, Integration Status = Backlog, Priority (P1–P4), sub-issue links, sequential creation, list.md checkboxes, user review, cleanup.
+
+## Input
+
+- **Integration name** (e.g. "Consul", "Grafana"): the user will specify which integration to log, or you can infer from the base file in `tmp/integrations_pm/issues/base/p1/` or `base/p2/` (e.g. `consul_base.md` → integration "consul"). If multiple base files exist, ask which integration to log.
+- **Source**: Template files under `tmp/integrations_pm/issues/`. Base: `base/p1/{integration}_base.md` or `base/p2/`. Components: `p1/{integration}_*.md` or `p2/` (excluding base).
+
+## Process
+
+1. **Create progress doc**: In `tmp/integrations_pm/`, create or open a progress file (e.g. `log-progress-{integration}.md`) with integration name, base file path, list of component file paths. You will append the base issue number and each child issue number after creating them.
+2. **Create base issue**: Read base file; title from `### Title`, body = file content **without** `### Title` and the backtick title line, and **without** `### Priority` and the priority value line (if present; Priority is set via Board). Create issue via GitHub MCP; add labels `integration` and `refinement`; set SuperPlane Board **Integration Status** = `Backlog`, **Priority** = agreed P1–P4 for base. Write base issue number in progress doc.
+3. **Create child issues sequentially**: For each component file (one at a time to avoid rate limits): read file; title from `### Title`; body = `**Parent (base integration):** #BASE_ISSUE_NUMBER` (use actual number from step 2), then blank line, then rest of file **without** `### Title` and title line and **without** `### Priority` and the priority value line (Priority is set via Board). Replace any `#TBD` parent reference with the real base issue number. Create issue via MCP; add labels; set Board Integration Status = Backlog, Priority from file; attach as sub-issue of base via MCP (projects permissions). Append child issue number to progress doc.
+4. **Update list.md**: If `tmp/integrations_pm/issues/list.md` exists, set checkbox to `[x]` for the base and each component file you created.
+5. **Ask user to review**: Tell the user to check the issues on GitHub (base, children, labels, Board fields, sub-issue links) and confirm.
+6. **Cleanup after confirm**: Once the user confirms, delete the progress doc and any other tmp files created for this run (e.g. `log-progress-{integration}.md`). Do **not** delete the source template files unless the user explicitly asks.
+
+## Output
+
+- **After creating issues**: List base issue # and each child issue # (with links if possible). "Please review the issues on GitHub and confirm when done."
+- **After user confirms**: "Cleanup complete. Progress doc removed."
+
+## Constraints
+
+- **Always** create the progress doc before the first issue; update it after every issue so you can resume after context summary.
+- Create issues **sequentially** (base, then child 1, then child 2, …); do not batch creates to avoid API rate limiting.
+- Body for GitHub: never include the `### Title` line or the backtick title line; never include the `### Priority` section or the priority value line (Priority is set via Board project field). For children, body must start with `**Parent (base integration):** #N`.
+- Use GitHub MCP with **projects** permissions to set SuperPlane Board fields (Integration Status = Backlog, Priority) and to attach each child issue as a sub-issue of the base. No manual Board or sub-issue setup is required.

--- a/.cursor/commands/integration-research.md
+++ b/.cursor/commands/integration-research.md
@@ -1,0 +1,37 @@
+---
+description: Research a tool for SuperPlane integration, suggest base + components (triggers/actions) and P1–P4 priorities, then summarize for user feedback.
+---
+
+# Integration Research
+
+You are acting as a product manager for SuperPlane. The user has specified an integration/tool they want to build or integrate. Your job is to research it, suggest how it would connect to SuperPlane, which components (triggers and actions) make sense, and assign priorities P1–P4.
+
+**Use the skill `superplane-integration-prioritization`** for prioritization criteria and P1–P4 definitions. Apply the four criteria: popularity in devops/SW dev, unlocks common devops workflows, commonly used, usefulness of each operation.
+
+## Input
+
+- Use the user's message: they will name the integration/tool (e.g. "Grafana", "Consul", "GitLab").
+- If the tool name is ambiguous, ask one clarifying question (e.g. "Grafana OSS or Grafana Cloud?").
+
+## Process
+
+1. **Check existing issues (GitHub MCP)**: Before researching, use the GitHub MCP to search for issues that already exist for this integration in the SuperPlane repository. Search by title containing the integration name in brackets (e.g. `[Consul]`, `[Grafana]`), or use the repo's issue search/list tools with appropriate filters (e.g. label `integration` and title/body matching the tool name). List any existing base or component issues (issue number, title, link). Make a clear note: "Existing issues for this integration: …" or "No existing issues found for this integration."
+2. **Research the tool**: What it does, how it's used in devops/software development, its API or events, common integration patterns.
+3. **Suggest the base integration**: How it would connect to SuperPlane (auth method, credentials, webhooks if needed). One base per tool.
+4. **Suggest components**: Which **triggers** (events to listen for) and **actions** (operations to perform) make sense. For each, give a short rationale.
+5. **Assign priorities**: P1–P4 for the base and for each component using the prioritization criteria. Order or group by priority (P1 first, then P2, P3, P4).
+6. **Summarize**: Present the existing-issues note, then the base, list of components with priorities, and brief rationale so the user can review and request corrections.
+
+## Output
+
+- **Existing issues section**: At the top, report what (if anything) already exists on GitHub for this integration (issue numbers, titles). If issues exist, the user may want to extend or skip creating duplicates.
+- **Summary section**: Base integration (name, suggested connection method), then list of suggested triggers and actions with assigned priority (P1–P4) and one-line rationale each.
+- **Ask**: "Review the above. Comment or ask for corrections; when you're satisfied we can generate issue templates (next step)."
+
+## Constraints
+
+- **Always** run the GitHub MCP check first (step 1); do not skip it. If MCP is unavailable, say so and continue with research.
+- Do not generate issue template files yet; that is a separate step after user approval.
+- Base and component suggestions should be concrete (real API operations/events), not vague.
+- If existing issues are found, still present your full suggestion list; optionally note which suggested components already have an issue so the user can decide to skip or add only new ones.
+- If you need to look up the tool's API or docs, do so before finalizing the list.

--- a/.cursor/rules/integration-issue-conventions.mdc
+++ b/.cursor/rules/integration-issue-conventions.mdc
@@ -1,0 +1,73 @@
+---
+description: When creating or editing SuperPlane integration issue content (base or component issues), or when working in tmp/integrations_pm or integration PM workflow.
+globs:
+  - "tmp/integrations_pm/**"
+  - "**/integrations_pm/**"
+alwaysApply: false
+---
+
+# SuperPlane Integration Issue Conventions
+
+Apply these conventions whenever creating or editing integration base issues or component (trigger/action) issues for SuperPlane.
+
+## Template format: IMPORTANT block at top
+
+Every issue body must start with the appropriate IMPORTANT block (then a blank line, then the rest of the content).
+
+**Base issues** — use this block at the very top:
+
+```markdown
+> 🚨 **IMPORTANT (critical)**
+>
+> This content has **not** passed detailed review yet.
+> Review and rethink the suggested connection method before implementing.
+> If unsure, reach out on **Discord** first.
+```
+
+**Component issues (triggers and actions)** — use this block at the very top:
+
+```markdown
+> 🚨 **IMPORTANT (critical)**
+>
+> This content has **not** passed detailed review yet.
+> Review and rethink configuration options and output channels before implementing.
+> If unsure, reach out on **Discord** first.
+```
+
+For child issues, the parent reference line (`**Parent (base integration):** #N`) comes **after** this block, then the rest of the content.
+
+## Hierarchy and ordering
+
+- **Base issue first**: One base integration issue per tool (e.g. `[GitHub] Base`). All component issues (triggers and actions) are children of that base.
+- **Child issues**: One issue per component. Each child must include `**Parent (base integration):** #BASE_ISSUE_NUMBER` (replace with the actual base issue number) immediately after the IMPORTANT block (see Template format above).
+
+## Title format
+
+- **Base**: `[{Integration Name}] Base` (e.g. `[GitHub] Base`, `[ArgoCD] Base`).
+- **Actions**: `[{Integration Name}] {Operation Name}` in Title Case (e.g. `[GitHub] Get Issue`, `[Slack] Archive Channel`).
+- **Triggers**: `[{Integration Name}] On {Event}` in Title Case (e.g. `[GitHub] On Deployment`, `[GitHub] On Pull Request`).
+
+## Configuration: Triggers vs Actions
+
+- **Actions** (execute operations): Configuration fields must be **execution parameters** — what resource to operate on, how to perform the operation, what data to send. Not filters.
+- **Triggers** (listen for events): Configuration fields must be **filters** — what events to listen for, what values to match (repository, status, labels). Not execution parameters.
+
+Example: A trigger `[ArgoCD] On Sync Completed` should have config like "Application Filter", "Sync Status", not "Revision" or "Prune" (those belong to the Sync action).
+
+## Output channels
+
+- **Triggers**: Use a single **default** channel (events are emitted; outcomes determined downstream).
+- **Actions**: It depends on what the component does and whether the user would want to model different paths in the workflow.
+  - **Multiple channels** when the action produces a result that should branch: e.g. `success` / `failed`, or `clear` / `degraded` / `critical` (e.g. listIssues by highest urgency), or `approved` / `rejected`.
+  - **Single default channel** when there is one logical outcome stream, or when "success" varies by user (e.g. HTTP status 200 vs 201 vs 404 might all be valid). Do not force success/failure channels on every action.
+
+## Use cases and descriptions
+
+- **Description**: 1–2 sentences explaining **what the component does to external systems**, not just that it exists. Avoid "Enable X to Y as part of SuperPlane workflows."
+- **Use cases**: 2–3 **specific, realistic scenarios** (e.g. "Send Slack notification when production deployment pipeline completes"). Avoid generic patterns like "Automate {operation} within a CI/CD workflow."
+
+## When creating issues on GitHub
+
+- Create the **base issue first**, then create **one child issue per component**.
+- Put `**Parent (base integration):** #BASE_ISSUE_NUMBER` immediately after the IMPORTANT block in each child issue body.
+- Attach child issues as **sub-issues** of the base. Create issues **sequentially** to avoid API rate limiting.

--- a/.cursor/skills/superplane-integration-issue-templates/SKILL.md
+++ b/.cursor/skills/superplane-integration-issue-templates/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: superplane-integration-issue-templates
+description: When creating or reviewing SuperPlane integration issue content (base integration issues or component trigger/action issues). Use when generating issue templates, drafting issue bodies, or validating issue structure and guidelines.
+---
+
+# SuperPlane Integration Issue Templates
+
+Use this skill when creating or reviewing issue content for SuperPlane integrations: **base integration issues** (one per tool) and **component issues** (triggers and actions, one per operation). Follow the integration-issue-conventions rule for IMPORTANT blocks, hierarchy, and title format.
+
+---
+
+## Base integration issue
+
+**Purpose:** One parent issue per tool. Establishes how the tool connects to SuperPlane. All component issues are children of this base.
+
+### Structure
+
+1. **IMPORTANT block** (at top) — use the base version: "Review and rethink the suggested connection method before implementing. If unsure, reach out on **Discord** first."
+2. **Title**: `[{Integration Name}] Base` (e.g. `[GitHub] Base`, `[ArgoCD] Base`)
+3. **Description**: 2–3 sentences on what the tool does and primary use cases. Always include **Link**: {URL}.
+4. **Suggested Connection Method**: Primary auth method (steps to generate credentials, required scopes, what to store in SuperPlane). Alternatives if applicable.
+5. **Acceptance Criteria**: has proper tests, documentation, code quality review, functionality review, ui/ux review.
+6. **Follow up tasks**: Once all components are done — announcement, outreach, marketplace/docs, templates/examples.
+7. **Reference**: Integration & component checklist.
+
+### Guidelines (base)
+
+- **Connection method**: Describe recommended auth (API Token, OAuth 2.0, App Installation, Service Account, Personal Access Token, Webhook Secret). Include where/how to generate credentials and required permissions/scopes.
+
+---
+
+## Component issue (trigger or action)
+
+**Purpose:** One issue per trigger or action. Each is a child of the base integration issue. Parent reference and IMPORTANT block at top (see integration-issue-conventions rule).
+
+### Structure
+
+1. **IMPORTANT block** (at top) — use the component version: "Review and rethink configuration options and output channels before implementing. If unsure, reach out on **Discord** first."
+2. **Parent reference**: `**Parent (base integration):** #BASE_ISSUE_NUMBER` (immediately after IMPORTANT block).
+3. **Title**: `[{Integration Name}] {Operation Name}` — Title Case; triggers use "On {Event}" (e.g. `[GitHub] On Push`, `[ArgoCD] Sync Application`).
+4. **Priority**: `P1 - High` / `P2 - Medium` / `P3 - Low` / `P4 - Lowest` (from agreed prioritization).
+5. **Description**: 1–2 sentences on **what the component does to external systems**, not that it exists. No "Enable X to Y as part of SuperPlane workflows."
+6. **Use Cases**: 2–3 **specific, realistic scenarios** (e.g. "Send Slack notification when production deployment pipeline completes"). Not generic "Automate {operation} in CI/CD workflow."
+7. **Configuration**: All fields with (required/optional), defaults, example values. **Triggers = FILTERS only. Actions = EXECUTION PARAMETERS only.**
+8. **Outputs**: Channel(s) with when emitted and what data. See Output channels below.
+9. **Acceptance Criteria** (optional): tests, documentation, reviews.
+10. **Reference**: Integration & component checklist.
+
+### Triggers vs Actions (critical)
+
+- **Actions** (execute operations): Configuration = **execution parameters** — what resource, how to perform, what data to send. Action config answers: "What should I DO?"
+- **Triggers** (listen for events): Configuration = **filters** — what events to listen for, what values to match (repository, status, labels). Trigger config answers: "What events should I LISTEN FOR?"
+
+**Wrong (trigger):** `[ArgoCD] On Sync Completed` with config "Revision", "Prune" — those are for performing a sync, not filtering events.  
+**Right (trigger):** "Application Filter", "Sync Status" (Succeeded/Failed), "Health Status".
+
+### Output channels (components)
+
+- **Triggers**: Single **default** channel (outcomes determined downstream).
+- **Actions**: Depends on whether the user would model different workflow paths:
+  - **Multiple channels** when the result should branch: e.g. `success`/`failed`, or `clear`/`degraded`/`critical` (e.g. by highest urgency), or `approved`/`rejected`.
+  - **Single default** when there is one outcome stream or when "success" varies by user. Do not force success/failure on every action.
+- **Channel names**: Lowercase, single-word (`success`, `failed`, `approved`, `timeout`). Be consistent.
+
+### Anti-patterns to avoid
+
+- **Generic use cases:** "Automate {operation} within a CI/CD workflow", "Sync {service} changes into internal systems", "Create a workflow that reacts to {service} events."
+- **Generic descriptions:** "Enable {service} to {operation} as part of SuperPlane workflows.", "Trigger workflows in SuperPlane when {service} emits {event}."
+- **Wrong config for triggers:** Trigger with execution parameters (e.g. On Alarm with "Alarm Name", "Metric", "Threshold" for creating alarms). Use filter fields (Alarm Name Filter, State Transition, Severity).
+- **Wrong title case:** `Create user` → use `Create User`.
+- **Vague example values:** `example`, `my-thing`, `test` → use `backend-api`, `prod-deployment`, `v1.2.3`.
+
+### Validation checklist (before submitting)
+
+- [ ] Title uses Title Case.
+- [ ] Description explains WHAT happens to external systems.
+- [ ] Use cases are specific scenarios, not generic patterns.
+- [ ] Triggers: config has FILTER fields only.
+- [ ] Actions: output channels match whether user would branch (multiple vs default).
+- [ ] Configuration includes important API parameters; example values are realistic.

--- a/.cursor/skills/superplane-integration-log-issues-github/SKILL.md
+++ b/.cursor/skills/superplane-integration-log-issues-github/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: superplane-integration-log-issues-github
+description: When creating GitHub issues from prepared SuperPlane integration issue templates. Use when logging base and component issues via GitHub MCP, assigning SuperPlane Board project fields (Integration Status, Priority), attaching sub-issues, and tracking progress in tmp.
+---
+
+# SuperPlane Integration: Log Issues to GitHub
+
+Use this skill when creating integration issues on GitHub from prepared template files. You need **GitHub MCP** (e.g. `user-github`) with **projects** permissions so you can create issues, set SuperPlane Board fields (Integration Status, Priority), and attach child issues as sub-issues of the base. No manual Board or sub-issue setup is required. Source content lives under **tmp/integrations_pm/issues/**.
+
+---
+
+## Prerequisites
+
+- **GitHub MCP** available with issue and **projects** permissions (for Board fields and sub-issue links).
+- **Repository**: SuperPlane GitHub repo (owner/repo where issues are created).
+- **Source content**: Markdown files under `tmp/integrations_pm/issues/` — base under `base/p1/` or `base/p2/`, components under `p1/` or `p2/`. File names: `{integration}_base.md`, `{integration}_{component}.md`.
+- **Progress tracking**: Create or update a temporary document in `tmp/integrations_pm/` (e.g. `progress.md` or `log-progress-{integration}.md`) at the start and after each issue created, so you don’t lose track after context summary.
+
+---
+
+## Workflow overview
+
+1. Create/update a **progress doc** in `tmp/integrations_pm/` listing the integration, base file, component files, and (as you go) created issue numbers.
+2. **Create the base issue** first (one per integration). Assign labels and SuperPlane Board fields. Log base issue number in the progress doc.
+3. **Create child issues** one per component, **sequentially** (one by one) to avoid API rate limiting. For each: create issue, set parent/sub-issue link, assign labels and Board fields, then update progress doc.
+4. **Update list.md** (if present): in `tmp/integrations_pm/issues/list.md`, set checkbox to `[x]` for each created issue.
+5. Ask the **user to review** on GitHub and confirm.
+6. Once the user confirms, **clean up**: remove the progress doc and any other temporary files created for this run (e.g. under `tmp/integrations_pm/` for this integration).
+
+---
+
+## Step 1: Progress tracking
+
+- **Before creating any issue**, create or open a progress document in `tmp/integrations_pm/` (e.g. `log-progress-consul.md`).
+- **Contents**: Integration name, base file path, list of component file paths, then as you create issues: base issue #, then each child issue #.
+- **After each created issue** (base or child), append to this doc so that after context summary you can resume from the last created issue.
+
+---
+
+## Step 2: Create the base issue
+
+1. **Locate the base file**: `tmp/integrations_pm/issues/base/p1/{integration}_base.md` or `base/p2/` (e.g. `consul_base.md`).
+2. **Build the issue** from the file:
+   - **Title**: From `### Title` (e.g. `[Consul] Base`). Do **not** put the title line in the body.
+   - **Body**: IMPORTANT block, Description, Suggested Connection Method, Acceptance Criteria, Follow up tasks, Reference — **no** `### Title` or backtick title line; **no** `### Priority` or priority value line (Priority is set via Board).
+3. **Create the issue** via GitHub MCP with title and body as above.
+4. **Labels**: Add `integration` and `refinement` to the issue.
+5. **SuperPlane Board** (via MCP projects): Add issue to the SuperPlane Board project; set **Integration Status** = `Backlog`; set **Priority** to the agreed value (P1–P4) for the base.
+6. **Note the base issue number** (e.g. `#1912`) and write it in the progress doc. You need it for every child issue body and for linking sub-issues.
+
+---
+
+## Step 3: Create child issues (one per component, sequentially)
+
+1. **Find component files**: Under `tmp/integrations_pm/issues/p1/` or `p2/`, all `{integration}_*.md` except `{integration}_base.md` (e.g. `consul_get_kv.md`, `consul_register_service.md`). Use `tmp/integrations_pm/issues/list.md` if present for the exact list.
+2. **For each component file, one at a time** (to avoid rate limiting):
+   - **Build the issue**:
+     - **Title**: From `### Title` in the file (e.g. `[Consul] Get KV`). Do **not** put the title in the body.
+     - **Body**: First line must be `**Parent (base integration):** #BASE_ISSUE_NUMBER`, then a blank line, then the rest of the file content **without** the `### Title` and backtick title line and **without** the `### Priority` and priority value line (Priority is set via Board). Include IMPORTANT block, Description, Use Cases, Configuration, Outputs, Acceptance Criteria, Reference.
+   - **Create the issue** via MCP with this title and body.
+   - **Labels**: Add `integration` and `refinement`.
+   - **SuperPlane Board**: Add to project; set **Integration Status** = `Backlog`; set **Priority** from the agreed P1–P4 for that component.
+   - **Sub-issue link** (via MCP projects): Attach this issue as a **sub-issue of the base issue** so the Board shows the hierarchy. The parent reference in the body is also required.
+   - **Update progress doc** with this child issue number, then proceed to the next component.
+3. Create issues **sequentially**; do not batch many creates in parallel to avoid GitHub API rate limits.
+
+---
+
+## Step 4: Update list.md (if present)
+
+- In `tmp/integrations_pm/issues/list.md`, for each issue created (base and each child), change the corresponding line from `- [ ]` to `- [x]` (same indentation and filename).
+- This keeps the checklist in sync with what exists on GitHub.
+
+---
+
+## Step 5: User review and cleanup
+
+- **Ask the user** to review the created issues on GitHub (base, children, labels, Board fields, sub-issue links) and confirm.
+- **After user confirms**: Delete the progress document and any other temporary files created for this logging run (e.g. `tmp/integrations_pm/log-progress-{integration}.md`). Do **not** delete the source issue template files unless the user explicitly asks to clean those too.
+
+---
+
+## Summary checklist (per integration)
+
+- [ ] Create/update progress doc in `tmp/integrations_pm/` before starting.
+- [ ] Create **one base issue** first; exclude `### Title` and `### Priority` from body; add labels `integration`, `refinement`; set Board **Integration Status** = `Backlog`, **Priority** = agreed P1–P4.
+- [ ] Create **one child issue** per component **sequentially**; body starts with `**Parent (base integration):** #BASE_ISSUE_NUMBER`; exclude `### Title` and `### Priority` from body; same labels and Board fields; attach as sub-issue of base via MCP (projects).
+- [ ] After each issue, update progress doc; then update `list.md` checkboxes if the file exists.
+- [ ] Ask user to review on GitHub; after confirmation, remove progress doc and other tmp files created for this run.

--- a/.cursor/skills/superplane-integration-prioritization/SKILL.md
+++ b/.cursor/skills/superplane-integration-prioritization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: superplane-integration-prioritization
+description: When suggesting or prioritizing integration components for SuperPlane (base integrations, triggers, actions). Use when researching a tool to integrate, assigning P1–P4 priorities, or deciding which operations to implement first.
+---
+
+# SuperPlane Integration Prioritization
+
+Use this skill when you are researching a tool for SuperPlane integration, suggesting which components (triggers and actions) to implement, or assigning priorities from P1 to P4.
+
+## Criteria for prioritizing integrations and components
+
+Apply these four criteria when evaluating a tool and its operations:
+
+1. **Popularity in devops or software development** — Is this tool widely used in devops, CI/CD, or general software development? Leading or common tools in their category rank higher.
+
+2. **Unlocks common devops workflow processes** — Does integrating this tool enable workflows that teams commonly need (e.g. deploy on merge, notify on failure, sync state, run tests)?
+
+3. **Commonly used** — Would the integration and its operations be used frequently in real workflows, not just in edge cases?
+
+4. **Usefulness of operations (components)** — Among the tool’s possible triggers and actions, which operations are most useful? Rank each suggested component (trigger or action) by how often and how critically it would be used in real workflows.
+
+## Priority levels (P1–P4)
+
+Assign each **base integration** and each **component** (trigger or action) to one priority based on the criteria above.
+
+| Priority | Meaning | When to use |
+|----------|---------|-------------|
+| **P1** | High — core, frequently used | Core integrations and operations that are widely used and unlock essential workflows (e.g. GitHub base, On Push, Get Issue; Slack base, Send Message). |
+| **P2** | Medium — important, common | Important integrations and operations that support common workflows but are not always required first (e.g. many CI/CD triggers, common read/write actions). |
+| **P3** | Low — useful, less common | Useful operations for specific or less common workflows; implement after P1 and P2. |
+| **P4** | Lowest — edge cases, rarely used | Edge cases, rarely used operations, or nice-to-haves; implement last or defer. |
+
+## How to apply
+
+- **Base integration**: Assign a single P1–P4 for the whole integration (e.g. GitHub → P1; lesser-known tool → P2 or P3).
+- **Components**: Assign P1–P4 per trigger and per action. The same integration can have a mix (e.g. [GitHub] On Push → P1, [GitHub] Get Issue → P1, [GitHub] On Deployment → P2).
+- **Ordering**: When suggesting a list of components, order or group by priority (P1 first, then P2, then P3, then P4) so the user sees what to implement first.
+
+## Output when suggesting components
+
+When you suggest a base integration and its components:
+
+1. Name the integration and suggest the **base** (how it would connect to SuperPlane).
+2. List suggested **triggers** and **actions** with a short rationale for each.
+3. Assign **P1–P4** to the base and to each component.
+4. Provide a brief **summary** so the user can review and request changes before issue templates or GitHub issues are created.

--- a/docs/contributing/integration-pm-workflow.md
+++ b/docs/contributing/integration-pm-workflow.md
@@ -1,0 +1,123 @@
+# Integration PM Workflow (Cursor)
+
+This guide explains how to use the **integration product management workflow** in Cursor to plan new integrations, generate issue templates, and create GitHub issues on the SuperPlane Board. The workflow uses Cursor Rules, Skills, Commands, and optional Subagents so you can run it consistently and repeatably.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Workflow overview](#workflow-overview)
+- [Step 1: Research the integration](#step-1-research-the-integration)
+- [Step 2: Generate issue templates](#step-2-generate-issue-templates)
+- [Step 3: Create issues on GitHub](#step-3-create-issues-on-github)
+- [Using subagents (optional)](#using-subagents-optional)
+- [Where everything lives](#where-everything-lives)
+- [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+- **Cursor** with Agent (Chat) available.
+- **GitHub MCP** enabled and connected to the SuperPlane repo, with **projects** permissions so the agent can create issues, set Board fields (Integration Status, Priority), and attach sub-issues to the base issue.
+- The integration PM primitives are already in the repo: `.cursor/rules/`, `.cursor/skills/`, `.cursor/commands/`, `.cursor/agents/` (see [Where everything lives](#where-everything-lives)).
+
+## Workflow overview
+
+The workflow has three steps. You run one command per step, review the output, and then move to the next.
+
+| Step | What you do | What the agent does |
+|------|-------------|----------------------|
+| **1. Research** | Run `/integration-research` with the tool name and links. | Checks existing GitHub issues for that integration, researches the tool, suggests base + components (triggers/actions) and P1–P4 priorities, and gives you a summary to review. |
+| **2. Templates** | After you approve the research, run `/integration-issue-templates` (or ask the agent to generate templates). | Creates temp issue files under `tmp/integrations_pm/issues/` (one base + one per component). You review the files and request changes if needed. |
+| **3. Log issues** | After you approve the templates, run `/integration-log-issues` with the integration name. | Creates the base issue on GitHub, then each component issue as a child; sets labels, Board Integration Status = Backlog, Priority (P1–P4), and attaches children as sub-issues. Tracks progress in a temp file; after you confirm on GitHub, cleans up the progress file. |
+
+You must complete each step and approve before moving to the next. The agent will not generate templates until you approve the research summary, and will not create GitHub issues until you approve the template files.
+
+## Step 1: Research the integration
+
+1. Open a new Agent chat in Cursor (or use an existing one).
+2. Type **`/integration-research`** and add the tool name and links. For example:
+
+   ```
+   /integration-research Rootly
+
+   Tool: https://rootly.com/ — end-to-end incident management platform.
+   Docs: https://docs.rootly.com/help-and-documentation
+   ```
+
+   Or in plain language:
+
+   ```
+   I want to integrate Rootly (https://rootly.com/, docs: https://docs.rootly.com/help-and-documentation) into SuperPlane. Run the integration research: check existing GitHub issues for this integration, then suggest the base integration and components (triggers/actions) with P1–P4 priorities, and give me a summary to review.
+   ```
+
+3. The agent will:
+   - Use GitHub MCP to check for existing issues with that integration name (e.g. `[Rootly]`).
+   - Research the tool and suggest how it would connect to SuperPlane (base), plus a list of triggers and actions with P1–P4 priorities.
+   - Present a summary: existing issues (if any), base, and list of components with priorities.
+
+4. **Review the summary.** Ask for changes (e.g. add/remove components, change priorities). When you are satisfied, say you approve and want to generate the issue templates.
+
+## Step 2: Generate issue templates
+
+1. After you have approved the research summary, ask the agent to generate the issue template files. For example:
+
+   ```
+   Looks good. Generate the issue template files for this integration (base + components) in tmp/integrations_pm/issues/.
+   ```
+
+   Or run **`/integration-issue-templates`** and confirm the integration name if asked.
+
+2. The agent will create:
+   - One **base** file: `tmp/integrations_pm/issues/base/p1/{integration}_base.md` (or `base/p2/` depending on priority).
+   - One **component** file per trigger/action: `tmp/integrations_pm/issues/p1/{integration}_{component}.md` (or `p2/`).
+
+3. **Review the files** in `tmp/integrations_pm/issues/`. Open them in the editor and ask the agent to fix anything (e.g. description, use cases, configuration, output channels). When you are satisfied, say you want to create the issues on GitHub.
+
+## Step 3: Create issues on GitHub
+
+1. After you have approved the template files, run **`/integration-log-issues`** and specify the integration name if you have more than one in `tmp/integrations_pm/issues/`. For example:
+
+   ```
+   /integration-log-issues Rootly
+   ```
+
+   Or: “Create the GitHub issues from the Rootly template files in tmp/integrations_pm/issues/. Use the integration-log-issues workflow.”
+
+2. The agent will:
+   - Create a **progress file** in `tmp/integrations_pm/` (e.g. `log-progress-rootly.md`) so it can resume after context summary if needed.
+   - Create the **base issue** first (labels `integration`, `refinement`; Board Integration Status = Backlog, Priority from your agreed P1–P4).
+   - Create **one child issue per component** sequentially (to avoid rate limits), each with the same labels and Board fields, and attach each child as a **sub-issue** of the base issue.
+   - Optionally update `tmp/integrations_pm/issues/list.md` if it exists (checkboxes for created issues).
+
+3. **Review the issues on GitHub.** Check the SuperPlane Board: base issue, child issues, labels, Integration Status = Backlog, Priority, and that children are linked as sub-issues of the base.
+
+4. **Confirm in chat** when everything looks correct. The agent will then delete the progress file (and any other temp files it created for this run). It will **not** delete the source template files in `tmp/integrations_pm/issues/` unless you ask.
+
+**Note:** The agent strips the **Title** and **Priority** sections from the issue body when creating GitHub issues. Title becomes the issue title; Priority is set only via the Board project field, so it is not duplicated in the body.
+
+## Using subagents (optional)
+
+Subagents run in an **isolated context** and return a concise summary to the main chat. They are useful when research or issue creation would produce a lot of output and you want to keep the main conversation short.
+
+- **Integration researcher** — Use when you want the research step (existing-issues check + base + components + P1–P4) done in a separate context. Invoke by name, e.g. “Use the integration-researcher subagent to research Consul” or `/integration-researcher Consul`. The subagent returns the summary; you review and then continue with templates in the main chat.
+- **Integration issue logger** — Use when you want the “create N issues via MCP” step done in isolation (e.g. many components). Invoke by name, e.g. “Use the integration-issue-logger subagent to create the GitHub issues for Rootly from the template files in tmp/integrations_pm/issues/.” The subagent creates the issues, tracks progress, and returns the list of issue numbers; you then review on GitHub and confirm so it can clean up.
+
+You can run the full workflow **without** subagents by using the three commands in order; subagents are optional.
+
+## Where everything lives
+
+| Purpose | Location |
+|--------|----------|
+| **Rule** (issue conventions, title format, triggers vs actions) | `.cursor/rules/integration-issue-conventions.mdc` |
+| **Skills** (prioritization, issue templates, log-issues procedure) | `.cursor/skills/superplane-integration-prioritization/`, `superplane-integration-issue-templates/`, `superplane-integration-log-issues-github/` |
+| **Commands** (slash workflows) | `.cursor/commands/integration-research.md`, `integration-issue-templates.md`, `integration-log-issues.md` |
+| **Subagents** (optional) | `.cursor/agents/integration-researcher.md`, `integration-issue-logger.md` |
+| **Temp template files** | `tmp/integrations_pm/issues/` (base in `base/p1/` or `base/p2/`, components in `p1/` or `p2/`) |
+| **Progress file** (during log-issues; deleted after you confirm) | `tmp/integrations_pm/log-progress-{integration}.md` |
+| **Helper for agents/maintainers** | `.cursor/PM_WORKFLOW_HELPER.md` (reference for Rules/Skills/Commands/Subagents and when to use which) |
+
+## Troubleshooting
+
+- **Commands don’t appear when I type `/`** — Ensure you are in Agent (Chat) and that the repo has `.cursor/commands/` with the integration PM command files. You can also describe what you want in plain language (e.g. “research Rootly for SuperPlane integration and suggest base + components + priorities”).
+- **GitHub MCP can’t set Board fields or sub-issues** — The GitHub MCP connection must have **projects** permissions for the SuperPlane repo. Check your Cursor/MCP configuration. Without projects permission, the agent can still create issues and labels; you would set Integration Status, Priority, and sub-issue links manually on the Board.
+- **Agent didn’t strip Title or Priority from the issue body** — The command and skill instruct the agent to omit the `### Title` and `### Priority` sections when building the GitHub issue body. If a run missed this, you can edit the issue body on GitHub to remove those lines, or re-run the workflow after fixing the instructions in `.cursor/commands/integration-log-issues.md` and `.cursor/skills/superplane-integration-log-issues-github/SKILL.md`.
+- **I want to change how priorities or templates work** — Edit the relevant Skill or Rule under `.cursor/` (see [Where everything lives](#where-everything-lives)). For a quick reference on what each primitive does, see `.cursor/PM_WORKFLOW_HELPER.md`.


### PR DESCRIPTION
Adder `rules/skills/subagents` for Cursor to enable it:

- Research potential integrations
- Suggest and prioritize components
- Create spec templates
- Log issues 
- Organize issues properly (proper project fields, sub-issues etc)