### PR TITLE
fix: Discord send text message component flags required fields

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/discord/send_text_message.ts
+++ b/web_src/src/pages/workflowv2/mappers/discord/send_text_message.ts
@@ -14,6 +14,7 @@ import { getState, getStateMap, getTriggerRenderer } from "..";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import type { MetadataItem } from "@/ui/metadataList";
 import discordIcon from "@/assets/icons/integrations/discord.svg";
+import type { SettingsValidationContext } from "../settingsValidation";
 
 interface SendTextMessageConfiguration {
   channel?: string;
@@ -77,6 +78,26 @@ export const sendTextMessageMapper: ComponentBaseMapper = {
     return renderTimeAgo(new Date(context.execution.createdAt));
   },
 };
+
+export function discordSendTextMessageSettingsValidation(context: SettingsValidationContext) {
+  if (context.integrationName && context.integrationName !== "discord") return [];
+
+  const content = typeof context.values.content === "string" ? context.values.content.trim() : "";
+  const embedTitle = typeof context.values.embedTitle === "string" ? context.values.embedTitle.trim() : "";
+  const embedDescription =
+    typeof context.values.embedDescription === "string" ? context.values.embedDescription.trim() : "";
+
+  const hasAnyContent = content.length > 0 || embedTitle.length > 0 || embedDescription.length > 0;
+  if (hasAnyContent) return [];
+
+  return [
+    {
+      field: "content",
+      message: "Provide Content or an Embed Title/Description",
+      type: "required" as const,
+    },
+  ];
+}
 
 function sendTextMessageMetadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];

--- a/web_src/src/pages/workflowv2/mappers/settingsValidation.ts
+++ b/web_src/src/pages/workflowv2/mappers/settingsValidation.ts
@@ -1,0 +1,31 @@
+import type { ConfigurationField } from "@/api-client";
+import { discordSendTextMessageSettingsValidation } from "./discord/send_text_message";
+
+export interface RealtimeValidationError {
+  field: string;
+  message: string;
+  type: "validation_rule" | "required" | "visibility";
+}
+
+export interface SettingsValidationContext {
+  blockName?: string;
+  integrationName?: string;
+  configurationFields: ConfigurationField[];
+  values: Record<string, unknown>;
+}
+
+type SettingsValidationFn = (context: SettingsValidationContext) => RealtimeValidationError[];
+
+const SETTINGS_VALIDATORS: Record<string, SettingsValidationFn> = {
+  "discord.sendTextMessage": discordSendTextMessageSettingsValidation,
+};
+
+export function getSettingsRealtimeValidationErrors(context: SettingsValidationContext): RealtimeValidationError[] {
+  const blockName = context.blockName;
+  if (!blockName) return [];
+
+  const validator = SETTINGS_VALIDATORS[blockName];
+  if (!validator) return [];
+
+  return validator(context);
+}

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/utils/components";
 import { useRealtimeValidation } from "@/hooks/useRealtimeValidation";
 import { SimpleTooltip } from "./SimpleTooltip";
+import { getSettingsRealtimeValidationErrors } from "@/pages/workflowv2/mappers/settingsValidation";
 
 interface SettingsTabProps {
   mode: "create" | "edit";
@@ -130,29 +131,13 @@ export function SettingsTab({
   );
 
   const componentSpecificRealtimeErrors = useMemo(() => {
-    if (!integrationName || !blockName) return [];
-
-    // Discord: Send Text Message requires either content or an embed (title/description).
-    if (integrationName === "discord" && blockName === "discord.sendTextMessage") {
-      const content = typeof nodeConfiguration.content === "string" ? nodeConfiguration.content.trim() : "";
-      const embedTitle = typeof nodeConfiguration.embedTitle === "string" ? nodeConfiguration.embedTitle.trim() : "";
-      const embedDescription =
-        typeof nodeConfiguration.embedDescription === "string" ? nodeConfiguration.embedDescription.trim() : "";
-
-      const hasAnyContent = content.length > 0 || embedTitle.length > 0 || embedDescription.length > 0;
-      if (!hasAnyContent) {
-        return [
-          {
-            field: "content",
-            message: "Provide Content or an Embed Title/Description",
-            type: "required",
-          },
-        ];
-      }
-    }
-
-    return [];
-  }, [integrationName, blockName, nodeConfiguration]);
+    return getSettingsRealtimeValidationErrors({
+      blockName,
+      integrationName,
+      configurationFields,
+      values: nodeConfiguration,
+    });
+  }, [blockName, integrationName, configurationFields, nodeConfiguration]);
 
   const combinedRealtimeValidationErrors = useMemo(() => {
     const merged = [...(realtimeValidationErrors ?? []), ...componentSpecificRealtimeErrors];

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -762,6 +762,7 @@ export const ComponentSidebar = ({
                   nodeId={nodeId}
                   nodeName={nodeName}
                   nodeLabel={nodeLabel}
+                  blockName={blockName}
                   configuration={nodeConfiguration}
                   configurationFields={nodeConfigurationFields}
                   onSave={onNodeConfigSave || (() => {})}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed
- Moved Discord `sendTextMessage` cross-field validation out of `SettingsTab` into the workflow mappers layer.
- Added a mapper-level settings validation registry (`web_src/src/pages/workflowv2/mappers/settingsValidation.ts`) so `SettingsTab` stays generic and can merge component-specific realtime errors.
- Fixed wiring so `blockName` is passed into `SettingsTab` (required for mapper lookup).

### Why
Per existing patterns, integration/component-specific logic should live in mappers (component-specific context), not in the generic sidebar settings UI.

### How to verify
- Open a workflow node using **Discord → Send Text Message**.
- Leave `Content`, `Embed Title`, and `Embed Description` empty.
- Confirm the configuration panel shows an inline “Required” error prompting you to provide Content or an Embed.

### Notes
- Backend validation remains unchanged; this only improves config-panel feedback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92a043a9-45f8-4192-b653-9d94c1a1c171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92a043a9-45f8-4192-b653-9d94c1a1c171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

