### PR TITLE
feat: Add github.createIssueComment component

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -24,6 +24,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in a GitHub repository" />
+  <LinkCard title="Create Issue Comment" href="#create-issue-comment" description="Add a comment to a GitHub issue or pull request" />
   <LinkCard title="Create Release" href="#create-release" description="Create a new release in a GitHub repository" />
   <LinkCard title="Delete Release" href="#delete-release" description="Delete a release from a GitHub repository" />
   <LinkCard title="Get Issue" href="#get-issue" description="Get a GitHub issue by number" />
@@ -980,6 +981,53 @@ Returns the created issue object with details including:
   },
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.issue"
+}
+```
+
+<a id="create-issue-comment"></a>
+
+## Create Issue Comment
+
+The Create Issue Comment component adds a comment to an existing GitHub issue or pull request.
+Issues and pull requests share the same comment API in GitHub.
+
+### Use Cases
+
+- **Deployment updates**: Post deployment status or remediation updates to GitHub issues
+- **Runbook linking**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitHub as comments
+- **Automated comments**: Add automated comments based on workflow events
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the issue
+- **Issue Number**: The issue or PR number to comment on (supports expressions, e.g. `{{ $.Trigger.issue.number }}`)
+- **Body**: The comment text (supports Markdown and expressions)
+
+### Output
+
+Returns the created comment object including:
+- Comment ID and URL
+- Comment body
+- Author information
+- Created timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "id": 5001,
+    "body": "Deployment to production completed successfully.",
+    "html_url": "https://github.com/acme/widgets/issues/42#issuecomment-5001",
+    "user": {
+      "login": "superplane-app[bot]"
+    },
+    "created_at": "2026-01-16T17:56:16Z",
+    "updated_at": "2026-01-16T17:56:16Z"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.issueComment"
 }
 ```
 

