### PR TITLE
chore(ui): cleanup BuildingBlock type

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/CategorySection.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/CategorySection.spec.tsx
@@ -11,7 +11,6 @@ function createCategory(name: string): BuildingBlockCategory {
         name: "smtp.send",
         label: "Send Email",
         type: "component",
-        componentSubtype: "action",
         integrationName: "smtp",
       },
     ],

--- a/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/CategorySection.tsx
@@ -4,26 +4,23 @@ import { resolveIcon } from "@/lib/utils";
 import { ChevronRight, GripVerticalIcon, Plug } from "lucide-react";
 import { useState } from "react";
 import { toTestId } from "../../lib/testID";
-import { getComponentSubtype } from "../buildingBlocks";
 import { getHeaderIconSrc, getIntegrationIconSrc } from "../componentSidebar/integrationIcons";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
 
-const SUBTYPE_HOVER_BG: Record<string, string> = {
+const TYPE_HOVER_BG: Record<string, string> = {
   trigger: "hover:bg-sky-100 dark:hover:bg-sky-900/20",
-  flow: "hover:bg-purple-100 dark:hover:bg-purple-900/20",
-  action: "hover:bg-green-100 dark:hover:bg-green-900/20",
+  component: "hover:bg-green-100 dark:hover:bg-green-900/20",
 };
 
-const SUBTYPE_BADGE_COLOR: Record<string, string> = {
+const TYPE_BADGE_COLOR: Record<string, string> = {
   trigger: "text-sky-600 dark:text-sky-400",
-  flow: "text-purple-600 dark:text-purple-400",
-  action: "text-green-600 dark:text-green-400",
+  component: "text-green-600 dark:text-green-400",
 };
 
-const SUBTYPE_LABEL: Record<string, string> = {
+const TYPE_LABEL: Record<string, string> = {
   trigger: "Trigger",
-  flow: "Flow",
-  action: "Action",
+  component: "Action",
+  blueprint: "Blueprint",
 };
 
 function resolveIconSlug(block: BuildingBlock): string {
@@ -76,9 +73,8 @@ function BlockItem({
 }: BlockItemProps) {
   const appIconSrc = getHeaderIconSrc(block.name);
   const IconComponent = resolveIcon(resolveIconSlug(block));
-  const subtype = block.componentSubtype || getComponentSubtype(block);
-  const hoverBg = SUBTYPE_HOVER_BG[subtype] || SUBTYPE_HOVER_BG.action;
-  const badgeColor = SUBTYPE_BADGE_COLOR[subtype] || SUBTYPE_BADGE_COLOR.action;
+  const hoverBg = TYPE_HOVER_BG[block.type] || TYPE_HOVER_BG.component;
+  const badgeColor = TYPE_BADGE_COLOR[block.type] || TYPE_BADGE_COLOR.component;
 
   return (
     <Item
@@ -122,13 +118,8 @@ function BlockItem({
           <span
             className={`inline-block text-left px-1.5 py-0.5 text-[11px] font-medium ${badgeColor} rounded whitespace-nowrap flex-shrink-0 ml-auto`}
           >
-            {SUBTYPE_LABEL[subtype] || "Action"}
+            {TYPE_LABEL[block.type] || "Action"}
           </span>
-          {block.deprecated && (
-            <span className="px-1.5 py-0.5 text-[11px] font-medium bg-gray-950/5 text-gray-500 rounded whitespace-nowrap flex-shrink-0">
-              Deprecated
-            </span>
-          )}
         </div>
       </ItemContent>
 
@@ -143,7 +134,7 @@ export interface CategorySectionProps {
   showIntegrationSetupStatus: boolean;
   canvasZoom: number;
   searchTerm?: string;
-  typeFilter?: "all" | "trigger" | "action" | "flow";
+  typeFilter?: "all" | "trigger" | "component";
   isDraggingRef: React.RefObject<boolean>;
   setHoveredBlock: (block: BuildingBlock | null) => void;
   dragPreviewRef: React.RefObject<HTMLDivElement | null>;
@@ -179,8 +170,7 @@ export function CategorySection({
 
   if (typeFilter !== "all") {
     allBlocks = allBlocks.filter((block) => {
-      const subtype = block.componentSubtype || getComponentSubtype(block);
-      return subtype === typeFilter;
+      return block.type === typeFilter;
     });
   }
 
@@ -241,18 +231,18 @@ export function CategorySection({
 
   let sortedBlocks: BuildingBlock[] = [];
   if (isOpen) {
-    const subtypeOrder: Record<"trigger" | "action" | "flow", number> = {
+    const typeOrder: Record<"trigger" | "component" | "blueprint", number> = {
       trigger: 0,
-      action: 1,
-      flow: 2,
+      component: 1,
+      blueprint: 2,
     };
 
     sortedBlocks = [...allBlocks].sort((a, b) => {
-      const aSubtype = a.componentSubtype || getComponentSubtype(a);
-      const bSubtype = b.componentSubtype || getComponentSubtype(b);
-      const subtypeComparison = subtypeOrder[aSubtype] - subtypeOrder[bSubtype];
-      if (subtypeComparison !== 0) {
-        return subtypeComparison;
+      const aType = a.type;
+      const bType = b.type;
+      const typeComparison = typeOrder[aType] - typeOrder[bType];
+      if (typeComparison !== 0) {
+        return typeComparison;
       }
 
       const aName = (a.label || a.name || "").toLowerCase();

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -192,7 +192,7 @@ function OpenBuildingBlocksSidebar({
   onBlockClick,
 }: OpenBuildingBlocksSidebarProps) {
   const [searchTerm, setSearchTerm] = useState("");
-  const [typeFilter, setTypeFilter] = useState<"all" | "trigger" | "action" | "flow">("all");
+  const [typeFilter, setTypeFilter] = useState<"all" | "trigger" | "component">("all");
   const sidebarRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const aiInputRef = useRef<HTMLTextAreaElement>(null);
@@ -621,8 +621,7 @@ function OpenBuildingBlocksSidebar({
             <SelectContent>
               <SelectItem value="all">All Types</SelectItem>
               <SelectItem value="trigger">Trigger</SelectItem>
-              <SelectItem value="action">Action</SelectItem>
-              <SelectItem value="flow">Flow</SelectItem>
+              <SelectItem value="component">Action</SelectItem>
             </SelectContent>
           </Select>
           <DropdownMenu>

--- a/web_src/src/ui/BuildingBlocksSidebar/types.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/types.ts
@@ -5,16 +5,12 @@ export interface BuildingBlock {
   label?: string;
   description?: string;
   type: "trigger" | "component" | "blueprint";
-  componentSubtype?: "trigger" | "action" | "flow";
   outputChannels?: Array<SuperplaneComponentsOutputChannel | SuperplaneBlueprintsOutputChannel>;
   configuration?: any[];
   icon?: string;
   color?: string;
   id?: string;
   integrationName?: string;
-  deprecated?: boolean;
-  exampleOutput?: Record<string, unknown>;
-  exampleData?: Record<string, unknown>;
 }
 
 export type BuildingBlockCategory = {

--- a/web_src/src/ui/buildingBlocks.ts
+++ b/web_src/src/ui/buildingBlocks.ts
@@ -1,32 +1,10 @@
 import type { BuildingBlock, BuildingBlockCategory } from "./BuildingBlocksSidebar";
 import type { TriggersTrigger, ComponentsComponent, IntegrationsIntegrationDefinition } from "@/api-client";
 
-// Flow control components that control workflow execution flow
-const FLOW_COMPONENT_NAMES = new Set(["if", "filter", "approval", "wait", "timeGate"]);
 const MEMORY_COMPONENT_NAMES = new Set(["addmemory", "readmemory", "updatememory", "deletememory", "upsertmemory"]);
 
 function isMemoryBlock(block: BuildingBlock): boolean {
   return MEMORY_COMPONENT_NAMES.has((block.name || "").toLowerCase());
-}
-
-/**
- * Determines the component subtype based on the building block's type and name.
- * - Triggers are always "trigger"
- * - Flow control components (if, filter, approval, wait, timeGate) are "flow"
- * - All other components are "action"
- * - Blueprints default to "action"
- */
-export function getComponentSubtype(block: BuildingBlock): "trigger" | "action" | "flow" {
-  if (block.type === "trigger") {
-    return "trigger";
-  }
-
-  if (block.type === "component" && block.name && FLOW_COMPONENT_NAMES.has(block.name)) {
-    return "flow";
-  }
-
-  // Default to "action" for components and blueprints
-  return "action";
 }
 
 // Build categories of building blocks from live data
@@ -51,9 +29,8 @@ export function buildBuildingBlockCategories(
         configuration: t.configuration,
         icon: t.icon,
         color: t.color,
-        exampleData: t.exampleData,
       };
-      block.componentSubtype = getComponentSubtype(block);
+
       return block;
     }),
     ...filteredComponents.map((c): BuildingBlock => {
@@ -66,9 +43,8 @@ export function buildBuildingBlockCategories(
         configuration: c.configuration,
         icon: c.icon,
         color: c.color,
-        exampleOutput: c.exampleOutput,
       };
-      block.componentSubtype = getComponentSubtype(block);
+
       return block;
     }),
   ];
@@ -96,9 +72,8 @@ export function buildBuildingBlockCategories(
           icon: t.icon,
           color: t.color,
           integrationName: integration.name,
-          exampleData: t.exampleData,
         };
-        block.componentSubtype = getComponentSubtype(block);
+
         blocks.push(block);
       });
     }
@@ -116,9 +91,8 @@ export function buildBuildingBlockCategories(
           icon: c.icon,
           color: c.color,
           integrationName: integration.name,
-          exampleOutput: c.exampleOutput,
         };
-        block.componentSubtype = getComponentSubtype(block);
+
         blocks.push(block);
       });
     }


### PR DESCRIPTION
The BuildingBlock type we have in the UI doesn't really match what we have in the backend, and it has some unused things:
- deprecated, exampleData, and exampleOutput are unused
- componentSubtype is used, but it is confusing. Backend has no concept of a subtype, and the subtype used in the UI is equal to the type in 2/3 of the cases. Makes no sense.

These problems seem small, but when you are trying to come up with a better registry API, they confuse you, so I'm just removing it.