### PR TITLE
fix: use edit-mode empty states in canvas blocks

### DIFF
--- a/web_src/src/pages/workflowv2/index.spec.ts
+++ b/web_src/src/pages/workflowv2/index.spec.ts
@@ -17,6 +17,7 @@ type FallbackComponentData = {
     error?: string;
     emptyStateProps?: {
       title?: string;
+      purpose?: string;
     };
   };
 };
@@ -92,6 +93,7 @@ describe("canvas node preparation resilience", () => {
     });
     expect(fallbackData.component.error).toBeUndefined();
     expect(fallbackData.component.emptyStateProps?.title).toBe("Can't display");
+    expect(fallbackData.component.emptyStateProps?.purpose).toBe("fallback");
   });
 
   it("returns null when a custom field renderer throws so sidebar rendering stays alive", () => {

--- a/web_src/src/pages/workflowv2/lib/canvas-node-fallback.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-fallback.ts
@@ -17,6 +17,7 @@ function buildMinimalEmptyStateProps(icon?: ComponentType<{ size?: number }>) {
     icon,
     title: CANVAS_NODE_FALLBACK_MESSAGE,
     description: undefined,
+    purpose: "fallback" as const,
   };
 }
 

--- a/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
@@ -245,6 +245,7 @@ function buildPlaceholderComponentNode(node: ComponentsNode): CanvasNode {
         emptyStateProps: {
           icon: Puzzle,
           title: "Select a component from the sidebar",
+          purpose: "setup",
         },
         error: "Select a component from the sidebar",
         parameters: [],
@@ -268,6 +269,7 @@ function resolveComponentEmptyStateProps(
     ...componentBaseProps.emptyStateProps,
     icon: componentBaseProps.emptyStateProps?.icon || Puzzle,
     title: "Finish configuring this component",
+    purpose: "setup",
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/safeMappers.ts
+++ b/web_src/src/pages/workflowv2/mappers/safeMappers.ts
@@ -111,6 +111,12 @@ function normalizeEmptyStateProps(
         : undefined,
     title: sanitizeString(emptyStateProps.title),
     description: sanitizeString(emptyStateProps.description),
+    purpose:
+      emptyStateProps.purpose === "runtime" ||
+      emptyStateProps.purpose === "setup" ||
+      emptyStateProps.purpose === "fallback"
+        ? emptyStateProps.purpose
+        : undefined,
   };
 }
 
@@ -159,6 +165,7 @@ function applyComponentBaseFallbacks(
     icon: undefined,
     title: CANVAS_NODE_FALLBACK_MESSAGE,
     description: undefined,
+    purpose: "fallback",
   };
   const isFallback = !isRecord(props) || typeof record.title !== "string";
 
@@ -284,6 +291,7 @@ function applyTriggerFallbacks(
       icon: undefined,
       title: CANVAS_NODE_FALLBACK_MESSAGE,
       description: undefined,
+      purpose: "fallback",
     },
   };
 }
@@ -323,6 +331,7 @@ export function createSafeComponentMapper(mapper: ComponentBaseMapper, mapperNam
           emptyStateProps: {
             title: CANVAS_NODE_FALLBACK_MESSAGE,
             description: undefined,
+            purpose: "fallback",
           },
         };
         return fallbackProps;
@@ -372,6 +381,7 @@ export function createSafeTriggerRenderer(renderer: TriggerRenderer, rendererNam
           emptyStateProps: {
             title: CANVAS_NODE_FALLBACK_MESSAGE,
             description: undefined,
+            purpose: "fallback",
           },
         };
         return fallbackProps;

--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -64,6 +64,50 @@ describe("Block fallback rendering", () => {
     expect(screen.getByText("Can't display")).toBeInTheDocument();
   });
 
