### PR TITLE
feat(semaphore): add Get Pipeline component

### DIFF
--- a/docs/components/Semaphore.mdx
+++ b/docs/components/Semaphore.mdx
@@ -18,6 +18,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Run Workflow" href="#run-workflow" description="Run Semaphore workflow" />
+  <LinkCard title="Get Pipeline" href="#get-pipeline" description="Fetch a Semaphore pipeline by ID" />
 </CardGrid>
 
 <a id="on-pipeline-done"></a>
@@ -245,6 +246,47 @@ The Run Workflow component triggers a Semaphore CI/CD workflow and waits for it 
   },
   "timestamp": "2026-01-22T15:32:56.061430218Z",
   "type": "semaphore.workflow.finished"
+}
+```
+
+<a id="get-pipeline"></a>
+
+## Get Pipeline
+
+The Get Pipeline component fetches a Semaphore pipeline by ID and returns its current state, result, workflow ID, and metadata.
+
+### Use Cases
+
+- **Poll pipeline status**: After triggering a workflow, poll for pipeline status to decide when to proceed
+- **Status verification**: Check if a specific pipeline passed or failed before triggering dependent actions
+- **Workflow branching**: Branch workflows based on pipeline state (running vs done) or result (passed/failed)
+
+### Configuration
+
+- **Pipeline ID**: The Semaphore pipeline ID (e.g., from Run Workflow output or On Pipeline Done event). Supports expressions.
+
+### Output
+
+**Default channel**: Emits pipeline data including:
+- `ppl_id`: Pipeline ID
+- `wf_id`: Workflow ID
+- `name`: Pipeline name
+- `state`: Current state (e.g., pending, running, done)
+- `result`: Result when done (e.g., passed, failed, cancelled)
+
+### Example Data
+
+```json
+{
+  "type": "semaphore.pipeline",
+  "timestamp": "2026-02-05T00:00:00Z",
+  "data": {
+    "ppl_id": "7f1a3c2b-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
+    "wf_id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "name": "test-pipeline",
+    "state": "done",
+    "result": "passed"
+  }
 }
 ```
 

--- a/pkg/integrations/semaphore/example.go
+++ b/pkg/integrations/semaphore/example.go
@@ -13,11 +13,17 @@ var exampleOutputRunWorkflowBytes []byte
 //go:embed example_data_on_pipeline_done.json
 var exampleDataOnPipelineDoneBytes []byte
 
+//go:embed example_output_get_pipeline.json
+var exampleOutputGetPipelineBytes []byte
+
 var exampleOutputOnce sync.Once
 var exampleOutput map[string]any
 
 var exampleDataOnce sync.Once
 var exampleData map[string]any
+
+var exampleOutputGetPipelineOnce sync.Once
+var exampleOutputGetPipeline map[string]any
 
 func (c *RunWorkflow) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputOnce, exampleOutputRunWorkflowBytes, &exampleOutput)
@@ -25,4 +31,8 @@ func (c *RunWorkflow) ExampleOutput() map[string]any {
 
 func (t *OnPipelineDone) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnce, exampleDataOnPipelineDoneBytes, &exampleData)
+}
+
+func (g *GetPipeline) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetPipelineOnce, exampleOutputGetPipelineBytes, &exampleOutputGetPipeline)
 }

--- a/pkg/integrations/semaphore/example_output_get_pipeline.json
+++ b/pkg/integrations/semaphore/example_output_get_pipeline.json
@@ -1,0 +1,9 @@
+{
+  "pipeline": {
+    "ppl_id": "7f1a3c2b-4d5e-6f7a-8b9c-0d1e2f3a4b5c",
+    "wf_id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+    "name": "test-pipeline",
+    "state": "done",
+    "result": "passed"
+  }
+}

--- a/pkg/integrations/semaphore/get_pipeline.go
+++ b/pkg/integrations/semaphore/get_pipeline.go
@@ -1,0 +1,160 @@
+package semaphore
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetPipelineOutputChannel = "default"
+const PipelinePayloadType = "semaphore.pipeline"
+
+type GetPipeline struct{}
+
+type GetPipelineSpec struct {
+	PipelineID string `json:"pipelineId" mapstructure:"pipelineId"`
+}
+
+type GetPipelineOutput struct {
+	PipelineID   string `json:"ppl_id"`
+	WorkflowID   string `json:"wf_id"`
+	Name         string `json:"name"`
+	State        string `json:"state"`
+	Result       string `json:"result"`
+}
+
+func (g *GetPipeline) Name() string {
+	return "semaphore.getPipeline"
+}
+
+func (g *GetPipeline) Label() string {
+	return "Get Pipeline"
+}
+
+func (g *GetPipeline) Description() string {
+	return "Fetch a Semaphore pipeline by ID"
+}
+
+func (g *GetPipeline) Documentation() string {
+	return `The Get Pipeline component fetches a Semaphore pipeline by ID and returns its current state, result, workflow ID, and metadata.
+
+## Use Cases
+
+- **Poll pipeline status**: After triggering a workflow, poll for pipeline status to decide when to proceed
+- **Status verification**: Check if a specific pipeline passed or failed before triggering dependent actions
+- **Workflow branching**: Branch workflows based on pipeline state (running vs done) or result (passed/failed)
+
+## Configuration
+
+- **Pipeline ID**: The Semaphore pipeline ID (e.g., from Run Workflow output or On Pipeline Done event). Supports expressions.
+
+## Output
+
+**Default channel**: Emits pipeline data including:
+- ppl_id: Pipeline ID
+- wf_id: Workflow ID
+- name: Pipeline name
+- state: Current state (e.g., pending, running, done)
+- result: Result when done (e.g., passed, failed, cancelled)
+
+Errors do not emit a payload.`
+}
+
+func (g *GetPipeline) Icon() string {
+	return "search"
+}
+
+func (g *GetPipeline) Color() string {
+	return "gray"
+}
+
+func (g *GetPipeline) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{
+			Name:  GetPipelineOutputChannel,
+			Label: "Default",
+		},
+	}
+}
+
+func (g *GetPipeline) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "pipelineId",
+			Label:       "Pipeline ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "e.g., 123e4567-e89b-12d3-a456-426614174000",
+			Description: "Semaphore pipeline ID to fetch",
+		},
+	}
+}
+
+func (g *GetPipeline) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetPipeline) Setup(ctx core.SetupContext) error {
+	config := GetPipelineSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &config)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.PipelineID == "" {
+		return fmt.Errorf("pipeline ID is required")
+	}
+
+	return nil
+}
+
+func (g *GetPipeline) Execute(ctx core.ExecutionContext) error {
+	spec := GetPipelineSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	pipeline, err := client.GetPipeline(spec.PipelineID)
+	if err != nil {
+		return fmt.Errorf("error fetching pipeline: %v", err)
+	}
+
+	output := GetPipelineOutput{
+		PipelineID: pipeline.PipelineID,
+		WorkflowID: pipeline.WorkflowID,
+		Name:       pipeline.PipelineName,
+		State:      pipeline.State,
+		Result:     pipeline.Result,
+	}
+
+	return ctx.ExecutionState.Emit(GetPipelineOutputChannel, PipelinePayloadType, []any{output})
+}
+
+func (g *GetPipeline) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetPipeline) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (g *GetPipeline) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (g *GetPipeline) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (g *GetPipeline) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/semaphore/get_pipeline_test.go
+++ b/pkg/integrations/semaphore/get_pipeline_test.go
@@ -1,0 +1,144 @@
+package semaphore
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetPipeline__Name(t *testing.T) {
+	component := &GetPipeline{}
+	assert.Equal(t, "semaphore.getPipeline", component.Name())
+}
+
+func Test__GetPipeline__Label(t *testing.T) {
+	component := &GetPipeline{}
+	assert.Equal(t, "Get Pipeline", component.Label())
+}
+
+func Test__GetPipeline__Configuration(t *testing.T) {
+	component := &GetPipeline{}
+	config := component.Configuration()
+
+	require.Len(t, config, 1)
+	assert.Equal(t, "pipelineId", config[0].Name)
+	assert.Equal(t, "Pipeline ID", config[0].Label)
+	assert.True(t, config[0].Required)
+}
+
+func Test__GetPipeline__OutputChannels(t *testing.T) {
+	component := &GetPipeline{}
+	channels := component.OutputChannels(nil)
+
+	require.Len(t, channels, 1)
+	assert.Equal(t, GetPipelineOutputChannel, channels[0].Name)
+	assert.Equal(t, "Default", channels[0].Label)
+}
+
+func Test__GetPipeline__Setup(t *testing.T) {
+	component := &GetPipeline{}
+
+	t.Run("pipeline ID is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"pipelineId": "",
+			},
+		})
+		require.ErrorContains(t, err, "pipeline ID is required")
+	})
+
+	t.Run("valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"pipelineId": "test-pipeline-123",
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid configuration type", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "invalid-config",
+		})
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+}
+
+func Test__GetPipeline__Execute(t *testing.T) {
+	component := &GetPipeline{}
+
+	t.Run("successful execution", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"pipeline":{"ppl_id":"test-pipeline-123","wf_id":"wf-456","name":"test-pipeline","state":"done","result":"passed"}}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"pipelineId": "test-pipeline-123",
+			},
+			ExecutionState: executionState,
+			HTTP:           httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"organizationUrl": "https://test.semaphoreci.com",
+					"apiToken":      "test-token",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(executionState.Payloads))
+		assert.Equal(t, GetPipelineOutputChannel, executionState.Channel)
+		assert.Equal(t, PipelinePayloadType, executionState.Type)
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"message":"Pipeline not found"}`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"pipelineId": "test-pipeline-123",
+			},
+			ExecutionState: &contexts.ExecutionStateContext{
+				KVs: make(map[string]string),
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"organizationUrl": "https://test.semaphoreci.com",
+					"apiToken":      "test-token",
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "error fetching pipeline")
+	})
+}
+
+func Test__GetPipeline__Cleanup(t *testing.T) {
+	component := &GetPipeline{}
+	err := component.Cleanup(core.SetupContext{})
+	assert.NoError(t, err)
+}

