### PR TITLE
feat: HashiCorp Vault base integration (Token auth, KV v2, Get Secret)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ CLAUDE.local.md
 .env
 .idea/
 .agents/
-.worktrees/
+.worktrees/.worktrees/

--- a/docs/superpowers/plans/2026-04-14-hashicorp-vault-base.md
+++ b/docs/superpowers/plans/2026-04-14-hashicorp-vault-base.md
@@ -1,0 +1,1107 @@
+# HashiCorp Vault Base Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the base HashiCorp Vault integration with Token auth and a single "Get Secret" component that reads from KV v2.
+
+**Architecture:** Follows the Perplexity integration pattern exactly — pure REST API, no webhooks, no triggers. The integration registers itself via `init()`, is verified in `Sync()` by calling `/v1/auth/token/lookup-self`, and exposes one component (`getSecret`) that calls `/v1/<mount>/data/<path>`.
+
+**Tech Stack:** Go, `mapstructure` (config decoding), `encoding/json` (response parsing), `github.com/stretchr/testify` (test assertions), `test/support/contexts` (mock HTTP/integration contexts).
+
+**Spec:** `docs/superpowers/specs/2026-04-14-hashicorp-vault-base-design.md`
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `pkg/integrations/hashicorp_vault/vault.go` |
+| Create | `pkg/integrations/hashicorp_vault/client.go` |
+| Create | `pkg/integrations/hashicorp_vault/get_secret.go` |
+| Create | `pkg/integrations/hashicorp_vault/example.go` |
+| Create | `pkg/integrations/hashicorp_vault/example_output_get_secret.json` |
+| Create | `pkg/integrations/hashicorp_vault/vault_test.go` |
+| Create | `pkg/integrations/hashicorp_vault/get_secret_test.go` |
+| Modify | `pkg/server/server.go` |
+
+---
+
+## Task 1: Integration struct, Sync, and HTTP client
+
+**Files:**
+- Create: `pkg/integrations/hashicorp_vault/vault_test.go`
+- Create: `pkg/integrations/hashicorp_vault/vault.go`
+- Create: `pkg/integrations/hashicorp_vault/client.go`
+
+---
+
+- [ ] **Step 1.1: Create `vault_test.go`**
+
+```go
+package hashicorp_vault
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestSync_Success(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":{"accessor":"abc123"}}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL": "https://vault.example.com",
+			"token":   "hvs.test",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"},
+		HTTP:          httpCtx,
+		Integration:   integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ready", integrationCtx.State)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/auth/token/lookup-self")
+	assert.Equal(t, "hvs.test", httpCtx.Requests[0].Header.Get("X-Vault-Token"))
+}
+
+func TestSync_InvalidToken(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":["permission denied"]}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL": "https://vault.example.com",
+			"token":   "bad-token",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "bad-token"},
+		HTTP:          httpCtx,
+		Integration:   integrationCtx,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.NotEqual(t, "ready", integrationCtx.State)
+}
+
+func TestSync_MissingToken(t *testing.T) {
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": ""},
+		HTTP:          &contexts.HTTPContext{},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token is required")
+}
+
+func TestSync_MissingBaseURL(t *testing.T) {
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "", "token": "hvs.test"},
+		HTTP:          &contexts.HTTPContext{},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "baseURL is required")
+}
+
+func TestSync_WithNamespace(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":{}}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL":   "https://vault.example.com",
+			"token":     "hvs.test",
+			"namespace": "admin/team-a",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger: logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{
+			"baseURL":   "https://vault.example.com",
+			"token":     "hvs.test",
+			"namespace": "admin/team-a",
+		},
+		HTTP:        httpCtx,
+		Integration: integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "admin/team-a", httpCtx.Requests[0].Header.Get("X-Vault-Namespace"))
+}
+```
+
+---
+
+- [ ] **Step 1.2: Create stub `vault.go` and `client.go` (enough to compile)**
+
+`pkg/integrations/hashicorp_vault/vault.go`:
+```go
+package hashicorp_vault
+
+import (
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("hashicorp_vault", &HashicorpVault{})
+}
+
+type HashicorpVault struct{}
+
+func (v *HashicorpVault) Name() string         { return "hashicorp_vault" }
+func (v *HashicorpVault) Label() string        { return "HashiCorp Vault" }
+func (v *HashicorpVault) Icon() string         { return "vault" }
+func (v *HashicorpVault) Description() string  { return "Securely read secrets from HashiCorp Vault" }
+func (v *HashicorpVault) Instructions() string { return "" }
+
+func (v *HashicorpVault) Configuration() []configuration.Field {
+	return []configuration.Field{}
+}
+
+func (v *HashicorpVault) Components() []core.Component  { return []core.Component{} }
+func (v *HashicorpVault) Triggers() []core.Trigger      { return []core.Trigger{} }
+func (v *HashicorpVault) Actions() []core.Action        { return []core.Action{} }
+func (v *HashicorpVault) HandleRequest(ctx core.HTTPRequestContext) {}
+
+func (v *HashicorpVault) Cleanup(ctx core.IntegrationCleanupContext) error   { return nil }
+func (v *HashicorpVault) HandleAction(ctx core.IntegrationActionContext) error { return nil }
+
+func (v *HashicorpVault) Sync(ctx core.SyncContext) error { return nil }
+
+func (v *HashicorpVault) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return []core.IntegrationResource{}, nil
+}
+```
+
+`pkg/integrations/hashicorp_vault/client.go`:
+```go
+package hashicorp_vault
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type Client struct {
+	BaseURL   string
+	Token     string
+	Namespace string
+	http      core.HTTPContext
+}
+
+func NewClient(httpCtx core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	baseURL, err := ctx.GetConfig("baseURL")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get baseURL: %w", err)
+	}
+
+	token, err := ctx.GetConfig("token")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+
+	namespace, _ := ctx.GetConfig("namespace")
+
+	return &Client{
+		BaseURL:   string(baseURL),
+		Token:     string(token),
+		Namespace: string(namespace),
+		http:      httpCtx,
+	}, nil
+}
+
+func (c *Client) LookupSelf() error {
+	return nil
+}
+
+func (c *Client) execRequest(method, path string, body io.Reader) ([]byte, error) {
+	return nil, nil
+}
+```
+
+---
+
+- [ ] **Step 1.3: Run tests — expect failures**
+
+```bash
+make test PKG_TEST_PACKAGES=./pkg/integrations/hashicorp_vault
+```
+
+Expected: multiple FAIL — `TestSync_Success` (state not "ready"), `TestSync_InvalidToken` (no error returned), `TestSync_WithNamespace` (no header sent), etc.
+
+---
+
+- [ ] **Step 1.4: Implement full `vault.go`**
+
+Replace `vault.go` with the complete implementation:
+
+```go
+package hashicorp_vault
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("hashicorp_vault", &HashicorpVault{})
+}
+
+type HashicorpVault struct{}
+
+type vaultConfig struct {
+	BaseURL   string `mapstructure:"baseURL"`
+	Namespace string `mapstructure:"namespace"`
+	Token     string `mapstructure:"token"`
+}
+
+func (v *HashicorpVault) Name() string         { return "hashicorp_vault" }
+func (v *HashicorpVault) Label() string        { return "HashiCorp Vault" }
+func (v *HashicorpVault) Icon() string         { return "vault" }
+func (v *HashicorpVault) Description() string  { return "Securely read secrets from HashiCorp Vault" }
+func (v *HashicorpVault) Instructions() string { return "" }
+
+func (v *HashicorpVault) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "baseURL",
+			Label:       "Base URL",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Vault server URL, e.g. https://vault.example.com",
+		},
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Vault Enterprise namespace. Leave empty for community edition.",
+		},
+		{
+			Name:        "token",
+			Label:       "Token",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Vault token (hvs.… or s.…)",
+		},
+	}
+}
+
+func (v *HashicorpVault) Components() []core.Component  { return []core.Component{} }
+func (v *HashicorpVault) Triggers() []core.Trigger      { return []core.Trigger{} }
+func (v *HashicorpVault) Actions() []core.Action        { return []core.Action{} }
+func (v *HashicorpVault) HandleRequest(ctx core.HTTPRequestContext) {}
+
+func (v *HashicorpVault) Cleanup(ctx core.IntegrationCleanupContext) error    { return nil }
+func (v *HashicorpVault) HandleAction(ctx core.IntegrationActionContext) error { return nil }
+
+func (v *HashicorpVault) Sync(ctx core.SyncContext) error {
+	cfg := vaultConfig{}
+	if err := mapstructure.Decode(ctx.Configuration, &cfg); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if cfg.BaseURL == "" {
+		return fmt.Errorf("baseURL is required")
+	}
+
+	if cfg.Token == "" {
+		return fmt.Errorf("token is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	if err := client.LookupSelf(); err != nil {
+		return err
+	}
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (v *HashicorpVault) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return []core.IntegrationResource{}, nil
+}
+```
+
+---
+
+- [ ] **Step 1.5: Implement full `client.go`**
+
+Replace `client.go` with the complete implementation:
+
+```go
+package hashicorp_vault
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type Client struct {
+	BaseURL   string
+	Token     string
+	Namespace string
+	http      core.HTTPContext
+}
+
+func NewClient(httpCtx core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	baseURL, err := ctx.GetConfig("baseURL")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get baseURL: %w", err)
+	}
+	if len(baseURL) == 0 {
+		return nil, fmt.Errorf("baseURL is required")
+	}
+
+	token, err := ctx.GetConfig("token")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+	if len(token) == 0 {
+		return nil, fmt.Errorf("token is required")
+	}
+
+	namespace, _ := ctx.GetConfig("namespace")
+
+	return &Client{
+		BaseURL:   string(baseURL),
+		Token:     string(token),
+		Namespace: string(namespace),
+		http:      httpCtx,
+	}, nil
+}
+
+func (c *Client) LookupSelf() error {
+	_, err := c.execRequest(http.MethodGet, "/v1/auth/token/lookup-self", nil)
+	return err
+}
+
+func (c *Client) execRequest(method, path string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, c.BaseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	req.Header.Set("X-Vault-Token", c.Token)
+	req.Header.Set("Content-Type", "application/json")
+	if c.Namespace != "" {
+		req.Header.Set("X-Vault-Namespace", c.Namespace)
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("request got %d: %s", res.StatusCode, string(responseBody))
+	}
+
+	return responseBody, nil
+}
+```
+
+---
+
+- [ ] **Step 1.6: Run tests — expect all to pass**
+
+```bash
+make test PKG_TEST_PACKAGES=./pkg/integrations/hashicorp_vault
+```
+
+Expected: `ok  github.com/superplanehq/superplane/pkg/integrations/hashicorp_vault`
+
+---
+
+- [ ] **Step 1.7: Format and commit**
+
+```bash
+make format.go
+git add pkg/integrations/hashicorp_vault/vault.go \
+        pkg/integrations/hashicorp_vault/client.go \
+        pkg/integrations/hashicorp_vault/vault_test.go
+git commit -m "feat: add HashiCorp Vault integration with Token auth and Sync verification"
+```
+
+---
+
+## Task 2: Get Secret component
+
+**Files:**
+- Create: `pkg/integrations/hashicorp_vault/get_secret_test.go`
+- Create: `pkg/integrations/hashicorp_vault/get_secret.go`
+- Create: `pkg/integrations/hashicorp_vault/example.go`
+- Create: `pkg/integrations/hashicorp_vault/example_output_get_secret.json`
+- Modify: `pkg/integrations/hashicorp_vault/client.go` (add `GetKVSecret`)
+- Modify: `pkg/integrations/hashicorp_vault/vault.go` (update `Components()`)
+
+---
+
+- [ ] **Step 2.1: Create `get_secret_test.go`**
+
+```go
+package hashicorp_vault
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func kvSecretJSON(dataJSON string) string {
+	return `{"data":{"data":` + dataJSON + `,"metadata":{"version":3,"created_time":"2025-01-01T00:00:00Z","deletion_time":"","destroyed":false}}}`
+}
+
+func TestGetSecret_Execute_AllData(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin","password":"s3cr3t"}`))),
+		}},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db"},
+		ExecutionState: execState,
+		HTTP:           httpCtx,
+		Integration:    integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, SecretPayloadType, execState.Type)
+	require.Len(t, execState.Payloads, 1)
+	wrapped := execState.Payloads[0].(map[string]any)
+	payload := wrapped["data"].(secretPayload)
+	assert.Equal(t, "secret", payload.Mount)
+	assert.Equal(t, "myapp/db", payload.Path)
+	assert.Equal(t, "admin", payload.Data["username"])
+	assert.Empty(t, payload.Value)
+}
+
+func TestGetSecret_Execute_SpecificKey(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin","password":"s3cr3t"}`))),
+		}},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db", "key": "username"},
+		ExecutionState: execState,
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.NoError(t, err)
+	wrapped := execState.Payloads[0].(map[string]any)
+	payload := wrapped["data"].(secretPayload)
+	assert.Equal(t, "admin", payload.Value)
+}
+
+func TestGetSecret_Execute_KeyNotFound(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin"}`))),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db", "key": "password"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"password" not found`)
+}
+
+func TestGetSecret_Execute_APIError(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":["permission denied"]}`)),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"path": "myapp/db"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestGetSecret_Setup_MissingPath(t *testing.T) {
+	c := &getSecret{}
+	err := c.Setup(core.SetupContext{
+		Configuration: map[string]any{"path": ""},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+		Metadata:      &contexts.MetadataContext{},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path is required")
+}
+
+func TestGetSecret_Execute_DefaultMount(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"key":"val"}`))),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"path": "myapp/config"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/secret/data/myapp/config")
+}
+```
+
+---
+
+- [ ] **Step 2.2: Create stub `get_secret.go` (compiles, returns nil/empty)**
+
+```go
+package hashicorp_vault
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const SecretPayloadType = "hashicorp_vault.secret"
+
+type getSecret struct{}
+
+type getSecretSpec struct {
+	Mount string `mapstructure:"mount"`
+	Path  string `mapstructure:"path"`
+	Key   string `mapstructure:"key"`
+}
+
+type secretPayload struct {
+	Mount    string           `json:"mount"`
+	Path     string           `json:"path"`
+	Data     map[string]any   `json:"data"`
+	Value    string           `json:"value,omitempty"`
+	Metadata KVSecretMetadata `json:"metadata"`
+}
+
+func (c *getSecret) Name() string         { return "hashicorp_vault.getSecret" }
+func (c *getSecret) Label() string        { return "Get Secret" }
+func (c *getSecret) Description() string  { return "Read a secret from HashiCorp Vault KV v2" }
+func (c *getSecret) Documentation() string { return "" }
+func (c *getSecret) Icon() string         { return "lock" }
+func (c *getSecret) Color() string        { return "gray" }
+
+func (c *getSecret) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *getSecret) Configuration() []configuration.Field {
+	return []configuration.Field{}
+}
+
+func (c *getSecret) Setup(ctx core.SetupContext) error   { return nil }
+func (c *getSecret) Execute(ctx core.ExecutionContext) error { return nil }
+func (c *getSecret) Cancel(ctx core.ExecutionContext) error  { return nil }
+func (c *getSecret) Cleanup(ctx core.SetupContext) error     { return nil }
+
+func (c *getSecret) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *getSecret) Actions() []core.Action                    { return []core.Action{} }
+func (c *getSecret) HandleAction(ctx core.ActionContext) error  { return nil }
+
+func (c *getSecret) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+```
+
+Note: `KVSecretMetadata` is referenced here but defined in `client.go` in Step 2.4.
+
+---
+
+- [ ] **Step 2.3: Add `GetKVSecret` and KV types to `client.go`** *(do this before running tests — stub references `KVSecretMetadata`)*
+
+Add these types and method to the end of `client.go` (before the closing of the file):
+
+```go
+// KVSecretMetadata holds version info returned by the KV v2 API.
+type KVSecretMetadata struct {
+	Version      int    `json:"version"`
+	CreatedTime  string `json:"created_time"`
+	DeletionTime string `json:"deletion_time"`
+	Destroyed    bool   `json:"destroyed"`
+}
+
+// KVSecret is the parsed result of a KV v2 GET request.
+type KVSecret struct {
+	Data     map[string]any   `json:"data"`
+	Metadata KVSecretMetadata `json:"metadata"`
+}
+
+type kvSecretResponse struct {
+	Data struct {
+		Data     map[string]any   `json:"data"`
+		Metadata KVSecretMetadata `json:"metadata"`
+	} `json:"data"`
+}
+
+func (c *Client) GetKVSecret(mount, path string) (*KVSecret, error) {
+	endpoint := fmt.Sprintf("/v1/%s/data/%s", mount, path)
+	body, err := c.execRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response kvSecretResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &KVSecret{
+		Data:     response.Data.Data,
+		Metadata: response.Data.Metadata,
+	}, nil
+}
+```
+
+Also add `"encoding/json"` to the import block at the top of `client.go`:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+```
+
+---
+
+- [ ] **Step 2.4: Run tests — expect failures on the new tests**
+
+```bash
+make test PKG_TEST_PACKAGES=./pkg/integrations/hashicorp_vault
+```
+
+Expected: Task 1 tests still pass. New tests fail — `TestGetSecret_Execute_AllData` (stub Execute returns nil, no payload emitted), etc.
+
+---
+
+- [ ] **Step 2.5: Implement full `get_secret.go`**
+
+Replace `get_secret.go` with the complete implementation:
+
+```go
+package hashicorp_vault
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const SecretPayloadType = "hashicorp_vault.secret"
+
+type getSecret struct{}
+
+type getSecretSpec struct {
+	Mount string `mapstructure:"mount"`
+	Path  string `mapstructure:"path"`
+	Key   string `mapstructure:"key"`
+}
+
+type secretPayload struct {
+	Mount    string           `json:"mount"`
+	Path     string           `json:"path"`
+	Data     map[string]any   `json:"data"`
+	Value    string           `json:"value,omitempty"`
+	Metadata KVSecretMetadata `json:"metadata"`
+}
+
+func (c *getSecret) Name() string        { return "hashicorp_vault.getSecret" }
+func (c *getSecret) Label() string       { return "Get Secret" }
+func (c *getSecret) Description() string { return "Read a secret from HashiCorp Vault KV v2" }
+func (c *getSecret) Icon() string        { return "lock" }
+func (c *getSecret) Color() string       { return "gray" }
+
+func (c *getSecret) Documentation() string {
+	return `The Get Secret component reads a secret from a HashiCorp Vault KV v2 secrets engine.
+
+## Use Cases
+
+- **Inject secrets into workflows**: Read credentials, API keys, or certificates at runtime
+- **Secret rotation checks**: Read the latest version of a secret after rotation
+- **Conditional workflows**: Branch based on secret values
+
+## Configuration
+
+- **Mount**: The KV v2 secrets engine mount path (default: "secret")
+- **Path**: The secret path within the mount, e.g. "myapp/db"
+- **Key**: Optional. If set, extracts a single key from the secret data. Available as "value" in the output.
+
+## Output
+
+Returns the full secret data map, optional extracted value, and version metadata.`
+}
+
+func (c *getSecret) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *getSecret) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "mount",
+			Label:       "Mount",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Default:     "secret",
+			Description: "KV v2 mount path",
+		},
+		{
+			Name:        "path",
+			Label:       "Secret Path",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "myapp/db",
+			Description: "Path to the secret, e.g. myapp/db",
+		},
+		{
+			Name:        "key",
+			Label:       "Key",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "password",
+			Description: "Optional. Extract a specific key from the secret data.",
+		},
+	}
+}
+
+func (c *getSecret) Setup(ctx core.SetupContext) error {
+	spec := getSecretSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	return nil
+}
+
+func (c *getSecret) Execute(ctx core.ExecutionContext) error {
+	spec := getSecretSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	mount := spec.Mount
+	if mount == "" {
+		mount = "secret"
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	secret, err := client.GetKVSecret(mount, spec.Path)
+	if err != nil {
+		return err
+	}
+
+	payload := secretPayload{
+		Mount:    mount,
+		Path:     spec.Path,
+		Data:     secret.Data,
+		Metadata: secret.Metadata,
+	}
+
+	if spec.Key != "" {
+		val, ok := secret.Data[spec.Key]
+		if !ok {
+			return fmt.Errorf("key %q not found in secret data", spec.Key)
+		}
+
+		strVal, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("key %q has non-string value", spec.Key)
+		}
+
+		payload.Value = strVal
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		SecretPayloadType,
+		[]any{payload},
+	)
+}
+
+func (c *getSecret) Cancel(ctx core.ExecutionContext) error  { return nil }
+func (c *getSecret) Cleanup(ctx core.SetupContext) error     { return nil }
+
+func (c *getSecret) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *getSecret) Actions() []core.Action                   { return []core.Action{} }
+func (c *getSecret) HandleAction(ctx core.ActionContext) error { return nil }
+
+func (c *getSecret) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+```
+
+---
+
+- [ ] **Step 2.6: Create `example_output_get_secret.json`**
+
+`pkg/integrations/hashicorp_vault/example_output_get_secret.json`:
+```json
+{
+  "mount": "secret",
+  "path": "myapp/db",
+  "data": {
+    "username": "admin",
+    "password": "s3cr3t"
+  },
+  "value": "",
+  "metadata": {
+    "version": 3,
+    "created_time": "2025-01-01T00:00:00Z",
+    "deletion_time": "",
+    "destroyed": false
+  }
+}
+```
+
+---
+
+- [ ] **Step 2.7: Create `example.go`**
+
+`pkg/integrations/hashicorp_vault/example.go`:
+```go
+package hashicorp_vault
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output_get_secret.json
+var exampleOutputGetSecretBytes []byte
+
+var exampleOutputGetSecretOnce sync.Once
+var exampleOutputGetSecret map[string]any
+
+func (c *getSecret) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetSecretOnce, exampleOutputGetSecretBytes, &exampleOutputGetSecret)
+}
+```
+
+---
+
+- [ ] **Step 2.8: Update `Components()` in `vault.go`**
+
+Change the `Components()` method in `vault.go` from:
+```go
+func (v *HashicorpVault) Components() []core.Component { return []core.Component{} }
+```
+to:
+```go
+func (v *HashicorpVault) Components() []core.Component {
+	return []core.Component{
+		&getSecret{},
+	}
+}
+```
+
+---
+
+- [ ] **Step 2.9: Run tests — expect all to pass**
+
+```bash
+make test PKG_TEST_PACKAGES=./pkg/integrations/hashicorp_vault
+```
+
+Expected: `ok  github.com/superplanehq/superplane/pkg/integrations/hashicorp_vault`
+
+All 11 tests pass (5 Sync + 6 GetSecret).
+
+---
+
+- [ ] **Step 2.10: Format and commit**
+
+```bash
+make format.go
+git add pkg/integrations/hashicorp_vault/
+git commit -m "feat: add HashiCorp Vault Get Secret component (KV v2)"
+```
+
+---
+
+## Task 3: Wire up integration into the server
+
+**Files:**
+- Modify: `pkg/server/server.go`
+
+---
+
+- [ ] **Step 3.1: Add blank import to `pkg/server/server.go`**
+
+In `pkg/server/server.go`, find the import block containing other integration blank imports. They are alphabetically sorted. Add the new line between `harness` and `hetzner`:
+
+```go
+	_ "github.com/superplanehq/superplane/pkg/integrations/harness"
+	_ "github.com/superplanehq/superplane/pkg/integrations/hashicorp_vault"
+	_ "github.com/superplanehq/superplane/pkg/integrations/hetzner"
+```
+
+---
+
+- [ ] **Step 3.2: Build and lint check**
+
+```bash
+make check.build.app
+make lint
+```
+
+Expected: no errors.
+
+---
+
+- [ ] **Step 3.3: Format and commit**
+
+```bash
+make format.go
+git add pkg/server/server.go
+git commit -m "feat: register HashiCorp Vault integration in server"
+```
+
+---
+
+## Done
+
+At this point:
+- All 11 unit tests pass
+- The integration compiles and is registered in the server
+- `pkg/integrations/hashicorp_vault/` contains all 7 files
+- One line added to `pkg/server/server.go`
+
+The PR is ready to open against `superplanehq/superplane` referencing issue #3928.

--- a/docs/superpowers/specs/2026-04-14-hashicorp-vault-base-design.md
+++ b/docs/superpowers/specs/2026-04-14-hashicorp-vault-base-design.md
@@ -1,0 +1,154 @@
+# HashiCorp Vault Base Integration — Design Spec
+
+**Date:** 2026-04-14
+**Issue:** [#3928](https://github.com/superplanehq/superplane/issues/3928)
+**Scope:** Base integration — Token auth, KV v2, Get Secret component only.
+
+---
+
+## Decisions
+
+- **Auth method:** Token only (simplest, covers the majority of real use cases; other methods deferred to follow-up).
+- **KV version:** KV v2 only (modern Vault default with versioned secrets; v1 can be added later).
+- **Components:** `Get Secret` only, as specified in the issue.
+- **Triggers:** None (Vault is pull-only; no event push mechanism to integrate with).
+
+---
+
+## File Structure
+
+```
+pkg/integrations/hashicorp_vault/
+  vault.go                          # integration struct, Configuration(), Sync(), registration
+  client.go                         # HTTP client with token + namespace header
+  get_secret.go                     # Get Secret component
+  example.go                        # embeds example output JSON
+  example_output_get_secret.json    # example payload for UI preview
+  vault_test.go                     # Sync() unit tests
+  get_secret_test.go                # Setup() and Execute() unit tests
+```
+
+One blank import added to `pkg/server/server.go` (alphabetically: after `harness`, before `hetzner`).
+
+---
+
+## Integration Config (`vault.go`)
+
+### `Configuration()` fields
+
+| Field       | Type   | Required | Sensitive | Description |
+|-------------|--------|----------|-----------|-------------|
+| `baseURL`   | string | yes      | no        | Vault server URL, e.g. `https://vault.example.com` |
+| `namespace` | string | no       | no        | Vault Enterprise namespace; sent as `X-Vault-Namespace` header. Leave empty for community edition. |
+| `token`     | string | yes      | yes       | Vault token (`hvs.…` or `s.…`) |
+
+### `Sync()` behaviour
+
+Calls `GET /v1/auth/token/lookup-self` with the configured token. On success, calls `ctx.Integration.Ready()`. On failure (401, network error, etc.), returns an error.
+
+### Other methods
+
+- `Triggers()` — returns empty slice.
+- `HandleRequest()` — no-op (no webhooks).
+- `Actions()` / `HandleAction()` — no-op.
+- `Cleanup()` — no-op.
+
+---
+
+## Client (`client.go`)
+
+```
+type Client struct {
+    BaseURL   string
+    Token     string
+    Namespace string
+    http      core.HTTPContext
+}
+```
+
+`NewClient(httpCtx, integrationCtx)` reads `baseURL`, `token`, `namespace` from integration config. Returns error if `baseURL` or `token` are empty.
+
+`execRequest(method, path, body)` — builds the full URL (`BaseURL + path`), sets:
+- `X-Vault-Token: <token>`
+- `X-Vault-Namespace: <namespace>` (only when non-empty)
+- `Content-Type: application/json`
+
+Returns error for non-2xx status codes, including the response body in the error message.
+
+`LookupSelf()` — calls `GET /v1/auth/token/lookup-self`, returns error on failure. Used by `Sync()` to verify credentials.
+
+`GetKVSecret(mount, path string)` — calls `GET /v1/<mount>/data/<path>`, returns a parsed `KVSecret` struct.
+
+---
+
+## `Get Secret` Component (`get_secret.go`)
+
+### Component identity
+
+| Method | Value |
+|--------|-------|
+| `Name()` | `"hashicorp_vault.getSecret"` |
+| `Label()` | `"Get Secret"` |
+| `Icon()` | `"lock"` |
+| `Color()` | `"gray"` |
+
+### `Configuration()` fields
+
+| Field   | Type   | Required | Default    | Description |
+|---------|--------|----------|------------|-------------|
+| `mount` | string | no       | `"secret"` | KV v2 mount path. The `Default` field in `Configuration()` must be set to `"secret"` so the UI pre-fills it. |
+| `path`  | string | yes      | —          | Secret path, e.g. `myapp/db` |
+| `key`   | string | no       | —          | If set, extract only this key from the secret data; populates `value` in the output |
+
+### `Setup()` validation
+
+- Returns error if `path` is empty.
+
+### `Execute()` flow
+
+1. Decode config into `getSecretSpec` struct.
+2. Build `Client` via `NewClient`.
+3. Call `client.GetKVSecret(spec.Mount, spec.Path)`.
+4. Build output payload (see below).
+5. Emit on `core.DefaultOutputChannel` with type `"hashicorp_vault.secret"`.
+
+### Output payload shape
+
+```json
+{
+  "mount": "secret",
+  "path": "myapp/db",
+  "data": { "username": "admin", "password": "s3cr3t" },
+  "value": "admin",
+  "metadata": {
+    "version": 3,
+    "created_time": "2025-01-01T00:00:00Z",
+    "deletion_time": "",
+    "destroyed": false
+  }
+}
+```
+
+- `data` — the full KV data map (always present).
+- `value` — only populated when `key` config field is set; the string value of that key. If the key does not exist in `data`, returns an error.
+- `metadata` — version info from the KV v2 response.
+
+---
+
+## Tests
+
+### `vault_test.go`
+
+- `TestSync_Success` — mock returns 200 from `/v1/auth/token/lookup-self`; assert `integrationCtx.State == "ready"`.
+- `TestSync_InvalidToken` — mock returns 403; assert error returned, state not ready.
+- `TestSync_MissingToken` — empty token in config; assert error without making HTTP request.
+- `TestSync_MissingBaseURL` — empty baseURL; assert error without making HTTP request.
+
+### `get_secret_test.go`
+
+- `TestGetSecret_Execute_AllData` — `key` not set; assert full `data` map in emitted payload, `value` empty.
+- `TestGetSecret_Execute_SpecificKey` — `key` set; assert `value` populated with correct string.
+- `TestGetSecret_Execute_KeyNotFound` — `key` set to a key not present in `data`; assert error.
+- `TestGetSecret_Execute_APIError` — mock returns 403; assert error propagated.
+- `TestGetSecret_Setup_MissingPath` — empty `path`; assert error from `Setup()`.
+- `TestGetSecret_Execute_DefaultMount` — `mount` not set; assert request uses `"secret"` as mount.

