### PR TITLE
fix: Implement WebSocket origin checking in production

### DIFF
--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -86,6 +86,31 @@ func (s *Server) WebsocketHub() *ws.Hub {
 	return s.wsHub
 }
 
+// allowedWebSocketOrigins returns the list of origins allowed for WebSocket connections.
+// In development (isDev true) returns nil (no restriction). Otherwise uses
+// WEBSOCKET_ALLOWED_ORIGINS if set (comma-separated), or the origin derived from baseURL (scheme + host).
+// Returns nil on parse error or when no origins are configured (fallback: allow all for backward compatibility).
+func allowedWebSocketOrigins(baseURL string, isDev bool) []string {
+	if isDev {
+		return nil
+	}
+	if env := os.Getenv("WEBSOCKET_ALLOWED_ORIGINS"); env != "" {
+		var list []string
+		for _, s := range strings.Split(env, ",") {
+			if o := strings.TrimSpace(s); o != "" {
+				list = append(list, o)
+			}
+		}
+		return list
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil
+	}
+	origin := u.Scheme + "://" + u.Host
+	return []string{origin}
+}
+
 func NewServer(
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
@@ -107,6 +132,13 @@ func NewServer(
 	providers := getOAuthProviders()
 	authHandler.InitializeProviders(providers)
 
+	isDev := appEnv == "development"
+	allowedOrigins := allowedWebSocketOrigins(baseURL, isDev)
+	allowedOriginsSet := make(map[string]struct{})
+	for _, o := range allowedOrigins {
+		allowedOriginsSet[strings.TrimSpace(o)] = struct{}{}
+	}
+
 	server := &Server{
 		BaseURL:               baseURL,
 		WebhooksBaseURL:       webhooksBaseURL,
@@ -121,10 +153,18 @@ func NewServer(
 		registry:              registry,
 		authService:           authorizationService,
 		upgrader: &websocket.Upgrader{
+			// In development all origins are accepted. Otherwise only WEBSOCKET_ALLOWED_ORIGINS
+			// (if set) or the origin derived from BASE_URL are accepted.
 			CheckOrigin: func(r *http.Request) bool {
-				// Allow all connections - you may want to restrict this in production
-				// TODO: implement origin checking
-				return true
+				if allowedOrigins == nil || len(allowedOriginsSet) == 0 {
+					return true
+				}
+				origin := strings.TrimSpace(r.Header.Get("Origin"))
+				if origin == "" {
+					return false
+				}
+				_, ok := allowedOriginsSet[origin]
+				return ok
 			},
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -86,31 +86,6 @@ func (s *Server) WebsocketHub() *ws.Hub {
 	return s.wsHub
 }
 
-// allowedWebSocketOrigins returns the list of origins allowed for WebSocket connections.
-// In development (isDev true) returns nil (no restriction). Otherwise uses
-// WEBSOCKET_ALLOWED_ORIGINS if set (comma-separated), or the origin derived from baseURL (scheme + host).
-// Returns nil on parse error or when no origins are configured (fallback: allow all for backward compatibility).
-func allowedWebSocketOrigins(baseURL string, isDev bool) []string {
-	if isDev {
-		return nil
-	}
-	if env := os.Getenv("WEBSOCKET_ALLOWED_ORIGINS"); env != "" {
-		var list []string
-		for _, s := range strings.Split(env, ",") {
-			if o := strings.TrimSpace(s); o != "" {
-				list = append(list, o)
-			}
-		}
-		return list
-	}
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return nil
-	}
-	origin := u.Scheme + "://" + u.Host
-	return []string{origin}
-}
-
 func NewServer(
 	encryptor crypto.Encryptor,
 	registry *registry.Registry,
@@ -132,13 +107,6 @@ func NewServer(
 	providers := getOAuthProviders()
 	authHandler.InitializeProviders(providers)
 
-	isDev := appEnv == "development"
-	allowedOrigins := allowedWebSocketOrigins(baseURL, isDev)
-	allowedOriginsSet := make(map[string]struct{})
-	for _, o := range allowedOrigins {
-		allowedOriginsSet[strings.TrimSpace(o)] = struct{}{}
-	}
-
 	server := &Server{
 		BaseURL:               baseURL,
 		WebhooksBaseURL:       webhooksBaseURL,
@@ -153,19 +121,9 @@ func NewServer(
 		registry:              registry,
 		authService:           authorizationService,
 		upgrader: &websocket.Upgrader{
-			// In development all origins are accepted. Otherwise only WEBSOCKET_ALLOWED_ORIGINS
-			// (if set) or the origin derived from BASE_URL are accepted.
-			CheckOrigin: func(r *http.Request) bool {
-				if allowedOrigins == nil || len(allowedOriginsSet) == 0 {
-					return true
-				}
-				origin := strings.TrimSpace(r.Header.Get("Origin"))
-				if origin == "" {
-					return false
-				}
-				_, ok := allowedOriginsSet[origin]
-				return ok
-			},
+			// In development all origins are accepted.
+			// In production only the origin derived from BASE_URL is accepted.
+			CheckOrigin:     newWebSocketCheckOrigin(appEnv, baseURL),
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},

--- a/pkg/public/websocket_origin.go
+++ b/pkg/public/websocket_origin.go
@@ -1,0 +1,55 @@
+package public
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// newWebSocketCheckOrigin returns a CheckOrigin callback tailored to the runtime environment.
+// - development: allow all origins to preserve local DX
+// - production: allow only the origin derived from BASE_URL
+func newWebSocketCheckOrigin(appEnv string, baseURL string) func(r *http.Request) bool {
+	// Keep current local-dev behavior: accept all origins.
+	if appEnv == "development" {
+		return func(_ *http.Request) bool {
+			return true
+		}
+	}
+
+	allowedOrigin, ok := baseOriginFromURL(baseURL)
+	// Security-first fallback in production:
+	// if BASE_URL is invalid, reject websocket upgrades instead of allowing all origins.
+	if !ok || allowedOrigin == "" {
+		return func(_ *http.Request) bool {
+			// If the origin is not allowed, return false.
+			// This is to prevent any potential security issues.
+			return false
+		}
+	}
+
+	return func(r *http.Request) bool {
+		// Browsers send Origin on websocket handshakes; empty origin is not accepted in production.
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		if origin == "" {
+			return false
+		}
+
+		return origin == allowedOrigin
+	}
+}
+
+func baseOriginFromURL(baseURL string) (string, bool) {
+	// baseOriginFromURL extracts the canonical origin (scheme://host) from BASE_URL.
+	// Example: https://app.example.com/path -> https://app.example.com
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return "", false
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", false
+	}
+
+	return parsedURL.Scheme + "://" + parsedURL.Host, true
+}

--- a/pkg/public/websocket_origin.go
+++ b/pkg/public/websocket_origin.go
@@ -35,7 +35,8 @@ func newWebSocketCheckOrigin(appEnv string, baseURL string) func(r *http.Request
 			return false
 		}
 
-		return origin == allowedOrigin
+		// RFC 6454 origin comparison is ASCII case-insensitive.
+		return strings.EqualFold(origin, allowedOrigin)
 	}
 }
 

--- a/pkg/public/websocket_origin_test.go
+++ b/pkg/public/websocket_origin_test.go
@@ -1,0 +1,27 @@
+package public
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test__newWebSocketCheckOrigin__ProductionComparisonIsCaseInsensitive(t *testing.T) {
+	checkOrigin := newWebSocketCheckOrigin("production", "HTTPS://App.Example.com")
+
+	request, err := http.NewRequest(http.MethodGet, "/ws", nil)
+	require.NoError(t, err)
+	request.Header.Set("Origin", "https://app.example.com")
+
+	require.True(t, checkOrigin(request))
+}
+
+func Test__newWebSocketCheckOrigin__ProductionRejectsEmptyOrigin(t *testing.T) {
+	checkOrigin := newWebSocketCheckOrigin("production", "https://app.example.com")
+
+	request, err := http.NewRequest(http.MethodGet, "/ws", nil)
+	require.NoError(t, err)
+
+	require.False(t, checkOrigin(request))
+}


### PR DESCRIPTION
## What

In production, WebSocket connections are now restricted to allowed origins only. In development, all origins are still accepted (no change for local dev).

## Why

Previously, the server accepted WebSocket connections from any origin. That could allow a third-party site to open a WebSocket to your SuperPlane instance using the user's cookies. Restricting origins in production reduces that risk and aligns with common security practice for WebSockets.

## How

- **`allowedWebSocketOrigins()`** builds the list of allowed origins:
  - In **development** (`APP_ENV=development`): returns no list → all origins accepted (unchanged behavior).
  - In **production**: uses `WEBSOCKET_ALLOWED_ORIGINS` if set (comma-separated), otherwise derives a single origin from `BASE_URL` (scheme + host).
- The WebSocket **`CheckOrigin`** callback now allows a connection only when:
  - there is no restriction list (dev / fallback), or
  - the request’s `Origin` header is in the allowed list.

## Configuration

- **`BASE_URL`**: In production, the origin derived from this URL is allowed (e.g. `https://app.example.com` → `https://app.example.com`).
- **`WEBSOCKET_ALLOWED_ORIGINS`** (optional): Comma-separated list of origins when you need multiple (e.g. `https://app.example.com,https://dashboard.example.com`).
- No change needed for local development; all origins remain accepted when `APP_ENV=development`.