### PR TITLE
fix: events callback not working for subscription messages

### DIFF
--- a/pkg/workers/contexts/integration_context_test.go
+++ b/pkg/workers/contexts/integration_context_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -252,4 +253,73 @@ func Test__IntegrationContext_RequestWebhook_MergesExistingWebhookConfig(t *test
 	configurationJSON, marshalErr := json.Marshal(updatedWebhook.Configuration.Data())
 	require.NoError(t, marshalErr)
 	assert.JSONEq(t, `{"eventTypes":["build_ended","deploy_ended"]}`, string(configurationJSON))
+}
+
+func Test__IntegrationContext_ListSubscriptions_UsesOnEventsCallback(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerName := "dummy.subscription-trigger"
+	r.Registry.Integrations["dummy"] = support.NewDummyIntegration(support.DummyIntegrationOptions{
+		Triggers: []core.Trigger{
+			support.NewDummyIntegrationTrigger(support.DummyIntegrationTriggerOptions{
+				Name: triggerName,
+				OnIntegrationMessage: func(ctx core.IntegrationMessageContext) error {
+					return ctx.Events.Emit("test.payload", map[string]any{"message": ctx.Message})
+				},
+			}),
+		},
+	})
+
+	integration, err := models.CreateIntegration(
+		uuid.New(),
+		r.Organization.ID,
+		"dummy",
+		support.RandomName("installation"),
+		map[string]any{},
+	)
+	require.NoError(t, err)
+
+	canvas, nodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID:        "trigger-1",
+				Name:          "trigger-1",
+				Type:          models.NodeTypeTrigger,
+				Ref:           datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: triggerName}}),
+				Configuration: datatypes.NewJSONType(map[string]any{}),
+			},
+		},
+		nil,
+	)
+	require.NotNil(t, canvas)
+	require.Len(t, nodes, 1)
+
+	node := nodes[0]
+	node.AppInstallationID = &integration.ID
+	require.NoError(t, database.Conn().Save(&node).Error)
+
+	newEvents := []models.CanvasEvent{}
+	onNewEvents := func(events []models.CanvasEvent) {
+		newEvents = append(newEvents, events...)
+	}
+
+	ctx := NewIntegrationContext(database.Conn(), &node, integration, r.Encryptor, r.Registry, onNewEvents)
+	_, err = ctx.Subscribe(map[string]any{"enabled": true})
+	require.NoError(t, err)
+
+	subscriptions, err := ctx.ListSubscriptions()
+	require.NoError(t, err)
+	require.Len(t, subscriptions, 1)
+
+	err = subscriptions[0].SendMessage(map[string]any{"hello": "world"})
+	require.NoError(t, err)
+
+	assert.Len(t, newEvents, 1)
+	assert.Equal(t, canvas.ID, newEvents[0].WorkflowID)
+	assert.Equal(t, node.NodeID, newEvents[0].NodeID)
+	support.VerifyCanvasNodeEventsCount(t, canvas.ID, node.NodeID, 1)
 }

--- a/pkg/workers/contexts/integration_subscription_context.go
+++ b/pkg/workers/contexts/integration_subscription_context.go
@@ -36,6 +36,7 @@ func NewIntegrationSubscriptionContext(
 		node:           node,
 		integration:    integration,
 		integrationCtx: integrationCtx,
+		onNewEvents:    onNewEvents,
 	}
 }
 

--- a/test/support/application.go
+++ b/test/support/application.go
@@ -10,6 +10,8 @@ import (
 //
 
 type DummyIntegration struct {
+	components   []core.Component
+	triggers     []core.Trigger
 	actions      []core.Action
 	handleAction func(ctx core.IntegrationActionContext) error
 	onSync       func(ctx core.SyncContext) error
@@ -17,6 +19,8 @@ type DummyIntegration struct {
 }
 
 type DummyIntegrationOptions struct {
+	Components   []core.Component
+	Triggers     []core.Trigger
 	Actions      []core.Action
 	HandleAction func(ctx core.IntegrationActionContext) error
 	OnSync       func(ctx core.SyncContext) error
@@ -25,6 +29,8 @@ type DummyIntegrationOptions struct {
 
 func NewDummyIntegration(options DummyIntegrationOptions) *DummyIntegration {
 	return &DummyIntegration{
+		components:   options.Components,
+		triggers:     options.Triggers,
 		actions:      options.Actions,
 		handleAction: options.HandleAction,
 		onSync:       options.OnSync,
@@ -57,11 +63,11 @@ func (t *DummyIntegration) Configuration() []configuration.Field {
 }
 
 func (t *DummyIntegration) Components() []core.Component {
-	return []core.Component{}
+	return t.components
 }
 
 func (t *DummyIntegration) Triggers() []core.Trigger {
-	return []core.Trigger{}
+	return t.triggers
 }
 
 func (t *DummyIntegration) Actions() []core.Action {
@@ -94,6 +100,83 @@ func (t *DummyIntegration) ListResources(resourceType string, ctx core.ListResou
 }
 
 func (t *DummyIntegration) HandleRequest(ctx core.HTTPRequestContext) {
+}
+
+type DummyIntegrationTriggerOptions struct {
+	Name                 string
+	OnIntegrationMessage func(ctx core.IntegrationMessageContext) error
+}
+
+type DummyIntegrationTrigger struct {
+	name                 string
+	onIntegrationMessage func(ctx core.IntegrationMessageContext) error
+}
+
+func NewDummyIntegrationTrigger(options DummyIntegrationTriggerOptions) *DummyIntegrationTrigger {
+	return &DummyIntegrationTrigger{
+		name:                 options.Name,
+		onIntegrationMessage: options.OnIntegrationMessage,
+	}
+}
+
+func (t *DummyIntegrationTrigger) Name() string {
+	return t.name
+}
+
+func (t *DummyIntegrationTrigger) Label() string {
+	return t.name
+}
+
+func (t *DummyIntegrationTrigger) Description() string {
+	return t.name
+}
+
+func (t *DummyIntegrationTrigger) Documentation() string {
+	return t.name
+}
+
+func (t *DummyIntegrationTrigger) Icon() string {
+	return "dummy"
+}
+
+func (t *DummyIntegrationTrigger) Color() string {
+	return "dummy"
+}
+
+func (t *DummyIntegrationTrigger) ExampleData() map[string]any {
+	return map[string]any{}
+}
+
+func (t *DummyIntegrationTrigger) Configuration() []configuration.Field {
+	return []configuration.Field{}
+}
+
+func (t *DummyIntegrationTrigger) HandleWebhook(ctx core.WebhookRequestContext) (int, error) {
+	return 200, nil
+}
+
+func (t *DummyIntegrationTrigger) Setup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *DummyIntegrationTrigger) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (t *DummyIntegrationTrigger) HandleAction(ctx core.TriggerActionContext) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+func (t *DummyIntegrationTrigger) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *DummyIntegrationTrigger) OnIntegrationMessage(ctx core.IntegrationMessageContext) error {
+	if t.onIntegrationMessage == nil {
+		return nil
+	}
+
+	return t.onIntegrationMessage(ctx)
 }
 
 type DummyWebhookHandlerOptions struct {


### PR DESCRIPTION
Fixes issue introduced in https://github.com/superplanehq/superplane/pull/3419, where events emitted in OnIntegrationMessage() are not propagating through RabbitMQ