### PR TITLE
feat: Expand available tools in the Agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ dev.logs.app:
 dev.logs.otel:
 	$(COMPOSE) logs -f otel
 
+dev.logs.agent:
+	$(COMPOSE) logs -f agent
+
 dev.down:
 	$(COMPOSE) down --remove-orphans
 

--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -12,6 +12,7 @@ from ai.superplane_client import SuperplaneClient
 @dataclass
 class AgentDeps:
     client: SuperplaneClient
+    canvas_id: str
     canvas_cache: dict[str, CanvasSummary] = field(default_factory=dict)
 
 
@@ -41,14 +42,15 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
     )
 
     @agent.tool
-    def get_canvas(ctx: RunContext[AgentDeps], canvas_id: str) -> CanvasSummary:
-        """Fetch a canvas summary (nodes/edges) by canvas ID."""
-        cached_summary = ctx.deps.canvas_cache.get(canvas_id)
+    def get_canvas(ctx: RunContext[AgentDeps]) -> CanvasSummary:
+        """Fetch the current request canvas summary (nodes/edges)."""
+        resolved_canvas_id = ctx.deps.canvas_id
+        cached_summary = ctx.deps.canvas_cache.get(resolved_canvas_id)
         if cached_summary is not None:
             return cached_summary
 
-        summary = ctx.deps.client.describe_canvas(canvas_id)
-        ctx.deps.canvas_cache[canvas_id] = summary
+        summary = ctx.deps.client.describe_canvas(resolved_canvas_id)
+        ctx.deps.canvas_cache[resolved_canvas_id] = summary
         return summary
 
     @agent.tool

--- a/agent/src/ai/repl_web.py
+++ b/agent/src/ai/repl_web.py
@@ -112,6 +112,14 @@ def _to_jsonable(value: Any) -> Any:
 
 def _build_deps(payload: ReplStreamRequest) -> AgentDeps:
     if payload.canvas_id is None:
+        _debug_log(
+            "missing canvas_id in payload",
+            model=payload.model,
+            org_id=payload.org_id,
+            has_base_url=bool(_normalize_optional(payload.base_url)),
+            has_token=bool(_normalize_optional(payload.token)),
+            question_preview=payload.question[:120],
+        )
         raise ValueError("canvas_id is required for non-test models.")
 
     base_url = _resolve_required(payload.base_url, "SUPERPLANE_BASE_URL")
@@ -134,11 +142,19 @@ def _build_deps(payload: ReplStreamRequest) -> AgentDeps:
     )
     return AgentDeps(
         client=client,
+        canvas_id=payload.canvas_id,
     )
 
 
 async def _stream_agent_run(payload: ReplStreamRequest) -> AsyncIterator[dict[str, Any]]:
     started_at = time.perf_counter()
+    _debug_log(
+        "starting agent run",
+        model=payload.model,
+        canvas_id=payload.canvas_id,
+        org_id=payload.org_id,
+        question_preview=payload.question[:120],
+    )
     yield {
         "type": "run_started",
         "model": payload.model,
@@ -146,6 +162,7 @@ async def _stream_agent_run(payload: ReplStreamRequest) -> AsyncIterator[dict[st
     }
 
     if payload.model == "test":
+        _debug_log("using test model run path", canvas_id=payload.canvas_id)
         test_agent: Agent[None, str] = Agent(model=TestModel(), output_type=str)
         async for event in test_agent.run_stream_events(user_prompt=payload.question):
             if isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
@@ -173,6 +190,12 @@ async def _stream_agent_run(payload: ReplStreamRequest) -> AsyncIterator[dict[st
 
     agent = build_agent(model=payload.model)
     deps = _build_deps(payload)
+    _debug_log(
+        "running non-test agent",
+        model=payload.model,
+        canvas_id=payload.canvas_id,
+        org_id=payload.org_id,
+    )
 
     output_tool_call_id: str | None = None
     output_tool_name_hints = {"final_result", "return_canvasanswer", "canvasanswer"}
@@ -358,6 +381,11 @@ def _create_app() -> FastAPI:
         )
 
     return app
+
+
+def create_app() -> FastAPI:
+    """Public app factory for uvicorn --factory usage."""
+    return _create_app()
 
 
 class WebServer:

--- a/agent/src/ai/superplane_client.py
+++ b/agent/src/ai/superplane_client.py
@@ -1,7 +1,19 @@
 import os
+import warnings
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
+
+# Suppress a known pydantic warning emitted by generated OpenAPI models.
+# Keep this narrow to avoid hiding unrelated warnings.
+warnings.filterwarnings(
+    "ignore",
+    message=(
+        r'Field name "validate" in "OrganizationsSetAgentOpenAIKeyBody" '
+        r'shadows an attribute in parent "BaseModel"'
+    ),
+    category=UserWarning,
+)
 
 from ai.models import (
     CanvasEdge,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -117,7 +117,13 @@ services:
       IN_DOCKER: "1"
       SUPERPLANE_BASE_URL: ${SUPERPLANE_BASE_URL:-http://app:8000}
       REPL_WEB_DEBUG: ${REPL_WEB_DEBUG:-true}
-    command: bash -lc "uv run python -m repl.main --server --test-repl-web-host 0.0.0.0 --test-repl-web-port 8090"
+    command: >-
+      bash -lc "uv run uvicorn ai.repl_web:create_app
+      --factory
+      --host 0.0.0.0
+      --port 8090
+      --reload
+      --reload-dir /app/src"
     tty: true
     stdin_open: true
     ports:


### PR DESCRIPTION
New tools:

```
get_canvas — Fetches the current canvas summary (nodes and edges).
list_components — Lists available components, optionally filtered by provider or search query.
describe_component — Describes a specific component, including its configuration fields and output channels.
list_triggers — Lists available triggers, optionally filtered by provider or search query.
describe_trigger — Describes a specific trigger, including its configuration fields and required flags.
list_org_integrations — Lists integrations connected to your organization.
list_integration_resources — Lists selectable resources for a given org integration resource type.
```