### PR TITLE
feat(cli): configure active canvas

### DIFF
--- a/pkg/cli/commands/canvases/active.go
+++ b/pkg/cli/commands/canvases/active.go
@@ -1,0 +1,91 @@
+package canvases
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ActiveCommand struct{}
+
+func (c *ActiveCommand) Execute(ctx core.CommandContext) error {
+	if len(ctx.Args) == 1 {
+		return c.setActiveByID(ctx, ctx.Args[0])
+	}
+
+	if !ctx.Renderer.IsText() {
+		return fmt.Errorf("interactive canvas selection requires text output")
+	}
+
+	return c.setActiveInteractively(ctx)
+}
+
+func (c *ActiveCommand) setActiveByID(ctx core.CommandContext, canvasID string) error {
+	canvasID = strings.TrimSpace(canvasID)
+	if canvasID == "" {
+		return fmt.Errorf("canvas id is required")
+	}
+
+	_, _, err := ctx.API.CanvasAPI.
+		CanvasesDescribeCanvas(ctx.Context, canvasID).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	return ctx.Config.SetActiveCanvas(canvasID)
+}
+
+func (c *ActiveCommand) setActiveInteractively(ctx core.CommandContext) error {
+	response, _, err := ctx.API.CanvasAPI.
+		CanvasesListCanvases(ctx.Context).
+		Execute()
+
+	if err != nil {
+		return err
+	}
+
+	canvases := response.GetCanvases()
+	if len(canvases) == 0 {
+		return fmt.Errorf("no canvases found")
+	}
+
+	err = ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		for i, canvas := range canvases {
+			prefix := " "
+			if *canvas.Metadata.Id == ctx.Config.GetActiveCanvas() {
+				prefix = "*"
+			}
+			_, _ = fmt.Fprintf(stdout, "%s %d. %s (%s)\n", prefix, i+1, *canvas.Metadata.Name, *canvas.Metadata.Id)
+		}
+		_, _ = fmt.Fprint(stdout, "Select a canvas number: ")
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(ctx.Cmd.InOrStdin())
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read selected canvas: %w", err)
+	}
+
+	selectedIndex, err := strconv.Atoi(strings.TrimSpace(input))
+	if err != nil {
+		return fmt.Errorf("invalid canvas selection %q", strings.TrimSpace(input))
+	}
+
+	if selectedIndex < 1 || selectedIndex > len(canvases) {
+		return fmt.Errorf("canvas selection must be between 1 and %d", len(canvases))
+	}
+
+	selected := canvases[selectedIndex-1]
+	return ctx.Config.SetActiveCanvas(*selected.Metadata.Id)
+}

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -26,6 +26,14 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	}
 	core.Bind(getCmd, &getCommand{}, options)
 
