### PR TITLE
chore: readd previous save undo buttons when versioning is off

### DIFF
--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -217,35 +217,6 @@ export function Header({
       />
     </div>
   ) : null;
-  const autoSaveToggle = onToggleAutoSave
-    ? wrapWithTooltip(
-        autoSaveDisabled,
-        autoSaveDisabledTooltip,
-        <div className="flex items-center gap-2">
-          <label
-            htmlFor="auto-save-toggle"
-            className={`text-sm hidden sm:inline ${autoSaveDisabled ? "text-gray-400" : "text-gray-800"}`}
-          >
-            Auto-save
-          </label>
-          <Switch
-            id="auto-save-toggle"
-            checked={isAutoSaveEnabled}
-            onCheckedChange={
-              isVersioningDisabledMode
-                ? onToggleAutoSave
-                : (checked) => {
-                    if (checked) {
-                      onSave?.();
-                    }
-                    onToggleAutoSave?.();
-                  }
-            }
-            disabled={autoSaveDisabled}
-          />
-        </div>,
-      )
-    : null;
 
   return (
     <>
@@ -477,7 +448,35 @@ export function Header({
                     {unsavedMessage}
                   </span>
                 ) : null}
-                {!isVersioningDisabledMode ? autoSaveToggle : null}
+                {onToggleAutoSave
+                  ? wrapWithTooltip(
+                      autoSaveDisabled,
+                      autoSaveDisabledTooltip,
+                      <div className="flex items-center gap-2">
+                        <label
+                          htmlFor="auto-save-toggle"
+                          className={`text-sm hidden sm:inline ${autoSaveDisabled ? "text-gray-400" : "text-gray-800"}`}
+                        >
+                          Auto-save
+                        </label>
+                        <Switch
+                          id="auto-save-toggle"
+                          checked={isAutoSaveEnabled}
+                          onCheckedChange={
+                            isVersioningDisabledMode
+                              ? onToggleAutoSave
+                              : (checked) => {
+                                  if (checked) {
+                                    onSave?.();
+                                  }
+                                  onToggleAutoSave?.();
+                                }
+                          }
+                          disabled={autoSaveDisabled}
+                        />
+                      </div>,
+                    )
+                  : null}
                 {onUndo && canUndo ? (
                   <Button onClick={onUndo} size="sm" variant="outline">
                     <Undo2 />
@@ -499,7 +498,6 @@ export function Header({
                       </Button>,
                     )
                   : null}
-                {isVersioningDisabledMode ? autoSaveToggle : null}
               </>
             ) : null}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore plain Save/Undo header buttons when versioning is off to revert to the prior UI for non-versioned canvases.

<div><a href="https://cursor.com/agents/bc-20102c21-062a-45f0-8779-079eb1c46621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20102c21-062a-45f0-8779-079eb1c46621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->