### PR TITLE
fix: Canvas nodes teleporting during autosave + dragging

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1175,6 +1175,15 @@ export function WorkflowPageV2() {
         return;
       }
 
+      // Mark the saved version as already applied so the version sync effect
+      // (which replaces canvas spec with loadedCanvasVersion.spec) doesn't
+      // overwrite the merged positions we set below.
+      const versionId = version.metadata?.id;
+      lastAppliedVersionSnapshotRef.current =
+        versionId && versionId === activeCanvasVersionIdRef.current
+          ? `${versionId}:${version.metadata?.updatedAt || ""}`
+          : lastAppliedVersionSnapshotRef.current;
+
       queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
         if (!current || getWorkflowSaveSignature(current) !== getWorkflowSaveSignature(workflow)) {
           return current;

--- a/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.spec.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@xyflow/react";
+import type { CanvasPageProps } from ".";
+import { useCanvasState } from "./useCanvasState";
+
+function makeNode(id: string, x: number, y: number): Node {
+  return {
+    id,
+    position: { x, y },
+    data: { type: "component", component: { collapsed: false } },
+    type: "custom",
+  };
+}
+
+function makeProps(nodes: Node[]): CanvasPageProps {
+  return { nodes, edges: [] } as unknown as CanvasPageProps;
+}
+
+describe("useCanvasState", () => {
+  it("preserves position of actively dragged nodes when props update", () => {
+    const initial = [makeNode("a", 0, 0), makeNode("b", 100, 100)];
+    const { result, rerender } = renderHook(({ props }) => useCanvasState(props), {
+      initialProps: { props: makeProps(initial) },
+    });
+
+    // Simulate dragging node "a" to (50, 50) — ReactFlow sets dragging: true
+    act(() => {
+      result.current.onNodesChange([{ id: "a", type: "position", position: { x: 50, y: 50 }, dragging: true }]);
+    });
+
+    expect(result.current.nodes.find((n) => n.id === "a")?.position).toEqual({ x: 50, y: 50 });
+
+    // Simulate a cache refetch that delivers stale server positions
+    const refetched = [makeNode("a", 0, 0), makeNode("b", 100, 100)];
+    rerender({ props: makeProps(refetched) });
+
+    // Node "a" should keep its drag position, not snap back to (0, 0)
+    const nodeA = result.current.nodes.find((n) => n.id === "a");
+    expect(nodeA?.position).toEqual({ x: 50, y: 50 });
+
+    // Node "b" (not dragging) should accept the new prop position
+    const nodeB = result.current.nodes.find((n) => n.id === "b");
+    expect(nodeB?.position).toEqual({ x: 100, y: 100 });
+  });
+
+  it("accepts new positions after drag ends", () => {
+    const initial = [makeNode("a", 0, 0)];
+    const { result, rerender } = renderHook(({ props }) => useCanvasState(props), {
+      initialProps: { props: makeProps(initial) },
+    });
+
+    // Start drag
+    act(() => {
+      result.current.onNodesChange([{ id: "a", type: "position", position: { x: 50, y: 50 }, dragging: true }]);
+    });
+
+    // End drag
+    act(() => {
+      result.current.onNodesChange([{ id: "a", type: "position", position: { x: 50, y: 50 }, dragging: false }]);
+    });
+
+    // Now a prop update should apply normally
+    const updated = [makeNode("a", 200, 200)];
+    rerender({ props: makeProps(updated) });
+
+    expect(result.current.nodes.find((n) => n.id === "a")?.position).toEqual({ x: 200, y: 200 });
+  });
+});

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -79,11 +79,13 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
           };
         }
 
-        // Preserve selected state from existing node
+        // Preserve selected state and position of actively dragged nodes
         return {
           ...newNode,
           data: nodeData,
           selected: existingNode?.selected ?? newNode.selected,
+          position: (existingNode?.dragging && existingNode.position) || newNode.position,
+          dragging: existingNode?.dragging,
         };
       });
 


### PR DESCRIPTION
**Problem**

Two race conditions caused nodes to snap back to old positions during autosave:

- **Versioned mode (edit mode):** After a save, the mutation's onSuccess handler updated the version detail cache with raw server positions. When hasPendingLocalCanvasState became false, the version sync effect replaced the canvas spec with the stale version data — undoing the position merge that syncCurrentCanvasWithSavedVersion had just applied.
- **Mid-drag refetch:** During an active drag, node positions only exist in ReactFlow's internal state — the query cache and pendingPositionUpdatesRef aren't updated until drag ends. If a cache refetch happened mid-drag (e.g. from a WebSocket echo), the prop sync effect in useCanvasState overwrote the in-progress drag position with stale server data.

**Fix**


- Version snapshot ref: syncCurrentCanvasWithSavedVersion now updates lastAppliedVersionSnapshotRef so the version sync effect recognizes the version as already applied and skips the spec replacement.
- Drag position preservation: The node sync effect in useCanvasState now preserves the position of any node with dragging: true, preventing cache refetches from interrupting active drags.


