### PR TITLE
feat: GitHub List Releases component

### DIFF
--- a/pkg/integrations/github/example.go
+++ b/pkg/integrations/github/example.go
@@ -31,6 +31,9 @@ var exampleOutputUpdateReleaseBytes []byte
 //go:embed example_output_delete_release.json
 var exampleOutputDeleteReleaseBytes []byte
 
+//go:embed example_output_list_releases.json
+var exampleOutputListReleasesBytes []byte
+
 //go:embed example_output_run_workflow.json
 var exampleOutputRunWorkflowBytes []byte
 
@@ -84,6 +87,9 @@ var exampleOutputUpdateRelease map[string]any
 
 var exampleOutputDeleteReleaseOnce sync.Once
 var exampleOutputDeleteRelease map[string]any
+
+var exampleOutputListReleasesOnce sync.Once
+var exampleOutputListReleases map[string]any
 
 var exampleOutputRunWorkflowOnce sync.Once
 var exampleOutputRunWorkflow map[string]any
@@ -149,6 +155,10 @@ func (c *UpdateRelease) ExampleOutput() map[string]any {
 
 func (c *DeleteRelease) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteReleaseOnce, exampleOutputDeleteReleaseBytes, &exampleOutputDeleteRelease)
+}
+
+func (c *ListReleases) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputListReleasesOnce, exampleOutputListReleasesBytes, &exampleOutputListReleases)
 }
 
 func (c *RunWorkflow) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/example_output_list_releases.json
+++ b/pkg/integrations/github/example_output_list_releases.json
@@ -1,0 +1,56 @@
+{
+  "data": [
+    {
+      "id": 3001,
+      "tag_name": "v1.2.3",
+      "name": "Release 1.2.3",
+      "body": "## What's Changed\n\n- Feature A\n- Bug fix B",
+      "html_url": "https://github.com/acme/widgets/releases/tag/v1.2.3",
+      "draft": false,
+      "prerelease": false,
+      "created_at": "2026-01-15T10:00:00Z",
+      "published_at": "2026-01-16T12:00:00Z",
+      "tarball_url": "https://api.github.com/repos/acme/widgets/tarball/v1.2.3",
+      "zipball_url": "https://api.github.com/repos/acme/widgets/zipball/v1.2.3",
+      "author": {
+        "login": "octocat",
+        "id": 1,
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "html_url": "https://github.com/octocat"
+      },
+      "assets": [
+        {
+          "id": 1,
+          "name": "app-v1.2.3.zip",
+          "label": "Application Bundle",
+          "content_type": "application/zip",
+          "size": 1024000,
+          "download_count": 42,
+          "browser_download_url": "https://github.com/acme/widgets/releases/download/v1.2.3/app-v1.2.3.zip"
+        }
+      ]
+    },
+    {
+      "id": 3000,
+      "tag_name": "v1.2.2",
+      "name": "Release 1.2.2",
+      "body": "## What's Changed\n\n- Minor improvements",
+      "html_url": "https://github.com/acme/widgets/releases/tag/v1.2.2",
+      "draft": false,
+      "prerelease": false,
+      "created_at": "2026-01-10T10:00:00Z",
+      "published_at": "2026-01-11T12:00:00Z",
+      "tarball_url": "https://api.github.com/repos/acme/widgets/tarball/v1.2.2",
+      "zipball_url": "https://api.github.com/repos/acme/widgets/zipball/v1.2.2",
+      "author": {
+        "login": "octocat",
+        "id": 1,
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "html_url": "https://github.com/octocat"
+      },
+      "assets": []
+    }
+  ],
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.releases"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -102,6 +102,7 @@ func (g *GitHub) Components() []core.Component {
 		&GetRelease{},
 		&UpdateRelease{},
 		&DeleteRelease{},
+		&ListReleases{},
 	}
 }
 

