### PR TITLE
feat: support both Docker and Podman as container runtimes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,15 @@ PUBLIC_API_PORT ?= 8000
 PORT ?= $(PUBLIC_API_PORT)
 API_PORT ?= $(PUBLIC_API_PORT)
 AGENT_HTTP_PORT ?= 8090
+# Docker BuildKit requires tagged images in cache_from; Podman's --cache-from
+# rejects tags ("repository must contain neither a tag nor digest").
+ifeq ($(CONTAINER_ENGINE),podman)
 APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
 AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
+else
+APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:app-latest
+AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:agent-latest
+endif
 export GRPC_SERVER_ADDR PORT API_PORT AGENT_HTTP_PORT APP_DEV_BASE_CACHE_IMAGE AGENT_DEV_BASE_CACHE_IMAGE
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client agent/src/superplaneapi api/swagger/superplane.swagger.json agent/src/usage_pb2.py agent/src/private/agents_pb2.py agent/src/private/agents_pb2_grpc.py
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,18 @@ PKG_TEST_PACKAGES := ./pkg/...
 E2E_TEST_PACKAGES := ./test/e2e/...
 AGENT_TEST_TARGETS ?= tests
 
-COMPOSE=docker compose -f docker-compose.dev.yml
-DOCKER_RUN_AS_CURRENT_USER=docker run --rm --user $(shell id -u):$(shell id -g)
+CONTAINER_ENGINE ?= docker
+COMPOSE = $(CONTAINER_ENGINE) compose -f docker-compose.dev.yml
+CONTAINER_RUN_AS_CURRENT_USER = $(CONTAINER_ENGINE) run --rm --user $(shell id -u):$(shell id -g)
+INTERNAL_API_PORT ?= 50051
+GRPC_SERVER_ADDR ?= 127.0.0.1:$(INTERNAL_API_PORT)
+PUBLIC_API_PORT ?= 8000
+PORT ?= $(PUBLIC_API_PORT)
+API_PORT ?= $(PUBLIC_API_PORT)
+AGENT_HTTP_PORT ?= 8090
+APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
+AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
+export GRPC_SERVER_ADDR PORT API_PORT AGENT_HTTP_PORT APP_DEV_BASE_CACHE_IMAGE AGENT_DEV_BASE_CACHE_IMAGE
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client agent/src/superplaneapi api/swagger/superplane.swagger.json agent/src/usage_pb2.py agent/src/private/agents_pb2.py agent/src/private/agents_pb2_grpc.py
 
 #
@@ -368,7 +378,7 @@ openapi.spec.gen:
 
 openapi.client.gen:
 	rm -rf pkg/openapi_client
-	$(DOCKER_RUN_AS_CURRENT_USER) \
+	$(CONTAINER_RUN_AS_CURRENT_USER) \
 		-v ${PWD}:/local openapitools/openapi-generator-cli:v7.13.0 generate \
 		-i /local/api/swagger/superplane.swagger.json \
 		-g go \
@@ -389,7 +399,7 @@ openapi.web.client.gen:
 
 openapi.python.client.gen:
 	rm -rf agent/src/superplaneapi
-	$(DOCKER_RUN_AS_CURRENT_USER) \
+	$(CONTAINER_RUN_AS_CURRENT_USER) \
 		-v ${PWD}:/local openapitools/openapi-generator-cli:v7.13.0 generate \
 		-i /local/api/swagger/superplane.swagger.json \
 		-g python \
@@ -421,22 +431,22 @@ IMAGE_TAG?=$(shell git rev-list -1 HEAD -- .)
 REGISTRY_HOST?=ghcr.io/superplanehq
 image.build:
 	$(MAKE) gen.setup
-	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f Dockerfile --target runner --build-arg BASE_URL=$(BASE_URL) --progress plain -t $(IMAGE):$(IMAGE_TAG) .
+	$(CONTAINER_ENGINE) build --platform linux/amd64 -f Dockerfile --target runner --build-arg BASE_URL=$(BASE_URL) --progress plain -t $(IMAGE):$(IMAGE_TAG) .
 
 agent.image.build:
 	$(MAKE) gen.setup.agent
-	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f agent/Dockerfile --target runner --progress plain -t $(AGENT_IMAGE):$(IMAGE_TAG) agent
+	$(CONTAINER_ENGINE) build --platform linux/amd64 -f agent/Dockerfile --target runner --progress plain -t $(AGENT_IMAGE):$(IMAGE_TAG) agent
 
 image.auth:
