### PR TITLE
feat(rootly): add Get Incident component

### DIFF
--- a/pkg/integrations/rootly/example.go
+++ b/pkg/integrations/rootly/example.go
@@ -19,6 +19,12 @@ var exampleOutputCreateEventBytes []byte
 var exampleOutputCreateEventOnce sync.Once
 var exampleOutputCreateEvent map[string]any
 
+//go:embed example_output_get_incident.json
+var exampleOutputGetIncidentBytes []byte
+
+var exampleOutputGetIncidentOnce sync.Once
+var exampleOutputGetIncident map[string]any
+
 //go:embed example_data_on_incident.json
 var exampleDataOnIncidentBytes []byte
 
@@ -31,6 +37,10 @@ func (c *CreateIncident) ExampleOutput() map[string]any {
 
 func (c *CreateEvent) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateEventOnce, exampleOutputCreateEventBytes, &exampleOutputCreateEvent)
+}
+
+func (g *GetIncident) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetIncidentOnce, exampleOutputGetIncidentBytes, &exampleOutputGetIncident)
 }
 
 func (t *OnIncident) ExampleData() map[string]any {

--- a/pkg/integrations/rootly/example_output_get_incident.json
+++ b/pkg/integrations/rootly/example_output_get_incident.json
@@ -1,0 +1,11 @@
+{
+  "id": "abc123-def456-789ghi",
+  "title": "Database connection timeout",
+  "summary": "Users experiencing slow response times due to database connectivity issues",
+  "status": "investigating",
+  "severity": "sev1",
+  "started_at": "2024-02-11T10:00:00Z",
+  "resolved_at": null,
+  "mitigated_at": "2024-02-11T10:30:00Z",
+  "url": "https://app.rootly.com/incidents/abc123"
+}

--- a/pkg/integrations/rootly/get_incident.go
+++ b/pkg/integrations/rootly/get_incident.go
@@ -1,0 +1,173 @@
+package rootly
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetIncident struct{}
+
+type GetIncidentSpec struct {
+	IncidentID string `json:"incidentId"`
+}
+
+func (g *GetIncident) Name() string {
+	return "rootly.getIncident"
+}
+
+func (g *GetIncident) Label() string {
+	return "Get Incident"
+}
+
+func (g *GetIncident) Description() string {
+	return "Retrieve a single incident from Rootly by ID"
+}
+
+func (g *GetIncident) Documentation() string {
+	return `The Get Incident component retrieves a single incident from Rootly by ID so workflows can read details, branch on status, or update external systems.
+
+## Use Cases
+
+- **Status checks**: Fetch incident details to branch workflow based on status or severity
+- **Slack notifications**: Get incident data to post detailed summaries to Slack
+- **External sync**: Retrieve incident details to update external ticketing systems
+- **Workflow enrichment**: Pull full incident data including events and action items
+
+## Configuration
+
+- **Incident ID**: The Rootly incident UUID to retrieve (required, supports expressions)
+
+## Output
+
+Returns the incident object with:
+- **id**: Incident ID
+- **title**: Incident title
+- **summary**: Incident description
+- **status**: Current incident status
+- **severity**: Incident severity level
+- **started_at**: When the incident started
+- **resolved_at**: When resolved (if applicable)
+- **mitigated_at**: When mitigated (if applicable)
+- **url**: Direct link to the incident
+
+## Examples
+
+### Branch on severity
+Use the severity field to determine workflow behavior:
+` + "```yaml" + `
+- getIncident:
+    incidentId: "abc123-def456"
+- if:
+    condition: "{{ incident.severity == 'sev0' }}"
+    then:
+      - sendSlack:
+          message: "SEV0 ALERT: {{ incident.title }}"
+` + "```" + `
+
+### Post summary to Slack
+Get incident details for rich notifications:
+` + "```yaml" + `
+- getIncident:
+    incidentId: "{{ trigger.incident_id }}"
+- sendSlack:
+    message: |
+      **{{ incident.title }}**
+      Status: {{ incident.status }}
+      Severity: {{ incident.severity }}
+      Started: {{ incident.started_at }}
+      [View Incident]({{ incident.url }})
+` + "```"
+}
+
+func (g *GetIncident) Icon() string {
+	return "search"
+}
+
+func (g *GetIncident) Color() string {
+	return "blue"
+}
+
+func (g *GetIncident) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetIncident) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "incidentId",
+			Label:       "Incident ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Rootly incident UUID to retrieve",
+			Placeholder: "e.g., abc123-def456-789ghi",
+		},
+	}
+}
+
+func (g *GetIncident) Setup(ctx core.SetupContext) error {
+	spec := GetIncidentSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.IncidentID == "" {
+		return errors.New("incidentId is required")
+	}
+
+	return nil
+}
+
+func (g *GetIncident) Execute(ctx core.ExecutionContext) error {
+	spec := GetIncidentSpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	incident, err := client.GetIncident(spec.IncidentID)
+	if err != nil {
+		return fmt.Errorf("failed to get incident: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"rootly.incident",
+		[]any{incident},
+	)
+}
+
+func (g *GetIncident) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetIncident) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetIncident) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (g *GetIncident) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (g *GetIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (g *GetIncident) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/rootly/get_incident_test.go
+++ b/pkg/integrations/rootly/get_incident_test.go
@@ -1,0 +1,227 @@
+package rootly
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetIncident__Setup(t *testing.T) {
+	component := &GetIncident{}
+
+	t.Run("invalid configuration -> decode error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "invalid",
+		})
+
+		require.ErrorContains(t, err, "error decoding configuration")
+	})
+
+	t.Run("missing incidentId -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "incidentId is required")
+	})
+
+	t.Run("empty incidentId -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "",
+			},
+		})
+
+		require.ErrorContains(t, err, "incidentId is required")
+	})
+
+	t.Run("valid configuration -> success", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123-def456-789ghi",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetIncident__Execute(t *testing.T) {
+	component := &GetIncident{}
+
+	t.Run("successful incident retrieval", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"data": {
+							"id": "abc123-def456-789ghi",
+							"type": "incidents",
+							"attributes": {
+								"title": "Database connection timeout",
+								"summary": "Users experiencing slow response times",
+								"status": "investigating",
+								"severity": "sev1",
+								"started_at": "2024-02-11T10:00:00Z",
+								"resolved_at": null,
+								"mitigated_at": "2024-02-11T10:30:00Z",
+								"url": "https://app.rootly.com/incidents/abc123"
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123-def456-789ghi",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "rootly.incident", executionState.Type)
+
+		require.Len(t, httpContext.Requests, 1)
+		req := httpContext.Requests[0]
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, "https://api.rootly.com/v1/incidents/abc123-def456-789ghi", req.URL.String())
+		assert.Equal(t, "application/vnd.api+json", req.Header.Get("Content-Type"))
+		assert.Equal(t, "application/vnd.api+json", req.Header.Get("Accept"))
+		assert.Equal(t, "Bearer test-api-key", req.Header.Get("Authorization"))
+	})
+
+	t.Run("API error -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"Incident not found"}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "nonexistent-incident",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.ErrorContains(t, err, "failed to get incident")
+	})
+
+	t.Run("missing API key -> error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{}, // No API key
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"incidentId": "abc123-def456-789ghi",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: executionState,
+		})
+
+		require.ErrorContains(t, err, "error creating client")
+	})
+}
+
+func Test__GetIncident__Name(t *testing.T) {
+	component := &GetIncident{}
+	assert.Equal(t, "rootly.getIncident", component.Name())
+}
+
+func Test__GetIncident__Label(t *testing.T) {
+	component := &GetIncident{}
+	assert.Equal(t, "Get Incident", component.Label())
+}
+
+func Test__GetIncident__Description(t *testing.T) {
+	component := &GetIncident{}
+	assert.Equal(t, "Retrieve a single incident from Rootly by ID", component.Description())
+}
+
+func Test__GetIncident__Icon(t *testing.T) {
+	component := &GetIncident{}
+	assert.Equal(t, "search", component.Icon())
+}
+
+func Test__GetIncident__Color(t *testing.T) {
+	component := &GetIncident{}
+	assert.Equal(t, "blue", component.Color())
+}
+
+func Test__GetIncident__Configuration(t *testing.T) {
+	component := &GetIncident{}
+	config := component.Configuration()
+
+	assert.Len(t, config, 1)
+	assert.Equal(t, "incidentId", config[0].Name)
+	assert.Equal(t, "Incident ID", config[0].Label)
+	assert.True(t, config[0].Required)
+}
+
+func Test__GetIncident__OutputChannels(t *testing.T) {
+	component := &GetIncident{}
+	channels := component.OutputChannels(nil)
+	
+	assert.Len(t, channels, 1)
+	assert.Equal(t, core.DefaultOutputChannel, channels[0])
+}
+
+func Test__GetIncident__Documentation(t *testing.T) {
+	component := &GetIncident{}
+	doc := component.Documentation()
+	
+	assert.NotEmpty(t, doc)
+	assert.Contains(t, doc, "Get Incident component")
+	assert.Contains(t, doc, "Use Cases")
+	assert.Contains(t, doc, "Configuration")
+	assert.Contains(t, doc, "Output")
+	assert.Contains(t, doc, "Examples")
+}

