### PR TITLE
chore: use BUILDKIT_PROGRESS = plain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ DB_PASSWORD=the-cake-is-a-lie
 DOCKER_COMPOSE_OPTS=-f docker-compose.dev.yml
 BASE_URL?=https://app.superplane.com
 
+export BUILDKIT_PROGRESS ?= plain
+
 PKG_TEST_PACKAGES := ./pkg/...
 E2E_TEST_PACKAGES := ./test/e2e/...
 

--- a/web_src/src/pages/workflowv2/mappers/merge.ts
+++ b/web_src/src/pages/workflowv2/mappers/merge.ts
@@ -176,7 +176,7 @@ export const mergeMapper: ComponentBaseMapper = {
   },
 
   subtitle(context: SubtitleContext): string {
-    return getMergeSubtitle(context.execution);
+    return getMergeSubtitle(context.execution, context.additionalData);
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {


### PR DESCRIPTION
Our job logs are unreadable due to our usage of BUILDKIT_PROGRESS=tty