### PR TITLE
fix: add missing GitHub event subscriptions to manifest

### DIFF
--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -35,6 +35,18 @@ To complete the GitHub app setup:
 `
 )
 
+var defaultGitHubAppEvents = []string{
+	"create",
+	"issue_comment",
+	"issues",
+	"pull_request",
+	"pull_request_review",
+	"pull_request_review_comment",
+	"push",
+	"release",
+	"workflow_run",
+}
+
 func init() {
 	registry.RegisterIntegrationWithWebhookHandler("github", &GitHub{}, &GitHubWebhookHandler{})
 }
@@ -473,9 +485,10 @@ func (g *GitHub) browserActionURL(organization string) string {
 
 func (g *GitHub) appManifest(ctx core.SyncContext) string {
 	manifest := map[string]any{
-		"name":   `SuperPlane GH integration`,
-		"public": false,
-		"url":    "https://superplane.com",
+		"name":           `SuperPlane GH integration`,
+		"public":         false,
+		"url":            "https://superplane.com",
+		"default_events": defaultGitHubAppEvents,
 		"default_permissions": map[string]string{
 			"issues":                      "write",
 			"actions":                     "write",

--- a/pkg/integrations/github/github_test.go
+++ b/pkg/integrations/github/github_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
+type githubManifest struct {
+	DefaultEvents []string `json:"default_events"`
+}
+
 func Test__GitHub__Setup(t *testing.T) {
 	g := &GitHub{}
 
@@ -30,6 +34,7 @@ func Test__GitHub__Setup(t *testing.T) {
 		assert.Equal(t, integrationCtx.BrowserAction.Method, "POST")
 		assert.NotEmpty(t, integrationCtx.BrowserAction.Description)
 		assert.Equal(t, integrationCtx.BrowserAction.URL, "https://github.com/settings/apps/new")
+		assertManifestContainsDefaultEvents(t, integrationCtx.BrowserAction.FormFields["manifest"])
 
 		//
 		// Metadata is set
@@ -54,6 +59,7 @@ func Test__GitHub__Setup(t *testing.T) {
 		assert.Equal(t, integrationCtx.BrowserAction.Method, "POST")
 		assert.NotEmpty(t, integrationCtx.BrowserAction.Description)
 		assert.Equal(t, integrationCtx.BrowserAction.URL, "https://github.com/organizations/testhq/settings/apps/new")
+		assertManifestContainsDefaultEvents(t, integrationCtx.BrowserAction.FormFields["manifest"])
 
 		//
 		// Metadata is set
@@ -136,4 +142,14 @@ func Test__listInstallationRepositories__paginates_all_pages(t *testing.T) {
 	require.Equal(t, int64(2), repos[1].ID)
 	require.Equal(t, "repo2", repos[1].Name)
 	require.Equal(t, "https://github.com/test/repo2", repos[1].URL)
+}
+
+func assertManifestContainsDefaultEvents(t *testing.T, manifestJSON string) {
+	t.Helper()
+
+	require.NotEmpty(t, manifestJSON)
+
+	var manifest githubManifest
+	require.NoError(t, json.Unmarshal([]byte(manifestJSON), &manifest))
+	require.Equal(t, defaultGitHubAppEvents, manifest.DefaultEvents)
 }


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/4237

Include event subscriptions to github manifest

<img width="878" height="452" alt="image" src="https://github.com/user-attachments/assets/34169a42-220a-44ed-abdf-b838071f66d0" />
<img width="1570" height="214" alt="image" src="https://github.com/user-attachments/assets/d34d4787-e875-489a-ada0-69af2ec02cee" />
<img width="1034" height="1654" alt="image" src="https://github.com/user-attachments/assets/0eebb676-e2fe-4e11-988a-54e326a65cf2" />
