### PR TITLE
fix: 500 error on list group users for non-existent groups

### DIFF
--- a/pkg/authorization/service.go
+++ b/pkg/authorization/service.go
@@ -283,26 +283,18 @@ func (a *AuthService) UpdateGroup(domainID string, domainType string, groupName 
 
 func (a *AuthService) AddUserToGroup(domainID string, domainType string, userID string, group string) error {
 	domain := prefixDomain(domainType, domainID)
-	prefixedGroupName := prefixGroupName(group)
 	prefixedUserID := prefixUserID(userID)
 
-	groups, err := a.enforcer.GetFilteredGroupingPolicy(0, prefixedGroupName, "", domain)
+	groupExists, err := a.groupExistsInDomain(group, domain)
 	if err != nil {
 		return fmt.Errorf("failed to check group existence: %w", err)
-	}
-
-	groupExists := false
-	for _, g := range groups {
-		if g[2] == domain {
-			groupExists = true
-			break
-		}
 	}
 
 	if !groupExists {
 		return fmt.Errorf("group %s does not exist in %s %s", group, domainType, domainID)
 	}
 
+	prefixedGroupName := prefixGroupName(group)
 	ruleAdded, err := a.enforcer.AddGroupingPolicy(prefixedUserID, prefixedGroupName, domain)
 	if err != nil {
 		return fmt.Errorf("failed to add user to group: %w", err)
@@ -334,6 +326,14 @@ func (a *AuthService) RemoveUserFromGroup(domainID string, domainType string, us
 
 func (a *AuthService) GetGroupUsers(domainID string, domainType string, group string) ([]string, error) {
 	domain := prefixDomain(domainType, domainID)
+	groupExists, err := a.groupExistsInDomain(group, domain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check group existence: %w", err)
+	}
+	if !groupExists {
+		return nil, fmt.Errorf("group %s does not exist in %s %s", group, domainType, domainID)
+	}
+
 	prefixedGroupName := prefixGroupName(group)
 
 	policies, err := a.enforcer.GetFilteredGroupingPolicy(1, prefixedGroupName, domain)
@@ -348,6 +348,22 @@ func (a *AuthService) GetGroupUsers(domainID string, domainType string, group st
 	}
 
 	return users, nil
+}
+
+func (a *AuthService) groupExistsInDomain(group, domain string) (bool, error) {
+	prefixedGroupName := prefixGroupName(group)
+	groups, err := a.enforcer.GetFilteredGroupingPolicy(0, prefixedGroupName, "", domain)
+	if err != nil {
+		return false, err
+	}
+
+	for _, g := range groups {
+		if len(g) >= 3 && g[2] == domain {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (a *AuthService) GetGroups(domainID string, domainType string) ([]string, error) {

--- a/pkg/grpc/actions/auth/delete_group_test.go
+++ b/pkg/grpc/actions/auth/delete_group_test.go
@@ -37,8 +37,8 @@ func Test_DeleteOrganizationGroup(t *testing.T) {
 		assert.NotNil(t, resp)
 
 		users, err = r.AuthService.GetGroupUsers(orgID, models.DomainTypeOrganization, "test-group")
-		require.NoError(t, err)
-		assert.Empty(t, users)
+		require.Error(t, err)
+		assert.Nil(t, users)
 
 		// Verify the group no longer exists in the groups list
 		groups, err = r.AuthService.GetGroups(orgID, models.DomainTypeOrganization)

--- a/pkg/grpc/actions/auth/list_group_users.go
+++ b/pkg/grpc/actions/auth/list_group_users.go
@@ -19,16 +19,16 @@ func ListGroupUsers(ctx context.Context, domainType, domainID, groupName string,
 		return nil, status.Error(codes.InvalidArgument, "group name must be specified")
 	}
 
+	role, err := authService.GetGroupRole(domainID, domainType, groupName)
+	if err != nil {
+		log.Errorf("failed to get group role: %v", err)
+		return nil, status.Error(codes.NotFound, "group not found")
+	}
+
 	userIDs, err := authService.GetGroupUsers(domainID, domainType, groupName)
 	if err != nil {
 		log.Errorf("failed to get group users: %v", err)
 		return nil, status.Error(codes.Internal, "failed to get group users")
-	}
-
-	role, err := authService.GetGroupRole(domainID, domainType, groupName)
-	if err != nil {
-		log.Errorf("failed to get group role: %v", err)
-		return nil, status.Error(codes.Internal, "failed to get group role")
 	}
 
 	roleMetadataMap, err := models.FindRoleMetadataByNames([]string{role}, domainType, domainID)
@@ -37,6 +37,9 @@ func ListGroupUsers(ctx context.Context, domainType, domainID, groupName string,
 	}
 
 	roleMetadata := roleMetadataMap[role]
+	if roleMetadata == nil {
+		return nil, status.Error(codes.NotFound, "role metadata not found")
+	}
 
 	dbUsers, err := models.FindUsersByIDs(userIDs)
 	if err != nil {

--- a/pkg/grpc/actions/auth/list_group_users_test.go
+++ b/pkg/grpc/actions/auth/list_group_users_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pbAuth "github.com/superplanehq/superplane/pkg/protos/authorization"
 	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func Test_ListGroupUsers(t *testing.T) {
@@ -55,5 +57,11 @@ func Test_ListGroupUsers(t *testing.T) {
 		assert.Equal(t, "empty-group", resp.Group.Metadata.Name)
 		assert.Equal(t, pbAuth.DomainType_DOMAIN_TYPE_ORGANIZATION, resp.Group.Metadata.DomainType)
 		assert.Equal(t, orgID, resp.Group.Metadata.DomainId)
+	})
+
+	t.Run("missing group returns not found instead of internal", func(t *testing.T) {
+		_, err := ListGroupUsers(ctx, models.DomainTypeOrganization, orgID, "missing-group", r.AuthService)
+		require.Error(t, err)
+		assert.Equal(t, codes.NotFound, status.Code(err))
 	})
 }


### PR DESCRIPTION
## Summary
- `ListGroupUsers` returned 500 Internal when queried with a group name that doesn't exist (e.g. `devops_team`, `security_and_compliance`)
- Added group existence validation in `GetGroupUsers` that returns a proper error before querying users
- `ListGroupUsers` now returns `NotFound` instead of `Internal` for missing groups
- Added nil check for role metadata to prevent nil pointer dereference

## Sentry Issues
- HTTP 500 /api/v1/groups/devops_team/users (Issue ID: 7376816811)
- HTTP 500 /api/v1/groups/security_and_compliance/users (Issue ID: 7359654997)

## Test plan
- [x] Test: missing group returns NotFound instead of Internal
- [x] Test: delete group test updated to expect error on GetGroupUsers for deleted group

🤖 Generated with [Claude Code](https://claude.com/claude-code)