--- a/pkg/integrations/hashicorp_vault/client.go
+++ b/pkg/integrations/hashicorp_vault/client.go
@@ -20,16 +20,10 @@ func NewClient(httpCtx core.HTTPContext, ctx core.IntegrationContext) (*Client, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get baseURL: %w", err)
 	}
-	if len(baseURL) == 0 {
-		return nil, fmt.Errorf("baseURL is required")
-	}
 
 	token, err := ctx.GetConfig("token")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token: %w", err)
-	}
-	if len(token) == 0 {
-		return nil, fmt.Errorf("token is required")
 	}
 
 	namespace, _ := ctx.GetConfig("namespace")

--- a/pkg/integrations/hashicorp_vault/client.go
+++ b/pkg/integrations/hashicorp_vault/client.go
@@ -1,0 +1,78 @@
+package hashicorp_vault
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type Client struct {
+	BaseURL   string
+	Token     string
+	Namespace string
+	http      core.HTTPContext
+}
+
+func NewClient(httpCtx core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	baseURL, err := ctx.GetConfig("baseURL")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get baseURL: %w", err)
+	}
+	if len(baseURL) == 0 {
+		return nil, fmt.Errorf("baseURL is required")
+	}
+
+	token, err := ctx.GetConfig("token")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token: %w", err)
+	}
+	if len(token) == 0 {
+		return nil, fmt.Errorf("token is required")
+	}
+
+	namespace, _ := ctx.GetConfig("namespace")
+
+	return &Client{
+		BaseURL:   string(baseURL),
+		Token:     string(token),
+		Namespace: string(namespace),
+		http:      httpCtx,
+	}, nil
+}
+
+func (c *Client) LookupSelf() error {
+	_, err := c.execRequest(http.MethodGet, "/v1/auth/token/lookup-self", nil)
+	return err
+}
+
+func (c *Client) execRequest(method, path string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, c.BaseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	req.Header.Set("X-Vault-Token", c.Token)
+	req.Header.Set("Content-Type", "application/json")
+	if c.Namespace != "" {
+		req.Header.Set("X-Vault-Namespace", c.Namespace)
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("request got %d: %s", res.StatusCode, string(responseBody))
+	}
+
+	return responseBody, nil
+}

