### PR TITLE
feat(cli): manage executions

### DIFF
--- a/pkg/cli/commands/executions/cancel.go
+++ b/pkg/cli/commands/executions/cancel.go
@@ -1,0 +1,33 @@
+package executions
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type CancelExecutionCommand struct {
+	CanvasID    *string
+	ExecutionID *string
+}
+
+func (c *CancelExecutionCommand) Execute(ctx core.CommandContext) error {
+	response, _, err := ctx.API.CanvasNodeExecutionAPI.
+		CanvasesCancelExecution(ctx.Context, *c.CanvasID, *c.ExecutionID).
+		Body(map[string]any{}).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		_, err := fmt.Fprintf(stdout, "Execution cancelled: %s\n", *c.ExecutionID)
+		return err
+	})
+}

--- a/pkg/cli/commands/executions/list.go
+++ b/pkg/cli/commands/executions/list.go
@@ -1,0 +1,71 @@
+package executions
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ListExecutionsCommand struct {
+	CanvasID *string
+	NodeID   *string
+	Limit    *int64
+	Before   *string
+}
+
+func (c *ListExecutionsCommand) Execute(ctx core.CommandContext) error {
+	request := ctx.API.CanvasNodeAPI.
+		CanvasesListNodeExecutions(ctx.Context, *c.CanvasID, *c.NodeID)
+
+	if c.Limit != nil && *c.Limit > 0 {
+		request = request.Limit(*c.Limit)
+	}
+
+	if c.Before != nil && *c.Before != "" {
+		beforeTime, err := time.Parse(time.RFC3339, *c.Before)
+		if err != nil {
+			return fmt.Errorf("invalid --before value %q: expected RFC3339 timestamp", *c.Before)
+		}
+		request = request.Before(beforeTime)
+	}
+
+	response, _, err := request.Execute()
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(response)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tNODE_ID\tSTATE\tRESULT\tMESSAGE\tCREATED_AT\tUPDATED_AT")
+		for _, execution := range response.GetExecutions() {
+			_, _ = fmt.Fprintf(
+				writer,
+				"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				execution.GetId(),
+				execution.GetNodeId(),
+				execution.GetState(),
+				execution.GetResult(),
+				stringOrDash(execution.GetResultMessage()),
+				execution.GetCreatedAt().Format(time.RFC3339),
+				execution.GetUpdatedAt().Format(time.RFC3339),
+			)
+		}
+
+		return writer.Flush()
+	})
+}
+
+func stringOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+
+	return s
+}

--- a/pkg/cli/commands/executions/root.go
+++ b/pkg/cli/commands/executions/root.go
@@ -1,0 +1,57 @@
+package executions
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+func NewCommand(options core.BindOptions) *cobra.Command {
+	var canvasID string
+	var nodeID string
+	var executionID string
+	var limit int64
+	var before string
+
+	root := &cobra.Command{
+		Use:     "executions",
+		Short:   "Manage canvas node executions",
+		Aliases: []string{"execution"},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List executions for a canvas node",
+		Args:  cobra.NoArgs,
+	}
+	listCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
+	listCmd.Flags().Int64Var(&limit, "limit", 20, "maximum number of items to return")
+	listCmd.Flags().StringVar(&before, "before", "", "return items before this timestamp (RFC3339)")
+	_ = listCmd.MarkFlagRequired("canvas-id")
+	_ = listCmd.MarkFlagRequired("node-id")
+	core.Bind(listCmd, &ListExecutionsCommand{
+		CanvasID: &canvasID,
+		NodeID:   &nodeID,
+		Limit:    &limit,
+		Before:   &before,
+	}, options)
+
+	cancelCmd := &cobra.Command{
+		Use:   "cancel",
+		Short: "Cancel an execution",
+		Args:  cobra.NoArgs,
+	}
+	cancelCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
+	cancelCmd.Flags().StringVar(&executionID, "execution-id", "", "execution ID")
+	_ = cancelCmd.MarkFlagRequired("canvas-id")
+	_ = cancelCmd.MarkFlagRequired("execution-id")
+	core.Bind(cancelCmd, &CancelExecutionCommand{
+		CanvasID:    &canvasID,
+		ExecutionID: &executionID,
+	}, options)
+
+	root.AddCommand(listCmd)
+	root.AddCommand(cancelCmd)
+
+	return root
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -13,6 +13,7 @@ import (
 	canvases "github.com/superplanehq/superplane/pkg/cli/commands/canvases"
 	config "github.com/superplanehq/superplane/pkg/cli/commands/config"
 	events "github.com/superplanehq/superplane/pkg/cli/commands/events"
+	executions "github.com/superplanehq/superplane/pkg/cli/commands/executions"
 	index "github.com/superplanehq/superplane/pkg/cli/commands/index"
 	integrations "github.com/superplanehq/superplane/pkg/cli/commands/integrations"
 	queue "github.com/superplanehq/superplane/pkg/cli/commands/queue"
@@ -53,6 +54,7 @@ func init() {
 
 	options := defaultBindOptions()
 	RootCmd.AddCommand(canvases.NewCommand(options))
+	RootCmd.AddCommand(executions.NewCommand(options))
 	RootCmd.AddCommand(events.NewCommand(options))
 	RootCmd.AddCommand(index.NewCommand(options))
 	RootCmd.AddCommand(integrations.NewCommand(options))


### PR DESCRIPTION
New CLI commands for managing executions:
- superplane executions list - for listing executions for a canvas node
- superplane executions cancel - for canceling an execution