### PR TITLE
fix: add default_events to GitHub App manifest to auto-subscribe

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -485,6 +485,28 @@ func (g *GitHub) appManifest(ctx core.SyncContext) string {
 			"statuses":                    "write",
 			"organization_administration": "read",
 		},
+		// Default events that the GitHub App should subscribe to.
+		// These match the events used by GitHub triggers:
+		// - onPush: push
+		// - onPullRequest: pull_request, pull_request_review, pull_request_review_comment
+		// - onIssue: issues
+		// - onIssueComment: issue_comment
+		// - onRelease: release
+		// - onTagCreated: create, delete
+		// - onBranchCreated: create, delete
+		// - onWorkflowRun: workflow_run
+		"default_events": []string{
+			"push",
+			"pull_request",
+			"pull_request_review",
+			"pull_request_review_comment",
+			"issues",
+			"issue_comment",
+			"release",
+			"create",
+			"delete",
+			"workflow_run",
+		},
 		"setup_url":    fmt.Sprintf(`%s/api/v1/integrations/%s/setup`, ctx.BaseURL, ctx.Integration.ID().String()),
 		"redirect_url": fmt.Sprintf(`%s/api/v1/integrations/%s/redirect`, ctx.BaseURL, ctx.Integration.ID().String()),
 		"hook_attributes": map[string]any{


### PR DESCRIPTION
Required events autosubscription

Closes #4237

When creating a GitHub App via manifest, the default_events field was missing, causing the app to be created with no event subscriptions. This meant that even though triggers appeared ready, no webhook events were delivered.

This fix adds all required event types that match SuperPlane's GitHub triggers:
- push, pull_request, pull_request_review, pull_request_review_comment
- issues, issue_comment, release, create, delete, workflow_run