### PR TITLE
fix: address Elastic component review findings

### DIFF
--- a/docs/components/Elastic.mdx
+++ b/docs/components/Elastic.mdx
@@ -59,9 +59,9 @@ Kibana substitutes `{{rule.id}}` and `{{rule.name}}` at delivery time. Fields om
 
 ### Filtering
 
-All filter fields are optional. Leave them empty to fire for every incoming alert. When multiple values are provided in a list, any value matching is sufficient (OR). All active filter types must match simultaneously (AND across types).
+Select at least one **Rule**. Additional filter fields are optional. When multiple values are provided in a list, any value matching is sufficient (OR). All active filter types must match simultaneously (AND across types).
 
-**Rule ID** is the most reliable filter because rule names are user-editable. Use it as the primary key when you need precise per-rule routing.
+**Rule ID** is the most reliable selector because rule names are user-editable. Use it when you need precise per-rule routing.
 
 ### Webhook Verification
 

--- a/pkg/integrations/elastic/elastic_test.go
+++ b/pkg/integrations/elastic/elastic_test.go
@@ -1,0 +1,134 @@
+package elastic
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Elastic__Sync__Validation(t *testing.T) {
+	integration := &Elastic{}
+	integrationCtx := &contexts.IntegrationContext{}
+
+	t.Run("missing authType", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"url":       "https://elastic.example.com",
+				"kibanaUrl": "https://kibana.example.com",
+			},
+			Integration: integrationCtx,
+			HTTP:        &contexts.HTTPContext{},
+		})
+		require.ErrorContains(t, err, "authType is required")
+	})
+
+	t.Run("apiKey auth without apiKey", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"url":       "https://elastic.example.com",
+				"kibanaUrl": "https://kibana.example.com",
+				"authType":  "apiKey",
+			},
+			Integration: integrationCtx,
+			HTTP:        &contexts.HTTPContext{},
+		})
+		require.ErrorContains(t, err, "apiKey is required when authType is apiKey")
+	})
+
+	t.Run("basic auth without username", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"url":       "https://elastic.example.com",
+				"kibanaUrl": "https://kibana.example.com",
+				"authType":  "basic",
+				"password":  "secret",
+			},
+			Integration: integrationCtx,
+			HTTP:        &contexts.HTTPContext{},
+		})
+		require.ErrorContains(t, err, "username is required when authType is basic")
+	})
+
+	t.Run("unknown authType", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"url":       "https://elastic.example.com",
+				"kibanaUrl": "https://kibana.example.com",
+				"authType":  "oauth",
+			},
+			Integration: integrationCtx,
+			HTTP:        &contexts.HTTPContext{},
+		})
+		require.ErrorContains(t, err, `unknown authType "oauth"`)
+	})
+}
+
+func Test__Elastic__Sync__Ready(t *testing.T) {
+	integration := &Elastic{}
+
+	t.Run("apiKey auth marks integration ready", func(t *testing.T) {
+		config := map[string]any{
+			"url":       "https://elastic.example.com",
+			"kibanaUrl": "https://kibana.example.com",
+			"authType":  "apiKey",
+			"apiKey":    "test-api-key",
+		}
+
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`[]`))},
+			},
+		}
+		integrationCtx := &contexts.IntegrationContext{Configuration: config}
+
+		err := integration.Sync(core.SyncContext{
+			Configuration: config,
+			Integration:   integrationCtx,
+			HTTP:          httpCtx,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+		require.Len(t, httpCtx.Requests, 2)
+		assert.Equal(t, "ApiKey test-api-key", httpCtx.Requests[0].Header.Get("Authorization"))
+		assert.Equal(t, "https://elastic.example.com/", httpCtx.Requests[0].URL.String())
+		assert.Equal(t, "https://kibana.example.com/api/actions/connectors", httpCtx.Requests[1].URL.String())
+	})
+
+	t.Run("basic auth marks integration ready", func(t *testing.T) {
+		config := map[string]any{
+			"url":       "https://elastic.example.com",
+			"kibanaUrl": "https://kibana.example.com",
+			"authType":  "basic",
+			"username":  "elastic",
+			"password":  "secret",
+		}
+
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`[]`))},
+			},
+		}
+		integrationCtx := &contexts.IntegrationContext{Configuration: config}
+
+		err := integration.Sync(core.SyncContext{
+			Configuration: config,
+			Integration:   integrationCtx,
+			HTTP:          httpCtx,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+		require.Len(t, httpCtx.Requests, 2)
+		user, pass, ok := httpCtx.Requests[0].BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "elastic", user)
+		assert.Equal(t, "secret", pass)
+	})
+}

