### PR TITLE
feat: add an option to delete agent chats

### DIFF
--- a/agent/src/ai/grpc.py
+++ b/agent/src/ai/grpc.py
@@ -82,6 +82,20 @@ class AgentsServicer:
 
         return agents_pb2.DescribeAgentChatResponse(chat=_serialize_chat(chat))  # type: ignore[attr-defined]
 
+    def DeleteAgentChat(self, request: Any, context: Any) -> Any:  # noqa: N802
+        try:
+            self._store.delete_agent_chat(
+                org_id=request.org_id,
+                user_id=request.user_id,
+                canvas_id=request.canvas_id,
+                chat_id=request.chat_id,
+            )
+        except AgentChatNotFoundError as error:
+            context.abort(grpc.StatusCode.NOT_FOUND, "chat not found")
+            raise error
+
+        return agents_pb2.DeleteAgentChatResponse()  # type: ignore[attr-defined]
+
     def ListAgentChatMessages(self, request: Any, context: Any) -> Any:  # noqa: N802
         try:
             messages = self._store.list_agent_chat_messages(
@@ -131,6 +145,11 @@ def add_agents_servicer_to_server(servicer: AgentsServicer, server: grpc.Server)
             servicer.DescribeAgentChat,
             request_deserializer=agents_pb2.DescribeAgentChatRequest.FromString,  # type: ignore[attr-defined]
             response_serializer=agents_pb2.DescribeAgentChatResponse.SerializeToString,  # type: ignore[attr-defined]
+        ),
+        "DeleteAgentChat": grpc.unary_unary_rpc_method_handler(
+            servicer.DeleteAgentChat,
+            request_deserializer=agents_pb2.DeleteAgentChatRequest.FromString,  # type: ignore[attr-defined]
+            response_serializer=agents_pb2.DeleteAgentChatResponse.SerializeToString,  # type: ignore[attr-defined]
         ),
         "ListAgentChatMessages": grpc.unary_unary_rpc_method_handler(
             servicer.ListAgentChatMessages,

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -353,6 +353,12 @@ class SessionStore:
             rows = session.scalars(stmt).all()
             return [self._to_stored_chat(row) for row in rows]
 
+    def delete_agent_chat(self, org_id: str, user_id: str, canvas_id: str, chat_id: str) -> None:
+        chat = self.describe_agent_chat(org_id, user_id, canvas_id, chat_id)
+        with self._session() as session:
+            with session.begin():
+                session.execute(delete(AgentChat).where(AgentChat.id == uuid.UUID(chat.id)))
+
     def describe_agent_chat(
         self, org_id: str, user_id: str, canvas_id: str, chat_id: str
     ) -> StoredAgentChat:

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -155,6 +155,7 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		pbAgents.Agents_ListAgentChats_FullMethodName:        {Resource: "agents", Action: "read", DomainType: models.DomainTypeOrganization},
 		pbAgents.Agents_DescribeAgentChat_FullMethodName:     {Resource: "agents", Action: "read", DomainType: models.DomainTypeOrganization},
 		pbAgents.Agents_ListAgentChatMessages_FullMethodName: {Resource: "agents", Action: "read", DomainType: models.DomainTypeOrganization},
+		pbAgents.Agents_DeleteAgentChat_FullMethodName:       {Resource: "agents", Action: "delete", DomainType: models.DomainTypeOrganization},
 
 		// Canvases rules
 		pbCanvases.Canvases_ListCanvases_FullMethodName: {Resource: "canvases", Action: "read", DomainType: models.DomainTypeOrganization},

--- a/pkg/grpc/actions/agents/delete_agent_chat.go
+++ b/pkg/grpc/actions/agents/delete_agent_chat.go
@@ -1,0 +1,43 @@
+package agents
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	pb "github.com/superplanehq/superplane/pkg/protos/agents"
+	internalpb "github.com/superplanehq/superplane/pkg/protos/private/agents"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func DeleteAgentChat(
+	ctx context.Context,
+	agentURL string,
+	orgID string,
+	userID string,
+	canvasID string,
+	chatID string,
+) (*pb.DeleteAgentChatResponse, error) {
+	conn, err := grpc.NewClient(agentURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, status.Error(codes.Unavailable, "failed to create agent GRPC client")
+	}
+	defer closeAgentConnection(conn)
+
+	client := internalpb.NewAgentsClient(conn)
+	_, err = client.DeleteAgentChat(ctx, &internalpb.DeleteAgentChatRequest{
+		OrgId:    orgID,
+		UserId:   userID,
+		CanvasId: canvasID,
+		ChatId:   chatID,
+	})
+
+	if err != nil {
+		log.WithError(err).Errorf("failed to delete agent chat %s for org %s, user %s", chatID, orgID, userID)
+		return nil, status.Error(codes.Unavailable, "failed to delete agent chat")
+	}
+
+	return &pb.DeleteAgentChatResponse{}, nil
+}

--- a/pkg/grpc/actions/agents/delete_agent_chat.go
+++ b/pkg/grpc/actions/agents/delete_agent_chat.go
@@ -35,6 +35,10 @@ func DeleteAgentChat(
 	})
 
 	if err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.NotFound {
+			return nil, status.Error(codes.NotFound, "agent chat not found")
+		}
+
 		log.WithError(err).Errorf("failed to delete agent chat %s for org %s, user %s", chatID, orgID, userID)
 		return nil, status.Error(codes.Unavailable, "failed to delete agent chat")
 	}

