### PR TITLE
fix: address review feedback for Dash0 synthetic checks

### DIFF
--- a/pkg/integrations/dash0/client.go
+++ b/pkg/integrations/dash0/client.go
@@ -165,6 +165,25 @@ type CheckRule struct {
 	Name string `json:"name,omitempty"`
 }
 
+type SyntheticCheck struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+type syntheticCheckResponse struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	Metadata struct {
+		Name   string            `json:"name"`
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata"`
+}
+
+type syntheticCheckListResponse struct {
+	Items []syntheticCheckResponse `json:"items"`
+	Data  []syntheticCheckResponse `json:"data"`
+}
+
 func (c *Client) ListCheckRules() ([]CheckRule, error) {
 	apiURL := fmt.Sprintf("%s/api/alerting/check-rules", c.BaseURL)
 
@@ -205,6 +224,71 @@ func (c *Client) ListCheckRules() ([]CheckRule, error) {
 	}
 
 	return checkRules, nil
+}
+
+func (c *Client) ListSyntheticChecks(dataset string) ([]SyntheticCheck, error) {
+	apiURL := fmt.Sprintf("%s/api/synthetic-checks?dataset=%s", c.BaseURL, url.QueryEscape(dataset))
+
+	responseBody, err := c.execRequest(http.MethodGet, apiURL, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var stringList []string
+	if err := json.Unmarshal(responseBody, &stringList); err == nil {
+		syntheticChecks := make([]SyntheticCheck, len(stringList))
+		for i, id := range stringList {
+			syntheticChecks[i] = SyntheticCheck{ID: id, Name: id}
+		}
+		return syntheticChecks, nil
+	}
+
+	var syntheticChecks []syntheticCheckResponse
+	if err := json.Unmarshal(responseBody, &syntheticChecks); err == nil {
+		return normalizeSyntheticChecks(syntheticChecks), nil
+	}
+
+	var wrapped syntheticCheckListResponse
+	if err := json.Unmarshal(responseBody, &wrapped); err != nil {
+		return nil, fmt.Errorf("error parsing synthetic checks response: %v", err)
+	}
+
+	if len(wrapped.Items) > 0 {
+		return normalizeSyntheticChecks(wrapped.Items), nil
+	}
+
+	return normalizeSyntheticChecks(wrapped.Data), nil
+}
+
+func normalizeSyntheticChecks(checks []syntheticCheckResponse) []SyntheticCheck {
+	syntheticChecks := make([]SyntheticCheck, 0, len(checks))
+	for _, check := range checks {
+		id := check.ID
+		if id == "" {
+			id = check.Metadata.Labels["dash0.com/id"]
+		}
+		if id == "" {
+			id = check.Metadata.Labels["dash0.com/origin"]
+		}
+		if id == "" {
+			continue
+		}
+
+		name := check.Name
+		if name == "" {
+			name = check.Metadata.Name
+		}
+		if name == "" {
+			name = id
+		}
+
+		syntheticChecks = append(syntheticChecks, SyntheticCheck{
+			ID:   id,
+			Name: name,
+		})
+	}
+
+	return syntheticChecks
 }
 
 // SyntheticCheckAssertion represents a single assertion in a synthetic check.

--- a/pkg/integrations/dash0/create_http_synthetic_check.go
+++ b/pkg/integrations/dash0/create_http_synthetic_check.go
@@ -226,7 +226,7 @@ func (c *CreateHTTPSyntheticCheck) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if spec.Name == "" {
+	if strings.TrimSpace(spec.Name) == "" {
 		return errors.New("name is required")
 	}
 

--- a/pkg/integrations/dash0/dash0.go
+++ b/pkg/integrations/dash0/dash0.go
@@ -117,7 +117,7 @@ func (d *Dash0) Cleanup(ctx core.IntegrationCleanupContext) error {
 }
 
 func (d *Dash0) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
-	if resourceType != "check-rule" {
+	if resourceType != "check-rule" && resourceType != "synthetic-check" {
 		return []core.IntegrationResource{}, nil
 	}
 
@@ -126,22 +126,44 @@ func (d *Dash0) ListResources(resourceType string, ctx core.ListResourcesContext
 		return nil, fmt.Errorf("error creating dash0 client: %w", err)
 	}
 
-	checkRules, err := client.ListCheckRules()
-	if err != nil {
-		ctx.Logger.Warnf("Error fetching check rules: %v", err)
+	switch resourceType {
+	case "check-rule":
+		checkRules, err := client.ListCheckRules()
+		if err != nil {
+			ctx.Logger.Warnf("Error fetching check rules: %v", err)
+			return []core.IntegrationResource{}, nil
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(checkRules))
+		for _, rule := range checkRules {
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: rule.Name,
+				ID:   rule.ID,
+			})
+		}
+
+		return resources, nil
+	case "synthetic-check":
+		syntheticChecks, err := client.ListSyntheticChecks("default")
+		if err != nil {
+			ctx.Logger.Warnf("Error fetching synthetic checks: %v", err)
+			return []core.IntegrationResource{}, nil
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(syntheticChecks))
+		for _, check := range syntheticChecks {
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: check.Name,
+				ID:   check.ID,
+			})
+		}
+
+		return resources, nil
+	default:
 		return []core.IntegrationResource{}, nil
 	}
