### PR TITLE
feat: stream canvas updates through websocket

### DIFF
--- a/pkg/grpc/actions/canvases/delete_canvas.go
+++ b/pkg/grpc/actions/canvases/delete_canvas.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -40,6 +41,10 @@ func DeleteCanvas(ctx context.Context, registry *registry.Registry, organization
 	if err != nil {
 		log.Errorf("failed to delete canvas %s: %v", canvas.ID.String(), err)
 		return nil, status.Error(codes.Internal, "failed to delete canvas")
+	}
+
+	if err := messages.NewCanvasDeletedMessage(canvas.ID.String()).Publish(false); err != nil {
+		log.Errorf("failed to publish canvas deleted RabbitMQ message: %v", err)
 	}
 
 	return &pb.DeleteCanvasResponse{}, nil

--- a/pkg/grpc/actions/canvases/update_canvas.go
+++ b/pkg/grpc/actions/canvases/update_canvas.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -150,6 +151,10 @@ func UpdateCanvas(ctx context.Context, encryptor crypto.Encryptor, registry *reg
 	protoCanvas, err := SerializeCanvas(existingCanvas, true)
 	if err != nil {
 		return nil, actions.ToStatus(err)
+	}
+
+	if err := messages.NewCanvasUpdatedMessage(existingCanvas.ID.String()).Publish(true); err != nil {
+		log.Errorf("failed to publish canvas updated RabbitMQ message: %v", err)
 	}
 
 	return &pb.UpdateCanvasResponse{

--- a/pkg/grpc/actions/messages/canvas.go
+++ b/pkg/grpc/actions/messages/canvas.go
@@ -1,0 +1,43 @@
+package messages
+
+import (
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	WorkflowCanvasUpdatedRoutingKey = "workflow-canvas-updated"
+	WorkflowCanvasDeletedRoutingKey = "workflow-canvas-deleted"
+)
+
+type CanvasMessage struct {
+	message *pb.CanvasMessage
+}
+
+func NewCanvasUpdatedMessage(canvasID string) CanvasMessage {
+	return CanvasMessage{
+		message: &pb.CanvasMessage{
+			Id:        canvasID,
+			CanvasId:  canvasID,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func NewCanvasDeletedMessage(canvasID string) CanvasMessage {
+	return CanvasMessage{
+		message: &pb.CanvasMessage{
+			Id:        canvasID,
+			CanvasId:  canvasID,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
+func (m CanvasMessage) Publish(updated bool) error {
+	if updated {
+		return Publish(WorkflowExchange, WorkflowCanvasUpdatedRoutingKey, toBytes(m.message))
+	}
+
+	return Publish(WorkflowExchange, WorkflowCanvasDeletedRoutingKey, toBytes(m.message))
+}

--- a/pkg/openapi_client/model_configuration_list_type_options.go
+++ b/pkg/openapi_client/model_configuration_list_type_options.go
@@ -22,6 +22,7 @@ var _ MappedNullable = &ConfigurationListTypeOptions{}
 type ConfigurationListTypeOptions struct {
 	ItemDefinition *ConfigurationListItemDefinition `json:"itemDefinition,omitempty"`
 	ItemLabel      *string                          `json:"itemLabel,omitempty"`
+	MaxItems       *int32                           `json:"maxItems,omitempty"`
 }
 
 // NewConfigurationListTypeOptions instantiates a new ConfigurationListTypeOptions object
@@ -105,6 +106,38 @@ func (o *ConfigurationListTypeOptions) SetItemLabel(v string) {
 	o.ItemLabel = &v
 }
 
+// GetMaxItems returns the MaxItems field value if set, zero value otherwise.
+func (o *ConfigurationListTypeOptions) GetMaxItems() int32 {
+	if o == nil || IsNil(o.MaxItems) {
+		var ret int32
+		return ret
+	}
+	return *o.MaxItems
+}
+
+// GetMaxItemsOk returns a tuple with the MaxItems field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConfigurationListTypeOptions) GetMaxItemsOk() (*int32, bool) {
+	if o == nil || IsNil(o.MaxItems) {
+		return nil, false
+	}
+	return o.MaxItems, true
+}
+
+// HasMaxItems returns a boolean if a field has been set.
+func (o *ConfigurationListTypeOptions) HasMaxItems() bool {
+	if o != nil && !IsNil(o.MaxItems) {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxItems gets a reference to the given int32 and assigns it to the MaxItems field.
+func (o *ConfigurationListTypeOptions) SetMaxItems(v int32) {
+	o.MaxItems = &v
+}
+
 func (o ConfigurationListTypeOptions) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -120,6 +153,9 @@ func (o ConfigurationListTypeOptions) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ItemLabel) {
 		toSerialize["itemLabel"] = o.ItemLabel
+	}
+	if !IsNil(o.MaxItems) {
+		toSerialize["maxItems"] = o.MaxItems
 	}
 	return toSerialize, nil
 }

--- a/pkg/protos/canvases/canvases.pb.go
+++ b/pkg/protos/canvases/canvases.pb.go
@@ -2839,6 +2839,66 @@ func (x *CanvasNodeQueueItemMessage) GetTimestamp() *timestamp.Timestamp {
 	return nil
 }
 
+type CanvasMessage struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	CanvasId      string                 `protobuf:"bytes,2,opt,name=canvas_id,json=canvasId,proto3" json:"canvas_id,omitempty"`
+	Timestamp     *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CanvasMessage) Reset() {
+	*x = CanvasMessage{}
+	mi := &file_canvases_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CanvasMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CanvasMessage) ProtoMessage() {}
+
+func (x *CanvasMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_canvases_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CanvasMessage.ProtoReflect.Descriptor instead.
+func (*CanvasMessage) Descriptor() ([]byte, []int) {
+	return file_canvases_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *CanvasMessage) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *CanvasMessage) GetCanvasId() string {
+	if x != nil {
+		return x.CanvasId
+	}
+	return ""
+}
+
+func (x *CanvasMessage) GetTimestamp() *timestamp.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
 type Canvas_Metadata struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Id             string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -2855,7 +2915,7 @@ type Canvas_Metadata struct {
 
 func (x *Canvas_Metadata) Reset() {
 	*x = Canvas_Metadata{}
-	mi := &file_canvases_proto_msgTypes[45]
+	mi := &file_canvases_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2867,7 +2927,7 @@ func (x *Canvas_Metadata) String() string {
 func (*Canvas_Metadata) ProtoMessage() {}
 
 func (x *Canvas_Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_canvases_proto_msgTypes[45]
+	mi := &file_canvases_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2949,7 +3009,7 @@ type Canvas_Spec struct {
 
 func (x *Canvas_Spec) Reset() {
 	*x = Canvas_Spec{}
-	mi := &file_canvases_proto_msgTypes[46]
+	mi := &file_canvases_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2961,7 +3021,7 @@ func (x *Canvas_Spec) String() string {
 func (*Canvas_Spec) ProtoMessage() {}
 
 func (x *Canvas_Spec) ProtoReflect() protoreflect.Message {
-	mi := &file_canvases_proto_msgTypes[46]
+	mi := &file_canvases_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3002,7 +3062,7 @@ type Canvas_Status struct {
 
 func (x *Canvas_Status) Reset() {
 	*x = Canvas_Status{}
-	mi := &file_canvases_proto_msgTypes[47]
+	mi := &file_canvases_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3014,7 +3074,7 @@ func (x *Canvas_Status) String() string {
 func (*Canvas_Status) ProtoMessage() {}
 
 func (x *Canvas_Status) ProtoReflect() protoreflect.Message {
-	mi := &file_canvases_proto_msgTypes[47]
+	mi := &file_canvases_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3354,11 @@ const file_canvases_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\tcanvas_id\x18\x02 \x01(\tR\bcanvasId\x12\x17\n" +
 	"\anode_id\x18\x03 \x01(\tR\x06nodeId\x128\n" +
-	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp2\xb7$\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"v\n" +
+	"\rCanvasMessage\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\tcanvas_id\x18\x02 \x01(\tR\bcanvasId\x128\n" +
+	"\ttimestamp\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp2\xb7$\n" +
 	"\bCanvases\x12\xb7\x01\n" +
 	"\fListCanvases\x12(.Superplane.Canvases.ListCanvasesRequest\x1a).Superplane.Canvases.ListCanvasesResponse\"R\x92A7\n" +
 	"\x06Canvas\x12\rList canvases\x1a\x1eReturns a list of all canvases\x82\xd3\xe4\x93\x02\x12\x12\x10/api/v1/canvases\x12\xb0\x01\n" +
@@ -3355,7 +3419,7 @@ func file_canvases_proto_rawDescGZIP() []byte {
 }
 
 var file_canvases_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_canvases_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_canvases_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_canvases_proto_goTypes = []any{
 	(CanvasNodeExecution_State)(0),            // 0: Superplane.Canvases.CanvasNodeExecution.State
 	(CanvasNodeExecution_Result)(0),           // 1: Superplane.Canvases.CanvasNodeExecution.Result
@@ -3405,13 +3469,14 @@ var file_canvases_proto_goTypes = []any{
 	(*CanvasNodeEventMessage)(nil),            // 45: Superplane.Canvases.CanvasNodeEventMessage
 	(*CanvasNodeExecutionMessage)(nil),        // 46: Superplane.Canvases.CanvasNodeExecutionMessage
 	(*CanvasNodeQueueItemMessage)(nil),        // 47: Superplane.Canvases.CanvasNodeQueueItemMessage
-	(*Canvas_Metadata)(nil),                   // 48: Superplane.Canvases.Canvas.Metadata
-	(*Canvas_Spec)(nil),                       // 49: Superplane.Canvases.Canvas.Spec
-	(*Canvas_Status)(nil),                     // 50: Superplane.Canvases.Canvas.Status
-	(*timestamp.Timestamp)(nil),               // 51: google.protobuf.Timestamp
-	(*_struct.Struct)(nil),                    // 52: google.protobuf.Struct
-	(*components.Node)(nil),                   // 53: Superplane.Components.Node
-	(*components.Edge)(nil),                   // 54: Superplane.Components.Edge
+	(*CanvasMessage)(nil),                     // 48: Superplane.Canvases.CanvasMessage
+	(*Canvas_Metadata)(nil),                   // 49: Superplane.Canvases.Canvas.Metadata
+	(*Canvas_Spec)(nil),                       // 50: Superplane.Canvases.Canvas.Spec
+	(*Canvas_Status)(nil),                     // 51: Superplane.Canvases.Canvas.Status
+	(*timestamp.Timestamp)(nil),               // 52: google.protobuf.Timestamp
+	(*_struct.Struct)(nil),                    // 53: google.protobuf.Struct
+	(*components.Node)(nil),                   // 54: Superplane.Components.Node
+	(*components.Edge)(nil),                   // 55: Superplane.Components.Edge
 }
 var file_canvases_proto_depIdxs = []int32{
 	14, // 0: Superplane.Canvases.ListCanvasesResponse.canvases:type_name -> Superplane.Canvases.Canvas
@@ -3420,102 +3485,103 @@ var file_canvases_proto_depIdxs = []int32{
 	14, // 3: Superplane.Canvases.CreateCanvasResponse.canvas:type_name -> Superplane.Canvases.Canvas
 	14, // 4: Superplane.Canvases.UpdateCanvasRequest.canvas:type_name -> Superplane.Canvases.Canvas
 	14, // 5: Superplane.Canvases.UpdateCanvasResponse.canvas:type_name -> Superplane.Canvases.Canvas
-	48, // 6: Superplane.Canvases.Canvas.metadata:type_name -> Superplane.Canvases.Canvas.Metadata
-	49, // 7: Superplane.Canvases.Canvas.spec:type_name -> Superplane.Canvases.Canvas.Spec
-	50, // 8: Superplane.Canvases.Canvas.status:type_name -> Superplane.Canvases.Canvas.Status
-	51, // 9: Superplane.Canvases.ListNodeEventsRequest.before:type_name -> google.protobuf.Timestamp
+	49, // 6: Superplane.Canvases.Canvas.metadata:type_name -> Superplane.Canvases.Canvas.Metadata
+	50, // 7: Superplane.Canvases.Canvas.spec:type_name -> Superplane.Canvases.Canvas.Spec
+	51, // 8: Superplane.Canvases.Canvas.status:type_name -> Superplane.Canvases.Canvas.Status
+	52, // 9: Superplane.Canvases.ListNodeEventsRequest.before:type_name -> google.protobuf.Timestamp
 	37, // 10: Superplane.Canvases.ListNodeEventsResponse.events:type_name -> Superplane.Canvases.CanvasEvent
-	51, // 11: Superplane.Canvases.ListNodeEventsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
-	52, // 12: Superplane.Canvases.EmitNodeEventRequest.data:type_name -> google.protobuf.Struct
-	51, // 13: Superplane.Canvases.ListNodeQueueItemsRequest.before:type_name -> google.protobuf.Timestamp
+	52, // 11: Superplane.Canvases.ListNodeEventsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
+	53, // 12: Superplane.Canvases.EmitNodeEventRequest.data:type_name -> google.protobuf.Struct
+	52, // 13: Superplane.Canvases.ListNodeQueueItemsRequest.before:type_name -> google.protobuf.Timestamp
 	30, // 14: Superplane.Canvases.ListNodeQueueItemsResponse.items:type_name -> Superplane.Canvases.CanvasNodeQueueItem
-	51, // 15: Superplane.Canvases.ListNodeQueueItemsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
-	53, // 16: Superplane.Canvases.UpdateNodePauseResponse.node:type_name -> Superplane.Components.Node
+	52, // 15: Superplane.Canvases.ListNodeQueueItemsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
+	54, // 16: Superplane.Canvases.UpdateNodePauseResponse.node:type_name -> Superplane.Components.Node
 	0,  // 17: Superplane.Canvases.ListNodeExecutionsRequest.states:type_name -> Superplane.Canvases.CanvasNodeExecution.State
 	1,  // 18: Superplane.Canvases.ListNodeExecutionsRequest.results:type_name -> Superplane.Canvases.CanvasNodeExecution.Result
-	51, // 19: Superplane.Canvases.ListNodeExecutionsRequest.before:type_name -> google.protobuf.Timestamp
+	52, // 19: Superplane.Canvases.ListNodeExecutionsRequest.before:type_name -> google.protobuf.Timestamp
 	29, // 20: Superplane.Canvases.ListNodeExecutionsResponse.executions:type_name -> Superplane.Canvases.CanvasNodeExecution
-	51, // 21: Superplane.Canvases.ListNodeExecutionsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
+	52, // 21: Superplane.Canvases.ListNodeExecutionsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
 	29, // 22: Superplane.Canvases.ListChildExecutionsResponse.executions:type_name -> Superplane.Canvases.CanvasNodeExecution
 	0,  // 23: Superplane.Canvases.CanvasNodeExecution.state:type_name -> Superplane.Canvases.CanvasNodeExecution.State
 	1,  // 24: Superplane.Canvases.CanvasNodeExecution.result:type_name -> Superplane.Canvases.CanvasNodeExecution.Result
 	2,  // 25: Superplane.Canvases.CanvasNodeExecution.result_reason:type_name -> Superplane.Canvases.CanvasNodeExecution.ResultReason
-	52, // 26: Superplane.Canvases.CanvasNodeExecution.input:type_name -> google.protobuf.Struct
-	52, // 27: Superplane.Canvases.CanvasNodeExecution.outputs:type_name -> google.protobuf.Struct
-	51, // 28: Superplane.Canvases.CanvasNodeExecution.created_at:type_name -> google.protobuf.Timestamp
-	51, // 29: Superplane.Canvases.CanvasNodeExecution.updated_at:type_name -> google.protobuf.Timestamp
-	52, // 30: Superplane.Canvases.CanvasNodeExecution.metadata:type_name -> google.protobuf.Struct
-	52, // 31: Superplane.Canvases.CanvasNodeExecution.configuration:type_name -> google.protobuf.Struct
+	53, // 26: Superplane.Canvases.CanvasNodeExecution.input:type_name -> google.protobuf.Struct
+	53, // 27: Superplane.Canvases.CanvasNodeExecution.outputs:type_name -> google.protobuf.Struct
+	52, // 28: Superplane.Canvases.CanvasNodeExecution.created_at:type_name -> google.protobuf.Timestamp
+	52, // 29: Superplane.Canvases.CanvasNodeExecution.updated_at:type_name -> google.protobuf.Timestamp
+	53, // 30: Superplane.Canvases.CanvasNodeExecution.metadata:type_name -> google.protobuf.Struct
+	53, // 31: Superplane.Canvases.CanvasNodeExecution.configuration:type_name -> google.protobuf.Struct
 	29, // 32: Superplane.Canvases.CanvasNodeExecution.child_executions:type_name -> Superplane.Canvases.CanvasNodeExecution
 	37, // 33: Superplane.Canvases.CanvasNodeExecution.root_event:type_name -> Superplane.Canvases.CanvasEvent
 	13, // 34: Superplane.Canvases.CanvasNodeExecution.cancelled_by:type_name -> Superplane.Canvases.UserRef
-	52, // 35: Superplane.Canvases.CanvasNodeQueueItem.input:type_name -> google.protobuf.Struct
+	53, // 35: Superplane.Canvases.CanvasNodeQueueItem.input:type_name -> google.protobuf.Struct
 	37, // 36: Superplane.Canvases.CanvasNodeQueueItem.root_event:type_name -> Superplane.Canvases.CanvasEvent
-	51, // 37: Superplane.Canvases.CanvasNodeQueueItem.created_at:type_name -> google.protobuf.Timestamp
-	52, // 38: Superplane.Canvases.InvokeNodeExecutionActionRequest.parameters:type_name -> google.protobuf.Struct
-	52, // 39: Superplane.Canvases.InvokeNodeTriggerActionRequest.parameters:type_name -> google.protobuf.Struct
-	52, // 40: Superplane.Canvases.InvokeNodeTriggerActionResponse.result:type_name -> google.protobuf.Struct
-	51, // 41: Superplane.Canvases.ListCanvasEventsRequest.before:type_name -> google.protobuf.Timestamp
+	52, // 37: Superplane.Canvases.CanvasNodeQueueItem.created_at:type_name -> google.protobuf.Timestamp
+	53, // 38: Superplane.Canvases.InvokeNodeExecutionActionRequest.parameters:type_name -> google.protobuf.Struct
+	53, // 39: Superplane.Canvases.InvokeNodeTriggerActionRequest.parameters:type_name -> google.protobuf.Struct
+	53, // 40: Superplane.Canvases.InvokeNodeTriggerActionResponse.result:type_name -> google.protobuf.Struct
+	52, // 41: Superplane.Canvases.ListCanvasEventsRequest.before:type_name -> google.protobuf.Timestamp
 	38, // 42: Superplane.Canvases.ListCanvasEventsResponse.events:type_name -> Superplane.Canvases.CanvasEventWithExecutions
-	51, // 43: Superplane.Canvases.ListCanvasEventsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
-	52, // 44: Superplane.Canvases.CanvasEvent.data:type_name -> google.protobuf.Struct
-	51, // 45: Superplane.Canvases.CanvasEvent.created_at:type_name -> google.protobuf.Timestamp
-	52, // 46: Superplane.Canvases.CanvasEventWithExecutions.data:type_name -> google.protobuf.Struct
-	51, // 47: Superplane.Canvases.CanvasEventWithExecutions.created_at:type_name -> google.protobuf.Timestamp
+	52, // 43: Superplane.Canvases.ListCanvasEventsResponse.last_timestamp:type_name -> google.protobuf.Timestamp
+	53, // 44: Superplane.Canvases.CanvasEvent.data:type_name -> google.protobuf.Struct
+	52, // 45: Superplane.Canvases.CanvasEvent.created_at:type_name -> google.protobuf.Timestamp
+	53, // 46: Superplane.Canvases.CanvasEventWithExecutions.data:type_name -> google.protobuf.Struct
+	52, // 47: Superplane.Canvases.CanvasEventWithExecutions.created_at:type_name -> google.protobuf.Timestamp
 	29, // 48: Superplane.Canvases.CanvasEventWithExecutions.executions:type_name -> Superplane.Canvases.CanvasNodeExecution
 	29, // 49: Superplane.Canvases.ListEventExecutionsResponse.executions:type_name -> Superplane.Canvases.CanvasNodeExecution
-	51, // 50: Superplane.Canvases.CanvasNodeEventMessage.timestamp:type_name -> google.protobuf.Timestamp
-	51, // 51: Superplane.Canvases.CanvasNodeExecutionMessage.timestamp:type_name -> google.protobuf.Timestamp
-	51, // 52: Superplane.Canvases.CanvasNodeQueueItemMessage.timestamp:type_name -> google.protobuf.Timestamp
-	51, // 53: Superplane.Canvases.Canvas.Metadata.created_at:type_name -> google.protobuf.Timestamp
-	51, // 54: Superplane.Canvases.Canvas.Metadata.updated_at:type_name -> google.protobuf.Timestamp
-	13, // 55: Superplane.Canvases.Canvas.Metadata.created_by:type_name -> Superplane.Canvases.UserRef
-	53, // 56: Superplane.Canvases.Canvas.Spec.nodes:type_name -> Superplane.Components.Node
-	54, // 57: Superplane.Canvases.Canvas.Spec.edges:type_name -> Superplane.Components.Edge
-	29, // 58: Superplane.Canvases.Canvas.Status.last_executions:type_name -> Superplane.Canvases.CanvasNodeExecution
-	30, // 59: Superplane.Canvases.Canvas.Status.next_queue_items:type_name -> Superplane.Canvases.CanvasNodeQueueItem
-	37, // 60: Superplane.Canvases.Canvas.Status.last_events:type_name -> Superplane.Canvases.CanvasEvent
-	3,  // 61: Superplane.Canvases.Canvases.ListCanvases:input_type -> Superplane.Canvases.ListCanvasesRequest
-	7,  // 62: Superplane.Canvases.Canvases.CreateCanvas:input_type -> Superplane.Canvases.CreateCanvasRequest
-	5,  // 63: Superplane.Canvases.Canvases.DescribeCanvas:input_type -> Superplane.Canvases.DescribeCanvasRequest
-	9,  // 64: Superplane.Canvases.Canvases.UpdateCanvas:input_type -> Superplane.Canvases.UpdateCanvasRequest
-	11, // 65: Superplane.Canvases.Canvases.DeleteCanvas:input_type -> Superplane.Canvases.DeleteCanvasRequest
-	19, // 66: Superplane.Canvases.Canvases.ListNodeQueueItems:input_type -> Superplane.Canvases.ListNodeQueueItemsRequest
-	21, // 67: Superplane.Canvases.Canvases.DeleteNodeQueueItem:input_type -> Superplane.Canvases.DeleteNodeQueueItemRequest
-	23, // 68: Superplane.Canvases.Canvases.UpdateNodePause:input_type -> Superplane.Canvases.UpdateNodePauseRequest
-	25, // 69: Superplane.Canvases.Canvases.ListNodeExecutions:input_type -> Superplane.Canvases.ListNodeExecutionsRequest
-	15, // 70: Superplane.Canvases.Canvases.ListNodeEvents:input_type -> Superplane.Canvases.ListNodeEventsRequest
-	17, // 71: Superplane.Canvases.Canvases.EmitNodeEvent:input_type -> Superplane.Canvases.EmitNodeEventRequest
-	31, // 72: Superplane.Canvases.Canvases.InvokeNodeExecutionAction:input_type -> Superplane.Canvases.InvokeNodeExecutionActionRequest
-	33, // 73: Superplane.Canvases.Canvases.InvokeNodeTriggerAction:input_type -> Superplane.Canvases.InvokeNodeTriggerActionRequest
-	27, // 74: Superplane.Canvases.Canvases.ListChildExecutions:input_type -> Superplane.Canvases.ListChildExecutionsRequest
-	41, // 75: Superplane.Canvases.Canvases.CancelExecution:input_type -> Superplane.Canvases.CancelExecutionRequest
-	43, // 76: Superplane.Canvases.Canvases.ResolveExecutionErrors:input_type -> Superplane.Canvases.ResolveExecutionErrorsRequest
-	35, // 77: Superplane.Canvases.Canvases.ListCanvasEvents:input_type -> Superplane.Canvases.ListCanvasEventsRequest
-	39, // 78: Superplane.Canvases.Canvases.ListEventExecutions:input_type -> Superplane.Canvases.ListEventExecutionsRequest
-	4,  // 79: Superplane.Canvases.Canvases.ListCanvases:output_type -> Superplane.Canvases.ListCanvasesResponse
-	8,  // 80: Superplane.Canvases.Canvases.CreateCanvas:output_type -> Superplane.Canvases.CreateCanvasResponse
-	6,  // 81: Superplane.Canvases.Canvases.DescribeCanvas:output_type -> Superplane.Canvases.DescribeCanvasResponse
-	10, // 82: Superplane.Canvases.Canvases.UpdateCanvas:output_type -> Superplane.Canvases.UpdateCanvasResponse
-	12, // 83: Superplane.Canvases.Canvases.DeleteCanvas:output_type -> Superplane.Canvases.DeleteCanvasResponse
-	20, // 84: Superplane.Canvases.Canvases.ListNodeQueueItems:output_type -> Superplane.Canvases.ListNodeQueueItemsResponse
-	22, // 85: Superplane.Canvases.Canvases.DeleteNodeQueueItem:output_type -> Superplane.Canvases.DeleteNodeQueueItemResponse
-	24, // 86: Superplane.Canvases.Canvases.UpdateNodePause:output_type -> Superplane.Canvases.UpdateNodePauseResponse
-	26, // 87: Superplane.Canvases.Canvases.ListNodeExecutions:output_type -> Superplane.Canvases.ListNodeExecutionsResponse
-	16, // 88: Superplane.Canvases.Canvases.ListNodeEvents:output_type -> Superplane.Canvases.ListNodeEventsResponse
-	18, // 89: Superplane.Canvases.Canvases.EmitNodeEvent:output_type -> Superplane.Canvases.EmitNodeEventResponse
-	32, // 90: Superplane.Canvases.Canvases.InvokeNodeExecutionAction:output_type -> Superplane.Canvases.InvokeNodeExecutionActionResponse
-	34, // 91: Superplane.Canvases.Canvases.InvokeNodeTriggerAction:output_type -> Superplane.Canvases.InvokeNodeTriggerActionResponse
-	28, // 92: Superplane.Canvases.Canvases.ListChildExecutions:output_type -> Superplane.Canvases.ListChildExecutionsResponse
-	42, // 93: Superplane.Canvases.Canvases.CancelExecution:output_type -> Superplane.Canvases.CancelExecutionResponse
-	44, // 94: Superplane.Canvases.Canvases.ResolveExecutionErrors:output_type -> Superplane.Canvases.ResolveExecutionErrorsResponse
-	36, // 95: Superplane.Canvases.Canvases.ListCanvasEvents:output_type -> Superplane.Canvases.ListCanvasEventsResponse
-	40, // 96: Superplane.Canvases.Canvases.ListEventExecutions:output_type -> Superplane.Canvases.ListEventExecutionsResponse
-	79, // [79:97] is the sub-list for method output_type
-	61, // [61:79] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	52, // 50: Superplane.Canvases.CanvasNodeEventMessage.timestamp:type_name -> google.protobuf.Timestamp
+	52, // 51: Superplane.Canvases.CanvasNodeExecutionMessage.timestamp:type_name -> google.protobuf.Timestamp
+	52, // 52: Superplane.Canvases.CanvasNodeQueueItemMessage.timestamp:type_name -> google.protobuf.Timestamp
+	52, // 53: Superplane.Canvases.CanvasMessage.timestamp:type_name -> google.protobuf.Timestamp
+	52, // 54: Superplane.Canvases.Canvas.Metadata.created_at:type_name -> google.protobuf.Timestamp
+	52, // 55: Superplane.Canvases.Canvas.Metadata.updated_at:type_name -> google.protobuf.Timestamp
+	13, // 56: Superplane.Canvases.Canvas.Metadata.created_by:type_name -> Superplane.Canvases.UserRef
+	54, // 57: Superplane.Canvases.Canvas.Spec.nodes:type_name -> Superplane.Components.Node
+	55, // 58: Superplane.Canvases.Canvas.Spec.edges:type_name -> Superplane.Components.Edge
+	29, // 59: Superplane.Canvases.Canvas.Status.last_executions:type_name -> Superplane.Canvases.CanvasNodeExecution
+	30, // 60: Superplane.Canvases.Canvas.Status.next_queue_items:type_name -> Superplane.Canvases.CanvasNodeQueueItem
+	37, // 61: Superplane.Canvases.Canvas.Status.last_events:type_name -> Superplane.Canvases.CanvasEvent
+	3,  // 62: Superplane.Canvases.Canvases.ListCanvases:input_type -> Superplane.Canvases.ListCanvasesRequest
+	7,  // 63: Superplane.Canvases.Canvases.CreateCanvas:input_type -> Superplane.Canvases.CreateCanvasRequest
+	5,  // 64: Superplane.Canvases.Canvases.DescribeCanvas:input_type -> Superplane.Canvases.DescribeCanvasRequest
+	9,  // 65: Superplane.Canvases.Canvases.UpdateCanvas:input_type -> Superplane.Canvases.UpdateCanvasRequest
+	11, // 66: Superplane.Canvases.Canvases.DeleteCanvas:input_type -> Superplane.Canvases.DeleteCanvasRequest
+	19, // 67: Superplane.Canvases.Canvases.ListNodeQueueItems:input_type -> Superplane.Canvases.ListNodeQueueItemsRequest
+	21, // 68: Superplane.Canvases.Canvases.DeleteNodeQueueItem:input_type -> Superplane.Canvases.DeleteNodeQueueItemRequest
+	23, // 69: Superplane.Canvases.Canvases.UpdateNodePause:input_type -> Superplane.Canvases.UpdateNodePauseRequest
+	25, // 70: Superplane.Canvases.Canvases.ListNodeExecutions:input_type -> Superplane.Canvases.ListNodeExecutionsRequest
+	15, // 71: Superplane.Canvases.Canvases.ListNodeEvents:input_type -> Superplane.Canvases.ListNodeEventsRequest
+	17, // 72: Superplane.Canvases.Canvases.EmitNodeEvent:input_type -> Superplane.Canvases.EmitNodeEventRequest
+	31, // 73: Superplane.Canvases.Canvases.InvokeNodeExecutionAction:input_type -> Superplane.Canvases.InvokeNodeExecutionActionRequest
+	33, // 74: Superplane.Canvases.Canvases.InvokeNodeTriggerAction:input_type -> Superplane.Canvases.InvokeNodeTriggerActionRequest
+	27, // 75: Superplane.Canvases.Canvases.ListChildExecutions:input_type -> Superplane.Canvases.ListChildExecutionsRequest
+	41, // 76: Superplane.Canvases.Canvases.CancelExecution:input_type -> Superplane.Canvases.CancelExecutionRequest
+	43, // 77: Superplane.Canvases.Canvases.ResolveExecutionErrors:input_type -> Superplane.Canvases.ResolveExecutionErrorsRequest
+	35, // 78: Superplane.Canvases.Canvases.ListCanvasEvents:input_type -> Superplane.Canvases.ListCanvasEventsRequest
+	39, // 79: Superplane.Canvases.Canvases.ListEventExecutions:input_type -> Superplane.Canvases.ListEventExecutionsRequest
+	4,  // 80: Superplane.Canvases.Canvases.ListCanvases:output_type -> Superplane.Canvases.ListCanvasesResponse
+	8,  // 81: Superplane.Canvases.Canvases.CreateCanvas:output_type -> Superplane.Canvases.CreateCanvasResponse
+	6,  // 82: Superplane.Canvases.Canvases.DescribeCanvas:output_type -> Superplane.Canvases.DescribeCanvasResponse
+	10, // 83: Superplane.Canvases.Canvases.UpdateCanvas:output_type -> Superplane.Canvases.UpdateCanvasResponse
+	12, // 84: Superplane.Canvases.Canvases.DeleteCanvas:output_type -> Superplane.Canvases.DeleteCanvasResponse
+	20, // 85: Superplane.Canvases.Canvases.ListNodeQueueItems:output_type -> Superplane.Canvases.ListNodeQueueItemsResponse
+	22, // 86: Superplane.Canvases.Canvases.DeleteNodeQueueItem:output_type -> Superplane.Canvases.DeleteNodeQueueItemResponse
+	24, // 87: Superplane.Canvases.Canvases.UpdateNodePause:output_type -> Superplane.Canvases.UpdateNodePauseResponse
+	26, // 88: Superplane.Canvases.Canvases.ListNodeExecutions:output_type -> Superplane.Canvases.ListNodeExecutionsResponse
+	16, // 89: Superplane.Canvases.Canvases.ListNodeEvents:output_type -> Superplane.Canvases.ListNodeEventsResponse
+	18, // 90: Superplane.Canvases.Canvases.EmitNodeEvent:output_type -> Superplane.Canvases.EmitNodeEventResponse
+	32, // 91: Superplane.Canvases.Canvases.InvokeNodeExecutionAction:output_type -> Superplane.Canvases.InvokeNodeExecutionActionResponse
+	34, // 92: Superplane.Canvases.Canvases.InvokeNodeTriggerAction:output_type -> Superplane.Canvases.InvokeNodeTriggerActionResponse
+	28, // 93: Superplane.Canvases.Canvases.ListChildExecutions:output_type -> Superplane.Canvases.ListChildExecutionsResponse
+	42, // 94: Superplane.Canvases.Canvases.CancelExecution:output_type -> Superplane.Canvases.CancelExecutionResponse
+	44, // 95: Superplane.Canvases.Canvases.ResolveExecutionErrors:output_type -> Superplane.Canvases.ResolveExecutionErrorsResponse
+	36, // 96: Superplane.Canvases.Canvases.ListCanvasEvents:output_type -> Superplane.Canvases.ListCanvasEventsResponse
+	40, // 97: Superplane.Canvases.Canvases.ListEventExecutions:output_type -> Superplane.Canvases.ListEventExecutionsResponse
+	80, // [80:98] is the sub-list for method output_type
+	62, // [62:80] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_canvases_proto_init() }
@@ -3529,7 +3595,7 @@ func file_canvases_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_canvases_proto_rawDesc), len(file_canvases_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   48,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/workers/event_distributer.go
+++ b/pkg/workers/event_distributer.go
@@ -57,6 +57,8 @@ func (e *EventDistributer) Start() error {
 		{messages.WorkflowExchange, messages.WorkflowExecutionRoutingKey, e.createHandler(eventdistributer.HandleCanvasExecution)},
 		{messages.WorkflowExchange, messages.WorkflowQueueItemCreatedRoutingKey, e.createHandler(eventdistributer.HandleQueueItemCreated)},
 		{messages.WorkflowExchange, messages.WorkflowQueueItemConsumedRoutingKey, e.createHandler(eventdistributer.HandleQueueItemConsumed)},
+		{messages.WorkflowExchange, messages.WorkflowCanvasUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasUpdated)},
+		{messages.WorkflowExchange, messages.WorkflowCanvasDeletedRoutingKey, e.createHandler(eventdistributer.HandleCanvasDeleted)},
 	}
 
 	// Start a consumer for each route

--- a/pkg/workers/eventdistributer/canvas.go
+++ b/pkg/workers/eventdistributer/canvas.go
@@ -1,0 +1,60 @@
+package eventdistributer
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/pkg/public/ws"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	CanvasUpdatedEvent = "canvas_updated"
+	CanvasDeletedEvent = "canvas_deleted"
+)
+
+type CanvasStatePayload struct {
+	ID string `json:"id"`
+}
+
+type CanvasStateWebsocketEvent struct {
+	Event   string             `json:"event"`
+	Payload CanvasStatePayload `json:"payload"`
+}
+
+func HandleCanvasUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	return handleCanvasState(messageBody, wsHub, CanvasUpdatedEvent)
+}
+
+func HandleCanvasDeleted(messageBody []byte, wsHub *ws.Hub) error {
+	return handleCanvasState(messageBody, wsHub, CanvasDeletedEvent)
+}
+
+func handleCanvasState(messageBody []byte, wsHub *ws.Hub, eventName string) error {
+	pbMsg := &pb.CanvasMessage{}
+	if err := proto.Unmarshal(messageBody, pbMsg); err != nil {
+		return fmt.Errorf("failed to unmarshal %s message: %w", eventName, err)
+	}
+
+	canvasID := pbMsg.CanvasId
+	if canvasID == "" {
+		return fmt.Errorf("missing canvas id in %s message", eventName)
+	}
+
+	wsEvent, err := json.Marshal(CanvasStateWebsocketEvent{
+		Event: eventName,
+		Payload: CanvasStatePayload{
+			ID: canvasID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s websocket event: %w", eventName, err)
+	}
+
+	wsHub.BroadcastToWorkflow(canvasID, wsEvent)
+	log.Debugf("Broadcasted %s event to workflow %s", eventName, canvasID)
+
+	return nil
+}

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -540,3 +540,9 @@ message CanvasNodeQueueItemMessage {
   string node_id = 3;
   google.protobuf.Timestamp timestamp = 4;
 }
+
+message CanvasMessage {
+  string id = 1;
+  string canvas_id = 2;
+  google.protobuf.Timestamp timestamp = 3;
+}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -61,6 +61,14 @@ import { withOrganizationHeader } from "@/utils/withOrganizationHeader";
 import { CreateCanvasModal } from "@/components/CreateCanvasModal";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   getComponentAdditionalDataBuilder,
   getComponentBaseMapper,
   getTriggerRenderer,
@@ -102,6 +110,7 @@ import { LogEntry, LogRunItem } from "@/ui/CanvasLogSidebar";
 const BUNDLE_ICON_SLUG = "component";
 const BUNDLE_COLOR = "gray";
 const CANVAS_AUTO_SAVE_STORAGE_KEY = "canvas-auto-save-enabled";
+const LOCAL_CANVAS_UPDATE_SUPPRESSION_MS = 2000;
 
 type UnsavedChangeKind = "position" | "structural";
 
@@ -133,7 +142,9 @@ export function WorkflowPageV2() {
   usePageTitle([canvas?.metadata?.name || "Canvas"]);
 
   const isTemplate = canvas?.metadata?.isTemplate ?? false;
-  const isReadOnly = isTemplate || !canUpdateCanvas;
+  const [canvasDeletedRemotely, setCanvasDeletedRemotely] = useState(false);
+  const [remoteCanvasUpdatePending, setRemoteCanvasUpdatePending] = useState(false);
+  const isReadOnly = isTemplate || !canUpdateCanvas || canvasDeletedRemotely;
   const isDev = import.meta.env.DEV;
   const [isUseTemplateOpen, setIsUseTemplateOpen] = useState(false);
   const createWorkflowMutation = useCreateCanvas(organizationId!);
@@ -212,6 +223,7 @@ export function WorkflowPageV2() {
   const [initialWorkflowSnapshot, setInitialWorkflowSnapshot] = useState<CanvasesCanvas | null>(null);
   const lastSavedWorkflowRef = useRef<CanvasesCanvas | null>(null);
   const canvasRef = useRef<CanvasesCanvas | null>(canvas ?? null);
+  const lastLocalCanvasSaveAtRef = useRef<number>(0);
   useEffect(() => {
     canvasRef.current = canvas ?? null;
   }, [canvas]);
@@ -235,11 +247,11 @@ export function WorkflowPageV2() {
         (canvasError as any)?.message?.includes("not found") ||
         (canvasError as any)?.message?.includes("404");
 
-      if (is404 && organizationId) {
+      if (is404 && organizationId && !canvasDeletedRemotely) {
         navigate(`/${organizationId}`, { replace: true });
       }
     }
-  }, [canvasError, canvasLoading, navigate, organizationId]);
+  }, [canvasError, canvasLoading, navigate, organizationId, canvasDeletedRemotely]);
 
   // Initialize store from workflow.status on workflow load (only once per workflow)
   const hasInitializedStoreRef = useRef<string | null>(null);
@@ -265,6 +277,7 @@ export function WorkflowPageV2() {
     setHasNonPositionalUnsavedChanges(false);
     setInitialWorkflowSnapshot(null);
     lastSavedWorkflowRef.current = null;
+    lastLocalCanvasSaveAtRef.current = 0;
   }, [canvasId]);
 
   useEffect(() => {
@@ -273,6 +286,17 @@ export function WorkflowPageV2() {
       setHasNonPositionalUnsavedChanges(false);
     }
   }, [isTemplate, canvasId]);
+
+  useEffect(() => {
+    if (!remoteCanvasUpdatePending || hasUnsavedChanges || canvasDeletedRemotely || !organizationId || !canvasId) {
+      return;
+    }
+
+    queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+    queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
+    setRemoteCanvasUpdatePending(false);
+    showSuccessToast("Canvas updated from another session");
+  }, [remoteCanvasUpdatePending, hasUnsavedChanges, canvasDeletedRemotely, organizationId, canvasId, queryClient]);
 
   // Build maps from store for canvas display (using initial data from workflow.status and websocket updates)
   // Rebuild whenever store version changes (indicates data was updated)
@@ -450,6 +474,7 @@ export function WorkflowPageV2() {
               : "Canvas changes saved";
 
             // Save the workflow with updated positions
+            lastLocalCanvasSaveAtRef.current = Date.now();
             await updateWorkflowMutation.mutateAsync({
               name: latestWorkflow.metadata?.name!,
               description: latestWorkflow.metadata?.description,
@@ -854,12 +879,42 @@ export function WorkflowPageV2() {
     [buildLiveRunEntryFromEvent, buildLiveRunItemFromExecution],
   );
 
+  const handleCanvasLifecycleEvent = useCallback(
+    (_payload: { id?: string; canvasId?: string }, eventName: string) => {
+      if (eventName === "canvas_deleted") {
+        setCanvasDeletedRemotely(true);
+        return;
+      }
+
+      const isLocalEcho =
+        eventName === "canvas_updated" &&
+        Date.now() - lastLocalCanvasSaveAtRef.current < LOCAL_CANVAS_UPDATE_SUPPRESSION_MS;
+      if (isLocalEcho) {
+        return;
+      }
+
+      if (eventName === "canvas_updated" && hasUnsavedChanges) {
+        setRemoteCanvasUpdatePending(true);
+      } else if (eventName === "canvas_updated") {
+        showSuccessToast("Canvas updated from another session");
+      }
+    },
+    [hasUnsavedChanges],
+  );
+
+  const shouldApplyCanvasUpdate = useCallback(
+    () => !hasUnsavedChanges && !canvasDeletedRemotely,
+    [hasUnsavedChanges, canvasDeletedRemotely],
+  );
+
   useCanvasWebsocket(
     canvasId!,
     organizationId!,
     handleNodeWebsocketEvent,
     handleWorkflowEventCreated,
     handleExecutionEvent,
+    handleCanvasLifecycleEvent,
+    shouldApplyCanvasUpdate,
   );
 
   const logEntries = useMemo(() => {
@@ -1298,6 +1353,7 @@ export function WorkflowPageV2() {
         : "Canvas changes saved";
 
       try {
+        lastLocalCanvasSaveAtRef.current = Date.now();
         await updateWorkflowMutation.mutateAsync({
           name: targetWorkflow.metadata?.name!,
           description: targetWorkflow.metadata?.description,
@@ -2486,6 +2542,7 @@ export function WorkflowPageV2() {
         : "Canvas changes saved";
 
       try {
+        lastLocalCanvasSaveAtRef.current = Date.now();
         await updateWorkflowMutation.mutateAsync({
           name: canvas.metadata?.name!,
           description: canvas.metadata?.description,
@@ -2766,7 +2823,39 @@ export function WorkflowPageV2() {
     );
   }
 
+  const handleReloadRemoteCanvas = async () => {
+    if (!organizationId || !canvasId) {
+      return;
+    }
+
+    pendingPositionUpdatesRef.current.clear();
+    pendingAnnotationUpdatesRef.current.clear();
+    setHasUnsavedChanges(false);
+    setHasNonPositionalUnsavedChanges(false);
+    setInitialWorkflowSnapshot(null);
+    setRemoteCanvasUpdatePending(false);
+    lastSavedWorkflowRef.current = null;
+
+    await queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+    await queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
+  };
+
   const hasRunBlockingChanges = hasUnsavedChanges && hasNonPositionalUnsavedChanges;
+  const remoteUpdateBanner = remoteCanvasUpdatePending ? (
+    <div className="bg-amber-100 px-4 py-2.5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="text-sm font-medium text-gray-900">Canvas updated elsewhere</p>
+        <p className="text-[13px] text-black/60">
+          A newer canvas version is available. Reloading will discard your unsaved local changes.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={handleReloadRemoteCanvas}>
+          Reload remote
+        </Button>
+      </div>
+    </div>
+  ) : null;
   const templateBanner = isTemplate ? (
     <div className="bg-orange-100 px-4 py-2.5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
       <div>
@@ -2778,6 +2867,15 @@ export function WorkflowPageV2() {
       </Button>
     </div>
   ) : null;
+  const headerBanner =
+    remoteUpdateBanner && templateBanner ? (
+      <div className="flex flex-col">
+        {remoteUpdateBanner}
+        {templateBanner}
+      </div>
+    ) : (
+      remoteUpdateBanner || templateBanner
+    );
   const saveDisabled = !canUpdateCanvas;
   const saveDisabledTooltip = saveDisabled ? "You don't have permission to edit this canvas." : undefined;
   const autoSaveDisabled = !canUpdateCanvas;
@@ -2785,14 +2883,16 @@ export function WorkflowPageV2() {
   const saveButtonHidden = isTemplate || !canUpdateCanvas || !hasUnsavedChanges;
   const saveIsPrimary = hasUnsavedChanges && !isTemplate && canUpdateCanvas;
   const canUndo = !isTemplate && canUpdateCanvas && !isAutoSaveEnabled && initialWorkflowSnapshot !== null;
-  const runDisabled = hasRunBlockingChanges || isTemplate || !canUpdateCanvas;
-  const runDisabledTooltip = !canUpdateCanvas
-    ? "You don't have permission to emit events on this canvas."
-    : isTemplate
-      ? "Templates are read-only"
-      : hasRunBlockingChanges
-        ? "Save canvas changes before running"
-        : undefined;
+  const runDisabled = hasRunBlockingChanges || isTemplate || !canUpdateCanvas || canvasDeletedRemotely;
+  const runDisabledTooltip = canvasDeletedRemotely
+    ? "This canvas was deleted in another session."
+    : !canUpdateCanvas
+      ? "You don't have permission to emit events on this canvas."
+      : isTemplate
+        ? "Templates are read-only"
+        : hasRunBlockingChanges
+          ? "Save canvas changes before running"
+          : undefined;
 
   return (
     <>
@@ -2811,7 +2911,7 @@ export function WorkflowPageV2() {
           }
         }}
         title={canvas?.metadata?.name || "Canvas"}
-        headerBanner={templateBanner}
+        headerBanner={headerBanner}
         nodes={nodes}
         edges={edges}
         organizationId={organizationId}
@@ -2917,6 +3017,27 @@ export function WorkflowPageV2() {
           fromTemplate
         />
       ) : null}
+      <Dialog open={canvasDeletedRemotely} onOpenChange={() => {}}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Canvas deleted</DialogTitle>
+            <DialogDescription>
+              This canvas was deleted from another session. You can no longer edit or run it.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                if (organizationId) {
+                  navigate(`/${organizationId}`, { replace: true });
+                }
+              }}
+            >
+              Go to canvases
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
When I have my canvas opened in the UI, and make changes in the CLI, I have to refresh the page to see the changes in the canvas. This is also true when the canvas is opened by multiple people at the same time. Here, we update the server to stream canvas updates and deletion through the WebSocket connection, so all the pages are updated.