--- a/pkg/integrations/hashicorp_vault/client.go
+++ b/pkg/integrations/hashicorp_vault/client.go
@@ -1,6 +1,7 @@
 package hashicorp_vault
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -69,4 +70,43 @@ func (c *Client) execRequest(method, path string, body io.Reader) ([]byte, error
 	}
 
 	return responseBody, nil
+}
+
+// KVSecretMetadata holds version info returned by the KV v2 API.
+type KVSecretMetadata struct {
+	Version      int    `json:"version"`
+	CreatedTime  string `json:"created_time"`
+	DeletionTime string `json:"deletion_time"`
+	Destroyed    bool   `json:"destroyed"`
+}
+
+// KVSecret is the parsed result of a KV v2 GET request.
+type KVSecret struct {
+	Data     map[string]any   `json:"data"`
+	Metadata KVSecretMetadata `json:"metadata"`
+}
+
+type kvSecretResponse struct {
+	Data struct {
+		Data     map[string]any   `json:"data"`
+		Metadata KVSecretMetadata `json:"metadata"`
+	} `json:"data"`
+}
+
+func (c *Client) GetKVSecret(mount, path string) (*KVSecret, error) {
+	endpoint := fmt.Sprintf("/v1/%s/data/%s", mount, path)
+	body, err := c.execRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response kvSecretResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &KVSecret{
+		Data:     response.Data.Data,
+		Metadata: response.Data.Metadata,
+	}, nil
 }

