### PR TITLE
fix: don't crash public API when usage client init fails

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -260,7 +260,9 @@ func startPublicAPI(baseURL, basePath string, encryptor crypto.Encryptor, regist
 	blockSignup := os.Getenv("BLOCK_SIGNUP") == "yes"
 	usageService, err := usage.NewServiceFromEnv()
 	if err != nil {
-		log.Panicf("failed to initialize usage service for public api: %v", err)
+		// Usage is an optional dependency; if it can't be initialized, continue with usage disabled.
+		log.Warnf("failed to initialize usage service for public api, continuing with usage disabled: %v", err)
+		usageService = usage.NewDisabledService()
 	}
 
 	webhooksBaseURL := getWebhookBaseURL(baseURL)

--- a/pkg/usage/service.go
+++ b/pkg/usage/service.go
@@ -47,6 +47,10 @@ func NewServiceFromEnv() (Service, error) {
 	}, nil
 }
 
+func NewDisabledService() Service {
+	return disabledService{}
+}
+
 func (disabledService) Enabled() bool {
 	return false
 }


### PR DESCRIPTION
Prevent the public API from crashing when the usage gRPC client can’t be initialized.
Fall back to a disabled usage service and log a warning instead.