### PR TITLE
chore: add _target blank and noreferrer to markdown renderer anchors

### DIFF
--- a/web_src/src/ui/IntegrationInstructions.tsx
+++ b/web_src/src/ui/IntegrationInstructions.tsx
@@ -39,7 +39,12 @@ export function IntegrationInstructions({ description, onContinue, className = "
               ol: ({ children }) => <ol className="list-decimal ml-5 space-y-1 mb-2">{children}</ol>,
               li: ({ children }) => <li>{children}</li>,
               a: ({ children, href }) => (
-                <a className="!underline underline-offset-2 decoration-2 decoration-current" href={href}>
+                <a
+                  className="!underline underline-offset-2 decoration-2 decoration-current"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={href}
+                >
                   {children}
                 </a>
               ),

--- a/web_src/src/ui/annotationComponent/index.tsx
+++ b/web_src/src/ui/annotationComponent/index.tsx
@@ -362,7 +362,7 @@ const AnnotationComponentBase: React.FC<AnnotationComponentProps> = ({
                         <pre className="bg-black/10 p-2 rounded text-xs overflow-auto mb-2">{children}</pre>
                       ),
                       a: ({ children, href }) => (
-                        <a href={href} className="underline text-blue-600">
+                        <a target="_blank" rel="noopener noreferrer" href={href} className="underline text-blue-600">
                           {children}
                         </a>
                       ),


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/3086