--- a/pkg/integrations/hashicorp_vault/example.go
+++ b/pkg/integrations/hashicorp_vault/example.go
@@ -1,0 +1,18 @@
+package hashicorp_vault
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output_get_secret.json
+var exampleOutputGetSecretBytes []byte
+
+var exampleOutputGetSecretOnce sync.Once
+var exampleOutputGetSecret map[string]any
+
+func (c *getSecret) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetSecretOnce, exampleOutputGetSecretBytes, &exampleOutputGetSecret)
+}

--- a/pkg/integrations/hashicorp_vault/example_output_get_secret.json
+++ b/pkg/integrations/hashicorp_vault/example_output_get_secret.json
@@ -1,0 +1,15 @@
+{
+  "mount": "secret",
+  "path": "myapp/db",
+  "data": {
+    "username": "admin",
+    "password": "s3cr3t"
+  },
+  "value": "",
+  "metadata": {
+    "version": 3,
+    "created_time": "2025-01-01T00:00:00Z",
+    "deletion_time": "",
+    "destroyed": false
+  }
+}

--- a/pkg/integrations/hashicorp_vault/example_output_get_secret.json
+++ b/pkg/integrations/hashicorp_vault/example_output_get_secret.json
@@ -5,7 +5,7 @@
     "username": "admin",
     "password": "s3cr3t"
   },
