### PR TITLE
fix: exchange type should be direct not topic

### DIFF
--- a/agent/src/ai/usage_publisher.py
+++ b/agent/src/ai/usage_publisher.py
@@ -48,7 +48,7 @@ class _Connection:
         params = pika.URLParameters(rabbitmq_url)
         self._conn = pika.BlockingConnection(params)
         self._chan = self._conn.channel()
-        self._chan.exchange_declare(exchange=AGENT_EXCHANGE, exchange_type="topic", durable=True)
+        self._chan.exchange_declare(exchange=AGENT_EXCHANGE, exchange_type="direct", durable=True)
         return self._chan
 
     def heartbeat(self) -> None:


### PR DESCRIPTION
### Error

```
[web] failed to publish agent run finished: (406, "PRECONDITION_FAILED - inequivalent arg 'type' for exchange 'superplane.agent-exchange' in vhost '/': received 'topic' but current is 'direct'")
```

### Fix

Change to publish to direct exchange type