### PR TITLE
feat: Add Render components (Get Service, Get Deploy, Cancel Deploy, Rollback Deploy, Purge Cache, Update Env Var)

### DIFF
--- a/docs/components/Render.mdx
+++ b/docs/components/Render.mdx
@@ -16,7 +16,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Actions
 
 <CardGrid>
+  <LinkCard title="Cancel Deploy" href="#cancel-deploy" description="Cancel an in-progress deploy for a Render service" />
   <LinkCard title="Deploy" href="#deploy" description="Trigger a deploy for a Render service and wait for it to complete" />
+  <LinkCard title="Get Deploy" href="#get-deploy" description="Retrieve a deploy by ID for a Render service" />
+  <LinkCard title="Get Service" href="#get-service" description="Retrieve a Render service by ID" />
+  <LinkCard title="Purge Cache" href="#purge-cache" description="Request a purge of the build cache for a Render service" />
+  <LinkCard title="Rollback Deploy" href="#rollback-deploy" description="Roll back a Render service to a previous deploy" />
+  <LinkCard title="Update Env Var" href="#update-env-var" description="Update or generate a value for a Render service environment variable" />
 </CardGrid>
 
 ## Instructions
@@ -119,6 +125,43 @@ The default output emits payload data fields like `deployId`, `eventId`, `servic
 }
 ```
 
+<a id="cancel-deploy"></a>
+
+## Cancel Deploy
+
+The Cancel Deploy component cancels an in-progress deploy for a Render service.
+
+### Use Cases
+
+- **Automated rollback/abort**: Cancel deploys when health checks fail
+- **Manual intervention**: Stop a deploy triggered earlier in a workflow
+
+### Configuration
+
+- **Service**: Render service that owns the deploy
+- **Deploy ID**: Deploy ID to cancel (supports expressions)
+
+### Output
+
+Emits a `render.deploy` payload for the cancelled deploy (status is typically `canceled`).
+
+### Example Output
+
+```json
+{
+  "data": {
+    "createdAt": "2026-02-05T16:10:00.000000Z",
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "finishedAt": "2026-02-05T16:12:00.000000Z",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "canceled",
+    "trigger": "api"
+  },
+  "timestamp": "2026-02-05T16:12:00.000000Z",
+  "type": "render.deploy"
+}
+```
+
 <a id="deploy"></a>
 
 ## Deploy
@@ -168,6 +211,198 @@ The Deploy component starts a new deploy for a Render service and waits for it t
   },
   "timestamp": "2026-02-05T16:15:00.000000Z",
   "type": "render.deploy.finished"
+}
+```
+
+<a id="get-deploy"></a>
+
+## Get Deploy
+
+The Get Deploy component fetches a deploy for a Render service.
+
+### Use Cases
+
+- **Status checks**: Inspect deploy status and timestamps
+- **Debugging**: Fetch deploy metadata after receiving an event
+
+### Configuration
+
+- **Service**: Render service that owns the deploy
+- **Deploy ID**: Deploy ID to retrieve (supports expressions)
+
+### Output
+
+Emits a `render.deploy` payload containing deploy fields like `deployId`, `status`, `trigger`, and timestamps when available.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "commit": {
+      "createdAt": "2026-02-05T16:09:30.000000Z",
+      "id": "1a2b3c4d5e6f",
+      "message": "Release v1.2.3"
+    },
+    "createdAt": "2026-02-05T16:10:00.000000Z",
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "finishedAt": "2026-02-05T16:15:00.000000Z",
+    "image": {
+      "ref": "registry.example.com/backend-api:1a2b3c4d",
+      "sha": "sha256:4f7c2d7f0bb27e2f8d4d9b3d2b3a1a9a3b2c1d0e"
+    },
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "startedAt": "2026-02-05T16:10:10.000000Z",
+    "status": "live",
+    "trigger": "api"
+  },
+  "timestamp": "2026-02-05T16:15:00.000000Z",
+  "type": "render.deploy"
+}
+```
+
+<a id="get-service"></a>
+
+## Get Service
+
+The Get Service component fetches details for a Render service.
+
+### Use Cases
+
+- **Service inspection**: Fetch current service configuration and metadata
+- **Workflow context**: Use service fields to drive branching decisions in later steps
+
+### Configuration
+
+- **Service**: Render service to retrieve
+
+### Output
+
+Emits a `render.service` payload containing service fields like `serviceId`, `serviceName`, `type`, `dashboardUrl`, and `suspended`.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "createdAt": "2026-02-05T15:00:00.000000Z",
+    "dashboardUrl": "https://dashboard.render.com/web/srv-cukouhrtq21c73e9scng",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "serviceName": "backend-api",
+    "suspended": false,
+    "type": "web_service",
+    "updatedAt": "2026-02-05T16:00:00.000000Z"
+  },
+  "timestamp": "2026-02-05T16:05:00.000000Z",
+  "type": "render.service"
+}
+```
+
+<a id="purge-cache"></a>
+
+## Purge Cache
+
+The Purge Cache component requests a build cache purge for a Render service.
+
+### Use Cases
+
+- **Cache reset**: Force a clean rebuild when you suspect stale dependencies or build artifacts
+- **Operational tooling**: Provide a one-click cache purge in incident response workflows
+
+### Configuration
+
+- **Service**: Render service whose build cache should be purged
+
+### Output
+
+Emits a `render.cache.purge.requested` payload with `serviceId` and a `status` field indicating the request was accepted.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "accepted"
+  },
+  "timestamp": "2026-02-05T16:20:00.000000Z",
+  "type": "render.cache.purge.requested"
+}
+```
+
+<a id="rollback-deploy"></a>
+
+## Rollback Deploy
+
+The Rollback Deploy component triggers a rollback deploy for a Render service.
+
+### Use Cases
+
+- **Automated recovery**: Roll back after detecting errors in a new deploy
+- **One-click rollback**: Trigger rollbacks from an incident workflow
+
+### Configuration
+
+- **Service**: Render service to roll back
+- **Deploy ID**: The deploy ID to roll back to (supports expressions)
+
+### Output
+
+Emits a `render.deploy` payload for the new rollback deploy, and includes the `rollbackToDeployId` field for reference.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "createdAt": "2026-02-05T16:18:00.000000Z",
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "rollbackToDeployId": "dep-cukouhrtq21c73e9scnf",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "build_in_progress",
+    "trigger": "rollback"
+  },
+  "timestamp": "2026-02-05T16:18:00.000000Z",
+  "type": "render.deploy"
+}
+```
+
+<a id="update-env-var"></a>
+
+## Update Env Var
+
+The Update Env Var component updates a Render service environment variable.
+
+### Use Cases
+
+- **Rotate secrets**: Generate a new value for an env var (for example, API tokens) and optionally emit it
+- **Configuration changes**: Update non-secret environment values as part of a workflow
+
+### Configuration
+
+- **Service**: Render service that owns the env var
+- **Key**: Env var key to update
+- **Value Strategy**:
+  - `Set value`: provide the `Value` field
+  - `Generate value`: request Render to generate a new value
+- **Value**: New env var value (sensitive). Required when using `Set value`
+- **Emit Value**: When enabled, include the env var `value` in output. Disabled by default to avoid leaking secrets.
+
+### Output
+
+Emits a `render.envVar.updated` payload with `serviceId`, `key`, and a `valueGenerated` boolean. The `value` field is only included when `emitValue` is enabled.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "key": "DATABASE_URL",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "valueGenerated": false
+  },
+  "timestamp": "2026-02-05T16:25:00.000000Z",
+  "type": "render.envVar.updated"
 }
 ```
 

