### PR TITLE
fix(http): apply exponential backoff to retry delay instead of request timeout

### DIFF
--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -528,7 +528,7 @@ func (e *HTTP) scheduleRetry(ctx core.ExecutionContext, lastError string, retryM
 		return err
 	}
 
-	return ctx.Requests.ScheduleActionCall("retryRequest", map[string]any{}, 1*time.Second)
+	return ctx.Requests.ScheduleActionCall("retryRequest", map[string]any{}, e.calculateTimeoutForAttempt(retryMetadata.TimeoutStrategy, 1, retryMetadata.Attempt - 1))
 }
 
 func (e *HTTP) handleRetryRequest(ctx core.ActionContext) error {


### PR DESCRIPTION
Currently, the `exponential` timeout strategy implementation incorrectly increases the request **timeout duration** (how long we wait for a response) rather than the **backoff delay** (how long we wait between attempts).

The delay in `scheduleRetry` was hardcoded to `1 * time.Second`, regardless of the configured strategy.

This PR fixes it by using `calculateTimeoutForAttempt` (with a 1s base) to determine the delay passed to `ScheduleActionCall`.

**Fixes:**
- Retry delay now grows exponentially: 1s -> 2s -> 4s...
- Maintains existing behavior for "fixed" strategy (1s delay).