--- a/pkg/integrations/rootly/rootly.go
+++ b/pkg/integrations/rootly/rootly.go
@@ -63,6 +63,7 @@ func (r *Rootly) Components() []core.Component {
 	return []core.Component{
 		&CreateIncident{},
 		&CreateEvent{},
+		&GetIncident{},
 	}
 }
 

--- a/web_src/src/pages/workflowv2/mappers/rootly/get_incident.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/get_incident.ts
@@ -1,0 +1,80 @@
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { MetadataItem } from "@/ui/metadataList";
+import rootlyIcon from "@/assets/icons/integrations/rootly.svg";
+import { Incident } from "./types";
+import { getDetailsForIncident } from "./base";
+import { formatTimeAgo } from "@/utils/date";
+
+export const getIncidentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      iconSrc: rootlyIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name ||
+        context.componentDefinition.label ||
+        context.componentDefinition.name ||
+        "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default: OutputPayload[] };
+    if (!outputs?.default || outputs.default.length === 0) {
+      return {};
+    }
+    const incident = outputs.default[0].data as Incident;
+    return getDetailsForIncident(incident);
+  },
+
+  subtitle(context: SubtitleContext): string {
+    if (!context.execution.createdAt) return "";
+    return formatTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as { incidentId?: string };
+
+  if (configuration?.incidentId) {
+    metadata.push({ icon: "search", label: "Incident ID: " + configuration.incidentId });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/rootly/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/rootly/index.ts
@@ -2,11 +2,13 @@ import { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../typ
 import { onIncidentTriggerRenderer } from "./on_incident";
 import { createIncidentMapper } from "./create_incident";
 import { createEventMapper } from "./create_event";
+import { getIncidentMapper } from "./get_incident";
 import { buildActionStateRegistry } from "../utils";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIncident: createIncidentMapper,
   createEvent: createEventMapper,
+  getIncident: getIncidentMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -16,4 +18,5 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIncident: buildActionStateRegistry("created"),
   createEvent: buildActionStateRegistry("created"),
+  getIncident: buildActionStateRegistry("retrieved"),
 };


### PR DESCRIPTION
## Summary

This PR implements the **Get Incident** component for the Rootly integration (#2536), allowing users to retrieve a single incident from Rootly by ID.

## Changes

- **Backend**: Added  component with full API client integration
- **Frontend**: Created TypeScript mappers and state registry for the UI
- **Testing**: Comprehensive test coverage (14 test cases) including setup, execution, and error handling
- **Documentation**: Rich component documentation with use cases and examples

## Features

- Retrieve incident details by ID (title, summary, status, severity, timestamps, URL)
- Support for expressions in incident ID field
- Comprehensive error handling for API errors and missing configuration
- Rich execution details display in the UI

## Use Cases

- **Status checks**: Branch workflow logic based on incident status or severity
- **Slack notifications**: Fetch incident data for detailed alert messages  
- **External sync**: Update external ticketing systems with incident details
- **Workflow enrichment**: Pull full incident context for downstream steps

## Testing

All tests pass:


Closes #2536

## Demo Video

I will create and attach a demo video showing:
1. Setting up the Get Incident component
2. Configuring the incident ID
3. Executing the component and viewing results
4. Using the output in downstream workflow steps