-
-	resources := make([]core.IntegrationResource, 0, len(checkRules))
-	for _, rule := range checkRules {
-		resources = append(resources, core.IntegrationResource{
-			Type: resourceType,
-			Name: rule.Name,
-			ID:   rule.ID,
-		})
-	}
-
-	return resources, nil
 }
 
 func (d *Dash0) HandleRequest(ctx core.HTTPRequestContext) {

--- a/pkg/integrations/dash0/dash0_list_resources_test.go
+++ b/pkg/integrations/dash0/dash0_list_resources_test.go
@@ -1,0 +1,100 @@
+package dash0
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Dash0__ListResources(t *testing.T) {
+	d := &Dash0{}
+
+	t.Run("unknown resource type returns empty list", func(t *testing.T) {
+		integrationContext := &contexts.IntegrationContext{}
+		httpContext := &contexts.HTTPContext{}
+
+		resources, err := d.ListResources("unknown", core.ListResourcesContext{
+			Logger:      logrus.NewEntry(logrus.New()),
+			HTTP:        httpContext,
+			Integration: integrationContext,
+		})
+
+		require.NoError(t, err)
+		require.Empty(t, resources)
+		require.Empty(t, httpContext.Requests)
+	})
+
+	t.Run("returns check rules", func(t *testing.T) {
+		integrationContext := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+				"baseURL":  "https://api.us-west-2.aws.dash0.com",
+			},
+		}
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(
+						strings.NewReader(`[{"id":"rule-1","name":"CPU high"},{"id":"rule-2","name":"Latency"}]`),
+					),
+				},
+			},
+		}
+
+		resources, err := d.ListResources("check-rule", core.ListResourcesContext{
+			Logger:      logrus.NewEntry(logrus.New()),
+			HTTP:        httpContext,
+			Integration: integrationContext,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		assert.Equal(t, "check-rule", resources[0].Type)
+		assert.Equal(t, "CPU high", resources[0].Name)
+		assert.Equal(t, "rule-1", resources[0].ID)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/api/alerting/check-rules")
+	})
+
+	t.Run("returns synthetic checks", func(t *testing.T) {
+		integrationContext := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+				"baseURL":  "https://api.us-west-2.aws.dash0.com",
+			},
+		}
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`[{"metadata":{"name":"Login health","labels":{"dash0.com/id":"check-1"}}}]`,
+					)),
+				},
+			},
+		}
+
+		resources, err := d.ListResources("synthetic-check", core.ListResourcesContext{
+			Logger:      logrus.NewEntry(logrus.New()),
+			HTTP:        httpContext,
+			Integration: integrationContext,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assert.Equal(t, "synthetic-check", resources[0].Type)
+		assert.Equal(t, "Login health", resources[0].Name)
+		assert.Equal(t, "check-1", resources[0].ID)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/api/synthetic-checks")
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "dataset=default")
+	})
+}

