### PR TITLE
feat(github): add Get Workflow Usage component (#2277)

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -30,6 +30,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Release" href="#delete-release" description="Delete a release from a GitHub repository" />
   <LinkCard title="Get Issue" href="#get-issue" description="Get a GitHub issue by number" />
   <LinkCard title="Get Release" href="#get-release" description="Get a release from a GitHub repository" />
+  <LinkCard title="Get Workflow Usage" href="#get-workflow-usage" description="Retrieve GitHub Actions usage (billable minutes) for the organization" />
   <LinkCard title="Publish Commit Status" href="#publish-commit-status" description="Publish a status check to a GitHub commit" />
   <LinkCard title="Run Workflow" href="#run-workflow" description="Run GitHub Actions workflow" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update a GitHub issue" />
@@ -1278,6 +1279,59 @@ Returns release information including:
   },
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.release"
+}
+```
+
+<a id="get-workflow-usage"></a>
+
+## Get Workflow Usage
+
+The Get Workflow Usage component retrieves billable GitHub Actions usage (minutes) for the organization associated with the integration's GitHub App installation.
+
+### Use Cases
+
+- **Billing monitoring**: Check Actions usage for billing or quota awareness from SuperPlane workflows
+- **Cost reporting**: Report on workflow run minutes (e.g., monthly) for cost or compliance purposes
+- **Usage alerts**: Compare usage against thresholds to alert when approaching limits
+- **Resource planning**: Track usage patterns to plan for capacity and costs
+
+### Configuration
+
+This component requires no additional configuration. It automatically uses the organization from the GitHub App installation.
+
+### Output
+
+Returns usage data including:
+- **total_minutes_used**: Total billable minutes consumed in the current billing cycle
+- **total_paid_minutes_used**: Minutes beyond the included free tier
+- **included_minutes**: Free minutes included in the plan
+- **minutes_used_breakdown**: Breakdown by runner OS (Linux, Windows, macOS)
+- **organization**: The organization name
+
+### Notes
+
+- Only private repositories on GitHub-hosted runners accrue billable minutes
+- Public repositories and self-hosted runners show zero billable usage
+- The GitHub App requires **Organization Administration (read)** permission to access billing data
+- Existing app installations may need to approve the new permission before this component works
+
+### Permissions
+
+This component requires the GitHub App to have **Administration (read)** organization permission. If this permission was not granted when the app was installed, organization owners will be prompted by GitHub to approve the new permission; until they do, this component will return a 403 error for those installations.
+
+### Example Output
+
+```json
+{
+  "included_minutes": 1000,
+  "minutes_used_breakdown": {
+    "MACOS": 100,
+    "UBUNTU": 800,
+    "WINDOWS": 350
+  },
+  "organization": "acme",
+  "total_minutes_used": 1250.5,
+  "total_paid_minutes_used": 250.5
 }
 ```
 

--- a/pkg/integrations/github/example.go
+++ b/pkg/integrations/github/example.go
@@ -40,6 +40,9 @@ var exampleOutputRunWorkflowBytes []byte
 //go:embed example_output_create_review.json
 var exampleOutputCreateReviewBytes []byte
 
+//go:embed example_output_get_workflow_usage.json
+var exampleOutputGetWorkflowUsageBytes []byte
+
 //go:embed example_data_on_issue_comment.json
 var exampleDataOnIssueCommentBytes []byte
 
@@ -99,6 +102,9 @@ var exampleOutputRunWorkflow map[string]any
 
 var exampleOutputCreateReviewOnce sync.Once
 var exampleOutputCreateReview map[string]any
+
+var exampleOutputGetWorkflowUsageOnce sync.Once
+var exampleOutputGetWorkflowUsage map[string]any
 
 var exampleDataOnIssueCommentOnce sync.Once
 var exampleDataOnIssueComment map[string]any
@@ -176,6 +182,14 @@ func (c *CreateReview) ExampleOutput() map[string]any {
 		&exampleOutputCreateReviewOnce,
 		exampleOutputCreateReviewBytes,
 		&exampleOutputCreateReview,
+	)
+}
+
+func (c *GetWorkflowUsage) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetWorkflowUsageOnce,
+		exampleOutputGetWorkflowUsageBytes,
+		&exampleOutputGetWorkflowUsage,
 	)
 }
 

--- a/pkg/integrations/github/example_output_get_workflow_usage.json
+++ b/pkg/integrations/github/example_output_get_workflow_usage.json
@@ -1,0 +1,11 @@
+{
+  "total_minutes_used": 1250.5,
+  "total_paid_minutes_used": 250.5,
+  "included_minutes": 1000,
+  "minutes_used_breakdown": {
+    "UBUNTU": 800,
+    "WINDOWS": 350,
+    "MACOS": 100
+  },
+  "organization": "acme"
+}

--- a/pkg/integrations/github/get_workflow_usage.go
+++ b/pkg/integrations/github/get_workflow_usage.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetWorkflowUsage struct{}
+
+type GetWorkflowUsageConfiguration struct {
+	// Note: Repository is optional for this component since billing is at org level
+}
+
+// GetWorkflowUsageOutput represents the output of the GetWorkflowUsage component
+type GetWorkflowUsageOutput struct {
+	TotalMinutesUsed     float64            `json:"total_minutes_used"`
+	TotalPaidMinutesUsed float64            `json:"total_paid_minutes_used"`
+	IncludedMinutes      float64            `json:"included_minutes"`
+	MinutesUsedBreakdown map[string]int     `json:"minutes_used_breakdown"`
+	Organization         string             `json:"organization"`
+}
+
+func (c *GetWorkflowUsage) Name() string {
+	return "github.getWorkflowUsage"
+}
+
+func (c *GetWorkflowUsage) Label() string {
+	return "Get Workflow Usage"
+}
+
+func (c *GetWorkflowUsage) Description() string {
+	return "Retrieve GitHub Actions usage (billable minutes) for the organization"
+}
+
+func (c *GetWorkflowUsage) Documentation() string {
+	return `The Get Workflow Usage component retrieves billable GitHub Actions usage (minutes) for the organization associated with the integration's GitHub App installation.
+
+## Use Cases
+
+- **Billing monitoring**: Check Actions usage for billing or quota awareness from SuperPlane workflows
+- **Cost reporting**: Report on workflow run minutes (e.g., monthly) for cost or compliance purposes
+- **Usage alerts**: Compare usage against thresholds to alert when approaching limits
+- **Resource planning**: Track usage patterns to plan for capacity and costs
+
+## Configuration
+
+This component requires no additional configuration. It automatically uses the organization from the GitHub App installation.
+
+## Output
+
+Returns usage data including:
+- **total_minutes_used**: Total billable minutes consumed in the current billing cycle
+- **total_paid_minutes_used**: Minutes beyond the included free tier
+- **included_minutes**: Free minutes included in the plan
+- **minutes_used_breakdown**: Breakdown by runner OS (Linux, Windows, macOS)
+- **organization**: The organization name
+
+## Notes
+
+- Only private repositories on GitHub-hosted runners accrue billable minutes
+- Public repositories and self-hosted runners show zero billable usage
+- The GitHub App requires **Organization Administration (read)** permission to access billing data
+- Existing app installations may need to approve the new permission before this component works
+
+## Permissions
+
+This component requires the GitHub App to have **Administration (read)** organization permission. If this permission was not granted when the app was installed, organization owners will be prompted by GitHub to approve the new permission; until they do, this component will return a 403 error for those installations.`
+}
+
+func (c *GetWorkflowUsage) Icon() string {
+	return "github"
+}
+
+func (c *GetWorkflowUsage) Color() string {
+	return "gray"
+}
+
+func (c *GetWorkflowUsage) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetWorkflowUsage) Configuration() []configuration.Field {
+	// No additional configuration needed - uses org from integration metadata
+	return []configuration.Field{}
+}
+
+func (c *GetWorkflowUsage) Setup(ctx core.SetupContext) error {
+	// Validate that we have the necessary integration metadata
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+
+	if appMetadata.Owner == "" {
+		return fmt.Errorf("organization/owner is not set in integration metadata")
+	}
+
+	if appMetadata.InstallationID == "" {
+		return fmt.Errorf("installation ID is not set in integration metadata")
+	}
+
+	return nil
+}
+
+func (c *GetWorkflowUsage) Execute(ctx core.ExecutionContext) error {
+	var appMetadata Metadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &appMetadata); err != nil {
+		return fmt.Errorf("failed to decode application metadata: %w", err)
+	}
+
+	// Initialize GitHub client
+	client, err := NewClient(ctx.Integration, appMetadata.GitHubApp.ID, appMetadata.InstallationID)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	// Get Actions billing for the organization
+	billing, _, err := client.Billing.GetActionsBillingOrg(
+		context.Background(),
+		appMetadata.Owner,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get Actions billing for organization %s: %w", appMetadata.Owner, err)
+	}
+
+	// Build output
+	output := GetWorkflowUsageOutput{
+		TotalMinutesUsed:     billing.TotalMinutesUsed,
+		TotalPaidMinutesUsed: billing.TotalPaidMinutesUsed,
+		IncludedMinutes:      billing.IncludedMinutes,
+		MinutesUsedBreakdown: billing.MinutesUsedBreakdown,
+		Organization:         appMetadata.Owner,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.workflowUsage",
+		[]any{output},
+	)
+}
+
+func (c *GetWorkflowUsage) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetWorkflowUsage) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (c *GetWorkflowUsage) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *GetWorkflowUsage) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *GetWorkflowUsage) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetWorkflowUsage) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/github/get_workflow_usage_test.go
+++ b/pkg/integrations/github/get_workflow_usage_test.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetWorkflowUsage__Setup(t *testing.T) {
+	component := GetWorkflowUsage{}
+
+	t.Run("fails when owner is not set", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				InstallationID: "12345",
+				Owner:          "",
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "organization/owner is not set in integration metadata")
+	})
+
+	t.Run("fails when installation ID is not set", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Owner:          "test-org",
+				InstallationID: "",
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "installation ID is not set in integration metadata")
+	})
+
+	t.Run("succeeds when metadata is valid", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Metadata: Metadata{
+				Owner:          "test-org",
+				InstallationID: "12345",
+				GitHubApp: GitHubAppMetadata{
+					ID:   123,
+					Slug: "test-app",
+				},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			Integration:   integrationCtx,
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: map[string]any{},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetWorkflowUsage__Execute(t *testing.T) {
+	component := GetWorkflowUsage{}
+
+	t.Run("fails when metadata decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    &contexts.IntegrationContext{Metadata: "not a map"},
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "failed to decode application metadata")
+	})
+}
+
+func Test__GetWorkflowUsage__Configuration(t *testing.T) {
+	component := GetWorkflowUsage{}
+
+	t.Run("has no required configuration fields", func(t *testing.T) {
+		config := component.Configuration()
+		require.Empty(t, config, "GetWorkflowUsage should have no configuration fields since it uses org from integration")
+	})
+}
+
+func Test__GetWorkflowUsage__Metadata(t *testing.T) {
+	component := GetWorkflowUsage{}
+
+	t.Run("name is correct", func(t *testing.T) {
+		require.Equal(t, "github.getWorkflowUsage", component.Name())
+	})
+
+	t.Run("label is correct", func(t *testing.T) {
+		require.Equal(t, "Get Workflow Usage", component.Label())
+	})
+
+	t.Run("description is set", func(t *testing.T) {
+		require.NotEmpty(t, component.Description())
+	})
+
+	t.Run("documentation is set", func(t *testing.T) {
+		require.NotEmpty(t, component.Documentation())
+		require.Contains(t, component.Documentation(), "billable")
+		require.Contains(t, component.Documentation(), "Administration")
+	})
+
+	t.Run("icon is github", func(t *testing.T) {
+		require.Equal(t, "github", component.Icon())
+	})
+
+	t.Run("color is gray", func(t *testing.T) {
+		require.Equal(t, "gray", component.Color())
+	})
+
+	t.Run("has default output channel", func(t *testing.T) {
+		channels := component.OutputChannels(nil)
+		require.Len(t, channels, 1)
+		require.Equal(t, core.DefaultOutputChannel, channels[0])
+	})
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -104,6 +104,7 @@ func (g *GitHub) Components() []core.Component {
 		&GetRelease{},
 		&UpdateRelease{},
 		&DeleteRelease{},
+		&GetWorkflowUsage{},
 	}
 }
 
@@ -486,12 +487,13 @@ func (g *GitHub) appManifest(ctx core.SyncContext) string {
 		"public": false,
 		"url":    "https://superplane.com",
 		"default_permissions": map[string]string{
-			"issues":           "write",
-			"actions":          "write",
-			"contents":         "write",
-			"pull_requests":    "write",
-			"repository_hooks": "write",
-			"statuses":         "write",
+			"issues":               "write",
+			"actions":              "write",
+			"contents":             "write",
+			"pull_requests":        "write",
+			"repository_hooks":     "write",
+			"statuses":             "write",
+			"organization_administration": "read",
 		},
 		"setup_url":    fmt.Sprintf(`%s/api/v1/integrations/%s/setup`, ctx.BaseURL, ctx.Integration.ID().String()),
 		"redirect_url": fmt.Sprintf(`%s/api/v1/integrations/%s/redirect`, ctx.BaseURL, ctx.Integration.ID().String()),

--- a/web_src/src/pages/workflowv2/mappers/github/get_workflow_usage.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/get_workflow_usage.ts
@@ -1,0 +1,66 @@
+import { ComponentBaseProps } from "@/ui/componentBase";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseProps } from "./base";
+
+interface WorkflowUsageOutput {
+  total_minutes_used: number;
+  total_paid_minutes_used: number;
+  included_minutes: number;
+  minutes_used_breakdown: Record<string, number>;
+  organization: string;
+}
+
+export const getWorkflowUsageMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    if (!outputs?.default || outputs.default.length === 0) {
+      return "Retrieving usage...";
+    }
+
+    const usage = outputs.default[0].data as WorkflowUsageOutput;
+    if (!usage) {
+      return "Usage retrieved";
+    }
+
+    return `${usage.total_minutes_used.toFixed(1)} minutes used`;
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const details: Record<string, string> = {};
+
+    if (!outputs?.default || outputs.default.length === 0) {
+      return details;
+    }
+
+    const usage = outputs.default[0].data as WorkflowUsageOutput;
+    if (!usage) {
+      return details;
+    }
+
+    details["Organization"] = usage.organization || "-";
+    details["Total Minutes Used"] = usage.total_minutes_used?.toFixed(2) || "-";
+    details["Paid Minutes Used"] = usage.total_paid_minutes_used?.toFixed(2) || "-";
+    details["Included Minutes"] = usage.included_minutes?.toString() || "-";
+
+    // Add breakdown by OS
+    if (usage.minutes_used_breakdown) {
+      const breakdown = Object.entries(usage.minutes_used_breakdown)
+        .map(([os, minutes]) => `${os}: ${minutes}`)
+        .join(", ");
+      details["Usage by OS"] = breakdown || "-";
+    }
+
+    return details;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -17,6 +17,7 @@ import { updateReleaseMapper } from "./update_release";
 import { deleteReleaseMapper } from "./delete_release";
 import { getReleaseMapper } from "./get_release";
 import { createReviewMapper } from "./create_review";
+import { getWorkflowUsageMapper } from "./get_workflow_usage";
 import { buildActionStateRegistry } from "../utils";
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -31,6 +32,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   updateRelease: buildActionStateRegistry("updated"),
   deleteRelease: buildActionStateRegistry("deleted"),
   getRelease: buildActionStateRegistry("retrieved"),
+  getWorkflowUsage: buildActionStateRegistry("retrieved"),
 };
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -45,6 +47,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   updateRelease: updateReleaseMapper,
   deleteRelease: deleteReleaseMapper,
   getRelease: getReleaseMapper,
+  getWorkflowUsage: getWorkflowUsageMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {


### PR DESCRIPTION
## Summary

Adds a new GitHub component to retrieve billable GitHub Actions usage (minutes) for the organization. This addresses issue #2277.

## Changes

### Backend (Go)
- `get_workflow_usage.go` - Main component implementation using GitHub's `Billing.GetActionsBillingOrg` API
- `get_workflow_usage_test.go` - Unit tests for setup, execute, and metadata
- `example_output_get_workflow_usage.json` - Example output data
- Updated `example.go` with embed for new example output
- Registered component in `github.go` Components()
- **Added `organization_administration: read` permission to app manifest**

### Frontend (TypeScript)
- `get_workflow_usage.ts` mapper for UI rendering
- Registered in `github/index.ts` with event state registry

### Documentation
- Updated `GitHub.mdx` with full component documentation
- Documented permission requirements and limitations

## Output Format

```json
{
  "total_minutes_used": 1250.5,
  "total_paid_minutes_used": 250.5,
  "included_minutes": 1000,
  "minutes_used_breakdown": {"UBUNTU": 800, "WINDOWS": 350, "MACOS": 100},
  "organization": "acme"
}
```

## Acceptance Criteria from Issue

- [x] Integration requests **Administration (read)** org permission
- [x] Document that breakdown is by OS (and repo when applicable), not by workflow
- [x] has proper tests
- [x] has proper documentation

## Important Notes

- **Permission Requirement**: This component requires the GitHub App to have **Organization Administration (read)** permission
- **Existing Installations**: Org owners will be prompted by GitHub to approve the new permission; until they do, this action will return 403
- Usage breakdown is by runner OS only, not by individual workflow (as noted in issue)
- Only private repos on GitHub-hosted runners accrue billable minutes

## Testing

```bash
go test ./pkg/integrations/github/... -run 'GetWorkflowUsage' -v
```

All tests pass ✅

Closes #2277