-  "value": "",
+  "value": "admin",
   "metadata": {
     "version": 3,
     "created_time": "2025-01-01T00:00:00Z",

--- a/pkg/integrations/hashicorp_vault/get_secret.go
+++ b/pkg/integrations/hashicorp_vault/get_secret.go
@@ -1,0 +1,168 @@
+package hashicorp_vault
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const SecretPayloadType = "hashicorp_vault.secret"
+
+type getSecret struct{}
+
+type getSecretSpec struct {
+	Mount string `mapstructure:"mount"`
+	Path  string `mapstructure:"path"`
+	Key   string `mapstructure:"key"`
+}
+
+type secretPayload struct {
+	Mount    string           `json:"mount"`
+	Path     string           `json:"path"`
+	Data     map[string]any   `json:"data"`
+	Value    string           `json:"value,omitempty"`
+	Metadata KVSecretMetadata `json:"metadata"`
+}
+
+func (c *getSecret) Name() string        { return "hashicorp_vault.getSecret" }
+func (c *getSecret) Label() string       { return "Get Secret" }
+func (c *getSecret) Description() string { return "Read a secret from HashiCorp Vault KV v2" }
+func (c *getSecret) Icon() string        { return "lock" }
+func (c *getSecret) Color() string       { return "gray" }
+
+func (c *getSecret) Documentation() string {
+	return `The Get Secret component reads a secret from a HashiCorp Vault KV v2 secrets engine.
+
+## Use Cases
+
+- **Inject secrets into workflows**: Read credentials, API keys, or certificates at runtime
+- **Secret rotation checks**: Read the latest version of a secret after rotation
+- **Conditional workflows**: Branch based on secret values
+
+## Configuration
+
+- **Mount**: The KV v2 secrets engine mount path (default: "secret")
+- **Path**: The secret path within the mount, e.g. "myapp/db"
+- **Key**: Optional. If set, extracts a single key from the secret data. Available as "value" in the output.
+
+## Output
+
+Returns the full secret data map, optional extracted value, and version metadata.`
+}
+
+func (c *getSecret) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *getSecret) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "mount",
+			Label:       "Mount",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Default:     "secret",
+			Description: "KV v2 mount path",
+		},
+		{
+			Name:        "path",
+			Label:       "Secret Path",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "myapp/db",
+			Description: "Path to the secret, e.g. myapp/db",
+		},
+		{
+			Name:        "key",
+			Label:       "Key",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Placeholder: "password",
+			Description: "Optional. Extract a specific key from the secret data.",
+		},
+	}
+}
+
+func (c *getSecret) Setup(ctx core.SetupContext) error {
+	spec := getSecretSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	return nil
+}
+
+func (c *getSecret) Execute(ctx core.ExecutionContext) error {
+	spec := getSecretSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if spec.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	mount := spec.Mount
+	if mount == "" {
+		mount = "secret"
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	secret, err := client.GetKVSecret(mount, spec.Path)
+	if err != nil {
+		return err
+	}
+
+	payload := secretPayload{
+		Mount:    mount,
+		Path:     spec.Path,
+		Data:     secret.Data,
+		Metadata: secret.Metadata,
+	}
+
+	if spec.Key != "" {
+		val, ok := secret.Data[spec.Key]
+		if !ok {
+			return fmt.Errorf("key %q not found in secret data", spec.Key)
+		}
+
+		strVal, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("key %q has non-string value", spec.Key)
+		}
+
+		payload.Value = strVal
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		SecretPayloadType,
+		[]any{payload},
+	)
+}
+
+func (c *getSecret) Cancel(ctx core.ExecutionContext) error  { return nil }
+func (c *getSecret) Cleanup(ctx core.SetupContext) error     { return nil }
+
+func (c *getSecret) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *getSecret) Actions() []core.Action                   { return []core.Action{} }
+func (c *getSecret) HandleAction(ctx core.ActionContext) error { return nil }
+
+func (c *getSecret) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/hashicorp_vault/get_secret_test.go
+++ b/pkg/integrations/hashicorp_vault/get_secret_test.go
@@ -1,0 +1,143 @@
+package hashicorp_vault
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func kvSecretJSON(dataJSON string) string {
+	return `{"data":{"data":` + dataJSON + `,"metadata":{"version":3,"created_time":"2025-01-01T00:00:00Z","deletion_time":"","destroyed":false}}}`
+}
+
+func TestGetSecret_Execute_AllData(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin","password":"s3cr3t"}`))),
+		}},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db"},
+		ExecutionState: execState,
+		HTTP:           httpCtx,
+		Integration:    integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, SecretPayloadType, execState.Type)
+	require.Len(t, execState.Payloads, 1)
+	wrapped := execState.Payloads[0].(map[string]any)
+	payload := wrapped["data"].(secretPayload)
+	assert.Equal(t, "secret", payload.Mount)
+	assert.Equal(t, "myapp/db", payload.Path)
+	assert.Equal(t, "admin", payload.Data["username"])
+	assert.Empty(t, payload.Value)
+}
+
+func TestGetSecret_Execute_SpecificKey(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin","password":"s3cr3t"}`))),
+		}},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db", "key": "username"},
+		ExecutionState: execState,
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.NoError(t, err)
+	wrapped := execState.Payloads[0].(map[string]any)
+	payload := wrapped["data"].(secretPayload)
+	assert.Equal(t, "admin", payload.Value)
+}
+
+func TestGetSecret_Execute_KeyNotFound(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"username":"admin"}`))),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"mount": "secret", "path": "myapp/db", "key": "password"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"password" not found`)
+}
+
+func TestGetSecret_Execute_APIError(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":["permission denied"]}`)),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"path": "myapp/db"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestGetSecret_Setup_MissingPath(t *testing.T) {
+	c := &getSecret{}
+	err := c.Setup(core.SetupContext{
+		Configuration: map[string]any{"path": ""},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+		Metadata:      &contexts.MetadataContext{},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "path is required")
+}
+
+func TestGetSecret_Execute_DefaultMount(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(kvSecretJSON(`{"key":"val"}`))),
+		}},
+	}
+
+	c := &getSecret{}
+	err := c.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"path": "myapp/config"},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		HTTP:           httpCtx,
+		Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"}},
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/secret/data/myapp/config")
+}

