### PR TITLE
fix: add deterministic CLI self-update

### DIFF
--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -153,71 +153,119 @@ func currentExecutablePath() (string, error) {
 }
 
 func downloadAndReplaceBinary(ctx context.Context, downloadURL, executablePath string) error {
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("self-update is not yet supported on Windows; download the binary directly from %s", downloadURL)
+	if err := validateSelfUpdateTarget(downloadURL); err != nil {
+		return err
 	}
 
+	fileMode, err := currentExecutableMode(executablePath)
+	if err != nil {
+		return err
+	}
+
+	tempPath, err := downloadBinaryToTempFile(ctx, downloadURL, filepath.Dir(executablePath), fileMode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	return replaceBinary(tempPath, executablePath)
+}
+
+func validateSelfUpdateTarget(downloadURL string) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+
+	return fmt.Errorf("self-update is not yet supported on Windows; download the binary directly from %s", downloadURL)
+}
+
+func currentExecutableMode(executablePath string) (os.FileMode, error) {
+	currentInfo, err := os.Stat(executablePath)
+	if err != nil {
+		return 0, fmt.Errorf("stat current executable: %w", err)
+	}
+
+	return currentInfo.Mode().Perm(), nil
+}
+
+func downloadBinaryToTempFile(ctx context.Context, downloadURL, tempDir string, fileMode os.FileMode) (string, error) {
+	binaryBody, err := downloadBinary(ctx, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	defer binaryBody.Close()
+
+	return writeBinaryToTempFile(binaryBody, tempDir, fileMode)
+}
+
+func downloadBinary(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
 	client := newReleaseDownloadClient()
 	ctx, cancel := context.WithTimeout(ctx, releaseDownloadTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
-		return fmt.Errorf("create download request: %w", err)
+		return nil, fmt.Errorf("create download request: %w", err)
 	}
 
 	req.Header.Set("Accept", "application/octet-stream")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("download updated binary: %w", err)
+		return nil, fmt.Errorf("download updated binary: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download updated binary: unexpected status %d", resp.StatusCode)
+		defer resp.Body.Close()
+		return nil, fmt.Errorf("download updated binary: unexpected status %d", resp.StatusCode)
 	}
 
-	currentInfo, err := os.Stat(executablePath)
-	if err != nil {
-		return fmt.Errorf("stat current executable: %w", err)
-	}
+	return resp.Body, nil
+}
 
