### PR TITLE
fix: disable live-mode edge and handle interaction affordances

### DIFF
--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -2,10 +2,21 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@xyflow/react", () => ({
-  Handle: ({ type, id, className }: { type: string; id?: string; className?: string }) => (
+  Handle: ({
+    type,
+    id,
+    className,
+    style,
+  }: {
+    type: string;
+    id?: string;
+    className?: string;
+    style?: { pointerEvents?: string };
+  }) => (
     <div
       data-testid={`handle-${type}-${id || "default"}`}
       data-highlighted={className === "highlighted" ? "true" : "false"}
+      data-pointer-events={style?.pointerEvents || "auto"}
     />
   ),
   Position: {
@@ -138,5 +149,28 @@ describe("Block fallback rendering", () => {
     );
 
     expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-highlighted", "false");
+  });
+
+  it("disables handle interactivity in live mode", () => {
+    render(
+      <Block
+        canvasMode="live"
+        nodeId="component-node"
+        data={{
+          label: "Component",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+          component: {
+            title: "Component",
+            iconSlug: "box",
+            collapsed: false,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("handle-target-default")).toHaveAttribute("data-pointer-events", "none");
+    expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-pointer-events", "none");
   });
 });

--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -74,20 +74,24 @@ function SingleRightHandle({
   connectingFrom,
   nodeId,
   allEdges,
+  isConnectionInteractive,
 }: {
   channel: string;
   hoveredEdge?: BlockEdgeState;
   connectingFrom?: BlockConnectionState;
   nodeId?: string;
   allEdges: BlockEdgeState[];
+  isConnectionInteractive: boolean;
 }) {
-  const isHighlighted = getSingleChannelHighlight({
-    hoveredEdge,
-    connectingFrom,
-    nodeId,
-    channel,
-    allEdges,
-  });
+  const isHighlighted =
+    isConnectionInteractive &&
+    getSingleChannelHighlight({
+      hoveredEdge,
+      connectingFrom,
+      nodeId,
+      channel,
+      allEdges,
+    });
 
   return (
     <Handle
@@ -98,6 +102,7 @@ function SingleRightHandle({
         ...HANDLE_STYLE,
         right: -15,
         top: 18,
+        pointerEvents: isConnectionInteractive ? "auto" : "none",
       }}
       className={isHighlighted ? "highlighted" : undefined}
     />
@@ -138,12 +143,14 @@ function MultiRightHandle({
   connectingFrom,
   nodeId,
   allEdges,
+  isConnectionInteractive,
 }: {
   channels: string[];
   hoveredEdge?: BlockEdgeState;
   connectingFrom?: BlockConnectionState;
   nodeId?: string;
   allEdges: BlockEdgeState[];
+  isConnectionInteractive: boolean;
 }) {
   const getChannelHighlight = getChannelHighlightResolver({
     hoveredEdge,
@@ -167,7 +174,7 @@ function MultiRightHandle({
   const channelPositions = channels.map((channel, index) => ({
     channel,
     offsetY: (index - (channels.length - 1) / 2) * channelSpacing,
-    isHighlighted: getChannelHighlight(channel),
+    isHighlighted: isConnectionInteractive && getChannelHighlight(channel),
   }));
 
   return (
@@ -229,7 +236,7 @@ function MultiRightHandle({
               left: handleLeftX,
               top: `calc(50% + ${offsetY}px)`,
               transform: "translateY(-50%)",
-              pointerEvents: "auto",
+              pointerEvents: isConnectionInteractive ? "auto" : "none",
             }}
             className={isHighlighted ? "highlighted" : undefined}
           />
@@ -239,7 +246,11 @@ function MultiRightHandle({
   );
 }
 
-export function LeftHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId">) {
+export function LeftHandle({
+  data,
+  nodeId,
+  isConnectionInteractive = true,
+}: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
   if (shouldHideLeftHandle(data)) return null;
 
   const hoveredEdge = data._hoveredEdge;
@@ -252,11 +263,12 @@ export function LeftHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId">
     connectingFrom?.handleId,
   );
   const isHighlighted =
-    (hoveredEdge && hoveredEdge.target === nodeId) ||
-    (connectingFrom &&
-      connectingFrom.nodeId !== nodeId &&
-      connectingFrom.handleType === "source" &&
-      !isAlreadyConnected);
+    isConnectionInteractive &&
+    ((hoveredEdge && hoveredEdge.target === nodeId) ||
+      (connectingFrom &&
+        connectingFrom.nodeId !== nodeId &&
+        connectingFrom.handleType === "source" &&
+        !isAlreadyConnected));
 
   return (
     <Handle
@@ -266,13 +278,18 @@ export function LeftHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId">
         ...HANDLE_STYLE,
         left: -15,
         top: 18,
+        pointerEvents: isConnectionInteractive ? "auto" : "none",
       }}
       className={isHighlighted ? "highlighted" : undefined}
     />
   );
 }
 
-export function RightHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId">) {
+export function RightHandle({
+  data,
+  nodeId,
+  isConnectionInteractive = true,
+}: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
   if (shouldHideRightHandle(data)) return null;
 
   const channels = getOutputChannels(data);
@@ -288,6 +305,7 @@ export function RightHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId"
         connectingFrom={connectingFrom}
         nodeId={nodeId}
         allEdges={allEdges}
+        isConnectionInteractive={isConnectionInteractive}
       />
     );
   }
@@ -299,6 +317,7 @@ export function RightHandle({ data, nodeId }: Pick<BlockProps, "data" | "nodeId"
       connectingFrom={connectingFrom}
       nodeId={nodeId}
       allEdges={allEdges}
+      isConnectionInteractive={isConnectionInteractive}
     />
   );
 }

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -11,12 +11,13 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const isHighlighted = data._isHighlighted || false;
   const hasHighlightedNodes = data._hasHighlightedNodes || false;
   const shouldDim = hasHighlightedNodes && !isHighlighted;
+  const isConnectionInteractive = props.canvasMode !== "live";
 
   return (
     <div className={`relative w-fit ${shouldDim ? "opacity-30" : ""}`} onClick={(e) => props.onClick?.(e)}>
-      <LeftHandle data={data} nodeId={props.nodeId} />
+      <LeftHandle data={data} nodeId={props.nodeId} isConnectionInteractive={isConnectionInteractive} />
       <BlockContent {...props} />
-      <RightHandle data={data} nodeId={props.nodeId} />
+      <RightHandle data={data} nodeId={props.nodeId} isConnectionInteractive={isConnectionInteractive} />
     </div>
   );
 });

--- a/web_src/src/ui/CanvasPage/CustomEdge.spec.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.spec.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const { setEdges } = vi.hoisted(() => ({
+  setEdges: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  BaseEdge: ({ className }: { className?: string }) => <div data-testid="base-edge" data-class-name={className} />,
+  EdgeLabelRenderer: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  getBezierPath: () => ["M0,0 C10,0 20,10 30,10", 15, 5],
+  useReactFlow: () => ({
+    setEdges,
+  }),
+}));
+
+import { CustomEdge } from "./CustomEdge";
+
+describe("CustomEdge", () => {
+  it("does not show the delete icon or delete on pointer down in live mode", () => {
+    const onDelete = vi.fn();
+
+    render(
+      <svg>
+        <CustomEdge
+          id="edge-1"
+          source="node-a"
+          target="node-b"
+          sourceX={0}
+          sourceY={0}
+          targetX={10}
+          targetY={10}
+          sourcePosition={"right" as never}
+          targetPosition={"left" as never}
+          selected={false}
+          data={{ isHovered: true, canDelete: false, onDelete }}
+        />
+      </svg>,
+    );
+
+    expect(screen.queryByTestId("edge-delete-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("edge-delete-hit-area")).not.toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("shows the delete icon and deletes the edge in edit mode", () => {
+    const onDelete = vi.fn();
+
+    render(
+      <svg>
+        <CustomEdge
+          id="edge-1"
+          source="node-a"
+          target="node-b"
+          sourceX={0}
+          sourceY={0}
+          targetX={10}
+          targetY={10}
+          sourcePosition={"right" as never}
+          targetPosition={"left" as never}
+          selected={false}
+          data={{ isHovered: true, canDelete: true, onDelete }}
+        />
+      </svg>,
+    );
+
+    expect(screen.getByTestId("edge-delete-icon")).toBeInTheDocument();
+    const hitArea = screen.getByTestId("edge-delete-hit-area");
+
+    fireEvent.pointerDown(hitArea, { button: 0, buttons: 1 });
+    expect(onDelete).toHaveBeenCalledWith("edge-1");
+  });
+});

--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -4,6 +4,65 @@ import type { EdgeProps } from "@xyflow/react";
 import { BaseEdge, EdgeLabelRenderer, getBezierPath, useReactFlow } from "@xyflow/react";
 import { CircleX } from "lucide-react";
 
+interface CustomEdgeData {
+  isHovered?: boolean;
+  canDelete?: boolean;
+  onDelete?: (edgeId: string) => void;
+}
+
+function DeleteEdgeControls({
+  canDelete,
+  edgePath,
+  labelX,
+  labelY,
+  shouldShowIcon,
+  onDelete,
+}: {
+  canDelete: boolean;
+  edgePath: string;
+  labelX: number;
+  labelY: number;
+  shouldShowIcon: boolean;
+  onDelete: (event: React.PointerEvent<SVGPathElement>) => void;
+}) {
+  if (!canDelete) {
+    return null;
+  }
+
+  return (
+    <>
+      <path
+        data-testid="edge-delete-hit-area"
+        d={edgePath}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={20}
+        style={{ cursor: "pointer", pointerEvents: "stroke" }}
+        onPointerDown={onDelete}
+      />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            width: "32px",
+            height: "32px",
+            zIndex: 1001,
+            pointerEvents: "none",
+            opacity: shouldShowIcon ? 1 : 0,
+            transition: "opacity 150ms ease",
+          }}
+          className="edge-label nodrag nopan flex items-center justify-center"
+        >
+          <div className="rounded-full bg-slate-100 p-1" data-testid="edge-delete-icon">
+            <CircleX size={18} className="text-slate-500" />
+          </div>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
 export const CustomEdge = React.memo(function CustomEdge({
   id,
   sourceX,
@@ -17,8 +76,10 @@ export const CustomEdge = React.memo(function CustomEdge({
   data,
 }: EdgeProps) {
   const { setEdges } = useReactFlow();
-  const isHovered = data?.isHovered || false;
-  const onDeleteEdge = data?.onDelete as ((edgeId: string) => void) | undefined;
+  const edgeData = data as CustomEdgeData | undefined;
+  const isHovered = edgeData?.isHovered === true;
+  const canDelete = edgeData?.canDelete === true;
+  const onDeleteEdge = edgeData?.onDelete;
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
@@ -45,42 +106,27 @@ export const CustomEdge = React.memo(function CustomEdge({
     strokeWidth: selected ? 3 : style.strokeWidth || 3,
     pointerEvents: "visibleStroke",
   };
-  const shouldShowIcon = isHovered || selected;
+  const shouldShowIcon = canDelete && (isHovered || selected === true);
+  const handleDeletePointerDown = useCallback(
+    (event: React.PointerEvent<SVGPathElement>) => {
+      if (event.button > 0) return;
+      event.stopPropagation();
+      handleEdgeDelete();
+    },
+    [handleEdgeDelete],
+  );
 
   return (
     <>
       <BaseEdge path={edgePath} style={edgeStyle} interactionWidth={20} className={isHovered ? "hovered" : undefined} />
-      <path
-        d={edgePath}
-        fill="none"
-        stroke="transparent"
-        strokeWidth={20}
-        style={{ cursor: "pointer", pointerEvents: "stroke" }}
-        onPointerDown={(event) => {
-          if (event.button !== 0) return;
-          event.stopPropagation();
-          handleEdgeDelete();
-        }}
+      <DeleteEdgeControls
+        canDelete={canDelete}
+        edgePath={edgePath}
+        labelX={labelX}
+        labelY={labelY}
+        shouldShowIcon={shouldShowIcon}
+        onDelete={handleDeletePointerDown}
       />
-      <EdgeLabelRenderer>
-        <div
-          style={{
-            position: "absolute",
-            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
-            width: "32px",
-            height: "32px",
-            zIndex: 1001,
-            pointerEvents: "none",
-            opacity: shouldShowIcon ? 1 : 0,
-            transition: "opacity 150ms ease",
-          }}
-          className="edge-label nodrag nopan flex items-center justify-center"
-        >
-          <div className="rounded-full bg-slate-100 p-1">
-            <CircleX size={18} className="text-slate-500" />
-          </div>
-        </div>
-      </EdgeLabelRenderer>
     </>
   );
 });

--- a/web_src/src/ui/CanvasPage/canvas-reset.css
+++ b/web_src/src/ui/CanvasPage/canvas-reset.css
@@ -55,6 +55,15 @@
   transition: stroke 0.2s ease-in-out;
 }
 
+.sp-canvas.sp-canvas-live .react-flow__edge,
+.sp-canvas.sp-canvas-live .react-flow__edge * {
+  cursor: default !important;
+}
+
+.sp-canvas.sp-canvas-live .react-flow__edge path {
+  transition: none;
+}
+
 .sp-canvas .react-flow__connectionline path {
   stroke: #A1AEC0 !important;
   stroke-width: 3 !important;
@@ -63,6 +72,11 @@
 
 .sp-canvas .react-flow__handle {
   transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.sp-canvas.sp-canvas-live .react-flow__handle {
+  cursor: default !important;
+  transition: none !important;
 }
 
 .sp-canvas .react-flow__handle::before {
@@ -76,10 +90,20 @@
   pointer-events: auto;
 }
 
+.sp-canvas.sp-canvas-live .react-flow__handle::before {
+  pointer-events: none;
+}
+
 .sp-canvas .react-flow__handle:hover {
   box-shadow: 0 0 0 3px #A1AEC0;
   border-color: #F1F5F9 !important;
   z-index: 10;
+}
+
+.sp-canvas.sp-canvas-live .react-flow__handle:hover {
+  box-shadow: none;
+  border-color: #C9D5E1 !important;
+  z-index: auto;
 }
 
 .sp-canvas .react-flow__handle.highlighted {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1138,7 +1138,13 @@ function CanvasPage(props: CanvasPageProps) {
   const showAwaitingFloatingBar = canvasStateMode === "awaiting-approval" && !!props.awaitingApprovalBanner;
 
   return (
-    <div ref={canvasWrapperRef} className="h-full w-full overflow-hidden sp-canvas relative flex flex-col">
+    <div
+      ref={canvasWrapperRef}
+      className={cn(
+        "h-full w-full overflow-hidden sp-canvas relative flex flex-col",
+        props.headerMode === "version-live" && "sp-canvas-live",
+      )}
+    >
       {/* Header at the top spanning full width */}
       <div className="relative z-30">
         <CanvasContentHeader
@@ -1983,6 +1989,15 @@ function CanvasContent({
   const [isSnapToGridEnabled, setIsSnapToGridEnabled] = useState(true);
   const isLiveMode = headerMode === "version-live";
   const isEditMode = !isLiveMode;
+
+  useEffect(() => {
+    if (isEditMode) {
+      return;
+    }
+
+    setHoveredEdgeId(null);
+  }, [isEditMode]);
+
   useEffect(() => {
     if (showBottomStatusControls) {
       localStorage.setItem(CONSOLE_OPEN_STORAGE_KEY, String(isLogSidebarOpen));
@@ -2455,12 +2470,15 @@ function CanvasContent({
         data: {
           ...e.data,
           isHovered: e.id === hoveredEdgeId,
-          onDelete: isReadOnly ? undefined : stableEdgeDelete,
+          canDelete: isEditMode && !isReadOnly,
+          onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
         },
         zIndex: e.id === hoveredEdgeId ? 1000 : 0,
       })),
-    [state.edges, hoveredEdgeId, stableEdgeDelete, isReadOnly],
+    [state.edges, hoveredEdgeId, stableEdgeDelete, isEditMode, isReadOnly],
   );
+
+  const isConnectionEditingEnabled = isEditMode && !isReadOnly && !!onEdgeCreate;
 
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -2566,13 +2584,13 @@ function CanvasContent({
             snapGrid={[48, 48]}
             panOnScrollSpeed={0.8}
             nodesDraggable={!isReadOnly}
-            nodesConnectable={!isReadOnly && !!onEdgeCreate}
+            nodesConnectable={isConnectionEditingEnabled}
             elementsSelectable={true}
             onNodesChange={handleNodesChange}
             onEdgesChange={handleEdgesChange}
-            onConnect={isReadOnly ? undefined : handleConnect}
-            onConnectStart={isReadOnly ? undefined : handleConnectStart}
-            onConnectEnd={isReadOnly ? undefined : handleConnectEnd}
+            onConnect={isConnectionEditingEnabled ? handleConnect : undefined}
+            onConnectStart={isConnectionEditingEnabled ? handleConnectStart : undefined}
+            onConnectEnd={isConnectionEditingEnabled ? handleConnectEnd : undefined}
             onDragOver={isReadOnly ? undefined : handleDragOver}
             onDrop={isReadOnly ? undefined : handleDrop}
             onMove={handleMove}
@@ -2588,8 +2606,8 @@ function CanvasContent({
               setIsSelecting(false);
               previouslySelectedRef.current = new Set();
             }}
-            onEdgeMouseEnter={handleEdgeMouseEnter}
-            onEdgeMouseLeave={handleEdgeMouseLeave}
+            onEdgeMouseEnter={isEditMode ? handleEdgeMouseEnter : undefined}
+            onEdgeMouseLeave={isEditMode ? handleEdgeMouseLeave : undefined}
             defaultViewport={viewport}
             fitView={false}
             style={{ opacity: isInitialized ? 1 : 0 }}


### PR DESCRIPTION
## Summary
This removes edit-only interaction affordances from canvas live mode so edges and handles no longer look clickable or editable.

## Changes
- Hide edge delete affordances in live mode
- Disable connection editing in live mode
- Make node handles inert in live mode
- Remove live-mode edge hover tracking
- Remove live-mode edge hover transitions and pointer cursor
- Remove live-mode handle hover styling so handles no longer glow or feel interactive
