### PR TITLE
fix: rename Merge component to Join

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -25,7 +25,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Filter" href="#filter" description="Filter events based on their content" />
   <LinkCard title="HTTP Request" href="#http-request" description="Make HTTP requests" />
   <LinkCard title="If" href="#if" description="Route events based on expression" />
-  <LinkCard title="Merge" href="#merge" description="Merge multiple upstream inputs and forward" />
+  <LinkCard title="Join" href="#join" description="Wait for all upstream nodes before continuing (fan-in)" />
   <LinkCard title="No Operation" href="#no-operation" description="Just pass events through without any additional processing" />
   <LinkCard title="Read Memory" href="#read-memory" description="Find values from canvas memory by namespace and field matches" />
   <LinkCard title="Send Email Notification" href="#send-email-notification" description="Send an email notification using the system email provider" />
@@ -485,28 +485,32 @@ The expression has access to:
 }
 ```
 
+<a id="join"></a>
 <a id="merge"></a>
 
-## Merge
+## Join
 
-The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.
+The Join component (internal name: `merge`) waits for events from all upstream nodes before continuing (fan-in / barrier).
 
 ### Use Cases
 
 - **Parallel processing**: Wait for multiple parallel operations to complete
-- **Data aggregation**: Combine results from multiple sources
 - **Synchronization**: Synchronize multiple workflow branches
 - **Fan-in patterns**: Collect outputs from multiple upstream nodes
 
 ### How It Works
 
-1. The Merge component waits for events from all distinct upstream source nodes
-2. Once all inputs are received, it emits the combined data to the Success channel
+1. Join waits for events from all distinct upstream source nodes
+2. Once all inputs are received, it emits a success event downstream
 3. Optional timeout and conditional stop features allow early completion
+
+### Output Payload
+
+Join does **not** merge upstream payload bodies into a single combined payload. Its output is metadata about what arrived (e.g., source node IDs and event IDs).
 
 ### Configuration Options
 
-- **Enable Timeout**: Cancel merge after a specified time if not all inputs are received
+- **Enable Timeout**: Cancel join after a specified time if not all inputs are received
 - **Enable Conditional Stop**: Stop waiting early when a condition is met (e.g., if one branch fails)
 
 ### Output Channels
@@ -518,7 +522,7 @@ The Merge component waits for events from all upstream nodes before forwarding a
 ### Behavior
 
 - Tracks distinct source nodes (ignoring multiple channels from the same source)
-- Combines all received event data into the output
+- Emits metadata describing what arrived
 - Supports timeout to prevent indefinite waiting
 - Supports conditional early stop based on expression evaluation
 

--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -16,9 +16,9 @@ import (
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
-// Merge is a component that passes its input downstream on
-// different channels based on execution outcome. The queue/worker
-// layer is responsible for aggregating inputs from multiple parents.
+// Merge is a fan-in/barrier component that waits for all distinct upstream
+// source nodes to reach it before continuing. The queue/worker layer is
+// responsible for aggregating arrivals from multiple parents.
 
 // Output channel names for Merge component
 const (
@@ -34,23 +34,26 @@ func init() {
 type Merge struct{}
 
 func (m *Merge) Name() string        { return "merge" }
-func (m *Merge) Label() string       { return "Merge" }
-func (m *Merge) Description() string { return "Merge multiple upstream inputs and forward" }
+func (m *Merge) Label() string       { return "Join" }
+func (m *Merge) Description() string { return "Wait for all upstream nodes before continuing (fan-in)" }
 func (m *Merge) Documentation() string {
-	return `The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.
+	return `The Join component (internal name: ` + "`merge`" + `) waits for events from all upstream nodes before continuing (fan-in / barrier).
 
 ## Use Cases
 
 - **Parallel processing**: Wait for multiple parallel operations to complete
-- **Data aggregation**: Combine results from multiple sources
 - **Synchronization**: Synchronize multiple workflow branches
 - **Fan-in patterns**: Collect outputs from multiple upstream nodes
 
 ## How It Works
 
-1. The Merge component waits for events from all distinct upstream source nodes
-2. Once all inputs are received, it emits the combined data to the Success channel
+1. Join waits for events from all distinct upstream source nodes
+2. Once all inputs are received, it emits a success event downstream
 3. Optional timeout and conditional stop features allow early completion
+
+## Output Payload
+
+Join does **not** merge upstream payload bodies into a single combined payload. Its output is metadata about what arrived (e.g., source node IDs and event IDs).
 
 ## Configuration Options
 
@@ -66,7 +69,7 @@ func (m *Merge) Documentation() string {
 ## Behavior
 
 - Tracks distinct source nodes (ignoring multiple channels from the same source)
-- Combines all received event data into the output
+- Emits metadata describing what arrived
 - Supports timeout to prevent indefinite waiting
 - Supports conditional early stop based on expression evaluation`
 }

