### PR TITLE
feat: add digitalocean Create and Get Database Cluster components

### DIFF
--- a/docs/components/DigitalOcean.mdx
+++ b/docs/components/DigitalOcean.mdx
@@ -502,7 +502,7 @@ Returns the created database cluster including:
     "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
     "region": "nyc1",
     "size": "db-s-1vcpu-1gb",
-    "status": "creating",
+    "status": "online",
     "version": "18.0"
   },
   "timestamp": "2026-03-27T13:00:05Z",

--- a/docs/components/DigitalOcean.mdx
+++ b/docs/components/DigitalOcean.mdx
@@ -15,6 +15,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Alert Policy" href="#create-alert-policy" description="Create a DigitalOcean monitoring alert policy for droplet metrics" />
   <LinkCard title="Create App" href="#create-app" description="Create a new DigitalOcean App Platform application with services, static sites, workers, or jobs" />
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record for a DigitalOcean domain" />
+  <LinkCard title="Create Database Cluster" href="#create-database-cluster" description="Create a new database cluster" />
   <LinkCard title="Create Droplet" href="#create-droplet" description="Create a new DigitalOcean Droplet" />
   <LinkCard title="Create Knowledge Base" href="#create-knowledge-base" description="Create a DigitalOcean Gradient AI knowledge base with one or more data sources" />
   <LinkCard title="Create Load Balancer" href="#create-load-balancer" description="Create a DigitalOcean Load Balancer with forwarding rules and targets" />
@@ -30,6 +31,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Detach Knowledge Base" href="#detach-knowledge-base" description="Detach a knowledge base from a DigitalOcean Gradient AI agent" />
   <LinkCard title="Get Alert Policy" href="#get-alert-policy" description="Fetch details of a DigitalOcean monitoring alert policy" />
   <LinkCard title="Get App" href="#get-app" description="Fetch details of a DigitalOcean App Platform application by ID" />
+  <LinkCard title="Get Database Cluster" href="#get-database-cluster" description="Retrieve details of a specific database cluster" />
   <LinkCard title="Get Droplet" href="#get-droplet" description="Fetch details of a DigitalOcean Droplet by ID" />
   <LinkCard title="Get Droplet Metrics" href="#get-droplet-metrics" description="Fetch CPU, memory, and network bandwidth metrics for a DigitalOcean Droplet" />
   <LinkCard title="Get Object" href="#get-object" description="Retrieve an object and its metadata from DigitalOcean Spaces Object Storage" />
@@ -437,6 +439,74 @@ Returns the created DNS record including:
   },
   "timestamp": "2026-03-16T09:50:03.222782653Z",
   "type": "digitalocean.dns.record.created"
