### PR TITLE
fix: webhoook trigger reset key not working

### DIFF
--- a/test/e2e/webhook_reset_test.go
+++ b/test/e2e/webhook_reset_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestWebhookResetSecret(t *testing.T) {
+	steps := &WebhookResetSteps{t: t}
+
+	t.Run("reset webhook secret shows new key", func(t *testing.T) {
+		steps.start()
+		steps.givenACanvasWithWebhook("Webhook Reset Canvas", "Webhook")
+		steps.openWebhookConfiguration("Webhook")
+		steps.waitForWebhookURL()
+		steps.resetWebhookSecret()
+		steps.assertNewSecretVisible()
+	})
+}
+
+type WebhookResetSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *WebhookResetSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *WebhookResetSteps) givenACanvasWithWebhook(canvasName, nodeName string) {
+	s.canvas = shared.NewCanvasSteps(canvasName, s.t, s.session)
+	s.canvas.Create()
+	s.addWebhookTrigger(nodeName, models.Position{X: 500, Y: 200})
+	s.canvas.Save()
+}
+
+func (s *WebhookResetSteps) addWebhookTrigger(name string, pos models.Position) {
+	s.canvas.OpenBuildingBlocksSidebar()
+
+	source := q.TestID("building-block-webhook")
+	target := q.TestID("rf__wrapper")
+
+	s.session.DragAndDrop(source, target, pos.X, pos.Y)
+	s.session.Sleep(500)
+
+	s.session.FillIn(q.TestID("node-name-input"), name)
+	s.session.Click(q.TestID("save-node-button"))
+	s.session.Sleep(500)
+}
+
+func (s *WebhookResetSteps) openWebhookConfiguration(nodeName string) {
+	s.canvas.StartEditingNode(nodeName)
+	s.session.Click(q.Text("Configuration"))
+	s.session.Sleep(200)
+}
+
+func (s *WebhookResetSteps) waitForWebhookURL() string {
+	start := time.Now()
+	input := q.Locator(`label:has-text("Webhook URL") + div input[type="text"]`)
+
+	for time.Since(start) < 20*time.Second {
+		loc := input.Run(s.session)
+		value, err := loc.InputValue()
+		if err == nil && strings.TrimSpace(value) != "" && !strings.Contains(value, "URL GENERATED") {
+			return value
+		}
+		s.session.Sleep(500)
+	}
+
+	s.t.Fatalf("timed out waiting for webhook URL")
+	return ""
+}
+
+func (s *WebhookResetSteps) resetWebhookSecret() {
+	s.session.Click(q.Text("Reset Signature Key"))
+}
+
+func (s *WebhookResetSteps) assertNewSecretVisible() {
+	s.session.AssertText("New signature key generated")
+	secretBlock := q.Locator(`div:has-text("New signature key generated") pre`)
+	loc := secretBlock.Run(s.session)
+	value, err := loc.TextContent()
+	require.NoError(s.t, err)
+	require.NotEmpty(s.t, strings.TrimSpace(value))
+}