--- a/pkg/integrations/dash0/delete_http_synthetic_check.go
+++ b/pkg/integrations/dash0/delete_http_synthetic_check.go
@@ -61,10 +61,14 @@ func (c *DeleteHTTPSyntheticCheck) Configuration() []configuration.Field {
 		{
 			Name:        "checkId",
 			Label:       "Check ID",
-			Type:        configuration.FieldTypeString,
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The Dash0 synthetic check ID to delete",
-			Placeholder: "64617368-3073-796e-7468-abc123def456",
+			Description: "Select the Dash0 synthetic check to delete",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "synthetic-check",
+				},
+			},
 		},
 		{
 			Name:        "dataset",

--- a/pkg/integrations/dash0/example_output_update_http_synthetic_check.json
+++ b/pkg/integrations/dash0/example_output_update_http_synthetic_check.json
@@ -1,1 +1,68 @@
-{"type":"dash0.syntheticCheck.updated","data":{"kind":"Dash0SyntheticCheck","metadata":{"annotations":{},"labels":{"dash0.com/dataset":"default","dash0.com/id":"64617368-3073-796e-7468-abc123def456","dash0.com/origin":"api-abc12345-6789-0123-4567-890abcdef012","dash0.com/version":"2"},"name":"login-api-health-check"},"spec":{"enabled":true,"schedule":{"interval":"1m","locations":["de-frankfurt","us-oregon"],"strategy":"all_locations"},"plugin":{"display":{"name":"Login API health check"},"kind":"http","spec":{"request":{"method":"get","url":"https://api.example.com/health","headers":[],"queryParameters":[],"redirects":"follow","tls":{"allowInsecure":false},"tracing":{"addTracingHeaders":true}},"assertions":{"criticalAssertions":[{"kind":"status_code","spec":{"operator":"is","value":"200"}}],"degradedAssertions":[]},"retries":{"kind":"fixed","spec":{"attempts":3,"delay":"1s"}}}}}},"timestamp":"2026-01-19T12:00:00Z"}
+{
+  "type": "dash0.syntheticCheck.updated",
+  "data": {
+    "kind": "Dash0SyntheticCheck",
+    "metadata": {
+      "annotations": {},
+      "labels": {
+        "dash0.com/dataset": "default",
+        "dash0.com/id": "64617368-3073-796e-7468-abc123def456",
+        "dash0.com/origin": "api-abc12345-6789-0123-4567-890abcdef012",
+        "dash0.com/version": "2"
+      },
+      "name": "login-api-health-check"
+    },
+    "spec": {
+      "enabled": true,
+      "schedule": {
+        "interval": "1m",
+        "locations": [
+          "de-frankfurt",
+          "us-oregon"
+        ],
+        "strategy": "all_locations"
+      },
+      "plugin": {
+        "display": {
+          "name": "Login API health check"
+        },
+        "kind": "http",
+        "spec": {
+          "request": {
+            "method": "get",
+            "url": "https://api.example.com/health",
+            "headers": [],
+            "queryParameters": [],
+            "redirects": "follow",
+            "tls": {
+              "allowInsecure": false
+            },
+            "tracing": {
+              "addTracingHeaders": true
+            }
+          },
+          "assertions": {
+            "criticalAssertions": [
+              {
+                "kind": "status_code",
+                "spec": {
+                  "operator": "is",
+                  "value": "200"
+                }
+              }
+            ],
+            "degradedAssertions": []
+          },
+          "retries": {
+            "kind": "fixed",
+            "spec": {
+              "attempts": 3,
+              "delay": "1s"
+            }
+          }
+        }
+      }
+    }
+  },
+  "timestamp": "2026-01-19T12:00:00Z"
+}

--- a/pkg/integrations/dash0/update_http_synthetic_check.go
+++ b/pkg/integrations/dash0/update_http_synthetic_check.go
@@ -64,10 +64,14 @@ func (c *UpdateHTTPSyntheticCheck) Configuration() []configuration.Field {
 		{
 			Name:        "checkId",
 			Label:       "Check ID",
-			Type:        configuration.FieldTypeString,
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The Dash0 synthetic check ID to update (e.g. from Create HTTP Synthetic Check output or dashboard)",
-			Placeholder: "64617368-3073-796e-7468-abc123def456",
+			Description: "Select the Dash0 synthetic check to update",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "synthetic-check",
+				},
+			},
 		},
 		{
 			Name:        "name",

--- a/web_src/src/pages/workflowv2/mappers/dash0/create_http_synthetic_check.ts
+++ b/web_src/src/pages/workflowv2/mappers/dash0/create_http_synthetic_check.ts
@@ -69,8 +69,8 @@ export const createHttpSyntheticCheckMapper: ComponentBaseMapper = {
   },
 
   subtitle(context: SubtitleContext): string {
-    if (!context.execution.createdAt) return "";
-    return formatTimeAgo(new Date(context.execution.createdAt));
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
   },
 };
 
