### PR TITLE
feat(github): add List Releases component

### DIFF
--- a/pkg/integrations/github/example.go
+++ b/pkg/integrations/github/example.go
@@ -31,6 +31,9 @@ var exampleOutputDeleteReleaseBytes []byte
 //go:embed example_output_run_workflow.json
 var exampleOutputRunWorkflowBytes []byte
 
+//go:embed example_output_list_releases.json
+var exampleOutputListReleasesBytes []byte
+
 //go:embed example_data_on_issue_comment.json
 var exampleDataOnIssueCommentBytes []byte
 
@@ -81,6 +84,9 @@ var exampleOutputDeleteRelease map[string]any
 
 var exampleOutputRunWorkflowOnce sync.Once
 var exampleOutputRunWorkflow map[string]any
+
+var exampleOutputListReleasesOnce sync.Once
+var exampleOutputListReleases map[string]any
 
 var exampleDataOnIssueCommentOnce sync.Once
 var exampleDataOnIssueComment map[string]any
@@ -139,6 +145,10 @@ func (c *UpdateRelease) ExampleOutput() map[string]any {
 
 func (c *DeleteRelease) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteReleaseOnce, exampleOutputDeleteReleaseBytes, &exampleOutputDeleteRelease)
+}
+
+func (c *ListReleases) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputListReleasesOnce, exampleOutputListReleasesBytes, &exampleOutputListReleases)
 }
 
 func (c *RunWorkflow) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/example_output_list_releases.json
+++ b/pkg/integrations/github/example_output_list_releases.json
@@ -1,0 +1,13 @@
+{
+  "releases": [
+    {
+      "id": 12345678,
+      "tag_name": "v1.2.0",
+      "name": "Release v1.2.0",
+      "body": "## What's Changed\n* Feature A\n* Bug fix B",
+      "draft": false,
+      "prerelease": false,
+      "published_at": "2024-01-15T10:30:00Z"
+    }
+  ]
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -101,6 +101,7 @@ func (g *GitHub) Components() []core.Component {
 		&CreateRelease{},
 		&UpdateRelease{},
 		&DeleteRelease{},
+		&ListReleases{},
 	}
 }
 

--- a/pkg/integrations/github/list_releases.go
+++ b/pkg/integrations/github/list_releases.go
@@ -1,0 +1,196 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type ListReleases struct{}
+
+type ListReleasesConfiguration struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	PerPage    int    `json:"perPage" mapstructure:"perPage"`
+	Page       int    `json:"page" mapstructure:"page"`
+}
+
+func (c *ListReleases) Name() string {
+	return "github.listReleases"
+}
+
+func (c *ListReleases) Label() string {
+	return "List Releases"
+}
+
+func (c *ListReleases) Description() string {
+	return "List releases for a GitHub repository"
+}
+
+func (c *ListReleases) Documentation() string {
+	return `The List Releases component retrieves releases from a GitHub repository with optional pagination.
+
+## Use Cases
+
+- **Changelog generation**: List releases for changelog or reporting from SuperPlane
+- **Latest releases**: Fetch the latest N releases for notifications or status pages
+- **External sync**: Sync release list to external systems (Jira, Slack)
+- **Release monitoring**: Track releases across repositories
+
+## Configuration
+
+- **Repository**: Select the GitHub repository to list releases from
+- **Per Page** (optional): Number of releases per page (default 30, max 100)
+- **Page** (optional): Page number for pagination (default 1)
+
+## Output
+
+Returns a list of release objects, each containing:
+- Release ID and tag name
+- Release name and body (description)
+- Published timestamp
+- Draft and prerelease flags
+- Author information
+- Assets (downloadable files)
+- Tarball and zipball URLs`
+}
+
+func (c *ListReleases) Icon() string {
+	return "github"
+}
+
+func (c *ListReleases) Color() string {
+	return "gray"
+}
+
+func (c *ListReleases) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *ListReleases) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "perPage",
+			Label:       "Per Page",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     30,
+			Description: "Number of releases per page (max 100)",
+		},
+		{
+			Name:        "page",
+			Label:       "Page",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     1,
+			Description: "Page number for pagination",
+		},
+	}
+}
+
+func (c *ListReleases) Setup(ctx core.SetupContext) error {
+	return ensureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.Configuration,
+	)
+}
+
+func (c *ListReleases) Execute(ctx core.ExecutionContext) error {
+	var config ListReleasesConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode application metadata: %w", err)
+	}
+
+	// Initialize GitHub client
+	client, err := NewClient(ctx.Integration, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	// Set defaults for pagination
+	perPage := config.PerPage
+	if perPage <= 0 {
+		perPage = 30
+	}
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	page := config.Page
+	if page <= 0 {
+		page = 1
+	}
+
+	// List releases
+	releases, _, err := client.Repositories.ListReleases(
+		context.Background(),
+		appMetadata.Owner,
+		config.Repository,
+		&github.ListOptions{
+			PerPage: perPage,
+			Page:    page,
+		},
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	// Convert to []any for emission
+	releaseList := make([]any, len(releases))
+	for i, release := range releases {
+		releaseList[i] = release
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.releases",
+		releaseList,
+	)
+}
+
+func (c *ListReleases) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *ListReleases) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *ListReleases) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *ListReleases) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *ListReleases) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *ListReleases) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/github/list_releases_test.go
+++ b/pkg/integrations/github/list_releases_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ListReleases__Setup(t *testing.T) {
+	helloRepo := Repository{ID: 123456, Name: "hello", URL: "https://github.com/testhq/hello"}
+	component := ListReleases{}
+
+	t.Run("repository is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": ""},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("repository is not accessible", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": "world"},
+		})
+
+		require.ErrorContains(t, err, "repository world is not accessible to app installation")
+	})
+
+	t.Run("metadata is set successfully", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"repository": "hello"},
+		}))
+
+		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})
+	})
+
+	t.Run("default pagination values are accepted", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"repository": "hello", "perPage": 50, "page": 2},
+		}))
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -14,6 +14,7 @@ import { publishCommitStatusMapper } from "./publish_commit_status";
 import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
 import { deleteReleaseMapper } from "./delete_release";