-	tempFile, err := os.CreateTemp(filepath.Dir(executablePath), ".superplane-update-*")
+func writeBinaryToTempFile(binaryBody io.Reader, tempDir string, fileMode os.FileMode) (string, error) {
+	tempFile, err := os.CreateTemp(tempDir, ".superplane-update-*")
 	if err != nil {
-		return fmt.Errorf("create temporary file: %w", err)
+		return "", fmt.Errorf("create temporary file: %w", err)
 	}
 
 	tempPath := tempFile.Name()
-	defer func() {
-		_ = os.Remove(tempPath)
-	}()
-
-	written, err := io.Copy(tempFile, resp.Body)
+	written, err := io.Copy(tempFile, binaryBody)
 	if err != nil {
 		_ = tempFile.Close()
-		return fmt.Errorf("write downloaded binary: %w", err)
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("write downloaded binary: %w", err)
 	}
 
 	if written == 0 {
 		_ = tempFile.Close()
-		return fmt.Errorf("downloaded binary is empty")
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("downloaded binary is empty")
 	}
 
-	if err := tempFile.Chmod(currentInfo.Mode().Perm()); err != nil {
+	if err := tempFile.Chmod(fileMode); err != nil {
 		_ = tempFile.Close()
-		return fmt.Errorf("set binary permissions: %w", err)
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("set binary permissions: %w", err)
 	}
 
 	if err := tempFile.Sync(); err != nil {
 		_ = tempFile.Close()
-		return fmt.Errorf("sync downloaded binary: %w", err)
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("sync downloaded binary: %w", err)
 	}
 
 	if err := tempFile.Close(); err != nil {
-		return fmt.Errorf("close downloaded binary: %w", err)
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("close downloaded binary: %w", err)
 	}
 
+	return tempPath, nil
+}
+
+func replaceBinary(tempPath, executablePath string) error {
 	if err := os.Rename(tempPath, executablePath); err != nil {
 		return fmt.Errorf("replace existing binary: %w", err)
 	}

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +14,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const releasesDownloadBaseURL = "https://github.com/superplanehq/superplane/releases/download"
+const (
+	releasesDownloadBaseURL      = "https://github.com/superplanehq/superplane/releases/download"
+	releaseDownloadHeaderTimeout = 30 * time.Second
+	releaseDownloadTimeout       = 15 * time.Minute
+)
 
 var latestReleaseURL = "https://api.github.com/repos/superplanehq/superplane/releases/latest"
 
@@ -57,7 +62,7 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("resolve current executable: %w", err)
 		}
 
-		if err := downloadAndReplaceBinary(asset.BrowserDownloadURL, executablePath); err != nil {
+		if err := downloadAndReplaceBinary(cmd.Context(), asset.BrowserDownloadURL, executablePath); err != nil {
 			return fmt.Errorf("upgrade CLI: %w", err)
 		}
 
@@ -101,10 +106,6 @@ func fetchLatestRelease() (*releaseInfo, error) {
 	}
 
 	return &release, nil
-}
-
-func currentCLIAssetName() string {
-	return cliAssetName(runtime.GOOS, runtime.GOARCH)
 }
 
 func cliAssetName(goos, goarch string) string {
@@ -151,14 +152,16 @@ func currentExecutablePath() (string, error) {
 	return path, nil
 }
 
-func downloadAndReplaceBinary(downloadURL, executablePath string) error {
+func downloadAndReplaceBinary(ctx context.Context, downloadURL, executablePath string) error {
 	if runtime.GOOS == "windows" {
 		return fmt.Errorf("self-update is not yet supported on Windows; download the binary directly from %s", downloadURL)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := newReleaseDownloadClient()
+	ctx, cancel := context.WithTimeout(ctx, releaseDownloadTimeout)
+	defer cancel()
 
-	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return fmt.Errorf("create download request: %w", err)
 	}
@@ -190,9 +193,15 @@ func downloadAndReplaceBinary(downloadURL, executablePath string) error {
 		_ = os.Remove(tempPath)
 	}()
 
-	if _, err := io.Copy(tempFile, resp.Body); err != nil {
+	written, err := io.Copy(tempFile, resp.Body)
+	if err != nil {
 		_ = tempFile.Close()
 		return fmt.Errorf("write downloaded binary: %w", err)
+	}
+
+	if written == 0 {
+		_ = tempFile.Close()
+		return fmt.Errorf("downloaded binary is empty")
 	}
 
 	if err := tempFile.Chmod(currentInfo.Mode().Perm()); err != nil {
@@ -214,4 +223,16 @@ func downloadAndReplaceBinary(downloadURL, executablePath string) error {
 	}
 
 	return nil
+}
+
+func newReleaseDownloadClient() *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Client{}
+	}
+
+	cloned := transport.Clone()
+	cloned.ResponseHeaderTimeout = releaseDownloadHeaderTimeout
+
+	return &http.Client{Transport: cloned}
 }

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const releasesDownloadBaseURL = "https://github.com/superplanehq/superplane/releases/download"
+
+var latestReleaseURL = "https://api.github.com/repos/superplanehq/superplane/releases/latest"
+
+type releaseInfo struct {
+	TagName string         `json:"tag_name"`
+	Assets  []releaseAsset `json:"assets"`
+}
+
+type releaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade",
+	Aliases: []string{"self-update"},
+	Short:   "Update the SuperPlane CLI to the latest release",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDevBuild() {
+			return fmt.Errorf("self-update is unavailable for dev builds")
+		}
+
+		release, err := fetchLatestRelease()
+		if err != nil {
+			return fmt.Errorf("check latest release: %w", err)
+		}
+
+		if !isNewerVersion(Version, release.TagName) {
+			fmt.Fprintf(cmd.OutOrStdout(), "superplane CLI is already up to date (%s)\n", Version)
+			return nil
+		}
+
+		asset, err := release.currentPlatformAsset()
+		if err != nil {
+			return err
+		}
+
+		executablePath, err := currentExecutablePath()
+		if err != nil {
+			return fmt.Errorf("resolve current executable: %w", err)
+		}
+
+		if err := downloadAndReplaceBinary(asset.BrowserDownloadURL, executablePath); err != nil {
+			return fmt.Errorf("upgrade CLI: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Updated superplane CLI: %s -> %s\n", Version, release.TagName)
+		fmt.Fprintf(cmd.OutOrStdout(), "Installed binary: %s\n", executablePath)
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(upgradeCmd)
+}
+
+func fetchLatestRelease() (*releaseInfo, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	req, err := http.NewRequest(http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var release releaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	if release.TagName == "" {
+		return nil, fmt.Errorf("latest release response is missing tag_name")
+	}
+
+	return &release, nil
+}
+
+func currentCLIAssetName() string {
+	return cliAssetName(runtime.GOOS, runtime.GOARCH)
+}
+
+func cliAssetName(goos, goarch string) string {
+	return fmt.Sprintf("superplane-cli-%s-%s", goos, goarch)
+}
+
+func cliDownloadURL(tagName, goos, goarch string) string {
+	return fmt.Sprintf("%s/%s/%s", releasesDownloadBaseURL, tagName, cliAssetName(goos, goarch))
+}
+
+func (r *releaseInfo) currentPlatformAsset() (*releaseAsset, error) {
+	return r.assetForPlatform(runtime.GOOS, runtime.GOARCH)
+}
+
+func (r *releaseInfo) assetForPlatform(goos, goarch string) (*releaseAsset, error) {
+	expectedName := cliAssetName(goos, goarch)
+
+	for _, asset := range r.Assets {
+		if asset.Name != expectedName {
+			continue
+		}
+
+		if asset.BrowserDownloadURL == "" {
+			asset.BrowserDownloadURL = cliDownloadURL(r.TagName, goos, goarch)
+		}
+
+		return &asset, nil
+	}
+
+	return nil, fmt.Errorf("release %s does not contain a CLI asset for %s/%s (expected %s)", r.TagName, goos, goarch, expectedName)
+}
+
+func currentExecutablePath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolvedPath, nil
+	}
+
+	return path, nil
+}
+
+func downloadAndReplaceBinary(downloadURL, executablePath string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("self-update is not yet supported on Windows; download the binary directly from %s", downloadURL)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download updated binary: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download updated binary: unexpected status %d", resp.StatusCode)
+	}
+
+	currentInfo, err := os.Stat(executablePath)
+	if err != nil {
+		return fmt.Errorf("stat current executable: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(executablePath), ".superplane-update-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file: %w", err)
+	}
+
+	tempPath := tempFile.Name()
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	if _, err := io.Copy(tempFile, resp.Body); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write downloaded binary: %w", err)
+	}
+
+	if err := tempFile.Chmod(currentInfo.Mode().Perm()); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("set binary permissions: %w", err)
+	}
+
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("sync downloaded binary: %w", err)
+	}
+
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close downloaded binary: %w", err)
+	}
+
+	if err := os.Rename(tempPath, executablePath); err != nil {
+		return fmt.Errorf("replace existing binary: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -191,6 +191,9 @@ func currentExecutableMode(executablePath string) (os.FileMode, error) {
 }
 
 func downloadBinaryToTempFile(ctx context.Context, downloadURL, tempDir string, fileMode os.FileMode) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, releaseDownloadTimeout)
