### PR TITLE
fix: align cursor launch agent output

### DIFF
--- a/docs/components/Cursor.mdx
+++ b/docs/components/Cursor.mdx
@@ -170,7 +170,7 @@ The Launch Cloud Agent component triggers a Cursor AI coding agent and waits for
     "agentId": "agent_12345",
     "branchName": "cursor/agent-550e8400",
     "prUrl": "https://github.com/org/repo/pull/42",
-    "status": "done",
+    "status": "FINISHED",
     "summary": "Refactored login logic."
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",

--- a/pkg/integrations/cursor/example.go
+++ b/pkg/integrations/cursor/example.go
@@ -1,0 +1,22 @@
+package cursor
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output_launch_agent.json
+var exampleOutputLaunchAgentBytes []byte
+
+var exampleOutputLaunchAgentOnce sync.Once
+var exampleOutputLaunchAgent map[string]any
+
+func getLaunchAgentExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputLaunchAgentOnce,
+		exampleOutputLaunchAgentBytes,
+		&exampleOutputLaunchAgent,
+	)
+}

--- a/pkg/integrations/cursor/example_output_launch_agent.json
+++ b/pkg/integrations/cursor/example_output_launch_agent.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "agentId": "agent_12345",
+    "branchName": "cursor/agent-550e8400",
+    "prUrl": "https://github.com/org/repo/pull/42",
+    "status": "FINISHED",
+    "summary": "Refactored login logic."
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cursor.launchAgent.finished"
+}

