### PR TITLE
fix: when adding new node, we Save() then Setup()

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -225,12 +225,22 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 	}
 
 	//
+	// When adding a node, we need to insert it first,
+	// so when we Setup() it, the contexts can create
+	// records pointing to the new workflow_node record.
+	//
+	err := p.tx.Create(&newNode).Error
+	if err != nil {
+		return err
+	}
+
+	//
 	// If node is already in error state, no need to run Setup() for it.
 	//
 	if newNode.State == models.CanvasNodeStateError {
 		node.Metadata = newNode.Metadata.Data()
 		p.finalNodes[node.ID] = node
-		return p.tx.Create(&newNode).Error
+		return nil
 	}
 
 	//
@@ -239,7 +249,7 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 	// If an error happens when setting up the node, we propagate that into
 	// the finalNodes that are going to be saved into workflow_versions.nodes.
 	//
-	err := p.setupNode(ctx, &newNode)
+	err = p.setupNode(ctx, &newNode)
 	if err != nil {
 		errorMsg := err.Error()
 		newNode.State = models.CanvasNodeStateError
@@ -249,7 +259,7 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 
 	node.Metadata = newNode.Metadata.Data()
 	p.finalNodes[node.ID] = node
-	return p.tx.Create(&newNode).Error
+	return p.tx.Save(&newNode).Error
 }
 
 func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChangeset_Change) error {

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -323,6 +323,45 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.Equal(t, activeMetadata, publishedNode.Metadata)
 	})
 
+	t.Run("add schedule trigger to live canvas creates pending node request", func(t *testing.T) {
+		r := support.Setup(t)
+
+		canvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{},
+			nil,
+		)
+
+		draft, err := models.SaveCanvasDraftInTransaction(
+			database.Conn(),
+			canvas.ID,
+			r.User,
+			[]models.Node{
+				triggerNode("schedule-trigger", "Schedule Trigger", "schedule", map[string]any{
+					"type":            "minutes",
+					"minutesInterval": 1,
+				}),
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		publisher, err := NewCanvasPublisher(database.Conn(), draft, canvasPublisherOptions(r))
+		require.NoError(t, err)
+
+		err = publisher.Publish(context.Background())
+		require.NoError(t, err)
+
+		request, err := models.FindPendingRequestForNode(database.Conn(), canvas.ID, "schedule-trigger")
+		require.NoError(t, err)
+		require.Equal(t, models.NodeRequestTypeInvokeAction, request.Type)
+		require.NotNil(t, request.Spec.Data().InvokeAction)
+		require.Equal(t, "emitEvent", request.Spec.Data().InvokeAction.ActionName)
+		require.Equal(t, map[string]any{}, request.Spec.Data().InvokeAction.Parameters)
+	})
+
 	t.Run("add node skips setup when node already has error", func(t *testing.T) {
 		r := support.Setup(t)
 
@@ -631,6 +670,18 @@ func componentNode(nodeID string, name string, component string, configuration m
 		Name:          name,
 		Type:          models.NodeTypeComponent,
 		Ref:           models.NodeRef{Component: &models.ComponentRef{Name: component}},
+		Configuration: configuration,
+		Metadata:      map[string]any{},
+		Position:      models.Position{X: 10, Y: 20},
+	}
+}
+
+func triggerNode(nodeID string, name string, trigger string, configuration map[string]any) models.Node {
+	return models.Node{
+		ID:            nodeID,
+		Name:          name,
+		Type:          models.NodeTypeTrigger,
+		Ref:           models.NodeRef{Trigger: &models.TriggerRef{Name: trigger}},
 		Configuration: configuration,
 		Metadata:      map[string]any{},
 		Position:      models.Position{X: 10, Y: 20},

--- a/pkg/grpc/actions/canvases/update_canvas_version.go
+++ b/pkg/grpc/actions/canvases/update_canvas_version.go
@@ -136,6 +136,8 @@ func UpdateCanvasVersionWithUsage(
 			return err
 		}
 
+		nodes := injectMetadataIntoNodes(version.Nodes, nodes)
+
 		if version.OwnerID == nil || *version.OwnerID != userUUID {
 			return status.Error(codes.PermissionDenied, "version owner mismatch")
 		}
@@ -173,4 +175,19 @@ func UpdateCanvasVersionWithUsage(
 	return &pb.UpdateCanvasVersionResponse{
 		Version: SerializeCanvasVersion(version, organizationID),
 	}, nil
+}
+
+func injectMetadataIntoNodes(versionNodes []models.Node, proposedNodes []models.Node) []models.Node {
+	result := make([]models.Node, len(proposedNodes))
+	copy(result, proposedNodes)
+
+	for i, proposedNode := range result {
+		for _, versionNode := range versionNodes {
+			if proposedNode.ID == versionNode.ID {
+				result[i].Metadata = versionNode.Metadata
+			}
+		}
+	}
+
+	return result
 }

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -671,13 +671,17 @@ func ProtoToNodes(nodes []*componentpb.Node) []models.Node {
 			warningMessage = &node.WarningMessage
 		}
 
+		//
+		// NOTE: we do not include metadata in here,
+		// to avoid allowing requests to override node metadata.
+		// Metadata is something only triggers/components implementations can set.
+		//
 		result[i] = models.Node{
 			ID:             node.Id,
 			Name:           node.Name,
 			Type:           ProtoToNodeType(node.Type),
 			Ref:            ProtoToNodeRef(node),
 			Configuration:  node.Configuration.AsMap(),
-			Metadata:       node.Metadata.AsMap(),
 			Position:       ProtoToPosition(node.Position),
 			IsCollapsed:    node.IsCollapsed,
 			IntegrationID:  integrationID,

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -677,6 +677,7 @@ func ProtoToNodes(nodes []*componentpb.Node) []models.Node {
 			Type:           ProtoToNodeType(node.Type),
 			Ref:            ProtoToNodeRef(node),
 			Configuration:  node.Configuration.AsMap(),
+			Metadata:       node.Metadata.AsMap(),
 			Position:       ProtoToPosition(node.Position),
 			IsCollapsed:    node.IsCollapsed,
 			IntegrationID:  integrationID,


### PR DESCRIPTION
Issue introduced by https://github.com/superplanehq/superplane/pull/4188.

The contexts given to triggers / components can create resources that reference the `workflow_node`. For example, the schedule trigger uses `ScheduleActionCall()` to create a workflow node request record. For that reason, for new nodes, we need to insert the record into the database, before running Setup().

### Other changes

We also fix the issue of metadata not being saved into the version nodes in UpdateCanvasVersion endpoint. Now, we inject the metadata into the nodes before saving them.