### PR TITLE
chore: WebhookContext is now available for action components in the Setup and Execute callback function

### DIFF
--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -153,6 +153,7 @@ type ExecutionContext struct {
 	Integration    IntegrationContext
 	Notifications  NotificationContext
 	Secrets        SecretsContext
+	Webhook        NodeWebhookContext
 }
 
 /*
@@ -178,6 +179,7 @@ type SetupContext struct {
 	Requests      RequestContext
 	Auth          AuthContext
 	Integration   IntegrationContext
+	Webhook       NodeWebhookContext
 }
 
 /*

--- a/pkg/grpc/actions/canvases/update_canvas.go
+++ b/pkg/grpc/actions/canvases/update_canvas.go
@@ -312,7 +312,7 @@ func setupNode(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor, reg
 	case models.NodeTypeTrigger:
 		return setupTrigger(ctx, tx, encryptor, registry, node, webhookBaseURL)
 	case models.NodeTypeComponent:
-		return setupComponent(tx, encryptor, registry, node)
+		return setupComponent(ctx, tx, encryptor, registry, node, webhookBaseURL)
 	case models.NodeTypeWidget:
 		// Widgets are not persisted and don't have any logic to execute and to setup.
 		return nil
@@ -363,7 +363,7 @@ func setupTrigger(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor, 
 	return tx.Save(node).Error
 }
 
-func setupComponent(tx *gorm.DB, encryptor crypto.Encryptor, registry *registry.Registry, node *models.CanvasNode) error {
+func setupComponent(ctx context.Context, tx *gorm.DB, encryptor crypto.Encryptor, registry *registry.Registry, node *models.CanvasNode, webhookBaseURL string) error {
 	ref := node.Ref.Data()
 	component, err := registry.GetComponent(ref.Component.Name)
 	if err != nil {
@@ -376,6 +376,7 @@ func setupComponent(tx *gorm.DB, encryptor crypto.Encryptor, registry *registry.
 		HTTP:          registry.HTTPContext(),
 		Metadata:      contexts.NewNodeMetadataContext(tx, node),
 		Requests:      contexts.NewNodeRequestContext(tx, node),
+		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
 	}
 
 	if node.AppInstallationID != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -80,7 +80,8 @@ func startWorkers(encryptor crypto.Encryptor, registry *registry.Registry, oidcP
 	if os.Getenv("START_WORKFLOW_NODE_EXECUTOR") == "yes" || os.Getenv("START_NODE_EXECUTOR") == "yes" {
 		log.Println("Starting Node Executor")
 
-		w := workers.NewNodeExecutor(encryptor, registry, baseURL)
+		webhookBaseURL := getWebhookBaseURL(baseURL)
+		w := workers.NewNodeExecutor(encryptor, registry, baseURL, webhookBaseURL)
 		go w.Start(context.Background())
 	}
 

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -27,20 +27,22 @@ import (
 var ErrRecordLocked = errors.New("record locked")
 
 type NodeExecutor struct {
-	encryptor crypto.Encryptor
-	registry  *registry.Registry
-	baseURL   string
-	semaphore *semaphore.Weighted
-	logger    *logrus.Entry
+	encryptor      crypto.Encryptor
+	registry       *registry.Registry
+	baseURL        string
+	webhookBaseURL string
+	semaphore      *semaphore.Weighted
+	logger         *logrus.Entry
 }
 
-func NewNodeExecutor(encryptor crypto.Encryptor, registry *registry.Registry, baseURL string) *NodeExecutor {
+func NewNodeExecutor(encryptor crypto.Encryptor, registry *registry.Registry, baseURL string, webhookBaseURL string) *NodeExecutor {
 	return &NodeExecutor{
-		encryptor: encryptor,
-		registry:  registry,
-		baseURL:   baseURL,
-		semaphore: semaphore.NewWeighted(25),
-		logger:    logrus.WithFields(logrus.Fields{"worker": "NodeExecutor"}),
+		encryptor:      encryptor,
+		registry:       registry,
+		baseURL:        baseURL,
+		webhookBaseURL: webhookBaseURL,
+		semaphore:      semaphore.NewWeighted(25),
+		logger:         logrus.WithFields(logrus.Fields{"worker": "NodeExecutor"}),
 	}
 }
 
@@ -290,6 +292,7 @@ func (w *NodeExecutor) executeComponentNode(tx *gorm.DB, execution *models.Canva
 		Auth:           contexts.NewAuthContext(tx, workflow.OrganizationID, nil, nil),
 		Notifications:  contexts.NewNotificationContext(tx, workflow.OrganizationID, execution.WorkflowID),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
+		Webhook:        contexts.NewNodeWebhookContext(context.Background(), tx, w.encryptor, node, w.webhookBaseURL),
 	}
 	ctx.ExpressionEnv = func(expression string) (map[string]any, error) {
 		builder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).

--- a/pkg/workers/node_executor_test.go
+++ b/pkg/workers/node_executor_test.go
@@ -56,12 +56,12 @@ func Test__NodeExecutor_PreventsConcurrentProcessing(t *testing.T) {
 	// Create two workers and have them try to process the execution concurrently.
 	//
 	go func() {
-		executor1 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+		executor1 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 		results <- executor1.LockAndProcessNodeExecution(execution.ID)
 	}()
 
 	go func() {
-		executor2 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+		executor2 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 		results <- executor2.LockAndProcessNodeExecution(execution.ID)
 	}()
 
@@ -146,7 +146,7 @@ func Test__NodeExecutor_BlueprintNodeExecution(t *testing.T) {
 	// Process the execution and verify the blueprint node creates a child execution
 	// and moves the parent execution to started state.
 	//
-	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 	err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
 
@@ -224,7 +224,7 @@ func Test__NodeExecutor_ComponentNodeWithoutStateChange(t *testing.T) {
 	// Process the execution and verify the execution is started but NOT finished.
 	// The approval component doesn't call Pass() in Execute(), so it should remain in started state.
 	//
-	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 	err = executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
 
@@ -291,7 +291,7 @@ func Test__NodeExecutor_ComponentNodeWithStateChange(t *testing.T) {
 	// Process the execution and verify the execution is both started AND finished.
 	// The noop component calls Pass() in Execute(), which should finish the execution.
 	//
-	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 	err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
 
@@ -372,7 +372,7 @@ func Test__NodeExecutor_BlueprintNodeExecutionFailsWhenConfigurationCannotBeBuil
 	// LockAndProcessNodeExecution should not return an error,
 	// since this isn't a runtime error, but a configuration error.
 	//
-	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost")
+	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost")
 	err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Needed in places where we don't have access to setting up a webhook via an API.
e.g. In Cursor.