### PR TITLE
feat: validate agent proposal configuration before showing to user

### DIFF
--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -72,12 +72,12 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
         if answer.proposal is None or not answer.proposal.operations:
             return answer
 
-        cache_key = (
-            f"{ctx.deps.canvas_id}:{ctx.deps.canvas_version_id or 'inspect'}"
-        )
+        cache_key = f"{ctx.deps.canvas_id}:{ctx.deps.canvas_version_id or 'inspect'}"
         canvas = ctx.deps.canvas_cache.get(cache_key)
         coerced = coerce_canvas_answer_proposal(
-            ctx.deps.client, answer, canvas,
+            ctx.deps.client,
+            answer,
+            canvas,
         )
 
         errors = validate_proposal_operations(
@@ -88,8 +88,7 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
         if errors:
             raise ModelRetry(
                 "The proposal has invalid node configuration. "
-                "Fix these errors and try again:\n"
-                + "\n".join(f"- {e}" for e in errors)
+                "Fix these errors and try again:\n" + "\n".join(f"- {e}" for e in errors)
             )
         return coerced
 

--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.models.anthropic import AnthropicModelSettings
 from pydantic_ai.models.test import TestModel
 
@@ -15,6 +15,8 @@ from ai.agent_deps import (
     _put_cached_catalog_list,
 )
 from ai.models import CanvasAnswer, CanvasQuestionRequest
+from ai.proposal_configuration_coerce import coerce_canvas_answer_proposal
+from ai.proposal_configuration_validate import validate_proposal_operations
 from ai.skills import skill_index_markdown
 from ai.tools import default_tools
 
@@ -67,9 +69,28 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
         ctx: RunContext[AgentDeps],
         answer: CanvasAnswer,
     ) -> CanvasAnswer:
-        # Placeholder for proposal validation.
-        #   raise ModelRetry("... explain why the proposal is invalid and what to do about it.")
+        if answer.proposal is None or not answer.proposal.operations:
+            return answer
 
-        return answer
+        cache_key = (
+            f"{ctx.deps.canvas_id}:{ctx.deps.canvas_version_id or 'inspect'}"
+        )
+        canvas = ctx.deps.canvas_cache.get(cache_key)
+        coerced = coerce_canvas_answer_proposal(
+            ctx.deps.client, answer, canvas,
+        )
+
+        errors = validate_proposal_operations(
+            ctx.deps.client,
+            list(coerced.proposal.operations),  # type: ignore[union-attr]
+            canvas,
+        )
+        if errors:
+            raise ModelRetry(
+                "The proposal has invalid node configuration. "
+                "Fix these errors and try again:\n"
+                + "\n".join(f"- {e}" for e in errors)
+            )
+        return coerced
 
     return agent

--- a/agent/src/ai/agent.py
+++ b/agent/src/ai/agent.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic_ai import Agent, ModelRetry, RunContext
 from pydantic_ai.models.anthropic import AnthropicModelSettings