--- a/pkg/integrations/render/cancel_deploy.go
+++ b/pkg/integrations/render/cancel_deploy.go
@@ -1,0 +1,156 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CancelDeploy struct{}
+
+type CancelDeployConfiguration struct {
+	Service  string `json:"service" mapstructure:"service"`
+	DeployID string `json:"deployId" mapstructure:"deployId"`
+}
+
+func (c *CancelDeploy) Name() string {
+	return "render.cancelDeploy"
+}
+
+func (c *CancelDeploy) Label() string {
+	return "Cancel Deploy"
+}
+
+func (c *CancelDeploy) Description() string {
+	return "Cancel an in-progress deploy for a Render service"
+}
+
+func (c *CancelDeploy) Documentation() string {
+	return `The Cancel Deploy component cancels an in-progress deploy for a Render service.
+
+## Use Cases
+
+- **Automated rollback/abort**: Cancel deploys when health checks fail
+- **Manual intervention**: Stop a deploy triggered earlier in a workflow
+
+## Configuration
+
+- **Service**: Render service that owns the deploy
+- **Deploy ID**: Deploy ID to cancel (supports expressions)
+
+## Output
+
+Emits a ` + "`render.deploy`" + ` payload for the cancelled deploy (status is typically ` + "`canceled`" + `).`
+}
+
+func (c *CancelDeploy) Icon() string {
+	return "circle-slash-2"
+}
+
+func (c *CancelDeploy) Color() string {
+	return "gray"
+}
+
+func (c *CancelDeploy) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CancelDeploy) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service that owns the deploy",
+		},
+		{
+			Name:        "deployId",
+			Label:       "Deploy ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Description: "Render deploy ID to cancel",
+		},
+	}
+}
+
+func decodeCancelDeployConfiguration(configuration any) (CancelDeployConfiguration, error) {
+	spec := CancelDeployConfiguration{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return CancelDeployConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	spec.DeployID = strings.TrimSpace(spec.DeployID)
+	if spec.Service == "" {
+		return CancelDeployConfiguration{}, fmt.Errorf("service is required")
+	}
+	if spec.DeployID == "" {
+		return CancelDeployConfiguration{}, fmt.Errorf("deployId is required")
+	}
+
+	return spec, nil
+}
+
+func (c *CancelDeploy) Setup(ctx core.SetupContext) error {
+	_, err := decodeCancelDeployConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *CancelDeploy) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CancelDeploy) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeCancelDeployConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	deploy, err := client.CancelDeploy(spec.Service, spec.DeployID)
+	if err != nil {
+		return err
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetDeployPayloadType,
+		[]any{deployDataFromDeployResponse(spec.Service, deploy)},
+	)
+}
+
+func (c *CancelDeploy) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *CancelDeploy) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *CancelDeploy) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *CancelDeploy) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CancelDeploy) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/cancel_deploy_test.go
+++ b/pkg/integrations/render/cancel_deploy_test.go
@@ -1,0 +1,75 @@
+package render
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_CancelDeploy__Setup(t *testing.T) {
+	component := &CancelDeploy{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"deployId": "dep-123"}})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("missing deployId -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123"}})
+		require.ErrorContains(t, err, "deployId is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123", "deployId": "dep-123"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_CancelDeploy__Execute(t *testing.T) {
+	component := &CancelDeploy{}
+
+	t.Run("valid configuration -> cancels deploy and emits payload", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"id":"dep-123","status":"canceled","trigger":"api","finishedAt":"2026-02-05T16:12:00.000000Z"}`,
+					)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration:  map[string]any{"service": "srv-123", "deployId": "dep-123"},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, GetDeployPayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "dep-123", data["deployId"])
+		assert.Equal(t, "canceled", data["status"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/deploys/dep-123/cancel")
+	})
+}

--- a/pkg/integrations/render/example.go
+++ b/pkg/integrations/render/example.go
@@ -16,6 +16,24 @@ var exampleDataOnBuildBytes []byte
 //go:embed example_output_deploy.json
 var exampleOutputDeployBytes []byte
 
+//go:embed example_output_get_service.json
+var exampleOutputGetServiceBytes []byte
+
+//go:embed example_output_get_deploy.json
+var exampleOutputGetDeployBytes []byte
+
+//go:embed example_output_cancel_deploy.json
+var exampleOutputCancelDeployBytes []byte
+
+//go:embed example_output_rollback_deploy.json
+var exampleOutputRollbackDeployBytes []byte
+
+//go:embed example_output_purge_cache.json
+var exampleOutputPurgeCacheBytes []byte
+
+//go:embed example_output_update_env_var.json
+var exampleOutputUpdateEnvVarBytes []byte
+
 var exampleDataOnDeployOnce sync.Once
 var exampleDataOnDeploy map[string]any
 
@@ -24,6 +42,24 @@ var exampleDataOnBuild map[string]any
 
 var exampleOutputDeployOnce sync.Once
 var exampleOutputDeploy map[string]any
+
+var exampleOutputGetServiceOnce sync.Once
+var exampleOutputGetService map[string]any
+
+var exampleOutputGetDeployOnce sync.Once
+var exampleOutputGetDeploy map[string]any
+
+var exampleOutputCancelDeployOnce sync.Once
+var exampleOutputCancelDeploy map[string]any
+
+var exampleOutputRollbackDeployOnce sync.Once
+var exampleOutputRollbackDeploy map[string]any
+
+var exampleOutputPurgeCacheOnce sync.Once
+var exampleOutputPurgeCache map[string]any
+
+var exampleOutputUpdateEnvVarOnce sync.Once
+var exampleOutputUpdateEnvVar map[string]any
 
 func (t *OnDeploy) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(
@@ -46,5 +82,53 @@ func (c *Deploy) ExampleOutput() map[string]any {
 		&exampleOutputDeployOnce,
 		exampleOutputDeployBytes,
 		&exampleOutputDeploy,
+	)
+}
+
+func (c *GetService) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetServiceOnce,
+		exampleOutputGetServiceBytes,
+		&exampleOutputGetService,
+	)
+}
+
+func (c *GetDeploy) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetDeployOnce,
+		exampleOutputGetDeployBytes,
+		&exampleOutputGetDeploy,
+	)
+}
+
+func (c *CancelDeploy) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputCancelDeployOnce,
+		exampleOutputCancelDeployBytes,
+		&exampleOutputCancelDeploy,
+	)
+}
+
+func (c *RollbackDeploy) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputRollbackDeployOnce,
+		exampleOutputRollbackDeployBytes,
+		&exampleOutputRollbackDeploy,
+	)
+}
+
+func (c *PurgeCache) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputPurgeCacheOnce,
+		exampleOutputPurgeCacheBytes,
+		&exampleOutputPurgeCache,
+	)
+}
+
+func (c *UpdateEnvVar) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputUpdateEnvVarOnce,
+		exampleOutputUpdateEnvVarBytes,
+		&exampleOutputUpdateEnvVar,
 	)
 }

--- a/pkg/integrations/render/example_output_cancel_deploy.json
+++ b/pkg/integrations/render/example_output_cancel_deploy.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "canceled",
+    "trigger": "api",
+    "createdAt": "2026-02-05T16:10:00.000000Z",
+    "finishedAt": "2026-02-05T16:12:00.000000Z"
+  },
+  "timestamp": "2026-02-05T16:12:00.000000Z",
+  "type": "render.deploy"
+}

--- a/pkg/integrations/render/example_output_get_deploy.json
+++ b/pkg/integrations/render/example_output_get_deploy.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "live",
+    "trigger": "api",
+    "createdAt": "2026-02-05T16:10:00.000000Z",
+    "startedAt": "2026-02-05T16:10:10.000000Z",
+    "finishedAt": "2026-02-05T16:15:00.000000Z",
+    "commit": {
+      "id": "1a2b3c4d5e6f",
+      "message": "Release v1.2.3",
+      "createdAt": "2026-02-05T16:09:30.000000Z"
+    },
+    "image": {
+      "ref": "registry.example.com/backend-api:1a2b3c4d",
+      "sha": "sha256:4f7c2d7f0bb27e2f8d4d9b3d2b3a1a9a3b2c1d0e"
+    }
+  },
+  "timestamp": "2026-02-05T16:15:00.000000Z",
+  "type": "render.deploy"
+}

--- a/pkg/integrations/render/example_output_get_service.json
+++ b/pkg/integrations/render/example_output_get_service.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "serviceName": "backend-api",
+    "type": "web_service",
+    "dashboardUrl": "https://dashboard.render.com/web/srv-cukouhrtq21c73e9scng",
+    "suspended": false,
+    "createdAt": "2026-02-05T15:00:00.000000Z",
+    "updatedAt": "2026-02-05T16:00:00.000000Z"
+  },
+  "timestamp": "2026-02-05T16:05:00.000000Z",
+  "type": "render.service"
+}

--- a/pkg/integrations/render/example_output_purge_cache.json
+++ b/pkg/integrations/render/example_output_purge_cache.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "accepted"
+  },
+  "timestamp": "2026-02-05T16:20:00.000000Z",
+  "type": "render.cache.purge.requested"
+}

--- a/pkg/integrations/render/example_output_rollback_deploy.json
+++ b/pkg/integrations/render/example_output_rollback_deploy.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "deployId": "dep-cukouhrtq21c73e9scng",
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "status": "build_in_progress",
+    "trigger": "rollback",
+    "createdAt": "2026-02-05T16:18:00.000000Z",
+    "rollbackToDeployId": "dep-cukouhrtq21c73e9scnf"
+  },
+  "timestamp": "2026-02-05T16:18:00.000000Z",
+  "type": "render.deploy"
+}

--- a/pkg/integrations/render/example_output_update_env_var.json
+++ b/pkg/integrations/render/example_output_update_env_var.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "serviceId": "srv-cukouhrtq21c73e9scng",
+    "key": "DATABASE_URL",
+    "valueGenerated": false
+  },
+  "timestamp": "2026-02-05T16:25:00.000000Z",
+  "type": "render.envVar.updated"
+}

--- a/pkg/integrations/render/get_deploy.go
+++ b/pkg/integrations/render/get_deploy.go
@@ -1,0 +1,158 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetDeployPayloadType = "render.deploy"
+
+type GetDeploy struct{}
+
+type GetDeployConfiguration struct {
+	Service  string `json:"service" mapstructure:"service"`
+	DeployID string `json:"deployId" mapstructure:"deployId"`
+}
+
+func (c *GetDeploy) Name() string {
+	return "render.getDeploy"
+}
+
+func (c *GetDeploy) Label() string {
+	return "Get Deploy"
+}
+
+func (c *GetDeploy) Description() string {
+	return "Retrieve a deploy by ID for a Render service"
+}
+
+func (c *GetDeploy) Documentation() string {
+	return `The Get Deploy component fetches a deploy for a Render service.
+
+## Use Cases
+
+- **Status checks**: Inspect deploy status and timestamps
+- **Debugging**: Fetch deploy metadata after receiving an event
+
+## Configuration
+
+- **Service**: Render service that owns the deploy
+- **Deploy ID**: Deploy ID to retrieve (supports expressions)
+
+## Output
+
+Emits a ` + "`render.deploy`" + ` payload containing deploy fields like ` + "`deployId`" + `, ` + "`status`" + `, ` + "`trigger`" + `, and timestamps when available.`
+}
+
+func (c *GetDeploy) Icon() string {
+	return "rocket"
+}
+
+func (c *GetDeploy) Color() string {
+	return "gray"
+}
+
+func (c *GetDeploy) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetDeploy) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service that owns the deploy",
+		},
+		{
+			Name:        "deployId",
+			Label:       "Deploy ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Description: "Render deploy ID to retrieve",
+		},
+	}
+}
+
+func decodeGetDeployConfiguration(configuration any) (GetDeployConfiguration, error) {
+	spec := GetDeployConfiguration{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return GetDeployConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	spec.DeployID = strings.TrimSpace(spec.DeployID)
+	if spec.Service == "" {
+		return GetDeployConfiguration{}, fmt.Errorf("service is required")
+	}
+	if spec.DeployID == "" {
+		return GetDeployConfiguration{}, fmt.Errorf("deployId is required")
+	}
+
+	return spec, nil
+}
+
+func (c *GetDeploy) Setup(ctx core.SetupContext) error {
+	_, err := decodeGetDeployConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *GetDeploy) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetDeploy) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeGetDeployConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	deploy, err := client.GetDeploy(spec.Service, spec.DeployID)
+	if err != nil {
+		return err
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetDeployPayloadType,
+		[]any{deployDataFromDeployResponse(spec.Service, deploy)},
+	)
+}
+
+func (c *GetDeploy) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *GetDeploy) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *GetDeploy) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *GetDeploy) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetDeploy) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/get_deploy_test.go
+++ b/pkg/integrations/render/get_deploy_test.go
@@ -1,0 +1,76 @@
+package render
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_GetDeploy__Setup(t *testing.T) {
+	component := &GetDeploy{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"deployId": "dep-123"}})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("missing deployId -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123"}})
+		require.ErrorContains(t, err, "deployId is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123", "deployId": "dep-123"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_GetDeploy__Execute(t *testing.T) {
+	component := &GetDeploy{}
+
+	t.Run("valid configuration -> emits deploy payload", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"id":"dep-123","status":"live","trigger":"api","createdAt":"2026-02-05T16:10:00.000000Z"}`,
+					)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration:  map[string]any{"service": "srv-123", "deployId": "dep-123"},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, GetDeployPayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "dep-123", data["deployId"])
+		assert.Equal(t, "live", data["status"])
+		assert.Equal(t, "api", data["trigger"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/deploys/dep-123")
+	})
+}

