### PR TITLE
fix: improving Daytona components

### DIFF
--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -165,7 +165,6 @@ type ExecutionContext struct {
  */
 type HTTPContext interface {
 	Do(*http.Request) (*http.Response, error)
-	DoWithTimeout(*http.Request, time.Duration) (*http.Response, error)
 }
 
 /*

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -165,6 +165,7 @@ type ExecutionContext struct {
  */
 type HTTPContext interface {
 	Do(*http.Request) (*http.Response, error)
+	DoWithTimeout(*http.Request, time.Duration) (*http.Response, error)
 }
 
 /*

--- a/pkg/integrations/daytona/client.go
+++ b/pkg/integrations/daytona/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -56,32 +55,6 @@ type CreateSandboxRequest struct {
 	AutoStopInterval int               `json:"autoStopInterval,omitempty"`
 }
 
-// ExecuteCodeRequest represents the request to execute code in a sandbox
-type ExecuteCodeRequest struct {
-	Code     string `json:"code"`
-	Language string `json:"language"`
-	Timeout  int    `json:"timeout,omitempty"`
-}
-
-// ExecuteCodeResponse represents the response from code execution
-type ExecuteCodeResponse struct {
-	ExitCode int    `json:"exitCode"`
-	Result   string `json:"result"`
-}
-
-// ExecuteCommandRequest represents the request to execute a command in a sandbox
-type ExecuteCommandRequest struct {
-	Command string `json:"command"`
-	Cwd     string `json:"cwd,omitempty"`
-	Timeout int    `json:"timeout,omitempty"`
-}
-
-// ExecuteCommandResponse represents the response from command execution
-type ExecuteCommandResponse struct {
-	ExitCode int    `json:"exitCode"`
-	Result   string `json:"result"`
-}
-
 // Snapshot represents a Daytona snapshot
 type Snapshot struct {
 	ID   string `json:"id"`
@@ -91,6 +64,52 @@ type Snapshot struct {
 // PaginatedSnapshots represents a paginated list of snapshots
 type PaginatedSnapshots struct {
 	Items []Snapshot `json:"items"`
+}
+
+// SessionExecuteRequest represents the request to execute a command in a session
+type SessionExecuteRequest struct {
+	Command  string `json:"command"`
+	RunAsync bool   `json:"runAsync"`
+}
+
+// SessionExecuteResponse represents the response from async session command execution
+type SessionExecuteResponse struct {
+	CmdID string `json:"cmdId"`
+}
+
+// SessionCommand represents a command within a session
+type SessionCommand struct {
+	CmdID    string `json:"cmdId"`
+	Command  string `json:"command"`
+	ExitCode *int   `json:"exitCode"`
+}
+
+// Session represents a Daytona session with its executed commands
+type Session struct {
+	SessionID string           `json:"sessionId"`
+	Commands  []SessionCommand `json:"commands"`
+}
+
+// FindCommand returns the command with the given ID, or nil if not found.
+func (s *Session) FindCommand(cmdID string) *SessionCommand {
+	for i := range s.Commands {
+		if s.Commands[i].CmdID == cmdID {
+			return &s.Commands[i]
+		}
+	}
+	return nil
+}
+
+// ExecuteCommandResponse represents the response from command execution
+type ExecuteCommandResponse struct {
+	ExitCode int    `json:"exitCode"`
+	Result   string `json:"result"`
+}
+
+// ExecuteCodeResponse represents the response from code execution
+type ExecuteCodeResponse struct {
+	ExitCode int    `json:"exitCode"`
+	Result   string `json:"result"`
 }
 
 // ListSnapshots lists available snapshots
@@ -154,9 +173,8 @@ func (c *Client) FetchConfig() (*APIConfig, error) {
 	return &config, nil
 }
 
-// toolboxURL returns the toolbox execute URL for a given sandbox.
-// It fetches the proxyToolboxUrl from /api/config and constructs the URL.
-func (c *Client) toolboxURL(sandboxID string) (string, error) {
+// toolboxBaseURL returns the base toolbox URL for a given sandbox.
+func (c *Client) toolboxBaseURL(sandboxID string) (string, error) {
 	config, err := c.FetchConfig()
 	if err != nil {
 		return "", err
@@ -166,77 +184,92 @@ func (c *Client) toolboxURL(sandboxID string) (string, error) {
 		return "", fmt.Errorf("proxyToolboxUrl not found in config")
 	}
 
-	return fmt.Sprintf("%s/%s/process/execute", config.ProxyToolboxURL, sandboxID), nil
+	return fmt.Sprintf("%s/%s", config.ProxyToolboxURL, sandboxID), nil
 }
 
-// ExecuteCode executes code in a sandbox (uses the execute command endpoint)
-func (c *Client) ExecuteCode(sandboxID string, req *ExecuteCodeRequest) (*ExecuteCodeResponse, error) {
-	url, err := c.toolboxURL(sandboxID)
+// CreateSession creates a new session in the sandbox.
+func (c *Client) CreateSession(sandboxID, sessionID string) error {
+	baseURL, err := c.toolboxBaseURL(sandboxID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve toolbox URL: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]string{"sessionId": sessionID})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	_, err = c.execRequest(http.MethodPost, baseURL+"/process/session", bytes.NewReader(body))
+	return err
+}
+
+// ExecuteSessionCommand executes a command asynchronously in a session.
+// Returns the command ID which can be used to poll for completion.
+func (c *Client) ExecuteSessionCommand(sandboxID, sessionID, command string) (*SessionExecuteResponse, error) {
+	baseURL, err := c.toolboxBaseURL(sandboxID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve toolbox URL: %v", err)
 	}
 
-	// Convert code execution to a command based on language
-	var command string
-	switch req.Language {
-	case "python":
-		command = fmt.Sprintf("python3 -c %q", req.Code)
-	case "javascript":
-		command = fmt.Sprintf("node -e %q", req.Code)
-	case "typescript":
-		command = fmt.Sprintf("npx ts-node -e %q", req.Code)
-	default:
-		command = fmt.Sprintf("python3 -c %q", req.Code)
+	reqBody := &SessionExecuteRequest{
+		Command:  command,
+		RunAsync: true,
 	}
 
-	cmdReq := &ExecuteCommandRequest{
-		Command: command,
-		Timeout: req.Timeout,
-	}
-
-	body, err := json.Marshal(cmdReq)
+	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	httpTimeout := time.Duration(req.Timeout+30) * time.Second
-	responseBody, err := c.execRequestWithTimeout(http.MethodPost, url, bytes.NewReader(body), httpTimeout)
+	url := fmt.Sprintf("%s/process/session/%s/exec", baseURL, sessionID)
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 
-	var response ExecuteCodeResponse
+	var response SessionExecuteResponse
 	if err := json.Unmarshal(responseBody, &response); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal execute code response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal session execute response: %v", err)
 	}
 
 	return &response, nil
 }
 
-// ExecuteCommand executes a shell command in a sandbox
-func (c *Client) ExecuteCommand(sandboxID string, req *ExecuteCommandRequest) (*ExecuteCommandResponse, error) {
-	url, err := c.toolboxURL(sandboxID)
+// GetSession retrieves a session and its command statuses.
+func (c *Client) GetSession(sandboxID, sessionID string) (*Session, error) {
+	baseURL, err := c.toolboxBaseURL(sandboxID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve toolbox URL: %v", err)
 	}
 
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %v", err)
-	}
-
-	httpTimeout := time.Duration(req.Timeout+30) * time.Second
-	responseBody, err := c.execRequestWithTimeout(http.MethodPost, url, bytes.NewReader(body), httpTimeout)
+	url := fmt.Sprintf("%s/process/session/%s", baseURL, sessionID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var response ExecuteCommandResponse
-	if err := json.Unmarshal(responseBody, &response); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal execute command response: %v", err)
+	var session Session
+	if err := json.Unmarshal(responseBody, &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session response: %v", err)
 	}
 
-	return &response, nil
+	return &session, nil
+}
+
+// GetSessionCommandLogs retrieves the logs for a specific command in a session.
+func (c *Client) GetSessionCommandLogs(sandboxID, sessionID, commandID string) (string, error) {
+	baseURL, err := c.toolboxBaseURL(sandboxID)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve toolbox URL: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/process/session/%s/command/%s/logs", baseURL, sessionID, commandID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(responseBody), nil
 }
 
 // DeleteSandbox deletes a sandbox
@@ -253,10 +286,6 @@ type APIError struct {
 }
 
 func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error) {
-	return c.execRequestWithTimeout(method, url, body, 0)
-}
-
-func (c *Client) execRequestWithTimeout(method, url string, body io.Reader, timeout time.Duration) ([]byte, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %v", err)
@@ -265,13 +294,7 @@ func (c *Client) execRequestWithTimeout(method, url string, body io.Reader, time
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 
-	var res *http.Response
-	if timeout > 0 {
-		res, err = c.http.DoWithTimeout(req, timeout)
-	} else {
-		res, err = c.http.Do(req)
-	}
-
+	res, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}

--- a/pkg/integrations/daytona/client.go
+++ b/pkg/integrations/daytona/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -198,7 +199,8 @@ func (c *Client) ExecuteCode(sandboxID string, req *ExecuteCodeRequest) (*Execut
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	httpTimeout := time.Duration(req.Timeout+30) * time.Second
+	responseBody, err := c.execRequestWithTimeout(http.MethodPost, url, bytes.NewReader(body), httpTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +225,8 @@ func (c *Client) ExecuteCommand(sandboxID string, req *ExecuteCommandRequest) (*
 		return nil, fmt.Errorf("failed to marshal request: %v", err)
 	}
 
-	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	httpTimeout := time.Duration(req.Timeout+30) * time.Second
+	responseBody, err := c.execRequestWithTimeout(http.MethodPost, url, bytes.NewReader(body), httpTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +253,10 @@ type APIError struct {
 }
 
 func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error) {
+	return c.execRequestWithTimeout(method, url, body, 0)
+}
+
+func (c *Client) execRequestWithTimeout(method, url string, body io.Reader, timeout time.Duration) ([]byte, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %v", err)
@@ -258,7 +265,13 @@ func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 
-	res, err := c.http.Do(req)
+	var res *http.Response
+	if timeout > 0 {
+		res, err = c.http.DoWithTimeout(req, timeout)
+	} else {
+		res, err = c.http.Do(req)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %v", err)
 	}
@@ -275,7 +288,6 @@ func (c *Client) execRequest(method, url string, body io.Reader) ([]byte, error)
 	}
 
 	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
-		// Try to parse error response for a cleaner message
 		var apiErr APIError
 		if json.Unmarshal(responseBody, &apiErr) == nil && apiErr.Message != "" {
 			return nil, fmt.Errorf("API error (%d): %s", res.StatusCode, apiErr.Message)

--- a/pkg/integrations/daytona/client_test.go
+++ b/pkg/integrations/daytona/client_test.go
@@ -175,132 +175,111 @@ func Test__Client__CreateSandbox(t *testing.T) {
 	})
 }
 
-func Test__Client__ExecuteCommand(t *testing.T) {
-	t.Run("successful command execution", func(t *testing.T) {
+func Test__Client__CreateSession(t *testing.T) {
+	t.Run("successful session creation", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				configResponse(),
 				{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"hello world"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"sessionId":"session-1"}`)),
 				},
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		response, err := client.ExecuteCommand("sandbox-123", &ExecuteCommandRequest{
-			Command: "echo hello world",
-		})
+		client := newTestClient(t, httpContext)
+		err := client.CreateSession("sandbox-123", "session-1")
 
 		require.NoError(t, err)
-		assert.Equal(t, 0, response.ExitCode)
-		assert.Equal(t, "hello world", response.Result)
 		require.Len(t, httpContext.Requests, 2)
-		assert.Contains(t, httpContext.Requests[1].URL.String(), "/toolbox/sandbox-123/process/execute")
-	})
-
-	t.Run("command execution failure -> error", func(t *testing.T) {
-		httpContext := &contexts.HTTPContext{
-			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusInternalServerError,
-					Body:       io.NopCloser(strings.NewReader(`{"message":"execution failed"}`)),
-				},
-			},
-		}
-
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		_, err = client.ExecuteCommand("sandbox-123", &ExecuteCommandRequest{
-			Command: "invalid",
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "500")
+		assert.Equal(t, http.MethodPost, httpContext.Requests[1].Method)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/toolbox/sandbox-123/process/session")
 	})
 }
 
-func Test__Client__ExecuteCode(t *testing.T) {
-	t.Run("successful python code execution", func(t *testing.T) {
+func Test__Client__ExecuteSessionCommand(t *testing.T) {
+	t.Run("successful async execution", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				configResponse(),
 				{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"42"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"cmdId":"cmd-abc"}`)),
 				},
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
+		client := newTestClient(t, httpContext)
+		resp, err := client.ExecuteSessionCommand("sandbox-123", "session-1", "echo hello")
+
+		require.NoError(t, err)
+		assert.Equal(t, "cmd-abc", resp.CmdID)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/process/session/session-1/exec")
+	})
+}
+
+func Test__Client__GetSession(t *testing.T) {
+	t.Run("command still running", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"sessionId":"session-1","commands":[{"cmdId":"cmd-abc","command":"echo hello","exitCode":null}]}`)),
+				},
 			},
 		}
 
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		response, err := client.ExecuteCode("sandbox-123", &ExecuteCodeRequest{
-			Code:     "print(42)",
-			Language: "python",
-		})
+		client := newTestClient(t, httpContext)
+		session, err := client.GetSession("sandbox-123", "session-1")
 
 		require.NoError(t, err)
-		assert.Equal(t, 0, response.ExitCode)
-		assert.Equal(t, "42", response.Result)
+		assert.Equal(t, "session-1", session.SessionID)
+		require.Len(t, session.Commands, 1)
+		assert.Nil(t, session.Commands[0].ExitCode)
 	})
 
-	t.Run("successful javascript code execution", func(t *testing.T) {
+	t.Run("command completed", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
+				configResponse(),
 				{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"hello"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"sessionId":"session-1","commands":[{"cmdId":"cmd-abc","command":"echo hello","exitCode":0}]}`)),
 				},
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
+		client := newTestClient(t, httpContext)
+		session, err := client.GetSession("sandbox-123", "session-1")
+
+		require.NoError(t, err)
+		cmd := session.FindCommand("cmd-abc")
+		require.NotNil(t, cmd)
+		require.NotNil(t, cmd.ExitCode)
+		assert.Equal(t, 0, *cmd.ExitCode)
+	})
+}
+
+func Test__Client__GetSessionCommandLogs(t *testing.T) {
+	t.Run("successful log retrieval", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`"hello world"`)),
+				},
 			},
 		}
 
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		response, err := client.ExecuteCode("sandbox-123", &ExecuteCodeRequest{
-			Code:     "console.log('hello')",
-			Language: "javascript",
-		})
+		client := newTestClient(t, httpContext)
+		logs, err := client.GetSessionCommandLogs("sandbox-123", "session-1", "cmd-abc")
 
 		require.NoError(t, err)
-		assert.Equal(t, 0, response.ExitCode)
+		assert.Contains(t, logs, "hello world")
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/process/session/session-1/command/cmd-abc/logs")
 	})
 }
 
@@ -315,16 +294,8 @@ func Test__Client__DeleteSandbox(t *testing.T) {
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		err = client.DeleteSandbox("sandbox-123", false)
+		client := newTestClient(t, httpContext)
+		err := client.DeleteSandbox("sandbox-123", false)
 
 		require.NoError(t, err)
 		require.Len(t, httpContext.Requests, 1)
@@ -343,16 +314,8 @@ func Test__Client__DeleteSandbox(t *testing.T) {
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		err = client.DeleteSandbox("sandbox-123", true)
+		client := newTestClient(t, httpContext)
+		err := client.DeleteSandbox("sandbox-123", true)
 
 		require.NoError(t, err)
 		assert.Contains(t, httpContext.Requests[0].URL.String(), "force=true")
@@ -368,17 +331,50 @@ func Test__Client__DeleteSandbox(t *testing.T) {
 			},
 		}
 
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
+		client := newTestClient(t, httpContext)
+		err := client.DeleteSandbox("invalid-id", false)
 
-		client, err := NewClient(httpContext, appCtx)
-		require.NoError(t, err)
-
-		err = client.DeleteSandbox("invalid-id", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "404")
 	})
+}
+
+func Test__Session__FindCommand(t *testing.T) {
+	session := &Session{
+		Commands: []SessionCommand{
+			{CmdID: "cmd-1", Command: "echo a"},
+			{CmdID: "cmd-2", Command: "echo b"},
+		},
+	}
+
+	t.Run("existing command", func(t *testing.T) {
+		cmd := session.FindCommand("cmd-2")
+		require.NotNil(t, cmd)
+		assert.Equal(t, "echo b", cmd.Command)
+	})
+
+	t.Run("missing command", func(t *testing.T) {
+		cmd := session.FindCommand("cmd-999")
+		assert.Nil(t, cmd)
+	})
+}
+
+func configResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
+	}
+}
+
+func newTestClient(t *testing.T, httpContext *contexts.HTTPContext) *Client {
+	t.Helper()
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"apiKey": "test-api-key",
+		},
+	}
+
+	client, err := NewClient(httpContext, appCtx)
+	require.NoError(t, err)
+	return client
 }

--- a/pkg/integrations/daytona/execute_code.go
+++ b/pkg/integrations/daytona/execute_code.go
@@ -3,6 +3,7 @@ package daytona
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -10,7 +11,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const ExecuteCodePayloadType = "daytona.execute.response"
+const (
+	ExecuteCodePayloadType  = "daytona.execute.response"
+	ExecuteCodePollInterval = 5 * time.Second
+)
 
 type ExecuteCode struct{}
 
@@ -19,6 +23,14 @@ type ExecuteCodeSpec struct {
 	Code      string `json:"code"`
 	Language  string `json:"language"`
 	Timeout   int    `json:"timeout,omitempty"`
+}
+
+type ExecuteCodeMetadata struct {
+	SandboxID string `json:"sandboxId" mapstructure:"sandboxId"`
+	SessionID string `json:"sessionId" mapstructure:"sessionId"`
+	CmdID     string `json:"cmdId" mapstructure:"cmdId"`
+	StartedAt int64  `json:"startedAt" mapstructure:"startedAt"`
+	Timeout   int    `json:"timeout" mapstructure:"timeout"`
 }
 
 func (e *ExecuteCode) Name() string {
@@ -36,19 +48,26 @@ func (e *ExecuteCode) Description() string {
 func (e *ExecuteCode) Documentation() string {
 	return `The Execute Code component runs code in an existing Daytona sandbox.
 
+## How It Works
+
+1. Creates a session in the sandbox and kicks off the code execution asynchronously
+2. Polls the session until the execution finishes
+3. Retrieves the output and emits the result
+
 ## Use Cases
 
 - **AI code execution**: Run AI-generated code safely
 - **Code testing**: Execute untrusted code in isolation
 - **Script automation**: Run Python, TypeScript, or JavaScript scripts
 - **Data processing**: Execute data transformation scripts
+- **Long-running scripts**: Scripts that take minutes to complete
 
 ## Configuration
 
 - **Sandbox ID**: The ID of the sandbox (from createSandbox output)
 - **Code**: The code to execute (supports expressions)
 - **Language**: The programming language (python, typescript, javascript)
-- **Timeout**: Optional execution timeout in milliseconds
+- **Timeout**: Optional execution timeout in seconds
 
 ## Output
 
@@ -162,22 +181,40 @@ func (e *ExecuteCode) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create client: %v", err)
 	}
 
-	req := &ExecuteCodeRequest{
-		Code:     spec.Code,
-		Language: spec.Language,
-		Timeout:  spec.Timeout,
+	var command string
+	switch spec.Language {
+	case "python":
+		command = fmt.Sprintf("python3 -c %q", spec.Code)
+	case "javascript":
+		command = fmt.Sprintf("node -e %q", spec.Code)
+	case "typescript":
+		command = fmt.Sprintf("npx ts-node -e %q", spec.Code)
+	default:
+		command = fmt.Sprintf("python3 -c %q", spec.Code)
 	}
 
-	response, err := client.ExecuteCode(spec.SandboxID, req)
+	sessionID := fmt.Sprintf("sp-%s", ctx.ID.String())
+	if err := client.CreateSession(spec.SandboxID, sessionID); err != nil {
+		return fmt.Errorf("failed to create session: %v", err)
+	}
+
+	result, err := client.ExecuteSessionCommand(spec.SandboxID, sessionID, command)
 	if err != nil {
 		return fmt.Errorf("failed to execute code: %v", err)
 	}
 
-	return ctx.ExecutionState.Emit(
-		core.DefaultOutputChannel.Name,
-		ExecuteCodePayloadType,
-		[]any{response},
-	)
+	metadata := ExecuteCodeMetadata{
+		SandboxID: spec.SandboxID,
+		SessionID: sessionID,
+		CmdID:     result.CmdID,
+		StartedAt: time.Now().Unix(),
+		Timeout:   spec.Timeout,
+	}
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCodePollInterval)
 }
 
 func (e *ExecuteCode) Cancel(ctx core.ExecutionContext) error {
@@ -189,11 +226,65 @@ func (e *ExecuteCode) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID
 }
 
 func (e *ExecuteCode) Actions() []core.Action {
-	return []core.Action{}
+	return []core.Action{
+		{Name: "poll", UserAccessible: false},
+	}
 }
 
 func (e *ExecuteCode) HandleAction(ctx core.ActionContext) error {
-	return nil
+	if ctx.Name == "poll" {
+		return e.poll(ctx)
+	}
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (e *ExecuteCode) poll(ctx core.ActionContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata ExecuteCodeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("decode metadata: %w", err)
+	}
+
+	if metadata.Timeout > 0 {
+		elapsed := time.Now().Unix() - metadata.StartedAt
+		if elapsed > int64(metadata.Timeout) {
+			return fmt.Errorf("execution timed out after %d seconds", metadata.Timeout)
+		}
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	session, err := client.GetSession(metadata.SandboxID, metadata.SessionID)
+	if err != nil {
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCodePollInterval)
+	}
+
+	cmd := session.FindCommand(metadata.CmdID)
+	if cmd == nil || cmd.ExitCode == nil {
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCodePollInterval)
+	}
+
+	logs, err := client.GetSessionCommandLogs(metadata.SandboxID, metadata.SessionID, metadata.CmdID)
+	if err != nil {
+		logs = ""
+	}
+
+	response := &ExecuteCodeResponse{
+		ExitCode: *cmd.ExitCode,
+		Result:   logs,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		ExecuteCodePayloadType,
+		[]any{response},
+	)
 }
 
 func (e *ExecuteCode) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {

--- a/pkg/integrations/daytona/execute_code_test.go
+++ b/pkg/integrations/daytona/execute_code_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
@@ -125,99 +127,65 @@ func Test__ExecuteCode__Setup(t *testing.T) {
 func Test__ExecuteCode__Execute(t *testing.T) {
 	component := ExecuteCode{}
 
-	t.Run("successful code execution", func(t *testing.T) {
+	t.Run("successful execution -> creates session and schedules poll", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"hello world"}`)),
-				},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"sp-test"}`))},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"cmdId":"cmd-abc"}`))},
 			},
 		}
 
 		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
+			Configuration: map[string]any{"apiKey": "test-api-key"},
 		}
 
-		execCtx := &contexts.ExecutionStateContext{}
+		metadataCtx := &contexts.MetadataContext{}
+		requestsCtx := &contexts.RequestContext{}
+		execCtx := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
 		err := component.Execute(core.ExecutionContext{
+			ID: uuid.New(),
 			Configuration: map[string]any{
 				"sandboxId": "sandbox-123",
 				"code":      "print('hello world')",
 				"language":  "python",
+				"timeout":   30,
 			},
 			HTTP:           httpContext,
 			Integration:    appCtx,
 			ExecutionState: execCtx,
+			Metadata:       metadataCtx,
+			Requests:       requestsCtx,
 		})
 
 		require.NoError(t, err)
-		assert.True(t, execCtx.Finished)
-		assert.True(t, execCtx.Passed)
-		assert.Equal(t, ExecuteCodePayloadType, execCtx.Type)
-		require.Len(t, execCtx.Payloads, 1)
+		assert.False(t, execCtx.Finished)
+		assert.Equal(t, "poll", requestsCtx.Action)
+		assert.Equal(t, ExecuteCodePollInterval, requestsCtx.Duration)
+
+		metadata, ok := metadataCtx.Metadata.(ExecuteCodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "sandbox-123", metadata.SandboxID)
+		assert.Equal(t, "cmd-abc", metadata.CmdID)
+		assert.NotEmpty(t, metadata.SessionID)
 	})
 
-	t.Run("code execution with non-zero exit code", func(t *testing.T) {
+	t.Run("session creation failure -> error", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":1,"result":"error: division by zero"}`)),
-				},
+				configResponse(),
+				{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(`{"message":"sandbox not found"}`))},
 			},
 		}
 
 		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
+			Configuration: map[string]any{"apiKey": "test-api-key"},
 		}
 
-		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
-			Configuration: map[string]any{
-				"sandboxId": "sandbox-123",
-				"code":      "print(1/0)",
-				"language":  "python",
-			},
-			HTTP:           httpContext,
-			Integration:    appCtx,
-			ExecutionState: execCtx,
-		})
-
-		require.NoError(t, err)
-		assert.True(t, execCtx.Finished)
-	})
-
-	t.Run("code execution failure -> error", func(t *testing.T) {
-		httpContext := &contexts.HTTPContext{
-			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"message":"sandbox not found"}`)),
-				},
-			},
-		}
-
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		execCtx := &contexts.ExecutionStateContext{}
-		err := component.Execute(core.ExecutionContext{
+			ID: uuid.New(),
 			Configuration: map[string]any{
 				"sandboxId": "invalid-sandbox",
 				"code":      "print('hello')",
@@ -225,11 +193,121 @@ func Test__ExecuteCode__Execute(t *testing.T) {
 			},
 			HTTP:           httpContext,
 			Integration:    appCtx,
-			ExecutionState: execCtx,
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Metadata:       &contexts.MetadataContext{},
+			Requests:       &contexts.RequestContext{},
 		})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to execute code")
+		assert.Contains(t, err.Error(), "failed to create session")
+	})
+}
+
+func Test__ExecuteCode__HandleAction(t *testing.T) {
+	component := ExecuteCode{}
+
+	t.Run("unknown action -> error", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{Name: "unknown"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown action")
+	})
+
+	t.Run("already finished -> no-op", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{
+			Name:           "poll",
+			ExecutionState: &contexts.ExecutionStateContext{Finished: true, KVs: map[string]string{}},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("command still running -> reschedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"s-1","commands":[{"cmdId":"cmd-abc","command":"python3 -c ...","exitCode":null}]}`))},
+			},
+		}
+
+		requestsCtx := &contexts.RequestContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-api-key"},
+			},
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCodeMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Unix(),
+					Timeout:   600,
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       requestsCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "poll", requestsCtx.Action)
+		assert.Equal(t, ExecuteCodePollInterval, requestsCtx.Duration)
+	})
+
+	t.Run("execution completed -> emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"s-1","commands":[{"cmdId":"cmd-abc","command":"python3 -c ...","exitCode":0}]}`))},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`"hello world"`))},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-api-key"},
+			},
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCodeMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Unix(),
+					Timeout:   600,
+				},
+			},
+			ExecutionState: execState,
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execState.Finished)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, ExecuteCodePayloadType, execState.Type)
+	})
+
+	t.Run("timeout exceeded -> error", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCodeMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Add(-10 * time.Minute).Unix(),
+					Timeout:   30,
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
 	})
 }
 
@@ -276,4 +354,13 @@ func Test__ExecuteCode__OutputChannels(t *testing.T) {
 	channels := component.OutputChannels(nil)
 	require.Len(t, channels, 1)
 	assert.Equal(t, core.DefaultOutputChannel, channels[0])
+}
+
+func Test__ExecuteCode__Actions(t *testing.T) {
+	component := ExecuteCode{}
+
+	actions := component.Actions()
+	require.Len(t, actions, 1)
+	assert.Equal(t, "poll", actions[0].Name)
+	assert.False(t, actions[0].UserAccessible)
 }

--- a/pkg/integrations/daytona/execute_command.go
+++ b/pkg/integrations/daytona/execute_command.go
@@ -3,6 +3,7 @@ package daytona
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -10,7 +11,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const ExecuteCommandPayloadType = "daytona.command.response"
+const (
+	ExecuteCommandPayloadType  = "daytona.command.response"
+	ExecuteCommandPollInterval = 5 * time.Second
+)
 
 type ExecuteCommand struct{}
 
@@ -19,6 +23,14 @@ type ExecuteCommandSpec struct {
 	Command   string `json:"command"`
 	Cwd       string `json:"cwd,omitempty"`
 	Timeout   int    `json:"timeout,omitempty"`
+}
+
+type ExecuteCommandMetadata struct {
+	SandboxID string `json:"sandboxId" mapstructure:"sandboxId"`
+	SessionID string `json:"sessionId" mapstructure:"sessionId"`
+	CmdID     string `json:"cmdId" mapstructure:"cmdId"`
+	StartedAt int64  `json:"startedAt" mapstructure:"startedAt"`
+	Timeout   int    `json:"timeout" mapstructure:"timeout"`
 }
 
 func (e *ExecuteCommand) Name() string {
@@ -36,12 +48,19 @@ func (e *ExecuteCommand) Description() string {
 func (e *ExecuteCommand) Documentation() string {
 	return `The Execute Command component runs shell commands in an existing Daytona sandbox.
 
+## How It Works
+
+1. Creates a session in the sandbox and kicks off the command asynchronously
+2. Polls the session until the command finishes
+3. Retrieves the command output and emits the result
+
 ## Use Cases
 
 - **Package installation**: Install dependencies (pip install, npm install)
 - **File operations**: Create, move, or delete files in the sandbox
 - **System commands**: Run any shell command in the isolated environment
 - **Build processes**: Execute build scripts or compilation commands
+- **Long-running tasks**: Commands that take minutes to complete (builds, deployments)
 
 ## Configuration
 
@@ -140,22 +159,33 @@ func (e *ExecuteCommand) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create client: %v", err)
 	}
 
-	req := &ExecuteCommandRequest{
-		Command: spec.Command,
-		Cwd:     spec.Cwd,
-		Timeout: spec.Timeout,
+	command := spec.Command
+	if spec.Cwd != "" {
+		command = fmt.Sprintf("cd %s && %s", spec.Cwd, spec.Command)
 	}
 
-	response, err := client.ExecuteCommand(spec.SandboxID, req)
+	sessionID := fmt.Sprintf("sp-%s", ctx.ID.String())
+	if err := client.CreateSession(spec.SandboxID, sessionID); err != nil {
+		return fmt.Errorf("failed to create session: %v", err)
+	}
+
+	result, err := client.ExecuteSessionCommand(spec.SandboxID, sessionID, command)
 	if err != nil {
 		return fmt.Errorf("failed to execute command: %v", err)
 	}
 
-	return ctx.ExecutionState.Emit(
-		core.DefaultOutputChannel.Name,
-		ExecuteCommandPayloadType,
-		[]any{response},
-	)
+	metadata := ExecuteCommandMetadata{
+		SandboxID: spec.SandboxID,
+		SessionID: sessionID,
+		CmdID:     result.CmdID,
+		StartedAt: time.Now().Unix(),
+		Timeout:   spec.Timeout,
+	}
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCommandPollInterval)
 }
 
 func (e *ExecuteCommand) Cancel(ctx core.ExecutionContext) error {
@@ -167,11 +197,65 @@ func (e *ExecuteCommand) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.U
 }
 
 func (e *ExecuteCommand) Actions() []core.Action {
-	return []core.Action{}
+	return []core.Action{
+		{Name: "poll", UserAccessible: false},
+	}
 }
 
 func (e *ExecuteCommand) HandleAction(ctx core.ActionContext) error {
-	return nil
+	if ctx.Name == "poll" {
+		return e.poll(ctx)
+	}
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (e *ExecuteCommand) poll(ctx core.ActionContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata ExecuteCommandMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("decode metadata: %w", err)
+	}
+
+	if metadata.Timeout > 0 {
+		elapsed := time.Now().Unix() - metadata.StartedAt
+		if elapsed > int64(metadata.Timeout) {
+			return fmt.Errorf("command timed out after %d seconds", metadata.Timeout)
+		}
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	session, err := client.GetSession(metadata.SandboxID, metadata.SessionID)
+	if err != nil {
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCommandPollInterval)
+	}
+
+	cmd := session.FindCommand(metadata.CmdID)
+	if cmd == nil || cmd.ExitCode == nil {
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, ExecuteCommandPollInterval)
+	}
+
+	logs, err := client.GetSessionCommandLogs(metadata.SandboxID, metadata.SessionID, metadata.CmdID)
+	if err != nil {
+		logs = ""
+	}
+
+	response := &ExecuteCommandResponse{
+		ExitCode: *cmd.ExitCode,
+		Result:   logs,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		ExecuteCommandPayloadType,
+		[]any{response},
+	)
 }
 
 func (e *ExecuteCommand) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {

--- a/pkg/integrations/daytona/execute_command_test.go
+++ b/pkg/integrations/daytona/execute_command_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
@@ -77,145 +79,220 @@ func Test__ExecuteCommand__Setup(t *testing.T) {
 func Test__ExecuteCommand__Execute(t *testing.T) {
 	component := ExecuteCommand{}
 
-	t.Run("successful command execution", func(t *testing.T) {
+	t.Run("successful execution -> creates session and schedules poll", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"hello world"}`)),
-				},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"sp-test"}`))},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"cmdId":"cmd-abc"}`))},
 			},
 		}
 
 		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
+			Configuration: map[string]any{"apiKey": "test-api-key"},
 		}
 
-		execCtx := &contexts.ExecutionStateContext{}
+		metadataCtx := &contexts.MetadataContext{}
+		requestsCtx := &contexts.RequestContext{}
+		execCtx := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
 		err := component.Execute(core.ExecutionContext{
+			ID: uuid.New(),
 			Configuration: map[string]any{
 				"sandboxId": "sandbox-123",
 				"command":   "echo hello world",
+				"timeout":   60,
 			},
 			HTTP:           httpContext,
 			Integration:    appCtx,
 			ExecutionState: execCtx,
+			Metadata:       metadataCtx,
+			Requests:       requestsCtx,
 		})
 
 		require.NoError(t, err)
-		assert.True(t, execCtx.Finished)
-		assert.True(t, execCtx.Passed)
-		assert.Equal(t, ExecuteCommandPayloadType, execCtx.Type)
-		require.Len(t, execCtx.Payloads, 1)
+		assert.False(t, execCtx.Finished)
+		assert.Equal(t, "poll", requestsCtx.Action)
+		assert.Equal(t, ExecuteCommandPollInterval, requestsCtx.Duration)
+
+		metadata, ok := metadataCtx.Metadata.(ExecuteCommandMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "sandbox-123", metadata.SandboxID)
+		assert.Equal(t, "cmd-abc", metadata.CmdID)
+		assert.NotEmpty(t, metadata.SessionID)
+		assert.NotZero(t, metadata.StartedAt)
 	})
 
-	t.Run("command execution with working directory", func(t *testing.T) {
+	t.Run("session creation failure -> error", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":0,"result":"/home/daytona"}`)),
-				},
+				configResponse(),
+				{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(`{"message":"internal error"}`))},
 			},
 		}
 
 		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
+			Configuration: map[string]any{"apiKey": "test-api-key"},
 		}
 
-		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
+			ID: uuid.New(),
 			Configuration: map[string]any{
 				"sandboxId": "sandbox-123",
-				"command":   "pwd",
-				"cwd":       "/home/daytona",
-			},
-			HTTP:           httpContext,
-			Integration:    appCtx,
-			ExecutionState: execCtx,
-		})
-
-		require.NoError(t, err)
-		assert.True(t, execCtx.Finished)
-		assert.True(t, execCtx.Passed)
-	})
-
-	t.Run("command with non-zero exit code", func(t *testing.T) {
-		httpContext := &contexts.HTTPContext{
-			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`)),
-				},
-				{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"exitCode":127,"result":"command not found"}`)),
-				},
-			},
-		}
-
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		execCtx := &contexts.ExecutionStateContext{}
-		err := component.Execute(core.ExecutionContext{
-			Configuration: map[string]any{
-				"sandboxId": "sandbox-123",
-				"command":   "nonexistent-command",
-			},
-			HTTP:           httpContext,
-			Integration:    appCtx,
-			ExecutionState: execCtx,
-		})
-
-		require.NoError(t, err)
-		assert.True(t, execCtx.Finished)
-	})
-
-	t.Run("command execution failure -> error", func(t *testing.T) {
-		httpContext := &contexts.HTTPContext{
-			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`{"message":"sandbox not found"}`)),
-				},
-			},
-		}
-
-		appCtx := &contexts.IntegrationContext{
-			Configuration: map[string]any{
-				"apiKey": "test-api-key",
-			},
-		}
-
-		execCtx := &contexts.ExecutionStateContext{}
-		err := component.Execute(core.ExecutionContext{
-			Configuration: map[string]any{
-				"sandboxId": "invalid-sandbox",
 				"command":   "echo hello",
 			},
 			HTTP:           httpContext,
 			Integration:    appCtx,
-			ExecutionState: execCtx,
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Metadata:       &contexts.MetadataContext{},
+			Requests:       &contexts.RequestContext{},
 		})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to execute command")
+		assert.Contains(t, err.Error(), "failed to create session")
+	})
+}
+
+func Test__ExecuteCommand__HandleAction(t *testing.T) {
+	component := ExecuteCommand{}
+
+	t.Run("unknown action -> error", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{Name: "unknown"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown action")
+	})
+
+	t.Run("already finished -> no-op", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{
+			Name:           "poll",
+			ExecutionState: &contexts.ExecutionStateContext{Finished: true, KVs: map[string]string{}},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("command still running -> reschedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"s-1","commands":[{"cmdId":"cmd-abc","command":"echo hi","exitCode":null}]}`))},
+			},
+		}
+
+		requestsCtx := &contexts.RequestContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-api-key"},
+			},
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCommandMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Unix(),
+					Timeout:   600,
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       requestsCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "poll", requestsCtx.Action)
+		assert.Equal(t, ExecuteCommandPollInterval, requestsCtx.Duration)
+	})
+
+	t.Run("command completed -> emits result", func(t *testing.T) {
+		exitCode := 0
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"s-1","commands":[{"cmdId":"cmd-abc","command":"echo hi","exitCode":0}]}`))},
+				configResponse(),
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`"hello world"`))},
+			},
+		}
+
+		_ = exitCode
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-api-key"},
+			},
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCommandMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Unix(),
+					Timeout:   600,
+				},
+			},
+			ExecutionState: execState,
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execState.Finished)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, ExecuteCommandPayloadType, execState.Type)
+	})
+
+	t.Run("timeout exceeded -> error", func(t *testing.T) {
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCommandMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Add(-10 * time.Minute).Unix(),
+					Timeout:   60,
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+	})
+
+	t.Run("get session error -> reschedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				configResponse(),
+				{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader(`{"message":"error"}`))},
+			},
+		}
+
+		requestsCtx := &contexts.RequestContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-api-key"},
+			},
+			Metadata: &contexts.MetadataContext{
+				Metadata: ExecuteCommandMetadata{
+					SandboxID: "sandbox-123",
+					SessionID: "s-1",
+					CmdID:     "cmd-abc",
+					StartedAt: time.Now().Unix(),
+					Timeout:   600,
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       requestsCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "poll", requestsCtx.Action)
 	})
 }
 
@@ -262,4 +339,13 @@ func Test__ExecuteCommand__OutputChannels(t *testing.T) {
 	channels := component.OutputChannels(nil)
 	require.Len(t, channels, 1)
 	assert.Equal(t, core.DefaultOutputChannel, channels[0])
+}
+
+func Test__ExecuteCommand__Actions(t *testing.T) {
+	component := ExecuteCommand{}
+
+	actions := component.Actions()
+	require.Len(t, actions, 1)
+	assert.Equal(t, "poll", actions[0].Name)
+	assert.False(t, actions[0].UserAccessible)
 }

--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -97,20 +97,27 @@ func NewHTTPContext(options HTTPOptions) (*HTTPContext, error) {
 }
 
 func (c *HTTPContext) Do(request *http.Request) (*http.Response, error) {
-	if len(c.privateIPRanges) == 0 && len(c.blockedHosts) == 0 {
-		return c.do(request)
-	}
-
-	err := c.validateURL(request.URL)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.do(request)
+	return c.doWithClient(request, c.client)
 }
 
-func (c *HTTPContext) do(request *http.Request) (*http.Response, error) {
-	resp, err := c.client.Do(request)
+func (c *HTTPContext) DoWithTimeout(request *http.Request, timeout time.Duration) (*http.Response, error) {
+	client := &http.Client{
+		Timeout:       timeout,
+		Transport:     c.client.Transport,
+		CheckRedirect: c.client.CheckRedirect,
+	}
+
+	return c.doWithClient(request, client)
+}
+
+func (c *HTTPContext) doWithClient(request *http.Request, client *http.Client) (*http.Response, error) {
+	if len(c.privateIPRanges) > 0 || len(c.blockedHosts) > 0 {
+		if err := c.validateURL(request.URL); err != nil {
+			return nil, err
+		}
+	}
+
+	resp, err := client.Do(request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/http.go
+++ b/pkg/registry/http.go
@@ -97,27 +97,13 @@ func NewHTTPContext(options HTTPOptions) (*HTTPContext, error) {
 }
 
 func (c *HTTPContext) Do(request *http.Request) (*http.Response, error) {
-	return c.doWithClient(request, c.client)
-}
-
-func (c *HTTPContext) DoWithTimeout(request *http.Request, timeout time.Duration) (*http.Response, error) {
-	client := &http.Client{
-		Timeout:       timeout,
-		Transport:     c.client.Transport,
-		CheckRedirect: c.client.CheckRedirect,
-	}
-
-	return c.doWithClient(request, client)
-}
-
-func (c *HTTPContext) doWithClient(request *http.Request, client *http.Client) (*http.Response, error) {
 	if len(c.privateIPRanges) > 0 || len(c.blockedHosts) > 0 {
 		if err := c.validateURL(request.URL); err != nil {
 			return nil, err
 		}
 	}
 
-	resp, err := client.Do(request)
+	resp, err := c.client.Do(request)
 	if err != nil {
 		return nil, err
 	}

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -319,6 +319,3 @@ func (c *HTTPContext) Do(request *http.Request) (*http.Response, error) {
 	return response, nil
 }
 
-func (c *HTTPContext) DoWithTimeout(request *http.Request, _ time.Duration) (*http.Response, error) {
-	return c.Do(request)
-}

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -318,3 +318,7 @@ func (c *HTTPContext) Do(request *http.Request) (*http.Response, error) {
 	c.Responses = c.Responses[1:]
 	return response, nil
 }
+
+func (c *HTTPContext) DoWithTimeout(request *http.Request, _ time.Duration) (*http.Response, error) {
+	return c.Do(request)
+}


### PR DESCRIPTION
## Problem

The `daytona.executeCommand` and `daytona.executeCode` components executed commands synchronously -- they sent the command to the Daytona toolbox API and held the HTTP connection open until it completed. With the platform's 30-second HTTP client timeout, any command taking longer than 30 seconds would fail with `context deadline exceeded`, regardless of the component's configured `timeout`.

## Solution

Replaced the synchronous execution model with an async kick-off + poll pattern using Daytona's Session API:

1. **Execute**: Creates a session, kicks off the command with `runAsync: true` (returns immediately with a `cmdId`), then stores metadata and schedules a poll action.
2. **Poll**: Periodically checks the session to see if the command has finished (`exitCode` is set). If still running, reschedules. If done, fetches the logs and emits the result.

Each individual HTTP call (create session, execute async, get session, get logs) completes well within the 30-second timeout. The poll interval is 5 seconds.

This also removes the `DoWithTimeout` method from `HTTPContext` that was added in the previous attempt, since it's no longer needed.