--- a/pkg/integrations/github/create_issue_comment.go
+++ b/pkg/integrations/github/create_issue_comment.go
@@ -1,0 +1,192 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CreateIssueComment struct{}
+
+type CreateIssueCommentConfiguration struct {
+	Repository  string `json:"repository" mapstructure:"repository"`
+	IssueNumber string `json:"issueNumber" mapstructure:"issueNumber"`
+	Body        string `json:"body" mapstructure:"body"`
+}
+
+func (c *CreateIssueComment) Name() string {
+	return "github.createIssueComment"
+}
+
+func (c *CreateIssueComment) Label() string {
+	return "Create Issue Comment"
+}
+
+func (c *CreateIssueComment) Description() string {
+	return "Add a comment to a GitHub issue or pull request"
+}
+
+func (c *CreateIssueComment) Documentation() string {
+	return `The Create Issue Comment component adds a comment to an existing GitHub issue or pull request.
+Issues and pull requests share the same comment API in GitHub.
+
+## Use Cases
+
+- **Deployment updates**: Post deployment status or remediation updates to GitHub issues
+- **Runbook linking**: Add runbook links, error details, or status for responders
+- **Cross-platform sync**: Sync Slack or PagerDuty notes into GitHub as comments
+- **Automated comments**: Add automated comments based on workflow events
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the issue
+- **Issue Number**: The issue or PR number to comment on (supports expressions)
+- **Body**: The comment text (supports Markdown and expressions)
+
+## Output
+
+Returns the created comment object including:
+- Comment ID and URL
+- Comment body
+- Author information
+- Created timestamp`
+}
+
+func (c *CreateIssueComment) Icon() string {
+	return "github"
+}
+
+func (c *CreateIssueComment) Color() string {
+	return "gray"
+}
+
+func (c *CreateIssueComment) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateIssueComment) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "issueNumber",
+			Label:       "Issue Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The issue or pull request number to comment on",
+		},
+		{
+			Name:        "body",
+			Label:       "Body",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The comment text. Supports Markdown formatting.",
+		},
+	}
+}
+
+func (c *CreateIssueComment) Setup(ctx core.SetupContext) error {
+	var config CreateIssueCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.IssueNumber == "" {
+		return errors.New("issue number is required")
+	}
+
+	if config.Body == "" {
+		return errors.New("body is required")
+	}
+
+	return ensureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.Configuration,
+	)
+}
+
+func (c *CreateIssueComment) Execute(ctx core.ExecutionContext) error {
+	var config CreateIssueCommentConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	issueNumber, err := strconv.Atoi(config.IssueNumber)
+	if err != nil {
+		return fmt.Errorf("issue number is not a number: %v", err)
+	}
+
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode application metadata: %w", err)
+	}
+
+	client, err := NewClient(ctx.Integration, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	comment := &github.IssueComment{
+		Body: &config.Body,
+	}
+
+	createdComment, _, err := client.Issues.CreateComment(
+		context.Background(),
+		appMetadata.Owner,
+		config.Repository,
+		issueNumber,
+		comment,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to create issue comment: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.issueComment",
+		[]any{createdComment},
+	)
+}
+
+func (c *CreateIssueComment) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateIssueComment) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *CreateIssueComment) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CreateIssueComment) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateIssueComment) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/github/create_issue_comment_test.go
+++ b/pkg/integrations/github/create_issue_comment_test.go
@@ -1,0 +1,107 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateIssueComment__Setup(t *testing.T) {
+	helloRepo := Repository{ID: 123456, Name: "hello", URL: "https://github.com/testhq/hello"}
+	component := CreateIssueComment{}
+
+	t.Run("issue number is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"issueNumber": "", "body": "test", "repository": "hello"},
+		})
+
+		require.ErrorContains(t, err, "issue number is required")
+	})
+
+	t.Run("body is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"issueNumber": "42", "body": "", "repository": "hello"},
+		})
+
+		require.ErrorContains(t, err, "body is required")
+	})
+
+	t.Run("repository is required", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"issueNumber": "42", "body": "test", "repository": ""},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("repository is not accessible", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{"issueNumber": "42", "body": "test", "repository": "world"},
+		})
+
+		require.ErrorContains(t, err, "repository world is not accessible to app installation")
+	})
+
+	t.Run("metadata is set successfully", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Repositories: []Repository{helloRepo},
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"issueNumber": "42", "body": "test", "repository": "hello"},
+		}))
+
+		require.Equal(t, nodeMetadataCtx.Get(), NodeMetadata{Repository: &helloRepo})
+	})
+}
+
+func Test__CreateIssueComment__Execute(t *testing.T) {
+	component := CreateIssueComment{}
+
+	t.Run("fails when issue number is not a number", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    &contexts.IntegrationContext{},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"issueNumber": "abc",
+				"body":        "test comment",
+				"repository":  "hello",
+			},
+		})
+
+		require.ErrorContains(t, err, "issue number is not a number")
+	})
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    &contexts.IntegrationContext{},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  "not a map",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+}

--- a/pkg/integrations/github/example.go
+++ b/pkg/integrations/github/example.go
@@ -10,6 +10,9 @@ import (
 //go:embed example_output_create_issue.json
 var exampleOutputCreateIssueBytes []byte
 
+//go:embed example_output_create_issue_comment.json
+var exampleOutputCreateIssueCommentBytes []byte
+
 //go:embed example_output_get_issue.json
 var exampleOutputGetIssueBytes []byte
 
@@ -64,6 +67,9 @@ var exampleDataOnWorkflowRunBytes []byte
 var exampleOutputCreateIssueOnce sync.Once
 var exampleOutputCreateIssue map[string]any
 
+var exampleOutputCreateIssueCommentOnce sync.Once
+var exampleOutputCreateIssueComment map[string]any
+
 var exampleOutputGetIssueOnce sync.Once
 var exampleOutputGetIssue map[string]any
 
@@ -117,6 +123,10 @@ var exampleDataOnWorkflowRun map[string]any
 
 func (c *CreateIssue) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIssueOnce, exampleOutputCreateIssueBytes, &exampleOutputCreateIssue)