--- a/pkg/integrations/render/get_service.go
+++ b/pkg/integrations/render/get_service.go
@@ -1,0 +1,144 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetServicePayloadType = "render.service"
+
+type GetService struct{}
+
+type GetServiceConfiguration struct {
+	Service string `json:"service" mapstructure:"service"`
+}
+
+func (c *GetService) Name() string {
+	return "render.getService"
+}
+
+func (c *GetService) Label() string {
+	return "Get Service"
+}
+
+func (c *GetService) Description() string {
+	return "Retrieve a Render service by ID"
+}
+
+func (c *GetService) Documentation() string {
+	return `The Get Service component fetches details for a Render service.
+
+## Use Cases
+
+- **Service inspection**: Fetch current service configuration and metadata
+- **Workflow context**: Use service fields to drive branching decisions in later steps
+
+## Configuration
+
+- **Service**: Render service to retrieve
+
+## Output
+
+Emits a ` + "`render.service`" + ` payload containing service fields like ` + "`serviceId`" + `, ` + "`serviceName`" + `, ` + "`type`" + `, ` + "`dashboardUrl`" + `, and ` + "`suspended`" + `.`
+}
+
+func (c *GetService) Icon() string {
+	return "server"
+}
+
+func (c *GetService) Color() string {
+	return "gray"
+}
+
+func (c *GetService) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetService) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service to retrieve",
+		},
+	}
+}
+
+func decodeGetServiceConfiguration(configuration any) (GetServiceConfiguration, error) {
+	spec := GetServiceConfiguration{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return GetServiceConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	if spec.Service == "" {
+		return GetServiceConfiguration{}, fmt.Errorf("service is required")
+	}
+
+	return spec, nil
+}
+
+func (c *GetService) Setup(ctx core.SetupContext) error {
+	_, err := decodeGetServiceConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *GetService) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetService) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeGetServiceConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	service, err := client.GetService(spec.Service)
+	if err != nil {
+		return err
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetServicePayloadType,
+		[]any{serviceDataFromService(service)},
+	)
+}
+
+func (c *GetService) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *GetService) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *GetService) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *GetService) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetService) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/get_service_test.go
+++ b/pkg/integrations/render/get_service_test.go
@@ -1,0 +1,68 @@
+package render
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_GetService__Setup(t *testing.T) {
+	component := &GetService{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{}})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_GetService__Execute(t *testing.T) {
+	component := &GetService{}
+
+	t.Run("valid configuration -> emits service payload", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"srv-123","name":"backend-api","suspended":"not_suspended"}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration:  map[string]any{"service": "srv-123"},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, GetServicePayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "backend-api", data["serviceName"])
+		assert.Equal(t, "not_suspended", data["suspended"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123")
+	})
+}