--- a/scripts/generate_components_docs.go
+++ b/scripts/generate_components_docs.go
@@ -127,7 +127,13 @@ func writeComponentSection(buf *bytes.Buffer, components []core.Component) {
 	}
 
 	for _, component := range components {
-		buf.WriteString(fmt.Sprintf("<a id=\"%s\"></a>\n\n", slugify(component.Label())))
+		anchor := slugify(component.Label())
+		buf.WriteString(fmt.Sprintf("<a id=\"%s\"></a>\n\n", anchor))
+		// Backward-compatible anchor for renamed core components.
+		// This preserves existing links like /components/core#merge even after renaming "Merge" → "Join".
+		if component.Name() == "merge" && anchor != "merge" {
+			buf.WriteString("<a id=\"merge\"></a>\n\n")
+		}
 		buf.WriteString(fmt.Sprintf("## %s\n\n", component.Label()))
 
 		// Write documentation if available, otherwise fall back to description
@@ -182,9 +188,15 @@ func writeCardGridComponents(buf *bytes.Buffer, components []core.Component) {
 	buf.WriteString("<CardGrid>\n")
 	for _, component := range components {
 		description := strings.TrimSpace(component.Description())
+		hrefAnchor := slugify(component.Label())
+		// Backward-compatible link for renamed core components.
+		// This preserves in-page navigation to #merge even after renaming "Merge" → "Join".
+		if component.Name() == "merge" && hrefAnchor != "merge" {
+			hrefAnchor = "merge"
+		}
 		buf.WriteString(fmt.Sprintf("  <LinkCard title=\"%s\" href=\"#%s\" description=\"%s\" />\n",
 			escapeQuotes(component.Label()),
-			slugify(component.Label()),
+			hrefAnchor,
 			escapeQuotes(description),
 		))
 	}

--- a/templates/canvases/incident-data-collection.yaml
+++ b/templates/canvases/incident-data-collection.yaml
@@ -226,7 +226,7 @@ spec:
       configuration:
         color: "yellow"
         height: 265
-        text: "### 3. Collect metrics and health data\n\nThis step uses Dash0 to collect health signals from multiple sources and prepare data for a summary. The Dash0 List Issues component retrieves all failing checks, while Prometheus Query components fetch database memory and CPU usage metrics.\n\nA Merge component waits for all three data collection nodes to complete before the workflow continues.\n\n___\n\n**To use this with your dash0 instance:**   \n- Ensure check rules are configured in Dash0\n- Review the queries used for database memory and CPU usage\n- Update the queries to match your environment\n"
+        text: "### 3. Collect metrics and health data\n\nThis step uses Dash0 to collect health signals from multiple sources and prepare data for a summary. The Dash0 List Issues component retrieves all failing checks, while Prometheus Query components fetch database memory and CPU usage metrics.\n\nA Join component waits for all three data collection nodes to complete before the workflow continues.\n\n___\n\n**To use this with your dash0 instance:**   \n- Ensure check rules are configured in Dash0\n- Review the queries used for database memory and CPU usage\n- Update the queries to match your environment\n"
         width: 977
       metadata: null
       position:

--- a/templates/canvases/incident-router.yaml
+++ b/templates/canvases/incident-router.yaml
@@ -154,7 +154,7 @@ spec:
       configuration:
         color: "yellow"
         height: 168
-        text: "### 3. Use AI to generate a title and description\n\nThe OpenAI component can access payloads from upstream nodes. Here, it generates a title and description used to create a PagerDuty incident and a GitHub issue. A Merge component waits for both outputs before continuing.\n\n___\n- See how the OpenAI component references upstream data\n- Explore how the [Merge component](https://docs.superplane.com/components/core/#merge) works\n"
+        text: "### 3. Use AI to generate a title and description\n\nThe OpenAI component can access payloads from upstream nodes. Here, it generates a title and description used to create a PagerDuty incident and a GitHub issue. A Join component waits for both outputs before continuing.\n\n___\n- See how the OpenAI component references upstream data\n- Explore how the [Join component](https://docs.superplane.com/components/core/#join) works\n"
         width: 759
       metadata: null
       position:

--- a/web_src/src/pages/workflowv2/mappers/merge.ts
+++ b/web_src/src/pages/workflowv2/mappers/merge.ts
@@ -172,7 +172,7 @@ export const mergeMapper: ComponentBaseMapper = {
       iconColor: getColorClass(context.componentDefinition?.color || "gray"),
       collapsedBackground: getBackgroundColorClass("white"),
       collapsed: context.node.isCollapsed,
-      title: context.node.name || context.componentDefinition?.label || "Merge",
+      title: context.node.name || context.componentDefinition?.label || "Join",
       eventSections: lastExecution
         ? getMergeEventSections(context.nodes, lastExecution, context.additionalData)
         : undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Rename the user-facing **Merge** component to **Join** to match its actual behavior (fan-in / barrier that waits for all upstream nodes).

## Why
Users expect “merge” to combine payloads. This component primarily synchronizes branches; its output is metadata about what arrived.

## Changes
- Backend `merge` component now reports label **Join** and clarifies behavior/output.
- Workflow v2 mapper fallback title updated to **Join**.
- `docs/components/Core.mdx` updated to show **Join**, while preserving the legacy `#merge` anchor.
- Canvas templates updated to reference **Join** and link to `#join`.

## Backward compatibility
- Internal component name remains `merge` (templates/canvases and saved nodes still work).
- Docs preserve old `#merge` anchor as an alias.

## Verification
- Ran `npm ci`, `make format.js`, and `npm run build` in `web_src/`.

Notes: Go tests/docs generator weren’t runnable in this environment because the repo requires Go 1.25 and the VM has Go 1.22 (no toolchain auto-download available).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e621c29f-f329-4cda-b8f6-0c0be8c93277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e621c29f-f329-4cda-b8f6-0c0be8c93277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