+}
+
+func (c *CreateIssueComment) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIssueCommentOnce, exampleOutputCreateIssueCommentBytes, &exampleOutputCreateIssueComment)
 }
 
 func (c *GetIssue) ExampleOutput() map[string]any {

--- a/pkg/integrations/github/example_output_create_issue_comment.json
+++ b/pkg/integrations/github/example_output_create_issue_comment.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "id": 5001,
+    "body": "Deployment to production completed successfully.",
+    "html_url": "https://github.com/acme/widgets/issues/42#issuecomment-5001",
+    "user": {
+      "login": "superplane-app[bot]"
+    },
+    "created_at": "2026-01-16T17:56:16Z",
+    "updated_at": "2026-01-16T17:56:16Z"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.issueComment"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -95,6 +95,7 @@ func (g *GitHub) Components() []core.Component {
 	return []core.Component{
 		&GetIssue{},
 		&CreateIssue{},
+		&CreateIssueComment{},
 		&UpdateIssue{},
 		&RunWorkflow{},
 		&PublishCommitStatus{},

--- a/web_src/src/pages/workflowv2/mappers/github/create_issue_comment.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/create_issue_comment.ts
@@ -1,0 +1,41 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+import { buildGithubExecutionSubtitle } from "./utils";
+import { Comment } from "./types";
+
+export const createIssueCommentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+  subtitle(context: SubtitleContext): string {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const comment = outputs.default[0].data as Comment;
+    Object.assign(details, {
+      "Created At": comment?.created_at ? new Date(comment.created_at).toLocaleString() : "-",
+      "Created By": comment?.user?.login || "-",
+    });
+
+    details["ID"] = comment?.id?.toString() || "-";
+    details["URL"] = comment?.html_url || "-";
+    details["Body"] = comment?.body || "-";
+
+    return details;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -11,6 +11,7 @@ import { onWorkflowRunTriggerRenderer } from "./on_workflow_run";
 import { baseIssueMapper } from "./base";
 import { RUN_WORKFLOW_STATE_REGISTRY, runWorkflowMapper, runWorkflowCustomFieldRenderer } from "./run_workflow";
 import { publishCommitStatusMapper } from "./publish_commit_status";
+import { createIssueCommentMapper } from "./create_issue_comment";
 import { createReleaseMapper } from "./create_release";
 import { updateReleaseMapper } from "./update_release";
 import { deleteReleaseMapper } from "./delete_release";
@@ -20,6 +21,7 @@ import { buildActionStateRegistry } from "../utils";
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   runWorkflow: RUN_WORKFLOW_STATE_REGISTRY,
   createIssue: buildActionStateRegistry("created"),
+  createIssueComment: buildActionStateRegistry("created"),
   getIssue: buildActionStateRegistry("retrieved"),
   updateIssue: buildActionStateRegistry("updated"),
   publishCommitStatus: buildActionStateRegistry("published"),
@@ -31,6 +33,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIssue: baseIssueMapper,
+  createIssueComment: createIssueCommentMapper,
   getIssue: baseIssueMapper,
   updateIssue: baseIssueMapper,
   runWorkflow: runWorkflowMapper,


### PR DESCRIPTION
Add Create Issue Comment component to the GitHub integration that allows posting comments on GitHub issues and pull requests from workflows.

Backend:
- New component with full interface implementation (Setup, Execute, etc.)
- FieldTypeString for issueNumber to support expression templates
- Setup validates issueNumber, body, and repository accessibility
- Execute calls GitHub Issues.CreateComment API via go-github v74
- Example output JSON with data/timestamp/type envelope
- 7 tests covering Setup validation and Execute error paths

Frontend:
- ComponentBaseMapper with execution details (ID, URL, Body, timestamps)
- Registered in eventStateRegistry and componentMappers

Documentation:
- Full component docs in GitHub.mdx with use cases, config, and output

Closes #2256