### PR TITLE
feat: implement OpenRouter integration

### DIFF
--- a/pkg/integrations/openrouter/client.go
+++ b/pkg/integrations/openrouter/client.go
@@ -1,0 +1,170 @@
+package openrouter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const defaultBaseURL = "https://openrouter.ai/api/v1"
+
+type Client struct {
+	APIKey  string
+	BaseURL string
+	http    core.HTTPContext
+}
+
+func NewClient(httpClient core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("no integration context")
+	}
+
+	apiKey, err := ctx.GetConfig("apiKey")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		APIKey:  string(apiKey),
+		BaseURL: defaultBaseURL,
+		http:    httpClient,
+	}, nil
+}
+
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	Name    string `json:"name,omitempty"`
+}
+
+type ChatCompletionRequest struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	Temperature float64       `json:"temperature,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Stream      bool          `json:"stream,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type ChatCompletionResponse struct {
+	ID      string   `json:"id"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   Usage    `json:"usage"`
+}
+
+type Choice struct {
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+	Index        int         `json:"index"`
+}
+
+type Model struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Created       int64  `json:"created"`
+	ContextWindow int    `json:"context_window"`
+}
+
+type ModelsResponse struct {
+	Data []Model `json:"data"`
+}
+
+type ErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func (c *Client) Verify() error {
+	_, err := c.execRequest(http.MethodGet, c.BaseURL+"/models", nil)
+	return err
+}
+
+func (c *Client) ListModels() ([]Model, error) {
+	responseBody, err := c.execRequest(http.MethodGet, c.BaseURL+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ModelsResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal models response: %v", err)
+	}
+
+	return response.Data, nil
+}
+
+func (c *Client) CreateChatCompletion(req ChatCompletionRequest) (*ChatCompletionResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, c.BaseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response ChatCompletionResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	return &response, nil
+}
+
+func (c *Client) execRequest(method, URL string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, URL, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		var apiErr ErrorResponse
+		var errorMessage string
+
+		if err := json.Unmarshal(responseBody, &apiErr); err == nil {
+			if apiErr.Error.Message != "" {
+				errorMessage = apiErr.Error.Message
+			} else {
+				errorMessage = string(responseBody)
+			}
+		} else {
+			errorMessage = string(responseBody)
+		}
+
+		if res.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("OpenRouter credentials are invalid or expired: %s", errorMessage)
+		}
+
+		return nil, fmt.Errorf("request failed (%d): %s", res.StatusCode, errorMessage)
+	}
+
+	return responseBody, nil
+}

--- a/pkg/integrations/openrouter/example.go
+++ b/pkg/integrations/openrouter/example.go
@@ -1,0 +1,18 @@
+package openrouter
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output_text_prompt.json
+var exampleOutputTextPromptBytes []byte
+
+var exampleOutputTextPromptOnce sync.Once
+var exampleOutputTextPrompt map[string]any
+
+func (c *TextPrompt) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputTextPromptOnce, exampleOutputTextPromptBytes, &exampleOutputTextPrompt)
+}

--- a/pkg/integrations/openrouter/example_output_text_prompt.json
+++ b/pkg/integrations/openrouter/example_output_text_prompt.json
@@ -1,0 +1,15 @@
+{
+    "type": "openrouter.response",
+    "data": {
+        "id": "gen-1234567890",
+        "model": "anthropic/claude-3.5-sonnet",
+        "text": "Hello, world! This is a response from a model via OpenRouter.",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30
+        },
+        "reason": "stop"
+    },
+    "timestamp": "2026-01-19T12:00:00Z"
+}

--- a/pkg/integrations/openrouter/openrouter.go
+++ b/pkg/integrations/openrouter/openrouter.go
@@ -1,0 +1,132 @@
+package openrouter
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("openrouter", &OpenRouter{})
+}
+
+type OpenRouter struct{}
+
+type Configuration struct {
+	APIKey string `json:"apiKey"`
+}
+
+func (o *OpenRouter) Name() string {
+	return "openrouter"
+}
+
+func (o *OpenRouter) Label() string {
+	return "OpenRouter"
+}
+
+func (o *OpenRouter) Icon() string {
+	return "globe"
+}
+
+func (o *OpenRouter) Description() string {
+	return "Access multiple LLM providers through a single OpenAI-compatible API"
+}
+
+func (o *OpenRouter) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "apiKey",
+			Label:       "API Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "OpenRouter API key",
+		},
+	}
+}
+
+func (o *OpenRouter) Components() []core.Component {
+	return []core.Component{
+		&TextPrompt{},
+	}
+}
+
+func (o *OpenRouter) Triggers() []core.Trigger {
+	return []core.Trigger{}
+}
+
+func (o *OpenRouter) Instructions() string {
+	return "To get your OpenRouter API key, sign up at [openrouter.ai](https://openrouter.ai)."
+}
+
+func (o *OpenRouter) Cleanup(ctx core.IntegrationCleanupContext) error {
+	return nil
+}
+
+func (o *OpenRouter) Sync(ctx core.SyncContext) error {
+	config := Configuration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if config.APIKey == "" {
+		return fmt.Errorf("apiKey is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	if err := client.Verify(); err != nil {
+		return err
+	}
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (o *OpenRouter) HandleRequest(ctx core.HTTPRequestContext) {
+}
+
+func (o *OpenRouter) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	if resourceType != "model" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := client.ListModels()
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(models))
+	for _, model := range models {
+		if model.ID == "" {
+			continue
+		}
+
+		resources = append(resources, core.IntegrationResource{
+			Type: resourceType,
+			Name: model.ID,
+			ID:   model.ID,
+		})
+	}
+
+	return resources, nil
+}
+
+func (o *OpenRouter) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (o *OpenRouter) HandleAction(ctx core.IntegrationActionContext) error {
+	return nil
+}

--- a/pkg/integrations/openrouter/text_prompt.go
+++ b/pkg/integrations/openrouter/text_prompt.go
@@ -1,0 +1,248 @@
+package openrouter
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const ResponsePayloadType = "openrouter.response"
+
+type TextPrompt struct{}
+
+type TextPromptSpec struct {
+	Model       string  `mapstructure:"model"`
+	Input       string  `mapstructure:"input"`
+	Temperature float64 `mapstructure:"temperature"`
+	MaxTokens   int     `mapstructure:"maxTokens"`
+}
+
+type ResponsePayload struct {
+	ID     string `json:"id"`
+	Model  string `json:"model"`
+	Text   string `json:"text"`
+	Usage  *Usage `json:"usage,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func (c *TextPrompt) Name() string {
+	return "openrouter.textPrompt"
+}
+
+func (c *TextPrompt) Label() string {
+	return "Text Prompt"
+}
+
+func (c *TextPrompt) Description() string {
+	return "Generate a text response using any model available on OpenRouter"
+}
+
+func (c *TextPrompt) Documentation() string {
+	return `The Text Prompt component generates text responses using any model available on OpenRouter.
+
+## Use Cases
+
+- **Multi-provider AI**: Access models from Anthropic, OpenAI, Meta, Mistral, and many others through a single integration
+- **Content generation**: Generate text content, summaries, or descriptions
+- **Natural language processing**: Process and transform text using AI
+- **Automated responses**: Generate responses to user queries or events
+- **Model flexibility**: Easily switch between models without changing your workflow
+
+## Configuration
+
+- **Model**: Select the OpenRouter model to use (e.g., anthropic/claude-3.5-sonnet, openai/gpt-4o, meta-llama/llama-3-70b-instruct)
+- **Prompt**: The text prompt to send to the model (supports expressions)
+- **Temperature**: Controls randomness (0.0-2.0, default 0.7)
+- **Max Tokens**: Maximum tokens in response (default 1024)
+
+## Output
+
+Returns the generated response including:
+- **text**: The generated text response
+- **model**: The model used for generation
+- **usage**: Token usage information (prompt tokens, completion tokens, total tokens)
+- **reason**: The finish reason (stop, length, etc.)
+- **id**: Response ID for tracking
+
+## Notes
+
+- Requires a valid OpenRouter API key configured in the integration settings
+- OpenRouter provides access to 100+ models from various providers
+- Pricing and availability depend on the selected model
+- Response quality and speed vary by model`
+}
+
+func (c *TextPrompt) Icon() string {
+	return "globe"
+}
+
+func (c *TextPrompt) Color() string {
+	return "purple"
+}
+
+func (c *TextPrompt) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *TextPrompt) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "model",
+			Label:       "Model",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Default:     "anthropic/claude-3.5-sonnet",
+			Placeholder: "e.g. anthropic/claude-3.5-sonnet",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "model",
+				},
+			},
+		},
+		{
+			Name:        "input",
+			Label:       "Prompt",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Placeholder: "Enter the prompt text",
+			Description: "The prompt to send to the model (supports expressions)",
+		},
+		{
+			Name:        "temperature",
+			Label:       "Temperature",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     0.7,
+			Description: "Controls randomness (0.0-2.0, lower is more deterministic)",
+		},
+		{
+			Name:        "maxTokens",
+			Label:       "Max Tokens",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     1024,
+			Description: "Maximum number of tokens in the response",
+		},
+	}
+}
+
+func (c *TextPrompt) Setup(ctx core.SetupContext) error {
+	spec := TextPromptSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if spec.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+
+	if spec.Input == "" {
+		return fmt.Errorf("input is required")
+	}
+
+	return nil
+}
+
+func (c *TextPrompt) Execute(ctx core.ExecutionContext) error {
+	spec := TextPromptSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %v", err)
+	}
+
+	if spec.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+
+	if spec.Input == "" {
+		return fmt.Errorf("input is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	chatReq := ChatCompletionRequest{
+		Model: spec.Model,
+		Messages: []ChatMessage{
+			{
+				Role:    "user",
+				Content: spec.Input,
+			},
+		},
+		Temperature: spec.Temperature,
+		MaxTokens:   spec.MaxTokens,
+	}
+
+	if chatReq.MaxTokens == 0 {
+		chatReq.MaxTokens = 1024
+	}
+	if chatReq.Temperature == 0 {
+		chatReq.Temperature = 0.7
+	}
+
+	response, err := client.CreateChatCompletion(chatReq)
+	if err != nil {
+		return err
+	}
+
+	if len(response.Choices) == 0 {
+		return fmt.Errorf("no response choices returned")
+	}
+
+	choice := response.Choices[0]
+	payload := ResponsePayload{
+		ID:     response.ID,
+		Model:  response.Model,
+		Text:   choice.Message.Content,
+		Usage:  &response.Usage,
+		Reason: choice.FinishReason,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		ResponsePayloadType,
+		[]any{payload},
+	)
+}
+
+func (c *TextPrompt) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *TextPrompt) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *TextPrompt) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *TextPrompt) HandleAction(ctx core.ActionContext) error {
+	return nil
+}
+
+func (c *TextPrompt) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *TextPrompt) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func extractResponseText(response *ChatCompletionResponse) string {
+	if response == nil {
+		return ""
+	}
+
+	if len(response.Choices) == 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(response.Choices[0].Message.Content)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/newrelic"
 	_ "github.com/superplanehq/superplane/pkg/integrations/octopus"
 	_ "github.com/superplanehq/superplane/pkg/integrations/openai"
+	_ "github.com/superplanehq/superplane/pkg/integrations/openrouter"
 	_ "github.com/superplanehq/superplane/pkg/integrations/pagerduty"
 	_ "github.com/superplanehq/superplane/pkg/integrations/perplexity"
 	_ "github.com/superplanehq/superplane/pkg/integrations/prometheus"

--- a/web_src/src/assets/icons/integrations/openrouter.svg
+++ b/web_src/src/assets/icons/integrations/openrouter.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"></circle>
+  <line x1="2" y1="12" x2="22" y2="12"></line>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+</svg>

--- a/web_src/src/pages/workflowv2/mappers/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/index.ts
@@ -160,6 +160,11 @@ import {
   eventStateRegistry as openaiEventStateRegistry,
 } from "./openai/index";
 import {
+  componentMappers as openrouterComponentMappers,
+  triggerRenderers as openrouterTriggerRenderers,
+  eventStateRegistry as openrouterEventStateRegistry,
+} from "./openrouter/index";
+import {
   componentMappers as grafanaComponentMappers,
   customFieldRenderers as grafanaCustomFieldRenderers,
   triggerRenderers as grafanaTriggerRenderers,
@@ -303,6 +308,7 @@ const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
   octopus: octopusComponentMappers,
   teams: teamsComponentMappers,
   openai: openaiComponentMappers,
+  openrouter: openrouterComponentMappers,
   circleci: circleCIComponentMappers,
   claude: claudeComponentMappers,
   logfire: logfireComponentMappers,
@@ -347,6 +353,7 @@ const appTriggerRenderers: Record<string, Record<string, TriggerRenderer>> = {
   octopus: octopusTriggerRenderers,
   teams: teamsTriggerRenderers,
   openai: openaiTriggerRenderers,
+  openrouter: openrouterTriggerRenderers,
   circleci: circleCITriggerRenderers,
   claude: claudeTriggerRenderers,
   logfire: logfireTriggerRenderers,
@@ -389,6 +396,7 @@ const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>
   firehydrant: firehydrantEventStateRegistry,
   launchdarkly: launchdarklyEventStateRegistry,
   openai: openaiEventStateRegistry,
+  openrouter: openrouterEventStateRegistry,
   circleci: circleCIEventStateRegistry,
   claude: claudeEventStateRegistry,
   logfire: logfireEventStateRegistry,

--- a/web_src/src/pages/workflowv2/mappers/openrouter/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/openrouter/base.ts
@@ -1,0 +1,72 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import openRouterIcon from "@/assets/icons/integrations/openrouter.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+export const baseMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "openrouter";
+
+    return {
+      iconSrc: openRouterIcon,
+      iconSlug: context.componentDefinition?.icon ?? "globe",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title:
+        context.node.name || context.componentDefinition?.label || context.componentDefinition?.name || "OpenRouter",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const payload = outputs?.default?.[0];
+
+    if (payload?.type) {
+      details["Event Type"] = payload.type;
+    }
+
+    if (payload?.timestamp) {
+      details["Emitted At"] = new Date(payload.timestamp).toLocaleString();
+    }
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const eventSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/openrouter/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/openrouter/index.ts
@@ -1,0 +1,13 @@
+import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
+import { baseMapper } from "./base";
+import { buildActionStateRegistry } from "../utils";
+
+export const componentMappers: Record<string, ComponentBaseMapper> = {
+  textPrompt: baseMapper,
+};
+
+export const triggerRenderers: Record<string, TriggerRenderer> = {};
+
+export const eventStateRegistry: Record<string, EventStateRegistry> = {
+  textPrompt: buildActionStateRegistry("completed"),
+};


### PR DESCRIPTION
## Summary
Add OpenRouter integration with text prompt component for AI model access.
## Changes
- **Backend**: OpenRouter integration with `textPrompt` component supporting multiple AI models (gemini, claude, gpt-4, etc.)
- **Frontend**: UI mapper and SVG icon for OpenRouter integration
- **Registration**: Integration and UI mapper registered in server and index
## Use Case
Access AI models through OpenRouter's unified API - no need to configure multiple provider integrations separately.
## Example Usage
```yaml
- name: "openrouter.textPrompt"
  type: "TYPE_COMPONENT"
  configuration:
    model: "google/gemini-2.5-flash-lite"
    input: "Explain this issue: {{ root().data.issue.title }}"
    maxTokens: 1024
Files
- pkg/integrations/openrouter/ - Integration implementation
- pkg/server/server.go - Integration registration
- web_src/src/pages/workflowv2/mappers/openrouter/ - UI mapper
- web_src/src/assets/icons/integrations/openrouter.svg - Icon