### PR TITLE
CodeBuild trigger and component

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -8,6 +8,7 @@ Manage resources and execute AWS commands in workflows
 
 <CardGrid>
   <LinkCard title="CodeArtifact • On Package Version" href="#code-artifact-•-on-package-version" description="Listen to AWS CodeArtifact package version events" />
+  <LinkCard title="CodeBuild • On Build" href="#code-build-•-on-build" description="Listen to AWS CodeBuild build state change events" />
   <LinkCard title="ECR • On Image Push" href="#ecr-•-on-image-push" description="Listen to AWS ECR image push events" />
   <LinkCard title="ECR • On Image Scan" href="#ecr-•-on-image-scan" description="Listen to AWS ECR image scan events" />
 </CardGrid>
@@ -18,6 +19,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="CodeArtifact • Get Package Version" href="#code-artifact-•-get-package-version" description="Describe an AWS CodeArtifact package version" />
+  <LinkCard title="CodeBuild • Run Build" href="#code-build-•-run-build" description="Start an AWS CodeBuild build and wait for it to finish" />
   <LinkCard title="ECR • Get Image" href="#ecr-•-get-image" description="Get an ECR image by digest or tag" />
   <LinkCard title="ECR • Get Image Scan Findings" href="#ecr-•-get-image-scan-findings" description="Get ECR image scan findings by digest or tag" />
   <LinkCard title="ECR • Scan Image" href="#ecr-•-scan-image" description="Scan an ECR image for vulnerabilities" />
@@ -80,6 +82,62 @@ The On Package Version trigger starts a workflow execution when a package versio
   },
   "timestamp": "2026-03-10T14:25:30.31254162Z",
   "type": "aws.codeartifact.package.version"
+}
+```
+
+<a id="code-build-•-on-build"></a>
+
+## CodeBuild • On Build
+
+The On Build trigger starts a workflow execution when AWS CodeBuild emits a build state change event.
+
+### Use Cases
+
+- **Build observability**: Trigger notifications when builds fail, succeed, or stop
+- **Automated quality gates**: Start follow-up checks after successful builds
+- **Pipeline orchestration**: Chain downstream workflows based on build outcomes
+
+### Event Data
+
+Each build state change event includes:
+- **detail.project-name**: CodeBuild project name
+- **detail.build-status**: Build status (for example: IN_PROGRESS, SUCCEEDED, FAILED)
+- **detail.build-id**: Build identifier ARN
+- **detail.current-phase**: Current phase of the build lifecycle
+
+### Example Data
+
+```json
+{
+  "data": {
+    "version": "0",
+    "id": "00112233-4455-6677-8899-aabbccddeeff",
+    "detail-type": "CodeBuild Build State Change",
+    "source": "aws.codebuild",
+    "account": "123456789012",
+    "time": "2026-02-03T12:00:00Z",
+    "region": "us-east-1",
+    "resources": [
+      "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20"
+    ],
+    "detail": {
+      "project-name": "backend-build",
+      "build-status": "SUCCEEDED",
+      "build-id": "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "current-phase": "COMPLETED",
+      "current-phase-context": "Build completed successfully",
+      "version": "1",
+      "additional-information": {
+        "initiator": "codepipeline/my-pipeline",
+        "source-version": "refs/heads/main",
+        "logs": {
+          "deep-link": "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build/build/backend-build%3A3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20/log"
+        }
+      }
+    }
+  },
+  "timestamp": "2026-02-03T12:00:01Z",
+  "type": "aws.codebuild.build"
 }
 ```
 
@@ -250,6 +308,53 @@ The Get Package Version component retrieves metadata for a specific package vers
   },
   "timestamp": "2026-02-03T12:00:00Z",
   "type": "aws.codeartifact.package.version"
+}
+```
+
+<a id="code-build-•-run-build"></a>
+
+## CodeBuild • Run Build
+
+The Run Build component starts a build in AWS CodeBuild and waits until the build reaches a terminal state.
+
+### Use Cases
+
+- **CI orchestration**: Trigger builds from workflow automation
+- **Release pipelines**: Block downstream steps until build completion
+- **Quality gates**: Fail workflow execution automatically when builds fail
+
+### How It Works
+
+1. Starts a new build for the selected CodeBuild project
+2. Polls CodeBuild for the build status until completion
+3. Emits build details when the build succeeds
+4. Fails the node if the build finishes with a failed status
+
+### Example Output
+
+```json
+{
+  "data": {
+    "id": "backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+    "arn": "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+    "buildNumber": 42,
+    "currentPhase": "COMPLETED",
+    "buildStatus": "SUCCEEDED",
+    "projectName": "backend-build",
+    "sourceVersion": "refs/heads/main",
+    "initiator": "codepipeline/my-pipeline",
+    "startTime": "2026-02-03T11:58:40Z",
+    "endTime": "2026-02-03T12:00:00Z",
+    "logs": {
+      "deepLink": "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build/build/backend-build%3A3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20/log",
+      "cloudWatchLogsArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/codebuild/backend-build:log-stream:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "groupName": "/aws/codebuild/backend-build",
+      "streamName": "3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "status": "SUCCEEDED"
+    }
+  },
+  "timestamp": "2026-02-03T12:00:00Z",
+  "type": "aws.codebuild.build"
 }
 ```
 

