### PR TITLE
fix(ci): use go mod download in test.setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test.setup:
 	@if [ -d "tmp/screenshots" ]; then rm -rf tmp/screenshots; fi
 	@mkdir -p tmp/screenshots
 	docker compose $(DOCKER_COMPOSE_OPTS) build
-	docker compose $(DOCKER_COMPOSE_OPTS) run --rm app go get ./...
+	docker compose $(DOCKER_COMPOSE_OPTS) run --rm app go mod download
 	$(MAKE) db.create DB_NAME=superplane_test
 	$(MAKE) db.migrate DB_NAME=superplane_test
 


### PR DESCRIPTION
Solves this issue we are getting in CI:

```
go: pattern ./...: directory tmp/go/pkg/mod/github.com/go-sourcemap/sourcemap@v2.1.3+incompatible outside main module or its selected dependencies02:25
go: pattern ./...: directory tmp/go/pkg/mod/github.com/go-sourcemap/sourcemap@v2.1.3+incompatible/internal/base64vlq outside main module or its selected dependencies02:25
```