+}
+```
+
+<a id="create-database-cluster"></a>
+
+## Create Database Cluster
+
+The Create Database Cluster component provisions a new DigitalOcean Managed Database cluster and waits until it is online.
+
+### Use Cases
+
+- **Environment bootstrap**: Provision a managed database cluster before creating apps or databases
+- **Platform setup**: Create a dedicated cluster for a service, team, or customer environment
+- **Migration workflows**: Stand up a new cluster before importing data or cutover
+
+### Configuration
+
+- **Name**: The database cluster name (required)
+- **Engine**: The database engine to provision, such as PostgreSQL or MySQL (required)
+- **Version**: The engine version to provision (required)
+- **Region**: The DigitalOcean region for the cluster (required)
+- **Size**: The node size slug for the cluster, for example `db-s-1vcpu-1gb` (required)
+- **Node Count**: The number of nodes in the cluster (required)
+
+### Output
+
+Returns the created database cluster including:
+- **id**: The cluster UUID
+- **name**: The cluster name
+- **engine**: The provisioned engine
+- **version**: The engine version
+- **region**: The cluster region
+- **size**: The selected node size slug
+- **num_nodes**: The number of nodes
+- **status**: The current cluster status
+- **connection**: Connection information when available
+
+### Important Notes
+
+- If you use custom token scopes, this action requires `database:create` and `database:read`
+- Valid versions, sizes, and node counts depend on the selected engine. Use the DigitalOcean Database Options API or dashboard values when configuring this component
+- The component polls until the cluster status becomes `online`
+
+### Example Output
+
+```json
+{
+  "data": {
+    "connection": {
+      "host": "superplane-db-do-user-123456-0.j.db.ondigitalocean.com",
+      "port": 25060,
+      "ssl": true,
+      "uri": "postgres://doadmin:[email protected]:25060/defaultdb?sslmode=require",
+      "user": "doadmin"
+    },
+    "created_at": "2026-03-27T13:00:00Z",
+    "engine": "pg",
+    "id": "65b497a5-1674-4b1a-a122-01aebe761ef7",
+    "name": "superplane-db",
+    "num_nodes": 1,
+    "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
+    "region": "nyc1",
+    "size": "db-s-1vcpu-1gb",
+    "status": "creating",
+    "version": "18.0"
+  },
+  "timestamp": "2026-03-27T13:00:05Z",
+  "type": "digitalocean.database.cluster.created"
 }
 ```
 
@@ -1313,6 +1383,68 @@ Returns the app object including:
   },
   "timestamp": "2026-03-26T08:21:30.077395918Z",
   "type": "digitalocean.app.fetched"
+}
+```
+
+<a id="get-database-cluster"></a>
+
+## Get Database Cluster
+
+The Get Database Cluster component retrieves the details of an existing DigitalOcean Managed Database cluster.
+
+### Use Cases
+
+- **Status checks**: Verify a cluster is online before creating databases or users
+- **Information retrieval**: Fetch connection details, sizing, engine, and region information
+- **Pre-flight validation**: Confirm a cluster exists before downstream operations
+
+### Configuration
+
+- **Database Cluster**: The managed database cluster to retrieve (required)
+
+### Output
+
+Returns the database cluster including:
+- **id**: The cluster UUID
+- **name**: The cluster name
+- **engine**: The configured engine
+- **version**: The engine version
+- **region**: The cluster region
+- **size**: The node size slug
+- **num_nodes**: The number of nodes
+- **status**: The cluster status
+- **connection**: Connection information when available
+
+### Important Notes
+
+- If you use custom token scopes, this action requires `database:read`
+- The returned connection information depends on the cluster type and provisioning state.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "connection": {
+      "host": "superplane-db-do-user-123456-0.j.db.ondigitalocean.com",
+      "port": 25060,
+      "ssl": true,
+      "uri": "postgres://doadmin:[email protected]:25060/defaultdb?sslmode=require",
+      "user": "doadmin"
+    },
+    "created_at": "2026-03-27T13:00:00Z",
+    "engine": "pg",
+    "id": "65b497a5-1674-4b1a-a122-01aebe761ef7",
+    "name": "superplane-db",
+    "num_nodes": 1,
+    "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
+    "region": "nyc1",
+    "size": "db-s-1vcpu-1gb",
+    "status": "online",
+    "version": "18.0"
+  },
+  "timestamp": "2026-03-27T13:05:00Z",
+  "type": "digitalocean.database.cluster.fetched"
 }
 ```
 

--- a/pkg/integrations/digitalocean/client.go
+++ b/pkg/integrations/digitalocean/client.go
@@ -2289,6 +2289,136 @@ func (c *Client) ListApps() ([]App, error) {
 	return response.Apps, nil
 }
 
+type DatabaseClusterConnection struct {
+	Host string `json:"host,omitempty"`
+	Port int    `json:"port,omitempty"`
+	User string `json:"user,omitempty"`
+	URI  string `json:"uri,omitempty"`
+	SSL  bool   `json:"ssl,omitempty"`
+}
+
+type DatabaseOptionLayout struct {
+	NumNodes int      `json:"num_nodes"`
+	Sizes    []string `json:"sizes"`
+}
+
+type DatabaseEngineOptions struct {
+	Regions        []string               `json:"regions"`
+	Versions       []string               `json:"versions"`
+	Layouts        []DatabaseOptionLayout `json:"layouts"`
+	DefaultVersion string                 `json:"default_version,omitempty"`
+}
+
+type DatabaseCluster struct {
+	ID                 string                     `json:"id"`
+	Name               string                     `json:"name"`
+	Engine             string                     `json:"engine,omitempty"`
+	Version            string                     `json:"version,omitempty"`
+	Region             string                     `json:"region,omitempty"`
+	Size               string                     `json:"size,omitempty"`
+	NumNodes           int                        `json:"num_nodes,omitempty"`
+	Status             string                     `json:"status,omitempty"`
+	CreatedAt          string                     `json:"created_at,omitempty"`
+	PrivateNetworkUUID string                     `json:"private_network_uuid,omitempty"`
+	Connection         *DatabaseClusterConnection `json:"connection,omitempty"`
+	PrivateConnection  *DatabaseClusterConnection `json:"private_connection,omitempty"`
+}
+
+type CreateDatabaseClusterRequest struct {
+	Name     string `json:"name"`
+	Engine   string `json:"engine"`
+	Version  string `json:"version"`
+	Region   string `json:"region"`
+	Size     string `json:"size"`
+	NumNodes int    `json:"num_nodes"`
+}
+
+func (c *Client) GetDatabaseOptions() (map[string]DatabaseEngineOptions, error) {
+	url := fmt.Sprintf("%s/databases/options", c.BaseURL)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Options map[string]DatabaseEngineOptions `json:"options"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if response.Options == nil {
+		return map[string]DatabaseEngineOptions{}, nil
+	}
+
+	return response.Options, nil
+}
+
+func (c *Client) ListDatabaseClusters() ([]DatabaseCluster, error) {
+	url := fmt.Sprintf("%s/databases?per_page=200", c.BaseURL)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Databases []DatabaseCluster `json:"databases"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if response.Databases == nil {
+		return []DatabaseCluster{}, nil
+	}
+
+	return response.Databases, nil
+}
+
+func (c *Client) CreateDatabaseCluster(req CreateDatabaseClusterRequest) (*DatabaseCluster, error) {
+	url := fmt.Sprintf("%s/databases", c.BaseURL)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Database DatabaseCluster `json:"database"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &response.Database, nil
+}
+
+func (c *Client) GetDatabaseCluster(clusterID string) (*DatabaseCluster, error) {
+	url := fmt.Sprintf("%s/databases/%s", c.BaseURL, clusterID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Database DatabaseCluster `json:"database"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &response.Database, nil
+}
+
 // EmbeddingModel represents a DigitalOcean Gradient AI embedding model
 type EmbeddingModel struct {
 	UUID               string `json:"uuid"`

--- a/pkg/integrations/digitalocean/create_database_cluster.go
+++ b/pkg/integrations/digitalocean/create_database_cluster.go
@@ -152,6 +152,26 @@ func (c *CreateDatabaseCluster) Configuration() []configuration.Field {
 			},
 		},
 		{
+			Name:        "numNodes",
+			Label:       "Node Count",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     "1",
+			Description: "The number of nodes in the cluster",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "1", Value: "1"},
+						{Label: "2", Value: "2"},
+						{Label: "3", Value: "3"},
+						{Label: "6", Value: "6"},
+						{Label: "9", Value: "9"},
+						{Label: "15", Value: "15"},
+					},
+				},
+			},
+		},
+		{
 			Name:        "size",
 			Label:       "Size",
 			Type:        configuration.FieldTypeIntegrationResource,
@@ -170,26 +190,6 @@ func (c *CreateDatabaseCluster) Configuration() []configuration.Field {
 							Name:      "numNodes",
 							ValueFrom: &configuration.ParameterValueFrom{Field: "numNodes"},
 						},
-					},
-				},
-			},
-		},
-		{
-			Name:        "numNodes",
-			Label:       "Node Count",
-			Type:        configuration.FieldTypeSelect,
-			Required:    true,
-			Default:     "1",
-			Description: "The number of nodes in the cluster",
-			TypeOptions: &configuration.TypeOptions{
-				Select: &configuration.SelectTypeOptions{
-					Options: []configuration.FieldOption{
-						{Label: "1", Value: "1"},
-						{Label: "2", Value: "2"},
-						{Label: "3", Value: "3"},
-						{Label: "6", Value: "6"},
-						{Label: "9", Value: "9"},
-						{Label: "15", Value: "15"},
 					},
 				},
 			},

--- a/pkg/integrations/digitalocean/create_database_cluster.go
+++ b/pkg/integrations/digitalocean/create_database_cluster.go
@@ -1,0 +1,335 @@
+package digitalocean
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const databaseClusterPollInterval = 30 * time.Second
+
+type CreateDatabaseCluster struct{}
+
+type CreateDatabaseClusterSpec struct {
+	Name     string `json:"name" mapstructure:"name"`
+	Engine   string `json:"engine" mapstructure:"engine"`
+	Version  string `json:"version" mapstructure:"version"`
+	Region   string `json:"region" mapstructure:"region"`
+	Size     string `json:"size" mapstructure:"size"`
+	NumNodes string `json:"numNodes" mapstructure:"numNodes"`
+}
+
+func (c *CreateDatabaseCluster) Name() string {
+	return "digitalocean.createDatabaseCluster"
+}
+
+func (c *CreateDatabaseCluster) Label() string {
+	return "Create Database Cluster"
+}
+
+func (c *CreateDatabaseCluster) Description() string {
+	return "Create a new database cluster"
+}
+
+func (c *CreateDatabaseCluster) Documentation() string {
+	return `The Create Database Cluster component provisions a new DigitalOcean Managed Database cluster and waits until it is online.
+
+## Use Cases
+
+- **Environment bootstrap**: Provision a managed database cluster before creating apps or databases
+- **Platform setup**: Create a dedicated cluster for a service, team, or customer environment
+- **Migration workflows**: Stand up a new cluster before importing data or cutover
+
+## Configuration
+
+- **Name**: The database cluster name (required)
+- **Engine**: The database engine to provision, such as PostgreSQL or MySQL (required)
+- **Version**: The engine version to provision (required)
+- **Region**: The DigitalOcean region for the cluster (required)
+- **Size**: The node size slug for the cluster, for example ` + "`db-s-1vcpu-1gb`" + ` (required)
+- **Node Count**: The number of nodes in the cluster (required)
+
+## Output
+
+Returns the created database cluster including:
+- **id**: The cluster UUID
+- **name**: The cluster name
+- **engine**: The provisioned engine
+- **version**: The engine version
+- **region**: The cluster region
+- **size**: The selected node size slug
+- **num_nodes**: The number of nodes
+- **status**: The current cluster status
+- **connection**: Connection information when available
+
+## Important Notes
+
+- If you use custom token scopes, this action requires ` + "`database:create`" + ` and ` + "`database:read`" + `
+- Valid versions, sizes, and node counts depend on the selected engine. Use the DigitalOcean Database Options API or dashboard values when configuring this component
+- The component polls until the cluster status becomes ` + "`online`" + ``
+}
+
+func (c *CreateDatabaseCluster) Icon() string {
+	return "database"
+}
+
+func (c *CreateDatabaseCluster) Color() string {
+	return "blue"
+}
+
+func (c *CreateDatabaseCluster) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateDatabaseCluster) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "name",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The name of the database cluster",
+			Placeholder: "superplane-db",
+		},
+		{
+			Name:        "engine",
+			Label:       "Engine",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     "pg",
+			Description: "The database engine to provision",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "PostgreSQL", Value: "pg"},
+						{Label: "MySQL", Value: "mysql"},
+						{Label: "MongoDB", Value: "mongodb"},
+						{Label: "Kafka", Value: "kafka"},
+						{Label: "OpenSearch", Value: "opensearch"},
+						{Label: "Redis", Value: "redis"},
+						{Label: "Valkey", Value: "valkey"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "version",
+			Label:       "Version",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The engine version to provision",
+			Placeholder: "Select a version",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "database_cluster_version",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "engine",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "engine"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "region",
+			Label:       "Region",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Placeholder: "Select a region",
+			Description: "The region to deploy the cluster in",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "region",
+				},
+			},
+		},
+		{
+			Name:        "size",
+			Label:       "Size",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The node size slug for the cluster",
+			Placeholder: "Select a size",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "database_cluster_size",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "engine",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "engine"},
+						},
+						{
+							Name:      "numNodes",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "numNodes"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "numNodes",
+			Label:       "Node Count",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     "1",
+			Description: "The number of nodes in the cluster",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "1", Value: "1"},
+						{Label: "2", Value: "2"},
+						{Label: "3", Value: "3"},
+						{Label: "6", Value: "6"},
+						{Label: "9", Value: "9"},
+						{Label: "15", Value: "15"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateDatabaseCluster) Setup(ctx core.SetupContext) error {
+	spec := CreateDatabaseClusterSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Name == "" {
+		return errors.New("name is required")
+	}
+	if spec.Engine == "" {
+		return errors.New("engine is required")
+	}
+	if spec.Version == "" {
+		return errors.New("version is required")
+	}
+	if spec.Region == "" {
+		return errors.New("region is required")
+	}
+	if spec.Size == "" {
+		return errors.New("size is required")
+	}
+	if spec.NumNodes == "" {
+		return errors.New("numNodes is required")
+	}
+	if _, err := strconv.Atoi(spec.NumNodes); err != nil {
+		return fmt.Errorf("invalid numNodes value %q: %v", spec.NumNodes, err)
+	}
+
+	return nil
+}
+
+func (c *CreateDatabaseCluster) Execute(ctx core.ExecutionContext) error {
+	spec := CreateDatabaseClusterSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	numNodes, err := strconv.Atoi(spec.NumNodes)
+	if err != nil {
+		return fmt.Errorf("invalid numNodes value %q: %v", spec.NumNodes, err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	cluster, err := client.CreateDatabaseCluster(CreateDatabaseClusterRequest{
+		Name:     spec.Name,
+		Engine:   spec.Engine,
+		Version:  spec.Version,
+		Region:   spec.Region,
+		Size:     spec.Size,
+		NumNodes: numNodes,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create database cluster: %v", err)
+	}
+
+	if cluster.Status == "online" {
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			"digitalocean.database.cluster.created",
+			[]any{cluster},
+		)
+	}
+
+	if err := ctx.Metadata.Set(map[string]any{"databaseClusterID": cluster.ID}); err != nil {
+		return fmt.Errorf("failed to store metadata: %v", err)
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, databaseClusterPollInterval)
+}
+
+func (c *CreateDatabaseCluster) Cancel(ctx core.ExecutionContext) error { return nil }
+func (c *CreateDatabaseCluster) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+func (c *CreateDatabaseCluster) Actions() []core.Action {
+	return []core.Action{
+		{
+			Name:           "poll",
+			UserAccessible: false,
+		},
+	}
+}
+
+func (c *CreateDatabaseCluster) HandleAction(ctx core.ActionContext) error {
+	if ctx.Name != "poll" {
+		return fmt.Errorf("unknown action: %s", ctx.Name)
+	}
+
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata struct {
+		DatabaseClusterID string `mapstructure:"databaseClusterID"`
+	}
+
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %v", err)
+	}
+
+	if metadata.DatabaseClusterID == "" {
+		return errors.New("database cluster ID is missing from metadata")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	cluster, err := client.GetDatabaseCluster(metadata.DatabaseClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get database cluster: %v", err)
+	}
+
+	switch cluster.Status {
+	case "online":
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			"digitalocean.database.cluster.created",
+			[]any{cluster},
+		)
+	case "failed":
+		return errors.New("database cluster reached failed status")
+	default:
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, databaseClusterPollInterval)
+	}
+}
+
+func (c *CreateDatabaseCluster) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+func (c *CreateDatabaseCluster) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/integrations/digitalocean/create_database_cluster_test.go
+++ b/pkg/integrations/digitalocean/create_database_cluster_test.go
@@ -1,0 +1,220 @@
+package digitalocean
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateDatabaseCluster__Setup(t *testing.T) {
+	component := &CreateDatabaseCluster{}
+
+	t.Run("missing required fields return errors", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("valid config returns no error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"name":     "superplane-db",
+				"engine":   "pg",
+				"version":  "18",
+				"region":   "nyc1",
+				"size":     "db-s-1vcpu-1gb",
+				"numNodes": "1",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateDatabaseCluster__Execute(t *testing.T) {
+	component := &CreateDatabaseCluster{}
+
+	t.Run("successful creation stores cluster ID and schedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body: io.NopCloser(strings.NewReader(`{
+						"database": {
+							"id": "cluster-1",
+							"name": "superplane-db",
+							"engine": "pg",
+							"version": "18.0",
+							"region": "nyc1",
+							"size": "db-s-1vcpu-1gb",
+							"num_nodes": 1,
+							"status": "creating"
+						}
+					}`)),
+				},
+			},
+		}
+
+		metadataCtx := &contexts.MetadataContext{}
+		requestCtx := &contexts.RequestContext{}
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"name":     "superplane-db",
+				"engine":   "pg",
+				"version":  "18",
+				"region":   "nyc1",
+				"size":     "db-s-1vcpu-1gb",
+				"numNodes": "1",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata:       metadataCtx,
+			Requests:       requestCtx,
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "cluster-1", metadata["databaseClusterID"])
+
+		assert.Equal(t, "poll", requestCtx.Action)
+		assert.Equal(t, databaseClusterPollInterval, requestCtx.Duration)
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("invalid numNodes returns error", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"name":     "superplane-db",
+				"engine":   "pg",
+				"version":  "18",
+				"region":   "nyc1",
+				"size":     "db-s-1vcpu-1gb",
+				"numNodes": "one",
+			},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+		})
+
+		require.ErrorContains(t, err, "invalid numNodes")
+	})
+}
+
+func Test__CreateDatabaseCluster__HandleAction(t *testing.T) {
+	component := &CreateDatabaseCluster{}
+
+	t.Run("online cluster emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"database": {
+							"id": "cluster-1",
+							"name": "superplane-db",
+							"engine": "pg",
+							"version": "18.0",
+							"region": "nyc1",
+							"size": "db-s-1vcpu-1gb",
+							"num_nodes": 1,
+							"status": "online"
+						}
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata:       &contexts.MetadataContext{Metadata: map[string]any{"databaseClusterID": "cluster-1"}},
+			ExecutionState: executionState,
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.database.cluster.created", executionState.Type)
+	})
+
+	t.Run("creating cluster reschedules poll", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"database": {
+							"id": "cluster-1",
+							"name": "superplane-db",
+							"status": "creating"
+						}
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		requestCtx := &contexts.RequestContext{}
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata:       &contexts.MetadataContext{Metadata: map[string]any{"databaseClusterID": "cluster-1"}},
+			ExecutionState: executionState,
+			Requests:       requestCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "poll", requestCtx.Action)
+		assert.Equal(t, databaseClusterPollInterval, requestCtx.Duration)
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("failed cluster returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"database": {
+							"id": "cluster-1",
+							"name": "superplane-db",
+							"status": "failed"
+						}
+					}`)),
+				},
+			},
+		}
+
+		err := component.HandleAction(core.ActionContext{
+			Name: "poll",
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata:       &contexts.MetadataContext{Metadata: map[string]any{"databaseClusterID": "cluster-1"}},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+			Requests:       &contexts.RequestContext{},
+		})
+
+		require.ErrorContains(t, err, "database cluster reached failed status")
+	})
+}