--- a/pkg/integrations/elastic/index_document.go
+++ b/pkg/integrations/elastic/index_document.go
@@ -3,6 +3,7 @@ package elastic
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -17,6 +18,10 @@ type IndexDocumentConfiguration struct {
 	Index      string         `json:"index" mapstructure:"index"`
 	Document   map[string]any `json:"document" mapstructure:"document"`
 	DocumentID string         `json:"documentId" mapstructure:"documentId"`
+}
+
+type IndexDocumentMetadata struct {
+	Index string `json:"index" mapstructure:"index"`
 }
 
 func (c *IndexDocument) Name() string  { return "elastic.indexDocument" }
@@ -93,12 +98,39 @@ func (c *IndexDocument) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if strings.TrimSpace(config.Index) == "" {
+	config.Index = strings.TrimSpace(config.Index)
+	if config.Index == "" {
 		return fmt.Errorf("index is required")
 	}
 
 	if config.Document == nil {
 		return fmt.Errorf("document is required and must be a JSON object")
+	}
+
+	resolvedIndex := config.Index
+	if !isTemplateExpression(config.Index) {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create Elastic client: %w", err)
+		}
+
+		indices, err := client.ListIndices()
+		if err != nil {
+			return fmt.Errorf("failed to list Elasticsearch indices: %w", err)
+		}
+
+		match := slices.IndexFunc(indices, func(index IndexInfo) bool {
+			return strings.EqualFold(index.Index, config.Index)
+		})
+		if match == -1 {
+			return fmt.Errorf("selected index %q was not found in Elasticsearch", config.Index)
+		}
+
+		resolvedIndex = indices[match].Index
+	}
+
+	if err := ctx.Metadata.Set(IndexDocumentMetadata{Index: resolvedIndex}); err != nil {
+		return fmt.Errorf("failed to set metadata: %w", err)
 	}
 
 	return nil

--- a/pkg/integrations/elastic/index_document_test.go
+++ b/pkg/integrations/elastic/index_document_test.go
@@ -14,6 +14,13 @@ import (
 
 func Test__IndexDocument__Setup(t *testing.T) {
 	c := &IndexDocument{}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"url":      "https://elastic.example.com",
+			"authType": "apiKey",
+			"apiKey":   "test-api-key",
+		},
+	}
 
 	t.Run("missing index -> error", func(t *testing.T) {
 		err := c.Setup(core.SetupContext{
@@ -40,14 +47,48 @@ func Test__IndexDocument__Setup(t *testing.T) {
 	})
 
 	t.Run("valid config -> success", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
 		err := c.Setup(core.SetupContext{
 			Configuration: map[string]any{
 				"index":    "my-index",
 				"document": map[string]any{"key": "value"},
 			},
-			Metadata: &contexts.MetadataContext{},
+			Metadata:    metadataCtx,
+			Integration: integrationCtx,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`[
+							{"index":".kibana"},
+							{"index":"my-index"}
+						]`)),
+					},
+				},
+			},
 		})
 		require.NoError(t, err)
+		assert.Equal(t, IndexDocumentMetadata{Index: "my-index"}, metadataCtx.Metadata)
+	})
+
+	t.Run("unknown index -> error", func(t *testing.T) {
+		err := c.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"index":    "missing-index",
+				"document": map[string]any{"key": "value"},
+			},
+			Metadata:    &contexts.MetadataContext{},
+			Integration: integrationCtx,
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`[{"index":"my-index"}]`)),
+					},
+				},
+			},
+		})
+		require.ErrorContains(t, err, `selected index "missing-index" was not found in Elasticsearch`)
 	})
 }
 

