### PR TITLE
fix: GitHub integration sync race condition  

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -153,6 +153,14 @@ func (g *GitHub) Sync(ctx core.SyncContext) error {
 		return nil
 	}
 
+	//
+	// App has been created but not yet installed - preserve existing state
+	// so the pending installation callback can validate it.
+	//
+	if metadata.GitHubApp.ID != 0 {
+		return nil
+	}
+
 	state, err := crypto.Base64String(32)
 	if err != nil {
 		return fmt.Errorf("Failed to generate GitHub App state: %v", err)
@@ -340,13 +348,16 @@ func (g *GitHub) afterAppCreation(ctx core.HTTPRequestContext, metadata Metadata
 	}
 
 	//
-	// Save installation metadata
+	// Save installation metadata.
+	// Preserve the state from the redirect so afterAppInstallation can validate it,
+	// even if Sync regenerated a different state while the user was on GitHub.
 	//
 	metadata.GitHubApp = GitHubAppMetadata{
 		ID:       appData.ID,
 		Slug:     appData.Slug,
 		ClientID: appData.ClientID,
 	}
+	metadata.State = state
 
 	ctx.Integration.SetMetadata(metadata)
 

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -12,6 +12,21 @@ import (
 func Test__GitHub__Setup(t *testing.T) {
 	g := &GitHub{}
 
+	t.Run("app created but not yet installed", func(t *testing.T) {
+		existingMetadata := Metadata{
+			State:     "some-state",
+			GitHubApp: GitHubAppMetadata{ID: 99},
+		}
+		integrationCtx := &contexts.IntegrationContext{Metadata: existingMetadata}
+		require.NoError(t, g.Sync(core.SyncContext{Integration: integrationCtx}))
+
+		//
+		// State is preserved - no new browser action or state generated
+		//
+		assert.Nil(t, integrationCtx.BrowserAction)
+		assert.Equal(t, existingMetadata, integrationCtx.Metadata)
+	})
+
 	t.Run("personal scope", func(t *testing.T) {
 		integrationCtx := &contexts.IntegrationContext{}
 		require.NoError(t, g.Sync(core.SyncContext{Integration: integrationCtx}))


### PR DESCRIPTION
Issue: When a GitHub App is created but not yet installed, the Sync worker runs on an interval and regenerates the OAuth state (since GitHubApp.ID is still 0 at that point in the original code). This causes the state stored in metadata to diverge from the state the user's browser is carrying through the OAuth flow, resulting in "invalid installation ID or state" on the setup callback.

Fix:
- Early-return in Sync when GitHubApp.ID != 0 — prevents state regeneration after app creation
- In afterAppCreation, explicitly write metadata.State = state from the redirect query param before saving — ensures the stored state always matches the one flowing through the OAuth redirect, even if Sync ran between the browser action being rendered and the user submitting the form.