### PR TITLE
feat: add cli version flag and update warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,8 +309,10 @@ openapi.python.client.gen:
 # Image and CLI build
 #
 
+CLI_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+
 cli.build:
-	$(COMPOSE) run --rm --no-deps -e GOOS=$(OS) -e GOARCH=$(ARCH) app bash -c 'go build -o build/cli cmd/cli/main.go'
+	$(COMPOSE) run --rm --no-deps -e GOOS=$(OS) -e GOARCH=$(ARCH) app bash -c 'go build -ldflags "-X github.com/superplanehq/superplane/pkg/cli.Version=$(CLI_VERSION)" -o build/cli cmd/cli/main.go'
 
 cli.build.m1:
 	$(MAKE) cli.build OS=darwin ARCH=arm64

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,7 +8,10 @@ import (
 )
 
 func main() {
-	if err := cli.RootCmd.Execute(); err != nil {
+	cli.StartUpdateCheck()
+	err := cli.RootCmd.Execute()
+	cli.PrintUpdateNotice()
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is set at build time via -ldflags.
+// Defaults to "dev" for development builds.
+var Version = "dev"
+
+var updateCheckResult <-chan *updateInfo
+
+type updateInfo struct {
+	latest string
+	err    error
+}
+
+func isDevBuild() bool {
+	return Version == "" || Version == "dev"
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the CLI version",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(Version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+
+	// Enable Cobra's built-in --version flag handling.
+	// We pre-register the "version" flag without a shorthand to prevent
+	// Cobra from adding -v, which conflicts with --verbose.
+	RootCmd.Version = Version
+	RootCmd.SetVersionTemplate("{{.Version}}\n")
+	RootCmd.Flags().Bool("version", false, "Print the CLI version")
+}
+
+// StartUpdateCheck begins an async check for a newer CLI version.
+// It is a no-op for dev builds.
+func StartUpdateCheck() {
+	if isDevBuild() {
+		return
+	}
+
+	ch := make(chan *updateInfo, 1)
+	updateCheckResult = ch
+	go func() {
+		latest, err := fetchLatestRelease()
+		ch <- &updateInfo{latest: latest, err: err}
+	}()
+}
+
+// PrintUpdateNotice prints an upgrade notice to stderr if a newer version
+// is available. It waits at most 1 second for the background check to finish.
+func PrintUpdateNotice() {
+	if updateCheckResult == nil {
+		return
+	}
+
+	var info *updateInfo
+	select {
+	case info = <-updateCheckResult:
+	case <-time.After(1 * time.Second):
+		return
+	}
+
+	if info.err != nil || info.latest == "" {
+		return
+	}
+
+	if isNewerVersion(Version, info.latest) {
+		fmt.Fprintf(os.Stderr, "\nA new version of superplane CLI is available: %s -> %s\n", Version, info.latest)
+		fmt.Fprintf(os.Stderr, "Download from: https://github.com/superplanehq/superplane/releases/tag/%s\n", info.latest)
+	}
+}
+
+const latestReleaseURL = "https://api.github.com/repos/superplanehq/superplane/releases/latest"
+
+func fetchLatestRelease() (string, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	req, err := http.NewRequest("GET", latestReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+
+	return release.TagName, nil
+}
+
+// isNewerVersion returns true if latest is a newer semver than current.
+// Both may optionally have a "v" prefix.
+func isNewerVersion(current, latest string) bool {
+	current = strings.TrimPrefix(current, "v")
+	latest = strings.TrimPrefix(latest, "v")
+
+	if current == latest {
+		return false
+	}
+
+	var cMajor, cMinor, cPatch int
+	var lMajor, lMinor, lPatch int
+
+	fmt.Sscanf(current, "%d.%d.%d", &cMajor, &cMinor, &cPatch)
+	fmt.Sscanf(latest, "%d.%d.%d", &lMajor, &lMinor, &lPatch)
+
+	if lMajor != cMajor {
+		return lMajor > cMajor
+	}
+
+	if lMinor != cMinor {
+		return lMinor > cMinor
+	}
+
+	return lPatch > cPatch
+}

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import "testing"
+
+func TestIsNewerVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		latest   string
+		expected bool
+	}{
+		{"minor bump", "v0.13.0", "v0.14.0", true},
+		{"patch bump", "v0.13.0", "v0.13.1", true},
+		{"major bump", "v0.13.0", "v1.0.0", true},
+		{"same version", "v0.13.0", "v0.13.0", false},
+		{"current is newer minor", "v0.14.0", "v0.13.0", false},
+		{"current is newer major", "v1.0.0", "v0.99.99", false},
+		{"no v prefix", "0.13.0", "0.14.0", true},
+		{"mixed prefixes", "v0.13.0", "0.14.0", true},
+		{"multi-digit versions", "v0.9.0", "v0.10.0", true},
+		{"current is newer patch", "v0.13.2", "v0.13.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isNewerVersion(tt.current, tt.latest)
+			if result != tt.expected {
+				t.Errorf("isNewerVersion(%q, %q) = %v, want %v", tt.current, tt.latest, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsDevBuild(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "dev"
+	if !isDevBuild() {
+		t.Error("expected dev build when Version is 'dev'")
+	}
+
+	Version = ""
+	if !isDevBuild() {
+		t.Error("expected dev build when Version is empty")
+	}
+
+	Version = "v0.13.0"
+	if isDevBuild() {
+		t.Error("expected non-dev build when Version is 'v0.13.0'")
+	}
+}


### PR DESCRIPTION
                                          
## Summary                                                      
                                                                
  - Add `superplane version` command and `--version` flag to print
   the current CLI version
  - Add background update check on every CLI invocation that      
  notifies users when a newer release is available                
  - Skip update check entirely for dev builds (`Version == "dev"`)
  - Inject version at build time via `-ldflags` in `make          
  cli.build` (defaults to latest git tag, or `"dev"` if none)     
                                                                  
  ## Details                                                      
                                                                
  **Version output:**                                             
  $ superplane --version
  v0.13.0                                                         
                                                                
  $ superplane version
  v0.13.0
     
  **Update notice** (printed to stderr, non-blocking):
  A new version of superplane CLI is available: v0.13.0 -> v0.14.0
  Download from:                                                  
  https://github.com/superplanehq/superplane/releases/tag/v0.14.0 
                                                                  
  - The update check runs in a background goroutine concurrent  
  with command execution
  - Queries `GET /repos/superplanehq/superplane/releases/latest`  
  with a 3s HTTP timeout                                          
  - Waits at most 1s for the result after the command finishes —  
  never blocks the user                                           
  - Silently swallows network errors (offline, rate-limited, etc.)
  - `--version` uses long form only since `-v` is taken by        
  `--verbose`                                                     