--- a/pkg/integrations/elastic/on_alert.go
+++ b/pkg/integrations/elastic/on_alert.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
@@ -20,6 +21,11 @@ type OnAlertFiresConfiguration struct {
 	Tags       []configuration.Predicate `json:"tags" mapstructure:"tags"`
 	Severities []configuration.Predicate `json:"severities" mapstructure:"severities"`
 	Statuses   []configuration.Predicate `json:"statuses" mapstructure:"statuses"`
+}
+
+type OnAlertFiresMetadata struct {
+	Rules  []string `json:"rules" mapstructure:"rules"`
+	Spaces []string `json:"spaces" mapstructure:"spaces"`
 }
 
 func (t *OnAlertFires) Name() string  { return "elastic.onAlertFires" }
@@ -57,9 +63,9 @@ Kibana substitutes ` + "`{{rule.id}}`" + ` and ` + "`{{rule.name}}`" + ` at deli
 
 ## Filtering
 
-All filter fields are optional. Leave them empty to fire for every incoming alert. When multiple values are provided in a list, any value matching is sufficient (OR). All active filter types must match simultaneously (AND across types).
+Select at least one **Rule**. Additional filter fields are optional. When multiple values are provided in a list, any value matching is sufficient (OR). All active filter types must match simultaneously (AND across types).
 
-**Rule ID** is the most reliable filter because rule names are user-editable. Use it as the primary key when you need precise per-rule routing.
+**Rule ID** is the most reliable selector because rule names are user-editable. Use it when you need precise per-rule routing.
 
 ## Webhook Verification
 