+	activeCmd := &cobra.Command{
+		Use:   "active [canvas-id]",
+		Short: "Set the active canvas",
+		Long:  "Without arguments, prompts for a canvas selection. With a canvas ID, sets it directly.",
+		Args:  cobra.MaximumNArgs(1),
+	}
+	core.Bind(activeCmd, &ActiveCommand{}, options)
+
 	var createFile string
 	createCmd := &cobra.Command{
 		Use:   "create [canvas-name]",
@@ -47,6 +55,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 
 	root.AddCommand(listCmd)
 	root.AddCommand(getCmd)
+	root.AddCommand(activeCmd)
 	root.AddCommand(createCmd)
 	root.AddCommand(updateCmd)
 

--- a/pkg/cli/commands/events/list.go
+++ b/pkg/cli/commands/events/list.go
@@ -25,8 +25,13 @@ func (c *ListEventsCommand) Execute(ctx core.CommandContext) error {
 }
 
 func (c *ListEventsCommand) listNodeEvents(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	request := ctx.API.CanvasNodeAPI.
-		CanvasesListNodeEvents(ctx.Context, *c.CanvasID, *c.NodeID)
+		CanvasesListNodeEvents(ctx.Context, canvasID, *c.NodeID)
 
 	if c.Limit != nil && *c.Limit > 0 {
 		request = request.Limit(*c.Limit)
@@ -68,8 +73,13 @@ func (c *ListEventsCommand) listNodeEvents(ctx core.CommandContext) error {
 }
 
 func (c *ListEventsCommand) listCanvasEvents(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	request := ctx.API.CanvasEventAPI.
-		CanvasesListCanvasEvents(ctx.Context, *c.CanvasID)
+		CanvasesListCanvasEvents(ctx.Context, canvasID)
 
 	if c.Limit != nil && *c.Limit > 0 {
 		request = request.Limit(*c.Limit)

--- a/pkg/cli/commands/events/list_executions.go
+++ b/pkg/cli/commands/events/list_executions.go
@@ -15,8 +15,13 @@ type ListEventExecutionsCommand struct {
 }
 
 func (c *ListEventExecutionsCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	response, _, err := ctx.API.CanvasEventAPI.
-		CanvasesListEventExecutions(ctx.Context, *c.CanvasID, *c.EventID).
+		CanvasesListEventExecutions(ctx.Context, canvasID, *c.EventID).
 		Execute()
 	if err != nil {
 		return err

--- a/pkg/cli/commands/events/root.go
+++ b/pkg/cli/commands/events/root.go
@@ -30,7 +30,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
 	listCmd.Flags().Int64Var(&limit, "limit", 20, "maximum number of items to return")
 	listCmd.Flags().StringVar(&before, "before", "", "return items before this timestamp (RFC3339)")
-	_ = listCmd.MarkFlagRequired("canvas-id")
 	core.Bind(listCmd, &ListEventsCommand{
 		CanvasID: &canvasID,
 		NodeID:   &nodeID,
@@ -48,7 +47,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	}
 	listExecutionsCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
 	listExecutionsCmd.Flags().StringVar(&eventID, "event-id", "", "event ID")
-	_ = listExecutionsCmd.MarkFlagRequired("canvas-id")
 	_ = listExecutionsCmd.MarkFlagRequired("event-id")
 	core.Bind(listExecutionsCmd, &ListEventExecutionsCommand{
 		CanvasID: &canvasID,

--- a/pkg/cli/commands/executions/cancel.go
+++ b/pkg/cli/commands/executions/cancel.go
@@ -13,8 +13,13 @@ type CancelExecutionCommand struct {
 }
 
 func (c *CancelExecutionCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	response, _, err := ctx.API.CanvasNodeExecutionAPI.
-		CanvasesCancelExecution(ctx.Context, *c.CanvasID, *c.ExecutionID).
+		CanvasesCancelExecution(ctx.Context, canvasID, *c.ExecutionID).
 		Body(map[string]any{}).
 		Execute()
 

--- a/pkg/cli/commands/executions/list.go
+++ b/pkg/cli/commands/executions/list.go
@@ -17,8 +17,13 @@ type ListExecutionsCommand struct {
 }
 
 func (c *ListExecutionsCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	request := ctx.API.CanvasNodeAPI.
-		CanvasesListNodeExecutions(ctx.Context, *c.CanvasID, *c.NodeID)
+		CanvasesListNodeExecutions(ctx.Context, canvasID, *c.NodeID)
 
 	if c.Limit != nil && *c.Limit > 0 {
 		request = request.Limit(*c.Limit)

--- a/pkg/cli/commands/executions/root.go
+++ b/pkg/cli/commands/executions/root.go
@@ -27,7 +27,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
 	listCmd.Flags().Int64Var(&limit, "limit", 20, "maximum number of items to return")
 	listCmd.Flags().StringVar(&before, "before", "", "return items before this timestamp (RFC3339)")
-	_ = listCmd.MarkFlagRequired("canvas-id")
 	_ = listCmd.MarkFlagRequired("node-id")
 	core.Bind(listCmd, &ListExecutionsCommand{
 		CanvasID: &canvasID,
@@ -43,7 +42,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	}
 	cancelCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
 	cancelCmd.Flags().StringVar(&executionID, "execution-id", "", "execution ID")
-	_ = cancelCmd.MarkFlagRequired("canvas-id")
 	_ = cancelCmd.MarkFlagRequired("execution-id")
 	core.Bind(cancelCmd, &CancelExecutionCommand{
 		CanvasID:    &canvasID,

--- a/pkg/cli/commands/queue/delete.go
+++ b/pkg/cli/commands/queue/delete.go
@@ -14,8 +14,13 @@ type DeleteQueueItemCommand struct {
 }
 
 func (c *DeleteQueueItemCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	response, _, err := ctx.API.CanvasNodeAPI.
-		CanvasesDeleteNodeQueueItem(ctx.Context, *c.CanvasID, *c.NodeID, *c.ItemID).
+		CanvasesDeleteNodeQueueItem(ctx.Context, canvasID, *c.NodeID, *c.ItemID).
 		Execute()
 
 	if err != nil {

--- a/pkg/cli/commands/queue/list.go
+++ b/pkg/cli/commands/queue/list.go
@@ -15,8 +15,13 @@ type ListQueueItemsCommand struct {
 }
 
 func (c *ListQueueItemsCommand) Execute(ctx core.CommandContext) error {
+	canvasID, err := core.ResolveCanvasID(ctx, *c.CanvasID)
+	if err != nil {
+		return err
+	}
+
 	response, _, err := ctx.API.CanvasNodeAPI.
-		CanvasesListNodeQueueItems(ctx.Context, *c.CanvasID, *c.NodeID).
+		CanvasesListNodeQueueItems(ctx.Context, canvasID, *c.NodeID).
 		Execute()
 
 	if err != nil {

--- a/pkg/cli/commands/queue/root.go
+++ b/pkg/cli/commands/queue/root.go
@@ -23,7 +23,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 
 	listCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
 	listCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
-	_ = listCmd.MarkFlagRequired("canvas-id")
 	_ = listCmd.MarkFlagRequired("node-id")
 
 	core.Bind(listCmd, &ListQueueItemsCommand{
@@ -40,7 +39,6 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	deleteCmd.Flags().StringVar(&canvasID, "canvas-id", "", "canvas ID")
 	deleteCmd.Flags().StringVar(&nodeID, "node-id", "", "node ID")
 	deleteCmd.Flags().StringVar(&itemID, "item-id", "", "queue item ID")
-	_ = deleteCmd.MarkFlagRequired("canvas-id")
 	_ = deleteCmd.MarkFlagRequired("node-id")
 	_ = deleteCmd.MarkFlagRequired("item-id")
 	core.Bind(deleteCmd, &DeleteQueueItemCommand{

--- a/pkg/cli/core/command.go
+++ b/pkg/cli/core/command.go
@@ -2,83 +2,11 @@ package core
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 
-	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
-
-type OutputFormat string
-
-const (
-	OutputFormatText OutputFormat = "text"
-	OutputFormatJSON OutputFormat = "json"
-	OutputFormatYAML OutputFormat = "yaml"
-)
-
-type Renderer struct {
-	format OutputFormat
-	stdout io.Writer
-}
-
-func NewRenderer(rawFormat string, stdout io.Writer) (Renderer, error) {
-	format := OutputFormat(rawFormat)
-	if format == "" {
-		format = OutputFormatText
-	}
-
-	switch format {
-	case OutputFormatText, OutputFormatJSON, OutputFormatYAML:
-		return Renderer{format: format, stdout: stdout}, nil
-	default:
-		return Renderer{}, fmt.Errorf("invalid output format %q, expected one of: text, json, yaml", rawFormat)
-	}
-}
-
-func (r Renderer) Format() OutputFormat {
-	return r.format
-}
-
-func (r Renderer) IsText() bool {
-	return r.format == OutputFormatText
-}
-
-func (r Renderer) Render(value any) error {
-	switch r.format {
-	case OutputFormatJSON:
-		payload, err := json.MarshalIndent(value, "", "  ")
-		if err != nil {
-			return err
-		}
-
-		_, err = fmt.Fprintln(r.stdout, string(payload))
-		return err
-	case OutputFormatYAML:
-		payload, err := yaml.Marshal(value)
-		if err != nil {
-			return err
-		}
-
-		_, err = fmt.Fprintln(r.stdout, string(payload))
-		return err
-	case OutputFormatText:
-		return fmt.Errorf("text output requires RenderText")
-	default:
-		return fmt.Errorf("unsupported output format %q", r.format)
-	}
-}
-
-func (r Renderer) RenderText(render func(io.Writer) error) error {
-	if r.format != OutputFormatText {
-		return fmt.Errorf("RenderText can only be used with text output")
-	}
-
-	return render(r.stdout)
-}
 
 type Command interface {
 	Execute(ctx CommandContext) error
@@ -91,10 +19,21 @@ type CommandContext struct {
 	Logger   *log.Entry
 	API      *openapi_client.APIClient
 	Renderer Renderer
+	Config   ConfigContext
+}
+
+/*
+ * Interface that allows commands to access
+ * and update the current configuration context.
+ */
+type ConfigContext interface {
+	GetActiveCanvas() string
+	SetActiveCanvas(canvasID string) error
 }
 
 type BindOptions struct {
 	NewAPIClient        func() *openapi_client.APIClient
+	NewConfigContext    func() ConfigContext
 	DefaultOutputFormat func() string
 }
 
@@ -129,6 +68,9 @@ func NewCommandContext(cmd *cobra.Command, args []string, options BindOptions) (
 
 	if options.NewAPIClient != nil {
 		commandContext.API = options.NewAPIClient()
+	}
+	if options.NewConfigContext != nil {
+		commandContext.Config = options.NewConfigContext()
 	}
 
 	return commandContext, nil

--- a/pkg/cli/core/common.go
+++ b/pkg/cli/core/common.go
@@ -56,3 +56,17 @@ func FindIntegrationDefinition(ctx CommandContext, name string) (openapi_client.
 
 	return openapi_client.IntegrationsIntegrationDefinition{}, fmt.Errorf("integration %q not found", name)
 }
+
+func ResolveCanvasID(ctx CommandContext, canvasID string) (string, error) {
+	canvasID = strings.TrimSpace(canvasID)
+	if canvasID != "" {
+		return canvasID, nil
+	}
+
+	activeCanvas := strings.TrimSpace(ctx.Config.GetActiveCanvas())
+	if activeCanvas == "" {
+		return "", fmt.Errorf("canvas id is required; pass --canvas-id or set one with \"superplane canvases active\"")
+	}
+
+	return activeCanvas, nil
+}

--- a/pkg/cli/core/renderer.go
+++ b/pkg/cli/core/renderer.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/ghodss/yaml"
+)
+
+type OutputFormat string
+
+const (
+	OutputFormatText OutputFormat = "text"
+	OutputFormatJSON OutputFormat = "json"
+	OutputFormatYAML OutputFormat = "yaml"
+)
+
+type Renderer struct {
+	format OutputFormat
+	stdout io.Writer
+}
+
+func NewRenderer(rawFormat string, stdout io.Writer) (Renderer, error) {
+	format := OutputFormat(rawFormat)
+	if format == "" {
+		format = OutputFormatText
+	}
+
+	switch format {
+	case OutputFormatText, OutputFormatJSON, OutputFormatYAML:
+		return Renderer{format: format, stdout: stdout}, nil
+	default:
+		return Renderer{}, fmt.Errorf("invalid output format %q, expected one of: text, json, yaml", rawFormat)
+	}
+}
+
+func (r Renderer) Format() OutputFormat {
+	return r.format
+}
+
+func (r Renderer) IsText() bool {
+	return r.format == OutputFormatText
+}
+
+func (r Renderer) Render(value any) error {
+	switch r.format {
+	case OutputFormatJSON:
+		payload, err := json.MarshalIndent(value, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprintln(r.stdout, string(payload))
+		return err
+	case OutputFormatYAML:
+		payload, err := yaml.Marshal(value)
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Fprintln(r.stdout, string(payload))
+		return err
+	case OutputFormatText:
+		return fmt.Errorf("text output requires RenderText")
+	default:
+		return fmt.Errorf("unsupported output format %q", r.format)
+	}
+}
+
+func (r Renderer) RenderText(render func(io.Writer) error) error {
+	if r.format != OutputFormatText {
+		return fmt.Errorf("RenderText can only be used with text output")
+	}
+
+	return render(r.stdout)
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -93,6 +93,14 @@ func defaultBindOptions() core.BindOptions {
 	return core.BindOptions{
 		NewAPIClient:        DefaultClient,
 		DefaultOutputFormat: GetOutputFormat,
+		NewConfigContext: func() core.ConfigContext {
+			context, ok := GetCurrentContext()
+			if !ok {
+				return nil
+			}
+
+			return NewCurrentContext(context)
+		},
 	}
 }
 


### PR DESCRIPTION
A lot of the CLI commands require a `--canvas-id` argument. However, it's a bad experience to always have to specify that since when you are using the CLI, you are usually working on a single canvas at a time. Here, we introduce a new `superplane canvases active` command that allows users to make a canvas active. If a canvas is active, we don't require the `--canvas-id` and use the active canvas instead.