### PR TITLE
feat: output canvas URL from CLI and document URL pattern

### DIFF
--- a/docs/contributing/cli-canvas-urls.md
+++ b/docs/contributing/cli-canvas-urls.md
@@ -1,0 +1,32 @@
+# Canvas URL Pattern
+
+When working with canvases programmatically (scripts, AI agents, CI jobs), the correct URL for viewing a canvas in the SuperPlane UI follows this pattern:
+
+```
+https://app.superplane.com/{orgId}/canvases/{canvasId}
+```
+
+**Both segments are required.** Constructing a URL without the `{orgId}` prefix will redirect to the homepage and will not open the intended canvas.
+
+## Getting the URL from the CLI
+
+The `canvases create` command prints the full URL on success:
+
+```
+$ superplane canvases create my-canvas
+Canvas "my-canvas" created (ID: 0f3c...)
+URL: https://app.superplane.com/<org-id>/canvases/0f3c...
+```
+
+The `canvases get` command supports a `--url` flag that outputs only the URL, suitable for piping into other tools:
+
+```
+$ superplane canvases get my-canvas --url
+https://app.superplane.com/<org-id>/canvases/0f3c...
+```
+
+## Use cases
+
+- **AI agents** that need to surface a clickable canvas link in their output
+- **CI jobs** that post canvas links into chat or issue trackers after creation
+- **Shell scripts** that open a canvas in the browser: `open $(superplane canvases get my-canvas --url)`

--- a/pkg/cli/commands/canvases/create.go
+++ b/pkg/cli/commands/canvases/create.go
@@ -135,7 +135,14 @@ func validateAndPrintCreateResponse(
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
-		_, err := fmt.Fprintf(stdout, "Canvas %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId())
+		if _, err := fmt.Fprintf(stdout, "Canvas %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId()); err != nil {
+			return err
+		}
+		orgID, err := core.ResolveOrganizationID(ctx)
+		if err != nil {
+			return nil
+		}
+		_, err = fmt.Fprintf(stdout, "URL: https://app.superplane.com/%s/canvases/%s\n", orgID, canvas.Metadata.GetId())
 		return err
 	})
 }

--- a/pkg/cli/commands/canvases/get.go
+++ b/pkg/cli/commands/canvases/get.go
@@ -14,6 +14,7 @@ import (
 
 type getCommand struct {
 	draft *bool
+	url   *bool
 }
 
 func (c *getCommand) Execute(ctx core.CommandContext) error {
@@ -59,6 +60,18 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	resource := models.CanvasResourceFromCanvas(canvas)
+
+	if c.url != nil && *c.url {
+		orgID, err := core.ResolveOrganizationID(ctx)
+		if err != nil {
+			return err
+		}
+		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+			_, err := fmt.Fprintf(stdout, "https://app.superplane.com/%s/canvases/%s\n", orgID, resource.Metadata.GetId())
+			return err
+		})
+	}
+
 	if !ctx.Renderer.IsText() {
 		return ctx.Renderer.Render(resource)
 	}

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -28,8 +28,10 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 	var getDraft bool
+	var getURL bool
 	getCmd.Flags().BoolVar(&getDraft, "draft", false, "get your draft version instead of the live version")
-	core.Bind(getCmd, &getCommand{draft: &getDraft}, options)
+	getCmd.Flags().BoolVar(&getURL, "url", false, "print only the canvas URL")
+	core.Bind(getCmd, &getCommand{draft: &getDraft, url: &getURL}, options)
 
 	activeCmd := &cobra.Command{
 		Use:   "active [canvas-id]",


### PR DESCRIPTION
Closes #4319.

## What

Addresses all three items from the issue:

1. **`canvases create` now prints the full canvas URL** on success, alongside the existing name and ID output.
2. **`canvases get` gets a `--url` flag** that prints only the URL — suitable for piping into other tools or scripts.
3. **New doc** at `docs/contributing/cli-canvas-urls.md` explaining the `{orgId}/canvases/{canvasId}` pattern, with examples aimed at agents, CI jobs, and scripts.

## Why

The URL pattern `https://app.superplane.com/{orgId}/canvases/{canvasId}` is not documented anywhere, and dropping the `{orgId}` prefix silently redirects to the homepage. AI agents and automation building canvas URLs programmatically will hit this; surfacing the URL directly from the CLI removes the footgun.

## Example output

**Before:**
```
$ superplane canvases create my-canvas
Canvas "my-canvas" created (ID: 0f3c...)
```

**After:**
```
$ superplane canvases create my-canvas
Canvas "my-canvas" created (ID: 0f3c...)
URL: https://app.superplane.com/<org-id>/canvases/0f3c...

$ superplane canvases get my-canvas --url
https://app.superplane.com/<org-id>/canvases/0f3c...
```

## Implementation notes

- Used `core.ResolveOrganizationID(ctx)` — the same helper already used in `canvases/update.go`, `groups/*`, and other commands — so the org resolution path is consistent with the rest of the CLI.
- In `create.go`, if org resolution fails the URL line is silently skipped rather than failing the whole command — the canvas has already been created successfully and printing the URL is additive.
- In `get.go`, `--url` short-circuits the normal render path; JSON/YAML output is unaffected.

## A note on local verification

I could not run `make lint` and `make check.build.app` locally — the Makefile invokes tooling through Docker, which isn't available in my current dev environment. I'm relying on CI for those checks. The changes are small, scoped, and mirror existing patterns in `update.go` and `groups/*`. Happy to address any CI feedback in follow-up commits.