--- a/pkg/integrations/hashicorp_vault/get_secret_test.go
+++ b/pkg/integrations/hashicorp_vault/get_secret_test.go
@@ -37,6 +37,8 @@ func TestGetSecret_Execute_AllData(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	assert.True(t, execState.Finished)
+	assert.True(t, execState.Passed)
 	assert.Equal(t, SecretPayloadType, execState.Type)
 	require.Len(t, execState.Payloads, 1)
 	wrapped := execState.Payloads[0].(map[string]any)
@@ -65,6 +67,7 @@ func TestGetSecret_Execute_SpecificKey(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.Len(t, execState.Payloads, 1)
 	wrapped := execState.Payloads[0].(map[string]any)
 	payload := wrapped["data"].(secretPayload)
 	assert.Equal(t, "admin", payload.Value)

--- a/pkg/integrations/hashicorp_vault/vault.go
+++ b/pkg/integrations/hashicorp_vault/vault.go
@@ -1,0 +1,94 @@
+package hashicorp_vault
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("hashicorp_vault", &HashicorpVault{})
+}
+
+type HashicorpVault struct{}
+
+type vaultConfig struct {
+	BaseURL   string `mapstructure:"baseURL"`
+	Namespace string `mapstructure:"namespace"`
+	Token     string `mapstructure:"token"`
+}
+
+func (v *HashicorpVault) Name() string         { return "hashicorp_vault" }
+func (v *HashicorpVault) Label() string        { return "HashiCorp Vault" }
+func (v *HashicorpVault) Icon() string         { return "vault" }
+func (v *HashicorpVault) Description() string  { return "Securely read secrets from HashiCorp Vault" }
+func (v *HashicorpVault) Instructions() string { return "" }
+
+func (v *HashicorpVault) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "baseURL",
+			Label:       "Base URL",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Vault server URL, e.g. https://vault.example.com",
+		},
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Vault Enterprise namespace. Leave empty for community edition.",
+		},
+		{
+			Name:        "token",
+			Label:       "Token",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Vault token (hvs.… or s.…)",
+		},
+	}
+}
+
+func (v *HashicorpVault) Components() []core.Component  { return []core.Component{} }
+func (v *HashicorpVault) Triggers() []core.Trigger      { return []core.Trigger{} }
+func (v *HashicorpVault) Actions() []core.Action        { return []core.Action{} }
+func (v *HashicorpVault) HandleRequest(ctx core.HTTPRequestContext) {}
+
+func (v *HashicorpVault) Cleanup(ctx core.IntegrationCleanupContext) error    { return nil }
+func (v *HashicorpVault) HandleAction(ctx core.IntegrationActionContext) error { return nil }
+
+func (v *HashicorpVault) Sync(ctx core.SyncContext) error {
+	cfg := vaultConfig{}
+	if err := mapstructure.Decode(ctx.Configuration, &cfg); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if cfg.BaseURL == "" {
+		return fmt.Errorf("baseURL is required")
+	}
+
+	if cfg.Token == "" {
+		return fmt.Errorf("token is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	if err := client.LookupSelf(); err != nil {
+		return err
+	}
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (v *HashicorpVault) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return []core.IntegrationResource{}, nil
+}

--- a/pkg/integrations/hashicorp_vault/vault.go
+++ b/pkg/integrations/hashicorp_vault/vault.go
@@ -54,7 +54,11 @@ func (v *HashicorpVault) Configuration() []configuration.Field {
 	}
 }
 