@@ -74,16 +74,19 @@ def build_agent(model: str | Literal["test"] = "test") -> Agent[AgentDeps, Canva
 
         cache_key = f"{ctx.deps.canvas_id}:{ctx.deps.canvas_version_id or 'inspect'}"
         canvas = ctx.deps.canvas_cache.get(cache_key)
+        schema_cache: dict[str, list[dict[str, Any]] | None] = {}
         coerced = coerce_canvas_answer_proposal(
             ctx.deps.client,
             answer,
             canvas,
+            schema_cache=schema_cache,
         )
 
         errors = validate_proposal_operations(
             ctx.deps.client,
             list(coerced.proposal.operations),  # type: ignore[union-attr]
             canvas,
+            schema_cache=schema_cache,
         )
         if errors:
             raise ModelRetry(

--- a/agent/src/ai/proposal_configuration_coerce.py
+++ b/agent/src/ai/proposal_configuration_coerce.py
@@ -250,11 +250,13 @@ def coerce_canvas_answer_proposal(
     client: SuperplaneClient,
     answer: CanvasAnswer,
     canvas: CanvasSummary | None = None,
+    schema_cache: dict[str, list[dict[str, Any]] | None] | None = None,
 ) -> CanvasAnswer:
     if answer.proposal is None or not answer.proposal.operations:
         return answer
 
-    schema_cache: dict[str, list[dict[str, Any]] | None] = {}
+    if schema_cache is None:
+        schema_cache = {}
     new_operations = _coerce_operations(
         client,
         list(answer.proposal.operations),

--- a/agent/src/ai/proposal_configuration_validate.py
+++ b/agent/src/ai/proposal_configuration_validate.py
@@ -27,24 +27,26 @@ from ai.superplane_client import SuperplaneClient
 
 _LOG = logging.getLogger(__name__)
 
-_STRING_LIKE_TYPES = frozenset({
-    "string",
-    "text",
-    "expression",
-    "xml",
-    "time",
-    "time-range",
-    "date",
-    "datetime",
-    "day-in-year",
-    "cron",
-    "timezone",
-    "user",
-    "role",
-    "group",
-    "git-ref",
-    "secret-key",
-})
+_STRING_LIKE_TYPES = frozenset(
+    {
+        "string",
+        "text",
+        "expression",
+        "xml",
+        "time",
+        "time-range",
+        "date",
+        "datetime",
+        "day-in-year",
+        "cron",
+        "timezone",
+        "user",
+        "role",
+        "group",
+        "git-ref",
+        "secret-key",
+    }
+)
 
 
 def _select_options(field: dict[str, Any]) -> list[str] | None:
@@ -245,14 +247,17 @@ def validate_proposal_operations(
 
         elif isinstance(op, UpdateNodeConfigOperation):
             block_name = _resolve_block_name_for_update(
-                op, block_by_node_key, canvas,
+                op,
+                block_by_node_key,
+                canvas,
             )
             if block_name:
                 fields = _cached_block_fields(client, block_name, schema_cache)
                 if fields:
                     node_label = op.node_name or block_name
                     for msg in validate_configuration(
-                        dict(op.configuration), fields,
+                        dict(op.configuration),
+                        fields,
                     ):
                         errors.append(f"{node_label} ({block_name}): {msg}")
 

--- a/agent/src/ai/proposal_configuration_validate.py
+++ b/agent/src/ai/proposal_configuration_validate.py
@@ -1,0 +1,259 @@
+"""Validate AI proposal configuration against component/trigger field schemas.
+
+Runs after coercion to catch values that coercion cannot fix. When the output
+validator in ``agent.py`` detects errors it raises ``ModelRetry`` so the LLM
+can correct the proposal itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ai.models import (
+    AddNodeOperation,
+    CanvasOperation,
+    CanvasSummary,
+    UpdateNodeConfigOperation,
+)
+from ai.proposal_configuration_coerce import (
+    _cached_block_fields,
+    _list_item_schema,
+    _object_schema_fields,
+    _resolve_block_name_for_update,
+    _type_options,
+)
+from ai.superplane_client import SuperplaneClient
+
+_LOG = logging.getLogger(__name__)
+
+_STRING_LIKE_TYPES = frozenset({
+    "string",
+    "text",
+    "expression",
+    "xml",
+    "time",
+    "time-range",
+    "date",
+    "datetime",
+    "day-in-year",
+    "cron",
+    "timezone",
+    "user",
+    "role",
+    "group",
+    "git-ref",
+    "secret-key",
+})
+
+
+def _select_options(field: dict[str, Any]) -> list[str] | None:
+    opts = _type_options(field)
+    select = opts.get("select")
+    if not isinstance(select, dict):
+        return None
+    options = select.get("options")
+    if not isinstance(options, list) or not options:
+        return None
+    return [
+        opt["value"]
+        for opt in options
+        if isinstance(opt, dict) and isinstance(opt.get("value"), str)
+    ]
+
+
+def _multi_select_options(field: dict[str, Any]) -> list[str] | None:
+    opts = _type_options(field)
+    ms = opts.get("multiSelect") or opts.get("multi_select")
+    if not isinstance(ms, dict):
+        return None
+    options = ms.get("options")
+    if not isinstance(options, list) or not options:
+        return None
+    return [
+        opt["value"]
+        for opt in options
+        if isinstance(opt, dict) and isinstance(opt.get("value"), str)
+    ]
+
+
+def _is_resource_multi(field: dict[str, Any]) -> bool:
+    opts = _type_options(field)
+    resource = opts.get("resource")
+    if not isinstance(resource, dict):
+        return False
+    return bool(resource.get("multi"))
+
+
+def validate_value_for_field(field: dict[str, Any], value: Any) -> str | None:
+    """Return ``None`` if *value* is valid for *field*, or an error message."""
+    ftype = field.get("type")
+    if not isinstance(ftype, str) or not ftype:
+        return None
+
+    if ftype in _STRING_LIKE_TYPES:
+        if not isinstance(value, str):
+            return "must be a string"
+        return None
+
+    if ftype == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return "must be a number"
+        return None
+
+    if ftype == "boolean":
+        if not isinstance(value, bool):
+            return "must be a boolean"
+        return None
+
+    if ftype == "select":
+        if not isinstance(value, str):
+            return "must be a string"
+        valid = _select_options(field)
+        if valid is not None and value not in valid:
+            return f"must be one of: {', '.join(valid)}"
+        return None
+
+    if ftype == "multi-select":
+        if not isinstance(value, list):
+            return "must be a list"
+        for item in value:
+            if not isinstance(item, str):
+                return "all items must be strings"
+        valid = _multi_select_options(field)
+        if valid is not None:
+            valid_set = set(valid)
+            for item in value:
+                if isinstance(item, str) and item not in valid_set:
+                    return f"item '{item}' must be one of: {', '.join(valid)}"
+        return None
+
+    if ftype in ("list", "days-of-week", "any-predicate-list"):
+        if not isinstance(value, list):
+            return "must be a list"
+        if ftype == "days-of-week":
+            for item in value:
+                if not isinstance(item, str):
+                    return "all items must be strings"
+        if ftype == "list":
+            item_schema = _list_item_schema(field)
+            if item_schema:
+                for i, item in enumerate(value):
+                    if isinstance(item, dict):
+                        nested = validate_configuration(item, item_schema)
+                        if nested:
+                            return f"item {i}: {nested[0]}"
+        return None
+
+    if ftype == "object":
+        nested_schema = _object_schema_fields(field)
+        if nested_schema:
+            if not isinstance(value, dict):
+                return "must be an object"
+            nested = validate_configuration(value, nested_schema)
+            if nested:
+                return nested[0]
+            return None
+        if not isinstance(value, (dict, list)):
+            return "must be an object or array"
+        return None
+
+    if ftype == "integration-resource":
+        if _is_resource_multi(field):
+            if not isinstance(value, list):
+                return "must be a list"
+            for item in value:
+                if not isinstance(item, str):
+                    return "all items must be strings"
+            return None
+        if not isinstance(value, str):
+            return "must be a string"
+        return None
+
+    return None
+
+
+def _is_required_by_condition(
+    field: dict[str, Any],
+    configuration: dict[str, Any],
+) -> bool:
+    conditions = field.get("required_conditions") or field.get("requiredConditions")
+    if not isinstance(conditions, list):
+        return False
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            continue
+        cond_field = condition.get("field")
+        cond_values = condition.get("values")
+        if not isinstance(cond_field, str) or not isinstance(cond_values, list):
+            continue
+        cond_value = configuration.get(cond_field)
+        if cond_value is not None and str(cond_value) in [str(v) for v in cond_values]:
+            return True
+    return False
+
+
+def validate_configuration(
+    configuration: dict[str, Any],
+    fields: list[dict[str, Any]],
+) -> list[str]:
+    """Validate *configuration* against *fields*. Return a list of error messages."""
+    errors: list[str] = []
+    fields_by_name: dict[str, dict[str, Any]] = {}
+    for item in fields:
+        name = item.get("name")
+        if isinstance(name, str) and name:
+            fields_by_name[name] = item
+
+    for name, field in fields_by_name.items():
+        value = configuration.get(name)
+        is_required = bool(field.get("required"))
+        if not is_required:
+            is_required = _is_required_by_condition(field, configuration)
+
+        if value is None:
+            if is_required:
+                errors.append(f"field '{name}' is required")
+            continue
+
+        error = validate_value_for_field(field, value)
+        if error is not None:
+            errors.append(f"field '{name}': {error}")
+
+    return errors
+
+
+def validate_proposal_operations(
+    client: SuperplaneClient,
+    operations: list[CanvasOperation],
+    canvas: CanvasSummary | None,
+) -> list[str]:
+    """Validate all operations in a proposal. Return error messages."""
+    errors: list[str] = []
+    schema_cache: dict[str, list[dict[str, Any]] | None] = {}
+    block_by_node_key: dict[str, str] = {}
+
+    for op in operations:
+        if isinstance(op, AddNodeOperation):
+            if op.node_key:
+                block_by_node_key[op.node_key] = op.block_name
+            fields = _cached_block_fields(client, op.block_name, schema_cache)
+            if fields:
+                node_label = op.node_name or op.block_name
+                for msg in validate_configuration(dict(op.configuration), fields):
+                    errors.append(f"{node_label} ({op.block_name}): {msg}")
+
+        elif isinstance(op, UpdateNodeConfigOperation):
+            block_name = _resolve_block_name_for_update(
+                op, block_by_node_key, canvas,
+            )
+            if block_name:
+                fields = _cached_block_fields(client, block_name, schema_cache)
+                if fields:
+                    node_label = op.node_name or block_name
+                    for msg in validate_configuration(
+                        dict(op.configuration), fields,
+                    ):
+                        errors.append(f"{node_label} ({block_name}): {msg}")
+
+    return errors

--- a/agent/src/ai/proposal_configuration_validate.py
+++ b/agent/src/ai/proposal_configuration_validate.py
@@ -201,16 +201,25 @@ def _is_required_by_condition(
         if not isinstance(cond_field, str) or not isinstance(cond_values, list):
             continue
         cond_value = configuration.get(cond_field)
-        if cond_value is not None and _go_fmt_value(cond_value) in [str(v) for v in cond_values]:
-            return True
+        if cond_value is None:
+            continue
+        # Go returns on the first condition whose field exists in config,
+        # regardless of whether the value matches.
+        return _go_fmt_value(cond_value) in [str(v) for v in cond_values]
     return False
 
 
 def validate_configuration(
     configuration: dict[str, Any],
     fields: list[dict[str, Any]],
+    *,
+    check_required: bool = True,
 ) -> list[str]:
-    """Validate *configuration* against *fields*. Return a list of error messages."""
+    """Validate *configuration* against *fields*. Return a list of error messages.
+
+    Set *check_required* to ``False`` for partial updates where only a subset
+    of fields is provided (e.g. ``update_node_config`` operations).
+    """
     errors: list[str] = []
     fields_by_name: dict[str, dict[str, Any]] = {}
     for item in fields:
@@ -220,13 +229,14 @@ def validate_configuration(
 
     for name, field in fields_by_name.items():
         value = configuration.get(name)
-        is_required = bool(field.get("required"))
-        if not is_required:
-            is_required = _is_required_by_condition(field, configuration)
 
         if value is None:
-            if is_required:
-                errors.append(f"field '{name}' is required")
+            if check_required:
+                is_required = bool(field.get("required"))
+                if not is_required:
+                    is_required = _is_required_by_condition(field, configuration)
+                if is_required:
+                    errors.append(f"field '{name}' is required")
             continue
 
         error = validate_value_for_field(field, value)
@@ -271,6 +281,7 @@ def validate_proposal_operations(
                     for msg in validate_configuration(
                         dict(op.configuration),
                         fields,
+                        check_required=False,
                     ):
                         errors.append(f"{node_label} ({block_name}): {msg}")
 

--- a/agent/src/ai/proposal_configuration_validate.py
+++ b/agent/src/ai/proposal_configuration_validate.py
@@ -175,6 +175,17 @@ def validate_value_for_field(field: dict[str, Any], value: Any) -> str | None:
     return None
 
 
+def _go_fmt_value(value: Any) -> str:
+    """Format *value* the way Go's ``fmt.Sprintf("%v", ...)`` would.
+
+    Python's ``str(True)`` gives ``"True"`` while Go gives ``"true"``.
+    Schema condition values follow Go conventions, so we must match them.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
 def _is_required_by_condition(
     field: dict[str, Any],
     configuration: dict[str, Any],
@@ -190,7 +201,7 @@ def _is_required_by_condition(
         if not isinstance(cond_field, str) or not isinstance(cond_values, list):
             continue
         cond_value = configuration.get(cond_field)
-        if cond_value is not None and str(cond_value) in [str(v) for v in cond_values]:
+        if cond_value is not None and _go_fmt_value(cond_value) in [str(v) for v in cond_values]:
             return True
     return False
 
@@ -229,10 +240,12 @@ def validate_proposal_operations(
     client: SuperplaneClient,
     operations: list[CanvasOperation],
     canvas: CanvasSummary | None,
+    schema_cache: dict[str, list[dict[str, Any]] | None] | None = None,
 ) -> list[str]:
     """Validate all operations in a proposal. Return error messages."""
     errors: list[str] = []
-    schema_cache: dict[str, list[dict[str, Any]] | None] = {}
+    if schema_cache is None:
+        schema_cache = {}
     block_by_node_key: dict[str, str] = {}
 
     for op in operations:

--- a/agent/tests/test_proposal_configuration_validate.py
+++ b/agent/tests/test_proposal_configuration_validate.py
@@ -149,9 +149,13 @@ def test_multi_select_rejects_invalid_option() -> None:
 
 
 def test_multi_select_without_options_accepts_string_list() -> None:
-    assert validate_value_for_field(
-        _field(ftype="multi-select"), ["x", "y"],
-    ) is None
+    assert (
+        validate_value_for_field(
+            _field(ftype="multi-select"),
+            ["x", "y"],
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -172,9 +176,13 @@ _OBJECT_WITH_SCHEMA = _field(
 
 
 def test_object_with_schema_accepts_dict() -> None:
-    assert validate_value_for_field(
-        _OBJECT_WITH_SCHEMA, {"enabled": True},
-    ) is None
+    assert (
+        validate_value_for_field(
+            _OBJECT_WITH_SCHEMA,
+            {"enabled": True},
+        )
+        is None
+    )
 
 
 def test_object_with_schema_rejects_list() -> None:
@@ -187,7 +195,8 @@ def test_object_with_schema_rejects_string() -> None:
 
 def test_object_with_schema_validates_nested() -> None:
     err = validate_value_for_field(
-        _OBJECT_WITH_SCHEMA, {"enabled": "yes"},
+        _OBJECT_WITH_SCHEMA,
+        {"enabled": "yes"},
     )
     assert err is not None
     assert "boolean" in err
@@ -229,20 +238,29 @@ _LIST_WITH_ITEM_SCHEMA = _field(
 
 
 def test_list_accepts_list() -> None:
-    assert validate_value_for_field(
-        _LIST_WITH_ITEM_SCHEMA, [{"key": "a"}],
-    ) is None
+    assert (
+        validate_value_for_field(
+            _LIST_WITH_ITEM_SCHEMA,
+            [{"key": "a"}],
+        )
+        is None
+    )
 
 
 def test_list_rejects_non_list() -> None:
-    assert validate_value_for_field(
-        _LIST_WITH_ITEM_SCHEMA, "not a list",
-    ) is not None
+    assert (
+        validate_value_for_field(
+            _LIST_WITH_ITEM_SCHEMA,
+            "not a list",
+        )
+        is not None
+    )
 
 
 def test_list_validates_item_schema() -> None:
     err = validate_value_for_field(
-        _LIST_WITH_ITEM_SCHEMA, [{"key": 123}],
+        _LIST_WITH_ITEM_SCHEMA,
+        [{"key": 123}],
     )
     assert err is not None
     assert "item 0" in err
@@ -254,21 +272,33 @@ def test_list_validates_item_schema() -> None:
 
 
 def test_days_of_week_accepts_string_list() -> None:
-    assert validate_value_for_field(
-        _field(ftype="days-of-week"), ["monday", "friday"],
-    ) is None
+    assert (
+        validate_value_for_field(
+            _field(ftype="days-of-week"),
+            ["monday", "friday"],
+        )
+        is None
+    )
 
 
 def test_days_of_week_rejects_non_list() -> None:
-    assert validate_value_for_field(
-        _field(ftype="days-of-week"), "monday",
-    ) is not None
+    assert (
+        validate_value_for_field(
+            _field(ftype="days-of-week"),
+            "monday",
+        )
+        is not None
+    )
 
 
 def test_days_of_week_rejects_non_string_item() -> None:
-    assert validate_value_for_field(
-        _field(ftype="days-of-week"), [1, 2],
-    ) is not None
+    assert (
+        validate_value_for_field(
+            _field(ftype="days-of-week"),
+            [1, 2],
+        )
+        is not None
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -277,15 +307,23 @@ def test_days_of_week_rejects_non_string_item() -> None:
 
 
 def test_integration_resource_single_accepts_string() -> None:
-    assert validate_value_for_field(
-        _field(ftype="integration-resource"), "res-1",
-    ) is None
+    assert (
+        validate_value_for_field(
+            _field(ftype="integration-resource"),
+            "res-1",
+        )
+        is None
+    )
 
 
 def test_integration_resource_single_rejects_list() -> None:
-    assert validate_value_for_field(
-        _field(ftype="integration-resource"), ["a"],
-    ) is not None
+    assert (
+        validate_value_for_field(
+            _field(ftype="integration-resource"),
+            ["a"],
+        )
+        is not None
+    )
 
 
 def test_integration_resource_multi_accepts_list() -> None:

--- a/agent/tests/test_proposal_configuration_validate.py
+++ b/agent/tests/test_proposal_configuration_validate.py
@@ -423,3 +423,20 @@ def test_validate_configuration_conditional_required_not_met() -> None:
     ]
     errors = validate_configuration({"method": "GET"}, fields)
     assert errors == []
+
+
+def test_validate_configuration_conditional_required_with_boolean() -> None:
+    """Python str(True) gives 'True' but Go gives 'true'; condition values use Go convention."""
+    fields = [
+        _field(name="enabled", ftype="boolean"),
+        _field(
+            name="target",
+            ftype="string",
+            required=False,
+            required_conditions=[{"field": "enabled", "values": ["true"]}],
+        ),
+    ]
+    errors = validate_configuration({"enabled": True}, fields)
+    assert len(errors) == 1
+    assert "required" in errors[0]
+    assert "target" in errors[0]

--- a/agent/tests/test_proposal_configuration_validate.py
+++ b/agent/tests/test_proposal_configuration_validate.py
@@ -440,3 +440,57 @@ def test_validate_configuration_conditional_required_with_boolean() -> None:
     assert len(errors) == 1
     assert "required" in errors[0]
     assert "target" in errors[0]
+
+
+def test_conditional_required_first_match_returns() -> None:
+    """Go returns on the first condition whose field exists, even if value doesn't match."""
+    fields = [
+        _field(
+            name="body",
+            ftype="string",
+            required=False,
+            required_conditions=[
+                {"field": "mode", "values": ["advanced"]},
+                {"field": "fallback", "values": ["yes"]},
+            ],
+        ),
+        _field(name="mode", ftype="select"),
+        _field(name="fallback", ftype="select"),
+    ]
+    # 'mode' exists but doesn't match 'advanced'; Go stops here and returns False.
+    # 'fallback' matches 'yes' but Go never checks it.
+    errors = validate_configuration(
+        {"mode": "simple", "fallback": "yes"},
+        fields,
+    )
+    assert errors == []
+
+
+def test_validate_configuration_check_required_false() -> None:
+    """Partial updates should skip required-field checks."""
+    fields = [
+        _field(name="url", ftype="string", required=True),
+        _field(name="method", ftype="select", required=True),
+    ]
+    # Only updating method — url is missing but that's fine for a partial update.
+    errors = validate_configuration(
+        {"method": "POST"},
+        fields,
+        check_required=False,
+    )
+    assert errors == []
+
+
+def test_validate_configuration_check_required_false_still_validates_types() -> None:
+    """Partial updates still reject wrong types on present fields."""
+    fields = [
+        _field(name="url", ftype="string", required=True),
+        _field(name="method", ftype="select", required=True),
+    ]
+    errors = validate_configuration(
+        {"method": 123},
+        fields,
+        check_required=False,
+    )
+    assert len(errors) == 1
+    assert "method" in errors[0]

--- a/agent/tests/test_proposal_configuration_validate.py
+++ b/agent/tests/test_proposal_configuration_validate.py
@@ -1,0 +1,387 @@
+"""Unit tests for proposal_configuration_validate (schema injected; no API)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ai.proposal_configuration_validate import (
+    validate_configuration,
+    validate_value_for_field,
+)
+
+
+def _field(
+    name: str = "f",
+    ftype: str = "string",
+    required: bool = False,
+    type_options: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {"name": name, "type": ftype, "required": required}
+    if type_options is not None:
+        out["type_options"] = type_options
+    out.update(kwargs)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# String-like types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ftype", ["string", "text", "expression", "xml"])
+def test_string_like_accepts_string(ftype: str) -> None:
+    assert validate_value_for_field(_field(ftype=ftype), "hello") is None
+
+
+@pytest.mark.parametrize("ftype", ["string", "text", "expression", "xml"])
+def test_string_like_rejects_non_string(ftype: str) -> None:
+    assert validate_value_for_field(_field(ftype=ftype), 123) is not None
+
+
+# ---------------------------------------------------------------------------
+# Number
+# ---------------------------------------------------------------------------
+
+
+def test_number_accepts_int() -> None:
+    assert validate_value_for_field(_field(ftype="number"), 42) is None
+
+
+def test_number_accepts_float() -> None:
+    assert validate_value_for_field(_field(ftype="number"), 3.5) is None
+
+
+def test_number_rejects_bool() -> None:
+    assert validate_value_for_field(_field(ftype="number"), True) is not None
+
+
+def test_number_rejects_string() -> None:
+    assert validate_value_for_field(_field(ftype="number"), "42") is not None
+
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+
+
+def test_boolean_accepts_true() -> None:
+    assert validate_value_for_field(_field(ftype="boolean"), True) is None
+
+
+def test_boolean_accepts_false() -> None:
+    assert validate_value_for_field(_field(ftype="boolean"), False) is None
+
+
+def test_boolean_rejects_string() -> None:
+    assert validate_value_for_field(_field(ftype="boolean"), "true") is not None
+
+
+def test_boolean_rejects_int() -> None:
+    assert validate_value_for_field(_field(ftype="boolean"), 1) is not None
+
+
+# ---------------------------------------------------------------------------
+# Select
+# ---------------------------------------------------------------------------
+
+
+_SELECT_FIELD = _field(
+    ftype="select",
+    type_options={"select": {"options": [{"label": "GET", "value": "GET"}]}},
+)
+
+
+def test_select_accepts_valid_option() -> None:
+    assert validate_value_for_field(_SELECT_FIELD, "GET") is None
+
+
+def test_select_rejects_invalid_option() -> None:
+    err = validate_value_for_field(_SELECT_FIELD, "FETCH")
+    assert err is not None
+    assert "must be one of" in err
+
+
+def test_select_rejects_non_string() -> None:
+    assert validate_value_for_field(_SELECT_FIELD, 123) is not None
+
+
+def test_select_without_options_accepts_any_string() -> None:
+    assert validate_value_for_field(_field(ftype="select"), "anything") is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-select
+# ---------------------------------------------------------------------------
+
+
+_MULTI_SELECT_FIELD = _field(
+    ftype="multi-select",
+    type_options={
+        "multiSelect": {
+            "options": [
+                {"label": "A", "value": "a"},
+                {"label": "B", "value": "b"},
+            ],
+        },
+    },
+)
+
+
+def test_multi_select_accepts_valid_items() -> None:
+    assert validate_value_for_field(_MULTI_SELECT_FIELD, ["a", "b"]) is None
+
+
+def test_multi_select_rejects_non_list() -> None:
+    assert validate_value_for_field(_MULTI_SELECT_FIELD, "a") is not None
+
+
+def test_multi_select_rejects_non_string_item() -> None:
+    assert validate_value_for_field(_MULTI_SELECT_FIELD, [1]) is not None
+
+
+def test_multi_select_rejects_invalid_option() -> None:
+    err = validate_value_for_field(_MULTI_SELECT_FIELD, ["a", "c"])
+    assert err is not None
+    assert "c" in err
+
+
+def test_multi_select_without_options_accepts_string_list() -> None:
+    assert validate_value_for_field(
+        _field(ftype="multi-select"), ["x", "y"],
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# Object
+# ---------------------------------------------------------------------------
+
+
+_OBJECT_WITH_SCHEMA = _field(
+    ftype="object",
+    type_options={
+        "object": {
+            "schema": [
+                {"name": "enabled", "type": "boolean", "required": False},
+            ],
+        },
+    },
+)
+
+
+def test_object_with_schema_accepts_dict() -> None:
+    assert validate_value_for_field(
+        _OBJECT_WITH_SCHEMA, {"enabled": True},
+    ) is None
+
+
+def test_object_with_schema_rejects_list() -> None:
+    assert validate_value_for_field(_OBJECT_WITH_SCHEMA, [1]) is not None
+
+
+def test_object_with_schema_rejects_string() -> None:
+    assert validate_value_for_field(_OBJECT_WITH_SCHEMA, "text") is not None
+
+
+def test_object_with_schema_validates_nested() -> None:
+    err = validate_value_for_field(
+        _OBJECT_WITH_SCHEMA, {"enabled": "yes"},
+    )
+    assert err is not None
+    assert "boolean" in err
+
+
+def test_object_without_schema_accepts_dict() -> None:
+    assert validate_value_for_field(_field(ftype="object"), {"a": 1}) is None
+
+
+def test_object_without_schema_accepts_list() -> None:
+    assert validate_value_for_field(_field(ftype="object"), [1, 2]) is None
+
+
+def test_object_without_schema_rejects_string() -> None:
+    assert validate_value_for_field(_field(ftype="object"), "text") is not None
+
+
+def test_object_without_schema_rejects_number() -> None:
+    assert validate_value_for_field(_field(ftype="object"), 42) is not None
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+_LIST_WITH_ITEM_SCHEMA = _field(
+    ftype="list",
+    type_options={
+        "list": {
+            "itemDefinition": {
+                "schema": [
+                    {"name": "key", "type": "string", "required": True},
+                ],
+            },
+        },
+    },
+)
+
+
+def test_list_accepts_list() -> None:
+    assert validate_value_for_field(
+        _LIST_WITH_ITEM_SCHEMA, [{"key": "a"}],
+    ) is None
+
+
+def test_list_rejects_non_list() -> None:
+    assert validate_value_for_field(
+        _LIST_WITH_ITEM_SCHEMA, "not a list",
+    ) is not None
+
+
+def test_list_validates_item_schema() -> None:
+    err = validate_value_for_field(
+        _LIST_WITH_ITEM_SCHEMA, [{"key": 123}],
+    )
+    assert err is not None
+    assert "item 0" in err
+
+
+# ---------------------------------------------------------------------------
+# Days-of-week
+# ---------------------------------------------------------------------------
+
+
+def test_days_of_week_accepts_string_list() -> None:
+    assert validate_value_for_field(
+        _field(ftype="days-of-week"), ["monday", "friday"],
+    ) is None
+
+
+def test_days_of_week_rejects_non_list() -> None:
+    assert validate_value_for_field(
+        _field(ftype="days-of-week"), "monday",
+    ) is not None
+
+
+def test_days_of_week_rejects_non_string_item() -> None:
+    assert validate_value_for_field(
+        _field(ftype="days-of-week"), [1, 2],
+    ) is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration-resource
+# ---------------------------------------------------------------------------
+
+
+def test_integration_resource_single_accepts_string() -> None:
+    assert validate_value_for_field(
+        _field(ftype="integration-resource"), "res-1",
+    ) is None
+
+
+def test_integration_resource_single_rejects_list() -> None:
+    assert validate_value_for_field(
+        _field(ftype="integration-resource"), ["a"],
+    ) is not None
+
+
+def test_integration_resource_multi_accepts_list() -> None:
+    f = _field(
+        ftype="integration-resource",
+        type_options={"resource": {"multi": True}},
+    )
+    assert validate_value_for_field(f, ["a", "b"]) is None
+
+
+def test_integration_resource_multi_rejects_string() -> None:
+    f = _field(
+        ftype="integration-resource",
+        type_options={"resource": {"multi": True}},
+    )
+    assert validate_value_for_field(f, "a") is not None
+
+
+# ---------------------------------------------------------------------------
+# Unknown / missing type
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_type_always_valid() -> None:
+    assert validate_value_for_field(_field(ftype="custom"), "any") is None
+
+
+def test_empty_type_always_valid() -> None:
+    assert validate_value_for_field({"name": "f"}, "any") is None
+
+
+# ---------------------------------------------------------------------------
+# validate_configuration
+# ---------------------------------------------------------------------------
+
+
+def test_validate_configuration_valid() -> None:
+    fields = [
+        _field(name="url", ftype="string", required=True),
+        _field(name="method", ftype="select"),
+    ]
+    errors = validate_configuration({"url": "https://x", "method": "GET"}, fields)
+    assert errors == []
+
+
+def test_validate_configuration_required_missing() -> None:
+    fields = [_field(name="url", ftype="string", required=True)]
+    errors = validate_configuration({}, fields)
+    assert len(errors) == 1
+    assert "required" in errors[0]
+
+
+def test_validate_configuration_optional_missing_ok() -> None:
+    fields = [_field(name="url", ftype="string", required=False)]
+    errors = validate_configuration({}, fields)
+    assert errors == []
+
+
+def test_validate_configuration_type_error() -> None:
+    fields = [_field(name="url", ftype="string")]
+    errors = validate_configuration({"url": 123}, fields)
+    assert len(errors) == 1
+    assert "url" in errors[0]
+
+
+def test_validate_configuration_extra_keys_ignored() -> None:
+    fields = [_field(name="url", ftype="string")]
+    errors = validate_configuration({"url": "ok", "extra": 999}, fields)
+    assert errors == []
+
+
+def test_validate_configuration_conditional_required() -> None:
+    fields = [
+        _field(name="method", ftype="select"),
+        _field(
+            name="json",
+            ftype="object",
+            required=False,
+            required_conditions=[{"field": "method", "values": ["POST"]}],
+        ),
+    ]
+    errors = validate_configuration({"method": "POST"}, fields)
+    assert len(errors) == 1
+    assert "required" in errors[0]
+    assert "json" in errors[0]
+
+
+def test_validate_configuration_conditional_required_not_met() -> None:
+    fields = [
+        _field(name="method", ftype="select"),
+        _field(
+            name="json",
+            ftype="object",
+            required=False,
+            required_conditions=[{"field": "method", "values": ["POST"]}],
+        ),
+    ]
+    errors = validate_configuration({"method": "GET"}, fields)
+    assert errors == []


### PR DESCRIPTION
Closes #4049 

## Summary

- Implement the output validator placeholder in `agent.py` to catch invalid node configurations before they reach the user
- Add `proposal_configuration_validate.py` module that mirrors the backend Go validation rules (`pkg/configuration/validation.go`)
- When validation fails, the agent retries via `ModelRetry` and fixes the configuration itself (up to 5 attempts, already configured)

## Context

The agent generates canvas proposals with freeform `configuration: dict[str, Any]` on `add_node` and `update_node_config` operations. It gets field schemas from `describe_component`/`describe_trigger` tool calls, but nothing validated the configuration before showing it to the user. Invalid configs (wrong types, bad select options, setting invisible fields) would pass through and fail on backend save.

The placeholder for this already existed at `agent.py:65-73` with a commented-out `ModelRetry` example and output_retries=5`.

## Design decisions

**Why output validation + ModelRetry, not post-hoc stripping?**
Considered stripping invalid fields from the proposal silently. The problem is the user would see a proposal with missing configuration and not understand why. With `ModelRetry`, the agent sees the specific error ("field 'json' must be an object") and produces a corrected, complete proposal. The user never sees the broken version.

**Why no system prompt changes?**
The LLM already receives full field schemas (type, options, visibility conditions) from `describe_component`/`describe_trigger` tool calls. Adding type formatting rules to the system prompt would duplicate what the schema already communicates. The validator catches what the LLM gets wrong — we can revisit prompt changes later if the validator fires too often.

**Why coerce before validating?**
The existing coercion layer (`proposal_configuration_coerce.py`) fixes predictable LLM serialization quirks: string `"true"` → `True`, `"42"` → `42`, stringified JSON arrays → lists. The validator runs after coercion so it doesn't reject values that coercion can trivially fix. Only truly unfixable values trigger a retry.

**Cost in the happy path (vast majority)?**
Zero. The validation is pure Python `isinstance()` checks on schema data already cached by coercion. No extra API calls, no LLM tokens, no added latency. The retry cost only applies when the agent actually produces invalid config.

## Test plan

- [x] 52 new tests in `test_proposal_configuration_validate.py` covering all field types, required fields, conditional required, nested validation, unknown types
- [x] Existing coercion tests pass (no regressions)
- [x] Existing agent tests pass (no regressions)