### PR TITLE
fix: missing auth guard in some places

### DIFF
--- a/web_src/src/hooks/useIntegrations.ts
+++ b/web_src/src/hooks/useIntegrations.ts
@@ -24,7 +24,7 @@ export const integrationKeys = {
 
 // Hook to fetch available integrations (catalog).
 // Normalizes each integration's label (e.g. "github" -> "GitHub") so consumers get correct display names.
-export const useAvailableIntegrations = () => {
+export const useAvailableIntegrations = (options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: integrationKeys.available(),
     queryFn: async () => {
@@ -40,11 +40,12 @@ export const useAvailableIntegrations = () => {
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
+    enabled: options?.enabled ?? true,
   });
 };
 
 // Hook to fetch connected integrations for an organization
-export const useConnectedIntegrations = (organizationId: string) => {
+export const useConnectedIntegrations = (organizationId: string, options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: integrationKeys.connected(organizationId),
     queryFn: async () => {
@@ -57,7 +58,7 @@ export const useConnectedIntegrations = (organizationId: string) => {
     },
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 5 * 60 * 1000, // 5 minutes
-    enabled: !!organizationId,
+    enabled: !!organizationId && (options?.enabled ?? true),
   });
 };
 

--- a/web_src/src/ui/CanvasPage/Block.tsx
+++ b/web_src/src/ui/CanvasPage/Block.tsx
@@ -55,6 +55,7 @@ interface BlockProps extends ComponentActionsProps {
   data: BlockData;
   nodeId?: string;
   selected?: boolean;
+  showHeader?: boolean;
   onAnnotationUpdate?: (
     nodeId: string,
     updates: { text?: string; color?: string; width?: number; height?: number; x?: number; y?: number },
@@ -385,6 +386,7 @@ function BlockContent({
   onToggleCollapse,
   onToggleView,
   onDelete,
+  showHeader,
   isCompactView,
 }: BlockProps) {
   const compactView =
@@ -428,13 +430,16 @@ function BlockContent({
 
   switch (data.type) {
     case "trigger":
-      return <Trigger {...(data.trigger as TriggerProps)} selected={selected} {...actionProps} />;
+      return (
+        <Trigger {...(data.trigger as TriggerProps)} selected={selected} showHeader={showHeader} {...actionProps} />
+      );
     case "component":
       return (
         <ComponentBase
           {...(data.component as ComponentBaseProps)}
           paused={(data.component as ComponentBaseProps)?.paused}
           selected={selected}
+          showHeader={showHeader}
           {...actionProps}
         />
       );
@@ -444,13 +449,28 @@ function BlockContent({
           {...(data.composite as CompositeProps)}
           onExpandChildEvents={handleExpand}
           selected={selected}
+          showHeader={showHeader}
           {...actionProps}
         />
       );
     case "switch":
-      return <SwitchComponent {...(data.switch as SwitchComponentProps)} selected={selected} {...actionProps} />;
+      return (
+        <SwitchComponent
+          {...(data.switch as SwitchComponentProps)}
+          selected={selected}
+          showHeader={showHeader}
+          {...actionProps}
+        />
+      );
     case "merge":
-      return <MergeComponent {...(data.merge as MergeComponentProps)} selected={selected} {...actionProps} />;
+      return (
+        <MergeComponent
+          {...(data.merge as MergeComponentProps)}
+          selected={selected}
+          showHeader={showHeader}
+          {...actionProps}
+        />
+      );
     case "annotation": {
       const handleAnnotationUpdate = (updates: {
         text?: string;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -135,6 +135,9 @@ export interface CanvasPageProps {
   autoSaveDisabled?: boolean;
   autoSaveDisabledTooltip?: string;
   readOnly?: boolean;
+  canReadIntegrations?: boolean;
+  canCreateIntegrations?: boolean;
+  canUpdateIntegrations?: boolean;
   onExportYamlCopy?: (nodes: CanvasNode[]) => void;
   onExportYamlDownload?: (nodes: CanvasNode[]) => void;
   // Undo functionality
@@ -283,6 +286,7 @@ const nodeTypes = {
         selected={nodeProps.selected}
         runDisabled={callbacks?.runDisabled}
         runDisabledTooltip={callbacks?.runDisabledTooltip}
+        showHeader={callbacks?.showHeader}
         onExpand={callbacks.handleNodeExpand}
         onClick={() => callbacks.handleNodeClick(nodeProps.id)}
         onEdit={() => callbacks.onNodeEdit.current?.(nodeProps.id)}
@@ -925,6 +929,10 @@ function CanvasPage(props: CanvasPageProps) {
             onHighlightedNodesChange={setHighlightedNodeIds}
             focusRequest={props.focusRequest}
             onExecutionChainHandled={props.onExecutionChainHandled}
+            readOnly={readOnly}
+            canReadIntegrations={props.canReadIntegrations}
+            canCreateIntegrations={props.canCreateIntegrations}
+            canUpdateIntegrations={props.canUpdateIntegrations}
           />
         </div>
       </div>
@@ -995,6 +1003,10 @@ function Sidebar({
   onHighlightedNodesChange,
   focusRequest,
   onExecutionChainHandled,
+  readOnly,
+  canReadIntegrations,
+  canCreateIntegrations,
+  canUpdateIntegrations,
 }: {
   state: CanvasPageState;
   getSidebarData?: (nodeId: string) => SidebarData | null;
@@ -1044,6 +1056,10 @@ function Sidebar({
   onHighlightedNodesChange?: (nodeIds: Set<string>) => void;
   focusRequest?: FocusRequest | null;
   onExecutionChainHandled?: () => void;
+  readOnly?: boolean;
+  canReadIntegrations?: boolean;
+  canCreateIntegrations?: boolean;
+  canUpdateIntegrations?: boolean;
 }) {
   const sidebarData = useMemo(() => {
     if (!state.componentSidebar.selectedNodeId || !getSidebarData) {
@@ -1175,6 +1191,9 @@ function Sidebar({
       integrationName={editingNodeData?.integrationName}
       integrationRef={editingNodeData?.integrationRef}
       integrations={integrations}
+      canReadIntegrations={canReadIntegrations}
+      canCreateIntegrations={canCreateIntegrations}
+      canUpdateIntegrations={canUpdateIntegrations}
       autocompleteExampleObj={autocompleteExampleObj}
       currentTab={isAnnotationNode ? "settings" : currentTab}
       onTabChange={onTabChange}
@@ -1190,6 +1209,7 @@ function Sidebar({
       onExecutionChainHandled={onExecutionChainHandled}
       hideRunsTab={isAnnotationNode}
       hideNodeId={isAnnotationNode}
+      readOnly={readOnly}
     />
   );
 }
@@ -1770,6 +1790,8 @@ function CanvasContent({
     [fitView, getViewport, onZoomChange, hasFitToViewRef, viewportRef, initialFocusNodeId],
   );
 
+  const showHeader = !isReadOnly;
+
   // Store callback handlers in a ref so they can be accessed without being in node data
   const callbacksRef = useRef({
     handleNodeExpand,
@@ -1787,6 +1809,7 @@ function CanvasContent({
     aiState: state.ai,
     runDisabled,
     runDisabledTooltip,
+    showHeader,
   });
   callbacksRef.current = {
     handleNodeExpand,
@@ -1804,6 +1827,7 @@ function CanvasContent({
     aiState: state.ai,
     runDisabled,
     runDisabledTooltip,
+    showHeader,
   };
 
   // Just pass the state nodes directly - callbacks will be added in nodeTypes

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -213,6 +213,7 @@ export interface ComponentBaseProps extends ComponentActionsProps {
   iconSlug?: string;
   iconColor?: string;
   title: string;
+  showHeader?: boolean;
   paused?: boolean;
   specs?: ComponentBaseSpec[];
   hideCount?: boolean;
@@ -242,6 +243,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   iconSlug,
   iconColor,
   title,
+  showHeader = true,
   specs,
   collapsed: _collapsed = false,
   collapsedBackground: _collapsedBackground,
@@ -297,81 +299,83 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
         data-view-mode={isCompactView ? "compact" : "expanded"}
       >
         <div className="absolute -top-8 right-0 z-10 h-8 w-44 opacity-0" />
-        <div className="absolute -top-8 right-0 z-10 hidden items-center gap-2 group-hover:flex nodrag">
-          {onRun && (
-            <button
-              type="button"
-              data-testid="node-action-run"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onRun();
-              }}
-              disabled={runDisabled}
-              className="flex items-center gap-1 px-1 py-0.5 text-[13px] font-medium text-gray-500 transition hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <RunIcon className="h-4 w-4" />
-              <span>Run</span>
-            </button>
-          )}
-          {onTogglePause && !hasError && (
-            <button
-              type="button"
-              data-testid="node-action-pause"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onTogglePause();
-              }}
-              className="flex items-center gap-1 px-1 py-0.5 text-[13px] font-medium text-gray-500 transition hover:text-gray-800"
-            >
-              {paused ? <ResumeIcon className="h-4 w-4" /> : <PauseIcon className="h-4 w-4" />}
-              <span>{paused ? "Resume" : "Pause"}</span>
-            </button>
-          )}
-          {onDuplicate && (
-            <button
-              type="button"
-              data-testid="node-action-duplicate"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onDuplicate();
-              }}
-              className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
-            >
-              <DuplicateIcon className="h-4 w-4" />
-            </button>
-          )}
-          {onToggleView && (
-            <button
-              type="button"
-              data-testid="node-action-toggle-view"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onToggleView();
-              }}
-              className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
-            >
-              <ToggleViewIcon className="h-4 w-4" />
-            </button>
-          )}
-          {onDelete && (
-            <button
-              type="button"
-              data-testid="node-action-delete"
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                onDelete();
-              }}
-              className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
-            >
-              <DeleteIcon className="h-4 w-4" />
-            </button>
-          )}
-        </div>
+        {showHeader ? (
+          <div className="absolute -top-8 right-0 z-10 hidden items-center gap-2 group-hover:flex nodrag">
+            {onRun && (
+              <button
+                type="button"
+                data-testid="node-action-run"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onRun();
+                }}
+                disabled={runDisabled}
+                className="flex items-center gap-1 px-1 py-0.5 text-[13px] font-medium text-gray-500 transition hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <RunIcon className="h-4 w-4" />
+                <span>Run</span>
+              </button>
+            )}
+            {onTogglePause && !hasError && (
+              <button
+                type="button"
+                data-testid="node-action-pause"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onTogglePause();
+                }}
+                className="flex items-center gap-1 px-1 py-0.5 text-[13px] font-medium text-gray-500 transition hover:text-gray-800"
+              >
+                {paused ? <ResumeIcon className="h-4 w-4" /> : <PauseIcon className="h-4 w-4" />}
+                <span>{paused ? "Resume" : "Pause"}</span>
+              </button>
+            )}
+            {onDuplicate && (
+              <button
+                type="button"
+                data-testid="node-action-duplicate"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onDuplicate();
+                }}
+                className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
+              >
+                <DuplicateIcon className="h-4 w-4" />
+              </button>
+            )}
+            {onToggleView && (
+              <button
+                type="button"
+                data-testid="node-action-toggle-view"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onToggleView();
+                }}
+                className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
+              >
+                <ToggleViewIcon className="h-4 w-4" />
+              </button>
+            )}
+            {onDelete && (
+              <button
+                type="button"
+                data-testid="node-action-delete"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onDelete();
+                }}
+                className="flex items-center justify-center p-1 text-gray-500 transition hover:text-gray-800"
+              >
+                <DeleteIcon className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        ) : null}
         <ComponentHeader
           iconSrc={iconSrc}
           iconSlug={iconSlug}
@@ -457,7 +461,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
             )}
 
             {customFieldPosition === "before" &&
-              (typeof customField === "function" ? customField(onRun) : customField || null)}
+              (typeof customField === "function" ? customField(runDisabled ? undefined : onRun) : customField || null)}
 
             {eventSections?.map((section, index) => (
               <EventSectionDisplay
@@ -483,7 +487,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
             {includeEmptyState && <EmptyState {...emptyStateProps} />}
 
             {customFieldPosition === "after" &&
-              (typeof customField === "function" ? customField(onRun) : customField || null)}
+              (typeof customField === "function" ? customField(runDisabled ? undefined : onRun) : customField || null)}
           </>
         )}
       </div>

--- a/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventActionsMenu.tsx
+++ b/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventActionsMenu.tsx
@@ -37,7 +37,7 @@ export const SidebarEventActionsMenu: React.FC<SidebarEventActionsMenuProps> = (
 
   const showPushThrough = supportsPushThrough && !!executionId && (isRunning || isWaiting);
   const showCancel = (kind === "queue" && isQueued) || (kind === "execution" && (isRunning || isWaiting));
-  const showReEmit = (isProcessed || isDiscarded) && kind === "trigger";
+  const showReEmit = (isProcessed || isDiscarded) && kind === "trigger" && !!onReEmit;
   const showDropdown = showPushThrough || showCancel || showReEmit;
 
   const handleReEmit = React.useCallback(

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -133,6 +133,9 @@ interface ComponentSidebarProps {
   integrationName?: string;
   integrationRef?: ComponentsIntegrationRef;
   integrations?: OrganizationsIntegration[];
+  canReadIntegrations?: boolean;
+  canCreateIntegrations?: boolean;
+  canUpdateIntegrations?: boolean;
   autocompleteExampleObj?: Record<string, unknown> | null;
 
   // Workflow metadata for ExecutionChainPage
@@ -150,6 +153,7 @@ interface ComponentSidebarProps {
   executionChainTriggerEvent?: SidebarEvent | null;
   executionChainRequestId?: number;
   onExecutionChainHandled?: () => void;
+  readOnly?: boolean;
 }
 
 export const ComponentSidebar = ({
@@ -212,6 +216,9 @@ export const ComponentSidebar = ({
   integrationName,
   integrationRef,
   integrations,
+  canReadIntegrations,
+  canCreateIntegrations,
+  canUpdateIntegrations,
   autocompleteExampleObj,
   workflowNodes = [],
   components = [],
@@ -223,6 +230,7 @@ export const ComponentSidebar = ({
   executionChainTriggerEvent,
   executionChainRequestId,
   onExecutionChainHandled,
+  readOnly = false,
 }: ComponentSidebarProps) => {
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     const saved = localStorage.getItem(COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY);
@@ -754,6 +762,10 @@ export const ComponentSidebar = ({
                   integrationName={integrationName}
                   integrationRef={integrationRef}
                   integrations={integrations}
+                  readOnly={readOnly}
+                  canReadIntegrations={canReadIntegrations}
+                  canCreateIntegrations={canCreateIntegrations}
+                  canUpdateIntegrations={canUpdateIntegrations}
                   integrationDefinition={createIntegrationDefinition}
                   autocompleteExampleObj={resolvedAutocompleteExampleObj}
                   onOpenCreateIntegrationDialog={handleOpenCreateIntegrationDialog}

--- a/web_src/src/ui/composite/index.tsx
+++ b/web_src/src/ui/composite/index.tsx
@@ -50,6 +50,7 @@ export interface CompositeProps extends ComponentActionsProps {
   iconSlug?: string;
   iconColor?: string;
   title: string;
+  showHeader?: boolean;
   metadata?: MetadataItem[];
   parameters?: ParameterGroup[];
   lastRunItem?: LastRunItem;
@@ -75,6 +76,7 @@ export const Composite: React.FC<CompositeProps> = ({
   iconSlug,
   iconColor,
   title,
+  showHeader,
   metadata,
   parameters = [],
   lastRunItem,
@@ -205,6 +207,7 @@ export const Composite: React.FC<CompositeProps> = ({
       iconSlug={iconSlug}
       iconColor={iconColor}
       title={title}
+      showHeader={showHeader}
       metadata={metadata}
       specs={specs}
       eventSections={eventSections}

--- a/web_src/src/ui/merge/index.tsx
+++ b/web_src/src/ui/merge/index.tsx
@@ -3,6 +3,7 @@ import { ComponentActionsProps } from "../types/componentActions";
 
 export interface MergeComponentProps extends ComponentActionsProps {
   title?: string;
+  showHeader?: boolean;
   lastEvent?: Omit<EventSection, "title">;
   // Show the next queued item for this merge node
   nextInQueue?: {
@@ -20,6 +21,7 @@ export interface MergeComponentProps extends ComponentActionsProps {
 
 export const MergeComponent: React.FC<MergeComponentProps> = ({
   title = "Merge",
+  showHeader,
   lastEvent,
   collapsed = false,
   selected = false,
@@ -50,6 +52,7 @@ export const MergeComponent: React.FC<MergeComponentProps> = ({
     <ComponentBase
       title={title}
       iconSlug="git-merge"
+      showHeader={showHeader}
       eventSections={eventSections}
       collapsed={collapsed}
       collapsedBackground={collapsedBackground}

--- a/web_src/src/ui/switchComponent/index.tsx
+++ b/web_src/src/ui/switchComponent/index.tsx
@@ -14,6 +14,7 @@ export interface SwitchStage {
 
 export interface SwitchComponentProps extends ComponentActionsProps {
   title?: string;
+  showHeader?: boolean;
   stages: SwitchStage[];
   collapsed?: boolean;
   selected?: boolean;
@@ -31,6 +32,7 @@ const HANDLE_STYLE = {
 
 export const SwitchComponent: React.FC<SwitchComponentProps> = ({
   title = "Branch processed events",
+  showHeader,
   stages,
   collapsed = false,
   selected = false,
@@ -91,6 +93,7 @@ export const SwitchComponent: React.FC<SwitchComponentProps> = ({
     <ComponentBase
       title={title}
       iconSlug="git-branch"
+      showHeader={showHeader}
       specs={specs}
       eventSections={eventSections}
       collapsed={collapsed}


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/2870

**Summary**
- Enforced RBAC across canvas interactions: emit/re-emit, resolve errors, and run actions now respect `canvases:update`.
- Added integration permission handling in settings: gated read/create/update, disabled configuration when read-only, and show a clear no-permission message.
- Hid node action controls (run/delete/etc.) when workflow isn’t editable, while keeping headers visible.

**Changes**
- Gated integrations queries with permissions and propagated `canRead/create/updateIntegrations`.
- Disabled run at the canvas level and for trigger template runs when user lacks update permission.
- Disabled resolve errors and re-emit actions without update permission.
- Settings tab now disables inputs when read-only and shows “no permission” messaging for integrations.
- Updated component headers/actions visibility semantics and propagated to composite/switch/merge.