--- a/pkg/integrations/digitalocean/database_cluster_metadata.go
+++ b/pkg/integrations/digitalocean/database_cluster_metadata.go
@@ -1,0 +1,61 @@
+package digitalocean
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DatabaseClusterNodeMetadata struct {
+	DatabaseClusterID   string `json:"databaseClusterId" mapstructure:"databaseClusterId"`
+	DatabaseClusterName string `json:"databaseClusterName" mapstructure:"databaseClusterName"`
+}
+
+func resolveDatabaseClusterMetadata(ctx core.SetupContext, clusterID string) error {
+	if strings.Contains(clusterID, "{{") {
+		return ctx.Metadata.Set(DatabaseClusterNodeMetadata{
+			DatabaseClusterID:   clusterID,
+			DatabaseClusterName: clusterID,
+		})
+	}
+
+	var existing DatabaseClusterNodeMetadata
+	err := mapstructure.Decode(ctx.Metadata.Get(), &existing)
+	if err == nil && existing.DatabaseClusterID == clusterID && existing.DatabaseClusterName != "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	clusters, err := client.ListDatabaseClusters()
+	if err != nil {
+		return fmt.Errorf("failed to list database clusters: %w", err)
+	}
+
+	clusterName := clusterID
+	found := false
+	for _, cluster := range clusters {
+		if cluster.ID != clusterID {
+			continue
+		}
+		found = true
+		if cluster.Name != "" {
+			clusterName = cluster.Name
+		}
+		break
+	}
+
+	if !found {
+		return fmt.Errorf("database cluster %q was not found", clusterID)
+	}
+
+	return ctx.Metadata.Set(DatabaseClusterNodeMetadata{
+		DatabaseClusterID:   clusterID,
+		DatabaseClusterName: clusterName,
+	})
+}

