### PR TITLE
fix: Minimap toggle persistence

### DIFF
--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -63,6 +63,7 @@ import { CustomEdge } from "./CustomEdge";
 import { Header, type BreadcrumbItem } from "./Header";
 import { Simulation } from "./storybooks/useSimulation";
 import { CanvasPageState, useCanvasState } from "./useCanvasState";
+import { useMinimapVisibility } from "./useMinimapVisibility";
 import { SidebarEvent } from "../componentSidebar/types";
 import { CanvasLogSidebar, type LogEntry, type LogScopeFilter, type LogTypeFilter } from "../CanvasLogSidebar";
 
@@ -1748,7 +1749,7 @@ function CanvasContent({
   const [expandedRuns, setExpandedRuns] = useState<Set<string>>(() => new Set());
   const [logSidebarHeight, setLogSidebarHeight] = useState(320);
   const [isSnapToGridEnabled, setIsSnapToGridEnabled] = useState(true);
-  const [isMinimapVisible, setIsMinimapVisible] = useState(true);
+  const { isMinimapVisible, setIsMinimapVisible } = useMinimapVisibility(false);
 
   useEffect(() => {
     if (!showBottomStatusControls) {
@@ -2497,7 +2498,7 @@ function CanvasContent({
                             ? "bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
                             : "text-slate-600 hover:text-slate-900"
                         }`}
-                        onClick={() => setIsMinimapVisible((prev) => !prev)}
+                        onClick={() => setIsMinimapVisible((prev: boolean) => !prev)}
                         aria-pressed={isMinimapVisible}
                       >
                         <MapIcon className="h-3 w-3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix minimap toggle state not persisting across sessions and resolve a TypeScript strictness issue.

The minimap toggle in `CanvasPage` had regressed to using a plain `useState(true)`, causing its visibility state to no longer be saved in `localStorage`. This PR re-wires it to `useMinimapVisibility` to restore persistence. A minor TypeScript strictness issue on the toggle handler was also fixed for a clean UI build.

---
<p><a href="https://cursor.com/agents/bc-ea2bced8-2526-442d-879c-a9cd2b0f26e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea2bced8-2526-442d-879c-a9cd2b0f26e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->