### PR TITLE
fix: Auto-layout multi select

### DIFF
--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -32,7 +32,7 @@ import { ZoomSlider } from "@/components/zoom-slider";
 import { NodeSearch } from "@/components/node-search";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent } from "react";
 
 import {
   ConfigurationField,
@@ -1783,6 +1783,11 @@ function CanvasContent({
   const [isSelecting, setIsSelecting] = useState(false);
   const previouslySelectedRef = useRef<Set<string>>(new Set());
 
+  const stopCanvasPointerEvent = useCallback((event: SyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
   useOnSelectionChange({
     onChange: useCallback(({ nodes }: { nodes: ReactFlowNode[] }) => {
       setMultiSelectedNodes(nodes.length >= 2 ? nodes : []);
@@ -2674,6 +2679,8 @@ function CanvasContent({
                   >
                     <div
                       className="nodrag nopan flex items-center gap-2"
+                      onPointerDown={stopCanvasPointerEvent}
+                      onMouseDown={stopCanvasPointerEvent}
                       style={{
                         transform: `scale(${1 / zoom})`,
                         transformOrigin: "bottom right",
@@ -2684,6 +2691,8 @@ function CanvasContent({
                         <button
                           type="button"
                           data-testid="multi-select-auto-layout"
+                          onPointerDown={stopCanvasPointerEvent}
+                          onMouseDown={stopCanvasPointerEvent}
                           onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();
@@ -2698,6 +2707,8 @@ function CanvasContent({
                         <button
                           type="button"
                           data-testid="multi-select-duplicate"
+                          onPointerDown={stopCanvasPointerEvent}
+                          onMouseDown={stopCanvasPointerEvent}
                           onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();
@@ -2712,6 +2723,8 @@ function CanvasContent({
                         <button
                           type="button"
                           data-testid="multi-select-delete"
+                          onPointerDown={stopCanvasPointerEvent}
+                          onMouseDown={stopCanvasPointerEvent}
                           onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix multi-select auto-layout clicks by preventing toolbar events from clearing selection.

ReactFlow's `onPaneClick` was firing on `pointer-down` and clearing the selection before the multi-select toolbar's click could trigger the auto-layout action. This fix adds `onPointerDown`/`onMouseDown` handlers to the toolbar to prevent this behavior.

<div><a href="https://cursor.com/agents/bc-e1921a4e-c031-438d-8fb1-b3c49aead47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1921a4e-c031-438d-8fb1-b3c49aead47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->