### PR TITLE
chore: Allow self-approval for core team

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -40,6 +40,7 @@ approval_rules:
           - "^agent/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -52,6 +53,7 @@ approval_rules:
           - "^protos/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -66,6 +68,7 @@ approval_rules:
           - "^rbac/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -79,6 +82,7 @@ approval_rules:
           - "^release/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -92,6 +96,7 @@ approval_rules:
           - "^pkg/core/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -104,6 +109,7 @@ approval_rules:
           - "^pkg/grpc/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -118,6 +124,7 @@ approval_rules:
           - "^pkg/workers/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -132,6 +139,7 @@ approval_rules:
           - "^pkg/models/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:
@@ -146,6 +154,7 @@ approval_rules:
           - "^web_src/.*$"
     options:
       allow_author: true
+      allow_contributor: true
     requires:
       count: 1
       users:


### PR DESCRIPTION
You need to set both apparently:

```
  # If true, approvals by the author of a pull request are considered when
  # calculating the status. False by default.
  allow_author: false

  # If true, the approvals of someone who has committed to the pull request are
  # considered when calculating the status. The pull request author is considered
  # a contributor. If allow_author and allow_contributor would disagree, this option
  # always wins. False by default.
  allow_contributor: false
```