### PR TITLE
fix: add memory namespace to expression autocomplete

### DIFF
--- a/agent/skills/expressions.md
+++ b/agent/skills/expressions.md
@@ -34,6 +34,17 @@ The **data-flow** skill describes how `$` is built during a run.
 | `previous()` | Immediate upstream node’s payload | `previous().data.status` |
 | `previous(n)` | Walk *n* levels upstream | `previous(2).data.version` |
 
+## Canvas memory
+
+`memory` is a namespace for reading records written by the **Add / Upsert / Update Memory** components. Records are scoped to the current canvas.
+
+| Method | Description | Example |
+|--------|-------------|---------|
+| `memory.find(ns, matches)` | Every record in namespace `ns` whose stored values contain all fields in `matches`. Newest first. | `memory.find("deploys", {"env": "prod"})` |
+| `memory.findFirst(ns, matches)` | Newest record matching, or `null`. | `memory.findFirst("deploys", {"env": "prod"}).version` |
+
+`matches` is matched with JSONB containment — the record must contain every key/value you pass, but may carry additional fields.
+
 ## Common Expr functions
 
 **String:** `lower()`, `upper()`, `trim()`, `split()`, `replace()`, `indexOf()`, `hasPrefix()`, `hasSuffix()`

--- a/web_src/src/components/AutoCompleteInput/core.spec.ts
+++ b/web_src/src/components/AutoCompleteInput/core.spec.ts
@@ -105,6 +105,50 @@ describe("getSuggestions", () => {
   });
 });
 
