### PR TITLE
fix: Adding Azure Integration from canvas modal

### DIFF
--- a/web_src/src/ui/IntegrationCreateDialog/index.tsx
+++ b/web_src/src/ui/IntegrationCreateDialog/index.tsx
@@ -429,10 +429,36 @@ export function IntegrationCreateDialog({
                 </Button>
               ) : (
                 <>
-                  <Button color="blue" onClick={handleClose}>
-                    Save
+                  <Button
+                    color="blue"
+                    disabled={updateIntegrationMutation.isPending}
+                    onClick={async () => {
+                      if (createdIntegrationId) {
+                        try {
+                          await updateIntegrationMutation.mutateAsync({
+                            configuration: { ...configuration },
+                          });
+                          await queryClient.invalidateQueries({
+                            queryKey: integrationKeys.connected(organizationId),
+                          });
+                        } catch {
+                          // Resync is best-effort
+                        }
+                        onCreated?.(createdIntegrationId);
+                      }
+                      handleClose();
+                    }}
+                  >
+                    {updateIntegrationMutation.isPending ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      "Save"
+                    )}
                   </Button>
-                  <Button variant="outline" onClick={handleClose}>
+                  <Button variant="outline" onClick={handleClose} disabled={updateIntegrationMutation.isPending}>
                     Cancel
                   </Button>
                 </>


### PR DESCRIPTION
Bug: when one goes to the Azure Integration page, everything works fine.
But when the Integration is being added from the canvas (via the modal), the second step instead of activating "sync" and moving the integration to READY, it was just closing the modal