### PR TITLE
fix: add proper error messages for cli errors

### DIFF
--- a/pkg/cli/core/errors.go
+++ b/pkg/cli/core/errors.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -8,28 +9,62 @@ import (
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
+const (
+	maxErrorBodyBytes       = 2048
+	badRequestDetailType    = "type.googleapis.com/google.rpc.BadRequest"
+	badRequestDetailTypeAlt = "google.rpc.BadRequest"
+)
+
 func FormatCommandError(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	var apiErr openapi_client.GenericOpenAPIError
+	var apiErr *openapi_client.GenericOpenAPIError
 	if !errors.As(err, &apiErr) {
 		return err
 	}
 
+	rpcStatus := extractGoogleRPCStatus(apiErr)
+	if formatted := formatGoogleRPCStatusError(rpcStatus); formatted != nil {
+		return appendFieldViolations(formatted, rpcStatus)
+	}
+
+	return fallbackAPIError(apiErr)
+}
+
+func extractGoogleRPCStatus(apiErr *openapi_client.GenericOpenAPIError) *openapi_client.GooglerpcStatus {
 	switch model := apiErr.Model().(type) {
 	case *openapi_client.GooglerpcStatus:
-		if formatted := formatGoogleRPCStatusError(model); formatted != nil {
-			return formatted
+		if model != nil && !isEmptyRPCStatus(model) {
+			return model
 		}
 	case openapi_client.GooglerpcStatus:
-		if formatted := formatGoogleRPCStatusError(&model); formatted != nil {
-			return formatted
+		if !isEmptyRPCStatus(&model) {
+			return &model
 		}
 	}
 
-	return err
+	body := apiErr.Body()
+	if len(body) == 0 {
+		return nil
+	}
+
+	var decoded openapi_client.GooglerpcStatus
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil
+	}
+	if isEmptyRPCStatus(&decoded) {
+		return nil
+	}
+	return &decoded
+}
+
+func isEmptyRPCStatus(status *openapi_client.GooglerpcStatus) bool {
+	if status == nil {
+		return true
+	}
+	return status.Message == nil && status.Code == nil && len(status.Details) == 0
 }
 
 func formatGoogleRPCStatusError(status *openapi_client.GooglerpcStatus) error {
@@ -64,25 +99,102 @@ func formatGoogleRPCStatusError(status *openapi_client.GooglerpcStatus) error {
 	return fmt.Errorf("%s", message)
 }
 
-// grpcCodePrefix returns a user-friendly prefix for known gRPC status codes.
-// See https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+func appendFieldViolations(base error, status *openapi_client.GooglerpcStatus) error {
+	violations := extractFieldViolations(status)
+	if len(violations) == 0 {
+		return base
+	}
+
+	var sb strings.Builder
+	sb.WriteString(base.Error())
+	for _, v := range violations {
+		sb.WriteString("\n  - ")
+		sb.WriteString(v)
+	}
+	return errors.New(sb.String())
+}
+
+func extractFieldViolations(status *openapi_client.GooglerpcStatus) []string {
+	if status == nil {
+		return nil
+	}
+
+	var out []string
+	for _, detail := range status.GetDetails() {
+		if !isBadRequestDetail(detail.GetType()) {
+			continue
+		}
+		raw, ok := detail.AdditionalProperties["fieldViolations"]
+		if !ok {
+			raw = detail.AdditionalProperties["field_violations"]
+		}
+		list, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range list {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			field, _ := entry["field"].(string)
+			desc, _ := entry["description"].(string)
+			switch {
+			case field != "" && desc != "":
+				out = append(out, fmt.Sprintf("%s: %s", field, desc))
+			case field != "":
+				out = append(out, field)
+			case desc != "":
+				out = append(out, desc)
+			}
+		}
+	}
+	return out
+}
+
+func isBadRequestDetail(typeURL string) bool {
+	trimmed := strings.TrimSpace(typeURL)
+	return trimmed == badRequestDetailType || trimmed == badRequestDetailTypeAlt
+}
+
+func fallbackAPIError(apiErr *openapi_client.GenericOpenAPIError) error {
+	status := strings.TrimSpace(apiErr.Error())
+	body := strings.TrimSpace(string(apiErr.Body()))
+
+	if body == "" {
+		if status == "" {
+			return apiErr
+		}
+		return errors.New(status)
+	}
+
+	if len(body) > maxErrorBodyBytes {
+		body = body[:maxErrorBodyBytes] + "... [truncated]"
+	}
+
+	if status == "" {
+		return errors.New(body)
+	}
+	return fmt.Errorf("%s\n%s", status, body)
+}
+
 func grpcCodePrefix(code int32) string {
 	switch code {
-	case 3: // InvalidArgument
+	case 3:
 		return "invalid request"
-	case 5: // NotFound
+	case 5:
 		return "not found"
-	case 6: // AlreadyExists
+	case 6:
 		return "already exists"
-	case 7: // PermissionDenied
+	case 7:
 		return "permission denied"
-	case 12: // Unimplemented
+	case 12:
 		return "not supported"
-	case 13: // Internal
+	case 13:
 		return "internal error"
-	case 14: // Unavailable
+	case 14:
 		return "service unavailable"
-	case 16: // Unauthenticated
+	case 16:
 		return "authentication required"
 	default:
 		return ""

--- a/pkg/cli/core/errors.go
+++ b/pkg/cli/core/errors.go
@@ -7,13 +7,24 @@ import (
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/openapi_client"
+	"google.golang.org/grpc/codes"
 )
 
 const (
-	maxErrorBodyBytes       = 2048
-	badRequestDetailType    = "type.googleapis.com/google.rpc.BadRequest"
-	badRequestDetailTypeAlt = "google.rpc.BadRequest"
+	maxErrorBodyBytes      = 2048
+	badRequestDetailSuffix = "BadRequest"
 )
+
+var grpcCodePrefixes = map[codes.Code]string{
+	codes.InvalidArgument:  "invalid request",
+	codes.NotFound:         "not found",
+	codes.AlreadyExists:    "already exists",
+	codes.PermissionDenied: "permission denied",
+	codes.Unimplemented:    "not supported",
+	codes.Internal:         "internal error",
+	codes.Unavailable:      "service unavailable",
+	codes.Unauthenticated:  "authentication required",
+}
 
 func FormatCommandError(err error) error {
 	if err == nil {
@@ -124,37 +135,52 @@ func extractFieldViolations(status *openapi_client.GooglerpcStatus) []string {
 		if !isBadRequestDetail(detail.GetType()) {
 			continue
 		}
-		raw, ok := detail.AdditionalProperties["fieldViolations"]
-		if !ok {
-			raw = detail.AdditionalProperties["field_violations"]
-		}
-		list, ok := raw.([]any)
-		if !ok {
-			continue
-		}
-		for _, item := range list {
-			entry, ok := item.(map[string]any)
-			if !ok {
-				continue
-			}
+		for _, entry := range getViolations(detail.AdditionalProperties) {
 			field, _ := entry["field"].(string)
 			desc, _ := entry["description"].(string)
-			switch {
-			case field != "" && desc != "":
-				out = append(out, fmt.Sprintf("%s: %s", field, desc))
-			case field != "":
-				out = append(out, field)
-			case desc != "":
-				out = append(out, desc)
+			if s := formatFieldDesc(field, desc); s != "" {
+				out = append(out, s)
 			}
 		}
 	}
 	return out
 }
 
+func getViolations(props map[string]any) []map[string]any {
+	raw, ok := props["fieldViolations"]
+	if !ok {
+		raw = props["field_violations"]
+	}
+
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func formatFieldDesc(field, desc string) string {
+	switch {
+	case field != "" && desc != "":
+		return fmt.Sprintf("%s: %s", field, desc)
+	case field != "":
+		return field
+	case desc != "":
+		return desc
+	default:
+		return ""
+	}
+}
+
 func isBadRequestDetail(typeURL string) bool {
-	trimmed := strings.TrimSpace(typeURL)
-	return trimmed == badRequestDetailType || trimmed == badRequestDetailTypeAlt
+	return strings.HasSuffix(strings.TrimSpace(typeURL), badRequestDetailSuffix)
 }
 
 func fallbackAPIError(apiErr *openapi_client.GenericOpenAPIError) error {
@@ -179,26 +205,7 @@ func fallbackAPIError(apiErr *openapi_client.GenericOpenAPIError) error {
 }
 
 func grpcCodePrefix(code int32) string {
-	switch code {
-	case 3:
-		return "invalid request"
-	case 5:
-		return "not found"
-	case 6:
-		return "already exists"
-	case 7:
-		return "permission denied"
-	case 12:
-		return "not supported"
-	case 13:
-		return "internal error"
-	case 14:
-		return "service unavailable"
-	case 16:
-		return "authentication required"
-	default:
-		return ""
-	}
+	return grpcCodePrefixes[codes.Code(code)]
 }
 
 func usageLimitError(message string) error {

--- a/pkg/cli/core/errors_test.go
+++ b/pkg/cli/core/errors_test.go
@@ -1,6 +1,12 @@
 package core
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -135,4 +141,108 @@ func TestFormatGoogleRPCStatusErrorUsageLimitTakesPrecedence(t *testing.T) {
 	err := formatGoogleRPCStatusError(&status)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "usage limit reached")
+}
+
+func TestFormatCommandErrorPassesThroughNonAPIErrors(t *testing.T) {
+	plain := fmt.Errorf("boom")
+	require.Equal(t, plain, FormatCommandError(plain))
+	require.NoError(t, FormatCommandError(nil))
+}
+
+func TestFormatCommandErrorDecodesValidationBody(t *testing.T) {
+	body := map[string]any{
+		"code":    3,
+		"message": "canvas name is required",
+	}
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "application/json", mustJSON(t, body))
+
+	require.Equal(t, "invalid request: canvas name is required", FormatCommandError(err).Error())
+}
+
+func TestFormatCommandErrorAppendsFieldViolations(t *testing.T) {
+	body := map[string]any{
+		"code":    3,
+		"message": "canvas is invalid",
+		"details": []any{
+			map[string]any{
+				"@type": "type.googleapis.com/google.rpc.BadRequest",
+				"fieldViolations": []any{
+					map[string]any{"field": "canvas.name", "description": "must not be empty"},
+					map[string]any{"field": "canvas.description", "description": "must be under 200 chars"},
+				},
+			},
+		},
+	}
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "application/json", mustJSON(t, body))
+
+	formatted := FormatCommandError(err)
+	require.Error(t, formatted)
+	require.Equal(t,
+		"invalid request: canvas is invalid\n  - canvas.name: must not be empty\n  - canvas.description: must be under 200 chars",
+		formatted.Error(),
+	)
+}
+
+func TestFormatCommandErrorFallsBackToBodyForNonJSONResponse(t *testing.T) {
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "text/plain", []byte("upstream validation failed: name must not be empty"))
+
+	formatted := FormatCommandError(err)
+	require.Error(t, formatted)
+	require.Contains(t, formatted.Error(), "upstream validation failed: name must not be empty")
+}
+
+func TestFormatCommandErrorHandlesEmptyBody(t *testing.T) {
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "", nil)
+
+	formatted := FormatCommandError(err)
+	require.Error(t, formatted)
+	require.Contains(t, formatted.Error(), "400 Bad Request")
+}
+
+func TestFormatCommandErrorHandlesZeroCodeBody(t *testing.T) {
+	body := map[string]any{
+		"message": "something broke",
+	}
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "application/json", mustJSON(t, body))
+
+	require.Equal(t, "something broke", FormatCommandError(err).Error())
+}
+
+func TestFormatCommandErrorTruncatesLargeBodies(t *testing.T) {
+	big := strings.Repeat("x", maxErrorBodyBytes+500)
+	err := runAPICallWithResponse(t, http.StatusBadRequest, "text/plain", []byte(big))
+
+	formatted := FormatCommandError(err).Error()
+	require.Contains(t, formatted, "... [truncated]")
+	require.Less(t, len(formatted), maxErrorBodyBytes+200)
+}
+
+func runAPICallWithResponse(t *testing.T, statusCode int, contentType string, body []byte) error {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.WriteHeader(statusCode)
+		if len(body) > 0 {
+			_, _ = w.Write(body)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := openapi_client.NewConfiguration()
+	cfg.Servers = openapi_client.ServerConfigurations{{URL: server.URL}}
+	client := openapi_client.NewAPIClient(cfg)
+
+	_, _, err := client.CanvasAPI.CanvasesDescribeCanvas(context.Background(), "canvas-id").Execute()
+	require.Error(t, err)
+	return err
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
 }


### PR DESCRIPTION
### Problem
CLI commands that failed validation printed only `400 Bad Request`, hiding the server's actual error message. Agents and scripts had to guess what went wrong and retry blindly.

### Changes

- Fixed the `errors.As` target in `FormatCommandError` and added a body fallback so the CLI always surfaces a useful message - decoded `GooglerpcStatus` when available, raw response body (capped) otherwise.
- Added end-to-end tests driving the real SDK via `httptest`.

### Before / After
Before:
`$ superplane canvases update --name ""` ... 400 Bad Request

After:
`$ superplane canvases update --name "" `... invalid request: canvas name is required

Closes: https://github.com/superplanehq/superplane/issues/4230