### PR TITLE
feat(cli): commands for managing node queue

### DIFF
--- a/pkg/cli/commands/queue/delete.go
+++ b/pkg/cli/commands/queue/delete.go
@@ -1,0 +1,33 @@
+package queue
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type DeleteQueueItemCommand struct {
+	CanvasID *string
+	NodeID   *string
+	ItemID   *string
+}
+
+func (c *DeleteQueueItemCommand) Execute(ctx core.CommandContext) error {
+	response, _, err := ctx.API.CanvasNodeAPI.
+		CanvasesDeleteNodeQueueItem(ctx.Context, *c.CanvasID, *c.NodeID, *c.ItemID).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if ctx.Renderer.IsText() {
+		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+			_, err := fmt.Fprintf(stdout, "Queue item deleted: %s\n", *c.ItemID)
+			return err
+		})
+	}
+
+	return ctx.Renderer.Render(response)
+}

--- a/pkg/cli/commands/queue/list.go
+++ b/pkg/cli/commands/queue/list.go
@@ -1,0 +1,47 @@
+package queue
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ListQueueItemsCommand struct {
+	CanvasID *string
+	NodeID   *string
+}
+
+func (c *ListQueueItemsCommand) Execute(ctx core.CommandContext) error {
+	response, _, err := ctx.API.CanvasNodeAPI.
+		CanvasesListNodeQueueItems(ctx.Context, *c.CanvasID, *c.NodeID).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tCREATED_AT\tROOT_EVENT_ID\tSOURCE")
+
+		for _, item := range response.GetItems() {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s\t%s\n",
+				item.GetId(),
+				item.GetCreatedAt().Format(time.RFC3339),
+				*item.RootEvent.Id,
+				*item.RootEvent.NodeId,
+			)
+		}
+
+		return writer.Flush()
+	})
+}

--- a/pkg/cli/commands/queue/root.go
+++ b/pkg/cli/commands/queue/root.go
@@ -1,0 +1,56 @@
+package queue
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+func NewCommand(options core.BindOptions) *cobra.Command {
+	var canvasID string
+	var nodeID string
+	var itemID string
+
+	root := &cobra.Command{
+		Use:   "queue",
+		Short: "Manage canvas node queues",
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List items in a node queue",
+		Args:  cobra.NoArgs,
+	}
+
+	listCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
+	_ = listCmd.MarkFlagRequired("canvas-id")
+	_ = listCmd.MarkFlagRequired("node-id")
+
+	core.Bind(listCmd, &ListQueueItemsCommand{
+		CanvasID: &canvasID,
+		NodeID:   &nodeID,
+	}, options)
+
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an item from a node queue",
+		Args:  cobra.NoArgs,
+	}
+
+	deleteCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	deleteCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
+	deleteCmd.Flags().StringVar(&itemID, "item-id", "", "queue item ID")
+	_ = deleteCmd.MarkFlagRequired("canvas-id")
+	_ = deleteCmd.MarkFlagRequired("node-id")
+	_ = deleteCmd.MarkFlagRequired("item-id")
+	core.Bind(deleteCmd, &DeleteQueueItemCommand{
+		CanvasID: &canvasID,
+		NodeID:   &nodeID,
+		ItemID:   &itemID,
+	}, options)
+
+	root.AddCommand(listCmd)
+	root.AddCommand(deleteCmd)
+
+	return root
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -14,6 +14,7 @@ import (
 	config "github.com/superplanehq/superplane/pkg/cli/commands/config"
 	index "github.com/superplanehq/superplane/pkg/cli/commands/index"
 	integrations "github.com/superplanehq/superplane/pkg/cli/commands/integrations"
+	queue "github.com/superplanehq/superplane/pkg/cli/commands/queue"
 	secrets "github.com/superplanehq/superplane/pkg/cli/commands/secrets"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 )
@@ -53,6 +54,7 @@ func init() {
 	RootCmd.AddCommand(canvases.NewCommand(options))
 	RootCmd.AddCommand(index.NewCommand(options))
 	RootCmd.AddCommand(integrations.NewCommand(options))
+	RootCmd.AddCommand(queue.NewCommand(options))
 	RootCmd.AddCommand(secrets.NewCommand(options))
 	RootCmd.AddCommand(config.NewCommand(options))
 }


### PR DESCRIPTION
New `superplane queue` root CLI command with two sub-commands:
- `superplane queue list` -> list queue items for a canvas node
- `superplane queue delete` -> deletes an item from a canvas node queue