### PR TITLE
fix(ui): filter nested invisible fields

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/daytona/create_repository_sandbox.ts
+++ b/web_src/src/pages/workflowv2/mappers/daytona/create_repository_sandbox.ts
@@ -1,6 +1,7 @@
 import { MetadataItem } from "@/ui/metadataList";
 import { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
 import { baseMapper } from "./base";
+import { ComponentBaseSpec } from "@/ui/componentBase";
 
 interface CreateRepositorySandboxConfiguration {
   snapshot?: string;
@@ -39,6 +40,7 @@ export const createRepositorySandboxMapper: ComponentBaseMapper = {
     return {
       ...props,
       metadata: createRepositorySandboxMetadataList(context.node),
+      specs: createRepositorySandboxSpecs(context.node),
     };
   },
 
@@ -84,9 +86,20 @@ function createRepositorySandboxMetadataList(node: ComponentBaseContext["node"])
     items.push({ icon: "terminal", label: `bootstrap: ${config.bootstrap.from}` });
   }
 
-  if (config?.bootstrap?.path) {
+  if (config?.bootstrap?.from === "file" && config?.bootstrap?.path) {
     items.push({ icon: "file-code", label: config.bootstrap.path });
   }
 
   return items;
+}
+
+function createRepositorySandboxSpecs(node: ComponentBaseContext["node"]): ComponentBaseSpec[] {
+  const config = node.configuration as CreateRepositorySandboxConfiguration | undefined;
+  const specs: ComponentBaseSpec[] = [];
+
+  if (config?.bootstrap?.from == "inline" && config?.bootstrap?.script) {
+    specs.push({ title: "Script", value: config.bootstrap.script });
+  }
+
+  return specs;
 }

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -12,7 +12,12 @@ import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { getIntegrationTypeDisplayName } from "@/utils/integrationDisplayName";
 import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
-import { isFieldRequired, isFieldVisible, parseDefaultValues, validateFieldForSubmission } from "@/utils/components";
+import {
+  filterVisibleConfiguration,
+  isFieldRequired,
+  parseDefaultValues,
+  validateFieldForSubmission,
+} from "@/utils/components";
 import { useRealtimeValidation } from "@/hooks/useRealtimeValidation";
 import { SimpleTooltip } from "./SimpleTooltip";
 
@@ -197,13 +202,7 @@ export function SettingsTab({
   // Function to filter out invisible fields
   const filterVisibleFields = useCallback(
     (config: Record<string, unknown>) => {
-      const filtered = { ...config };
-      configurationFields.forEach((field) => {
-        if (field.name && !isFieldVisible(field, config)) {
-          delete filtered[field.name];
-        }
-      });
-      return filtered;
+      return filterVisibleConfiguration(config, configurationFields);
     },
     [configurationFields],
   );


### PR DESCRIPTION
When filtering fields based on visibility, we should consider the ones inside of nested objects too.