--- a/pkg/integrations/semaphore/semaphore.go
+++ b/pkg/integrations/semaphore/semaphore.go
@@ -217,6 +217,7 @@ func (s *Semaphore) CleanupWebhook(ctx core.CleanupWebhookContext) error {
 func (s *Semaphore) Components() []core.Component {
 	return []core.Component{
 		&RunWorkflow{},
+		&GetPipeline{},
 	}
 }
 


### PR DESCRIPTION
## Description

Implements the **Get Pipeline** component for the Semaphore integration as specified in #2827.

### Changes

**Backend (Go)**
- `get_pipeline.go`: Complete Component implementation with Setup/Execute using existing `Client.GetPipeline()`
- `get_pipeline_test.go`: Comprehensive tests covering valid config, missing/empty ID, invalid config format, API success/error
- `example_output_get_pipeline.json`: Example output for the component
- `example.go`: Added `ExampleOutput` method with embedded JSON
- `semaphore.go`: Registered `GetPipeline` in `Components()`

### Configuration

- **Pipeline ID** (required): Semaphore pipeline UUID. Supports expressions from previous steps.

### Output

Single output channel emitting `semaphore.pipeline` with pipeline data:
- `ppl_id`: Pipeline ID
- `wf_id`: Workflow ID  
- `name`: Pipeline name
- `state`: Current state (pending, running, done)
- `result`: Result when done (passed, failed, cancelled)

### Testing

All tests pass:
```
=== RUN   Test__GetPipeline__Name
--- PASS
=== RUN   Test__GetPipeline__Setup
    --- PASS: pipeline_ID_is_required
    --- PASS: valid_configuration
    --- PASS: invalid_configuration_type
=== RUN   Test__GetPipeline__Execute
    --- PASS: successful_execution
    --- PASS: API_error
```

Closes #2827