### PR TITLE
fix: run title expression syntax, resolution, and display

### DIFF
--- a/pkg/grpc/actions/canvases/emit_node_event.go
+++ b/pkg/grpc/actions/canvases/emit_node_event.go
@@ -45,7 +45,10 @@ func EmitNodeEvent(
 	}
 
 	customName, err := resolveCustomName(node, data)
-	if err == nil && customName != nil {
+	if err != nil {
+		failed := fmt.Sprintf("Failed to resolve run title: %s", err.Error())
+		event.CustomName = &failed
+	} else if customName != nil {
 		event.CustomName = customName
 	}
 
@@ -88,7 +91,8 @@ func resolveCustomName(node *models.CanvasNode, payload map[string]any) (*string
 
 	builder := contexts.NewNodeConfigurationBuilder(database.Conn(), node.WorkflowID).
 		WithNodeID(node.NodeID).
-		WithInput(map[string]any{node.NodeID: payload})
+		WithInput(map[string]any{node.NodeID: payload}).
+		WithRootPayload(payload)
 	resolved, err := builder.ResolveTemplateExpressions(template)
 	if err != nil {
 		return nil, err

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -1097,11 +1097,11 @@ func AppendGlobalTriggerFields(fields []configuration.Field) []configuration.Fie
 
 	fields = append(fields, configuration.Field{
 		Name:        "customName",
-		Label:       "Run title (optional)",
+		Label:       "Run title",
 		Type:        configuration.FieldTypeString,
 		Togglable:   true,
-		Description: "Optional run title template. Supports expressions like {{ $.data }}.",
-		Placeholder: "Deploy {{ $.repository.name }} @ {{ $.head_commit.id }}",
+		Description: "Give each run a dynamic title using expressions. Use root().data to access the trigger payload.",
+		Placeholder: "{{ root().data.foo }}",
 	})
 
 	return fields

--- a/pkg/integrations/github/delete_release.go
+++ b/pkg/integrations/github/delete_release.go
@@ -114,7 +114,7 @@ func (c *DeleteRelease) Configuration() []configuration.Field {
 			Name:        "tagName",
 			Label:       "Tag Name",
 			Type:        configuration.FieldTypeString,
-			Placeholder: "e.g., v1.0.0 or {{$.data.tag_name}}",
+			Placeholder: "e.g., v1.0.0 or {{ root().data.tag_name }}",
 			Description: "Git tag identifying the release to delete. Supports template variables from previous steps.",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{

--- a/pkg/integrations/github/get_release.go
+++ b/pkg/integrations/github/get_release.go
@@ -124,7 +124,7 @@ func (c *GetRelease) Configuration() []configuration.Field {
 			Name:        "tagName",
 			Label:       "Tag Name",
 			Type:        configuration.FieldTypeString,
-			Placeholder: "e.g., v1.0.0 or {{$.data.tag_name}}",
+			Placeholder: "e.g., v1.0.0 or {{ root().data.tag_name }}",
 			Description: "Git tag identifying the release. Supports template variables from previous steps.",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{
@@ -143,7 +143,7 @@ func (c *GetRelease) Configuration() []configuration.Field {
 			Name:        "releaseId",
 			Label:       "Release ID",
 			Type:        configuration.FieldTypeString,
-			Placeholder: "e.g., 12345678 or {{$.data.release_id}}",
+			Placeholder: "e.g., 12345678 or {{ root().data.release_id }}",
 			Description: "Numeric release ID. Supports template variables from previous steps.",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{

--- a/pkg/integrations/github/update_release.go
+++ b/pkg/integrations/github/update_release.go
@@ -122,7 +122,7 @@ func (c *UpdateRelease) Configuration() []configuration.Field {
 			Name:        "tagName",
 			Label:       "Tag Name",
 			Type:        configuration.FieldTypeString,
-			Placeholder: "e.g., v1.0.0 or {{$.data.tag_name}}",
+			Placeholder: "e.g., v1.0.0 or {{ root().data.tag_name }}",
 			Description: "Git tag identifying the release to update. Supports template variables from previous steps.",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{

--- a/pkg/workers/contexts/event_context.go
+++ b/pkg/workers/contexts/event_context.go
@@ -53,8 +53,11 @@ func (s *EventContext) Emit(payloadType string, payload any) error {
 	}
 
 	wrappedPayload := map[string]any{"data": payload}
-	customName, err := s.resolveCustomName(wrappedPayload)
-	if err == nil && customName != nil {
+	customName, err := s.resolveCustomName(wrappedPayload, structuredPayload)
+	if err != nil {
+		failed := fmt.Sprintf("Failed to resolve run title: %s", err.Error())
+		event.CustomName = &failed
+	} else if customName != nil {
 		event.CustomName = customName
 	}
 
@@ -70,7 +73,7 @@ func (s *EventContext) Emit(payloadType string, payload any) error {
 	return nil
 }
 
-func (s *EventContext) resolveCustomName(payload any) (*string, error) {
+func (s *EventContext) resolveCustomName(payload any, rootPayload any) (*string, error) {
 	config := s.node.Configuration.Data()
 	if config == nil {
 		return nil, nil
@@ -93,7 +96,8 @@ func (s *EventContext) resolveCustomName(payload any) (*string, error) {
 
 	builder := NewNodeConfigurationBuilder(s.tx, s.node.WorkflowID).
 		WithNodeID(s.node.NodeID).
-		WithInput(map[string]any{s.node.NodeID: payload})
+		WithInput(map[string]any{s.node.NodeID: payload}).
+		WithRootPayload(rootPayload)
 	resolved, err := builder.ResolveTemplateExpressions(template)
 	if err != nil {
 		return nil, err

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -25,6 +25,7 @@ type NodeConfigurationBuilder struct {
 	nodeID              string
 	previousExecutionID *uuid.UUID
 	rootEventID         *uuid.UUID
+	rootPayload         any
 	input               any
 	parentBlueprintNode *models.CanvasNode
 	configurationFields []configuration.Field
@@ -49,6 +50,11 @@ func (b *NodeConfigurationBuilder) WithNodeID(nodeID string) *NodeConfigurationB
 
 func (b *NodeConfigurationBuilder) WithRootEvent(rootEventID *uuid.UUID) *NodeConfigurationBuilder {
 	b.rootEventID = rootEventID
+	return b
+}
+
+func (b *NodeConfigurationBuilder) WithRootPayload(payload any) *NodeConfigurationBuilder {
+	b.rootPayload = payload
 	return b
 }
 
@@ -491,7 +497,11 @@ func (b *NodeConfigurationBuilder) resolveRootPayload() (any, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if rootEvent == nil {
+		if b.rootPayload != nil {
+			return b.rootPayload, nil
+		}
 		return nil, fmt.Errorf("no root event found")
 	}
 

--- a/test/e2e/trigger_run_title_test.go
+++ b/test/e2e/trigger_run_title_test.go
@@ -1,0 +1,143 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	q "github.com/superplanehq/superplane/test/e2e/queries"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestTriggerRunTitle(t *testing.T) {
+	t.Run("sets run title on a manual trigger and persists it", func(t *testing.T) {
+		steps := &triggerRunTitleSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithManualTrigger("RunTitle Canvas", "MyTrigger")
+		steps.whenRunTitleToggleIsEnabled()
+		steps.whenRunTitleIsSetTo("Deploy {{ root().data.version }}")
+		steps.waitForAutoSave()
+		steps.thenRunTitleInDBEquals("MyTrigger", "Deploy {{ root().data.version }}")
+	})
+
+	t.Run("clearing run title removes it from configuration", func(t *testing.T) {
+		steps := &triggerRunTitleSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithManualTrigger("RunTitle Clear", "ClearTrigger")
+		steps.whenRunTitleToggleIsEnabled()
+		steps.whenRunTitleIsSetTo("some title")
+		steps.waitForAutoSave()
+		steps.thenRunTitleInDBEquals("ClearTrigger", "some title")
+		steps.whenRunTitleIsSetTo("")
+		steps.waitForAutoSave()
+		steps.thenRunTitleIsAbsentInDB("ClearTrigger")
+	})
+}
+
+type triggerRunTitleSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+	nodeID  string
+}
+
+func (s *triggerRunTitleSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *triggerRunTitleSteps) givenACanvasWithManualTrigger(canvasName, triggerName string) {
+	s.canvas = shared.NewCanvasSteps(canvasName, s.t, s.session)
+	s.canvas.Create()
+	s.canvas.EnterEditMode()
+	s.canvas.AddManualTrigger(triggerName, models.Position{X: 500, Y: 250})
+	s.nodeID = s.waitForNodeID()
+}
+
+func (s *triggerRunTitleSteps) whenRunTitleToggleIsEnabled() {
+	// The Run title field is togglable — click the switch next to "Run title" label to enable it.
+	runTitleSwitch := q.Locator(`div:has(> label:has-text("Run title")) button[role="switch"]`)
+	s.session.Click(runTitleSwitch)
+	s.session.Sleep(300)
+}
+
+func (s *triggerRunTitleSteps) whenRunTitleIsSetTo(value string) {
+	runTitleInput := q.TestID("string-field-customname")
+	s.session.FillIn(runTitleInput, value)
+}
+
+func (s *triggerRunTitleSteps) waitForAutoSave() {
+	s.session.Sleep(500)
+}
+
+func (s *triggerRunTitleSteps) thenRunTitleInDBEquals(nodeName, expected string) {
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		val, exists, found := s.getCustomNameField()
+		if found && exists && val == expected {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	val, exists, found := s.getCustomNameField()
+	require.True(s.t, found, "expected node to exist in DB")
+	require.True(s.t, exists, "expected customName key to exist in DB config")
+	require.Equal(s.t, expected, val, "expected customName=%q in DB but got %v", expected, val)
+}
+
+func (s *triggerRunTitleSteps) thenRunTitleIsAbsentInDB(nodeName string) {
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		val, exists, found := s.getCustomNameField()
+		if found && (!exists || val == "") {
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	val, exists, found := s.getCustomNameField()
+	require.True(s.t, found, "expected node to exist in DB")
+	if exists {
+		require.Equal(s.t, "", val, "expected customName to be absent or empty but got %v", val)
+	}
+}
+
+func (s *triggerRunTitleSteps) waitForNodeID() string {
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		draft := s.canvas.FindCurrentDraft()
+		if draft != nil && len(draft.Nodes) == 1 {
+			return draft.Nodes[0].ID
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	draft := s.canvas.FindCurrentDraft()
+	require.NotNil(s.t, draft, "no draft version found")
+	require.Len(s.t, draft.Nodes, 1, "expected exactly one node in draft")
+	return draft.Nodes[0].ID
+}
+
+func (s *triggerRunTitleSteps) getCustomNameField() (any, bool, bool) {
+	if s.nodeID == "" {
+		return nil, false, false
+	}
+
+	draft := s.canvas.FindCurrentDraft()
+	if draft == nil {
+		return nil, false, false
+	}
+
+	for _, node := range draft.Nodes {
+		if node.ID == s.nodeID {
+			val, exists := node.Configuration["customName"]
+			return val, exists, true
+		}
+	}
+
+	return nil, false, false
+}

--- a/test/e2e/trigger_run_title_test.go
+++ b/test/e2e/trigger_run_title_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
@@ -12,27 +13,24 @@ import (
 )
 
 func TestTriggerRunTitle(t *testing.T) {
-	t.Run("sets run title on a manual trigger and persists it", func(t *testing.T) {
+	t.Run("resolves run title expression when event is emitted", func(t *testing.T) {
 		steps := &triggerRunTitleSteps{t: t}
 		steps.start()
-		steps.givenACanvasWithManualTrigger("RunTitle Canvas", "MyTrigger")
-		steps.whenRunTitleToggleIsEnabled()
-		steps.whenRunTitleIsSetTo("Deploy {{ root().data.version }}")
-		steps.waitForAutoSave()
-		steps.thenRunTitleInDBEquals("MyTrigger", "Deploy {{ root().data.version }}")
-	})
+		steps.givenACanvasWithManualTrigger("RunTitle Resolve", "Start")
 
-	t.Run("clearing run title removes it from configuration", func(t *testing.T) {
-		steps := &triggerRunTitleSteps{t: t}
-		steps.start()
-		steps.givenACanvasWithManualTrigger("RunTitle Clear", "ClearTrigger")
+		// Set a run title that references the trigger payload.
+		// The default manual trigger template sends {"message": "Hello, World!"}
 		steps.whenRunTitleToggleIsEnabled()
-		steps.whenRunTitleIsSetTo("some title")
+		steps.whenRunTitleIsSetTo("Run: {{ root().message }}")
 		steps.waitForAutoSave()
-		steps.thenRunTitleInDBEquals("ClearTrigger", "some title")
-		steps.whenRunTitleIsSetTo("")
-		steps.waitForAutoSave()
-		steps.thenRunTitleIsAbsentInDB("ClearTrigger")
+		steps.thenRunTitleInDBEquals("Run: {{ root().message }}")
+
+		// Publish and trigger an event
+		steps.saveAndPublish()
+		steps.runManualTrigger()
+
+		// The emitted event should have the resolved custom name
+		steps.thenEventCustomNameEquals("Run: Hello, World!")
 	})
 }
 
@@ -58,22 +56,30 @@ func (s *triggerRunTitleSteps) givenACanvasWithManualTrigger(canvasName, trigger
 }
 
 func (s *triggerRunTitleSteps) whenRunTitleToggleIsEnabled() {
-	// The Run title field is togglable — click the switch next to "Run title" label to enable it.
 	runTitleSwitch := q.Locator(`div:has(> label:has-text("Run title")) button[role="switch"]`)
 	s.session.Click(runTitleSwitch)
 	s.session.Sleep(300)
 }
 
 func (s *triggerRunTitleSteps) whenRunTitleIsSetTo(value string) {
-	runTitleInput := q.TestID("string-field-customname")
-	s.session.FillIn(runTitleInput, value)
+	s.session.FillIn(q.TestID("string-field-customname"), value)
 }
 
 func (s *triggerRunTitleSteps) waitForAutoSave() {
 	s.session.Sleep(500)
 }
 
-func (s *triggerRunTitleSteps) thenRunTitleInDBEquals(nodeName, expected string) {
+func (s *triggerRunTitleSteps) saveAndPublish() {
+	s.canvas.Save()
+	s.canvas.Publish()
+}
+
+func (s *triggerRunTitleSteps) runManualTrigger() {
+	s.canvas.RunManualTrigger("Start")
+	s.session.Sleep(2000)
+}
+
+func (s *triggerRunTitleSteps) thenRunTitleInDBEquals(expected string) {
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		val, exists, found := s.getCustomNameField()
@@ -89,21 +95,34 @@ func (s *triggerRunTitleSteps) thenRunTitleInDBEquals(nodeName, expected string)
 	require.Equal(s.t, expected, val, "expected customName=%q in DB but got %v", expected, val)
 }
 
-func (s *triggerRunTitleSteps) thenRunTitleIsAbsentInDB(nodeName string) {
+func (s *triggerRunTitleSteps) thenEventCustomNameEquals(expected string) {
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
-		val, exists, found := s.getCustomNameField()
-		if found && (!exists || val == "") {
+		event := s.findLatestRootEvent()
+		if event != nil && event.CustomName != nil && *event.CustomName == expected {
 			return
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
 
-	val, exists, found := s.getCustomNameField()
-	require.True(s.t, found, "expected node to exist in DB")
-	if exists {
-		require.Equal(s.t, "", val, "expected customName to be absent or empty but got %v", val)
+	event := s.findLatestRootEvent()
+	require.NotNil(s.t, event, "no root event found for canvas")
+	require.NotNil(s.t, event.CustomName, "event custom name is nil, expected %q", expected)
+	require.Equal(s.t, expected, *event.CustomName)
+}
+
+func (s *triggerRunTitleSteps) findLatestRootEvent() *models.CanvasEvent {
+	var event models.CanvasEvent
+	err := database.Conn().
+		Where("workflow_id = ?", s.canvas.WorkflowID).
+		Where("execution_id IS NULL").
+		Order("created_at DESC").
+		First(&event).Error
+
+	if err != nil {
+		return nil
 	}
+	return &event
 }
 
 func (s *triggerRunTitleSteps) waitForNodeID() string {

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.stories.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.stories.tsx
@@ -27,10 +27,12 @@ type Story = StoryObj<typeof meta>;
 
 const exprLangObject = {
   $: {
-    data: {
-      version: "1.2.3",
-      service: "api",
-      env: "prod",
+    trigger: {
+      data: {
+        version: "1.2.3",
+        service: "api",
+        env: "prod",
+      },
     },
     deploy: {
       id: "dep_123",
@@ -42,7 +44,7 @@ const exprLangObject = {
 export const ExprLanguage: Story = {
   args: {
     exampleObj: exprLangObject,
-    placeholder: "{{ $.data.version }} deployment",
+    placeholder: "{{ $.trigger.data.version }} deployment",
     inputSize: "sm",
     startWord: "{",
     prefix: "{{ ",

--- a/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
+++ b/web_src/src/components/AutoCompleteInput/AutoCompleteInput.tsx
@@ -21,6 +21,8 @@ export interface AutoCompleteInputProps extends Omit<React.ComponentPropsWithout
   showValuePreview?: boolean;
   quickTip?: string;
   expressionMode?: "wrapped" | "raw";
+  /** Labels of suggestions to hide (e.g., ["$", "previous"] to restrict to root() only). */
+  excludedSuggestions?: string[];
 }
 
 const suggestionSortPriority = {
@@ -48,6 +50,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       showValuePreview = false,
       quickTip,
       expressionMode = "wrapped",
+      excludedSuggestions,
       ...rest
     } = props;
     const [inputValue, setInputValue] = useState(value);
@@ -911,21 +914,23 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
 
       const newSuggestions = getSuggestions(context.expressionText, context.expressionCursor, exampleObj ?? {}, {
         limit: 150,
-      }).sort((a, b) => {
-        const aPriority = suggestionSortPriority[a.label as keyof typeof suggestionSortPriority];
-        const bPriority = suggestionSortPriority[b.label as keyof typeof suggestionSortPriority];
+      })
+        .filter((s) => !excludedSuggestions?.includes(s.label))
+        .sort((a, b) => {
+          const aPriority = suggestionSortPriority[a.label as keyof typeof suggestionSortPriority];
+          const bPriority = suggestionSortPriority[b.label as keyof typeof suggestionSortPriority];
 
-        if (aPriority !== undefined && bPriority !== undefined) {
-          return aPriority - bPriority;
-        }
-        if (aPriority !== undefined) {
-          return -1;
-        }
-        if (bPriority !== undefined) {
-          return 1;
-        }
-        return a.label.localeCompare(b.label);
-      });
+          if (aPriority !== undefined && bPriority !== undefined) {
+            return aPriority - bPriority;
+          }
+          if (aPriority !== undefined) {
+            return -1;
+          }
+          if (bPriority !== undefined) {
+            return 1;
+          }
+          return a.label.localeCompare(b.label);
+        });
       setSuggestions(newSuggestions);
       setIsOpen(newSuggestions.length > 0);
       const nextHighlightedIndex = showValuePreview && newSuggestions.length > 0 ? 0 : -1;
@@ -948,6 +953,7 @@ export const AutoCompleteInput = forwardRef<HTMLTextAreaElement, AutoCompleteInp
       onChange,
       showValuePreview,
       exampleObj,
+      excludedSuggestions,
       computeHighlightedValue,
     ]);
 

--- a/web_src/src/pages/workflowv2/utils.ts
+++ b/web_src/src/pages/workflowv2/utils.ts
@@ -1335,6 +1335,7 @@ export function buildEventInfo(event: CanvasesCanvasEvent): EventInfo | undefine
   return {
     id: event.id!,
     createdAt: event.createdAt!,
+    customName: event.customName,
     data: event.data?.data || {},
     nodeId: event.nodeId!,
     type: (event.data?.type as string) || "",

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -486,6 +486,37 @@ export function SettingsTab({
           />
         </div>
 
+        {/* Run title field — rendered right after name, before the separator */}
+        {(() => {
+          const runTitleField = configurationFields?.find((f) => f.name === "customName");
+          if (!runTitleField || !shouldShowConfiguration) return null;
+          return (
+            <div className={isReadOnly ? "pointer-events-none opacity-60" : ""}>
+              <ConfigurationFieldRenderer
+                allowExpressions={true}
+                field={runTitleField}
+                value={nodeConfiguration[runTitleField.name!]}
+                onChange={(value) => {
+                  setNodeConfiguration((prev) => ({
+                    ...prev,
+                    [runTitleField.name!]: value,
+                  }));
+                  if (value === undefined || value === null || value === "") {
+                    requestAutosave();
+                  }
+                }}
+                allValues={nodeConfiguration}
+                domainId={domainId}
+                domainType={domainType}
+                organizationId={domainId}
+                autocompleteExampleObj={resolvedAutocompleteExampleObj}
+                realtimeValidationErrors={realtimeValidationErrors}
+                enableRealtimeValidation={true}
+              />
+            </div>
+          );
+        })()}
+
         {/* Integration section — one container, three states: Connect / error or incomplete / ready */}
         {integrationName && (
           <div
@@ -664,7 +695,7 @@ export function SettingsTab({
             className={`border-t border-gray-200 dark:border-gray-700 pt-6 space-y-4 ${isReadOnly ? "pointer-events-none opacity-60" : ""}`}
           >
             {configurationFields.map((field) => {
-              if (!field.name) return null;
+              if (!field.name || field.name === "customName") return null;
               const fieldName = field.name;
               return (
                 <ConfigurationFieldRenderer

--- a/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
@@ -56,6 +56,8 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
     );
   }
 
+  const isRunTitle = field.name === "customName";
+
   return (
     <AutoCompleteInput
       exampleObj={autocompleteExampleObj ?? null}
@@ -70,6 +72,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
       quickTip="Tip: type `{{` to start an expression."
       className=""
       data-testid={toTestId(`string-field-${field.name}`)}
+      excludedSuggestions={isRunTitle ? ["$", "previous"] : undefined}
     />
   );
 };

--- a/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
@@ -10,6 +10,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
   onChange,
   autocompleteExampleObj,
   allowExpressions = false,
+  excludedSuggestions,
 }) => {
   const hasInitialized = useRef(false);
   const shouldPreserveEmpty = field.togglable === true;
@@ -56,8 +57,6 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
     );
   }
 
-  const isRunTitle = field.name === "customName";
-
   return (
     <AutoCompleteInput
       exampleObj={autocompleteExampleObj ?? null}
@@ -72,7 +71,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
       quickTip="Tip: type `{{` to start an expression."
       className=""
       data-testid={toTestId(`string-field-${field.name}`)}
-      excludedSuggestions={isRunTitle ? ["$", "previous"] : undefined}
+      excludedSuggestions={excludedSuggestions}
     />
   );
 };

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -47,6 +47,9 @@ interface ConfigurationFieldRendererProps extends FieldRendererProps {
 
 type ConfigurationField = FieldRendererProps["field"];
 
+/** Stable reference for trigger run-title fields — hides node/previous sources that don't apply. */
+const RUN_TITLE_EXCLUDED_SUGGESTIONS = ["$", "previous"];
+
 function getInitialSelectValue(field: ConfigurationField, parsedDefaultValue: unknown): unknown {
   const selectOptions = field.typeOptions?.select?.options;
   if (!selectOptions) {
@@ -272,6 +275,7 @@ export const ConfigurationFieldRenderer = ({
       integrationId,
       organizationId,
       allowExpressions,
+      excludedSuggestions: field.name === "customName" ? RUN_TITLE_EXCLUDED_SUGGESTIONS : undefined,
     };
 
     switch (field.type) {

--- a/web_src/src/ui/configurationFieldRenderer/types.ts
+++ b/web_src/src/ui/configurationFieldRenderer/types.ts
@@ -20,4 +20,5 @@ export interface FieldRendererProps {
   fieldPath?: string;
   autocompleteExampleObj?: Record<string, unknown> | null;
   allowExpressions?: boolean;
+  excludedSuggestions?: string[];
 }


### PR DESCRIPTION
  Closes: https://github.com/superplanehq/superplane/issues/1611
  
  ## Summary

  - Fix run title (`customName`) field on triggers: update expression syntax from `$.data` to `root().data`, improve label/description, and re-add togglable behavior
  - Make `root()` work in run title expressions by injecting the event payload directly into the expression builder (previously failed because the root event doesn't exist yet at resolution time)
  - Show a "Failed to resolve run title" message when expression resolution fails instead of silently swallowing the error
  - Fix frontend: `buildEventInfo()` was stripping `customName` from events, so custom titles never displayed
  - Restrict run title autocomplete to only show `root()` (hide `$` and `previous()` which don't apply to triggers)
  - Move run title field above the separator in the trigger settings sidebar, right after the Name field
  - Update `$.data` placeholders to `root().data` in GitHub integration components (get_release, update_release, delete_release)
  - Fix AutoCompleteInput story to use realistic node names
  
  
<img width="1058" height="749" alt="image" src="https://github.com/user-attachments/assets/e5f59b61-8f6f-4029-9dd8-c7eb32b8e27f" />


  ## Test plan

  - [x] E2E test: sets run title template, emits manual trigger event, verifies resolved title on the created event
  - [x] Go builds clean
  - [x] TypeScript type-checks clean