### PR TITLE
fix: daytona.executeCode syntax error

### DIFF
--- a/pkg/integrations/daytona/client.go
+++ b/pkg/integrations/daytona/client.go
@@ -225,18 +225,8 @@ func (c *Client) ExecuteCode(sandboxID string, req *ExecuteCodeRequest) (*Execut
 		return nil, fmt.Errorf("failed to resolve toolbox URL: %v", err)
 	}
 
-	// Convert code execution to a command based on language
-	var command string
-	switch req.Language {
-	case "python":
-		command = fmt.Sprintf("python3 -c %q", req.Code)
-	case "javascript":
-		command = fmt.Sprintf("node -e %q", req.Code)
-	case "typescript":
-		command = fmt.Sprintf("npx ts-node -e %q", req.Code)
-	default:
-		command = fmt.Sprintf("python3 -c %q", req.Code)
-	}
+	// Convert code execution to a command based on language.
+	command := buildExecuteCodeCommand(req.Language, req.Code)
 
 	cmdReq := &ExecuteCommandRequest{
 		Command: command,

--- a/pkg/integrations/daytona/execute_code.go
+++ b/pkg/integrations/daytona/execute_code.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	ExecuteCodePayloadType  = "daytona.execute.response"
-	ExecuteCodePollInterval = 5 * time.Second
+	ExecuteCodePayloadType          = "daytona.execute.response"
+	ExecuteCodePollInterval         = 5 * time.Second
+	ExecuteCodeOutputChannelSuccess = "success"
+	ExecuteCodeOutputChannelFailed  = "failed"
 )
 
 type ExecuteCode struct{}
@@ -84,7 +86,10 @@ func (e *ExecuteCode) Color() string {
 }
 
 func (e *ExecuteCode) OutputChannels(configuration any) []core.OutputChannel {
-	return []core.OutputChannel{core.DefaultOutputChannel}
+	return []core.OutputChannel{
+		{Name: ExecuteCodeOutputChannelSuccess, Label: "Success"},
+		{Name: ExecuteCodeOutputChannelFailed, Label: "Failed"},
+	}
 }
 
 func (e *ExecuteCode) Configuration() []configuration.Field {
@@ -178,17 +183,7 @@ func (e *ExecuteCode) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create client: %v", err)
 	}
 
-	var command string
-	switch spec.Language {
-	case "python":
-		command = fmt.Sprintf("python3 -c %q", spec.Code)
-	case "javascript":
-		command = fmt.Sprintf("node -e %q", spec.Code)
-	case "typescript":
-		command = fmt.Sprintf("npx ts-node -e %q", spec.Code)
-	default:
-		command = fmt.Sprintf("python3 -c %q", spec.Code)
-	}
+	command := buildExecuteCodeCommand(spec.Language, spec.Code)
 	command = wrapCommandWithSandboxSecretEnv(command)
 
 	sessionID := uuid.New().String()
@@ -281,8 +276,13 @@ func (e *ExecuteCode) poll(ctx core.ActionContext) error {
 		Result:   logs,
 	}
 
+	channel := ExecuteCodeOutputChannelFailed
+	if *cmd.ExitCode == 0 {
+		channel = ExecuteCodeOutputChannelSuccess
+	}
+
 	return ctx.ExecutionState.Emit(
-		core.DefaultOutputChannel.Name,
+		channel,
 		ExecuteCodePayloadType,
 		[]any{result},
 	)
@@ -294,4 +294,19 @@ func (e *ExecuteCode) HandleWebhook(ctx core.WebhookRequestContext) (int, error)
 
 func (e *ExecuteCode) Cleanup(ctx core.SetupContext) error {
 	return nil
+}
+
+func buildExecuteCodeCommand(language, code string) string {
+	quotedCode := shellQuote(code)
+
+	switch language {
+	case "python":
+		return fmt.Sprintf("python3 -c %s", quotedCode)
+	case "javascript":
+		return fmt.Sprintf("node -e %s", quotedCode)
+	case "typescript":
+		return fmt.Sprintf("npx ts-node -e %s", quotedCode)
+	default:
+		return fmt.Sprintf("python3 -c %s", quotedCode)
+	}
 }

--- a/pkg/integrations/daytona/execute_code_test.go
+++ b/pkg/integrations/daytona/execute_code_test.go
@@ -1,6 +1,7 @@
 package daytona
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -207,6 +208,51 @@ func Test__ExecuteCode__Execute(t *testing.T) {
 		assert.Contains(t, string(body), "python3 -c")
 	})
 
