### PR TITLE
fix: preserve Policy Bot approvals on update branch merges

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -3,6 +3,7 @@ approval_defaults:
     request_review:
       enabled: true
       mode: all-users
+    ignore_update_merges: true
 
 policy:
   approval:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- set `approval_defaults.options.ignore_update_merges: true` in `.policy.yml`
- prevents Policy Bot from invalidating approvals when GitHub's **Update branch** button creates an update merge commit

## Why
Issue #4132 reports that approvals are being invalidated after clicking **Update branch**. In Policy Bot, update merges can be explicitly ignored via `ignore_update_merges`, which keeps approvals intact for this specific non-code-change merge path.

## Validation
- inspected current repository policy configuration and confirmed this option was not set
- applied a minimal policy-only change at the defaults level so it consistently applies across rules
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de9effed-3ba5-42cc-8687-3d77102930d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de9effed-3ba5-42cc-8687-3d77102930d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