@@ -106,12 +106,14 @@ function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componen
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? formatTimeAgo(new Date(subtitleTimestamp)) : "";
 
   return [
     {
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
-      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventSubtitle,
       eventState: getState(componentName)(execution),
       eventId: execution.rootEvent!.id!,
     },

--- a/web_src/src/pages/workflowv2/mappers/dash0/delete_http_synthetic_check.ts
+++ b/web_src/src/pages/workflowv2/mappers/dash0/delete_http_synthetic_check.ts
@@ -59,8 +59,8 @@ export const deleteHttpSyntheticCheckMapper: ComponentBaseMapper = {
   },
 
   subtitle(context: SubtitleContext): string {
-    if (!context.execution.createdAt) return "";
-    return formatTimeAgo(new Date(context.execution.createdAt));
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
   },
 };
 
@@ -85,12 +85,14 @@ function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componen
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? formatTimeAgo(new Date(subtitleTimestamp)) : "";
 
   return [
     {
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
-      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventSubtitle,
       eventState: getState(componentName)(execution),
       eventId: execution.rootEvent!.id!,
     },

--- a/web_src/src/pages/workflowv2/mappers/dash0/update_http_synthetic_check.ts
+++ b/web_src/src/pages/workflowv2/mappers/dash0/update_http_synthetic_check.ts
@@ -69,8 +69,8 @@ export const updateHttpSyntheticCheckMapper: ComponentBaseMapper = {
   },
 
   subtitle(context: SubtitleContext): string {
-    if (!context.execution.createdAt) return "";
-    return formatTimeAgo(new Date(context.execution.createdAt));
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? formatTimeAgo(new Date(timestamp)) : "";
   },
 };
 
@@ -112,12 +112,14 @@ function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componen
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? formatTimeAgo(new Date(subtitleTimestamp)) : "";
 
   return [
     {
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
-      eventSubtitle: formatTimeAgo(new Date(execution.createdAt!)),
+      eventSubtitle,
       eventState: getState(componentName)(execution),
       eventId: execution.rootEvent!.id!,
     },


### PR DESCRIPTION
Summary: use updatedAt fallback in mapper subtitles, trim-space name validation in create synthetic check, convert checkId to integration resource field, add synthetic-check list resources support, add list resources tests, and format the update example JSON. Validation: go test ./pkg/integrations/dash0 -count=1; cd web_src && npm run format:check; GOCACHE=/tmp/go-build go build cmd/server/main.go; GOCACHE=/tmp/go-build make gen.components.docs.