### PR TITLE
cli: print canvas URL after create, update, and get

### DIFF
--- a/pkg/cli/commands/canvases/create.go
+++ b/pkg/cli/commands/canvases/create.go
@@ -136,6 +136,12 @@ func validateAndPrintCreateResponse(
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		_, err := fmt.Fprintf(stdout, "Canvas %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId())
+		if err != nil {
+			return err
+		}
+		if url := core.CanvasURL(ctx, canvas.Metadata.GetId()); url != "" {
+			_, err = fmt.Fprintf(stdout, "Canvas URL: %s\n", url)
+		}
 		return err
 	})
 }

--- a/pkg/cli/commands/canvases/create_test.go
+++ b/pkg/cli/commands/canvases/create_test.go
@@ -18,10 +18,15 @@ import (
 func newCanvasCreateServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "/api/v1/canvases", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"abc-123","name":"my-canvas"}}}`))
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/canvases":
+			_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"abc-123","name":"my-canvas"}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"user-1","organizationId":"org-1"}}`))
+		default:
+			require.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
+		}
 	}))
 	t.Cleanup(server.Close)
 	return server

--- a/pkg/cli/commands/canvases/get.go
+++ b/pkg/cli/commands/canvases/get.go
@@ -66,6 +66,9 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		_, _ = fmt.Fprintf(stdout, "ID: %s\n", resource.Metadata.GetId())
 		_, _ = fmt.Fprintf(stdout, "Name: %s\n", resource.Metadata.GetName())
+		if url := core.CanvasURL(ctx, resource.Metadata.GetId()); url != "" {
+			_, _ = fmt.Fprintf(stdout, "Canvas URL: %s\n", url)
+		}
 		_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(resource.Spec.GetNodes()))
 		_, err := fmt.Fprintf(stdout, "Edges: %d\n", len(resource.Spec.GetEdges()))
 		return err

--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -232,6 +232,9 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 
 		_, _ = fmt.Fprintf(stdout, "Canvas version updated: %s\n", metadata.GetId())
 		_, _ = fmt.Fprintf(stdout, "Canvas ID: %s\n", metadata.GetCanvasId())
+		if url := core.CanvasURL(ctx, metadata.GetCanvasId()); url != "" {
+			_, _ = fmt.Fprintf(stdout, "Canvas URL: %s\n", url)
+		}
 		_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(spec.GetNodes()))
 		_, _ = fmt.Fprintf(stdout, "Edges: %d\n", len(spec.GetEdges()))
 

--- a/pkg/cli/commands/canvases/update_test.go
+++ b/pkg/cli/commands/canvases/update_test.go
@@ -178,6 +178,15 @@ func TestUpdateFromFileAppliesChangeManagementEnabledAfterSpecUpdateWhenNotDraft
 				_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"` + canvasID + `","name":"parse-check"},"spec":{"changeManagement":{"enabled":true}}}}`))
 			},
 		},
+		// 7. Resolve org for canvas URL
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/me",
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"user":{"id":"user-1","organizationId":"org-1"}}`))
+			},
+		},
 	)
 
 	filePath := writeTestCanvasFileWithChangeManagementEnabled(t, canvasID, true)
@@ -195,6 +204,7 @@ func TestUpdateFromFileAppliesChangeManagementEnabledAfterSpecUpdateWhenNotDraft
 		http.MethodPut + " /api/v1/canvases/" + canvasID + "/versions",
 		http.MethodPatch + " /api/v1/canvases/" + canvasID + "/versions/ver-1/publish",
 		http.MethodPut + " /api/v1/canvases/" + canvasID,
+		http.MethodGet + " /api/v1/me",
 	})
 }
 
@@ -281,6 +291,15 @@ func TestUpdateFromFileDisablesChangeManagementBeforeSpecUpdate(t *testing.T) {
 				_, _ = w.Write([]byte(`{"version":{"metadata":{"id":"ver-1","canvasId":"` + canvasID + `"}}}`))
 			},
 		},
+		// 8. Resolve org for canvas URL
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/me",
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"user":{"id":"user-1","organizationId":"org-1"}}`))
+			},
+		},
 	)
 
 	filePath := writeTestCanvasFileWithChangeManagementEnabled(t, canvasID, false)
@@ -300,6 +319,7 @@ func TestUpdateFromFileDisablesChangeManagementBeforeSpecUpdate(t *testing.T) {
 		http.MethodPost + " /api/v1/canvases/" + canvasID + "/versions",
 		http.MethodPut + " /api/v1/canvases/" + canvasID + "/versions",
 		http.MethodPatch + " /api/v1/canvases/" + canvasID + "/versions/ver-1/publish",
+		http.MethodGet + " /api/v1/me",
 	})
 }
 
@@ -351,6 +371,15 @@ func TestUpdateFromFileEnablesChangeManagementBeforeDraftUpdate(t *testing.T) {
 				_, _ = w.Write([]byte(`{"version":{"metadata":{"id":"draft-1","canvasId":"` + canvasID + `"},"spec":{"nodes":[],"edges":[]}}}`))
 			},
 		},
+		// Resolve org for canvas URL
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/me",
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"user":{"id":"user-1","organizationId":"org-1"}}`))
+			},
+		},
 	)
 
 	filePath := writeTestCanvasFileWithChangeManagementEnabled(t, canvasID, true)
@@ -366,6 +395,7 @@ func TestUpdateFromFileEnablesChangeManagementBeforeDraftUpdate(t *testing.T) {
 		http.MethodPut + " /api/v1/canvases/" + canvasID,
 		http.MethodGet + " /api/v1/canvases/" + canvasID + "/versions",
 		http.MethodPut + " /api/v1/canvases/" + canvasID + "/versions",
+		http.MethodGet + " /api/v1/me",
 	})
 }
 

--- a/pkg/cli/core/urls.go
+++ b/pkg/cli/core/urls.go
@@ -1,0 +1,14 @@
+package core
+
+import "fmt"
+
+// TODO: make the base URL configurable via config/env
+const appBaseURL = "https://app.superplane.com"
+
+func CanvasURL(ctx CommandContext, canvasID string) string {
+	orgID, err := ResolveOrganizationID(ctx)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/canvases/%s", appBaseURL, orgID, canvasID)
+}


### PR DESCRIPTION
Print the full canvas URL (`https://app.superplane.com/{orgId}/canvases/{canvasId}`) in text output for `canvases create`, `canvases update`, and `canvases get`.

Adds `core.CanvasURL()` helper that resolves org ID and builds the URL. Returns empty string on failure (non-blocking). Base URL hardcoded with a TODO to make configurable.

**Changes:**
- `pkg/cli/core/urls.go` — new `CanvasURL()` helper
- `create.go`, `update.go`, `get.go` — print Canvas URL in text output
- Tests updated

Fixes #4319