### PR TITLE
feat(cli): new root events command

### DIFF
--- a/pkg/cli/commands/events/list.go
+++ b/pkg/cli/commands/events/list.go
@@ -1,0 +1,113 @@
+package events
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ListEventsCommand struct {
+	CanvasID *string
+	NodeID   *string
+	Limit    *int64
+	Before   *string
+}
+
+func (c *ListEventsCommand) Execute(ctx core.CommandContext) error {
+	if c.NodeID != nil && *c.NodeID != "" {
+		return c.listNodeEvents(ctx)
+	}
+
+	return c.listCanvasEvents(ctx)
+}
+
+func (c *ListEventsCommand) listNodeEvents(ctx core.CommandContext) error {
+	request := ctx.API.CanvasNodeAPI.
+		CanvasesListNodeEvents(ctx.Context, *c.CanvasID, *c.NodeID)
+
+	if c.Limit != nil && *c.Limit > 0 {
+		request = request.Limit(*c.Limit)
+	}
+
+	if c.Before != nil && *c.Before != "" {
+		beforeTime, err := time.Parse(time.RFC3339, *c.Before)
+		if err != nil {
+			return fmt.Errorf("invalid --before value %q: expected RFC3339 timestamp", *c.Before)
+		}
+		request = request.Before(beforeTime)
+	}
+
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tCHANNEL\tCREATED_AT")
+		for _, event := range response.GetEvents() {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s\n",
+				event.GetId(),
+				event.GetChannel(),
+				event.GetCreatedAt().Format(time.RFC3339),
+			)
+		}
+
+		return writer.Flush()
+	})
+}
+
+func (c *ListEventsCommand) listCanvasEvents(ctx core.CommandContext) error {
+	request := ctx.API.CanvasEventAPI.
+		CanvasesListCanvasEvents(ctx.Context, *c.CanvasID)
+
+	if c.Limit != nil && *c.Limit > 0 {
+		request = request.Limit(*c.Limit)
+	}
+
+	if c.Before != nil && *c.Before != "" {
+		beforeTime, err := time.Parse(time.RFC3339, *c.Before)
+		if err != nil {
+			return fmt.Errorf("invalid --before value %q: expected RFC3339 timestamp", *c.Before)
+		}
+		request = request.Before(beforeTime)
+	}
+
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tNODE_ID\tCHANNEL\tEXECUTIONS\tCREATED_AT")
+		for _, event := range response.GetEvents() {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s\t%d\t%s\n",
+				event.GetId(),
+				event.GetNodeId(),
+				event.GetChannel(),
+				len(event.GetExecutions()),
+				event.GetCreatedAt().Format(time.RFC3339),
+			)
+		}
+
+		return writer.Flush()
+	})
+}

--- a/pkg/cli/commands/events/list_executions.go
+++ b/pkg/cli/commands/events/list_executions.go
@@ -1,0 +1,47 @@
+package events
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ListEventExecutionsCommand struct {
+	CanvasID *string
+	EventID  *string
+}
+
+func (c *ListEventExecutionsCommand) Execute(ctx core.CommandContext) error {
+	response, _, err := ctx.API.CanvasEventAPI.
+		CanvasesListEventExecutions(ctx.Context, *c.CanvasID, *c.EventID).
+		Execute()
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tNODE_ID\tSTATE\tRESULT\tCREATED_AT\tUPDATED_AT")
+		for _, execution := range response.GetExecutions() {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
+				execution.GetId(),
+				execution.GetNodeId(),
+				execution.GetState(),
+				execution.GetResult(),
+				execution.GetCreatedAt().Format(time.RFC3339),
+				execution.GetUpdatedAt().Format(time.RFC3339),
+			)
+		}
+
+		return writer.Flush()
+	})
+}

--- a/pkg/cli/commands/events/root.go
+++ b/pkg/cli/commands/events/root.go
@@ -1,0 +1,62 @@
+package events
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+func NewCommand(options core.BindOptions) *cobra.Command {
+	var canvasID string
+	var nodeID string
+	var eventID string
+	var limit int64
+	var before string
+
+	root := &cobra.Command{
+		Use:     "events",
+		Short:   "List canvas events and executions",
+		Aliases: []string{"event"},
+	}
+
+	//
+	// List command
+	//
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List root events for a canvas or events for a specific node",
+		Args:  cobra.NoArgs,
+	}
+	listCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
+	listCmd.Flags().Int64Var(&limit, "limit", 20, "maximum number of items to return")
+	listCmd.Flags().StringVar(&before, "before", "", "return items before this timestamp (RFC3339)")
+	_ = listCmd.MarkFlagRequired("canvas-id")
+	core.Bind(listCmd, &ListEventsCommand{
+		CanvasID: &canvasID,
+		NodeID:   &nodeID,
+		Limit:    &limit,
+		Before:   &before,
+	}, options)
+
+	//
+	// List executions command
+	//
+	listExecutionsCmd := &cobra.Command{
+		Use:   "list-executions",
+		Short: "List executions for a root event",
+		Args:  cobra.NoArgs,
+	}
+	listExecutionsCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	listExecutionsCmd.Flags().StringVar(&eventID, "event-id", "", "event ID")
+	_ = listExecutionsCmd.MarkFlagRequired("canvas-id")
+	_ = listExecutionsCmd.MarkFlagRequired("event-id")
+	core.Bind(listExecutionsCmd, &ListEventExecutionsCommand{
+		CanvasID: &canvasID,
+		EventID:  &eventID,
+	}, options)
+
+	root.AddCommand(listCmd)
+	root.AddCommand(listExecutionsCmd)
+
+	return root
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	canvases "github.com/superplanehq/superplane/pkg/cli/commands/canvases"
 	config "github.com/superplanehq/superplane/pkg/cli/commands/config"
+	events "github.com/superplanehq/superplane/pkg/cli/commands/events"
 	index "github.com/superplanehq/superplane/pkg/cli/commands/index"
 	integrations "github.com/superplanehq/superplane/pkg/cli/commands/integrations"
 	queue "github.com/superplanehq/superplane/pkg/cli/commands/queue"
@@ -52,6 +53,7 @@ func init() {
 
 	options := defaultBindOptions()
 	RootCmd.AddCommand(canvases.NewCommand(options))
+	RootCmd.AddCommand(events.NewCommand(options))
 	RootCmd.AddCommand(index.NewCommand(options))
 	RootCmd.AddCommand(integrations.NewCommand(options))
 	RootCmd.AddCommand(queue.NewCommand(options))


### PR DESCRIPTION
New commands for analyzing events in a canvas:
- superplane events list --canvas-id CANVAS_ID -> list root events in a canvas
- superplane events list --canvas-id CANVAS_ID --node-id -> list events emitted by a node
- superplane events list-executions --canvas-id CANVAS_ID --event-id EVENT_ID -> list executions for a root event