+	t.Run("constructs python command with multiline code", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"cmdId":"cmd-001"}`))},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		multilineCode := "print('hello')\nprint('world')"
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"sandbox":  "sandbox-123",
+				"code":     multilineCode,
+				"language": "python",
+			},
+			HTTP:           httpContext,
+			Integration:    appCtx,
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Metadata:       &contexts.MetadataContext{},
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 4)
+
+		body, err := io.ReadAll(httpContext.Requests[3].Body)
+		require.NoError(t, err)
+
+		var req SessionExecuteRequest
+		err = json.Unmarshal(body, &req)
+		require.NoError(t, err)
+		expectedCommand := wrapCommandWithSandboxSecretEnv(buildExecuteCodeCommand("python", multilineCode))
+		assert.Equal(t, expectedCommand, req.Command)
+		assert.Contains(t, req.Command, "\n")
+		assert.NotContains(t, req.Command, "\\n")
+	})
+
 	t.Run("create session failure -> error", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
@@ -315,6 +361,49 @@ func Test__ExecuteCode__HandleAction(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, execCtx.Finished)
 		assert.True(t, execCtx.Passed)
+		assert.Equal(t, ExecuteCodeOutputChannelSuccess, execCtx.Channel)
+		assert.Equal(t, ExecuteCodePayloadType, execCtx.Type)
+		require.Len(t, execCtx.Payloads, 1)
+	})
+
+	t.Run("poll emits failed channel when command exits with non-zero status", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"sessionId":"session-abc","commands":[{"id":"cmd-001","exitCode":1}]}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"proxyToolboxUrl":"https://app.daytona.io/api/toolbox"}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`Traceback (most recent call last)`))},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-api-key",
+			},
+		}
+
+		execCtx := &contexts.ExecutionStateContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Metadata: &contexts.MetadataContext{
+				Metadata: map[string]any{
+					"sandboxId": "sandbox-123",
+					"sessionId": "session-abc",
+					"cmdId":     "cmd-001",
+					"startedAt": time.Now().Unix(),
+					"timeout":   300,
+				},
+			},
+			ExecutionState: execCtx,
+			Requests:       &contexts.RequestContext{},
+			Integration:    appCtx,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execCtx.Finished)
+		assert.True(t, execCtx.Passed)
+		assert.Equal(t, ExecuteCodeOutputChannelFailed, execCtx.Channel)
 		assert.Equal(t, ExecuteCodePayloadType, execCtx.Type)
 		require.Len(t, execCtx.Payloads, 1)
 	})
@@ -416,6 +505,7 @@ func Test__ExecuteCode__OutputChannels(t *testing.T) {
 	component := ExecuteCode{}
 
 	channels := component.OutputChannels(nil)
-	require.Len(t, channels, 1)
-	assert.Equal(t, core.DefaultOutputChannel, channels[0])
+	require.Len(t, channels, 2)
+	assert.Equal(t, ExecuteCodeOutputChannelSuccess, channels[0].Name)
+	assert.Equal(t, ExecuteCodeOutputChannelFailed, channels[1].Name)
 }

--- a/web_src/src/pages/workflowv2/mappers/daytona/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/daytona/index.ts
@@ -19,7 +19,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createSandbox: buildActionStateRegistry("created"),
   createRepositorySandbox: buildActionStateRegistry("created"),
   getPreviewUrl: buildActionStateRegistry("generated"),
-  executeCode: buildActionStateRegistry("executed"),
+  executeCode: EXECUTE_COMMAND_STATE_REGISTRY,
   executeCommand: EXECUTE_COMMAND_STATE_REGISTRY,
   deleteSandbox: buildActionStateRegistry("deleted"),
 };


### PR DESCRIPTION
## Summary
This PR improves `daytona.executeCode` reliability and failure handling.

It fixes code execution command escaping (especially multiline Python snippets) and adds explicit output channel routing so workflows can branch on execution failures.

## Changes
- Refactored execute-code command building into a shared helper (`buildExecuteCodeCommand`) that uses shell-safe quoting.
- Replaced `%q`-based command construction with shell-quoted command generation in:
  - `ExecuteCode.Execute`
  - `Client.ExecuteCode`
- Added output channels to `daytona.executeCode`:
  - `success`
  - `failed`
- Updated `executeCode` polling behavior to emit:
  - `success` when `exitCode == 0`
  - `failed` when `exitCode != 0`
- Updated Daytona workflow mapper so `executeCode` uses the same failed-state registry as `executeCommand`:
  - `web_src/src/pages/workflowv2/mappers/daytona/index.ts`
