### PR TITLE
feat: add SSH key as ResourceType for DigitalOcean droplet creation

### DIFF
--- a/docs/components/DigitalOcean.mdx
+++ b/docs/components/DigitalOcean.mdx
@@ -164,7 +164,7 @@ The Create Droplet component creates a new droplet in DigitalOcean.
 - **Region**: Region slug where the droplet will be created (required)
 - **Size**: Size slug for the droplet (required)
 - **Image**: Image slug or ID for the droplet OS (required)
-- **SSH Keys**: SSH key fingerprints or IDs to add to the droplet (optional)
+- **SSH Keys**: SSH keys to add to the droplet. Must have been added to the DigitalOcean team. (optional)
 - **Tags**: Tags to apply to the droplet (optional)
 - **User Data**: Cloud-init user data script (optional)
 

--- a/pkg/integrations/digitalocean/client.go
+++ b/pkg/integrations/digitalocean/client.go
@@ -155,6 +155,32 @@ func (c *Client) ListSizes() ([]Size, error) {
 	return response.Sizes, nil
 }
 
+// SSHKey represents a DigitalOcean SSH key
+type SSHKey struct {
+	ID          int    `json:"id"`
+	Fingerprint string `json:"fingerprint"`
+	Name        string `json:"name"`
+}
+
+// ListSSHKeys retrieves all SSH keys on the account
+func (c *Client) ListSSHKeys() ([]SSHKey, error) {
+	url := fmt.Sprintf("%s/account/keys?per_page=200", c.BaseURL)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		SSHKeys []SSHKey `json:"ssh_keys"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return response.SSHKeys, nil
+}
+
 // Image represents a DigitalOcean image
 type Image struct {
 	ID           int    `json:"id"`

--- a/pkg/integrations/digitalocean/create_droplet.go
+++ b/pkg/integrations/digitalocean/create_droplet.go
@@ -56,7 +56,7 @@ func (c *CreateDroplet) Documentation() string {
 - **Region**: Region slug where the droplet will be created (required)
 - **Size**: Size slug for the droplet (required)
 - **Image**: Image slug or ID for the droplet OS (required)
-- **SSH Keys**: SSH key fingerprints or IDs to add to the droplet (optional)
+- **SSH Keys**: SSH keys to add to the droplet. Must have been added to the DigitalOcean team. (optional)
 - **Tags**: Tags to apply to the droplet (optional)
 - **User Data**: Cloud-init user data script (optional)
 
@@ -133,16 +133,15 @@ func (c *CreateDroplet) Configuration() []configuration.Field {
 		{
 			Name:        "sshKeys",
 			Label:       "SSH Keys",
-			Type:        configuration.FieldTypeList,
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
 			Togglable:   true,
-			Description: "SSH key fingerprints or IDs to add to the droplet",
+			Description: "SSH keys to add to the droplet",
+			Placeholder: "Select SSH keys",
 			TypeOptions: &configuration.TypeOptions{
-				List: &configuration.ListTypeOptions{
-					ItemLabel: "SSH Key",
-					ItemDefinition: &configuration.ListItemDefinition{
-						Type: configuration.FieldTypeString,
-					},
+				Resource: &configuration.ResourceTypeOptions{
+					Type:  "ssh_key",
+					Multi: true,
 				},
 			},
 		},

--- a/pkg/integrations/digitalocean/example_output_create_droplet.json
+++ b/pkg/integrations/digitalocean/example_output_create_droplet.json
@@ -7,7 +7,11 @@
     "disk": 25,
     "status": "new",
     "region": { "name": "New York 3", "slug": "nyc3" },
-    "image": { "id": 12345, "name": "Ubuntu 24.04 (LTS) x64", "slug": "ubuntu-24-04-x64" },
+    "image": {
+      "id": 12345,
+      "name": "Ubuntu 24.04 (LTS) x64",
+      "slug": "ubuntu-24-04-x64"
+    },
     "size_slug": "s-1vcpu-1gb",
     "networks": {
       "v4": [{ "ip_address": "104.131.186.241", "type": "public" }]

--- a/pkg/integrations/digitalocean/list_resources.go
+++ b/pkg/integrations/digitalocean/list_resources.go
@@ -26,6 +26,8 @@ func (d *DigitalOcean) ListResources(resourceType string, ctx core.ListResources
 		return listLoadBalancers(ctx)
 	case "reserved_ip":
 		return listReservedIPs(ctx)
+	case "ssh_key":
+		return listSSHKeys(ctx)
 	default:
 		return []core.IntegrationResource{}, nil
 	}
@@ -244,6 +246,29 @@ func listReservedIPs(ctx core.ListResourcesContext) ([]core.IntegrationResource,
 			Type: "reserved_ip",
 			Name: ip.IP,
 			ID:   ip.IP,
+		})
+	}
+
+	return resources, nil
+}
+
+func listSSHKeys(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	keys, err := client.ListSSHKeys()
+	if err != nil {
+		return nil, fmt.Errorf("error listing SSH keys: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(keys))
+	for _, key := range keys {
+		resources = append(resources, core.IntegrationResource{
+			Type: "ssh_key",
+			Name: key.Name,
+			ID:   key.Fingerprint,
 		})
 	}
 


### PR DESCRIPTION
Implements: #3486

## What changed:

The sshKeys field in the Create Droplet component has been changed from a plain free-text list to an integration resource multi-select picker.

## Why:

The DigitalOcean API requires that SSH keys be attached to the project/account before they can be assigned to a droplet. Letting users type fingerprints or IDs manually was error-prone. Tying the field to the account's actual keys ensures only valid, pre-existing keys can be selected.

## How:

client.go: Added SSHKey struct and ListSSHKeys() method.
list_resources.go: Added a "ssh_key" case to the ListResources switch 

## Demo:
https://www.youtube.com/watch?v=CQquaUt9gbw