+	defer cancel()
+
 	binaryBody, err := downloadBinary(ctx, downloadURL)
 	if err != nil {
 		return "", err
@@ -202,8 +205,6 @@ func downloadBinaryToTempFile(ctx context.Context, downloadURL, tempDir string, 
 
 func downloadBinary(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
 	client := newReleaseDownloadClient()
-	ctx, cancel := context.WithTimeout(ctx, releaseDownloadTimeout)
-	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {

--- a/pkg/cli/upgrade_test.go
+++ b/pkg/cli/upgrade_test.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -110,4 +112,34 @@ func TestDownloadAndReplaceBinaryRejectsEmptyDownload(t *testing.T) {
 	contents, readErr := os.ReadFile(executablePath)
 	require.NoError(t, readErr)
 	require.Equal(t, "old-binary", string(contents))
+}
+
+func TestDownloadAndReplaceBinaryReadsStreamedBodyAfterHeaders(t *testing.T) {
+	tmpDir := t.TempDir()
+	executablePath := filepath.Join(tmpDir, "superplane")
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		_, err := fmt.Fprint(w, "chunk-one-")
+		require.NoError(t, err)
+		flusher.Flush()
+
+		time.Sleep(50 * time.Millisecond)
+
+		_, err = fmt.Fprint(w, "chunk-two")
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	err := downloadAndReplaceBinary(context.Background(), server.URL, executablePath)
+	require.NoError(t, err)
+
+	contents, readErr := os.ReadFile(executablePath)
+	require.NoError(t, readErr)
+	require.Equal(t, "chunk-one-chunk-two", string(contents))
 }

--- a/pkg/cli/upgrade_test.go
+++ b/pkg/cli/upgrade_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -79,7 +80,7 @@ func TestDownloadAndReplaceBinary(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	err := downloadAndReplaceBinary(server.URL, executablePath)
+	err := downloadAndReplaceBinary(context.Background(), server.URL, executablePath)
 	require.NoError(t, err)
 
 	contents, readErr := os.ReadFile(executablePath)
@@ -89,4 +90,24 @@ func TestDownloadAndReplaceBinary(t *testing.T) {
 	info, statErr := os.Stat(executablePath)
 	require.NoError(t, statErr)
 	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestDownloadAndReplaceBinaryRejectsEmptyDownload(t *testing.T) {
+	tmpDir := t.TempDir()
+	executablePath := filepath.Join(tmpDir, "superplane")
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	err := downloadAndReplaceBinary(context.Background(), server.URL, executablePath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "downloaded binary is empty")
+
+	contents, readErr := os.ReadFile(executablePath)
+	require.NoError(t, readErr)
+	require.Equal(t, "old-binary", string(contents))
 }

--- a/pkg/cli/upgrade_test.go
+++ b/pkg/cli/upgrade_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIAssetName(t *testing.T) {
+	require.Equal(t, "superplane-cli-darwin-arm64", cliAssetName("darwin", "arm64"))
+	require.Equal(t, "superplane-cli-linux-amd64", cliAssetName("linux", "amd64"))
+}
+
+func TestCLIDownloadURL(t *testing.T) {
+	require.Equal(
+		t,
+		"https://github.com/superplanehq/superplane/releases/download/v0.17.0/superplane-cli-linux-amd64",
+		cliDownloadURL("v0.17.0", "linux", "amd64"),
+	)
+}
+
+func TestReleaseAssetForPlatformUsesPublishedAssetURL(t *testing.T) {
+	release := &releaseInfo{
+		TagName: "v0.17.0",
+		Assets: []releaseAsset{
+			{
+				Name:               "superplane-cli-linux-amd64",
+				BrowserDownloadURL: "https://example.com/linux-amd64",
+			},
+		},
+	}
+
+	asset, err := release.assetForPlatform("linux", "amd64")
+	require.NoError(t, err)
+	require.Equal(t, "superplane-cli-linux-amd64", asset.Name)
+	require.Equal(t, "https://example.com/linux-amd64", asset.BrowserDownloadURL)
+}
+
+func TestReleaseAssetForPlatformFallsBackToDeterministicURL(t *testing.T) {
+	release := &releaseInfo{
+		TagName: "v0.17.0",
+		Assets: []releaseAsset{
+			{
+				Name: "superplane-cli-darwin-arm64",
+			},
+		},
+	}
+
+	asset, err := release.assetForPlatform("darwin", "arm64")
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://github.com/superplanehq/superplane/releases/download/v0.17.0/superplane-cli-darwin-arm64",
+		asset.BrowserDownloadURL,
+	)
+}
+
+func TestReleaseAssetForPlatformReturnsHelpfulErrorWhenMissing(t *testing.T) {
+	release := &releaseInfo{TagName: "v0.17.0"}
+
+	_, err := release.assetForPlatform("linux", "arm64")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected superplane-cli-linux-arm64")
+}
+
+func TestDownloadAndReplaceBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	executablePath := filepath.Join(tmpDir, "superplane")
+	require.NoError(t, os.WriteFile(executablePath, []byte("old-binary"), 0o755))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		_, err := w.Write([]byte("new-binary"))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	err := downloadAndReplaceBinary(server.URL, executablePath)
+	require.NoError(t, err)
+
+	contents, readErr := os.ReadFile(executablePath)
+	require.NoError(t, readErr)
+	require.Equal(t, "new-binary", string(contents))
+
+	info, statErr := os.Stat(executablePath)
+	require.NoError(t, statErr)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,10 +1,9 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,8 +17,8 @@ var Version = "dev"
 var updateCheckResult <-chan *updateInfo
 
 type updateInfo struct {
-	latest string
-	err    error
+	release *releaseInfo
+	err     error
 }
 
 func isDevBuild() bool {
@@ -56,8 +55,8 @@ func StartUpdateCheck() {
 	ch := make(chan *updateInfo, 1)
 	updateCheckResult = ch
 	go func() {
-		latest, err := fetchLatestRelease()
-		ch <- &updateInfo{latest: latest, err: err}
+		release, err := fetchLatestRelease()
+		ch <- &updateInfo{release: release, err: err}
 	}()
 }
 
@@ -83,7 +82,7 @@ func ShouldStartUpdateCheck(args []string) bool {
 		case "--config", "--output", "-o":
 			skipValue = true
 			continue
-		case "-h", "--help", "help", "--version", "version", "completion":
+		case "-h", "--help", "help", "--version", "version", "completion", "upgrade", "self-update":
 			return false
 		}
 
@@ -115,47 +114,33 @@ func PrintUpdateNotice() {
 		return
 	}
 
-	if info.err != nil || info.latest == "" {
+	if info.err != nil || info.release == nil {
 		return
 	}
 
-	if isNewerVersion(Version, info.latest) {
-		fmt.Fprintf(os.Stderr, "\nA new version of superplane CLI is available: %s -> %s\n", Version, info.latest)
-		fmt.Fprintf(os.Stderr, "Download from: https://github.com/superplanehq/superplane/releases/tag/%s\n", info.latest)
+	notice := buildUpdateNotice(Version, info.release, runtime.GOOS, runtime.GOARCH)
+	if notice != "" {
+		fmt.Fprint(os.Stderr, notice)
 	}
 }
 
-const latestReleaseURL = "https://api.github.com/repos/superplanehq/superplane/releases/latest"
-
-func fetchLatestRelease() (string, error) {
-	client := &http.Client{Timeout: 3 * time.Second}
-
-	req, err := http.NewRequest("GET", latestReleaseURL, nil)
-	if err != nil {
-		return "", err
+func buildUpdateNotice(currentVersion string, release *releaseInfo, goos, goarch string) string {
+	if release == nil || !isNewerVersion(currentVersion, release.TagName) {
+		return ""
 	}
 
-	req.Header.Set("Accept", "application/vnd.github+json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	downloadURL := cliDownloadURL(release.TagName, goos, goarch)
+	asset, err := release.assetForPlatform(goos, goarch)
+	if err == nil && asset.BrowserDownloadURL != "" {
+		downloadURL = asset.BrowserDownloadURL
 	}
 
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return "", err
-	}
-
-	return release.TagName, nil
+	return fmt.Sprintf(
+		"\nA new version of superplane CLI is available: %s -> %s\nRun: superplane upgrade\nDirect download: %s\n",
+		currentVersion,
+		release.TagName,
+		downloadURL,
+	)
 }
 
 // isNewerVersion returns true if latest is a newer semver than current.

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestIsNewerVersion(t *testing.T) {
 	tests := []struct {
@@ -70,6 +74,8 @@ func TestShouldStartUpdateCheck(t *testing.T) {
 		{name: "version subcommand", args: []string{"version"}, expected: false},
 		{name: "version flag", args: []string{"--version"}, expected: false},
 		{name: "completion command", args: []string{"completion", "zsh"}, expected: false},
+		{name: "upgrade command", args: []string{"upgrade"}, expected: false},
+		{name: "self-update alias", args: []string{"self-update"}, expected: false},
 		{name: "networked command", args: []string{"whoami"}, expected: true},
 		{name: "networked subcommand with flags", args: []string{"canvases", "list", "-o", "json"}, expected: true},
 		{name: "flag before local subcommand", args: []string{"-o", "json", "version"}, expected: false},
@@ -83,4 +89,34 @@ func TestShouldStartUpdateCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildUpdateNotice(t *testing.T) {
+	release := &releaseInfo{
+		TagName: "v0.17.0",
+		Assets: []releaseAsset{
+			{
+				Name:               "superplane-cli-linux-amd64",
+				BrowserDownloadURL: "https://github.com/superplanehq/superplane/releases/download/v0.17.0/superplane-cli-linux-amd64",
+			},
+		},
+	}
+
+	notice := buildUpdateNotice("v0.16.0", release, "linux", "amd64")
+	require.Contains(t, notice, "A new version of superplane CLI is available: v0.16.0 -> v0.17.0")
+	require.Contains(t, notice, "Run: superplane upgrade")
+	require.Contains(t, notice, "Direct download: https://github.com/superplanehq/superplane/releases/download/v0.17.0/superplane-cli-linux-amd64")
+}
+
+func TestBuildUpdateNoticeFallsBackToDeterministicURL(t *testing.T) {
+	release := &releaseInfo{TagName: "v0.17.0"}
+
+	notice := buildUpdateNotice("v0.16.0", release, "darwin", "arm64")
+	require.Contains(t, notice, "Direct download: https://github.com/superplanehq/superplane/releases/download/v0.17.0/superplane-cli-darwin-arm64")
+}
+
+func TestBuildUpdateNoticeEmptyWhenAlreadyCurrent(t *testing.T) {
+	release := &releaseInfo{TagName: "v0.17.0"}
+
+	require.Empty(t, buildUpdateNotice("v0.17.0", release, "linux", "amd64"))
 }

--- a/release/create-github-release.js
+++ b/release/create-github-release.js
@@ -7,6 +7,12 @@ const fs = require("fs");
 const path = require("path");
 
 const cliAssetPattern = /^superplane-cli-(darwin|linux)-(amd64|arm64)$/;
+const expectedCLIAssets = [
+  "superplane-cli-darwin-amd64",
+  "superplane-cli-darwin-arm64",
+  "superplane-cli-linux-amd64",
+  "superplane-cli-linux-arm64",
+];
 
 async function main() {
   const version = process.argv[2];
@@ -166,6 +172,24 @@ function loadCLIAssets(cliAssetsDir, cliAssetPrefix) {
     if (!cliAssetPattern.test(assetName)) {
       console.error(
         `Error: invalid CLI asset name ${assetName}. Expected superplane-cli-<os>-<arch> raw binaries.`
+      );
+      process.exit(1);
+    }
+  }
+
+  if (cliAssets.length !== expectedCLIAssets.length) {
+    console.error(
+      `Error: expected exactly ${expectedCLIAssets.length} CLI assets (${expectedCLIAssets.join(
+        ", "
+      )}), found ${cliAssets.length}: ${cliAssets.join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  for (const expectedAsset of expectedCLIAssets) {
+    if (!cliAssets.includes(expectedAsset)) {
+      console.error(
+        `Error: missing CLI asset ${expectedAsset}. Release uploads must include the full supported platform matrix.`
       );
       process.exit(1);
     }

--- a/release/create-github-release.js
+++ b/release/create-github-release.js
@@ -124,7 +124,13 @@ async function main() {
     assetPath: sbomPath,
   });
 
-  const cliAssets = loadCLIAssets(cliAssetsDir, cliAssetPrefix);
+  const cliAssets = fs
+    .readdirSync(cliAssetsDir)
+    .filter((name) => name.startsWith(cliAssetPrefix))
+    .map((name) => ({
+      assetName: name,
+      assetPath: path.join(cliAssetsDir, name),
+    }));
 
   for (const cliAsset of cliAssets) {
     await uploadAsset({
@@ -138,32 +144,6 @@ async function main() {
     });
   }
   console.log("Done.");
-}
-
-function loadCLIAssets(cliAssetsDir, cliAssetPrefix) {
-  if (!fs.existsSync(cliAssetsDir)) {
-    console.error(
-      `Error: ${cliAssetsDir} does not exist. Build CLI assets before creating a release.`
-    );
-    process.exit(1);
-  }
-
-  const cliAssets = fs
-    .readdirSync(cliAssetsDir)
-    .filter((name) => name.startsWith(cliAssetPrefix))
-    .sort();
-
-  if (cliAssets.length === 0) {
-    console.error(
-      `Error: no CLI assets found in ${cliAssetsDir}. Expected files like superplane-cli-darwin-arm64.`
-    );
-    process.exit(1);
-  }
-
-  return cliAssets.map((assetName) => ({
-    assetName,
-    assetPath: path.join(cliAssetsDir, assetName),
-  }));
 }
 
 async function uploadAsset({

--- a/release/create-github-release.js
+++ b/release/create-github-release.js
@@ -6,8 +6,6 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 
-const cliAssetPattern = /^superplane-cli-(darwin|linux)-(amd64|arm64)$/;
-
 async function main() {
   const version = process.argv[2];
 
@@ -160,15 +158,6 @@ function loadCLIAssets(cliAssetsDir, cliAssetPrefix) {
       `Error: no CLI assets found in ${cliAssetsDir}. Expected files like superplane-cli-darwin-arm64.`
     );
     process.exit(1);
-  }
-
-  for (const assetName of cliAssets) {
-    if (!cliAssetPattern.test(assetName)) {
-      console.error(
-        `Error: invalid CLI asset name ${assetName}. Expected superplane-cli-<os>-<arch> raw binaries.`
-      );
-      process.exit(1);
-    }
   }
 
   return cliAssets.map((assetName) => ({

--- a/release/create-github-release.js
+++ b/release/create-github-release.js
@@ -6,6 +6,8 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 
+const cliAssetPattern = /^superplane-cli-(darwin|linux)-(amd64|arm64)$/;
+
 async function main() {
   const version = process.argv[2];
 
@@ -124,13 +126,7 @@ async function main() {
     assetPath: sbomPath,
   });
 
-  const cliAssets = fs
-    .readdirSync(cliAssetsDir)
-    .filter((name) => name.startsWith(cliAssetPrefix))
-    .map((name) => ({
-      assetName: name,
-      assetPath: path.join(cliAssetsDir, name),
-    }));
+  const cliAssets = loadCLIAssets(cliAssetsDir, cliAssetPrefix);
 
   for (const cliAsset of cliAssets) {
     await uploadAsset({
@@ -144,6 +140,41 @@ async function main() {
     });
   }
   console.log("Done.");
+}
+
+function loadCLIAssets(cliAssetsDir, cliAssetPrefix) {
+  if (!fs.existsSync(cliAssetsDir)) {
+    console.error(
+      `Error: ${cliAssetsDir} does not exist. Build CLI assets before creating a release.`
+    );
+    process.exit(1);
+  }
+
+  const cliAssets = fs
+    .readdirSync(cliAssetsDir)
+    .filter((name) => name.startsWith(cliAssetPrefix))
+    .sort();
+
+  if (cliAssets.length === 0) {
+    console.error(
+      `Error: no CLI assets found in ${cliAssetsDir}. Expected files like superplane-cli-darwin-arm64.`
+    );
+    process.exit(1);
+  }
+
+  for (const assetName of cliAssets) {
+    if (!cliAssetPattern.test(assetName)) {
+      console.error(
+        `Error: invalid CLI asset name ${assetName}. Expected superplane-cli-<os>-<arch> raw binaries.`
+      );
+      process.exit(1);
+    }
+  }
+
+  return cliAssets.map((assetName) => ({
+    assetName,
+    assetPath: path.join(cliAssetsDir, assetName),
+  }));
 }
 
 async function uploadAsset({

--- a/release/create-github-release.js
+++ b/release/create-github-release.js
@@ -7,12 +7,6 @@ const fs = require("fs");
 const path = require("path");
 
 const cliAssetPattern = /^superplane-cli-(darwin|linux)-(amd64|arm64)$/;
-const expectedCLIAssets = [
-  "superplane-cli-darwin-amd64",
-  "superplane-cli-darwin-arm64",
-  "superplane-cli-linux-amd64",
-  "superplane-cli-linux-arm64",
-];
 
 async function main() {
   const version = process.argv[2];
@@ -172,24 +166,6 @@ function loadCLIAssets(cliAssetsDir, cliAssetPrefix) {
     if (!cliAssetPattern.test(assetName)) {
       console.error(
         `Error: invalid CLI asset name ${assetName}. Expected superplane-cli-<os>-<arch> raw binaries.`
-      );
-      process.exit(1);
-    }
-  }
-
-  if (cliAssets.length !== expectedCLIAssets.length) {
-    console.error(
-      `Error: expected exactly ${expectedCLIAssets.length} CLI assets (${expectedCLIAssets.join(
-        ", "
-      )}), found ${cliAssets.length}: ${cliAssets.join(", ")}`
-    );
-    process.exit(1);
-  }
-
-  for (const expectedAsset of expectedCLIAssets) {
-    if (!cliAssets.includes(expectedAsset)) {
-      console.error(
-        `Error: missing CLI asset ${expectedAsset}. Release uploads must include the full supported platform matrix.`
       );
       process.exit(1);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a first-party `superplane upgrade` / `superplane self-update` command for release-built CLI binaries
- switch update notices to print a direct platform-specific download URL instead of only linking to the release page
- harden updater downloads by removing the dead helper, using a header timeout plus command-scoped deadline instead of a whole-request client timeout, rejecting empty replacement binaries, and keeping the download context alive until the response body has been fully copied
- split `downloadAndReplaceBinary` into smaller helper functions so validation, download, temp-file writing, and replacement are easier to follow and maintain

## Testing
- `go test pkg/cli/version.go pkg/cli/upgrade.go pkg/cli/version_test.go pkg/cli/upgrade_test.go pkg/cli/root_stub_tmp_test.go` (temporary local-only stub used during file-scoped validation; not committed)
- added coverage for streamed response bodies in `TestDownloadAndReplaceBinaryReadsStreamedBodyAfterHeaders`
- `node --check release/create-github-release.js`
- attempted `go test ./pkg/cli` but this checkout is missing generated `pkg/openapi_client`, so repo-wide CLI package tests could not run in this environment

closes: https://github.com/superplanehq/superplane/issues/4269

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8144fe7-3140-4f2b-ba65-e3789a430110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8144fe7-3140-4f2b-ba65-e3789a430110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

closes: https://github.com/superplanehq/superplane/issues/4269

