### PR TITLE
fix: defer AI chat loading until AI tab opens

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
@@ -1,0 +1,234 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadChatSessions, loadChatConversation, sendChatPrompt } = vi.hoisted(() => ({
+  loadChatSessions: vi.fn(),
+  loadChatConversation: vi.fn(),
+  sendChatPrompt: vi.fn(),
+}));
+
+vi.mock("../CanvasPage", () => ({
+  COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY: "sp:test-sidebar-width",
+}));
+
+vi.mock("./CategorySection", () => ({
+  CategorySection: () => <div>category section</div>,
+}));
+
+vi.mock("@/components/ui/tabs", async () => {
+  const React = await import("react");
+  const TabsContext = React.createContext<{
+    value: string;
+    onValueChange?: (value: string) => void;
+  }>({ value: "" });
+
+  return {
+    Tabs: ({
+      value,
+      onValueChange,
+      children,
+      className,
+    }: {
+      value: string;
+      onValueChange?: (value: string) => void;
+      children: ReactNode;
+      className?: string;
+    }) => (
+      <TabsContext.Provider value={{ value, onValueChange }}>
+        <div className={className}>{children}</div>
+      </TabsContext.Provider>
+    ),
+    TabsList: ({ children, className }: { children: ReactNode; className?: string }) => (
+      <div className={className}>{children}</div>
+    ),
+    TabsTrigger: ({ value, children, className }: { value: string; children: ReactNode; className?: string }) => {
+      const context = React.useContext(TabsContext);
+
+      return (
+        <button
+          type="button"
+          role="tab"
+          data-state={context.value === value ? "active" : "inactive"}
+          className={className}
+          onClick={() => context.onValueChange?.(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+    TabsContent: ({ value, children, className }: { value: string; children: ReactNode; className?: string }) => {
+      const context = React.useContext(TabsContext);
+
+      if (context.value !== value) {
+        return null;
+      }
+
+      return <div className={className}>{children}</div>;
+    },
+  };
+});
+
+vi.mock("./AiBuilderChatPanel", () => ({
+  AiBuilderChatPanel: ({
+    chatSessions,
+    currentChatId,
+    aiMessages,
+    onSelectChat,
+  }: {
+    chatSessions: Array<{ id: string }>;
+    currentChatId: string | null;
+    aiMessages: Array<{ id: string }>;
+    onSelectChat: (chatId: string) => void;
+  }) => (
+    <div>
+      <div>ai builder panel</div>
+      <div data-testid="chat-session-count">{chatSessions.length}</div>
+      <div data-testid="current-chat-id">{currentChatId ?? "none"}</div>
+      <div data-testid="ai-message-count">{aiMessages.length}</div>
+      <button
+        type="button"
+        onClick={() => {
+          if (chatSessions[0]?.id) {
+            onSelectChat(chatSessions[0].id);
+          }
+        }}
+      >
+        select first chat
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../componentBase", () => ({
+  ComponentBase: () => <div>component base</div>,
+}));
+
+vi.mock("./agentChat", () => ({
+  loadChatSessions,
+  loadChatConversation,
+  sendChatPrompt,
+  pushAiMessages: (previous: unknown[], next: unknown | unknown[]) => [
+    ...previous,
+    ...(Array.isArray(next) ? next : [next]),
+  ],
+}));
+
+import { BuildingBlocksSidebar } from "./index";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+
+  return { promise, resolve };
+}
+
+const defaultProps = {
+  isOpen: true,
+  onToggle: vi.fn(),
+  blocks: [],
+  showAiBuilderTab: true,
+  canvasId: "canvas-1",
+  organizationId: "org-1",
+};
+
+describe("BuildingBlocksSidebar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    loadChatSessions.mockResolvedValue([]);
+    loadChatConversation.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const flushEffects = async () => {
+    await act(async () => {
+      vi.runAllTimers();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  it("does not load chat sessions before the AI tab is opened", async () => {
+    render(<BuildingBlocksSidebar {...defaultProps} />);
+
+    await flushEffects();
+
+    expect(screen.getByRole("tab", { name: "Components" })).toHaveAttribute("data-state", "active");
+    expect(loadChatSessions).not.toHaveBeenCalled();
+    expect(loadChatConversation).not.toHaveBeenCalled();
+  });
+
+  it("loads chat sessions when the AI tab is opened", async () => {
+    render(<BuildingBlocksSidebar {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "AI Builder" }));
+    await flushEffects();
+
+    expect(loadChatSessions).toHaveBeenCalledWith({
+      canvasId: "canvas-1",
+      organizationId: "org-1",
+    });
+  });
+
+  it("does not refetch AI data when reopening the AI tab", async () => {
+    loadChatSessions.mockResolvedValue([{ id: "chat-1", title: "Chat 1" }]);
+    loadChatConversation.mockResolvedValue([{ id: "message-1", role: "assistant", content: "hello" }]);
+
+    render(<BuildingBlocksSidebar {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "AI Builder" }));
+    await flushEffects();
+
+    fireEvent.click(screen.getByRole("button", { name: "select first chat" }));
+    await flushEffects();
+
+    expect(screen.getByTestId("current-chat-id")).toHaveTextContent("chat-1");
+    expect(screen.getByTestId("ai-message-count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Components" }));
+    await flushEffects();
+
+    fireEvent.click(screen.getByRole("tab", { name: "AI Builder" }));
+    await flushEffects();
+
+    expect(screen.getByTestId("current-chat-id")).toHaveTextContent("chat-1");
+    expect(screen.getByTestId("ai-message-count")).toHaveTextContent("1");
+    expect(loadChatSessions).toHaveBeenCalledTimes(1);
+    expect(loadChatConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears AI state when the canvas changes", async () => {
+    const deferredChatSessions = createDeferred<Array<{ id: string; title: string }>>();
+
+    loadChatSessions
+      .mockResolvedValueOnce([{ id: "chat-1", title: "Chat 1" }])
+      .mockImplementationOnce(() => deferredChatSessions.promise);
+
+    const { rerender } = render(<BuildingBlocksSidebar {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "AI Builder" }));
+    await flushEffects();
+
+    expect(screen.getByTestId("chat-session-count")).toHaveTextContent("1");
+
+    rerender(<BuildingBlocksSidebar {...defaultProps} canvasId="canvas-2" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "AI Builder" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("chat-session-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("current-chat-id")).toHaveTextContent("none");
+    expect(screen.getByTestId("ai-message-count")).toHaveTextContent("0");
+  });
+});

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -253,6 +253,7 @@ function OpenBuildingBlocksSidebar({
   const [currentChatId, setCurrentChatId] = useState<string | null>(null);
   const [isLoadingChatSessions, setIsLoadingChatSessions] = useState(false);
   const [isLoadingChatMessages, setIsLoadingChatMessages] = useState(false);
+  const [hasOpenedAiTab, setHasOpenedAiTab] = useState(false);
   const [isGeneratingResponse, setIsGeneratingResponse] = useState(false);
   const [isApplyingProposal, setIsApplyingProposal] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
@@ -420,12 +421,20 @@ function OpenBuildingBlocksSidebar({
   }, [showAiBuilderTab, activeTab]);
 
   useEffect(() => {
+    if (showAiBuilderTab && activeTab === "ai") {
+      setHasOpenedAiTab(true);
+    }
+  }, [activeTab, showAiBuilderTab]);
+
+  useEffect(() => {
     setActiveTab("components");
+    setChatSessions([]);
     setCurrentChatId(null);
     setAiMessages([]);
     setPendingProposal(null);
     setAiError(null);
     setAiInput("");
+    setHasOpenedAiTab(false);
   }, [canvasId]);
 
   useEffect(() => {
@@ -449,10 +458,8 @@ function OpenBuildingBlocksSidebar({
   useEffect(() => {
     let cancelled = false;
 
-    if (!canvasId || !organizationId) {
-      setChatSessions([]);
-      setCurrentChatId(null);
-      setAiMessages([]);
+    if (!showAiBuilderTab || !hasOpenedAiTab || !canvasId || !organizationId) {
+      setIsLoadingChatSessions(false);
       return () => {
         cancelled = true;
       };
@@ -461,10 +468,7 @@ function OpenBuildingBlocksSidebar({
     void (async () => {
       setIsLoadingChatSessions(true);
       try {
-        const sessions = await loadChatSessions({
-          canvasId,
-          organizationId,
-        });
+        const sessions = await loadChatSessions({ canvasId, organizationId });
         if (cancelled) {
           return;
         }
@@ -491,16 +495,17 @@ function OpenBuildingBlocksSidebar({
     return () => {
       cancelled = true;
     };
-  }, [canvasId, organizationId]);
+  }, [canvasId, hasOpenedAiTab, organizationId, showAiBuilderTab]);
 
   useEffect(() => {
     let cancelled = false;
 
-    if (!canvasId || !organizationId || !currentChatId) {
-      if (!currentChatId) {
-        setAiMessages([]);
-        setPendingProposal(null);
-      }
+    if (!currentChatId) {
+      setAiMessages([]);
+      setPendingProposal(null);
+    }
+
+    if (!showAiBuilderTab || !hasOpenedAiTab || !canvasId || !organizationId || !currentChatId) {
       setIsLoadingChatMessages(false);
       return () => {
         cancelled = true;
@@ -536,7 +541,7 @@ function OpenBuildingBlocksSidebar({
     return () => {
       cancelled = true;
     };
-  }, [canvasId, currentChatId, organizationId]);
+  }, [canvasId, currentChatId, hasOpenedAiTab, organizationId, showAiBuilderTab]);
 
   // Auto-focus search input when sidebar opens
   useEffect(() => {


### PR DESCRIPTION
What changed:
- defer loading AI chat sessions and messages until the AI Builder tab is opened
- preserve loaded AI chat state when switching between Components and AI Builder
- reset AI chat state when the canvas changes
- add regression tests covering lazy loading, tab reopen behavior, and canvas changes

Why:
- avoid unnecessary agent connection attempts during sidebar render when the agent is not configured
- prevent the noisy console error reported in issue #3837

How:
- gate the AI session and conversation effects behind a hasOpenedAiTab flag and showAiBuilderTab
- clear sidebar AI state only when the canvas changes
- add focused sidebar tests for the affected state transitions

Related issues:
- Closes #3837 

Test plan:
- cd web_src && npx eslint src/ui/BuildingBlocksSidebar/index.tsx src/ui/BuildingBlocksSidebar/index.spec.tsx
- cd web_src && npx prettier --check src/ui/BuildingBlocksSidebar/index.tsx src/ui/BuildingBlocksSidebar/index.spec.tsx
- cd web_src && npm run test:run -- src/ui/BuildingBlocksSidebar/index.spec.tsx
- make check.build.ui