### PR TITLE
fix: fix empty payload on dash0 getHTTPSyntheticCheck

### DIFF
--- a/docs/components/Dash0.mdx
+++ b/docs/components/Dash0.mdx
@@ -396,6 +396,7 @@ The Get HTTP Synthetic Check component retrieves the full configuration and oper
 ### Output Channels
 
 - **Healthy**: The check is passing — the most recent run outcome is "Healthy"
+- **Degraded**: The check is degraded — the most recent run outcome is "Degraded"
 - **Critical**: The check is failing — the most recent run outcome is "Critical"
 
 ### Output

--- a/pkg/integrations/dash0/get_http_synthetic_check.go
+++ b/pkg/integrations/dash0/get_http_synthetic_check.go
@@ -15,13 +15,13 @@ import (
 type GetHTTPSyntheticCheck struct{}
 
 type GetHTTPSyntheticCheckSpec struct {
-	CheckID string `mapstructure:"checkId"`
-	Dataset string `mapstructure:"dataset"`
+	SyntheticCheck string `mapstructure:"syntheticCheck"`
+	Dataset        string `mapstructure:"dataset"`
 }
 
 type GetHTTPSyntheticCheckNodeMetadata struct {
-	CheckName string `json:"checkName" mapstructure:"checkName"`
-	CheckID   string `json:"checkId" mapstructure:"checkId"`
+	CheckName      string `json:"checkName" mapstructure:"checkName"`
+	SyntheticCheck string `json:"syntheticCheck" mapstructure:"syntheticCheck"`
 }
 
 func (c *GetHTTPSyntheticCheck) Name() string {
@@ -53,6 +53,7 @@ func (c *GetHTTPSyntheticCheck) Documentation() string {
 ## Output Channels
 
 - **Healthy**: The check is passing — the most recent run outcome is "Healthy"
+- **Degraded**: The check is degraded — the most recent run outcome is "Degraded"
 - **Critical**: The check is failing — the most recent run outcome is "Critical"
 
 ## Output
@@ -90,6 +91,7 @@ const ChannelNameHealthy = "healthy"
 func (c *GetHTTPSyntheticCheck) OutputChannels(configuration any) []core.OutputChannel {
 	return []core.OutputChannel{
 		{Name: ChannelNameHealthy, Label: "Healthy", Description: "The check is passing"},
+		{Name: ChannelNameDegraded, Label: "Degraded", Description: "The check is degraded"},
 		{Name: ChannelNameCritical, Label: "Critical", Description: "The check is failing"},
 	}
 }
@@ -97,8 +99,8 @@ func (c *GetHTTPSyntheticCheck) OutputChannels(configuration any) []core.OutputC
 func (c *GetHTTPSyntheticCheck) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "checkId",
-			Label:       "Check ID",
+			Name:        "syntheticCheck",
+			Label:       "Synthetic Check",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
 			Description: "The synthetic check to retrieve",
@@ -126,8 +128,8 @@ func (c *GetHTTPSyntheticCheck) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if strings.TrimSpace(spec.CheckID) == "" {
-		return errors.New("checkId is required")
+	if strings.TrimSpace(spec.SyntheticCheck) == "" {
+		return errors.New("syntheticCheck is required")
 	}
 	if strings.TrimSpace(spec.Dataset) == "" {
 		return errors.New("dataset is required")
@@ -139,7 +141,7 @@ func (c *GetHTTPSyntheticCheck) Setup(ctx core.SetupContext) error {
 	if err != nil {
 		return fmt.Errorf("error decoding metadata: %v", err)
 	}
-	if nodeMetadata.CheckName != "" && nodeMetadata.CheckID == spec.CheckID {
+	if nodeMetadata.CheckName != "" && nodeMetadata.SyntheticCheck == spec.SyntheticCheck {
 		return nil
 	}
 
@@ -148,7 +150,7 @@ func (c *GetHTTPSyntheticCheck) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error creating client during setup: %v", err)
 	}
 
-	checkConfig, err := client.GetSyntheticCheck(spec.CheckID, spec.Dataset)
+	checkConfig, err := client.GetSyntheticCheck(spec.SyntheticCheck, spec.Dataset)
 	if err != nil {
 		return fmt.Errorf("failed to get synthetic check during setup: %v", err)
 	}
@@ -159,8 +161,8 @@ func (c *GetHTTPSyntheticCheck) Setup(ctx core.SetupContext) error {
 	}
 
 	return ctx.Metadata.Set(GetHTTPSyntheticCheckNodeMetadata{
-		CheckName: checkName,
-		CheckID:   spec.CheckID,
+		CheckName:      checkName,
+		SyntheticCheck: spec.SyntheticCheck,
 	})
 }
 
@@ -182,13 +184,13 @@ func (c *GetHTTPSyntheticCheck) Execute(ctx core.ExecutionContext) error {
 	}
 
 	// Fetch the check configuration from the Dash0 API.
-	checkConfig, err := client.GetSyntheticCheck(spec.CheckID, dataset)
+	checkConfig, err := client.GetSyntheticCheck(spec.SyntheticCheck, dataset)
 	if err != nil {
 		return fmt.Errorf("failed to get synthetic check: %v", err)
 	}
 
 	// Fetch operational metrics from Prometheus (best-effort).
-	metrics := FetchSyntheticCheckMetrics(ctx, client, dataset, spec.CheckID)
+	metrics := FetchSyntheticCheckMetrics(ctx, client, dataset, spec.SyntheticCheck)
 
 	// Determine the output channel from the last run outcome.
 	channel := outcomeToChannel(metrics.LastOutcome)
@@ -211,6 +213,8 @@ func outcomeToChannel(outcome string) string {
 	switch outcome {
 	case "Healthy":
 		return ChannelNameHealthy
+	case "Degraded":
+		return ChannelNameDegraded
 	case "Critical":
 		return ChannelNameCritical
 	default:

--- a/pkg/integrations/dash0/get_http_synthetic_check_test.go
+++ b/pkg/integrations/dash0/get_http_synthetic_check_test.go
@@ -15,41 +15,41 @@ import (
 func Test__GetHTTPSyntheticCheck__Setup(t *testing.T) {
 	component := GetHTTPSyntheticCheck{}
 
-	t.Run("checkId is required", func(t *testing.T) {
+	t.Run("syntheticCheck is required", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
 			Metadata:      &contexts.MetadataContext{},
 			Configuration: map[string]any{},
 		})
 
-		require.ErrorContains(t, err, "checkId is required")
+		require.ErrorContains(t, err, "syntheticCheck is required")
 	})
 
-	t.Run("checkId cannot be empty", func(t *testing.T) {
+	t.Run("syntheticCheck cannot be empty", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
 			Metadata:      &contexts.MetadataContext{},
-			Configuration: map[string]any{"checkId": ""},
+			Configuration: map[string]any{"syntheticCheck": ""},
 		})
 
-		require.ErrorContains(t, err, "checkId is required")
+		require.ErrorContains(t, err, "syntheticCheck is required")
 	})
 
-	t.Run("checkId cannot be whitespace", func(t *testing.T) {
+	t.Run("syntheticCheck cannot be whitespace", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
 			Metadata:      &contexts.MetadataContext{},
-			Configuration: map[string]any{"checkId": "   "},
+			Configuration: map[string]any{"syntheticCheck": "   "},
 		})
 
-		require.ErrorContains(t, err, "checkId is required")
+		require.ErrorContains(t, err, "syntheticCheck is required")
 	})
 
 	t.Run("dataset is required", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Integration:   &contexts.IntegrationContext{},
 			Metadata:      &contexts.MetadataContext{},
-			Configuration: map[string]any{"checkId": "64617368-3073-796e-7468-73599f287bf4"},
+			Configuration: map[string]any{"syntheticCheck": "64617368-3073-796e-7468-73599f287bf4"},
 		})
 
 		require.ErrorContains(t, err, "dataset is required")
@@ -65,13 +65,13 @@ func Test__GetHTTPSyntheticCheck__Setup(t *testing.T) {
 			},
 			Metadata: &contexts.MetadataContext{
 				Metadata: map[string]any{
-					"checkName": "Already Set",
-					"checkId":   "64617368-3073-796e-7468-73599f287bf4",
+					"checkName":      "Already Set",
+					"syntheticCheck": "64617368-3073-796e-7468-73599f287bf4",
 				},
 			},
 			Configuration: map[string]any{
-				"checkId": "64617368-3073-796e-7468-73599f287bf4",
-				"dataset": "default",
+				"syntheticCheck": "64617368-3073-796e-7468-73599f287bf4",
+				"dataset":        "default",
 			},
 		})
 
@@ -111,8 +111,8 @@ func Test__GetHTTPSyntheticCheck__Setup(t *testing.T) {
 			},
 			Metadata: metadata,
 			Configuration: map[string]any{
-				"checkId": "64617368-3073-796e-7468-73599f287bf4",
-				"dataset": "production",
+				"syntheticCheck": "64617368-3073-796e-7468-73599f287bf4",
+				"dataset":        "production",
 			},
 		})
 
@@ -366,8 +366,8 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "64617368-3073-796e-7468-73599f287bf4",
-				"dataset": "default",
+				"syntheticCheck": "64617368-3073-796e-7468-73599f287bf4",
+				"dataset":        "default",
 			},
 			HTTP: httpContext,
 			Integration: &contexts.IntegrationContext{
@@ -568,8 +568,8 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "test-check-id",
-				"dataset": "default",
+				"syntheticCheck": "test-check-id",
+				"dataset":        "default",
 			},
 			HTTP: httpContext,
 			Integration: &contexts.IntegrationContext{
@@ -657,7 +657,7 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "test-check-id",
+				"syntheticCheck": "test-check-id",
 				// dataset not provided
 			},
 			HTTP: httpContext,