--- a/pkg/integrations/aws/aws.go
+++ b/pkg/integrations/aws/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/codebuild"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/codeartifact"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/ecr"
@@ -130,6 +131,7 @@ func (a *AWS) Configuration() []configuration.Field {
 
 func (a *AWS) Components() []core.Component {
 	return []core.Component{
+		&codebuild.RunBuild{},
 		&codeartifact.GetPackageVersion{},
 		&ecr.GetImage{},
 		&ecr.GetImageScanFindings{},
@@ -140,6 +142,7 @@ func (a *AWS) Components() []core.Component {
 
 func (a *AWS) Triggers() []core.Trigger {
 	return []core.Trigger{
+		&codebuild.OnBuild{},
 		&codeartifact.OnPackageVersion{},
 		&ecr.OnImageScan{},
 		&ecr.OnImagePush{},

--- a/pkg/integrations/aws/codebuild/client.go
+++ b/pkg/integrations/aws/codebuild/client.go
@@ -1,0 +1,240 @@
+package codebuild
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+const targetPrefix = "CodeBuild_20161006."
+
+type Client struct {
+	http        core.HTTPContext
+	region      string
+	credentials *aws.Credentials
+	signer      *v4.Signer
+}
+
+type Build struct {
+	ID           string           `json:"id"`
+	Arn          string           `json:"arn"`
+	BuildNumber  int64            `json:"buildNumber"`
+	CurrentPhase string           `json:"currentPhase"`
+	BuildStatus  string           `json:"buildStatus"`
+	ProjectName  string           `json:"projectName"`
+	SourceVersion string          `json:"sourceVersion"`
+	Initiator    string           `json:"initiator"`
+	StartTime    common.FloatTime `json:"startTime,omitempty"`
+	EndTime      common.FloatTime `json:"endTime,omitempty"`
+	Logs         *BuildLogs       `json:"logs,omitempty"`
+}
+
+type BuildLogs struct {
+	DeepLink         string `json:"deepLink"`
+	CloudWatchLogsArn string `json:"cloudWatchLogsArn"`
+	GroupName        string `json:"groupName"`
+	StreamName       string `json:"streamName"`
+	Status           string `json:"status"`
+}
+
+func NewClient(httpCtx core.HTTPContext, credentials *aws.Credentials, region string) *Client {
+	return &Client{
+		http:        httpCtx,
+		region:      region,
+		credentials: credentials,
+		signer:      v4.NewSigner(),
+	}
+}
+
+func (c *Client) ListProjects() ([]string, error) {
+	projects := []string{}
+	nextToken := ""
+
+	for {
+		payload := map[string]any{}
+		if strings.TrimSpace(nextToken) != "" {
+			payload["nextToken"] = strings.TrimSpace(nextToken)
+		}
+
+		var response struct {
+			Projects  []string `json:"projects"`
+			NextToken string   `json:"nextToken"`
+		}
+
+		if err := c.postJSON("ListProjects", payload, &response); err != nil {
+			return nil, err
+		}
+
+		projects = append(projects, response.Projects...)
+		if strings.TrimSpace(response.NextToken) == "" {
+			break
+		}
+
+		nextToken = response.NextToken
+	}
+
+	return projects, nil
+}
+
+func (c *Client) DescribeProject(projectName string) (*Project, error) {
+	projects, err := c.BatchGetProjects([]string{projectName})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(projects) == 0 {
+		return nil, fmt.Errorf("project not found: %s", projectName)
+	}
+
+	return &projects[0], nil
+}
+
+func (c *Client) BatchGetProjects(projectNames []string) ([]Project, error) {
+	if len(projectNames) == 0 {
+		return []Project{}, nil
+	}
+
+	payload := map[string]any{
+		"names": projectNames,
+	}
+
+	var response struct {
+		Projects []struct {
+			Name string `json:"name"`
+			Arn  string `json:"arn"`
+		} `json:"projects"`
+	}
+
+	if err := c.postJSON("BatchGetProjects", payload, &response); err != nil {
+		return nil, err
+	}
+
+	projects := make([]Project, 0, len(response.Projects))
+	for _, project := range response.Projects {
+		projects = append(projects, Project{
+			ProjectName: project.Name,
+			ProjectArn:  project.Arn,
+		})
+	}
+
+	return projects, nil
+}
+
+func (c *Client) StartBuild(projectName string, sourceVersion string) (*Build, error) {
+	projectName = strings.TrimSpace(projectName)
+	if projectName == "" {
+		return nil, fmt.Errorf("project name is required")
+	}
+
+	payload := map[string]any{
+		"projectName": projectName,
+	}
+	if strings.TrimSpace(sourceVersion) != "" {
+		payload["sourceVersion"] = strings.TrimSpace(sourceVersion)
+	}
+
+	var response struct {
+		Build Build `json:"build"`
+	}
+
+	if err := c.postJSON("StartBuild", payload, &response); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(response.Build.ID) == "" {
+		return nil, fmt.Errorf("start build response missing build ID")
+	}
+
+	return &response.Build, nil
+}
+
+func (c *Client) BatchGetBuilds(buildIDs []string) ([]Build, error) {
+	if len(buildIDs) == 0 {
+		return nil, fmt.Errorf("build IDs are required")
+	}
+
+	payload := map[string]any{
+		"ids": buildIDs,
+	}
+
+	var response struct {
+		Builds         []Build  `json:"builds"`
+		BuildsNotFound []string `json:"buildsNotFound"`
+	}
+
+	if err := c.postJSON("BatchGetBuilds", payload, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Builds) == 0 && len(response.BuildsNotFound) > 0 {
+		return nil, fmt.Errorf("build not found: %s", strings.Join(response.BuildsNotFound, ", "))
+	}
+
+	return response.Builds, nil
+}
+
+func (c *Client) postJSON(action string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("https://codebuild.%s.amazonaws.com/", c.region)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-amz-json-1.1")
+	req.Header.Set("X-Amz-Target", targetPrefix+action)
+
+	if err := c.signRequest(req, body); err != nil {
+		return err
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		if awsErr := common.ParseError(responseBody); awsErr != nil {
+			return awsErr
+		}
+		return fmt.Errorf("CodeBuild API request failed with %d: %s", res.StatusCode, string(responseBody))
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) signRequest(req *http.Request, payload []byte) error {
+	hash := sha256.Sum256(payload)
+	payloadHash := hex.EncodeToString(hash[:])
+	return c.signer.SignHTTP(context.Background(), *c.credentials, req, payloadHash, "codebuild", c.region, time.Now())
+}

--- a/pkg/integrations/aws/codebuild/codebuild.go
+++ b/pkg/integrations/aws/codebuild/codebuild.go
@@ -1,0 +1,88 @@
+package codebuild
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+const (
+	Source                     = "aws.codebuild"
+	DetailTypeBuildStateChange = "CodeBuild Build State Change"
+)
+
+type Project struct {
+	ProjectName string `json:"projectName" mapstructure:"projectName"`
+	ProjectArn  string `json:"projectArn" mapstructure:"projectArn"`
+}
+
+func validateProject(ctx core.TriggerContext, region string, projectRef string, existing *Project) (*Project, error) {
+	return validateProjectWithIntegration(ctx.HTTP, ctx.Integration, region, projectRef, existing)
+}
+
+func projectMatchesRef(project *Project, projectRef string) bool {
+	if project == nil {
+		return false
+	}
+	return projectRef == project.ProjectName || projectRef == project.ProjectArn
+}
+
+func projectNameFromRef(projectRef string) (string, error) {
+	projectRef = strings.TrimSpace(projectRef)
+	if projectRef == "" {
+		return "", fmt.Errorf("project is required")
+	}
+
+	if !strings.HasPrefix(projectRef, "arn:") {
+		return projectRef, nil
+	}
+
+	parts := strings.SplitN(projectRef, "project/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[1]) == "" {
+		return "", fmt.Errorf("invalid project ARN: %s", projectRef)
+	}
+
+	return strings.TrimSpace(parts[1]), nil
+}
+
+func validateProjectWithIntegration(
+	httpCtx core.HTTPContext,
+	integration core.IntegrationContext,
+	region string,
+	projectRef string,
+	existing *Project,
+) (*Project, error) {
+	projectRef = strings.TrimSpace(projectRef)
+	if projectRef == "" {
+		return nil, fmt.Errorf("project is required")
+	}
+
+	if existing != nil && projectMatchesRef(existing, projectRef) {
+		return existing, nil
+	}
+
+	credentials, err := common.CredentialsFromInstallation(integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	projectName, err := projectNameFromRef(projectRef)
+	if err != nil {
+		return nil, err
+	}
+
+	client := NewClient(httpCtx, credentials, region)
+	project, err := client.DescribeProject(projectName)
+	if err != nil {
+		var awsErr *common.Error
+		if errors.As(err, &awsErr) && awsErr.Code == "ResourceNotFoundException" {
+			return nil, fmt.Errorf("project not found: %s", projectName)
+		}
+		return nil, err
+	}
+
+	return project, nil
+}

--- a/pkg/integrations/aws/codebuild/example.go
+++ b/pkg/integrations/aws/codebuild/example.go
@@ -1,0 +1,28 @@
+package codebuild
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_data_on_build.json
+var exampleDataOnBuildBytes []byte
+
+//go:embed example_output_run_build.json
+var exampleOutputRunBuildBytes []byte
+
+var exampleDataOnBuildOnce sync.Once
+var exampleDataOnBuild map[string]any
+
+var exampleOutputRunBuildOnce sync.Once
+var exampleOutputRunBuild map[string]any
+
+func (t *OnBuild) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnBuildOnce, exampleDataOnBuildBytes, &exampleDataOnBuild)
+}
+
+func (c *RunBuild) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputRunBuildOnce, exampleOutputRunBuildBytes, &exampleOutputRunBuild)
+}

--- a/pkg/integrations/aws/codebuild/example_data_on_build.json
+++ b/pkg/integrations/aws/codebuild/example_data_on_build.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "version": "0",
+    "id": "00112233-4455-6677-8899-aabbccddeeff",
+    "detail-type": "CodeBuild Build State Change",
+    "source": "aws.codebuild",
+    "account": "123456789012",
+    "time": "2026-02-03T12:00:00Z",
+    "region": "us-east-1",
+    "resources": [
+      "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20"
+    ],
+    "detail": {
+      "project-name": "backend-build",
+      "build-status": "SUCCEEDED",
+      "build-id": "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "current-phase": "COMPLETED",
+      "current-phase-context": "Build completed successfully",
+      "version": "1",
+      "additional-information": {
+        "initiator": "codepipeline/my-pipeline",
+        "source-version": "refs/heads/main",
+        "logs": {
+          "deep-link": "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build/build/backend-build%3A3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20/log"
+        }
+      }
+    }
+  },
+  "timestamp": "2026-02-03T12:00:01Z",
+  "type": "aws.codebuild.build"
+}

--- a/pkg/integrations/aws/codebuild/example_output_run_build.json
+++ b/pkg/integrations/aws/codebuild/example_output_run_build.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "id": "backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+    "arn": "arn:aws:codebuild:us-east-1:123456789012:build/backend-build:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+    "buildNumber": 42,
+    "currentPhase": "COMPLETED",
+    "buildStatus": "SUCCEEDED",
+    "projectName": "backend-build",
+    "sourceVersion": "refs/heads/main",
+    "initiator": "codepipeline/my-pipeline",
+    "startTime": "2026-02-03T11:58:40Z",
+    "endTime": "2026-02-03T12:00:00Z",
+    "logs": {
+      "deepLink": "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build/build/backend-build%3A3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20/log",
+      "cloudWatchLogsArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/codebuild/backend-build:log-stream:3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "groupName": "/aws/codebuild/backend-build",
+      "streamName": "3d8b9b4e-5f0a-4d64-a74d-6f7aab2f9a20",
+      "status": "SUCCEEDED"
+    }
+  },
+  "timestamp": "2026-02-03T12:00:00Z",
+  "type": "aws.codebuild.build"
+}

