### PR TITLE
fix: draft resetting on tab switch

### DIFF
--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -164,6 +164,7 @@ export const useCanvas = (organizationId: string, canvasId: string) => {
       return response.data?.canvas;
     },
     staleTime: 0,
+    refetchOnWindowFocus: false,
     enabled: !!organizationId && !!canvasId,
   });
 };


### PR DESCRIPTION
## Problem
Switching to another browser tab and returning to Superplane triggered a refetch of the canvas detail query. This reset the local canvas state — including in-progress draft edits and node positions — to the server's last saved state.

## Fix
Added refetchOnWindowFocus: false to the useCanvas query, matching every other canvas query in the file. Canvas state is already kept up to date via WebSocket lifecycle events.