### PR TITLE
fix: Use webhook base url for OIDC

### DIFF
--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -453,7 +453,7 @@ type jwksResponse struct {
 }
 
 func (s *Server) handleOIDCConfiguration(w http.ResponseWriter, _ *http.Request) {
-	baseURL := strings.TrimRight(s.BaseURL, "/")
+	baseURL := strings.TrimRight(s.WebhooksBaseURL, "/")
 	response := oidcDiscoveryResponse{
 		Issuer:                           baseURL,
 		JWKSURI:                          baseURL + "/.well-known/jwks.json",


### PR DESCRIPTION
Two reasons:

1/ This unblocks using OIDC for superplane-demo images
2/ While developing, you don't need to set both the BASE_URL and WEBHOOKS_BASE_URL to the ngrok generated url.

---

Why is setting ngrok url to both BASE_URL and WEBHOOKS_BASE_URL suboptimal?

Ngrok has request limits, vite package reloading reloading frequently breaches that limit.