--- a/pkg/integrations/digitalocean/digitalocean.go
+++ b/pkg/integrations/digitalocean/digitalocean.go
@@ -113,6 +113,8 @@ func (d *DigitalOcean) Components() []core.Component {
 		&CopyObject{},
 		&DeleteObject{},
 		&CreateApp{},
+		&CreateDatabaseCluster{},
+		&GetDatabaseCluster{},
 		&GetApp{},
 		&DeleteApp{},
 		&UpdateApp{},

--- a/pkg/integrations/digitalocean/example.go
+++ b/pkg/integrations/digitalocean/example.go
@@ -227,6 +227,20 @@ func (c *CreateApp) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateAppOnce, exampleOutputCreateAppBytes, &exampleOutputCreateApp)
 }
 
+//go:embed example_output_create_database_cluster.json
+var exampleOutputCreateDatabaseClusterBytes []byte
+
+var exampleOutputCreateDatabaseClusterOnce sync.Once
+var exampleOutputCreateDatabaseCluster map[string]any
+
+func (c *CreateDatabaseCluster) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputCreateDatabaseClusterOnce,
+		exampleOutputCreateDatabaseClusterBytes,
+		&exampleOutputCreateDatabaseCluster,
+	)
+}
+
 //go:embed example_output_get_app.json
 var exampleOutputGetAppBytes []byte
 
@@ -235,6 +249,20 @@ var exampleOutputGetApp map[string]any
 
 func (g *GetApp) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetAppOnce, exampleOutputGetAppBytes, &exampleOutputGetApp)
+}
+
+//go:embed example_output_get_database_cluster.json
+var exampleOutputGetDatabaseClusterBytes []byte
+
+var exampleOutputGetDatabaseClusterOnce sync.Once
+var exampleOutputGetDatabaseCluster map[string]any
+
+func (g *GetDatabaseCluster) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetDatabaseClusterOnce,
+		exampleOutputGetDatabaseClusterBytes,
+		&exampleOutputGetDatabaseCluster,
+	)
 }
 
 //go:embed example_output_delete_app.json

--- a/pkg/integrations/digitalocean/example_output_create_database_cluster.json
+++ b/pkg/integrations/digitalocean/example_output_create_database_cluster.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "connection": {
+      "host": "superplane-db-do-user-123456-0.j.db.ondigitalocean.com",
+      "port": 25060,
+      "ssl": true,
+      "uri": "postgres://doadmin:[email protected]:25060/defaultdb?sslmode=require",
+      "user": "doadmin"
+    },
+    "created_at": "2026-03-27T13:00:00Z",
+    "engine": "pg",
+    "id": "65b497a5-1674-4b1a-a122-01aebe761ef7",
+    "name": "superplane-db",
+    "num_nodes": 1,
+    "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
+    "region": "nyc1",
+    "size": "db-s-1vcpu-1gb",
+    "status": "creating",
+    "version": "18.0"
+  },
+  "timestamp": "2026-03-27T13:00:05Z",
+  "type": "digitalocean.database.cluster.created"
+}

