### PR TITLE
fix: detect integration binding changes in workflow publish state

### DIFF
--- a/web_src/src/pages/workflowv2/VersionNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/VersionNodeDiff.tsx
@@ -6,6 +6,7 @@ import { Diff, Hunk, parseDiff } from "react-diff-view";
 import { useMemo } from "react";
 import * as yaml from "js-yaml";
 import "react-diff-view/style/index.css";
+import { getComparableIntegrationId } from "./utils";
 import { WorkflowMarkdownPreview } from "./WorkflowMarkdownPreview";
 
 export function buildInitials(name?: string): string {
@@ -104,7 +105,7 @@ export function summarizeNodeDiff(
     configuration: node.configuration || null,
     position: node.position || null,
     isCollapsed: node.isCollapsed || false,
-    integrationId: node.integrationId || null,
+    integrationId: getComparableIntegrationId(node),
   });
 
   const formatDiffValueLines = (value: unknown): string[] => {

--- a/web_src/src/pages/workflowv2/draftNodeDiff.spec.ts
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 
 describe("hasDraftVersusLiveGraphDiff", () => {
-  const node = (id: string) => ({
+  const node = (id: string, integrationId?: string | null) => ({
     id,
     name: "N",
     type: "TYPE_COMPONENT",
@@ -10,7 +10,7 @@ describe("hasDraftVersusLiveGraphDiff", () => {
     configuration: {},
     position: { x: 0, y: 0 },
     isCollapsed: false,
-    integrationId: null,
+    integration: integrationId ? { id: integrationId, name: `integration-${integrationId}` } : undefined,
   });
 
   it("returns true when only edges differ", () => {
@@ -38,5 +38,22 @@ describe("hasDraftVersusLiveGraphDiff", () => {
     const draft = { spec: { nodes, edges } };
 
     expect(hasDraftVersusLiveGraphDiff(live as never, draft as never)).toBe(false);
+  });
+
+  it("returns true when only the integration binding changes", () => {
+    const live = {
+      spec: {
+        nodes: [node("a", "github-1")],
+        edges: [] as { sourceId: string; targetId: string; channel: string }[],
+      },
+    };
+    const draft = {
+      spec: {
+        nodes: [node("a", "github-2")],
+        edges: [] as { sourceId: string; targetId: string; channel: string }[],
+      },
+    };
+
+    expect(hasDraftVersusLiveGraphDiff(live as never, draft as never)).toBe(true);
   });
 });

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -1,5 +1,6 @@
 import type { CanvasesCanvasVersion } from "@/api-client";
 import * as yaml from "js-yaml";
+import { getComparableIntegrationId } from "./utils";
 
 export type DraftDiffLine = {
   prefix: "meta" | "context" | "+" | "-";
@@ -81,7 +82,7 @@ export function buildDraftNodeDiffSummary(
     configuration: node.configuration || null,
     position: node.position || null,
     isCollapsed: node.isCollapsed || false,
-    integrationId: node.integrationId || null,
+    integrationId: getComparableIntegrationId(node),
   });
 
   const formatDiffValueLines = (value: unknown): string[] => {

--- a/web_src/src/pages/workflowv2/index.spec.ts
+++ b/web_src/src/pages/workflowv2/index.spec.ts
@@ -1,12 +1,13 @@
 import { QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ComponentsComponent, SuperplaneComponentsNode } from "@/api-client";
-import { makeComponentsNode } from "@/test/factories";
+import { makeCanvas, makeComponentsNode } from "@/test/factories";
 import type { CustomFieldRenderer } from "./mappers/types";
 import * as mappers from "./mappers";
 import { createSafeCustomFieldRenderer } from "./mappers/safeMappers";
 import { prepareComponentBaseNode, prepareTriggerNode } from "./lib/canvas-node-preparation";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
+import { getWorkflowSaveSignature } from "./utils";
 
 type FallbackComponentData = {
   renderFallback?: {
@@ -143,5 +144,40 @@ describe("canvas node preparation resilience", () => {
 
     expect(triggerData.trigger.error).toBeUndefined();
     expect(triggerData.trigger.warning).toBeUndefined();
+  });
+});
+
+describe("getWorkflowSaveSignature", () => {
+  it("treats integration refs with the same id as the same saved draft even when only the display name differs", () => {
+    const workflowWithIntegrationName = makeCanvas({
+      spec: {
+        nodes: [
+          makeNode({
+            integration: {
+              id: "integration-1",
+              name: "github-1",
+            },
+          }),
+        ],
+        edges: [],
+      },
+    });
+
+    const workflowWithPersistedIntegrationShape = makeCanvas({
+      spec: {
+        nodes: [
+          makeNode({
+            integration: {
+              id: "integration-1",
+            },
+          }),
+        ],
+        edges: [],
+      },
+    });
+
+    expect(getWorkflowSaveSignature(workflowWithIntegrationName)).toBe(
+      getWorkflowSaveSignature(workflowWithPersistedIntegrationShape),
+    );
   });
 });

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -128,6 +128,7 @@ import {
   mapQueueItemsToSidebarEvents,
   mapTriggerEventsToSidebarEvents,
   mapWorkflowEventsToRunLogEntries,
+  getWorkflowSaveSignature,
   summarizeWorkflowChanges,
 } from "./utils";
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
@@ -158,19 +159,6 @@ type QueuedCanvasSaveRequest = {
 };
 
 type CanvasEchoRelease = () => void;
-
-function getWorkflowSaveSignature(workflow: CanvasesCanvas | null | undefined): string {
-  if (!workflow) {
-    return "";
-  }
-
-  return JSON.stringify({
-    name: workflow.metadata?.name ?? "",
-    description: workflow.metadata?.description ?? "",
-    nodes: workflow.spec?.nodes ?? [],
-    edges: workflow.spec?.edges ?? [],
-  });
-}
 
 export function WorkflowPageV2() {
   const { organizationId, canvasId } = useParams<{

--- a/web_src/src/pages/workflowv2/utils.ts
+++ b/web_src/src/pages/workflowv2/utils.ts
@@ -27,6 +27,41 @@ export function generateNodeId(blockName: string, nodeName: string): string {
   return `${sanitizedBlock}-${sanitizedName}-${randomChars}`;
 }
 
+export function getComparableIntegrationId(node: Record<string, unknown>): string | null {
+  const integration = node.integration;
+  if (integration && typeof integration === "object" && "id" in integration) {
+    const integrationId = integration.id;
+    return typeof integrationId === "string" && integrationId ? integrationId : null;
+  }
+
+  const integrationId = node.integrationId;
+  return typeof integrationId === "string" && integrationId ? integrationId : null;
+}
+
+function normalizeNodeForSaveSignature(node: ComponentsNode): ComponentsNode {
+  if (!node.integration) {
+    return node;
+  }
+
+  return {
+    ...node,
+    integration: node.integration.id ? { id: node.integration.id } : undefined,
+  };
+}
+
+export function getWorkflowSaveSignature(workflow: CanvasesCanvas | null | undefined): string {
+  if (!workflow) {
+    return "";
+  }
+
+  return JSON.stringify({
+    name: workflow.metadata?.name ?? "",
+    description: workflow.metadata?.description ?? "",
+    nodes: (workflow.spec?.nodes ?? []).map(normalizeNodeForSaveSignature),
+    edges: workflow.spec?.edges ?? [],
+  });
+}
+
 /**
  * Generates a unique node name based on component name + ordinal number.
  * First instance: "if", second: "if2", third: "if3", etc.


### PR DESCRIPTION
## Summary

Closes: https://github.com/superplanehq/superplane/issues/4225

Fixes a frontend issue where changing a node’s integration binding was not treated as a draft change, so the `Publish` button could stay disabled or fail to recognize the update correctly.

## Problem

When a user changed a component or trigger from one integration instance to another, the draft/live diff logic did not correctly detect that integration-binding change.

As a result:
- the draft was treated as unchanged
- `Publish` did not reliably reflect that there was something to publish

## Fix

- Updated workflow diff/signature comparison so integration binding changes are detected correctly.
- Normalized integration comparison to use the comparable integration identity instead of UI-only integration object differences.
- Reused the same integration comparison helper across workflow diff code.