--- a/pkg/integrations/render/payloads.go
+++ b/pkg/integrations/render/payloads.go
@@ -1,0 +1,117 @@
+package render
+
+func serviceDataFromService(service Service) map[string]any {
+	data := map[string]any{
+		"serviceId":   service.ID,
+		"serviceName": service.Name,
+		"suspended":   service.Suspended,
+	}
+
+	if service.OwnerID != "" {
+		data["ownerId"] = service.OwnerID
+	}
+	if service.Type != "" {
+		data["type"] = service.Type
+	}
+	if service.CreatedAt != "" {
+		data["createdAt"] = service.CreatedAt
+	}
+	if service.UpdatedAt != "" {
+		data["updatedAt"] = service.UpdatedAt
+	}
+	if service.DashboardURL != "" {
+		data["dashboardUrl"] = service.DashboardURL
+	}
+	if service.Slug != "" {
+		data["slug"] = service.Slug
+	}
+	if service.RootDir != "" {
+		data["rootDir"] = service.RootDir
+	}
+	if len(service.Suspenders) > 0 {
+		data["suspenders"] = service.Suspenders
+	}
+	if service.AutoDeploy != "" {
+		data["autoDeploy"] = service.AutoDeploy
+	}
+	if service.NotifyOnFail != "" {
+		data["notifyOnFail"] = service.NotifyOnFail
+	}
+	if service.Repo != "" {
+		data["repo"] = service.Repo
+	}
+	if service.Branch != "" {
+		data["branch"] = service.Branch
+	}
+	if service.EnvironmentID != "" {
+		data["environmentId"] = service.EnvironmentID
+	}
+	if service.ImagePath != "" {
+		data["imagePath"] = service.ImagePath
+	}
+	if len(service.ServiceDetails) > 0 {
+		data["serviceDetails"] = service.ServiceDetails
+	}
+
+	return data
+}
+
+func deployDataFromDeployResponse(serviceID string, deploy DeployResponse) map[string]any {
+	data := map[string]any{
+		"deployId":  deploy.ID,
+		"serviceId": serviceID,
+	}
+
+	if deploy.Status != "" {
+		data["status"] = deploy.Status
+	}
+	if deploy.Trigger != "" {
+		data["trigger"] = deploy.Trigger
+	}
+	if deploy.CreatedAt != "" {
+		data["createdAt"] = deploy.CreatedAt
+	}
+	if deploy.UpdatedAt != "" {
+		data["updatedAt"] = deploy.UpdatedAt
+	}
+	if deploy.StartedAt != "" {
+		data["startedAt"] = deploy.StartedAt
+	}
+	if deploy.FinishedAt != "" {
+		data["finishedAt"] = deploy.FinishedAt
+	}
+
+	if deploy.Commit != nil {
+		commit := map[string]any{}
+		if deploy.Commit.ID != "" {
+			commit["id"] = deploy.Commit.ID
+		}
+		if deploy.Commit.Message != "" {
+			commit["message"] = deploy.Commit.Message
+		}
+		if deploy.Commit.CreatedAt != "" {
+			commit["createdAt"] = deploy.Commit.CreatedAt
+		}
+		if len(commit) > 0 {
+			data["commit"] = commit
+		}
+	}
+
+	if deploy.Image != nil {
+		image := map[string]any{}
+		if deploy.Image.Ref != "" {
+			image["ref"] = deploy.Image.Ref
+		}
+		if deploy.Image.SHA != "" {
+			image["sha"] = deploy.Image.SHA
+		}
+		if deploy.Image.RegistryCredential != "" {
+			image["registryCredential"] = deploy.Image.RegistryCredential
+		}
+		if len(image) > 0 {
+			data["image"] = image
+		}
+	}
+
+	return data
+}

