### PR TITLE
[CircleCI] Base integration (trigger pipeline + on workflow completed)Bounty/1957 circleci base

### DIFF
--- a/pkg/integrations/circleci/circleci.go
+++ b/pkg/integrations/circleci/circleci.go
@@ -162,9 +162,9 @@ func (c *CircleCI) SetupWebhook(ctx core.SetupWebhookContext) (any, error) {
 
 	name := fmt.Sprintf("superplane-%s", ctx.Webhook.GetID())
 	wh, err := client.CreateWebhook(CreateWebhookRequest{
-		Name:         name,
-		URL:          ctx.Webhook.GetURL(),
-		VerifyTLS:    true,
+		Name:          name,
+		URL:           ctx.Webhook.GetURL(),
+		VerifyTLS:     true,
 		SigningSecret: string(secret),
 		Scope: WebhookScope{
 			ID:   cfg.ProjectID,

--- a/pkg/integrations/circleci/client.go
+++ b/pkg/integrations/circleci/client.go
@@ -169,11 +169,11 @@ type WebhookScope struct {
 }
 
 type CreateWebhookRequest struct {
-	Name          string      `json:"name"`
-	Events        []string    `json:"events"`
-	URL           string      `json:"url"`
-	VerifyTLS     bool        `json:"verify-tls"`
-	SigningSecret string      `json:"signing-secret"`
+	Name          string       `json:"name"`
+	Events        []string     `json:"events"`
+	URL           string       `json:"url"`
+	VerifyTLS     bool         `json:"verify-tls"`
+	SigningSecret string       `json:"signing-secret"`
 	Scope         WebhookScope `json:"scope"`
 }
 
@@ -199,4 +199,3 @@ func (c *Client) DeleteWebhook(webhookID string) error {
 	_, err := c.exec(http.MethodDelete, "/webhook/"+webhookID, nil, http.StatusOK)
 	return err
 }
-

--- a/pkg/integrations/circleci/on_workflow_completed.go
+++ b/pkg/integrations/circleci/on_workflow_completed.go
@@ -25,9 +25,11 @@ type OnWorkflowCompletedMetadata struct {
 	Project *Project `json:"project" mapstructure:"project"`
 }
 
-func (t *OnWorkflowCompleted) Name() string        { return "circleci.onWorkflowCompleted" }
-func (t *OnWorkflowCompleted) Label() string       { return "On Workflow Completed" }
-func (t *OnWorkflowCompleted) Description() string { return "Start a workflow when a CircleCI workflow completes" }
+func (t *OnWorkflowCompleted) Name() string  { return "circleci.onWorkflowCompleted" }
+func (t *OnWorkflowCompleted) Label() string { return "On Workflow Completed" }
+func (t *OnWorkflowCompleted) Description() string {
+	return "Start a workflow when a CircleCI workflow completes"
+}
 
 func (t *OnWorkflowCompleted) Documentation() string {
 	return `The On Workflow Completed trigger starts a workflow execution when a CircleCI workflow completes.
@@ -154,4 +156,3 @@ func (t *OnWorkflowCompleted) HandleWebhook(ctx core.WebhookRequestContext) (int
 }
 
 func (t *OnWorkflowCompleted) Cleanup(ctx core.TriggerContext) error { return nil }
-

--- a/pkg/integrations/circleci/on_workflow_completed_test.go
+++ b/pkg/integrations/circleci/on_workflow_completed_test.go
@@ -69,4 +69,3 @@ func Test__OnWorkflowCompleted__HandleWebhook(t *testing.T) {
 		assert.Equal(t, "circleci.workflow.completed", events.Payloads[0].Type)
 	})
 }
-

--- a/pkg/integrations/circleci/trigger_pipeline.go
+++ b/pkg/integrations/circleci/trigger_pipeline.go
@@ -202,5 +202,5 @@ func (t *TriggerPipeline) Actions() []core.Action { return []core.Action{} }
 func (t *TriggerPipeline) HandleAction(ctx core.ActionContext) error {
 	return nil
 }
-func (t *TriggerPipeline) Cancel(ctx core.ExecutionContext) error  { return nil }
-func (t *TriggerPipeline) Cleanup(ctx core.SetupContext) error     { return nil }
+func (t *TriggerPipeline) Cancel(ctx core.ExecutionContext) error { return nil }
+func (t *TriggerPipeline) Cleanup(ctx core.SetupContext) error    { return nil }


### PR DESCRIPTION
Fixes #1957

Adds a new **CircleCI** integration with:

- Component: `circleci.triggerPipeline`
-   - Triggers a pipeline for a project slug (e.g. `gh/my-org/my-repo`)
-   - Supports `branch` or `tag` plus optional pipeline parameters
-   - Emits: `circleci.pipeline.triggered`
- - Trigger: `circleci.onWorkflowCompleted`
-   - Provisions an outbound webhook scoped to the CircleCI project
-   - Verifies incoming requests via `circleci-signature` (`v1=` HMAC-SHA256 over the raw request body)
-   - Emits: `circleci.workflow.completed`
Notes:
- CircleCI API v2 does not provide a universal “list projects” endpoint, so `ListResources` currently returns an empty list and the component/trigger accept a project slug directly.
- - Includes unit tests for webhook signature verification and event emission.
- 