### PR TITLE
fix: respect layout in apply changeset endpoint

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
@@ -23,9 +23,8 @@ type CanvasPatcher struct {
 	//
 	// Using maps to keep lookup operations fast
 	//
-	nodes    map[string]models.Node
-	edges    map[string]models.Edge
-	newNodes []string
+	nodes map[string]models.Node
+	edges map[string]models.Edge
 }
 
 func NewCanvasPatcher(tx *gorm.DB, orgID uuid.UUID, registry *registry.Registry, canvas *models.CanvasVersion) *CanvasPatcher {
@@ -36,7 +35,6 @@ func NewCanvasPatcher(tx *gorm.DB, orgID uuid.UUID, registry *registry.Registry,
 		originalVersion: canvas,
 		nodes:           make(map[string]models.Node),
 		edges:           make(map[string]models.Edge),
-		newNodes:        []string{},
 	}
 
 	for _, node := range p.originalVersion.Nodes {
@@ -91,15 +89,8 @@ func (p *CanvasPatcher) buildFinalVersion(autoLayout *pb.CanvasAutoLayout) (*mod
 		v.Edges = append(v.Edges, p.edges[edgeKey])
 	}
 
-	//
-	// If auto layout is not provided, we only auto layout the new nodes.
-	//
 	if autoLayout == nil {
-		autoLayout = &pb.CanvasAutoLayout{
-			Algorithm: pb.CanvasAutoLayout_ALGORITHM_HORIZONTAL,
-			NodeIds:   p.newNodes,
-			Scope:     pb.CanvasAutoLayout_SCOPE_CONNECTED_COMPONENT,
-		}
+		return v, nil
 	}
 
 	nodes, edges, err := layout.ApplyLayout(v.Nodes, v.Edges, autoLayout)
@@ -207,7 +198,6 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 		errorMessage := err.Error()
 		newNode.ErrorMessage = &errorMessage
 		p.nodes[nodeID] = newNode
-		p.newNodes = append(p.newNodes, nodeID)
 		return nil
 	}
 
@@ -217,7 +207,6 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 		errorMessage := err.Error()
 		newNode.ErrorMessage = &errorMessage
 		p.nodes[nodeID] = newNode
-		p.newNodes = append(p.newNodes, nodeID)
 		return nil
 	}
 
@@ -232,13 +221,11 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 		newNode.ErrorMessage = &errorMessage
 		newNode.Configuration = nodeConfiguration
 		p.nodes[nodeID] = newNode
-		p.newNodes = append(p.newNodes, nodeID)
 		return nil
 	}
 
 	newNode.Configuration = nodeConfiguration
 	p.nodes[nodeID] = newNode
-	p.newNodes = append(p.newNodes, nodeID)
 	return nil
 }
 

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
@@ -161,6 +161,50 @@ func Test__CanvasPatcher(t *testing.T) {
 		require.Nil(t, steps.finalVersion)
 	})
 
+	t.Run("does not apply layout when auto layout is omitted", func(t *testing.T) {
+		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
+		steps.givenCanvasVersion(
+			[]models.Node{
+				{
+					ID:   "node-a",
+					Name: "Node A",
+					Type: models.NodeTypeComponent,
+					Ref: models.NodeRef{
+						Component: &models.ComponentRef{Name: "noop"},
+					},
+					Position: models.Position{X: 125, Y: 240},
+				},
+				{
+					ID:   "node-b",
+					Name: "Node B",
+					Type: models.NodeTypeComponent,
+					Ref: models.NodeRef{
+						Component: &models.ComponentRef{Name: "noop"},
+					},
+					Position: models.Position{X: 780, Y: 95},
+				},
+			},
+			nil,
+		)
+
+		steps.whenHandling(&pb.CanvasChangeset{
+			Changes: []*pb.CanvasChangeset_Change{
+				{
+					Type: pb.CanvasChangeset_Change_ADD_EDGE,
+					Edge: &pb.CanvasChangeset_Change_Edge{
+						SourceId: "node-a",
+						TargetId: "node-b",
+						Channel:  "default",
+					},
+				},
+			},
+		}, nil)
+
+		steps.assertNoError()
+		steps.assertNodePosition("node-a", 125, 240)
+		steps.assertNodePosition("node-b", 780, 95)
+	})
+
 	t.Run("returns error when change object is misconfigured", func(t *testing.T) {
 		testCases := []struct {
 			name            string
@@ -826,6 +870,16 @@ func (s *CanvasPatcherSteps) assertNodeErrorContains(nodeID string, text string)
 	require.True(s.t, i != -1, "expected node %s", nodeID)
 	require.NotNil(s.t, s.finalVersion.Nodes[i].ErrorMessage)
 	require.Contains(s.t, *s.finalVersion.Nodes[i].ErrorMessage, text)
+}
+
+func (s *CanvasPatcherSteps) assertNodePosition(nodeID string, x int, y int) {
+	i := slices.IndexFunc(s.finalVersion.Nodes, func(node models.Node) bool {
+		return node.ID == nodeID
+	})
+
+	require.True(s.t, i != -1, "expected node %s", nodeID)
+	require.Equal(s.t, x, s.finalVersion.Nodes[i].Position.X)
+	require.Equal(s.t, y, s.finalVersion.Nodes[i].Position.Y)
 }
 
 func (s *CanvasPatcherSteps) findBlockName(node models.Node) string {

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -3105,6 +3105,14 @@ export function WorkflowPageV2() {
 
       const releaseCanvasVersionUpdatedEcho = registerIgnoredCanvasVersionUpdatedEcho(versionId);
       const releaseCanvasUpdatedEcho = registerIgnoredCanvasUpdatedEcho();
+      const autoLayoutNodeIds = Array.from(
+        new Set(
+          operations
+            .filter((operation) => operation.type === "ADD_NODE")
+            .map((operation) => operation.node?.id)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
 
       try {
         const response = await canvasesApplyCanvasVersionChangeset(
@@ -3117,6 +3125,15 @@ export function WorkflowPageV2() {
               changeset: {
                 changes: operations,
               },
+              ...(autoLayoutNodeIds.length > 0
+                ? {
+                    autoLayout: {
+                      algorithm: "ALGORITHM_HORIZONTAL",
+                      scope: "SCOPE_CONNECTED_COMPONENT",
+                      nodeIds: autoLayoutNodeIds,
+                    },
+                  }
+                : {}),
             },
           }),
         );


### PR DESCRIPTION
CanvasPatcher is not really respecting the auto layout choice sent in the request. That was OK initially when this endpoint was intended only for agent use, but now, we want to migrate the UI to use it as well, so we need to respect what is in the request.