### PR TITLE
feat(rootly): add CreateEvent and UpdateEvent components

### DIFF
--- a/pkg/integrations/rootly/client.go
+++ b/pkg/integrations/rootly/client.go
@@ -427,3 +427,177 @@ func (c *Client) DeleteWebhookEndpoint(id string) error {
 	_, err := c.execRequest(http.MethodDelete, url, nil)
 	return err
 }
+
+// IncidentEvent represents a Rootly incident timeline event
+type IncidentEvent struct {
+	ID            string `json:"id"`
+	Event         string `json:"event"`
+	Visibility    string `json:"visibility"`
+	Kind          string `json:"kind"`
+	OccurredAt    string `json:"occurred_at"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+	UserDisplayName string `json:"user_display_name"`
+}
+
+type IncidentEventData struct {
+	ID         string                  `json:"id"`
+	Type       string                  `json:"type"`
+	Attributes IncidentEventAttributes `json:"attributes"`
+}
+
+type IncidentEventAttributes struct {
+	Event           string `json:"event"`
+	Visibility      string `json:"visibility"`
+	Kind            string `json:"kind"`
+	OccurredAt      string `json:"occurred_at"`
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
+	UserDisplayName string `json:"user_display_name"`
+}
+
+type IncidentEventResponse struct {
+	Data IncidentEventData `json:"data"`
+}
+
+type IncidentEventsResponse struct {
+	Data []IncidentEventData `json:"data"`
+}
+
+// CreateIncidentEventRequest represents the request to create an incident event
+type CreateIncidentEventRequest struct {
+	Data CreateIncidentEventData `json:"data"`
+}
+
+type CreateIncidentEventData struct {
+	Type       string                        `json:"type"`
+	Attributes CreateIncidentEventAttributes `json:"attributes"`
+}
+
+type CreateIncidentEventAttributes struct {
+	Event      string `json:"event"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// CreateIncidentEvent creates a new timeline event for an incident
+func (c *Client) CreateIncidentEvent(incidentID, event, visibility string) (*IncidentEvent, error) {
+	request := CreateIncidentEventRequest{
+		Data: CreateIncidentEventData{
+			Type: "incident_events",
+			Attributes: CreateIncidentEventAttributes{
+				Event:      event,
+				Visibility: visibility,
+			},
+		},
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/incidents/%s/events", c.BaseURL, incidentID)
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response IncidentEventResponse
+	err = json.Unmarshal(responseBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &IncidentEvent{
+		ID:              response.Data.ID,
+		Event:           response.Data.Attributes.Event,
+		Visibility:      response.Data.Attributes.Visibility,
+		Kind:            response.Data.Attributes.Kind,
+		OccurredAt:      response.Data.Attributes.OccurredAt,
+		CreatedAt:       response.Data.Attributes.CreatedAt,
+		UpdatedAt:       response.Data.Attributes.UpdatedAt,
+		UserDisplayName: response.Data.Attributes.UserDisplayName,
+	}, nil
+}
+
+// UpdateIncidentEventRequest represents the request to update an incident event
+type UpdateIncidentEventRequest struct {
+	Data UpdateIncidentEventData `json:"data"`
+}
+
+type UpdateIncidentEventData struct {
+	Type       string                        `json:"type"`
+	Attributes UpdateIncidentEventAttributes `json:"attributes"`
+}
+
+type UpdateIncidentEventAttributes struct {
+	Event      string `json:"event,omitempty"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// UpdateIncidentEvent updates an existing timeline event for an incident
+func (c *Client) UpdateIncidentEvent(incidentID, eventID, event, visibility string) (*IncidentEvent, error) {
+	request := UpdateIncidentEventRequest{
+		Data: UpdateIncidentEventData{
+			Type: "incident_events",
+			Attributes: UpdateIncidentEventAttributes{
+				Event:      event,
+				Visibility: visibility,
+			},
+		},
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/incidents/%s/events/%s", c.BaseURL, incidentID, eventID)
+	responseBody, err := c.execRequest(http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response IncidentEventResponse
+	err = json.Unmarshal(responseBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &IncidentEvent{
+		ID:              response.Data.ID,
+		Event:           response.Data.Attributes.Event,
+		Visibility:      response.Data.Attributes.Visibility,
+		Kind:            response.Data.Attributes.Kind,
+		OccurredAt:      response.Data.Attributes.OccurredAt,
+		CreatedAt:       response.Data.Attributes.CreatedAt,
+		UpdatedAt:       response.Data.Attributes.UpdatedAt,
+		UserDisplayName: response.Data.Attributes.UserDisplayName,
+	}, nil
+}
+
+// GetIncidentEvent retrieves an incident event by ID
+func (c *Client) GetIncidentEvent(incidentID, eventID string) (*IncidentEvent, error) {
+	url := fmt.Sprintf("%s/incidents/%s/events/%s", c.BaseURL, incidentID, eventID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response IncidentEventResponse
+	err = json.Unmarshal(responseBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &IncidentEvent{
+		ID:              response.Data.ID,
+		Event:           response.Data.Attributes.Event,
+		Visibility:      response.Data.Attributes.Visibility,
+		Kind:            response.Data.Attributes.Kind,
+		OccurredAt:      response.Data.Attributes.OccurredAt,
+		CreatedAt:       response.Data.Attributes.CreatedAt,
+		UpdatedAt:       response.Data.Attributes.UpdatedAt,
+		UserDisplayName: response.Data.Attributes.UserDisplayName,
+	}, nil
+}

--- a/pkg/integrations/rootly/create_event.go
+++ b/pkg/integrations/rootly/create_event.go
@@ -1,0 +1,214 @@
+package rootly
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const CreateEventPayloadType = "rootly.incident.event.created"
+const CreateEventSuccessChannel = "success"
+
+type CreateEvent struct{}
+
+type CreateEventSpec struct {
+	IncidentID string `json:"incidentId" mapstructure:"incidentId"`
+	Event      string `json:"event" mapstructure:"event"`
+	Visibility string `json:"visibility" mapstructure:"visibility"`
+}
+
+type CreateEventOutput struct {
+	ID         string `json:"id"`
+	Event      string `json:"event"`
+	Visibility string `json:"visibility"`
+	OccurredAt string `json:"occurredAt"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func (c *CreateEvent) Name() string {
+	return "rootly.createEvent"
+}
+
+func (c *CreateEvent) Label() string {
+	return "Create Event"
+}
+
+func (c *CreateEvent) Description() string {
+	return "Add a timeline event to a Rootly incident"
+}
+
+func (c *CreateEvent) Documentation() string {
+	return `The Create Event component adds a timeline event (note/annotation) to a Rootly incident.
+
+## Use Cases
+
+- **Investigation notes**: Post investigation notes from SuperPlane when a step completes
+- **Automated status updates**: Add automated status updates to the incident timeline from CI or monitoring
+- **Cross-system sync**: Sync comments from Jira or Slack into the Rootly incident timeline
+
+## How It Works
+
+1. Takes an incident ID and event text
+2. Creates a new timeline event via the Rootly API
+3. Returns the created event with its ID and timestamps
+4. Emits the data on the success channel
+
+## Configuration
+
+- **Incident ID** (required): The Rootly incident UUID to add the event to. Accepts expressions.
+- **Event** (required): The note/annotation text. Supports Markdown formatting in Rootly.
+- **Visibility** (optional): Set to "internal" or "external". Defaults to Rootly's default if not specified.
+
+## Output
+
+Single output channel that emits:
+- ` + "`id`" + `: The event ID
+- ` + "`event`" + `: The event text
+- ` + "`visibility`" + `: Event visibility (internal/external)
+- ` + "`occurredAt`" + `: When the event occurred
+- ` + "`createdAt`" + `: When the event was created
+
+## Notes
+
+- Markdown is supported in the event text
+- Events appear in the incident timeline in chronological order
+- If the incident doesn't exist, an error is returned`
+}
+
+func (c *CreateEvent) Icon() string {
+	return "plus-circle"
+}
+
+func (c *CreateEvent) Color() string {
+	return "orange"
+}
+
+func (c *CreateEvent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{
+			Name:  CreateEventSuccessChannel,
+			Label: "Success",
+		},
+	}
+}
+
+func (c *CreateEvent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g. abc123",
+			Description: "The Rootly incident UUID to add the event to",
+		},
+		{
+			Name:        "event",
+			Label:       "Event",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "Investigation note or status update...",
+			Description: "The note/annotation text (supports Markdown)",
+			TypeOptions: &configuration.TypeOptions{
+				String: &configuration.StringTypeOptions{
+					Multiline: true,
+				},
+			},
+		},
+		{
+			Name:        "visibility",
+			Label:       "Visibility",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "Event visibility (internal or external)",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.SelectOption{
+						{Value: "", Label: "Default"},
+						{Value: "internal", Label: "Internal"},
+						{Value: "external", Label: "External"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateEvent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateEvent) Setup(ctx core.SetupContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CreateEvent) Execute(ctx core.ExecutionContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.IncidentID == "" {
+		return fmt.Errorf("incident ID is required")
+	}
+
+	if spec.Event == "" {
+		return fmt.Errorf("event text is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %w", err)
+	}
+
+	ctx.Logger.Infof("Creating event for incident=%s", spec.IncidentID)
+
+	event, err := client.CreateIncidentEvent(spec.IncidentID, spec.Event, spec.Visibility)
+	if err != nil {
+		return fmt.Errorf("error creating event: %w", err)
+	}
+
+	ctx.Logger.Infof("Created event=%s for incident=%s", event.ID, spec.IncidentID)
+
+	output := CreateEventOutput{
+		ID:         event.ID,
+		Event:      event.Event,
+		Visibility: event.Visibility,
+		OccurredAt: event.OccurredAt,
+		CreatedAt:  event.CreatedAt,
+	}
+
+	// Store metadata for reference
+	ctx.Metadata.Set(map[string]any{
+		"eventId":    event.ID,
+		"incidentId": spec.IncidentID,
+	})
+
+	return ctx.Requests.Emit(CreateEventSuccessChannel, CreateEventPayloadType, []any{output})
+}
+
+func (c *CreateEvent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateEvent) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CreateEvent) HandleAction(ctx core.ActionContext) error {
+	return fmt.Errorf("no actions available for CreateEvent")
+}
+
+func (c *CreateEvent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -63,6 +63,8 @@ func (r *Rootly) Configuration() []configuration.Field {
 func (r *Rootly) Components() []core.Component {
 	return []core.Component{
 		&CreateIncident{},
+		&CreateEvent{},
+		&UpdateEvent{},
 	}
 }
 

--- a/pkg/integrations/rootly/update_event.go
+++ b/pkg/integrations/rootly/update_event.go
@@ -1,0 +1,228 @@
+package rootly
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const UpdateEventPayloadType = "rootly.incident.event.updated"
+const UpdateEventSuccessChannel = "success"
+
+type UpdateEvent struct{}
+
+type UpdateEventSpec struct {
+	IncidentID string `json:"incidentId" mapstructure:"incidentId"`
+	EventID    string `json:"eventId" mapstructure:"eventId"`
+	Event      string `json:"event" mapstructure:"event"`
+	Visibility string `json:"visibility" mapstructure:"visibility"`
+}
+
+type UpdateEventOutput struct {
+	ID         string `json:"id"`
+	Event      string `json:"event"`
+	Visibility string `json:"visibility"`
+	OccurredAt string `json:"occurredAt"`
+	UpdatedAt  string `json:"updatedAt"`
+}
+
+func (u *UpdateEvent) Name() string {
+	return "rootly.updateEvent"
+}
+
+func (u *UpdateEvent) Label() string {
+	return "Update Event"
+}
+
+func (u *UpdateEvent) Description() string {
+	return "Update an existing incident timeline event in Rootly"
+}
+
+func (u *UpdateEvent) Documentation() string {
+	return `The Update Event component updates an existing incident timeline event in Rootly.
+
+## Use Cases
+
+- **Correction**: Correct a typo or update investigation notes from a workflow step
+- **Visibility changes**: Change event visibility (internal to external) for customer-facing updates
+- **Cross-system sync**: Sync edits from Jira or Slack back to the Rootly timeline
+
+## How It Works
+
+1. Takes an incident ID, event ID, and updated content
+2. Updates the existing timeline event via the Rootly API
+3. Returns the updated event with new timestamps
+4. Emits the data on the success channel
+
+## Configuration
+
+- **Incident ID** (required): The Rootly incident UUID the event belongs to. Accepts expressions.
+- **Event ID** (required): The Rootly incident event UUID to update. Accepts expressions.
+- **Event** (required): The new note/annotation text. Supports Markdown formatting.
+- **Visibility** (optional): Set to "internal" or "external" to change visibility.
+
+## Output
+
+Single output channel that emits:
+- ` + "`id`" + `: The event ID
+- ` + "`event`" + `: The updated event text
+- ` + "`visibility`" + `: Event visibility (internal/external)
+- ` + "`occurredAt`" + `: When the event occurred
+- ` + "`updatedAt`" + `: When the event was last updated
+
+## Notes
+
+- Only the provided fields are updated; omit visibility to keep existing value
+- If the incident or event doesn't exist, an error is returned
+- Update history is preserved in Rootly`
+}
+
+func (u *UpdateEvent) Icon() string {
+	return "edit"
+}
+
+func (u *UpdateEvent) Color() string {
+	return "orange"
+}
+
+func (u *UpdateEvent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{
+			Name:  UpdateEventSuccessChannel,
+			Label: "Success",
+		},
+	}
+}
+
+func (u *UpdateEvent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g. abc123",
+			Description: "The Rootly incident UUID the event belongs to",
+		},
+		{
+			Name:        "eventId",
+			Label:       "Event ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g. evt456",
+			Description: "The Rootly incident event UUID to update",
+		},
+		{
+			Name:        "event",
+			Label:       "Event",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "Updated investigation note...",
+			Description: "The new note/annotation text (supports Markdown)",
+			TypeOptions: &configuration.TypeOptions{
+				String: &configuration.StringTypeOptions{
+					Multiline: true,
+				},
+			},
+		},
+		{
+			Name:        "visibility",
+			Label:       "Visibility",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "Event visibility (internal or external)",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.SelectOption{
+						{Value: "", Label: "Keep existing"},
+						{Value: "internal", Label: "Internal"},
+						{Value: "external", Label: "External"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (u *UpdateEvent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (u *UpdateEvent) Setup(ctx core.SetupContext) error {
+	spec := UpdateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	return nil
+}
+
+func (u *UpdateEvent) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.IncidentID == "" {
+		return fmt.Errorf("incident ID is required")
+	}
+
+	if spec.EventID == "" {
+		return fmt.Errorf("event ID is required")
+	}
+
+	if spec.Event == "" {
+		return fmt.Errorf("event text is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %w", err)
+	}
+
+	ctx.Logger.Infof("Updating event=%s for incident=%s", spec.EventID, spec.IncidentID)
+
+	event, err := client.UpdateIncidentEvent(spec.IncidentID, spec.EventID, spec.Event, spec.Visibility)
+	if err != nil {
+		return fmt.Errorf("error updating event: %w", err)
+	}
+
+	ctx.Logger.Infof("Updated event=%s for incident=%s", event.ID, spec.IncidentID)
+
+	output := UpdateEventOutput{
+		ID:         event.ID,
+		Event:      event.Event,
+		Visibility: event.Visibility,
+		OccurredAt: event.OccurredAt,
+		UpdatedAt:  event.UpdatedAt,
+	}
+
+	// Store metadata for reference
+	ctx.Metadata.Set(map[string]any{
+		"eventId":    event.ID,
+		"incidentId": spec.IncidentID,
+	})
+
+	return ctx.Requests.Emit(UpdateEventSuccessChannel, UpdateEventPayloadType, []any{output})
+}
+
+func (u *UpdateEvent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (u *UpdateEvent) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (u *UpdateEvent) HandleAction(ctx core.ActionContext) error {
+	return fmt.Errorf("no actions available for UpdateEvent")
+}
+
+func (u *UpdateEvent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}


### PR DESCRIPTION
## Description

This PR adds CreateEvent and UpdateEvent components to the Rootly integration.

Closes #2821, #2822

### Changes
- client.go: Added event types and methods
- create_event.go: New component
- update_event.go: New component
- rootly.go: Registered components

Signed-off-by: Quantum-Forge-Code <heinzjg@hotmail.com>