### PR TITLE
feat: add prompt aborting in agent chat

### DIFF
--- a/web_src/src/components/AiBuilderInputForm.tsx
+++ b/web_src/src/components/AiBuilderInputForm.tsx
@@ -1,6 +1,6 @@
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, Square } from "lucide-react";
 import type { FormEvent, KeyboardEvent, RefObject } from "react";
 
 export type InputFormProps = {
@@ -8,6 +8,7 @@ export type InputFormProps = {
   aiInput: string;
   onAiInputChange: (value: string) => void;
   onSendPrompt: () => void;
+  onStopPrompt: () => void;
   disabled: boolean;
   canvasId?: string;
   isGeneratingResponse: boolean;
@@ -28,18 +29,25 @@ const SUBMIT_BUTTON_CLASSNAME = cn(
   "flex items-center justify-center",
 );
 
+const STOP_BUTTON_CLASSNAME = cn(
+  "p-1 rounded-full bg-slate-600 text-white hover:bg-slate-700",
+  "cursor-pointer",
+  "flex items-center justify-center",
+);
+
 export function InputForm({
   aiInputRef,
   aiInput,
   onAiInputChange,
   onSendPrompt,
+  onStopPrompt,
   disabled,
   canvasId,
   isGeneratingResponse,
   maxAiInputHeight,
   expanded = false,
 }: InputFormProps) {
-  const isDisabled = disabled || isGeneratingResponse || !canvasId || !aiInput.trim();
+  const isSendDisabled = disabled || isGeneratingResponse || !canvasId || !aiInput.trim();
 
   const keyDownHandler = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -72,9 +80,26 @@ export function InputForm({
         />
 
         <div className="flex items-center justify-end">
-          <button type="submit" className={SUBMIT_BUTTON_CLASSNAME} disabled={isDisabled} aria-label="Send prompt">
-            <ArrowUp size={14} />
-          </button>
+          {isGeneratingResponse ? (
+            <button
+              type="button"
+              className={STOP_BUTTON_CLASSNAME}
+              onClick={onStopPrompt}
+              aria-label="Stop prompt"
+              title="Stop prompt"
+            >
+              <Square size={14} />
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className={SUBMIT_BUTTON_CLASSNAME}
+              disabled={isSendDisabled}
+              aria-label="Send prompt"
+            >
+              <ArrowUp size={14} />
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/web_src/src/ui/BuildingBlocksSidebar/AiBuilderChatPanel.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/AiBuilderChatPanel.tsx
@@ -31,6 +31,7 @@ type AiBuilderChatPanelProps = {
   onSelectChat: (chatId: string) => void;
   onStartNewSession: () => void;
   onSendPrompt: () => void;
+  onStopPrompt: () => void;
   aiInputRef: RefObject<HTMLTextAreaElement | null>;
 };
 
@@ -55,6 +56,7 @@ export function AiBuilderChatPanel({
   onSelectChat,
   onStartNewSession,
   onSendPrompt,
+  onStopPrompt,
   aiInputRef,
 }: AiBuilderChatPanelProps) {
   const aiMessagesContainerRef = useRef<HTMLDivElement>(null);
@@ -92,6 +94,7 @@ export function AiBuilderChatPanel({
               aiInput={aiInput}
               onAiInputChange={onAiInputChange}
               onSendPrompt={onSendPrompt}
+              onStopPrompt={onStopPrompt}
               disabled={disabled}
               canvasId={canvasId}
               isGeneratingResponse={isGeneratingResponse}
@@ -144,6 +147,7 @@ export function AiBuilderChatPanel({
               aiInput={aiInput}
               onAiInputChange={onAiInputChange}
               onSendPrompt={onSendPrompt}
+              onStopPrompt={onStopPrompt}
               disabled={disabled}
               canvasId={canvasId}
               isGeneratingResponse={isGeneratingResponse}

--- a/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import {
   agentsCreateAgentChat,
   agentsListAgentChatMessages,
@@ -16,6 +16,7 @@ import type {
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { consumeChatResponseStream } from "./agentChatSupport";
 import {
+  applyChatPromptCancellation,
   addLocalPromptMessages,
   applyChatPromptFailure,
   applyStreamOutcome,
@@ -161,6 +162,18 @@ function requireChatSessionPayload(payload: AgentsCreateAgentChatResponse | Agen
   return { token, url };
 }
 
+function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException) {
+    return error.name === "AbortError";
+  }
+
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return "name" in error && (error as { name?: string }).name === "AbortError";
+}
+
 export async function loadChatSessions({
   canvasId,
   organizationId,
@@ -226,6 +239,7 @@ type SendChatPromptArgs = {
   setAiError: Dispatch<SetStateAction<string | null>>;
   setIsGeneratingResponse: Dispatch<SetStateAction<boolean>>;
   setPendingProposal: Dispatch<SetStateAction<AiBuilderProposal | null>>;
+  chatAbortControllerRef?: MutableRefObject<AbortController | null>;
   focusInput: () => void;
 };
 
@@ -290,13 +304,16 @@ async function fetchChatStreamResponse({
   nextPrompt,
   token,
   url,
+  signal,
 }: {
   nextPrompt: string;
   token: string;
   url: string;
+  signal?: AbortSignal;
 }): Promise<Response> {
   const response = await fetch(url, {
     method: "POST",
+    signal,
     headers: {
       "Content-Type": "application/json",
       Accept: "text/event-stream",
@@ -348,6 +365,7 @@ export async function sendChatPrompt({
   setAiError,
   setIsGeneratingResponse,
   setPendingProposal,
+  chatAbortControllerRef,
   focusInput,
 }: SendChatPromptArgs): Promise<void> {
   const nextPrompt = (value ?? aiInput).trim();
@@ -380,6 +398,8 @@ export async function sendChatPrompt({
     focusInput,
   });
   let pendingNewChatId: string | null = null;
+  let streamAbortController: AbortController | null = null;
+  let wasAborted = false;
 
   try {
     setPendingProposal(null);
@@ -396,10 +416,16 @@ export async function sendChatPrompt({
       pendingNewChatId = session.chatId;
     }
 
+    streamAbortController = new AbortController();
+    if (chatAbortControllerRef) {
+      chatAbortControllerRef.current = streamAbortController;
+    }
+
     const response = await fetchChatStreamResponse({
       nextPrompt,
       token: session.token,
       url: session.url,
+      signal: streamAbortController.signal,
     });
 
     const { assistantContentSnapshot, streamedAnyAnswer, runModel } = await consumeChatResponseStream({
@@ -425,18 +451,40 @@ export async function sendChatPrompt({
 
     refreshChatSessions({ canvasId, organizationId, setChatSessions });
   } catch (error) {
-    applyChatPromptFailure({
-      assistantMessageId,
-      error,
-      pushAiMessages,
-      setAiError,
-      setAiMessages,
-      trimAiMessages,
-    });
+    if (isAbortError(error)) {
+      wasAborted = true;
+      applyChatPromptCancellation({
+        assistantMessageId,
+        pushAiMessages,
+        setAiError,
+        setAiMessages,
+        trimAiMessages,
+      });
+    } else {
+      applyChatPromptFailure({
+        assistantMessageId,
+        error,
+        pushAiMessages,
+        setAiError,
+        setAiMessages,
+        trimAiMessages,
+      });
+    }
   } finally {
+    if (chatAbortControllerRef?.current === streamAbortController) {
+      chatAbortControllerRef.current = null;
+    }
     setIsGeneratingResponse(false);
-    if (pendingNewChatId) {
+    if (!wasAborted && pendingNewChatId) {
       setCurrentChatId(pendingNewChatId);
     }
   }
+}
+
+export function stopRunningChatPrompt({
+  chatAbortControllerRef,
+}: {
+  chatAbortControllerRef?: MutableRefObject<AbortController | null>;
+}): void {
+  chatAbortControllerRef?.current?.abort();
 }

--- a/web_src/src/ui/BuildingBlocksSidebar/agentChatUi.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/agentChatUi.ts
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import type { AiBuilderMessage, AiBuilderProposal, AiChatSession } from "./agentChat";
 
 const GENERIC_FAILURE_MESSAGE = "I couldn't generate changes right now. Please try again.";
+const CANCELLATION_MESSAGE = "Stopped.";
 
 type SendChatPromptUiArgs = {
   focusInput: () => void;
@@ -112,6 +113,44 @@ export function applyChatPromptFailure({
       role: "assistant",
       content: GENERIC_FAILURE_MESSAGE,
     });
+  });
+}
+
+export function applyChatPromptCancellation({
+  assistantMessageId,
+  pushAiMessages,
+  setAiError,
+  setAiMessages,
+  trimAiMessages,
+}: {
+  assistantMessageId: string;
+  pushAiMessages: (previous: AiBuilderMessage[], next: AiBuilderMessage | AiBuilderMessage[]) => AiBuilderMessage[];
+  setAiError: Dispatch<SetStateAction<string | null>>;
+  setAiMessages: Dispatch<SetStateAction<AiBuilderMessage[]>>;
+  trimAiMessages: (messages: AiBuilderMessage[]) => AiBuilderMessage[];
+}): void {
+  setAiError(null);
+  setAiMessages((previous) => {
+    const existingIndex = previous.findIndex((message) => message.id === assistantMessageId);
+    if (existingIndex < 0) {
+      return pushAiMessages(previous, {
+        id: `assistant-${Date.now()}`,
+        role: "assistant",
+        content: CANCELLATION_MESSAGE,
+      });
+    }
+
+    const existingMessage = previous[existingIndex];
+    if (existingMessage.role === "assistant" && existingMessage.content.trim().length === 0) {
+      const updated = [...previous];
+      updated[existingIndex] = {
+        ...existingMessage,
+        content: CANCELLATION_MESSAGE,
+      };
+      return trimAiMessages(updated);
+    }
+
+    return previous;
   });
 }
 

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -11,7 +11,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY } from "../CanvasPage";
 import { ComponentBase } from "../componentBase";
 import type { AiChatSession, AiBuilderMessage, AiBuilderProposal } from "./agentChat";
-import { loadChatConversation, loadChatSessions, pushAiMessages, sendChatPrompt } from "./agentChat";
+import {
+  loadChatConversation,
+  loadChatSessions,
+  pushAiMessages,
+  sendChatPrompt,
+  stopRunningChatPrompt,
+} from "./agentChat";
 import { AiBuilderChatPanel } from "./AiBuilderChatPanel";
 import { CategorySection } from "./CategorySection";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
@@ -196,6 +202,7 @@ function OpenBuildingBlocksSidebar({
   const sidebarRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const aiInputRef = useRef<HTMLTextAreaElement>(null);
+  const chatAbortControllerRef = useRef<AbortController | null>(null);
   const isDraggingRef = useRef(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     if (typeof window === "undefined") {
@@ -246,6 +253,7 @@ function OpenBuildingBlocksSidebar({
         setAiError,
         setIsGeneratingResponse,
         setPendingProposal,
+        chatAbortControllerRef,
         focusInput: () => aiInputRef.current?.focus(),
       });
     },
@@ -270,6 +278,10 @@ function OpenBuildingBlocksSidebar({
 
   const handleDiscardProposal = useCallback(() => {
     setPendingProposal(null);
+  }, []);
+
+  const handleStopPrompt = useCallback(() => {
+    stopRunningChatPrompt({ chatAbortControllerRef });
   }, []);
 
   const formatOperation = useCallback((operation: CanvasOperation, proposal?: AiBuilderProposal) => {
@@ -384,6 +396,7 @@ function OpenBuildingBlocksSidebar({
   }, [showAiBuilderTab, activeTab]);
 
   useEffect(() => {
+    stopRunningChatPrompt({ chatAbortControllerRef });
     setActiveTab("components");
     setCurrentChatId(null);
     setAiMessages([]);
@@ -391,6 +404,12 @@ function OpenBuildingBlocksSidebar({
     setAiError(null);
     setAiInput("");
   }, [canvasId]);
+
+  useEffect(() => {
+    return () => {
+      stopRunningChatPrompt({ chatAbortControllerRef });
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -788,6 +807,7 @@ function OpenBuildingBlocksSidebar({
             onSelectChat={handleSelectChatSession}
             onStartNewSession={handleStartNewChatSession}
             onSendPrompt={() => void handleSendPrompt()}
+            onStopPrompt={handleStopPrompt}
             aiInputRef={aiInputRef}
           />
         )}


### PR DESCRIPTION
## What Changed

This PR adds prompt cancellation support to the Agent chat UI in the workflow sidebar.

- Added a "Stop" action while a response is generating (square icon replaces send button while running, also kind of works like a "Steer" feature.).
- Introduced request cancellation via `AbortController` for the agent stream request and added explicit abort handling so canceled runs do not show an error and instead show `Stopped.`.
- Prevented new chat session selection updates when a run is aborted.
- Added cleanup to cancel in-flight agent streams on canvas and component unmount.

## How

- Added an `onStopPrompt` callback next to `onSendPrompt`.
- Added `chatAbortControllerRef` state in sidebar scope and passed it into `sendChatPrompt`.
- Added abort-aware error detection (`AbortError`) and a dedicated cancellation UI path.
- Added `stopRunningChatPrompt(...)` helper:
  - explicit stop button click
  - canvas change reset
  - component unmount cleanup

## Related Issues

Closes #4076 

Let me know if anything needs to be changed. Much love.