--- a/pkg/integrations/cursor/launch_agent.go
+++ b/pkg/integrations/cursor/launch_agent.go
@@ -41,7 +41,7 @@ func (c *LaunchAgent) Color() string { return "#8B5CF6" }
 func (c *LaunchAgent) ExampleOutput() map[string]any {
 	return map[string]any{
 		"data": map[string]any{
-			"status":     LaunchAgentStatusDone,
+			"status":     LaunchAgentStatusFinished,
 			"agentId":    "agent_12345",
 			"summary":    "Refactored login logic.",
 			"prUrl":      "https://github.com/org/repo/pull/42",

--- a/pkg/integrations/cursor/launch_agent.go
+++ b/pkg/integrations/cursor/launch_agent.go
@@ -39,17 +39,7 @@ func (c *LaunchAgent) Icon() string { return "cpu" }
 func (c *LaunchAgent) Color() string { return "#8B5CF6" }
 
 func (c *LaunchAgent) ExampleOutput() map[string]any {
-	return map[string]any{
-		"data": map[string]any{
-			"status":     LaunchAgentStatusFinished,
-			"agentId":    "agent_12345",
-			"summary":    "Refactored login logic.",
-			"prUrl":      "https://github.com/org/repo/pull/42",
-			"branchName": "cursor/agent-550e8400",
-		},
-		"timestamp": "2026-03-26T19:29:35.841265352Z",
-		"type":      LaunchAgentPayloadType,
-	}
+	return getLaunchAgentExampleOutput()
 }
 
 func (c *LaunchAgent) OutputChannels(config any) []core.OutputChannel {

--- a/pkg/integrations/cursor/launch_agent_monitor.go
+++ b/pkg/integrations/cursor/launch_agent_monitor.go
@@ -55,18 +55,21 @@ func (c *LaunchAgent) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.
 
 	// 5. Update State
 	executionCtx.Logger.Infof("Received webhook for Agent %s: %s", payload.ID, payload.Status)
-	if metadata.Agent == nil {
-		metadata.Agent = &AgentMetadata{}
-	}
-	metadata.Agent.ID = payload.ID
-	metadata.Agent.Status = payload.Status
-	metadata.Agent.Summary = payload.Summary
+	mergeWebhookPayloadIntoMetadata(&metadata, payload)
 
-	if metadata.Target == nil {
-		metadata.Target = &TargetMetadata{}
-	}
-	if payload.PrURL != "" {
-		metadata.Target.PrURL = payload.PrURL
+	if isTerminalStatus(payload.Status) &&
+		(metadata.Agent.Summary == "" || metadata.Target == nil || metadata.Target.PrURL == "") &&
+		executionCtx.HTTP != nil &&
+		executionCtx.Integration != nil {
+		client, err := NewClient(executionCtx.HTTP, executionCtx.Integration)
+		if err == nil && client.LaunchAgentKey != "" {
+			agentStatus, err := client.GetAgentStatus(payload.ID)
+			if err == nil {
+				mergeAgentResponseIntoMetadata(&metadata, agentStatus)
+			} else {
+				executionCtx.Logger.WithError(err).Warnf("Failed to refresh terminal Cursor Agent %s after webhook", payload.ID)
+			}
+		}
 	}
 
 	if err := executionCtx.Metadata.Set(metadata); err != nil {
@@ -75,11 +78,13 @@ func (c *LaunchAgent) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.
 
 	// 6. Complete Workflow if finished
 	if isTerminalStatus(payload.Status) {
+		prURL := ""
 		branchName := ""
 		if metadata.Target != nil {
+			prURL = metadata.Target.PrURL
 			branchName = metadata.Target.BranchName
 		}
-		outputPayload := buildOutputPayload(payload.Status, payload.ID, payload.PrURL, payload.Summary, branchName)
+		outputPayload := buildOutputPayload(metadata.Agent.Status, metadata.Agent.ID, prURL, metadata.Agent.Summary, branchName)
 		if err := executionCtx.ExecutionState.Emit(LaunchAgentDefaultChannel, LaunchAgentPayloadType, []any{outputPayload}); err != nil {
 			return http.StatusInternalServerError, nil, err
 		}
@@ -158,33 +163,18 @@ func (c *LaunchAgent) poll(ctx core.ActionContext) error {
 
 	// Update Metadata
 	pollErrors = 0
-	metadata.Agent.Status = agentStatus.Status
-	metadata.Agent.Summary = agentStatus.Summary
-	if agentStatus.Target != nil {
-		if metadata.Target == nil {
-			metadata.Target = &TargetMetadata{}
-		}
-		if agentStatus.Target.URL != "" {
-			metadata.Agent.URL = agentStatus.Target.URL
-		}
-		if agentStatus.Target.PrURL != "" {
-			metadata.Target.PrURL = agentStatus.Target.PrURL
-		}
-		if agentStatus.Target.BranchName != "" {
-			metadata.Target.BranchName = agentStatus.Target.BranchName
-		}
-	}
+	mergeAgentResponseIntoMetadata(&metadata, agentStatus)
 	_ = ctx.Metadata.Set(metadata) // Best effort save
 
 	// Check for Completion
-	if isTerminalStatus(agentStatus.Status) {
+	if isTerminalStatus(metadata.Agent.Status) {
 		prURL := ""
 		branchName := ""
 		if metadata.Target != nil {
 			prURL = metadata.Target.PrURL
 			branchName = metadata.Target.BranchName
 		}
-		outputPayload := buildOutputPayload(agentStatus.Status, metadata.Agent.ID, prURL, agentStatus.Summary, branchName)
+		outputPayload := buildOutputPayload(metadata.Agent.Status, metadata.Agent.ID, prURL, metadata.Agent.Summary, branchName)
 		return ctx.ExecutionState.Emit(LaunchAgentDefaultChannel, LaunchAgentPayloadType, []any{outputPayload})
 	}
 

--- a/pkg/integrations/cursor/launch_agent_monitor_test.go
+++ b/pkg/integrations/cursor/launch_agent_monitor_test.go
@@ -312,6 +312,90 @@ func Test__LaunchAgent__Poll(t *testing.T) {
 		assert.Equal(t, LaunchAgentPayloadType, executionStateCtx.Type)
 	})
 
+	t.Run("terminal webhook payload without summary or pr url refreshes agent status", func(t *testing.T) {
+		secret := "test-secret"
+		payload := launchAgentWebhookPayload{
+			Event:  "statusChange",
+			ID:     "agent-123",
+			Status: "FINISHED",
+			Target: &launchAgentWebhookTarget{
+				BranchName: "cursor/agent-abc123",
+			},
+		}
+		body, _ := json.Marshal(payload)
+		signature := generateSignature(body, secret)
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"id": "agent-123",
+						"status": "FINISHED",
+						"summary": "Task completed",
+						"target": {
+							"branchName": "cursor/agent-abc123",
+							"prUrl": "https://github.com/org/repo/pull/42"
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"launchAgentKey": "test-key",
+			},
+		}
+		metadataCtx := &contexts.MetadataContext{
+			Metadata: LaunchAgentExecutionMetadata{
+				Agent: &AgentMetadata{
+					ID:     "agent-123",
+					Status: "RUNNING",
+				},
+				Target: &TargetMetadata{
+					BranchName: "cursor/agent-abc123",
+				},
+			},
+		}
+		executionStateCtx := &contexts.ExecutionStateContext{
+			KVs: map[string]string{
+				"agent_id": "agent-123",
+			},
+		}
+
+		webhookCtx := core.WebhookRequestContext{
+			Body:        body,
+			Headers:     http.Header{LaunchAgentWebhookSignatureHeader: []string{signature}},
+			Webhook:     &contexts.NodeWebhookContext{Secret: secret},
+			HTTP:        httpContext,
+			Integration: integrationCtx,
+			FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+				return &core.ExecutionContext{
+					Metadata:       metadataCtx,
+					ExecutionState: executionStateCtx,
+					Logger:         logrus.NewEntry(logrus.New()),
+					HTTP:           httpContext,
+					Integration:    integrationCtx,
+				}, nil
+			},
+		}
+
+		status, _, err := c.HandleWebhook(webhookCtx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+
+		require.Len(t, executionStateCtx.Payloads, 1)
+		emittedPayload := executionStateCtx.Payloads[0].(map[string]any)["data"].(LaunchAgentOutputPayload)
+		assert.Equal(t, "FINISHED", emittedPayload.Status)
+		assert.Equal(t, "https://github.com/org/repo/pull/42", emittedPayload.PrURL)
+		assert.Equal(t, "Task completed", emittedPayload.Summary)
+
+		updatedMetadata := metadataCtx.Metadata.(LaunchAgentExecutionMetadata)
+		assert.Equal(t, "Task completed", updatedMetadata.Agent.Summary)
+		assert.Equal(t, "https://github.com/org/repo/pull/42", updatedMetadata.Target.PrURL)
+	})
+
 	t.Run("poll API error -> schedules next poll with error count", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{

--- a/pkg/integrations/cursor/launch_agent_test.go
+++ b/pkg/integrations/cursor/launch_agent_test.go
@@ -213,8 +213,11 @@ func Test__LaunchAgent__HandleWebhook(t *testing.T) {
 		payload := launchAgentWebhookPayload{
 			ID:      "agent-123",
 			Status:  "FINISHED",
-			PrURL:   "https://github.com/org/repo/pull/42",
 			Summary: "Fixed the bug",
+			Target: &launchAgentWebhookTarget{
+				PrURL:      "https://github.com/org/repo/pull/42",
+				BranchName: "cursor/agent-abc123",
+			},
 		}
 		body, _ := json.Marshal(payload)
 		signature := generateSignature(body, secret)
@@ -260,6 +263,11 @@ func Test__LaunchAgent__HandleWebhook(t *testing.T) {
 		updatedMetadata := metadataCtx.Metadata.(LaunchAgentExecutionMetadata)
 		assert.Equal(t, "FINISHED", updatedMetadata.Agent.Status)
 		assert.Equal(t, "https://github.com/org/repo/pull/42", updatedMetadata.Target.PrURL)
+		require.Len(t, executionStateCtx.Payloads, 1)
+		payloadData := executionStateCtx.Payloads[0].(map[string]any)["data"].(LaunchAgentOutputPayload)
+		assert.Equal(t, "FINISHED", payloadData.Status)
+		assert.Equal(t, "https://github.com/org/repo/pull/42", payloadData.PrURL)
+		assert.Equal(t, "Fixed the bug", payloadData.Summary)
 	})
 
 	t.Run("failed agent webhook", func(t *testing.T) {
@@ -305,6 +313,91 @@ func Test__LaunchAgent__HandleWebhook(t *testing.T) {
 
 		// Verify emit was called on default channel
 		assert.Equal(t, LaunchAgentDefaultChannel, executionStateCtx.Channel)
+	})
+
+	t.Run("terminal webhook refreshes missing summary and pr url from agent status", func(t *testing.T) {
+		secret := "test-secret"
+		payload := launchAgentWebhookPayload{
+			ID:     "agent-123",
+			Status: "FINISHED",
+			Target: &launchAgentWebhookTarget{
+				BranchName: "cursor/agent-abc123",
+			},
+		}
+		body, _ := json.Marshal(payload)
+		signature := generateSignature(body, secret)
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"id": "agent-123",
+						"status": "FINISHED",
+						"summary": "Fixed the bug",
+						"target": {
+							"branchName": "cursor/agent-abc123",
+							"prUrl": "https://github.com/org/repo/pull/42"
+						}
+					}`)),
+				},
+			},
+		}
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"launchAgentKey": "test-key",
+			},
+		}
+		metadataCtx := &contexts.MetadataContext{
+			Metadata: LaunchAgentExecutionMetadata{
+				Agent: &AgentMetadata{
+					ID:     "agent-123",
+					Status: "RUNNING",
+				},
+				Target: &TargetMetadata{
+					BranchName: "cursor/agent-abc123",
+				},
+			},
+		}
+		executionStateCtx := &contexts.ExecutionStateContext{
+			KVs: map[string]string{
+				"agent_id": "agent-123",
+			},
+		}
+
+		webhookCtx := core.WebhookRequestContext{
+			Body:        body,
+			Headers:     http.Header{LaunchAgentWebhookSignatureHeader: []string{signature}},
+			Webhook:     &contexts.NodeWebhookContext{Secret: secret},
+			HTTP:        httpContext,
+			Integration: integrationCtx,
+			FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+				return &core.ExecutionContext{
+					HTTP:           httpContext,
+					Integration:    integrationCtx,
+					Metadata:       metadataCtx,
+					ExecutionState: executionStateCtx,
+					Logger:         logrus.NewEntry(logrus.New()),
+				}, nil
+			},
+		}
+
+		status, _, err := c.HandleWebhook(webhookCtx)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, status)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cursor.com/v0/agents/agent-123", httpContext.Requests[0].URL.String())
+
+		updatedMetadata := metadataCtx.Metadata.(LaunchAgentExecutionMetadata)
+		assert.Equal(t, "Fixed the bug", updatedMetadata.Agent.Summary)
+		assert.Equal(t, "https://github.com/org/repo/pull/42", updatedMetadata.Target.PrURL)
+
+		require.Len(t, executionStateCtx.Payloads, 1)
+		payloadData := executionStateCtx.Payloads[0].(map[string]any)["data"].(LaunchAgentOutputPayload)
+		assert.Equal(t, "FINISHED", payloadData.Status)
+		assert.Equal(t, "https://github.com/org/repo/pull/42", payloadData.PrURL)
+		assert.Equal(t, "Fixed the bug", payloadData.Summary)
+		assert.Equal(t, "cursor/agent-abc123", payloadData.BranchName)
 	})
 
 	t.Run("missing agent ID -> bad request", func(t *testing.T) {

--- a/pkg/integrations/cursor/launch_agent_types.go
+++ b/pkg/integrations/cursor/launch_agent_types.go
@@ -126,10 +126,19 @@ type launchAgentTargetResponse struct {
 }
 
 type launchAgentWebhookPayload struct {
-	ID      string `json:"id"`
-	Status  string `json:"status"`
-	PrURL   string `json:"prUrl,omitempty"`
-	Summary string `json:"summary,omitempty"`
+	Event     string                    `json:"event,omitempty"`
+	Timestamp string                    `json:"timestamp,omitempty"`
+	ID        string                    `json:"id"`
+	Status    string                    `json:"status"`
+	Target    *launchAgentWebhookTarget `json:"target,omitempty"`
+	PrURL     string                    `json:"prUrl,omitempty"`
+	Summary   string                    `json:"summary,omitempty"`
+}
+
+type launchAgentWebhookTarget struct {
+	URL        string `json:"url,omitempty"`
+	BranchName string `json:"branchName,omitempty"`
+	PrURL      string `json:"prUrl,omitempty"`
 }
 
 type LaunchAgentOutputPayload struct {
@@ -164,6 +173,90 @@ func buildOutputPayload(status, agentID, prURL, summary, branchName string) Laun
 		PrURL:      prURL,
 		Summary:    summary,
 		BranchName: branchName,
+	}
+}
+
+func ensureLaunchAgentMetadata(metadata *LaunchAgentExecutionMetadata) {
+	if metadata.Agent == nil {
+		metadata.Agent = &AgentMetadata{}
+	}
+	if metadata.Target == nil {
+		metadata.Target = &TargetMetadata{}
+	}
+	if metadata.Source == nil {
+		metadata.Source = &SourceMetadata{}
+	}
+}
+
+func mergeAgentResponseIntoMetadata(metadata *LaunchAgentExecutionMetadata, response *LaunchAgentResponse) {
+	if response == nil {
+		return
+	}
+
+	ensureLaunchAgentMetadata(metadata)
+
+	if response.ID != "" {
+		metadata.Agent.ID = response.ID
+	}
+	if response.Name != "" {
+		metadata.Agent.Name = response.Name
+	}
+	if response.Status != "" {
+		metadata.Agent.Status = response.Status
+	}
+	if response.Summary != "" {
+		metadata.Agent.Summary = response.Summary
+	}
+
+	if response.Source != nil {
+		if response.Source.Repository != "" {
+			metadata.Source.Repository = response.Source.Repository
+		}
+		if response.Source.Ref != "" {
+			metadata.Source.Ref = response.Source.Ref
+		}
+	}
+
+	if response.Target == nil {
+		return
+	}
+
+	if response.Target.URL != "" {
+		metadata.Agent.URL = response.Target.URL
+	}
+	if response.Target.BranchName != "" {
+		metadata.Target.BranchName = response.Target.BranchName
+	}
+	if response.Target.PrURL != "" {
+		metadata.Target.PrURL = response.Target.PrURL
+	}
+}
+
+func mergeWebhookPayloadIntoMetadata(metadata *LaunchAgentExecutionMetadata, payload launchAgentWebhookPayload) {
+	ensureLaunchAgentMetadata(metadata)
+
+	if payload.ID != "" {
+		metadata.Agent.ID = payload.ID
+	}
+	if payload.Status != "" {
+		metadata.Agent.Status = payload.Status
+	}
+	if payload.Summary != "" {
+		metadata.Agent.Summary = payload.Summary
+	}
+	if payload.Target != nil {
+		if payload.Target.URL != "" {
+			metadata.Agent.URL = payload.Target.URL
+		}
+		if payload.Target.BranchName != "" {
+			metadata.Target.BranchName = payload.Target.BranchName
+		}
+		if payload.Target.PrURL != "" {
+			metadata.Target.PrURL = payload.Target.PrURL
+		}
+	}
+	if payload.PrURL != "" {
+		metadata.Target.PrURL = payload.PrURL
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- align `cursor.launchAgent` examples with the live Cursor Cloud Agent API by using `FINISHED` in the emitted example output
- decode webhook payloads using the documented nested `target.prUrl` shape and preserve branch metadata from webhook and status responses
- refresh final agent status on terminal webhooks when optional fields like `summary` or `prUrl` are missing, and add regression tests for the webhook and polling paths
- add an embedded `example_output_launch_agent.json` fixture so the Cursor component's example JSON and rendered example output stay in sync

Closes: https://github.com/superplanehq/superplane/issues/4299
