### PR TITLE
feat(rootly): add Create Event component

### DIFF
--- a/pkg/integrations/rootly/client.go
+++ b/pkg/integrations/rootly/client.go
@@ -427,3 +427,82 @@ func (c *Client) DeleteWebhookEndpoint(id string) error {
 	_, err := c.execRequest(http.MethodDelete, url, nil)
 	return err
 }
+
+// IncidentEvent represents a Rootly incident timeline event
+type IncidentEvent struct {
+	ID         string `json:"id"`
+	Event      string `json:"event"`
+	Visibility string `json:"visibility"`
+	OccurredAt string `json:"occurred_at"`
+	CreatedAt  string `json:"created_at"`
+}
+
+type IncidentEventData struct {
+	ID         string                  `json:"id"`
+	Type       string                  `json:"type"`
+	Attributes IncidentEventAttributes `json:"attributes"`
+}
+
+type IncidentEventAttributes struct {
+	Event      string `json:"event"`
+	Visibility string `json:"visibility"`
+	OccurredAt string `json:"occurred_at"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+type IncidentEventResponse struct {
+	Data IncidentEventData `json:"data"`
+}
+
+// CreateIncidentEventRequest represents the request to create an incident event
+type CreateIncidentEventRequest struct {
+	Data CreateIncidentEventData `json:"data"`
+}
+
+type CreateIncidentEventData struct {
+	Type       string                        `json:"type"`
+	Attributes CreateIncidentEventAttributes `json:"attributes"`
+}
+
+type CreateIncidentEventAttributes struct {
+	Event      string `json:"event"`
+	Visibility string `json:"visibility,omitempty"`
+}
+
+func (c *Client) CreateIncidentEvent(incidentID, event, visibility string) (*IncidentEvent, error) {
+	request := CreateIncidentEventRequest{
+		Data: CreateIncidentEventData{
+			Type: "incident_events",
+			Attributes: CreateIncidentEventAttributes{
+				Event:      event,
+				Visibility: visibility,
+			},
+		},
+	}
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/incidents/%s/events", c.BaseURL, incidentID)
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response IncidentEventResponse
+	err = json.Unmarshal(responseBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &IncidentEvent{
+		ID:         response.Data.ID,
+		Event:      response.Data.Attributes.Event,
+		Visibility: response.Data.Attributes.Visibility,
+		OccurredAt: response.Data.Attributes.OccurredAt,
+		CreatedAt:  response.Data.Attributes.CreatedAt,
+	}, nil
+}

--- a/pkg/integrations/rootly/create_event.go
+++ b/pkg/integrations/rootly/create_event.go
@@ -1,0 +1,171 @@
+package rootly
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CreateEvent struct{}
+
+type CreateEventSpec struct {
+	IncidentID string `json:"incidentId"`
+	Event      string `json:"event"`
+	Visibility string `json:"visibility"`
+}
+
+func (c *CreateEvent) Name() string {
+	return "rootly.createEvent"
+}
+
+func (c *CreateEvent) Label() string {
+	return "Create Event"
+}
+
+func (c *CreateEvent) Description() string {
+	return "Add a timeline event to a Rootly incident"
+}
+
+func (c *CreateEvent) Documentation() string {
+	return `The Create Event component adds a timeline event (note/annotation) to an existing Rootly incident.
+
+## Use Cases
+
+- **Post investigation notes**: Add notes from SuperPlane when a step completes
+- **Automated status updates**: Add automated updates to the incident timeline from CI or monitoring
+- **Sync comments**: Sync comments from Jira or Slack into the Rootly incident timeline
+- **Track workflow progress**: Document automated workflow actions in the incident timeline
+
+## Configuration
+
+- **Incident ID**: The Rootly incident UUID to add the event to (required, supports expressions)
+- **Event**: The note/annotation text to add to the timeline (required, supports Markdown)
+- **Visibility**: Whether the event is internal or external (optional, defaults to Rootly's default)
+
+## Output
+
+Returns the created incident event object including:
+- **id**: Event ID
+- **event**: The event text
+- **visibility**: Event visibility (internal or external)
+- **occurred_at**: When the event occurred
+- **created_at**: When the event was created`
+}
+
+func (c *CreateEvent) Icon() string {
+	return "calendar-plus"
+}
+
+func (c *CreateEvent) Color() string {
+	return "gray"
+}
+
+func (c *CreateEvent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateEvent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Rootly incident UUID to add the event to",
+		},
+		{
+			Name:        "event",
+			Label:       "Event",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The note/annotation text (supports Markdown)",
+		},
+		{
+			Name:        "visibility",
+			Label:       "Visibility",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "The visibility of the timeline event",
+			Placeholder: "Default (per Rootly settings)",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Internal", Value: "internal"},
+						{Label: "External", Value: "external"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateEvent) Setup(ctx core.SetupContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.IncidentID == "" {
+		return errors.New("incident ID is required")
+	}
+
+	if spec.Event == "" {
+		return errors.New("event is required")
+	}
+
+	return nil
+}
+
+func (c *CreateEvent) Execute(ctx core.ExecutionContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	event, err := client.CreateIncidentEvent(spec.IncidentID, spec.Event, spec.Visibility)
+	if err != nil {
+		return fmt.Errorf("failed to create incident event: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"rootly.incidentEvent",
+		[]any{event},
+	)
+}
+
+func (c *CreateEvent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateEvent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateEvent) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CreateEvent) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *CreateEvent) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *CreateEvent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/create_event_test.go
+++ b/pkg/integrations/rootly/create_event_test.go
@@ -1,0 +1,230 @@
+package rootly
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateEvent__Setup(t *testing.T) {
+	component := &CreateEvent{}
+
+	t.Run("valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"event":      "Investigation started",
+				"visibility": "internal",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("missing incident ID returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"event":      "Investigation started",
+				"visibility": "internal",
+			},
+		})
+
+		require.ErrorContains(t, err, "incident ID is required")
+	})
+
+	t.Run("empty incident ID returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "",
+				"event":      "Investigation started",
+				"visibility": "internal",
+			},
+		})
+
+		require.ErrorContains(t, err, "incident ID is required")
+	})
+
+	t.Run("missing event returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"visibility": "internal",
+			},
+		})
+
+		require.ErrorContains(t, err, "event is required")
+	})
+
+	t.Run("empty event returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"event":      "",
+				"visibility": "internal",
+			},
+		})
+
+		require.ErrorContains(t, err, "event is required")
+	})
+
+	t.Run("visibility is optional", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"event":      "Investigation started",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid configuration format -> decode error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "invalid-config",
+		})
+
+		require.ErrorContains(t, err, "error decoding configuration")
+	})
+}
+
+func Test__CreateEvent__Execute(t *testing.T) {
+	component := &CreateEvent{}
+
+	t.Run("successful event creation", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"data": {
+								"id": "evt-456",
+								"type": "incident_events",
+								"attributes": {
+									"event": "Investigation started",
+									"visibility": "internal",
+									"occurred_at": "2024-01-15T10:30:00.000Z",
+									"created_at": "2024-01-15T10:30:00.000Z",
+									"updated_at": "2024-01-15T10:30:00.000Z"
+								}
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"event":      "Investigation started",
+				"visibility": "internal",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.rootly.com/v1/incidents/inc-123/events", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+
+		// Verify emission
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "rootly.incidentEvent", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+	})
+
+	t.Run("event creation without visibility", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"data": {
+								"id": "evt-789",
+								"type": "incident_events",
+								"attributes": {
+									"event": "Status update",
+									"visibility": "external",
+									"occurred_at": "2024-01-15T11:00:00.000Z",
+									"created_at": "2024-01-15T11:00:00.000Z",
+									"updated_at": "2024-01-15T11:00:00.000Z"
+								}
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "inc-123",
+				"event":      "Status update",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 1)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error": "Incident not found"}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "invalid-id",
+				"event":      "Test event",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create incident event")
+	})
+}

--- a/pkg/integrations/rootly/example.go
+++ b/pkg/integrations/rootly/example.go
@@ -13,6 +13,12 @@ var exampleOutputCreateIncidentBytes []byte
 var exampleOutputCreateIncidentOnce sync.Once
 var exampleOutputCreateIncident map[string]any
 
+//go:embed example_output_create_event.json
+var exampleOutputCreateEventBytes []byte
+
+var exampleOutputCreateEventOnce sync.Once
+var exampleOutputCreateEvent map[string]any
+
 //go:embed example_data_on_incident.json
 var exampleDataOnIncidentBytes []byte
 
@@ -21,6 +27,10 @@ var exampleDataOnIncident map[string]any
 
 func (c *CreateIncident) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIncidentOnce, exampleOutputCreateIncidentBytes, &exampleOutputCreateIncident)
+}
+
+func (c *CreateEvent) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateEventOnce, exampleOutputCreateEventBytes, &exampleOutputCreateEvent)
 }
 
 func (t *OnIncident) ExampleData() map[string]any {

--- a/pkg/integrations/rootly/example_output_create_event.json
+++ b/pkg/integrations/rootly/example_output_create_event.json
@@ -1,0 +1,7 @@
+{
+  "id": "evt-6e1916b2-9655-4b6e-9e7d-d5cadb4bf4b4",
+  "event": "Investigation started: checking API logs for error patterns",
+  "visibility": "internal",
+  "occurred_at": "2024-01-15T10:30:00.000Z",
+  "created_at": "2024-01-15T10:30:00.000Z"
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -63,6 +63,7 @@ func (r *Rootly) Configuration() []configuration.Field {
 func (r *Rootly) Components() []core.Component {
 	return []core.Component{
 		&CreateIncident{},
+		&CreateEvent{},
 	}
 }
 

--- a/web_src/src/pages/workflowv2/mappers/rootly/create_event.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/create_event.ts
@@ -1,0 +1,108 @@
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import rootlyIcon from "@/assets/icons/integrations/rootly.svg";
+import { formatTimeAgo } from "@/utils/date";
+
+export interface IncidentEvent {
+  id?: string;
+  event?: string;
+  visibility?: string;
+  occurred_at?: string;
+  created_at?: string;
+}
+
+export const createEventMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      iconSrc: rootlyIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name ||
+        context.componentDefinition.label ||
+        context.componentDefinition.name ||
+        "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default: OutputPayload[] };
+    if (!outputs?.default || outputs.default.length === 0) {
+      return {};
+    }
+    const event = outputs.default[0].data as IncidentEvent;
+    return getDetailsForEvent(event);
+  },
+
+  subtitle(context: SubtitleContext): string {
+    if (!context.execution.createdAt) return "";
+    return formatTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function getDetailsForEvent(event: IncidentEvent): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  details.ID = event?.id || "-";
+  details.Event = event?.event || "-";
+  details.Visibility = event?.visibility || "-";
+
+  if (event?.occurred_at) {
+    details["Occurred At"] = new Date(event.occurred_at).toLocaleString();
+  }
+
+  if (event?.created_at) {
+    details["Created At"] = new Date(event.created_at).toLocaleString();
+  }
+
+  return details;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as { visibility?: string; incidentId?: string };
+
+  if (configuration?.visibility) {
+    metadata.push({ icon: "eye", label: "Visibility: " + configuration.visibility });
+  }
+
+  if (configuration?.incidentId) {
+    metadata.push({ icon: "hashtag", label: "Incident: " + configuration.incidentId });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/rootly/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/index.ts
@@ -1,10 +1,12 @@
 import { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { onIncidentTriggerRenderer } from "./on_incident";
 import { createIncidentMapper } from "./create_incident";
+import { createEventMapper } from "./create_event";
 import { buildActionStateRegistry } from "../utils";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIncident: createIncidentMapper,
+  createEvent: createEventMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -13,4 +15,5 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIncident: buildActionStateRegistry("created"),
+  createEvent: buildActionStateRegistry("created"),
 };


### PR DESCRIPTION
## Summary

This PR adds a new **Create Event** component for the Rootly integration that allows adding timeline events (notes/annotations) to existing Rootly incidents.

## Changes

### Backend (`pkg/integrations/rootly/`)
- **client.go**: Added `CreateIncidentEvent` API method with proper JSON:API request/response handling
- **create_event.go**: New component implementation with:
  - Configuration fields: incidentId (required), event (required), visibility (optional)
  - Proper setup validation and execution logic
  - Documentation with use cases
- **create_event_test.go**: Comprehensive tests for Setup and Execute methods
- **example.go**: Added ExampleOutput method for the component
- **example_output_create_event.json**: Example output data
- **rootly.go**: Registered the new component

### Frontend (`web_src/src/pages/workflowv2/mappers/rootly/`)
- **create_event.ts**: New mapper with execution details display and metadata rendering
- **index.ts**: Exported the new component mapper

## Use Cases

- Post investigation notes from SuperPlane when a step completes
- Add automated status updates to the incident timeline from CI or monitoring
- Sync comments from Jira or Slack into the Rootly incident timeline
- Track workflow progress by documenting automated actions in the timeline

## Configuration

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| Incident ID | String | Yes | Rootly incident UUID to add the event to |
| Event | Text | Yes | The note/annotation text (supports Markdown) |
| Visibility | Select | No | internal or external (defaults per Rootly settings) |

## Output

The component emits the created incident event with:
- `id`: Event ID
- `event`: The event text
- `visibility`: Event visibility (internal or external)
- `occurred_at`: When the event occurred
- `created_at`: When the event was created

## Testing

All tests pass:
```
=== RUN   Test__CreateEvent__Setup
--- PASS: Test__CreateEvent__Setup (0.00s)
=== RUN   Test__CreateEvent__Execute
--- PASS: Test__CreateEvent__Execute (0.00s)
```

## Video Demo

*Video will be attached showing: (1) setting up the integration, and (2) the working component in use.*

---

Closes #2821