### PR TITLE
chore: skip CI blocks for docs-only changes

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -75,7 +75,7 @@ blocks:
   - name: "Agent Tests"
     dependencies: []
     run:
-      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
+      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'}) OR change_in('/agent/**/*.md', {default_branch: 'main'}) OR change_in('/agent/**/*.mdx', {default_branch: 'main'})"
     task:
       env_vars:
         - name: DOCKER_BUILDKIT

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,6 +12,8 @@ auto_cancel:
 blocks:
   - name: "License Check"
     dependencies: []
+    run:
+      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
     task:
       prologue:
         commands:
@@ -23,6 +25,8 @@ blocks:
 
   - name: "Backend Tests"
     dependencies: []
+    run:
+      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
     task:
       env_vars:
         - name: DOCKER_BUILDKIT
@@ -70,6 +74,8 @@ blocks:
 
   - name: "Agent Tests"
     dependencies: []
+    run:
+      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
     task:
       env_vars:
         - name: DOCKER_BUILDKIT
@@ -98,6 +104,8 @@ blocks:
 
   - name: "Frondend Tests"
     dependencies: []
+    run:
+      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
     task:
       prologue:
         commands:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `run.when` conditions to Semaphore CI blocks so docs-only changes can skip expensive CI work
- Keep `License Check`, `Backend Tests`, and `Frontend Tests` skipped for docs-only changes
- Ensure `Agent Tests` still run when Markdown/system prompt files under `agent/` change

## Behavior
- `License Check`, `Backend Tests`, `Frontend Tests` run when non-doc files change:
  - `change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})`
- `Agent Tests` run when either:
  - Non-doc files change (same as above), **or**
  - Markdown files in `agent/` change:
    - `change_in('/agent/**/*.md', {default_branch: 'main'})`
    - `change_in('/agent/**/*.mdx', {default_branch: 'main'})`

## Validation
- Verified `.semaphore/semaphore.yml` now includes the agent-specific markdown override in the `Agent Tests` block
- Confirmed intended outcome: docs-only changes outside `agent/` skip expensive CI; prompt/docs updates in `agent/` still trigger Agent Tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f24af8cf-9dce-4ae3-bcdd-2b364ddd8e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f24af8cf-9dce-4ae3-bcdd-2b364ddd8e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

