### PR TITLE
fix: add dialog descriptions and keep canvas websocket reconnecting

### DIFF
--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -180,7 +180,7 @@ export function useCanvasWebsocket(
 
   useWebSocket(`${SOCKET_SERVER_URL}${canvasId}?organization_id=${organizationId}`, {
     shouldReconnect: () => true,
-    reconnectAttempts: 10,
+    reconnectAttempts: Number.POSITIVE_INFINITY,
     heartbeat: false,
     reconnectInterval: 3000,
     onOpen: () => {},

--- a/web_src/src/ui/EmitEventModal/index.tsx
+++ b/web_src/src/ui/EmitEventModal/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { showErrorToast, showSuccessToast } from "@/utils/toast";
@@ -107,9 +107,9 @@ export const EmitEventModal = ({ isOpen, onClose, nodeName, channels, onEmit, in
             Emit Event
           </DialogTitle>
 
-          <div className="text-sm text-gray-500 dark:text-gray-400">
+          <DialogDescription className="text-sm text-gray-500 dark:text-gray-400">
             Manually emit an output event for node: <strong>{nodeName}</strong>
-          </div>
+          </DialogDescription>
 
           <div className="space-y-4">
             <div className="flex items-center gap-3">

--- a/web_src/src/ui/chainItem/ChainItem.tsx
+++ b/web_src/src/ui/chainItem/ChainItem.tsx
@@ -12,7 +12,7 @@ import { CanvasesCanvasNodeExecution, ComponentsNode, CanvasesCanvasEvent } from
 import JsonView from "@uiw/react-json-view";
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { formatTimeAgo } from "@/utils/date";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { getComponentBaseMapper } from "@/pages/workflowv2/mappers";
 
 export interface ChildExecution {
@@ -984,6 +984,7 @@ export const ChainItem: React.FC<ChainItemProps> = ({
           <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between">
               <DialogTitle>Payload</DialogTitle>
+              <DialogDescription className="sr-only">Expanded payload viewer.</DialogDescription>
               <SimpleTooltip content={payloadCopied ? "Copied!" : "Copy"} hideOnClick={false}>
                 <button
                   onClick={(e) => {

--- a/web_src/src/ui/command/index.tsx
+++ b/web_src/src/ui/command/index.tsx
@@ -6,7 +6,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { Dialog, DialogContent } from "../dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -27,6 +27,8 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <DialogDescription className="sr-only">Search and select a command to run.</DialogDescription>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -3,7 +3,7 @@ import Editor from "@monaco-editor/react";
 import { FieldRendererProps } from "./types";
 import { ConfigurationFieldRenderer } from "./index";
 import { resolveIcon } from "@/lib/utils";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { useMonacoExpressionAutocomplete } from "./useMonacoExpressionAutocomplete";
 
@@ -193,6 +193,9 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
           <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between">
               <DialogTitle>{field.label || field.name}</DialogTitle>
+              <DialogDescription className="sr-only">
+                Expanded JSON editor for {field.label || field.name}.
+              </DialogDescription>
               <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
                 <button
                   onClick={(e) => {

--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Editor from "@monaco-editor/react";
 import { FieldRendererProps } from "./types";
 import { resolveIcon } from "@/lib/utils";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { useMonacoExpressionAutocomplete } from "./useMonacoExpressionAutocomplete";
 
@@ -90,6 +90,9 @@ export const TextFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, 
         <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between">
             <DialogTitle>{field.label || field.name}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Expanded text editor for {field.label || field.name}.
+            </DialogDescription>
             <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
               <button
                 onClick={(e) => {

--- a/web_src/src/ui/configurationFieldRenderer/XMLFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/XMLFieldRenderer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Editor from "@monaco-editor/react";
 import { FieldRendererProps } from "./types";
 import { resolveIcon } from "@/lib/utils";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { useMonacoExpressionAutocomplete } from "./useMonacoExpressionAutocomplete";
 
@@ -117,6 +117,9 @@ export const XMLFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, o
         <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between">
             <DialogTitle>{field.label || field.name}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Expanded XML editor for {field.label || field.name}.
+            </DialogDescription>
             <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
               <button
                 onClick={(e) => {


### PR DESCRIPTION
## Summary
- Add missing dialog descriptions to satisfy Radix accessibility warnings.
- Keep the canvas websocket reconnecting instead of hitting the max attempts limit.

## Changes
- Provide `DialogDescription` (sr-only where appropriate) for dialogs without descriptions.
- Use unlimited reconnect attempts for the canvas websocket hook.