-func (v *HashicorpVault) Components() []core.Component  { return []core.Component{} }
+func (v *HashicorpVault) Components() []core.Component {
+	return []core.Component{
+		&getSecret{},
+	}
+}
 func (v *HashicorpVault) Triggers() []core.Trigger      { return []core.Trigger{} }
 func (v *HashicorpVault) Actions() []core.Action        { return []core.Action{} }
 func (v *HashicorpVault) HandleRequest(ctx core.HTTPRequestContext) {}

--- a/pkg/integrations/hashicorp_vault/vault.go
+++ b/pkg/integrations/hashicorp_vault/vault.go
@@ -15,7 +15,7 @@ func init() {
 
 type HashicorpVault struct{}
 
-type vaultConfig struct {
+type vaultSettings struct {
 	BaseURL   string `mapstructure:"baseURL"`
 	Namespace string `mapstructure:"namespace"`
 	Token     string `mapstructure:"token"`
@@ -63,9 +63,9 @@ func (v *HashicorpVault) Cleanup(ctx core.IntegrationCleanupContext) error    { 
 func (v *HashicorpVault) HandleAction(ctx core.IntegrationActionContext) error { return nil }
 
 func (v *HashicorpVault) Sync(ctx core.SyncContext) error {
-	cfg := vaultConfig{}
+	cfg := vaultSettings{}
 	if err := mapstructure.Decode(ctx.Configuration, &cfg); err != nil {
-		return fmt.Errorf("failed to decode configuration: %v", err)
+		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
 	if cfg.BaseURL == "" {

--- a/pkg/integrations/hashicorp_vault/vault_test.go
+++ b/pkg/integrations/hashicorp_vault/vault_test.go
@@ -1,0 +1,133 @@
+package hashicorp_vault
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestSync_Success(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":{"accessor":"abc123"}}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL": "https://vault.example.com",
+			"token":   "hvs.test",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "hvs.test"},
+		HTTP:          httpCtx,
+		Integration:   integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ready", integrationCtx.State)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/auth/token/lookup-self")
+	assert.Equal(t, "hvs.test", httpCtx.Requests[0].Header.Get("X-Vault-Token"))
+}
+
+func TestSync_InvalidToken(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader(`{"errors":["permission denied"]}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL": "https://vault.example.com",
+			"token":   "bad-token",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": "bad-token"},
+		HTTP:          httpCtx,
+		Integration:   integrationCtx,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+	assert.NotEqual(t, "ready", integrationCtx.State)
+}
+
+func TestSync_MissingToken(t *testing.T) {
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": ""},
+		HTTP:          &contexts.HTTPContext{},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token is required")
+}
+
+func TestSync_MissingBaseURL(t *testing.T) {
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{"baseURL": "", "token": "hvs.test"},
+		HTTP:          &contexts.HTTPContext{},
+		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "baseURL is required")
+}
+
+func TestSync_WithNamespace(t *testing.T) {
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"data":{}}`)),
+			},
+		},
+	}
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"baseURL":   "https://vault.example.com",
+			"token":     "hvs.test",
+			"namespace": "admin/team-a",
+		},
+	}
+
+	v := &HashicorpVault{}
+	err := v.Sync(core.SyncContext{
+		Logger: logrus.NewEntry(logrus.New()),
+		Configuration: map[string]any{
+			"baseURL":   "https://vault.example.com",
+			"token":     "hvs.test",
+			"namespace": "admin/team-a",
+		},
+		HTTP:        httpCtx,
+		Integration: integrationCtx,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "admin/team-a", httpCtx.Requests[0].Header.Get("X-Vault-Namespace"))
+}

