### PR TITLE
fix: propagate caller context in LocalProvider.Load

### DIFF
--- a/pkg/secrets/local_provider.go
+++ b/pkg/secrets/local_provider.go
@@ -26,7 +26,7 @@ func NewLocalProvider(tx *gorm.DB, encryptor crypto.Encryptor, record *models.Se
 
 func (p *LocalProvider) Load(ctx context.Context) (map[string]string, error) {
 	name := p.record.Name
-	decrypted, err := p.encryptor.Decrypt(context.TODO(), p.record.Data, []byte(name))
+	decrypted, err := p.encryptor.Decrypt(ctx, p.record.Data, []byte(name))
 	if err != nil {
 		return nil, fmt.Errorf("error decrypting secret %s: %v", name, err)
 	}

--- a/pkg/secrets/local_provider_test.go
+++ b/pkg/secrets/local_provider_test.go
@@ -1,0 +1,118 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+// contextCapturingEncryptor records the context passed to Decrypt so tests
+// can assert that LocalProvider forwards the caller's context instead of
+// substituting context.TODO() or context.Background().
+type contextCapturingEncryptor struct {
+	plaintext   []byte
+	decryptErr  error
+	receivedCtx context.Context
+}
+
+var _ crypto.Encryptor = (*contextCapturingEncryptor)(nil)
+
+func (e *contextCapturingEncryptor) Encrypt(_ context.Context, data []byte, _ []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (e *contextCapturingEncryptor) Decrypt(ctx context.Context, _ []byte, _ []byte) ([]byte, error) {
+	e.receivedCtx = ctx
+	if e.decryptErr != nil {
+		return nil, e.decryptErr
+	}
+	return e.plaintext, nil
+}
+
+func Test__LocalProvider(t *testing.T) {
+	type ctxKey string
+
+	t.Run("forwards caller context value to encryptor", func(t *testing.T) {
+		payload, err := json.Marshal(map[string]string{"key": "value"})
+		require.NoError(t, err)
+
+		encryptor := &contextCapturingEncryptor{plaintext: payload}
+		provider := NewLocalProvider(nil, encryptor, &models.Secret{
+			Name: "test-secret",
+			Data: payload,
+		})
+
+		ctx := context.WithValue(context.Background(), ctxKey("trace-id"), "abc-123")
+
+		_, err = provider.Load(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, encryptor.receivedCtx)
+		require.Equal(t, "abc-123", encryptor.receivedCtx.Value(ctxKey("trace-id")),
+			"expected encryptor to receive caller's context, but the value was not propagated")
+	})
+
+	t.Run("forwards caller context cancellation to encryptor", func(t *testing.T) {
+		payload, err := json.Marshal(map[string]string{"key": "value"})
+		require.NoError(t, err)
+
+		encryptor := &contextCapturingEncryptor{plaintext: payload}
+		provider := NewLocalProvider(nil, encryptor, &models.Secret{
+			Name: "test-secret",
+			Data: payload,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = provider.Load(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, encryptor.receivedCtx)
+		require.ErrorIs(t, encryptor.receivedCtx.Err(), context.Canceled,
+			"expected propagated context to carry caller's cancellation")
+	})
+
+	t.Run("returns parsed values on successful decryption", func(t *testing.T) {
+		expected := map[string]string{"username": "admin", "password": "s3cret"}
+		serialized, err := json.Marshal(expected)
+		require.NoError(t, err)
+
+		encryptor := &contextCapturingEncryptor{plaintext: serialized}
+		provider := NewLocalProvider(nil, encryptor, &models.Secret{
+			Name: "creds",
+			Data: serialized,
+		})
+
+		got, err := provider.Load(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("wraps decryption errors with the secret name", func(t *testing.T) {
+		encryptor := &contextCapturingEncryptor{decryptErr: errors.New("boom")}
+		provider := NewLocalProvider(nil, encryptor, &models.Secret{
+			Name: "broken",
+			Data: []byte("garbage"),
+		})
+
+		_, err := provider.Load(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error decrypting secret broken")
+	})
+
+	t.Run("returns error when decrypted payload is not valid JSON", func(t *testing.T) {
+		encryptor := &contextCapturingEncryptor{plaintext: []byte("not-json")}
+		provider := NewLocalProvider(nil, encryptor, &models.Secret{
+			Name: "malformed",
+			Data: []byte("garbage"),
+		})
+
+		_, err := provider.Load(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error unmarshaling secret malformed")
+	})
+}


### PR DESCRIPTION
## What
Forward the caller's `context.Context` from `LocalProvider.Load` to `encryptor.Decrypt`. Previously, `context.TODO()` was passed instead, dropping any cancellation, deadlines, and values (tracing, request IDs) from the caller.

## Why
`LocalProvider.Load` has the correct signature (`func (p *LocalProvider) Load(ctx context.Context)`), but the received `ctx` was ignored at the decryption boundary:

```go
decrypted, err := p.encryptor.Decrypt(context.TODO(), p.record.Data, []byte(name))
```

Consequences in production:

- A client disconnect mid-request cannot cancel an in-flight decrypt operation (wasted work, slower shutdown under load).
- Request-scoped telemetry (trace/span IDs, request IDs) carried via `context.Value` never reaches the encryptor or anything it calls.
- Future deadline-based rate limiting or timeout middleware in `crypto.Encryptor` implementations would silently be bypassed for `LocalProvider`.

## How
Single-line fix: replace `context.TODO()` with the caller's `ctx`.

Added `pkg/secrets/local_provider_test.go` (the package previously had no tests for `LocalProvider`) covering:

- **context value propagation** — asserts that a value placed in the caller's context reaches the encryptor.
- **context cancellation propagation** — asserts that a cancelled caller context is observed by the encryptor (`context.Canceled`).
- **happy path** — successful decrypt + JSON unmarshal.
- **decryption error wrapping** — verifies the existing `"error decrypting secret %s"` wrapping.
- **JSON unmarshal error wrapping** — verifies the existing `"error unmarshaling secret %s"` wrapping.

The tests use a small `contextCapturingEncryptor` mock (implements `crypto.Encryptor`) to record and assert on the context seen by the encryptor without touching the database.

## Verification
- `make test PKG_TEST_PACKAGES=./pkg/secrets` — 6/6 pass
- `make lint` — clean
- `make format.go` — no changes (file was already gofmt-clean)
- `make check.build.app` — binary builds
- `make test` (full backend suite) — 5797 pass, 0 failures