### PR TITLE
fix: sidebar integration selector shouldn't auto-pick first instance

### DIFF
--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -226,29 +226,16 @@ export function SettingsTab({
     setShowValidation(false);
   }, [configuration, nodeName, defaultValuesWithoutToggles, filterVisibleFields, integrationRef]);
 
-  // Auto-select the first installation if none is selected or selection is invalid
+  // Keep selection honest: if the currently selected integration no longer exists, clear it.
+  // Do not auto-select an integration; users must choose explicitly (or inherit from the node's saved integrationRef).
   useEffect(() => {
-    if (integrationsOfType.length === 0) {
-      if (selectedIntegration) {
-        setSelectedIntegration(undefined);
-      }
-      return;
-    }
-
     const selectedId = selectedIntegration?.id;
-    const hasSelected = selectedId
-      ? integrationsOfType.some((integration) => integration.metadata?.id === selectedId)
-      : false;
-    if (hasSelected) {
-      return;
-    }
-
-    const firstIntegration = integrationsOfType[0];
-    setSelectedIntegration({
-      id: firstIntegration.metadata?.id,
-      name: firstIntegration.metadata?.name,
-    });
-  }, [integrationsOfType, selectedIntegration]);
+    if (!selectedId) return;
+    if (integrationsOfType.length === 0) return;
+    const stillExists = integrationsOfType.some((integration) => integration.metadata?.id === selectedId);
+    if (stillExists) return;
+    setSelectedIntegration(undefined);
+  }, [integrationsOfType, selectedIntegration?.id]);
 
   const shouldShowConfiguration = true;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What
Fixes the sidebar integration selector showing an integration as selected even when the node has no persisted integration set.

### Why
This mismatch made nodes show an "integration required" error while the sidebar appeared configured (because it auto-selected the first available integration instance).

### Changes
- Stop auto-selecting the first integration instance in `SettingsTab`; the dropdown now only reflects the node’s saved `integrationRef` or an explicit user choice.
- If a previously selected integration disappears, clear the selection.

### Verification
- Ran `npm run format` and `npm run build` in `web_src/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dae7dc12-01e1-4854-bc64-e627cbe95d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dae7dc12-01e1-4854-bc64-e627cbe95d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