--- a/pkg/integrations/render/purge_cache.go
+++ b/pkg/integrations/render/purge_cache.go
@@ -1,0 +1,148 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const PurgeCachePayloadType = "render.cache.purge.requested"
+
+type PurgeCache struct{}
+
+type PurgeCacheConfiguration struct {
+	Service string `json:"service" mapstructure:"service"`
+}
+
+func (c *PurgeCache) Name() string {
+	return "render.purgeCache"
+}
+
+func (c *PurgeCache) Label() string {
+	return "Purge Cache"
+}
+
+func (c *PurgeCache) Description() string {
+	return "Request a purge of the build cache for a Render service"
+}
+
+func (c *PurgeCache) Documentation() string {
+	return `The Purge Cache component requests a build cache purge for a Render service.
+
+## Use Cases
+
+- **Cache reset**: Force a clean rebuild when you suspect stale dependencies or build artifacts
+- **Operational tooling**: Provide a one-click cache purge in incident response workflows
+
+## Configuration
+
+- **Service**: Render service whose build cache should be purged
+
+## Output
+
+Emits a ` + "`render.cache.purge.requested`" + ` payload with ` + "`serviceId`" + ` and a ` + "`status`" + ` field indicating the request was accepted.`
+}
+
+func (c *PurgeCache) Icon() string {
+	return "trash-2"
+}
+
+func (c *PurgeCache) Color() string {
+	return "gray"
+}
+
+func (c *PurgeCache) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *PurgeCache) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service whose build cache should be purged",
+		},
+	}
+}
+
+func decodePurgeCacheConfiguration(configuration any) (PurgeCacheConfiguration, error) {
+	spec := PurgeCacheConfiguration{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return PurgeCacheConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	if spec.Service == "" {
+		return PurgeCacheConfiguration{}, fmt.Errorf("service is required")
+	}
+
+	return spec, nil
+}
+
+func (c *PurgeCache) Setup(ctx core.SetupContext) error {
+	_, err := decodePurgeCacheConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *PurgeCache) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *PurgeCache) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodePurgeCacheConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	if err := client.PurgeCache(spec.Service); err != nil {
+		return err
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		PurgeCachePayloadType,
+		[]any{
+			map[string]any{
+				"serviceId": spec.Service,
+				"status":    "accepted",
+			},
+		},
+	)
+}
+
+func (c *PurgeCache) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *PurgeCache) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *PurgeCache) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *PurgeCache) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *PurgeCache) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/purge_cache_test.go
+++ b/pkg/integrations/render/purge_cache_test.go
@@ -1,0 +1,67 @@
+package render
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_PurgeCache__Setup(t *testing.T) {
+	component := &PurgeCache{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{}})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_PurgeCache__Execute(t *testing.T) {
+	component := &PurgeCache{}
+
+	t.Run("valid configuration -> purges cache and emits payload", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusAccepted,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration:  map[string]any{"service": "srv-123"},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, PurgeCachePayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "accepted", data["status"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/cache/purge")
+	})
+}

