### PR TITLE
feat: Enable canvas rename

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1049,7 +1049,7 @@ export function WorkflowPageV2() {
    */
   const pendingPositionUpdatesRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const pendingAnnotationUpdatesRef = useRef<Map<string, { text?: string; color?: string }>>(new Map());
-  const logNodeSelectRef = useRef<(nodeId: string) => void>(() => {});
+  const logNodeSelectRef = useRef<(nodeId: string) => void>(() => { });
 
   /**
    * Debounced auto-save function for node position changes.
@@ -2490,13 +2490,13 @@ export function WorkflowPageV2() {
         integration: integrationRef,
         position: position
           ? {
-              x: Math.round(position.x),
-              y: Math.round(position.y),
-            }
+            x: Math.round(position.x),
+            y: Math.round(position.y),
+          }
           : {
-              x: (latestWorkflow?.spec?.nodes?.length || 0) * 250,
-              y: 100,
-            },
+            x: (latestWorkflow?.spec?.nodes?.length || 0) * 250,
+            y: 100,
+          },
       };
 
       // Add type-specific reference
@@ -3111,9 +3111,9 @@ export function WorkflowPageV2() {
       const updatedNodes = canvas.spec?.nodes?.map((node) =>
         node.id === nodeId
           ? {
-              ...node,
-              position: roundedPosition,
-            }
+            ...node,
+            position: roundedPosition,
+          }
           : node,
       );
 
@@ -3167,9 +3167,9 @@ export function WorkflowPageV2() {
       const updatedNodes = canvas.spec?.nodes?.map((node) =>
         node.id && positionMap.has(node.id)
           ? {
-              ...node,
-              position: positionMap.get(node.id)!,
-            }
+            ...node,
+            position: positionMap.get(node.id)!,
+          }
           : node,
       );
 
@@ -3224,9 +3224,9 @@ export function WorkflowPageV2() {
       const updatedNodes = canvas.spec?.nodes?.map((node) =>
         node.id === nodeId
           ? {
-              ...node,
-              isCollapsed: newIsCollapsed,
-            }
+            ...node,
+            isCollapsed: newIsCollapsed,
+          }
           : node,
       );
 
@@ -4858,18 +4858,18 @@ function prepareCompositeNode(
         parameters:
           Object.keys(node.configuration!).length > 0
             ? [
-                {
-                  icon: "cog",
-                  items: Object.keys(node.configuration!).reduce(
-                    (acc, key) => {
-                      const displayKey = fieldLabelMap[key] || key;
-                      acc[displayKey] = `${node.configuration![key]}`;
-                      return acc;
-                    },
-                    {} as Record<string, string>,
-                  ),
-                },
-              ]
+              {
+                icon: "cog",
+                items: Object.keys(node.configuration!).reduce(
+                  (acc, key) => {
+                    const displayKey = fieldLabelMap[key] || key;
+                    acc[displayKey] = `${node.configuration![key]}`;
+                    return acc;
+                  },
+                  {} as Record<string, string>,
+                ),
+              },
+            ]
             : [],
       },
     },
@@ -5080,15 +5080,15 @@ function prepareComponentBaseNode(
 
   const additionalData = componentDef
     ? getComponentAdditionalDataBuilder(node.component?.name || "")?.buildAdditionalData({
-        nodes: nodes.map((n) => buildNodeInfo(n)),
-        node: buildNodeInfo(node),
-        componentDefinition: buildComponentDefinition(componentDef!),
-        lastExecutions: executions.map((e) => buildExecutionInfo(e)),
-        canvasId: workflowId,
-        queryClient: queryClient,
-        organizationId: organizationId,
-        currentUser: currentUser,
-      })
+      nodes: nodes.map((n) => buildNodeInfo(n)),
+      node: buildNodeInfo(node),
+      componentDefinition: buildComponentDefinition(componentDef!),
+      lastExecutions: executions.map((e) => buildExecutionInfo(e)),
+      canvasId: workflowId,
+      queryClient: queryClient,
+      organizationId: organizationId,
+      currentUser: currentUser,
+    })
     : undefined;
 
   const componentBaseProps = getComponentBaseMapper(node.component?.name || "").props({
@@ -5114,10 +5114,10 @@ function prepareComponentBaseNode(
   const emptyStateProps =
     hasError && showingEmptyState
       ? {
-          ...componentBaseProps.emptyStateProps,
-          icon: componentBaseProps.emptyStateProps?.icon || Puzzle,
-          title: "Finish configuring this component",
-        }
+        ...componentBaseProps.emptyStateProps,
+        icon: componentBaseProps.emptyStateProps?.icon || Puzzle,
+        title: "Finish configuring this component",
+      }
       : componentBaseProps.emptyStateProps;
 
   return {

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -3932,6 +3932,22 @@ export function WorkflowPageV2() {
     setSearchParams,
   ]);
 
+  const handleRenameCanvas = useCallback(
+    async (newName: string) => {
+      if (!canvas || !organizationId || !canvasId) return;
+
+      lastLocalCanvasSaveAtRef.current = Date.now();
+      await updateCanvasVersionMutation.mutateAsync({
+        name: newName,
+        description: canvas.metadata?.description,
+        nodes: canvas.spec?.nodes,
+        edges: canvas.spec?.edges,
+      });
+
+      showSuccessToast("Canvas renamed");
+    },
+    [canvas, organizationId, canvasId, updateCanvasVersionMutation],
+  );
   const getYamlExportPayload = useCallback(
     (canvasNodes: CanvasNode[]) => {
       if (!canvas) return null;
@@ -4541,6 +4557,7 @@ export function WorkflowPageV2() {
               />
             ) : undefined
           }
+          onRenameCanvas={!isReadOnly && !isTemplate ? handleRenameCanvas : undefined}
         />
       </div>
       {canvas ? (

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -12,6 +12,7 @@ import {
   SquarePen,
   Pencil,
   Rocket,
+  Edit,
 } from "lucide-react";
 import { Button } from "../button";
 import { Switch } from "../switch";
@@ -20,6 +21,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
+import { Dialog, DialogActions, DialogBody, DialogTitle } from "@/components/Dialog/dialog";
+import { Field, Label } from "@/components/Fieldset/fieldset";
+import { Input } from "@/components/Input/input";
 
 export interface BreadcrumbItem {
   label: string;
@@ -61,6 +65,7 @@ interface HeaderProps {
   autoSaveDisabledTooltip?: string;
   onExportYamlCopy?: () => void;
   onExportYamlDownload?: () => void;
+  onRenameCanvas?: (name: string) => Promise<void>;
   topViewMode?: "canvas" | "memory" | "versioning";
   onTopViewModeChange?: (mode: "canvas" | "memory" | "versioning") => void;
   showVersioningTab?: boolean;
@@ -102,6 +107,7 @@ export function Header({
   autoSaveDisabledTooltip,
   onExportYamlCopy,
   onExportYamlDownload,
+  onRenameCanvas,
   topViewMode,
   onTopViewModeChange,
   showVersioningTab = true,
@@ -126,6 +132,61 @@ export function Header({
   const [isEditingMenuOpen, setIsEditingMenuOpen] = useState(false);
   const [isSaveMenuOpen, setIsSaveMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const [isRenameOpen, setIsRenameOpen] = useState(false);
+  const [renameName, setRenameName] = useState("");
+  const [renameError, setRenameError] = useState("");
+  const [isRenaming, setIsRenaming] = useState(false);
+
+  const MAX_CANVAS_NAME_LENGTH = 50;
+
+  const handleRenameOpen = () => {
+    setRenameName(currentWorkflowName);
+    setRenameError("");
+    setIsRenaming(false);
+    setIsMenuOpen(false);
+    setIsRenameOpen(true);
+  };
+
+  const handleRenameClose = () => {
+    setIsRenameOpen(false);
+    setRenameName("");
+    setRenameError("");
+  };
+
+  const handleRenameSubmit = async () => {
+    const trimmed = renameName.trim();
+
+    if (!trimmed) {
+      setRenameError("Name is required");
+      return;
+    }
+    if (trimmed.length > MAX_CANVAS_NAME_LENGTH) {
+      setRenameError(`Name must be ${MAX_CANVAS_NAME_LENGTH} characters or less`);
+      return;
+    }
+    if (trimmed === currentWorkflowName) {
+      handleRenameClose();
+      return;
+    }
+    if (!onRenameCanvas) {
+      return;
+    };
+
+    setIsRenaming(true);
+    try {
+      await onRenameCanvas(trimmed);
+      handleRenameClose();
+    } catch (error) {
+      const message = (error as Error)?.message || "Failed to rename canvas";
+      if (message.toLowerCase().includes("already") || message.toLowerCase().includes("exists")) {
+        setRenameError("A canvas with this name already exists");
+      } else {
+        setRenameError(message);
+      }
+    } finally {
+      setIsRenaming(false);
+    }
+  };
 
   // Get the workflow name from the workflows list if workflowId is available
   // Otherwise, use breadcrumbs[1] which is always the workflow name (index 0 is "Canvases")
@@ -237,6 +298,25 @@ export function Header({
                 {isMenuOpen && !workflowsLoading && (
                   <div className="absolute left-0 top-13 z-50 min-w-[15rem] w-max rounded-md outline outline-slate-950/20 bg-white shadow-lg">
                     <div className="px-4 pt-3 pb-4">
+                      {/* Rename Canvas */}
+                      {onRenameCanvas && (
+                        <div className="mb-2">
+                          <button
+                            type="button"
+                            onClick={handleRenameOpen}
+                            className="group flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-gray-500 hover:text-gray-800"
+                          >
+                            <Edit size={16} className="text-gray-500 transition group-hover:text-gray-800" />
+                            <span>Rename Canvas</span>
+                          </button>
+                        </div>
+                      )}
+                      {onRenameCanvas && (
+                        <>
+                          {/* Divider */}
+                          <div className="border-b border-gray-300 mb-2"></div>
+                        </>
+                      )}
                       {/* All Canvases Link */}
                       <div className="mb-2">
                         <a
