### PR TITLE
feat: New styling for add component and add note buttons

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -11,7 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import type { CanvasOperation } from "@/lib/ai";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { Plus, Search, Settings2, StickyNote, X } from "lucide-react";
+import { Search, Settings2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY } from "../CanvasPage";
 import { ComponentBase } from "../componentBase";
@@ -51,7 +51,6 @@ export interface BuildingBlocksSidebarProps {
   disabled?: boolean;
   disabledMessage?: string;
   onBlockClick?: (block: BuildingBlock) => void;
-  onAddNote?: () => void;
 }
 
 export function BuildingBlocksSidebar({
@@ -67,19 +66,11 @@ export function BuildingBlocksSidebar({
   disabled = false,
   disabledMessage,
   onBlockClick,
-  onAddNote,
 }: BuildingBlocksSidebarProps) {
   const disabledTooltip = disabledMessage || "Finish configuring the selected component first";
 
   if (!isOpen) {
-    return (
-      <ClosedBuildingBlocksSidebar
-        disabled={disabled}
-        disabledTooltip={disabledTooltip}
-        onAddNote={onAddNote}
-        onToggle={onToggle}
-      />
-    );
+    return null;
   }
 
   return (
@@ -96,76 +87,6 @@ export function BuildingBlocksSidebar({
       disabledTooltip={disabledTooltip}
       onBlockClick={onBlockClick}
     />
-  );
-}
-
-interface ClosedBuildingBlocksSidebarProps {
-  disabled: boolean;
-  disabledTooltip: string;
-  onAddNote?: () => void;
-  onToggle: (open: boolean) => void;
-}
-
-function ClosedBuildingBlocksSidebar({
-  disabled,
-  disabledTooltip,
-  onAddNote,
-  onToggle,
-}: ClosedBuildingBlocksSidebarProps) {
-  const addNoteButton = (
-    <Button
-      variant="outline"
-      onClick={() => {
-        if (disabled) return;
-        onAddNote?.();
-      }}
-      aria-label="Add Note"
-      data-testid="add-note-button"
-      disabled={disabled}
-    >
-      <StickyNote size={16} />
-      Add Note
-    </Button>
-  );
-  const openSidebarButton = (
-    <Button
-      variant="outline"
-      onClick={() => {
-        if (disabled) return;
-        onToggle(true);
-      }}
-      aria-label="Open sidebar"
-      data-testid="open-sidebar-button"
-      disabled={disabled}
-    >
-      <Plus size={16} />
-      Components
-    </Button>
-  );
-
-  return (
-    <div className="absolute top-4 right-4 z-10 flex gap-3">
-      {disabled ? (
-        <Tooltip>
-          <TooltipTrigger asChild>{addNoteButton}</TooltipTrigger>
-          <TooltipContent side="left" sideOffset={10}>
-            <p>{disabledTooltip}</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        addNoteButton
-      )}
-      {disabled ? (
-        <Tooltip>
-          <TooltipTrigger asChild>{openSidebarButton}</TooltipTrigger>
-          <TooltipContent side="left" sideOffset={10}>
-            <p>{disabledTooltip}</p>
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        openSidebarButton
-      )}
-    </div>
   );
 }
 

--- a/web_src/src/ui/CanvasPage/RightSideControls.tsx
+++ b/web_src/src/ui/CanvasPage/RightSideControls.tsx
@@ -1,0 +1,63 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Plus, StickyNote } from "lucide-react";
+
+export type RightSideControlsProps = {
+  readOnly: boolean;
+  onSidebarOpen: () => void;
+  onAddNote: () => void | Promise<void>;
+};
+
+export function RightSideControls({ readOnly, onSidebarOpen, onAddNote }: RightSideControlsProps) {
+  return (
+    <div className="absolute top-4 right-4 z-10 flex flex-col gap-1.5">
+      <ControlButton
+        tooltip="Add component"
+        hidden={readOnly}
+        onClick={onSidebarOpen}
+        testId="open-sidebar-button"
+        icon={<Plus />}
+      />
+
+      <ControlButton
+        tooltip="Add note"
+        hidden={readOnly}
+        onClick={onAddNote}
+        testId="add-note-button"
+        icon={<StickyNote />}
+      />
+    </div>
+  );
+}
+
+interface ControlButtonProps {
+  hidden: boolean;
+  tooltip: string;
+  onClick: () => void;
+  testId?: string;
+  icon: React.ReactNode;
+}
+
+function ControlButton(props: ControlButtonProps) {
+  if (props.hidden) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={props.onClick}
+          aria-label={props.tooltip}
+          data-testid={props.testId}
+        >
+          {props.icon}
+        </Button>
+      </TooltipTrigger>
+
+      <TooltipContent side="left" sideOffset={10}>
+        {props.tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -82,6 +82,7 @@ import "./canvas-reset.css";
 import { CustomEdge } from "./CustomEdge";
 import { clampGroupChildNodePositionChanges, resizeGroupsAfterChildChanges } from "./groupLayout";
 import { Header, type BreadcrumbItem } from "./Header";
+import { RightSideControls } from "./RightSideControls";
 import type { CanvasPageState } from "./useCanvasState";
 import { useCanvasState } from "./useCanvasState";
 
@@ -1226,9 +1227,16 @@ function CanvasPage(props: CanvasPageProps) {
       ) : (
         <div className="flex-1 flex relative overflow-hidden">
           {props.versionControlSidebar}
-          {props.hideAddControls ? null : (
+
+          <RightSideControls
+            readOnly={readOnly}
+            onSidebarOpen={() => handleSidebarToggle(true)}
+            onAddNote={handleAddNote}
+          />
+
+          {props.hideAddControls || !isBuildingBlocksSidebarOpen ? null : (
             <BuildingBlocksSidebar
-              isOpen={isBuildingBlocksSidebarOpen}
+              isOpen
               onToggle={handleSidebarToggle}
               blocks={props.buildingBlocks || []}
               agentContext={props.agentContext}
@@ -1241,7 +1249,6 @@ function CanvasPage(props: CanvasPageProps) {
               disabled={readOnly}
               disabledMessage="You don't have permission to edit this canvas."
               onBlockClick={handleBuildingBlockClick}
-              onAddNote={handleAddNote}
             />
           )}
 


### PR DESCRIPTION
related to: https://github.com/superplanehq/superplane/issues/4129

Two new buttons in the sidebar:

<img width="2304" height="734" alt="CleanShot 2026-04-15 at 15 03 54@2x" src="https://github.com/user-attachments/assets/4b053bfb-f48e-4396-a21c-18bcc2417063" />

Also, extracted the code and tightened up.