### PR TITLE
fix: API and CLI return errors on unknown fields

### DIFF
--- a/pkg/cli/commands/canvases/models/canvas.go
+++ b/pkg/cli/commands/canvases/models/canvas.go
@@ -1,11 +1,10 @@
 package models
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -21,19 +20,9 @@ type Canvas struct {
 }
 
 func ParseCanvas(raw []byte) (*Canvas, error) {
-	var yamlObject any
-	if err := yaml.Unmarshal(raw, &yamlObject); err != nil {
-		return nil, fmt.Errorf("failed to parse canvas resource: %w", err)
-	}
-
-	jsonData, err := json.Marshal(yamlObject)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert canvas resource to json: %w", err)
-	}
-
 	var resource Canvas
-	if err := json.Unmarshal(jsonData, &resource); err != nil {
-		return nil, fmt.Errorf("failed to parse canvas json payload: %w", err)
+	if err := core.NewDecoder(raw).DecodeYAML(&resource); err != nil {
+		return nil, fmt.Errorf("failed to parse canvas yaml: %w", err)
 	}
 
 	if resource.Kind != CanvasKind {

--- a/pkg/cli/commands/canvases/models/canvas_test.go
+++ b/pkg/cli/commands/canvases/models/canvas_test.go
@@ -1,6 +1,10 @@
 package models
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestParseCanvasPreservesPositionYFromUnquotedKey(t *testing.T) {
 	raw := []byte(`
@@ -60,4 +64,32 @@ spec:
 	if edges[0].GetTargetId() != "manual-plan-start" {
 		t.Fatalf("expected targetId=manual-plan-start, got %q", edges[0].GetTargetId())
 	}
+}
+
+func TestParseCanvasRejectsUnknownNodeComponentFields(t *testing.T) {
+	raw := []byte(`
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: unknown-field-test
+spec:
+  changeManagement:
+    enabled: false
+  edges: []
+  nodes:
+    - id: wait-1
+      name: wait
+      type: TYPE_COMPONENT
+      component:
+        name: wait
+        hello: what
+`)
+
+	_, err := ParseCanvas(raw)
+	if err == nil {
+		t.Fatalf("expected ParseCanvas to fail for unknown field")
+	}
+
+	assert.ErrorContains(t, err, "failed to parse canvas yaml")
+	assert.ErrorContains(t, err, `unknown field "hello"`)
 }

--- a/pkg/cli/commands/canvases/models/canvas_test.go
+++ b/pkg/cli/commands/canvases/models/canvas_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
 
 func TestParseCanvasPreservesPositionYFromUnquotedKey(t *testing.T) {
@@ -92,4 +93,154 @@ spec:
 
 	assert.ErrorContains(t, err, "failed to parse canvas yaml")
 	assert.ErrorContains(t, err, `unknown field "hello"`)
+}
+
+func TestParseCanvasValidationErrors(t *testing.T) {
+	t.Run("rejects unsupported kind", func(t *testing.T) {
+		raw := []byte(`
+apiVersion: v1
+kind: NotCanvas
+metadata:
+  name: invalid-kind
+spec:
+  nodes: []
+  edges: []
+`)
+
+		_, err := ParseCanvas(raw)
+		assert.EqualError(t, err, `unsupported resource kind "NotCanvas"`)
+	})
+
+	t.Run("rejects missing apiVersion", func(t *testing.T) {
+		raw := []byte(`
+kind: Canvas
+metadata:
+  name: missing-version
+spec:
+  nodes: []
+  edges: []
+`)
+
+		_, err := ParseCanvas(raw)
+		assert.EqualError(t, err, "canvas apiVersion is required")
+	})
+
+	t.Run("rejects missing metadata", func(t *testing.T) {
+		raw := []byte(`
+apiVersion: v1
+kind: Canvas
+spec:
+  nodes: []
+  edges: []
+`)
+
+		_, err := ParseCanvas(raw)
+		assert.EqualError(t, err, "canvas metadata is required")
+	})
+
+	t.Run("rejects missing metadata.name", func(t *testing.T) {
+		raw := []byte(`
+apiVersion: v1
+kind: Canvas
+metadata: {}
+spec:
+  nodes: []
+  edges: []
+`)
+
+		_, err := ParseCanvas(raw)
+		assert.EqualError(t, err, "canvas metadata.name is required")
+	})
+
+	t.Run("rejects invalid yaml", func(t *testing.T) {
+		raw := []byte("apiVersion: v1\nkind: Canvas\nmetadata: [\n")
+		_, err := ParseCanvas(raw)
+		assert.ErrorContains(t, err, "failed to parse canvas yaml")
+		assert.ErrorContains(t, err, "invalid yaml")
+	})
+}
+
+func TestCanvasConversions(t *testing.T) {
+	metadata := openapi_client.NewCanvasesCanvasMetadata()
+	metadata.SetName("my-canvas")
+	metadata.SetId("canvas-id")
+
+	spec := EmptyCanvasSpec()
+
+	resource := Canvas{
+		APIVersion: "v1",
+		Kind:       CanvasKind,
+		Metadata:   metadata,
+		Spec:       spec,
+	}
+
+	t.Run("CanvasFromCanvas", func(t *testing.T) {
+		canvas := CanvasFromCanvas(resource)
+		metadata := canvas.GetMetadata()
+		spec := canvas.GetSpec()
+		assert.Equal(t, "my-canvas", metadata.GetName())
+		assert.Equal(t, "canvas-id", metadata.GetId())
+		assert.NotNil(t, spec.GetNodes())
+		assert.NotNil(t, spec.GetEdges())
+	})
+
+	t.Run("CanvasResourceFromCanvas", func(t *testing.T) {
+		canvas := CanvasFromCanvas(resource)
+		resourceFromCanvas := CanvasResourceFromCanvas(canvas)
+
+		assert.Equal(t, "v1", resourceFromCanvas.APIVersion)
+		assert.Equal(t, CanvasKind, resourceFromCanvas.Kind)
+		assert.Equal(t, "my-canvas", resourceFromCanvas.Metadata.GetName())
+		assert.NotNil(t, resourceFromCanvas.Spec.GetNodes())
+		assert.NotNil(t, resourceFromCanvas.Spec.GetEdges())
+	})
+}
+
+func TestCreateCanvasRequestFromCanvas(t *testing.T) {
+	metadata := openapi_client.NewCanvasesCanvasMetadata()
+	metadata.SetName("my-canvas")
+
+	t.Run("without autoLayout", func(t *testing.T) {
+		resource := Canvas{
+			APIVersion: "v1",
+			Kind:       CanvasKind,
+			Metadata:   metadata,
+			Spec:       EmptyCanvasSpec(),
+		}
+
+		request := CreateCanvasRequestFromCanvas(resource)
+		assert.True(t, request.HasCanvas())
+		assert.False(t, request.HasAutoLayout())
+		canvas := request.GetCanvas()
+		metadata := canvas.GetMetadata()
+		assert.Equal(t, "my-canvas", metadata.GetName())
+	})
+
+	t.Run("with autoLayout", func(t *testing.T) {
+		autoLayout := openapi_client.NewCanvasesCanvasAutoLayout()
+		autoLayout.SetNodeIds([]string{"node-1", "node-2"})
+
+		resource := Canvas{
+			APIVersion: "v1",
+			Kind:       CanvasKind,
+			Metadata:   metadata,
+			Spec:       EmptyCanvasSpec(),
+			AutoLayout: autoLayout,
+		}
+
+		request := CreateCanvasRequestFromCanvas(resource)
+		assert.True(t, request.HasCanvas())
+		assert.True(t, request.HasAutoLayout())
+		requestAutoLayout := request.GetAutoLayout()
+		assert.Equal(t, []string{"node-1", "node-2"}, requestAutoLayout.GetNodeIds())
+	})
+}
+
+func TestEmptyCanvasSpec(t *testing.T) {
+	spec := EmptyCanvasSpec()
+	assert.NotNil(t, spec)
+	assert.NotNil(t, spec.Nodes)
+	assert.NotNil(t, spec.Edges)
+	assert.Len(t, spec.Nodes, 0)
+	assert.Len(t, spec.Edges, 0)
 }

--- a/pkg/cli/commands/groups/common.go
+++ b/pkg/cli/commands/groups/common.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
@@ -45,7 +44,7 @@ func parseGroupFile(path string) (*groupResource, error) {
 	}
 
 	resource := groupResource{}
-	if err := yaml.Unmarshal(data, &resource); err != nil {
+	if err := core.NewDecoder(data).DecodeYAML(&resource); err != nil {
 		return nil, fmt.Errorf("failed to parse group resource: %w", err)
 	}
 

--- a/pkg/cli/commands/groups/create_test.go
+++ b/pkg/cli/commands/groups/create_test.go
@@ -146,6 +146,27 @@ func TestCreateFromFileRequiresMetadataName(t *testing.T) {
 	require.Contains(t, err.Error(), "metadata.name is required")
 }
 
+func TestCreateFromFileRejectsUnknownFields(t *testing.T) {
+	ctx, _ := newTestContext(t, newMeOnlyServer(t), "text")
+
+	dir := t.TempDir()
+	path := dir + "/group.yaml"
+	content := []byte("apiVersion: v1\nkind: Group\nmetadata:\n  name: from-file\nspec:\n  displayName: FromFile\n  role: org_viewer\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	empty := ""
+	cmd := &createCommand{
+		file:        &path,
+		displayName: &empty,
+		description: &empty,
+		role:        &empty,
+	}
+	err := cmd.Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
 func TestCreateRejectsInlineFlagsWithFile(t *testing.T) {
 	ctx, _ := newTestContext(t, newMeOnlyServer(t), "text")
 

--- a/pkg/cli/commands/roles/common.go
+++ b/pkg/cli/commands/roles/common.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
@@ -45,7 +44,7 @@ func parseRoleFile(path string) (*roleResource, error) {
 	}
 
 	resource := roleResource{}
-	if err := yaml.Unmarshal(data, &resource); err != nil {
+	if err := core.NewDecoder(data).DecodeYAML(&resource); err != nil {
 		return nil, fmt.Errorf("failed to parse role resource: %w", err)
 	}
 

--- a/pkg/cli/commands/roles/crud_test.go
+++ b/pkg/cli/commands/roles/crud_test.go
@@ -111,6 +111,28 @@ func TestCreateRoleRequiresMetadataName(t *testing.T) {
 	require.Contains(t, err.Error(), "metadata.name is required")
 }
 
+func TestCreateRoleRejectsUnknownFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/me" {
+			writeMeResponse(w)
+			return
+		}
+		t.Fatalf("unexpected %s %s; create should fail client-side before any API call", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	path := dir + "/role.yaml"
+	content := []byte("apiVersion: v1\nkind: Role\nmetadata:\n  name: release_manager\nspec:\n  displayName: Release Manager\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	ctx, _ := newTestContext(t, server, "text")
+	err := (&createCommand{file: &path}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
 func TestUpdateRoleFromFile(t *testing.T) {
 	var seen rolePayload
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cli/commands/secrets/common.go
+++ b/pkg/cli/commands/secrets/common.go
@@ -8,7 +8,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
@@ -45,7 +44,7 @@ func parseSecretFile(path string) (*secretResource, error) {
 	}
 
 	resource := secretResource{}
-	if err := yaml.Unmarshal(data, &resource); err != nil {
+	if err := core.NewDecoder(data).DecodeYAML(&resource); err != nil {
 		return nil, fmt.Errorf("failed to parse secret resource: %w", err)
 	}
 

--- a/pkg/cli/commands/secrets/common_test.go
+++ b/pkg/cli/commands/secrets/common_test.go
@@ -1,0 +1,20 @@
+package secrets
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSecretFileRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/secret.yaml"
+	content := []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: from-file\nspec:\n  provider: PROVIDER_LOCAL\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	_, err := parseSecretFile(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}

--- a/pkg/cli/core/decoder.go
+++ b/pkg/cli/core/decoder.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Decoder struct {
+	raw []byte
+}
+
+func NewDecoder(raw []byte) *Decoder {
+	return &Decoder{raw: raw}
+}
+
+func (d *Decoder) DecodeYAML(out any) error {
+	// We intentionally decode YAML by round-tripping through JSON:
+	// 1. Parse YAML with yaml.v3 to preserve YAML behavior used by existing CLI files.
+	// 2. Marshal to JSON.
+	// 3. Decode with json.Decoder + DisallowUnknownFields so unknown keys fail fast.
+	//
+	// This is deliberate because our CLI resource structs and generated API models
+	// are keyed by json tags (camelCase API field names). Using yaml.v3 KnownFields
+	// directly would validate against YAML field names/tags, which is not aligned
+	// with those json-tagged types.
+	var yamlObject any
+	if err := yaml.Unmarshal(d.raw, &yamlObject); err != nil {
+		return fmt.Errorf("invalid yaml: %w", err)
+	}
+
+	jsonData, err := json.Marshal(yamlObject)
+	if err != nil {
+		return fmt.Errorf("invalid yaml: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(jsonData))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return fmt.Errorf("invalid yaml: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cli/core/decoder_test.go
+++ b/pkg/cli/core/decoder_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecoderDecodeYAML(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	t.Run("accepts known fields", func(t *testing.T) {
+		raw := []byte("name: valid")
+		var out payload
+
+		err := NewDecoder(raw).DecodeYAML(&out)
+		if err != nil {
+			t.Fatalf("DecodeYAML returned error: %v", err)
+		}
+		if out.Name != "valid" {
+			t.Fatalf("expected name=valid, got %q", out.Name)
+		}
+	})
+
+	t.Run("rejects unknown fields", func(t *testing.T) {
+		raw := []byte("name: valid\nunknown: true\n")
+		var out payload
+
+		err := NewDecoder(raw).DecodeYAML(&out)
+		if err == nil {
+			t.Fatal("expected DecodeYAML to fail for unknown field")
+		}
+		if !strings.Contains(err.Error(), "unknown field") {
+			t.Fatalf("expected unknown field error, got %v", err)
+		}
+	})
+
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -61,6 +61,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const (
@@ -218,10 +219,30 @@ func getOAuthProviders() map[string]authentication.ProviderConfig {
 	return providers
 }
 
+func newGRPCGatewayMarshaler() runtime.Marshaler {
+	// Keep parity with grpc-gateway's default marshaler configuration
+	// (HTTPBodyMarshaler + JSONPb + EmitUnpopulated=true), but reject unknown
+	// request fields by setting DiscardUnknown=false.
+	//
+	// Note: because this is an explicit override, grpc-gateway default option
+	// changes in future upgrades are not picked up automatically.
+	return &runtime.HTTPBodyMarshaler{
+		Marshaler: &runtime.JSONPb{
+			MarshalOptions: protojson.MarshalOptions{
+				EmitUnpopulated: true,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: false,
+			},
+		},
+	}
+}
+
 func (s *Server) RegisterGRPCGateway(grpcServerAddr string) error {
 	ctx := context.Background()
 
 	grpcGatewayMux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, newGRPCGatewayMarshaler()),
 		runtime.WithIncomingHeaderMatcher(headersMatcher),
 		runtime.WithMetadata(func(ctx context.Context, _ *http.Request) metadata.MD {
 			/*

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authorization"
@@ -19,6 +21,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
+	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
 	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/usage"
@@ -190,6 +193,63 @@ func Test__GRPCGatewayRegistration(t *testing.T) {
 
 	require.Equal(t, "", response.Body.String())
 	require.Equal(t, 200, response.Code)
+}
+
+type canvasesGatewayStubServer struct {
+	pbCanvases.UnimplementedCanvasesServer
+	createCanvasCalled bool
+}
+
+func (s *canvasesGatewayStubServer) CreateCanvas(
+	context.Context,
+	*pbCanvases.CreateCanvasRequest,
+) (*pbCanvases.CreateCanvasResponse, error) {
+	s.createCanvasCalled = true
+	return &pbCanvases.CreateCanvasResponse{}, nil
+}
+
+func Test__GRPCGatewayRejectsUnknownFields(t *testing.T) {
+	mux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, newGRPCGatewayMarshaler()),
+	)
+
+	server := &canvasesGatewayStubServer{}
+	err := pbCanvases.RegisterCanvasesHandlerServer(context.Background(), mux, server)
+	require.NoError(t, err)
+
+	requestBody := `{
+  "canvas": {
+    "metadata": { "name": "unknown-field-test" },
+    "spec": {
+      "nodes": [{
+        "id": "wait-1",
+        "name": "wait",
+        "type": "TYPE_COMPONENT",
+        "component": {
+          "name": "wait",
+          "hello": "what"
+        }
+      }],
+      "edges": []
+    }
+  }
+}`
+
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/canvases", strings.NewReader(requestBody))
+	request.Header.Set("Content-Type", "application/json")
+
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	var statusBody struct {
+		Code    int32  `json:"code"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &statusBody))
+	require.Equal(t, int32(3), statusBody.Code)
+	require.Contains(t, statusBody.Message, `unknown field "hello"`)
+	require.False(t, server.createCanvasCalled)
 }
 
 // Helper function to check if the required Swagger files exist


### PR DESCRIPTION
Fixes https://github.com/superplanehq/superplane/issues/3250

---

Current behavior when using unknown fields in API requests or CLI YAMLs is to ignore them. That leads to less predictable behavior, especially when using coding agents. Rejecting API requests and CLI commands using unknown fields early makes things more predictable.