--- a/pkg/integrations/github/list_releases.go
+++ b/pkg/integrations/github/list_releases.go
@@ -1,0 +1,218 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type ListReleases struct{}
+
+type ListReleasesConfiguration struct {
+	Repository string `mapstructure:"repository"`
+	PerPage    *int   `mapstructure:"perPage,omitempty"`
+	Page       *int   `mapstructure:"page,omitempty"`
+}
+
+func (c *ListReleases) Name() string {
+	return "github.listReleases"
+}
+
+func (c *ListReleases) Label() string {
+	return "List Releases"
+}
+
+func (c *ListReleases) Description() string {
+	return "List releases for a GitHub repository"
+}
+
+func (c *ListReleases) Documentation() string {
+	return `The List Releases component retrieves a list of releases from a GitHub repository.
+
+## Use Cases
+
+- **Changelog Generation**: List releases for changelog or reporting from SuperPlane
+- **Release Notifications**: Fetch the latest N releases for notifications or status pages
+- **System Synchronization**: Sync release list to external systems (Jira, Slack)
+- **Release Monitoring**: Monitor all releases in a repository
+- **Deployment Tracking**: Track release history for deployment pipelines
+
+## Configuration
+
+- **Repository**: Select the GitHub repository to list releases from
+- **Per Page**: Number of releases to return per page (1-100, default: 30)
+- **Page**: Page number for pagination (default: 1)
+
+## Output
+
+Returns a list of releases, each containing:
+- Release ID, name, and tag name
+- Release body/description
+- Draft and prerelease status
+- Created and published timestamps
+- Author information
+- Asset URLs (tarball, zipball, and uploaded assets)`
+}
+
+func (c *ListReleases) Icon() string {
+	return "github"
+}
+
+func (c *ListReleases) Color() string {
+	return "gray"
+}
+
+func (c *ListReleases) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *ListReleases) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "perPage",
+			Label:       "Per Page",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     30,
+			Placeholder: "30",
+			Description: "Number of releases to return per page (1-100). Default: 30",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: intPtr(1),
+					Max: intPtr(100),
+				},
+			},
+		},
+		{
+			Name:        "page",
+			Label:       "Page",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     1,
+			Placeholder: "1",
+			Description: "Page number for pagination. Supports template variables (e.g., {{$.data.page}})",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: intPtr(1),
+				},
+			},
+		},
+	}
+}
+
+// intPtr returns a pointer to an int value
+func intPtr(i int) *int {
+	return &i
+}
+
+func (c *ListReleases) Setup(ctx core.SetupContext) error {
+	return ensureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.Configuration,
+	)
+}
+
+func (c *ListReleases) Execute(ctx core.ExecutionContext) error {
+	var config ListReleasesConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	var nodeMetadata NodeMetadata
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &nodeMetadata); err != nil {
+		return fmt.Errorf("failed to decode node metadata: %w", err)
+	}
+
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+
+	client, err := NewClient(ctx.Integration, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	// Set default pagination values
+	perPage := 30
+	if config.PerPage != nil && *config.PerPage > 0 {
+		perPage = *config.PerPage
+		if perPage > 100 {
+			perPage = 100
+		}
+	}
+
+	page := 1
+	if config.Page != nil && *config.Page > 0 {
+		page = *config.Page
+	}
+
+	// Fetch the list of releases
+	releases, _, err := client.Repositories.ListReleases(
+		context.Background(),
+		appMetadata.Owner,
+		config.Repository,
+		&github.ListOptions{
+			PerPage: perPage,
+			Page:    page,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to list releases: %w", err)
+	}
+
+	// Convert to []any for emission
+	releaseList := make([]any, len(releases))
+	for i, release := range releases {
+		releaseList[i] = release
+	}
+
+	// Emit output with releases data
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.releases",
+		releaseList,
+	)
+}
+
+func (c *ListReleases) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *ListReleases) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *ListReleases) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *ListReleases) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *ListReleases) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *ListReleases) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/github/list_releases_test.go
+++ b/pkg/integrations/github/list_releases_test.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ListReleases__Setup(t *testing.T) {
+	helloRepo := Repository{ID: 123456, Name: "hello", URL: "https://github.com/testhq/hello"}
+	component := ListReleases{}
+
+	t.Run("repository is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": ""},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("repository is not accessible", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": "world"},
+		})
+
+		require.ErrorContains(t, err, "repository world is not accessible to app installation")
+	})
+
+	t.Run("metadata is set successfully", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"repository": "hello"},
+		}))
+
+		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})
+	})
+}
+
+func Test__ListReleases__Configuration(t *testing.T) {
+	component := ListReleases{}
+
+	t.Run("returns correct configuration fields", func(t *testing.T) {
+		config := component.Configuration()
+
+		require.Len(t, config, 3)
+
+		// Repository field
+		require.Equal(t, "repository", config[0].Name)
+		require.Equal(t, "Repository", config[0].Label)
+		require.True(t, config[0].Required)
+
+		// PerPage field
+		require.Equal(t, "perPage", config[1].Name)
+		require.Equal(t, "Per Page", config[1].Label)
+		require.False(t, config[1].Required)
+		require.Equal(t, 30, config[1].Default)
+
+		// Page field
+		require.Equal(t, "page", config[2].Name)
+		require.Equal(t, "Page", config[2].Label)
+		require.False(t, config[2].Required)
+		require.Equal(t, 1, config[2].Default)
+	})
+}
+
+func Test__ListReleases__Metadata(t *testing.T) {
+	component := ListReleases{}
+
+	t.Run("returns correct component name", func(t *testing.T) {
+		require.Equal(t, "github.listReleases", component.Name())
+	})
+
+	t.Run("returns correct label", func(t *testing.T) {
+		require.Equal(t, "List Releases", component.Label())
+	})
+
+	t.Run("returns correct description", func(t *testing.T) {
+		require.Equal(t, "List releases for a GitHub repository", component.Description())
+	})
+
+	t.Run("returns documentation", func(t *testing.T) {
+		doc := component.Documentation()
+		require.Contains(t, doc, "List Releases")
+		require.Contains(t, doc, "Use Cases")
+		require.Contains(t, doc, "Configuration")
+		require.Contains(t, doc, "Output")
+	})
+
+	t.Run("returns correct icon", func(t *testing.T) {
+		require.Equal(t, "github", component.Icon())
+	})
+
+	t.Run("returns correct color", func(t *testing.T) {
+		require.Equal(t, "gray", component.Color())
+	})
+}
+
+func Test__ListReleases__OutputChannels(t *testing.T) {
+	component := ListReleases{}
+
+	t.Run("returns default output channel", func(t *testing.T) {
+		channels := component.OutputChannels(nil)
+		require.Len(t, channels, 1)
+		require.Equal(t, core.DefaultOutputChannel, channels[0])
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -15,6 +15,7 @@ import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
 import { deleteReleaseMapper } from "./delete_release";
 import { getReleaseMapper } from "./get_release";
+import { listReleasesMapper } from "./list_releases";
 import { buildActionStateRegistry } from "../utils";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -27,6 +28,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   updateRelease: buildActionStateRegistry("updated"),
   deleteRelease: buildActionStateRegistry("deleted"),
   getRelease: buildActionStateRegistry("retrieved"),
+  listReleases: buildActionStateRegistry("listed"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -39,6 +41,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   updateRelease: updateReleaseMapper,
   deleteRelease: deleteReleaseMapper,
   getRelease: getReleaseMapper,
+  listReleases: listReleasesMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/workflowv2/mappers/github/list_releases.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/list_releases.ts
@@ -1,0 +1,120 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseMapper,
+  ComponentBaseContext,
+  SubtitleContext,
+  ExecutionDetailsContext,
+  OutputPayload,
+  NodeInfo,
+} from "../types";
+import { baseProps } from "./base";
+import { buildGithubExecutionSubtitle } from "./utils";
+import { MetadataItem } from "@/ui/metadataList";
+
+interface ReleaseOutput {
+  id?: number;
+  tag_name?: string;
+  name?: string;
+  html_url?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  created_at?: string;
+  published_at?: string;
+  tarball_url?: string;
+  zipball_url?: string;
+  author?: {
+    login?: string;
+    html_url?: string;
+  };
+  assets?: Array<{
+    name?: string;
+    size?: number;
+    download_count?: number;
+  }>;
+}
+
+interface ListReleasesConfiguration {
+  repository?: string;
+  perPage?: number;
+  page?: number;
+}
+
+function getListReleasesMetadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as ListReleasesConfiguration | undefined;
+  const nodeMetadata = node.metadata as { repository?: { name?: string } } | undefined;
+
+  if (nodeMetadata?.repository?.name) {
+    metadata.push({ icon: "book", label: nodeMetadata.repository.name });
+  }
+
+  if (configuration?.perPage && configuration.perPage !== 30) {
+    metadata.push({ icon: "list", label: `${configuration.perPage} per page` });
+  }
+
+  if (configuration?.page && configuration.page > 1) {
+    metadata.push({ icon: "file", label: `Page ${configuration.page}` });
+  }
+
+  return metadata;
+}
+
+export const listReleasesMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+
+    return {
+      ...base,
+      metadata: getListReleasesMetadataList(context.node),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    Object.assign(details, {
+      "Retrieved At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+    });
+
+    if (outputs && outputs.default && outputs.default.length > 0) {
+      const releases = outputs.default.map((o) => o.data as ReleaseOutput);
+
+      details["Releases Found"] = releases.length.toString();
+
+      if (releases.length > 0) {
+        // Show info about the first release
+        const firstRelease = releases[0];
+        if (firstRelease?.tag_name) {
+          details["Latest Tag"] = firstRelease.tag_name;
+        }
+        if (firstRelease?.name) {
+          details["Latest Name"] = firstRelease.name;
+        }
+        if (firstRelease?.html_url) {
+          details["Latest URL"] = firstRelease.html_url;
+        }
+        if (firstRelease?.published_at) {
+          details["Latest Published"] = new Date(firstRelease.published_at).toLocaleString();
+        }
+
+        // Count drafts and prereleases
+        const draftCount = releases.filter((r) => r?.draft).length;
+        const prereleaseCount = releases.filter((r) => r?.prerelease).length;
+
+        if (draftCount > 0) {
+          details["Drafts"] = draftCount.toString();
+        }
+        if (prereleaseCount > 0) {
+          details["Prereleases"] = prereleaseCount.toString();
+        }
+      }
+    }
+
+    return details;
+  },
+};


### PR DESCRIPTION
## Description

Add new component to list releases from a GitHub repository with optional pagination support.

## Configuration

- **Repository** (required): GitHub repository to list releases from
- **Per Page** (optional): Number of releases per page (1-100, default: 30)
- **Page** (optional): Page number for pagination (default: 1)

## Output

Emits a list of releases, each containing:
- Release ID, tag name, and name
- Release body/description
- Draft and prerelease status
- Created and published timestamps
- Author information
- Asset URLs (tarball, zipball, and uploaded assets)

## Changes

- Added `list_releases.go` - Backend component implementation (Go)
- Added `list_releases_test.go` - Unit tests
- Added `example_output_list_releases.json` - Example output for documentation
- Added `list_releases.ts` - Frontend mapper (TypeScript)
- Updated `github.go` to register the new component
- Updated `example.go` with embedded example output
- Updated `index.ts` to register the frontend mapper

## Testing

- All unit tests pass
- Go build successful

Closes #2818