### PR TITLE
feat: add `--draft` flag to canvas `get` for versioned canvases

### DIFF
--- a/pkg/cli/commands/canvases/get.go
+++ b/pkg/cli/commands/canvases/get.go
@@ -3,6 +3,8 @@ package canvases
 import (
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/cli/commands/canvases/models"
@@ -10,7 +12,9 @@ import (
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
-type getCommand struct{}
+type getCommand struct {
+	draft *bool
+}
 
 func (c *getCommand) Execute(ctx core.CommandContext) error {
 	canvasID, err := findCanvasID(ctx, ctx.API, ctx.Args[0])
@@ -22,8 +26,43 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 	if err != nil {
 		return err
 	}
+	if response.Canvas == nil {
+		return fmt.Errorf("canvas %q not found", canvasID)
+	}
 
-	resource := models.CanvasResourceFromCanvas(*response.Canvas)
+	canvas := *response.Canvas
+	if c.draft != nil && *c.draft {
+		if canvas.Metadata == nil || !canvas.Metadata.GetCanvasVersioningEnabled() {
+			return fmt.Errorf("--draft cannot be used when effective canvas versioning is disabled; remove --draft to get the live canvas directly")
+		}
+
+		me, _, err := ctx.API.MeAPI.MeMe(ctx.Context).Execute()
+		if err != nil {
+			return err
+		}
+		currentUserID := strings.TrimSpace(me.GetId())
+		if currentUserID == "" {
+			return fmt.Errorf("current user id not found")
+		}
+
+		versionID, err := findOwnedDraftVersionID(ctx, canvasID, currentUserID)
+		if err != nil {
+			return err
+		}
+		if versionID == "" {
+			return fmt.Errorf("draft version not found for current user")
+		}
+
+		version, err := describeCanvasVersionByID(ctx, canvasID, versionID)
+		if err != nil {
+			return err
+		}
+		if version.Spec != nil {
+			canvas.SetSpec(*version.Spec)
+		}
+	}
+
+	resource := models.CanvasResourceFromCanvas(canvas)
 	if !ctx.Renderer.IsText() {
 		return ctx.Renderer.Render(resource)
 	}
@@ -35,6 +74,60 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 		_, err := fmt.Fprintf(stdout, "Edges: %d\n", len(resource.Spec.GetEdges()))
 		return err
 	})
+}
+
+func findOwnedDraftVersionID(ctx core.CommandContext, canvasID string, userID string) (string, error) {
+	trimmedUserID := strings.TrimSpace(userID)
+	if trimmedUserID == "" {
+		return "", nil
+	}
+
+	var before *time.Time
+	for {
+		req := ctx.API.CanvasVersionAPI.
+			CanvasesListCanvasVersions(ctx.Context, canvasID).
+			Limit(50)
+		if before != nil {
+			req = req.Before(*before)
+		}
+
+		response, _, err := req.Execute()
+		if err != nil {
+			return "", err
+		}
+
+		for _, version := range response.GetVersions() {
+			metadata := version.GetMetadata()
+			if metadata.GetIsPublished() {
+				continue
+			}
+
+			ownerID := ""
+			if metadata.Owner != nil {
+				ownerID = strings.TrimSpace(metadata.Owner.GetId())
+			}
+			if ownerID == "" || !strings.EqualFold(ownerID, trimmedUserID) {
+				continue
+			}
+
+			versionID := strings.TrimSpace(metadata.GetId())
+			if versionID == "" {
+				continue
+			}
+
+			return versionID, nil
+		}
+
+		if !response.GetHasNextPage() {
+			return "", nil
+		}
+
+		last, ok := response.GetLastTimestampOk()
+		if !ok || last == nil {
+			return "", nil
+		}
+		before = last
+	}
 }
 
 func findCanvasID(ctx core.CommandContext, client *openapi_client.APIClient, nameOrID string) (string, error) {

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -25,7 +25,9 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Get a canvas",
 		Args:  cobra.ExactArgs(1),
 	}
-	core.Bind(getCmd, &getCommand{}, options)
+	var getDraft bool
+	getCmd.Flags().BoolVar(&getDraft, "draft", false, "get your draft version (only available when effective canvas versioning is enabled)")
+	core.Bind(getCmd, &getCommand{draft: &getDraft}, options)
 
 	activeCmd := &cobra.Command{
 		Use:   "active [canvas-id]",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Summary

Adds a `--draft` flag to `superplane canvases get` that returns **your draft** (an unpublished canvas version owned by the current user), matching the web UI behavior.

## Changes

- CLI: `superplane canvases get --draft <name-or-id>`
  - Verifies effective canvas versioning is enabled.
  - Finds the latest **unpublished** version where `version.metadata.owner.id` matches the current user.
  - Fetches it via `DescribeCanvasVersion` and renders it as the canvas spec.

## Notes

- No backend/proto changes. Draft retrieval uses existing canvas versions APIs.

## Tests

- Ran `go test ./pkg/cli/commands/canvases/...`.


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddc9744f-d1e6-440c-bbd7-964f0cd90660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddc9744f-d1e6-440c-bbd7-964f0cd90660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