+import { listReleasesMapper } from "./list_releases";
 import { buildActionStateRegistry } from "../utils";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -25,6 +26,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createRelease: buildActionStateRegistry("created"),
   updateRelease: buildActionStateRegistry("updated"),
   deleteRelease: buildActionStateRegistry("deleted"),
+  listReleases: buildActionStateRegistry("listed"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -36,6 +38,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createRelease: createReleaseMapper,
   updateRelease: updateReleaseMapper,
   deleteRelease: deleteReleaseMapper,
+  listReleases: listReleasesMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/workflowv2/mappers/github/list_releases.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/list_releases.ts
@@ -1,0 +1,61 @@
+import {
+  ComponentsNode,
+  ComponentsComponent,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasNodeQueueItem,
+} from "@/api-client";
+import { ComponentBaseProps } from "@/ui/componentBase";
+import { ComponentBaseMapper, OutputPayload } from "../types";
+import { baseProps } from "./base";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface ReleaseOutput {
+  id?: number;
+  tag_name?: string;
+  name?: string;
+  html_url?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  published_at?: string;
+}
+
+export const listReleasesMapper: ComponentBaseMapper = {
+  props(
+    nodes: ComponentsNode[],
+    node: ComponentsNode,
+    componentDefinition: ComponentsComponent,
+    lastExecutions: CanvasesCanvasNodeExecution[],
+    queueItems: CanvasesCanvasNodeQueueItem[],
+  ): ComponentBaseProps {
+    return baseProps(nodes, node, componentDefinition, lastExecutions, queueItems);
+  },
+  subtitle(_node: ComponentsNode, execution: CanvasesCanvasNodeExecution): string {
+    return buildGithubExecutionSubtitle(execution);
+  },
+
+  getExecutionDetails(execution: CanvasesCanvasNodeExecution, _node: ComponentsNode): Record<string, string> {
+    const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (outputs && outputs.default && outputs.default.length > 0) {
+      const releases = outputs.default[0].data as ReleaseOutput[];
+      
+      if (Array.isArray(releases)) {
+        details["Releases Found"] = releases.length.toString();
+        
+        if (releases.length > 0) {
+          // Show first release info
+          const firstRelease = releases[0];
+          details["Latest Tag"] = firstRelease?.tag_name || "-";
+          details["Latest Name"] = firstRelease?.name || "-";
+          
+          if (firstRelease?.published_at) {
+            details["Latest Published"] = new Date(firstRelease.published_at).toLocaleString();
+          }
+        }
+      }
+    }
+
+    return details;
+  },
+};


### PR DESCRIPTION
## Description

This PR implements the **List Releases** component for the GitHub integration, as specified in #2818.

### Changes

**Backend (Go):**
- `list_releases.go`: New component with `Setup` and `Execute` methods
- Supports pagination with `perPage` (default 30, max 100) and `page` parameters
- Returns release objects including id, tag_name, name, body, published_at, assets, etc.

**Tests:**
- `list_releases_test.go`: Setup validation tests for repository access and metadata

**Frontend (TypeScript):**
- `list_releases.ts`: Mapper for UI rendering showing release count and latest release info

**Other:**
- Updated `github.go` to register the component
- Updated `example.go` with embedded example output JSON
- Updated frontend `index.ts` to export the new mapper

### Use Cases
- List releases for changelog or reporting from SuperPlane
- Fetch the latest N releases for notifications or status pages
- Sync release list to external systems (Jira, Slack)

Closes #2818