### PR TITLE
chore: Remove validation tool and replace it with output validator

### DIFF
--- a/agent/evals/cases.py
+++ b/agent/evals/cases.py
@@ -5,10 +5,7 @@ from pydantic_evals import Case, Dataset
 import evals.evaluators as evals
 
 dataset = Dataset(
-    evaluators=(
-        evals.ToolCalled("get_canvas"),
-        evals.ToolCalled("validate_proposal"),
-    ),
+    evaluators=(evals.ToolCalled("get_canvas"),),
     cases=[
         Case(
             name="manual_run_then_two_noops",

--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -9,7 +9,6 @@ from pydantic_ai.models.test import TestModel
 from ai.config import config
 from ai.models import (
     CanvasAnswer,
-    CanvasProposal,
     CanvasQuestionRequest,
     CanvasShape,
     CanvasSummary,
@@ -129,6 +128,7 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
         model=resolved_model,
         output_type=CanvasAnswer,
         system_prompt=load_system_prompt(),
+        output_retries=5,
         model_settings=AnthropicModelSettings(
             parallel_tool_calls=True,
             anthropic_cache_instructions="1h",
@@ -141,23 +141,15 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
         if config.debug:
             print(f"[web][agent] {message}", flush=True)
 
-    @agent.tool
-    def validate_proposal(
-        _ctx: RunContext[AgentDeps],
-        proposal: CanvasProposal,
-    ) -> dict[str, Any]:
-        """Validate and normalize a draft canvas proposal against live catalog schemas.
+    @agent.output_validator
+    def validate_answer_proposal(
+        ctx: RunContext[AgentDeps],
+        answer: CanvasAnswer,
+    ) -> CanvasAnswer:
+        # Placeholder for proposal validation.
+        #   raise ModelRetry("... explain why the proposal is invalid and what to do about it.")
 
-        Call this with the same structured proposal you plan to include in your final
-        answer when the user asked for canvas edits. The server applies the same
-        coercion and type checks as the workflow UI. On success, copy the returned
-        ``proposal`` into your final ``CanvasAnswer``. On failure, read ``errors``,
-        fix configurations (use describe_component / describe_trigger), and call again.
-        """
-        return {
-            "ok": True,
-            "proposal": proposal.model_dump(mode="json", by_alias=True),
-        }
+        return answer
 
     @agent.tool
     def get_canvas(ctx: RunContext[AgentDeps]) -> CanvasSummary:

--- a/agent/tests/test_tool_called_evaluator.py
+++ b/agent/tests/test_tool_called_evaluator.py
@@ -25,13 +25,13 @@ def test_tool_called_passes_when_tool_invoked() -> None:
     try:
         q = "Build a workflow"
         record_tool_call(q, "get_canvas")
-        record_tool_call(q, "validate_proposal")
+        record_tool_call(q, "describe_component")
         answer = CanvasAnswer(
             answer="ok",
             confidence=0.5,
             proposal=CanvasProposal(summary="s", operations=[]),
         )
-        result = ToolCalled("validate_proposal").evaluate(_ctx(q, answer))
+        result = ToolCalled("describe_component").evaluate(_ctx(q, answer))
         assert result.value is True
     finally:
         clear_tool_call_registry()
@@ -43,7 +43,7 @@ def test_tool_called_fails_when_tool_missing() -> None:
         q = "Build a workflow"
         record_tool_call(q, "get_canvas")
         answer = CanvasAnswer(answer="ok", confidence=0.5, proposal=None)
-        result = ToolCalled("validate_proposal").evaluate(_ctx(q, answer))
+        result = ToolCalled("describe_component").evaluate(_ctx(q, answer))
         assert result.value is False
     finally:
         clear_tool_call_registry()
@@ -53,12 +53,12 @@ def test_tool_called_min_calls_two() -> None:
     clear_tool_call_registry()
     try:
         q = "Build a workflow"
-        record_tool_call(q, "validate_proposal")
+        record_tool_call(q, "describe_component")
         answer = CanvasAnswer(answer="ok", confidence=0.5, proposal=None)
-        result = ToolCalled("validate_proposal", min_calls=2).evaluate(_ctx(q, answer))
+        result = ToolCalled("describe_component", min_calls=2).evaluate(_ctx(q, answer))
         assert result.value is False
-        record_tool_call(q, "validate_proposal")
-        result = ToolCalled("validate_proposal", min_calls=2).evaluate(_ctx(q, answer))
+        record_tool_call(q, "describe_component")
+        result = ToolCalled("describe_component", min_calls=2).evaluate(_ctx(q, answer))
         assert result.value is True
     finally:
         clear_tool_call_registry()

--- a/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
@@ -96,7 +96,6 @@ function formatToolLabel(toolName: string): string {
     list_node_events: "Listing node events",
     list_node_executions: "Listing node executions",
     list_available_blocks: "Listing available components",
-    validate_proposal: "Validating proposal",
   };
   if (labelByTool[normalized]) {
     return labelByTool[normalized];


### PR DESCRIPTION
The serialized CanvasProposal json schema is token intensive. If we have two tools that expose it, it doubles the most heave instruction that we send to the agent.

Instead of that, a better approach is to use an output validator.
How this works:

1/ The agent things and proposes a pydantic final Output
2/ The output validator check for correctness, and if there are problems it raises an ModelError
3/ The agent reties 5 times to correct it