### PR TITLE
feat: Steer AI builder toward root() for run-start payloads

### DIFF
--- a/agent/evals/evaluators.py
+++ b/agent/evals/evaluators.py
@@ -1,7 +1,12 @@
+from collections.abc import Iterator
 from dataclasses import dataclass
-from pydantic_evals.evaluators import Evaluator, EvaluatorContext, EvaluationReason
-from ai.models import CanvasAnswer, CanvasOperation
 from typing import Any
+
+from pydantic_evals.evaluators import EvaluationReason, Evaluator, EvaluatorContext
+
+from ai.models import CanvasAnswer, CanvasOperation
+
+_FORBIDDEN_DOLLAR_DATA = "$.data."
 
 @dataclass
 class WorkflowShape(Evaluator):
@@ -23,14 +28,62 @@ class WorkflowShape(Evaluator):
 
     # Check if the number of nodes and edges match
     if len(wf.nodes) != len(self.nodes):
-      return EvaluationReason(value=False, reason=f"Workflow has {len(wf.nodes)} nodes, expected {len(self.nodes)}")
+      return EvaluationReason(
+          value=False,
+          reason=f"Workflow has {len(wf.nodes)} nodes, expected {len(self.nodes)}",
+      )
 
     # Check if the number of edges match
     if len(wf.edges) != len(self.edges):
-      return EvaluationReason(value=False, reason=f"Workflow has {len(wf.edges)} edges, expected {len(self.edges)}")
+      return EvaluationReason(
+          value=False,
+          reason=f"Workflow has {len(wf.edges)} edges, expected {len(self.edges)}",
+      )
 
     # Everything matches, return success
     return EvaluationReason(value=True, reason="Workflow shape matches")
+
+
+@dataclass
+class NoDollarDataAsRoot(Evaluator):
+    """Reject proposals that treat $.data. as run-start payload (use root().data...)."""
+
+    def evaluate(self, ctx: EvaluatorContext[str, CanvasAnswer, Any]) -> EvaluationReason:
+        if ctx.output.proposal is None:
+            return EvaluationReason(value=True, reason="No proposal to check")
+
+        for text in iter_config_strings_from_operations(ctx.output.proposal.operations):
+            if _FORBIDDEN_DOLLAR_DATA in text:
+                snippet = text if len(text) <= 120 else text[:117] + "..."
+                msg = "Forbidden $.data. in configuration; use root().data... for run-start fields"
+                return EvaluationReason(
+                    value=False,
+                    reason=f"{msg}; example: {snippet!r}",
+                )
+
+        return EvaluationReason(value=True, reason="No forbidden $.data. in configuration")
+
+
+def iter_config_strings_from_operations(
+    operations: list[CanvasOperation],
+) -> Iterator[str]:
+    for op in operations:
+        if op.type == "add_node":
+            yield from _iter_strings_in_value(op.configuration)
+        elif op.type == "update_node_config":
+            yield from _iter_strings_in_value(op.configuration)
+
+
+def _iter_strings_in_value(value: Any) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for nested in value.values():
+            yield from _iter_strings_in_value(nested)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_strings_in_value(item)
+
 
 # Helper functions
 

--- a/agent/evals/runner.py
+++ b/agent/evals/runner.py
@@ -8,8 +8,7 @@ from pydantic_evals import Case, Dataset
 from ai.agent import AgentDeps, build_agent, build_prompt
 from ai.models import CanvasAnswer, CanvasQuestionRequest
 from ai.superplane_client import SuperplaneClient, SuperplaneClientConfig
-
-from evals.evaluators import WorkflowShape
+from evals.evaluators import NoDollarDataAsRoot, WorkflowShape
 from evals.report import ReportBuilder
 
 dataset = Dataset(
@@ -33,6 +32,20 @@ dataset = Dataset(
                   nodes=["github.onPRComment", "slack.sendTextMessage"],
                   edges=[("github.onPRComment", "slack.sendTextMessage")],
                 )
+            ],
+        ),
+        Case(
+            name="github_issue_opened_to_discord",
+            inputs=(
+                "When a GitHub issue is opened, post a Discord message "
+                "that includes the issue title"
+            ),
+            evaluators=[
+                WorkflowShape(
+                    nodes=["github.onIssue", "discord.sendTextMessage"],
+                    edges=[("github.onIssue", "discord.sendTextMessage")],
+                ),
+                NoDollarDataAsRoot(),
             ],
         ),
         Case(

--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -1,7 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import Any
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.test import TestModel
@@ -53,9 +52,20 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
             "Use exact block names from catalog tools, include node references by nodeId "
             "for existing nodes, and keep operation order executable. "
             "Do not invent unknown fields or operation types. "
-            "Use get_canvas at most once per answer unless the user asks to refresh or use a different canvas. "
-            "Keep responses short by default (about 3-5 lines) unless the user asks for deep analysis."
-            "If a tool returns an error payload, continue with other tools and provide the best-effort proposal instead of aborting."
+            "In proposals, expression fields use this model: $ is the message chain—"
+            "a map of upstream node outputs keyed by each node's name on the canvas "
+            "(use keyed access like $['Node name']...); it is not the run-start event object. "
+            "root() is the original event that started the run; "
+            "when that payload nests under data, "
+            "use root().data.... previous() refers to upstream output. "
+            "Never use $.data. for run-start payload fields; use root().data. or the correct path "
+            "under root() instead. "
+            "Use get_canvas at most once per answer unless the user asks to refresh or "
+            "use a different canvas. "
+            "Keep responses short by default (about 3-5 lines) unless the user asks for "
+            "deep analysis. "
+            "If a tool returns an error payload, continue with other tools and provide the "
+            "best-effort proposal instead of aborting. "
             "Common patterns: "
             "- if the user says 'pull-request comments' it maps to 'github.onPRComment'"
         ),


### PR DESCRIPTION
### Problem (https://github.com/superplanehq/superplane/issues/3622)

When users asked the canvas agent to build workflows such as streaming opened GitHub issues to Discord, proposals often used **$.data.issue…** as if **$** were the root/trigger payload. In SuperPlane, **$** is the message chain keyed by upstream node names; the run-start event is accessed with **root()** (e.g. **root().data.issue…**), as described in the data flow docs.

### What we changed

System prompt 1: Added a short, provider-agnostic note on expressions—**$** vs **root()** vs **previous()**—and explicitly discouraged **$.data.** for run-start fields.
Eval harness 2: Introduced **NoDollarDataAsRoot**, which fails a case if any string in **add_node** / **update_node_config** configuration contains **$.data.**.
Regression case 3: Added **github_issue_opened_to_discord**—GitHub issue opened → Discord message including the issue title—with **WorkflowShape** plus **NoDollarDataAsRoot**.

### How to verify

**make test.agent.evals** (with compose and model/API env configured as usual).