-	@printf "%s" "$(GITHUB_TOKEN)" | docker login ghcr.io -u superplanehq --password-stdin
+	@printf "%s" "$(GITHUB_TOKEN)" | $(CONTAINER_ENGINE) login ghcr.io -u superplanehq --password-stdin
 
 image.push:
-	docker tag $(IMAGE):$(IMAGE_TAG) $(REGISTRY_HOST)/$(IMAGE):$(IMAGE_TAG)
-	docker push $(REGISTRY_HOST)/$(IMAGE):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) tag $(IMAGE):$(IMAGE_TAG) $(REGISTRY_HOST)/$(IMAGE):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) push $(REGISTRY_HOST)/$(IMAGE):$(IMAGE_TAG)
 
 agent.image.push:
-	docker tag $(AGENT_IMAGE):$(IMAGE_TAG) $(REGISTRY_HOST)/$(AGENT_IMAGE):$(IMAGE_TAG)
-	docker push $(REGISTRY_HOST)/$(AGENT_IMAGE):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) tag $(AGENT_IMAGE):$(IMAGE_TAG) $(REGISTRY_HOST)/$(AGENT_IMAGE):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) push $(REGISTRY_HOST)/$(AGENT_IMAGE):$(IMAGE_TAG)
 
 #
 # Tag creation

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@ AGENT_TEST_TARGETS ?= tests
 CONTAINER_ENGINE ?= docker
 COMPOSE = $(CONTAINER_ENGINE) compose -f docker-compose.dev.yml
 CONTAINER_RUN_AS_CURRENT_USER = $(CONTAINER_ENGINE) run --rm --user $(shell id -u):$(shell id -g)
-INTERNAL_API_PORT ?= 50051
-GRPC_SERVER_ADDR ?= 127.0.0.1:$(INTERNAL_API_PORT)
-PUBLIC_API_PORT ?= 8000
-PORT ?= $(PUBLIC_API_PORT)
-API_PORT ?= $(PUBLIC_API_PORT)
-AGENT_HTTP_PORT ?= 8090
 # Docker BuildKit requires tagged images in cache_from; Podman's --cache-from
 # rejects tags ("repository must contain neither a tag nor digest").
 ifeq ($(CONTAINER_ENGINE),podman)
@@ -28,7 +22,7 @@ else
 APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:app-latest
 AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:agent-latest
 endif
-export GRPC_SERVER_ADDR PORT API_PORT AGENT_HTTP_PORT APP_DEV_BASE_CACHE_IMAGE AGENT_DEV_BASE_CACHE_IMAGE
+export APP_DEV_BASE_CACHE_IMAGE AGENT_DEV_BASE_CACHE_IMAGE
 GENERATED_ARTIFACT_PATHS := pkg/protos pkg/openapi_client web_src/src/api-client agent/src/superplaneapi api/swagger/superplane.swagger.json agent/src/usage_pb2.py agent/src/private/agents_pb2.py agent/src/private/agents_pb2_grpc.py
 
 #

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,6 +1,7 @@
 .PHONY: db.create db.delete db.migration.create db.migrate lint lint.fix format format.check typecheck
 
-COMPOSE=docker compose -f ../docker-compose.dev.yml
+CONTAINER_ENGINE ?= docker
+COMPOSE = $(CONTAINER_ENGINE) compose -f ../docker-compose.dev.yml
 DB_NAME ?= agents_dev
 DB_PASSWORD ?= the-cake-is-a-lie
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -5,6 +5,17 @@ COMPOSE = $(CONTAINER_ENGINE) compose -f ../docker-compose.dev.yml
 DB_NAME ?= agents_dev
 DB_PASSWORD ?= the-cake-is-a-lie
 
+# Keep in sync with ../Makefile. Docker BuildKit requires tagged cache_from
+# images; Podman's --cache-from rejects tags.
+ifeq ($(CONTAINER_ENGINE),podman)
+APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
+AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base
+else
+APP_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:app-latest
+AGENT_DEV_BASE_CACHE_IMAGE ?= ghcr.io/superplanehq/superplane-dev-base:agent-latest
+endif
+export APP_DEV_BASE_CACHE_IMAGE AGENT_DEV_BASE_CACHE_IMAGE
+
 lint:
 	$(COMPOSE) run --rm agent uv run --group dev ruff check
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,9 +37,9 @@ services:
       START_WEB_SERVER: "yes"
       PUBLIC_API_PORT: ${PUBLIC_API_PORT:-8000}
       INTERNAL_API_PORT: ${INTERNAL_API_PORT:-50051}
