### PR TITLE
feat: Add Rootly On Event trigger

### DIFF
--- a/pkg/integrations/rootly/on_event.go
+++ b/pkg/integrations/rootly/on_event.go
@@ -1,0 +1,260 @@
+package rootly
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type OnEvent struct{}
+
+type OnEventConfiguration struct {
+	Events     []string `json:"events"`
+	EventKinds []string `json:"eventKinds,omitempty"`
+	Visibility []string `json:"visibility,omitempty"`
+}
+
+func (t *OnEvent) Name() string {
+	return "rootly.onEvent"
+}
+
+func (t *OnEvent) Label() string {
+	return "On Event"
+}
+
+func (t *OnEvent) Description() string {
+	return "Listen to incident timeline events"
+}
+
+func (t *OnEvent) Documentation() string {
+	return `The On Event trigger starts a workflow execution when Rootly incident timeline events occur.
+
+## Use Cases
+
+- **Timeline automation**: Run a workflow when someone adds a note to an incident
+- **Sync timeline events**: Sync notes and annotations to Slack or external systems
+- **Investigation tracking**: React to new investigation notes being added
+- **Status updates**: Trigger notifications when timeline annotations are created
+
+## Configuration
+
+- **Events**: Select which timeline events to listen for (created, updated)
+- **Event Kinds** (optional): Filter by event kind (note, status_update, action_item, etc.)
+- **Visibility** (optional): Filter by visibility (internal, external)
+
+## Event Data
+
+Each timeline event includes:
+- **event**: Event type (timeline_event.created, timeline_event.updated)
+- **id**: Timeline event ID
+- **kind**: Event kind (note, annotation, status_update, etc.)
+- **body**: Event content/body
+- **occurred_at**: When the event occurred
+- **created_at**: When the event was created
+- **user_display_name**: Who created the event
+- **incident**: Associated incident information
+
+## Webhook Setup
+
+This trigger automatically sets up a Rootly webhook endpoint when configured. The endpoint is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (t *OnEvent) Icon() string {
+	return "message-square"
+}
+
+func (t *OnEvent) Color() string {
+	return "gray"
+}
+
+func (t *OnEvent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "events",
+			Label:    "Events",
+			Type:     configuration.FieldTypeMultiSelect,
+			Required: true,
+			Default:  []string{"timeline_event.created"},
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Created", Value: "timeline_event.created"},
+						{Label: "Updated", Value: "timeline_event.updated"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "eventKinds",
+			Label:       "Event Kinds",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    false,
+			Description: "Filter by event kind (leave empty for all)",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Note", Value: "note"},
+						{Label: "Annotation", Value: "annotation"},
+						{Label: "Status Update", Value: "status_update"},
+						{Label: "Action Item", Value: "action_item"},
+						{Label: "Alert", Value: "alert"},
+						{Label: "Page", Value: "page"},
+						{Label: "Slack Message", Value: "slack_message"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "visibility",
+			Label:       "Visibility",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    false,
+			Description: "Filter by visibility (leave empty for all)",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Internal", Value: "internal"},
+						{Label: "External", Value: "external"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *OnEvent) Setup(ctx core.TriggerContext) error {
+	config := OnEventConfiguration{}
+	err := mapstructure.Decode(ctx.Configuration, &config)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if len(config.Events) == 0 {
+		return fmt.Errorf("at least one event type must be chosen")
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		Events: config.Events,
+	})
+}
+
+func (t *OnEvent) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (t *OnEvent) HandleAction(ctx core.TriggerActionContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (t *OnEvent) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	config := OnEventConfiguration{}
+	err := mapstructure.Decode(ctx.Configuration, &config)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	// Verify signature
+	signature := ctx.Headers.Get("X-Rootly-Signature")
+	secret, err := ctx.Webhook.GetSecret()
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error getting secret: %v", err)
+	}
+
+	if err := verifyWebhookSignature(signature, ctx.Body, secret); err != nil {
+		return http.StatusForbidden, fmt.Errorf("invalid signature: %v", err)
+	}
+
+	// Parse webhook payload
+	var webhook TimelineEventWebhookPayload
+	err = json.Unmarshal(ctx.Body, &webhook)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	eventType := webhook.Event.Type
+
+	// Filter by event type
+	if !slices.Contains(config.Events, eventType) {
+		return http.StatusOK, nil
+	}
+
+	// Filter by event kind if specified
+	if len(config.EventKinds) > 0 {
+		eventKind, ok := webhook.Data["kind"].(string)
+		if !ok || !slices.Contains(config.EventKinds, eventKind) {
+			return http.StatusOK, nil
+		}
+	}
+
+	// Filter by visibility if specified
+	if len(config.Visibility) > 0 {
+		visibility, ok := webhook.Data["visibility"].(string)
+		if !ok || !slices.Contains(config.Visibility, visibility) {
+			return http.StatusOK, nil
+		}
+	}
+
+	err = ctx.Events.Emit(
+		fmt.Sprintf("rootly.%s", eventType),
+		buildTimelineEventPayload(webhook),
+	)
+
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil
+}
+
+// TimelineEventWebhookPayload represents the Rootly webhook payload for timeline events
+type TimelineEventWebhookPayload struct {
+	Event WebhookEvent   `json:"event"`
+	Data  map[string]any `json:"data"`
+}
+
+func buildTimelineEventPayload(webhook TimelineEventWebhookPayload) map[string]any {
+	payload := map[string]any{
+		"event":     webhook.Event.Type,
+		"event_id":  webhook.Event.ID,
+		"issued_at": webhook.Event.IssuedAt,
+	}
+
+	// Extract timeline event fields
+	if webhook.Data != nil {
+		if id, ok := webhook.Data["id"]; ok {
+			payload["id"] = id
+		}
+		if kind, ok := webhook.Data["kind"]; ok {
+			payload["kind"] = kind
+		}
+		if body, ok := webhook.Data["body"]; ok {
+			payload["body"] = body
+		}
+		if occurredAt, ok := webhook.Data["occurred_at"]; ok {
+			payload["occurred_at"] = occurredAt
+		}
+		if createdAt, ok := webhook.Data["created_at"]; ok {
+			payload["created_at"] = createdAt
+		}
+		if userDisplayName, ok := webhook.Data["user_display_name"]; ok {
+			payload["user_display_name"] = userDisplayName
+		}
+		if visibility, ok := webhook.Data["visibility"]; ok {
+			payload["visibility"] = visibility
+		}
+		if incident, ok := webhook.Data["incident"]; ok {
+			payload["incident"] = incident
+		}
+	}
+
+	return payload
+}
+
+func (t *OnEvent) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/on_event_test.go
+++ b/pkg/integrations/rootly/on_event_test.go
@@ -1,0 +1,119 @@
+package rootly
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnEvent_Name(t *testing.T) {
+	trigger := &OnEvent{}
+	assert.Equal(t, "rootly.onEvent", trigger.Name())
+}
+
+func TestOnEvent_Label(t *testing.T) {
+	trigger := &OnEvent{}
+	assert.Equal(t, "On Event", trigger.Label())
+}
+
+func TestOnEvent_Description(t *testing.T) {
+	trigger := &OnEvent{}
+	assert.Equal(t, "Listen to incident timeline events", trigger.Description())
+}
+
+func TestOnEvent_Configuration(t *testing.T) {
+	trigger := &OnEvent{}
+	config := trigger.Configuration()
+
+	assert.Len(t, config, 3)
+
+	// Events field
+	assert.Equal(t, "events", config[0].Name)
+	assert.True(t, config[0].Required)
+
+	// EventKinds field
+	assert.Equal(t, "eventKinds", config[1].Name)
+	assert.False(t, config[1].Required)
+
+	// Visibility field
+	assert.Equal(t, "visibility", config[2].Name)
+	assert.False(t, config[2].Required)
+}
+
+func TestBuildTimelineEventPayload(t *testing.T) {
+	webhook := TimelineEventWebhookPayload{
+		Event: WebhookEvent{
+			ID:       "evt_123",
+			Type:     "timeline_event.created",
+			IssuedAt: "2026-02-08T10:00:00Z",
+		},
+		Data: map[string]any{
+			"id":                "te_456",
+			"kind":              "note",
+			"body":              "This is a test note",
+			"occurred_at":       "2026-02-08T09:55:00Z",
+			"created_at":        "2026-02-08T10:00:00Z",
+			"user_display_name": "John Doe",
+			"visibility":        "internal",
+			"incident": map[string]any{
+				"id":    "inc_789",
+				"title": "Test Incident",
+			},
+		},
+	}
+
+	payload := buildTimelineEventPayload(webhook)
+
+	assert.Equal(t, "timeline_event.created", payload["event"])
+	assert.Equal(t, "evt_123", payload["event_id"])
+	assert.Equal(t, "2026-02-08T10:00:00Z", payload["issued_at"])
+	assert.Equal(t, "te_456", payload["id"])
+	assert.Equal(t, "note", payload["kind"])
+	assert.Equal(t, "This is a test note", payload["body"])
+	assert.Equal(t, "John Doe", payload["user_display_name"])
+	assert.Equal(t, "internal", payload["visibility"])
+	assert.NotNil(t, payload["incident"])
+}
+
+func TestBuildTimelineEventPayload_MinimalData(t *testing.T) {
+	webhook := TimelineEventWebhookPayload{
+		Event: WebhookEvent{
+			ID:       "evt_123",
+			Type:     "timeline_event.created",
+			IssuedAt: "2026-02-08T10:00:00Z",
+		},
+		Data: nil,
+	}
+
+	payload := buildTimelineEventPayload(webhook)
+
+	assert.Equal(t, "timeline_event.created", payload["event"])
+	assert.Equal(t, "evt_123", payload["event_id"])
+	_, hasKind := payload["kind"]
+	assert.False(t, hasKind)
+}
+
+func TestTimelineEventWebhookPayload_Unmarshal(t *testing.T) {
+	jsonData := `{
+		"event": {
+			"id": "evt_123",
+			"type": "timeline_event.created",
+			"issued_at": "2026-02-08T10:00:00Z"
+		},
+		"data": {
+			"id": "te_456",
+			"kind": "note",
+			"body": "Test note content"
+		}
+	}`
+
+	var payload TimelineEventWebhookPayload
+	err := json.Unmarshal([]byte(jsonData), &payload)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "evt_123", payload.Event.ID)
+	assert.Equal(t, "timeline_event.created", payload.Event.Type)
+	assert.Equal(t, "te_456", payload.Data["id"])
+	assert.Equal(t, "note", payload.Data["kind"])
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -69,6 +69,7 @@ func (r *Rootly) Components() []core.Component {
 func (r *Rootly) Triggers() []core.Trigger {
 	return []core.Trigger{
 		&OnIncident{},
+		&OnEvent{},
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements #2820 - On Event trigger that listens to Rootly incident timeline events.

## Features
- ✅ Listen to `timeline_event.created` and `timeline_event.updated` webhook events
- ✅ Filter by event kind (note, annotation, status_update, action_item, alert, page, slack_message)
- ✅ Filter by visibility (internal/external)
- ✅ Emits complete event payload

## Event Data Output
```json
{
  "event": "timeline_event.created",
  "id": "te_456",
  "kind": "note",
  "body": "Investigation notes...",
  "user_display_name": "John Doe",
  "visibility": "internal",
  "incident": { ... }
}
```

## Use Cases
- Run workflows when someone adds a note to an incident
- Sync timeline events to Slack or external systems
- React to investigation notes being added

## Files Changed
- `pkg/integrations/rootly/on_event.go` - New On Event trigger
- `pkg/integrations/rootly/on_event_test.go` - Tests
- `pkg/integrations/rootly/rootly.go` - Register trigger

## Payment Wallets
- **USDC (Solana):** `zARG9WZCiRRzghuCzx1kqSynhYanBnGdjfz4kjSjvin`
- **USDT (TRC20):** `TBabyyVX41RBX4gPRA3KX4ceovsuS7KdD7`

Closes #2820
