### PR TITLE
docs: clarify demo vs development server ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ A few concrete things teams build with SuperPlane:
 
 ## Quick start
 
+Then open http://localhost:3000 and follow the quick start guide.
+
+> **Note:** The demo container runs on port `3000`.
+> If you are setting up the full development environment for contributing, follow the instructions in `CONTRIBUTING.md`, where the local dev server starts on `http://localhost:8000`.
+
 Run the latest demo container:
 
 ```


### PR DESCRIPTION
## Summary
Adds a short note to clarify the difference between the demo container quick start and the local development setup.

## Why
The README quick start points users to localhost:3000 for the demo container, while the development setup uses a different local server port. This clarification should reduce confusion for first-time contributors.

## Testing
Documentation-only change.