--- a/pkg/integrations/digitalocean/example_output_create_database_cluster.json
+++ b/pkg/integrations/digitalocean/example_output_create_database_cluster.json
@@ -15,7 +15,7 @@
     "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
     "region": "nyc1",
     "size": "db-s-1vcpu-1gb",
-    "status": "creating",
+    "status": "online",
     "version": "18.0"
   },
   "timestamp": "2026-03-27T13:00:05Z",

--- a/pkg/integrations/digitalocean/example_output_get_database_cluster.json
+++ b/pkg/integrations/digitalocean/example_output_get_database_cluster.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "connection": {
+      "host": "superplane-db-do-user-123456-0.j.db.ondigitalocean.com",
+      "port": 25060,
+      "ssl": true,
+      "uri": "postgres://doadmin:[email protected]:25060/defaultdb?sslmode=require",
+      "user": "doadmin"
+    },
+    "created_at": "2026-03-27T13:00:00Z",
+    "engine": "pg",
+    "id": "65b497a5-1674-4b1a-a122-01aebe761ef7",
+    "name": "superplane-db",
+    "num_nodes": 1,
+    "private_network_uuid": "7e6d2691-182b-4dd1-8452-529f88feb996",
+    "region": "nyc1",
+    "size": "db-s-1vcpu-1gb",
+    "status": "online",
+    "version": "18.0"
+  },
+  "timestamp": "2026-03-27T13:05:00Z",
+  "type": "digitalocean.database.cluster.fetched"
+}

--- a/pkg/integrations/digitalocean/get_database_cluster.go
+++ b/pkg/integrations/digitalocean/get_database_cluster.go
@@ -1,0 +1,144 @@
+package digitalocean
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetDatabaseCluster struct{}
+
+type GetDatabaseClusterSpec struct {
+	DatabaseCluster string `json:"databaseCluster" mapstructure:"databaseCluster"`
+}
+
+func (g *GetDatabaseCluster) Name() string {
+	return "digitalocean.getDatabaseCluster"
+}
+
+func (g *GetDatabaseCluster) Label() string {
+	return "Get Database Cluster"
+}
+
+func (g *GetDatabaseCluster) Description() string {
+	return "Retrieve details of a specific database cluster"
+}
+
+func (g *GetDatabaseCluster) Documentation() string {
+	return `The Get Database Cluster component retrieves the details of an existing DigitalOcean Managed Database cluster.
+
+## Use Cases
+
+- **Status checks**: Verify a cluster is online before creating databases or users
+- **Information retrieval**: Fetch connection details, sizing, engine, and region information
+- **Pre-flight validation**: Confirm a cluster exists before downstream operations
+
+## Configuration
+
+- **Database Cluster**: The managed database cluster to retrieve (required)
+
+## Output
+
+Returns the database cluster including:
+- **id**: The cluster UUID
+- **name**: The cluster name
+- **engine**: The configured engine
+- **version**: The engine version
+- **region**: The cluster region
+- **size**: The node size slug
+- **num_nodes**: The number of nodes
+- **status**: The cluster status
+- **connection**: Connection information when available
+
+## Important Notes
+
+- If you use custom token scopes, this action requires ` + "`database:read`" + `
+- The returned connection information depends on the cluster type and provisioning state.`
+}
+
+func (g *GetDatabaseCluster) Icon() string {
+	return "info"
+}
+
+func (g *GetDatabaseCluster) Color() string {
+	return "gray"
+}
+
+func (g *GetDatabaseCluster) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetDatabaseCluster) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "databaseCluster",
+			Label:       "Database Cluster",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The database cluster to retrieve",
+			Placeholder: "Select a database cluster",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "database_cluster",
+					UseNameAsValue: false,
+				},
+			},
+		},
+	}
+}
+
+func (g *GetDatabaseCluster) Setup(ctx core.SetupContext) error {
+	spec := GetDatabaseClusterSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.DatabaseCluster == "" {
+		return errors.New("databaseCluster is required")
+	}
+
+	if err := resolveDatabaseClusterMetadata(ctx, spec.DatabaseCluster); err != nil {
+		return fmt.Errorf("error resolving database cluster metadata: %v", err)
+	}
+
+	return nil
+}
+
+func (g *GetDatabaseCluster) Execute(ctx core.ExecutionContext) error {
+	spec := GetDatabaseClusterSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	cluster, err := client.GetDatabaseCluster(spec.DatabaseCluster)
+	if err != nil {
+		return fmt.Errorf("failed to get database cluster: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"digitalocean.database.cluster.fetched",
+		[]any{cluster},
+	)
+}
+
+func (g *GetDatabaseCluster) Cancel(ctx core.ExecutionContext) error { return nil }
+func (g *GetDatabaseCluster) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+func (g *GetDatabaseCluster) Actions() []core.Action                    { return []core.Action{} }
+func (g *GetDatabaseCluster) HandleAction(ctx core.ActionContext) error { return nil }
+func (g *GetDatabaseCluster) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+func (g *GetDatabaseCluster) Cleanup(ctx core.SetupContext) error { return nil }

--- a/pkg/integrations/digitalocean/get_database_cluster_test.go
+++ b/pkg/integrations/digitalocean/get_database_cluster_test.go
@@ -1,0 +1,98 @@
+package digitalocean
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetDatabaseCluster__Setup(t *testing.T) {
+	component := &GetDatabaseCluster{}
+
+	t.Run("missing cluster returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "databaseCluster is required")
+	})
+
+	t.Run("valid cluster resolves metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"databaseCluster": "cluster-1",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"databases": [
+								{"id": "cluster-1", "name": "superplane-db"}
+							]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, DatabaseClusterNodeMetadata{
+			DatabaseClusterID:   "cluster-1",
+			DatabaseClusterName: "superplane-db",
+		}, metadataCtx.Metadata)
+	})
+}
+
+func Test__GetDatabaseCluster__Execute(t *testing.T) {
+	component := &GetDatabaseCluster{}
+
+	t.Run("successful retrieval emits cluster", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"database": {
+							"id": "cluster-1",
+							"name": "superplane-db",
+							"engine": "pg",
+							"version": "18.0",
+							"region": "nyc1",
+							"size": "db-s-1vcpu-1gb",
+							"num_nodes": 1,
+							"status": "online"
+						}
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"databaseCluster": "cluster-1",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "digitalocean.database.cluster.fetched", executionState.Type)
+	})
+}

--- a/pkg/integrations/digitalocean/list_resources.go
+++ b/pkg/integrations/digitalocean/list_resources.go
@@ -36,6 +36,12 @@ func (d *DigitalOcean) ListResources(resourceType string, ctx core.ListResources
 		return listSpacesBuckets(ctx)
 	case "app":
 		return listApps(ctx)
+	case "database_cluster":
+		return listDatabaseClusters(ctx)
+	case "database_cluster_version":
+		return listDatabaseClusterVersions(ctx)
+	case "database_cluster_size":
+		return listDatabaseClusterSizes(ctx)
 	case "embedding_model":
 		return listEmbeddingModels(ctx)
 	case "project":
@@ -271,6 +277,109 @@ func listReservedIPs(ctx core.ListResourcesContext) ([]core.IntegrationResource,
 			Name: ip.IP,
 			ID:   ip.IP,
 		})
