### PR TITLE
chore: simplify error handling in deleteAllTemplateWorkflows

### DIFF
--- a/pkg/templates/seed.go
+++ b/pkg/templates/seed.go
@@ -98,39 +98,31 @@ func SeedTemplates(registry *registry.Registry) error {
 }
 
 func deleteAllTemplateWorkflows(tx *gorm.DB) error {
-	var err error
-
 	var workflowIDs []uuid.UUID
 
-	err = tx.
+	if err := tx.
 		Unscoped().
 		Model(&models.Canvas{}).
 		Where("organization_id = ?", models.TemplateOrganizationID).
 		Where("is_template = ?", true).
-		Pluck("id", &workflowIDs).Error
-
-	if err != nil {
+		Pluck("id", &workflowIDs).Error; err != nil {
 		return err
 	}
 
-	err = tx.
+	if err := tx.
 		Unscoped().
 		Model(&models.CanvasNode{}).
 		Where("workflow_id IN (?)", workflowIDs).
-		Delete(&models.CanvasNode{}).Error
-
-	if err != nil {
+		Delete(&models.CanvasNode{}).Error; err != nil {
 		return err
 	}
 
-	err = tx.
+	if err := tx.
 		Unscoped().
 		Model(&models.Canvas{}).
 		Where("organization_id = ?", models.TemplateOrganizationID).
 		Where("is_template = ?", true).
-		Delete(&models.Canvas{}).Error
-
-	if err != nil {
+		Delete(&models.Canvas{}).Error; err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description
Refactored error handling in `deleteAllTemplateWorkflows` function to use idiomatic Go patterns.

## Changes
- Removed unnecessary `var err error` declaration
- Moved error handling inline with each operation using `if err := ...; err != nil` pattern
- Maintains the same functionality while improving code clarity and reducing variable scope

## Type of Change
- Code quality improvement (chore)