### PR TITLE
feat(github): add Create Issue Comment component

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -26,6 +26,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in a GitHub repository" />
+  <LinkCard title="Create Issue Comment" href="#create-issue-comment" description="Add a comment to a GitHub issue or pull request" />
   <LinkCard title="Create Release" href="#create-release" description="Create a new release in a GitHub repository" />
   <LinkCard title="Delete Release" href="#delete-release" description="Delete a release from a GitHub repository" />
   <LinkCard title="Get Issue" href="#get-issue" description="Get a GitHub issue by number" />
@@ -982,6 +983,53 @@ Returns the created issue object with details including:
   },
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.issue"
+}
+```
+
+<a id="create-issue-comment"></a>
+
+## Create Issue Comment
+
+The Create Issue Comment component adds a comment to a GitHub issue or pull request.
+
+### Use Cases
+
+- **Deployment status updates**: Post deployment status or remediation updates to GitHub issues from SuperPlane
+- **Runbook links**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitHub as comments
+- **Automated feedback**: Add automated test results, build status, or review comments
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the issue/PR
+- **Issue Number**: The issue or pull request number to comment on (supports expressions)
+- **Body**: The comment text (Markdown supported, supports expressions)
+
+### Output
+
+Returns the created comment object with details including:
+- Comment ID
+- Body text
+- Author information
+- Created timestamp
+- HTML URL to the comment
+
+### Example Output
+
+```json
+{
+  "data": {
+    "id": 1234567890,
+    "body": "Deployment completed successfully! ✅",
+    "html_url": "https://github.com/acme/widgets/issues/42#issuecomment-1234567890",
+    "created_at": "2026-01-16T18:30:00Z",
+    "user": {
+      "login": "superplane-bot",
+      "id": 12345678
+    }
+  },
+  "timestamp": "2026-01-16T18:30:00.123456789Z",
+  "type": "github.issueComment"
 }
 ```
 

--- a/pkg/integrations/github/create_issue_comment.go
+++ b/pkg/integrations/github/create_issue_comment.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CreateIssueComment struct{}
+
+type CreateIssueCommentConfiguration struct {
+	Repository  string `mapstructure:"repository"`
+	IssueNumber int    `mapstructure:"issueNumber"`
+	Body        string `mapstructure:"body"`
+}
+
+func (c *CreateIssueComment) Name() string {
+	return "github.createIssueComment"
+}
+
+func (c *CreateIssueComment) Label() string {
+	return "Create Issue Comment"
+}
+
+func (c *CreateIssueComment) Description() string {
+	return "Add a comment to a GitHub issue or pull request"
+}
+
+func (c *CreateIssueComment) Documentation() string {
+	return `The Create Issue Comment component adds a comment to a GitHub issue or pull request.
+
+## Use Cases
+
+- **Deployment status updates**: Post deployment status or remediation updates to GitHub issues from SuperPlane
+- **Runbook links**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitHub as comments
+- **Automated feedback**: Add automated test results, build status, or review comments
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the issue/PR
+- **Issue Number**: The issue or pull request number to comment on (supports expressions)
+- **Body**: The comment text (Markdown supported, supports expressions)
+
+## Output
+
+Returns the created comment object with details including:
+- Comment ID
+- Body text
+- Author information
+- Created timestamp
+- HTML URL to the comment`
+}
+
+func (c *CreateIssueComment) Icon() string {
+	return "github"
+}
+
+func (c *CreateIssueComment) Color() string {
+	return "gray"
+}
+
+func (c *CreateIssueComment) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateIssueComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:     "issueNumber",
+			Label:    "Issue Number",
+			Type:     configuration.FieldTypeNumber,
+			Required: true,
+		},
+		{
+			Name:     "body",
+			Label:    "Body",
+			Type:     configuration.FieldTypeText,
+			Required: true,
+		},
+	}
+}
+
+func (c *CreateIssueComment) Setup(ctx core.SetupContext) error {
+	return ensureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.Configuration,
+	)
+}
+
+func (c *CreateIssueComment) Execute(ctx core.ExecutionContext) error {
+	var config CreateIssueCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode application metadata: %w", err)
+	}
+
+	client, err := NewClient(ctx.Integration, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	// Create the comment
+	comment, _, err := client.Issues.CreateComment(
+		context.Background(),
+		appMetadata.Owner,
+		config.Repository,
+		config.IssueNumber,
+		&github.IssueComment{
+			Body: &config.Body,
+		},
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to create issue comment: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.issueComment",
+		[]any{comment},
+	)
+}
+
+func (c *CreateIssueComment) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateIssueComment) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *CreateIssueComment) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CreateIssueComment) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/github/create_issue_comment_test.go
+++ b/pkg/integrations/github/create_issue_comment_test.go
@@ -1,0 +1,131 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateIssueComment__Setup(t *testing.T) {
+	helloRepo := Repository{ID: 123456, Name: "hello", URL: "https://github.com/testhq/hello"}
+	component := CreateIssueComment{}
+
+	t.Run("repository is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": ""},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("repository is not accessible", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"repository": "world"},
+		})
+
+		require.ErrorContains(t, err, "repository world is not accessible to app installation")
+	})
+
+	t.Run("metadata is set successfully", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"repository": "hello"},
+		}))
+
+		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})
+	})
+}
+
+func Test__CreateIssueComment__Configuration(t *testing.T) {
+	component := CreateIssueComment{}
+	config := component.Configuration()
+
+	t.Run("has required fields", func(t *testing.T) {
+		fieldNames := make([]string, len(config))
+		for i, field := range config {
+			fieldNames[i] = field.Name
+		}
+
+		require.Contains(t, fieldNames, "repository")
+		require.Contains(t, fieldNames, "issueNumber")
+		require.Contains(t, fieldNames, "body")
+	})
+
+	t.Run("repository field is required", func(t *testing.T) {
+		for _, field := range config {
+			if field.Name == "repository" {
+				require.True(t, field.Required)
+			}
+		}
+	})
+
+	t.Run("issueNumber field is required", func(t *testing.T) {
+		for _, field := range config {
+			if field.Name == "issueNumber" {
+				require.True(t, field.Required)
+			}
+		}
+	})
+
+	t.Run("body field is required", func(t *testing.T) {
+		for _, field := range config {
+			if field.Name == "body" {
+				require.True(t, field.Required)
+			}
+		}
+	})
+}
+
+func Test__CreateIssueComment__Metadata(t *testing.T) {
+	component := CreateIssueComment{}
+
+	t.Run("has correct name", func(t *testing.T) {
+		require.Equal(t, "github.createIssueComment", component.Name())
+	})
+
+	t.Run("has correct label", func(t *testing.T) {
+		require.Equal(t, "Create Issue Comment", component.Label())
+	})
+
+	t.Run("has correct icon", func(t *testing.T) {
+		require.Equal(t, "github", component.Icon())
+	})
+
+	t.Run("has correct color", func(t *testing.T) {
+		require.Equal(t, "gray", component.Color())
+	})
+
+	t.Run("has default output channel", func(t *testing.T) {
+		channels := component.OutputChannels(nil)
+		require.Len(t, channels, 1)
+		require.Equal(t, core.DefaultOutputChannel, channels[0])
+	})
+
+	t.Run("has description", func(t *testing.T) {
+		require.NotEmpty(t, component.Description())
+	})
+
+	t.Run("has documentation", func(t *testing.T) {
+		require.NotEmpty(t, component.Documentation())
+	})
+}

--- a/pkg/integrations/github/example.go
+++ b/pkg/integrations/github/example.go
@@ -10,6 +10,9 @@ import (
 //go:embed example_output_create_issue.json
 var exampleOutputCreateIssueBytes []byte
 
+//go:embed example_output_create_issue_comment.json
+var exampleOutputCreateIssueCommentBytes []byte
+
 //go:embed example_output_get_issue.json
 var exampleOutputGetIssueBytes []byte
 
@@ -64,6 +67,9 @@ var exampleDataOnWorkflowRunBytes []byte
 var exampleOutputCreateIssueOnce sync.Once
 var exampleOutputCreateIssue map[string]any
 
+var exampleOutputCreateIssueCommentOnce sync.Once
+var exampleOutputCreateIssueComment map[string]any
+
 var exampleOutputGetIssueOnce sync.Once
 var exampleOutputGetIssue map[string]any
 
@@ -117,6 +123,10 @@ var exampleDataOnWorkflowRun map[string]any
 
 func (c *CreateIssue) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIssueOnce, exampleOutputCreateIssueBytes, &exampleOutputCreateIssue)
+}
+
+func (c *CreateIssueComment) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIssueCommentOnce, exampleOutputCreateIssueCommentBytes, &exampleOutputCreateIssueComment)
 }
 
 func (c *GetIssue) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/example_output_create_issue_comment.json
+++ b/pkg/integrations/github/example_output_create_issue_comment.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": 1234567890,
+    "body": "Deployment completed successfully! ✅",
+    "html_url": "https://github.com/acme/widgets/issues/42#issuecomment-1234567890",
+    "created_at": "2026-01-16T18:30:00Z",
+    "user": {
+      "login": "superplane-bot",
+      "id": 12345678
+    }
+  },
+  "timestamp": "2026-01-16T18:30:00.123456789Z",
+  "type": "github.issueComment"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -95,6 +95,7 @@ func (g *GitHub) Components() []core.Component {
 	return []core.Component{
 		&GetIssue{},
 		&CreateIssue{},
+		&CreateIssueComment{},
 		&UpdateIssue{},
 		&RunWorkflow{},
 		&PublishCommitStatus{},

--- a/web_src/src/pages/workflowv2/mappers/github/create_issue_comment.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/create_issue_comment.ts
@@ -1,0 +1,55 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface IssueComment {
+  id?: number;
+  body?: string;
+  html_url?: string;
+  created_at?: string;
+  updated_at?: string;
+  user?: {
+    login?: string;
+    html_url?: string;
+  };
+}
+
+export const createIssueCommentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+  subtitle(context: SubtitleContext): string {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    let details: Record<string, string> = {};
+
+    if (outputs && outputs.default && outputs.default.length > 0) {
+      const comment = outputs.default[0].data as IssueComment;
+      Object.assign(details, {
+        "Created At": comment.created_at ? new Date(comment.created_at).toLocaleString() : "-",
+        "Created By": comment.user?.login || "-",
+      });
+
+      if (comment.updated_at) {
+        details["Updated At"] = new Date(comment.updated_at).toLocaleString();
+      }
+
+      details["Comment ID"] = comment?.id?.toString() || "";
+      details["Body"] = comment?.body || "";
+      details["URL"] = comment?.html_url || "";
+      details["Author URL"] = comment?.user?.html_url || "";
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -15,11 +15,13 @@ import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
 import { deleteReleaseMapper } from "./delete_release";
 import { getReleaseMapper } from "./get_release";
+import { createIssueCommentMapper } from "./create_issue_comment";
 import { buildActionStateRegistry } from "../utils";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   runWorkflow: RUN_WORKFLOW_STATE_REGISTRY,
   createIssue: buildActionStateRegistry("created"),
+  createIssueComment: buildActionStateRegistry("created"),
   getIssue: buildActionStateRegistry("retrieved"),
   updateIssue: buildActionStateRegistry("updated"),
   publishCommitStatus: buildActionStateRegistry("published"),
@@ -31,6 +33,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIssue: baseIssueMapper,
+  createIssueComment: createIssueCommentMapper,
   getIssue: baseIssueMapper,
   updateIssue: baseIssueMapper,
   runWorkflow: runWorkflowMapper,


### PR DESCRIPTION
## Summary

Implements the GitHub Create Issue Comment component per issue #2256.

## Changes

- Adds `create_issue_comment.go` with full component implementation
- Adds `create_issue_comment_test.go` with comprehensive tests  
- Adds `example_output_create_issue_comment.json` for UI schema
- Updates `github.go` to register the new component
- Updates `example.go` with embed directive for example output
- Adds `create_issue_comment.ts` UI mapper
- Updates `mappers/github/index.ts` with new component references
- Updates `docs/components/GitHub.mdx` with component documentation

## Component Details

The Create Issue Comment component allows adding comments to GitHub issues or PRs with:

### Configuration
- **Repository**: Select the GitHub repository containing the issue/PR
- **Issue Number**: The issue or pull request number (supports expressions)
- **Body**: The comment text (Markdown supported, supports expressions)

### Use Cases
- Post deployment status or remediation updates
- Add runbook links, error details, or status for responders
- Sync Slack or PagerDuty notes into GitHub as comments
- Add automated test results, build status, or review comments

### Output
Returns the created comment object with:
- Comment ID
- Body text
- Author information  
- Created timestamp
- HTML URL to the comment

## Testing

All tests pass:
```
go test ./pkg/integrations/github/... -v -run "CreateIssueComment"
```

TypeScript compiles without errors.

## Demo Video

[Will be attached separately]

Closes #2256