+	}
+
+	return resources, nil
+}
+
+func listDatabaseClusters(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	clusters, err := client.ListDatabaseClusters()
+	if err != nil {
+		return nil, fmt.Errorf("error listing database clusters: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(clusters))
+	for _, cluster := range clusters {
+		name := cluster.Name
+		if name == "" {
+			name = cluster.ID
+		}
+
+		resources = append(resources, core.IntegrationResource{
+			Type: "database_cluster",
+			Name: name,
+			ID:   cluster.ID,
+		})
+	}
+
+	return resources, nil
+}
+
+func listDatabaseClusterVersions(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	engine := ctx.Parameters["engine"]
+	if engine == "" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	options, err := client.GetDatabaseOptions()
+	if err != nil {
+		return nil, fmt.Errorf("error listing database cluster versions: %w", err)
+	}
+
+	engineOptions, ok := options[engine]
+	if !ok {
+		return []core.IntegrationResource{}, nil
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(engineOptions.Versions))
+	for _, version := range engineOptions.Versions {
+		resources = append(resources, core.IntegrationResource{
+			Type: "database_cluster_version",
+			Name: version,
+			ID:   version,
+		})
+	}
+
+	return resources, nil
+}
+
+func listDatabaseClusterSizes(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	engine := ctx.Parameters["engine"]
+	numNodes := ctx.Parameters["numNodes"]
+	if engine == "" || numNodes == "" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	options, err := client.GetDatabaseOptions()
+	if err != nil {
+		return nil, fmt.Errorf("error listing database cluster sizes: %w", err)
+	}
+
+	engineOptions, ok := options[engine]
+	if !ok {
+		return []core.IntegrationResource{}, nil
+	}
+
+	resources := []core.IntegrationResource{}
+	for _, layout := range engineOptions.Layouts {
+		if fmt.Sprintf("%d", layout.NumNodes) != numNodes {
+			continue
+		}
+
+		resources = make([]core.IntegrationResource, 0, len(layout.Sizes))
+		for _, size := range layout.Sizes {
+			resources = append(resources, core.IntegrationResource{
+				Type: "database_cluster_size",
+				Name: size,
+				ID:   size,
+			})
+		}
+		break
 	}
 
 	return resources, nil

--- a/pkg/integrations/digitalocean/list_resources_test.go
+++ b/pkg/integrations/digitalocean/list_resources_test.go
@@ -279,6 +279,152 @@ func Test__ListResources__Sizes(t *testing.T) {
 	})
 }
 
+func Test__ListResources__DatabaseClusters(t *testing.T) {
+	integration := &DigitalOcean{}
+
+	t.Run("successful cluster listing returns resources", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"databases": [
+							{"id": "cluster-1", "name": "superplane-db", "engine": "pg"},
+							{"id": "cluster-2", "name": "analytics-db", "engine": "mysql"}
+						]
+					}`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("database_cluster", core.ListResourcesContext{
+			HTTP:        httpContext,
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		assert.Equal(t, "database_cluster", resources[0].Type)
+		assert.Equal(t, "superplane-db", resources[0].Name)
+		assert.Equal(t, "cluster-1", resources[0].ID)
+	})
+
+	t.Run("null database list returns empty resources", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"databases": null
+					}`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("database_cluster", core.ListResourcesContext{
+			HTTP:        httpContext,
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+}
+
+func Test__ListResources__DatabaseClusterVersions(t *testing.T) {
+	integration := &DigitalOcean{}
+
+	t.Run("missing engine returns empty resources", func(t *testing.T) {
+		resources, err := integration.ListResources("database_cluster_version", core.ListResourcesContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+
+	t.Run("successful version listing returns versions for engine", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"options": {
+							"pg": {
+								"versions": ["14", "15", "16", "18"],
+								"layouts": []
+							},
+							"mysql": {
+								"versions": ["8"],
+								"layouts": []
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("database_cluster_version", core.ListResourcesContext{
+			HTTP:        httpContext,
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+			Parameters:  map[string]string{"engine": "pg"},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 4)
+		assert.Equal(t, "14", resources[0].ID)
+		assert.Equal(t, "18", resources[3].Name)
+	})
+}
+
+func Test__ListResources__DatabaseClusterSizes(t *testing.T) {
+	integration := &DigitalOcean{}
+
+	t.Run("missing parameters returns empty resources", func(t *testing.T) {
+		resources, err := integration.ListResources("database_cluster_size", core.ListResourcesContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+			Parameters:  map[string]string{"engine": "pg"},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+
+	t.Run("successful size listing returns sizes for engine and node count", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"options": {
+							"pg": {
+								"versions": ["18"],
+								"layouts": [
+									{"num_nodes": 1, "sizes": ["db-s-1vcpu-1gb", "db-s-1vcpu-2gb"]},
+									{"num_nodes": 2, "sizes": ["db-s-1vcpu-2gb", "db-s-2vcpu-4gb"]}
+								]
+							}
+						}
+					}`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("database_cluster_size", core.ListResourcesContext{
+			HTTP:        httpContext,
+			Integration: &contexts.IntegrationContext{Configuration: map[string]any{"apiToken": "test-token"}},
+			Parameters:  map[string]string{"engine": "pg", "numNodes": "2"},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		assert.Equal(t, "db-s-1vcpu-2gb", resources[0].ID)
+		assert.Equal(t, "db-s-2vcpu-4gb", resources[1].Name)
+	})
+}
+
 func Test__ListResources__Images(t *testing.T) {
 	integration := &DigitalOcean{}
 

--- a/templates/skills/digitalocean.createDatabaseCluster.md
+++ b/templates/skills/digitalocean.createDatabaseCluster.md
@@ -1,0 +1,21 @@
+# digitalocean.createDatabaseCluster
+
+Create a new DigitalOcean Managed Database cluster.
+
+## When to use
+
+- Provision a fresh managed database cluster for a service or environment
+- Create database infrastructure before downstream app, database, or migration steps
+
+## Expected inputs
+
+- `Name`
+- `Engine`
+- `Version`
+- `Region`
+- `Size`
+- `Node Count`
+
+## Output
+
+- The created cluster object, including its ID, engine, version, region, size, and status

--- a/templates/skills/digitalocean.getDatabaseCluster.md
+++ b/templates/skills/digitalocean.getDatabaseCluster.md
@@ -1,0 +1,16 @@
+# digitalocean.getDatabaseCluster
+
+Retrieve details of an existing DigitalOcean Managed Database cluster.
+
+## When to use
+
+- Inspect a cluster before creating databases, users, or connection pools
+- Read connection details, sizing, and current status for routing or validation steps
+
+## Expected inputs
+
+- `Database Cluster`
+
+## Output
+
+- The database cluster object, including ID, engine, version, region, size, node count, status, and connection details

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
@@ -1,6 +1,6 @@
 import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
 import type React from "react";
-import { getBackgroundColorClass } from "@/utils/colors";
+import { getBackgroundColorClass } from "@/lib/colors";
 import { getState, getStateMap, getTriggerRenderer } from "..";
 import type {
   ComponentBaseContext,

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
@@ -1,0 +1,98 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import doIcon from "@/assets/icons/integrations/digitalocean.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import type { CreateDatabaseClusterConfiguration } from "./types";
+
+export const createDatabaseClusterMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "digitalocean";
+
+    return {
+      iconSrc: doIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const cluster = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!cluster) return details;
+
+    details["Cluster ID"] = String(cluster.id || "-");
+    details["Name"] = String(cluster.name || "-");
+    details["Engine"] = String(cluster.engine || "-");
+    details["Version"] = String(cluster.version || "-");
+    details["Region"] = String(cluster.region || "-");
+    details["Size"] = String(cluster.size || "-");
+    details["Node Count"] = String(cluster.num_nodes || "-");
+    details["Status"] = String(cluster.status || "-");
+
+    const connection = cluster.connection as Record<string, unknown> | undefined;
+    if (connection?.host) details["Host"] = String(connection.host);
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as CreateDatabaseClusterConfiguration;
+
+  if (configuration?.name) metadata.push({ icon: "database", label: configuration.name });
+  if (configuration?.engine) metadata.push({ icon: "cpu", label: configuration.engine });
+  if (configuration?.region) metadata.push({ icon: "map-pinned", label: configuration.region });
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.id || !execution.createdAt) return [];
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) return [];
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
@@ -44,7 +44,6 @@ export const createDatabaseClusterMapper: ComponentBaseMapper = {
     const cluster = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
     if (!cluster) return details;
 
-    details["Cluster ID"] = String(cluster.id || "-");
     details["Name"] = String(cluster.name || "-");
     details["Engine"] = String(cluster.engine || "-");
     details["Version"] = String(cluster.version || "-");

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/create_database_cluster.ts
@@ -49,7 +49,7 @@ export const createDatabaseClusterMapper: ComponentBaseMapper = {
     details["Version"] = String(cluster.version || "-");
     details["Region"] = String(cluster.region || "-");
     details["Size"] = String(cluster.size || "-");
-    details["Node Count"] = String(cluster.num_nodes || "-");
+    details["Node Count"] = String(cluster.num_nodes ?? "-");
     details["Status"] = String(cluster.status || "-");
 
     const connection = cluster.connection as Record<string, unknown> | undefined;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/database_cluster.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/database_cluster.spec.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+
+import { createDatabaseClusterMapper } from "./create_database_cluster";
+import { getDatabaseClusterMapper } from "./get_database_cluster";
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+
+const defaultDefinition: ComponentDefinition = {
+  name: "digitalocean.createDatabaseCluster",
+  label: "Create Database Cluster",
+  description: "",
+  icon: "database",
+  color: "blue",
+};
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "digitalocean.createDatabaseCluster",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "digitalocean.result",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      roles: [],
+      groups: [],
+    },
+    actions: {
+      invokeNodeExecutionAction: async () => {},
+    },
+    ...overrides,
+  };
+}
+
+const clusterMappers = [
+  { label: "createDatabaseClusterMapper", mapper: createDatabaseClusterMapper },
+  { label: "getDatabaseClusterMapper", mapper: getDatabaseClusterMapper },
+] as const;
+
+describe.each(clusterMappers)("$label.getExecutionDetails", ({ mapper }) => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => mapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => mapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data fields are all missing", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => mapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts cluster fields and uses dash placeholders", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              name: "superplane-db",
+              engine: "pg",
+              version: "18.0",
+              region: "nyc1",
+              size: "db-s-1vcpu-1gb",
+              num_nodes: 1,
+              status: "online",
+            }),
+          ],
+        },
+      },
+    });
+    const details = mapper.getExecutionDetails(ctx);
+    expect(details["Name"]).toBe("superplane-db");
+    expect(details["Engine"]).toBe("pg");
+    expect(details["Version"]).toBe("18.0");
+    expect(details["Region"]).toBe("nyc1");
+    expect(details["Size"]).toBe("db-s-1vcpu-1gb");
+    expect(details["Node Count"]).toBe("1");
+    expect(details["Status"]).toBe("online");
+  });
+
+  it("includes Host when connection.host is present", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              name: "db",
+              connection: { host: "db.example.com", port: 25060 },
+            }),
+          ],
+        },
+      },
+    });
+    expect(mapper.getExecutionDetails(ctx)["Host"]).toBe("db.example.com");
+  });
+
+  it("omits Host when connection is missing or has no host", () => {
+    const withoutConnection = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({ name: "db" })] } },
+    });
+    expect(mapper.getExecutionDetails(withoutConnection)["Host"]).toBeUndefined();
+
+    const emptyHost = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({ connection: { port: 123 } })] } },
+    });
+    expect(mapper.getExecutionDetails(emptyHost)["Host"]).toBeUndefined();
+  });
+});
+
+describe("createDatabaseClusterMapper.props", () => {
+  it("includes name, engine, and region in metadata when configured", () => {
+    const props = createDatabaseClusterMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: {
+            name: "my-cluster",
+            engine: "pg",
+            region: "nyc1",
+          },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "my-cluster" },
+      { icon: "cpu", label: "pg" },
+      { icon: "map-pinned", label: "nyc1" },
+    ]);
+  });
+
+  it("omits metadata entries when configuration fields are absent", () => {
+    const props = createDatabaseClusterMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: { name: "only-name" } }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "database", label: "only-name" }]);
+  });
+});
+
+describe("getDatabaseClusterMapper.props", () => {
+  it("prefers database cluster name from node metadata", () => {
+    const props = getDatabaseClusterMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          componentName: "digitalocean.getDatabaseCluster",
+          metadata: { databaseClusterName: "Resolved Name" },
+          configuration: { databaseCluster: "cluster-uuid" },
+        }),
+        componentDefinition: {
+          ...defaultDefinition,
+          name: "digitalocean.getDatabaseCluster",
+          label: "Get Database Cluster",
+        },
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "database", label: "Resolved Name" }]);
+  });
+
+  it("falls back to cluster id label when name metadata is absent", () => {
+    const props = getDatabaseClusterMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          componentName: "digitalocean.getDatabaseCluster",
+          metadata: {},
+          configuration: { databaseCluster: "65b497a5-1674-4b1a-a122-01aebe761ef7" },
+        }),
+        componentDefinition: {
+          ...defaultDefinition,
+          name: "digitalocean.getDatabaseCluster",
+          label: "Get Database Cluster",
+        },
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "info", label: "Cluster ID: 65b497a5-1674-4b1a-a122-01aebe761ef7" }]);
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
@@ -14,7 +14,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import doIcon from "@/assets/icons/integrations/digitalocean.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import type { DatabaseClusterNodeMetadata } from "./types";
+import type { DatabaseClusterNodeMetadata, GetDatabaseClusterConfiguration } from "./types";
 
 export const getDatabaseClusterMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
@@ -67,9 +67,12 @@ export const getDatabaseClusterMapper: ComponentBaseMapper = {
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const nodeMetadata = node.metadata as DatabaseClusterNodeMetadata | undefined;
+  const configuration = node.configuration as GetDatabaseClusterConfiguration;
 
   if (nodeMetadata?.databaseClusterName) {
     metadata.push({ icon: "database", label: nodeMetadata.databaseClusterName });
+  } else if (configuration?.databaseCluster) {
+    metadata.push({ icon: "info", label: `Cluster ID: ${configuration.databaseCluster}` });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
@@ -1,6 +1,6 @@
 import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
 import type React from "react";
-import { getBackgroundColorClass } from "@/utils/colors";
+import { getBackgroundColorClass } from "@/lib/colors";
 import { getState, getStateMap, getTriggerRenderer } from "..";
 import type {
   ComponentBaseContext,

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
@@ -1,0 +1,101 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/utils/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import doIcon from "@/assets/icons/integrations/digitalocean.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import type { DatabaseClusterNodeMetadata, GetDatabaseClusterConfiguration } from "./types";
+
+export const getDatabaseClusterMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "digitalocean";
+
+    return {
+      iconSrc: doIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const cluster = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!cluster) return details;
+
+    details["Cluster ID"] = String(cluster.id || "-");
+    details["Name"] = String(cluster.name || "-");
+    details["Engine"] = String(cluster.engine || "-");
+    details["Version"] = String(cluster.version || "-");
+    details["Region"] = String(cluster.region || "-");
+    details["Size"] = String(cluster.size || "-");
+    details["Node Count"] = String(cluster.num_nodes || "-");
+    details["Status"] = String(cluster.status || "-");
+
+    const connection = cluster.connection as Record<string, unknown> | undefined;
+    if (connection?.host) details["Host"] = String(connection.host);
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as DatabaseClusterNodeMetadata | undefined;
+  const configuration = node.configuration as GetDatabaseClusterConfiguration;
+
+  if (nodeMetadata?.databaseClusterName) {
+    metadata.push({ icon: "database", label: nodeMetadata.databaseClusterName });
+  } else if (configuration?.databaseCluster) {
+    metadata.push({ icon: "info", label: `Cluster ID: ${configuration.databaseCluster}` });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.id || !execution.createdAt) return [];
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) return [];
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
@@ -14,7 +14,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import doIcon from "@/assets/icons/integrations/digitalocean.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import type { DatabaseClusterNodeMetadata, GetDatabaseClusterConfiguration } from "./types";
+import type { DatabaseClusterNodeMetadata } from "./types";
 
 export const getDatabaseClusterMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
@@ -44,7 +44,6 @@ export const getDatabaseClusterMapper: ComponentBaseMapper = {
     const cluster = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
     if (!cluster) return details;
 
-    details["Cluster ID"] = String(cluster.id || "-");
     details["Name"] = String(cluster.name || "-");
     details["Engine"] = String(cluster.engine || "-");
     details["Version"] = String(cluster.version || "-");
@@ -68,12 +67,9 @@ export const getDatabaseClusterMapper: ComponentBaseMapper = {
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const nodeMetadata = node.metadata as DatabaseClusterNodeMetadata | undefined;
-  const configuration = node.configuration as GetDatabaseClusterConfiguration;
 
   if (nodeMetadata?.databaseClusterName) {
     metadata.push({ icon: "database", label: nodeMetadata.databaseClusterName });
-  } else if (configuration?.databaseCluster) {
-    metadata.push({ icon: "info", label: `Cluster ID: ${configuration.databaseCluster}` });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/get_database_cluster.ts
@@ -49,7 +49,7 @@ export const getDatabaseClusterMapper: ComponentBaseMapper = {
     details["Version"] = String(cluster.version || "-");
     details["Region"] = String(cluster.region || "-");
     details["Size"] = String(cluster.size || "-");
-    details["Node Count"] = String(cluster.num_nodes || "-");
+    details["Node Count"] = String(cluster.num_nodes ?? "-");
     details["Status"] = String(cluster.status || "-");
 
     const connection = cluster.connection as Record<string, unknown> | undefined;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/index.ts
@@ -21,7 +21,9 @@ import { putObjectMapper, PUT_OBJECT_STATE_REGISTRY } from "./put_object";
 import { deleteObjectMapper, DELETE_OBJECT_STATE_REGISTRY } from "./delete_object";
 import { copyObjectMapper, COPY_OBJECT_STATE_REGISTRY } from "./copy_object";
 import { createAppMapper } from "./create_app";
+import { createDatabaseClusterMapper } from "./create_database_cluster";
 import { getAppMapper } from "./get_app";
+import { getDatabaseClusterMapper } from "./get_database_cluster";
 import { deleteAppMapper } from "./delete_app";
 import { updateAppMapper } from "./update_app";
 import { createKnowledgeBaseMapper } from "./create_knowledge_base";
@@ -54,7 +56,9 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   deleteObject: deleteObjectMapper,
   copyObject: copyObjectMapper,
   createApp: createAppMapper,
+  createDatabaseCluster: createDatabaseClusterMapper,
   getApp: getAppMapper,
+  getDatabaseCluster: getDatabaseClusterMapper,
   deleteApp: deleteAppMapper,
   updateApp: updateAppMapper,
   createKnowledgeBase: createKnowledgeBaseMapper,
@@ -89,7 +93,9 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   deleteObject: DELETE_OBJECT_STATE_REGISTRY,
   copyObject: COPY_OBJECT_STATE_REGISTRY,
   createApp: buildActionStateRegistry("created"),
+  createDatabaseCluster: buildActionStateRegistry("created"),
   getApp: buildActionStateRegistry("fetched"),
+  getDatabaseCluster: buildActionStateRegistry("fetched"),
   deleteApp: buildActionStateRegistry("deleted"),
   updateApp: buildActionStateRegistry("updated"),
   createKnowledgeBase: buildActionStateRegistry("created"),

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/types.ts
@@ -203,6 +203,24 @@ export interface AppNodeMetadata {
   appName?: string;
 }
 
+export interface DatabaseClusterNodeMetadata {
+  databaseClusterId?: string;
+  databaseClusterName?: string;
+}
+
+export interface CreateDatabaseClusterConfiguration {
+  name?: string;
+  engine?: string;
+  version?: string;
+  region?: string;
+  size?: string;
+  numNodes?: string;
+}
+
+export interface GetDatabaseClusterConfiguration {
+  databaseCluster: string;
+}
+
 export interface CreateAppConfiguration {
   name: string;
   region: string;


### PR DESCRIPTION
Implements https://github.com/superplanehq/superplane/issues/3736

This expands the DigitalOcean integration by adding the following components:

- `digitalocean.CreateDatabaseCluster`
- `digitalocean.GetDatabaseCluster`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DigitalOcean API calls and workflow components that provision managed database clusters and poll for readiness, which can impact user workflows if API responses/options handling differ from expectations.
> 
> **Overview**
> Adds two new DigitalOcean workflow actions: `digitalocean.createDatabaseCluster` (provisions a managed DB cluster and polls until `online`) and `digitalocean.getDatabaseCluster` (fetches cluster details).
> 
> Extends the DigitalOcean client and resource listing to support managed database clusters plus option-driven UI resources (cluster list, engine versions, and size-by-node-count), and wires these into docs, templates, example outputs, and the workflow UI mappers/state registries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0d60bfe225a1075fb0d0bf81657b8255ee2c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->