### PR TITLE
fix: return 404 for organization-scoping failures instead of 401

### DIFF
--- a/pkg/public/middleware/auth_test.go
+++ b/pkg/public/middleware/auth_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestOrganizationAuthMiddleware_CookieAuthErrors(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test-secret")
+
+	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	require.NoError(t, err)
+
+	handler := OrganizationAuthMiddleware(signer)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	t.Run("missing account cookie returns unauthorized", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req.Header.Set("x-organization-id", r.Organization.ID.String())
+
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusUnauthorized, res.Code)
+	})
+
+	t.Run("missing organization id returns not found", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusNotFound, res.Code)
+	})
+
+	t.Run("organization without matching user returns not found", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+		req.Header.Set("x-organization-id", uuid.NewString())
+
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusNotFound, res.Code)
+	})
+
+	t.Run("valid cookie and organization reaches next handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+		req.Header.Set("x-organization-id", r.Organization.ID.String())
+
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusNoContent, res.Code)
+	})
+}

--- a/web_src/src/lib/utils.ts
+++ b/web_src/src/lib/utils.ts
@@ -154,7 +154,3 @@ export function isUrl(value: string): boolean {
     return false;
   }
 }
-
-export const isUUID = (value: string): boolean => {
-  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(value);
-};

--- a/web_src/src/utils/withOrganizationHeader.ts
+++ b/web_src/src/utils/withOrganizationHeader.ts
@@ -1,11 +1,7 @@
-import { isUUID } from "@/lib/utils";
 import { useParams } from "react-router-dom";
 
 export const useOrganizationId = (): string | null => {
   const { organizationId } = useParams<{ organizationId: string }>();
-  if (organizationId && !isUUID(organizationId)) {
-    return null;
-  }
   return organizationId || null;
 };
 


### PR DESCRIPTION
**PR description**
This PR fixes organization-scoped cookie auth behavior in the public middleware.

- Updated `OrganizationAuthMiddleware` in `pkg/public/middleware/auth.go` to distinguish auth failures from organization lookup failures.
- `authenticateUserByCookie` now returns typed error states:
1. `account_not_found_error` for missing/invalid account cookie or account lookup failure
2. `organization_not_found_error` for missing org ID or no matching user in that organization
- Middleware response mapping:
1. `organization_not_found_error` -> `404 Not Found`
2. all other auth failures -> `401 Unauthorized`
- Added tests in `pkg/public/middleware/auth_test.go` covering:
1. missing account cookie -> `401`
2. missing organization ID -> `404`
3. organization without matching user -> `404`
4. valid cookie + organization -> request reaches next handler (`204`)