### PR TITLE
feat: integration state and configuration should be on the same page

### DIFF
--- a/web_src/src/pages/organization/settings/IntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationDetails.tsx
@@ -334,8 +334,7 @@ export function IntegrationDetails({ organizationId }: IntegrationDetailsProps) 
           <div className="p-6">
             <h2 className="text-lg font-medium text-red-600 dark:text-red-400 mb-2">Danger Zone</h2>
             <p className="text-sm text-gray-800 dark:text-gray-100 mb-4">
-              Once you delete this integration, all its data will be permanently deleted. This action cannot be
-              undone.
+              Once you delete this integration, all its data will be permanently deleted. This action cannot be undone.
             </p>
             <PermissionTooltip
               allowed={canDeleteIntegrations || permissionsLoading}


### PR DESCRIPTION
The integration configuration and the integration state should be displayed together, so I can see the state changing when I update the configuration. This also makes flows where subsequent browser actions are required to set up the integration. Once I update the configuration, I can see the next browser action right away without leaving the page.