### PR TITLE
fix: skip draft lookup when versioning is off

### DIFF
--- a/test/e2e/canvas_auto_save_test.go
+++ b/test/e2e/canvas_auto_save_test.go
@@ -26,6 +26,28 @@ func TestCanvasAutoSave(t *testing.T) {
 		steps.moveNode("Auto Save Node", 100, 80)
 		steps.waitForSaved()
 	})
+
+	t.Run("node position preserved when moved again during autosave", func(t *testing.T) {
+		steps := &canvasAutoSaveSteps{t: t}
+		steps.start()
+		steps.givenCanvasWithVersioningEnabled("E2E Auto Save Race")
+		steps.enterEditMode()
+		steps.addNoopNode("Race Node", models.Position{X: 300, Y: 200})
+		steps.waitForSaved()
+		steps.dismissSidebar()
+
+		// First move triggers autosave (100ms debounce).
+		// Use moveNodeFast (no trailing sleep) so the second move
+		// happens while the first save is likely still in-flight.
+		steps.moveNodeFast("Race Node", 100, 0)
+		// Second move happens immediately — races with the first save response.
+		steps.moveNode("Race Node", 100, 0)
+
+		steps.waitForSaved()
+
+		// The persisted position must reflect BOTH moves.
+		steps.assertNodePositionInDB("Race Node", 500, 200)
+	})
 }
 
 type canvasAutoSaveSteps struct {
@@ -105,6 +127,75 @@ func (s *canvasAutoSaveSteps) moveNode(name string, deltaX, deltaY int) {
 	require.NoError(s.t, s.session.Page().Mouse().Up())
 
 	s.session.Sleep(300)
+}
+
+// moveNodeFast is like moveNode but without the trailing sleep,
+// allowing a subsequent move to race with the autosave triggered by this one.
+func (s *canvasAutoSaveSteps) moveNodeFast(name string, deltaX, deltaY int) {
+	loc := nodeHeaderSelector(name).Run(s.session)
+
+	err := loc.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(10000),
+	})
+	require.NoError(s.t, err)
+
+	box, err := loc.BoundingBox()
+	require.NoError(s.t, err)
+	require.NotNil(s.t, box)
+
+	startX := box.X + box.Width/2
+	startY := box.Y + box.Height/2
+
+	require.NoError(s.t, s.session.Page().Mouse().Move(startX, startY))
+	require.NoError(s.t, s.session.Page().Mouse().Down())
+	require.NoError(s.t, s.session.Page().Mouse().Move(
+		startX+float64(deltaX),
+		startY+float64(deltaY),
+		pw.MouseMoveOptions{Steps: pw.Int(10)},
+	))
+	require.NoError(s.t, s.session.Page().Mouse().Up())
+}
+
+// assertNodePositionInDB verifies that the persisted node position matches
+// the expected coordinates (draft version when versioning is enabled, live
+// version when versioning is disabled).
+func (s *canvasAutoSaveSteps) assertNodePositionInDB(name string, expectedX, expectedY int) {
+	canvas, err := models.FindCanvas(s.session.OrgID, s.canvas.WorkflowID)
+	require.NoError(s.t, err, "finding canvas")
+
+	organizationVersioningEnabled, err := models.IsCanvasVersioningEnabled(s.session.OrgID)
+	require.NoError(s.t, err, "finding organization versioning state")
+
+	isVersioningEnabled := organizationVersioningEnabled || canvas.VersioningEnabled
+
+	var version *models.CanvasVersion
+	if isVersioningEnabled {
+		draft, draftErr := models.FindCanvasDraftInTransaction(
+			database.Conn(), s.canvas.WorkflowID, s.session.UserID,
+		)
+		require.NoError(s.t, draftErr, "finding user draft")
+
+		version, err = models.FindCanvasVersion(s.canvas.WorkflowID, draft.VersionID)
+		require.NoError(s.t, err, "finding canvas version")
+	} else {
+		version, err = models.FindLiveCanvasVersionInTransaction(database.Conn(), s.canvas.WorkflowID)
+		require.NoError(s.t, err, "finding live canvas version")
+	}
+
+	var found bool
+	for _, node := range version.Nodes {
+		if node.Name != name {
+			continue
+		}
+		found = true
+		require.Equal(s.t, expectedX, node.Position.X,
+			"node %q X position: want %d, got %d", name, expectedX, node.Position.X)
+		require.Equal(s.t, expectedY, node.Position.Y,
+			"node %q Y position: want %d, got %d", name, expectedY, node.Position.Y)
+		break
+	}
+	require.True(s.t, found, "node %q not found in version nodes", name)
 }
 
 // waitForSaved polls the canvas save status indicator until it reports "saved".

--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -27,6 +27,7 @@ type TestSession struct {
 
 	BaseURL string
 	OrgID   uuid.UUID
+	UserID  uuid.UUID
 	Account *models.Account
 }
 
@@ -201,6 +202,7 @@ func (s *TestSession) setupUserAndOrganization() {
 	}
 
 	s.OrgID = organization.ID
+	s.UserID = user.ID
 	s.Account = account
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update canvas autosave e2e DB assertion to check whether versioning is enabled before reading `workflow_user_drafts`
- when versioning is enabled, read the draft by the session **user ID** (not account ID)
- when versioning is disabled, assert persisted node position from the live canvas version instead of a draft
- keep `TestSession` user identity available via `UserID` for e2e DB assertions

## Validation
- attempted to run: `go test ./test/e2e -run TestCanvasAutoSave -count=1`
- blocked in this cloud environment due to unavailable Go 1.25 toolchain (`go.mod` requires go >= 1.25)

## Notes
- this directly addresses the failure mode where `finding user draft` returns `record not found` in autosave tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7f81c98-76b8-4658-bfa8-057a3882eacd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7f81c98-76b8-4658-bfa8-057a3882eacd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

