### PR TITLE
feat: add noindex response headers for non-production environments

### DIFF
--- a/pkg/web/asset_handler.go
+++ b/pkg/web/asset_handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -15,10 +16,11 @@ import (
 // AssetHandler serves static files from the assets filesystem
 // and handles SPA routing by serving index.html for non-asset routes.
 type AssetHandler struct {
-	assets       http.FileSystem
-	basePath     string
-	indexContent []byte
-	indexModTime time.Time
+	assets        http.FileSystem
+	basePath      string
+	indexContent  []byte
+	indexModTime  time.Time
+	shouldNoIndex bool
 }
 
 // NewAssetHandler creates a new AssetHandler with the given file system.
@@ -26,15 +28,20 @@ func NewAssetHandler(assets http.FileSystem, basePath string) http.Handler {
 	indexContent, indexModTime := loadIndexContent(assets)
 
 	return &AssetHandler{
-		assets:       assets,
-		basePath:     basePath,
-		indexContent: indexContent,
-		indexModTime: indexModTime,
+		assets:        assets,
+		basePath:      basePath,
+		indexContent:  indexContent,
+		indexModTime:  indexModTime,
+		shouldNoIndex: os.Getenv("APP_ENV") != "production",
 	}
 }
 
 // ServeHTTP implements the http.Handler interface.
 func (h *AssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.shouldNoIndex {
+		w.Header().Set("X-Robots-Tag", "noindex")
+	}
+
 	// Handle /assets/* paths
 	if h.isAssetPath(r.URL.Path) {
 		h.serveAsset(w, r)

--- a/pkg/web/asset_handler_test.go
+++ b/pkg/web/asset_handler_test.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestAssetHandlerNoIndexHeader(t *testing.T) {
+	tests := []struct {
+		name       string
+		appEnv     string
+		path       string
+		wantStatus int
+		wantHeader string
+	}{
+		{
+			name:       "index in staging includes noindex header",
+			appEnv:     "staging",
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantHeader: "noindex",
+		},
+		{
+			name:       "asset in development includes noindex header",
+			appEnv:     "development",
+			path:       "/assets/main.js",
+			wantStatus: http.StatusOK,
+			wantHeader: "noindex",
+		},
+		{
+			name:       "missing asset in test includes noindex header",
+			appEnv:     "test",
+			path:       "/assets/missing.js",
+			wantStatus: http.StatusNotFound,
+			wantHeader: "noindex",
+		},
+		{
+			name:       "index in production does not include noindex header",
+			appEnv:     "production",
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantHeader: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("APP_ENV", tt.appEnv)
+
+			handler := NewAssetHandler(http.FS(fstest.MapFS{
+				"index.html":     &fstest.MapFile{Data: []byte("<html><body>Hello</body></html>")},
+				"assets/main.js": &fstest.MapFile{Data: []byte("console.log('ok')")},
+			}), "")
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, recorder.Code)
+			}
+
+			gotHeader := recorder.Header().Get("X-Robots-Tag")
+			if gotHeader != tt.wantHeader {
+				t.Fatalf("expected X-Robots-Tag %q, got %q", tt.wantHeader, gotHeader)
+			}
+		})
+	}
+}

--- a/web_src/vite.config.ts
+++ b/web_src/vite.config.ts
@@ -25,6 +25,7 @@ const setHmrPortFromPortPlugin = {
 // https://vite.dev/config/
 export default defineConfig(({ command }: { command: string }) => {
   const isDev = command !== "build";
+  const isProduction = process.env.APP_ENV === "production";
   const apiPort = process.env.API_PORT || process.env.PUBLIC_API_PORT || "8000";
   const devPort = Number.parseInt(process.env.VITE_DEV_PORT || "5173", 10);
 
@@ -35,6 +36,7 @@ export default defineConfig(({ command }: { command: string }) => {
       port: devPort,
       strictPort: true,
       host: true,
+      headers: !isProduction ? { "X-Robots-Tag": "noindex" } : undefined,
       watch: {
         usePolling: true,
         interval: 1000,


### PR DESCRIPTION
## Changes and Why
Added google's noindex response headers for non-production environments. Using meta tags for this would introduce extra complexity as we would need to make index.html dynamic or add other vite plugins. See [this](https://developers.google.com/search/docs/crawling-indexing/block-indexing#http-response-header) for more details. 

## Related Issues
Closes #4150 