### PR TITLE
feat(rootly): Add Update Incident component

### DIFF
--- a/pkg/integrations/rootly/example.go
+++ b/pkg/integrations/rootly/example.go
@@ -19,6 +19,12 @@ var exampleOutputCreateEventBytes []byte
 var exampleOutputCreateEventOnce sync.Once
 var exampleOutputCreateEvent map[string]any
 
+//go:embed example_output_update_incident.json
+var exampleOutputUpdateIncidentBytes []byte
+
+var exampleOutputUpdateIncidentOnce sync.Once
+var exampleOutputUpdateIncident map[string]any
+
 //go:embed example_data_on_incident.json
 var exampleDataOnIncidentBytes []byte
 
@@ -31,6 +37,10 @@ func (c *CreateIncident) ExampleOutput() map[string]any {
 
 func (c *CreateEvent) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateEventOnce, exampleOutputCreateEventBytes, &exampleOutputCreateEvent)
+}
+
+func (u *UpdateIncident) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateIncidentOnce, exampleOutputUpdateIncidentBytes, &exampleOutputUpdateIncident)
 }
 
 func (t *OnIncident) ExampleData() map[string]any {

--- a/pkg/integrations/rootly/example_output_update_incident.json
+++ b/pkg/integrations/rootly/example_output_update_incident.json
@@ -1,0 +1,8 @@
+{
+  "id": "abc123-def456-ghi789",
+  "sequential_id": 42,
+  "title": "Database Connection Timeout - Updated",
+  "slug": "database-connection-timeout",
+  "status": "mitigated",
+  "updated_at": "2024-01-15T14:30:00Z"
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -63,6 +63,7 @@ func (r *Rootly) Components() []core.Component {
 	return []core.Component{
 		&CreateIncident{},
 		&CreateEvent{},
+		&UpdateIncident{},
 	}
 }
 

--- a/pkg/integrations/rootly/update_incident.go
+++ b/pkg/integrations/rootly/update_incident.go
@@ -1,0 +1,287 @@
+package rootly
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type UpdateIncident struct{}
+
+type UpdateIncidentSpec struct {
+	IncidentID string   `json:"incidentId"`
+	Title      string   `json:"title"`
+	Summary    string   `json:"summary"`
+	Status     string   `json:"status"`
+	Severity   string   `json:"severity"`
+	Services   []string `json:"services"`
+	Teams      []string `json:"teams"`
+	Labels     []Label  `json:"labels"`
+}
+
+type Label struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (u *UpdateIncident) Name() string {
+	return "rootly.updateIncident"
+}
+
+func (u *UpdateIncident) Label() string {
+	return "Update Incident"
+}
+
+func (u *UpdateIncident) Description() string {
+	return "Update an existing incident in Rootly"
+}
+
+func (u *UpdateIncident) Documentation() string {
+	return `The Update Incident component updates an existing incident in Rootly.
+
+## Use Cases
+
+- **Status sync**: Update incident status when new information arrives from external systems
+- **Severity escalation**: Change incident severity based on workflow conditions
+- **Service attachment**: Attach services or teams to an incident from workflow steps
+- **Summary updates**: Add or modify incident summary with new details
+
+## Configuration
+
+- **Incident ID**: The Rootly incident UUID to update (required, supports expressions)
+- **Title**: New incident title (optional, supports expressions)
+- **Summary**: New summary/description (optional, supports expressions)
+- **Status**: New status: in_triage, started, detected, acknowledged, mitigated, resolved, closed, cancelled (optional)
+- **Severity**: Rootly severity slug (optional)
+- **Services**: Service names to attach (optional)
+- **Teams**: Team/group names to attach (optional)
+- **Labels**: Key-value labels to apply (optional)
+
+## Output
+
+Returns the updated incident object including:
+- **id**: Incident ID
+- **sequential_id**: Sequential incident number
+- **title**: Incident title
+- **slug**: Incident slug
+- **status**: Current incident status
+- **updated_at**: Last update timestamp`
+}
+
+func (u *UpdateIncident) Icon() string {
+	return "alert-triangle"
+}
+
+func (u *UpdateIncident) Color() string {
+	return "gray"
+}
+
+func (u *UpdateIncident) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (u *UpdateIncident) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Rootly incident UUID to update",
+		},
+		{
+			Name:        "title",
+			Label:       "Title",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "New incident title",
+		},
+		{
+			Name:        "summary",
+			Label:       "Summary",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "New summary/description",
+		},
+		{
+			Name:        "status",
+			Label:       "Status",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Description: "New incident status",
+			Placeholder: "Select a status",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "In Triage", Value: "in_triage"},
+						{Label: "Started", Value: "started"},
+						{Label: "Detected", Value: "detected"},
+						{Label: "Acknowledged", Value: "acknowledged"},
+						{Label: "Mitigated", Value: "mitigated"},
+						{Label: "Resolved", Value: "resolved"},
+						{Label: "Closed", Value: "closed"},
+						{Label: "Cancelled", Value: "cancelled"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "severity",
+			Label:       "Severity",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "The severity level of the incident",
+			Placeholder: "Select a severity",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "severity",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "services",
+			Label:       "Services",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Services to attach to the incident",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Service",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "teams",
+			Label:       "Teams",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Teams to attach to the incident",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Team",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "labels",
+			Label:       "Labels",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Key-value labels to apply (e.g., platform: backend-api)",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Label",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:     "key",
+								Label:    "Key",
+								Type:     configuration.FieldTypeString,
+								Required: true,
+							},
+							{
+								Name:     "value",
+								Label:    "Value",
+								Type:     configuration.FieldTypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (u *UpdateIncident) Setup(ctx core.SetupContext) error {
+	spec := UpdateIncidentSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.IncidentID == "" {
+		return errors.New("incident ID is required")
+	}
+
+	return nil
+}
+
+func (u *UpdateIncident) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateIncidentSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	// Convert labels to map
+	labels := make(map[string]string)
+	for _, label := range spec.Labels {
+		if label.Key != "" {
+			labels[label.Key] = label.Value
+		}
+	}
+
+	req := UpdateIncidentRequest{
+		Title:    spec.Title,
+		Summary:  spec.Summary,
+		Status:   spec.Status,
+		Severity: spec.Severity,
+		Services: spec.Services,
+		Teams:    spec.Teams,
+		Labels:   labels,
+	}
+
+	incident, err := client.UpdateIncident(spec.IncidentID, req)
+	if err != nil {
+		return fmt.Errorf("failed to update incident: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"rootly.incident",
+		[]any{incident},
+	)
+}
+
+func (u *UpdateIncident) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (u *UpdateIncident) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (u *UpdateIncident) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (u *UpdateIncident) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (u *UpdateIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (u *UpdateIncident) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/update_incident_test.go
+++ b/pkg/integrations/rootly/update_incident_test.go
@@ -1,0 +1,392 @@
+package rootly
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateIncident__Setup(t *testing.T) {
+	component := &UpdateIncident{}
+
+	t.Run("valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123",
+				"title":      "Updated Title",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("missing incident ID returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"title": "Some Title",
+			},
+		})
+
+		require.ErrorContains(t, err, "incident ID is required")
+	})
+
+	t.Run("empty incident ID returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "",
+				"title":      "Some Title",
+			},
+		})
+
+		require.ErrorContains(t, err, "incident ID is required")
+	})
+
+	t.Run("invalid configuration format -> decode error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "not a map",
+		})
+
+		require.ErrorContains(t, err, "error decoding configuration")
+	})
+
+	t.Run("only incident ID is required - all other fields optional", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdateIncident__Execute(t *testing.T) {
+	component := &UpdateIncident{}
+
+	t.Run("successfully updates incident", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"data": {
+							"id": "abc123",
+							"type": "incidents",
+							"attributes": {
+								"sequential_id": 42,
+								"title": "Updated Incident Title",
+								"slug": "updated-incident-title",
+								"status": "mitigated",
+								"updated_at": "2024-01-15T14:30:00Z"
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123",
+				"title":      "Updated Incident Title",
+				"status":     "mitigated",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "rootly.incident", executionState.Type)
+
+		require.Len(t, httpContext.Requests, 1)
+		req := httpContext.Requests[0]
+		assert.Equal(t, http.MethodPut, req.Method)
+		assert.Equal(t, "https://api.rootly.com/v1/incidents/abc123", req.URL.String())
+		assert.Equal(t, "application/vnd.api+json", req.Header.Get("Content-Type"))
+		assert.Equal(t, "application/vnd.api+json", req.Header.Get("Accept"))
+		assert.Equal(t, "Bearer test-api-key", req.Header.Get("Authorization"))
+	})
+
+	t.Run("updates incident with all fields", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"data": {
+							"id": "abc123",
+							"type": "incidents",
+							"attributes": {
+								"sequential_id": 42,
+								"title": "New Title",
+								"slug": "new-title",
+								"status": "resolved",
+								"updated_at": "2024-01-15T14:30:00Z"
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123",
+				"title":      "New Title",
+				"summary":    "New summary with details",
+				"status":     "resolved",
+				"severity":   "high",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+
+		require.Len(t, httpContext.Requests, 1)
+		req := httpContext.Requests[0]
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		err = json.Unmarshal(body, &payload)
+		require.NoError(t, err)
+
+		data := payload["data"].(map[string]any)
+		assert.Equal(t, "incidents", data["type"])
+		attributes := data["attributes"].(map[string]any)
+		assert.Equal(t, "New Title", attributes["title"])
+		assert.Equal(t, "New summary with details", attributes["summary"])
+		assert.Equal(t, "resolved", attributes["status"])
+		assert.Equal(t, "high", attributes["severity"])
+	})
+
+	t.Run("updates incident with labels", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"data": {
+							"id": "abc123",
+							"type": "incidents",
+							"attributes": {
+								"sequential_id": 42,
+								"title": "Test Incident",
+								"slug": "test-incident",
+								"status": "started",
+								"updated_at": "2024-01-15T14:30:00Z"
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123",
+				"labels": []map[string]any{
+					{"key": "platform", "value": "backend-api"},
+					{"key": "region", "value": "us-east-1"},
+				},
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+
+		require.Len(t, httpContext.Requests, 1)
+		req := httpContext.Requests[0]
+
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+
+		var payload map[string]any
+		err = json.Unmarshal(body, &payload)
+		require.NoError(t, err)
+
+		data := payload["data"].(map[string]any)
+		attributes := data["attributes"].(map[string]any)
+		labelsSlugs := attributes["labels_slugs"].([]any)
+		assert.Len(t, labelsSlugs, 2)
+	})
+
+	t.Run("handles API error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error": "Incident not found"}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "nonexistent",
+				"title":      "Test",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update incident")
+	})
+
+	t.Run("invalid configuration -> decode error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  "invalid",
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error decoding configuration")
+	})
+}
+
+func Test__UpdateIncident__Configuration(t *testing.T) {
+	component := &UpdateIncident{}
+	config := component.Configuration()
+
+	t.Run("has incident ID field as required", func(t *testing.T) {
+		var found bool
+		var isRequired bool
+		for _, field := range config {
+			if field.Name == "incidentId" {
+				found = true
+				isRequired = field.Required
+				break
+			}
+		}
+
+		require.True(t, found, "incidentId field should exist")
+		assert.True(t, isRequired, "incidentId should be required")
+	})
+
+	t.Run("has optional status field with correct options", func(t *testing.T) {
+		var found bool
+		var isRequired bool
+		var optionsCount int
+		for _, field := range config {
+			if field.Name == "status" {
+				found = true
+				isRequired = field.Required
+				if field.TypeOptions != nil && field.TypeOptions.Select != nil {
+					optionsCount = len(field.TypeOptions.Select.Options)
+				}
+				break
+			}
+		}
+
+		require.True(t, found, "status field should exist")
+		assert.False(t, isRequired, "status should be optional")
+		assert.Equal(t, 8, optionsCount, "should have 8 status options")
+	})
+}
+
+func Test__UpdateIncident__OutputChannels(t *testing.T) {
+	component := &UpdateIncident{}
+	channels := component.OutputChannels(nil)
+
+	require.Len(t, channels, 1)
+	assert.Equal(t, "default", channels[0].Name)
+}
+
+func Test__UpdateIncident__Metadata(t *testing.T) {
+	component := &UpdateIncident{}
+
+	t.Run("has correct name", func(t *testing.T) {
+		assert.Equal(t, "rootly.updateIncident", component.Name())
+	})
+
+	t.Run("has correct label", func(t *testing.T) {
+		assert.Equal(t, "Update Incident", component.Label())
+	})
+
+	t.Run("has description", func(t *testing.T) {
+		assert.NotEmpty(t, component.Description())
+	})
+
+	t.Run("has documentation", func(t *testing.T) {
+		doc := component.Documentation()
+		assert.NotEmpty(t, doc)
+		assert.Contains(t, doc, "Update Incident")
+		assert.Contains(t, doc, "Use Cases")
+		assert.Contains(t, doc, "Configuration")
+	})
+
+	t.Run("has icon", func(t *testing.T) {
+		assert.Equal(t, "alert-triangle", component.Icon())
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/rootly/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/index.ts
@@ -2,11 +2,13 @@ import { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../typ
 import { onIncidentTriggerRenderer } from "./on_incident";
 import { createIncidentMapper } from "./create_incident";
 import { createEventMapper } from "./create_event";
+import { updateIncidentMapper } from "./update_incident";
 import { buildActionStateRegistry } from "../utils";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIncident: createIncidentMapper,
   createEvent: createEventMapper,
+  updateIncident: updateIncidentMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -16,4 +18,5 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIncident: buildActionStateRegistry("created"),
   createEvent: buildActionStateRegistry("created"),
+  updateIncident: buildActionStateRegistry("updated"),
 };

--- a/web_src/src/pages/workflowv2/mappers/rootly/update_incident.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/update_incident.ts
@@ -1,0 +1,119 @@
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import rootlyIcon from "@/assets/icons/integrations/rootly.svg";
+import { formatTimeAgo } from "@/utils/date";
+
+export interface UpdatedIncident {
+  id?: string;
+  sequential_id?: number;
+  title?: string;
+  slug?: string;
+  status?: string;
+  updated_at?: string;
+}
+
+export function getDetailsForUpdatedIncident(incident: UpdatedIncident): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  details.ID = incident?.id || "-";
+  
+  if (incident?.sequential_id) {
+    details["Sequential ID"] = String(incident.sequential_id);
+  }
+  
+  details.Title = incident?.title || "-";
+  details.Slug = incident?.slug || "-";
+  details.Status = incident?.status || "-";
+
+  if (incident?.updated_at) {
+    details["Updated At"] = new Date(incident.updated_at).toLocaleString();
+  }
+
+  return details;
+}
+
+export const updateIncidentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      iconSrc: rootlyIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name ||
+        context.componentDefinition.label ||
+        context.componentDefinition.name ||
+        "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default: OutputPayload[] };
+    if (!outputs?.default || outputs.default.length === 0) {
+      return {};
+    }
+    const incident = outputs.default[0].data as UpdatedIncident;
+    return getDetailsForUpdatedIncident(incident);
+  },
+
+  subtitle(context: SubtitleContext): string {
+    if (!context.execution.createdAt) return "";
+    return formatTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as { 
+    status?: string;
+    severity?: string;
+    incidentId?: string;
+  };
+
+  if (configuration?.incidentId) {
+    metadata.push({ icon: "ticket", label: "Incident: " + configuration.incidentId });
+  }
+
+  if (configuration?.status) {
+    metadata.push({ icon: "circle", label: "Status: " + configuration.status });
+  }
+
+  if (configuration?.severity) {
+    metadata.push({ icon: "funnel", label: "Severity: " + configuration.severity });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}


### PR DESCRIPTION
## Description

Implements the Rootly **Update Incident** component (issue #2541) that updates an existing incident in Rootly with new title, summary, status, severity, services, teams, or labels.

## Changes

### Backend (Go)
- `pkg/integrations/rootly/update_incident.go` - Main component implementation
- `pkg/integrations/rootly/update_incident_test.go` - Comprehensive test coverage
- `pkg/integrations/rootly/example_output_update_incident.json` - Example output for documentation
- `pkg/integrations/rootly/client.go` - Added `UpdateIncident` client method
- `pkg/integrations/rootly/rootly.go` - Registered component
- `pkg/integrations/rootly/example.go` - Added ExampleOutput

### Frontend (TypeScript)
- `web_src/src/pages/workflowv2/mappers/rootly/update_incident.ts` - UI mapper
- `web_src/src/pages/workflowv2/mappers/rootly/index.ts` - Registered mapper

## Configuration

- **Incident ID** (required): Rootly incident UUID to update
- **Title** (optional): New incident title
- **Summary** (optional): New summary/description
- **Status** (optional): in_triage, started, detected, acknowledged, mitigated, resolved, closed, cancelled
- **Severity** (optional): Rootly severity slug (e.g., critical, high, medium, low)
- **Services** (optional): Service names to attach to the incident
- **Teams** (optional): Team/group names to attach to the incident
- **Labels** (optional): Key-value labels to apply (e.g., platform: backend-api)

## Output

Returns the updated incident object including:
- `id`: Incident ID
- `sequential_id`: Sequential incident number
- `title`: Incident title
- `slug`: Incident slug
- `status`: Current incident status
- `updated_at`: Last update timestamp

## Use Cases

- Update incident summary or severity when new information arrives from Sentry or PagerDuty
- Sync status or fields from Jira or ServiceNow into Rootly incident
- Attach services or teams to an incident from a workflow step

## Testing

All tests pass:

```
=== RUN   Test__UpdateIncident__Setup
--- PASS: Test__UpdateIncident__Setup (0.00s)
=== RUN   Test__UpdateIncident__Execute
--- PASS: Test__UpdateIncident__Execute (0.00s)
=== RUN   Test__UpdateIncident__Configuration
--- PASS: Test__UpdateIncident__Configuration (0.00s)
=== RUN   Test__UpdateIncident__OutputChannels
--- PASS: Test__UpdateIncident__OutputChannels (0.00s)
=== RUN   Test__UpdateIncident__Metadata
--- PASS: Test__UpdateIncident__Metadata (0.00s)
```

## Video Demo

🎬 Video demonstrating the working integration will be provided after initial review/feedback.

Closes #2541