### PR TITLE
fix(http): make timeout errors easier to understand

### DIFF
--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -625,6 +625,10 @@ func (e *HTTP) executeRequest(httpCtx core.HTTPContext, spec Spec, timeout time.
 
 	resp, err := httpCtx.Do(req)
 	if err != nil {
+		if reqCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("request timed out after %s", timeout)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
Timeout errors currently show the raw Go error context deadline exceeded. This change returns a clear message like request timed out after 10s instead.

Fixes #3198