### PR TITLE
feat: Add AWS CodePipeline Get Pipeline component

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -27,6 +27,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="CodeArtifact • Dispose Package Versions" href="#code-artifact-•-dispose-package-versions" description="Delete assets and set package version status to Disposed (record remains)" />
   <LinkCard title="CodeArtifact • Get Package Version" href="#code-artifact-•-get-package-version" description="Describe an AWS CodeArtifact package version" />
   <LinkCard title="CodeArtifact • Update Package Versions Status" href="#code-artifact-•-update-package-versions-status" description="Update the status of one or more package versions (Archived, Published, Unlisted)" />
+  <LinkCard title="CodePipeline • Get Pipeline" href="#code-pipeline-•-get-pipeline" description="Retrieve the definition of an AWS CodePipeline pipeline" />
   <LinkCard title="CodePipeline • Run Pipeline" href="#code-pipeline-•-run-pipeline" description="Start an AWS CodePipeline execution and wait for it to complete" />
   <LinkCard title="EC2 • Copy Image" href="#ec2-•-copy-image" description="Copy an EC2 AMI image to another region" />
   <LinkCard title="EC2 • Create Image" href="#ec2-•-create-image" description="Create a new AMI image from an EC2 instance" />
@@ -611,6 +612,81 @@ The Update Package Versions Status component sets the status of package versions
       "status": "Archived"
     }
   }
