### PR TITLE
fix: hide sidebar runs tab in canvas edit mode

### DIFF
--- a/test/e2e/settings_autosave_test.go
+++ b/test/e2e/settings_autosave_test.go
@@ -23,7 +23,7 @@ func TestSettingsAutoSave(t *testing.T) {
 		steps.assertExpressionFieldCleared("FilterPartial")
 	})
 
-	t.Run("partial configuration persists after switching to Runs tab", func(t *testing.T) {
+	t.Run("partial configuration persists after switching to Info tab", func(t *testing.T) {
 		steps := &settingsAutoSaveSteps{t: t}
 		steps.start()
 		steps.givenACanvasExists("Autosave Tab Switch")
@@ -31,7 +31,7 @@ func TestSettingsAutoSave(t *testing.T) {
 		steps.assertExpressionFieldEquals("FilterSwitch", "true")
 		steps.clearExpressionField()
 		steps.waitForAutoSave()
-		steps.switchToRunsTab()
+		steps.switchToInfoTab()
 		steps.switchToConfigurationTab()
 		steps.assertExpressionInputEquals("")
 		steps.assertExpressionFieldCleared("FilterSwitch")
@@ -71,8 +71,8 @@ func (s *settingsAutoSaveSteps) waitForAutoSave() {
 	s.session.Sleep(500)
 }
 
-func (s *settingsAutoSaveSteps) switchToRunsTab() {
-	s.session.Click(q.Text("Runs"))
+func (s *settingsAutoSaveSteps) switchToInfoTab() {
+	s.session.Click(q.Text("Info"))
 	s.session.Sleep(500)
 }
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1337,6 +1337,7 @@ function CanvasPage(props: CanvasPageProps) {
             configurationSaveMode={props.configurationSaveMode}
             currentTab={currentTab}
             onTabChange={setCurrentTab}
+            canvasMode={props.headerMode === "version-live" ? "live" : "edit"}
             organizationId={props.organizationId}
             getCustomField={props.getCustomField}
             integrations={props.integrations}
@@ -1400,6 +1401,7 @@ function Sidebar({
   configurationSaveMode = "manual",
   currentTab,
   onTabChange,
+  canvasMode,
   organizationId,
   getCustomField,
   integrations,
@@ -1446,6 +1448,7 @@ function Sidebar({
   configurationSaveMode?: "manual" | "auto";
   currentTab?: "latest" | "settings" | "docs";
   onTabChange?: (tab: "latest" | "settings" | "docs") => void;
+  canvasMode: "live" | "edit";
   organizationId?: string;
   getCustomField?: (
     nodeId: string,
@@ -1482,6 +1485,7 @@ function Sidebar({
 
   const [latestEvents, setLatestEvents] = useState<SidebarEvent[]>(sidebarData?.latestEvents || []);
   const [nextInQueueEvents, setNextInQueueEvents] = useState<SidebarEvent[]>(sidebarData?.nextInQueueEvents || []);
+  const shouldShowRunsSidebar = canvasMode === "live" && !isAnnotationNode;
 
   // Trigger data loading when sidebar opens for a node
   useEffect(() => {
@@ -1545,7 +1549,7 @@ function Sidebar({
   }
 
   // Show loading state when data is being fetched (skip for annotation nodes)
-  if (sidebarData.isLoading && currentTab === "latest" && !isAnnotationNode) {
+  if (sidebarData.isLoading && currentTab === "latest" && shouldShowRunsSidebar) {
     const saved = localStorage.getItem(COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY);
     const sidebarWidth = saved ? parseInt(saved, 10) : 450;
 
@@ -1568,6 +1572,7 @@ function Sidebar({
     <ComponentSidebar
       key={state.componentSidebar.selectedNodeId}
       isOpen={state.componentSidebar.isOpen}
+      canvasMode={canvasMode}
       onClose={onSidebarClose || state.componentSidebar.close}
       latestEvents={latestEvents}
       nextInQueueEvents={nextInQueueEvents}

--- a/web_src/src/ui/componentSidebar/index.spec.tsx
+++ b/web_src/src/ui/componentSidebar/index.spec.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { createContext, useContext, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const TabsContext = createContext<{ value: string }>({ value: "latest" });
+
+vi.mock("../CanvasPage", () => ({
+  COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY: "component-sidebar-width",
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ value, children }: { value: string; children?: ReactNode }) => (
+    <TabsContext.Provider value={{ value }}>{children}</TabsContext.Provider>
+  ),
+  TabsContent: ({ value, children }: { value: string; children?: ReactNode }) => {
+    const context = useContext(TabsContext);
+
+    if (context.value !== value) {
+      return null;
+    }
+
+    return <div data-testid={`tab-content-${value}`}>{children}</div>;
+  },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/loading-button", () => ({
+  LoadingButton: ({ children, ...props }: { children?: ReactNode }) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: object) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children }: { children?: ReactNode }) => <label>{children}</label>,
+}));
+
+vi.mock("@/lib/integrationDisplayName", () => ({
+  getIntegrationTypeDisplayName: () => "Integration",
+}));
+
+vi.mock("@/lib/utils", () => ({
+  resolveIcon: () => () => <div data-testid="resolved-icon" />,
+}));
+
+vi.mock("@/ui/componentSidebar/integrationIcons", () => ({
+  getHeaderIconSrc: () => undefined,
+  IntegrationIcon: () => <div data-testid="integration-icon" />,
+}));
+
+vi.mock("@/hooks/useIntegrations", () => ({
+  useAvailableIntegrations: () => ({ data: [] }),
+  useCreateIntegration: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+  }),
+  useIntegration: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+  useUpdateIntegration: () => ({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/ui/configurationFieldRenderer", () => ({
+  ConfigurationFieldRenderer: () => <div data-testid="configuration-field-renderer" />,
+}));
+
+vi.mock("@/lib/errors", () => ({
+  getApiErrorMessage: () => "error",
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+}));
+
+vi.mock("@/ui/IntegrationCreateDialog", () => ({
+  IntegrationCreateDialog: () => null,
+}));
+
+vi.mock("@/ui/IntegrationInstructions", () => ({
+  IntegrationInstructions: () => null,
+}));
+
+vi.mock("./DocsTab", () => ({
+  DocsTab: () => <div data-testid="docs-tab">Docs Tab</div>,
+}));
+
+vi.mock("./LatestTab", () => ({
+  LatestTab: () => <div data-testid="latest-tab">Latest Tab</div>,
+}));
+
+vi.mock("./SettingsTab", () => ({
+  SettingsTab: () => <div data-testid="settings-tab">Settings Tab</div>,
+}));
+
+vi.mock("./pages", () => ({
+  ExecutionChainPage: () => <div data-testid="execution-chain-page" />,
+  HistoryQueuePage: () => <div data-testid="history-queue-page" />,
+  PageHeader: () => <div data-testid="page-header" />,
+}));
+
+vi.mock("@/pages/workflowv2/utils", () => ({
+  mapTriggerEventToSidebarEvent: vi.fn(),
+}));
+
+import { ComponentSidebar } from "./index";
+
+function renderSidebar(props?: Partial<React.ComponentProps<typeof ComponentSidebar>>) {
+  return render(
+    <ComponentSidebar
+      isOpen={true}
+      canvasMode="live"
+      latestEvents={[]}
+      nextInQueueEvents={[]}
+      totalInQueueCount={0}
+      totalInHistoryCount={0}
+      showSettingsTab={true}
+      nodeName="Node"
+      nodeConfiguration={{}}
+      nodeConfigurationFields={[]}
+      workflowNodes={[]}
+      components={[]}
+      triggers={[]}
+      blueprints={[]}
+      {...props}
+    />,
+  );
+}
+
+describe("ComponentSidebar", () => {
+  it("shows runs content in live mode", () => {
+    renderSidebar({
+      canvasMode: "live",
+      currentTab: "latest",
+    });
+
+    expect(screen.getByText("Runs")).toBeInTheDocument();
+    expect(screen.getByTestId("latest-tab")).toBeInTheDocument();
+    expect(screen.queryByTestId("settings-tab")).not.toBeInTheDocument();
+  });
+
+  it("hides runs content in edit mode and normalizes latest tab to settings", async () => {
+    const onTabChange = vi.fn();
+
+    renderSidebar({
+      canvasMode: "edit",
+      currentTab: "latest",
+      onTabChange,
+    });
+
+    expect(screen.queryByText("Runs")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("latest-tab")).not.toBeInTheDocument();
+    expect(screen.getByTestId("settings-tab")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onTabChange).toHaveBeenCalledWith("settings");
+    });
+  });
+});

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -55,6 +55,7 @@ const CREATE_INTEGRATION_DIALOG_OPTIONS: Record<
 
 interface ComponentSidebarProps {
   isOpen?: boolean;
+  canvasMode?: "live" | "edit";
 
   latestEvents: SidebarEvent[];
   nextInQueueEvents: SidebarEvent[];
@@ -163,6 +164,7 @@ interface ComponentSidebarProps {
 
 export const ComponentSidebar = ({
   isOpen,
+  canvasMode = "live",
   nodeId,
   iconSrc,
   iconSlug,
@@ -244,7 +246,21 @@ export const ComponentSidebar = ({
   const [activeExecutionChainEventId, setActiveExecutionChainEventId] = useState<string | null>(null);
   const [activeExecutionChainTriggerEvent, setActiveExecutionChainTriggerEvent] = useState<SidebarEvent | null>(null);
   const [selectedExecutionId, setSelectedExecutionId] = useState<string | null>(null);
-  const activeTab = currentTab || "latest";
+  const shouldShowRunsTab = !hideRunsTab && canvasMode === "live";
+  const activeTab = useMemo(() => {
+    if (shouldShowRunsTab || currentTab !== "latest") {
+      return currentTab || "latest";
+    }
+
+    return "settings";
+  }, [currentTab, shouldShowRunsTab]);
+
+  useEffect(() => {
+    if (!shouldShowRunsTab && currentTab === "latest") {
+      onTabChange?.("settings");
+    }
+  }, [currentTab, onTabChange, shouldShowRunsTab]);
+
   const [justCopied, setJustCopied] = useState(false);
   const [isCreateIntegrationDialogOpen, setIsCreateIntegrationDialogOpen] = useState(false);
   const [configureIntegrationId, setConfigureIntegrationId] = useState<string | null>(null);
@@ -658,7 +674,7 @@ export const ComponentSidebar = ({
             {showSettingsTab && (
               <div className="border-border border-b-1">
                 <div className="flex px-4">
-                  {!hideRunsTab && (
+                  {shouldShowRunsTab && (
                     <button
                       onClick={() => onTabChange?.("latest")}
                       className={`py-2 mr-4 text-sm mb-[-1px] font-medium border-b transition-colors ${
@@ -699,32 +715,34 @@ export const ComponentSidebar = ({
               </div>
             )}
 
-            <TabsContent
-              value="latest"
-              className={!showSettingsTab ? "overflow-y-auto" : "mt-0"}
-              style={!showSettingsTab ? { maxHeight: "40vh" } : undefined}
-            >
-              <LatestTab
-                latestEvents={latestEvents}
-                nextInQueueEvents={nextInQueueEvents}
-                totalInQueueCount={totalInQueueCount}
-                hideQueueEvents={hideQueueEvents}
-                openEventIds={openEventIds}
-                onToggleOpen={handleToggleOpen}
-                onEventClick={onEventClick}
-                onSeeFullHistory={handleSeeFullHistory}
-                onSeeQueue={handleSeeQueue}
-                onSeeExecutionChain={handleSeeExecutionChain}
-                getTabData={getTabData}
-                onCancelQueueItem={onCancelQueueItem}
-                onCancelExecution={onCancelExecution}
-                onReEmit={onReEmit}
-                loadExecutionChain={loadExecutionChain}
-                getExecutionState={getExecutionState}
-                workflowNodes={workflowNodes}
-                components={components}
-              />
-            </TabsContent>
+            {shouldShowRunsTab && (
+              <TabsContent
+                value="latest"
+                className={!showSettingsTab ? "overflow-y-auto" : "mt-0"}
+                style={!showSettingsTab ? { maxHeight: "40vh" } : undefined}
+              >
+                <LatestTab
+                  latestEvents={latestEvents}
+                  nextInQueueEvents={nextInQueueEvents}
+                  totalInQueueCount={totalInQueueCount}
+                  hideQueueEvents={hideQueueEvents}
+                  openEventIds={openEventIds}
+                  onToggleOpen={handleToggleOpen}
+                  onEventClick={onEventClick}
+                  onSeeFullHistory={handleSeeFullHistory}
+                  onSeeQueue={handleSeeQueue}
+                  onSeeExecutionChain={handleSeeExecutionChain}
+                  getTabData={getTabData}
+                  onCancelQueueItem={onCancelQueueItem}
+                  onCancelExecution={onCancelExecution}
+                  onReEmit={onReEmit}
+                  loadExecutionChain={loadExecutionChain}
+                  getExecutionState={getExecutionState}
+                  workflowNodes={workflowNodes}
+                  components={components}
+                />
+              </TabsContent>
+            )}
 
             {showSettingsTab && (
               <TabsContent value="settings" className="mt-0">


### PR DESCRIPTION
## Summary
This removes the node sidebar `Runs` / `Latest` view when the canvas is in edit mode, so the sidebar behaves like an editor instead of a live runtime viewer.

## Changes
- Pass canvas mode into `ComponentSidebar`
- Hide the `Runs` tab in edit mode
- Do not render `LatestTab` content in edit mode
- Normalize stale `latest` tab state back to `settings` when runs are unavailable
- Skip the runs loading state in edit mode
- Add a focused sidebar test covering live vs edit tab behavior

<img width="1750" height="706" alt="image" src="https://github.com/user-attachments/assets/857b8638-adff-4348-95e9-e920493e3db6" />

