### PR TITLE
fix: skip background release update check for local-only commands

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,7 +8,9 @@ import (
 )
 
 func main() {
-	cli.StartUpdateCheck()
+	if cli.ShouldStartUpdateCheck(os.Args[1:]) {
+		cli.StartUpdateCheck()
+	}
 	err := cli.RootCmd.Execute()
 	cli.PrintUpdateNotice()
 	if err != nil {

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -61,6 +61,46 @@ func StartUpdateCheck() {
 	}()
 }
 
+func ShouldStartUpdateCheck(args []string) bool {
+	if isDevBuild() {
+		return false
+	}
+
+	if len(args) == 0 {
+		return false
+	}
+
+	skipValue := false
+	for _, arg := range args {
+		if skipValue {
+			skipValue = false
+			continue
+		}
+
+		switch arg {
+		case "", "--":
+			continue
+		case "--config", "--output", "-o":
+			skipValue = true
+			continue
+		case "-h", "--help", "help", "--version", "version", "completion":
+			return false
+		}
+
+		if strings.HasPrefix(arg, "--config=") || strings.HasPrefix(arg, "--output=") || strings.HasPrefix(arg, "-o=") {
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
 // PrintUpdateNotice prints an upgrade notice to stderr if a newer version
 // is available. It waits at most 1 second for the background check to finish.
 func PrintUpdateNotice() {

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -50,3 +50,37 @@ func TestIsDevBuild(t *testing.T) {
 		t.Error("expected non-dev build when Version is 'v0.13.0'")
 	}
 }
+
+func TestShouldStartUpdateCheck(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = "v0.13.0"
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{name: "no args", args: nil, expected: false},
+		{name: "root help when no args", args: []string{}, expected: false},
+		{name: "help subcommand", args: []string{"help"}, expected: false},
+		{name: "help flag", args: []string{"--help"}, expected: false},
+		{name: "short help flag", args: []string{"-h"}, expected: false},
+		{name: "version subcommand", args: []string{"version"}, expected: false},
+		{name: "version flag", args: []string{"--version"}, expected: false},
+		{name: "completion command", args: []string{"completion", "zsh"}, expected: false},
+		{name: "networked command", args: []string{"whoami"}, expected: true},
+		{name: "networked subcommand with flags", args: []string{"canvases", "list", "-o", "json"}, expected: true},
+		{name: "flag before local subcommand", args: []string{"-o", "json", "version"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShouldStartUpdateCheck(tt.args)
+			if result != tt.expected {
+				t.Fatalf("ShouldStartUpdateCheck(%v) = %v, want %v", tt.args, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix CLI behavior in restricted/offline environments by skipping the background release update check for local-only commands such as `help` and `version`.

## Changes

- Add `ShouldStartUpdateCheck(...)` to detect whether the invoked command actually needs network access
- Skip `StartUpdateCheck()` for local-only commands
- Cover the new behavior with tests, including root flags before local subcommands

## Why

Fresh CLI usage in sandboxed environments should not trigger unnecessary network access or permission prompts when the user is only asking for local information.

