### PR TITLE
feat: add Mapper component for reshaping data between nodes

### DIFF
--- a/pkg/components/mapper/example.go
+++ b/pkg/components/mapper/example.go
@@ -1,0 +1,18 @@
+package mapper
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output.json
+var exampleOutputBytes []byte
+
+var exampleOutputOnce sync.Once
+var exampleOutput map[string]any
+
+func (m *Mapper) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputOnce, exampleOutputBytes, &exampleOutput)
+}

--- a/pkg/components/mapper/example_output.json
+++ b/pkg/components/mapper/example_output.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "name": "John",
+    "email": "john@example.com"
+  },
+  "timestamp": "2026-02-07T12:00:00.000000000Z",
+  "type": "mapper.executed"
+}

--- a/pkg/components/mapper/mapper.go
+++ b/pkg/components/mapper/mapper.go
@@ -1,0 +1,268 @@
+package mapper
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+const ComponentName = "mapper"
+
+func init() {
+	registry.RegisterComponent(ComponentName, &Mapper{})
+}
+
+type Spec struct {
+	Fields         []FieldMapping `json:"fields" mapstructure:"fields"`
+	KeepOnlyMapped bool           `json:"keepOnlyMapped" mapstructure:"keepOnlyMapped"`
+}
+
+type FieldMapping struct {
+	Name  string `json:"name" mapstructure:"name"`
+	Value any    `json:"value" mapstructure:"value"`
+}
+
+type Mapper struct{}
+
+func (m *Mapper) Name() string {
+	return ComponentName
+}
+
+func (m *Mapper) Label() string {
+	return "Mapper"
+}
+
+func (m *Mapper) Description() string {
+	return "Map fields from previous node results to a new structure"
+}
+
+func (m *Mapper) Documentation() string {
+	return `The Mapper component allows you to reshape data by defining field name/value pairs that create a new data structure.
+
+## Use Cases
+
+- **Data transformation**: Reshape event data into a different structure
+- **API preparation**: Map fields to match an expected API request format
+- **Field extraction**: Pull out specific fields from complex nested data
+- **Field renaming**: Rename fields from upstream nodes
+
+## How It Works
+
+1. Define field mappings as name/value pairs
+2. Field values support ` + "`{{expression}}`" + ` syntax to reference data from previous nodes
+3. Expressions are resolved automatically before execution
+4. The Mapper constructs a new output object from the resolved mappings
+
+## Field Mappings
+
+Each mapping has:
+- **Name**: The output field name (static, no expressions)
+- **Value**: The value to assign (supports ` + "`{{expression}}`" + ` syntax)
+
+## Dot Notation
+
+Use dots in field names to create nested structures:
+- ` + "`user.name`" + ` creates ` + "`{\"user\": {\"name\": \"value\"}}`" + `
+- ` + "`user.profile.email`" + ` creates ` + "`{\"user\": {\"profile\": {\"email\": \"value\"}}}`" + `
+
+## Keep Only Mapped
+
+- When enabled (default): output contains only the explicitly mapped fields
+- When disabled: output starts with the incoming event data, then mapped fields are applied on top
+
+## Examples
+
+- Map a GitHub push ref: Name = ` + "`branch`" + `, Value = ` + "`{{$[\"GitHub Push\"].data.ref}}`" + `
+- Static value: Name = ` + "`status`" + `, Value = ` + "`active`" + `
+- Nested output: Name = ` + "`user.email`" + `, Value = ` + "`{{$[\"User Lookup\"].data.email}}`" + ``
+}
+
+func (m *Mapper) Icon() string {
+	return "replace"
+}
+
+func (m *Mapper) Color() string {
+	return "purple"
+}
+
+func (m *Mapper) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (m *Mapper) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "fields",
+			Label:       "Field Mappings",
+			Type:        configuration.FieldTypeList,
+			Required:    true,
+			Description: "Define the fields to map into the output",
+			Default:     []map[string]any{{"name": "myField", "value": ""}},
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Field",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:               "name",
+								Label:              "Field Name",
+								Type:               configuration.FieldTypeString,
+								Required:           true,
+								Placeholder:        "e.g. user.email",
+								DisallowExpression: true,
+							},
+							{
+								Name:        "value",
+								Label:       "Value",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Placeholder: "e.g. {{$[\"Node\"].data.email}}",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "keepOnlyMapped",
+			Label:       "Keep Only Mapped Fields",
+			Type:        configuration.FieldTypeBool,
+			Description: "When enabled, output contains only the mapped fields. When disabled, mapped fields are merged on top of the incoming data.",
+			Default:     true,
+		},
+	}
+}
+
+func (m *Mapper) Setup(ctx core.SetupContext) error {
+	spec := Spec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(spec.Fields) == 0 {
+		return fmt.Errorf("at least one field mapping is required")
+	}
+
+	seen := make(map[string]bool, len(spec.Fields))
+	for _, field := range spec.Fields {
+		if strings.TrimSpace(field.Name) == "" {
+			return fmt.Errorf("field name cannot be empty")
+		}
+		if seen[field.Name] {
+			return fmt.Errorf("duplicate field name: %s", field.Name)
+		}
+		seen[field.Name] = true
+	}
+
+	return nil
+}
+
+func (m *Mapper) Execute(ctx core.ExecutionContext) error {
+	spec := Spec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	// Store the field mappings in metadata for auditability
+	metadata := map[string]any{
+		"fields":         spec.Fields,
+		"keepOnlyMapped": spec.KeepOnlyMapped,
+	}
+	err = ctx.Metadata.Set(metadata)
+	if err != nil {
+		return fmt.Errorf("error setting metadata: %w", err)
+	}
+
+	// Build the output map
+	var output map[string]any
+	if spec.KeepOnlyMapped {
+		output = map[string]any{}
+	} else {
+		output = copyInputData(ctx.Data)
+	}
+
+	// Apply field mappings
+	for _, field := range spec.Fields {
+		setNestedField(output, field.Name, field.Value)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"mapper.executed",
+		[]any{output},
+	)
+}
+
+// setNestedField sets a value in a nested map structure using dot notation.
+// For example, setNestedField(m, "user.profile.name", "Alice") creates:
+// {"user": {"profile": {"name": "Alice"}}}
+func setNestedField(target map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := target
+
+	for i := 0; i < len(parts)-1; i++ {
+		key := parts[i]
+		if existing, ok := current[key]; ok {
+			if existingMap, ok := existing.(map[string]any); ok {
+				current = existingMap
+				continue
+			}
+		}
+		newMap := map[string]any{}
+		current[key] = newMap
+		current = newMap
+	}
+
+	current[parts[len(parts)-1]] = value
+}
+
+// copyInputData creates a shallow copy of the incoming event data.
+func copyInputData(data any) map[string]any {
+	if data == nil {
+		return map[string]any{}
+	}
+
+	inputMap, ok := data.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+
+	result := make(map[string]any, len(inputMap))
+	for k, v := range inputMap {
+		result[k] = v
+	}
+	return result
+}
+
+func (m *Mapper) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (m *Mapper) HandleAction(ctx core.ActionContext) error {
+	return fmt.Errorf("mapper does not support actions")
+}
+
+func (m *Mapper) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (m *Mapper) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (m *Mapper) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (m *Mapper) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/components/mapper/mapper_test.go
+++ b/pkg/components/mapper/mapper_test.go
@@ -1,0 +1,428 @@
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestMapper_Execute_SingleField(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{"input": "data"},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "greeting", "value": "hello"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+	assert.True(t, stateCtx.Passed)
+	assert.True(t, stateCtx.Finished)
+	assert.Equal(t, "default", stateCtx.Channel)
+	assert.Equal(t, "mapper.executed", stateCtx.Type)
+	assert.Len(t, stateCtx.Payloads, 1)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "hello", data["greeting"])
+}
+
+func TestMapper_Execute_MultipleFields(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "name", "value": "John"},
+				{"name": "email", "value": "john@example.com"},
+				{"name": "active", "value": "true"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+	assert.True(t, stateCtx.Passed)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "John", data["name"])
+	assert.Equal(t, "john@example.com", data["email"])
+	assert.Equal(t, "true", data["active"])
+}
+
+func TestMapper_Execute_KeepOnlyMappedTrue(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{
+			"existing": "value",
+			"other":    "data",
+		},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "newField", "value": "newValue"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+
+	// Only mapped fields should be in the output
+	assert.Equal(t, "newValue", data["newField"])
+	assert.NotContains(t, data, "existing")
+	assert.NotContains(t, data, "other")
+}
+
+func TestMapper_Execute_KeepOnlyMappedFalse(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{
+			"existing": "value",
+			"other":    "data",
+		},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "newField", "value": "newValue"},
+			},
+			"keepOnlyMapped": false,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+
+	// Both existing and mapped fields should be in the output
+	assert.Equal(t, "newValue", data["newField"])
+	assert.Equal(t, "value", data["existing"])
+	assert.Equal(t, "data", data["other"])
+}
+
+func TestMapper_Execute_DotNotation(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "user.profile.name", "value": "Alice"},
+				{"name": "user.profile.email", "value": "alice@example.com"},
+				{"name": "user.active", "value": "true"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+
+	user, ok := data["user"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "true", user["active"])
+
+	profile, ok := user["profile"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "Alice", profile["name"])
+	assert.Equal(t, "alice@example.com", profile["email"])
+}
+
+func TestMapper_Execute_ResolvedExpressions(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	// Simulate values already resolved by NodeConfigurationBuilder
+	ctx := core.ExecutionContext{
+		Data: map[string]any{},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "branch", "value": "refs/heads/main"},
+				{"name": "author", "value": "john@example.com"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "refs/heads/main", data["branch"])
+	assert.Equal(t, "john@example.com", data["author"])
+}
+
+func TestMapper_Execute_MetadataStorage(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "field1", "value": "value1"},
+			},
+			"keepOnlyMapped": true,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, metadataCtx.Metadata)
+
+	metadata, ok := metadataCtx.Metadata.(map[string]any)
+	assert.True(t, ok)
+	assert.Contains(t, metadata, "fields")
+	assert.Equal(t, true, metadata["keepOnlyMapped"])
+}
+
+func TestMapper_Setup_EmptyFields(t *testing.T) {
+	mapper := &Mapper{}
+
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"fields":         []map[string]any{},
+			"keepOnlyMapped": true,
+		},
+	}
+
+	err := mapper.Setup(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one field mapping is required")
+}
+
+func TestMapper_Setup_DuplicateFieldNames(t *testing.T) {
+	mapper := &Mapper{}
+
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "field1", "value": "value1"},
+				{"name": "field1", "value": "value2"},
+			},
+			"keepOnlyMapped": true,
+		},
+	}
+
+	err := mapper.Setup(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate field name: field1")
+}
+
+func TestMapper_Setup_EmptyFieldName(t *testing.T) {
+	mapper := &Mapper{}
+
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "", "value": "value1"},
+			},
+			"keepOnlyMapped": true,
+		},
+	}
+
+	err := mapper.Setup(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "field name cannot be empty")
+}
+
+func TestMapper_Setup_ValidConfiguration(t *testing.T) {
+	mapper := &Mapper{}
+
+	ctx := core.SetupContext{
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "field1", "value": "value1"},
+				{"name": "field2", "value": "value2"},
+			},
+			"keepOnlyMapped": true,
+		},
+	}
+
+	err := mapper.Setup(ctx)
+	assert.NoError(t, err)
+}
+
+func TestMapper_Execute_NilInputData(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: nil,
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "field1", "value": "value1"},
+			},
+			"keepOnlyMapped": false,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+	assert.True(t, stateCtx.Passed)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "value1", data["field1"])
+}
+
+func TestMapper_Execute_DotNotationOverwritesExisting(t *testing.T) {
+	mapper := &Mapper{}
+
+	stateCtx := &contexts.ExecutionStateContext{}
+	metadataCtx := &contexts.MetadataContext{}
+
+	ctx := core.ExecutionContext{
+		Data: map[string]any{
+			"user": map[string]any{
+				"name":  "Old Name",
+				"email": "old@example.com",
+			},
+		},
+		Configuration: map[string]any{
+			"fields": []map[string]any{
+				{"name": "user.name", "value": "New Name"},
+			},
+			"keepOnlyMapped": false,
+		},
+		ExecutionState: stateCtx,
+		Metadata:       metadataCtx,
+	}
+
+	err := mapper.Execute(ctx)
+
+	assert.NoError(t, err)
+
+	payload, ok := stateCtx.Payloads[0].(map[string]any)
+	assert.True(t, ok)
+	data, ok := payload["data"].(map[string]any)
+	assert.True(t, ok)
+
+	user, ok := data["user"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "New Name", user["name"])
+}
+
+func Test_setNestedField(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		value    any
+		expected map[string]any
+	}{
+		{
+			name:     "simple key",
+			path:     "name",
+			value:    "Alice",
+			expected: map[string]any{"name": "Alice"},
+		},
+		{
+			name:  "nested key",
+			path:  "user.name",
+			value: "Alice",
+			expected: map[string]any{
+				"user": map[string]any{"name": "Alice"},
+			},
+		},
+		{
+			name:  "deeply nested key",
+			path:  "a.b.c.d",
+			value: "deep",
+			expected: map[string]any{
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": map[string]any{"d": "deep"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := map[string]any{}
+			setNestedField(target, tt.path, tt.value)
+			assert.Equal(t, tt.expected, target)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/components/filter"
 	_ "github.com/superplanehq/superplane/pkg/components/http"
 	_ "github.com/superplanehq/superplane/pkg/components/if"
+	_ "github.com/superplanehq/superplane/pkg/components/mapper"
 	_ "github.com/superplanehq/superplane/pkg/components/merge"
 	_ "github.com/superplanehq/superplane/pkg/components/noop"
 	_ "github.com/superplanehq/superplane/pkg/components/ssh"

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/components/filter"
 	_ "github.com/superplanehq/superplane/pkg/components/http"
 	_ "github.com/superplanehq/superplane/pkg/components/if"
+	_ "github.com/superplanehq/superplane/pkg/components/mapper"
 	_ "github.com/superplanehq/superplane/pkg/components/merge"
 	_ "github.com/superplanehq/superplane/pkg/components/noop"
 	_ "github.com/superplanehq/superplane/pkg/components/ssh"


### PR DESCRIPTION
## Summary                                                                           
                                                                                                                                                              
   - Add new **Mapper** core component that reshapes data between workflow nodes by defining field name/value pairs                                           
   - Supports `{{expression}}` syntax in values (resolved by existing `NodeConfigurationBuilder`)                                                             
   - Supports dot notation for nested field creation (e.g., `user.profile.email` → `{"user": {"profile": {"email": "..."}}}`)                                 
   - `keepOnlyMapped` toggle: output only mapped fields (default) or merge on top of incoming data

Borrowed the idea from the popular [Edit Fields (Set)](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.set/) n8n node.

## Demo

[Watch demo video](https://www.loom.com/share/9eede28af6b54fd5a2a3500e5f3534a1)       

   ## Configuration

   | Field | Type | Description |
   |-------|------|-------------|
   | `fields` | list of `{name, value}` | Field mappings to apply |
   | `keepOnlyMapped` | boolean (default: `true`) | When false, merges mapped fields with incoming data |

   ## Validation

   - [x] `make format.go` — clean
   - [x] `make lint` — no warnings
   - [x] `make test PKG_TEST_PACKAGES=./pkg/components/mapper/...` — 17 tests pass
   - [x] `make check.build.app` — compiles

   ## Test plan

   - [ ] Verify single and multiple field mappings produce correct output
   - [ ] Verify `keepOnlyMapped: true` excludes incoming data from output
   - [ ] Verify `keepOnlyMapped: false` merges mapped fields on top of incoming data
   - [ ] Verify dot notation creates nested structures
   - [ ] Verify Setup rejects empty fields, duplicate names, and empty names
   - [ ] Verify component registers and appears in the component registry

## Question

Would you like it to be **Mapper** or **Map**, considering we have verbs like Merge and Schedule, and nouns like Approval and HTTP Request?