+}
+```
+
+<a id="code-pipeline-•-get-pipeline"></a>
+
+## CodePipeline • Get Pipeline
+
+The Get Pipeline component retrieves the full definition of an AWS CodePipeline pipeline.
+
+### Use Cases
+
+- **Pipeline inspection**: Fetch pipeline stages, actions, and configuration
+- **Workflow branching**: Route workflow based on pipeline structure or version
+- **Audit and compliance**: Retrieve pipeline definitions for auditing purposes
+
+### Configuration
+
+- **Region**: AWS region where the pipeline exists
+- **Pipeline**: Pipeline name to retrieve
+
+### Output
+
+Emits the full pipeline definition including:
+- Pipeline name, version, and role ARN
+- All stages and their actions
+- Pipeline metadata (ARN, creation date, last updated date)
+
+### Example Output
+
+```json
+{
+  "data": {
+    "metadata": {
+      "created": "2025-01-15T10:30:00Z",
+      "pipelineArn": "arn:aws:codepipeline:us-east-1:123456789012:my-deploy-pipeline",
+      "updated": "2026-02-20T14:00:00Z"
+    },
+    "pipeline": {
+      "name": "my-deploy-pipeline",
+      "roleArn": "arn:aws:iam::123456789012:role/pipeline-role",
+      "stages": [
+        {
+          "actions": [
+            {
+              "actionTypeId": {
+                "category": "Source",
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
+              },
+              "name": "SourceAction"
+            }
+          ],
+          "name": "Source"
+        },
+        {
+          "actions": [
+            {
+              "actionTypeId": {
+                "category": "Deploy",
+                "owner": "AWS",
+                "provider": "CodeDeploy",
+                "version": "1"
+              },
+              "name": "DeployAction"
+            }
+          ],
+          "name": "Deploy"
+        }
+      ],
+      "version": 3
+    }
+  },
+  "timestamp": "2026-02-22T10:00:00.000000000Z",
+  "type": "aws.codepipeline.pipeline"
 }
 ```
 

--- a/pkg/integrations/aws/aws.go
+++ b/pkg/integrations/aws/aws.go
@@ -144,6 +144,7 @@ func (a *AWS) Components() []core.Component {
 		&codeartifact.DisposePackageVersions{},
 		&codeartifact.GetPackageVersion{},
 		&codeartifact.UpdatePackageVersionsStatus{},
+		&codepipeline.GetPipeline{},
 		&codepipeline.RunPipeline{},
 		&ecs.CreateService{},
 		&ecs.DescribeService{},

--- a/pkg/integrations/aws/codepipeline/client.go
+++ b/pkg/integrations/aws/codepipeline/client.go
@@ -35,6 +35,31 @@ func NewClient(httpCtx core.HTTPContext, credentials *aws.Credentials, region st
 	}
 }
 
+type GetPipelineResponseBody struct {
+	Pipeline map[string]any             `json:"pipeline"`
+	Metadata PipelineDefinitionMetadata `json:"metadata"`
+}
+
+type PipelineDefinitionMetadata struct {
+	PipelineARN       string           `json:"pipelineArn"`
+	Created           common.FloatTime `json:"created"`
+	Updated           common.FloatTime `json:"updated"`
+	PollingDisabledAt common.FloatTime `json:"pollingDisabledAt,omitempty"`
+}
+
+func (c *Client) GetPipeline(name string) (*GetPipelineResponseBody, error) {
+	payload := map[string]any{
+		"name": name,
+	}
+
+	var response GetPipelineResponseBody
+	if err := c.postJSON("GetPipeline", payload, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
 type StartPipelineExecutionResponse struct {
 	PipelineExecutionID string `json:"pipelineExecutionId"`
 }

--- a/pkg/integrations/aws/codepipeline/example.go
+++ b/pkg/integrations/aws/codepipeline/example.go
@@ -20,3 +20,17 @@ func (r *RunPipeline) ExampleOutput() map[string]any {
 		&exampleOutputRunPipeline,
 	)
 }
+
+//go:embed example_output_get_pipeline.json
+var exampleOutputGetPipelineBytes []byte
+
+var exampleOutputGetPipelineOnce sync.Once
+var exampleOutputGetPipeline map[string]any
+
+func (c *GetPipeline) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetPipelineOnce,
+		exampleOutputGetPipelineBytes,
+		&exampleOutputGetPipeline,
+	)
+}

--- a/pkg/integrations/aws/codepipeline/example_output_get_pipeline.json
+++ b/pkg/integrations/aws/codepipeline/example_output_get_pipeline.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "pipeline": {
+      "name": "my-deploy-pipeline",
+      "roleArn": "arn:aws:iam::123456789012:role/pipeline-role",
+      "version": 3,
+      "stages": [
+        {
+          "name": "Source",
+          "actions": [
+            {
+              "name": "SourceAction",
+              "actionTypeId": {
+                "category": "Source",
+                "owner": "AWS",
+                "provider": "CodeStarSourceConnection",
+                "version": "1"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Deploy",
+          "actions": [
+            {
+              "name": "DeployAction",
+              "actionTypeId": {
+                "category": "Deploy",
+                "owner": "AWS",
+                "provider": "CodeDeploy",
+                "version": "1"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "metadata": {
+      "pipelineArn": "arn:aws:codepipeline:us-east-1:123456789012:my-deploy-pipeline",
+      "created": "2025-01-15T10:30:00Z",
+      "updated": "2026-02-20T14:00:00Z"
+    }
+  },
+  "timestamp": "2026-02-22T10:00:00.000000000Z",
+  "type": "aws.codepipeline.pipeline"
+}

--- a/pkg/integrations/aws/codepipeline/get_pipeline.go
+++ b/pkg/integrations/aws/codepipeline/get_pipeline.go
@@ -1,0 +1,175 @@
+package codepipeline
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type GetPipeline struct{}
+
+type GetPipelineSpec struct {
+	Region   string `json:"region" mapstructure:"region"`
+	Pipeline string `json:"pipeline" mapstructure:"pipeline"`
+}
+
+func (c *GetPipeline) Name() string {
+	return "aws.codepipeline.getPipeline"
+}
+
+func (c *GetPipeline) Label() string {
+	return "CodePipeline • Get Pipeline"
+}
+
+func (c *GetPipeline) Description() string {
+	return "Retrieve the definition of an AWS CodePipeline pipeline"
+}
+
+func (c *GetPipeline) Documentation() string {
+	return `The Get Pipeline component retrieves the full definition of an AWS CodePipeline pipeline.
+
+## Use Cases
+
+- **Pipeline inspection**: Fetch pipeline stages, actions, and configuration
+- **Workflow branching**: Route workflow based on pipeline structure or version
+- **Audit and compliance**: Retrieve pipeline definitions for auditing purposes
+
+## Configuration
+
+- **Region**: AWS region where the pipeline exists
+- **Pipeline**: Pipeline name to retrieve
+
+## Output
+
+Emits the full pipeline definition including:
+- Pipeline name, version, and role ARN
+- All stages and their actions
+- Pipeline metadata (ARN, creation date, last updated date)`
+}
+
+func (c *GetPipeline) Icon() string {
+	return "aws"
+}
+
+func (c *GetPipeline) Color() string {
+	return "orange"
+}
+
+func (c *GetPipeline) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "region",
+			Label:    "Region",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "us-east-1",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: common.AllRegions,
+				},
+			},
+		},
+		{
+			Name:        "pipeline",
+			Label:       "Pipeline",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "CodePipeline pipeline to retrieve",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "codepipeline.pipeline",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name: "region",
+							ValueFrom: &configuration.ParameterValueFrom{
+								Field: "region",
+							},
+						},
+					},
+				},
+			},
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{
+					Field:  "region",
+					Values: []string{"*"},
+				},
+			},
+		},
+	}
+}
+
+func (c *GetPipeline) Setup(ctx core.SetupContext) error {
+	spec := GetPipelineSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if strings.TrimSpace(spec.Region) == "" {
+		return fmt.Errorf("region is required")
+	}
+
+	if strings.TrimSpace(spec.Pipeline) == "" {
+		return fmt.Errorf("pipeline is required")
+	}
+
+	return nil
+}
+
+func (c *GetPipeline) Execute(ctx core.ExecutionContext) error {
+	spec := GetPipelineSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	credentials, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, credentials, spec.Region)
+
+	response, err := client.GetPipeline(spec.Pipeline)
+	if err != nil {
+		return fmt.Errorf("failed to get pipeline: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"aws.codepipeline.pipeline",
+		[]any{response},
+	)
+}
+
+func (c *GetPipeline) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetPipeline) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetPipeline) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *GetPipeline) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *GetPipeline) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return http.StatusOK, nil
+}
+
+func (c *GetPipeline) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetPipeline) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/aws/codepipeline/get_pipeline_test.go
+++ b/pkg/integrations/aws/codepipeline/get_pipeline_test.go
@@ -1,0 +1,140 @@
+package codepipeline
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetPipeline__Setup(t *testing.T) {
+	component := &GetPipeline{}
+
+	t.Run("invalid configuration -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: "invalid",
+		})
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":   " ",
+				"pipeline": "my-pipeline",
+			},
+		})
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing pipeline -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region": "us-east-1",
+			},
+		})
+		require.ErrorContains(t, err, "pipeline is required")
+	})
+
+	t.Run("valid configuration -> ok", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"pipeline": "my-pipeline",
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetPipeline__Execute(t *testing.T) {
+	component := &GetPipeline{}
+
+	t.Run("invalid configuration -> error", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  "invalid",
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("missing credentials -> error", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"pipeline": "my-pipeline",
+			},
+			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+		require.ErrorContains(t, err, "AWS session credentials are missing")
+	})
+
+	t.Run("valid request -> emits pipeline definition", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+                        "pipeline": {
+                            "name": "my-pipeline",
+                            "roleArn": "arn:aws:iam::123456789012:role/pipeline-role",
+                            "version": 3,
+                            "stages": [
+                                {
+                                    "name": "Source",
+                                    "actions": [
+                                        {"name": "SourceAction", "actionTypeId": {"category": "Source"}}
+                                    ]
+                                },
+                                {
+                                    "name": "Deploy",
+                                    "actions": [
+                                        {"name": "DeployAction", "actionTypeId": {"category": "Deploy"}}
+                                    ]
+                                }
+                            ]
+                        },
+                        "metadata": {
+                            "pipelineArn": "arn:aws:codepipeline:us-east-1:123456789012:my-pipeline",
+                            "created": "2025-01-15T10:30:00Z",
+                            "updated": "2026-02-20T14:00:00Z"
+                        }
+                    }`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"pipeline": "my-pipeline",
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration: &contexts.IntegrationContext{
+				Secrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, execState.Payloads, 1)
+
+		// Verify the HTTP request went to the right endpoint
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t,
+			"https://codepipeline.us-east-1.amazonaws.com/",
+			httpContext.Requests[0].URL.String(),
+		)
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/codepipeline/get_pipeline.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/codepipeline/get_pipeline.ts
@@ -1,0 +1,119 @@
+import {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../../types";
+import { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import { getBackgroundColorClass, getColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "../..";
+import { MetadataItem } from "@/ui/metadataList";
+import { formatTimeAgo } from "@/utils/date";
+import { stringOrDash } from "../../utils";
+import awsCodePipelineIcon from "@/assets/icons/integrations/aws.codepipeline.svg";
+
+interface GetPipelineConfiguration {
+  region?: string;
+  pipeline?: string;
+}
+
+interface GetPipelineOutput {
+  pipeline?: {
+    name?: string;
+    roleArn?: string;
+    version?: number;
+    stages?: unknown[];
+  };
+  metadata?: {
+    pipelineArn?: string;
+    created?: string;
+    updated?: string;
+  };
+}
+
+export const getPipelineMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      iconSrc: awsCodePipelineIcon,
+      iconColor: getColorClass(context.componentDefinition.color),
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      eventSections: lastExecution ? getEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      metadata: getMetadataList(context.node),
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as GetPipelineOutput | undefined;
+
+    const timestamp = context.execution.updatedAt
+      ? new Date(context.execution.updatedAt).toLocaleString()
+      : context.execution.createdAt
+        ? new Date(context.execution.createdAt).toLocaleString()
+        : "-";
+
+    const details: Record<string, string> = {
+      "Retrieved At": timestamp,
+    };
+
+    if (result?.pipeline) {
+      details["Pipeline"] = stringOrDash(result.pipeline.name);
+      details["Version"] = result.pipeline.version ? String(result.pipeline.version) : "-";
+      details["Stages"] = result.pipeline.stages ? String(result.pipeline.stages.length) : "-";
+    }
+
+    if (result?.metadata?.pipelineArn) {
+      details["Pipeline ARN"] = result.metadata.pipelineArn;
+    }
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string {
+    if (!context.execution.createdAt) {
+      return "";
+    }
+    return formatTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function getMetadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetPipelineConfiguration | undefined;
+
+  if (configuration?.pipeline) {
+    metadata.push({ icon: "file-text", label: configuration.pipeline });
+  }
+
+  if (configuration?.region) {
+    metadata.push({ icon: "globe", label: configuration.region });
+  }
+
+  return metadata;
+}
+
+function getEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt ?? 0),
+      eventTitle: title,
+      eventSubtitle: formatTimeAgo(new Date(execution.createdAt ?? 0)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent?.id ?? "",
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/index.ts
@@ -32,6 +32,7 @@ import { getSubscriptionMapper } from "./sns/get_subscription";
 import { getTopicMapper } from "./sns/get_topic";
 import { publishMessageMapper } from "./sns/publish_message";
 import { RUN_PIPELINE_STATE_REGISTRY, runPipelineMapper } from "./codepipeline/run_pipeline";
+import { getPipelineMapper } from "./codepipeline/get_pipeline";
 import { onImageTriggerRenderer } from "./ec2/on_image";
 import { createImageMapper } from "./ec2/create_image";
 import { getImageMapper as getEc2ImageMapper } from "./ec2/get_image";
@@ -43,6 +44,7 @@ import { enableImageDeprecationMapper } from "./ec2/enable_image_deprecation";
 import { disableImageDeprecationMapper } from "./ec2/disable_image_deprecation";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
+  "codepipeline.getPipeline": getPipelineMapper,
   "codepipeline.runPipeline": runPipelineMapper,
   "lambda.runFunction": runFunctionMapper,
   "ecs.createService": createServiceMapper,
@@ -94,6 +96,7 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 };
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
+  "codepipeline.getPipeline": buildActionStateRegistry("retrieved"),
   "codepipeline.runPipeline": RUN_PIPELINE_STATE_REGISTRY,
   "ecs.createService": buildActionStateRegistry("created"),
   "ecs.describeService": buildActionStateRegistry("described"),


### PR DESCRIPTION
Implements #2753

This PR adds the `aws.codepipeline.getPipeline` component, which retrieves the full definition of an AWS CodePipeline pipeline using the [GetPipeline API](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_GetPipeline.html).

## What
The component returns the complete pipeline definition including stages, actions, role ARN, version, and metadata (ARN, creation/update timestamps). Timestamps use `common.FloatTime` for consistent handling across AWS integrations.

## Backend

- `pkg/integrations/aws/codepipeline/get_pipeline.go` - component (all `core.Component` methods)
- `pkg/integrations/aws/codepipeline/client.go` - `GetPipeline()` method, `GetPipelineResponseBody` / `PipelineDefinitionMetadata` structs
- `pkg/integrations/aws/codepipeline/get_pipeline_test.go` - Setup + Execute tests
- `pkg/integrations/aws/codepipeline/example_output_get_pipeline.json` - example output
- `pkg/integrations/aws/codepipeline/example.go` - `ExampleOutput()` wiring
- `pkg/integrations/aws/aws.go` - registered in `Components()`

## Frontend

- `web_src/src/pages/workflowv2/mappers/aws/codepipeline/get_pipeline.ts` - canvas mapper
- `web_src/src/pages/workflowv2/mappers/aws/index.ts` - registered mapper + state registry

## Docs

- `docs/components/AWS.mdx` - generated with `make gen.components.docs`

## Tests

- Setup: invalid config, missing region, missing pipeline, valid config
- Execute: invalid config, missing credentials, valid request emits pipeline definition

## Demo

https://github.com/user-attachments/assets/b6abb56e-1779-40e1-858c-7c66482f058d