### PR TITLE
chore: update API listing limits

### DIFF
--- a/pkg/grpc/actions/canvases/list_node_executions.go
+++ b/pkg/grpc/actions/canvases/list_node_executions.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	DefaultLimit = 25
-	MaxLimit     = 50
+	DefaultLimit = 10
+	MaxLimit     = 25
 )
 
 func ListNodeExecutions(ctx context.Context, registry *registry.Registry, workflowID, nodeID string, pbStates []pb.CanvasNodeExecution_State, pbResults []pb.CanvasNodeExecution_Result, limit uint32, before *timestamppb.Timestamp) (*pb.ListNodeExecutionsResponse, error) {

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -244,7 +244,7 @@ export const useCanvasChangeRequests = (organizationId: string, canvasId: string
       const response = await canvasesListCanvasChangeRequests(
         withOrganizationHeader({
           path: { canvasId },
-          query: { limit: 100, statusFilter: "all" },
+          query: { limit: 25, statusFilter: "all" },
         }),
       );
       return response.data?.changeRequests || [];
@@ -720,7 +720,7 @@ export const useDeleteCanvas = (organizationId: string) => {
 };
 
 export const useInfiniteCanvasEvents = (canvasId: string, enabled = true) => {
-  const limit = 50;
+  const limit = 25;
 
   return useInfiniteQuery({
     queryKey: canvasKeys.infiniteEvents(canvasId),


### PR DESCRIPTION
Nowhere in the UI we need these limits to be this big. Safer to be more restrictive right now and open up later on than the opposite