@@ -688,8 +688,8 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "non-existent-id",
-				"dataset": "default",
+				"syntheticCheck": "non-existent-id",
+				"dataset":        "default",
 			},
 			HTTP: httpContext,
 			Integration: &contexts.IntegrationContext{
@@ -709,8 +709,8 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "test-id",
-				"dataset": "default",
+				"syntheticCheck": "test-id",
+				"dataset":        "default",
 			},
 			HTTP: &contexts.HTTPContext{},
 			Integration: &contexts.IntegrationContext{
@@ -784,8 +784,8 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		execCtx := &contexts.ExecutionStateContext{}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"checkId": "failing-check-id",
-				"dataset": "default",
+				"syntheticCheck": "failing-check-id",
+				"dataset":        "default",
 			},
 			HTTP: httpContext,
 			Integration: &contexts.IntegrationContext{
@@ -801,6 +801,88 @@ func Test__GetHTTPSyntheticCheck__Execute(t *testing.T) {
 		assert.True(t, execCtx.Finished)
 		assert.True(t, execCtx.Passed)
 		assert.Equal(t, ChannelNameCritical, execCtx.Channel)
+		assert.Equal(t, "dash0.syntheticCheck.fetched", execCtx.Type)
+		require.Len(t, execCtx.Payloads, 1)
+	})
+
+	t.Run("emits on degraded channel when outcome is Degraded", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				// GetSyntheticCheck response
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"kind": "Dash0SyntheticCheck",
+							"metadata": {"name": "Degraded Check"},
+							"spec": {
+								"display": {"name": "Degraded Check"},
+								"enabled": true,
+								"labels": {},
+								"notifications": {"channels": [], "onlyCriticalChannels": []},
+								"plugin": {
+									"kind": "http",
+									"spec": {
+										"assertions": {"criticalAssertions": [], "degradedAssertions": []},
+										"request": {"url": "https://slow.example.com", "method": "get"}
+									}
+								},
+								"retries": {"kind": "off", "spec": {}},
+								"schedule": {"interval": "1m", "locations": ["us-east-1"], "strategy": "all_locations"}
+							}
+						}
+					`)),
+				},
+				// 8 scalar metric responses (empty)
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"status": "success", "data": {"resultType": "vector", "result": []}}`))},
+				// lastOutcome - Degraded
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"status": "success",
+							"data": {
+								"resultType": "vector",
+								"result": [
+									{
+										"metric": {"dash0_synthetic_check_outcome": "Degraded"},
+										"value": [1234567890, "1234567890"]
+									}
+								]
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		execCtx := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"syntheticCheck": "degraded-check-id",
+				"dataset":        "default",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken": "token123",
+					"baseURL":  "https://api.us-west-2.aws.dash0.com",
+				},
+			},
+			ExecutionState: execCtx,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execCtx.Finished)
+		assert.True(t, execCtx.Passed)
+		assert.Equal(t, ChannelNameDegraded, execCtx.Channel)
 		assert.Equal(t, "dash0.syntheticCheck.fetched", execCtx.Type)
 		require.Len(t, execCtx.Payloads, 1)
 	})

