### PR TITLE
chore: improve sendgrid component designs

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/sendgrid/send_email.ts
+++ b/web_src/src/pages/workflowv2/mappers/sendgrid/send_email.ts
@@ -51,16 +51,18 @@ export const sendEmailMapper: ComponentBaseMapper = {
     const outputs = context.execution.outputs as { default?: OutputPayload[]; failed?: OutputPayload[] } | undefined;
     const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
     const failed = outputs?.failed?.[0]?.data as Record<string, unknown> | undefined;
+    const sentAt = formatTimestamp(context.execution.updatedAt, context.execution.createdAt);
 
     if (failed) {
       return {
-        Error: stringOrDash(failed.error),
+        "Sent At": sentAt,
         Status: stringOrDash(failed.statusCode),
+        Error: stringOrDash(failed.error),
       };
     }
 
     return {
-      "Sent At": new Date(context.execution.updatedAt!).toLocaleString(),
+      "Sent At": sentAt,
       Status: stringOrDash(result?.status),
       "Message ID": stringOrDash(result?.messageId),
       To: stringOrDash(result?.to),
@@ -117,4 +119,13 @@ function stringOrDash(value?: unknown): string {
   }
 
   return String(value);
+}
+
+function formatTimestamp(updatedAt?: string, createdAt?: string): string {
+  const timestamp = updatedAt || createdAt;
+  if (!timestamp) {
+    return "-";
+  }
+
+  return new Date(timestamp).toLocaleString();
 }


### PR DESCRIPTION
## Summary
- Adjusted SendGrid trigger run item title to `email · Event Type` with time-only subtitle
- Ensured Details tab always includes a timestamp and places errors last for SendGrid actions
- Hid default trigger metadata (all events, `*` category) and summarized long event lists
- Displayed SendGrid contact list IDs as specs/badges instead of inline metadata
<img width="298" height="224" alt="image" src="https://github.com/user-attachments/assets/c9c48f91-e912-480b-b476-c858b2cd4473" />
<img width="678" height="154" alt="image" src="https://github.com/user-attachments/assets/bbd790af-10d0-4e7b-9a4f-a2299ec6c474" />