--- a/pkg/integrations/aws/codebuild/on_build.go
+++ b/pkg/integrations/aws/codebuild/on_build.go
@@ -1,0 +1,324 @@
+package codebuild
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type OnBuild struct{}
+
+type OnBuildConfiguration struct {
+	Region  string `json:"region" mapstructure:"region"`
+	Project string `json:"project" mapstructure:"project"`
+}
+
+type OnBuildMetadata struct {
+	Region         string   `json:"region" mapstructure:"region"`
+	SubscriptionID string   `json:"subscriptionId" mapstructure:"subscriptionId"`
+	Project        *Project `json:"project" mapstructure:"project"`
+}
+
+func (p *OnBuild) Name() string {
+	return "aws.codebuild.onBuild"
+}
+
+func (p *OnBuild) Label() string {
+	return "CodeBuild • On Build"
+}
+
+func (p *OnBuild) Description() string {
+	return "Listen to AWS CodeBuild build state change events"
+}
+
+func (p *OnBuild) Documentation() string {
+	return `The On Build trigger starts a workflow execution when AWS CodeBuild emits a build state change event.
+
+## Use Cases
+
+- **Build observability**: Trigger notifications when builds fail, succeed, or stop
+- **Automated quality gates**: Start follow-up checks after successful builds
+- **Pipeline orchestration**: Chain downstream workflows based on build outcomes
+
+## Event Data
+
+Each build state change event includes:
+- **detail.project-name**: CodeBuild project name
+- **detail.build-status**: Build status (for example: IN_PROGRESS, SUCCEEDED, FAILED)
+- **detail.build-id**: Build identifier ARN
+- **detail.current-phase**: Current phase of the build lifecycle`
+}
+
+func (p *OnBuild) Icon() string {
+	return "aws"
+}
+
+func (p *OnBuild) Color() string {
+	return "gray"
+}
+
+func (p *OnBuild) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "region",
+			Label:    "Region",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "us-east-1",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: common.AllRegions,
+				},
+			},
+		},
+		{
+			Name:        "project",
+			Label:       "Project",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Filter by CodeBuild project name",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{
+					Field:  "region",
+					Values: []string{"*"},
+				},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "codebuild.project",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name: "region",
+							ValueFrom: &configuration.ParameterValueFrom{
+								Field: "region",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (p *OnBuild) Setup(ctx core.TriggerContext) error {
+	metadata := OnBuildMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	config, err := decodeOnBuildConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	project, err := validateProject(ctx, config.Region, config.Project, metadata.Project)
+	if err != nil {
+		return fmt.Errorf("failed to validate project: %w", err)
+	}
+
+	//
+	// If already subscribed for this project, nothing to do.
+	//
+	if metadata.SubscriptionID != "" && metadata.Project != nil && projectMatchesRef(metadata.Project, config.Project) {
+		return nil
+	}
+
+	integrationMetadata := common.IntegrationMetadata{}
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &integrationMetadata); err != nil {
+		return fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+
+	rule := common.EventBridgeRuleMetadata{}
+	ok := false
+	if integrationMetadata.EventBridge != nil && integrationMetadata.EventBridge.Rules != nil {
+		rule, ok = integrationMetadata.EventBridge.Rules[Source]
+	}
+	if !ok || !slices.Contains(rule.DetailTypes, DetailTypeBuildStateChange) {
+		if err := ctx.Metadata.Set(OnBuildMetadata{
+			Region:  config.Region,
+			Project: project,
+		}); err != nil {
+			return fmt.Errorf("failed to set metadata: %w", err)
+		}
+
+		return p.provisionRule(ctx.Integration, ctx.Requests, config.Region)
+	}
+
+	subscriptionID, err := ctx.Integration.Subscribe(p.subscriptionPattern(config.Region, project.ProjectName))
+	if err != nil {
+		return fmt.Errorf("failed to subscribe: %w", err)
+	}
+
+	return ctx.Metadata.Set(OnBuildMetadata{
+		Region:         config.Region,
+		SubscriptionID: subscriptionID.String(),
+		Project:        project,
+	})
+}
+
+func (p *OnBuild) provisionRule(integration core.IntegrationContext, requests core.RequestContext, region string) error {
+	err := integration.ScheduleActionCall(
+		"provisionRule",
+		common.ProvisionRuleParameters{
+			Region:     region,
+			Source:     Source,
+			DetailType: DetailTypeBuildStateChange,
+		},
+		time.Second,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to schedule rule provisioning for integration: %w", err)
+	}
+
+	return requests.ScheduleActionCall(
+		"checkRuleAvailability",
+		map[string]any{},
+		5*time.Second,
+	)
+}
+
+func (p *OnBuild) subscriptionPattern(region string, projectName string) *common.EventBridgeEvent {
+	return &common.EventBridgeEvent{
+		Region:     region,
+		DetailType: DetailTypeBuildStateChange,
+		Source:     Source,
+		Detail: map[string]any{
+			"project-name": projectName,
+		},
+	}
+}
+
+func (p *OnBuild) Actions() []core.Action {
+	return []core.Action{
+		{
+			Name:        "checkRuleAvailability",
+			Description: "Check if the EventBridge rule is available",
+		},
+	}
+}
+
+func (p *OnBuild) HandleAction(ctx core.TriggerActionContext) (map[string]any, error) {
+	switch ctx.Name {
+	case "checkRuleAvailability":
+		return p.checkRuleAvailability(ctx)
+
+	default:
+		return nil, fmt.Errorf("unknown action: %s", ctx.Name)
+	}
+}
+
+func (p *OnBuild) checkRuleAvailability(ctx core.TriggerActionContext) (map[string]any, error) {
+	metadata := OnBuildMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return nil, fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	integrationMetadata := common.IntegrationMetadata{}
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &integrationMetadata); err != nil {
+		return nil, fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+
+	rule := common.EventBridgeRuleMetadata{}
+	ok := false
+	if integrationMetadata.EventBridge != nil && integrationMetadata.EventBridge.Rules != nil {
+		rule, ok = integrationMetadata.EventBridge.Rules[Source]
+	}
+	if !ok {
+		ctx.Logger.Infof("Rule not found for source %s - checking again in 10 seconds", Source)
+		return nil, ctx.Requests.ScheduleActionCall(
+			"checkRuleAvailability",
+			map[string]any{},
+			10*time.Second,
+		)
+	}
+
+	if !slices.Contains(rule.DetailTypes, DetailTypeBuildStateChange) {
+		ctx.Logger.Infof(
+			"Rule does not have detail type '%s' - checking again in 10 seconds",
+			DetailTypeBuildStateChange,
+		)
+		return nil, ctx.Requests.ScheduleActionCall(
+			"checkRuleAvailability",
+			map[string]any{},
+			10*time.Second,
+		)
+	}
+
+	if metadata.Project == nil || strings.TrimSpace(metadata.Project.ProjectName) == "" {
+		return nil, fmt.Errorf("project metadata is missing")
+	}
+
+	subscriptionID, err := ctx.Integration.Subscribe(p.subscriptionPattern(metadata.Region, metadata.Project.ProjectName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe: %w", err)
+	}
+
+	metadata.SubscriptionID = subscriptionID.String()
+	return nil, ctx.Metadata.Set(metadata)
+}
+
+func (p *OnBuild) OnIntegrationMessage(ctx core.IntegrationMessageContext) error {
+	metadata := OnBuildMetadata{}
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	event := common.EventBridgeEvent{}
+	if err := mapstructure.Decode(ctx.Message, &event); err != nil {
+		return fmt.Errorf("failed to decode message: %w", err)
+	}
+
+	projectName, ok := event.Detail["project-name"]
+	if !ok {
+		return fmt.Errorf("missing project-name in event")
+	}
+
+	currentProject, ok := projectName.(string)
+	if !ok || strings.TrimSpace(currentProject) == "" {
+		return fmt.Errorf("invalid project-name in event")
+	}
+
+	if metadata.Project != nil && metadata.Project.ProjectName != "" && currentProject != metadata.Project.ProjectName {
+		ctx.Logger.Infof("Skipping event for project %s, expected %s", currentProject, metadata.Project.ProjectName)
+		return nil
+	}
+
+	return ctx.Events.Emit("aws.codebuild.build", ctx.Message)
+}
+
+func (p *OnBuild) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	// no-op, since events are received through the integration
+	// and routed to OnIntegrationMessage()
+	return http.StatusOK, nil
+}
+
+func (p *OnBuild) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func decodeOnBuildConfiguration(configuration any) (OnBuildConfiguration, error) {
+	config := OnBuildConfiguration{}
+	if err := mapstructure.Decode(configuration, &config); err != nil {
+		return OnBuildConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Region = strings.TrimSpace(config.Region)
+	config.Project = strings.TrimSpace(config.Project)
+
+	if config.Region == "" {
+		return OnBuildConfiguration{}, fmt.Errorf("region is required")
+	}
+
+	if config.Project == "" {
+		return OnBuildConfiguration{}, fmt.Errorf("project is required")
+	}
+
+	return config, nil
+}

--- a/pkg/integrations/aws/codebuild/on_build_test.go
+++ b/pkg/integrations/aws/codebuild/on_build_test.go
@@ -1,0 +1,248 @@
+package codebuild
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnBuild__Setup(t *testing.T) {
+	trigger := &OnBuild{}
+
+	t.Run("rule missing -> schedules provisioning and check", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"projects": [
+								{
+									"name": "backend-build",
+									"arn": "arn:aws:codebuild:us-east-1:123456789012:project/backend-build"
+								}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+		requests := &contexts.RequestContext{}
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: common.IntegrationMetadata{
+				EventBridge: &common.EventBridgeMetadata{
+					Rules: map[string]common.EventBridgeRuleMetadata{},
+				},
+			},
+			Secrets: map[string]core.IntegrationSecret{
+				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+			},
+		}
+
+		err := trigger.Setup(core.TriggerContext{
+			Logger:        logrus.NewEntry(logrus.New()),
+			HTTP:          httpContext,
+			Integration:   integrationCtx,
+			Metadata:      metadata,
+			Requests:      requests,
+			Configuration: OnBuildConfiguration{Region: "us-east-1", Project: "backend-build"},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, integrationCtx.ActionRequests, 1)
+		assert.Equal(t, "provisionRule", integrationCtx.ActionRequests[0].ActionName)
+		params := integrationCtx.ActionRequests[0].Parameters.(common.ProvisionRuleParameters)
+		assert.Equal(t, "us-east-1", params.Region)
+		assert.Equal(t, Source, params.Source)
+		assert.Equal(t, DetailTypeBuildStateChange, params.DetailType)
+
+		assert.Equal(t, "checkRuleAvailability", requests.Action)
+		assert.Equal(t, 5*time.Second, requests.Duration)
+
+		stored, ok := metadata.Get().(OnBuildMetadata)
+		require.True(t, ok)
+		require.NotNil(t, stored.Project)
+		assert.Equal(t, "backend-build", stored.Project.ProjectName)
+	})
+
+	t.Run("rule available -> subscribes", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"projects": [
+								{
+									"name": "backend-build",
+									"arn": "arn:aws:codebuild:us-east-1:123456789012:project/backend-build"
+								}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: common.IntegrationMetadata{
+				EventBridge: &common.EventBridgeMetadata{
+					Rules: map[string]common.EventBridgeRuleMetadata{
+						Source: {
+							Source:      Source,
+							DetailTypes: []string{DetailTypeBuildStateChange},
+						},
+					},
+				},
+			},
+			Secrets: map[string]core.IntegrationSecret{
+				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+			},
+		}
+
+		err := trigger.Setup(core.TriggerContext{
+			Logger:        logrus.NewEntry(logrus.New()),
+			HTTP:          httpContext,
+			Integration:   integrationCtx,
+			Metadata:      metadata,
+			Configuration: OnBuildConfiguration{Region: "us-east-1", Project: "backend-build"},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, integrationCtx.Subscriptions, 1)
+		stored, ok := metadata.Get().(OnBuildMetadata)
+		require.True(t, ok)
+		assert.NotEmpty(t, stored.SubscriptionID)
+		require.NotNil(t, stored.Project)
+		assert.Equal(t, "backend-build", stored.Project.ProjectName)
+	})
+}
+
+func Test__OnBuild__HandleAction(t *testing.T) {
+	trigger := &OnBuild{}
+
+	t.Run("rule missing -> reschedules check", func(t *testing.T) {
+		requests := &contexts.RequestContext{}
+		_, err := trigger.HandleAction(core.TriggerActionContext{
+			Name:     "checkRuleAvailability",
+			Logger:   logrus.NewEntry(logrus.New()),
+			Requests: requests,
+			Metadata: &contexts.MetadataContext{
+				Metadata: OnBuildMetadata{
+					Region: "us-east-1",
+					Project: &Project{
+						ProjectName: "backend-build",
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: common.IntegrationMetadata{
+					EventBridge: &common.EventBridgeMetadata{
+						Rules: map[string]common.EventBridgeRuleMetadata{},
+					},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "checkRuleAvailability", requests.Action)
+		assert.Equal(t, 10*time.Second, requests.Duration)
+	})
+
+	t.Run("rule available -> subscribes", func(t *testing.T) {
+		requests := &contexts.RequestContext{}
+		metadata := &contexts.MetadataContext{
+			Metadata: OnBuildMetadata{
+				Region: "us-east-1",
+				Project: &Project{
+					ProjectName: "backend-build",
+				},
+			},
+		}
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: common.IntegrationMetadata{
+				EventBridge: &common.EventBridgeMetadata{
+					Rules: map[string]common.EventBridgeRuleMetadata{
+						Source: {
+							Source:      Source,
+							DetailTypes: []string{DetailTypeBuildStateChange},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := trigger.HandleAction(core.TriggerActionContext{
+			Name:        "checkRuleAvailability",
+			Logger:      logrus.NewEntry(logrus.New()),
+			Requests:    requests,
+			Metadata:    metadata,
+			Integration: integrationCtx,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, integrationCtx.Subscriptions, 1)
+		stored, ok := metadata.Get().(OnBuildMetadata)
+		require.True(t, ok)
+		assert.NotEmpty(t, stored.SubscriptionID)
+	})
+}
+
+func Test__OnBuild__OnIntegrationMessage(t *testing.T) {
+	trigger := &OnBuild{}
+
+	t.Run("project mismatch -> no event", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+		err := trigger.OnIntegrationMessage(core.IntegrationMessageContext{
+			Logger: logrus.NewEntry(logrus.New()),
+			Events: eventContext,
+			NodeMetadata: &contexts.MetadataContext{
+				Metadata: OnBuildMetadata{
+					Project: &Project{ProjectName: "backend-build"},
+				},
+			},
+			Message: common.EventBridgeEvent{
+				Detail: map[string]any{"project-name": "frontend-build"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, eventContext.Count())
+	})
+
+	t.Run("project match -> emits event", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+		err := trigger.OnIntegrationMessage(core.IntegrationMessageContext{
+			Logger: logrus.NewEntry(logrus.New()),
+			Events: eventContext,
+			NodeMetadata: &contexts.MetadataContext{
+				Metadata: OnBuildMetadata{
+					Project: &Project{ProjectName: "backend-build"},
+				},
+			},
+			Message: common.EventBridgeEvent{
+				Detail: map[string]any{"project-name": "backend-build"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "aws.codebuild.build", eventContext.Payloads[0].Type)
+	})
+}

--- a/pkg/integrations/aws/codebuild/resources.go
+++ b/pkg/integrations/aws/codebuild/resources.go
@@ -1,0 +1,43 @@
+package codebuild
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+func ListProjects(ctx core.ListResourcesContext, resourceType string) ([]core.IntegrationResource, error) {
+	credentials, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	region := strings.TrimSpace(ctx.Parameters["region"])
+	if region == "" {
+		return nil, fmt.Errorf("region is required")
+	}
+
+	client := NewClient(ctx.HTTP, credentials, region)
+	projects, err := client.ListProjects()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list CodeBuild projects: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(projects))
+	for _, project := range projects {
+		project = strings.TrimSpace(project)
+		if project == "" {
+			continue
+		}
+
+		resources = append(resources, core.IntegrationResource{
+			Type: resourceType,
+			Name: project,
+			ID:   project,
+		})
+	}
+
+	return resources, nil
+}

--- a/pkg/integrations/aws/codebuild/run_build.go
+++ b/pkg/integrations/aws/codebuild/run_build.go
@@ -1,0 +1,326 @@
+package codebuild
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+const (
+	BuildPayloadType  = "aws.codebuild.build"
+	BuildPollInterval = 10 * time.Second
+)
+
+type RunBuild struct{}
+
+type RunBuildConfiguration struct {
+	Region        string `json:"region" mapstructure:"region"`
+	Project       string `json:"project" mapstructure:"project"`
+	SourceVersion string `json:"sourceVersion" mapstructure:"sourceVersion"`
+}
+
+type RunBuildMetadata struct {
+	Region      string `json:"region" mapstructure:"region"`
+	ProjectName string `json:"projectName" mapstructure:"projectName"`
+	BuildID     string `json:"buildId" mapstructure:"buildId"`
+}
+
+func (c *RunBuild) Name() string {
+	return "aws.codebuild.runBuild"
+}
+
+func (c *RunBuild) Label() string {
+	return "CodeBuild • Run Build"
+}
+
+func (c *RunBuild) Description() string {
+	return "Start an AWS CodeBuild build and wait for it to finish"
+}
+
+func (c *RunBuild) Documentation() string {
+	return `The Run Build component starts a build in AWS CodeBuild and waits until the build reaches a terminal state.
+
+## Use Cases
+
+- **CI orchestration**: Trigger builds from workflow automation
+- **Release pipelines**: Block downstream steps until build completion
+- **Quality gates**: Fail workflow execution automatically when builds fail
+
+## How It Works
+
+1. Starts a new build for the selected CodeBuild project
+2. Polls CodeBuild for the build status until completion
+3. Emits build details when the build succeeds
+4. Fails the node if the build finishes with a failed status
+
+## Configuration
+
+- **Region**: AWS region where the CodeBuild project exists
+- **Project**: CodeBuild project name
+- **Source Version** (optional): Specific source revision, branch, or commit to build`
+}
+
+func (c *RunBuild) Icon() string {
+	return "aws"
+}
+
+func (c *RunBuild) Color() string {
+	return "gray"
+}
+
+func (c *RunBuild) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *RunBuild) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "region",
+			Label:    "Region",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "us-east-1",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: common.AllRegions,
+				},
+			},
+		},
+		{
+			Name:        "project",
+			Label:       "Project",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "CodeBuild project name",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{
+					Field:  "region",
+					Values: []string{"*"},
+				},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "codebuild.project",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name: "region",
+							ValueFrom: &configuration.ParameterValueFrom{
+								Field: "region",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "sourceVersion",
+			Label:       "Source Version",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional source revision, branch, or commit to build",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{
+					Field:  "project",
+					Values: []string{"*"},
+				},
+			},
+		},
+	}
+}
+
+func (c *RunBuild) Setup(ctx core.SetupContext) error {
+	_, err := decodeRunBuildConfiguration(ctx.Configuration)
+	return err
+}
+
+func (c *RunBuild) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *RunBuild) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeRunBuildConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	credentials, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	projectName, err := projectNameFromRef(config.Project)
+	if err != nil {
+		return err
+	}
+
+	client := NewClient(ctx.HTTP, credentials, config.Region)
+	build, err := client.StartBuild(projectName, config.SourceVersion)
+	if err != nil {
+		return fmt.Errorf("failed to start build: %w", err)
+	}
+
+	if strings.TrimSpace(build.ID) == "" {
+		return fmt.Errorf("build ID is missing")
+	}
+
+	if finished, succeeded := isBuildTerminalStatus(build.BuildStatus); finished {
+		if !succeeded {
+			return buildFailureError(build)
+		}
+		return c.emitBuild(ctx.ExecutionState, build)
+	}
+
+	if err := ctx.Metadata.Set(RunBuildMetadata{
+		Region:      config.Region,
+		ProjectName: projectName,
+		BuildID:     build.ID,
+	}); err != nil {
+		return fmt.Errorf("failed to set metadata: %w", err)
+	}
+
+	return ctx.Requests.ScheduleActionCall("pollBuild", map[string]any{}, BuildPollInterval)
+}
+
+func (c *RunBuild) Actions() []core.Action {
+	return []core.Action{
+		{
+			Name:        "pollBuild",
+			Description: "Poll build status",
+		},
+	}
+}
+
+func (c *RunBuild) HandleAction(ctx core.ActionContext) error {
+	switch ctx.Name {
+	case "pollBuild":
+		return c.pollBuild(ctx)
+
+	default:
+		return fmt.Errorf("unknown action: %s", ctx.Name)
+	}
+}
+
+func (c *RunBuild) pollBuild(ctx core.ActionContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	metadata := RunBuildMetadata{}
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+
+	if strings.TrimSpace(metadata.BuildID) == "" {
+		return fmt.Errorf("build ID is missing from metadata")
+	}
+
+	credentials, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, credentials, metadata.Region)
+	builds, err := client.BatchGetBuilds([]string{metadata.BuildID})
+	if err != nil {
+		return fmt.Errorf("failed to get build status: %w", err)
+	}
+
+	if len(builds) == 0 {
+		return fmt.Errorf("build not found: %s", metadata.BuildID)
+	}
+
+	build := &builds[0]
+	if finished, succeeded := isBuildTerminalStatus(build.BuildStatus); finished {
+		if !succeeded {
+			return buildFailureError(build)
+		}
+		return c.emitBuild(ctx.ExecutionState, build)
+	}
+
+	return ctx.Requests.ScheduleActionCall("pollBuild", map[string]any{}, BuildPollInterval)
+}
+
+func (c *RunBuild) emitBuild(executionState core.ExecutionStateContext, build *Build) error {
+	return executionState.Emit(core.DefaultOutputChannel.Name, BuildPayloadType, []any{build})
+}
+
+func (c *RunBuild) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *RunBuild) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *RunBuild) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func decodeRunBuildConfiguration(configuration any) (RunBuildConfiguration, error) {
+	config := RunBuildConfiguration{}
+	if err := mapstructure.Decode(configuration, &config); err != nil {
+		return RunBuildConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Region = strings.TrimSpace(config.Region)
+	config.Project = strings.TrimSpace(config.Project)
+	config.SourceVersion = strings.TrimSpace(config.SourceVersion)
+
+	if config.Region == "" {
+		return RunBuildConfiguration{}, fmt.Errorf("region is required")
+	}
+
+	if config.Project == "" {
+		return RunBuildConfiguration{}, fmt.Errorf("project is required")
+	}
+
+	if _, err := projectNameFromRef(config.Project); err != nil {
+		return RunBuildConfiguration{}, err
+	}
+
+	return config, nil
+}
+
+func isBuildTerminalStatus(status string) (finished bool, succeeded bool) {
+	normalized := strings.ToUpper(strings.TrimSpace(status))
+
+	switch normalized {
+	case "SUCCEEDED":
+		return true, true
+
+	case "FAILED", "FAULT", "TIMED_OUT", "STOPPED":
+		return true, false
+
+	default:
+		return false, false
+	}
+}
+
+func buildFailureError(build *Build) error {
+	if build == nil {
+		return fmt.Errorf("CodeBuild build finished with status UNKNOWN")
+	}
+
+	status := strings.ToUpper(strings.TrimSpace(build.BuildStatus))
+	if status == "" {
+		status = "UNKNOWN"
+	}
+
+	if build != nil && build.Logs != nil && strings.TrimSpace(build.Logs.DeepLink) != "" {
+		return fmt.Errorf(
+			"CodeBuild build %s finished with status %s: %s",
+			strings.TrimSpace(build.ID),
+			status,
+			strings.TrimSpace(build.Logs.DeepLink),
+		)
+	}
+
+	return fmt.Errorf("CodeBuild build %s finished with status %s", strings.TrimSpace(build.ID), status)
+}

--- a/pkg/integrations/aws/codebuild/run_build_test.go
+++ b/pkg/integrations/aws/codebuild/run_build_test.go
@@ -1,0 +1,458 @@
+package codebuild
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__RunBuild__Setup(t *testing.T) {
+	component := &RunBuild{}
+
+	t.Run("invalid configuration -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "invalid",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":  " ",
+				"project": "backend-build",
+			},
+		})
+
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing project -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region": "us-east-1",
+			},
+		})
+
+		require.ErrorContains(t, err, "project is required")
+	})
+
+	t.Run("invalid project arn -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "arn:aws:codebuild:us-east-1:123456789012:project",
+			},
+		})
+
+		require.ErrorContains(t, err, "invalid project ARN")
+	})
+
+	t.Run("valid configuration -> ok", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "backend-build",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__RunBuild__Execute(t *testing.T) {
+	component := &RunBuild{}
+
+	t.Run("missing credentials -> error", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "backend-build",
+			},
+			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+
+		require.ErrorContains(t, err, "AWS session credentials are missing")
+	})
+
+	t.Run("build in progress -> schedules poll action", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"build": {
+								"id": "backend-build:build-123",
+								"projectName": "backend-build",
+								"buildStatus": "IN_PROGRESS",
+								"currentPhase": "BUILD"
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+		requests := &contexts.RequestContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "backend-build",
+			},
+			HTTP:           httpContext,
+			Metadata:       metadata,
+			Requests:       requests,
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		stored, ok := metadata.Get().(RunBuildMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "us-east-1", stored.Region)
+		assert.Equal(t, "backend-build", stored.ProjectName)
+		assert.Equal(t, "backend-build:build-123", stored.BuildID)
+
+		assert.Equal(t, "pollBuild", requests.Action)
+		assert.Equal(t, BuildPollInterval, requests.Duration)
+	})
+
+	t.Run("build succeeded immediately -> emits payload", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"build": {
+								"id": "backend-build:build-123",
+								"projectName": "backend-build",
+								"buildStatus": "SUCCEEDED",
+								"currentPhase": "COMPLETED"
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "backend-build",
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, execState.Payloads, 1)
+		assert.Equal(t, BuildPayloadType, execState.Type)
+		payload := execState.Payloads[0].(map[string]any)["data"]
+		build, ok := payload.(*Build)
+		require.True(t, ok)
+		assert.Equal(t, "SUCCEEDED", build.BuildStatus)
+	})
+
+	t.Run("build fails immediately -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"build": {
+								"id": "backend-build:build-123",
+								"projectName": "backend-build",
+								"buildStatus": "FAILED",
+								"currentPhase": "COMPLETED"
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":  "us-east-1",
+				"project": "backend-build",
+			},
+			HTTP:           httpContext,
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "status FAILED")
+	})
+}
+
+func Test__RunBuild__HandleAction(t *testing.T) {
+	component := &RunBuild{}
+
+	t.Run("unknown action -> error", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{
+			Name: "unknown",
+		})
+
+		require.ErrorContains(t, err, "unknown action")
+	})
+
+	t.Run("build still running -> schedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"builds": [
+								{
+									"id": "backend-build:build-123",
+									"projectName": "backend-build",
+									"buildStatus": "IN_PROGRESS",
+									"currentPhase": "BUILD"
+								}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		requests := &contexts.RequestContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name:     "pollBuild",
+			HTTP:     httpContext,
+			Requests: requests,
+			Metadata: &contexts.MetadataContext{
+				Metadata: RunBuildMetadata{
+					Region:      "us-east-1",
+					ProjectName: "backend-build",
+					BuildID:     "backend-build:build-123",
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "pollBuild", requests.Action)
+		assert.Equal(t, BuildPollInterval, requests.Duration)
+	})
+
+	t.Run("build succeeded -> emits payload", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"builds": [
+								{
+									"id": "backend-build:build-123",
+									"projectName": "backend-build",
+									"buildStatus": "SUCCEEDED",
+									"currentPhase": "COMPLETED"
+								}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.HandleAction(core.ActionContext{
+			Name:           "pollBuild",
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Metadata: &contexts.MetadataContext{
+				Metadata: RunBuildMetadata{
+					Region:      "us-east-1",
+					ProjectName: "backend-build",
+					BuildID:     "backend-build:build-123",
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, execState.Payloads, 1)
+		payload := execState.Payloads[0].(map[string]any)["data"]
+		build, ok := payload.(*Build)
+		require.True(t, ok)
+		assert.Equal(t, "SUCCEEDED", build.BuildStatus)
+	})
+
+	t.Run("build failed -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"builds": [
+								{
+									"id": "backend-build:build-123",
+									"projectName": "backend-build",
+									"buildStatus": "FAILED",
+									"currentPhase": "COMPLETED"
+								}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		err := component.HandleAction(core.ActionContext{
+			Name: "pollBuild",
+			HTTP: httpContext,
+			Metadata: &contexts.MetadataContext{
+				Metadata: RunBuildMetadata{
+					Region:      "us-east-1",
+					ProjectName: "backend-build",
+					BuildID:     "backend-build:build-123",
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "status FAILED")
+	})
+}
+
+func Test__IsBuildTerminalStatus(t *testing.T) {
+	t.Run("succeeded", func(t *testing.T) {
+		finished, succeeded := isBuildTerminalStatus("SUCCEEDED")
+		assert.True(t, finished)
+		assert.True(t, succeeded)
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		finished, succeeded := isBuildTerminalStatus("FAILED")
+		assert.True(t, finished)
+		assert.False(t, succeeded)
+	})
+
+	t.Run("in progress", func(t *testing.T) {
+		finished, succeeded := isBuildTerminalStatus("IN_PROGRESS")
+		assert.False(t, finished)
+		assert.False(t, succeeded)
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		finished, succeeded := isBuildTerminalStatus("PENDING")
+		assert.False(t, finished)
+		assert.False(t, succeeded)
+	})
+}
+
+func Test__BuildFailureError(t *testing.T) {
+	err := buildFailureError(&Build{
+		ID:          "backend-build:build-123",
+		BuildStatus: "FAILED",
+		Logs: &BuildLogs{
+			DeepLink: "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status FAILED")
+	assert.Contains(t, err.Error(), "https://console.aws.amazon.com/codesuite/codebuild/projects/backend-build")
+}
+
+func Test__RunBuild__ExecuteSchedulesPollInterval(t *testing.T) {
+	component := &RunBuild{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`
+					{
+						"build": {
+							"id": "backend-build:build-123",
+							"projectName": "backend-build",
+							"buildStatus": "IN_PROGRESS",
+							"currentPhase": "BUILD"
+						}
+					}
+				`)),
+			},
+		},
+	}
+
+	requests := &contexts.RequestContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"region":  "us-east-1",
+			"project": "backend-build",
+		},
+		HTTP:           httpContext,
+		Metadata:       &contexts.MetadataContext{},
+		Requests:       requests,
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Integration: &contexts.IntegrationContext{
+			Secrets: map[string]core.IntegrationSecret{
+				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "pollBuild", requests.Action)
+	assert.Equal(t, 10*time.Second, requests.Duration)
+}

--- a/pkg/integrations/aws/resources.go
+++ b/pkg/integrations/aws/resources.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/codebuild"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/codeartifact"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/ecr"
 	"github.com/superplanehq/superplane/pkg/integrations/aws/lambda"
@@ -20,6 +21,9 @@ func (a *AWS) ListResources(resourceType string, ctx core.ListResourcesContext) 
 
 	case "codeartifact.domain":
 		return codeartifact.ListDomains(ctx, resourceType)
+
+	case "codebuild.project":
+		return codebuild.ListProjects(ctx, resourceType)
 
 	default:
 		return []core.IntegrationResource{}, nil

--- a/web_src/src/pages/workflowv2/mappers/aws/codebuild/on_build.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/codebuild/on_build.ts
@@ -1,0 +1,83 @@
+import { getBackgroundColorClass } from "@/utils/colors";
+import { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../../types";
+import { TriggerProps } from "@/ui/trigger";
+import awsIcon from "@/assets/icons/integrations/aws.svg";
+import { CodeBuildBuildEvent, CodeBuildTriggerConfiguration, CodeBuildTriggerMetadata } from "./types";
+import { buildProjectMetadataItems, getProjectLabel } from "./utils";
+import { formatTimeAgo } from "@/utils/date";
+import { stringOrDash } from "../../utils";
+
+/**
+ * Renderer for the "aws.codebuild.onBuild" trigger
+ */
+export const onBuildTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string } => {
+    const eventData = getBuildEvent(context);
+    const detail = eventData?.detail;
+    const project = getProjectLabel(undefined, undefined, detail?.["project-name"]);
+    const status = detail?.["build-status"];
+
+    const title = project ? `${project}${status ? ` · ${status}` : ""}` : "CodeBuild build";
+    const subtitle = context.event?.createdAt ? formatTimeAgo(new Date(context.event?.createdAt || "")) : "";
+
+    return { title, subtitle };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = getBuildEvent(context);
+    const detail = eventData?.detail;
+
+    return {
+      Project: stringOrDash(getProjectLabel(undefined, undefined, detail?.["project-name"])),
+      "Build Status": stringOrDash(detail?.["build-status"]),
+      "Build ID": stringOrDash(detail?.["build-id"]),
+      "Current Phase": stringOrDash(detail?.["current-phase"]),
+      "Phase Context": stringOrDash(detail?.["current-phase-context"]),
+      "Source Version": stringOrDash(detail?.["additional-information"]?.["source-version"]),
+      Initiator: stringOrDash(detail?.["additional-information"]?.initiator),
+      "Logs Link": stringOrDash(detail?.["additional-information"]?.logs?.["deep-link"]),
+      Region: stringOrDash(eventData?.region),
+      Account: stringOrDash(eventData?.account),
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext) => {
+    const { node, definition, lastEvent } = context;
+    const metadata = node.metadata as CodeBuildTriggerMetadata | undefined;
+    const configuration = node.configuration as CodeBuildTriggerConfiguration | undefined;
+    const metadataItems = buildProjectMetadataItems(metadata, configuration);
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Unnamed trigger",
+      iconSrc: awsIcon,
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata: metadataItems,
+    };
+
+    if (lastEvent) {
+      const { title, subtitle } = onBuildTriggerRenderer.getTitleAndSubtitle({ event: lastEvent });
+      props.lastEventData = {
+        title,
+        subtitle,
+        receivedAt: new Date(lastEvent.createdAt),
+        state: "triggered",
+        eventId: lastEvent.id,
+      };
+    }
+
+    return props;
+  },
+};
+
+function getBuildEvent(context: TriggerEventContext): CodeBuildBuildEvent {
+  const eventData = context.event?.data as CodeBuildBuildEvent | { data?: CodeBuildBuildEvent } | undefined;
+  if (!eventData) {
+    return {};
+  }
+
+  if (typeof eventData === "object" && "data" in eventData && eventData.data) {
+    return eventData.data;
+  }
+
+  return eventData;
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/codebuild/run_build.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/codebuild/run_build.ts
@@ -1,0 +1,97 @@
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../../types";
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass, getColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "../..";
+import awsIcon from "@/assets/icons/integrations/aws.svg";
+import { formatTimeAgo } from "@/utils/date";
+import { formatTimestampInUserTimezone } from "@/utils/timezone";
+import { MetadataItem } from "@/ui/metadataList";
+import { CodeBuildBuildOutput, CodeBuildConfiguration, CodeBuildTriggerMetadata } from "./types";
+import { buildProjectMetadataItems } from "./utils";
+import { stringOrDash } from "../../utils";
+
+interface RunBuildMetadata {
+  projectName?: string;
+}
+
+export const runBuildMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      iconSrc: awsIcon,
+      iconColor: getColorClass(context.componentDefinition.color),
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      eventSections: lastExecution ? getBuildEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      metadata: getBuildMetadataList(context.node),
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const build = outputs?.default?.[0]?.data as CodeBuildBuildOutput | undefined;
+    if (!build) {
+      return {};
+    }
+
+    return {
+      Project: stringOrDash(build.projectName),
+      "Build Status": stringOrDash(build.buildStatus),
+      "Current Phase": stringOrDash(build.currentPhase),
+      "Build Number": stringOrDash(build.buildNumber),
+      "Build ID": stringOrDash(build.id),
+      "Build ARN": stringOrDash(build.arn),
+      "Source Version": stringOrDash(build.sourceVersion),
+      Initiator: stringOrDash(build.initiator),
+      "Started At": build.startTime ? formatTimestampInUserTimezone(build.startTime) : "-",
+      "Finished At": build.endTime ? formatTimestampInUserTimezone(build.endTime) : "-",
+      "Logs Link": stringOrDash(build.logs?.deepLink),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string {
+    if (!context.execution.createdAt) {
+      return "";
+    }
+
+    return formatTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function getBuildMetadataList(node: NodeInfo): MetadataItem[] {
+  const metadata = node.metadata as CodeBuildTriggerMetadata | RunBuildMetadata | undefined;
+  const configuration = node.configuration as CodeBuildConfiguration | undefined;
+  const metadataProjectName =
+    metadata && typeof metadata === "object" && "projectName" in metadata ? metadata.projectName : undefined;
+
+  return buildProjectMetadataItems(metadata as CodeBuildTriggerMetadata, configuration, metadataProjectName);
+}
+
+function getBuildEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/codebuild/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/codebuild/types.ts
@@ -1,0 +1,64 @@
+export interface CodeBuildProject {
+  projectName?: string;
+  projectArn?: string;
+}
+
+export interface CodeBuildConfiguration {
+  region?: string;
+  project?: string;
+  sourceVersion?: string;
+}
+
+export interface CodeBuildTriggerConfiguration extends CodeBuildConfiguration {}
+
+export interface CodeBuildTriggerMetadata {
+  region?: string;
+  subscriptionId?: string;
+  project?: CodeBuildProject;
+}
+
+export interface CodeBuildBuildEventDetail {
+  "project-name"?: string;
+  "build-status"?: string;
+  "build-id"?: string;
+  "current-phase"?: string;
+  "current-phase-context"?: string;
+  version?: string;
+  "additional-information"?: {
+    initiator?: string;
+    "source-version"?: string;
+    logs?: {
+      "deep-link"?: string;
+    };
+  };
+}
+
+export interface CodeBuildBuildEvent {
+  account?: string;
+  region?: string;
+  time?: string;
+  "detail-type"?: string;
+  detail?: CodeBuildBuildEventDetail;
+}
+
+export interface CodeBuildBuildLogs {
+  deepLink?: string;
+  cloudWatchLogsArn?: string;
+  groupName?: string;
+  streamName?: string;
+  status?: string;
+}
+
+export interface CodeBuildBuildOutput {
+  id?: string;
+  arn?: string;
+  buildNumber?: number;
+  currentPhase?: string;
+  buildStatus?: string;
+  projectName?: string;
+  sourceVersion?: string;
+  initiator?: string;
+  startTime?: string;
+  endTime?: string;
+  logs?: CodeBuildBuildLogs;
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/codebuild/utils.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/codebuild/utils.ts
@@ -1,0 +1,49 @@
+import { MetadataItem } from "@/ui/metadataList";
+import { CodeBuildConfiguration, CodeBuildTriggerMetadata } from "./types";
+
+export function getProjectLabel(
+  metadata?: CodeBuildTriggerMetadata,
+  configuration?: CodeBuildConfiguration,
+  fallback?: string,
+): string | undefined {
+  const projectRef =
+    metadata?.project?.projectName || metadata?.project?.projectArn || configuration?.project || fallback;
+
+  if (!projectRef) {
+    return undefined;
+  }
+
+  return extractProjectName(projectRef);
+}
+
+export function extractProjectName(projectRef: string): string {
+  const trimmed = projectRef.trim();
+  if (!trimmed.startsWith("arn:")) {
+    return trimmed;
+  }
+
+  const parts = trimmed.split("project/");
+  if (parts.length !== 2 || !parts[1]) {
+    return trimmed;
+  }
+
+  return parts[1];
+}
+
+export function buildProjectMetadataItems(
+  metadata?: CodeBuildTriggerMetadata,
+  configuration?: CodeBuildConfiguration,
+  fallback?: string,
+): MetadataItem[] {
+  const projectLabel = getProjectLabel(metadata, configuration, fallback);
+  if (!projectLabel) {
+    return [];
+  }
+
+  return [
+    {
+      icon: "hammer",
+      label: projectLabel,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/index.ts
@@ -8,6 +8,8 @@ import { buildActionStateRegistry } from "../utils";
 import { scanImageMapper } from "./ecr/scan_image";
 import { onPackageVersionTriggerRenderer } from "./codeartifact/on_package_version";
 import { getPackageVersionMapper } from "./codeartifact/get_package_version";
+import { onBuildTriggerRenderer } from "./codebuild/on_build";
+import { runBuildMapper } from "./codebuild/run_build";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   "lambda.runFunction": runFunctionMapper,
@@ -15,10 +17,12 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   "ecr.getImageScanFindings": getImageScanFindingsMapper,
   "ecr.scanImage": scanImageMapper,
   "codeArtifact.getPackageVersion": getPackageVersionMapper,
+  "codebuild.runBuild": runBuildMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
   "codeArtifact.onPackageVersion": onPackageVersionTriggerRenderer,
+  "codebuild.onBuild": onBuildTriggerRenderer,
   "ecr.onImagePush": onImagePushTriggerRenderer,
   "ecr.onImageScan": onImageScanTriggerRenderer,
 };
@@ -28,4 +32,5 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   "ecr.getImageScanFindings": buildActionStateRegistry("retrieved"),
   "ecr.scanImage": buildActionStateRegistry("scanned"),
   "codeArtifact.getPackageVersion": buildActionStateRegistry("retrieved"),
+  "codebuild.runBuild": buildActionStateRegistry("finished"),
 };

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -413,6 +413,7 @@ function CategorySection({
     dockerhub: dockerIcon,
     aws: {
       codeArtifact: awsIcon,
+      codebuild: awsIcon,
       lambda: awsLambdaIcon,
       ecr: awsEcrIcon,
     },
@@ -486,6 +487,7 @@ function CategorySection({
             dockerhub: dockerIcon,
             aws: {
               codeArtifact: awsCodeArtifactIcon,
+              codebuild: awsIcon,
               ecr: awsEcrIcon,
               lambda: awsLambdaIcon,
             },

--- a/web_src/src/ui/componentSidebar/integrationIcons.tsx
+++ b/web_src/src/ui/componentSidebar/integrationIcons.tsx
@@ -66,6 +66,7 @@ export const APP_LOGO_MAP: Record<string, string | Record<string, string>> = {
   render: renderIcon,
   dockerhub: dockerIcon,
   aws: {
+    codebuild: awsIcon,
     lambda: awsLambdaIcon,
   },
 };
@@ -95,7 +96,7 @@ export function getHeaderIconSrc(blockName: string | undefined): string | undefi
     const nested = appLogo[nameParts[1]];
     if (nested) return nested;
   }
-  // AWS has a nested map (lambda only); use main AWS icon for other aws.* components
+  // AWS has a partial nested map; use main AWS icon for other aws.* components
   if (first === "aws") return getIntegrationIconSrc("aws");
   return undefined;
 }


### PR DESCRIPTION
Add AWS CodeBuild trigger (`aws.codebuild.onBuild`) and component (`aws.codebuild.runBuild`) to extend AWS integration for build event-driven workflows and orchestration.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ca318384-6698-47b4-b053-40e5eb1d3b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca318384-6698-47b4-b053-40e5eb1d3b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

