### PR TITLE
fix: correct typos in error messages and comments

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -114,7 +114,7 @@ func (a *Handler) RegisterRoutes(router *mux.Router) {
 
 	//
 	// If we are running the application locally,
-	// we provide handlers that auto-autenticate to
+	// we provide handlers that auto-authenticate to
 	// avoid having to authenticate with GitHub every time.
 	//
 	if a.isDev {

--- a/pkg/grpc/actions/canvases/list_node_queue_items.go
+++ b/pkg/grpc/actions/canvases/list_node_queue_items.go
@@ -56,7 +56,7 @@ func SerializeNodeQueueItems(queueItems []models.CanvasNodeQueueItem) ([]*pb.Can
 	//
 	inputEvents, err := models.FindCanvasEvents(eventIDsFromQueueItems(queueItems))
 	if err != nil {
-		return nil, fmt.Errorf("error find input events: %v", err)
+		return nil, fmt.Errorf("error finding input events: %v", err)
 	}
 
 	//

--- a/pkg/grpc/actions/organizations/remove_user.go
+++ b/pkg/grpc/actions/organizations/remove_user.go
@@ -34,8 +34,8 @@ func RemoveUser(ctx context.Context, authService authorization.Authorization, or
 	//
 	roles, err := authService.GetUserRolesForOrg(user.ID.String(), orgID)
 	if err != nil {
-		log.Errorf("Error determing user roles for %s: %v", user.ID.String(), err)
-		return nil, status.Error(codes.Internal, "error determing user roles")
+		log.Errorf("Error determining user roles for %s: %v", user.ID.String(), err)
+		return nil, status.Error(codes.Internal, "error determining user roles")
 	}
 
 	for _, role := range roles {

--- a/pkg/integrations/github/run_workflow.go
+++ b/pkg/integrations/github/run_workflow.go
@@ -400,7 +400,7 @@ func (r *RunWorkflow) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.
 
 	newMetadata, data, err := metadataFromPayload(payload)
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("error determing new metadata: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("error determining new metadata: %v", err)
 	}
 
 	//

--- a/pkg/integrations/pagerduty/pagerduty.go
+++ b/pkg/integrations/pagerduty/pagerduty.go
@@ -290,7 +290,7 @@ func (p *PagerDuty) appOAuthSync(ctx core.SyncContext, configuration Configurati
 
 	services, err := client.ListServices()
 	if err != nil {
-		return fmt.Errorf("error determing abilities: %v", err)
+		return fmt.Errorf("error determining abilities: %v", err)
 	}
 
 	ctx.Integration.SetMetadata(Metadata{Services: services})


### PR DESCRIPTION
## Summary
- Fix "determing" → "determining" in error messages across `remove_user.go`, `pagerduty.go`, and `run_workflow.go`
- Fix "auto-autenticate" → "auto-authenticate" in `authentication.go` comment
- Fix "error find" → "error finding" in `list_node_queue_items.go` for grammatical correctness

## Test plan
- [ ] No functional changes — typo-only fixes in strings and comments
- [ ] Verified Go code compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)