-      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR:-127.0.0.1:50051}
-      PORT: ${PORT:-8000}
-      API_PORT: ${API_PORT:-8000}
+      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR:-127.0.0.1:${INTERNAL_API_PORT:-50051}}
+      PORT: ${PORT:-${PUBLIC_API_PORT:-8000}}
+      API_PORT: ${API_PORT:-${PUBLIC_API_PORT:-8000}}
       VITE_DEV_PORT: ${VITE_DEV_PORT:-5173}
       START_EVENT_DISTRIBUTER: "yes"
       START_EVENT_ROUTER: "yes"
@@ -154,7 +154,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - ${AGENT_HTTP_PORT:-8090}:8090
+      - ${AGENT_HTTP_PORT:-${AGENT_REPL_WEB_PORT:-8090}}:8090
     volumes:
       - .:/app
       - ./tmp/agent/evals:/app/tmp/agent/evals

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev-base
       cache_from:
-        - ${APP_DEV_BASE_CACHE_IMAGE}
+        - ${APP_DEV_BASE_CACHE_IMAGE:-ghcr.io/superplanehq/superplane-dev-base:app-latest}
     tty: true
     command: bash /app/docker-entrypoint.dev.sh
     environment:
@@ -37,9 +37,9 @@ services:
       START_WEB_SERVER: "yes"
       PUBLIC_API_PORT: ${PUBLIC_API_PORT:-8000}
       INTERNAL_API_PORT: ${INTERNAL_API_PORT:-50051}
-      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR}
-      PORT: ${PORT}
-      API_PORT: ${API_PORT}
+      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR:-127.0.0.1:50051}
+      PORT: ${PORT:-8000}
+      API_PORT: ${API_PORT:-8000}
       VITE_DEV_PORT: ${VITE_DEV_PORT:-5173}
       START_EVENT_DISTRIBUTER: "yes"
       START_EVENT_ROUTER: "yes"
@@ -117,7 +117,7 @@ services:
       dockerfile: Dockerfile
       target: dev
       cache_from:
-        - ${AGENT_DEV_BASE_CACHE_IMAGE}
+        - ${AGENT_DEV_BASE_CACHE_IMAGE:-ghcr.io/superplanehq/superplane-dev-base:agent-latest}
     working_dir: /app/agent
     env_file:
       - agent/.env
@@ -154,7 +154,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - ${AGENT_HTTP_PORT}:8090
+      - ${AGENT_HTTP_PORT:-8090}:8090
     volumes:
       - .:/app
       - ./tmp/agent/evals:/app/tmp/agent/evals

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       target: dev-base
       cache_from:
-        - ghcr.io/superplanehq/superplane-dev-base:app-latest
+        - ${APP_DEV_BASE_CACHE_IMAGE}
     tty: true
     command: bash /app/docker-entrypoint.dev.sh
     environment:
@@ -37,9 +37,9 @@ services:
       START_WEB_SERVER: "yes"
       PUBLIC_API_PORT: ${PUBLIC_API_PORT:-8000}
       INTERNAL_API_PORT: ${INTERNAL_API_PORT:-50051}
-      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR:-127.0.0.1:${INTERNAL_API_PORT:-50051}}
-      PORT: ${PORT:-${PUBLIC_API_PORT:-8000}}
-      API_PORT: ${API_PORT:-${PUBLIC_API_PORT:-8000}}
+      GRPC_SERVER_ADDR: ${GRPC_SERVER_ADDR}
+      PORT: ${PORT}
+      API_PORT: ${API_PORT}
       VITE_DEV_PORT: ${VITE_DEV_PORT:-5173}
       START_EVENT_DISTRIBUTER: "yes"
       START_EVENT_ROUTER: "yes"
@@ -117,7 +117,7 @@ services:
       dockerfile: Dockerfile
       target: dev
       cache_from:
-        - ghcr.io/superplanehq/superplane-dev-base:agent-latest
+        - ${AGENT_DEV_BASE_CACHE_IMAGE}
     working_dir: /app/agent
     env_file:
       - agent/.env
@@ -154,7 +154,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - ${AGENT_HTTP_PORT:-${AGENT_REPL_WEB_PORT:-8090}}:8090
+      - ${AGENT_HTTP_PORT}:8090
     volumes:
       - .:/app
       - ./tmp/agent/evals:/app/tmp/agent/evals

--- a/scripts/vscode_run_tests.sh
+++ b/scripts/vscode_run_tests.sh
@@ -16,9 +16,9 @@ ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT_DIR"
 
 # Docker Compose config (assumes compose is already up)