--- a/web_src/src/pages/node-run/index.tsx
+++ b/web_src/src/pages/node-run/index.tsx
@@ -10,19 +10,19 @@ import { CanvasEdge, CanvasNode, CanvasPage } from "@/ui/CanvasPage";
 import { getBackgroundColorClass, getColorClass } from "@/utils/colors";
 
 export function NodeRunPage() {
-  const { organizationId, workflowId, nodeId, executionId } = useParams();
-  const { data: workflow } = useCanvas(organizationId!, workflowId!);
+  const { organizationId, canvasId, nodeId, executionId } = useParams();
+  const { data: canvas } = useCanvas(organizationId!, canvasId!);
 
-  usePageTitle([workflow?.metadata?.name]);
+  usePageTitle([canvas?.metadata?.name]);
 
   // Node details within the workflow
-  const node = workflow?.spec?.nodes?.find((n) => n.id === nodeId);
+  const node = canvas?.spec?.nodes?.find((n) => n.id === nodeId);
 
   // If this is a blueprint node, load the blueprint definition
   const { data: blueprint } = useBlueprint(organizationId || "", node?.blueprint?.id || "");
 
   // Fetch child executions based on the executionId from the URL
-  const { data: childExecsResp } = useChildExecutions(workflowId || "", executionId || null);
+  const { data: childExecsResp } = useChildExecutions(canvasId || "", executionId || null);
   const childExecs = childExecsResp?.executions || [];
 
   // Components metadata for icon/color/channel information
@@ -64,12 +64,12 @@ export function NodeRunPage() {
 
   const isSidebarOpenRef = useRef<boolean | null>(false);
   const breadcrumbs = useBreadcrumbs();
-  const workflowName = workflow?.metadata?.name || "Workflow";
+  const canvasName = canvas?.metadata?.name || "Canvas";
 
   return (
     <div className="h-screen w-screen bg-slate-50">
       <CanvasPage
-        title={workflowName}
+        title={canvasName}
         breadcrumbs={breadcrumbs}
         organizationId={organizationId}
         nodes={nodes}
@@ -170,19 +170,19 @@ function friendlyChildLabel(ce: any, nodes: ComponentsNode[]) {
 }
 
 function useBreadcrumbs() {
-  const { organizationId, workflowId, nodeId, executionId } = useParams();
-  const { data: workflow } = useCanvas(organizationId || "", workflowId || "");
-  const { data: childExecsResp } = useChildExecutions(workflowId || "", executionId || null);
+  const { organizationId, canvasId, nodeId, executionId } = useParams();
+  const { data: canvas } = useCanvas(organizationId || "", canvasId || "");
+  const { data: childExecsResp } = useChildExecutions(canvasId || "", executionId || null);
   const { data: blueprints = [] } = useBlueprints(organizationId || "");
   const { data: components = [] } = useComponents(organizationId || "");
 
-  const nodeName = workflow?.spec?.nodes?.find((n) => n.id === nodeId)?.name || "Component";
+  const nodeName = canvas?.spec?.nodes?.find((n) => n.id === nodeId)?.name || "Component";
   const selectedExecution = childExecsResp?.executions?.[0];
-  const node = workflow?.spec?.nodes?.find((n) => n.id === nodeId);
+  const node = canvas?.spec?.nodes?.find((n) => n.id === nodeId);
 
   const latestRunTitle = (() => {
     if (!selectedExecution) return undefined;
-    const rootNode = workflow?.spec?.nodes?.find((n) => n.id === selectedExecution.rootEvent?.nodeId);
+    const rootNode = canvas?.spec?.nodes?.find((n) => n.id === selectedExecution.rootEvent?.nodeId);
     const renderer = getTriggerRenderer(rootNode?.trigger?.name || "");
     if (selectedExecution.rootEvent) {
       return renderer.getTitleAndSubtitle(selectedExecution.rootEvent).title;
@@ -208,7 +208,7 @@ function useBreadcrumbs() {
 
   return [
     { label: "Canvases", href: `/${organizationId}` },
-    { label: workflow?.metadata?.name || "Workflow", href: `/${organizationId}/canvases/${workflowId}` },
+    { label: canvas?.metadata?.name || "Canvas", href: `/${organizationId}/canvases/${canvasId}` },
     {
       label: nodeName,
       iconSlug: iconSlug || "boxes",

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -185,7 +185,7 @@ const ResetAuthButton: React.FC<{
   const [isResetting, setIsResetting] = useState(false);
   const [newSecret, setNewSecret] = useState<string | null>(null);
   const queryClient = useQueryClient();
-  const { organizationId, workflowId } = useParams<{ organizationId: string; workflowId: string }>();
+  const { organizationId, canvasId } = useParams<{ organizationId: string; canvasId: string }>();
 
   const getAuthLabels = () => {
     switch (authMethod) {
@@ -218,14 +218,14 @@ const ResetAuthButton: React.FC<{
   const labels = getAuthLabels();
 
   const handleResetAuth = async () => {
-    if (authMethod === "none" || !workflowId) return;
+    if (authMethod === "none" || !canvasId) return;
 
     setIsResetting(true);
     try {
       const response = await canvasesInvokeNodeTriggerAction(
         withOrganizationHeader({
           path: {
-            canvasId: workflowId,
+            canvasId: canvasId,
             nodeId: nodeId,
             actionName: "resetAuthentication",
           },
@@ -243,7 +243,7 @@ const ResetAuthButton: React.FC<{
         // Invalidate workflow queries to refresh the UI
         if (organizationId) {
           queryClient.invalidateQueries({
-            queryKey: canvasKeys.detail(organizationId, workflowId),
+            queryKey: canvasKeys.detail(organizationId, canvasId),
           });
         }
       }
@@ -319,13 +319,13 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
 export PAYLOAD='{"hello":"world"}'
 
 export SIGNATURE=$(echo -n "$PAYLOAD" \\
-  | openssl dgst -sha256 -hmac "$SIGNATURE_KEY" \\
-  | awk '{print $2}')
+  | openssl dgst -sha256 -hmac "$SIGNATURE_KEY" -binary \\
+  | xxd -p -c 256)
 
 curl -X POST \\
   -H "X-Signature-256: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
-  --data "$PAYLOAD" \\
+  --data-binary "$PAYLOAD" \\
   ${webhookUrl}`;
           break;
 


### PR DESCRIPTION
## What

- Fixes webhook reset action in UI by using the correct canvasId route param.
- Adds e2e coverage for the “Reset Signature Key” webhook button flow.
- Updates the webhook code example to generate HMAC signatures reliably and use --data-binary.

## Why
- The reset button silently no‑oped because it was reading workflowId instead of canvasId.
- The updated snippet avoids empty signatures from brittle awk parsing.