### PR TITLE
feat: Add Rootly Create Event action

### DIFF
--- a/pkg/integrations/rootly/create_event.go
+++ b/pkg/integrations/rootly/create_event.go
@@ -1,0 +1,212 @@
+package rootly
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const CreateEventPayloadType = "rootly.timeline_event"
+const CreateEventOutputChannel = "default"
+
+type CreateEvent struct{}
+
+type CreateEventSpec struct {
+	IncidentID string `json:"incidentId"`
+	Body       string `json:"body"`
+	Visibility string `json:"visibility"`
+}
+
+func (c *CreateEvent) Name() string {
+	return "rootly.createEvent"
+}
+
+func (c *CreateEvent) Label() string {
+	return "Create Event"
+}
+
+func (c *CreateEvent) Description() string {
+	return "Add a timeline event to a Rootly incident"
+}
+
+func (c *CreateEvent) Documentation() string {
+	return `The Create Event component adds a timeline event (note/annotation) to a Rootly incident.
+
+## Use Cases
+
+- **Investigation notes**: Post investigation notes from SuperPlane when a workflow step completes
+- **Automated status updates**: Add status updates to the incident timeline from CI or monitoring
+- **Cross-system sync**: Sync comments from Jira or Slack into the Rootly incident timeline
+- **Audit trail**: Record workflow actions in the incident timeline
+
+## Configuration
+
+- **Incident ID** (required): The Rootly incident UUID to add the event to. Accepts expressions (e.g., ` + "`{{ event.incident.id }}`" + `).
+- **Event** (required): The note/annotation text. Supports Markdown formatting in Rootly.
+- **Visibility** (optional): Event visibility - "internal" (default) or "external".
+
+## Output
+
+Emits the created timeline event to the default channel:
+- **id**: Timeline event ID
+- **body**: Event content
+- **visibility**: Event visibility
+- **occurred_at**: When the event occurred
+- **created_at**: When the event was created
+
+## Notes
+
+- This is a synchronous component - it creates the event and returns immediately
+- Use expressions to pass incident IDs from upstream components (e.g., On Incident trigger)
+- Markdown is supported in the event body`
+}
+
+func (c *CreateEvent) Icon() string {
+	return "message-square"
+}
+
+func (c *CreateEvent) Color() string {
+	return "gray"
+}
+
+func (c *CreateEvent) ExampleOutput() map[string]any {
+	return map[string]any{
+		"id":          "te_12345678",
+		"body":        "Investigation started by automation workflow",
+		"visibility":  "internal",
+		"occurred_at": "2026-02-08T10:00:00Z",
+		"created_at":  "2026-02-08T10:00:00Z",
+	}
+}
+
+func (c *CreateEvent) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{
+			Name:        CreateEventOutputChannel,
+			Label:       "Default",
+			Description: "Emits the created timeline event",
+		},
+	}
+}
+
+func (c *CreateEvent) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Rootly incident UUID to add the event to",
+			Placeholder: "e.g. {{ event.incident.id }}",
+		},
+		{
+			Name:        "body",
+			Label:       "Event",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "The note/annotation text (supports Markdown)",
+			Placeholder: "Enter your timeline event content...",
+		},
+		{
+			Name:        "visibility",
+			Label:       "Visibility",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "Event visibility (internal or external)",
+			Default:     "internal",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Internal", Value: "internal"},
+						{Label: "External", Value: "external"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateEvent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateEvent) Setup(ctx core.SetupContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	// Body is required but may be an expression, so we only validate if it's a literal
+	return nil
+}
+
+func (c *CreateEvent) Execute(ctx core.ExecutionContext) error {
+	spec := CreateEventSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.IncidentID == "" {
+		return ctx.ExecutionState.Fail("validation_error", "incident ID is required")
+	}
+
+	if spec.Body == "" {
+		return ctx.ExecutionState.Fail("validation_error", "event body is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create Rootly client: %w", err)
+	}
+
+	visibility := spec.Visibility
+	if visibility == "" {
+		visibility = "internal"
+	}
+
+	event, err := client.CreateTimelineEvent(spec.IncidentID, spec.Body, visibility)
+	if err != nil {
+		return ctx.ExecutionState.Fail("api_error", fmt.Sprintf("failed to create timeline event: %v", err))
+	}
+
+	if event == nil {
+		return ctx.ExecutionState.Fail("api_error", "timeline event creation returned empty response")
+	}
+
+	payload := map[string]any{
+		"id":          event.ID,
+		"body":        event.Body,
+		"visibility":  event.Visibility,
+		"occurred_at": event.OccurredAt,
+		"created_at":  event.CreatedAt,
+	}
+
+	return ctx.ExecutionState.Emit(CreateEventOutputChannel, CreateEventPayloadType, []any{payload})
+}
+
+func (c *CreateEvent) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CreateEvent) HandleAction(ctx core.ActionContext) error {
+	return errors.New("no actions available")
+}
+
+func (c *CreateEvent) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *CreateEvent) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateEvent) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/create_event_test.go
+++ b/pkg/integrations/rootly/create_event_test.go
@@ -1,0 +1,78 @@
+package rootly
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateEvent_Name(t *testing.T) {
+	component := &CreateEvent{}
+	assert.Equal(t, "rootly.createEvent", component.Name())
+}
+
+func TestCreateEvent_Label(t *testing.T) {
+	component := &CreateEvent{}
+	assert.Equal(t, "Create Event", component.Label())
+}
+
+func TestCreateEvent_Description(t *testing.T) {
+	component := &CreateEvent{}
+	assert.Equal(t, "Add a timeline event to a Rootly incident", component.Description())
+}
+
+func TestCreateEvent_Configuration(t *testing.T) {
+	component := &CreateEvent{}
+	config := component.Configuration()
+
+	assert.Len(t, config, 3)
+
+	// Incident ID field
+	assert.Equal(t, "incidentId", config[0].Name)
+	assert.True(t, config[0].Required)
+
+	// Body field
+	assert.Equal(t, "body", config[1].Name)
+	assert.True(t, config[1].Required)
+
+	// Visibility field
+	assert.Equal(t, "visibility", config[2].Name)
+	assert.False(t, config[2].Required)
+	assert.Equal(t, "internal", config[2].Default)
+}
+
+func TestCreateEvent_OutputChannels(t *testing.T) {
+	component := &CreateEvent{}
+	channels := component.OutputChannels(nil)
+
+	assert.Len(t, channels, 1)
+	assert.Equal(t, "default", channels[0].Name)
+}
+
+func TestCreateEvent_ExampleOutput(t *testing.T) {
+	component := &CreateEvent{}
+	example := component.ExampleOutput()
+
+	assert.NotNil(t, example)
+	assert.Contains(t, example, "id")
+	assert.Contains(t, example, "body")
+	assert.Contains(t, example, "visibility")
+	assert.Contains(t, example, "occurred_at")
+	assert.Contains(t, example, "created_at")
+}
+
+func TestCreateEvent_Icon(t *testing.T) {
+	component := &CreateEvent{}
+	assert.Equal(t, "message-square", component.Icon())
+}
+
+func TestCreateEvent_Color(t *testing.T) {
+	component := &CreateEvent{}
+	assert.Equal(t, "gray", component.Color())
+}
+
+func TestCreateEvent_Actions(t *testing.T) {
+	component := &CreateEvent{}
+	actions := component.Actions()
+	assert.Empty(t, actions)
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -63,6 +63,7 @@ func (r *Rootly) Configuration() []configuration.Field {
 func (r *Rootly) Components() []core.Component {
 	return []core.Component{
 		&CreateIncident{},
+		&CreateEvent{},
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements #2821 - Create Event component for adding timeline events (notes/annotations) to Rootly incidents.

## Features
- ✅ Add timeline events to Rootly incidents via API
- ✅ Configuration: incident_id, body (Markdown supported), visibility
- ✅ Visibility options: internal (default) or external
- ✅ Returns created event data to output channel

## Configuration
| Field | Type | Required | Description |
|-------|------|----------|-------------|
| incidentId | String | Yes | Rootly incident UUID (supports expressions) |
| body | Text | Yes | Event content (supports Markdown) |
| visibility | Select | No | internal (default) or external |

## Output
```json
{
  "id": "te_12345678",
  "body": "Investigation started by automation",
  "visibility": "internal",
  "occurred_at": "2026-02-08T10:00:00Z",
  "created_at": "2026-02-08T10:00:00Z"
}
```

## Use Cases
- Post investigation notes when workflow steps complete
- Add automated status updates from CI or monitoring
- Sync comments from Jira or Slack into Rootly

## Files Changed
- `pkg/integrations/rootly/create_event.go` - New component
- `pkg/integrations/rootly/create_event_test.go` - Unit tests
- `pkg/integrations/rootly/client.go` - Added CreateTimelineEvent API method
- `pkg/integrations/rootly/rootly.go` - Registered component

## Payment Wallets
- **USDC (Solana):** `zARG9WZCiRRzghuCzx1kqSynhYanBnGdjfz4kjSjvin`
- **USDT (TRC20):** `TBabyyVX41RBX4gPRA3KX4ceovsuS7KdD7`

Closes #2821