-COMPOSE="docker compose -f docker-compose.dev.yml"
+COMPOSE="${CONTAINER_ENGINE:-docker} compose -f docker-compose.dev.yml"
 
-docker_exec() {
+compose_exec() {
   # Pass DB_NAME=superplane_test to match Makefile test environment
   # Also force Go build cache to a writable, persisted path in the repo
   echo "+ ${COMPOSE} exec -e DB_NAME=superplane_test -e GOCACHE=/app/tmp/go-build -e XDG_CACHE_HOME=/app/tmp app bash -lc \"$*\""
@@ -107,7 +107,7 @@ subtest_name_for_line() {
 
 run_all() {
   echo "Running in docker: go test -p 1 -v ./..."
-  docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v ./..."
+  compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v ./..."
 }
 
 run_file() {
@@ -118,7 +118,7 @@ run_file() {
     # Not a test file: run the package containing the file
     pkg=$(pkg_for_path "$file")
     echo "Running package tests in docker: go test -p 1 -v $pkg"
-    docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
+    compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
     return
     ;;
   esac
@@ -128,7 +128,7 @@ run_file() {
   tests_list=$(extract_tests_in_file "$file" || true)
   if [ -z "${tests_list:-}" ]; then
     echo "No tests found in $file; running package in docker: $pkg"
-    docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
+    compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
     return
   fi
 
@@ -136,7 +136,7 @@ run_file() {
   regex="^($(printf '%s' "$tests_list" | paste -sd '|' -))$"
   echo "Running tests in file: $file"
   echo "docker exec: go test -p 1 -v $pkg -run $regex"
-  docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '$regex'"
+  compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '$regex'"
 }
 
 run_line() {
@@ -147,7 +147,7 @@ run_line() {
     *_test.go) : ;;
     *)
     echo "File is not a test file; running package in docker: $pkg"
-    docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
+    compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg'"
     return
     ;;
   esac
@@ -162,9 +162,9 @@ run_line() {
 
   if [ -n "${subtest_name:-}" ]; then
     echo "Running subtest: $test_name/$subtest_name"
-    docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '^$test_name$/^$subtest_name$'"
+    compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '^$test_name$/^$subtest_name$'"
   else
-    docker_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '^$test_name$'"
+    compose_exec "cd /app && GOFLAGS= go test -count=1 -p 1 -v '$pkg' -run '^$test_name$'"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Introduce `CONTAINER_ENGINE ?= docker` in Makefiles, allowing developers to opt into Podman via `CONTAINER_ENGINE=podman`
- Replace all hardcoded `docker` / `docker compose` references with `$(CONTAINER_ENGINE)` / `$(CONTAINER_ENGINE) compose`
- Parameterize `cache_from` image references so both engines can parse them (untagged for Podman, tagged for Docker)

## Motivation

Docker Desktop's memory consumption is a pain point for some developers. Podman is a lightweight, daemonless alternative that supports the same CLI interface. Rather than choosing one over the other, this change lets each developer use their preferred engine while keeping Docker as the default.

## Changes

| File                          | What changed                                                                                                            |
| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| `Makefile`                    | `CONTAINER_ENGINE` selector, computed env var exports, `CONTAINER_RUN_AS_CURRENT_USER` rename, image build/push targets |
| `agent/Makefile`              | Same `CONTAINER_ENGINE` pattern                                                                                         |
| `docker-compose.dev.yml`      | Parameterized `cache_from` with engine-aware defaults                                                                   |
| `scripts/vscode_run_tests.sh` | Respects `CONTAINER_ENGINE`, renamed `docker_exec` → `compose_exec`                                                     |

## Usage

```bash
# Docker (default, no change needed)
make dev.setup
make dev.start

# Podman (explicit opt-in)
make dev.setup CONTAINER_ENGINE=podman
make dev.start CONTAINER_ENGINE=podman

# Or export once in your shell profile
export CONTAINER_ENGINE=podman
make dev.setup
make dev.start
```

## Podman compatibility notes

- **Minimum `podman-compose` version**: Nested variable interpolation (`${VAR:-${VAR2:-default}}`) in compose files requires the March 2026 release or later (podman-compose PR #1419). Earlier versions will fail to parse the compose file.
- **`--cache-from` tags**: Podman/Buildah rejects tagged image references in `--cache-from` by design. The Makefile conditionally uses untagged refs for Podman and tagged refs for Docker.
- **`depends_on: condition: service_healthy`**: Has partial support in some `podman-compose` versions. If health-check gating doesn't work, services may start before dependencies are ready.