### PR TITLE
fix: separate arguments for superplane contexts command

### DIFF
--- a/agent/src/ai/superplane_client.py
+++ b/agent/src/ai/superplane_client.py
@@ -498,7 +498,7 @@ class SuperplaneClient:
             label=cap.label,
             description=cap.description,
             configuration=cap.configuration,
-            output_channels=cap.output_channels,
+            outputChannels=cap.output_channels,
         )
 
     @staticmethod

--- a/agent/src/ai/superplane_client.py
+++ b/agent/src/ai/superplane_client.py
@@ -498,7 +498,7 @@ class SuperplaneClient:
             label=cap.label,
             description=cap.description,
             configuration=cap.configuration,
-            outputChannels=cap.output_channels,
+            output_channels=cap.output_channels,
         )
 
     @staticmethod

--- a/agent/tests/test_superplane_client.py
+++ b/agent/tests/test_superplane_client.py
@@ -627,6 +627,9 @@ def test_list_components_includes_integration_scoped_components() -> None:
                                 "type": "TYPE_ACTION",
                                 "name": "slack.sendTextMessage",
                                 "label": "Send Text Message",
+                                "outputChannels": [
+                                    {"name": "default", "label": "Default", "description": ""},
+                                ],
                             }
                         ],
                     }
@@ -641,7 +644,7 @@ def test_list_components_includes_integration_scoped_components() -> None:
     assert components[0]["name"] == "slack.sendTextMessage"
     assert components[0]["provider"] == "slack"
     assert "configuration_fields" not in components[0]
