### PR TITLE
chore(refactor): AuthContext -> AuthReader

### DIFF
--- a/pkg/components/approval/approval.go
+++ b/pkg/components/approval/approval.go
@@ -230,7 +230,7 @@ func (m *Metadata) validateAction(record *Record, ctx core.ActionContext) error 
 	return fmt.Errorf("unknown record type: %s", record.Type)
 }
 
-func (a *Approval) newNodeMetadata(auth core.AuthContext, items []Item) (*NodeMetadata, error) {
+func (a *Approval) newNodeMetadata(auth core.AuthReader, items []Item) (*NodeMetadata, error) {
 	records := []Record{}
 
 	for i, item := range items {
@@ -247,7 +247,7 @@ func (a *Approval) newNodeMetadata(auth core.AuthContext, items []Item) (*NodeMe
 	}, nil
 }
 
-func approvalItemToRecord(auth core.AuthContext, item Item, index int) (*Record, error) {
+func approvalItemToRecord(auth core.AuthReader, item Item, index int) (*Record, error) {
 	switch item.Type {
 	case ItemTypeAnyone:
 		return &Record{

--- a/pkg/components/send_email/send_email.go
+++ b/pkg/components/send_email/send_email.go
@@ -282,7 +282,7 @@ func (c *SendEmail) Cleanup(ctx core.SetupContext) error {
 	return nil
 }
 
-func buildReceivers(config Config, auth core.AuthContext) (core.NotificationReceivers, error) {
+func buildReceivers(config Config, auth core.AuthReader) (core.NotificationReceivers, error) {
 	emailSet := map[string]struct{}{}
 	groupSet := map[string]struct{}{}
 	roleSet := map[string]struct{}{}
@@ -307,7 +307,7 @@ func buildReceivers(config Config, auth core.AuthContext) (core.NotificationRece
 	}, nil
 }
 
-func resolveUserEmail(rawID string, auth core.AuthContext, dest map[string]struct{}) error {
+func resolveUserEmail(rawID string, auth core.AuthReader, dest map[string]struct{}) error {
 	if rawID == "" {
 		return nil
 	}

--- a/pkg/core/auth.go
+++ b/pkg/core/auth.go
@@ -1,0 +1,12 @@
+package core
+
+import "github.com/google/uuid"
+
+type AuthReader interface {
+	AuthenticatedUser() *User
+	GetUser(id uuid.UUID) (*User, error)
+	GetRole(name string) (*RoleRef, error)
+	GetGroup(name string) (*GroupRef, error)
+	HasRole(role string) (bool, error)
+	InGroup(group string) (bool, error)
+}

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -150,7 +150,7 @@ type ExecutionContext struct {
 	NodeMetadata   MetadataContext
 	ExecutionState ExecutionStateContext
 	Requests       RequestContext
-	Auth           AuthContext
+	Auth           AuthReader
 	Integration    IntegrationContext
 	Notifications  NotificationContext
 	Secrets        SecretsContext
@@ -184,7 +184,7 @@ type SetupContext struct {
 	HTTP          HTTPContext
 	Metadata      MetadataContext
 	Requests      RequestContext
-	Auth          AuthContext
+	Auth          AuthReader
 	Integration   IntegrationContext
 	Webhook       NodeWebhookContext
 }
@@ -262,7 +262,7 @@ type ActionContext struct {
 	HTTP           HTTPContext
 	Metadata       MetadataContext
 	ExecutionState ExecutionStateContext
-	Auth           AuthContext
+	Auth           AuthReader
 	Requests       RequestContext
 	Integration    IntegrationContext
 	Notifications  NotificationContext
@@ -317,15 +317,6 @@ type ProcessQueueContext struct {
 	// same source)
 	//
 	DistinctIncomingSources func() ([]Node, error)
-}
-
-type AuthContext interface {
-	AuthenticatedUser() *User
-	GetUser(id uuid.UUID) (*User, error)
-	GetRole(name string) (*RoleRef, error)
-	GetGroup(name string) (*GroupRef, error)
-	HasRole(role string) (bool, error)
-	InGroup(group string) (bool, error)
 }
 
 type NotificationReceivers struct {

--- a/pkg/grpc/actions/canvases/cancel_execution.go
+++ b/pkg/grpc/actions/canvases/cancel_execution.go
@@ -100,7 +100,7 @@ func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authori
 				Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
 				ExecutionState: contexts.NewExecutionStateContext(tx, execution, nil),
 				Requests:       contexts.NewExecutionRequestContext(tx, execution),
-				Auth:           contexts.NewAuthContext(tx, orgUUID, authService, user),
+				Auth:           contexts.NewAuthReader(tx, orgUUID, authService, user),
 				Notifications:  contexts.NewNotificationContext(tx, orgUUID, execution.WorkflowID),
 				CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID),
 			}

--- a/pkg/grpc/actions/canvases/invoke_node_execution_action.go
+++ b/pkg/grpc/actions/canvases/invoke_node_execution_action.go
@@ -93,7 +93,7 @@ func InvokeNodeExecutionAction(
 		HTTP:           registry.HTTPContext(),
 		Metadata:       contexts.NewExecutionMetadataContext(tx, execution),
 		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
-		Auth:           contexts.NewAuthContext(tx, orgID, authService, user),
+		Auth:           contexts.NewAuthReader(tx, orgID, authService, user),
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
 		Notifications:  contexts.NewNotificationContext(tx, orgID, canvas.ID),
 	}

--- a/pkg/grpc/actions/canvases/runtime_node_setup.go
+++ b/pkg/grpc/actions/canvases/runtime_node_setup.go
@@ -328,7 +328,7 @@ func setupComponent(
 		Metadata:      contexts.NewNodeMetadataContext(tx, node),
 		Requests:      contexts.NewNodeRequestContext(tx, node),
 		Webhook:       contexts.NewNodeWebhookContext(ctx, tx, encryptor, node, webhookBaseURL),
-		Auth:          contexts.NewAuthContext(tx, orgID, authService, nil),
+		Auth:          contexts.NewAuthReader(tx, orgID, authService, nil),
 	}
 
 	if node.AppInstallationID != nil {

--- a/pkg/workers/contexts/auth_reader.go
+++ b/pkg/workers/contexts/auth_reader.go
@@ -11,15 +11,15 @@ import (
 	"gorm.io/gorm"
 )
 
-type AuthContext struct {
+type AuthReader struct {
 	tx                *gorm.DB
 	orgID             uuid.UUID
 	authService       authorization.Authorization
 	authenticatedUser *models.User
 }
 
-func NewAuthContext(tx *gorm.DB, orgID uuid.UUID, authService authorization.Authorization, authenticatedUser *models.User) *AuthContext {
-	return &AuthContext{
+func NewAuthReader(tx *gorm.DB, orgID uuid.UUID, authService authorization.Authorization, authenticatedUser *models.User) *AuthReader {
+	return &AuthReader{
 		tx:                tx,
 		orgID:             orgID,
 		authService:       authService,
@@ -27,7 +27,7 @@ func NewAuthContext(tx *gorm.DB, orgID uuid.UUID, authService authorization.Auth
 	}
 }
 
-func (c *AuthContext) AuthenticatedUser() *core.User {
+func (c *AuthReader) AuthenticatedUser() *core.User {
 	if c.authenticatedUser == nil {
 		return nil
 	}
@@ -39,7 +39,7 @@ func (c *AuthContext) AuthenticatedUser() *core.User {
 	}
 }
 
-func (c *AuthContext) GetUser(id uuid.UUID) (*core.User, error) {
+func (c *AuthReader) GetUser(id uuid.UUID) (*core.User, error) {
 	user, err := models.FindActiveUserByIDInTransaction(c.tx, c.orgID.String(), id.String())
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (c *AuthContext) GetUser(id uuid.UUID) (*core.User, error) {
 	}, nil
 }
 
-func (c *AuthContext) GetRole(name string) (*core.RoleRef, error) {
+func (c *AuthReader) GetRole(name string) (*core.RoleRef, error) {
 	roleDefinition, err := c.authService.GetRoleDefinition(name, models.DomainTypeOrganization, c.orgID.String())
 	if err != nil {
 		return nil, fmt.Errorf("error getting role definition: %v", err)
@@ -66,7 +66,7 @@ func (c *AuthContext) GetRole(name string) (*core.RoleRef, error) {
 	return &core.RoleRef{Name: roleDefinition.Name, DisplayName: roleMetadata.DisplayName}, nil
 }
 
-func (c *AuthContext) GetGroup(name string) (*core.GroupRef, error) {
+func (c *AuthReader) GetGroup(name string) (*core.GroupRef, error) {
 	groupMetadata, err := models.FindGroupMetadata(name, models.DomainTypeOrganization, c.orgID.String())
 	if err != nil {
 		return nil, fmt.Errorf("error getting group metadata: %v", err)
@@ -75,7 +75,7 @@ func (c *AuthContext) GetGroup(name string) (*core.GroupRef, error) {
 	return &core.GroupRef{Name: groupMetadata.GroupName, DisplayName: groupMetadata.DisplayName}, nil
 }
 
-func (c *AuthContext) HasRole(role string) (bool, error) {
+func (c *AuthReader) HasRole(role string) (bool, error) {
 	if c.authenticatedUser == nil {
 		return false, fmt.Errorf("user not authenticated")
 	}
@@ -94,7 +94,7 @@ func (c *AuthContext) HasRole(role string) (bool, error) {
 	return false, nil
 }
 
-func (c *AuthContext) InGroup(group string) (bool, error) {
+func (c *AuthReader) InGroup(group string) (bool, error) {
 	if c.authenticatedUser == nil {
 		return false, fmt.Errorf("user not authenticated")
 	}

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -385,7 +385,7 @@ func (w *NodeExecutor) executeComponentNode(tx *gorm.DB, execution *models.Canva
 		NodeMetadata:   contexts.NewNodeMetadataContext(tx, node),
 		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
-		Auth:           contexts.NewAuthContext(tx, workflow.OrganizationID, w.authService, nil),
+		Auth:           contexts.NewAuthReader(tx, workflow.OrganizationID, w.authService, nil),
 		Notifications:  contexts.NewNotificationContext(tx, workflow.OrganizationID, execution.WorkflowID),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
 		CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID),

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -326,7 +326,7 @@ func (w *NodeRequestWorker) invokeParentNodeComponentAction(
 		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
 		Notifications:  contexts.NewNotificationContext(tx, uuid.Nil, node.WorkflowID),
-		Auth:           contexts.NewAuthContext(tx, workflow.OrganizationID, w.authService, nil),
+		Auth:           contexts.NewAuthReader(tx, workflow.OrganizationID, w.authService, nil),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
 	}
 
@@ -412,7 +412,7 @@ func (w *NodeRequestWorker) invokeChildNodeComponentAction(
 		ExecutionState: contexts.NewExecutionStateContext(tx, execution, onNewEvents),
 		Requests:       contexts.NewExecutionRequestContext(tx, execution),
 		Notifications:  contexts.NewNotificationContext(tx, uuid.Nil, execution.WorkflowID),
-		Auth:           contexts.NewAuthContext(tx, workflow.OrganizationID, nil, nil),
+		Auth:           contexts.NewAuthReader(tx, workflow.OrganizationID, nil, nil),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
 	}
 


### PR DESCRIPTION
Separating core interfaces between readers / writers is showing to be a better idea than having one for everything. Starting this movement with the AuthContext one, which is already a reader by its nature.