### PR TITLE
fix: increase root_event size to 64KiB

### DIFF
--- a/pkg/workers/contexts/common.go
+++ b/pkg/workers/contexts/common.go
@@ -4,4 +4,4 @@ package contexts
  * DefaultMaxPayloadSize is used to enforce reasonably-sized
  * event payloads from components and trigger implementations.
  */
-const DefaultMaxPayloadSize = 32 * 1024
+const DefaultMaxPayloadSize = 64 * 1024


### PR DESCRIPTION
## Summary

Increase the shared event payload size limit from 32 KiB to 64 KiB.

This fixes webhook requests that were failing with `500` when the emitted root event payload was larger than the previous global cap, including larger GitHub `pull_request` webhook payloads.

## Changes

- Updated `DefaultMaxPayloadSize` in `pkg/workers/contexts/common.go`
  - from `32 * 1024`
  - to `64 * 1024`

## Why

Root event emission uses the shared payload size limit enforced by `EventContext` and `ExecutionStateContext`.

Some webhook payloads, especially GitHub PR events, can exceed 32 KiB. When that happened, event persistence returned `event payload too large`, which bubbled up as a `500` from the webhook endpoint.

Raising the limit to 64 KiB keeps the fix simple and avoids the broader jump to 256 KiB.