-    assert components[0].get("output_channel_names") == []
+    assert components[0].get("output_channel_names") == ["default"]
 
 
 def test_list_triggers_includes_integration_scoped_triggers() -> None:

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -9,10 +9,11 @@ import (
 )
 
 type ConfigContext struct {
-	URL          string  `json:"url" yaml:"url"`
-	Organization string  `json:"organization" yaml:"organization"`
-	APIToken     string  `json:"apiToken" yaml:"apiToken"`
-	Canvas       *string `json:"canvas,omitempty" yaml:"canvas,omitempty"`
+	URL            string  `json:"url" yaml:"url"`
+	Organization   string  `json:"organization" yaml:"organization"`
+	OrganizationID string  `json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
+	APIToken       string  `json:"apiToken" yaml:"apiToken"`
+	Canvas         *string `json:"canvas,omitempty" yaml:"canvas,omitempty"`
 }
 
 func normalizeBaseURL(raw string) string {
@@ -23,18 +24,18 @@ func normalizeBaseURL(raw string) string {
 func normalizeContext(context ConfigContext) ConfigContext {
 	context.URL = normalizeBaseURL(context.URL)
 	context.Organization = strings.TrimSpace(context.Organization)
+	context.OrganizationID = strings.TrimSpace(context.OrganizationID)
 	context.APIToken = strings.TrimSpace(context.APIToken)
-
-	if context.Canvas != nil {
-		context.Canvas = context.Canvas
-	}
-
 	return context
 }
 
 func ContextSelector(context ConfigContext) string {
 	context = normalizeContext(context)
-	return fmt.Sprintf("%s/%s", context.URL, context.Organization)
+	id := context.OrganizationID
+	if id == "" {
+		id = context.Organization
+	}
+	return fmt.Sprintf("%s/%s", context.URL, id)
 }
 
 func normalizeContextSelector(raw string) string {
@@ -102,35 +103,42 @@ func SaveContexts(contexts []ConfigContext) error {
 	return WriteConfig()
 }
 
-func SaveCurrentContextBySelector(selector string) (*ConfigContext, error) {
+// SwitchContext makes the context identified by (baseURL, org) current. The
+// org argument matches on organization ID first and then on organization name.
+func SwitchContext(baseURL, org string) (*ConfigContext, error) {
 	contexts := GetContexts()
 	if len(contexts) == 0 {
 		return nil, fmt.Errorf("no contexts configured")
 	}
 
-	normalizedSelector := normalizeContextSelector(selector)
-	if normalizedSelector == "" {
-		return nil, fmt.Errorf("context selector is required")
+	url := normalizeBaseURL(baseURL)
+	name := strings.TrimSpace(org)
+	if url == "" {
+		return nil, fmt.Errorf("base URL is required")
+	}
+	if name == "" {
+		return nil, fmt.Errorf("organization is required")
 	}
 
-	selectedIndex := -1
-	for i, context := range contexts {
-		if ContextSelector(context) == normalizedSelector {
-			selectedIndex = i
-			break
+	for i, c := range contexts {
+		if c.URL == url && c.OrganizationID != "" && c.OrganizationID == name {
+			return saveCurrent(contexts[i])
+		}
+	}
+	for i, c := range contexts {
+		if c.URL == url && c.Organization == name {
+			return saveCurrent(contexts[i])
 		}
 	}
 
-	if selectedIndex == -1 {
-		return nil, fmt.Errorf("context %q not found", normalizedSelector)
-	}
+	return nil, fmt.Errorf("no context found for %s %q", url, name)
+}
 
-	selected := contexts[selectedIndex]
+func saveCurrent(selected ConfigContext) (*ConfigContext, error) {
 	viper.Set(ConfigKeyCurrentContext, ContextSelector(selected))
 	if err := WriteConfig(); err != nil {
 		return nil, err
 	}
-
 	return &selected, nil
 }
 
@@ -144,13 +152,7 @@ func UpsertContext(context ConfigContext) (ConfigContext, error) {
 	}
 
 	contexts := GetContexts()
-	existingIndex := -1
-	for i, existing := range contexts {
-		if ContextSelector(existing) == ContextSelector(context) {
-			existingIndex = i
-			break
-		}
-	}
+	existingIndex := findMatchingContextIndex(contexts, context)
 
 	if existingIndex >= 0 {
 		contexts[existingIndex] = context
@@ -165,6 +167,30 @@ func UpsertContext(context ConfigContext) (ConfigContext, error) {
 	}
 
 	return context, nil
+}
+
+func findMatchingContextIndex(contexts []ConfigContext, context ConfigContext) int {
+	selector := ContextSelector(context)
+	for i, existing := range contexts {
+		if ContextSelector(existing) == selector {
+			return i
+		}
+	}
+
+	if context.OrganizationID == "" || context.Organization == "" {
+		return -1
+	}
+
+	for i, existing := range contexts {
+		if existing.OrganizationID != "" {
+			continue
+		}
+		if existing.URL == context.URL && existing.Organization == context.Organization {
+			return i
+		}
+	}
+
+	return -1
 }
 
 /*

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -132,6 +133,94 @@ func SwitchContext(baseURL, org string) (*ConfigContext, error) {
 	}
 
 	return nil, fmt.Errorf("no context found for %s %q", url, name)
+}
+
+func contextMatchesOrgArg(c ConfigContext, orgOrID string) bool {
+	if c.OrganizationID != "" && c.OrganizationID == orgOrID {
+		return true
+	}
+	return c.Organization == orgOrID
+}
+
+func distinctBaseURLs(contexts []ConfigContext) []string {
+	seen := make(map[string]struct{}, len(contexts))
+	for _, c := range contexts {
+		if c.URL != "" {
+			seen[c.URL] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for u := range seen {
+		out = append(out, u)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatURLBulletList(urls []string) string {
+	var b strings.Builder
+	for _, u := range urls {
+		b.WriteString("- ")
+		b.WriteString(u)
+		b.WriteString("\n")
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// SwitchContextByOrganization sets the current context using organization id or
+// name across saved installations. When urlFilter is non-empty, only contexts
+// at that base URL are considered (so multiple matches are always same-installation
+// duplicates, never cross-installation ambiguity). Multiple matches on different
+// base URLs without urlFilter returns an error that lists installations and suggests --url.
+func SwitchContextByOrganization(orgOrID, urlFilter string) (*ConfigContext, error) {
+	orgOrID = strings.TrimSpace(orgOrID)
+	if orgOrID == "" {
+		return nil, fmt.Errorf("organization id or name is required")
+	}
+
+	contexts := GetContexts()
+	if len(contexts) == 0 {
+		return nil, fmt.Errorf("no contexts configured")
+	}
+
+	wantURL := normalizeBaseURL(urlFilter)
+	var candidates []ConfigContext
+	for _, c := range contexts {
+		if !contextMatchesOrgArg(c, orgOrID) {
+			continue
+		}
+		if wantURL != "" && c.URL != wantURL {
+			continue
+		}
+		candidates = append(candidates, c)
+	}
+
+	if len(candidates) == 0 {
+		if wantURL != "" {
+			return nil, fmt.Errorf("no context found for %q at %s", orgOrID, wantURL)
+		}
+		return nil, fmt.Errorf("no context found for organization %q", orgOrID)
+	}
+
+	if len(candidates) == 1 {
+		return saveCurrent(candidates[0])
+	}
+
+	urls := distinctBaseURLs(candidates)
+	if len(urls) == 1 {
+		return nil, fmt.Errorf(
+			"multiple saved contexts match %q at %s; remove duplicate entries from your config",
+			orgOrID,
+			urls[0],
+		)
+	}
+
+	return nil, fmt.Errorf(
+		"ambiguous organization %q matches multiple installations:\n%s\n\nUse: superplane context %q --url <base-url>",
+		orgOrID,
+		formatURLBulletList(urls),
+		orgOrID,
+	)
 }
 
 func saveCurrent(selected ConfigContext) (*ConfigContext, error) {

--- a/pkg/cli/configuration_test.go
+++ b/pkg/cli/configuration_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func setupViper(t *testing.T) {
+	t.Helper()
+
+	viper.Reset()
+
+	path := filepath.Join(t.TempDir(), ".superplane.yaml")
+	viper.SetConfigFile(path)
+	viper.SetConfigType("yaml")
+	require.NoError(t, viper.WriteConfigAs(path))
+	require.NoError(t, viper.ReadInConfig())
+
+	t.Cleanup(viper.Reset)
+}
+
+func TestContextSelectorPrefersOrganizationID(t *testing.T) {
+	withID := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Nandor Lite Playground",
+		OrganizationID: "eb3aca82-3864-4f76-b1d6-f670c297f136",
+		APIToken:       "tok",
+	}
+	require.Equal(t,
+		"https://app.superplane.com/eb3aca82-3864-4f76-b1d6-f670c297f136",
+		ContextSelector(withID),
+	)
+
+	legacy := ConfigContext{
+		URL:          "https://app.superplane.com",
+		Organization: "Nandor Lite Playground",
+		APIToken:     "tok",
+	}
+	require.Equal(t,
+		"https://app.superplane.com/Nandor Lite Playground",
+		ContextSelector(legacy),
+	)
+}
+
+func TestSwitchContextMatchesByNameAndID(t *testing.T) {
+	setupViper(t)
+
+	ctx := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Nandor Lite Playground",
+		OrganizationID: "eb3aca82-3864-4f76-b1d6-f670c297f136",
+		APIToken:       "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{ctx}))
+
+	byName, err := SwitchContext("https://app.superplane.com", "Nandor Lite Playground")
+	require.NoError(t, err)
+	require.Equal(t, ctx.OrganizationID, byName.OrganizationID)
+
+	byID, err := SwitchContext("https://app.superplane.com", "eb3aca82-3864-4f76-b1d6-f670c297f136")
+	require.NoError(t, err)
+	require.Equal(t, ctx.OrganizationID, byID.OrganizationID)
+
+	withTrailingSlash, err := SwitchContext("https://app.superplane.com/", "Nandor Lite Playground")
+	require.NoError(t, err)
+	require.Equal(t, ctx.OrganizationID, withTrailingSlash.OrganizationID)
+}
+
+func TestSwitchContextErrorsOnUnknownAndEmpty(t *testing.T) {
+	setupViper(t)
+
+	ctx := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Nandor Lite Playground",
+		OrganizationID: "eb3aca82-3864-4f76-b1d6-f670c297f136",
+		APIToken:       "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{ctx}))
+
+	_, err := SwitchContext("https://app.superplane.com", "Does Not Exist")
+	require.Error(t, err)
+
+	_, err = SwitchContext("https://wrong.example.com", "Nandor Lite Playground")
+	require.Error(t, err)
+
+	_, err = SwitchContext("", "Nandor Lite Playground")
+	require.Error(t, err)
+	_, err = SwitchContext("https://app.superplane.com", "")
+	require.Error(t, err)
+}
+
+func TestSwitchContextDisambiguatesBySameNameDifferentURL(t *testing.T) {
+	setupViper(t)
+
+	prod := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Shared Name",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok-prod",
+	}
+	staging := ConfigContext{
+		URL:            "https://staging.superplane.com",
+		Organization:   "Shared Name",
+		OrganizationID: "bbbbbbbb-0000-0000-0000-000000000002",
+		APIToken:       "tok-staging",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{prod, staging}))
+
+	got, err := SwitchContext("https://staging.superplane.com", "Shared Name")
+	require.NoError(t, err)
+	require.Equal(t, staging.OrganizationID, got.OrganizationID)
+
+	got, err = SwitchContext("https://app.superplane.com", "Shared Name")
+	require.NoError(t, err)
+	require.Equal(t, prod.OrganizationID, got.OrganizationID)
+}
+
+func TestUpsertContextUpgradesLegacyEntryInPlace(t *testing.T) {
+	setupViper(t)
+
+	legacy := ConfigContext{
+		URL:          "https://app.superplane.com",
+		Organization: "Nandor Lite Playground",
+		APIToken:     "tok-legacy",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{legacy}))
+
+	upgraded := legacy
+	upgraded.OrganizationID = "eb3aca82-3864-4f76-b1d6-f670c297f136"
+	upgraded.APIToken = "tok-new"
+
+	_, err := UpsertContext(upgraded)
+	require.NoError(t, err)
+
+	all := GetContexts()
+	require.Len(t, all, 1)
+	require.Equal(t, "eb3aca82-3864-4f76-b1d6-f670c297f136", all[0].OrganizationID)
+	require.Equal(t, "tok-new", all[0].APIToken)
+}
+
+func TestGetCurrentContextResolvesAfterUpgrade(t *testing.T) {
+	setupViper(t)
+
+	legacy := ConfigContext{
+		URL:          "https://app.superplane.com",
+		Organization: "Nandor Lite Playground",
+		APIToken:     "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{legacy}))
+	viper.Set(ConfigKeyCurrentContext, ContextSelector(legacy))
+	require.NoError(t, WriteConfig())
+
+	upgraded := legacy
+	upgraded.OrganizationID = "eb3aca82-3864-4f76-b1d6-f670c297f136"
+	_, err := UpsertContext(upgraded)
+	require.NoError(t, err)
+
+	current, ok := GetCurrentContext()
+	require.True(t, ok)
+	require.Equal(t, upgraded.OrganizationID, current.OrganizationID)
+}

--- a/pkg/cli/configuration_test.go
+++ b/pkg/cli/configuration_test.go
@@ -141,6 +141,126 @@ func TestUpsertContextUpgradesLegacyEntryInPlace(t *testing.T) {
 	require.Equal(t, "tok-new", all[0].APIToken)
 }
 
+func TestSwitchContextByOrganizationUniqueByID(t *testing.T) {
+	setupViper(t)
+
+	ctx := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Playground",
+		OrganizationID: "eb3aca82-3864-4f76-b1d6-f670c297f136",
+		APIToken:       "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{ctx}))
+
+	got, err := SwitchContextByOrganization("eb3aca82-3864-4f76-b1d6-f670c297f136", "")
+	require.NoError(t, err)
+	require.Equal(t, ctx.OrganizationID, got.OrganizationID)
+
+	current, ok := GetCurrentContext()
+	require.True(t, ok)
+	require.Equal(t, ctx.OrganizationID, current.OrganizationID)
+}
+
+func TestSwitchContextByOrganizationUniqueByName(t *testing.T) {
+	setupViper(t)
+
+	ctx := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Playground",
+		OrganizationID: "eb3aca82-3864-4f76-b1d6-f670c297f136",
+		APIToken:       "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{ctx}))
+
+	got, err := SwitchContextByOrganization("Playground", "")
+	require.NoError(t, err)
+	require.Equal(t, ctx.OrganizationID, got.OrganizationID)
+}
+
+func TestSwitchContextByOrganizationAmbiguousWithoutURL(t *testing.T) {
+	setupViper(t)
+
+	a := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Shared",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok-a",
+	}
+	b := ConfigContext{
+		URL:            "https://staging.example.com",
+		Organization:   "Shared",
+		OrganizationID: "bbbbbbbb-0000-0000-0000-000000000002",
+		APIToken:       "tok-b",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{a, b}))
+
+	_, err := SwitchContextByOrganization("Shared", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ambiguous organization")
+	require.Contains(t, err.Error(), "https://app.superplane.com")
+	require.Contains(t, err.Error(), "https://staging.example.com")
+}
+
+func TestSwitchContextByOrganizationResolvesWithURLFlag(t *testing.T) {
+	setupViper(t)
+
+	a := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Shared",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok-a",
+	}
+	b := ConfigContext{
+		URL:            "https://staging.example.com",
+		Organization:   "Shared",
+		OrganizationID: "bbbbbbbb-0000-0000-0000-000000000002",
+		APIToken:       "tok-b",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{a, b}))
+
+	got, err := SwitchContextByOrganization("Shared", "https://staging.example.com")
+	require.NoError(t, err)
+	require.Equal(t, b.OrganizationID, got.OrganizationID)
+}
+
+func TestSwitchContextByOrganizationDuplicateSameURLError(t *testing.T) {
+	setupViper(t)
+
+	a := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Dup",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok-a",
+	}
+	b := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Dup",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok-b",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{a, b}))
+
+	_, err := SwitchContextByOrganization("Dup", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple saved contexts")
+}
+
+func TestSwitchContextByOrganizationUnknown(t *testing.T) {
+	setupViper(t)
+
+	ctx := ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Only",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "tok",
+	}
+	require.NoError(t, SaveContexts([]ConfigContext{ctx}))
+
+	_, err := SwitchContextByOrganization("nope", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no context found")
+}
+
 func TestGetCurrentContextResolvesAfterUpgrade(t *testing.T) {
 	setupViper(t)
 

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -28,29 +28,30 @@ func (c *ConnectCommand) Execute(ctx core.CommandContext) error {
 		return fmt.Errorf("failed to authenticate with the provided token: %w", err)
 	}
 
+	orgID := me.User.GetOrganizationId()
 	organizationResponse, _, err := api.OrganizationAPI.
-		OrganizationsDescribeOrganization(ctx.Context, me.User.GetOrganizationId()).
+		OrganizationsDescribeOrganization(ctx.Context, orgID).
 		Execute()
 
 	if err != nil {
-		return fmt.Errorf("failed to describe organization %s: %w", me.User.GetOrganizationId(), err)
+		return fmt.Errorf("failed to describe organization %s: %w", orgID, err)
 	}
 
 	orgName := *organizationResponse.Organization.Metadata.Name
 
-	_, err = UpsertContext(ConfigContext{
-		URL:          baseURL,
-		Organization: orgName,
-		APIToken:     apiToken,
+	saved, err := UpsertContext(ConfigContext{
+		URL:            baseURL,
+		Organization:   orgName,
+		OrganizationID: orgID,
+		APIToken:       apiToken,
 	})
-
 	if err != nil {
 		return err
 	}
 
 	if ctx.Renderer.IsText() {
 		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
-			_, err := fmt.Fprintf(stdout, "Connected to %q (%s)\n", orgName, baseURL)
+			_, err := fmt.Fprintf(stdout, "Connected to %q (%s)\n", orgName, saved.URL)
 			if err != nil {
 				return err
 			}
@@ -60,8 +61,9 @@ func (c *ConnectCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	return ctx.Renderer.Render(map[string]any{
-		"organization": orgName,
-		"url":          baseURL,
+		"organization":   orgName,
+		"organizationId": orgID,
+		"url":            baseURL,
 	})
 }
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ContextCommand struct{}
+
+func (c *ContextCommand) Execute(ctx core.CommandContext) error {
+	contexts := GetContexts()
+	if len(contexts) == 0 {
+		return fmt.Errorf("no contexts configured; run superplane connect [BASE_URL] [API_TOKEN]")
+	}
+
+	if len(ctx.Args) == 0 {
+		if !ctx.Renderer.IsText() || !ctx.IsInteractive() {
+			return renderContextsOutput(ctx, contexts)
+		}
+
+		selected, err := promptContextSelection(ctx, contexts)
+		if err != nil {
+			return err
+		}
+
+		org := selected.OrganizationID
+		if org == "" {
+			org = selected.Organization
+		}
+		switched, err := SwitchContext(selected.URL, org)
+		if err != nil {
+			return err
+		}
+		return renderContextOutput(ctx, *switched)
+	}
+
+	urlFlag, err := ctx.Cmd.Flags().GetString("url")
+	if err != nil {
+		return err
+	}
+
+	selected, err := SwitchContextByOrganization(ctx.Args[0], urlFlag)
+	if err != nil {
+		return err
+	}
+	return renderContextOutput(ctx, *selected)
+}
+
+var contextCmd = &cobra.Command{
+	Use:   "context [ORG_OR_ID]",
+	Short: "Switch CLI context by organization id or name",
+	Long: "With ORG_OR_ID, switches to the saved context for that organization (matches id first, then name). " +
+		"If the same id or name exists on multiple installations, pass --url with the installation base URL. " +
+		"Without arguments, lists contexts and prompts for a selection (same as \"superplane contexts\"). " +
+		"To switch using an explicit base URL and organization, use \"superplane contexts BASE_URL ORGANIZATION\".",
+	Args: cobra.MaximumNArgs(1),
+}
+
+func init() {
+	contextCmd.Flags().String("url", "", "installation base URL when multiple contexts match")
+	core.Bind(contextCmd, &ContextCommand{}, defaultBindOptions())
+	RootCmd.AddCommand(contextCmd)
+}

--- a/pkg/cli/contexts.go
+++ b/pkg/cli/contexts.go
@@ -19,31 +19,28 @@ func (c *ContextsCommand) Execute(ctx core.CommandContext) error {
 		return fmt.Errorf("no contexts configured; run superplane connect [BASE_URL] [API_TOKEN]")
 	}
 
-	if len(ctx.Args) == 1 {
-		selected, err := SaveCurrentContextBySelector(ctx.Args[0])
+	if len(ctx.Args) == 2 {
+		selected, err := SwitchContext(ctx.Args[0], ctx.Args[1])
 		if err != nil {
 			return err
 		}
-
 		return c.renderContext(ctx, *selected)
 	}
 
-	//
-	// If not in text mode or stdin is not a terminal, render the contexts as a list.
-	//
 	if !ctx.Renderer.IsText() || !ctx.IsInteractive() {
 		return c.renderContexts(ctx, contexts)
 	}
 
-	//
-	// Otherwise, select the context interactively.
-	//
 	selected, err := c.selectContextInteractively(ctx, contexts)
 	if err != nil {
 		return err
 	}
 
-	selected, err = SaveCurrentContextBySelector(ContextSelector(*selected))
+	org := selected.OrganizationID
+	if org == "" {
+		org = selected.Organization
+	}
+	selected, err = SwitchContext(selected.URL, org)
 	if err != nil {
 		return err
 	}
@@ -58,10 +55,7 @@ func (c *ContextsCommand) renderContexts(ctx core.CommandContext, contexts []Con
 	if !ctx.Renderer.IsText() {
 		ctxs := make([]map[string]any, 0, len(contexts))
 		for _, context := range contexts {
-			ctxs = append(ctxs, map[string]any{
-				"organization": context.Organization,
-				"url":          context.URL,
-			})
+			ctxs = append(ctxs, contextToMap(context))
 		}
 
 		return ctx.Renderer.Render(map[string]any{
@@ -71,27 +65,32 @@ func (c *ContextsCommand) renderContexts(ctx core.CommandContext, contexts []Con
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		for i, context := range contexts {
-			_, _ = fmt.Fprintf(stdout, "%d. %s (%s)\n", i+1, context.Organization, ContextSelector(context))
+			_, _ = fmt.Fprintf(stdout, "%d. %s (%s)\n", i+1, context.Organization, context.URL)
 		}
 		return nil
 	})
 }
 
-/*
- * Do not render the API token in the output for security reasons.
- */
 func (c *ContextsCommand) renderContext(ctx core.CommandContext, context ConfigContext) error {
 	if !ctx.Renderer.IsText() {
-		return ctx.Renderer.Render(map[string]any{
-			"organization": context.Organization,
-			"url":          context.URL,
-		})
+		return ctx.Renderer.Render(contextToMap(context))
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		_, _ = fmt.Fprintf(stdout, "Current context: %q (%s)\n", context.Organization, context.URL)
 		return nil
 	})
+}
+
+func contextToMap(context ConfigContext) map[string]any {
+	m := map[string]any{
+		"organization": context.Organization,
+		"url":          context.URL,
+	}
+	if context.OrganizationID != "" {
+		m["organizationId"] = context.OrganizationID
+	}
+	return m
 }
 
 func (c *ContextsCommand) selectContextInteractively(ctx core.CommandContext, contexts []ConfigContext) (*ConfigContext, error) {
@@ -107,7 +106,7 @@ func (c *ContextsCommand) selectContextInteractively(ctx core.CommandContext, co
 			if hasCurrentContext && ContextSelector(context) == currentSelector {
 				currentPrefix = "*"
 			}
-			_, _ = fmt.Fprintf(stdout, "%s %d. %s (%s)\n", currentPrefix, i+1, context.Organization, ContextSelector(context))
+			_, _ = fmt.Fprintf(stdout, "%s %d. %s (%s)\n", currentPrefix, i+1, context.Organization, context.URL)
 		}
 		_, _ = fmt.Fprint(stdout, "Select a context number: ")
 		return nil
@@ -140,10 +139,19 @@ func (c *ContextsCommand) selectContextInteractively(ctx core.CommandContext, co
 }
 
 var contextsCmd = &cobra.Command{
-	Use:   "contexts [BASE_URL/ORGANIZATION]",
+	Use:   "contexts [BASE_URL] [ORGANIZATION]",
 	Short: "List and switch CLI contexts",
-	Long:  "Without arguments, shows available contexts and prompts for a selection. With a BASE_URL/ORGANIZATION selector, switches directly.",
-	Args:  cobra.MaximumNArgs(1),
+	Long: "Without arguments, lists available contexts and prompts for a selection. " +
+		"With BASE_URL and ORGANIZATION, switches directly. " +
+		"ORGANIZATION can be the organization name or ID.",
+	Args: cobra.MatchAll(
+		func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || len(args) == 2 {
+				return nil
+			}
+			return fmt.Errorf("accepts 0 or 2 args, received %d", len(args))
+		},
+	),
 }
 
 func init() {

--- a/pkg/cli/contexts.go
+++ b/pkg/cli/contexts.go
@@ -24,14 +24,14 @@ func (c *ContextsCommand) Execute(ctx core.CommandContext) error {
 		if err != nil {
 			return err
 		}
-		return c.renderContext(ctx, *selected)
+		return renderContextOutput(ctx, *selected)
 	}
 
 	if !ctx.Renderer.IsText() || !ctx.IsInteractive() {
-		return c.renderContexts(ctx, contexts)
+		return renderContextsOutput(ctx, contexts)
 	}
 
-	selected, err := c.selectContextInteractively(ctx, contexts)
+	selected, err := promptContextSelection(ctx, contexts)
 	if err != nil {
 		return err
 	}
@@ -45,13 +45,13 @@ func (c *ContextsCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	return c.renderContext(ctx, *selected)
+	return renderContextOutput(ctx, *selected)
 }
 
 /*
  * Do not render the API token in the output for security reasons.
  */
-func (c *ContextsCommand) renderContexts(ctx core.CommandContext, contexts []ConfigContext) error {
+func renderContextsOutput(ctx core.CommandContext, contexts []ConfigContext) error {
 	if !ctx.Renderer.IsText() {
 		ctxs := make([]map[string]any, 0, len(contexts))
 		for _, context := range contexts {
@@ -71,7 +71,7 @@ func (c *ContextsCommand) renderContexts(ctx core.CommandContext, contexts []Con
 	})
 }
 
-func (c *ContextsCommand) renderContext(ctx core.CommandContext, context ConfigContext) error {
+func renderContextOutput(ctx core.CommandContext, context ConfigContext) error {
 	if !ctx.Renderer.IsText() {
 		return ctx.Renderer.Render(contextToMap(context))
 	}
@@ -93,7 +93,7 @@ func contextToMap(context ConfigContext) map[string]any {
 	return m
 }
 
-func (c *ContextsCommand) selectContextInteractively(ctx core.CommandContext, contexts []ConfigContext) (*ConfigContext, error) {
+func promptContextSelection(ctx core.CommandContext, contexts []ConfigContext) (*ConfigContext, error) {
 	currentContext, hasCurrentContext := GetCurrentContext()
 	currentSelector := ContextSelector(currentContext)
 
@@ -143,7 +143,8 @@ var contextsCmd = &cobra.Command{
 	Short: "List and switch CLI contexts",
 	Long: "Without arguments, lists available contexts and prompts for a selection. " +
 		"With BASE_URL and ORGANIZATION, switches directly. " +
-		"ORGANIZATION can be the organization name or ID.",
+		"ORGANIZATION can be the organization name or ID. " +
+		"To switch by organization id or name across installations, use \"superplane context\".",
 	Args: cobra.MatchAll(
 		func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 || len(args) == 2 {


### PR DESCRIPTION
### Demo:
https://drive.google.com/file/d/1BO69k3OSEwVU3nOkMMZwXsan7lnPNjek/view?usp=sharing

The superplane contexts switch command used to take a single `<URL>/<org-name>` selector. That was confusing because it looked like a browser URL but wasn't - the real web URL is `app.superplane.com/<orgId>`.

### Summary:
We switch the command to one positional arg with optional `--url` argument for ambiguous cases:
```
superplane context                                                                               # same list / interactive flow as above when you omit args
superplane context aa291812-efb5-4cd4-9f5f-5bcc77865ad7                                          # switch if that id is unique among saved contexts
superplane context "My Org"                                                                      # switch if that name is unique among saved contexts
superplane context "My Org" --url https://app.superplane.com                                     # disambiguate when the same name (or id) exists on multiple base URLs
```

Closes: https://github.com/superplanehq/superplane/issues/4244