--- a/pkg/grpc/actions/agents/delete_agent_chat_test.go
+++ b/pkg/grpc/actions/agents/delete_agent_chat_test.go
@@ -1,0 +1,45 @@
+package agents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__DeleteAgentChat(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		addr, _ := startMockAgentServer(t)
+
+		resp, err := DeleteAgentChat(context.Background(), addr, "org-1", "user-1", "canvas-1", "chat-1")
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("returns not found when chat does not exist", func(t *testing.T) {
+		addr, _ := startMockAgentServer(t)
+
+		_, err := DeleteAgentChat(context.Background(), addr, "org-1", "user-1", "canvas-1", "not-found")
+		require.Error(t, err)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("closes gRPC connection after call", func(t *testing.T) {
+		addr, tracker := startMockAgentServer(t)
+
+		_, err := DeleteAgentChat(context.Background(), addr, "org-1", "user-1", "canvas-1", "chat-1")
+		require.NoError(t, err)
+
+		assert.Eventually(t, func() bool { return tracker.open.Load() == 0 }, 2*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("returns unavailable when agent is down", func(t *testing.T) {
+		_, err := DeleteAgentChat(context.Background(), "127.0.0.1:1", "org-1", "user-1", "canvas-1", "chat-1")
+		require.Error(t, err)
+		assert.Equal(t, codes.Unavailable, status.Code(err))
+	})
+}

--- a/pkg/grpc/actions/agents/helpers_test.go
+++ b/pkg/grpc/actions/agents/helpers_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 	internalpb "github.com/superplanehq/superplane/pkg/protos/private/agents"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -38,6 +40,13 @@ func (m *mockAgentsServer) ListAgentChatMessages(ctx context.Context, req *inter
 			{Id: "msg-1", Role: "user", Content: "hello"},
 		},
 	}, nil
+}
+
+func (m *mockAgentsServer) DeleteAgentChat(ctx context.Context, req *internalpb.DeleteAgentChatRequest) (*internalpb.DeleteAgentChatResponse, error) {
+	if req.ChatId == "not-found" {
+		return nil, status.Error(codes.NotFound, "chat not found")
+	}
+	return &internalpb.DeleteAgentChatResponse{}, nil
 }
 
 // connTracker is a gRPC stats handler that counts open connections.

--- a/pkg/grpc/actions/auth/describe_role_test.go
+++ b/pkg/grpc/actions/auth/describe_role_test.go
@@ -22,7 +22,7 @@ func Test_DescribeRole(t *testing.T) {
 		assert.NotNil(t, resp.Role.Spec.InheritedRole)
 		assert.Equal(t, models.RoleOrgAdmin, resp.Role.Metadata.Name)
 		assert.Equal(t, models.RoleOrgViewer, resp.Role.Spec.InheritedRole.Metadata.Name)
-		assert.Len(t, resp.Role.Spec.Permissions, 35)
+		assert.Len(t, resp.Role.Spec.Permissions, 36)
 		assert.Len(t, resp.Role.Spec.InheritedRole.Spec.Permissions, 8)
 		assert.Equal(t, "Admin", resp.Role.Spec.DisplayName)
 		assert.Equal(t, "Viewer", resp.Role.Spec.InheritedRole.Spec.DisplayName)

--- a/pkg/grpc/agent_service.go
+++ b/pkg/grpc/agent_service.go
@@ -115,6 +115,21 @@ func (s *AgentsService) ListAgentChats(ctx context.Context, req *pb.ListAgentCha
 	return agents.ListAgentChats(ctx, url, organizationID, userID, req.CanvasId)
 }
 
+func (s *AgentsService) DeleteAgentChat(ctx context.Context, req *pb.DeleteAgentChatRequest) (*pb.DeleteAgentChatResponse, error) {
+	url := config.AgentGRPCURL()
+	if url == "" {
+		return nil, status.Error(codes.Unavailable, "agent GRPC URL not configured")
+	}
+
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	userID, err := userIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return agents.DeleteAgentChat(ctx, url, organizationID, userID, req.CanvasId, req.ChatId)
+}
+
 func (s *AgentsService) ListAgentChatMessages(ctx context.Context, req *pb.ListAgentChatMessagesRequest) (*pb.ListAgentChatMessagesResponse, error) {
 	url := config.AgentGRPCURL()
 	if url == "" {

--- a/protos/agents.proto
+++ b/protos/agents.proto
@@ -82,6 +82,17 @@ service Agents {
     };
   }
 
+  rpc DeleteAgentChat(DeleteAgentChatRequest) returns (DeleteAgentChatResponse) {
+    option (google.api.http) = {
+      delete: "/api/v1/agents/chats/{chat_id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete an agent chat";
+      description: "Permanently deletes an agent chat and all its messages";
+      tags: "Agent";
+    };
+  }
+
 }
 
 message ListAgentChatsRequest {
@@ -137,6 +148,13 @@ message ResumeAgentChatResponse {
   string token = 1;
   string url = 2;
 }
+
+message DeleteAgentChatRequest {
+  string canvas_id = 1;
+  string chat_id = 2;
+}
+
+message DeleteAgentChatResponse {}
 
 message AgentChatInfo {
   string id = 1;

--- a/protos/private/agents.proto
+++ b/protos/private/agents.proto
@@ -16,6 +16,7 @@ service Agents {
   rpc ListAgentChats(ListAgentChatsRequest) returns (ListAgentChatsResponse);
   rpc DescribeAgentChat(DescribeAgentChatRequest) returns (DescribeAgentChatResponse);
   rpc ListAgentChatMessages(ListAgentChatMessagesRequest) returns (ListAgentChatMessagesResponse);
+  rpc DeleteAgentChat(DeleteAgentChatRequest) returns (DeleteAgentChatResponse);
   rpc DescribeOrganizationAgentUsage(DescribeOrganizationAgentUsageRequest) returns (DescribeOrganizationAgentUsageResponse);
 }
 
@@ -69,6 +70,15 @@ message CreateAgentChatRequest {
 message CreateAgentChatResponse {
   ChatInfo chat = 1;
 }
+
+message DeleteAgentChatRequest {
+  string org_id = 1;
+  string canvas_id = 2;
+  string user_id = 3;
+  string chat_id = 4;
+}
+
+message DeleteAgentChatResponse {}
 
 message ChatInfo {
   string id = 1;

--- a/rbac/rbac_org_policy.csv
+++ b/rbac/rbac_org_policy.csv
@@ -35,6 +35,7 @@ p,/roles/org_admin,/org/*,service_accounts,create
 p,/roles/org_admin,/org/*,service_accounts,update
 p,/roles/org_admin,/org/*,service_accounts,delete
 p,/roles/org_admin,/org/*,agents,create
+p,/roles/org_admin,/org/*,agents,delete
 p,/roles/org_owner,/org/*,integrations,delete
 p,/roles/org_owner,/org/*,org,update
 p,/roles/org_owner,/org/*,org,delete

--- a/web_src/src/components/AiBuilderConversationList.tsx
+++ b/web_src/src/components/AiBuilderConversationList.tsx
@@ -1,8 +1,19 @@
+import { useState } from "react";
 import { TimeAgo } from "@/components/TimeAgo";
 import { Button } from "@/components/ui/button";
 import type { AiChatSession } from "@/ui/BuildingBlocksSidebar/agentChat";
 import { cn } from "@/lib/utils";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/ui/alertDialog";
 
 export type ConversationListProps = {
   chatSessions: AiChatSession[];
@@ -10,6 +21,7 @@ export type ConversationListProps = {
   isLoadingChatSessions: boolean;
   isGeneratingResponse: boolean;
   onSelectChat: (chatId: string) => void;
+  onDeleteChat?: (chatId: string) => void;
   onStartNewSession: () => void;
   title?: string;
   className?: string;
@@ -36,11 +48,14 @@ export function ConversationList({
   isLoadingChatSessions,
   isGeneratingResponse,
   onSelectChat,
+  onDeleteChat,
   onStartNewSession,
   title,
   className,
   fillAvailable = false,
 }: ConversationListProps) {
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
   const currentSession = currentChatId ? chatSessions.find((s) => s.id === currentChatId) : undefined;
   const showCurrentSessionHeader = Boolean(currentChatId);
 
@@ -112,25 +127,71 @@ export function ConversationList({
 
           {chatSessions.map((session) => {
             return (
-              <button
-                key={session.id}
-                type="button"
-                onClick={() => onSelectChat(session.id)}
-                disabled={isGeneratingResponse}
-                title={session.createdAt ? formatSessionDate(session.createdAt) : undefined}
-                className="w-full rounded-md border border-slate-200 bg-white px-2 py-2 text-left text-slate-700 transition-colors hover:bg-slate-50"
-              >
-                <div className="flex min-w-0 items-center justify-between gap-2">
-                  <div className="min-w-0 truncate text-sm font-medium">{session.title}</div>
-                  {session.createdAt ? (
-                    <TimeAgo date={session.createdAt} className="shrink-0 text-[11px] tabular-nums text-slate-500" />
-                  ) : null}
-                </div>
-              </button>
+              <div key={session.id} className="group relative">
+                <button
+                  type="button"
+                  onClick={() => onSelectChat(session.id)}
+                  disabled={isGeneratingResponse}
+                  title={session.createdAt ? formatSessionDate(session.createdAt) : undefined}
+                  className="w-full rounded-md border border-slate-200 bg-white px-2 py-2 text-left text-slate-700 transition-colors hover:bg-slate-50"
+                >
+                  <div className="flex min-w-0 items-center justify-between gap-2">
+                    <div className="min-w-0 truncate text-sm font-medium">{session.title}</div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {session.createdAt ? (
+                        <TimeAgo
+                          date={session.createdAt}
+                          className="shrink-0 text-[11px] tabular-nums text-slate-500 group-hover:hidden"
+                        />
+                      ) : null}
+                    </div>
+                  </div>
+                </button>
+                {onDeleteChat ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setPendingDeleteId(session.id);
+                    }}
+                    disabled={isGeneratingResponse}
+                    className="absolute top-1/2 right-2 hidden -translate-y-1/2 rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-red-500 group-hover:block"
+                    aria-label="Delete conversation"
+                    title="Delete"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+              </div>
             );
           })}
         </div>
       ) : null}
+
+      <AlertDialog open={pendingDeleteId !== null} onOpenChange={(open) => !open && setPendingDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete this conversation and all its messages. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={() => {
+                if (pendingDeleteId && onDeleteChat) {
+                  onDeleteChat(pendingDeleteId);
+                }
+                setPendingDeleteId(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/web_src/src/components/AiBuilderConversationList.tsx
+++ b/web_src/src/components/AiBuilderConversationList.tsx
@@ -184,19 +184,20 @@ export function ConversationList({
                   </div>
                 </button>
                 {onDeleteChat ? (
-                  <button
-                    type="button"
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
                     onClick={(event) => {
                       event.stopPropagation();
                       setPendingDeleteId(session.id);
                     }}
                     disabled={isGeneratingResponse}
-                    className="absolute top-1/2 right-2 hidden -translate-y-1/2 rounded p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-red-500 group-hover:block"
+                    className="absolute top-1/2 right-2 hidden -translate-y-1/2 text-slate-400 hover:text-red-500 group-hover:block"
                     aria-label="Delete conversation"
                     title="Delete"
                   >
                     <Trash2 className="h-3.5 w-3.5" />
-                  </button>
+                  </Button>
                 ) : null}
               </div>
             );

--- a/web_src/src/components/AiBuilderConversationList.tsx
+++ b/web_src/src/components/AiBuilderConversationList.tsx
@@ -42,6 +42,65 @@ function formatSessionDate(value: string): string {
   });
 }
 
+function DeleteConfirmDialog({
+  pendingDeleteId,
+  onClose,
+  onConfirm,
+}: {
+  pendingDeleteId: string | null;
+  onClose: () => void;
+  onConfirm: (id: string) => void;
+}) {
+  return (
+    <AlertDialog open={pendingDeleteId !== null} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete this conversation and all its messages. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={() => {
+              if (pendingDeleteId) {
+                onConfirm(pendingDeleteId);
+              }
+              onClose();
+            }}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function CurrentSessionHeader({ session, isLoading }: { session: AiChatSession | undefined; isLoading: boolean }) {
+  if (isLoading) {
+    return <span className="text-xs text-slate-500">Loading…</span>;
+  }
+
+  if (session) {
+    return (
+      <div
+        className="flex min-w-0 flex-1 items-center justify-between gap-2"
+        title={session.createdAt ? formatSessionDate(session.createdAt) : undefined}
+      >
+        <div className="min-w-0 truncate text-sm font-medium text-slate-800">{session.title}</div>
+        {session.createdAt ? (
+          <TimeAgo date={session.createdAt} className="shrink-0 text-[11px] tabular-nums text-slate-500" />
+        ) : null}
+      </div>
+    );
+  }
+
+  return <span className="text-sm text-slate-600">Conversation</span>;
+}
+
 export function ConversationList({
   chatSessions,
   currentChatId,
@@ -57,36 +116,13 @@ export function ConversationList({
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   const currentSession = currentChatId ? chatSessions.find((s) => s.id === currentChatId) : undefined;
-  const showCurrentSessionHeader = Boolean(currentChatId);
-
-  const currentSessionHeader = () => {
-    if (isLoadingChatSessions) {
-      return <span className="text-xs text-slate-500">Loading…</span>;
-    }
-
-    if (currentSession) {
-      return (
-        <div
-          className="flex min-w-0 flex-1 items-center justify-between gap-2"
-          title={currentSession.createdAt ? formatSessionDate(currentSession.createdAt) : undefined}
-        >
-          <div className="min-w-0 truncate text-sm font-medium text-slate-800">{currentSession.title}</div>
-          {currentSession.createdAt ? (
-            <TimeAgo date={currentSession.createdAt} className="shrink-0 text-[11px] tabular-nums text-slate-500" />
-          ) : null}
-        </div>
-      );
-    }
-
-    return <span className="text-sm text-slate-600">Conversation</span>;
-  };
 
   return (
     <div
       className={cn("border-b border-border px-2 py-2 space-y-2", fillAvailable && "flex min-h-0 flex-col", className)}
     >
       <div className="flex min-w-0 items-center gap-2">
-        {showCurrentSessionHeader ? (
+        {currentChatId ? (
           <>
             <Button
               size="icon-xs"
@@ -99,7 +135,7 @@ export function ConversationList({
             >
               <ArrowLeft className="h-4 w-4" />
             </Button>
-            {currentSessionHeader()}
+            <CurrentSessionHeader session={currentSession} isLoading={isLoadingChatSessions} />
           </>
         ) : (
           <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-slate-500">
@@ -168,30 +204,13 @@ export function ConversationList({
         </div>
       ) : null}
 
-      <AlertDialog open={pendingDeleteId !== null} onOpenChange={(open) => !open && setPendingDeleteId(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete conversation?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete this conversation and all its messages. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
-              onClick={() => {
-                if (pendingDeleteId && onDeleteChat) {
-                  onDeleteChat(pendingDeleteId);
-                }
-                setPendingDeleteId(null);
-              }}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {onDeleteChat ? (
+        <DeleteConfirmDialog
+          pendingDeleteId={pendingDeleteId}
+          onClose={() => setPendingDeleteId(null)}
+          onConfirm={onDeleteChat}
+        />
+      ) : null}
     </div>
   );
 }

--- a/web_src/src/ui/BuildingBlocksSidebar/AiBuilderChatPanel.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/AiBuilderChatPanel.tsx
@@ -29,6 +29,7 @@ type AiBuilderChatPanelProps = {
   aiInput: string;
   onAiInputChange: (value: string) => void;
   onSelectChat: (chatId: string) => void;
+  onDeleteChat?: (chatId: string) => void;
   onStartNewSession: () => void;
   onSendPrompt: () => void;
   aiInputRef: RefObject<HTMLTextAreaElement | null>;
@@ -53,6 +54,7 @@ export function AiBuilderChatPanel({
   aiInput,
   onAiInputChange,
   onSelectChat,
+  onDeleteChat,
   onStartNewSession,
   onSendPrompt,
   aiInputRef,
@@ -105,6 +107,7 @@ export function AiBuilderChatPanel({
               isLoadingChatSessions={isLoadingChatSessions}
               isGeneratingResponse={isGeneratingResponse}
               onSelectChat={onSelectChat}
+              onDeleteChat={onDeleteChat}
               onStartNewSession={onStartNewSession}
               title="Previous chats"
               className="flex-1 min-h-0 px-2 py-2 space-y-2"
@@ -120,6 +123,7 @@ export function AiBuilderChatPanel({
                 isLoadingChatSessions={isLoadingChatSessions}
                 isGeneratingResponse={isGeneratingResponse}
                 onSelectChat={onSelectChat}
+                onDeleteChat={onDeleteChat}
                 onStartNewSession={onStartNewSession}
               />
             ) : null}

--- a/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
+++ b/web_src/src/ui/BuildingBlocksSidebar/agentChat.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/api-client";
 import {
   agentsCreateAgentChat,
+  agentsDeleteAgentChat,
   agentsListAgentChatMessages,
   agentsListAgentChats,
   agentsResumeAgentChat,
@@ -241,6 +242,24 @@ export async function loadChatConversation({
   );
 
   return normalizePersistedMessages(messagesResponse.data);
+}
+
+export async function deleteAgentChatSession({
+  chatId,
+  canvasId,
+  organizationId,
+}: {
+  chatId: string;
+  canvasId: string;
+  organizationId: string;
+}): Promise<void> {
+  await agentsDeleteAgentChat(
+    withOrganizationHeader({
+      organizationId,
+      path: { chatId },
+      query: { canvasId },
+    }),
+  );
 }
 
 type SendChatPromptArgs = {

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -209,12 +209,15 @@ function OpenBuildingBlocksSidebar({
       }
 
       setChatSessions((previous) => previous.filter((s) => s.id !== chatId));
-      setCurrentChatId((previous) => (previous === chatId ? null : previous));
-      if (currentChatId === chatId) {
-        setAiMessages([]);
-        setPendingProposal(null);
-        setAiError(null);
-      }
+      setCurrentChatId((previous) => {
+        if (previous === chatId) {
+          setAiMessages([]);
+          setPendingProposal(null);
+          setAiError(null);
+          return null;
+        }
+        return previous;
+      });
 
       void deleteAgentChatSession({ chatId, canvasId, organizationId }).then(
         () => showSuccessToast("Conversation deleted"),
@@ -227,7 +230,7 @@ function OpenBuildingBlocksSidebar({
         },
       );
     },
-    [canvasId, organizationId, currentChatId],
+    [canvasId, organizationId],
   );
 
   const handleDiscardProposal = useCallback(() => {

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -148,6 +148,8 @@ function OpenBuildingBlocksSidebar({
   const [aiMessages, setAiMessages] = useState<AiBuilderMessage[]>([]);
   const [chatSessions, setChatSessions] = useState<AiChatSession[]>([]);
   const [currentChatId, setCurrentChatId] = useState<string | null>(null);
+  const currentChatIdRef = useRef(currentChatId);
+  currentChatIdRef.current = currentChatId;
   const [isLoadingChatSessions, setIsLoadingChatSessions] = useState(false);
   const [isLoadingChatMessages, setIsLoadingChatMessages] = useState(false);
   const [isGeneratingResponse, setIsGeneratingResponse] = useState(false);
@@ -209,15 +211,12 @@ function OpenBuildingBlocksSidebar({
       }
 
       setChatSessions((previous) => previous.filter((s) => s.id !== chatId));
-      setCurrentChatId((previous) => {
-        if (previous === chatId) {
-          setAiMessages([]);
-          setPendingProposal(null);
-          setAiError(null);
-          return null;
-        }
-        return previous;
-      });
+      if (currentChatIdRef.current === chatId) {
+        setCurrentChatId(null);
+        setAiMessages([]);
+        setPendingProposal(null);
+        setAiError(null);
+      }
 
       void deleteAgentChatSession({ chatId, canvasId, organizationId }).then(
         () => showSuccessToast("Conversation deleted"),

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -10,13 +10,20 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getBackgroundColorClass } from "@/lib/colors";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { Search, Settings2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY } from "../CanvasPage";
 import { ComponentBase } from "../componentBase";
 import type { AgentContext, AiBuilderMessage, AiBuilderProposal, AiChatSession } from "./agentChat";
-import { loadChatConversation, loadChatSessions, pushAiMessages, sendChatPrompt } from "./agentChat";
+import {
+  deleteAgentChatSession,
+  loadChatConversation,
+  loadChatSessions,
+  pushAiMessages,
+  sendChatPrompt,
+} from "./agentChat";
 import { AiBuilderChatPanel } from "./AiBuilderChatPanel";
 import { CategorySection } from "./CategorySection";
 import type { BuildingBlock, BuildingBlockCategory } from "./types";
@@ -194,6 +201,34 @@ function OpenBuildingBlocksSidebar({
     setPendingProposal(null);
     setAiError(null);
   }, []);
+
+  const handleDeleteChatSession = useCallback(
+    (chatId: string) => {
+      if (!canvasId || !organizationId) {
+        return;
+      }
+
+      setChatSessions((previous) => previous.filter((s) => s.id !== chatId));
+      setCurrentChatId((previous) => (previous === chatId ? null : previous));
+      if (currentChatId === chatId) {
+        setAiMessages([]);
+        setPendingProposal(null);
+        setAiError(null);
+      }
+
+      void deleteAgentChatSession({ chatId, canvasId, organizationId }).then(
+        () => showSuccessToast("Conversation deleted"),
+        () => {
+          showErrorToast("Failed to delete conversation");
+          void loadChatSessions({ canvasId, organizationId }).then(
+            (sessions) => setChatSessions(sessions),
+            () => {},
+          );
+        },
+      );
+    },
+    [canvasId, organizationId, currentChatId],
+  );
 
   const handleDiscardProposal = useCallback(() => {
     setPendingProposal(null);
@@ -695,6 +730,7 @@ function OpenBuildingBlocksSidebar({
             aiInput={aiInput}
             onAiInputChange={setAiInput}
             onSelectChat={handleSelectChatSession}
+            onDeleteChat={handleDeleteChatSession}
             onStartNewSession={handleStartNewChatSession}
             onSendPrompt={() => void handleSendPrompt()}
             aiInputRef={aiInputRef}


### PR DESCRIPTION
- Allow users to delete AI agent conversations from the canvas builder sidebar, with a confirmation dialog and optimistic UI updates
- Add DeleteAgentChat RPC across the full stack: protobuf definitions (public + internal), Python agent service handler with ownership verification, Go backend proxy, RBAC policy, and frontend wiring