--- a/pkg/integrations/hashicorp_vault/vault_test.go
+++ b/pkg/integrations/hashicorp_vault/vault_test.go
@@ -40,6 +40,7 @@ func TestSync_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ready", integrationCtx.State)
 	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
 	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/v1/auth/token/lookup-self")
 	assert.Equal(t, "hvs.test", httpCtx.Requests[0].Header.Get("X-Vault-Token"))
 }
@@ -79,7 +80,12 @@ func TestSync_MissingToken(t *testing.T) {
 		Logger:        logrus.NewEntry(logrus.New()),
 		Configuration: map[string]any{"baseURL": "https://vault.example.com", "token": ""},
 		HTTP:          &contexts.HTTPContext{},
-		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"baseURL": "https://vault.example.com",
+				"token":   "",
+			},
+		},
 	})
 
 	require.Error(t, err)
@@ -92,7 +98,12 @@ func TestSync_MissingBaseURL(t *testing.T) {
 		Logger:        logrus.NewEntry(logrus.New()),
 		Configuration: map[string]any{"baseURL": "", "token": "hvs.test"},
 		HTTP:          &contexts.HTTPContext{},
-		Integration:   &contexts.IntegrationContext{Configuration: map[string]any{}},
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"baseURL": "",
+				"token":   "hvs.test",
+			},
+		},
 	})
 
 	require.Error(t, err)
@@ -129,5 +140,7 @@ func TestSync_WithNamespace(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
 	assert.Equal(t, "admin/team-a", httpCtx.Requests[0].Header.Get("X-Vault-Namespace"))
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,6 +59,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/gitlab"
 	_ "github.com/superplanehq/superplane/pkg/integrations/grafana"
 	_ "github.com/superplanehq/superplane/pkg/integrations/harness"
+	_ "github.com/superplanehq/superplane/pkg/integrations/hashicorp_vault"
 	_ "github.com/superplanehq/superplane/pkg/integrations/hetzner"
 	_ "github.com/superplanehq/superplane/pkg/integrations/honeycomb"
 	_ "github.com/superplanehq/superplane/pkg/integrations/incident"


### PR DESCRIPTION
Closes #3928

## Summary

- Adds `pkg/integrations/hashicorp_vault/` — new integration package for HashiCorp Vault
- **Auth:** Token only (`X-Vault-Token` header); optional Enterprise namespace via `X-Vault-Namespace`
- **`Sync()`:** calls `GET /v1/auth/token/lookup-self` to verify credentials and mark integration ready
- **`Get Secret` component:** reads a KV v2 secret (`GET /v1/<mount>/data/<path>`); optionally extracts a single key via the `key` config field; emits `hashicorp_vault.secret` payload on the default output channel
- Registers the integration with a blank import in `pkg/server/server.go` (alphabetically between `harness` and `hetzner`)

## Configuration

| Field | Required | Description |
|---|---|---|
| `baseURL` | yes | Vault server URL, e.g. `https://vault.example.com` |
| `token` | yes | Vault token (`hvs.…` or `s.…`) |
| `namespace` | no | Vault Enterprise namespace; omit for community edition |

## Get Secret component inputs

| Field | Required | Default | Description |
|---|---|---|---|
| `mount` | no | `secret` | KV v2 mount path |
| `path` | yes | — | Secret path, e.g. `myapp/db` |
| `key` | no | — | If set, extract only this key into `value` |

## Test plan

- [ ] `vault_test.go` — `TestSync_Success`, `TestSync_InvalidToken`, `TestSync_MissingToken`, `TestSync_MissingBaseURL`, `TestSync_WithNamespace`
- [ ] `get_secret_test.go` — `TestGetSecret_Execute_AllData`, `TestGetSecret_Execute_SpecificKey`, `TestGetSecret_Execute_KeyNotFound`, `TestGetSecret_Execute_APIError`, `TestGetSecret_Setup_MissingPath`, `TestGetSecret_Execute_DefaultMount`