### PR TITLE
feat: Editor/LiveCanvas toggle

### DIFF
--- a/test/e2e/canvas_auto_save_test.go
+++ b/test/e2e/canvas_auto_save_test.go
@@ -100,11 +100,11 @@ func (s *canvasAutoSaveSteps) givenCanvasWithChangeManagementEnabled(name string
 	s.canvas.Create()
 	s.canvas.Visit()
 
-	s.session.AssertVisible(q.Locator(`header button:has-text("Edit")`))
+	s.session.AssertVisible(q.TestID("canvas-view-mode-editor"))
 }
 
 func (s *canvasAutoSaveSteps) enterEditMode() {
-	editButton := q.Locator(`header button:has-text("Edit")`).Run(s.session)
+	editButton := q.TestID("canvas-view-mode-editor").Run(s.session)
 	deadline := time.Now().Add(15 * time.Second)
 
 	for {
@@ -115,7 +115,7 @@ func (s *canvasAutoSaveSteps) enterEditMode() {
 		}
 
 		if time.Now().After(deadline) {
-			s.t.Fatalf("edit button did not become enabled")
+			s.t.Fatalf("editor control did not become enabled")
 		}
 
 		time.Sleep(200 * time.Millisecond)

--- a/test/e2e/canvas_change_requests_test.go
+++ b/test/e2e/canvas_change_requests_test.go
@@ -82,7 +82,7 @@ func (s *canvasChangeRequestSteps) givenCanvasWithOrganizationChangeManagementEn
 	s.canvas.Create()
 	s.canvas.Visit()
 
-	s.session.AssertVisible(q.Locator(`header button:has-text("Edit")`))
+	s.session.AssertVisible(q.TestID("canvas-view-mode-editor"))
 }
 
 func (s *canvasChangeRequestSteps) setOrganizationChangeManagementInDB(enabled bool) {
@@ -95,7 +95,7 @@ func (s *canvasChangeRequestSteps) setOrganizationChangeManagementInDB(enabled b
 }
 
 func (s *canvasChangeRequestSteps) enterEditMode() {
-	editButton := q.Locator(`header button:has-text("Edit")`).Run(s.session)
+	editButton := q.TestID("canvas-view-mode-editor").Run(s.session)
 	deadline := time.Now().Add(15 * time.Second)
 
 	for {
@@ -106,7 +106,7 @@ func (s *canvasChangeRequestSteps) enterEditMode() {
 		}
 
 		if time.Now().After(deadline) {
-			s.t.Fatalf("edit button did not become enabled")
+			s.t.Fatalf("editor control did not become enabled")
 		}
 
 		time.Sleep(200 * time.Millisecond)

--- a/test/e2e/canvas_sidebar_close_test.go
+++ b/test/e2e/canvas_sidebar_close_test.go
@@ -53,11 +53,11 @@ func (s *sidebarCloseSteps) givenCanvasWithChangeManagementEnabled(name string) 
 	s.canvas.Create()
 	s.canvas.Visit()
 
-	s.session.AssertVisible(q.Locator(`header button:has-text("Edit")`))
+	s.session.AssertVisible(q.TestID("canvas-view-mode-editor"))
 }
 
 func (s *sidebarCloseSteps) enterEditMode() {
-	editButton := q.Locator(`header button:has-text("Edit")`).Run(s.session)
+	editButton := q.TestID("canvas-view-mode-editor").Run(s.session)
 	deadline := time.Now().Add(15 * time.Second)
 
 	for {
@@ -68,7 +68,7 @@ func (s *sidebarCloseSteps) enterEditMode() {
 		}
 
 		if time.Now().After(deadline) {
-			s.t.Fatalf("edit button did not become enabled")
+			s.t.Fatalf("editor control did not become enabled")
 		}
 
 		time.Sleep(200 * time.Millisecond)
@@ -91,9 +91,21 @@ func (s *sidebarCloseSteps) assertSidebarHidden() {
 }
 
 func (s *sidebarCloseSteps) exitEditMode() {
-	exitButton := q.Locator(`button[aria-label="Exit edit mode"]`).Run(s.session)
-	require.NoError(s.t, exitButton.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
-	s.session.AssertVisible(q.Locator(`header button:has-text("Edit")`))
+	liveButton := q.TestID("canvas-view-mode-live").Run(s.session)
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		disabled, err := liveButton.IsDisabled()
+		require.NoError(s.t, err)
+		if !disabled {
+			break
+		}
+		if time.Now().After(deadline) {
+			s.t.Fatalf("live canvas control did not become enabled")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	require.NoError(s.t, liveButton.Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	s.session.AssertVisible(q.TestID("canvas-view-mode-editor"))
 	s.session.Sleep(500)
 }
 

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -28,10 +28,10 @@ func NewCanvasSteps(name string, t *testing.T, session *session.TestSession) *Ca
 	return &CanvasSteps{t: t, session: session, CanvasName: name}
 }
 
-// EnterEditMode clicks the Edit button in the header to create a draft version.
+// EnterEditMode clicks the Editor segment in the header to create a draft version.
 // This must be called before making any canvas changes.
 func (s *CanvasSteps) EnterEditMode() {
-	editButton := q.Locator(`header button:has-text("Edit")`).Run(s.session)
+	editButton := q.TestID("canvas-view-mode-editor").Run(s.session)
 
 	deadline := time.Now().Add(15 * time.Second)
 	for {
@@ -41,7 +41,7 @@ func (s *CanvasSteps) EnterEditMode() {
 			break
 		}
 		if time.Now().After(deadline) {
-			s.t.Fatalf("edit button did not become enabled")
+			s.t.Fatalf("editor control did not become enabled")
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
@@ -108,7 +108,7 @@ func (s *CanvasSteps) OpenBuildingBlocksSidebar() {
 	}
 
 	openButton := q.TestID("open-sidebar-button").Run(s.session)
-	editButton := q.Locator(`button:has-text("Edit")`).Run(s.session)
+	editButton := q.TestID("canvas-view-mode-editor").Run(s.session)
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -1,8 +1,9 @@
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
 import { Button as UIButton } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { MoreVertical, Pencil, RotateCcw, Settings } from "lucide-react";
+import { MoreVertical, RotateCcw, Settings } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../button";
 
@@ -28,6 +29,9 @@ interface HeaderProps {
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
+  onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
   /** Label for the publish/propose-change button in version edit mode. Defaults to "Publish". */
   publishVersionLabel?: string;
   /** When &gt; 0 (unpublished draft diff items), shown as badge count on the publish button in version edit mode. */
@@ -55,6 +59,9 @@ export function Header({
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
+  onExitEditMode,
+  exitEditModeDisabled,
+  exitEditModeDisabledTooltip,
   publishVersionLabel = "Publish",
   unpublishedDraftChangeCount = 0,
   showCanvasSettingsMenu = true,
@@ -62,7 +69,6 @@ export function Header({
   const headerTitle = canvasName.trim() || "Canvas";
 
   const isDefaultMode = mode === "default";
-  const showEditButton = mode === "version-live";
   const showVersionEditActions = mode === "version-edit";
   const hasChanges = unpublishedDraftChangeCount > 0;
   const publishButtonLabel = hasChanges
@@ -85,6 +91,7 @@ export function Header({
         saveDisabled={saveDisabled}
         saveDisabledTooltip={saveDisabledTooltip}
         saveIsPrimary={saveIsPrimary}
+        headerMode={mode}
         showVersionEditActions={showVersionEditActions}
         hasChanges={hasChanges}
         onDiscardVersion={onDiscardVersion}
@@ -94,10 +101,12 @@ export function Header({
         publishVersionDisabledTooltip={publishVersionDisabledTooltip}
         onPublishVersion={onPublishVersion}
         publishButtonLabel={publishButtonLabel}
-        showEditButton={showEditButton}
+        onEnterEditMode={onEnterEditMode}
         enterEditModeDisabled={enterEditModeDisabled}
         enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
-        onEnterEditMode={onEnterEditMode}
+        onExitEditMode={onExitEditMode}
+        exitEditModeDisabled={exitEditModeDisabled}
+        exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       />
     </header>
   );
@@ -160,6 +169,7 @@ function SecondaryHeader({
   saveDisabled,
   saveDisabledTooltip,
   saveIsPrimary,
+  headerMode,
   showVersionEditActions,
   hasChanges,
   onDiscardVersion,
@@ -169,10 +179,12 @@ function SecondaryHeader({
   publishVersionDisabledTooltip,
   onPublishVersion,
   publishButtonLabel,
-  showEditButton,
+  onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
-  onEnterEditMode,
+  onExitEditMode,
+  exitEditModeDisabled,
+  exitEditModeDisabledTooltip,
 }: {
   isDefaultMode: boolean;
   onSave?: () => void;
@@ -180,6 +192,7 @@ function SecondaryHeader({
   saveDisabled?: boolean;
   saveDisabledTooltip?: string;
   saveIsPrimary?: boolean;
+  headerMode: HeaderMode;
   showVersionEditActions: boolean;
   hasChanges: boolean;
   onDiscardVersion?: () => void;
@@ -189,48 +202,63 @@ function SecondaryHeader({
   publishVersionDisabledTooltip?: string;
   onPublishVersion?: () => void;
   publishButtonLabel: string;
-  showEditButton: boolean;
+  onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
-  onEnterEditMode?: () => void;
+  onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
 }) {
-  return (
-    <div className="relative flex h-12 items-center justify-end gap-2 px-4 bg-slate-100 border-b border-slate-950/15">
-      {isDefaultMode && onSave && !saveButtonHidden ? (
-        <SaveButton
-          onSave={onSave}
-          saveDisabled={saveDisabled}
-          saveDisabledTooltip={saveDisabledTooltip}
-          saveIsPrimary={saveIsPrimary}
-        />
-      ) : null}
+  const showCanvasViewModeToggle = headerMode === "version-live" || headerMode === "version-edit";
+  const canvasViewMode = headerMode === "version-edit" ? "version-edit" : "version-live";
 
-      {showVersionEditActions ? (
-        <div className="flex items-center gap-2">
-          {hasChanges ? (
-            <DiscardDraftButton
-              onDiscard={() => onDiscardVersion?.()}
-              disabled={discardVersionDisabled || !onDiscardVersion}
-              disabledTooltip={discardVersionDisabledTooltip}
+  return (
+    <div className="relative flex h-12 items-center border-b border-slate-950/15 bg-slate-100 px-4">
+      <div className="pointer-events-none absolute inset-x-0 flex justify-center px-16 sm:px-24">
+        <div className="pointer-events-auto">
+          {showCanvasViewModeToggle && onEnterEditMode && onExitEditMode ? (
+            <CanvasViewModeToggle
+              mode={canvasViewMode}
+              onSelectEditor={onEnterEditMode}
+              onSelectLive={onExitEditMode}
+              enterEditorDisabled={!!enterEditModeDisabled}
+              enterEditorDisabledTooltip={enterEditModeDisabledTooltip}
+              exitEditorDisabled={!!exitEditModeDisabled}
+              exitEditorDisabledTooltip={exitEditModeDisabledTooltip}
             />
           ) : null}
-          <PublishVersionButton
-            onPublish={() => onPublishVersion?.()}
-            label={publishButtonLabel}
-            disabled={publishVersionDisabled || !onPublishVersion}
-            publishVersionDisabled={!!publishVersionDisabled}
-            publishVersionDisabledTooltip={publishVersionDisabledTooltip}
-          />
         </div>
-      ) : null}
+      </div>
 
-      {showEditButton ? (
-        <EnterEditModeButton
-          onClick={onEnterEditMode}
-          disabled={enterEditModeDisabled}
-          disabledTooltip={enterEditModeDisabledTooltip}
-        />
-      ) : null}
+      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
+        {isDefaultMode && onSave && !saveButtonHidden ? (
+          <SaveButton
+            onSave={onSave}
+            saveDisabled={saveDisabled}
+            saveDisabledTooltip={saveDisabledTooltip}
+            saveIsPrimary={saveIsPrimary}
+          />
+        ) : null}
+
+        {showVersionEditActions ? (
+          <div className="flex items-center gap-2">
+            {hasChanges ? (
+              <DiscardDraftButton
+                onDiscard={() => onDiscardVersion?.()}
+                disabled={discardVersionDisabled || !onDiscardVersion}
+                disabledTooltip={discardVersionDisabledTooltip}
+              />
+            ) : null}
+            <PublishVersionButton
+              onPublish={() => onPublishVersion?.()}
+              label={publishButtonLabel}
+              disabled={publishVersionDisabled || !onPublishVersion}
+              publishVersionDisabled={!!publishVersionDisabled}
+              publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+            />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -349,35 +377,78 @@ function PublishVersionButton({
   );
 }
 
-function EnterEditModeButton({
-  onClick,
-  disabled,
-  disabledTooltip,
+type CanvasViewMode = "version-live" | "version-edit";
+
+function CanvasViewModeToggle({
+  mode,
+  onSelectEditor,
+  onSelectLive,
+  enterEditorDisabled,
+  enterEditorDisabledTooltip,
+  exitEditorDisabled,
+  exitEditorDisabledTooltip,
 }: {
-  onClick?: () => void;
-  disabled?: boolean;
-  disabledTooltip?: string;
+  mode: CanvasViewMode;
+  onSelectEditor: () => void;
+  onSelectLive: () => void;
+  enterEditorDisabled: boolean;
+  enterEditorDisabledTooltip?: string;
+  exitEditorDisabled: boolean;
+  exitEditorDisabledTooltip?: string;
 }) {
-  if (disabled && disabledTooltip) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="inline-flex">
-            <UIButton type="button" variant="outline" size="sm" onClick={onClick} disabled={disabled}>
-              <Pencil className="size-3.5" />
-              Edit
-            </UIButton>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="top">{disabledTooltip}</TooltipContent>
-      </Tooltip>
-    );
-  }
+  const handleValueChange = (next: string) => {
+    if (next === "version-edit" && mode === "version-live") {
+      void onSelectEditor();
+    } else if (next === "version-live" && mode === "version-edit") {
+      void onSelectLive();
+    }
+  };
+
+  const editorDisabled = mode === "version-live" && enterEditorDisabled;
+  const liveDisabled = mode === "version-edit" && exitEditorDisabled;
+
+  const editorTrigger = (
+    <TabsTrigger
+      value="version-edit"
+      disabled={editorDisabled}
+      data-testid="canvas-view-mode-editor"
+      aria-label="Editor"
+    >
+      Editor
+    </TabsTrigger>
+  );
+
+  const liveTrigger = (
+    <TabsTrigger
+      value="version-live"
+      disabled={liveDisabled}
+      data-testid="canvas-view-mode-live"
+      aria-label="Live Canvas"
+    >
+      Live Canvas
+    </TabsTrigger>
+  );
 
   return (
-    <UIButton type="button" variant="outline" size="sm" onClick={onClick} disabled={disabled}>
-      <Pencil className="size-3.5" />
-      Edit
-    </UIButton>
+    <Tabs value={mode} onValueChange={handleValueChange} className="inline-flex w-auto" aria-label="Canvas view">
+      <TabsList className="h-8 w-fit gap-0">
+        {editorDisabled && enterEditorDisabledTooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{editorTrigger}</TooltipTrigger>
+            <TooltipContent side="top">{enterEditorDisabledTooltip}</TooltipContent>
+          </Tooltip>
+        ) : (
+          editorTrigger
+        )}
+        {liveDisabled && exitEditorDisabledTooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{liveTrigger}</TooltipTrigger>
+            <TooltipContent side="top">{exitEditorDisabledTooltip}</TooltipContent>
+          </Tooltip>
+        ) : (
+          liveTrigger
+        )}
+      </TabsList>
+    </Tabs>
   );
 }

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -1,11 +1,11 @@
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
 import { Button as UIButton } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { MoreVertical, RotateCcw, Settings } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../button";
+import { CanvasModeToggle } from "./components/CanvasModeToggle";
 
 type HeaderMode = "default" | "version-live" | "version-edit";
 
@@ -180,11 +180,7 @@ function SecondaryHeader({
   onPublishVersion,
   publishButtonLabel,
   onEnterEditMode,
-  enterEditModeDisabled,
-  enterEditModeDisabledTooltip,
   onExitEditMode,
-  exitEditModeDisabled,
-  exitEditModeDisabledTooltip,
 }: {
   isDefaultMode: boolean;
   onSave?: () => void;
@@ -217,15 +213,7 @@ function SecondaryHeader({
       <div className="pointer-events-none absolute inset-x-0 flex justify-center px-16 sm:px-24">
         <div className="pointer-events-auto">
           {showCanvasViewModeToggle && onEnterEditMode && onExitEditMode ? (
-            <CanvasViewModeToggle
-              mode={canvasViewMode}
-              onSelectEditor={onEnterEditMode}
-              onSelectLive={onExitEditMode}
-              enterEditorDisabled={!!enterEditModeDisabled}
-              enterEditorDisabledTooltip={enterEditModeDisabledTooltip}
-              exitEditorDisabled={!!exitEditModeDisabled}
-              exitEditorDisabledTooltip={exitEditModeDisabledTooltip}
-            />
+            <CanvasModeToggle mode={canvasViewMode} onSelectEditor={onEnterEditMode} onSelectLive={onExitEditMode} />
           ) : null}
         </div>
       </div>
@@ -374,81 +362,5 @@ function PublishVersionButton({
     <UIButton type="button" variant="default" size="sm" onClick={onPublish} disabled={disabled}>
       {label}
     </UIButton>
-  );
-}
-
-type CanvasViewMode = "version-live" | "version-edit";
-
-function CanvasViewModeToggle({
-  mode,
-  onSelectEditor,
-  onSelectLive,
-  enterEditorDisabled,
-  enterEditorDisabledTooltip,
-  exitEditorDisabled,
-  exitEditorDisabledTooltip,
-}: {
-  mode: CanvasViewMode;
-  onSelectEditor: () => void;
-  onSelectLive: () => void;
-  enterEditorDisabled: boolean;
-  enterEditorDisabledTooltip?: string;
-  exitEditorDisabled: boolean;
-  exitEditorDisabledTooltip?: string;
-}) {
-  const handleValueChange = (next: string) => {
-    if (next === "version-edit" && mode === "version-live") {
-      void onSelectEditor();
-    } else if (next === "version-live" && mode === "version-edit") {
-      void onSelectLive();
-    }
-  };
-
-  const editorDisabled = mode === "version-live" && enterEditorDisabled;
-  const liveDisabled = mode === "version-edit" && exitEditorDisabled;
-
-  const editorTrigger = (
-    <TabsTrigger
-      value="version-edit"
-      disabled={editorDisabled}
-      data-testid="canvas-view-mode-editor"
-      aria-label="Editor"
-    >
-      Editor
-    </TabsTrigger>
-  );
-
-  const liveTrigger = (
-    <TabsTrigger
-      value="version-live"
-      disabled={liveDisabled}
-      data-testid="canvas-view-mode-live"
-      aria-label="Live Canvas"
-    >
-      Live Canvas
-    </TabsTrigger>
-  );
-
-  return (
-    <Tabs value={mode} onValueChange={handleValueChange} className="inline-flex w-auto" aria-label="Canvas view">
-      <TabsList className="h-8 w-fit gap-0">
-        {editorDisabled && enterEditorDisabledTooltip ? (
-          <Tooltip>
-            <TooltipTrigger asChild>{editorTrigger}</TooltipTrigger>
-            <TooltipContent side="top">{enterEditorDisabledTooltip}</TooltipContent>
-          </Tooltip>
-        ) : (
-          editorTrigger
-        )}
-        {liveDisabled && exitEditorDisabledTooltip ? (
-          <Tooltip>
-            <TooltipTrigger asChild>{liveTrigger}</TooltipTrigger>
-            <TooltipContent side="top">{exitEditorDisabledTooltip}</TooltipContent>
-          </Tooltip>
-        ) : (
-          liveTrigger
-        )}
-      </TabsList>
-    </Tabs>
   );
 }

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -2,7 +2,7 @@ import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { MoreVertical, RotateCcw, Settings } from "lucide-react";
+import { MoreVertical, Settings } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../button";
 import { CanvasModeToggle } from "./components/CanvasModeToggle";
@@ -305,28 +305,25 @@ function DiscardDraftButton({
   disabled: boolean;
   disabledTooltip?: string;
 }) {
-  const tooltipText =
-    disabled && disabledTooltip ? disabledTooltip : "Discard draft changes and reset to the current live version.";
+  if (disabled && disabledTooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="inline-flex">
+            <UIButton type="button" variant="outline" size="sm" onClick={onDiscard} disabled={disabled}>
+              Discard
+            </UIButton>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{disabledTooltip}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className="inline-flex">
-          <UIButton
-            type="button"
-            variant="outline"
-            size="icon-xs"
-            className="shrink-0"
-            onClick={onDiscard}
-            disabled={disabled}
-            aria-label="Discard draft"
-          >
-            <RotateCcw className="h-3.5 w-3.5" />
-          </UIButton>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{tooltipText}</TooltipContent>
-    </Tooltip>
+    <UIButton type="button" variant="outline" size="sm" onClick={onDiscard} disabled={disabled}>
+      Discard
+    </UIButton>
   );
 }
 

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -19,11 +19,22 @@ export function CanvasModeToggle({ mode, onSelectEditor, onSelectLive }: CanvasM
 
   return (
     <Tabs value={mode} onValueChange={handleValueChange} className="inline-flex w-auto" aria-label="Canvas view">
-      <TabsList className="h-8 w-fit gap-0">
-        <TabsTrigger value="version-edit" data-testid="canvas-view-mode-editor" aria-label="Editor">
+      <TabsList className="h-8 w-fit gap-0 p-0 bg-transparent border border-slate-300 rounded-sm">
+        <TabsTrigger
+          value="version-edit"
+          data-testid="canvas-view-mode-editor"
+          aria-label="Editor"
+          className="rounded-sm rounded-br-none rounded-tr-none border-none py-1 px-3"
+        >
           Editor
         </TabsTrigger>
-        <TabsTrigger value="version-live" data-testid="canvas-view-mode-live" aria-label="Live Canvas">
+        <div className="h-full w-px bg-slate-300"></div>
+        <TabsTrigger
+          value="version-live"
+          data-testid="canvas-view-mode-live"
+          aria-label="Live Canvas"
+          className="rounded-sm rounded-bl-none rounded-tl-none border-none py-1 px-3"
+        >
           Live Canvas
         </TabsTrigger>
       </TabsList>

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,0 +1,32 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type CanvasMode = "version-live" | "version-edit";
+
+interface CanvasModeToggleProps {
+  mode: CanvasMode;
+  onSelectEditor: () => void;
+  onSelectLive: () => void;
+}
+
+export function CanvasModeToggle({ mode, onSelectEditor, onSelectLive }: CanvasModeToggleProps) {
+  const handleValueChange = (next: string) => {
+    if (next === "version-edit" && mode === "version-live") {
+      void onSelectEditor();
+    } else if (next === "version-live" && mode === "version-edit") {
+      void onSelectLive();
+    }
+  };
+
+  return (
+    <Tabs value={mode} onValueChange={handleValueChange} className="inline-flex w-auto" aria-label="Canvas view">
+      <TabsList className="h-8 w-fit gap-0">
+        <TabsTrigger value="version-edit" data-testid="canvas-view-mode-editor" aria-label="Editor">
+          Editor
+        </TabsTrigger>
+        <TabsTrigger value="version-live" data-testid="canvas-view-mode-live" aria-label="Live Canvas">
+          Live Canvas
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1665,11 +1665,7 @@ function CanvasContentHeader({
   discardVersionDisabledTooltip,
   headerMode,
   onEnterEditMode,
-  enterEditModeDisabled,
-  enterEditModeDisabledTooltip,
   onExitEditMode,
-  exitEditModeDisabled,
-  exitEditModeDisabledTooltip,
   publishVersionLabel,
   unpublishedDraftChangeCount,
   showCanvasSettingsMenu,
@@ -1690,11 +1686,7 @@ function CanvasContentHeader({
   discardVersionDisabledTooltip?: string;
   headerMode?: "default" | "version-live" | "version-edit";
   onEnterEditMode?: () => void;
-  enterEditModeDisabled?: boolean;
-  enterEditModeDisabledTooltip?: string;
   onExitEditMode?: () => void;
-  exitEditModeDisabled?: boolean;
-  exitEditModeDisabledTooltip?: string;
   publishVersionLabel?: string;
   unpublishedDraftChangeCount?: number;
   showCanvasSettingsMenu?: boolean;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1170,46 +1170,15 @@ function CanvasPage(props: CanvasPageProps) {
           onEnterEditMode={props.onEnterEditMode}
           enterEditModeDisabled={props.enterEditModeDisabled}
           enterEditModeDisabledTooltip={props.enterEditModeDisabledTooltip}
+          onExitEditMode={props.onExitEditMode}
+          exitEditModeDisabled={props.exitEditModeDisabled}
+          exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
           publishVersionLabel={props.publishVersionLabel}
           unpublishedDraftChangeCount={props.unpublishedDraftChangeCount}
           showCanvasSettingsMenu={props.showCanvasSettingsMenu}
         />
         {props.headerBanner ? <div className="border-b border-black/20">{props.headerBanner}</div> : null}
       </div>
-
-      {canvasStateMode === "editing" ? (
-        <div
-          className="shrink-0 flex min-h-8 items-center justify-center gap-2 bg-amber-200 px-4 py-1.5 text-[13px] font-medium text-amber-700"
-          role="status"
-        >
-          <p className="m-0 text-amber-700">You’re editing the canvas</p>
-          <span className="select-none text-amber-700" aria-hidden>
-            ·
-          </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  type="button"
-                  variant="link"
-                  size="sm"
-                  className="min-h-0 shrink-0 gap-1 rounded-sm border border-amber-700 px-1.5 h-5 text-[13px] font-medium !text-amber-700 underline-offset-2 hover:!text-amber-700 hover:bg-white/10 hover:no-underline"
-                  onClick={() => props.onExitEditMode?.()}
-                  disabled={props.exitEditModeDisabled}
-                  aria-label="Exit edit mode"
-                >
-                  Exit
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {props.exitEditModeDisabled && props.exitEditModeDisabledTooltip
-                ? props.exitEditModeDisabledTooltip
-                : "Return to the live version. Draft will be preserved."}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      ) : null}
 
       {/* Main content area with sidebar and canvas */}
       <div className="flex-1 flex relative overflow-hidden">
@@ -1698,6 +1667,9 @@ function CanvasContentHeader({
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
+  onExitEditMode,
+  exitEditModeDisabled,
+  exitEditModeDisabledTooltip,
   publishVersionLabel,
   unpublishedDraftChangeCount,
   showCanvasSettingsMenu,
@@ -1720,6 +1692,9 @@ function CanvasContentHeader({
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
+  onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
   publishVersionLabel?: string;
   unpublishedDraftChangeCount?: number;
   showCanvasSettingsMenu?: boolean;
@@ -1759,6 +1734,9 @@ function CanvasContentHeader({
       onEnterEditMode={onEnterEditMode}
       enterEditModeDisabled={enterEditModeDisabled}
       enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
+      onExitEditMode={onExitEditMode}
+      exitEditModeDisabled={exitEditModeDisabled}
+      exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       publishVersionLabel={publishVersionLabel}
       unpublishedDraftChangeCount={unpublishedDraftChangeCount}
       showCanvasSettingsMenu={showCanvasSettingsMenu}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1732,11 +1732,7 @@ function CanvasContentHeader({
       discardVersionDisabledTooltip={discardVersionDisabledTooltip}
       mode={headerMode}
       onEnterEditMode={onEnterEditMode}
-      enterEditModeDisabled={enterEditModeDisabled}
-      enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
       onExitEditMode={onExitEditMode}
-      exitEditModeDisabled={exitEditModeDisabled}
-      exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       publishVersionLabel={publishVersionLabel}
       unpublishedDraftChangeCount={unpublishedDraftChangeCount}
       showCanvasSettingsMenu={showCanvasSettingsMenu}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1665,7 +1665,11 @@ function CanvasContentHeader({
   discardVersionDisabledTooltip,
   headerMode,
   onEnterEditMode,
+  enterEditModeDisabled,
+  enterEditModeDisabledTooltip,
   onExitEditMode,
+  exitEditModeDisabled,
+  exitEditModeDisabledTooltip,
   publishVersionLabel,
   unpublishedDraftChangeCount,
   showCanvasSettingsMenu,
@@ -1686,7 +1690,11 @@ function CanvasContentHeader({
   discardVersionDisabledTooltip?: string;
   headerMode?: "default" | "version-live" | "version-edit";
   onEnterEditMode?: () => void;
+  enterEditModeDisabled?: boolean;
+  enterEditModeDisabledTooltip?: string;
   onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
   publishVersionLabel?: string;
   unpublishedDraftChangeCount?: number;
   showCanvasSettingsMenu?: boolean;
@@ -1724,7 +1732,11 @@ function CanvasContentHeader({
       discardVersionDisabledTooltip={discardVersionDisabledTooltip}
       mode={headerMode}
       onEnterEditMode={onEnterEditMode}
+      enterEditModeDisabled={enterEditModeDisabled}
+      enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
       onExitEditMode={onExitEditMode}
+      exitEditModeDisabled={exitEditModeDisabled}
+      exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       publishVersionLabel={publishVersionLabel}
       unpublishedDraftChangeCount={unpublishedDraftChangeCount}
       showCanvasSettingsMenu={showCanvasSettingsMenu}


### PR DESCRIPTION
related to: https://github.com/superplanehq/superplane/issues/4129

Added a toggle between live and editor:

<img width="3186" height="546" alt="CleanShot 2026-04-16 at 01 58 34@2x" src="https://github.com/user-attachments/assets/f1d7fc24-01b9-4c08-b35a-b0ca7b762998" />