+  it("replaces runtime empty states with edit-mode copy", () => {
+    render(
+      <Block
+        canvasMode="edit"
+        data={{
+          label: "Draft Component",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+          component: {
+            title: "Draft Component",
+            iconSlug: "box",
+            collapsed: false,
+            includeEmptyState: true,
+            emptyStateProps: {
+              title: "Waiting for the first run",
+              purpose: "runtime",
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Runtime data appears in live mode")).toBeInTheDocument();
+    expect(screen.queryByText("Waiting for the first run")).not.toBeInTheDocument();
+  });
+
+  it("preserves fallback empty states in edit mode", () => {
+    render(
+      <Block
+        canvasMode="edit"
+        data={{
+          label: "Broken Component",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Can't display")).toBeInTheDocument();
+    expect(screen.queryByText("Runtime data appears in live mode")).not.toBeInTheDocument();
+  });
+
   it("does not highlight a right handle when the target node is already connected", () => {
     render(
       <Block

--- a/web_src/src/ui/CanvasPage/Block/content.tsx
+++ b/web_src/src/ui/CanvasPage/Block/content.tsx
@@ -44,16 +44,20 @@ function getActionProps(data: BlockProps["data"], compactView: boolean, props: P
   };
 }
 
-function renderFallbackBlock(
-  data: BlockProps["data"],
-  fallbackTitle: string,
-  selected: boolean,
-  showHeader: boolean | undefined,
-  actionProps: ReturnType<typeof getActionProps>,
-) {
+function renderFallbackBlock(args: {
+  data: BlockProps["data"];
+  fallbackTitle: string;
+  selected: boolean;
+  showHeader: boolean | undefined;
+  canvasMode: BlockProps["canvasMode"];
+  actionProps: ReturnType<typeof getActionProps>;
+}) {
+  const { data, fallbackTitle, selected, showHeader, canvasMode, actionProps } = args;
+
   return (
     <ComponentBase
       {...buildFallbackComponentProps(data, fallbackTitle)}
+      canvasMode={canvasMode}
       selected={selected}
       showHeader={showHeader}
       {...actionProps}
@@ -66,6 +70,7 @@ function AnnotationBlockContent({
   nodeId,
   selected,
   showHeader,
+  canvasMode,
   onAnnotationUpdate,
   onAnnotationBlur,
   actionProps,
@@ -74,6 +79,7 @@ function AnnotationBlockContent({
   nodeId?: string;
   selected: boolean;
   showHeader?: boolean;
+  canvasMode?: BlockProps["canvasMode"];
   onAnnotationUpdate?: BlockProps["onAnnotationUpdate"];
   onAnnotationBlur?: BlockProps["onAnnotationBlur"];
   actionProps: ReturnType<typeof getActionProps>;
@@ -93,7 +99,14 @@ function AnnotationBlockContent({
   };
 
   if (!safeAnnotationProps) {
-    return renderFallbackBlock(data, "Annotation", selected, showHeader, actionProps);
+    return renderFallbackBlock({
+      data,
+      fallbackTitle: "Annotation",
+      selected,
+      showHeader,
+      canvasMode,
+      actionProps,
+    });
   }
 
   return (
@@ -113,23 +126,40 @@ function renderBlockByType(args: {
   nodeId?: string;
   selected: boolean;
   showHeader?: boolean;
+  canvasMode?: BlockProps["canvasMode"];
   onAnnotationUpdate?: BlockProps["onAnnotationUpdate"];
   onAnnotationBlur?: BlockProps["onAnnotationBlur"];
   actionProps: ReturnType<typeof getActionProps>;
 }) {
-  const { data, nodeId, selected, showHeader, onAnnotationUpdate, onAnnotationBlur, actionProps } = args;
+  const { data, nodeId, selected, showHeader, canvasMode, onAnnotationUpdate, onAnnotationBlur, actionProps } = args;
 
   switch (data.type) {
     case "trigger":
       if (!isRecord(data.trigger)) {
-        return renderFallbackBlock(data, "Trigger", selected, showHeader, actionProps);
+        return renderFallbackBlock({
+          data,
+          fallbackTitle: "Trigger",
+          selected,
+          showHeader,
+          canvasMode,
+          actionProps,
+        });
       }
-      return <Trigger {...getSafeTriggerProps(data)} selected={selected} showHeader={showHeader} {...actionProps} />;
+      return (
+        <Trigger
+          {...getSafeTriggerProps(data)}
+          canvasMode={canvasMode}
+          selected={selected}
+          showHeader={showHeader}
+          {...actionProps}
+        />
+      );
     case "component": {
       const safeComponentProps = getSafeComponentProps(data);
       return (
         <ComponentBase
           {...safeComponentProps}
+          canvasMode={canvasMode}
           paused={safeComponentProps.paused}
           selected={selected}
           showHeader={showHeader}
@@ -139,7 +169,13 @@ function renderBlockByType(args: {
     }
     case "composite":
       return (
-        <Composite {...getSafeCompositeProps(data)} selected={selected} showHeader={showHeader} {...actionProps} />
+        <Composite
+          {...getSafeCompositeProps(data)}
+          canvasMode={canvasMode}
+          selected={selected}
+          showHeader={showHeader}
+          {...actionProps}
+        />
       );
     case "annotation":
       return (
@@ -148,15 +184,30 @@ function renderBlockByType(args: {
           nodeId={nodeId}
           selected={selected}
           showHeader={showHeader}
+          canvasMode={canvasMode}
           onAnnotationUpdate={onAnnotationUpdate}
           onAnnotationBlur={onAnnotationBlur}
           actionProps={actionProps}
         />
       );
     case "group":
-      return renderFallbackBlock(data, "Group", selected, showHeader, actionProps);
+      return renderFallbackBlock({
+        data,
+        fallbackTitle: "Group",
+        selected,
+        showHeader,
+        canvasMode,
+        actionProps,
+      });
     default:
-      return renderFallbackBlock(data, "Component", selected, showHeader, actionProps);
+      return renderFallbackBlock({
+        data,
+        fallbackTitle: "Component",
+        selected,
+        showHeader,
+        canvasMode,
+        actionProps,
+      });
   }
 }
 
@@ -174,6 +225,7 @@ export function BlockContent({
   onToggleView,
   onDelete,
   showHeader,
+  canvasMode,
   isCompactView,
   onAnnotationUpdate,
   onAnnotationBlur,
@@ -196,6 +248,7 @@ export function BlockContent({
     nodeId,
     selected,
     showHeader,
+    canvasMode,
     onAnnotationUpdate,
     onAnnotationBlur,
     actionProps,

--- a/web_src/src/ui/CanvasPage/Block/data.ts
+++ b/web_src/src/ui/CanvasPage/Block/data.ts
@@ -22,7 +22,7 @@ export function buildFallbackComponentProps(data: BlockData, fallbackTitle: stri
     iconSlug: "circle-off",
     metadata: [],
     includeEmptyState: true,
-    emptyStateProps: { title: "Can't display" },
+    emptyStateProps: { title: "Can't display", purpose: "fallback" },
   };
 }
 

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -69,6 +69,7 @@ export interface BlockProps extends ComponentActionsProps {
   nodeId?: string;
   selected?: boolean;
   showHeader?: boolean;
+  canvasMode?: "live" | "edit";
   onAnnotationUpdate?: (
     nodeId: string,
     updates: { text?: string; color?: string; width?: number; height?: number; x?: number; y?: number },

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -395,6 +395,7 @@ type CanvasNodeRendererCallbacks = {
   runDisabledTooltip?: string;
   showHeader: boolean;
   hasMultiSelection: boolean;
+  canvasMode: "live" | "edit";
 };
 
 type CanvasBlockNodeData = CanvasBlockData & {
@@ -498,6 +499,7 @@ function buildInteractiveNodeBlockProps(
 
   return {
     showHeader: callbacks.showHeader && !callbacks.hasMultiSelection,
+    canvasMode: callbacks.canvasMode,
     onClick: (event) => callbacks.handleNodeClick(nodeId, event),
     onEdit: getNodeAction(callbacks.onNodeEdit, nodeId),
     onDelete: getNodeAction(callbacks.onNodeDelete, nodeId),
@@ -657,7 +659,9 @@ const nodeTypes = {
 function CanvasPage(props: CanvasPageProps) {
   const state = useCanvasState(props);
   const readOnly = props.readOnly ?? false;
-  const [currentTab, setCurrentTab] = useState<"latest" | "settings" | "docs">("latest");
+  const [currentTab, setCurrentTab] = useState<"latest" | "settings" | "docs">(() =>
+    props.canvasStateMode === "editing" ? "settings" : "latest",
+  );
   const [templateNodeId, setTemplateNodeId] = useState<string | null>(null);
   const [highlightedNodeIds, setHighlightedNodeIds] = useState<Set<string>>(new Set());
   const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -1105,7 +1109,7 @@ function CanvasPage(props: CanvasPageProps) {
 
     state.componentSidebar.close();
     // Reset to latest tab when sidebar closes
-    setCurrentTab("latest");
+    setCurrentTab(props.canvasStateMode === "editing" ? "settings" : "latest");
 
     // Only remove the node if it's a pending connection node (not yet configured)
     if (isPendingConnection && state.componentSidebar.selectedNodeId) {
@@ -1126,7 +1130,7 @@ function CanvasPage(props: CanvasPageProps) {
         selected: false,
       })),
     );
-  }, [state, templateNodeId]);
+  }, [props.canvasStateMode, state, templateNodeId]);
 
   const canvasStateMode = props.canvasStateMode || "default";
   const showPreviewFloatingBar =
@@ -2092,7 +2096,7 @@ function CanvasContent({
         );
 
         if (setCurrentTab) {
-          setCurrentTab(hasConfigurationWarning ? "settings" : "latest");
+          setCurrentTab(hasConfigurationWarning || isEditMode ? "settings" : "latest");
         }
 
         if (onBuildingBlocksSidebarToggle) {
@@ -2107,7 +2111,7 @@ function CanvasContent({
         })),
       );
     },
-    [workflowNodes, onBuildingBlocksSidebarToggle, onPendingConnectionNodeClick, setCurrentTab],
+    [workflowNodes, onBuildingBlocksSidebarToggle, onPendingConnectionNodeClick, setCurrentTab, isEditMode],
   );
 
   const onRunRef = useRef(onRun);
@@ -2320,6 +2324,7 @@ function CanvasContent({
     runDisabledTooltip,
     showHeader,
     hasMultiSelection,
+    canvasMode: isEditMode ? ("edit" as const) : ("live" as const),
   });
   callbacksRef.current = {
     handleNodeClick,
@@ -2338,6 +2343,7 @@ function CanvasContent({
     runDisabledTooltip,
     showHeader,
     hasMultiSelection,
+    canvasMode: isEditMode ? "edit" : "live",
   };
 
   // Just pass the state nodes directly - callbacks will be added in nodeTypes

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -1,6 +1,6 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { calcRelativeTimeFromDiff, resolveIcon } from "@/lib/utils";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, PencilLine } from "lucide-react";
 import React from "react";
 import { ComponentHeader } from "../componentHeader";
 import { EmptyState } from "../emptyState";
@@ -123,6 +123,8 @@ export interface ComponentBaseSpec {
   contentType?: "json" | "xml" | "text";
 }
 
+export type EmptyStatePurpose = "runtime" | "setup" | "fallback";
+
 export type EventState = "success" | "failed" | "neutral" | "queued" | "running" | string;
 
 export interface EventStateStyle {
@@ -221,9 +223,12 @@ export interface ComponentBaseProps extends ComponentActionsProps {
     icon?: React.ComponentType<{ size?: number }>;
     title?: string;
     description?: string;
+    purpose?: EmptyStatePurpose;
+    tone?: "accent" | "neutral";
   };
   error?: string;
   warning?: string;
+  canvasMode?: "live" | "edit";
 }
 
 export const ComponentBase: React.FC<ComponentBaseProps> = ({
@@ -258,6 +263,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   error,
   warning,
   paused,
+  canvasMode = "live",
 }) => {
   const safeMetadata = Array.isArray(metadata) ? metadata : undefined;
   const safeSpecs = Array.isArray(specs) ? specs : undefined;
@@ -282,6 +288,22 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   const hasError = safeError.trim() !== "";
   const hasWarning = safeWarning.trim() !== "";
   const hasBadge = hasError || hasWarning;
+  const emptyStatePurpose =
+    emptyStateProps?.purpose || (includeEmptyState ? (hasError ? "setup" : "runtime") : undefined);
+  const resolvedEmptyStateProps = React.useMemo(() => {
+    if (canvasMode !== "edit" || emptyStatePurpose !== "runtime") {
+      return emptyStateProps;
+    }
+
+    return {
+      ...emptyStateProps,
+      icon: emptyStateProps?.icon || PencilLine,
+      title: "Runtime data appears in live mode",
+      description: undefined,
+      purpose: "runtime" as const,
+      tone: "neutral" as const,
+    };
+  }, [canvasMode, emptyStateProps, emptyStatePurpose]);
   const PauseIcon = React.useMemo(() => resolveIcon("pause"), []);
   const ResumeIcon = React.useMemo(() => resolveIcon("step-forward"), []);
   const DuplicateIcon = React.useMemo(() => resolveIcon("copy"), []);
@@ -474,7 +496,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
               />
             ))}
 
-            {includeEmptyState && <EmptyState compact {...emptyStateProps} />}
+            {includeEmptyState && <EmptyState compact {...resolvedEmptyStateProps} />}
 
             {safeCustomFieldPosition === "after" &&
               (typeof safeCustomField === "function"

--- a/web_src/src/ui/composite/index.tsx
+++ b/web_src/src/ui/composite/index.tsx
@@ -49,6 +49,7 @@ export interface CompositeProps extends ComponentActionsProps {
   iconColor?: string;
   title: string;
   showHeader?: boolean;
+  canvasMode?: "live" | "edit";
   metadata?: MetadataItem[];
   parameters?: ParameterGroup[];
   lastRunItem?: LastRunItem;
@@ -72,6 +73,7 @@ export const Composite: React.FC<CompositeProps> = ({
   iconColor,
   title,
   showHeader,
+  canvasMode,
   metadata,
   parameters = [],
   lastRunItem,
@@ -196,6 +198,7 @@ export const Composite: React.FC<CompositeProps> = ({
       iconColor={iconColor}
       title={title}
       showHeader={showHeader}
+      canvasMode={canvasMode}
       metadata={metadata}
       specs={specs}
       eventSections={eventSections}
@@ -213,7 +216,7 @@ export const Composite: React.FC<CompositeProps> = ({
       onDelete={onDelete}
       isCompactView={isCompactView}
       includeEmptyState={eventsToDisplay.length === 0}
-      emptyStateProps={{ title: "No executions received yet" }}
+      emptyStateProps={{ title: "No executions received yet", purpose: "runtime" }}
       customField={customField}
       error={error}
       warning={warning}

--- a/web_src/src/ui/emptyState/index.tsx
+++ b/web_src/src/ui/emptyState/index.tsx
@@ -7,6 +7,7 @@ interface EmptyStateProps {
   description?: string;
   className?: string;
   compact?: boolean;
+  tone?: "accent" | "neutral";
 }
 
 export const EmptyState: React.FC<EmptyStateProps> = ({
@@ -15,16 +16,21 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   description,
   className = "",
   compact = false,
+  tone = "accent",
 }) => {
+  const iconContainerClassName = tone === "neutral" ? "text-slate-500 bg-slate-100" : "text-yellow-700 bg-orange-100";
+  const titleClassName = tone === "neutral" ? "text-slate-500" : "text-gray-500";
+  const descriptionClassName = tone === "neutral" ? "text-slate-400" : "text-gray-400";
+
   if (compact) {
     return (
       <div className={`flex items-center gap-2.5 px-2 py-3 ${className}`}>
-        <div className="flex justify-center items-center w-8 h-8 text-yellow-700 bg-orange-100 p-1.5 rounded-md shrink-0">
+        <div className={`flex justify-center items-center w-8 h-8 p-1.5 rounded-md shrink-0 ${iconContainerClassName}`}>
           <Icon size={14} />
         </div>
         <div className="flex flex-col min-w-0">
-          <span className="text-sm text-gray-500">{title}</span>
-          {description && <span className="text-xs text-gray-400 truncate">{description}</span>}
+          <span className={`text-sm ${titleClassName}`}>{title}</span>
+          {description && <span className={`text-xs truncate ${descriptionClassName}`}>{description}</span>}
         </div>
       </div>
     );
@@ -32,11 +38,11 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
 
   return (
     <div className={`flex flex-col justify-center items-center py-5 gap-3 ${className}`}>
-      <div className="flex justify-center items-center w-12 h-12 text-yellow-700 bg-orange-100 p-3 rounded-md">
+      <div className={`flex justify-center items-center w-12 h-12 p-3 rounded-md ${iconContainerClassName}`}>
         <Icon size={16} />
       </div>
-      <span className="text-sm text-gray-500">{title}</span>
-      {description && <span className="text-sm text-gray-400 text-center max-w-xs">{description}</span>}
+      <span className={`text-sm ${titleClassName}`}>{title}</span>
+      {description && <span className={`text-sm text-center max-w-xs ${descriptionClassName}`}>{description}</span>}
     </div>
   );
 };

--- a/web_src/src/ui/trigger/index.tsx
+++ b/web_src/src/ui/trigger/index.tsx
@@ -37,7 +37,7 @@ export const Trigger: React.FC<TriggerProps> = ({ lastEventData, ...componentBas
       <ComponentBase
         {...componentBaseProps}
         includeEmptyState
-        emptyStateProps={{ title: "Waiting for the first event" }}
+        emptyStateProps={{ title: "Waiting for the first event", purpose: "runtime" }}
       />
     );
   }


### PR DESCRIPTION
## Summary
This updates canvas node empty states so draft/edit mode no longer shows live-runtime messaging like `Waiting for the first run` or the rabbit icon.

## Changes
- Make node empty states mode-aware in `CanvasPage`
- Show a neutral edit-mode message for runtime-only empty states
- Keep setup and fallback empty states unchanged
- Default the node sidebar to `Settings` in edit mode instead of `Latest`
- Add coverage for edit-mode empty-state behavior in `Block.spec.tsx`

<img width="1426" height="702" alt="image" src="https://github.com/user-attachments/assets/97d1304d-079a-4adc-b52f-04d27663acaf" />
