### PR TITLE
fix: image builds

### DIFF
--- a/release/agent-image/build.sh
+++ b/release/agent-image/build.sh
@@ -20,6 +20,8 @@ IMAGE_REPO="${AGENT_IMAGE_REPO:-ghcr.io/superplanehq/superplane-agent}"
 
 echo "Building SuperPlane Agent image (${IMAGE_REPO})"
 
+make gen.setup.agent
+
 docker buildx build \
   --platform "linux/${ARCH}" \
   --progress=plain \

--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -20,12 +20,14 @@ IMAGE_REPO="${STANDARD_IMAGE_REPO:-ghcr.io/superplanehq/superplane}"
 
 echo "Building SuperPlane image (${IMAGE_REPO})"
 
+make gen.setup.backend
+make gen.setup.ui
+
 docker buildx build \
-  --platform "linux/${ARCH}" \
   --progress=plain \
   --provenance=false \
   --push \
   --cache-from ghcr.io/superplanehq/superplane-dev-base:app-latest \
-  -t "${IMAGE_REPO}:${VERSION}-${ARCH}" \
+  -t "dasdas-dasdasdas" \
   -f Dockerfile \
   .

--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -24,6 +24,7 @@ make gen.setup.backend
 make gen.setup.ui
 
 docker buildx build \
+  --platform "linux/${ARCH}" \
   --progress=plain \
   --provenance=false \
   --push \

--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -28,6 +28,6 @@ docker buildx build \
   --provenance=false \
   --push \
   --cache-from ghcr.io/superplanehq/superplane-dev-base:app-latest \
-  -t "dasdas-dasdasdas" \
+  -t "${IMAGE_REPO}:${VERSION}-${ARCH}" \
   -f Dockerfile \
   .


### PR DESCRIPTION
Release jobs clone a clean checkout and build images directly. Since generated protobuf/OpenAPI artifacts are no longer committed, the image builds must generate them before building. Without this, the app image fails during go build because pkg/protos/... packages are missing, and the agent image has the same issue for generated Python client/protobuf files.