--- a/pkg/integrations/render/render.go
+++ b/pkg/integrations/render/render.go
@@ -100,6 +100,12 @@ func (r *Render) Configuration() []configuration.Field {
 func (r *Render) Components() []core.Component {
 	return []core.Component{
 		&Deploy{},
+		&GetService{},
+		&GetDeploy{},
+		&CancelDeploy{},
+		&RollbackDeploy{},
+		&PurgeCache{},
+		&UpdateEnvVar{},
 	}
 }
 

--- a/pkg/integrations/render/rollback_deploy.go
+++ b/pkg/integrations/render/rollback_deploy.go
@@ -1,0 +1,159 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type RollbackDeploy struct{}
+
+type RollbackDeployConfiguration struct {
+	Service            string `json:"service" mapstructure:"service"`
+	RollbackToDeployID string `json:"deployId" mapstructure:"deployId"`
+}
+
+func (c *RollbackDeploy) Name() string {
+	return "render.rollbackDeploy"
+}
+
+func (c *RollbackDeploy) Label() string {
+	return "Rollback Deploy"
+}
+
+func (c *RollbackDeploy) Description() string {
+	return "Roll back a Render service to a previous deploy"
+}
+
+func (c *RollbackDeploy) Documentation() string {
+	return `The Rollback Deploy component triggers a rollback deploy for a Render service.
+
+## Use Cases
+
+- **Automated recovery**: Roll back after detecting errors in a new deploy
+- **One-click rollback**: Trigger rollbacks from an incident workflow
+
+## Configuration
+
+- **Service**: Render service to roll back
+- **Deploy ID**: The deploy ID to roll back to (supports expressions)
+
+## Output
+
+Emits a ` + "`render.deploy`" + ` payload for the new rollback deploy, and includes the ` + "`rollbackToDeployId`" + ` field for reference.`
+}
+
+func (c *RollbackDeploy) Icon() string {
+	return "rotate-ccw"
+}
+
+func (c *RollbackDeploy) Color() string {
+	return "gray"
+}
+
+func (c *RollbackDeploy) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *RollbackDeploy) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service to roll back",
+		},
+		{
+			Name:        "deployId",
+			Label:       "Deploy ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Description: "Deploy ID to roll back to",
+		},
+	}
+}
+
+func decodeRollbackDeployConfiguration(configuration any) (RollbackDeployConfiguration, error) {
+	spec := RollbackDeployConfiguration{}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return RollbackDeployConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	spec.RollbackToDeployID = strings.TrimSpace(spec.RollbackToDeployID)
+	if spec.Service == "" {
+		return RollbackDeployConfiguration{}, fmt.Errorf("service is required")
+	}
+	if spec.RollbackToDeployID == "" {
+		return RollbackDeployConfiguration{}, fmt.Errorf("deployId is required")
+	}
+
+	return spec, nil
+}
+
+func (c *RollbackDeploy) Setup(ctx core.SetupContext) error {
+	_, err := decodeRollbackDeployConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *RollbackDeploy) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *RollbackDeploy) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeRollbackDeployConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	deploy, err := client.RollbackDeploy(spec.Service, spec.RollbackToDeployID)
+	if err != nil {
+		return err
+	}
+
+	data := deployDataFromDeployResponse(spec.Service, deploy)
+	data["rollbackToDeployId"] = spec.RollbackToDeployID
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetDeployPayloadType,
+		[]any{data},
+	)
+}
+
+func (c *RollbackDeploy) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *RollbackDeploy) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *RollbackDeploy) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *RollbackDeploy) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *RollbackDeploy) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/rollback_deploy_test.go
+++ b/pkg/integrations/render/rollback_deploy_test.go
@@ -1,0 +1,84 @@
+package render
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_RollbackDeploy__Setup(t *testing.T) {
+	component := &RollbackDeploy{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"deployId": "dep-123"}})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("missing deployId -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123"}})
+		require.ErrorContains(t, err, "deployId is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{"service": "srv-123", "deployId": "dep-123"}})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_RollbackDeploy__Execute(t *testing.T) {
+	component := &RollbackDeploy{}
+
+	t.Run("valid configuration -> triggers rollback and emits payload", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"id":"dep-new","status":"build_in_progress","trigger":"rollback","createdAt":"2026-02-05T16:18:00.000000Z"}`,
+					)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration:  map[string]any{"service": "srv-123", "deployId": "dep-old"},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, GetDeployPayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "dep-new", data["deployId"])
+		assert.Equal(t, "dep-old", data["rollbackToDeployId"])
+		assert.Equal(t, "rollback", data["trigger"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/rollback")
+
+		body, readErr := io.ReadAll(request.Body)
+		require.NoError(t, readErr)
+
+		payload := map[string]any{}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, "dep-old", payload["deployId"])
+	})
+}

--- a/pkg/integrations/render/update_env_var.go
+++ b/pkg/integrations/render/update_env_var.go
@@ -1,0 +1,252 @@
+package render
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const UpdateEnvVarPayloadType = "render.envVar.updated"
+
+const (
+	updateEnvVarValueStrategySet      = "set"
+	updateEnvVarValueStrategyGenerate = "generate"
+)
+
+type UpdateEnvVar struct{}
+
+type UpdateEnvVarConfiguration struct {
+	Service       string  `json:"service" mapstructure:"service"`
+	Key           string  `json:"key" mapstructure:"key"`
+	ValueStrategy string  `json:"valueStrategy" mapstructure:"valueStrategy"`
+	Value         *string `json:"value" mapstructure:"value"`
+	EmitValue     bool    `json:"emitValue" mapstructure:"emitValue"`
+}
+
+func (c *UpdateEnvVar) Name() string {
+	return "render.updateEnvVar"
+}
+
+func (c *UpdateEnvVar) Label() string {
+	return "Update Env Var"
+}
+
+func (c *UpdateEnvVar) Description() string {
+	return "Update or generate a value for a Render service environment variable"
+}
+
+func (c *UpdateEnvVar) Documentation() string {
+	return `The Update Env Var component updates a Render service environment variable.
+
+## Use Cases
+
+- **Rotate secrets**: Generate a new value for an env var (for example, API tokens) and optionally emit it
+- **Configuration changes**: Update non-secret environment values as part of a workflow
+
+## Configuration
+
+- **Service**: Render service that owns the env var
+- **Key**: Env var key to update
+- **Value Strategy**:
+  - ` + "`Set value`" + `: provide the ` + "`Value`" + ` field
+  - ` + "`Generate value`" + `: request Render to generate a new value
+- **Value**: New env var value (sensitive). Required when using ` + "`Set value`" + `
+- **Emit Value**: When enabled, include the env var ` + "`value`" + ` in output. Disabled by default to avoid leaking secrets.
+
+## Output
+
+Emits a ` + "`render.envVar.updated`" + ` payload with ` + "`serviceId`" + `, ` + "`key`" + `, and a ` + "`valueGenerated`" + ` boolean. The ` + "`value`" + ` field is only included when ` + "`emitValue`" + ` is enabled.`
+}
+
+func (c *UpdateEnvVar) Icon() string {
+	return "sliders-horizontal"
+}
+
+func (c *UpdateEnvVar) Color() string {
+	return "gray"
+}
+
+func (c *UpdateEnvVar) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateEnvVar) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "service",
+			Label:    "Service",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "service",
+				},
+			},
+			Description: "Render service that owns the env var",
+		},
+		{
+			Name:        "key",
+			Label:       "Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., DATABASE_URL",
+			Description: "Env var key to update",
+		},
+		{
+			Name:        "valueStrategy",
+			Label:       "Value Strategy",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     updateEnvVarValueStrategySet,
+			Description: "How to update the env var value",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Set value", Value: updateEnvVarValueStrategySet},
+						{Label: "Generate value", Value: updateEnvVarValueStrategyGenerate},
+					},
+				},
+			},
+		},
+		{
+			Name:        "value",
+			Label:       "Value",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Sensitive:   true,
+			Description: "New env var value (only used when value strategy is set)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "valueStrategy", Values: []string{updateEnvVarValueStrategySet}},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "valueStrategy", Values: []string{updateEnvVarValueStrategySet}},
+			},
+		},
+		{
+			Name:        "emitValue",
+			Label:       "Emit Value",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     false,
+			Description: "When enabled, include the env var value in output (disabled by default to avoid leaking secrets)",
+		},
+	}
+}
+
+func decodeUpdateEnvVarConfiguration(configuration any) (UpdateEnvVarConfiguration, error) {
+	spec := UpdateEnvVarConfiguration{
+		ValueStrategy: updateEnvVarValueStrategySet,
+	}
+	if err := mapstructure.Decode(configuration, &spec); err != nil {
+		return UpdateEnvVarConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	spec.Service = strings.TrimSpace(spec.Service)
+	spec.Key = strings.TrimSpace(spec.Key)
+	spec.ValueStrategy = strings.ToLower(strings.TrimSpace(spec.ValueStrategy))
+	if spec.ValueStrategy == "" {
+		spec.ValueStrategy = updateEnvVarValueStrategySet
+	}
+
+	if spec.Service == "" {
+		return UpdateEnvVarConfiguration{}, fmt.Errorf("service is required")
+	}
+	if spec.Key == "" {
+		return UpdateEnvVarConfiguration{}, fmt.Errorf("key is required")
+	}
+
+	switch spec.ValueStrategy {
+	case updateEnvVarValueStrategySet:
+		if spec.Value == nil {
+			return UpdateEnvVarConfiguration{}, fmt.Errorf("value is required")
+		}
+	case updateEnvVarValueStrategyGenerate:
+	default:
+		return UpdateEnvVarConfiguration{}, fmt.Errorf("invalid valueStrategy: %s", spec.ValueStrategy)
+	}
+
+	return spec, nil
+}
+
+func (c *UpdateEnvVar) Setup(ctx core.SetupContext) error {
+	_, err := decodeUpdateEnvVarConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *UpdateEnvVar) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateEnvVar) Execute(ctx core.ExecutionContext) error {
+	spec, err := decodeUpdateEnvVarConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	request := UpdateEnvVarRequest{}
+	valueGenerated := false
+	switch spec.ValueStrategy {
+	case updateEnvVarValueStrategyGenerate:
+		valueGenerated = true
+		generate := true
+		request.GenerateValue = &generate
+	case updateEnvVarValueStrategySet:
+		request.Value = spec.Value
+	}
+
+	envVar, err := client.UpdateEnvVar(spec.Service, spec.Key, request)
+	if err != nil {
+		return err
+	}
+
+	key := strings.TrimSpace(envVar.Key)
+	if key == "" {
+		key = spec.Key
+	}
+
+	data := map[string]any{
+		"serviceId":      spec.Service,
+		"key":            key,
+		"valueGenerated": valueGenerated,
+	}
+
+	if spec.EmitValue {
+		data["value"] = envVar.Value
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		UpdateEnvVarPayloadType,
+		[]any{data},
+	)
+}
+
+func (c *UpdateEnvVar) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *UpdateEnvVar) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *UpdateEnvVar) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *UpdateEnvVar) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateEnvVar) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/render/update_env_var_test.go
+++ b/pkg/integrations/render/update_env_var_test.go
@@ -1,0 +1,159 @@
+package render
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Render_UpdateEnvVar__Setup(t *testing.T) {
+	component := &UpdateEnvVar{}
+
+	t.Run("missing service -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"key": "DATABASE_URL", "value": "postgres://..."},
+		})
+		require.ErrorContains(t, err, "service is required")
+	})
+
+	t.Run("missing key -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"service": "srv-123", "value": "postgres://..."},
+		})
+		require.ErrorContains(t, err, "key is required")
+	})
+
+	t.Run("set strategy without value -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"service": "srv-123", "key": "DATABASE_URL"},
+		})
+		require.ErrorContains(t, err, "value is required")
+	})
+
+	t.Run("generate strategy without value -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"service": "srv-123", "key": "DATABASE_URL", "valueStrategy": "generate"},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test__Render_UpdateEnvVar__Execute(t *testing.T) {
+	component := &UpdateEnvVar{}
+
+	t.Run("set strategy -> updates env var and does not emit value by default", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"key":"DATABASE_URL","value":"postgres://example"}`,
+					)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"service":       "srv-123",
+				"key":           "DATABASE_URL",
+				"valueStrategy": "set",
+				"value":         "postgres://example",
+			},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, UpdateEnvVarPayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "DATABASE_URL", data["key"])
+		assert.Equal(t, false, data["valueGenerated"])
+		_, hasValue := data["value"]
+		assert.False(t, hasValue)
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPut, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/env-vars/DATABASE_URL")
+
+		body, readErr := io.ReadAll(request.Body)
+		require.NoError(t, readErr)
+
+		payload := map[string]any{}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, "postgres://example", payload["value"])
+		_, hasGenerateValue := payload["generateValue"]
+		assert.False(t, hasGenerateValue)
+	})
+
+	t.Run("generate strategy with emitValue -> emits generated value", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"key":"API_TOKEN","value":"generated"}`,
+					)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			HTTP:           httpCtx,
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "rnd_test"}},
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"service":       "srv-123",
+				"key":           "API_TOKEN",
+				"valueStrategy": "generate",
+				"emitValue":     true,
+			},
+		})
+
+		require.NoError(t, err)
+
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, UpdateEnvVarPayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		emittedPayload := readMap(executionState.Payloads[0])
+		data := readMap(emittedPayload["data"])
+		assert.Equal(t, "srv-123", data["serviceId"])
+		assert.Equal(t, "API_TOKEN", data["key"])
+		assert.Equal(t, true, data["valueGenerated"])
+		assert.Equal(t, "generated", data["value"])
+
+		require.Len(t, httpCtx.Requests, 1)
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPut, request.Method)
+		assert.Contains(t, request.URL.Path, "/v1/services/srv-123/env-vars/API_TOKEN")
+
+		body, readErr := io.ReadAll(request.Body)
+		require.NoError(t, readErr)
+
+		payload := map[string]any{}
+		require.NoError(t, json.Unmarshal(body, &payload))
+		assert.Equal(t, true, payload["generateValue"])
+		_, hasValue := payload["value"]
+		assert.False(t, hasValue)
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/render/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/base.ts
@@ -1,0 +1,46 @@
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass, getColorClass } from "@/utils/colors";
+import { formatTimeAgo } from "@/utils/date";
+import renderIcon from "@/assets/icons/integrations/render.svg";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import { ComponentDefinition, ExecutionInfo, NodeInfo } from "../types";
+
+export function baseProps(
+  nodes: NodeInfo[],
+  node: NodeInfo,
+  componentDefinition: ComponentDefinition,
+  lastExecutions: ExecutionInfo[],
+): ComponentBaseProps {
+  const lastExecution = lastExecutions.length > 0 ? lastExecutions[0] : null;
+  const componentName = componentDefinition.name || node.componentName || "render.unknown";
+
+  return {
+    title: node.name || componentDefinition.label || componentDefinition.name || "Unnamed component",
+    iconSrc: renderIcon,
+    iconColor: getColorClass(componentDefinition.color),
+    collapsedBackground: getBackgroundColorClass(componentDefinition.color),
+    collapsed: node.isCollapsed,
+    eventSections: lastExecution ? baseEventSections(nodes, lastExecution, componentName) : undefined,
+    includeEmptyState: !lastExecution,
+    eventStateMap: getStateMap(componentName),
+  };
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((node) => node.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? formatTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/render/cancel_deploy.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/cancel_deploy.ts
@@ -1,0 +1,3 @@
+import { getDeployMapper } from "./get_deploy";
+
+export const cancelDeployMapper = getDeployMapper;

--- a/web_src/src/pages/workflowv2/mappers/render/get_deploy.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/get_deploy.ts
@@ -1,0 +1,108 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { formatTimestamp, stringOrDash } from "./common";
+import { baseProps } from "./base";
+
+interface GetDeployConfiguration {
+  service?: string;
+  deployId?: string;
+}
+
+interface DeployCommitOutput {
+  id?: string;
+  message?: string;
+  createdAt?: string;
+}
+
+interface DeployImageOutput {
+  ref?: string;
+  sha?: string;
+}
+
+interface GetDeployOutput {
+  serviceId?: string;
+  deployId?: string;
+  status?: string;
+  trigger?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  rollbackToDeployId?: string;
+  commit?: DeployCommitOutput;
+  image?: DeployImageOutput;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetDeployConfiguration | undefined;
+
+  if (configuration?.service) {
+    metadata.push({ icon: "server", label: `Service: ${configuration.service}` });
+  }
+  if (configuration?.deployId) {
+    metadata.push({ icon: "hash", label: `Deploy: ${configuration.deployId}` });
+  }
+
+  return metadata;
+}
+
+export const getDeployMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    return { ...base, metadata: metadataList(context.node) };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as GetDeployOutput | undefined;
+
+    const details: Record<string, string> = {
+      "Retrieved At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      "Service ID": stringOrDash(result?.serviceId),
+      "Deploy ID": stringOrDash(result?.deployId),
+      Status: stringOrDash(result?.status),
+      Trigger: stringOrDash(result?.trigger),
+      "Created At": formatTimestamp(result?.createdAt),
+      "Started At": formatTimestamp(result?.startedAt),
+      "Finished At": formatTimestamp(result?.finishedAt),
+    };
+
+    if (result?.rollbackToDeployId) {
+      details["Rollback To"] = result.rollbackToDeployId;
+    }
+
+    if (result?.commit?.id) {
+      details["Commit ID"] = result.commit.id;
+    }
+    if (result?.commit?.message) {
+      details["Commit Message"] = result.commit.message;
+    }
+    if (result?.image?.ref) {
+      details["Image Ref"] = result.image.ref;
+    }
+    if (result?.image?.sha) {
+      details["Image SHA"] = result.image.sha;
+    }
+
+    if (result?.updatedAt) {
+      details["Updated At"] = formatTimestamp(result.updatedAt);
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/render/get_service.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/get_service.ts
@@ -1,0 +1,66 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { formatTimestamp, stringOrDash } from "./common";
+import { baseProps } from "./base";
+
+interface GetServiceConfiguration {
+  service?: string;
+}
+
+interface GetServiceOutput {
+  serviceId?: string;
+  serviceName?: string;
+  type?: string;
+  suspended?: boolean;
+  dashboardUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetServiceConfiguration | undefined;
+
+  if (configuration?.service) {
+    metadata.push({ icon: "server", label: `Service: ${configuration.service}` });
+  }
+
+  return metadata;
+}
+
+export const getServiceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    return { ...base, metadata: metadataList(context.node) };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as GetServiceOutput | undefined;
+
+    return {
+      "Retrieved At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      "Service ID": stringOrDash(result?.serviceId),
+      "Service Name": stringOrDash(result?.serviceName),
+      Type: stringOrDash(result?.type),
+      Suspended: result?.suspended === undefined ? "-" : result.suspended ? "Yes" : "No",
+      "Dashboard URL": stringOrDash(result?.dashboardUrl),
+      "Created At": formatTimestamp(result?.createdAt),
+      "Updated At": formatTimestamp(result?.updatedAt),
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/render/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/index.ts
@@ -1,10 +1,22 @@
 import { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { deployMapper, DEPLOY_STATE_REGISTRY } from "./deploy";
+import { cancelDeployMapper } from "./cancel_deploy";
+import { getDeployMapper } from "./get_deploy";
+import { getServiceMapper } from "./get_service";
 import { onBuildTriggerRenderer } from "./on_build";
 import { onDeployTriggerRenderer } from "./on_deploy";
+import { purgeCacheMapper } from "./purge_cache";
+import { rollbackDeployMapper } from "./rollback_deploy";
+import { updateEnvVarMapper } from "./update_env_var";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   deploy: deployMapper,
+  getService: getServiceMapper,
+  getDeploy: getDeployMapper,
+  cancelDeploy: cancelDeployMapper,
+  rollbackDeploy: rollbackDeployMapper,
+  purgeCache: purgeCacheMapper,
+  updateEnvVar: updateEnvVarMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {

--- a/web_src/src/pages/workflowv2/mappers/render/purge_cache.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/purge_cache.ts
@@ -1,0 +1,56 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { stringOrDash } from "./common";
+import { baseProps } from "./base";
+
+interface PurgeCacheConfiguration {
+  service?: string;
+}
+
+interface PurgeCacheOutput {
+  serviceId?: string;
+  status?: string;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as PurgeCacheConfiguration | undefined;
+
+  if (configuration?.service) {
+    metadata.push({ icon: "server", label: `Service: ${configuration.service}` });
+  }
+
+  return metadata;
+}
+
+export const purgeCacheMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    return { ...base, metadata: metadataList(context.node) };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as PurgeCacheOutput | undefined;
+
+    return {
+      "Requested At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      "Service ID": stringOrDash(result?.serviceId),
+      Status: stringOrDash(result?.status),
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/render/rollback_deploy.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/rollback_deploy.ts
@@ -1,0 +1,70 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { formatTimestamp, stringOrDash } from "./common";
+import { baseProps } from "./base";
+
+interface RollbackDeployConfiguration {
+  service?: string;
+  deployId?: string;
+}
+
+interface RollbackDeployOutput {
+  serviceId?: string;
+  deployId?: string;
+  rollbackToDeployId?: string;
+  status?: string;
+  trigger?: string;
+  createdAt?: string;
+  finishedAt?: string;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as RollbackDeployConfiguration | undefined;
+
+  if (configuration?.service) {
+    metadata.push({ icon: "server", label: `Service: ${configuration.service}` });
+  }
+  if (configuration?.deployId) {
+    metadata.push({ icon: "rotate-ccw", label: `Rollback to: ${configuration.deployId}` });
+  }
+
+  return metadata;
+}
+
+export const rollbackDeployMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    return { ...base, metadata: metadataList(context.node) };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as RollbackDeployOutput | undefined;
+
+    return {
+      "Triggered At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      "Service ID": stringOrDash(result?.serviceId),
+      "Deploy ID": stringOrDash(result?.deployId),
+      "Rollback To": stringOrDash(result?.rollbackToDeployId),
+      Status: stringOrDash(result?.status),
+      Trigger: stringOrDash(result?.trigger),
+      "Created At": formatTimestamp(result?.createdAt),
+      "Finished At": formatTimestamp(result?.finishedAt),
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/render/update_env_var.ts
+++ b/web_src/src/pages/workflowv2/mappers/render/update_env_var.ts
@@ -1,0 +1,79 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { stringOrDash } from "./common";
+import { baseProps } from "./base";
+
+interface UpdateEnvVarConfiguration {
+  service?: string;
+  key?: string;
+  valueStrategy?: string;
+  emitValue?: boolean;
+}
+
+interface UpdateEnvVarOutput {
+  serviceId?: string;
+  key?: string;
+  valueGenerated?: boolean;
+  value?: string;
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as UpdateEnvVarConfiguration | undefined;
+
+  if (configuration?.service) {
+    metadata.push({ icon: "server", label: `Service: ${configuration.service}` });
+  }
+  if (configuration?.key) {
+    metadata.push({ icon: "key-round", label: configuration.key });
+  }
+
+  if (configuration?.valueStrategy) {
+    metadata.push({ icon: "sliders-horizontal", label: `Strategy: ${configuration.valueStrategy}` });
+  }
+
+  if (configuration?.emitValue) {
+    metadata.push({ icon: "shield-alert", label: "Emits value" });
+  }
+
+  return metadata;
+}
+
+export const updateEnvVarMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const base = baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+    return { ...base, metadata: metadataList(context.node) };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as UpdateEnvVarOutput | undefined;
+
+    const details: Record<string, string> = {
+      "Updated At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      "Service ID": stringOrDash(result?.serviceId),
+      Key: stringOrDash(result?.key),
+      "Value Generated": result?.valueGenerated === undefined ? "-" : result.valueGenerated ? "Yes" : "No",
+    };
+
+    if (result?.value !== undefined) {
+      details.Value = result.value;
+    }
+
+    return details;
+  },
+};


### PR DESCRIPTION
Closes #2989

Hey! This PR adds 6 new components to the Render integration. I've tested all of them against a live Render service and everything works as expected.

## What's included

**New components:**
- Get Service - fetches service details by ID
- Get Deploy - retrieves deploy info
- Cancel Deploy - stops a running deploy
- Rollback Deploy - rolls back to a previous deploy
- Purge Cache - clears the build cache
- Update Env Var - updates environment variables (supports both set value and generate value strategies)

All components include backend implementation, frontend mappers, tests, and example outputs.

## Implementation notes

Used the Render API v1 with the existing API key auth. The payload structures are kept flat so they're easy to use in workflow expressions.

I did need to fix a small bug in the existing code - the `Service.Suspended` field was typed as `bool` but the API actually returns a string like "not_suspended", so I changed it to match the real API response.

## Demo

https://youtu.be/Ok8-S31hdbI

The video shows all 6 components working against my test service: https://github.com/vikramships/superplane-render-test

## Testing

All 77 unit tests pass. I manually tested each component with the actual Render API to make sure everything behaves correctly.

Let me know if you need any changes!