### PR TITLE
fix: agent not able to list integration resources

### DIFF
--- a/agent/src/ai/superplane_client.py
+++ b/agent/src/ai/superplane_client.py
@@ -2,7 +2,6 @@ import re
 import warnings
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlencode
 
 # Suppress a known pydantic warning emitted by generated OpenAPI models.
 # Keep this narrow to avoid hiding unrelated warnings.
@@ -766,6 +765,37 @@ class SuperplaneClient:
             if isinstance(integration, OrganizationsIntegration)
         ]
 
+    # This endpoint expects top-level query keys (e.g. `?type=project`) so grpc-gateway
+    # can map them into req.parameters["type"]. The generated OpenAPI clients model it as
+    # a single `parameters` query field, which sends `?parameters=type%3Dproject` and
+    # causes a 400 ("resource type is required"), so we build the request manually here.
+    def _list_integration_resources_raw(
+        self, integration_id: str, query_params: dict[str, str]
+    ) -> OrganizationsListIntegrationResourcesResponse | None:
+        request = self._api_client.param_serialize(
+            method="GET",
+            resource_path="/api/v1/organizations/{id}/integrations/{integrationId}/resources",
+            path_params={"id": self._config.organization_id, "integrationId": integration_id},
+            query_params=list(query_params.items()),
+            header_params={"Accept": "application/json"},
+            post_params=[],
+            files={},
+            auth_settings=[],
+            collection_formats={},
+        )
+        response_data = self._api_client.call_api(
+            *request,
+            _request_timeout=self._config.timeout_seconds,
+        )
+        response_data.read()  # type: ignore[no-untyped-call]
+        deserialized = self._api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map={"200": "OrganizationsListIntegrationResourcesResponse"},
+        )
+        if isinstance(deserialized.data, OrganizationsListIntegrationResourcesResponse):
+            return deserialized.data
+        return None
+
     def list_integration_resources(
         self,
         integration_id: str,
@@ -777,14 +807,8 @@ class SuperplaneClient:
             query_params.update(
                 {str(key): str(value) for key, value in parameters.items() if key and value}
             )
-        encoded_parameters = urlencode(query_params)
         response = self._api_request(
-            lambda: self._organization_api.organizations_list_integration_resources(
-                self._config.organization_id,
-                integration_id,
-                parameters=encoded_parameters,
-                _request_timeout=self._config.timeout_seconds,
-            ),
+            lambda: self._list_integration_resources_raw(integration_id, query_params),
             operation="organizations_list_integration_resources",
         )
         if not isinstance(response, OrganizationsListIntegrationResourcesResponse):

--- a/agent/tests/test_superplane_client.py
+++ b/agent/tests/test_superplane_client.py
@@ -22,6 +22,9 @@ from superplaneapi.models.canvases_validate_canvas_version_changeset_response im
 from superplaneapi.models.components_list_components_response import (
     ComponentsListComponentsResponse,
 )
+from superplaneapi.models.organizations_list_integration_resources_response import (
+    OrganizationsListIntegrationResourcesResponse,
+)
 from superplaneapi.models.superplane_integrations_list_integrations_response import (
     SuperplaneIntegrationsListIntegrationsResponse,
 )
@@ -197,6 +200,84 @@ class FakeIntegrationApi:
         result = SuperplaneIntegrationsListIntegrationsResponse.from_dict(payload)
         assert result is not None
         return result
+
+
+class FakeListResourcesResponseData:
+    def __init__(self) -> None:
+        self.status = 200
+        self.data: bytes | None = None
+
+    def read(self) -> bytes:
+        self.data = b'{"resources":[{"id":"proj-1","name":"Project 1","type":"project"}]}'
+        return self.data
+
+    def getheader(self, name: str) -> str | None:
+        if name.lower() == "content-type":
+            return "application/json"
+        return None
+
+    def getheaders(self) -> list[tuple[str, str]]:
+        return [("content-type", "application/json")]
+
+
+class FakeListResourcesApiClient:
+    def __init__(self) -> None:
+        self.query_params: list[tuple[str, str]] = []
+        self.request_timeout: int | tuple[int, int] | None = None
+
+    def param_serialize(
+        self,
+        method: str,
+        resource_path: str,
+        path_params: dict[str, str] | None = None,
+        query_params: list[tuple[str, str]] | None = None,
+        header_params: dict[str, str] | None = None,
+        body: Any = None,
+        post_params: list[Any] | None = None,
+        files: dict[str, Any] | None = None,
+        auth_settings: list[str] | None = None,
+        collection_formats: dict[str, str] | None = None,
+        _host: str | None = None,
+        _request_auth: Any = None,
+    ) -> tuple[str, str, dict[str, str], Any, list[Any]]:
+        _ = (
+            path_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            auth_settings,
+            collection_formats,
+            _host,
+            _request_auth,
+        )
+        self.query_params = query_params or []
+        return method, f"https://example.test{resource_path}", {}, None, []
+
+    def call_api(
+        self,
+        method: str,
+        url: str,
+        header_params: dict[str, str] | None = None,
+        body: Any = None,
+        post_params: list[Any] | None = None,
+        _request_timeout: int | tuple[int, int] | None = None,
+    ) -> FakeListResourcesResponseData:
+        _ = (method, url, header_params, body, post_params)
+        self.request_timeout = _request_timeout
+        return FakeListResourcesResponseData()
+
+    def response_deserialize(
+        self,
+        response_data: FakeListResourcesResponseData,
+        response_types_map: dict[str, str] | None = None,
+    ) -> Any:
+        _ = (response_data, response_types_map)
+        payload = OrganizationsListIntegrationResourcesResponse.from_dict(
+            {"resources": [{"id": "proj-1", "name": "Project 1", "type": "project"}]}
+        )
+        assert payload is not None
+        return type("ResponseWrapper", (), {"data": payload})()
 
 
 class FakeSuperplaneClient(SuperplaneClient):
@@ -461,6 +542,26 @@ def test_list_node_executions_maps_rows() -> None:
     assert rows[0].result_message == "timeout"
     assert rows[0].created_at is not None
     assert rows[0].updated_at is not None
+
+
+def test_list_integration_resources_sends_top_level_query_params() -> None:
+    client = FakeSuperplaneClient(payloads={})
+    fake_api_client = FakeListResourcesApiClient()
+    client._api_client = fake_api_client  # type: ignore[assignment]
+
+    resources = client.list_integration_resources(
+        integration_id="int-1",
+        type="project",
+        parameters={"region": "us-east-1", "ignored-empty": "", "": "ignored-key"},
+    )
+
+    assert resources == [{"id": "proj-1", "name": "Project 1", "type": "project"}]
+    query = dict(fake_api_client.query_params)
+    assert query["type"] == "project"
+    assert query["region"] == "us-east-1"
+    assert "parameters" not in query
+    assert "ignored-empty" not in query
+    assert fake_api_client.request_timeout == client._config.timeout_seconds
 
 
 def test_get_canvas_shape_returns_nodes_and_connections_without_channel_details() -> None:


### PR DESCRIPTION
The ListResources endpoint is a bit special, and the OpenAPI-based SDK does not handle it properly. See https://github.com/superplanehq/superplane/pull/2891 for more details. Due to that, the agent has not been able to list integration resources, getting a `400 resource type is required` error every time. To work around it, we form the URL directly instead of relying on the generated SDK method.