### PR TITLE
feat: persist agent run and restore chat state after disconnect

### DIFF
--- a/agent/db/migrations/20260421120636_add-latest-run-status-to-agent-chats.up.sql
+++ b/agent/db/migrations/20260421120636_add-latest-run-status-to-agent-chats.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_chats
+    ADD COLUMN latest_run_status TEXT NOT NULL DEFAULT '';

--- a/agent/db/migrations/20260421120636_add-latest-run-status-to-agent-chats.up.sql
+++ b/agent/db/migrations/20260421120636_add-latest-run-status-to-agent-chats.up.sql
@@ -1,2 +1,5 @@
 ALTER TABLE agent_chats
     ADD COLUMN latest_run_status TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE agent_chat_messages
+    ADD COLUMN proposal TEXT;

--- a/agent/db/structure.sql
+++ b/agent/db/structure.sql
@@ -45,7 +45,8 @@ CREATE TABLE public.agent_chat_messages (
     message jsonb NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    run_id uuid
+    run_id uuid,
+    proposal text
 );
 
 

--- a/agent/db/structure.sql
+++ b/agent/db/structure.sql
@@ -80,7 +80,8 @@ CREATE TABLE public.agent_chats (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     total_input_tokens bigint DEFAULT 0 NOT NULL,
     total_output_tokens bigint DEFAULT 0 NOT NULL,
-    total_tokens bigint DEFAULT 0 NOT NULL
+    total_tokens bigint DEFAULT 0 NOT NULL,
+    latest_run_status text DEFAULT ''::text NOT NULL
 );
 
 
@@ -211,7 +212,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260412145739	f
+20260421120636	f
 \.
 
 

--- a/agent/src/ai/grpc.py
+++ b/agent/src/ai/grpc.py
@@ -34,6 +34,7 @@ def _serialize_chat(chat: StoredAgentChat) -> Any:
         id=chat.id,
         initial_message=chat.initial_message or "",
         created_at=_timestamp(chat.created_at),
+        latest_run_status=chat.latest_run_status,
     )
 
 
@@ -45,6 +46,7 @@ def _serialize_message(message: StoredAgentChatMessage) -> Any:
         tool_call_id=message.tool_call_id or "",
         tool_status=message.tool_status or "",
         created_at=_timestamp(message.created_at),
+        proposal=message.proposal or "",
     )
 
 

--- a/agent/src/ai/persisted_run_recorder.py
+++ b/agent/src/ai/persisted_run_recorder.py
@@ -48,13 +48,18 @@ class PersistedRunRecorder:
             self._current_response_message_id, self._current_response
         )
 