@@ -627,6 +707,49 @@ export function Header({
           </div>
         </div>
       </header>
+
+      {/* Rename Canvas Dialog */}
+      <Dialog open={isRenameOpen} onClose={handleRenameClose} size="sm">
+        <DialogTitle>Rename Canvas</DialogTitle>
+        <DialogBody>
+          <Field>
+            <Label className="block text-sm font-medium text-gray-700 mb-2">Canvas name</Label>
+            <Input
+              type="text"
+              autoComplete="off"
+              value={renameName}
+              onChange={(e) => {
+                if (e.target.value.length <= MAX_CANVAS_NAME_LENGTH) {
+                  setRenameName(e.target.value);
+                }
+                if (renameError) {
+                  setRenameError("");
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && renameName.trim() && !isRenaming) {
+                  handleRenameSubmit();
+                }
+              }}
+              className={`w-full ${renameError ? "border-red-500" : ""}`}
+              autoFocus
+              maxLength={MAX_CANVAS_NAME_LENGTH}
+            />
+            <div className="text-xs text-gray-500 mt-1">
+              {renameName.length}/{MAX_CANVAS_NAME_LENGTH} characters
+            </div>
+            {renameError && <div className="text-xs text-red-600 mt-1">{renameError}</div>}
+          </Field>
+        </DialogBody>
+        <DialogActions>
+          <Button onClick={handleRenameSubmit} disabled={!renameName.trim() || isRenaming}>
+            {isRenaming ? "Renaming..." : "Rename"}
+          </Button>
+          <Button variant="outline" onClick={handleRenameClose}>
+            Cancel
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 }

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -339,11 +339,10 @@ export function Header({
                               key={workflow.metadata?.id}
                               type="button"
                               onClick={() => handleWorkflowClick(workflow.metadata?.id || "")}
-                              className={`group flex items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-left ${
-                                isSelected
-                                  ? "bg-sky-100 text-gray-800"
-                                  : "text-gray-500 hover:bg-sky-100 hover:text-gray-800"
-                              }`}
+                              className={`group flex items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-left ${isSelected
+                                ? "bg-sky-100 text-gray-800"
+                                : "text-gray-500 hover:bg-sky-100 hover:text-gray-800"
+                                }`}
                             >
                               {isSelected ? (
                                 <Palette size={16} className="text-gray-800 transition group-hover:text-gray-800" />
@@ -368,18 +367,16 @@ export function Header({
                 <button
                   type="button"
                   onClick={() => onTopViewModeChange("canvas")}
-                  className={`rounded px-2 py-1 text-xs font-medium ${
-                    topViewMode === "canvas" ? "bg-slate-900 text-white" : "text-gray-700 hover:bg-gray-100"
-                  }`}
+                  className={`rounded px-2 py-1 text-xs font-medium ${topViewMode === "canvas" ? "bg-slate-900 text-white" : "text-gray-700 hover:bg-gray-100"
+                    }`}
                 >
                   Canvas
                 </button>
                 <button
                   type="button"
                   onClick={() => onTopViewModeChange("memory")}
-                  className={`rounded px-2 py-1 text-xs font-medium ${
-                    topViewMode === "memory" ? "bg-slate-900 text-white" : "text-gray-700 hover:bg-gray-100"
-                  }`}
+                  className={`rounded px-2 py-1 text-xs font-medium ${topViewMode === "memory" ? "bg-slate-900 text-white" : "text-gray-700 hover:bg-gray-100"
+                    }`}
                 >
                   <span className="inline-flex items-center gap-1">
                     <span>Memory</span>

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -199,6 +199,7 @@ export interface CanvasPageProps {
   canUpdateIntegrations?: boolean;
   onExportYamlCopy?: (nodes: CanvasNode[]) => void;
   onExportYamlDownload?: (nodes: CanvasNode[]) => void;
+  onRenameCanvas?: (name: string) => Promise<void>;
   // Undo functionality
   onUndo?: () => void;
   canUndo?: boolean;
@@ -910,6 +911,7 @@ function CanvasPage(props: CanvasPageProps) {
           versioningItemCount={props.versioningItemCount}
           onExportYamlCopy={props.onExportYamlCopy}
           onExportYamlDownload={props.onExportYamlDownload}
+          onRenameCanvas={props.onRenameCanvas}
         />
         {props.headerBanner ? <div className="border-b border-black/20">{props.headerBanner}</div> : null}
       </div>
@@ -1413,6 +1415,7 @@ function CanvasContentHeader({
   versioningItemCount,
   onExportYamlCopy,
   onExportYamlDownload,
+  onRenameCanvas,
 }: {
   state: CanvasPageState;
   onSave?: (nodes: CanvasNode[]) => void;
@@ -1455,6 +1458,7 @@ function CanvasContentHeader({
   versioningItemCount?: number;
   onExportYamlCopy?: (nodes: CanvasNode[]) => void;
   onExportYamlDownload?: (nodes: CanvasNode[]) => void;
+  onRenameCanvas?: (name: string) => Promise<void>;
 }) {
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -1527,6 +1531,7 @@ function CanvasContentHeader({
       versioningItemCount={versioningItemCount}
       onExportYamlCopy={onExportYamlCopy ? handleExportYamlCopy : undefined}
       onExportYamlDownload={onExportYamlDownload ? handleExportYamlDownload : undefined}
+      onRenameCanvas={onRenameCanvas}
     />
   );
 }


### PR DESCRIPTION
This PR addresses #3335.

It reuses existing _UpdateCanvas_ service to rename a canvas. There is a sanity check if the same canvas name exists already, showing toast on successful rename.