### PR TITLE
fix: Daytona execute command ui

### DIFF
--- a/docs/components/Daytona.mdx
+++ b/docs/components/Daytona.mdx
@@ -219,6 +219,7 @@ Routes to one of two channels:
 
 The payload includes:
 - **exitCode**: The process exit code (0 for success)
+- **timeout**: Whether the command timed out
 - **result**: The stdout/output from the command execution
 
 ### Notes
@@ -233,7 +234,8 @@ The payload includes:
 {
   "data": {
     "exitCode": 0,
-    "result": "Successfully installed requests-2.31.0\n"
+    "result": "Successfully installed requests-2.31.0\n",
+    "timeout": false
   },
   "timestamp": "2026-01-19T12:00:00Z",
   "type": "daytona.command.response"

--- a/pkg/integrations/daytona/client.go
+++ b/pkg/integrations/daytona/client.go
@@ -78,6 +78,7 @@ type ExecuteCommandRequest struct {
 // ExecuteCommandResponse represents the response from command execution
 type ExecuteCommandResponse struct {
 	ExitCode int    `json:"exitCode"`
+	Timeout  bool   `json:"timeout"`
 	Result   string `json:"result"`
 }
 

--- a/pkg/integrations/daytona/example_output_execute_command.json
+++ b/pkg/integrations/daytona/example_output_execute_command.json
@@ -2,6 +2,7 @@
     "type": "daytona.command.response",
     "data": {
         "exitCode": 0,
+        "timeout": false,
         "result": "Successfully installed requests-2.31.0\n"
     },
     "timestamp": "2026-01-19T12:00:00Z"

--- a/web_src/src/pages/workflowv2/mappers/daytona/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/daytona/base.ts
@@ -12,6 +12,11 @@ import {
 import daytonaIcon from "@/assets/icons/integrations/daytona.svg";
 import { formatTimeAgo } from "@/utils/date";
 
+interface ExecuteCommandOutput {
+  exitCode?: number | null;
+  timeout?: boolean;
+}
+
 export const baseMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
@@ -29,13 +34,11 @@ export const baseMapper: ComponentBaseMapper = {
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const payload = getFirstOutputPayload(context.execution.outputs);
 
-    if (!outputs || !outputs.default || outputs.default.length === 0) {
+    if (!payload) {
       return { Response: "No data returned" };
     }
-
-    const payload = outputs.default[0];
     const responseData = payload?.data as Record<string, any> | undefined;
 
     if (!responseData) {
@@ -84,22 +87,60 @@ export const baseMapper: ComponentBaseMapper = {
   },
 
   subtitle(context: SubtitleContext): string {
-    if (!context.execution.createdAt) return "";
-    return formatTimeAgo(new Date(context.execution.createdAt));
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    if (!timestamp) return "";
+
+    return (
+      buildExecuteCommandSubtitle(context.node.componentName, context.execution) || formatTimeAgo(new Date(timestamp))
+    );
   },
 };
 
+function getFirstOutputPayload(outputs: unknown): OutputPayload | undefined {
+  const typedOutputs = outputs as
+    | { success?: OutputPayload[]; failed?: OutputPayload[]; default?: OutputPayload[] }
+    | undefined;
+  return typedOutputs?.default?.[0] ?? typedOutputs?.success?.[0] ?? typedOutputs?.failed?.[0];
+}
+
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const eventTitle = title || "Event";
+  const eventSubtitle = buildExecuteCommandSubtitle(componentName, execution);
 
   return [
     {
       receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
+      eventTitle,
+      eventSubtitle,
       eventState: getState(componentName)(execution),
       eventId: execution.rootEvent?.id ?? "",
     },
   ];
+}
+
+function buildExecuteCommandSubtitle(componentName: string, execution: ExecutionInfo): string | undefined {
+  if (componentName !== "daytona.executeCommand") {
+    return undefined;
+  }
+
+  const timestamp = execution.updatedAt || execution.createdAt;
+  if (!timestamp) return "";
+
+  const timeAgo = formatTimeAgo(new Date(timestamp));
+
+  const payload = getFirstOutputPayload(execution.outputs);
+  const data = payload?.data as ExecuteCommandOutput | undefined;
+
+  if (data?.timeout === true) {
+    return `timed out · ${timeAgo}`;
+  }
+
+  if (typeof data?.exitCode === "number") {
+    return `exit code ${data.exitCode} · ${timeAgo}`;
+  }
+
+  return timeAgo;
 }

--- a/web_src/src/pages/workflowv2/mappers/daytona/execute_command.ts
+++ b/web_src/src/pages/workflowv2/mappers/daytona/execute_command.ts
@@ -1,0 +1,51 @@
+import { EventStateRegistry, OutputPayload, StateFunction } from "../types";
+import { DEFAULT_EVENT_STATE_MAP, EventStateMap } from "@/ui/componentBase";
+import { defaultStateFunction } from "../stateRegistry";
+
+interface ExecuteCommandOutput {
+  exitCode?: number;
+}
+
+export const EXECUTE_COMMAND_STATE_MAP: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  executed: DEFAULT_EVENT_STATE_MAP.success,
+  failed: {
+    icon: "circle-x",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-red-100",
+    badgeColor: "bg-red-500",
+  },
+};
+
+export const executeCommandStateFunction: StateFunction = (execution) => {
+  if (!execution) return "neutral";
+
+  const defaultState = defaultStateFunction(execution);
+  if (defaultState !== "success") {
+    return defaultState;
+  }
+
+  const outputs = execution.outputs as
+    | { success?: OutputPayload[]; failed?: OutputPayload[]; default?: OutputPayload[] }
+    | undefined;
+
+  if (outputs?.failed?.length) {
+    return "failed";
+  }
+
+  const payload =
+    (outputs?.success?.[0]?.data as ExecuteCommandOutput | undefined) ??
+    (outputs?.failed?.[0]?.data as ExecuteCommandOutput | undefined) ??
+    (outputs?.default?.[0]?.data as ExecuteCommandOutput | undefined);
+
+  if (typeof payload?.exitCode === "number" && payload.exitCode !== 0) {
+    return "failed";
+  }
+
+  return "executed";
+};
+
+export const EXECUTE_COMMAND_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: EXECUTE_COMMAND_STATE_MAP,
+  getState: executeCommandStateFunction,
+};

--- a/web_src/src/pages/workflowv2/mappers/daytona/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/daytona/index.ts
@@ -2,6 +2,7 @@ import { ComponentBaseMapper, TriggerRenderer, EventStateRegistry } from "../typ
 import { baseMapper } from "./base";
 import { buildActionStateRegistry } from "../utils";
 import { createRepositorySandboxMapper } from "./create_repository_sandbox";
+import { EXECUTE_COMMAND_STATE_REGISTRY } from "./execute_command";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createSandbox: baseMapper,
@@ -19,6 +20,6 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createRepositorySandbox: buildActionStateRegistry("created"),
   getPreviewUrl: buildActionStateRegistry("generated"),
   executeCode: buildActionStateRegistry("executed"),
-  executeCommand: buildActionStateRegistry("executed"),
+  executeCommand: EXECUTE_COMMAND_STATE_REGISTRY,
   deleteSandbox: buildActionStateRegistry("deleted"),
 };


### PR DESCRIPTION
## Summary
This PR improves the Daytona `executeCommand` experience in both backend payloads and workflow UI rendering.

## What changed

- Added a custom Daytona UI state registry for `executeCommand`:
  - `executed` state for successful command completion
  - `failed` state (red) when command is routed to failed output / non-zero exit code
- Added execute-command-specific subtitle rendering (Daytona only):
  - `exit code 0 · <time>`
  - `exit code 1 · <time>` (or any non-zero exit code)
  - `timed out · <time>`
- Added `eventSubtitle` in Daytona event sections using the same execute-command-specific logic.
- Updated Daytona backend emit payload shape to include timeout info consistently:
  - normal completion: `timeout: false`
  - timeout path: `timeout: true`
- Extended Daytona command response model with `timeout` field.
- Updated Daytona example output JSON to include `timeout`.
- Updated Daytona tests to assert emitted payload data for:
  - success (`exitCode`, `timeout: false`)
  - non-zero exit (`exitCode`, `timeout: false`)
  - timeout (`exitCode: nil`, `timeout: true`)
  
  
<img width="1550" height="782" alt="image" src="https://github.com/user-attachments/assets/058275a9-2452-472b-84e0-f0f7282c3187" />