--- a/pkg/integrations/dash0/synthetic_check_metrics.go
+++ b/pkg/integrations/dash0/synthetic_check_metrics.go
@@ -18,7 +18,7 @@ type SyntheticCheckMetrics struct {
 	CriticalRuns7d  int     `json:"criticalRuns7d"`
 	TotalRuns7d     int     `json:"totalRuns7d"`
 	AvgDuration7d   float64 `json:"avgDuration7dMs"` // Milliseconds
-	LastOutcome     string  `json:"lastOutcome"`     // Most recent run outcome: Healthy or Critical
+	LastOutcome     string  `json:"lastOutcome"`     // Most recent run outcome: Healthy, Degraded, or Critical
 }
 
 // FetchSyntheticCheckMetrics queries the Dash0 Prometheus API for operational metrics
@@ -91,12 +91,12 @@ func FetchSyntheticCheckMetrics(ctx core.ExecutionContext, client *Client, datas
 	}
 
 	// Fetch the most recent run outcome.
-	metrics.LastOutcome = fetchLastSyntheticCheckOutcome(ctx, client, dataset, checkID)
+	metrics.LastOutcome = fetchLastSyntheticCheckOutcome(client, dataset, checkID)
 
 	return metrics
 }
 
-func fetchLastSyntheticCheckOutcome(ctx core.ExecutionContext, client *Client, dataset, checkID string) string {
+func fetchLastSyntheticCheckOutcome(client *Client, dataset, checkID string) string {
 	query := fmt.Sprintf(
 		`topk(1, max by (dash0_synthetic_check_outcome) (timestamp({otel_metric_name="dash0.synthetic_check.runs", dash0_check_id="%s"})))`,
 		checkID,
@@ -112,7 +112,7 @@ func fetchLastSyntheticCheckOutcome(ctx core.ExecutionContext, client *Client, d
 		return ""
 	}
 	outcome := data.Result[0].Metric["dash0_synthetic_check_outcome"]
-	if outcome != "Healthy" && outcome != "Critical" {
+	if outcome != "Healthy" && outcome != "Degraded" && outcome != "Critical" {
 		return ""
 	}
 

--- a/web_src/src/pages/workflowv2/mappers/dash0/get_http_synthetic_check.ts
+++ b/web_src/src/pages/workflowv2/mappers/dash0/get_http_synthetic_check.ts
@@ -24,12 +24,14 @@ import { formatTimeAgo } from "@/utils/date";
 
 // Output channel names matching the backend constants
 const CHANNEL_HEALTHY = "healthy";
+const CHANNEL_DEGRADED = "degraded";
 const CHANNEL_CRITICAL = "critical";
 
 // Type for outputs with channel structure
 type GetHttpSyntheticCheckOutputs = {
   default?: OutputPayload[];
   healthy?: OutputPayload[];
+  degraded?: OutputPayload[];
   critical?: OutputPayload[];
 };
 
@@ -190,7 +192,7 @@ function getFirstPayload(execution: ExecutionInfo): OutputPayload | null {
   const outputs = execution.outputs as GetHttpSyntheticCheckOutputs | undefined;
   if (!outputs) return null;
 
-  for (const channel of [CHANNEL_CRITICAL, CHANNEL_HEALTHY]) {
+  for (const channel of [CHANNEL_CRITICAL, CHANNEL_DEGRADED, CHANNEL_HEALTHY]) {
     const channelOutputs = outputs[channel as keyof GetHttpSyntheticCheckOutputs];
     if (channelOutputs && channelOutputs.length > 0) {
       return channelOutputs[0];
@@ -220,6 +222,7 @@ function getActiveChannel(execution: ExecutionInfo): string | null {
   if (!outputs) return null;
 
   if (outputs.critical && outputs.critical.length > 0) return CHANNEL_CRITICAL;
+  if (outputs.degraded && outputs.degraded.length > 0) return CHANNEL_DEGRADED;
   if (outputs.healthy && outputs.healthy.length > 0) return CHANNEL_HEALTHY;
   if (outputs.default && outputs.default.length > 0) return "default";
 
@@ -235,6 +238,8 @@ function channelLabel(channel: string): string {
   switch (channel) {
     case CHANNEL_CRITICAL:
       return "failing";
+    case CHANNEL_DEGRADED:
+      return "degraded";
     case CHANNEL_HEALTHY:
       return "passing";
     case "":
@@ -253,6 +258,12 @@ export const GET_HTTP_SYNTHETIC_CHECK_STATE_MAP: EventStateMap = {
     textColor: "text-gray-800",
     backgroundColor: "bg-green-100",
     badgeColor: "bg-green-500",
+  },
+  degraded: {
+    icon: "alert-triangle",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-amber-100",
+    badgeColor: "bg-amber-500",
   },
   critical: {
     icon: "circle-x",
@@ -291,6 +302,7 @@ export const getHttpSyntheticCheckStateFunction: StateFunction = (execution: Exe
     const activeChannel = getActiveChannel(execution);
 
     if (activeChannel === CHANNEL_CRITICAL) return "critical";
+    if (activeChannel === CHANNEL_DEGRADED) return "degraded";
     if (activeChannel === CHANNEL_HEALTHY) return "healthy";
     if (activeChannel === "") return "noStatus";
 


### PR DESCRIPTION
Related to: #2906

## What changed:

- Modified the Dash0 Get HTTP Synthetic Check component to emit payloads when no outcome status is available, instead of silently passing
- Added a "degraded" output channel alongside existing "healthy" and "critical" channels
- Updated UI mapper to display "Degraded" state with amber styling when check is degraded

## Why:

- Previously, when Prometheus metrics were unavailable (no outcome data), the component would call Pass() without emitting any payload
- The degraded state is a valid outcome from Dash0 synthetic checks that indicates performance issues without complete failure

## How:
### Backend: 
- Added ChannelNameDegraded to output channels and updated outcomeToChannel() to map "Degraded" outcome
- Updated fetchLastSyntheticCheckOutcome() in synthetic_check_metrics.go to accept "Degraded" as a valid outcome

### Frontend :
- Added CHANNEL_DEGRADED constant and updated output types to include degraded channel
- Added "noStatus" state (gray, alert-circle icon) for empty channel cases
- Added "degraded" state (amber, alert-triangle icon) for degraded checks
- Updated channel detection and label functions to handle both new states
- Modified getExecutionDetails() to always display metric fields marked as "Not Available" when data is missing

## Demo
https://youtu.be/9gAjuDt3Ac4