### PR TITLE
fix: hide node runtime actions in canvas edit mode

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1618,6 +1618,7 @@ export function WorkflowPageV2() {
     () => buildBuildingBlockCategories(triggers, components, availableIntegrations),
     [triggers, components, availableIntegrations],
   );
+  const canvasMode = hasEditableVersion ? "edit" : "live";
 
   const { nodes: preparedNodes, edges } = useMemo(() => {
     if (!canvas || canvasLoading || triggersLoading || blueprintsLoading || componentsLoading || integrationsLoading) {
@@ -1635,6 +1636,7 @@ export function WorkflowPageV2() {
       canvasId!,
       queryClient,
       me,
+      canvasMode,
     );
   }, [
     canvas,
@@ -1653,6 +1655,7 @@ export function WorkflowPageV2() {
     integrationsLoading,
     organizationId,
     me,
+    canvasMode,
   ]);
 
   const nodesWithIntegrationStatus = useMemo(
@@ -5100,7 +5103,7 @@ export function WorkflowPageV2() {
     canvasDeletedRemotely,
     isPreparingVersionAction,
   });
-  const headerMode = hasEditableVersion ? "version-edit" : "version-live";
+  const headerMode = canvasMode === "edit" ? "version-edit" : "version-live";
   const hasUnpublishedDraftChanges =
     !suppressUnpublishedDraftDiscard && !!latestDraftVersion && pendingDraftDiffSummary.items.length > 0;
   const canvasStateMode = hasEditableVersion
@@ -5526,6 +5529,7 @@ function prepareData(
   workflowId: string,
   queryClient: QueryClient,
   user?: SuperplaneMeUser | null,
+  canvasMode: "live" | "edit" = "live",
 ): {
   nodes: CanvasNode[];
   edges: CanvasEdge[];
@@ -5550,6 +5554,7 @@ function prepareData(
           queryClient,
           currentUser,
           workflowEdges,
+          canvasMode,
         );
       })
       .map((node) => ({
@@ -5574,10 +5579,11 @@ function prepareNode(
   queryClient: QueryClient,
   currentUser?: User,
   edges?: ComponentsEdge[],
+  canvasMode: "live" | "edit" = "live",
 ): CanvasNode {
   switch (node.type) {
     case "TYPE_TRIGGER":
-      return prepareTriggerNode(node, triggers, nodeEventsMap);
+      return prepareTriggerNode(node, triggers, nodeEventsMap, canvasMode);
     case "TYPE_BLUEPRINT": {
       const componentMetadata = components.find((c) => c.name === node.component?.name);
       const compositeNode = prepareCompositeNode(nodes, node, blueprints, nodeExecutionsMap, nodeQueueItemsMap);
@@ -5612,6 +5618,7 @@ function prepareNode(
         queryClient,
         currentUser,
         edges,
+        canvasMode,
       });
   }
 }

--- a/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
@@ -46,6 +46,7 @@ type PrepareComponentNodeArgs = {
   organizationId?: string;
   currentUser?: User;
   edges?: ComponentsEdge[];
+  canvasMode?: "live" | "edit";
 };
 
 type PrepareComponentBaseNodeArgs = {
@@ -58,6 +59,7 @@ type PrepareComponentBaseNodeArgs = {
   queryClient: QueryClient;
   currentUser?: User;
   edges?: ComponentsEdge[];
+  canvasMode?: "live" | "edit";
 };
 
 type NodePosition = {
@@ -94,14 +96,16 @@ function buildPreparedTriggerCanvasNode(args: {
   nodeEventsMap: Record<string, CanvasesCanvasEvent[]>;
   displayLabel: string;
   position: NodePosition;
+  canvasMode?: "live" | "edit";
 }): CanvasNode {
-  const { node, triggerMetadata, nodeEventsMap, displayLabel, position } = args;
+  const { node, triggerMetadata, nodeEventsMap, displayLabel, position, canvasMode = "live" } = args;
   const renderer = getTriggerRenderer(node.trigger?.name || "");
   const lastEvent = nodeEventsMap[node.id!]?.[0];
   const triggerProps = renderer.getTriggerProps({
     node: buildNodeInfo(node),
     definition: buildComponentDefinition(triggerMetadata),
     lastEvent: buildEventInfo(lastEvent),
+    canvasMode,
   });
 
   return {
@@ -277,6 +281,7 @@ export function prepareTriggerNode(
   node: ComponentsNode,
   triggers: TriggersTrigger[],
   nodeEventsMap: Record<string, CanvasesCanvasEvent[]>,
+  canvasMode: "live" | "edit" = "live",
 ): CanvasNode {
   const triggerMetadata = triggers.find((t) => t.name === node.trigger?.name);
   const displayLabel = getTriggerDisplayLabel(node, triggerMetadata);
@@ -289,6 +294,7 @@ export function prepareTriggerNode(
       nodeEventsMap,
       displayLabel,
       position,
+      canvasMode,
     });
   } catch (error) {
     console.error(`[CanvasPage] Failed to prepare trigger node "${node.id}":`, error);
@@ -348,6 +354,7 @@ export function prepareComponentNode(args: PrepareComponentNodeArgs): CanvasNode
     queryClient,
     currentUser,
     edges,
+    canvasMode: args.canvasMode,
   });
 }
 
@@ -372,6 +379,7 @@ export function prepareComponentBaseNode(args: PrepareComponentBaseNodeArgs): Ca
       nodeQueueItems: nodeQueueItems?.map((q) => buildQueueItemInfo(q)),
       currentUser: buildUserInfo(currentUser),
       actions: buildActionContext(queryClient, canvasId, node.id!),
+      canvasMode: args.canvasMode,
     });
 
     if (!componentBaseProps.iconSrc) {

--- a/web_src/src/pages/workflowv2/mappers/approval.ts
+++ b/web_src/src/pages/workflowv2/mappers/approval.ts
@@ -303,6 +303,7 @@ function approvalItemPropsForRecord(
   isAwaitingApproval: boolean,
 ): ApprovalItemProps {
   const canAct =
+    context.canvasMode !== "edit" &&
     record.state === "pending" &&
     isAwaitingApproval &&
     canCurrentUserActOnRecord(record, context.currentUser) &&

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -10,24 +10,42 @@ import { waitMapper } from "./wait";
 import type { ComponentBaseContext, ExecutionInfo, TriggerRendererContext } from "./types";
 
 function makeExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  const now = new Date().toISOString();
+
   return {
     id: "execution-1",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: now,
+    updatedAt: now,
     state: "STATE_PENDING",
     result: "RESULT_PASSED",
     resultReason: "RESULT_REASON_OK",
     resultMessage: "",
     metadata: {},
     configuration: {},
-    rootEvent: undefined,
+    rootEvent: {
+      id: "event-1",
+      createdAt: now,
+      customName: "Start event",
+      data: {},
+      nodeId: "trigger-1",
+      type: "trigger",
+    },
     ...overrides,
   };
 }
 
 function makeComponentBaseContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
   return {
-    nodes: [],
+    nodes: [
+      {
+        id: "trigger-1",
+        name: "Start",
+        componentName: "start",
+        isCollapsed: false,
+        configuration: {},
+        metadata: {},
+      },
+    ],
     node: {
       id: "node-1",
       name: "Node",

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ComponentBase } from "@/ui/componentBase";
+import { Trigger } from "@/ui/trigger";
+import { approvalMapper } from "./approval";
+import { startTriggerRenderer } from "./start";
+import { timeGateMapper } from "./timegate";
+import { waitMapper } from "./wait";
+import type { ComponentBaseContext, ExecutionInfo, TriggerRendererContext } from "./types";
+
+function makeExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "execution-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_PENDING",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function makeComponentBaseContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: {
+      id: "node-1",
+      name: "Node",
+      componentName: "test",
+      isCollapsed: false,
+      configuration: {},
+      metadata: {},
+    },
+    componentDefinition: {
+      name: "test",
+      label: "Test",
+      description: "",
+      icon: "play",
+      color: "orange",
+    },
+    lastExecutions: [],
+    currentUser: {
+      id: "user-1",
+      name: "User",
+      email: "user@example.com",
+      roles: [],
+      groups: [],
+    },
+    actions: {
+      invokeNodeExecutionAction: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+function makeTriggerContext(overrides?: Partial<TriggerRendererContext>): TriggerRendererContext {
+  return {
+    node: {
+      id: "trigger-1",
+      name: "Start",
+      componentName: "start",
+      isCollapsed: false,
+      configuration: {
+        templates: [{ name: "Example", payload: { ok: true } }],
+      },
+    },
+    definition: {
+      name: "start",
+      label: "Start",
+      description: "",
+      icon: "play",
+      color: "purple",
+    },
+    lastEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("workflow v2 edit-mode action affordances", () => {
+  it("hides start trigger run buttons in edit mode", () => {
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "edit",
+    });
+
+    render(<Trigger {...props} canvasMode="edit" onRun={vi.fn()} />);
+
+    expect(screen.queryByTestId("start-template-run")).not.toBeInTheDocument();
+    expect(screen.getByText("Example")).toBeInTheDocument();
+  });
+
+  it("keeps start trigger run buttons in live mode", () => {
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+    });
+
+    render(<Trigger {...props} canvasMode="live" onRun={vi.fn()} />);
+
+    expect(screen.getByTestId("start-template-run")).toBeInTheDocument();
+  });
+
+  it("disables approval actions in edit mode", () => {
+    const props = approvalMapper.props(
+      makeComponentBaseContext({
+        canvasMode: "edit",
+        componentDefinition: {
+          name: "approval",
+          label: "Approval",
+          description: "",
+          icon: "hand",
+          color: "orange",
+        },
+        lastExecutions: [
+          makeExecution({
+            metadata: {
+              records: [
+                {
+                  index: 0,
+                  state: "pending",
+                  type: "user",
+                  user: {
+                    id: "user-1",
+                    name: "User",
+                    email: "user@example.com",
+                    roles: [],
+                    groups: [],
+                  },
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(React.isValidElement(props.customField)).toBe(true);
+    const approvalField = props.customField as React.ReactElement<{
+      approvals: Array<{ interactive: boolean }>;
+    }>;
+
+    expect(approvalField.props.approvals[0].interactive).toBe(false);
+  });
+
+  it("hides wait and time gate push-through actions in edit mode", () => {
+    const waitProps = waitMapper.props(
+      makeComponentBaseContext({
+        canvasMode: "edit",
+        componentDefinition: {
+          name: "wait",
+          label: "Wait",
+          description: "",
+          icon: "clock",
+          color: "orange",
+        },
+        lastExecutions: [makeExecution()],
+      }),
+    );
+    const timeGateProps = timeGateMapper.props(
+      makeComponentBaseContext({
+        canvasMode: "edit",
+        componentDefinition: {
+          name: "timeGate",
+          label: "Time Gate",
+          description: "",
+          icon: "clock",
+          color: "orange",
+        },
+        lastExecutions: [makeExecution()],
+      }),
+    );
+
+    render(
+      <>
+        <ComponentBase {...waitProps} canvasMode="edit" />
+        <ComponentBase {...timeGateProps} canvasMode="edit" />
+      </>,
+    );
+
+    expect(waitProps.customFieldVisibility).toBe("live-only");
+    expect(timeGateProps.customFieldVisibility).toBe("live-only");
+    expect(screen.queryByText("Push through")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/safeMappers.ts
+++ b/web_src/src/pages/workflowv2/mappers/safeMappers.ts
@@ -144,6 +144,7 @@ function buildNormalizedComponentBaseProps(
     metadata: sanitizeArray(record.metadata),
     customField: sanitizeCustomField(record.customField as ComponentBaseProps["customField"], fallbackTitle),
     customFieldPosition: record.customFieldPosition === "before" ? "before" : "after",
+    customFieldVisibility: record.customFieldVisibility === "live-only" ? "live-only" : "always",
     eventStateMap: isRecord(record.eventStateMap)
       ? (record.eventStateMap as ComponentBaseProps["eventStateMap"])
       : undefined,
@@ -264,6 +265,7 @@ function buildNormalizedTriggerProps(
     metadata,
     customField: normalizeTriggerCustomField(record.customField),
     customFieldPosition: record.customFieldPosition === "before" ? "before" : "after",
+    customFieldVisibility: record.customFieldVisibility === "live-only" ? "live-only" : "always",
     eventStateMap: isRecord(record.eventStateMap)
       ? (record.eventStateMap as ComponentBaseProps["eventStateMap"])
       : undefined,

--- a/web_src/src/pages/workflowv2/mappers/start.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start.tsx
@@ -115,19 +115,20 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
               </div>
               <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
             </div>
-            <Button
-              size="sm"
-              data-testid="start-template-run"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleRun(template);
-              }}
-              disabled={!context?.onRun}
-              className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
-            >
-              Run
-            </Button>
+            {context?.onRun && (
+              <Button
+                size="sm"
+                data-testid="start-template-run"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleRun(template);
+                }}
+                className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
+              >
+                Run
+              </Button>
+            )}
           </div>
         ))}
       </div>

--- a/web_src/src/pages/workflowv2/mappers/timegate.tsx
+++ b/web_src/src/pages/workflowv2/mappers/timegate.tsx
@@ -55,6 +55,7 @@ export const timeGateMapper: ComponentBaseMapper = {
       specs: getTimeGateSpecs(context.node),
       eventStateMap: getStateMap(componentName),
       customField: getTimeGateCustomField(context),
+      customFieldVisibility: "live-only",
     };
   },
   subtitle(context: SubtitleContext): React.ReactNode {

--- a/web_src/src/pages/workflowv2/mappers/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/types.ts
@@ -55,6 +55,7 @@ export type TriggerRendererContext = {
   node: NodeInfo;
   definition: ComponentDefinition;
   lastEvent: EventInfo;
+  canvasMode?: "live" | "edit";
 };
 
 export type EventInfo =
@@ -121,6 +122,7 @@ export type ComponentBaseContext = {
   nodeQueueItems?: QueueItemInfo[];
   currentUser: User | undefined;
   actions: ActionContext;
+  canvasMode?: "live" | "edit";
 };
 
 export type ActionContext = {

--- a/web_src/src/pages/workflowv2/mappers/wait.tsx
+++ b/web_src/src/pages/workflowv2/mappers/wait.tsx
@@ -83,6 +83,7 @@ export const waitMapper: ComponentBaseMapper = {
       hideMetadataList: false,
       eventStateMap: getStateMap(componentName),
       customField: getWaitCustomField(context),
+      customFieldVisibility: "live-only",
     };
   },
 

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -217,6 +217,8 @@ export interface ComponentBaseProps extends ComponentActionsProps {
   customField?: React.ReactNode | ((onRun?: () => void, nodeId?: string) => React.ReactNode);
   /** Where to render customField: "before" (before events) or "after" (after events, default) */
   customFieldPosition?: "before" | "after";
+  /** Whether the custom field should only be shown in live mode */
+  customFieldVisibility?: "always" | "live-only";
   eventStateMap?: EventStateMap;
   includeEmptyState?: boolean;
   emptyStateProps?: {
@@ -257,6 +259,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   metadata,
   customField,
   customFieldPosition = "after",
+  customFieldVisibility = "always",
   eventStateMap,
   includeEmptyState = false,
   emptyStateProps,
@@ -271,6 +274,7 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   const safeError = typeof error === "string" ? error : "";
   const safeWarning = typeof warning === "string" ? warning : "";
   const safeCustomFieldPosition = customFieldPosition === "before" ? "before" : "after";
+  const safeCustomFieldVisibility = customFieldVisibility === "live-only" ? "live-only" : "always";
   const safeCustomField = React.useMemo(() => {
     if (typeof customField === "function") {
       return (onRunHandler?: () => void, nodeId?: string) => {
@@ -318,6 +322,13 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
     safeEventSections && safeEventSections.length > 0
       ? (resolvedEventStateMap[compactEventState] || resolvedEventStateMap.neutral).badgeColor
       : undefined;
+  const customFieldOnRun = canvasMode === "edit" || runDisabled ? undefined : onRun;
+  const renderedCustomField =
+    safeCustomFieldVisibility === "live-only" && canvasMode === "edit"
+      ? null
+      : typeof safeCustomField === "function"
+        ? safeCustomField(customFieldOnRun)
+        : safeCustomField || null;
 
   return (
     <SelectionWrapper selected={selected}>
@@ -470,16 +481,13 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
               </div>
             )}
 
-            {safeCustomFieldPosition === "before" &&
-              (typeof safeCustomField === "function"
-                ? safeCustomField(runDisabled ? undefined : onRun)
-                : safeCustomField || null)}
+            {safeCustomFieldPosition === "before" && renderedCustomField}
 
             {safeEventSections?.map((section, index) => (
               <EventSectionDisplay
                 className={
                   "pb-3" +
-                  (!!includeEmptyState || (!!safeCustomField && safeCustomFieldPosition === "after")
+                  (!!includeEmptyState || (!!renderedCustomField && safeCustomFieldPosition === "after")
                     ? " border-b border-slate-950/20"
                     : "")
                 }
@@ -491,17 +499,14 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
                 lastSection={
                   index === safeEventSections.length - 1 &&
                   !includeEmptyState &&
-                  !(safeCustomField && safeCustomFieldPosition === "after")
+                  !(renderedCustomField && safeCustomFieldPosition === "after")
                 }
               />
             ))}
 
             {includeEmptyState && <EmptyState compact {...resolvedEmptyStateProps} />}
 
-            {safeCustomFieldPosition === "after" &&
-              (typeof safeCustomField === "function"
-                ? safeCustomField(runDisabled ? undefined : onRun)
-                : safeCustomField || null)}
+            {safeCustomFieldPosition === "after" && renderedCustomField}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
This removes runtime action affordances from workflow canvas nodes while editing, so edit mode no longer exposes actions that only make sense in live mode.

## Changes
- Thread canvas mode into workflow v2 node mapper contexts
- Hide start trigger `Run` actions in edit mode while keeping template content visible
- Hide wait/time gate push-through actions in edit mode
- Keep approval state visible in edit mode but disable approve/reject actions
- Centralize edit-mode custom-field behavior in `ComponentBase` with `live-only` custom field visibility
- Add focused mapper coverage for edit vs live action behavior

### Edit mode

<img width="1966" height="790" alt="image" src="https://github.com/user-attachments/assets/ac320575-c6a0-41f9-9f94-8ac943dee051" />


### Live

<img width="1960" height="872" alt="image" src="https://github.com/user-attachments/assets/0de918c5-1fcc-4fa1-a853-08fda53cfd19" />
