### PR TITLE
fix: use superplane-agent as default User-Agent

### DIFF
--- a/agent/src/ai/config.py
+++ b/agent/src/ai/config.py
@@ -9,7 +9,7 @@ class Config:
 
         self.superplane_base_url: str = self._parse_str("SUPERPLANE_BASE_URL")
         self.superplane_user_agent: str = self._parse_str(
-            "SUPERPLANE_USER_AGENT", default="curl/8.7.1"
+            "SUPERPLANE_USER_AGENT", default="superplane-agent"
         )
         self.drain_timeout: float = self._parse_float(
             "DRAIN_TIMEOUT",


### PR DESCRIPTION
## Summary

This PR updates the agent’s default User-Agent header to superplane-agent instead of curl/8.7.1, so API traffic is correctly attributed in logs/analytics. The header remains overridable via SUPERPLANE_USER_AGENT.

Closes #4088 