-    def save_authoritative_messages(self, messages: Any) -> None:
+    def save_authoritative_messages(
+        self,
+        messages: Any,
+        coerced_proposal_json: str | None = None,
+    ) -> None:
         validated_messages = ModelMessagesTypeAdapter.validate_python(messages)
         self._store.replace_agent_chat_messages_after(
             self._chat_id,
             self._history_count_before_run,
             list(validated_messages),
             run_id=self._run_id,
+            coerced_proposal_json=coerced_proposal_json,
         )
         self._authoritative_messages_saved = True
         self._current_response_message_id = None

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -17,7 +17,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -166,6 +166,36 @@ def _extract_output_tool_answer(payload: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_output_proposal(payload: dict[str, Any]) -> dict[str, Any] | None:
+    parts = payload.get("parts")
+    if not isinstance(parts, list):
+        return None
+
+    for part in reversed(parts):
+        if not isinstance(part, dict):
+            continue
+        if part.get("part_kind") != "tool-call":
+            continue
+        if not _likely_output_tool_name(part.get("tool_name")):
+            continue
+
+        args = part.get("args")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except json.JSONDecodeError:
+                continue
+
+        if not isinstance(args, dict):
+            continue
+
+        proposal = args.get("proposal")
+        if isinstance(proposal, dict):
+            return proposal
+
+    return None
+
+
 @dataclass(frozen=True)
 class StoredAgentChat:
     id: str
@@ -178,6 +208,7 @@ class StoredAgentChat:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_tokens: int = 0
+    latest_run_status: str = ""
 
 
 @dataclass(frozen=True)
@@ -206,6 +237,7 @@ class StoredAgentChatMessage:
     tool_call_id: str | None
     tool_status: str | None
     created_at: datetime
+    proposal: str | None = None
 
 
 @dataclass(frozen=True)
@@ -562,6 +594,9 @@ class SessionStore:
                 if chat is None:
                     raise AgentChatNotFoundError(chat_id)
 
+                chat.latest_run_status = "running"
+                chat.updated_at = now
+
                 session.add(
                     AgentChatRun(
                         id=run_id,
@@ -614,7 +649,43 @@ class SessionStore:
                 chat.total_input_tokens = int(totals[0])
                 chat.total_output_tokens = int(totals[1])
                 chat.total_tokens = int(totals[2])
+                chat.latest_run_status = "completed"
                 chat.updated_at = now
+
+    def mark_run_failed(self, chat_id: str) -> None:
+        cid = uuid.UUID(chat_id)
+        now = _utcnow()
+
+        with self._session() as session:
+            with session.begin():
+                chat = self._lock_chat(session, cid)
+                if chat is None:
+                    return
+
+                # Don't overwrite a successfully-recorded completion.
+                if chat.latest_run_status == "completed":
+                    return
+
+                chat.latest_run_status = "failed"
+                chat.updated_at = now
+
+    def reset_stale_running_chats(self) -> int:
+        """Mark all chats stuck in 'running' as 'failed'.
+
+        Called once on startup to recover from a previous crash or OOM kill
+        that left latest_run_status = 'running' in the DB with no live agent
+        task to complete them.  Returns the number of rows updated.
+        """
+        now = _utcnow()
+        stmt = (
+            update(AgentChat)
+            .where(AgentChat.latest_run_status == "running")
+            .values(latest_run_status="failed", updated_at=now)
+        )
+        with self._session() as session:
+            with session.begin():
+                result = session.execute(stmt)
+                return result.rowcount
 
     # ---- org usage ----
 
@@ -707,6 +778,8 @@ class SessionStore:
             assistant_content = "".join(assistant_parts)
             if not assistant_content:
                 assistant_content = _extract_output_tool_answer(record.message)
+            proposal_dict = _extract_output_proposal(record.message)
+            proposal_json = json.dumps(proposal_dict) if proposal_dict is not None else None
             if assistant_content:
                 flattened.append(
                     StoredAgentChatMessage(
@@ -717,6 +790,7 @@ class SessionStore:
                         tool_call_id=None,
                         tool_status=None,
                         created_at=record.created_at,
+                        proposal=proposal_json,
                     )
                 )
 
@@ -735,6 +809,7 @@ class SessionStore:
             total_input_tokens=int(row.total_input_tokens or 0),
             total_output_tokens=int(row.total_output_tokens or 0),
             total_tokens=int(row.total_tokens or 0),
+            latest_run_status=str(row.latest_run_status or ""),
         )
 
     @staticmethod

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -226,6 +226,7 @@ class StoredAgentChatMessageRecord:
     message: dict[str, Any]
     created_at: datetime
     updated_at: datetime
+    proposal: str | None = None
 
 
 @dataclass(frozen=True)
@@ -532,9 +533,11 @@ class SessionStore:
         preserved_message_count: int,
         messages: list[ModelMessage],
         run_id: str | None = None,
+        coerced_proposal_json: str | None = None,
     ) -> None:
         now = _utcnow()
         cid = uuid.UUID(chat_id)
+        last_index = preserved_message_count + len(messages) - 1
 
         with self._session() as session:
             with session.begin():
@@ -552,13 +555,18 @@ class SessionStore:
                 for offset, msg in enumerate(messages):
                     serialized_message = _serialize_model_message(msg)
                     created_at = _message_timestamp(msg)
+                    index = preserved_message_count + offset
+                    # Set the coerced proposal only on the last message (which
+                    # contains the output tool call whose args have been coerced).
+                    proposal = coerced_proposal_json if index == last_index else None
                     session.add(
                         AgentChatMessage(
                             id=uuid.uuid4(),
                             chat_id=cid,
                             run_id=uuid.UUID(run_id) if run_id else None,
-                            message_index=preserved_message_count + offset,
+                            message_index=index,
                             message=serialized_message,
+                            proposal=proposal,
                             created_at=created_at,
                             updated_at=now,
                         )
@@ -778,8 +786,13 @@ class SessionStore:
             assistant_content = "".join(assistant_parts)
             if not assistant_content:
                 assistant_content = _extract_output_tool_answer(record.message)
-            proposal_dict = _extract_output_proposal(record.message)
-            proposal_json = json.dumps(proposal_dict) if proposal_dict is not None else None
+            # Prefer the explicitly saved proposal (already coerced) over the
+            # value extracted from raw tool-call args (which is pre-coercion).
+            if record.proposal is not None:
+                proposal_json = record.proposal
+            else:
+                proposal_dict = _extract_output_proposal(record.message)
+                proposal_json = json.dumps(proposal_dict) if proposal_dict is not None else None
             if assistant_content:
                 flattened.append(
                     StoredAgentChatMessage(
@@ -825,6 +838,7 @@ class SessionStore:
             message=payload,
             created_at=_from_db_time(row.created_at),
             updated_at=_from_db_time(row.updated_at),
+            proposal=row.proposal,
         )
 
     @staticmethod

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -160,7 +160,9 @@ def _extract_output_tool_arg(payload: dict[str, Any], key: str) -> Any:
         if not isinstance(args, dict):
             continue
 
-        return args.get(key)
+        if key in args:
+            return args[key]
+        # Key absent in this tool call — keep searching earlier parts.
 
     return None
 

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -136,37 +136,8 @@ def _deserialize_model_message(payload: Any) -> ModelMessage:
     return messages[0]
 
 
-def _extract_output_tool_answer(payload: dict[str, Any]) -> str:
-    parts = payload.get("parts")
-    if not isinstance(parts, list):
-        return ""
-
-    for part in reversed(parts):
-        if not isinstance(part, dict):
-            continue
-        if part.get("part_kind") != "tool-call":
-            continue
-        if not _likely_output_tool_name(part.get("tool_name")):
-            continue
-
-        args = part.get("args")
-        if isinstance(args, str):
-            try:
-                args = json.loads(args)
-            except json.JSONDecodeError:
-                continue
-
-        if not isinstance(args, dict):
-            continue
-
-        answer = args.get("answer")
-        if isinstance(answer, str) and answer:
-            return answer
-
-    return ""
-
-
-def _extract_output_proposal(payload: dict[str, Any]) -> dict[str, Any] | None:
+def _extract_output_tool_arg(payload: dict[str, Any], key: str) -> Any:
+    """Return the value of *key* from the last output tool-call's args, or None."""
     parts = payload.get("parts")
     if not isinstance(parts, list):
         return None
@@ -189,11 +160,19 @@ def _extract_output_proposal(payload: dict[str, Any]) -> dict[str, Any] | None:
         if not isinstance(args, dict):
             continue
 
-        proposal = args.get("proposal")
-        if isinstance(proposal, dict):
-            return proposal
+        return args.get(key)
 
     return None
+
+
+def _extract_output_tool_answer(payload: dict[str, Any]) -> str:
+    value = _extract_output_tool_arg(payload, "answer")
+    return value if isinstance(value, str) and value else ""
+
+
+def _extract_output_proposal(payload: dict[str, Any]) -> dict[str, Any] | None:
+    value = _extract_output_tool_arg(payload, "proposal")
+    return value if isinstance(value, dict) else None
 
 
 @dataclass(frozen=True)

--- a/agent/src/ai/session_store.py
+++ b/agent/src/ai/session_store.py
@@ -19,7 +19,7 @@ from pydantic_ai.messages import (
 )
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import CursorResult, Engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from ai.config import config
@@ -671,8 +671,8 @@ class SessionStore:
         )
         with self._session() as session:
             with session.begin():
-                result = session.execute(stmt)
-                return result.rowcount
+                result: CursorResult[Any] = session.execute(stmt)  # type: ignore[assignment]
+                return int(result.rowcount)
 
     # ---- org usage ----
 
@@ -768,7 +768,7 @@ class SessionStore:
             # Prefer the explicitly saved proposal (already coerced) over the
             # value extracted from raw tool-call args (which is pre-coercion).
             if record.proposal is not None:
-                proposal_json = record.proposal
+                proposal_json: str | None = record.proposal
             else:
                 proposal_dict = _extract_output_proposal(record.message)
                 proposal_json = json.dumps(proposal_dict) if proposal_dict is not None else None

--- a/agent/src/ai/web.py
+++ b/agent/src/ai/web.py
@@ -538,8 +538,8 @@ async def _stream_agent_run(
                 list(result.new_messages()),
                 persisted_tool_display_labels,
             )
-            recorder.save_authoritative_messages(messages)
             resolved_output = result.output
+            coerced_proposal_json: str | None = None
             if isinstance(resolved_output, CanvasAnswer):
                 cache_key = f"{deps.canvas_id}:{deps.canvas_version_id or 'inspect'}"
                 canvas_summary = deps.canvas_cache.get(cache_key)
@@ -548,6 +548,9 @@ async def _stream_agent_run(
                     resolved_output,
                     canvas_summary,
                 )
+                if resolved_output.proposal is not None:
+                    coerced_proposal_json = json.dumps(_to_jsonable(resolved_output.proposal))
+            recorder.save_authoritative_messages(messages, coerced_proposal_json=coerced_proposal_json)
             output = _to_jsonable(resolved_output)
             if isinstance(output, dict) and not streamed_any_answer_delta:
                 answer = output.get("answer")

--- a/agent/src/ai/web.py
+++ b/agent/src/ai/web.py
@@ -160,6 +160,12 @@ def _record_usage(
         )
     except Exception as error:
         print(f"[web] failed to record usage for run {run_id}: {error}", flush=True)
+        # update_run_usage sets latest_run_status = "completed"; if it fails the
+        # chat stays stuck at "running". Mark it failed so the UI doesn't spin forever.
+        try:
+            store.mark_run_failed(chat_id)
+        except Exception as mark_error:
+            print(f"[web] failed to mark run as failed after usage error {run_id}: {mark_error}", flush=True)
 
     # DB write and RabbitMQ publish are independent
     # a DB failure won't prevent publishing, and each has its own error logging
@@ -584,6 +590,36 @@ async def _stream_agent_run(
     yield {"type": "done"}
 
 
+async def _run_agent_to_queue(
+    chat_id: str,
+    payload: AgentStreamRequest,
+    request: Request,
+    queue: "asyncio.Queue[dict[str, Any] | None]",
+) -> None:
+    """Run the agent to completion, placing every SSE event into queue.
+
+    Runs as an independent asyncio.Task so the agent is never interrupted when
+    the SSE client disconnects.  The sentinel value None is always placed last
+    (even after errors) so the consumer knows the task is done.
+    """
+    try:
+        async for event in _stream_agent_run(chat_id, payload, request):
+            await queue.put(event)
+    except Exception as error:
+        print(f"[web] agent task failed chat_id={chat_id} error={error}", flush=True)
+        import sentry_sdk
+
+        sentry_sdk.capture_exception(error)
+        try:
+            store: SessionStore = request.app.state.session_store
+            store.mark_run_failed(chat_id)
+        except Exception as mark_error:
+            print(f"[web] failed to mark run as failed in agent task chat_id={chat_id}: {mark_error}", flush=True)
+        await queue.put({"type": "_agent_error", "error": error})
+    finally:
+        await queue.put(None)  # sentinel — always sent so the consumer can exit
+
+
 def _create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -603,6 +639,13 @@ def _create_app() -> FastAPI:
         app.state.stream_tracker = tracker
         app.state.publisher = publisher
         app.state.limit_checker = limit_checker
+
+        # Reset any chats that were left in 'running' by a previous crash/OOM
+        # kill so they don't permanently show a spinner in the UI.
+        stale_count = store.reset_stale_running_chats()
+        if stale_count:
+            print(f"[web] startup: reset {stale_count} stale running chat(s) to failed", flush=True)
+
         grpc_server = InternalAgentServer.from_env(store)
         grpc_server.start()
         app.state.internal_agent_server = grpc_server
@@ -661,26 +704,53 @@ def _create_app() -> FastAPI:
         try:
 
             async def event_generator() -> AsyncIterator[str]:
-                try:
-                    async for event in _stream_agent_run(chat_id, payload, request):
-                        if await request.is_disconnected():
-                            _debug_log("client disconnected", chat_id=chat_id)
-                            break
-                        yield _encode_sse_event(event)
-                except Exception as error:
-                    import sentry_sdk
+                # The agent runs in an independent task so it is never interrupted
+                # by the SSE connection closing.  The SSE generator just reads from
+                # the shared queue; when the client disconnects we return early and
+                # the task keeps running until _record_usage persists the final state.
+                queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+                agent_task = asyncio.create_task(
+                    _run_agent_to_queue(chat_id, payload, request, queue)
+                )
+                register_background_task(agent_task)
 
-                    sentry_sdk.capture_exception(error)
-                    print(f"[web] stream failed chat_id={chat_id} error={error}", flush=True)
-                    yield _encode_sse_event(
-                        {
-                            "type": "run_failed",
-                            "error": _friendly_error_message(error),
-                        }
-                    )
-                    yield _encode_sse_event({"type": "done"})
+                try:
+                    while True:
+                        try:
+                            event = await asyncio.wait_for(queue.get(), timeout=0.1)
+                        except TimeoutError:
+                            if await request.is_disconnected():
+                                _debug_log("client disconnected, agent continues in background", chat_id=chat_id)
+                                return
+                            continue
+
+                        if event is None:  # sentinel — agent task finished
+                            break
+
+                        if event.get("type") == "_agent_error":
+                            error = event["error"]
+                            yield _encode_sse_event(
+                                {
+                                    "type": "run_failed",
+                                    "error": _friendly_error_message(error),
+                                }
+                            )
+                            yield _encode_sse_event({"type": "done"})
+                            return
+
+                        yield _encode_sse_event(event)
                 finally:
-                    await tracker.release()
+                    if agent_task.done():
+                        # Agent finished before/alongside the SSE connection — release immediately.
+                        await tracker.release()
+                    else:
+                        # SSE closed but agent is still running in the background.
+                        # Transfer tracker ownership so graceful shutdown waits for
+                        # the agent task to actually finish before draining.
+                        loop = asyncio.get_running_loop()
+                        agent_task.add_done_callback(
+                            lambda _: loop.create_task(tracker.release())
+                        )
 
             return StreamingResponse(
                 event_generator(),

--- a/agent/src/ai/web.py
+++ b/agent/src/ai/web.py
@@ -165,7 +165,10 @@ def _record_usage(
         try:
             store.mark_run_failed(chat_id)
         except Exception as mark_error:
-            print(f"[web] failed to mark run as failed after usage error {run_id}: {mark_error}", flush=True)
+            print(
+                f"[web] failed to mark run as failed after usage error {run_id}: {mark_error}",
+                flush=True,
+            )
 
     # DB write and RabbitMQ publish are independent
     # a DB failure won't prevent publishing, and each has its own error logging
@@ -550,7 +553,9 @@ async def _stream_agent_run(
                 )
                 if resolved_output.proposal is not None:
                     coerced_proposal_json = json.dumps(_to_jsonable(resolved_output.proposal))
-            recorder.save_authoritative_messages(messages, coerced_proposal_json=coerced_proposal_json)
+            recorder.save_authoritative_messages(
+                messages, coerced_proposal_json=coerced_proposal_json
+            )
             output = _to_jsonable(resolved_output)
             if isinstance(output, dict) and not streamed_any_answer_delta:
                 answer = output.get("answer")
@@ -617,7 +622,10 @@ async def _run_agent_to_queue(
             store: SessionStore = request.app.state.session_store
             store.mark_run_failed(chat_id)
         except Exception as mark_error:
-            print(f"[web] failed to mark run as failed in agent task chat_id={chat_id}: {mark_error}", flush=True)
+            print(
+                f"[web] failed to mark run as failed in agent task chat_id={chat_id}: {mark_error}",
+                flush=True,
+            )
         await queue.put({"type": "_agent_error", "error": error})
     finally:
         await queue.put(None)  # sentinel — always sent so the consumer can exit
@@ -723,7 +731,10 @@ def _create_app() -> FastAPI:
                             event = await asyncio.wait_for(queue.get(), timeout=0.1)
                         except TimeoutError:
                             if await request.is_disconnected():
-                                _debug_log("client disconnected, agent continues in background", chat_id=chat_id)
+                                _debug_log(
+                                    "client disconnected, agent continues in background",
+                                    chat_id=chat_id,
+                                )
                                 return
                             continue
 
@@ -751,9 +762,7 @@ def _create_app() -> FastAPI:
                         # Transfer tracker ownership so graceful shutdown waits for
                         # the agent task to actually finish before draining.
                         loop = asyncio.get_running_loop()
-                        agent_task.add_done_callback(
-                            lambda _: loop.create_task(tracker.release())
-                        )
+                        agent_task.add_done_callback(lambda _: loop.create_task(tracker.release()))
 
             return StreamingResponse(
                 event_generator(),

--- a/agent/src/db/models.py
+++ b/agent/src/db/models.py
@@ -39,6 +39,7 @@ class AgentChat(Base):
     total_input_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
     total_output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
     total_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    latest_run_status: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
 
     messages: Mapped[list["AgentChatMessage"]] = relationship(
         back_populates="chat", cascade="all, delete-orphan"

--- a/agent/src/db/models.py
+++ b/agent/src/db/models.py
@@ -73,6 +73,7 @@ class AgentChatMessage(Base):
     )
     message_index: Mapped[int] = mapped_column(nullable=False)
     message: Mapped[dict] = mapped_column(JSONB, nullable=False)  # type: ignore[type-arg]
+    proposal: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         TimestampTZ, nullable=False, server_default=func.now()
     )

--- a/pkg/grpc/actions/agents/describe_agent_chat.go
+++ b/pkg/grpc/actions/agents/describe_agent_chat.go
@@ -43,8 +43,9 @@ func DescribeAgentChat(
 	}
 
 	chat := &pb.AgentChatInfo{
-		Id:             response.Chat.Id,
-		InitialMessage: response.Chat.InitialMessage,
+		Id:              response.Chat.Id,
+		InitialMessage:  response.Chat.InitialMessage,
+		LatestRunStatus: response.Chat.LatestRunStatus,
 	}
 
 	if response.Chat.CreatedAt != nil {

--- a/pkg/grpc/actions/agents/list_agent_chat_messages.go
+++ b/pkg/grpc/actions/agents/list_agent_chat_messages.go
@@ -52,6 +52,7 @@ func serializeAgentChatMessages(in []*internalpb.AgentChatMessage) []*pb.AgentCh
 			Content:    message.Content,
 			ToolCallId: message.ToolCallId,
 			ToolStatus: message.ToolStatus,
+			Proposal:   message.Proposal,
 		}
 
 		if message.CreatedAt != nil {

--- a/pkg/grpc/actions/agents/list_agent_chats.go
+++ b/pkg/grpc/actions/agents/list_agent_chats.go
@@ -46,8 +46,9 @@ func serializeAgentChats(in []*internalpb.ChatInfo) []*pb.AgentChatInfo {
 		}
 
 		chat := &pb.AgentChatInfo{
-			Id:             c.Id,
-			InitialMessage: c.InitialMessage,
+			Id:              c.Id,
+			InitialMessage:  c.InitialMessage,
+			LatestRunStatus: c.LatestRunStatus,
 		}
 
 		if c.CreatedAt != nil {

--- a/protos/agents.proto
+++ b/protos/agents.proto
@@ -128,6 +128,7 @@ message AgentChatMessage {
   string tool_call_id = 4;
   string tool_status = 5;
   google.protobuf.Timestamp created_at = 6;
+  string proposal = 7;
 }
 
 message CreateAgentChatRequest {
@@ -160,4 +161,5 @@ message AgentChatInfo {
   string id = 1;
   string initial_message = 2;
   google.protobuf.Timestamp created_at = 3;
+  string latest_run_status = 4;
 }

--- a/protos/private/agents.proto
+++ b/protos/private/agents.proto
@@ -59,6 +59,7 @@ message AgentChatMessage {
   string tool_call_id = 4;
   string tool_status = 5;
   google.protobuf.Timestamp created_at = 6;
+  string proposal = 7;
 }
 
 message CreateAgentChatRequest {
@@ -84,6 +85,7 @@ message ChatInfo {
   string id = 1;
   string initial_message = 2;
   google.protobuf.Timestamp created_at = 3;
+  string latest_run_status = 4;
 }
 
 message ChatUsage {

--- a/web_src/src/components/AgentSidebar/agentChat.ts
+++ b/web_src/src/components/AgentSidebar/agentChat.ts
@@ -20,6 +20,7 @@ import {
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import type { Dispatch, SetStateAction } from "react";
 import { consumeChatResponseStream } from "./agentChatSupport";
+import { normalizeAiProposal } from "./agentChatProposal";
 import {
   addLocalPromptMessages,
   applyChatPromptFailure,
@@ -47,6 +48,7 @@ export type AiChatSession = {
   title: string;
   initialMessage?: string;
   createdAt?: string;
+  latestRunStatus?: string;
 };
 
 export type AgentMode = { mode: "inspect" } | { mode: "build"; canvasVersion: string };
@@ -156,12 +158,17 @@ function normalizeChatSession(chat: AgentsAgentChatInfo): AiChatSession | null {
 
   const initialMessage = typeof chat.initialMessage === "string" ? chat.initialMessage.trim() : "";
   const createdAt = typeof chat.createdAt === "string" && chat.createdAt.trim().length > 0 ? chat.createdAt : undefined;
+  const latestRunStatus =
+    typeof chat.latestRunStatus === "string" && chat.latestRunStatus.trim().length > 0
+      ? chat.latestRunStatus.trim()
+      : undefined;
 
   return {
     id,
     title: initialMessage || UNTITLED_CHAT_SESSION,
     initialMessage: initialMessage || undefined,
     createdAt,
+    latestRunStatus,
   };
 }
 
@@ -177,6 +184,26 @@ function normalizePersistedMessages(payload: AgentsListAgentChatMessagesResponse
       .map((message) => normalizePersistedMessage(message))
       .filter((message): message is AiBuilderMessage => Boolean(message)),
   );
+}
+
+function extractPendingProposalFromApiMessages(apiMessages: AgentsAgentChatMessage[]): AiBuilderProposal | null {
+  for (let i = apiMessages.length - 1; i >= 0; i--) {
+    const msg = apiMessages[i];
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    const raw = typeof msg.proposal === "string" ? msg.proposal.trim() : "";
+    if (!raw) {
+      // Last assistant message has no proposal — nothing pending.
+      break;
+    }
+    try {
+      return normalizeAiProposal(JSON.parse(raw));
+    } catch {
+      break;
+    }
+  }
+  return null;
 }
 
 function requireChatSessionPayload(payload: AgentsCreateAgentChatResponse | AgentsResumeAgentChatResponse): {
@@ -216,6 +243,11 @@ export async function loadChatSessions({
   return normalizeChatSessions(listResponse.data);
 }
 
+export type ChatConversation = {
+  messages: AiBuilderMessage[];
+  pendingProposal: AiBuilderProposal | null;
+};
+
 export async function loadChatConversation({
   chatId,
   canvasId,
@@ -224,9 +256,9 @@ export async function loadChatConversation({
   chatId?: string | null;
   canvasId?: string;
   organizationId?: string;
-}): Promise<AiBuilderMessage[]> {
+}): Promise<ChatConversation> {
   if (!canvasId || !organizationId || !chatId) {
-    return [];
+    return { messages: [], pendingProposal: null };
   }
 
   const messagesResponse = await agentsListAgentChatMessages(
@@ -241,7 +273,11 @@ export async function loadChatConversation({
     }),
   );
 
-  return normalizePersistedMessages(messagesResponse.data);
+  const apiMessages = messagesResponse.data?.messages ?? [];
+  return {
+    messages: normalizePersistedMessages(messagesResponse.data),
+    pendingProposal: extractPendingProposalFromApiMessages(apiMessages),
+  };
 }
 
 export async function deleteAgentChatSession({

--- a/web_src/src/components/AgentSidebar/index.tsx
+++ b/web_src/src/components/AgentSidebar/index.tsx
@@ -294,6 +294,7 @@ function useChatHandlers(p: UseChatHandlersParams) {
     p.setAiMessages([]);
     p.setPendingProposal(null);
     p.setAiError(null);
+    p.setIsGeneratingResponse(false);
     requestAnimationFrame(() => p.aiInputRef.current?.focus());
   };
 
@@ -301,6 +302,7 @@ function useChatHandlers(p: UseChatHandlersParams) {
     p.setCurrentChatId(chatId);
     p.setPendingProposal(null);
     p.setAiError(null);
+    p.setIsGeneratingResponse(false);
   };
 
   return { handleSendPrompt, handleStartNewChatSession, handleSelectChatSession };

--- a/web_src/src/components/AgentSidebar/index.tsx
+++ b/web_src/src/components/AgentSidebar/index.tsx
@@ -9,6 +9,7 @@ import type { AgentState } from "./useAgentState";
 import { useApplyAiProposal } from "./useApplyAiProposal";
 import { useLoadChatConversation } from "./useLoadChatConversation";
 import { useLoadChatSessions } from "./useLoadChatSessions";
+import { usePollForMessages } from "./usePollForMessages";
 import { useSidebarWidth } from "./useSidebarWidth";
 
 export interface AgentSidebarProps {
@@ -28,15 +29,18 @@ export function AgentSidebar({ agentState }: AgentSidebarProps) {
 }
 
 function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
-  const { canvasId, organizationId, agentContext, onApplyAiOperations } = agentState;
+  const { canvasId, organizationId, agentContext, onApplyAiOperations, currentChatId, setCurrentChatId } = agentState;
 
   const aiInputRef = useRef<HTMLTextAreaElement>(null);
   const [aiInput, setAiInput] = useState("");
   const [aiMessages, setAiMessages] = useState<AiBuilderMessage[]>([]);
   const [chatSessions, setChatSessions] = useState<AiChatSession[]>([]);
-  const [currentChatId, setCurrentChatId] = useState<string | null>(null);
   const [isGeneratingResponse, setIsGeneratingResponse] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
+
+  // Track whether an SSE stream is actively delivering events so the polling
+  // hook knows to stand down.
+  const isStreamingRef = useRef(false);
 
   const { isApplyingProposal, setPendingProposal, pendingProposal, handleDiscardProposal, onApplyProposal } =
     useProposalState({
@@ -45,24 +49,30 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
       onApplyAiOperations,
     });
 
-  const handleSendPrompt = async (value?: string) =>
-    await sendChatPrompt({
-      value,
-      aiInput,
-      canvasId,
-      organizationId,
-      agentContext,
-      currentChatId,
-      isGeneratingResponse,
-      setChatSessions,
-      setCurrentChatId,
-      setAiMessages,
-      setAiInput,
-      setAiError,
-      setIsGeneratingResponse,
-      setPendingProposal,
-      focusInput: () => aiInputRef.current?.focus(),
-    });
+  const handleSendPrompt = async (value?: string) => {
+    isStreamingRef.current = true;
+    try {
+      await sendChatPrompt({
+        value,
+        aiInput,
+        canvasId,
+        organizationId,
+        agentContext,
+        currentChatId,
+        isGeneratingResponse,
+        setChatSessions,
+        setCurrentChatId,
+        setAiMessages,
+        setAiInput,
+        setAiError,
+        setIsGeneratingResponse,
+        setPendingProposal,
+        focusInput: () => aiInputRef.current?.focus(),
+      });
+    } finally {
+      isStreamingRef.current = false;
+    }
+  };
 
   const handleStartNewChatSession = () => {
     setCurrentChatId(null);
@@ -80,14 +90,13 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
     setAiError(null);
   };
 
-  // reset state when canvasId changes
+  // reset local state when canvasId changes (currentChatId reset is handled in useAgentState)
   useEffect(() => {
-    setCurrentChatId(null);
     setAiMessages([]);
     setPendingProposal(null);
     setAiError(null);
     setAiInput("");
-  }, [canvasId, setCurrentChatId, setAiMessages, setPendingProposal, setAiError, setAiInput]);
+  }, [canvasId, setAiMessages, setPendingProposal, setAiError, setAiInput]);
 
   // load previous chat sessions
   const isLoadingChatSessions = useLoadChatSessions({
@@ -103,9 +112,24 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
     canvasId,
     organizationId,
     currentChatId,
+    setChatSessions,
     setAiMessages,
     setPendingProposal,
     setAiError,
+    setIsGeneratingResponse,
+  });
+
+  // poll for updates when a run is in progress but no SSE stream is active
+  usePollForMessages({
+    canvasId,
+    organizationId,
+    currentChatId,
+    isGeneratingResponse,
+    isStreamingRef,
+    setChatSessions,
+    setAiMessages,
+    setIsGeneratingResponse,
+    setPendingProposal,
   });
 
   const sidebarTitle = useMemo(() => {

--- a/web_src/src/components/AgentSidebar/index.tsx
+++ b/web_src/src/components/AgentSidebar/index.tsx
@@ -16,6 +16,24 @@ export interface AgentSidebarProps {
   agentState: AgentState;
 }
 
+type UseChatHandlersParams = {
+  aiInput: string;
+  aiInputRef: React.RefObject<HTMLTextAreaElement | null>;
+  canvasId?: string;
+  organizationId?: string;
+  agentContext: AgentState["agentContext"];
+  currentChatId: string | null;
+  isGeneratingResponse: boolean;
+  isStreamingRef: React.MutableRefObject<boolean>;
+  setChatSessions: Dispatch<SetStateAction<AiChatSession[]>>;
+  setCurrentChatId: Dispatch<SetStateAction<string | null>>;
+  setAiMessages: Dispatch<SetStateAction<AiBuilderMessage[]>>;
+  setAiInput: Dispatch<SetStateAction<string>>;
+  setAiError: Dispatch<SetStateAction<string | null>>;
+  setIsGeneratingResponse: Dispatch<SetStateAction<boolean>>;
+  setPendingProposal: Dispatch<SetStateAction<AiBuilderProposal | null>>;
+};
+
 export function AgentSidebar({ agentState }: AgentSidebarProps) {
   if (!agentState.showAgentSidebarToggle) {
     return null;
@@ -49,54 +67,23 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
       onApplyAiOperations,
     });
 
-  const handleSendPrompt = async (value?: string) => {
-    isStreamingRef.current = true;
-    try {
-      await sendChatPrompt({
-        value,
-        aiInput,
-        canvasId,
-        organizationId,
-        agentContext,
-        currentChatId,
-        isGeneratingResponse,
-        setChatSessions,
-        setCurrentChatId,
-        setAiMessages,
-        setAiInput,
-        setAiError,
-        setIsGeneratingResponse,
-        setPendingProposal,
-        focusInput: () => aiInputRef.current?.focus(),
-      });
-    } finally {
-      isStreamingRef.current = false;
-    }
-  };
-
-  const handleStartNewChatSession = () => {
-    setCurrentChatId(null);
-    setAiMessages([]);
-    setPendingProposal(null);
-    setAiError(null);
-    requestAnimationFrame(() => {
-      aiInputRef.current?.focus();
-    });
-  };
-
-  const handleSelectChatSession = (chatId: string) => {
-    setCurrentChatId(chatId);
-    setPendingProposal(null);
-    setAiError(null);
-  };
-
-  // reset local state when canvasId changes (currentChatId reset is handled in useAgentState)
-  useEffect(() => {
-    setAiMessages([]);
-    setPendingProposal(null);
-    setAiError(null);
-    setAiInput("");
-  }, [canvasId, setAiMessages, setPendingProposal, setAiError, setAiInput]);
+  const { handleSendPrompt, handleStartNewChatSession, handleSelectChatSession } = useChatHandlers({
+    aiInput,
+    aiInputRef,
+    canvasId,
+    organizationId,
+    agentContext,
+    currentChatId,
+    isGeneratingResponse,
+    isStreamingRef,
+    setChatSessions,
+    setCurrentChatId,
+    setAiMessages,
+    setAiInput,
+    setAiError,
+    setIsGeneratingResponse,
+    setPendingProposal,
+  });
 
   // load previous chat sessions
   const isLoadingChatSessions = useLoadChatSessions({
@@ -266,6 +253,57 @@ function CloseButton({ onClose }: { onClose: () => void }) {
       <X size={16} />
     </button>
   );
+}
+
+function useChatHandlers(p: UseChatHandlersParams) {
+  // reset local state when canvasId changes (currentChatId reset is handled in useAgentState)
+  useEffect(() => {
+    p.setAiMessages([]);
+    p.setPendingProposal(null);
+    p.setAiError(null);
+    p.setAiInput("");
+  }, [p.canvasId, p.setAiMessages, p.setPendingProposal, p.setAiError, p.setAiInput]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSendPrompt = async (value?: string) => {
+    p.isStreamingRef.current = true;
+    try {
+      await sendChatPrompt({
+        value,
+        aiInput: p.aiInput,
+        canvasId: p.canvasId,
+        organizationId: p.organizationId,
+        agentContext: p.agentContext,
+        currentChatId: p.currentChatId,
+        isGeneratingResponse: p.isGeneratingResponse,
+        setChatSessions: p.setChatSessions,
+        setCurrentChatId: p.setCurrentChatId,
+        setAiMessages: p.setAiMessages,
+        setAiInput: p.setAiInput,
+        setAiError: p.setAiError,
+        setIsGeneratingResponse: p.setIsGeneratingResponse,
+        setPendingProposal: p.setPendingProposal,
+        focusInput: () => p.aiInputRef.current?.focus(),
+      });
+    } finally {
+      p.isStreamingRef.current = false;
+    }
+  };
+
+  const handleStartNewChatSession = () => {
+    p.setCurrentChatId(null);
+    p.setAiMessages([]);
+    p.setPendingProposal(null);
+    p.setAiError(null);
+    requestAnimationFrame(() => p.aiInputRef.current?.focus());
+  };
+
+  const handleSelectChatSession = (chatId: string) => {
+    p.setCurrentChatId(chatId);
+    p.setPendingProposal(null);
+    p.setAiError(null);
+  };
+
+  return { handleSendPrompt, handleStartNewChatSession, handleSelectChatSession };
 }
 
 function useProposalState({

--- a/web_src/src/components/AgentSidebar/useAgentState.ts
+++ b/web_src/src/components/AgentSidebar/useAgentState.ts
@@ -44,6 +44,12 @@ export function useAgentState({
 }: UseAgentStateOptions) {
   const agentContext = useAgentContext(isEditing, canvasVersion);
   const [isAgentSidebarOpen, setIsAgentSidebarOpen] = useState(readInitialAgentSidebarOpen);
+  const [currentChatId, setCurrentChatId] = useState<string | null>(null);
+
+  // Reset the active chat when the canvas changes.
+  useEffect(() => {
+    setCurrentChatId(null);
+  }, [canvasId]);
 
   const persistAgentSidebarOpen = useCallback((open: boolean) => {
     if (typeof window !== "undefined") {
@@ -103,6 +109,8 @@ export function useAgentState({
     readOnly,
     onApplyAiOperations: onApplyAiOperations ?? (async () => {}),
     closeSidebar: closeAgentSidebar,
+    currentChatId,
+    setCurrentChatId,
   };
 }
 

--- a/web_src/src/components/AgentSidebar/useLoadChatConversation.ts
+++ b/web_src/src/components/AgentSidebar/useLoadChatConversation.ts
@@ -33,6 +33,7 @@ export function useLoadChatConversation({
       if (!currentChatId) {
         setAiMessages([]);
         setPendingProposal(null);
+        setIsGeneratingResponse(false);
       }
       setIsLoadingChatMessages(false);
       return () => {
@@ -65,6 +66,7 @@ export function useLoadChatConversation({
         if (session?.latestRunStatus === "running") {
           setIsGeneratingResponse(true);
         } else {
+          setIsGeneratingResponse(false);
           setPendingProposal(loadedProposal);
         }
       } catch (error) {

--- a/web_src/src/components/AgentSidebar/useLoadChatConversation.ts
+++ b/web_src/src/components/AgentSidebar/useLoadChatConversation.ts
@@ -1,24 +1,28 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useState } from "react";
-import type { AiBuilderMessage, AiBuilderProposal } from "./agentChat";
-import { loadChatConversation } from "./agentChat";
+import type { AiBuilderMessage, AiBuilderProposal, AiChatSession } from "./agentChat";
+import { loadChatConversation, loadChatSessions } from "./agentChat";
 
 export type UseLoadChatConversationParams = {
   canvasId?: string;
   organizationId?: string;
   currentChatId: string | null;
+  setChatSessions: Dispatch<SetStateAction<AiChatSession[]>>;
   setAiMessages: Dispatch<SetStateAction<AiBuilderMessage[]>>;
   setPendingProposal: Dispatch<SetStateAction<AiBuilderProposal | null>>;
   setAiError: Dispatch<SetStateAction<string | null>>;
+  setIsGeneratingResponse: Dispatch<SetStateAction<boolean>>;
 };
 
 export function useLoadChatConversation({
   canvasId,
   organizationId,
   currentChatId,
+  setChatSessions,
   setAiMessages,
   setPendingProposal,
   setAiError,
+  setIsGeneratingResponse,
 }: UseLoadChatConversationParams): boolean {
   const [isLoadingChatMessages, setIsLoadingChatMessages] = useState(false);
 
@@ -39,17 +43,30 @@ export function useLoadChatConversation({
     void (async () => {
       setIsLoadingChatMessages(true);
       try {
-        const messages = await loadChatConversation({
-          chatId: currentChatId,
-          canvasId,
-          organizationId,
-        });
+        // Fetch messages and sessions in parallel so we have authoritative, fresh
+        // latestRunStatus at the exact moment we decide whether to show the spinner.
+        const [{ messages, pendingProposal: loadedProposal }, freshSessions] = await Promise.all([
+          loadChatConversation({ chatId: currentChatId, canvasId, organizationId }),
+          loadChatSessions({ canvasId, organizationId }),
+        ]);
+
         if (cancelled) {
           return;
         }
 
+        setChatSessions(freshSessions);
         setAiMessages(messages);
         setAiError(null);
+
+        // If the run is still in progress, show the spinner so the user knows the
+        // agent is working and the polling loop can take over.
+        // Don't restore a proposal yet — wait for the run to finish.
+        const session = freshSessions.find((s) => s.id === currentChatId);
+        if (session?.latestRunStatus === "running") {
+          setIsGeneratingResponse(true);
+        } else {
+          setPendingProposal(loadedProposal);
+        }
       } catch (error) {
         if (!cancelled) {
           console.warn("Failed to load chat conversation:", error);
@@ -69,8 +86,10 @@ export function useLoadChatConversation({
     canvasId,
     currentChatId,
     organizationId,
+    setChatSessions,
     setAiError,
     setAiMessages,
+    setIsGeneratingResponse,
     setIsLoadingChatMessages,
     setPendingProposal,
   ]);

--- a/web_src/src/components/AgentSidebar/usePollForMessages.ts
+++ b/web_src/src/components/AgentSidebar/usePollForMessages.ts
@@ -36,9 +36,10 @@ export function usePollForMessages({
 
     let cancelled = false;
     let timerId: number | null = null;
+    let isPolling = false;
 
     const poll = async () => {
-      if (cancelled) {
+      if (cancelled || isPolling) {
         return;
       }
 
@@ -54,6 +55,7 @@ export function usePollForMessages({
         return;
       }
 
+      isPolling = true;
       try {
         const [sessions, { messages, pendingProposal: polledProposal }] = await Promise.all([
           loadChatSessions({ canvasId, organizationId }),
@@ -75,6 +77,8 @@ export function usePollForMessages({
         }
       } catch (error) {
         console.warn("Polling for messages failed:", error);
+      } finally {
+        isPolling = false;
       }
 
       schedule();

--- a/web_src/src/components/AgentSidebar/usePollForMessages.ts
+++ b/web_src/src/components/AgentSidebar/usePollForMessages.ts
@@ -1,0 +1,121 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { useEffect } from "react";
+import type { AiBuilderMessage, AiBuilderProposal, AiChatSession } from "./agentChat";
+import { loadChatConversation, loadChatSessions } from "./agentChat";
+
+const POLL_INTERVAL_MS = 2000;
+
+export type UsePollForMessagesParams = {
+  canvasId?: string;
+  organizationId?: string;
+  currentChatId: string | null;
+  isGeneratingResponse: boolean;
+  isStreamingRef: MutableRefObject<boolean>;
+  setChatSessions: Dispatch<SetStateAction<AiChatSession[]>>;
+  setAiMessages: Dispatch<SetStateAction<AiBuilderMessage[]>>;
+  setIsGeneratingResponse: Dispatch<SetStateAction<boolean>>;
+  setPendingProposal: Dispatch<SetStateAction<AiBuilderProposal | null>>;
+};
+
+export function usePollForMessages({
+  canvasId,
+  organizationId,
+  currentChatId,
+  isGeneratingResponse,
+  isStreamingRef,
+  setChatSessions,
+  setAiMessages,
+  setIsGeneratingResponse,
+  setPendingProposal,
+}: UsePollForMessagesParams): void {
+  useEffect(() => {
+    // Only poll when the spinner is showing and there's no active SSE stream.
+    if (!isGeneratingResponse || !currentChatId || !canvasId || !organizationId) {
+      return;
+    }
+
+    let cancelled = false;
+    let timerId: number | null = null;
+
+    const poll = async () => {
+      // Skip a tick if the SSE stream is actively delivering events.
+      if (isStreamingRef.current) {
+        schedule();
+        return;
+      }
+
+      // Skip a tick if the tab is hidden — no point burning requests nobody sees.
+      if (typeof document !== "undefined" && document.hidden) {
+        schedule();
+        return;
+      }
+
+      try {
+        const [sessions, { messages, pendingProposal: polledProposal }] = await Promise.all([
+          loadChatSessions({ canvasId, organizationId }),
+          loadChatConversation({ chatId: currentChatId, canvasId, organizationId }),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setChatSessions(sessions);
+        setAiMessages(messages);
+
+        const session = sessions.find((s) => s.id === currentChatId);
+        if (session?.latestRunStatus !== "running") {
+          setIsGeneratingResponse(false);
+          setPendingProposal(polledProposal);
+          return;
+        }
+      } catch (error) {
+        console.warn("Polling for messages failed:", error);
+      }
+
+      schedule();
+    };
+
+    const schedule = () => {
+      timerId = window.setTimeout(() => void poll(), POLL_INTERVAL_MS);
+    };
+
+    // When the user returns to the tab, fire immediately instead of waiting for
+    // the next scheduled tick (which may have been skipped while hidden).
+    const onVisibilityChange = () => {
+      if (!document.hidden) {
+        if (timerId !== null) {
+          window.clearTimeout(timerId);
+          timerId = null;
+        }
+        void poll();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    // useLoadChatConversation already fetched fresh messages and sessions when it
+    // set isGeneratingResponse = true, so we don't need to poll immediately —
+    // wait one interval to avoid a redundant double-fetch on chat open.
+    schedule();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+      }
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [
+    isGeneratingResponse,
+    currentChatId,
+    canvasId,
+    organizationId,
+    // isStreamingRef is a stable object; included to satisfy exhaustive-deps.
+    // .current is read synchronously inside poll() and never causes a re-run.
+    isStreamingRef,
+    setChatSessions,
+    setAiMessages,
+    setIsGeneratingResponse,
+    setPendingProposal,
+  ]);
+}

--- a/web_src/src/components/AgentSidebar/usePollForMessages.ts
+++ b/web_src/src/components/AgentSidebar/usePollForMessages.ts
@@ -38,6 +38,10 @@ export function usePollForMessages({
     let timerId: number | null = null;
 
     const poll = async () => {
+      if (cancelled) {
+        return;
+      }
+
       // Skip a tick if the SSE stream is actively delivering events.
       if (isStreamingRef.current) {
         schedule();


### PR DESCRIPTION
## Summary

Agent execution now continues on the server after the user closes the
sidebar or refreshes the page. When they return they see the same chat
in the same state — spinner if the run is still in progress, streamed
messages as they arrive, and the canvas-change proposal once the run
finishes.

## What changed

**Python agent (`agent/`)**
- `_run_agent_to_queue` runs the agent as an independent `asyncio.Task`,
  fully decoupled from the SSE connection. Closing the browser tab no
  longer cancels the underlying AI call.
- New `latest_run_status` column on `agent_chats` (`running` →
  `completed` / `failed`). Set atomically by `create_agent_chat_run`,
  `update_run_usage`, and `mark_run_failed`.
- `mark_run_failed` is called on task error and also as a fallback if
  `update_run_usage` fails, so the DB never stays stuck at `running`.
  Guarded against overwriting a `completed` status.
- `reset_stale_running_chats()` runs at startup to flip any chats left
  `running` by a previous crash or OOM kill.
- `proposal` JSON persisted on each assistant message so the
  canvas-change approval UI survives a refresh.
- `ActiveStreamTracker` ownership transferred to the background task on
  disconnect so graceful shutdown waits for real agent completion, not
  just the SSE connection lifetime.
- SSE queue consumer changed from a busy-poll loop (100 wakeups/s) to
  `asyncio.wait_for(queue.get(), timeout=0.1)`.

**Proto / Go (`protos/`, `pkg/`)**
- `proposal` added to `AgentChatMessage` (field 7).
- `latest_run_status` added to `AgentChatInfo` / `ChatInfo` (field 4).
- Mapped through `describe_agent_chat`, `list_agent_chats`, and
  `list_agent_chat_messages`.

**Frontend (`web_src/`)**
- `extractPendingProposalFromApiMessages` parses the persisted proposal
  from loaded messages.
- `useLoadChatConversation` fetches messages and sessions in parallel;
  restores the spinner when `latestRunStatus === "running"` and the
  proposal when the run is done.
- New `usePollForMessages` hook polls every 2 s when a run is in progress
  but no SSE stream is active. Skips ticks while the tab is hidden;
  fires immediately on tab focus via `visibilitychange`.
- `currentChatId` lifted into `useAgentState` so canvas changes
  correctly reset it.

## Test plan

- [x] Send a prompt that triggers a canvas-change proposal. While the
  agent is thinking, refresh the page and navigate back to the chat.
  Verify the spinner shows and the proposal appears when the run finishes.
- [x] Send a simple prompt ("what nodes are on my canvas?"), get a
  response, refresh. Verify the conversation is restored.
- [x] Open a chat mid-run and switch to another browser tab while the
  agent works. Verify no polling requests fire while the tab is hidden,
  and messages appear promptly when you switch back.
  
  Closes #4104