@@ -76,8 +82,8 @@ func (t *OnAlertFires) Configuration() []configuration.Field {
 			Name:        "rules",
 			Label:       "Rules",
 			Type:        configuration.FieldTypeIntegrationResource,
-			Required:    false,
-			Description: "Only fire for alerts from these Kibana alert rules. Leave empty to accept alerts from all rules.",
+			Required:    true,
+			Description: "Only fire for alerts from these Kibana alert rules.",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type:           ResourceTypeKibanaRule,
@@ -139,9 +145,83 @@ func (t *OnAlertFires) Configuration() []configuration.Field {
 }
 
 func (t *OnAlertFires) Setup(ctx core.TriggerContext) error {
+	var config OnAlertFiresConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Rules = normalizeStringList(config.Rules)
+	config.Spaces = normalizeStringList(config.Spaces)
+
+	if len(config.Rules) == 0 {
+		return fmt.Errorf("at least one rule is required")
+	}
+
 	kibanaURL, err := ctx.Integration.GetConfig("kibanaUrl")
 	if err != nil {
 		return fmt.Errorf("failed to get Kibana URL: %w", err)
+	}
+
+	resolvedRules := make([]string, 0, len(config.Rules))
+	resolvedSpaces := make([]string, 0, len(config.Spaces))
+
+	requiresRuleValidation := hasStaticSelection(config.Rules)
+	requiresSpaceValidation := hasStaticSelection(config.Spaces)
+
+	if requiresRuleValidation || requiresSpaceValidation {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create Elastic client: %w", err)
+		}
+
+		var rules []KibanaRule
+		if requiresRuleValidation {
+			rules, err = client.ListKibanaRules()
+			if err != nil {
+				return fmt.Errorf("failed to list Kibana rules: %w", err)
+			}
+		}
+
+		var spaces []KibanaSpace
+		if requiresSpaceValidation {
+			spaces, err = client.ListKibanaSpaces()
+			if err != nil {
+				return fmt.Errorf("failed to list Kibana spaces: %w", err)
+			}
+		}
+
+		for _, selectedRule := range config.Rules {
+			if isTemplateExpression(selectedRule) {
+				resolvedRules = append(resolvedRules, selectedRule)
+				continue
+			}
+
+			ruleName, ok := findRuleName(rules, selectedRule)
+			if !ok {
+				return fmt.Errorf("selected rule %q was not found in Kibana", selectedRule)
+			}
+			resolvedRules = append(resolvedRules, ruleName)
+		}
+
+		for _, selectedSpace := range config.Spaces {
+			if isTemplateExpression(selectedSpace) {
+				resolvedSpaces = append(resolvedSpaces, selectedSpace)
+				continue
+			}
+
+			spaceName, ok := findSpaceName(spaces, selectedSpace)
+			if !ok {
+				return fmt.Errorf("selected space %q was not found in Kibana", selectedSpace)
+			}
+			resolvedSpaces = append(resolvedSpaces, spaceName)
+		}
+	} else {
+		resolvedRules = append(resolvedRules, config.Rules...)
+		resolvedSpaces = append(resolvedSpaces, config.Spaces...)
+	}
+
+	if err := ctx.Metadata.Set(OnAlertFiresMetadata{Rules: resolvedRules, Spaces: resolvedSpaces}); err != nil {
+		return fmt.Errorf("failed to set metadata: %w", err)
 	}
 
 	return ctx.Integration.RequestWebhook(map[string]any{"kibanaUrl": string(kibanaURL)})
@@ -270,12 +350,9 @@ func extractStringSlice(payload map[string]any, key string) []string {
 
 // containsIgnoreCase reports whether value is in list (case-insensitive).
 func containsIgnoreCase(list []string, value string) bool {
-	for _, item := range list {
-		if strings.EqualFold(item, value) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(list, func(item string) bool {
+		return strings.EqualFold(item, value)
+	})
 }
 
 // matchesAnyString reports whether any candidate appears in list (case-insensitive).
@@ -290,4 +367,55 @@ func matchesAnyString(list []string, candidates ...string) bool {
 	}
 
 	return false
+}
+
+func normalizeStringList(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	return normalized
+}
+
+func hasStaticSelection(values []string) bool {
+	return slices.ContainsFunc(values, func(value string) bool {
+		return !isTemplateExpression(value)
+	})
+}
+
+func isTemplateExpression(value string) bool {
+	return strings.Contains(value, "{{") && strings.Contains(value, "}}")
+}
+
+func findRuleName(rules []KibanaRule, selected string) (string, bool) {
+	selected = strings.TrimSpace(selected)
+	match := slices.IndexFunc(rules, func(rule KibanaRule) bool {
+		return strings.EqualFold(strings.TrimSpace(rule.ID), selected) ||
+			strings.EqualFold(strings.TrimSpace(rule.Name), selected)
+	})
+	if match == -1 {
+		return "", false
+	}
+	if strings.TrimSpace(rules[match].Name) == "" {
+		return selected, true
+	}
+	return rules[match].Name, true
+}
+
+func findSpaceName(spaces []KibanaSpace, selected string) (string, bool) {
+	selected = strings.TrimSpace(selected)
+	match := slices.IndexFunc(spaces, func(space KibanaSpace) bool {
+		return strings.EqualFold(strings.TrimSpace(space.ID), selected) ||
+			strings.EqualFold(strings.TrimSpace(space.Name), selected)
+	})
+	if match == -1 {
+		return "", false
+	}
+	if strings.TrimSpace(spaces[match].Name) == "" {
+		return selected, true
+	}
+	return spaces[match].Name, true
 }

--- a/pkg/integrations/elastic/on_alert_test.go
+++ b/pkg/integrations/elastic/on_alert_test.go
@@ -1,7 +1,9 @@
 package elastic
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +15,98 @@ import (
 
 func eq(value string) configuration.Predicate {
 	return configuration.Predicate{Type: configuration.PredicateTypeEquals, Value: value}
+}
+
+func Test__OnAlertFires__Setup(t *testing.T) {
+	trigger := &OnAlertFires{}
+
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"url":       "https://elastic.example.com",
+			"kibanaUrl": "https://kibana.example.com",
+			"authType":  "apiKey",
+			"apiKey":    "api-key",
+		},
+	}
+
+	t.Run("rules are required", func(t *testing.T) {
+		err := trigger.Setup(core.TriggerContext{
+			Configuration: map[string]any{},
+			Integration:   integrationCtx,
+			HTTP:          &contexts.HTTPContext{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "at least one rule is required")
+	})
+
+	t.Run("valid rules and spaces are validated and stored in metadata", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"page": 1,
+						"per_page": 100,
+						"total": 1,
+						"data": [{"id":"rule-123","name":"High error rate"}]
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`[{"id":"default","name":"Default"}]`)),
+				},
+			},
+		}
+		metadataCtx := &contexts.MetadataContext{}
+		testIntegration := &contexts.IntegrationContext{
+			Configuration: integrationCtx.Configuration,
+		}
+
+		err := trigger.Setup(core.TriggerContext{
+			Configuration: map[string]any{
+				"rules":  []string{"High error rate"},
+				"spaces": []string{"default"},
+			},
+			Integration: testIntegration,
+			HTTP:        httpCtx,
+			Metadata:    metadataCtx,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, OnAlertFiresMetadata{
+			Rules:  []string{"High error rate"},
+			Spaces: []string{"Default"},
+		}, metadataCtx.Metadata)
+		require.Len(t, testIntegration.WebhookRequests, 1)
+		assert.Equal(t, map[string]any{
+			"kibanaUrl": "https://kibana.example.com",
+		}, testIntegration.WebhookRequests[0])
+	})
+
+	t.Run("unknown rule returns a validation error", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"page": 1,
+						"per_page": 100,
+						"total": 0,
+						"data": []
+					}`)),
+				},
+			},
+		}
+
+		err := trigger.Setup(core.TriggerContext{
+			Configuration: map[string]any{
+				"rules": []string{"missing-rule"},
+			},
+			Integration: integrationCtx,
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, `selected rule "missing-rule" was not found in Kibana`)
+	})
 }
 
 func Test__OnAlertFires__HandleWebhook(t *testing.T) {

--- a/web_src/src/pages/workflowv2/mappers/elastic/index_document.ts
+++ b/web_src/src/pages/workflowv2/mappers/elastic/index_document.ts
@@ -7,7 +7,6 @@ import {
   ExecutionDetailsContext,
   ExecutionInfo,
   NodeInfo,
-  OutputPayload,
   SubtitleContext,
 } from "../types";
 import { MetadataItem } from "@/ui/metadataList";
@@ -17,6 +16,20 @@ import { formatTimeAgo } from "@/utils/date";
 interface IndexDocumentConfiguration {
   index?: string;
   documentId?: string;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+interface OutputPayloadView {
+  timestamp?: string;
+  data?: unknown;
+}
+
+interface IndexDocumentOutputData {
+  id?: string;
+  index?: string;
+  result?: string;
+  version?: string | number;
 }
 
 export const indexDocumentMapper: ComponentBaseMapper = {
@@ -41,11 +54,11 @@ export const indexDocumentMapper: ComponentBaseMapper = {
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const outputs = context.execution.outputs as { default: OutputPayload[] };
-    if (!outputs?.default?.[0]?.data) {
+    const payload = getFirstOutputPayload(context.execution.outputs);
+    const doc = toIndexDocumentOutputData(payload?.data);
+    if (!doc) {
       return {};
     }
-    const doc = outputs.default[0].data as Record<string, any>;
     return getDetailsForDocument(doc);
   },
 
@@ -57,7 +70,7 @@ export const indexDocumentMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
-  const configuration = node.configuration as IndexDocumentConfiguration | undefined;
+  const configuration = toIndexDocumentConfiguration(node.configuration);
 
   if (configuration?.index) {
     metadata.push({ icon: "database", label: configuration.index });
@@ -87,7 +100,7 @@ function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componen
   ];
 }
 
-function getDetailsForDocument(doc: Record<string, any>): Record<string, string> {
+function getDetailsForDocument(doc: IndexDocumentOutputData): Record<string, string> {
   const details: Record<string, string> = {};
 
   if (doc?.id) {
@@ -107,4 +120,58 @@ function getDetailsForDocument(doc: Record<string, any>): Record<string, string>
   }
 
   return details;
+}
+
+function getFirstOutputPayload(outputs: unknown): OutputPayloadView | undefined {
+  const outputRecord = toUnknownRecord(outputs);
+  if (!outputRecord) return undefined;
+
+  const payload =
+    getOutputPayloadFromChannel(outputRecord.default) ||
+    getOutputPayloadFromChannel(outputRecord.success) ||
+    getOutputPayloadFromChannel(outputRecord.failed);
+
+  if (!payload) return undefined;
+
+  return {
+    timestamp: toOptionalString(payload.timestamp),
+    data: payload.data,
+  };
+}
+
+function getOutputPayloadFromChannel(channel: unknown): UnknownRecord | undefined {
+  if (!Array.isArray(channel) || channel.length === 0) return undefined;
+  return toUnknownRecord(channel[0]);
+}
+
+function toIndexDocumentConfiguration(value: unknown): IndexDocumentConfiguration {
+  const config = toUnknownRecord(value);
+  return {
+    index: toOptionalString(config?.index),
+    documentId: toOptionalString(config?.documentId),
+  };
+}
+
+function toIndexDocumentOutputData(value: unknown): IndexDocumentOutputData | undefined {
+  const payload = toUnknownRecord(value);
+  if (!payload) return undefined;
+
+  const version = payload.version;
+  const parsedVersion = typeof version === "number" || typeof version === "string" ? version : undefined;
+
+  return {
+    id: toOptionalString(payload.id),
+    index: toOptionalString(payload.index),
+    result: toOptionalString(payload.result),
+    version: parsedVersion,
+  };
+}
+
+function toUnknownRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }

--- a/web_src/src/pages/workflowv2/mappers/elastic/on_alert.ts
+++ b/web_src/src/pages/workflowv2/mappers/elastic/on_alert.ts
@@ -5,9 +5,31 @@ import { TriggerProps } from "@/ui/trigger";
 import { MetadataItem } from "@/ui/metadataList";
 import elasticIcon from "@/assets/icons/integrations/elastic.svg";
 
+type UnknownRecord = Record<string, unknown>;
+
+interface ElasticAlertPayload {
+  ruleName?: string;
+  alertName?: string;
+  ruleId?: string;
+  spaceId?: string;
+  status?: string;
+  severity?: string;
+  tags?: string[];
+  name?: string;
+  title?: string;
+}
+
+interface OnAlertConfiguration {
+  rules: string[];
+  spaces: string[];
+  tags: Predicate[];
+  severities: Predicate[];
+  statuses: Predicate[];
+}
+
 export const onAlertFiresTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string } => {
-    const payload = context.event?.data as Record<string, any> | undefined;
+    const payload = toAlertPayload(context.event?.data);
 
     const title = alertTitle(payload);
     const subtitle = context.event?.createdAt ? formatTimeAgo(new Date(context.event.createdAt)) : "";
@@ -16,7 +38,7 @@ export const onAlertFiresTriggerRenderer: TriggerRenderer = {
   },
 
   getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
-    const payload = context.event?.data as Record<string, any> | undefined;
+    const payload = toAlertPayload(context.event?.data);
 
     const details: Record<string, string> = {};
 
@@ -37,11 +59,11 @@ export const onAlertFiresTriggerRenderer: TriggerRenderer = {
 
   getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
     const { node, definition, lastEvent } = context;
-    const config = node.configuration as Record<string, any> | undefined;
+    const config = toOnAlertConfiguration(node.configuration);
     const metadataItems: MetadataItem[] = buildMetadataItems(config);
 
     if (lastEvent) {
-      const payload = lastEvent.data as Record<string, any> | undefined;
+      const payload = toAlertPayload(lastEvent.data);
       const title = alertTitle(payload);
       const subtitle = formatTimeAgo(new Date(lastEvent.createdAt));
 
@@ -78,15 +100,9 @@ function predicateLabel(predicates: Predicate[]): string {
   return predicates.map((p) => (p.type === "equals" ? p.value : `${p.type}: ${p.value}`)).join(", ");
 }
 
-function buildMetadataItems(config: Record<string, any> | undefined): MetadataItem[] {
+function buildMetadataItems(config: OnAlertConfiguration): MetadataItem[] {
   const items: MetadataItem[] = [];
-  if (!config) return items;
-
-  const rules: string[] = Array.isArray(config.rules) ? config.rules : [];
-  const spaces: string[] = Array.isArray(config.spaces) ? config.spaces : [];
-  const tags: Predicate[] = Array.isArray(config.tags) ? config.tags : [];
-  const severities: Predicate[] = Array.isArray(config.severities) ? config.severities : [];
-  const statuses: Predicate[] = Array.isArray(config.statuses) ? config.statuses : [];
+  const { rules, spaces, tags, severities, statuses } = config;
 
   if (rules.length > 0) items.push({ icon: "bell", label: rules.join(", ") });
   if (spaces.length > 0) items.push({ icon: "layers", label: spaces.join(", ") });
@@ -97,8 +113,64 @@ function buildMetadataItems(config: Record<string, any> | undefined): MetadataIt
   return items;
 }
 
-function alertTitle(payload: Record<string, any> | undefined): string {
+function alertTitle(payload: ElasticAlertPayload | undefined): string {
   if (!payload) return "Elastic alert received";
   const baseTitle = payload.ruleName || payload.alertName || payload.name || payload.title || "Elastic alert received";
   return payload.spaceId ? `${baseTitle} · ${payload.spaceId}` : baseTitle;
+}
+
+function toOnAlertConfiguration(value: unknown): OnAlertConfiguration {
+  const config = toUnknownRecord(value);
+  return {
+    rules: toStringList(config?.rules),
+    spaces: toStringList(config?.spaces),
+    tags: toPredicates(config?.tags),
+    severities: toPredicates(config?.severities),
+    statuses: toPredicates(config?.statuses),
+  };
+}
+
+function toAlertPayload(value: unknown): ElasticAlertPayload | undefined {
+  const payload = toUnknownRecord(value);
+  if (!payload) return undefined;
+
+  return {
+    ruleName: toOptionalString(payload.ruleName),
+    alertName: toOptionalString(payload.alertName),
+    ruleId: toOptionalString(payload.ruleId),
+    spaceId: toOptionalString(payload.spaceId),
+    status: toOptionalString(payload.status),
+    severity: toOptionalString(payload.severity),
+    tags: toStringList(payload.tags),
+    name: toOptionalString(payload.name),
+    title: toOptionalString(payload.title),
+  };
+}
+
+function toUnknownRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function toStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function toPredicates(value: unknown): Predicate[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => {
+      const predicate = toUnknownRecord(item);
+      const type = toOptionalString(predicate?.type);
+      const predicateValue = toOptionalString(predicate?.value);
+      if (!type || !predicateValue) return undefined;
+      return { type, value: predicateValue };
+    })
+    .filter((predicate): predicate is Predicate => predicate !== undefined);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce Elastic trigger scoping by requiring selected Kibana rules and validating selected resources in `Setup()`
- validate selected Elasticsearch index in `IndexDocument.Setup()` and store resolved resource metadata
- add missing Elastic `Sync()` unit tests and expand setup tests for rule/index validation
- harden Elastic workflow mappers by replacing broad `any` casts with typed parsing helpers
- align Elastic docs wording with required rule selection behavior

## Testing
- `npm run build` (in `web_src`) ✅
- `npm run lint -- src/pages/workflowv2/mappers/elastic/on_alert.ts src/pages/workflowv2/mappers/elastic/index_document.ts` ⚠️ exits non-zero because workspace-wide existing lint findings are still present
- `make lint && make check.build.app` ❌ blocked (`docker: not found` in this environment)
- `make check.build.ui` ❌ blocked (`docker: not found` in this environment)
- `go test ./pkg/integrations/elastic` ❌ blocked (repo requires Go 1.25 toolchain; not available on this machine)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df2bae57-6f54-4a6a-96e1-436f4c949c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df2bae57-6f54-4a6a-96e1-436f4c949c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

