### PR TITLE
fix: remove incorrect "events" alias from whoami command

### DIFF
--- a/pkg/cli/whoami.go
+++ b/pkg/cli/whoami.go
@@ -65,9 +65,9 @@ func (w *whoamiCommand) Execute(ctx core.CommandContext) error {
 }
 
 var whoamiCmd = &cobra.Command{
-	Use:     "whoami",
-	Short:   "Get information about the currently authenticated user",
-	Args:    cobra.NoArgs,
+	Use:   "whoami",
+	Short: "Get information about the currently authenticated user",
+	Args:  cobra.NoArgs,
 }
 
 func init() {


### PR DESCRIPTION
Fixes #3642 

 ## Summary

  - Remove the events alias from the whoami command, which conflicted with the standalone events top-level command
  - whoami --help no longer advertises events as an alias

 ## Context

  Found during the CLI audit on 2026-03-25. The whoami command incorrectly listed events as an alias, even though events is a real top-level command for listing canvas events and executions.

 ## Test plan

  - [x] Run whoami --help and confirm the Aliases: section no longer appears
  - [x] Run events --help and confirm it still works as its own command
  - [x] go build ./pkg/cli/... passes
  
  ## CLI Output
  
<img width="649" height="256" alt="image" src="https://github.com/user-attachments/assets/0d361fc4-3865-4380-9d4d-d5d5ea5e9265" />
