### PR TITLE
chore: update bottom toolbar

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5045,8 +5045,8 @@ export function WorkflowPageV2() {
           awaitingApprovalBanner={awaitingApprovalBanner}
           showCanvasSettingsMenu={canUpdateCanvas}
           isVersionControlOpen={isVersionControlOpen}
-          onOpenVersionControl={!hasEditableVersion ? () => setIsVersionControlOpen(true) : undefined}
-          versionControlButtonTooltip="Open versions"
+          onOpenVersionControl={!hasEditableVersion ? () => setIsVersionControlOpen((prev) => !prev) : undefined}
+          versionControlButtonTooltip={isVersionControlOpen ? "Close versions" : "Open versions"}
           versionControlNotificationCount={pendingApprovalVersions.length}
           showBottomStatusControls={!isTemplate}
           hideAddControls={isTemplate}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -132,6 +132,7 @@ import {
   generateUniqueNodeName,
   mapCanvasNodesToLogEntries,
   mapExecutionsToSidebarEvents,
+  mergeWorkflowLogEntries,
   mapQueueItemsToSidebarEvents,
   mapTriggerEventsToSidebarEvents,
   mapWorkflowEventsToRunLogEntries,
@@ -1942,58 +1943,27 @@ export function WorkflowPageV2() {
   );
 
   const logEntries = useMemo(() => {
-    if (!isViewingLiveVersion) {
-      return [];
-    }
-
     const nodes = canvas?.spec?.nodes || [];
-    const rootEvents = canvasEventsResponse?.events || [];
-
-    const runEntries = mapWorkflowEventsToRunLogEntries({
-      events: rootEvents,
-      nodes,
-      onNodeSelect: handleLogRunNodeSelect,
-      onExecutionSelect: handleLogRunExecutionSelect,
-    });
-
-    const mergedRunEntries = new Map<string, LogEntry>();
-    runEntries.forEach((entry) => mergedRunEntries.set(entry.id, entry));
-    liveRunEntries.forEach((entry) => mergedRunEntries.set(entry.id, entry));
-    const allRunEntries = Array.from(mergedRunEntries.values());
-
     const canvasEntries = mapCanvasNodesToLogEntries({
       nodes,
       workflowUpdatedAt: canvas?.metadata?.updatedAt || "",
       onNodeSelect: handleLogNodeSelect,
     });
 
-    const allCanvasEntries = [...liveCanvasEntries, ...canvasEntries];
-
-    const resolvedEntries = [...allRunEntries, ...allCanvasEntries].map((entry) => {
-      if (!entry.runItems?.length || resolvedExecutionIds.size === 0) {
-        return entry;
-      }
-
-      const runItems = entry.runItems.map((item) => {
-        if (!resolvedExecutionIds.has(item.id)) {
-          return item;
-        }
-        return {
-          ...item,
-          type: "resolved-error" as const,
-        };
-      });
-
-      return {
-        ...entry,
-        runItems,
-      };
+    const rootEvents = canvasEventsResponse?.events || [];
+    const runEntries = mapWorkflowEventsToRunLogEntries({
+      events: rootEvents,
+      nodes,
+      onNodeSelect: handleLogRunNodeSelect,
+      onExecutionSelect: handleLogRunExecutionSelect,
     });
-
-    return resolvedEntries.sort((a, b) => {
-      const aTime = Date.parse(a.timestamp || "") || 0;
-      const bTime = Date.parse(b.timestamp || "") || 0;
-      return aTime - bTime;
+    return mergeWorkflowLogEntries({
+      isViewingLiveVersion,
+      runEntries,
+      liveRunEntries,
+      canvasEntries,
+      liveCanvasEntries,
+      resolvedExecutionIds,
     });
   }, [
     isViewingLiveVersion,

--- a/web_src/src/pages/workflowv2/utils.spec.ts
+++ b/web_src/src/pages/workflowv2/utils.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasNodeExecutionRef } from "@/api-client";
 import { makeComponentsNode } from "@/test/factories";
-import { buildRunItemFromExecutionRef } from "./utils";
+import type { LogEntry } from "@/ui/CanvasLogSidebar";
+import { buildRunItemFromExecutionRef, mapCanvasNodesToLogEntries, mergeWorkflowLogEntries } from "./utils";
 
 function makeExecutionRef(overrides: Partial<CanvasesCanvasNodeExecutionRef> = {}): CanvasesCanvasNodeExecutionRef {
   return {
@@ -39,5 +40,72 @@ describe("buildRunItemFromExecutionRef", () => {
     });
 
     expect(runItem.type).toBe("resolved-error");
+  });
+});
+
+describe("mergeWorkflowLogEntries", () => {
+  it("keeps canvas warnings visible outside live mode", () => {
+    const canvasEntries = mapCanvasNodesToLogEntries({
+      nodes: [
+        makeComponentsNode({
+          id: "draft-node",
+          name: "Draft Node",
+          warningMessage: "Draft contains a warning",
+        }),
+      ],
+      workflowUpdatedAt: "2026-04-03T12:00:00Z",
+      onNodeSelect: vi.fn(),
+    });
+
+    const result = mergeWorkflowLogEntries({
+      isViewingLiveVersion: false,
+      runEntries: [
+        {
+          id: "run-1",
+          source: "runs",
+          timestamp: "2026-04-04T12:00:00Z",
+          title: "Live run",
+          type: "run",
+        } satisfies LogEntry,
+      ],
+      liveRunEntries: [],
+      canvasEntries,
+      liveCanvasEntries: [],
+      resolvedExecutionIds: new Set(["execution-1"]),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.type).toBe("warning");
+    expect(result[0]?.source).toBe("canvas");
+    expect(result[0]?.searchText).toContain("Draft contains a warning");
+  });
+
+  it("preserves resolved run item state in live mode", () => {
+    const result = mergeWorkflowLogEntries({
+      isViewingLiveVersion: true,
+      runEntries: [
+        {
+          id: "run-1",
+          source: "runs",
+          timestamp: "2026-04-04T12:00:00Z",
+          title: "Live run",
+          type: "run",
+          runItems: [
+            {
+              id: "execution-1",
+              type: "error",
+              title: "Execution failed",
+              timestamp: "2026-04-04T12:00:00Z",
+            },
+          ],
+        } satisfies LogEntry,
+      ],
+      liveRunEntries: [],
+      canvasEntries: [],
+      liveCanvasEntries: [],
+      resolvedExecutionIds: new Set(["execution-1"]),
+    });
+
+    expect(result[0]?.runItems?.[0]?.type).toBe("resolved-error");
   });
 });

--- a/web_src/src/pages/workflowv2/utils.spec.ts
+++ b/web_src/src/pages/workflowv2/utils.spec.ts
@@ -48,9 +48,14 @@ describe("mergeWorkflowLogEntries", () => {
     const canvasEntries = mapCanvasNodesToLogEntries({
       nodes: [
         makeComponentsNode({
-          id: "draft-node",
-          name: "Draft Node",
-          warningMessage: "Draft contains a warning",
+          id: "draft-node-newer",
+          name: "Draft Node Newer",
+          warningMessage: "Newer warning",
+        }),
+        makeComponentsNode({
+          id: "draft-node-older",
+          name: "Draft Node Older",
+          warningMessage: "Older warning",
         }),
       ],
       workflowUpdatedAt: "2026-04-03T12:00:00Z",
@@ -69,15 +74,21 @@ describe("mergeWorkflowLogEntries", () => {
         } satisfies LogEntry,
       ],
       liveRunEntries: [],
-      canvasEntries,
-      liveCanvasEntries: [],
+      canvasEntries: [canvasEntries[0]!],
+      liveCanvasEntries: [
+        {
+          ...canvasEntries[1]!,
+          timestamp: "2026-04-02T12:00:00Z",
+        },
+      ],
       resolvedExecutionIds: new Set(["execution-1"]),
     });
 
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
+    expect(result.map((entry) => entry.id)).toEqual(["warning-2", "warning-1"]);
     expect(result[0]?.type).toBe("warning");
     expect(result[0]?.source).toBe("canvas");
-    expect(result[0]?.searchText).toContain("Draft contains a warning");
+    expect(result[0]?.searchText).toContain("Older warning");
   });
 
   it("preserves resolved run item state in live mode", () => {

--- a/web_src/src/pages/workflowv2/utils.ts
+++ b/web_src/src/pages/workflowv2/utils.ts
@@ -509,6 +509,60 @@ export function mapCanvasNodesToLogEntries(options: {
   return entries;
 }
 
+export function mergeWorkflowLogEntries(options: {
+  isViewingLiveVersion: boolean;
+  runEntries: LogEntry[];
+  liveRunEntries: LogEntry[];
+  canvasEntries: LogEntry[];
+  liveCanvasEntries: LogEntry[];
+  resolvedExecutionIds: Set<string>;
+}): LogEntry[] {
+  const { isViewingLiveVersion, runEntries, liveRunEntries, canvasEntries, liveCanvasEntries, resolvedExecutionIds } =
+    options;
+  const allCanvasEntries = [...liveCanvasEntries, ...canvasEntries];
+
+  if (!isViewingLiveVersion) {
+    return allCanvasEntries.sort((a, b) => {
+      const aTime = Date.parse(a.timestamp || "") || 0;
+      const bTime = Date.parse(b.timestamp || "") || 0;
+      return bTime - aTime;
+    });
+  }
+
+  const mergedRunEntries = new Map<string, LogEntry>();
+  runEntries.forEach((entry) => mergedRunEntries.set(entry.id, entry));
+  liveRunEntries.forEach((entry) => mergedRunEntries.set(entry.id, entry));
+  const allRunEntries = Array.from(mergedRunEntries.values());
+
+  return [...allRunEntries, ...allCanvasEntries]
+    .map((entry) => {
+      if (!entry.runItems?.length || resolvedExecutionIds.size === 0) {
+        return entry;
+      }
+
+      const runItems = entry.runItems.map((item) => {
+        if (!resolvedExecutionIds.has(item.id)) {
+          return item;
+        }
+
+        return {
+          ...item,
+          type: "resolved-error" as const,
+        };
+      });
+
+      return {
+        ...entry,
+        runItems,
+      };
+    })
+    .sort((a, b) => {
+      const aTime = Date.parse(a.timestamp || "") || 0;
+      const bTime = Date.parse(b.timestamp || "") || 0;
+      return aTime - bTime;
+    });
+}
+
 export function buildCanvasStatusLogEntry(options: {
   id: string;
   message: string;

--- a/web_src/src/pages/workflowv2/utils.ts
+++ b/web_src/src/pages/workflowv2/utils.ts
@@ -525,7 +525,7 @@ export function mergeWorkflowLogEntries(options: {
     return allCanvasEntries.sort((a, b) => {
       const aTime = Date.parse(a.timestamp || "") || 0;
       const bTime = Date.parse(b.timestamp || "") || 0;
-      return bTime - aTime;
+      return aTime - bTime;
     });
   }
 

--- a/web_src/src/ui/CanvasLogSidebar/index.tsx
+++ b/web_src/src/ui/CanvasLogSidebar/index.tsx
@@ -49,6 +49,7 @@ export interface LogCounts {
 export interface CanvasLogSidebarProps {
   isOpen: boolean;
   onClose: () => void;
+  showRunsTab?: boolean;
   height?: number;
   defaultHeight?: number;
   minHeight?: number;
@@ -100,6 +101,7 @@ function formatLogTimestamp(value: string) {
 export function CanvasLogSidebar({
   isOpen,
   onClose,
+  showRunsTab = true,
   height,
   defaultHeight = 320,
   minHeight = 240,
@@ -123,9 +125,26 @@ export function CanvasLogSidebar({
   onRunExecutionSelect,
   onAcknowledgeErrors,
 }: CanvasLogSidebarProps) {
-  const [internalTab, setInternalTab] = useState<ConsoleTab>("runs");
-  const activeTab = controlledTab ?? internalTab;
-  const setActiveTab = onTabChange ?? setInternalTab;
+  const fallbackTab: Exclude<ConsoleTab, "runs"> = "errors";
+  const [internalTab, setInternalTab] = useState<ConsoleTab>(showRunsTab ? "runs" : fallbackTab);
+  const activeTab = useMemo(() => {
+    const nextTab = controlledTab ?? internalTab;
+    if (showRunsTab || nextTab !== "runs") {
+      return nextTab;
+    }
+    return fallbackTab;
+  }, [controlledTab, fallbackTab, internalTab, showRunsTab]);
+  const setActiveTab = useCallback(
+    (tab: ConsoleTab) => {
+      const nextTab = !showRunsTab && tab === "runs" ? fallbackTab : tab;
+      if (onTabChange) {
+        onTabChange(nextTab);
+        return;
+      }
+      setInternalTab(nextTab);
+    },
+    [fallbackTab, onTabChange, showRunsTab],
+  );
 
   const [internalHeight, setInternalHeight] = useState(defaultHeight);
   const [isResizing, setIsResizing] = useState(false);
@@ -183,6 +202,14 @@ export function CanvasLogSidebar({
 
     container.scrollTop = container.scrollHeight;
   }, [isOpen]);
+
+  useEffect(() => {
+    if (showRunsTab || activeTab !== "runs") {
+      return;
+    }
+
+    setActiveTab(fallbackTab);
+  }, [activeTab, fallbackTab, setActiveTab, showRunsTab]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -278,19 +305,21 @@ export function CanvasLogSidebar({
         </div>
         <div className="flex items-center justify-between pl-4 pr-2 border-b border-gray-200 h-8">
           <div className="flex items-center gap-4 -mb-2">
-            <button
-              type="button"
-              onClick={() => setActiveTab("runs")}
-              className={cn(
-                "flex items-center gap-2 pb-2 !text-[13px] font-medium leading-none border-b transition-colors",
-                activeTab === "runs"
-                  ? "border-gray-800 text-gray-800"
-                  : "border-transparent text-gray-500 hover:text-gray-800",
-              )}
-            >
-              <Play className="h-4 w-4" />
-              Runs
-            </button>
+            {showRunsTab ? (
+              <button
+                type="button"
+                onClick={() => setActiveTab("runs")}
+                className={cn(
+                  "flex items-center gap-2 pb-2 !text-[13px] font-medium leading-none border-b transition-colors",
+                  activeTab === "runs"
+                    ? "border-gray-800 text-gray-800"
+                    : "border-transparent text-gray-500 hover:text-gray-800",
+                )}
+              >
+                <Play className="h-4 w-4" />
+                Runs
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={() => setActiveTab("errors")}

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -2,7 +2,7 @@ import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
-import { MoreVertical, Settings } from "lucide-react";
+import { GitBranch, MoreVertical, Settings } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../button";
 import { CanvasModeToggle } from "./components/CanvasModeToggle";
@@ -38,6 +38,10 @@ interface HeaderProps {
   unpublishedDraftChangeCount?: number;
   /** Canvas settings route requires `canvases:update`; hide the menu when the user cannot update. */
   showCanvasSettingsMenu?: boolean;
+  isVersionControlOpen?: boolean;
+  onOpenVersionControl?: () => void;
+  versionControlButtonTooltip?: string;
+  versionControlNotificationCount?: number;
 }
 
 export function Header({
@@ -65,6 +69,10 @@ export function Header({
   publishVersionLabel = "Publish",
   unpublishedDraftChangeCount = 0,
   showCanvasSettingsMenu = true,
+  isVersionControlOpen,
+  onOpenVersionControl,
+  versionControlButtonTooltip,
+  versionControlNotificationCount = 0,
 }: HeaderProps) {
   const headerTitle = canvasName.trim() || "Canvas";
 
@@ -107,6 +115,10 @@ export function Header({
         onExitEditMode={onExitEditMode}
         exitEditModeDisabled={exitEditModeDisabled}
         exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
+        isVersionControlOpen={isVersionControlOpen}
+        onOpenVersionControl={onOpenVersionControl}
+        versionControlButtonTooltip={versionControlButtonTooltip}
+        versionControlNotificationCount={versionControlNotificationCount}
       />
     </header>
   );
@@ -181,6 +193,10 @@ function SecondaryHeader({
   publishButtonLabel,
   onEnterEditMode,
   onExitEditMode,
+  isVersionControlOpen,
+  onOpenVersionControl,
+  versionControlButtonTooltip,
+  versionControlNotificationCount = 0,
 }: {
   isDefaultMode: boolean;
   onSave?: () => void;
@@ -204,6 +220,10 @@ function SecondaryHeader({
   onExitEditMode?: () => void;
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
+  isVersionControlOpen?: boolean;
+  onOpenVersionControl?: () => void;
+  versionControlButtonTooltip?: string;
+  versionControlNotificationCount?: number;
 }) {
   const showCanvasViewModeToggle = headerMode === "version-live" || headerMode === "version-edit";
   const canvasViewMode = headerMode === "version-edit" ? "version-edit" : "version-live";
@@ -218,36 +238,154 @@ function SecondaryHeader({
         </div>
       </div>
 
-      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
-        {isDefaultMode && onSave && !saveButtonHidden ? (
-          <SaveButton
-            onSave={onSave}
-            saveDisabled={saveDisabled}
-            saveDisabledTooltip={saveDisabledTooltip}
-            saveIsPrimary={saveIsPrimary}
-          />
-        ) : null}
-
-        {showVersionEditActions ? (
-          <div className="flex items-center gap-2">
-            {hasChanges ? (
-              <DiscardDraftButton
-                onDiscard={() => onDiscardVersion?.()}
-                disabled={discardVersionDisabled || !onDiscardVersion}
-                disabledTooltip={discardVersionDisabledTooltip}
-              />
-            ) : null}
-            <PublishVersionButton
-              onPublish={() => onPublishVersion?.()}
-              label={publishButtonLabel}
-              disabled={publishVersionDisabled || !onPublishVersion}
-              publishVersionDisabled={!!publishVersionDisabled}
-              publishVersionDisabledTooltip={publishVersionDisabledTooltip}
-            />
-          </div>
-        ) : null}
-      </div>
+      <SecondaryHeaderActions
+        headerMode={headerMode}
+        isVersionControlOpen={isVersionControlOpen}
+        onOpenVersionControl={onOpenVersionControl}
+        versionControlButtonTooltip={versionControlButtonTooltip}
+        versionControlNotificationCount={versionControlNotificationCount}
+        isDefaultMode={isDefaultMode}
+        onSave={onSave}
+        saveButtonHidden={saveButtonHidden}
+        saveDisabled={saveDisabled}
+        saveDisabledTooltip={saveDisabledTooltip}
+        saveIsPrimary={saveIsPrimary}
+        showVersionEditActions={showVersionEditActions}
+        hasChanges={hasChanges}
+        onDiscardVersion={onDiscardVersion}
+        discardVersionDisabled={discardVersionDisabled}
+        discardVersionDisabledTooltip={discardVersionDisabledTooltip}
+        onPublishVersion={onPublishVersion}
+        publishButtonLabel={publishButtonLabel}
+        publishVersionDisabled={publishVersionDisabled}
+        publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+      />
     </div>
+  );
+}
+
+function SecondaryHeaderActions({
+  headerMode,
+  isVersionControlOpen,
+  onOpenVersionControl,
+  versionControlButtonTooltip,
+  versionControlNotificationCount = 0,
+  isDefaultMode,
+  onSave,
+  saveButtonHidden,
+  saveDisabled,
+  saveDisabledTooltip,
+  saveIsPrimary,
+  showVersionEditActions,
+  hasChanges,
+  onDiscardVersion,
+  discardVersionDisabled,
+  discardVersionDisabledTooltip,
+  onPublishVersion,
+  publishButtonLabel,
+  publishVersionDisabled,
+  publishVersionDisabledTooltip,
+}: {
+  headerMode: HeaderMode;
+  isVersionControlOpen?: boolean;
+  onOpenVersionControl?: () => void;
+  versionControlButtonTooltip?: string;
+  versionControlNotificationCount?: number;
+  isDefaultMode: boolean;
+  onSave?: () => void;
+  saveButtonHidden?: boolean;
+  saveDisabled?: boolean;
+  saveDisabledTooltip?: string;
+  saveIsPrimary?: boolean;
+  showVersionEditActions: boolean;
+  hasChanges: boolean;
+  onDiscardVersion?: () => void;
+  discardVersionDisabled?: boolean;
+  discardVersionDisabledTooltip?: string;
+  onPublishVersion?: () => void;
+  publishButtonLabel: string;
+  publishVersionDisabled?: boolean;
+  publishVersionDisabledTooltip?: string;
+}) {
+  const showVersionControlTrigger = headerMode === "version-live" && !!onOpenVersionControl;
+
+  return (
+    <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
+      {showVersionControlTrigger ? (
+        <VersionControlButton
+          onToggle={onOpenVersionControl}
+          isOpen={!!isVersionControlOpen}
+          tooltip={versionControlButtonTooltip}
+          notificationCount={versionControlNotificationCount}
+        />
+      ) : null}
+
+      {isDefaultMode && onSave && !saveButtonHidden ? (
+        <SaveButton
+          onSave={onSave}
+          saveDisabled={saveDisabled}
+          saveDisabledTooltip={saveDisabledTooltip}
+          saveIsPrimary={saveIsPrimary}
+        />
+      ) : null}
+
+      {showVersionEditActions ? (
+        <div className="flex items-center gap-2">
+          {hasChanges ? (
+            <DiscardDraftButton
+              onDiscard={() => onDiscardVersion?.()}
+              disabled={discardVersionDisabled || !onDiscardVersion}
+              disabledTooltip={discardVersionDisabledTooltip}
+            />
+          ) : null}
+          <PublishVersionButton
+            onPublish={() => onPublishVersion?.()}
+            label={publishButtonLabel}
+            disabled={publishVersionDisabled || !onPublishVersion}
+            publishVersionDisabled={!!publishVersionDisabled}
+            publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function VersionControlButton({
+  onToggle,
+  isOpen,
+  tooltip,
+  notificationCount,
+}: {
+  onToggle: () => void;
+  isOpen: boolean;
+  tooltip?: string;
+  notificationCount: number;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="relative inline-flex">
+          <UIButton
+            type="button"
+            variant="outline"
+            size="icon"
+            className={isOpen ? "h-8 w-8 bg-slate-200 border-slate-300" : "h-8 w-8"}
+            onClick={onToggle}
+            aria-label={isOpen ? "Close version control" : "Open version control"}
+            aria-pressed={isOpen}
+          >
+            <GitBranch className="h-4 w-4" />
+          </UIButton>
+          {notificationCount > 0 ? (
+            <span className="absolute left-5 -top-1.5 inline-flex min-w-[1.125rem] items-center justify-center rounded-full bg-orange-600 px-1 text-[10px] font-semibold leading-4 text-white">
+              {notificationCount > 99 ? "99+" : notificationCount}
+            </span>
+          ) : null}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip || "Open version control"}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -20,17 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ZoomSlider } from "@/components/zoom-slider";
 import { cn } from "@/lib/utils";
-import {
-  CircleX,
-  Copy,
-  Group,
-  LayoutDashboard,
-  LayoutGrid,
-  Loader2,
-  Play,
-  Trash2,
-  TriangleAlert,
-} from "lucide-react";
+import { CircleX, Copy, Group, LayoutDashboard, LayoutGrid, Loader2, Play, Trash2, TriangleAlert } from "lucide-react";
 import {
   Component,
   memo,

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -21,11 +21,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ZoomSlider } from "@/components/zoom-slider";
 import { cn } from "@/lib/utils";
 import {
-  ChevronsDownUp,
-  ChevronsUpDown,
   CircleX,
   Copy,
-  GitBranch,
   Group,
   LayoutDashboard,
   LayoutGrid,
@@ -1175,6 +1172,10 @@ function CanvasPage(props: CanvasPageProps) {
           publishVersionLabel={props.publishVersionLabel}
           unpublishedDraftChangeCount={props.unpublishedDraftChangeCount}
           showCanvasSettingsMenu={props.showCanvasSettingsMenu}
+          isVersionControlOpen={props.isVersionControlOpen}
+          onOpenVersionControl={props.onOpenVersionControl}
+          versionControlButtonTooltip={props.versionControlButtonTooltip}
+          versionControlNotificationCount={props.versionControlNotificationCount}
         />
         {props.headerBanner ? <div className="border-b border-black/20">{props.headerBanner}</div> : null}
       </div>
@@ -1284,11 +1285,8 @@ function CanvasPage(props: CanvasPageProps) {
               highlightedNodeIds={highlightedNodeIds}
               workflowNodes={props.workflowNodes}
               setCurrentTab={setCurrentTab}
-              isVersionControlOpen={props.isVersionControlOpen}
-              onOpenVersionControl={props.onOpenVersionControl}
-              versionControlButtonTooltip={props.versionControlButtonTooltip}
-              versionControlNotificationCount={props.versionControlNotificationCount}
               showBottomStatusControls={props.showBottomStatusControls}
+              headerMode={props.headerMode}
               isAutoLayoutOnUpdateEnabled={props.isAutoLayoutOnUpdateEnabled}
               onToggleAutoLayoutOnUpdate={props.onToggleAutoLayoutOnUpdate}
               autoLayoutOnUpdateDisabled={props.autoLayoutOnUpdateDisabled}
@@ -1672,6 +1670,10 @@ function CanvasContentHeader({
   publishVersionLabel,
   unpublishedDraftChangeCount,
   showCanvasSettingsMenu,
+  isVersionControlOpen,
+  onOpenVersionControl,
+  versionControlButtonTooltip,
+  versionControlNotificationCount,
 }: {
   state: CanvasPageState;
   canvasName: string;
@@ -1697,6 +1699,10 @@ function CanvasContentHeader({
   publishVersionLabel?: string;
   unpublishedDraftChangeCount?: number;
   showCanvasSettingsMenu?: boolean;
+  isVersionControlOpen?: boolean;
+  onOpenVersionControl?: () => void;
+  versionControlButtonTooltip?: string;
+  versionControlNotificationCount?: number;
 }) {
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -1739,6 +1745,10 @@ function CanvasContentHeader({
       publishVersionLabel={publishVersionLabel}
       unpublishedDraftChangeCount={unpublishedDraftChangeCount}
       showCanvasSettingsMenu={showCanvasSettingsMenu}
+      isVersionControlOpen={isVersionControlOpen}
+      onOpenVersionControl={onOpenVersionControl}
+      versionControlButtonTooltip={versionControlButtonTooltip}
+      versionControlNotificationCount={versionControlNotificationCount}
     />
   );
 }
@@ -1807,11 +1817,8 @@ function CanvasContent({
   highlightedNodeIds,
   workflowNodes,
   setCurrentTab,
-  isVersionControlOpen,
-  onOpenVersionControl,
-  versionControlButtonTooltip,
-  versionControlNotificationCount = 0,
   showBottomStatusControls = true,
+  headerMode,
   isAutoLayoutOnUpdateEnabled,
   onToggleAutoLayoutOnUpdate,
   autoLayoutOnUpdateDisabled,
@@ -1873,11 +1880,8 @@ function CanvasContent({
   highlightedNodeIds: Set<string>;
   workflowNodes?: ComponentsNode[];
   setCurrentTab?: (tab: "latest" | "settings" | "docs") => void;
-  isVersionControlOpen?: boolean;
-  onOpenVersionControl?: () => void;
-  versionControlButtonTooltip?: string;
-  versionControlNotificationCount?: number;
   showBottomStatusControls?: boolean;
+  headerMode?: CanvasPageProps["headerMode"];
   isAutoLayoutOnUpdateEnabled?: boolean;
   onToggleAutoLayoutOnUpdate?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
@@ -1983,6 +1987,8 @@ function CanvasContent({
     return saved ? parseInt(saved, 10) : 320;
   });
   const [isSnapToGridEnabled, setIsSnapToGridEnabled] = useState(true);
+  const isLiveMode = headerMode === "version-live";
+  const isEditMode = !isLiveMode;
   useEffect(() => {
     if (showBottomStatusControls) {
       localStorage.setItem(CONSOLE_OPEN_STORAGE_KEY, String(isLogSidebarOpen));
@@ -2012,6 +2018,14 @@ function CanvasContent({
       setIsLogSidebarOpen(false);
     }
   }, [showBottomStatusControls]);
+
+  useEffect(() => {
+    if (isLiveMode || consoleTab !== "runs") {
+      return;
+    }
+
+    setConsoleTab("errors");
+  }, [consoleTab, isLiveMode]);
 
   const [multiSelectedNodes, setMultiSelectedNodes] = useState<ReactFlowNode[]>([]);
   const [isSelecting, setIsSelecting] = useState(false);
@@ -2200,10 +2214,6 @@ function CanvasContent({
     [reportZoom, viewportRef],
   );
 
-  const handleToggleCollapse = useCallback(() => {
-    state.toggleCollapse();
-  }, [state.toggleCollapse]);
-
   const handleToggleAutoLayoutOnUpdate = useCallback(() => {
     if (isReadOnly || !onToggleAutoLayoutOnUpdate || autoLayoutOnUpdateDisabled) {
       return;
@@ -2236,20 +2246,6 @@ function CanvasContent({
     );
     fitView({ nodes: [targetNode], duration: 500, maxZoom: 1.2 });
   }, [focusRequest, fitView]);
-
-  // Add keyboard shortcut for toggling collapse/expand
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Toggle collapse: Ctrl/Cmd + E
-      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === "e") {
-        e.preventDefault();
-        handleToggleCollapse();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleToggleCollapse]);
 
   const handlePaneClick = useCallback(() => {
     previouslySelectedRef.current = new Set();
@@ -2551,8 +2547,6 @@ function CanvasContent({
     setIsLogSidebarOpen(true);
   }, []);
 
-  const showVersionControlTrigger = showBottomStatusControls && !!onOpenVersionControl && !isVersionControlOpen;
-
   return (
     <div className="h-full w-full relative">
       <div className="h-full">
@@ -2621,74 +2615,35 @@ function CanvasContent({
                 </div>
               )}
               <div className="flex items-center gap-3">
-                {showVersionControlTrigger ? (
-                  <div className="bg-white text-gray-800 outline-1 outline-slate-950/15 flex items-center rounded-md p-0.5 h-8">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="relative inline-flex">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 items-center text-xs font-medium gap-1.5"
-                            onClick={onOpenVersionControl}
-                            aria-label="Open version control"
-                          >
-                            <GitBranch className="h-3 w-3" />
-                          </Button>
-                          {versionControlNotificationCount > 0 ? (
-                            <span className="absolute left-6 -top-2 inline-flex min-w-[1.125rem] items-center justify-center rounded-full bg-orange-600 px-1 text-[10px] font-semibold leading-4 text-white">
-                              {versionControlNotificationCount > 99 ? "99+" : versionControlNotificationCount}
-                            </span>
-                          ) : null}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>{versionControlButtonTooltip || "Open version control"}</TooltipContent>
-                    </Tooltip>
-                  </div>
-                ) : null}
                 <ZoomSlider
                   orientation="horizontal"
                   className="!static !m-0"
-                  isSnapToGridEnabled={isSnapToGridEnabled}
-                  onSnapToGridToggle={() => setIsSnapToGridEnabled((prev) => !prev)}
+                  isSnapToGridEnabled={isEditMode ? isSnapToGridEnabled : undefined}
+                  onSnapToGridToggle={isEditMode ? () => setIsSnapToGridEnabled((prev) => !prev) : undefined}
                 >
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="ghost" size="icon-sm" onClick={handleToggleCollapse}>
-                        {state.isCollapsed ? (
-                          <ChevronsUpDown className="h-3 w-3" />
-                        ) : (
-                          <ChevronsDownUp className="h-3 w-3" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {state.isCollapsed
-                        ? "Switch components to Detailed view (Ctrl/Cmd + E)"
-                        : "Switch components to Compact view (Ctrl/Cmd + E)"}
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 w-8 px-0 text-slate-600 hover:text-slate-900"
-                          onClick={handleToggleAutoLayoutOnUpdate}
-                          disabled={isAutoLayoutToggleDisabled}
-                          aria-pressed={isAutoLayoutOnUpdateEnabled}
-                        >
-                          {isAutoLayoutOnUpdateEnabled ? (
-                            <LayoutGrid className="h-3 w-3" />
-                          ) : (
-                            <LayoutDashboard className="h-3 w-3" />
-                          )}
-                        </Button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{autoLayoutTooltipMessage}</TooltipContent>
-                  </Tooltip>
+                  {isEditMode ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 px-0 text-slate-600 hover:text-slate-900"
+                            onClick={handleToggleAutoLayoutOnUpdate}
+                            disabled={isAutoLayoutToggleDisabled}
+                            aria-pressed={isAutoLayoutOnUpdateEnabled}
+                          >
+                            {isAutoLayoutOnUpdateEnabled ? (
+                              <LayoutGrid className="h-3 w-3" />
+                            ) : (
+                              <LayoutDashboard className="h-3 w-3" />
+                            )}
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{autoLayoutTooltipMessage}</TooltipContent>
+                    </Tooltip>
+                  ) : null}
                   <NodeSearch
                     onSearch={(searchString) => {
                       const query = searchString.toLowerCase();
@@ -2712,36 +2667,41 @@ function CanvasContent({
                 </ZoomSlider>
                 {showBottomStatusControls && !isLogSidebarOpen ? (
                   <div className="bg-white text-gray-800 outline-1 outline-slate-950/15 flex items-center gap-1 rounded-md p-0.5 h-8">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className={cn(
-                            "h-8 items-center text-xs font-medium",
-                            runsCountInfo.running > 0 && "text-blue-600",
-                          )}
-                          onClick={() => handleLogButtonClick("runs")}
-                        >
-                          {runsCountInfo.running > 0 ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                          ) : (
-                            <Play className="h-3 w-3" />
-                          )}
-                          <span className={cn(runsCountInfo.running > 0 ? "text-blue-600" : "text-gray-800")}>
-                            Runs ·{" "}
-                            <span className="tabular-nums">
-                              {(runsCountInfo.running > 0 ? runsCountInfo.running : runsCountInfo.total).toLocaleString(
-                                "en-US",
-                              )}
+                    {isLiveMode ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className={cn(
+                              "h-8 items-center text-xs font-medium",
+                              runsCountInfo.running > 0 && "text-blue-600",
+                            )}
+                            onClick={() => handleLogButtonClick("runs")}
+                          >
+                            {runsCountInfo.running > 0 ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <Play className="h-3 w-3" />
+                            )}
+                            <span className={cn(runsCountInfo.running > 0 ? "text-blue-600" : "text-gray-800")}>
+                              Runs ·{" "}
+                              <span className="tabular-nums">
+                                {(runsCountInfo.running > 0
+                                  ? runsCountInfo.running
+                                  : runsCountInfo.total
+                                ).toLocaleString("en-US")}
+                              </span>
                             </span>
-                          </span>
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {runsCountInfo.running > 0 ? `${runsCountInfo.running} running` : `${runsCountInfo.total} runs`}
-                      </TooltipContent>
-                    </Tooltip>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {runsCountInfo.running > 0
+                            ? `${runsCountInfo.running} running`
+                            : `${runsCountInfo.total} runs`}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null}
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
@@ -2939,6 +2899,7 @@ function CanvasContent({
         <CanvasLogSidebar
           isOpen={isLogSidebarOpen}
           onClose={() => setIsLogSidebarOpen(false)}
+          showRunsTab={isLiveMode}
           height={logSidebarHeight}
           onHeightChange={setLogSidebarHeight}
           searchValue={logSearch}

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -1,6 +1,6 @@
 import type { Edge, EdgeChange, Node, NodeChange, NodePositionChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CanvasPageProps } from ".";
 
 export interface CanvasPageState {
@@ -13,8 +13,6 @@ export interface CanvasPageState {
   onNodesChange: (changes: NodeChange[]) => void;
   onEdgesChange: (changes: EdgeChange[]) => void;
 
-  isCollapsed: boolean;
-  toggleCollapse: () => void;
   toggleNodeCollapse: (nodeId: string) => void;
 
   componentSidebar: {
@@ -28,30 +26,13 @@ export interface CanvasPageState {
 export function useCanvasState(props: CanvasPageProps): CanvasPageState {
   const { nodes: initialNodes, edges: initialEdges, startCollapsed } = props;
 
-  const loadedFirstCollapsedNodeIds = useRef(false);
   const [nodes, setNodes] = useState<Node[]>(() => initialNodes ?? []);
   const [edges, setEdges] = useState<Edge[]>(() => initialEdges ?? []);
-  const isCollapsed = useMemo<boolean>(() => {
-    if (startCollapsed !== undefined) {
-      return startCollapsed;
-    }
-
-    const isMajorityCollapsed =
-      nodes.filter((node) => {
-        const nodeType = node.data.type as string;
-        const componentData = node.data[nodeType] as { collapsed: boolean };
-        return componentData.collapsed;
-      }).length >
-      nodes.length / 2;
-    return isMajorityCollapsed;
-  }, [startCollapsed, nodes]);
-  const [, setCollapsedNodeIds] = useState<string[]>([]);
 
   // Sync node data changes from parent (but not collapsed state or selected state)
   useEffect(() => {
     if (!initialNodes) return;
 
-    const newCollapsedNodeIds: string[] = [];
     setNodes((currentNodes) => {
       // Preserve locally-added template and pending connection nodes
       const localOnlyNodes = currentNodes.filter((node) => node.data.isTemplate || node.data.isPendingConnection);
@@ -66,7 +47,6 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
           const existingType = existingNode.data.type as string;
           const existingCollapsed =
             existingType && (existingNode.data[existingType] as { collapsed: boolean })?.collapsed;
-          newCollapsedNodeIds.push(existingNode.id);
           nodeData[nodeType] = {
             ...nodeData[nodeType],
             collapsed: existingCollapsed,
@@ -86,22 +66,6 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
       // Append local-only nodes at the end
       return [...syncedNodes, ...localOnlyNodes];
     });
-  }, [initialNodes]);
-
-  useEffect(() => {
-    if (initialNodes.length === 0 || loadedFirstCollapsedNodeIds.current) return;
-
-    setCollapsedNodeIds(
-      initialNodes
-        .filter((node) => {
-          const nodeType = node.data.type as string;
-          const componentData = node.data[nodeType] as { collapsed: boolean };
-          return componentData.collapsed;
-        })
-        .map((node) => node.id),
-    );
-
-    loadedFirstCollapsedNodeIds.current = true;
   }, [initialNodes]);
 
   useEffect(() => {
@@ -200,50 +164,21 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
     [props.onEdgeDelete],
   );
 
-  const toggleCollapse = useCallback(() => {
-    const newCollapsed = !isCollapsed;
-    setNodes((nds) =>
-      nds.map((node) => {
-        const nodeData = { ...node.data };
-        const nodeType = nodeData.type as string;
-
-        if (nodeType && nodeData[nodeType]) {
-          nodeData[nodeType] = {
-            ...nodeData[nodeType],
-            collapsed: newCollapsed,
-          };
-        }
-
-        return { ...node, data: nodeData };
-      }),
-    );
-
-    if (newCollapsed) {
-      setCollapsedNodeIds(nodes.map((node) => node.id));
-    } else {
-      setCollapsedNodeIds([]);
-    }
-    return newCollapsed;
-  }, [nodes, setNodes, isCollapsed]);
-
   const toggleNodeCollapse = useCallback(
     (nodeId: string) => {
-      let isCurrentlyCollapsed = false;
-      setCollapsedNodeIds((prev) => {
-        isCurrentlyCollapsed = prev.includes(nodeId);
-        return isCurrentlyCollapsed ? prev.filter((id) => id !== nodeId) : [...prev, nodeId];
-      });
-
       setNodes((nds) =>
         nds.map((node) => {
+          if (node.id !== nodeId) {
+            return node;
+          }
+
           const nodeData = { ...node.data };
           const nodeType = nodeData.type as string;
-          const componentData = nodeData[nodeType] as { collapsed: boolean };
-
           if (nodeType && nodeData[nodeType]) {
+            const componentData = nodeData[nodeType] as { collapsed?: boolean };
             nodeData[nodeType] = {
               ...nodeData[nodeType],
-              collapsed: nodeId === node.id ? !isCurrentlyCollapsed : (componentData.collapsed as boolean),
+              collapsed: !componentData.collapsed,
             };
           }
 
@@ -264,8 +199,6 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
     setEdges,
     onNodesChange,
     onEdgesChange,
-    isCollapsed,
-    toggleCollapse,
     toggleNodeCollapse,
   };
 }


### PR DESCRIPTION
## Summary

- remove the global compact toggle from the canvas bottom toolbar
- show auto-layout and snap-to-grid only in edit mode
- show runs controls only in live mode, while keeping errors and warnings in both modes
- move the versions control into the header action area on live mode
- keep the versions control as an icon-only toggle with tooltip and active state
- restore draft warnings in edit mode logs sidebar


## Live Canvas

<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/9af74487-90ed-4fb9-b58f-194339a25ca9" />

## Edit Mode

<img width="3024" height="1646" alt="image" src="https://github.com/user-attachments/assets/941fa3e0-70c4-4569-a5dd-5fa62301726a" />
