### PR TITLE
Organization 404 error

### DIFF
--- a/web_src/src/contexts/PermissionsContext.tsx
+++ b/web_src/src/contexts/PermissionsContext.tsx
@@ -31,10 +31,11 @@ interface PermissionsProviderProps {
 
 export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ children }) => {
   const organizationId = useOrganizationId();
-  const { data: me, isLoading: meLoading } = useMe();
+  const { data: me, isLoading: meLoading, isFetching: meFetching } = useMe();
 
   const userId = me?.id;
 
+  const permissionsQueryEnabled = !!organizationId && !!userId;
   const permissionsQuery = useQuery({
     queryKey: ["permissions", organizationId, userId],
     queryFn: async () => {
@@ -46,7 +47,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
       );
       return response.data?.permissions || [];
     },
-    enabled: !!organizationId && !!userId,
+    enabled: permissionsQueryEnabled,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
   });
@@ -74,7 +75,14 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     [permissionSet],
   );
 
-  const isLoading = meLoading || permissionsQuery.isLoading;
+  // Consider loading if:
+  // 1. organizationId is not yet available (waiting for route params)
+  // 2. me query is loading or fetching
+  // 3. permissions query is loading or fetching
+  // When queries are disabled (enabled=false), isLoading/isFetching are false,
+  // so we need to explicitly check if organizationId is available.
+  const isLoading =
+    !organizationId || meLoading || meFetching || permissionsQuery.isLoading || permissionsQuery.isFetching;
 
   return (
     <PermissionsContext.Provider value={{ permissions, isLoading, canAct }}>{children}</PermissionsContext.Provider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes a 404 error when opening an organization from the home page.

Addresses a race condition in `PermissionsContext` where `isLoading` was incorrectly `false` when `organizationId` was not yet available, leading to `NotFoundPage` being shown prematurely. The fix updates the `isLoading` calculation to account for the `organizationId` being unavailable and for queries being in a fetching state.

<div><a href="https://cursor.com/agents/bc-c774d335-0c6b-42f8-98d8-78d4fd714c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c774d335-0c6b-42f8-98d8-78d4fd714c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->