+describe("getSuggestions memory namespace", () => {
+  it("suggests the memory namespace among top-level completions", () => {
+    const suggestions = getSuggestions("m", 1, {});
+    const memory = suggestions.find((item) => item.label === "memory");
+    expect(memory).toBeDefined();
+    expect(memory?.kind).toBe("variable");
+    expect(memory?.insertText).toBe("memory.");
+  });
+
+  it("suggests memory.find and memory.findFirst after the dot", () => {
+    const expression = "memory.";
+    const suggestions = getSuggestions(expression, expression.length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toContain("find");
+    expect(labels).toContain("findFirst");
+    const findFirst = suggestions.find((item) => item.label === "findFirst");
+    expect(findFirst?.kind).toBe("function");
+    expect(findFirst?.insertText).toBe('findFirst("${1:namespace}", {${2}})');
+  });
+
+  it("filters memory methods by the typed member prefix", () => {
+    const expression = "memory.f";
+    const suggestions = getSuggestions(expression, expression.length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toEqual(expect.arrayContaining(["find", "findFirst"]));
+  });
+
+  it("hides the exact-match memory method from suggestions", () => {
+    const expression = "memory.find";
+    const suggestions = getSuggestions(expression, expression.length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toContain("findFirst");
+    expect(labels).not.toContain("find");
+  });
+
+  it("does not treat an unrelated identifier as a namespace", () => {
+    const expression = "notAMemory.";
+    const suggestions = getSuggestions(expression, expression.length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).not.toContain("find");
+    expect(labels).not.toContain("findFirst");
+  });
+});
+
 describe("getSuggestions config fields", () => {
   it("suggests config fields for $['NodeName'].config.", () => {
     const expression = '$["my-component"].config.';

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -610,6 +610,23 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
       }
     }
 
+    // Handle namespace method suggestions (e.g., memory.findFirst(...))
+    if (!isFunctionCall) {
+      const namespaceMethods = getNamespaceMethods(baseExpr);
+      if (namespaceMethods.length > 0) {
+        return namespaceMethods
+          .filter((m) => m.name.toLowerCase().startsWith(mp) && mp !== m.name.toLowerCase())
+          .slice(0, limit)
+          .map((m) => ({
+            label: m.name,
+            kind: "function" as const,
+            insertText: m.snippet ?? `${m.name}()`,
+            detail: m.returnType,
+            description: m.description,
+          }));
+      }
+    }
+
     const resolvableBase = isFunctionCall ? baseExpr : extractTailPathExpression(baseExpr);
     const target = resolveExprToValue(resolvableBase, globals);
 
@@ -673,6 +690,18 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
           detail: "function",
           description: fn.description,
           example: fn.example,
+        });
+      }
+    }
+
+    for (const [name, info] of Object.entries(SUPERPLANE_NAMESPACES)) {
+      if (!prefix || name.toLowerCase().startsWith(prefix)) {
+        out.push({
+          label: name,
+          kind: "variable",
+          insertText: `${name}.`,
+          detail: "namespace",
+          description: info.description,
         });
       }
     }
@@ -801,6 +830,44 @@ const FUNCTION_RETURN_METHODS: Record<string, MethodInfo[]> = {
 
 function getFunctionReturnMethods(funcName: string): MethodInfo[] {
   return FUNCTION_RETURN_METHODS[funcName.toLowerCase()] ?? [];
+}
+
+type NamespaceInfo = {
+  /** One-line summary shown as the suggestion description. */
+  description: string;
+  /** Methods reachable via dot-access on the namespace (e.g. memory.findFirst). */
+  methods: MethodInfo[];
+};
+
+/**
+ * Top-level namespaces exposed in the Expr environment — objects whose entries
+ * are reached via dot-access, e.g. `memory.findFirst("deploys", {"env": "prod"})`.
+ */
+const SUPERPLANE_NAMESPACES: Record<string, NamespaceInfo> = {
+  memory: {
+    description:
+      "Canvas-level key/value memory. Read records previously written by the Add / Upsert / Update Memory components.",
+    methods: [
+      {
+        name: "find",
+        snippet: 'find("${1:namespace}", {${2}})',
+        returnType: "array",
+        description:
+          "Returns every canvas-memory record in the namespace whose stored values contain all fields in the second argument. Newest first.",
+      },
+      {
+        name: "findFirst",
+        snippet: 'findFirst("${1:namespace}", {${2}})',
+        returnType: "object | null",
+        description:
+          "Returns the newest canvas-memory record in the namespace whose stored values contain all fields in the second argument, or null if none matches.",
+      },
+    ],
+  },
+};
+
+function getNamespaceMethods(name: string): MethodInfo[] {
+  return SUPERPLANE_NAMESPACES[name]?.methods ?? [];
 }
 
 type EnvKeyTrigger = { quote: "'" | '"' };


### PR DESCRIPTION
## Summary

The Expr environment exposes `memory.find(ns, matches)` and `memory.findFirst(ns, matches)` for reading canvas-scoped key/value records written by the Add / Upsert / Update Memory components. The backend registers these in `pkg/workers/contexts/node_configuration_builder.go` (the `memory` entry in the Expr `env` map built in `ResolveExpression`), and they evaluate correctly at runtime — only the frontend autocomplete didn't know about them. Typing `{{ m` in an expression field never surfaced `memory`, and typing `{{ memory.` offered no methods.

Fixes #4200

## How

Register `memory` as a namespace in `web_src/src/components/AutoCompleteInput/core.ts`:

- **New `SUPERPLANE_NAMESPACES` table** alongside the existing `FUNCTION_RETURN_METHODS`. Top-level namespace objects reuse the same `MethodInfo` shape already used for `now()` / `date()` / `duration()` method completions, so there's one mechanism for all method-on-thing suggestions.
- **Dot-completion branch:** when `baseExpr` is exactly a namespace name and the context isn't a function call, return the namespace's methods — mirroring the existing `isFunctionCall` branch.
- **Default-completion branch:** emit each namespace as a `kind: "variable"` suggestion whose `insertText` ends in `.` so the follow-up suggest immediately offers the methods. Same pattern the UI already uses for `$`.

`memory` is semantically a namespace object, not a callable function, so it does *not* belong in `EXPR_FUNCTIONS` — otherwise the suggestion would insert `memory()` which doesn't compile.

Also updates `agent/skills/expressions.md` with a Canvas memory section.

## Test plan

- [x] Unit tests in `core.spec.ts` — 5 new cases: top-level suggestion, dot-suggestions, prefix filter, hide-exact-match, negative case for unrelated identifiers. Full suite: 21/21 passing.
- [x] `tsc --noEmit` — clean.
- [x] `npm run build` — clean production build.
- [x] Manual reproduction in the local dev instance:
  - Before fix: typing `{{ m` in an http-component URL field surfaces only `map / max / mean / median / min`; `memory` never appears.
  - After fix: `{{ m` surfaces `memory` as a namespace; `{{ memory.` surfaces `find` and `findFirst` with correct snippets; selecting `findFirst` and wiring up a canvas that writes with **Add Memory** and reads with `{{ memory.findFirst("ns", {"k":"v"}).k }}` round-trips end-to-end (httpbin.org returns `"url": "https://httpbin.org/anything/v"`).