### PR TITLE
feat: add oci instances components

### DIFF
--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -10,6 +10,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="On Compute Instance Created" href="#on-compute-instance-created" description="Fires when a new OCI Compute instance reaches RUNNING state (via OCI Events Service)" />
+  <LinkCard title="On Instance State Change" href="#on-instance-state-change" description="Fires when an OCI Compute instance starts, stops, resets, or terminates" />
 </CardGrid>
 
 ## Actions
@@ -20,7 +21,11 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Function" href="#create-function" description="Deploy a new function within an OCI Functions application" />
   <LinkCard title="Delete Application" href="#delete-application" description="Delete an OCI Functions application" />
   <LinkCard title="Delete Function" href="#delete-function" description="Remove a function from an OCI Functions application" />
+  <LinkCard title="Delete Instance" href="#delete-instance" description="Terminate an OCI Compute instance and wait for termination" />
+  <LinkCard title="Get Instance" href="#get-instance" description="Fetch details for an OCI Compute instance" />
   <LinkCard title="Invoke Function" href="#invoke-function" description="Execute an OCI Function and capture its response" />
+  <LinkCard title="Manage Instance Power" href="#manage-instance-power" description="Start, stop, or reset an OCI Compute instance and wait for the target state" />
+  <LinkCard title="Update Instance" href="#update-instance" description="Update mutable OCI Compute instance attributes" />
 </CardGrid>
 
 ## Instructions
@@ -140,6 +145,65 @@ Each event payload includes:
 }
 ```
 
+<a id="on-instance-state-change"></a>
+
+## On Instance State Change
+
+The On Instance State Change trigger starts a workflow execution whenever an Oracle Cloud Infrastructure Compute instance completes a power or termination operation.
+
+### How It Works
+
+When this trigger is added to a workflow, SuperPlane creates an **OCI Events rule** in the configured compartment that forwards Compute instance lifecycle events to the integration's shared OCI Notifications topic.
+
+### Configuration
+
+- **Compartment**: The compartment to monitor for Compute instance state changes.
+
+### Event Data
+
+Each event payload includes:
+- `eventType` — the OCI Compute API event type, such as `com.oraclecloud.computeapi.stopinstance.end`
+- `data.resourceId` — the instance OCID
+- `data.resourceName` — the instance display name
+- `data.compartmentId` — the compartment OCID
+- `data.availabilityDomain` — the availability domain
+- `eventTime` — ISO-8601 timestamp of the event
+
+### Example Data
+
+```json
+{
+  "data": {
+    "cloudEventsVersion": "0.1",
+    "contentType": "application/json",
+    "data": {
+      "additionalDetails": {
+        "imageId": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaa4ktlslmw2fqu5trx2xk3rnnqozgstuqutjm3ffusi6juo3ef4zaq",
+        "shape": "VM.Standard.E2.1.Micro",
+        "type": "CustomerVmi"
+      },
+      "availabilityDomain": "pYRG:EU-FRANKFURT-1-AD-3",
+      "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq",
+      "compartmentName": "root",
+      "definedTags": {},
+      "freeformTags": {},
+      "resourceId": "ocid1.instance.oc1.eu-frankfurt-1.antheljthvjhcwice6b33efkswzlk56zv4n5rcnb7xf4gsdlvuqlihvszjlq",
+      "resourceName": "test-instance-12"
+    },
+    "eventID": "8fc0df4c-ea5d-4438-a817-db7fa6440b8a",
+    "eventTime": "2026-04-22T20:34:54Z",
+    "eventType": "com.oraclecloud.computeapi.stopinstance.end",
+    "eventTypeVersion": "2.0",
+    "extensions": {
+      "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq"
+    },
+    "source": "ComputeApi"
+  },
+  "timestamp": "2026-04-22T20:35:05.079372195Z",
+  "type": "oci.onInstanceStateChange"
+}
+```
+
 <a id="create-application"></a>
 
 ## Create Application
@@ -237,6 +301,193 @@ Emits the created instance details on the default output channel, including:
   },
   "timestamp": "2026-04-22T20:31:58.249783188Z",
   "type": "oci.computeInstanceCreated"
+}
+```
+
+<a id="delete-instance"></a>
+
+## Delete Instance
+
+The Delete Instance component terminates an Oracle Cloud Infrastructure Compute instance and waits until OCI reports it as terminated.
+
+### Use Cases
+
+- **Cleanup workflows**: Tear down temporary instances after a test or deployment finishes
+- **Cost controls**: Delete unused Compute instances from automation
+- **Incident remediation**: Terminate compromised or unhealthy instances after replacement capacity exists
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to terminate.
+- **Preserve Boot Volume**: When enabled, OCI preserves the boot volume after instance termination.
+
+### Output
+
+Emits a minimal deletion payload on the default output channel:
+- `instanceId` — instance OCID
+- `lifecycleState` — `TERMINATED`
+
+### Example Output
+
+```json
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "TERMINATED"
+  },
+  "timestamp": "2026-04-22T20:40:00.000Z",
+  "type": "oci.deleteInstance"
+}
+```
+
+<a id="get-instance"></a>
+
+## Get Instance
+
+The Get Instance component fetches the latest details for an Oracle Cloud Infrastructure Compute instance.
+
+### Use Cases
+
+- **Inventory checks**: Read instance state, shape, region, and network addresses during a workflow
+- **Deployment gates**: Verify a target instance exists and is in the expected lifecycle state
+- **Audit workflows**: Capture instance metadata before another operation runs
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to fetch.
+
+### Output
+
+Emits the instance details on the default output channel, including:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — current lifecycle state
+- `publicIp` — public IP address, if assigned
+- `privateIp` — primary private IP address, if available
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "RUNNING",
+    "privateIp": "10.0.0.17",
+    "publicIp": "192.0.2.1",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:32:00.000Z",
+  "type": "oci.getInstance"
+}
+```
+
+<a id="manage-instance-power"></a>
+
+## Manage Instance Power
+
+The Manage Instance Power component performs a power lifecycle action on an Oracle Cloud Infrastructure Compute instance and waits for the target state.
+
+### Use Cases
+
+- **Scheduled shutdowns**: Stop instances outside business hours to reduce cost
+- **Recovery workflows**: Reset or soft-reset an instance after an incident
+- **Startup automation**: Start instances before a deployment, test, or maintenance workflow runs
+
+### Configuration
+
+- **Instance**: The OCI Compute instance.
+- **Action**: One of `START`, `STOP`, `SOFTSTOP`, `RESET`, or `SOFTRESET`.
+
+### Output
+
+Emits the instance details on the default output channel once the instance reaches the expected lifecycle state:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — `RUNNING` for start/reset actions, or `STOPPED` for stop actions
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "STOPPED",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:35:00.000Z",
+  "type": "oci.manageInstancePower"
+}
+```
+
+<a id="update-instance"></a>
+
+## Update Instance
+
+The Update Instance component updates mutable attributes on an Oracle Cloud Infrastructure Compute instance.
+
+### Use Cases
+
+- **Rename instances**: Update the display name for operational clarity
+- **Resize flex shapes**: Adjust OCPUs or memory for supported flexible shapes
+- **Post-provisioning changes**: Apply instance settings after a workflow decides the desired capacity
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to update.
+- **Display Name**: Optional new display name.
+- **OCPUs**: Optional OCPU count for flexible shapes.
+- **Memory (GB)**: Optional memory size for flexible shapes.
+
+### Output
+
+Emits the updated instance details on the default output channel, including:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — current lifecycle state
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-renamed",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "RUNNING",
+    "privateIp": "10.0.0.17",
+    "publicIp": "192.0.2.1",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:33:00.000Z",
+  "type": "oci.updateInstance"
 }
 ```
 
@@ -396,4 +647,3 @@ Emits the function response on the default output channel:
   "type": "oci.functionInvoked"
 }
 ```
-

--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -467,6 +467,8 @@ Emits the updated instance details on the default output channel, including:
 - `instanceId` — instance OCID
 - `displayName` — instance display name
 - `lifecycleState` — current lifecycle state
+- `publicIp` — public IP address, if assigned
+- `privateIp` — primary private IP address, if available
 - `shape` — the instance shape
 - `availabilityDomain` — the availability domain
 - `compartmentId` — the compartment OCID

--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -307,195 +307,6 @@ Emits the created instance details on the default output channel, including:
 }
 ```
 
-<a id="delete-instance"></a>
-
-## Delete Instance
-
-The Delete Instance component terminates an Oracle Cloud Infrastructure Compute instance and waits until OCI reports it as terminated.
-
-### Use Cases
-
-- **Cleanup workflows**: Tear down temporary instances after a test or deployment finishes
-- **Cost controls**: Delete unused Compute instances from automation
-- **Incident remediation**: Terminate compromised or unhealthy instances after replacement capacity exists
-
-### Configuration
-
-- **Instance**: The OCI Compute instance to terminate.
-- **Preserve Boot Volume**: When enabled, OCI preserves the boot volume after instance termination.
-
-### Output
-
-Emits a minimal deletion payload on the default output channel:
-- `instanceId` — instance OCID
-- `lifecycleState` — `TERMINATED`
-
-### Example Output
-
-```json
-{
-  "data": {
-    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
-    "lifecycleState": "TERMINATED"
-  },
-  "timestamp": "2026-04-22T20:40:00.000Z",
-  "type": "oci.deleteInstance"
-}
-```
-
-<a id="get-instance"></a>
-
-## Get Instance
-
-The Get Instance component fetches the latest details for an Oracle Cloud Infrastructure Compute instance.
-
-### Use Cases
-
-- **Inventory checks**: Read instance state, shape, region, and network addresses during a workflow
-- **Deployment gates**: Verify a target instance exists and is in the expected lifecycle state
-- **Audit workflows**: Capture instance metadata before another operation runs
-
-### Configuration
-
-- **Instance**: The OCI Compute instance to fetch.
-
-### Output
-
-Emits the instance details on the default output channel, including:
-- `instanceId` — instance OCID
-- `displayName` — instance display name
-- `lifecycleState` — current lifecycle state
-- `publicIp` — public IP address, if assigned
-- `privateIp` — primary private IP address, if available
-- `shape` — the instance shape
-- `availabilityDomain` — the availability domain
-- `compartmentId` — the compartment OCID
-- `region` — the region
-- `timeCreated` — ISO-8601 creation timestamp
-
-### Example Output
-
-```json
-{
-  "data": {
-    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
-    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
-    "displayName": "test-instance-12",
-    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
-    "lifecycleState": "RUNNING",
-    "privateIp": "10.0.0.17",
-    "publicIp": "192.0.2.1",
-    "region": "eu-frankfurt-1",
-    "shape": "VM.Standard.E2.1.Micro",
-    "timeCreated": "2026-04-22T20:31:25.145Z"
-  },
-  "timestamp": "2026-04-22T20:32:00.000Z",
-  "type": "oci.getInstance"
-}
-```
-
-<a id="manage-instance-power"></a>
-
-## Manage Instance Power
-
-The Manage Instance Power component performs a power lifecycle action on an Oracle Cloud Infrastructure Compute instance and waits for the target state.
-
-### Use Cases
-
-- **Scheduled shutdowns**: Stop instances outside business hours to reduce cost
-- **Recovery workflows**: Reset or soft-reset an instance after an incident
-- **Startup automation**: Start instances before a deployment, test, or maintenance workflow runs
-
-### Configuration
-
-- **Instance**: The OCI Compute instance.
-- **Action**: One of `START`, `STOP`, `SOFTSTOP`, `RESET`, or `SOFTRESET`.
-
-### Output
-
-Emits the instance details on the default output channel once the instance reaches the expected lifecycle state:
-- `instanceId` — instance OCID
-- `displayName` — instance display name
-- `lifecycleState` — `RUNNING` for start/reset actions, or `STOPPED` for stop actions
-- `shape` — the instance shape
-- `availabilityDomain` — the availability domain
-- `compartmentId` — the compartment OCID
-- `region` — the region
-- `timeCreated` — ISO-8601 creation timestamp
-
-### Example Output
-
-```json
-{
-  "data": {
-    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
-    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
-    "displayName": "test-instance-12",
-    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
-    "lifecycleState": "STOPPED",
-    "region": "eu-frankfurt-1",
-    "shape": "VM.Standard.E2.1.Micro",
-    "timeCreated": "2026-04-22T20:31:25.145Z"
-  },
-  "timestamp": "2026-04-22T20:35:00.000Z",
-  "type": "oci.manageInstancePower"
-}
-```
-
-<a id="update-instance"></a>
-
-## Update Instance
-
-The Update Instance component updates mutable attributes on an Oracle Cloud Infrastructure Compute instance.
-
-### Use Cases
-
-- **Rename instances**: Update the display name for operational clarity
-- **Resize flex shapes**: Adjust OCPUs or memory for supported flexible shapes
-- **Post-provisioning changes**: Apply instance settings after a workflow decides the desired capacity
-
-### Configuration
-
-- **Instance**: The OCI Compute instance to update.
-- **Display Name**: Optional new display name.
-- **OCPUs**: Optional OCPU count for flexible shapes.
-- **Memory (GB)**: Optional memory size for flexible shapes.
-
-### Output
-
-Emits the updated instance details on the default output channel, including:
-- `instanceId` — instance OCID
-- `displayName` — instance display name
-- `lifecycleState` — current lifecycle state
-- `publicIp` — public IP address, if assigned
-- `privateIp` — primary private IP address, if available
-- `shape` — the instance shape
-- `availabilityDomain` — the availability domain
-- `compartmentId` — the compartment OCID
-- `region` — the region
-- `timeCreated` — ISO-8601 creation timestamp
-
-### Example Output
-
-```json
-{
-  "data": {
-    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
-    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
-    "displayName": "test-instance-renamed",
-    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
-    "lifecycleState": "RUNNING",
-    "privateIp": "10.0.0.17",
-    "publicIp": "192.0.2.1",
-    "region": "eu-frankfurt-1",
-    "shape": "VM.Standard.E2.1.Micro",
-    "timeCreated": "2026-04-22T20:31:25.145Z"
-  },
-  "timestamp": "2026-04-22T20:33:00.000Z",
-  "type": "oci.updateInstance"
-}
-```
-
 <a id="create-function"></a>
 
 ## Create Function
@@ -613,6 +424,93 @@ Emits the deleted function ID on the default output channel:
 }
 ```
 
+<a id="delete-instance"></a>
+
+## Delete Instance
+
+The Delete Instance component terminates an Oracle Cloud Infrastructure Compute instance and waits until OCI reports it as terminated.
+
+### Use Cases
+
+- **Cleanup workflows**: Tear down temporary instances after a test or deployment finishes
+- **Cost controls**: Delete unused Compute instances from automation
+- **Incident remediation**: Terminate compromised or unhealthy instances after replacement capacity exists
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to terminate.
+- **Preserve Boot Volume**: When enabled, OCI preserves the boot volume after instance termination.
+
+### Output
+
+Emits a minimal deletion payload on the default output channel:
+- `instanceId` — instance OCID
+- `lifecycleState` — `TERMINATED`
+
+### Example Output
+
+```json
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "TERMINATED"
+  },
+  "timestamp": "2026-04-22T20:40:00.000Z",
+  "type": "oci.deleteInstance"
+}
+```
+
+<a id="get-instance"></a>
+
+## Get Instance
+
+The Get Instance component fetches the latest details for an Oracle Cloud Infrastructure Compute instance.
+
+### Use Cases
+
+- **Inventory checks**: Read instance state, shape, region, and network addresses during a workflow
+- **Deployment gates**: Verify a target instance exists and is in the expected lifecycle state
+- **Audit workflows**: Capture instance metadata before another operation runs
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to fetch.
+
+### Output
+
+Emits the instance details on the default output channel, including:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — current lifecycle state
+- `publicIp` — public IP address, if assigned
+- `privateIp` — primary private IP address, if available
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "RUNNING",
+    "privateIp": "10.0.0.17",
+    "publicIp": "192.0.2.1",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:32:00.000Z",
+  "type": "oci.getInstance"
+}
+```
+
 <a id="invoke-function"></a>
 
 ## Invoke Function
@@ -652,3 +550,106 @@ Emits the function response on the default output channel:
   "type": "oci.functionInvoked"
 }
 ```
+
+<a id="manage-instance-power"></a>
+
+## Manage Instance Power
+
+The Manage Instance Power component performs a power lifecycle action on an Oracle Cloud Infrastructure Compute instance and waits for the target state.
+
+### Use Cases
+
+- **Scheduled shutdowns**: Stop instances outside business hours to reduce cost
+- **Recovery workflows**: Reset or soft-reset an instance after an incident
+- **Startup automation**: Start instances before a deployment, test, or maintenance workflow runs
+
+### Configuration
+
+- **Instance**: The OCI Compute instance.
+- **Action**: One of `START`, `STOP`, `SOFTSTOP`, `RESET`, or `SOFTRESET`.
+
+### Output
+
+Emits the instance details on the default output channel once the instance reaches the expected lifecycle state:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — `RUNNING` for start/reset actions, or `STOPPED` for stop actions
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "STOPPED",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:35:00.000Z",
+  "type": "oci.manageInstancePower"
+}
+```
+
+<a id="update-instance"></a>
+
+## Update Instance
+
+The Update Instance component updates mutable attributes on an Oracle Cloud Infrastructure Compute instance.
+
+### Use Cases
+
+- **Rename instances**: Update the display name for operational clarity
+- **Resize flex shapes**: Adjust OCPUs or memory for supported flexible shapes
+- **Post-provisioning changes**: Apply instance settings after a workflow decides the desired capacity
+
+### Configuration
+
+- **Instance**: The OCI Compute instance to update.
+- **Display Name**: Optional new display name.
+- **OCPUs**: Optional OCPU count for flexible shapes.
+- **Memory (GB)**: Optional memory size for flexible shapes.
+
+### Output
+
+Emits the updated instance details on the default output channel, including:
+- `instanceId` — instance OCID
+- `displayName` — instance display name
+- `lifecycleState` — current lifecycle state
+- `publicIp` — public IP address, if assigned
+- `privateIp` — primary private IP address, if available
+- `shape` — the instance shape
+- `availabilityDomain` — the availability domain
+- `compartmentId` — the compartment OCID
+- `region` — the region
+- `timeCreated` — ISO-8601 creation timestamp
+
+### Example Output
+
+```json
+{
+  "data": {
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "displayName": "test-instance-renamed",
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "RUNNING",
+    "privateIp": "10.0.0.17",
+    "publicIp": "192.0.2.1",
+    "region": "eu-frankfurt-1",
+    "shape": "VM.Standard.E2.1.Micro",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:33:00.000Z",
+  "type": "oci.updateInstance"
+}
+```
+

--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -158,15 +158,17 @@ When this trigger is added to a workflow, SuperPlane creates an **OCI Events rul
 ### Configuration
 
 - **Compartment**: The compartment to monitor for Compute instance state changes.
+- **State Changes**: Optional list of state changes to emit. Leave empty to emit all supported state changes.
 
 ### Event Data
 
 Each event payload includes:
-- `eventType` — the OCI Compute API event type, such as `com.oraclecloud.computeapi.stopinstance.end`
+- `eventType` — the OCI Compute API event type, such as `com.oraclecloud.computeapi.instanceaction.end`
 - `data.resourceId` — the instance OCID
 - `data.resourceName` — the instance display name
 - `data.compartmentId` — the compartment OCID
 - `data.availabilityDomain` — the availability domain
+- `data.additionalDetails.instanceActionType` — the completed power action, such as `start`, `stop`, or `softstop`
 - `eventTime` — ISO-8601 timestamp of the event
 
 ### Example Data
@@ -179,6 +181,7 @@ Each event payload includes:
     "data": {
       "additionalDetails": {
         "imageId": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaa4ktlslmw2fqu5trx2xk3rnnqozgstuqutjm3ffusi6juo3ef4zaq",
+        "instanceActionType": "stop",
         "shape": "VM.Standard.E2.1.Micro",
         "type": "CustomerVmi"
       },
@@ -192,7 +195,7 @@ Each event payload includes:
     },
     "eventID": "8fc0df4c-ea5d-4438-a817-db7fa6440b8a",
     "eventTime": "2026-04-22T20:34:54Z",
-    "eventType": "com.oraclecloud.computeapi.stopinstance.end",
+    "eventType": "com.oraclecloud.computeapi.instanceaction.end",
     "eventTypeVersion": "2.0",
     "extensions": {
       "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq"

--- a/pkg/integrations/oci/client.go
+++ b/pkg/integrations/oci/client.go
@@ -123,6 +123,29 @@ func (c *Client) GetInstance(instanceID string) (*Instance, error) {
 	return &instance, nil
 }
 
+// ListInstances lists Compute instances in a compartment.
+func (c *Client) ListInstances(compartmentID string) ([]Instance, error) {
+	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
+	url := fmt.Sprintf(
+		"https://%s/%s/instances?compartmentId=%s&limit=100",
+		host,
+		coreServicesAPIVersion,
+		neturl.QueryEscape(compartmentID),
+	)
+
+	respBody, err := c.doRequest(http.MethodGet, host, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var instances []Instance
+	if err := json.Unmarshal(respBody, &instances); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
+	}
+
+	return instances, nil
+}
+
 // ListVNICAttachments lists VNIC attachments for an instance, used to find IP addresses.
 func (c *Client) ListVNICAttachments(compartmentID, instanceID string) ([]VNICAttachment, error) {
 	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
@@ -438,6 +461,11 @@ type CreateVnicDetails struct {
 type InstanceShapeConfig struct {
 	OCPUs       *float64 `json:"ocpus,omitempty"`
 	MemoryInGBs *float64 `json:"memoryInGBs,omitempty"`
+}
+
+type UpdateInstanceRequest struct {
+	DisplayName *string              `json:"displayName,omitempty"`
+	ShapeConfig *InstanceShapeConfig `json:"shapeConfig,omitempty"`
 }
 
 type ShieldedInstanceConfig struct {
@@ -846,6 +874,62 @@ func (c *Client) AttachVolume(instanceID, volumeID string) (*VolumeAttachment, e
 	}
 
 	return &attachment, nil
+}
+
+// UpdateInstance updates mutable Compute instance attributes.
+func (c *Client) UpdateInstance(instanceID string, req UpdateInstanceRequest) (*Instance, error) {
+	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
+	url := fmt.Sprintf("https://%s/%s/instances/%s", host, coreServicesAPIVersion, instanceID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal update instance request: %w", err)
+	}
+
+	respBody, err := c.doRequest(http.MethodPut, host, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var instance Instance
+	if err := json.Unmarshal(respBody, &instance); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instance response: %w", err)
+	}
+
+	return &instance, nil
+}
+
+// InstanceAction performs a power lifecycle action on a Compute instance.
+func (c *Client) InstanceAction(instanceID, action string) (*Instance, error) {
+	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
+	url := fmt.Sprintf("https://%s/%s/instances/%s?action=%s", host, coreServicesAPIVersion, instanceID, neturl.QueryEscape(action))
+
+	respBody, err := c.doRequest(http.MethodPost, host, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var instance Instance
+	if err := json.Unmarshal(respBody, &instance); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instance response: %w", err)
+	}
+
+	return &instance, nil
+}
+
+// TerminateInstance terminates a Compute instance, optionally preserving the boot volume.
+func (c *Client) TerminateInstance(instanceID string, preserveBootVolume bool) error {
+	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
+	url := fmt.Sprintf(
+		"https://%s/%s/instances/%s?preserveBootVolume=%t",
+		host,
+		coreServicesAPIVersion,
+		instanceID,
+		preserveBootVolume,
+	)
+
+	_, err := c.doRequest(http.MethodDelete, host, url, nil)
+	return err
 }
 
 // ONS (Notifications) types

--- a/pkg/integrations/oci/client.go
+++ b/pkg/integrations/oci/client.go
@@ -37,6 +37,15 @@ type Client struct {
 	http        core.HTTPContext
 }
 
+type OCIAPIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *OCIAPIError) Error() string {
+	return fmt.Sprintf("OCI API returned %d: %s", e.StatusCode, e.Body)
+}
+
 func NewClient(httpCtx core.HTTPContext, integration core.IntegrationContext) (*Client, error) {
 	tenancyOCID, err := integration.GetConfig("tenancyOcid")
 	if err != nil {
@@ -360,7 +369,10 @@ func (c *Client) doRequest(method, host, url string, body io.Reader) ([]byte, er
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("OCI API returned %d: %s", resp.StatusCode, string(respBody))
+		return nil, &OCIAPIError{
+			StatusCode: resp.StatusCode,
+			Body:       string(respBody),
+		}
 	}
 
 	return respBody, nil

--- a/pkg/integrations/oci/client.go
+++ b/pkg/integrations/oci/client.go
@@ -321,8 +321,10 @@ func (c *Client) doRequest(method, host, url string, body io.Reader) ([]byte, er
 		}
 	}
 
+	includeBodyHeaders := method == http.MethodPost || method == http.MethodPut
+
 	var bodyReader io.Reader
-	if len(bodyBytes) > 0 {
+	if len(bodyBytes) > 0 || includeBodyHeaders {
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
@@ -334,14 +336,15 @@ func (c *Client) doRequest(method, host, url string, body io.Reader) ([]byte, er
 	req.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
 	req.Header.Set("Host", host)
 
-	if len(bodyBytes) > 0 {
+	if includeBodyHeaders {
 		hash := sha256.Sum256(bodyBytes)
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(bodyBytes)))
 		req.Header.Set("x-content-sha256", base64.StdEncoding.EncodeToString(hash[:]))
+		req.ContentLength = int64(len(bodyBytes))
 	}
 
-	if err := c.signRequest(req, len(bodyBytes) > 0); err != nil {
+	if err := c.signRequest(req, includeBodyHeaders); err != nil {
 		return nil, fmt.Errorf("failed to sign request: %w", err)
 	}
 

--- a/pkg/integrations/oci/client.go
+++ b/pkg/integrations/oci/client.go
@@ -108,7 +108,7 @@ func (c *Client) LaunchInstance(req LaunchInstanceRequest) (*Instance, error) {
 // GetInstance retrieves a Compute instance by OCID.
 func (c *Client) GetInstance(instanceID string) (*Instance, error) {
 	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
-	url := fmt.Sprintf("https://%s/%s/instances/%s", host, coreServicesAPIVersion, instanceID)
+	url := fmt.Sprintf("https://%s/%s/instances/%s", host, coreServicesAPIVersion, neturl.PathEscape(instanceID))
 
 	respBody, err := c.doRequest(http.MethodGet, host, url, nil)
 	if err != nil {
@@ -882,7 +882,7 @@ func (c *Client) AttachVolume(instanceID, volumeID string) (*VolumeAttachment, e
 // UpdateInstance updates mutable Compute instance attributes.
 func (c *Client) UpdateInstance(instanceID string, req UpdateInstanceRequest) (*Instance, error) {
 	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
-	url := fmt.Sprintf("https://%s/%s/instances/%s", host, coreServicesAPIVersion, instanceID)
+	url := fmt.Sprintf("https://%s/%s/instances/%s", host, coreServicesAPIVersion, neturl.PathEscape(instanceID))
 
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -905,7 +905,7 @@ func (c *Client) UpdateInstance(instanceID string, req UpdateInstanceRequest) (*
 // InstanceAction performs a power lifecycle action on a Compute instance.
 func (c *Client) InstanceAction(instanceID, action string) (*Instance, error) {
 	host := fmt.Sprintf(coreServicesHostTemplate, c.region)
-	url := fmt.Sprintf("https://%s/%s/instances/%s?action=%s", host, coreServicesAPIVersion, instanceID, neturl.QueryEscape(action))
+	url := fmt.Sprintf("https://%s/%s/instances/%s?action=%s", host, coreServicesAPIVersion, neturl.PathEscape(instanceID), neturl.QueryEscape(action))
 
 	respBody, err := c.doRequest(http.MethodPost, host, url, nil)
 	if err != nil {
@@ -927,7 +927,7 @@ func (c *Client) TerminateInstance(instanceID string, preserveBootVolume bool) e
 		"https://%s/%s/instances/%s?preserveBootVolume=%t",
 		host,
 		coreServicesAPIVersion,
-		instanceID,
+		neturl.PathEscape(instanceID),
 		preserveBootVolume,
 	)
 

--- a/pkg/integrations/oci/client_instance_test.go
+++ b/pkg/integrations/oci/client_instance_test.go
@@ -1,0 +1,75 @@
+package oci
+
+import (
+	"net/http"
+	neturl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Client__EscapesInstanceIDInPath(t *testing.T) {
+	instanceID := "ocid1.instance.oc1.test/with slash"
+	escapedPath := "/20160918/instances/" + neturl.PathEscape(instanceID)
+	displayName := "renamed"
+
+	tests := []struct {
+		name      string
+		response  *http.Response
+		call      func(*Client) error
+		queryName string
+	}{
+		{
+			name:     "get",
+			response: ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+			call: func(client *Client) error {
+				_, err := client.GetInstance(instanceID)
+				return err
+			},
+		},
+		{
+			name:     "update",
+			response: ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+			call: func(client *Client) error {
+				_, err := client.UpdateInstance(instanceID, UpdateInstanceRequest{DisplayName: &displayName})
+				return err
+			},
+		},
+		{
+			name:     "action",
+			response: ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateStopped)),
+			call: func(client *Client) error {
+				_, err := client.InstanceAction(instanceID, "STOP")
+				return err
+			},
+			queryName: "action",
+		},
+		{
+			name:     "terminate",
+			response: ociMockResponse(http.StatusNoContent, ``),
+			call: func(client *Client) error {
+				return client.TerminateInstance(instanceID, true)
+			},
+			queryName: "preserveBootVolume",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpCtx := &contexts.HTTPContext{
+				Responses: []*http.Response{tt.response},
+			}
+			client, err := NewClient(httpCtx, ociIntegrationContext())
+			require.NoError(t, err)
+
+			require.NoError(t, tt.call(client))
+			require.Len(t, httpCtx.Requests, 1)
+			assert.Equal(t, escapedPath, httpCtx.Requests[0].URL.EscapedPath())
+			if tt.queryName != "" {
+				assert.NotEmpty(t, httpCtx.Requests[0].URL.Query().Get(tt.queryName))
+			}
+		})
+	}
+}

--- a/pkg/integrations/oci/create_compute_instance.go
+++ b/pkg/integrations/oci/create_compute_instance.go
@@ -532,40 +532,13 @@ func (c *CreateComputeInstance) poll(ctx core.ActionHookContext) error {
 func (c *CreateComputeInstance) emitInstance(ctx core.ActionHookContext, client *Client, instance *Instance, metadata CreateInstanceExecutionMetadata) error {
 	payload := instanceToMap(instance)
 
-	c.enrichWithVNICIPs(ctx, client, instance, payload)
+	enrichInstanceWithVNICIPs(ctx.Logger, client, instance, payload)
 
 	if err := c.ensureBlockVolumeAttached(ctx, client, instance, &metadata, payload); err != nil {
 		return err
 	}
 
 	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, ComputeInstancePayloadType, []any{payload})
-}
-
-// enrichWithVNICIPs looks up the primary VNIC for the instance and adds publicIp / privateIp
-// to payload. Errors are logged as warnings so a transient VNIC-lookup failure does not block
-// the execution from completing.
-func (c *CreateComputeInstance) enrichWithVNICIPs(ctx core.ActionHookContext, client *Client, instance *Instance, payload map[string]any) {
-	attachments, err := client.ListVNICAttachments(instance.CompartmentID, instance.ID)
-	if err != nil {
-		ctx.Logger.Warnf("failed to list VNIC attachments for instance %s: %v", instance.ID, err)
-		return
-	}
-
-	for _, att := range attachments {
-		if att.LifecycleState != "ATTACHED" || att.VNICID == "" {
-			continue
-		}
-
-		vnic, err := client.GetVNIC(att.VNICID)
-		if err != nil {
-			ctx.Logger.Warnf("failed to get VNIC %s for instance %s: %v", att.VNICID, instance.ID, err)
-			return
-		}
-
-		payload["publicIp"] = vnic.PublicIP
-		payload["privateIp"] = vnic.PrivateIP
-		return
-	}
 }
 
 // ensureBlockVolumeAttached attaches the configured block volume (if any) to the instance and

--- a/pkg/integrations/oci/delete_instance.go
+++ b/pkg/integrations/oci/delete_instance.go
@@ -22,8 +22,9 @@ type DeleteInstanceSpec struct {
 }
 
 type DeleteInstanceMetadata struct {
-	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
-	PollErrors int    `json:"pollErrors" mapstructure:"pollErrors"`
+	InstanceID   string `json:"instanceId" mapstructure:"instanceId"`
+	PollErrors   int    `json:"pollErrors" mapstructure:"pollErrors"`
+	PollAttempts int    `json:"pollAttempts" mapstructure:"pollAttempts"`
 }
 
 func (c *DeleteInstance) Name() string {
@@ -135,20 +136,20 @@ func (c *DeleteInstance) Execute(ctx core.ExecutionContext) error {
 	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
 }
 
-func (c *DeleteInstance) Actions() []core.Action {
-	return []core.Action{
-		{Name: "poll", UserAccessible: false},
+func (c *DeleteInstance) Hooks() []core.Hook {
+	return []core.Hook{
+		{Name: "poll", Type: core.HookTypeInternal},
 	}
 }
 
-func (c *DeleteInstance) HandleAction(ctx core.ActionContext) error {
+func (c *DeleteInstance) HandleHook(ctx core.ActionHookContext) error {
 	if ctx.Name == "poll" {
 		return c.poll(ctx)
 	}
-	return fmt.Errorf("unknown action: %s", ctx.Name)
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
-func (c *DeleteInstance) poll(ctx core.ActionContext) error {
+func (c *DeleteInstance) poll(ctx core.ActionHookContext) error {
 	if ctx.ExecutionState.IsFinished() {
 		return nil
 	}
@@ -184,6 +185,7 @@ func (c *DeleteInstance) poll(ctx core.ActionContext) error {
 	}
 
 	metadata.PollErrors = 0
+	metadata.PollAttempts++
 	if err := ctx.Metadata.Set(metadata); err != nil {
 		return err
 	}
@@ -191,11 +193,14 @@ func (c *DeleteInstance) poll(ctx core.ActionContext) error {
 	if instance.LifecycleState == instanceStateTerminated {
 		return c.emitTerminated(ctx, metadata.InstanceID)
 	}
+	if metadata.PollAttempts >= maxPollAttempts {
+		return fmt.Errorf("timed out waiting for instance %s to terminate after %d poll attempts (state: %s)", metadata.InstanceID, metadata.PollAttempts, instance.LifecycleState)
+	}
 
 	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
 }
 
-func (c *DeleteInstance) emitTerminated(ctx core.ActionContext, instanceID string) error {
+func (c *DeleteInstance) emitTerminated(ctx core.ActionHookContext, instanceID string) error {
 	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, DeleteInstancePayloadType, []any{
 		map[string]any{
 			"instanceId":     instanceID,

--- a/pkg/integrations/oci/delete_instance.go
+++ b/pkg/integrations/oci/delete_instance.go
@@ -1,0 +1,221 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const DeleteInstancePayloadType = "oci.deleteInstance"
+
+type DeleteInstance struct{}
+
+type DeleteInstanceSpec struct {
+	InstanceID         string `json:"instanceId" mapstructure:"instanceId"`
+	PreserveBootVolume bool   `json:"preserveBootVolume" mapstructure:"preserveBootVolume"`
+}
+
+type DeleteInstanceMetadata struct {
+	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+	PollErrors int    `json:"pollErrors" mapstructure:"pollErrors"`
+}
+
+func (c *DeleteInstance) Name() string {
+	return "oci.deleteInstance"
+}
+
+func (c *DeleteInstance) Label() string {
+	return "Delete Instance"
+}
+
+func (c *DeleteInstance) Description() string {
+	return "Terminate an OCI Compute instance and wait for termination"
+}
+
+func (c *DeleteInstance) Documentation() string {
+	return `The Delete Instance component terminates an Oracle Cloud Infrastructure Compute instance and waits until OCI reports it as terminated.
+
+## Use Cases
+
+- **Cleanup workflows**: Tear down temporary instances after a test or deployment finishes
+- **Cost controls**: Delete unused Compute instances from automation
+- **Incident remediation**: Terminate compromised or unhealthy instances after replacement capacity exists
+
+## Configuration
+
+- **Instance**: The OCI Compute instance to terminate.
+- **Preserve Boot Volume**: When enabled, OCI preserves the boot volume after instance termination.
+
+## Output
+
+Emits a minimal deletion payload on the default output channel:
+- ` + "`instanceId`" + ` — instance OCID
+- ` + "`lifecycleState`" + ` — ` + "`TERMINATED`" + `
+`
+}
+
+func (c *DeleteInstance) Icon() string {
+	return "oci"
+}
+
+func (c *DeleteInstance) Color() string {
+	return "red"
+}
+
+func (c *DeleteInstance) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteInstance) ExampleOutput() map[string]any {
+	return exampleOutputDeleteInstance()
+}
+
+func (c *DeleteInstance) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instanceId",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Compute instance to terminate",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "preserveBootVolume",
+			Label:       "Preserve Boot Volume",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Togglable:   true,
+			Default:     false,
+			Description: "Preserve the boot volume after terminating the instance",
+		},
+	}
+}
+
+func (c *DeleteInstance) Setup(ctx core.SetupContext) error {
+	spec := DeleteInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if strings.TrimSpace(spec.InstanceID) == "" {
+		return errors.New("instanceId is required")
+	}
+	return nil
+}
+
+func (c *DeleteInstance) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	if err := client.TerminateInstance(spec.InstanceID, spec.PreserveBootVolume); err != nil {
+		return fmt.Errorf("failed to terminate instance: %w", err)
+	}
+
+	if err := ctx.Metadata.Set(DeleteInstanceMetadata{InstanceID: spec.InstanceID}); err != nil {
+		return err
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+}
+
+func (c *DeleteInstance) Actions() []core.Action {
+	return []core.Action{
+		{Name: "poll", UserAccessible: false},
+	}
+}
+
+func (c *DeleteInstance) HandleAction(ctx core.ActionContext) error {
+	if ctx.Name == "poll" {
+		return c.poll(ctx)
+	}
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (c *DeleteInstance) poll(ctx core.ActionContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata DeleteInstanceMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+	if metadata.InstanceID == "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	instance, err := client.GetInstance(metadata.InstanceID)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return c.emitTerminated(ctx, metadata.InstanceID)
+		}
+
+		metadata.PollErrors++
+		ctx.Logger.Warnf("failed to get instance %s (attempt %d/%d): %v", metadata.InstanceID, metadata.PollErrors, maxPollErrors, err)
+		if metadata.PollErrors >= maxPollErrors {
+			return fmt.Errorf("giving up polling instance %s after %d consecutive errors: %w", metadata.InstanceID, maxPollErrors, err)
+		}
+		if err := ctx.Metadata.Set(metadata); err != nil {
+			return err
+		}
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+	}
+
+	metadata.PollErrors = 0
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	if instance.LifecycleState == instanceStateTerminated {
+		return c.emitTerminated(ctx, metadata.InstanceID)
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+}
+
+func (c *DeleteInstance) emitTerminated(ctx core.ActionContext, instanceID string) error {
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, DeleteInstancePayloadType, []any{
+		map[string]any{
+			"instanceId":     instanceID,
+			"lifecycleState": instanceStateTerminated,
+		},
+	})
+}
+
+func (c *DeleteInstance) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteInstance) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteInstance) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteInstance) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/oci/delete_instance.go
+++ b/pkg/integrations/oci/delete_instance.go
@@ -159,7 +159,7 @@ func (c *DeleteInstance) poll(ctx core.ActionHookContext) error {
 		return fmt.Errorf("failed to decode metadata: %w", err)
 	}
 	if metadata.InstanceID == "" {
-		return nil
+		return fmt.Errorf("poll metadata is missing instanceId: execution state may be corrupted")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/oci/delete_instance.go
+++ b/pkg/integrations/oci/delete_instance.go
@@ -169,7 +169,8 @@ func (c *DeleteInstance) poll(ctx core.ActionHookContext) error {
 
 	instance, err := client.GetInstance(metadata.InstanceID)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") {
+		var apiErr *OCIAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 			return c.emitTerminated(ctx, metadata.InstanceID)
 		}
 

--- a/pkg/integrations/oci/delete_instance.go
+++ b/pkg/integrations/oci/delete_instance.go
@@ -17,7 +17,7 @@ const DeleteInstancePayloadType = "oci.deleteInstance"
 type DeleteInstance struct{}
 
 type DeleteInstanceSpec struct {
-	InstanceID         string `json:"instanceId" mapstructure:"instanceId"`
+	Instance           string `json:"instance" mapstructure:"instance"`
 	PreserveBootVolume bool   `json:"preserveBootVolume" mapstructure:"preserveBootVolume"`
 }
 
@@ -80,7 +80,7 @@ func (c *DeleteInstance) ExampleOutput() map[string]any {
 func (c *DeleteInstance) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instanceId",
+			Name:        "instance",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -108,8 +108,8 @@ func (c *DeleteInstance) Setup(ctx core.SetupContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.InstanceID) == "" {
-		return errors.New("instanceId is required")
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
 	}
 	return nil
 }
@@ -125,11 +125,11 @@ func (c *DeleteInstance) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if err := client.TerminateInstance(spec.InstanceID, spec.PreserveBootVolume); err != nil {
+	if err := client.TerminateInstance(spec.Instance, spec.PreserveBootVolume); err != nil {
 		return fmt.Errorf("failed to terminate instance: %w", err)
 	}
 
-	if err := ctx.Metadata.Set(DeleteInstanceMetadata{InstanceID: spec.InstanceID}); err != nil {
+	if err := ctx.Metadata.Set(DeleteInstanceMetadata{InstanceID: spec.Instance}); err != nil {
 		return err
 	}
 

--- a/pkg/integrations/oci/delete_instance_test.go
+++ b/pkg/integrations/oci/delete_instance_test.go
@@ -56,7 +56,7 @@ func Test__DeleteInstance__PollEmitsWhenTerminated(t *testing.T) {
 	}
 	executionState := &contexts.ExecutionStateContext{}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:        "poll",
 		HTTP:        httpCtx,
 		Integration: ociIntegrationContext(),
@@ -86,7 +86,7 @@ func Test__DeleteInstance__PollTreats404AsTerminated(t *testing.T) {
 	}
 	executionState := &contexts.ExecutionStateContext{}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:        "poll",
 		HTTP:        httpCtx,
 		Integration: ociIntegrationContext(),
@@ -115,7 +115,7 @@ func Test__DeleteInstance__PollHandlesTransientErrors(t *testing.T) {
 	}
 	requests := &contexts.RequestContext{}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:           "poll",
 		HTTP:           httpCtx,
 		Integration:    ociIntegrationContext(),
@@ -138,7 +138,7 @@ func Test__DeleteInstance__PollStopsAfterMaxErrors(t *testing.T) {
 		},
 	}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:        "poll",
 		HTTP:        httpCtx,
 		Integration: ociIntegrationContext(),
@@ -152,4 +152,28 @@ func Test__DeleteInstance__PollStopsAfterMaxErrors(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "giving up polling instance")
+}
+
+func Test__DeleteInstance__PollStopsAfterMaxAttempts(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateTerminating)),
+		},
+	}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID, PollAttempts: maxPollAttempts - 1},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for instance")
 }

--- a/pkg/integrations/oci/delete_instance_test.go
+++ b/pkg/integrations/oci/delete_instance_test.go
@@ -1,0 +1,155 @@
+package oci
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteInstance__Setup(t *testing.T) {
+	component := &DeleteInstance{}
+
+	err := component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": ""},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instanceId is required")
+}
+
+func Test__DeleteInstance__Execute(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusNoContent, ``),
+		},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{"instanceId": testInstanceID, "preserveBootVolume": true},
+		HTTP:          httpCtx,
+		Integration:   ociIntegrationContext(),
+		Metadata:      metadata,
+		Requests:      requests,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, http.MethodDelete, httpCtx.Requests[0].Method)
+	assert.Equal(t, "true", httpCtx.Requests[0].URL.Query().Get("preserveBootVolume"))
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, DeleteInstanceMetadata{InstanceID: testInstanceID}, metadata.Metadata)
+}
+
+func Test__DeleteInstance__PollEmitsWhenTerminated(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateTerminated)),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: executionState,
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, DeleteInstancePayloadType, executionState.Type)
+	require.Len(t, executionState.Payloads, 1)
+	wrapped := executionState.Payloads[0].(map[string]any)
+	data := wrapped["data"].(map[string]any)
+	assert.Equal(t, instanceStateTerminated, data["lifecycleState"])
+}
+
+func Test__DeleteInstance__PollTreats404AsTerminated(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusNotFound, `{"code":"NotAuthorizedOrNotFound"}`),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: executionState,
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, DeleteInstancePayloadType, executionState.Type)
+}
+
+func Test__DeleteInstance__PollHandlesTransientErrors(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusInternalServerError, `{"code":"InternalError"}`),
+		},
+	}
+	metadata := &contexts.MetadataContext{
+		Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID},
+	}
+	requests := &contexts.RequestContext{}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:           "poll",
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		Metadata:       metadata,
+		Requests:       requests,
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, DeleteInstanceMetadata{InstanceID: testInstanceID, PollErrors: 1}, metadata.Metadata)
+}
+
+func Test__DeleteInstance__PollStopsAfterMaxErrors(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusInternalServerError, `{"code":"InternalError"}`),
+		},
+	}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID, PollErrors: maxPollErrors - 1},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "giving up polling instance")
+}

--- a/pkg/integrations/oci/delete_instance_test.go
+++ b/pkg/integrations/oci/delete_instance_test.go
@@ -147,6 +147,35 @@ func Test__DeleteInstance__PollHandlesTransientErrors(t *testing.T) {
 	assert.Equal(t, DeleteInstanceMetadata{InstanceID: testInstanceID, PollErrors: 1}, metadata.Metadata)
 }
 
+func Test__DeleteInstance__PollDoesNotTreatNon404BodyAsTerminated(t *testing.T) {
+	component := &DeleteInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusInternalServerError, `{"message":"upstream mentioned 404"}`),
+		},
+	}
+	metadata := &contexts.MetadataContext{
+		Metadata: DeleteInstanceMetadata{InstanceID: testInstanceID},
+	}
+	requests := &contexts.RequestContext{}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:           "poll",
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		Metadata:       metadata,
+		Requests:       requests,
+		ExecutionState: executionState,
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, executionState.Passed)
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, DeleteInstanceMetadata{InstanceID: testInstanceID, PollErrors: 1}, metadata.Metadata)
+}
+
 func Test__DeleteInstance__PollStopsAfterMaxErrors(t *testing.T) {
 	component := &DeleteInstance{}
 	httpCtx := &contexts.HTTPContext{

--- a/pkg/integrations/oci/delete_instance_test.go
+++ b/pkg/integrations/oci/delete_instance_test.go
@@ -103,6 +103,23 @@ func Test__DeleteInstance__PollTreats404AsTerminated(t *testing.T) {
 	assert.Equal(t, DeleteInstancePayloadType, executionState.Type)
 }
 
+func Test__DeleteInstance__PollErrorsWhenMetadataMissingInstanceID(t *testing.T) {
+	component := &DeleteInstance{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:           "poll",
+		HTTP:           &contexts.HTTPContext{},
+		Integration:    ociIntegrationContext(),
+		Metadata:       &contexts.MetadataContext{Metadata: DeleteInstanceMetadata{}},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll metadata is missing instanceId")
+}
+
 func Test__DeleteInstance__PollHandlesTransientErrors(t *testing.T) {
 	component := &DeleteInstance{}
 	httpCtx := &contexts.HTTPContext{

--- a/pkg/integrations/oci/delete_instance_test.go
+++ b/pkg/integrations/oci/delete_instance_test.go
@@ -14,11 +14,11 @@ func Test__DeleteInstance__Setup(t *testing.T) {
 	component := &DeleteInstance{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": ""},
+		Configuration: map[string]any{"instance": ""},
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instanceId is required")
+	assert.Contains(t, err.Error(), "instance is required")
 }
 
 func Test__DeleteInstance__Execute(t *testing.T) {
@@ -32,7 +32,7 @@ func Test__DeleteInstance__Execute(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "preserveBootVolume": true},
+		Configuration: map[string]any{"instance": testInstanceID, "preserveBootVolume": true},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,

--- a/pkg/integrations/oci/example.go
+++ b/pkg/integrations/oci/example.go
@@ -76,3 +76,53 @@ var exampleOutputDeleteFunctionCache map[string]any
 func exampleOutputDeleteFunction() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteFunctionOnce, exampleOutputDeleteFunctionBytes, &exampleOutputDeleteFunctionCache)
 }
+
+//go:embed example_output_get_instance.json
+var exampleOutputGetInstanceBytes []byte
+
+var exampleOutputGetInstanceOnce sync.Once
+var exampleOutputGetInstanceCache map[string]any
+
+func exampleOutputGetInstance() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetInstanceOnce, exampleOutputGetInstanceBytes, &exampleOutputGetInstanceCache)
+}
+
+//go:embed example_output_update_instance.json
+var exampleOutputUpdateInstanceBytes []byte
+
+var exampleOutputUpdateInstanceOnce sync.Once
+var exampleOutputUpdateInstanceCache map[string]any
+
+func exampleOutputUpdateInstance() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateInstanceOnce, exampleOutputUpdateInstanceBytes, &exampleOutputUpdateInstanceCache)
+}
+
+//go:embed example_output_manage_instance_power.json
+var exampleOutputManageInstancePowerBytes []byte
+
+var exampleOutputManageInstancePowerOnce sync.Once
+var exampleOutputManageInstancePowerCache map[string]any
+
+func exampleOutputManageInstancePower() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputManageInstancePowerOnce, exampleOutputManageInstancePowerBytes, &exampleOutputManageInstancePowerCache)
+}
+
+//go:embed example_output_delete_instance.json
+var exampleOutputDeleteInstanceBytes []byte
+
+var exampleOutputDeleteInstanceOnce sync.Once
+var exampleOutputDeleteInstanceCache map[string]any
+
+func exampleOutputDeleteInstance() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteInstanceOnce, exampleOutputDeleteInstanceBytes, &exampleOutputDeleteInstanceCache)
+}
+
+//go:embed example_data_on_instance_state_change.json
+var exampleDataOnInstanceStateChangeBytes []byte
+
+var exampleDataOnInstanceStateChangeOnce sync.Once
+var exampleDataOnInstanceStateChangeCache map[string]any
+
+func exampleDataOnInstanceStateChange() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnInstanceStateChangeOnce, exampleDataOnInstanceStateChangeBytes, &exampleDataOnInstanceStateChangeCache)
+}

--- a/pkg/integrations/oci/example_data_on_instance_state_change.json
+++ b/pkg/integrations/oci/example_data_on_instance_state_change.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "cloudEventsVersion": "0.1",
+    "contentType": "application/json",
+    "data": {
+      "additionalDetails": {
+        "imageId": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaa4ktlslmw2fqu5trx2xk3rnnqozgstuqutjm3ffusi6juo3ef4zaq",
+        "shape": "VM.Standard.E2.1.Micro",
+        "type": "CustomerVmi"
+      },
+      "availabilityDomain": "pYRG:EU-FRANKFURT-1-AD-3",
+      "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq",
+      "compartmentName": "root",
+      "definedTags": {},
+      "freeformTags": {},
+      "resourceId": "ocid1.instance.oc1.eu-frankfurt-1.antheljthvjhcwice6b33efkswzlk56zv4n5rcnb7xf4gsdlvuqlihvszjlq",
+      "resourceName": "test-instance-12"
+    },
+    "eventID": "8fc0df4c-ea5d-4438-a817-db7fa6440b8a",
+    "eventTime": "2026-04-22T20:34:54Z",
+    "eventType": "com.oraclecloud.computeapi.stopinstance.end",
+    "eventTypeVersion": "2.0",
+    "extensions": {
+      "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq"
+    },
+    "source": "ComputeApi"
+  },
+  "timestamp": "2026-04-22T20:35:05.079372195Z",
+  "type": "oci.onInstanceStateChange"
+}

--- a/pkg/integrations/oci/example_data_on_instance_state_change.json
+++ b/pkg/integrations/oci/example_data_on_instance_state_change.json
@@ -5,6 +5,7 @@
     "data": {
       "additionalDetails": {
         "imageId": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaa4ktlslmw2fqu5trx2xk3rnnqozgstuqutjm3ffusi6juo3ef4zaq",
+        "instanceActionType": "stop",
         "shape": "VM.Standard.E2.1.Micro",
         "type": "CustomerVmi"
       },
@@ -18,7 +19,7 @@
     },
     "eventID": "8fc0df4c-ea5d-4438-a817-db7fa6440b8a",
     "eventTime": "2026-04-22T20:34:54Z",
-    "eventType": "com.oraclecloud.computeapi.stopinstance.end",
+    "eventType": "com.oraclecloud.computeapi.instanceaction.end",
     "eventTypeVersion": "2.0",
     "extensions": {
       "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaorle4tqd7rmhv2w7h37k32u6bskjrsnbnfem6i7qjupvexidmwpq"

--- a/pkg/integrations/oci/example_output_delete_instance.json
+++ b/pkg/integrations/oci/example_output_delete_instance.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "lifecycleState": "TERMINATED"
+  },
+  "timestamp": "2026-04-22T20:40:00.000Z",
+  "type": "oci.deleteInstance"
+}

--- a/pkg/integrations/oci/example_output_get_instance.json
+++ b/pkg/integrations/oci/example_output_get_instance.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "lifecycleState": "RUNNING",
+    "shape": "VM.Standard.E2.1.Micro",
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "region": "eu-frankfurt-1",
+    "timeCreated": "2026-04-22T20:31:25.145Z",
+    "publicIp": "192.0.2.1",
+    "privateIp": "10.0.0.17"
+  },
+  "timestamp": "2026-04-22T20:32:00.000Z",
+  "type": "oci.getInstance"
+}

--- a/pkg/integrations/oci/example_output_manage_instance_power.json
+++ b/pkg/integrations/oci/example_output_manage_instance_power.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "displayName": "test-instance-12",
+    "lifecycleState": "STOPPED",
+    "shape": "VM.Standard.E2.1.Micro",
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "region": "eu-frankfurt-1",
+    "timeCreated": "2026-04-22T20:31:25.145Z"
+  },
+  "timestamp": "2026-04-22T20:35:00.000Z",
+  "type": "oci.manageInstancePower"
+}

--- a/pkg/integrations/oci/example_output_update_instance.json
+++ b/pkg/integrations/oci/example_output_update_instance.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "instanceId": "ocid1.instance.oc1.eu-frankfurt-1.aaaaExample1234567890",
+    "displayName": "test-instance-renamed",
+    "lifecycleState": "RUNNING",
+    "shape": "VM.Standard.E2.1.Micro",
+    "availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+    "compartmentId": "ocid1.tenancy.oc1..aaaaaaaExample1234567890",
+    "region": "eu-frankfurt-1",
+    "timeCreated": "2026-04-22T20:31:25.145Z",
+    "publicIp": "192.0.2.1",
+    "privateIp": "10.0.0.17"
+  },
+  "timestamp": "2026-04-22T20:33:00.000Z",
+  "type": "oci.updateInstance"
+}

--- a/pkg/integrations/oci/get_instance.go
+++ b/pkg/integrations/oci/get_instance.go
@@ -122,38 +122,17 @@ func (c *GetInstance) Execute(ctx core.ExecutionContext) error {
 	}
 
 	payload := instanceToMap(instance)
-	addInstanceIPAddresses(client, instance, payload)
+	enrichInstanceWithVNICIPs(ctx.Logger, client, instance, payload)
 
 	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, GetInstancePayloadType, []any{payload})
 }
 
-func addInstanceIPAddresses(client *Client, instance *Instance, payload map[string]any) {
-	attachments, err := client.ListVNICAttachments(instance.CompartmentID, instance.ID)
-	if err != nil || len(attachments) == 0 {
-		return
-	}
-
-	for _, att := range attachments {
-		if att.LifecycleState != "ATTACHED" || att.VNICID == "" {
-			continue
-		}
-
-		vnic, err := client.GetVNIC(att.VNICID)
-		if err != nil {
-			return
-		}
-		payload["publicIp"] = vnic.PublicIP
-		payload["privateIp"] = vnic.PrivateIP
-		return
-	}
+func (c *GetInstance) Hooks() []core.Hook {
+	return []core.Hook{}
 }
 
-func (c *GetInstance) Actions() []core.Action {
-	return []core.Action{}
-}
-
-func (c *GetInstance) HandleAction(ctx core.ActionContext) error {
-	return fmt.Errorf("unknown action: %s", ctx.Name)
+func (c *GetInstance) HandleHook(ctx core.ActionHookContext) error {
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
 func (c *GetInstance) Cancel(ctx core.ExecutionContext) error {

--- a/pkg/integrations/oci/get_instance.go
+++ b/pkg/integrations/oci/get_instance.go
@@ -1,0 +1,173 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetInstancePayloadType = "oci.getInstance"
+
+type GetInstance struct{}
+
+type GetInstanceSpec struct {
+	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+}
+
+func (c *GetInstance) Name() string {
+	return "oci.getInstance"
+}
+
+func (c *GetInstance) Label() string {
+	return "Get Instance"
+}
+
+func (c *GetInstance) Description() string {
+	return "Fetch details for an OCI Compute instance"
+}
+
+func (c *GetInstance) Documentation() string {
+	return `The Get Instance component fetches the latest details for an Oracle Cloud Infrastructure Compute instance.
+
+## Use Cases
+
+- **Inventory checks**: Read instance state, shape, region, and network addresses during a workflow
+- **Deployment gates**: Verify a target instance exists and is in the expected lifecycle state
+- **Audit workflows**: Capture instance metadata before another operation runs
+
+## Configuration
+
+- **Instance**: The OCI Compute instance to fetch.
+
+## Output
+
+Emits the instance details on the default output channel, including:
+- ` + "`instanceId`" + ` — instance OCID
+- ` + "`displayName`" + ` — instance display name
+- ` + "`lifecycleState`" + ` — current lifecycle state
+- ` + "`publicIp`" + ` — public IP address, if assigned
+- ` + "`privateIp`" + ` — primary private IP address, if available
+- ` + "`shape`" + ` — the instance shape
+- ` + "`availabilityDomain`" + ` — the availability domain
+- ` + "`compartmentId`" + ` — the compartment OCID
+- ` + "`region`" + ` — the region
+- ` + "`timeCreated`" + ` — ISO-8601 creation timestamp
+`
+}
+
+func (c *GetInstance) Icon() string {
+	return "oci"
+}
+
+func (c *GetInstance) Color() string {
+	return "red"
+}
+
+func (c *GetInstance) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetInstance) ExampleOutput() map[string]any {
+	return exampleOutputGetInstance()
+}
+
+func (c *GetInstance) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instanceId",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Compute instance to fetch",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+	}
+}
+
+func (c *GetInstance) Setup(ctx core.SetupContext) error {
+	spec := GetInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if strings.TrimSpace(spec.InstanceID) == "" {
+		return errors.New("instanceId is required")
+	}
+	return nil
+}
+
+func (c *GetInstance) Execute(ctx core.ExecutionContext) error {
+	spec := GetInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	instance, err := client.GetInstance(spec.InstanceID)
+	if err != nil {
+		return fmt.Errorf("failed to get instance: %w", err)
+	}
+
+	payload := instanceToMap(instance)
+	addInstanceIPAddresses(client, instance, payload)
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, GetInstancePayloadType, []any{payload})
+}
+
+func addInstanceIPAddresses(client *Client, instance *Instance, payload map[string]any) {
+	attachments, err := client.ListVNICAttachments(instance.CompartmentID, instance.ID)
+	if err != nil || len(attachments) == 0 {
+		return
+	}
+
+	for _, att := range attachments {
+		if att.LifecycleState != "ATTACHED" || att.VNICID == "" {
+			continue
+		}
+
+		vnic, err := client.GetVNIC(att.VNICID)
+		if err != nil {
+			return
+		}
+		payload["publicIp"] = vnic.PublicIP
+		payload["privateIp"] = vnic.PrivateIP
+		return
+	}
+}
+
+func (c *GetInstance) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *GetInstance) HandleAction(ctx core.ActionContext) error {
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (c *GetInstance) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetInstance) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetInstance) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetInstance) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/oci/get_instance.go
+++ b/pkg/integrations/oci/get_instance.go
@@ -17,7 +17,7 @@ const GetInstancePayloadType = "oci.getInstance"
 type GetInstance struct{}
 
 type GetInstanceSpec struct {
-	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+	Instance string `json:"instance" mapstructure:"instance"`
 }
 
 func (c *GetInstance) Name() string {
@@ -80,7 +80,7 @@ func (c *GetInstance) ExampleOutput() map[string]any {
 func (c *GetInstance) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instanceId",
+			Name:        "instance",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -99,8 +99,8 @@ func (c *GetInstance) Setup(ctx core.SetupContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.InstanceID) == "" {
-		return errors.New("instanceId is required")
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func (c *GetInstance) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	instance, err := client.GetInstance(spec.InstanceID)
+	instance, err := client.GetInstance(spec.Instance)
 	if err != nil {
 		return fmt.Errorf("failed to get instance: %w", err)
 	}

--- a/pkg/integrations/oci/get_instance_test.go
+++ b/pkg/integrations/oci/get_instance_test.go
@@ -1,0 +1,59 @@
+package oci
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetInstance__Setup(t *testing.T) {
+	component := &GetInstance{}
+
+	err := component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": ""},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instanceId is required")
+}
+
+func Test__GetInstance__Execute(t *testing.T) {
+	component := &GetInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+			ociMockResponse(http.StatusOK, `[{"vnicId":"ocid1.vnic.oc1.test","lifecycleState":"ATTACHED"}]`),
+			ociMockResponse(http.StatusOK, `{"id":"ocid1.vnic.oc1.test","publicIp":"192.0.2.1","privateIp":"10.0.0.17"}`),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"instanceId": testInstanceID},
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 3)
+	assert.Equal(t, http.MethodGet, httpCtx.Requests[0].Method)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/20160918/instances/"+testInstanceID)
+	assert.Contains(t, httpCtx.Requests[1].URL.String(), "/20160918/vnicAttachments")
+	assert.Contains(t, httpCtx.Requests[2].URL.String(), "/20160918/vnics/ocid1.vnic.oc1.test")
+
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+	assert.Equal(t, GetInstancePayloadType, executionState.Type)
+	require.Len(t, executionState.Payloads, 1)
+
+	wrapped := executionState.Payloads[0].(map[string]any)
+	data := wrapped["data"].(map[string]any)
+	assert.Equal(t, testInstanceID, data["instanceId"])
+	assert.Equal(t, "192.0.2.1", data["publicIp"])
+	assert.Equal(t, "10.0.0.17", data["privateIp"])
+}

--- a/pkg/integrations/oci/get_instance_test.go
+++ b/pkg/integrations/oci/get_instance_test.go
@@ -14,11 +14,11 @@ func Test__GetInstance__Setup(t *testing.T) {
 	component := &GetInstance{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": ""},
+		Configuration: map[string]any{"instance": ""},
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instanceId is required")
+	assert.Contains(t, err.Error(), "instance is required")
 }
 
 func Test__GetInstance__Execute(t *testing.T) {
@@ -33,7 +33,7 @@ func Test__GetInstance__Execute(t *testing.T) {
 	executionState := &contexts.ExecutionStateContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration:  map[string]any{"instanceId": testInstanceID},
+		Configuration:  map[string]any{"instance": testInstanceID},
 		HTTP:           httpCtx,
 		Integration:    ociIntegrationContext(),
 		ExecutionState: executionState,

--- a/pkg/integrations/oci/instance_configuration_test.go
+++ b/pkg/integrations/oci/instance_configuration_test.go
@@ -1,0 +1,35 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+func Test__InstanceComponents__ConfigurationUsesInstanceResource(t *testing.T) {
+	components := []struct {
+		name   string
+		fields []configuration.Field
+	}{
+		{name: "get", fields: (&GetInstance{}).Configuration()},
+		{name: "update", fields: (&UpdateInstance{}).Configuration()},
+		{name: "power", fields: (&ManageInstancePower{}).Configuration()},
+		{name: "delete", fields: (&DeleteInstance{}).Configuration()},
+	}
+
+	for _, component := range components {
+		t.Run(component.name, func(t *testing.T) {
+			require.NotEmpty(t, component.fields)
+			field := component.fields[0]
+
+			assert.Equal(t, "instanceId", field.Name)
+			assert.Equal(t, "Instance", field.Label)
+			assert.Equal(t, configuration.FieldTypeIntegrationResource, field.Type)
+			require.NotNil(t, field.TypeOptions)
+			require.NotNil(t, field.TypeOptions.Resource)
+			assert.Equal(t, ResourceTypeInstance, field.TypeOptions.Resource.Type)
+		})
+	}
+}

--- a/pkg/integrations/oci/instance_configuration_test.go
+++ b/pkg/integrations/oci/instance_configuration_test.go
@@ -24,7 +24,11 @@ func Test__InstanceComponents__ConfigurationUsesInstanceResource(t *testing.T) {
 			require.NotEmpty(t, component.fields)
 			field := component.fields[0]
 
-			assert.Equal(t, "instanceId", field.Name)
+			expectedName := "instanceId"
+			if component.name == "power" {
+				expectedName = "instance"
+			}
+			assert.Equal(t, expectedName, field.Name)
 			assert.Equal(t, "Instance", field.Label)
 			assert.Equal(t, configuration.FieldTypeIntegrationResource, field.Type)
 			require.NotNil(t, field.TypeOptions)

--- a/pkg/integrations/oci/instance_configuration_test.go
+++ b/pkg/integrations/oci/instance_configuration_test.go
@@ -24,7 +24,7 @@ func Test__InstanceComponents__ConfigurationUsesInstanceResource(t *testing.T) {
 			require.NotEmpty(t, component.fields)
 			field := component.fields[0]
 
-			assert.Equal(t, "instanceId", field.Name)
+			assert.Equal(t, "instance", field.Name)
 			assert.Equal(t, "Instance", field.Label)
 			assert.Equal(t, configuration.FieldTypeIntegrationResource, field.Type)
 			require.NotNil(t, field.TypeOptions)

--- a/pkg/integrations/oci/instance_configuration_test.go
+++ b/pkg/integrations/oci/instance_configuration_test.go
@@ -24,11 +24,7 @@ func Test__InstanceComponents__ConfigurationUsesInstanceResource(t *testing.T) {
 			require.NotEmpty(t, component.fields)
 			field := component.fields[0]
 
-			expectedName := "instanceId"
-			if component.name == "power" {
-				expectedName = "instance"
-			}
-			assert.Equal(t, expectedName, field.Name)
+			assert.Equal(t, "instanceId", field.Name)
 			assert.Equal(t, "Instance", field.Label)
 			assert.Equal(t, configuration.FieldTypeIntegrationResource, field.Type)
 			require.NotNil(t, field.TypeOptions)

--- a/pkg/integrations/oci/instance_helpers.go
+++ b/pkg/integrations/oci/instance_helpers.go
@@ -1,0 +1,82 @@
+package oci
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+func extractWebhookID(webhookURL string) (string, error) {
+	parsedURL, err := url.Parse(webhookURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse webhook URL: %w", err)
+	}
+
+	webhookID := strings.Trim(strings.TrimRight(parsedURL.Path, "/"), "/")
+	if webhookID == "" {
+		return "", fmt.Errorf("webhook URL path is empty")
+	}
+
+	segments := strings.Split(webhookID, "/")
+	return segments[len(segments)-1], nil
+}
+
+func enrichInstanceWithVNICIPs(logger *log.Entry, client *Client, instance *Instance, payload map[string]any) {
+	attachments, err := client.ListVNICAttachments(instance.CompartmentID, instance.ID)
+	if err != nil {
+		if logger != nil {
+			logger.Warnf("failed to list VNIC attachments for instance %s: %v", instance.ID, err)
+		}
+		return
+	}
+
+	for _, att := range attachments {
+		if att.LifecycleState != "ATTACHED" || att.VNICID == "" {
+			continue
+		}
+
+		vnic, err := client.GetVNIC(att.VNICID)
+		if err != nil {
+			if logger != nil {
+				logger.Warnf("failed to get VNIC %s for instance %s: %v", att.VNICID, instance.ID, err)
+			}
+			return
+		}
+
+		payload["publicIp"] = vnic.PublicIP
+		payload["privateIp"] = vnic.PrivateIP
+		return
+	}
+}
+
+func confirmONSSubscription(ctx core.WebhookRequestContext, confirmURL string) (int, *core.WebhookResponseBody, error) {
+	if err := validateONSConfirmationURL(confirmURL); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("refusing ONS confirmation URL: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, confirmURL, nil)
+	if err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to build ONS confirmation request: %w", err)
+	}
+
+	resp, err := ctx.HTTP.Do(req)
+	if err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to confirm ONS subscription: %w", err)
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return http.StatusInternalServerError, nil, fmt.Errorf("ONS confirmation returned %d", resp.StatusCode)
+	}
+
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/oci/instance_helpers.go
+++ b/pkg/integrations/oci/instance_helpers.go
@@ -4,27 +4,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/core"
 )
-
-func extractWebhookID(webhookURL string) (string, error) {
-	parsedURL, err := url.Parse(webhookURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse webhook URL: %w", err)
-	}
-
-	webhookID := strings.Trim(strings.TrimRight(parsedURL.Path, "/"), "/")
-	if webhookID == "" {
-		return "", fmt.Errorf("webhook URL path is empty")
-	}
-
-	segments := strings.Split(webhookID, "/")
-	return segments[len(segments)-1], nil
-}
 
 func enrichInstanceWithVNICIPs(logger *log.Entry, client *Client, instance *Instance, payload map[string]any) {
 	attachments, err := client.ListVNICAttachments(instance.CompartmentID, instance.ID)

--- a/pkg/integrations/oci/list_resources.go
+++ b/pkg/integrations/oci/list_resources.go
@@ -18,6 +18,7 @@ const (
 	ResourceTypeFunction            = "function"
 	ResourceTypeContainerRepository = "containerRepository"
 	ResourceTypeContainerImage      = "containerImage"
+	ResourceTypeInstance            = "instance"
 )
 
 func (o *OCI) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
@@ -44,6 +45,8 @@ func (o *OCI) ListResources(resourceType string, ctx core.ListResourcesContext) 
 		return listContainerRepositories(ctx)
 	case ResourceTypeContainerImage:
 		return listContainerImages(ctx)
+	case ResourceTypeInstance:
+		return listInstances(ctx)
 	default:
 		return nil, fmt.Errorf("unsupported resource type: %s", resourceType)
 	}
@@ -409,6 +412,51 @@ func listFunctions(ctx core.ListResourcesContext) ([]core.IntegrationResource, e
 			Name: fn.DisplayName,
 			ID:   fn.ID,
 		})
+	}
+
+	return resources, nil
+}
+
+func listInstances(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	compartmentIDs := []string{client.tenancyOCID}
+	compartments, err := client.ListCompartments()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list compartments: %w", err)
+	}
+
+	for _, c := range compartments {
+		if c.LifecycleState == "ACTIVE" {
+			compartmentIDs = append(compartmentIDs, c.ID)
+		}
+	}
+
+	resources := []core.IntegrationResource{}
+	for _, compartmentID := range compartmentIDs {
+		instances, err := client.ListInstances(compartmentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list instances in compartment %s: %w", compartmentID, err)
+		}
+
+		for _, instance := range instances {
+			if instance.LifecycleState == instanceStateTerminated || instance.LifecycleState == instanceStateTerminating {
+				continue
+			}
+
+			name := instance.DisplayName
+			if name == "" {
+				name = instance.ID
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: ResourceTypeInstance,
+				Name: name,
+				ID:   instance.ID,
+			})
+		}
 	}
 
 	return resources, nil

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -33,10 +33,11 @@ type ManageInstancePowerSpec struct {
 }
 
 type ManageInstancePowerMetadata struct {
-	InstanceID  string `json:"instanceId" mapstructure:"instanceId"`
-	Action      string `json:"action" mapstructure:"action"`
-	TargetState string `json:"targetState" mapstructure:"targetState"`
-	PollErrors  int    `json:"pollErrors" mapstructure:"pollErrors"`
+	InstanceID   string `json:"instanceId" mapstructure:"instanceId"`
+	Action       string `json:"action" mapstructure:"action"`
+	TargetState  string `json:"targetState" mapstructure:"targetState"`
+	PollErrors   int    `json:"pollErrors" mapstructure:"pollErrors"`
+	PollAttempts int    `json:"pollAttempts" mapstructure:"pollAttempts"`
 }
 
 func (c *ManageInstancePower) Name() string {
@@ -174,20 +175,20 @@ func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
 	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
 }
 
-func (c *ManageInstancePower) Actions() []core.Action {
-	return []core.Action{
-		{Name: "poll", UserAccessible: false},
+func (c *ManageInstancePower) Hooks() []core.Hook {
+	return []core.Hook{
+		{Name: "poll", Type: core.HookTypeInternal},
 	}
 }
 
-func (c *ManageInstancePower) HandleAction(ctx core.ActionContext) error {
+func (c *ManageInstancePower) HandleHook(ctx core.ActionHookContext) error {
 	if ctx.Name == "poll" {
 		return c.poll(ctx)
 	}
-	return fmt.Errorf("unknown action: %s", ctx.Name)
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
-func (c *ManageInstancePower) poll(ctx core.ActionContext) error {
+func (c *ManageInstancePower) poll(ctx core.ActionHookContext) error {
 	if ctx.ExecutionState.IsFinished() {
 		return nil
 	}
@@ -219,12 +220,16 @@ func (c *ManageInstancePower) poll(ctx core.ActionContext) error {
 	}
 
 	metadata.PollErrors = 0
+	metadata.PollAttempts++
 	if err := ctx.Metadata.Set(metadata); err != nil {
 		return err
 	}
 
 	if instance.LifecycleState == metadata.TargetState {
 		return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, ManageInstancePowerPayloadType, []any{instanceToMap(instance)})
+	}
+	if metadata.PollAttempts >= maxPollAttempts {
+		return fmt.Errorf("timed out waiting for instance %s to reach %s after %d poll attempts (state: %s)", metadata.InstanceID, metadata.TargetState, metadata.PollAttempts, instance.LifecycleState)
 	}
 
 	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -28,6 +28,7 @@ var instancePowerTargetStates = map[string]string{
 type ManageInstancePower struct{}
 
 type ManageInstancePowerSpec struct {
+	Instance   string `json:"instance" mapstructure:"instance"`
 	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
 	Action     string `json:"action" mapstructure:"action"`
 }
@@ -99,7 +100,7 @@ func (c *ManageInstancePower) ExampleOutput() map[string]any {
 func (c *ManageInstancePower) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instanceId",
+			Name:        "instance",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -131,13 +132,20 @@ func (c *ManageInstancePower) Configuration() []configuration.Field {
 	}
 }
 
+func (s ManageInstancePowerSpec) selectedInstance() string {
+	if strings.TrimSpace(s.Instance) != "" {
+		return s.Instance
+	}
+	return s.InstanceID
+}
+
 func (c *ManageInstancePower) Setup(ctx core.SetupContext) error {
 	spec := ManageInstancePowerSpec{}
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.InstanceID) == "" {
-		return errors.New("instanceId is required")
+	if strings.TrimSpace(spec.selectedInstance()) == "" {
+		return errors.New("instance is required")
 	}
 	if strings.TrimSpace(spec.Action) == "" {
 		return errors.New("action is required")
@@ -153,19 +161,20 @@ func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
+	instance := spec.selectedInstance()
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if _, err := client.InstanceAction(spec.InstanceID, spec.Action); err != nil {
+	if _, err := client.InstanceAction(instance, spec.Action); err != nil {
 		return fmt.Errorf("failed to run instance action: %w", err)
 	}
 
 	targetState := instancePowerTargetStates[spec.Action]
 	if err := ctx.Metadata.Set(ManageInstancePowerMetadata{
-		InstanceID:  spec.InstanceID,
+		InstanceID:  instance,
 		Action:      spec.Action,
 		TargetState: targetState,
 	}); err != nil {

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -1,0 +1,247 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const (
+	ManageInstancePowerPayloadType = "oci.manageInstancePower"
+	instanceStateStopped           = "STOPPED"
+)
+
+var instancePowerTargetStates = map[string]string{
+	"START":     instanceStateRunning,
+	"STOP":      instanceStateStopped,
+	"SOFTSTOP":  instanceStateStopped,
+	"RESET":     instanceStateRunning,
+	"SOFTRESET": instanceStateRunning,
+}
+
+type ManageInstancePower struct{}
+
+type ManageInstancePowerSpec struct {
+	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+	Action     string `json:"action" mapstructure:"action"`
+}
+
+type ManageInstancePowerMetadata struct {
+	InstanceID  string `json:"instanceId" mapstructure:"instanceId"`
+	Action      string `json:"action" mapstructure:"action"`
+	TargetState string `json:"targetState" mapstructure:"targetState"`
+	PollErrors  int    `json:"pollErrors" mapstructure:"pollErrors"`
+}
+
+func (c *ManageInstancePower) Name() string {
+	return "oci.manageInstancePower"
+}
+
+func (c *ManageInstancePower) Label() string {
+	return "Manage Instance Power"
+}
+
+func (c *ManageInstancePower) Description() string {
+	return "Start, stop, or reset an OCI Compute instance and wait for the target state"
+}
+
+func (c *ManageInstancePower) Documentation() string {
+	return `The Manage Instance Power component performs a power lifecycle action on an Oracle Cloud Infrastructure Compute instance and waits for the target state.
+
+## Use Cases
+
+- **Scheduled shutdowns**: Stop instances outside business hours to reduce cost
+- **Recovery workflows**: Reset or soft-reset an instance after an incident
+- **Startup automation**: Start instances before a deployment, test, or maintenance workflow runs
+
+## Configuration
+
+- **Instance**: The OCI Compute instance.
+- **Action**: One of ` + "`START`" + `, ` + "`STOP`" + `, ` + "`SOFTSTOP`" + `, ` + "`RESET`" + `, or ` + "`SOFTRESET`" + `.
+
+## Output
+
+Emits the instance details on the default output channel once the instance reaches the expected lifecycle state:
+- ` + "`instanceId`" + ` — instance OCID
+- ` + "`displayName`" + ` — instance display name
+- ` + "`lifecycleState`" + ` — ` + "`RUNNING`" + ` for start/reset actions, or ` + "`STOPPED`" + ` for stop actions
+- ` + "`shape`" + ` — the instance shape
+- ` + "`availabilityDomain`" + ` — the availability domain
+- ` + "`compartmentId`" + ` — the compartment OCID
+- ` + "`region`" + ` — the region
+- ` + "`timeCreated`" + ` — ISO-8601 creation timestamp
+`
+}
+
+func (c *ManageInstancePower) Icon() string {
+	return "oci"
+}
+
+func (c *ManageInstancePower) Color() string {
+	return "red"
+}
+
+func (c *ManageInstancePower) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *ManageInstancePower) ExampleOutput() map[string]any {
+	return exampleOutputManageInstancePower()
+}
+
+func (c *ManageInstancePower) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instanceId",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Compute instance",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "action",
+			Label:       "Action",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Description: "Power action to perform on the instance",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Start", Value: "START"},
+						{Label: "Stop", Value: "STOP"},
+						{Label: "Soft Stop", Value: "SOFTSTOP"},
+						{Label: "Reset", Value: "RESET"},
+						{Label: "Soft Reset", Value: "SOFTRESET"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *ManageInstancePower) Setup(ctx core.SetupContext) error {
+	spec := ManageInstancePowerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if strings.TrimSpace(spec.InstanceID) == "" {
+		return errors.New("instanceId is required")
+	}
+	if strings.TrimSpace(spec.Action) == "" {
+		return errors.New("action is required")
+	}
+	if _, ok := instancePowerTargetStates[spec.Action]; !ok {
+		return fmt.Errorf("unsupported action: %s", spec.Action)
+	}
+	return nil
+}
+
+func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
+	spec := ManageInstancePowerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	if _, err := client.InstanceAction(spec.InstanceID, spec.Action); err != nil {
+		return fmt.Errorf("failed to run instance action: %w", err)
+	}
+
+	targetState := instancePowerTargetStates[spec.Action]
+	if err := ctx.Metadata.Set(ManageInstancePowerMetadata{
+		InstanceID:  spec.InstanceID,
+		Action:      spec.Action,
+		TargetState: targetState,
+	}); err != nil {
+		return err
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+}
+
+func (c *ManageInstancePower) Actions() []core.Action {
+	return []core.Action{
+		{Name: "poll", UserAccessible: false},
+	}
+}
+
+func (c *ManageInstancePower) HandleAction(ctx core.ActionContext) error {
+	if ctx.Name == "poll" {
+		return c.poll(ctx)
+	}
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (c *ManageInstancePower) poll(ctx core.ActionContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata ManageInstancePowerMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+	if metadata.InstanceID == "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	instance, err := client.GetInstance(metadata.InstanceID)
+	if err != nil {
+		metadata.PollErrors++
+		ctx.Logger.Warnf("failed to get instance %s (attempt %d/%d): %v", metadata.InstanceID, metadata.PollErrors, maxPollErrors, err)
+		if metadata.PollErrors >= maxPollErrors {
+			return fmt.Errorf("giving up polling instance %s after %d consecutive errors: %w", metadata.InstanceID, maxPollErrors, err)
+		}
+		if err := ctx.Metadata.Set(metadata); err != nil {
+			return err
+		}
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+	}
+
+	metadata.PollErrors = 0
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	if instance.LifecycleState == metadata.TargetState {
+		return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, ManageInstancePowerPayloadType, []any{instanceToMap(instance)})
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, createInstancePollInterval)
+}
+
+func (c *ManageInstancePower) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *ManageInstancePower) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *ManageInstancePower) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *ManageInstancePower) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -198,7 +198,7 @@ func (c *ManageInstancePower) poll(ctx core.ActionHookContext) error {
 		return fmt.Errorf("failed to decode metadata: %w", err)
 	}
 	if metadata.InstanceID == "" {
-		return nil
+		return fmt.Errorf("poll metadata is missing instanceId: execution state may be corrupted")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -28,8 +28,8 @@ var instancePowerTargetStates = map[string]string{
 type ManageInstancePower struct{}
 
 type ManageInstancePowerSpec struct {
-	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
-	Action     string `json:"action" mapstructure:"action"`
+	Instance string `json:"instance" mapstructure:"instance"`
+	Action   string `json:"action" mapstructure:"action"`
 }
 
 type ManageInstancePowerMetadata struct {
@@ -99,7 +99,7 @@ func (c *ManageInstancePower) ExampleOutput() map[string]any {
 func (c *ManageInstancePower) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instanceId",
+			Name:        "instance",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -136,8 +136,8 @@ func (c *ManageInstancePower) Setup(ctx core.SetupContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.InstanceID) == "" {
-		return errors.New("instanceId is required")
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
 	}
 	if strings.TrimSpace(spec.Action) == "" {
 		return errors.New("action is required")
@@ -159,13 +159,13 @@ func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if _, err := client.InstanceAction(spec.InstanceID, spec.Action); err != nil {
+	if _, err := client.InstanceAction(spec.Instance, spec.Action); err != nil {
 		return fmt.Errorf("failed to run instance action: %w", err)
 	}
 
 	targetState := instancePowerTargetStates[spec.Action]
 	if err := ctx.Metadata.Set(ManageInstancePowerMetadata{
-		InstanceID:  spec.InstanceID,
+		InstanceID:  spec.Instance,
 		Action:      spec.Action,
 		TargetState: targetState,
 	}); err != nil {

--- a/pkg/integrations/oci/manage_instance_power.go
+++ b/pkg/integrations/oci/manage_instance_power.go
@@ -28,7 +28,6 @@ var instancePowerTargetStates = map[string]string{
 type ManageInstancePower struct{}
 
 type ManageInstancePowerSpec struct {
-	Instance   string `json:"instance" mapstructure:"instance"`
 	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
 	Action     string `json:"action" mapstructure:"action"`
 }
@@ -100,7 +99,7 @@ func (c *ManageInstancePower) ExampleOutput() map[string]any {
 func (c *ManageInstancePower) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instance",
+			Name:        "instanceId",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -132,20 +131,13 @@ func (c *ManageInstancePower) Configuration() []configuration.Field {
 	}
 }
 
-func (s ManageInstancePowerSpec) selectedInstance() string {
-	if strings.TrimSpace(s.Instance) != "" {
-		return s.Instance
-	}
-	return s.InstanceID
-}
-
 func (c *ManageInstancePower) Setup(ctx core.SetupContext) error {
 	spec := ManageInstancePowerSpec{}
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.selectedInstance()) == "" {
-		return errors.New("instance is required")
+	if strings.TrimSpace(spec.InstanceID) == "" {
+		return errors.New("instanceId is required")
 	}
 	if strings.TrimSpace(spec.Action) == "" {
 		return errors.New("action is required")
@@ -161,20 +153,19 @@ func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	instance := spec.selectedInstance()
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if _, err := client.InstanceAction(instance, spec.Action); err != nil {
+	if _, err := client.InstanceAction(spec.InstanceID, spec.Action); err != nil {
 		return fmt.Errorf("failed to run instance action: %w", err)
 	}
 
 	targetState := instancePowerTargetStates[spec.Action]
 	if err := ctx.Metadata.Set(ManageInstancePowerMetadata{
-		InstanceID:  instance,
+		InstanceID:  spec.InstanceID,
 		Action:      spec.Action,
 		TargetState: targetState,
 	}); err != nil {

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -73,7 +73,7 @@ func Test__ManageInstancePower__PollReschedulesUntilTargetState(t *testing.T) {
 	requests := &contexts.RequestContext{}
 	executionState := &contexts.ExecutionStateContext{}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:           "poll",
 		HTTP:           httpCtx,
 		Integration:    ociIntegrationContext(),
@@ -97,7 +97,7 @@ func Test__ManageInstancePower__PollEmitsAtTargetState(t *testing.T) {
 	}
 	executionState := &contexts.ExecutionStateContext{}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:        "poll",
 		HTTP:        httpCtx,
 		Integration: ociIntegrationContext(),
@@ -134,7 +134,7 @@ func Test__ManageInstancePower__PollHandlesConsecutiveErrors(t *testing.T) {
 		},
 	}
 
-	err := component.HandleAction(core.ActionContext{
+	err := component.HandleHook(core.ActionHookContext{
 		Name:           "poll",
 		HTTP:           httpCtx,
 		Integration:    ociIntegrationContext(),
@@ -146,4 +146,33 @@ func Test__ManageInstancePower__PollHandlesConsecutiveErrors(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "giving up polling instance")
+}
+
+func Test__ManageInstancePower__PollStopsAfterMaxAttempts(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody("STOPPING")),
+		},
+	}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerMetadata{
+				InstanceID:   testInstanceID,
+				Action:       "STOP",
+				TargetState:  instanceStateStopped,
+				PollAttempts: maxPollAttempts - 1,
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for instance")
 }

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -1,0 +1,149 @@
+package oci
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ManageInstancePower__Setup(t *testing.T) {
+	component := &ManageInstancePower{}
+
+	err := component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": "", "action": "STOP"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instanceId is required")
+
+	err = component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": ""},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "action is required")
+}
+
+func Test__ManageInstancePower__Execute(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody("STOPPING")),
+		},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
+		HTTP:          httpCtx,
+		Integration:   ociIntegrationContext(),
+		Metadata:      metadata,
+		Requests:      requests,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
+	assert.Equal(t, "STOP", httpCtx.Requests[0].URL.Query().Get("action"))
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, ManageInstancePowerMetadata{
+		InstanceID:  testInstanceID,
+		Action:      "STOP",
+		TargetState: instanceStateStopped,
+	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__PollReschedulesUntilTargetState(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+		},
+	}
+	metadata := &contexts.MetadataContext{
+		Metadata: ManageInstancePowerMetadata{
+			InstanceID:  testInstanceID,
+			Action:      "STOP",
+			TargetState: instanceStateStopped,
+		},
+	}
+	requests := &contexts.RequestContext{}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:           "poll",
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		Metadata:       metadata,
+		Requests:       requests,
+		ExecutionState: executionState,
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.False(t, executionState.Passed)
+	assert.Equal(t, "poll", requests.Action)
+}
+
+func Test__ManageInstancePower__PollEmitsAtTargetState(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateStopped)),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:        "poll",
+		HTTP:        httpCtx,
+		Integration: ociIntegrationContext(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerMetadata{
+				InstanceID:  testInstanceID,
+				Action:      "STOP",
+				TargetState: instanceStateStopped,
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: executionState,
+		Logger:         ociLogger(),
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ManageInstancePowerPayloadType, executionState.Type)
+}
+
+func Test__ManageInstancePower__PollHandlesConsecutiveErrors(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusInternalServerError, `{"code":"InternalError"}`),
+		},
+	}
+	metadata := &contexts.MetadataContext{
+		Metadata: ManageInstancePowerMetadata{
+			InstanceID:  testInstanceID,
+			Action:      "STOP",
+			TargetState: instanceStateStopped,
+			PollErrors:  maxPollErrors - 1,
+		},
+	}
+
+	err := component.HandleAction(core.ActionContext{
+		Name:           "poll",
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		Metadata:       metadata,
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "giving up polling instance")
+}

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -14,13 +14,13 @@ func Test__ManageInstancePower__Setup(t *testing.T) {
 	component := &ManageInstancePower{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": "", "action": "STOP"},
+		Configuration: map[string]any{"instance": "", "action": "STOP"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instanceId is required")
+	assert.Contains(t, err.Error(), "instance is required")
 
 	err = component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": ""},
+		Configuration: map[string]any{"instance": testInstanceID, "action": ""},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "action is required")
@@ -37,7 +37,7 @@ func Test__ManageInstancePower__Execute(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
+		Configuration: map[string]any{"instance": testInstanceID, "action": "STOP"},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,
@@ -54,6 +54,16 @@ func Test__ManageInstancePower__Execute(t *testing.T) {
 		Action:      "STOP",
 		TargetState: instanceStateStopped,
 	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__SupportsLegacyInstanceIDConfiguration(t *testing.T) {
+	component := &ManageInstancePower{}
+
+	err := component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
+	})
+
+	require.NoError(t, err)
 }
 
 func Test__ManageInstancePower__PollReschedulesUntilTargetState(t *testing.T) {

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -16,13 +16,13 @@ func Test__ManageInstancePower__Setup(t *testing.T) {
 	component := &ManageInstancePower{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": "", "action": "STOP"},
+		Configuration: map[string]any{"instance": "", "action": "STOP"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instanceId is required")
+	assert.Contains(t, err.Error(), "instance is required")
 
 	err = component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": ""},
+		Configuration: map[string]any{"instance": testInstanceID, "action": ""},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "action is required")
@@ -39,7 +39,7 @@ func Test__ManageInstancePower__Execute(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
+		Configuration: map[string]any{"instance": testInstanceID, "action": "STOP"},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,
@@ -74,7 +74,7 @@ func Test__ManageInstancePower__Execute__SoftStop(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": "SOFTSTOP"},
+		Configuration: map[string]any{"instance": testInstanceID, "action": "SOFTSTOP"},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -16,13 +16,13 @@ func Test__ManageInstancePower__Setup(t *testing.T) {
 	component := &ManageInstancePower{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instance": "", "action": "STOP"},
+		Configuration: map[string]any{"instanceId": "", "action": "STOP"},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instance is required")
+	assert.Contains(t, err.Error(), "instanceId is required")
 
 	err = component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instance": testInstanceID, "action": ""},
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": ""},
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "action is required")
@@ -39,7 +39,7 @@ func Test__ManageInstancePower__Execute(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instance": testInstanceID, "action": "STOP"},
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,
@@ -74,7 +74,7 @@ func Test__ManageInstancePower__Execute__SoftStop(t *testing.T) {
 	requests := &contexts.RequestContext{}
 
 	err := component.Execute(core.ExecutionContext{
-		Configuration: map[string]any{"instance": testInstanceID, "action": "SOFTSTOP"},
+		Configuration: map[string]any{"instanceId": testInstanceID, "action": "SOFTSTOP"},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      metadata,
@@ -90,16 +90,6 @@ func Test__ManageInstancePower__Execute__SoftStop(t *testing.T) {
 		Action:      "SOFTSTOP",
 		TargetState: instanceStateStopped,
 	}, metadata.Metadata)
-}
-
-func Test__ManageInstancePower__SupportsLegacyInstanceIDConfiguration(t *testing.T) {
-	component := &ManageInstancePower{}
-
-	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": testInstanceID, "action": "STOP"},
-	})
-
-	require.NoError(t, err)
 }
 
 func Test__ManageInstancePower__PollReschedulesUntilTargetState(t *testing.T) {

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -154,6 +154,23 @@ func Test__ManageInstancePower__PollEmitsAtTargetState(t *testing.T) {
 	assert.Equal(t, ManageInstancePowerPayloadType, executionState.Type)
 }
 
+func Test__ManageInstancePower__PollErrorsWhenMetadataMissingInstanceID(t *testing.T) {
+	component := &ManageInstancePower{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:           "poll",
+		HTTP:           &contexts.HTTPContext{},
+		Integration:    ociIntegrationContext(),
+		Metadata:       &contexts.MetadataContext{Metadata: ManageInstancePowerMetadata{}},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll metadata is missing instanceId")
+}
+
 func Test__ManageInstancePower__PollHandlesConsecutiveErrors(t *testing.T) {
 	component := &ManageInstancePower{}
 	httpCtx := &contexts.HTTPContext{

--- a/pkg/integrations/oci/manage_instance_power_test.go
+++ b/pkg/integrations/oci/manage_instance_power_test.go
@@ -1,6 +1,8 @@
 package oci
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -48,10 +50,44 @@ func Test__ManageInstancePower__Execute(t *testing.T) {
 	require.Len(t, httpCtx.Requests, 1)
 	assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
 	assert.Equal(t, "STOP", httpCtx.Requests[0].URL.Query().Get("action"))
+	assert.Equal(t, "0", httpCtx.Requests[0].Header.Get("Content-Length"))
+	assert.Equal(t, "application/json", httpCtx.Requests[0].Header.Get("Content-Type"))
+	emptyHash := sha256.Sum256(nil)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(emptyHash[:]), httpCtx.Requests[0].Header.Get("x-content-sha256"))
+	assert.Contains(t, httpCtx.Requests[0].Header.Get("Authorization"), "content-length content-type x-content-sha256")
 	assert.Equal(t, "poll", requests.Action)
 	assert.Equal(t, ManageInstancePowerMetadata{
 		InstanceID:  testInstanceID,
 		Action:      "STOP",
+		TargetState: instanceStateStopped,
+	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__Execute__SoftStop(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody("STOPPING")),
+		},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{"instance": testInstanceID, "action": "SOFTSTOP"},
+		HTTP:          httpCtx,
+		Integration:   ociIntegrationContext(),
+		Metadata:      metadata,
+		Requests:      requests,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, "SOFTSTOP", httpCtx.Requests[0].URL.Query().Get("action"))
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, ManageInstancePowerMetadata{
+		InstanceID:  testInstanceID,
+		Action:      "SOFTSTOP",
 		TargetState: instanceStateStopped,
 	}, metadata.Metadata)
 }

--- a/pkg/integrations/oci/oci.go
+++ b/pkg/integrations/oci/oci.go
@@ -168,12 +168,17 @@ func (o *OCI) Actions() []core.Action {
 		&CreateFunction{},
 		&DeleteFunction{},
 		&InvokeFunction{},
+		&GetInstance{},
+		&UpdateInstance{},
+		&ManageInstancePower{},
+		&DeleteInstance{},
 	}
 }
 
 func (o *OCI) Triggers() []core.Trigger {
 	return []core.Trigger{
 		&OnComputeInstanceCreated{},
+		&OnInstanceStateChange{},
 	}
 }
 

--- a/pkg/integrations/oci/on_compute_instance_created.go
+++ b/pkg/integrations/oci/on_compute_instance_created.go
@@ -3,7 +3,6 @@ package oci
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -191,30 +190,7 @@ func (t *OnComputeInstanceCreated) HandleWebhook(ctx core.WebhookRequestContext)
 }
 
 func (t *OnComputeInstanceCreated) handleONSConfirmation(ctx core.WebhookRequestContext, confirmURL string) (int, *core.WebhookResponseBody, error) {
-	if err := validateONSConfirmationURL(confirmURL); err != nil {
-		return http.StatusBadRequest, nil, fmt.Errorf("refusing ONS confirmation URL: %w", err)
-	}
-
-	req, err := http.NewRequest(http.MethodGet, confirmURL, nil)
-	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("failed to build ONS confirmation request: %w", err)
-	}
-
-	resp, err := ctx.HTTP.Do(req)
-	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Errorf("failed to confirm ONS subscription: %w", err)
-	}
-
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return http.StatusInternalServerError, nil, fmt.Errorf("ONS confirmation returned %d", resp.StatusCode)
-	}
-
-	return http.StatusOK, nil, nil
+	return confirmONSSubscription(ctx, confirmURL)
 }
 
 func parseEventEnvelope(body []byte) (map[string]any, error) {

--- a/pkg/integrations/oci/on_instance_state_change.go
+++ b/pkg/integrations/oci/on_instance_state_change.go
@@ -1,0 +1,250 @@
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type OnInstanceStateChange struct{}
+
+const OnInstanceStateChangePayloadType = "oci.onInstanceStateChange"
+
+var ociInstanceStateChangeEventTypes = map[string]struct{}{
+	"com.oraclecloud.computeapi.startinstance.end":     {},
+	"com.oraclecloud.computeapi.stopinstance.end":      {},
+	"com.oraclecloud.computeapi.terminateinstance.end": {},
+	"com.oraclecloud.computeapi.resetinstance.end":     {},
+	"com.oraclecloud.computeapi.softstopinstance.end":  {},
+	"com.oraclecloud.computeapi.softresetinstance.end": {},
+}
+
+type OnInstanceStateChangeConfiguration struct {
+	CompartmentID string `json:"compartmentId" mapstructure:"compartmentId"`
+}
+
+type OnInstanceStateChangeMetadata struct {
+	CompartmentID string `json:"compartmentId" mapstructure:"compartmentId"`
+	EventsRuleID  string `json:"eventsRuleId" mapstructure:"eventsRuleId"`
+}
+
+func (t *OnInstanceStateChange) Name() string {
+	return "oci.onInstanceStateChange"
+}
+
+func (t *OnInstanceStateChange) Label() string {
+	return "On Instance State Change"
+}
+
+func (t *OnInstanceStateChange) Description() string {
+	return "Fires when an OCI Compute instance starts, stops, resets, or terminates"
+}
+
+func (t *OnInstanceStateChange) Documentation() string {
+	return `The On Instance State Change trigger starts a workflow execution whenever an Oracle Cloud Infrastructure Compute instance completes a power or termination operation.
+
+## How It Works
+
+When this trigger is added to a workflow, SuperPlane creates an **OCI Events rule** in the configured compartment that forwards Compute instance lifecycle events to the integration's shared OCI Notifications topic.
+
+## Configuration
+
+- **Compartment**: The compartment to monitor for Compute instance state changes.
+
+## Event Data
+
+Each event payload includes:
+- ` + "`eventType`" + ` — the OCI Compute API event type, such as ` + "`com.oraclecloud.computeapi.stopinstance.end`" + `
+- ` + "`data.resourceId`" + ` — the instance OCID
+- ` + "`data.resourceName`" + ` — the instance display name
+- ` + "`data.compartmentId`" + ` — the compartment OCID
+- ` + "`data.availabilityDomain`" + ` — the availability domain
+- ` + "`eventTime`" + ` — ISO-8601 timestamp of the event
+`
+}
+
+func (t *OnInstanceStateChange) Icon() string {
+	return "oci"
+}
+
+func (t *OnInstanceStateChange) Color() string {
+	return "red"
+}
+
+func (t *OnInstanceStateChange) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "compartmentId",
+			Label:       "Compartment",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The compartment to filter instance state-change events from",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeCompartment,
+				},
+			},
+		},
+	}
+}
+
+func (t *OnInstanceStateChange) ExampleData() map[string]any {
+	return exampleDataOnInstanceStateChange()
+}
+
+func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
+	var config OnInstanceStateChangeConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode trigger configuration: %w", err)
+	}
+
+	if config.CompartmentID == "" {
+		return fmt.Errorf("compartmentId is required")
+	}
+
+	var integrationMetadata IntegrationMetadata
+	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &integrationMetadata); err != nil {
+		return fmt.Errorf("failed to decode integration metadata: %w", err)
+	}
+	if integrationMetadata.TopicID == "" {
+		return fmt.Errorf("integration topic not ready yet; ensure the OCI integration has been fully set up")
+	}
+
+	var metadata OnInstanceStateChangeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode trigger metadata: %w", err)
+	}
+
+	if metadata.CompartmentID == config.CompartmentID && metadata.EventsRuleID != "" {
+		return ctx.Integration.RequestWebhook(WebhookConfiguration{
+			CompartmentID: config.CompartmentID,
+			TopicID:       integrationMetadata.TopicID,
+		})
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	if metadata.EventsRuleID != "" && metadata.CompartmentID != config.CompartmentID {
+		if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
+			ctx.Logger.Warnf("failed to delete old Events rule %q: %v", metadata.EventsRuleID, err)
+		}
+	}
+
+	condition := `{"eventType": ["com.oraclecloud.computeapi.startinstance.end","com.oraclecloud.computeapi.stopinstance.end","com.oraclecloud.computeapi.terminateinstance.end","com.oraclecloud.computeapi.resetinstance.end","com.oraclecloud.computeapi.softstopinstance.end","com.oraclecloud.computeapi.softresetinstance.end"]}`
+
+	webhookURL, err := ctx.Webhook.Setup()
+	if err != nil {
+		return fmt.Errorf("failed to set up webhook URL: %w", err)
+	}
+	ruleName := fmt.Sprintf("superplane-instance-state-change-%s", path.Base(webhookURL))
+	rule, err := client.CreateEventsRule(
+		config.CompartmentID,
+		ruleName,
+		condition,
+		integrationMetadata.TopicID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create Events rule: %w", err)
+	}
+
+	if err := ctx.Metadata.Set(OnInstanceStateChangeMetadata{
+		CompartmentID: config.CompartmentID,
+		EventsRuleID:  rule.ID,
+	}); err != nil {
+		return fmt.Errorf("failed to persist trigger metadata: %w", err)
+	}
+
+	return ctx.Integration.RequestWebhook(WebhookConfiguration{
+		CompartmentID: config.CompartmentID,
+		TopicID:       integrationMetadata.TopicID,
+	})
+}
+
+func (t *OnInstanceStateChange) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (t *OnInstanceStateChange) HandleAction(ctx core.TriggerActionContext) (map[string]any, error) {
+	return nil, fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (t *OnInstanceStateChange) Cleanup(ctx core.TriggerContext) error {
+	var metadata OnInstanceStateChangeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		ctx.Logger.Warnf("failed to decode trigger metadata during cleanup: %v", err)
+		return nil
+	}
+
+	if metadata.EventsRuleID == "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client during cleanup: %w", err)
+	}
+
+	if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
+		ctx.Logger.Warnf("failed to delete Events rule %q during cleanup: %v", metadata.EventsRuleID, err)
+	}
+
+	return nil
+}
+
+func (t *OnInstanceStateChange) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	cfg := OnInstanceStateChangeConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &cfg); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	var envelope map[string]any
+	if err := json.Unmarshal(ctx.Body, &envelope); err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("failed to parse webhook body: %w", err)
+	}
+
+	if confirmURL := ctx.Headers.Get("X-OCI-NS-ConfirmationURL"); confirmURL != "" {
+		if err := validateONSConfirmationURL(confirmURL); err != nil {
+			return http.StatusBadRequest, nil, fmt.Errorf("refusing ONS confirmation URL: %w", err)
+		}
+		req, err := http.NewRequest(http.MethodGet, confirmURL, nil)
+		if err != nil {
+			return http.StatusInternalServerError, nil, fmt.Errorf("failed to build ONS confirmation request: %w", err)
+		}
+		resp, err := ctx.HTTP.Do(req)
+		if err != nil {
+			return http.StatusInternalServerError, nil, fmt.Errorf("failed to confirm ONS subscription: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return http.StatusInternalServerError, nil, fmt.Errorf("ONS confirmation returned %d", resp.StatusCode)
+		}
+		return http.StatusOK, nil, nil
+	}
+
+	eventType, _ := envelope["eventType"].(string)
+	if _, ok := ociInstanceStateChangeEventTypes[eventType]; !ok {
+		return http.StatusOK, nil, nil
+	}
+
+	if cfg.CompartmentID != "" {
+		data, _ := envelope["data"].(map[string]any)
+		compartmentID, _ := data["compartmentId"].(string)
+		if compartmentID != cfg.CompartmentID {
+			return http.StatusOK, nil, nil
+		}
+	}
+
+	if err := ctx.Events.Emit(OnInstanceStateChangePayloadType, envelope); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to emit event: %w", err)
+	}
+
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/oci/on_instance_state_change.go
+++ b/pkg/integrations/oci/on_instance_state_change.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -144,7 +143,11 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	if err != nil {
 		return fmt.Errorf("failed to set up webhook URL: %w", err)
 	}
-	ruleName := fmt.Sprintf("superplane-instance-state-change-%s", path.Base(webhookURL))
+	webhookID, err := extractWebhookID(webhookURL)
+	if err != nil {
+		return err
+	}
+	ruleName := fmt.Sprintf("superplane-instance-state-change-%s", webhookID)
 	rule, err := client.CreateEventsRule(
 		config.CompartmentID,
 		ruleName,
@@ -168,12 +171,12 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	})
 }
 
-func (t *OnInstanceStateChange) Actions() []core.Action {
-	return []core.Action{}
+func (t *OnInstanceStateChange) Hooks() []core.Hook {
+	return []core.Hook{}
 }
 
-func (t *OnInstanceStateChange) HandleAction(ctx core.TriggerActionContext) (map[string]any, error) {
-	return nil, fmt.Errorf("unknown action: %s", ctx.Name)
+func (t *OnInstanceStateChange) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
 func (t *OnInstanceStateChange) Cleanup(ctx core.TriggerContext) error {
@@ -205,28 +208,13 @@ func (t *OnInstanceStateChange) HandleWebhook(ctx core.WebhookRequestContext) (i
 		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
+	if confirmURL := ctx.Headers.Get("X-OCI-NS-ConfirmationURL"); confirmURL != "" {
+		return confirmONSSubscription(ctx, confirmURL)
+	}
+
 	var envelope map[string]any
 	if err := json.Unmarshal(ctx.Body, &envelope); err != nil {
 		return http.StatusBadRequest, nil, fmt.Errorf("failed to parse webhook body: %w", err)
-	}
-
-	if confirmURL := ctx.Headers.Get("X-OCI-NS-ConfirmationURL"); confirmURL != "" {
-		if err := validateONSConfirmationURL(confirmURL); err != nil {
-			return http.StatusBadRequest, nil, fmt.Errorf("refusing ONS confirmation URL: %w", err)
-		}
-		req, err := http.NewRequest(http.MethodGet, confirmURL, nil)
-		if err != nil {
-			return http.StatusInternalServerError, nil, fmt.Errorf("failed to build ONS confirmation request: %w", err)
-		}
-		resp, err := ctx.HTTP.Do(req)
-		if err != nil {
-			return http.StatusInternalServerError, nil, fmt.Errorf("failed to confirm ONS subscription: %w", err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return http.StatusInternalServerError, nil, fmt.Errorf("ONS confirmation returned %d", resp.StatusCode)
-		}
-		return http.StatusOK, nil, nil
 	}
 
 	eventType, _ := envelope["eventType"].(string)

--- a/pkg/integrations/oci/on_instance_state_change.go
+++ b/pkg/integrations/oci/on_instance_state_change.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -15,21 +16,45 @@ type OnInstanceStateChange struct{}
 const OnInstanceStateChangePayloadType = "oci.onInstanceStateChange"
 
 var ociInstanceStateChangeEventTypes = map[string]struct{}{
-	"com.oraclecloud.computeapi.startinstance.end":     {},
-	"com.oraclecloud.computeapi.stopinstance.end":      {},
+	"com.oraclecloud.computeapi.instanceaction.end":    {},
 	"com.oraclecloud.computeapi.terminateinstance.end": {},
-	"com.oraclecloud.computeapi.resetinstance.end":     {},
-	"com.oraclecloud.computeapi.softstopinstance.end":  {},
-	"com.oraclecloud.computeapi.softresetinstance.end": {},
+}
+
+var ociInstanceStateChangeActionTypes = map[string]struct{}{
+	"start":     {},
+	"stop":      {},
+	"reset":     {},
+	"softstop":  {},
+	"softreset": {},
+}
+
+const (
+	ociInstanceStateChangeStart     = "start"
+	ociInstanceStateChangeStop      = "stop"
+	ociInstanceStateChangeReset     = "reset"
+	ociInstanceStateChangeSoftStop  = "softstop"
+	ociInstanceStateChangeSoftReset = "softreset"
+	ociInstanceStateChangeTerminate = "terminate"
+)
+
+var ociInstanceStateChangeOptions = []configuration.FieldOption{
+	{Label: "Start", Value: ociInstanceStateChangeStart},
+	{Label: "Stop", Value: ociInstanceStateChangeStop},
+	{Label: "Reset", Value: ociInstanceStateChangeReset},
+	{Label: "Soft Stop", Value: ociInstanceStateChangeSoftStop},
+	{Label: "Soft Reset", Value: ociInstanceStateChangeSoftReset},
+	{Label: "Terminate", Value: ociInstanceStateChangeTerminate},
 }
 
 type OnInstanceStateChangeConfiguration struct {
-	CompartmentID string `json:"compartmentId" mapstructure:"compartmentId"`
+	CompartmentID string   `json:"compartmentId" mapstructure:"compartmentId"`
+	StateChanges  []string `json:"stateChanges" mapstructure:"stateChanges"`
 }
 
 type OnInstanceStateChangeMetadata struct {
 	CompartmentID string `json:"compartmentId" mapstructure:"compartmentId"`
 	EventsRuleID  string `json:"eventsRuleId" mapstructure:"eventsRuleId"`
+	Condition     string `json:"condition" mapstructure:"condition"`
 }
 
 func (t *OnInstanceStateChange) Name() string {
@@ -54,15 +79,17 @@ When this trigger is added to a workflow, SuperPlane creates an **OCI Events rul
 ## Configuration
 
 - **Compartment**: The compartment to monitor for Compute instance state changes.
+- **State Changes**: Optional list of state changes to emit. Leave empty to emit all supported state changes.
 
 ## Event Data
 
 Each event payload includes:
-- ` + "`eventType`" + ` — the OCI Compute API event type, such as ` + "`com.oraclecloud.computeapi.stopinstance.end`" + `
+- ` + "`eventType`" + ` — the OCI Compute API event type, such as ` + "`com.oraclecloud.computeapi.instanceaction.end`" + `
 - ` + "`data.resourceId`" + ` — the instance OCID
 - ` + "`data.resourceName`" + ` — the instance display name
 - ` + "`data.compartmentId`" + ` — the compartment OCID
 - ` + "`data.availabilityDomain`" + ` — the availability domain
+- ` + "`data.additionalDetails.instanceActionType`" + ` — the completed power action, such as ` + "`start`" + `, ` + "`stop`" + `, or ` + "`softstop`" + `
 - ` + "`eventTime`" + ` — ISO-8601 timestamp of the event
 `
 }
@@ -89,6 +116,26 @@ func (t *OnInstanceStateChange) Configuration() []configuration.Field {
 				},
 			},
 		},
+		{
+			Name:     "stateChanges",
+			Label:    "State Changes",
+			Type:     configuration.FieldTypeMultiSelect,
+			Required: true,
+			Default: []string{
+				ociInstanceStateChangeStart,
+				ociInstanceStateChangeStop,
+				ociInstanceStateChangeReset,
+				ociInstanceStateChangeSoftStop,
+				ociInstanceStateChangeSoftReset,
+				ociInstanceStateChangeTerminate,
+			},
+			Description: "Only emit events for these state changes. Leave empty to emit all supported state changes.",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: ociInstanceStateChangeOptions,
+				},
+			},
+		},
 	}
 }
 
@@ -105,6 +152,9 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	if config.CompartmentID == "" {
 		return fmt.Errorf("compartmentId is required")
 	}
+	if err := validateStateChanges(config.StateChanges); err != nil {
+		return err
+	}
 
 	var integrationMetadata IntegrationMetadata
 	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &integrationMetadata); err != nil {
@@ -119,7 +169,9 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode trigger metadata: %w", err)
 	}
 
-	if metadata.CompartmentID == config.CompartmentID && metadata.EventsRuleID != "" {
+	condition := `{"eventType": ["com.oraclecloud.computeapi.instanceaction.end","com.oraclecloud.computeapi.terminateinstance.end"]}`
+
+	if metadata.CompartmentID == config.CompartmentID && metadata.EventsRuleID != "" && metadata.Condition == condition {
 		return ctx.Integration.RequestWebhook(WebhookConfiguration{
 			CompartmentID: config.CompartmentID,
 			TopicID:       integrationMetadata.TopicID,
@@ -131,13 +183,11 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if metadata.EventsRuleID != "" && metadata.CompartmentID != config.CompartmentID {
+	if metadata.EventsRuleID != "" {
 		if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
 			ctx.Logger.Warnf("failed to delete old Events rule %q: %v", metadata.EventsRuleID, err)
 		}
 	}
-
-	condition := `{"eventType": ["com.oraclecloud.computeapi.startinstance.end","com.oraclecloud.computeapi.stopinstance.end","com.oraclecloud.computeapi.terminateinstance.end","com.oraclecloud.computeapi.resetinstance.end","com.oraclecloud.computeapi.softstopinstance.end","com.oraclecloud.computeapi.softresetinstance.end"]}`
 
 	webhookURL, err := ctx.Webhook.Setup()
 	if err != nil {
@@ -161,6 +211,7 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	if err := ctx.Metadata.Set(OnInstanceStateChangeMetadata{
 		CompartmentID: config.CompartmentID,
 		EventsRuleID:  rule.ID,
+		Condition:     condition,
 	}); err != nil {
 		return fmt.Errorf("failed to persist trigger metadata: %w", err)
 	}
@@ -222,8 +273,25 @@ func (t *OnInstanceStateChange) HandleWebhook(ctx core.WebhookRequestContext) (i
 		return http.StatusOK, nil, nil
 	}
 
+	data, _ := envelope["data"].(map[string]any)
+	if eventType == "com.oraclecloud.computeapi.instanceaction.end" {
+		additionalDetails, _ := data["additionalDetails"].(map[string]any)
+		actionType, _ := additionalDetails["instanceActionType"].(string)
+		if _, ok := ociInstanceStateChangeActionTypes[actionType]; !ok {
+			return http.StatusOK, nil, nil
+		}
+		if len(cfg.StateChanges) > 0 && !slices.Contains(cfg.StateChanges, actionType) {
+			return http.StatusOK, nil, nil
+		}
+	}
+
+	if eventType == "com.oraclecloud.computeapi.terminateinstance.end" {
+		if len(cfg.StateChanges) > 0 && !slices.Contains(cfg.StateChanges, ociInstanceStateChangeTerminate) {
+			return http.StatusOK, nil, nil
+		}
+	}
+
 	if cfg.CompartmentID != "" {
-		data, _ := envelope["data"].(map[string]any)
 		compartmentID, _ := data["compartmentId"].(string)
 		if compartmentID != cfg.CompartmentID {
 			return http.StatusOK, nil, nil
@@ -235,4 +303,20 @@ func (t *OnInstanceStateChange) HandleWebhook(ctx core.WebhookRequestContext) (i
 	}
 
 	return http.StatusOK, nil, nil
+}
+
+func validateStateChanges(stateChanges []string) error {
+	for _, stateChange := range stateChanges {
+		if !slices.Contains([]string{
+			ociInstanceStateChangeStart,
+			ociInstanceStateChangeStop,
+			ociInstanceStateChangeReset,
+			ociInstanceStateChangeSoftStop,
+			ociInstanceStateChangeSoftReset,
+			ociInstanceStateChangeTerminate,
+		}, stateChange) {
+			return fmt.Errorf("unsupported state change: %s", stateChange)
+		}
+	}
+	return nil
 }

--- a/pkg/integrations/oci/on_instance_state_change.go
+++ b/pkg/integrations/oci/on_instance_state_change.go
@@ -47,8 +47,8 @@ var ociInstanceStateChangeOptions = []configuration.FieldOption{
 }
 
 type OnInstanceStateChangeConfiguration struct {
-	CompartmentID string   `json:"compartmentId" mapstructure:"compartmentId"`
-	StateChanges  []string `json:"stateChanges" mapstructure:"stateChanges"`
+	Compartment  string   `json:"compartment" mapstructure:"compartment"`
+	StateChanges []string `json:"stateChanges" mapstructure:"stateChanges"`
 }
 
 type OnInstanceStateChangeMetadata struct {
@@ -105,7 +105,7 @@ func (t *OnInstanceStateChange) Color() string {
 func (t *OnInstanceStateChange) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "compartmentId",
+			Name:        "compartment",
 			Label:       "Compartment",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -149,8 +149,8 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to decode trigger configuration: %w", err)
 	}
 
-	if config.CompartmentID == "" {
-		return fmt.Errorf("compartmentId is required")
+	if config.Compartment == "" {
+		return fmt.Errorf("compartment is required")
 	}
 	if err := validateStateChanges(config.StateChanges); err != nil {
 		return err
@@ -171,9 +171,9 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 
 	condition := `{"eventType": ["com.oraclecloud.computeapi.instanceaction.end","com.oraclecloud.computeapi.terminateinstance.end"]}`
 
-	if metadata.CompartmentID == config.CompartmentID && metadata.EventsRuleID != "" && metadata.Condition == condition {
+	if metadata.CompartmentID == config.Compartment && metadata.EventsRuleID != "" && metadata.Condition == condition {
 		return ctx.Integration.RequestWebhook(WebhookConfiguration{
-			CompartmentID: config.CompartmentID,
+			CompartmentID: config.Compartment,
 			TopicID:       integrationMetadata.TopicID,
 		})
 	}
@@ -199,7 +199,7 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	}
 	ruleName := fmt.Sprintf("superplane-instance-state-change-%s", webhookID)
 	rule, err := client.CreateEventsRule(
-		config.CompartmentID,
+		config.Compartment,
 		ruleName,
 		condition,
 		integrationMetadata.TopicID,
@@ -209,7 +209,7 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	}
 
 	if err := ctx.Metadata.Set(OnInstanceStateChangeMetadata{
-		CompartmentID: config.CompartmentID,
+		CompartmentID: config.Compartment,
 		EventsRuleID:  rule.ID,
 		Condition:     condition,
 	}); err != nil {
@@ -217,7 +217,7 @@ func (t *OnInstanceStateChange) Setup(ctx core.TriggerContext) error {
 	}
 
 	return ctx.Integration.RequestWebhook(WebhookConfiguration{
-		CompartmentID: config.CompartmentID,
+		CompartmentID: config.Compartment,
 		TopicID:       integrationMetadata.TopicID,
 	})
 }
@@ -291,9 +291,9 @@ func (t *OnInstanceStateChange) HandleWebhook(ctx core.WebhookRequestContext) (i
 		}
 	}
 
-	if cfg.CompartmentID != "" {
+	if cfg.Compartment != "" {
 		compartmentID, _ := data["compartmentId"].(string)
-		if compartmentID != cfg.CompartmentID {
+		if compartmentID != cfg.Compartment {
 			return http.StatusOK, nil, nil
 		}
 	}

--- a/pkg/integrations/oci/on_instance_state_change_test.go
+++ b/pkg/integrations/oci/on_instance_state_change_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -22,7 +23,7 @@ func Test__OnInstanceStateChange__HandleWebhook_ConfirmsSubscription(t *testing.
 	headers.Set("X-OCI-NS-ConfirmationURL", "https://notification.eu-frankfurt-1.oraclecloud.com/confirm")
 
 	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-		Body:    []byte(`{}`),
+		Body:    []byte(`not-json`),
 		HTTP:    httpCtx,
 		Events:  &contexts.EventContext{},
 		Headers: headers,
@@ -32,6 +33,32 @@ func Test__OnInstanceStateChange__HandleWebhook_ConfirmsSubscription(t *testing.
 	assert.Equal(t, http.StatusOK, status)
 	require.Len(t, httpCtx.Requests, 1)
 	assert.Equal(t, "https://notification.eu-frankfurt-1.oraclecloud.com/confirm", httpCtx.Requests[0].URL.String())
+}
+
+func Test__OnInstanceStateChange__Setup_UsesWebhookPathIDForRuleName(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, `{"id":"ocid1.eventsrule.oc1.test"}`),
+		},
+	}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{"compartmentId": testCompartmentID},
+		HTTP:          httpCtx,
+		Integration:   ociIntegrationContext(),
+		Metadata:      &contexts.MetadataContext{},
+		Webhook:       fixedNodeWebhookContext{url: "https://example.com/api/v1/webhooks/webhook-id?token=abc#frag"},
+		Logger:        ociLogger(),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Contains(t, httpCtx.Requests[0].URL.String(), "/20181201/rules")
+	body, err := io.ReadAll(httpCtx.Requests[0].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"displayName":"superplane-instance-state-change-webhook-id"`)
+	assert.NotContains(t, string(body), "token=abc")
 }
 
 func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownEventTypes(t *testing.T) {
@@ -121,4 +148,28 @@ func instanceStateChangeEventBody(t *testing.T, eventType, compartmentID string)
 	})
 	require.NoError(t, err)
 	return body
+}
+
+type fixedNodeWebhookContext struct {
+	url string
+}
+
+func (w fixedNodeWebhookContext) Setup() (string, error) {
+	return w.url, nil
+}
+
+func (w fixedNodeWebhookContext) GetSecret() ([]byte, error) {
+	return nil, nil
+}
+
+func (w fixedNodeWebhookContext) ResetSecret() ([]byte, []byte, error) {
+	return nil, nil, nil
+}
+
+func (w fixedNodeWebhookContext) SetSecret(secret []byte) error {
+	return nil
+}
+
+func (w fixedNodeWebhookContext) GetBaseURL() string {
+	return "http://localhost:3000/api/v1"
 }

--- a/pkg/integrations/oci/on_instance_state_change_test.go
+++ b/pkg/integrations/oci/on_instance_state_change_test.go
@@ -1,0 +1,124 @@
+package oci
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnInstanceStateChange__HandleWebhook_ConfirmsSubscription(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, `{}`),
+		},
+	}
+	headers := http.Header{}
+	headers.Set("X-OCI-NS-ConfirmationURL", "https://notification.eu-frankfurt-1.oraclecloud.com/confirm")
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    []byte(`{}`),
+		HTTP:    httpCtx,
+		Events:  &contexts.EventContext{},
+		Headers: headers,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.Len(t, httpCtx.Requests, 1)
+	assert.Equal(t, "https://notification.eu-frankfurt-1.oraclecloud.com/confirm", httpCtx.Requests[0].URL.String())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownEventTypes(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.launchinstance.end", testCompartmentID),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, 0, events.Count())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_FiltersDifferentCompartment(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.stopinstance.end", "other-compartment"),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, 0, events.Count())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_EmitsValidEventTypes(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	validEventTypes := []string{
+		"com.oraclecloud.computeapi.startinstance.end",
+		"com.oraclecloud.computeapi.stopinstance.end",
+		"com.oraclecloud.computeapi.terminateinstance.end",
+		"com.oraclecloud.computeapi.resetinstance.end",
+		"com.oraclecloud.computeapi.softstopinstance.end",
+		"com.oraclecloud.computeapi.softresetinstance.end",
+	}
+
+	for _, eventType := range validEventTypes {
+		t.Run(eventType, func(t *testing.T) {
+			events := &contexts.EventContext{}
+
+			status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+				Body:    instanceStateChangeEventBody(t, eventType, testCompartmentID),
+				Events:  events,
+				Headers: http.Header{},
+				Configuration: map[string]any{
+					"compartmentId": testCompartmentID,
+				},
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, status)
+			require.Len(t, events.Payloads, 1)
+			assert.Equal(t, OnInstanceStateChangePayloadType, events.Payloads[0].Type)
+		})
+	}
+}
+
+func instanceStateChangeEventBody(t *testing.T, eventType, compartmentID string) []byte {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"eventType": eventType,
+		"eventTime": "2026-04-22T20:34:54Z",
+		"data": map[string]any{
+			"resourceId":         testInstanceID,
+			"resourceName":       "test-instance",
+			"compartmentId":      compartmentID,
+			"compartmentName":    "root",
+			"availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+			"additionalDetails": map[string]any{
+				"shape": "VM.Standard.E2.1.Micro",
+			},
+		},
+	})
+	require.NoError(t, err)
+	return body
+}

--- a/pkg/integrations/oci/on_instance_state_change_test.go
+++ b/pkg/integrations/oci/on_instance_state_change_test.go
@@ -45,7 +45,7 @@ func Test__OnInstanceStateChange__Setup_UsesWebhookPathIDForRuleName(t *testing.
 	}
 
 	err := trigger.Setup(core.TriggerContext{
-		Configuration: map[string]any{"compartmentId": testCompartmentID},
+		Configuration: map[string]any{"compartment": testCompartmentID},
 		HTTP:          httpCtx,
 		Integration:   ociIntegrationContext(),
 		Metadata:      &contexts.MetadataContext{},
@@ -67,8 +67,8 @@ func Test__OnInstanceStateChange__Setup_RejectsUnsupportedStateChanges(t *testin
 
 	err := trigger.Setup(core.TriggerContext{
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
-			"stateChanges":  []string{"hibernate"},
+			"compartment":  testCompartmentID,
+			"stateChanges": []string{"hibernate"},
 		},
 		Integration: ociIntegrationContext(),
 		Metadata:    &contexts.MetadataContext{},
@@ -114,7 +114,7 @@ func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownEventTypes(t *test
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
+			"compartment": testCompartmentID,
 		},
 	})
 
@@ -132,7 +132,7 @@ func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownInstanceActionType
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
+			"compartment": testCompartmentID,
 		},
 	})
 
@@ -150,8 +150,8 @@ func Test__OnInstanceStateChange__HandleWebhook_FiltersUnselectedStateChanges(t 
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
-			"stateChanges":  []string{"start"},
+			"compartment":  testCompartmentID,
+			"stateChanges": []string{"start"},
 		},
 	})
 
@@ -169,8 +169,8 @@ func Test__OnInstanceStateChange__HandleWebhook_EmitsSelectedStateChanges(t *tes
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
-			"stateChanges":  []string{"softstop"},
+			"compartment":  testCompartmentID,
+			"stateChanges": []string{"softstop"},
 		},
 	})
 
@@ -189,8 +189,8 @@ func Test__OnInstanceStateChange__HandleWebhook_FiltersTerminate(t *testing.T) {
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
-			"stateChanges":  []string{"stop"},
+			"compartment":  testCompartmentID,
+			"stateChanges": []string{"stop"},
 		},
 	})
 
@@ -208,7 +208,7 @@ func Test__OnInstanceStateChange__HandleWebhook_FiltersDifferentCompartment(t *t
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
-			"compartmentId": testCompartmentID,
+			"compartment": testCompartmentID,
 		},
 	})
 
@@ -241,7 +241,7 @@ func Test__OnInstanceStateChange__HandleWebhook_EmitsValidEventTypes(t *testing.
 				Events:  events,
 				Headers: http.Header{},
 				Configuration: map[string]any{
-					"compartmentId": testCompartmentID,
+					"compartment": testCompartmentID,
 				},
 			})
 

--- a/pkg/integrations/oci/on_instance_state_change_test.go
+++ b/pkg/integrations/oci/on_instance_state_change_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -61,16 +62,135 @@ func Test__OnInstanceStateChange__Setup_UsesWebhookPathIDForRuleName(t *testing.
 	assert.NotContains(t, string(body), "token=abc")
 }
 
+func Test__OnInstanceStateChange__Setup_RejectsUnsupportedStateChanges(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+			"stateChanges":  []string{"hibernate"},
+		},
+		Integration: ociIntegrationContext(),
+		Metadata:    &contexts.MetadataContext{},
+		Logger:      ociLogger(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported state change: hibernate")
+}
+
+func Test__OnInstanceStateChange__Configuration(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	fields := trigger.Configuration()
+
+	byName := map[string]configuration.Field{}
+	for _, field := range fields {
+		byName[field.Name] = field
+	}
+
+	stateChanges, ok := byName["stateChanges"]
+	require.True(t, ok, "stateChanges field should exist")
+	assert.Equal(t, configuration.FieldTypeMultiSelect, stateChanges.Type)
+	assert.True(t, stateChanges.Required)
+	assert.Equal(t, []string{
+		ociInstanceStateChangeStart,
+		ociInstanceStateChangeStop,
+		ociInstanceStateChangeReset,
+		ociInstanceStateChangeSoftStop,
+		ociInstanceStateChangeSoftReset,
+		ociInstanceStateChangeTerminate,
+	}, stateChanges.Default)
+	require.NotNil(t, stateChanges.TypeOptions)
+	require.NotNil(t, stateChanges.TypeOptions.MultiSelect)
+	assert.False(t, stateChanges.TypeOptions.MultiSelect.UseCheckboxes)
+}
+
 func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownEventTypes(t *testing.T) {
 	trigger := &OnInstanceStateChange{}
 	events := &contexts.EventContext{}
 
 	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.launchinstance.end", testCompartmentID),
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.launchinstance.end", testCompartmentID, ""),
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
 			"compartmentId": testCompartmentID,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, 0, events.Count())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_IgnoresUnknownInstanceActionTypes(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.instanceaction.end", testCompartmentID, "senddiagnosticinterrupt"),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, 0, events.Count())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_FiltersUnselectedStateChanges(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.instanceaction.end", testCompartmentID, "stop"),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+			"stateChanges":  []string{"start"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, 0, events.Count())
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_EmitsSelectedStateChanges(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.instanceaction.end", testCompartmentID, "softstop"),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+			"stateChanges":  []string{"softstop"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.Len(t, events.Payloads, 1)
+	assert.Equal(t, OnInstanceStateChangePayloadType, events.Payloads[0].Type)
+}
+
+func Test__OnInstanceStateChange__HandleWebhook_FiltersTerminate(t *testing.T) {
+	trigger := &OnInstanceStateChange{}
+	events := &contexts.EventContext{}
+
+	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.terminateinstance.end", testCompartmentID, ""),
+		Events:  events,
+		Headers: http.Header{},
+		Configuration: map[string]any{
+			"compartmentId": testCompartmentID,
+			"stateChanges":  []string{"stop"},
 		},
 	})
 
@@ -84,7 +204,7 @@ func Test__OnInstanceStateChange__HandleWebhook_FiltersDifferentCompartment(t *t
 	events := &contexts.EventContext{}
 
 	status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.stopinstance.end", "other-compartment"),
+		Body:    instanceStateChangeEventBody(t, "com.oraclecloud.computeapi.instanceaction.end", "other-compartment", "stop"),
 		Events:  events,
 		Headers: http.Header{},
 		Configuration: map[string]any{
@@ -99,21 +219,25 @@ func Test__OnInstanceStateChange__HandleWebhook_FiltersDifferentCompartment(t *t
 
 func Test__OnInstanceStateChange__HandleWebhook_EmitsValidEventTypes(t *testing.T) {
 	trigger := &OnInstanceStateChange{}
-	validEventTypes := []string{
-		"com.oraclecloud.computeapi.startinstance.end",
-		"com.oraclecloud.computeapi.stopinstance.end",
-		"com.oraclecloud.computeapi.terminateinstance.end",
-		"com.oraclecloud.computeapi.resetinstance.end",
-		"com.oraclecloud.computeapi.softstopinstance.end",
-		"com.oraclecloud.computeapi.softresetinstance.end",
+	validEvents := []struct {
+		name       string
+		eventType  string
+		actionType string
+	}{
+		{name: "start", eventType: "com.oraclecloud.computeapi.instanceaction.end", actionType: "start"},
+		{name: "stop", eventType: "com.oraclecloud.computeapi.instanceaction.end", actionType: "stop"},
+		{name: "reset", eventType: "com.oraclecloud.computeapi.instanceaction.end", actionType: "reset"},
+		{name: "softstop", eventType: "com.oraclecloud.computeapi.instanceaction.end", actionType: "softstop"},
+		{name: "softreset", eventType: "com.oraclecloud.computeapi.instanceaction.end", actionType: "softreset"},
+		{name: "terminate", eventType: "com.oraclecloud.computeapi.terminateinstance.end"},
 	}
 
-	for _, eventType := range validEventTypes {
-		t.Run(eventType, func(t *testing.T) {
+	for _, event := range validEvents {
+		t.Run(event.name, func(t *testing.T) {
 			events := &contexts.EventContext{}
 
 			status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-				Body:    instanceStateChangeEventBody(t, eventType, testCompartmentID),
+				Body:    instanceStateChangeEventBody(t, event.eventType, testCompartmentID, event.actionType),
 				Events:  events,
 				Headers: http.Header{},
 				Configuration: map[string]any{
@@ -129,8 +253,15 @@ func Test__OnInstanceStateChange__HandleWebhook_EmitsValidEventTypes(t *testing.
 	}
 }
 
-func instanceStateChangeEventBody(t *testing.T, eventType, compartmentID string) []byte {
+func instanceStateChangeEventBody(t *testing.T, eventType, compartmentID, actionType string) []byte {
 	t.Helper()
+
+	additionalDetails := map[string]any{
+		"shape": "VM.Standard.E2.1.Micro",
+	}
+	if actionType != "" {
+		additionalDetails["instanceActionType"] = actionType
+	}
 
 	body, err := json.Marshal(map[string]any{
 		"eventType": eventType,
@@ -141,9 +272,7 @@ func instanceStateChangeEventBody(t *testing.T, eventType, compartmentID string)
 			"compartmentId":      compartmentID,
 			"compartmentName":    "root",
 			"availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
-			"additionalDetails": map[string]any{
-				"shape": "VM.Standard.E2.1.Micro",
-			},
+			"additionalDetails":  additionalDetails,
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/integrations/oci/testdata_test.go
+++ b/pkg/integrations/oci/testdata_test.go
@@ -1,0 +1,84 @@
+package oci
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+const testOCIPrivateKey = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDBaw/KsqBmsyjy
+jyVsbvmYE5OPKi7wmqJ44t/OnUGr1MqmPD/fAsPE0H9we7iSP7j0UApNGmVFPKA9
+2Fc4jUlEAudiKqVhPQPFKpI3+tiO55hYp8EjZwks21u035dxTnQwHtGfOxYaltOW
+xKgAPZqJUCxxZfG7EEDa+igPRv0vnM7wSM6EwKP5ysRF0N6NXXskM0Vj08Z5jNgN
+Y3DXPaPHZClh0eltv3hlh/lh3+PN8nNWvACSHtBtgwk9tGEjc5SE86rDuBMAw2nk
+0gKO9JIQgWzuMzOHeqexx/SmWMMcHmeteKR01+uQjGtSruo36mXLg8/1/RdNla5k
+UQuVqlgnAgMBAAECggEAN9e6z/mBsRUSAfINSoDB5EPmqwNxWPs0ZHWQS32Aq+U8
+ewFTKYaJUiYmXSoDUIpAUp1XVAqGaZaG50QybnvwRsgV2PRaGjh9Aax4Wdw9MQkx
+pYsNirShZAeTMyYI+eg+SHRlbjUnfRbF0TZHEQa4OuPgaP8XazxWlUJ7VWnYCKob
+QysttNOZJKTzikVhSIZvDW1RyK5nbpv44ZDJS8+ZQBbTPFrp+GzxpKDPWc3KVuO3
+7jQGRUuF2YwcjbcDH2271b0fn19Abm6DLDLhfGSFPkXuISbeQ+eNSmvXZfHZhzLj
+dJefJIsntB+/VvJxyOdDrOCCPhUXWaN9Stch7ziIXQKBgQDoQge7U0CFI+mj98cp
+miuuGZYM1Fk8+hGnw/O9Gvpyt7aXkteIx26JjJZiNPcxvbMgJOtKu7Qdcf5cPfsA
+XAanokVteNvgBQqKSPqqqKpW5r8QeSKPKtrbMgtmy3KZT6KxbaH6xCBpnzvZ6gT5
+EgvUuqFipPDSrgZqFnNs4duY+wKBgQDVMKIAqh6NYeVRX6XS7s0el8iWUE52hAq+
+kD27gb+aIt5i/KidJj1Qbbc0Mr69BtmsQsnrNtaRjMkx6nfgc6ODfYpxKHux/xyx
+fYVKa5+5AuZg04PatNpkju2wckPC5GCrw6LLRLuyy0+Pf6BfmUas/TXBDMlirtK7
+pqJiOiStxQKBgGUiA23dNXYECkN8q/uAh06bE4xolqcHmNJ9b8/DRJTZTCe6KCIF
+/SrlzcHboFvHZ40ypkX3b9l2frS5xGcGq1spPKQLgWqNp2ZJmuTe5rVKap4IsTS4
+C25w3ygWpML/Oy+ZNnQUHK0BSjV8QkgWRJKP5aAnhDmoz2A4gHBD9LQrAoGAPUDh
+6yr16E1uY/kFXhu618VonreoM6kwpRwwgIWBFbpbBzntAGoSR9+eOeMypoEnXbU6
+6tgwwlUfIbZqhxTysD8L3gNxtuzDw8N63q0ZkUDiDIP5aId6EFZ4uK+8BG010WQ+
+jATNoUuFKofS/mS9x8pg/Xy9CBuO9Nel5G8sRrkCgYBH3i9kkjwiGEkEC9yDuaSN
+e8GQFwd4MCKwzDB+mjqxgTKNlpzTcfmqI5fGSFFY//XLxaIJxeMqg6nVIfEg+/+t
+lT4hHZpmGCUnXTBwAKd5DzCxYFMA9mOIsXzw30qzT20XtGAjBKOfOnzQCdJl0ZYr
+BhAK7kaeOgKerVxbFJ57Yw==
+-----END PRIVATE KEY-----`
+
+const testInstanceID = "ocid1.instance.oc1.eu-frankfurt-1.testinstance"
+const testCompartmentID = "ocid1.tenancy.oc1..testtenancy"
+
+func ociIntegrationContext() *contexts.IntegrationContext {
+	return &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"tenancyOcid": "ocid1.tenancy.oc1..testtenancy",
+			"userOcid":    "ocid1.user.oc1..testuser",
+			"fingerprint": "12:34:56:78:90:ab:cd:ef",
+			"privateKey":  testOCIPrivateKey,
+			"region":      "eu-frankfurt-1",
+		},
+		Metadata: IntegrationMetadata{TopicID: "ocid1.onstopic.oc1.eu-frankfurt-1.testtopic"},
+	}
+}
+
+func ociMockResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{},
+		Request:    &http.Request{},
+	}
+}
+
+func ociInstanceBody(state string) string {
+	return `{
+		"id": "` + testInstanceID + `",
+		"displayName": "test-instance",
+		"lifecycleState": "` + state + `",
+		"shape": "VM.Standard.E2.1.Micro",
+		"availabilityDomain": "XXXX:eu-frankfurt-1-AD-1",
+		"compartmentId": "` + testCompartmentID + `",
+		"region": "eu-frankfurt-1",
+		"timeCreated": "2026-04-22T20:31:25.145Z"
+	}`
+}
+
+func ociLogger() *logrus.Entry {
+	logger := logrus.New()
+	logger.Out = io.Discard
+	return logrus.NewEntry(logger)
+}

--- a/pkg/integrations/oci/update_instance.go
+++ b/pkg/integrations/oci/update_instance.go
@@ -1,0 +1,199 @@
+package oci
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const UpdateInstancePayloadType = "oci.updateInstance"
+
+type UpdateInstance struct{}
+
+type UpdateInstanceSpec struct {
+	InstanceID  string   `json:"instanceId" mapstructure:"instanceId"`
+	DisplayName string   `json:"displayName" mapstructure:"displayName"`
+	OCPUs       *float64 `json:"ocpus" mapstructure:"ocpus"`
+	MemoryInGBs *float64 `json:"memoryInGBs" mapstructure:"memoryInGBs"`
+}
+
+func (c *UpdateInstance) Name() string {
+	return "oci.updateInstance"
+}
+
+func (c *UpdateInstance) Label() string {
+	return "Update Instance"
+}
+
+func (c *UpdateInstance) Description() string {
+	return "Update mutable OCI Compute instance attributes"
+}
+
+func (c *UpdateInstance) Documentation() string {
+	return `The Update Instance component updates mutable attributes on an Oracle Cloud Infrastructure Compute instance.
+
+## Use Cases
+
+- **Rename instances**: Update the display name for operational clarity
+- **Resize flex shapes**: Adjust OCPUs or memory for supported flexible shapes
+- **Post-provisioning changes**: Apply instance settings after a workflow decides the desired capacity
+
+## Configuration
+
+- **Instance**: The OCI Compute instance to update.
+- **Display Name**: Optional new display name.
+- **OCPUs**: Optional OCPU count for flexible shapes.
+- **Memory (GB)**: Optional memory size for flexible shapes.
+
+## Output
+
+Emits the updated instance details on the default output channel, including:
+- ` + "`instanceId`" + ` — instance OCID
+- ` + "`displayName`" + ` — instance display name
+- ` + "`lifecycleState`" + ` — current lifecycle state
+- ` + "`shape`" + ` — the instance shape
+- ` + "`availabilityDomain`" + ` — the availability domain
+- ` + "`compartmentId`" + ` — the compartment OCID
+- ` + "`region`" + ` — the region
+- ` + "`timeCreated`" + ` — ISO-8601 creation timestamp
+`
+}
+
+func (c *UpdateInstance) Icon() string {
+	return "oci"
+}
+
+func (c *UpdateInstance) Color() string {
+	return "red"
+}
+
+func (c *UpdateInstance) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateInstance) ExampleOutput() map[string]any {
+	return exampleOutputUpdateInstance()
+}
+
+func (c *UpdateInstance) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instanceId",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Compute instance to update",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "displayName",
+			Label:       "Display Name",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+			Description: "New display name for the instance",
+			Placeholder: "my-instance",
+		},
+		{
+			Name:        "ocpus",
+			Label:       "OCPUs",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Togglable:   true,
+			Description: "Number of OCPUs for a flexible shape",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { v := 1; return &v }(),
+				},
+			},
+		},
+		{
+			Name:        "memoryInGBs",
+			Label:       "Memory (GB)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Togglable:   true,
+			Description: "Memory in GB for a flexible shape",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { v := 1; return &v }(),
+				},
+			},
+		},
+	}
+}
+
+func (c *UpdateInstance) Setup(ctx core.SetupContext) error {
+	spec := UpdateInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if strings.TrimSpace(spec.InstanceID) == "" {
+		return errors.New("instanceId is required")
+	}
+	return nil
+}
+
+func (c *UpdateInstance) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create OCI client: %w", err)
+	}
+
+	req := UpdateInstanceRequest{}
+	if strings.TrimSpace(spec.DisplayName) != "" {
+		req.DisplayName = &spec.DisplayName
+	}
+	if spec.OCPUs != nil || spec.MemoryInGBs != nil {
+		req.ShapeConfig = &InstanceShapeConfig{
+			OCPUs:       spec.OCPUs,
+			MemoryInGBs: spec.MemoryInGBs,
+		}
+	}
+
+	instance, err := client.UpdateInstance(spec.InstanceID, req)
+	if err != nil {
+		return fmt.Errorf("failed to update instance: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, UpdateInstancePayloadType, []any{instanceToMap(instance)})
+}
+
+func (c *UpdateInstance) Actions() []core.Action {
+	return []core.Action{}
+}
+
+func (c *UpdateInstance) HandleAction(ctx core.ActionContext) error {
+	return fmt.Errorf("unknown action: %s", ctx.Name)
+}
+
+func (c *UpdateInstance) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateInstance) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateInstance) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *UpdateInstance) Cleanup(ctx core.SetupContext) error {
+	return nil
+}

--- a/pkg/integrations/oci/update_instance.go
+++ b/pkg/integrations/oci/update_instance.go
@@ -174,12 +174,12 @@ func (c *UpdateInstance) Execute(ctx core.ExecutionContext) error {
 	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, UpdateInstancePayloadType, []any{instanceToMap(instance)})
 }
 
-func (c *UpdateInstance) Actions() []core.Action {
-	return []core.Action{}
+func (c *UpdateInstance) Hooks() []core.Hook {
+	return []core.Hook{}
 }
 
-func (c *UpdateInstance) HandleAction(ctx core.ActionContext) error {
-	return fmt.Errorf("unknown action: %s", ctx.Name)
+func (c *UpdateInstance) HandleHook(ctx core.ActionHookContext) error {
+	return fmt.Errorf("unknown hook: %s", ctx.Name)
 }
 
 func (c *UpdateInstance) Cancel(ctx core.ExecutionContext) error {

--- a/pkg/integrations/oci/update_instance.go
+++ b/pkg/integrations/oci/update_instance.go
@@ -57,6 +57,8 @@ Emits the updated instance details on the default output channel, including:
 - ` + "`instanceId`" + ` — instance OCID
 - ` + "`displayName`" + ` — instance display name
 - ` + "`lifecycleState`" + ` — current lifecycle state
+- ` + "`publicIp`" + ` — public IP address, if assigned
+- ` + "`privateIp`" + ` — primary private IP address, if available
 - ` + "`shape`" + ` — the instance shape
 - ` + "`availabilityDomain`" + ` — the availability domain
 - ` + "`compartmentId`" + ` — the compartment OCID
@@ -171,7 +173,10 @@ func (c *UpdateInstance) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to update instance: %w", err)
 	}
 
-	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, UpdateInstancePayloadType, []any{instanceToMap(instance)})
+	payload := instanceToMap(instance)
+	enrichInstanceWithVNICIPs(ctx.Logger, client, instance, payload)
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, UpdateInstancePayloadType, []any{payload})
 }
 
 func (c *UpdateInstance) Hooks() []core.Hook {

--- a/pkg/integrations/oci/update_instance.go
+++ b/pkg/integrations/oci/update_instance.go
@@ -17,7 +17,7 @@ const UpdateInstancePayloadType = "oci.updateInstance"
 type UpdateInstance struct{}
 
 type UpdateInstanceSpec struct {
-	InstanceID  string   `json:"instanceId" mapstructure:"instanceId"`
+	Instance    string   `json:"instance" mapstructure:"instance"`
 	DisplayName string   `json:"displayName" mapstructure:"displayName"`
 	OCPUs       *float64 `json:"ocpus" mapstructure:"ocpus"`
 	MemoryInGBs *float64 `json:"memoryInGBs" mapstructure:"memoryInGBs"`
@@ -86,7 +86,7 @@ func (c *UpdateInstance) ExampleOutput() map[string]any {
 func (c *UpdateInstance) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "instanceId",
+			Name:        "instance",
 			Label:       "Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -140,8 +140,8 @@ func (c *UpdateInstance) Setup(ctx core.SetupContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
-	if strings.TrimSpace(spec.InstanceID) == "" {
-		return errors.New("instanceId is required")
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
 	}
 	return nil
 }
@@ -168,7 +168,7 @@ func (c *UpdateInstance) Execute(ctx core.ExecutionContext) error {
 		}
 	}
 
-	instance, err := client.UpdateInstance(spec.InstanceID, req)
+	instance, err := client.UpdateInstance(spec.Instance, req)
 	if err != nil {
 		return fmt.Errorf("failed to update instance: %w", err)
 	}

--- a/pkg/integrations/oci/update_instance_test.go
+++ b/pkg/integrations/oci/update_instance_test.go
@@ -1,0 +1,65 @@
+package oci
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateInstance__Setup(t *testing.T) {
+	component := &UpdateInstance{}
+
+	err := component.Setup(core.SetupContext{
+		Configuration: map[string]any{"instanceId": ""},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instanceId is required")
+}
+
+func Test__UpdateInstance__Execute(t *testing.T) {
+	component := &UpdateInstance{}
+	httpCtx := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"instanceId":  testInstanceID,
+			"displayName": "renamed",
+			"ocpus":       2.0,
+			"memoryInGBs": 16.0,
+		},
+		HTTP:           httpCtx,
+		Integration:    ociIntegrationContext(),
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpCtx.Requests, 1)
+	req := httpCtx.Requests[0]
+	assert.Equal(t, http.MethodPut, req.Method)
+	assert.Contains(t, req.URL.String(), "/20160918/instances/"+testInstanceID)
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	assert.Equal(t, "renamed", payload["displayName"])
+	require.Contains(t, payload, "shapeConfig")
+	shapeConfig := payload["shapeConfig"].(map[string]any)
+	assert.Equal(t, float64(2), shapeConfig["ocpus"])
+	assert.Equal(t, float64(16), shapeConfig["memoryInGBs"])
+
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, UpdateInstancePayloadType, executionState.Type)
+}

--- a/pkg/integrations/oci/update_instance_test.go
+++ b/pkg/integrations/oci/update_instance_test.go
@@ -28,6 +28,8 @@ func Test__UpdateInstance__Execute(t *testing.T) {
 	httpCtx := &contexts.HTTPContext{
 		Responses: []*http.Response{
 			ociMockResponse(http.StatusOK, ociInstanceBody(instanceStateRunning)),
+			ociMockResponse(http.StatusOK, `[{"vnicId":"ocid1.vnic.oc1.test","lifecycleState":"ATTACHED"}]`),
+			ociMockResponse(http.StatusOK, `{"id":"ocid1.vnic.oc1.test","publicIp":"192.0.2.1","privateIp":"10.0.0.17"}`),
 		},
 	}
 	executionState := &contexts.ExecutionStateContext{}
@@ -45,10 +47,12 @@ func Test__UpdateInstance__Execute(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Len(t, httpCtx.Requests, 1)
+	require.Len(t, httpCtx.Requests, 3)
 	req := httpCtx.Requests[0]
 	assert.Equal(t, http.MethodPut, req.Method)
 	assert.Contains(t, req.URL.String(), "/20160918/instances/"+testInstanceID)
+	assert.Contains(t, httpCtx.Requests[1].URL.String(), "/20160918/vnicAttachments")
+	assert.Contains(t, httpCtx.Requests[2].URL.String(), "/20160918/vnics/ocid1.vnic.oc1.test")
 
 	body, err := io.ReadAll(req.Body)
 	require.NoError(t, err)
@@ -62,4 +66,10 @@ func Test__UpdateInstance__Execute(t *testing.T) {
 
 	assert.True(t, executionState.Passed)
 	assert.Equal(t, UpdateInstancePayloadType, executionState.Type)
+	require.Len(t, executionState.Payloads, 1)
+
+	wrapped := executionState.Payloads[0].(map[string]any)
+	data := wrapped["data"].(map[string]any)
+	assert.Equal(t, "192.0.2.1", data["publicIp"])
+	assert.Equal(t, "10.0.0.17", data["privateIp"])
 }

--- a/pkg/integrations/oci/update_instance_test.go
+++ b/pkg/integrations/oci/update_instance_test.go
@@ -16,11 +16,11 @@ func Test__UpdateInstance__Setup(t *testing.T) {
 	component := &UpdateInstance{}
 
 	err := component.Setup(core.SetupContext{
-		Configuration: map[string]any{"instanceId": ""},
+		Configuration: map[string]any{"instance": ""},
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "instanceId is required")
+	assert.Contains(t, err.Error(), "instance is required")
 }
 
 func Test__UpdateInstance__Execute(t *testing.T) {
@@ -36,7 +36,7 @@ func Test__UpdateInstance__Execute(t *testing.T) {
 
 	err := component.Execute(core.ExecutionContext{
 		Configuration: map[string]any{
-			"instanceId":  testInstanceID,
+			"instance":    testInstanceID,
 			"displayName": "renamed",
 			"ocpus":       2.0,
 			"memoryInGBs": 16.0,

--- a/web_src/src/pages/workflowv2/mappers/oci/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/base.ts
@@ -52,6 +52,18 @@ export const baseMapper: ComponentBaseMapper = {
   },
 };
 
+export function compactDetails(entries: Array<[string, string | undefined]>): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  for (const [key, value] of entries) {
+    if (value) {
+      details[key] = value;
+    }
+  }
+
+  return details;
+}
+
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const rootEvent = execution.rootEvent;
   if (!rootEvent?.nodeId || !rootEvent?.id) {

--- a/web_src/src/pages/workflowv2/mappers/oci/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/base.ts
@@ -13,6 +13,10 @@ import type {
 import ociIcon from "@/assets/icons/integrations/oci.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 
+type DefaultChannelPayload<T> = OutputPayload & {
+  data?: T;
+};
+
 export const baseMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
@@ -63,6 +67,18 @@ export function compactDetails(entries: Array<[string, string | null | undefined
   }
 
   return details;
+}
+
+/** First item on the default output channel: uses `data` when present, otherwise the payload object. */
+export function getDefaultChannelOutputData<T>(context: ExecutionDetailsContext): T | undefined {
+  const outputs = context.execution.outputs as { default?: DefaultChannelPayload<T>[] } | undefined;
+  const payload = outputs?.default?.[0];
+  if (!payload) return undefined;
+  return (payload.data ?? payload) as T;
+}
+
+export function executedAt(context: ExecutionDetailsContext): string {
+  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {

--- a/web_src/src/pages/workflowv2/mappers/oci/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/base.ts
@@ -52,11 +52,12 @@ export const baseMapper: ComponentBaseMapper = {
   },
 };
 
-export function compactDetails(entries: Array<[string, string | undefined]>): Record<string, string> {
+/** Omits only null/undefined keys — keeps empty strings and other falsy string values. */
+export function compactDetails(entries: Array<[string, string | null | undefined]>): Record<string, string> {
   const details: Record<string, string> = {};
 
   for (const [key, value] of entries) {
-    if (value) {
+    if (value != null) {
       details[key] = value;
     }
   }

--- a/web_src/src/pages/workflowv2/mappers/oci/create_compute_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/create_compute_instance.ts
@@ -28,6 +28,7 @@ interface CreateComputeInstanceConfiguration {
 }
 
 interface CreateComputeInstanceOutputData {
+  instanceId?: string;
   displayName?: string;
   lifecycleState?: string;
   shape?: string;
@@ -36,6 +37,7 @@ interface CreateComputeInstanceOutputData {
   region?: string;
   timeCreated?: string;
   publicIp?: string;
+  privateIp?: string;
 }
 
 type CreateComputeInstanceOutputPayload = OutputPayload & {
@@ -82,6 +84,10 @@ export const createComputeInstanceMapper: ComponentBaseMapper = {
 
     if (!data) return details;
 
+    if (data.instanceId) {
+      details["Instance ID"] = data.instanceId;
+    }
+
     if (data.displayName) {
       details["Display Name"] = data.displayName;
     }
@@ -106,6 +112,10 @@ export const createComputeInstanceMapper: ComponentBaseMapper = {
       details["Public IP"] = data.publicIp;
     }
 
+    if (data.privateIp) {
+      details["Private IP"] = data.privateIp;
+    }
+
     return details;
   },
 };
@@ -124,6 +134,15 @@ function createComputeInstanceMetadataList(node: ComponentBaseContext["node"]): 
 
   if (config?.availabilityDomain) {
     items.push({ icon: "map-pin", label: config.availabilityDomain });
+  }
+
+  if (config?.imageOs) {
+    items.push({ icon: "layers", label: config.imageOs });
+  }
+
+  if (config?.ocpus) {
+    const memory = config.memoryInGBs ? ` / ${config.memoryInGBs} GB RAM` : "";
+    items.push({ icon: "zap", label: `${config.ocpus} OCPUs${memory}` });
   }
 
   return items;

--- a/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
@@ -1,0 +1,69 @@
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseMapper } from "./base";
+
+interface DeleteInstanceConfiguration {
+  instanceId?: string;
+  preserveBootVolume?: boolean;
+}
+
+interface InstanceOutputData {
+  instanceId?: string;
+  lifecycleState?: string;
+}
+
+type InstanceOutputPayload = OutputPayload & {
+  data?: InstanceOutputData;
+};
+
+function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
+  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
+  const payload = outputs?.default?.[0];
+  if (!payload) return undefined;
+  return (payload.data ?? payload) as InstanceOutputData;
+}
+
+function executedAt(context: ExecutionDetailsContext): string {
+  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
+}
+
+export const deleteInstanceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext) {
+    const props = baseMapper.props(context);
+    const config = context.node.configuration as DeleteInstanceConfiguration | undefined;
+    const metadata: MetadataItem[] = [];
+
+    if (config?.instanceId) {
+      metadata.push({ icon: "trash-2", label: config.instanceId });
+    }
+    if (config?.preserveBootVolume) {
+      metadata.push({ icon: "archive", label: "Preserve boot volume" });
+    }
+
+    return {
+      ...props,
+      metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const config = context.node.configuration as DeleteInstanceConfiguration | undefined;
+    const data = getOutputData(context);
+    return {
+      "Executed At": executedAt(context),
+      "Instance ID": data?.instanceId ?? "-",
+      State: data?.lifecycleState ?? "-",
+      "Preserve Boot Volume": config?.preserveBootVolume ? "Yes" : "No",
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
@@ -9,7 +9,7 @@ import type {
 import { baseMapper } from "./base";
 
 interface DeleteInstanceConfiguration {
-  instanceId?: string;
+  instance?: string;
   preserveBootVolume?: boolean;
 }
 
@@ -39,8 +39,8 @@ export const deleteInstanceMapper: ComponentBaseMapper = {
     const config = context.node.configuration as DeleteInstanceConfiguration | undefined;
     const metadata: MetadataItem[] = [];
 
-    if (config?.instanceId) {
-      metadata.push({ icon: "trash-2", label: config.instanceId });
+    if (config?.instance) {
+      metadata.push({ icon: "trash-2", label: config.instance });
     }
     if (config?.preserveBootVolume) {
       metadata.push({ icon: "archive", label: "Preserve boot volume" });

--- a/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/delete_instance.ts
@@ -1,12 +1,6 @@
 import type { MetadataItem } from "@/ui/metadataList";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
-import { baseMapper } from "./base";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { baseMapper, executedAt, getDefaultChannelOutputData } from "./base";
 
 interface DeleteInstanceConfiguration {
   instance?: string;
@@ -16,21 +10,6 @@ interface DeleteInstanceConfiguration {
 interface InstanceOutputData {
   instanceId?: string;
   lifecycleState?: string;
-}
-
-type InstanceOutputPayload = OutputPayload & {
-  data?: InstanceOutputData;
-};
-
-function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
-  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
-  const payload = outputs?.default?.[0];
-  if (!payload) return undefined;
-  return (payload.data ?? payload) as InstanceOutputData;
-}
-
-function executedAt(context: ExecutionDetailsContext): string {
-  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
 }
 
 export const deleteInstanceMapper: ComponentBaseMapper = {
@@ -58,7 +37,7 @@ export const deleteInstanceMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const config = context.node.configuration as DeleteInstanceConfiguration | undefined;
-    const data = getOutputData(context);
+    const data = getDefaultChannelOutputData<InstanceOutputData>(context);
     return {
       "Executed At": executedAt(context),
       "Instance ID": data?.instanceId ?? "-",

--- a/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
@@ -1,0 +1,70 @@
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseMapper } from "./base";
+
+interface GetInstanceConfiguration {
+  instanceId?: string;
+}
+
+interface InstanceOutputData {
+  instanceId?: string;
+  displayName?: string;
+  lifecycleState?: string;
+  shape?: string;
+  availabilityDomain?: string;
+  compartmentId?: string;
+  region?: string;
+  timeCreated?: string;
+  publicIp?: string;
+  privateIp?: string;
+}
+
+type InstanceOutputPayload = OutputPayload & {
+  data?: InstanceOutputData;
+};
+
+function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
+  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
+  const payload = outputs?.default?.[0];
+  if (!payload) return undefined;
+  return (payload.data ?? payload) as InstanceOutputData;
+}
+
+function executedAt(context: ExecutionDetailsContext): string {
+  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
+}
+
+export const getInstanceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext) {
+    const props = baseMapper.props(context);
+    const config = context.node.configuration as GetInstanceConfiguration | undefined;
+    const metadata: MetadataItem[] = config?.instanceId ? [{ icon: "server", label: config.instanceId }] : [];
+
+    return {
+      ...props,
+      metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = getOutputData(context);
+    return {
+      "Executed At": executedAt(context),
+      "Instance ID": data?.instanceId ?? "-",
+      "Display Name": data?.displayName ?? "-",
+      State: data?.lifecycleState ?? "-",
+      Shape: data?.shape ?? "-",
+      Region: data?.region ?? "-",
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
@@ -9,7 +9,7 @@ import type {
 import { baseMapper } from "./base";
 
 interface GetInstanceConfiguration {
-  instanceId?: string;
+  instance?: string;
 }
 
 interface InstanceOutputData {
@@ -44,7 +44,7 @@ export const getInstanceMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext) {
     const props = baseMapper.props(context);
     const config = context.node.configuration as GetInstanceConfiguration | undefined;
-    const metadata: MetadataItem[] = config?.instanceId ? [{ icon: "server", label: config.instanceId }] : [];
+    const metadata: MetadataItem[] = config?.instance ? [{ icon: "server", label: config.instance }] : [];
 
     return {
       ...props,

--- a/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/get_instance.ts
@@ -1,12 +1,6 @@
 import type { MetadataItem } from "@/ui/metadataList";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
-import { baseMapper } from "./base";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { baseMapper, executedAt, getDefaultChannelOutputData } from "./base";
 
 interface GetInstanceConfiguration {
   instance?: string;
@@ -23,21 +17,6 @@ interface InstanceOutputData {
   timeCreated?: string;
   publicIp?: string;
   privateIp?: string;
-}
-
-type InstanceOutputPayload = OutputPayload & {
-  data?: InstanceOutputData;
-};
-
-function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
-  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
-  const payload = outputs?.default?.[0];
-  if (!payload) return undefined;
-  return (payload.data ?? payload) as InstanceOutputData;
-}
-
-function executedAt(context: ExecutionDetailsContext): string {
-  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
 }
 
 export const getInstanceMapper: ComponentBaseMapper = {
@@ -57,7 +36,7 @@ export const getInstanceMapper: ComponentBaseMapper = {
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const data = getOutputData(context);
+    const data = getDefaultChannelOutputData<InstanceOutputData>(context);
     return {
       "Executed At": executedAt(context),
       "Instance ID": data?.instanceId ?? "-",

--- a/web_src/src/pages/workflowv2/mappers/oci/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/index.ts
@@ -1,11 +1,16 @@
 import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { createComputeInstanceMapper } from "./create_compute_instance";
+import { deleteInstanceMapper } from "./delete_instance";
+import { getInstanceMapper } from "./get_instance";
+import { manageInstancePowerMapper } from "./manage_instance_power";
 import { onComputeInstanceCreatedTriggerRenderer } from "./on_compute_instance_created";
 import { createApplicationMapper } from "./create_application";
 import { deleteApplicationMapper } from "./delete_application";
 import { createFunctionMapper } from "./create_function";
 import { deleteFunctionMapper } from "./delete_function";
 import { invokeFunctionMapper } from "./invoke_function";
+import { onInstanceStateChangeTriggerRenderer } from "./on_instance_state_change";
+import { updateInstanceMapper } from "./update_instance";
 import { buildActionStateRegistry } from "../utils";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
@@ -15,10 +20,15 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createFunction: createFunctionMapper,
   deleteFunction: deleteFunctionMapper,
   invokeFunction: invokeFunctionMapper,
+  getInstance: getInstanceMapper,
+  updateInstance: updateInstanceMapper,
+  manageInstancePower: manageInstancePowerMapper,
+  deleteInstance: deleteInstanceMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
   onComputeInstanceCreated: onComputeInstanceCreatedTriggerRenderer,
+  onInstanceStateChange: onInstanceStateChangeTriggerRenderer,
 };
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -28,4 +38,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createFunction: buildActionStateRegistry("created"),
   deleteFunction: buildActionStateRegistry("deleted"),
   invokeFunction: buildActionStateRegistry("success"),
+  getInstance: buildActionStateRegistry("fetched"),
+  updateInstance: buildActionStateRegistry("updated"),
+  manageInstancePower: buildActionStateRegistry("completed"),
+  deleteInstance: buildActionStateRegistry("deleted"),
 };

--- a/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
@@ -9,6 +9,7 @@ import type {
 import { baseMapper } from "./base";
 
 interface ManageInstancePowerConfiguration {
+  instance?: string;
   instanceId?: string;
   action?: string;
 }
@@ -47,9 +48,10 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
     const props = baseMapper.props(context);
     const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
     const metadata: MetadataItem[] = [];
+    const instance = config?.instance ?? config?.instanceId;
 
-    if (config?.instanceId) {
-      metadata.push({ icon: "server", label: config.instanceId });
+    if (instance) {
+      metadata.push({ icon: "server", label: instance });
     }
     if (config?.action) {
       metadata.push({ icon: "zap", label: config.action });

--- a/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
@@ -1,0 +1,80 @@
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseMapper } from "./base";
+
+interface ManageInstancePowerConfiguration {
+  instanceId?: string;
+  action?: string;
+}
+
+interface InstanceOutputData {
+  instanceId?: string;
+  displayName?: string;
+  lifecycleState?: string;
+  shape?: string;
+  availabilityDomain?: string;
+  compartmentId?: string;
+  region?: string;
+  timeCreated?: string;
+  publicIp?: string;
+  privateIp?: string;
+  action?: string;
+}
+
+type InstanceOutputPayload = OutputPayload & {
+  data?: InstanceOutputData;
+};
+
+function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
+  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
+  const payload = outputs?.default?.[0];
+  if (!payload) return undefined;
+  return (payload.data ?? payload) as InstanceOutputData;
+}
+
+function executedAt(context: ExecutionDetailsContext): string {
+  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
+}
+
+export const manageInstancePowerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext) {
+    const props = baseMapper.props(context);
+    const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
+    const metadata: MetadataItem[] = [];
+
+    if (config?.instanceId) {
+      metadata.push({ icon: "server", label: config.instanceId });
+    }
+    if (config?.action) {
+      metadata.push({ icon: "zap", label: config.action });
+    }
+
+    return {
+      ...props,
+      metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
+    const data = getOutputData(context);
+    return {
+      "Executed At": executedAt(context),
+      Action: config?.action ?? data?.action ?? "-",
+      "Instance ID": data?.instanceId ?? "-",
+      "Display Name": data?.displayName ?? "-",
+      State: data?.lifecycleState ?? "-",
+      Region: data?.region ?? "-",
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
@@ -1,12 +1,6 @@
 import type { MetadataItem } from "@/ui/metadataList";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
-import { baseMapper } from "./base";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { baseMapper, executedAt, getDefaultChannelOutputData } from "./base";
 
 interface ManageInstancePowerConfiguration {
   instance?: string;
@@ -25,21 +19,6 @@ interface InstanceOutputData {
   publicIp?: string;
   privateIp?: string;
   action?: string;
-}
-
-type InstanceOutputPayload = OutputPayload & {
-  data?: InstanceOutputData;
-};
-
-function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
-  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
-  const payload = outputs?.default?.[0];
-  if (!payload) return undefined;
-  return (payload.data ?? payload) as InstanceOutputData;
-}
-
-function executedAt(context: ExecutionDetailsContext): string {
-  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
 }
 
 export const manageInstancePowerMapper: ComponentBaseMapper = {
@@ -67,7 +46,7 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
-    const data = getOutputData(context);
+    const data = getDefaultChannelOutputData<InstanceOutputData>(context);
     return {
       "Executed At": executedAt(context),
       Action: config?.action ?? data?.action ?? "-",

--- a/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
@@ -9,7 +9,6 @@ import type {
 import { baseMapper } from "./base";
 
 interface ManageInstancePowerConfiguration {
-  instance?: string;
   instanceId?: string;
   action?: string;
 }
@@ -48,10 +47,9 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
     const props = baseMapper.props(context);
     const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
     const metadata: MetadataItem[] = [];
-    const instance = config?.instance ?? config?.instanceId;
 
-    if (instance) {
-      metadata.push({ icon: "server", label: instance });
+    if (config?.instanceId) {
+      metadata.push({ icon: "server", label: config.instanceId });
     }
     if (config?.action) {
       metadata.push({ icon: "zap", label: config.action });

--- a/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/manage_instance_power.ts
@@ -9,7 +9,7 @@ import type {
 import { baseMapper } from "./base";
 
 interface ManageInstancePowerConfiguration {
-  instanceId?: string;
+  instance?: string;
   action?: string;
 }
 
@@ -48,8 +48,8 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
     const config = context.node.configuration as ManageInstancePowerConfiguration | undefined;
     const metadata: MetadataItem[] = [];
 
-    if (config?.instanceId) {
-      metadata.push({ icon: "server", label: config.instanceId });
+    if (config?.instance) {
+      metadata.push({ icon: "server", label: config.instance });
     }
     if (config?.action) {
       metadata.push({ icon: "zap", label: config.action });

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -361,8 +361,8 @@ describe("eventStateRegistry", () => {
   it("maps in-progress executions to running", () => {
     const execution = buildExecution({
       state: "STATE_STARTED",
-      result: "RESULT_UNSPECIFIED",
-      resultReason: "RESULT_REASON_UNSPECIFIED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
     });
 
     expect(eventStateRegistry.getInstance.getState(execution)).toBe("running");

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -81,7 +81,7 @@ function buildComponentContext(overrides?: {
     },
     lastExecutions: overrides?.lastExecutions ?? [],
     currentUser: undefined,
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 
@@ -141,7 +141,7 @@ const componentCases: Array<{
   {
     name: "manageInstancePower",
     mapper: manageInstancePowerMapper,
-    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
+    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
     metadata: [
       { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
       { icon: "zap", label: "STOP" },

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest";
+
+import { deleteInstanceMapper } from "./delete_instance";
+import { eventStateRegistry } from "./index";
+import { getInstanceMapper } from "./get_instance";
+import { manageInstancePowerMapper } from "./manage_instance_power";
+import { onInstanceStateChangeTriggerRenderer } from "./on_instance_state_change";
+import { updateInstanceMapper } from "./update_instance";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ComponentDefinition,
+  EventInfo,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  TriggerRendererContext,
+} from "../types";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "oci.getInstance",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "oci.result",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: "2026-04-22T20:32:00.000Z",
+    updatedAt: "2026-04-22T20:32:10.000Z",
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+function buildComponentContext(overrides?: {
+  node?: Partial<NodeInfo>;
+  lastExecutions?: ExecutionInfo[];
+  componentDefinition?: Partial<ComponentDefinition>;
+}): ComponentBaseContext {
+  const node = buildNode(overrides?.node);
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: {
+      name: "oci.getInstance",
+      label: "Get Instance",
+      description: "",
+      icon: "oci",
+      color: "red",
+      ...overrides?.componentDefinition,
+    },
+    lastExecutions: overrides?.lastExecutions ?? [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionAction: async () => {} },
+  };
+}
+
+const fullInstanceOutput = {
+  instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example",
+  displayName: "test-instance",
+  lifecycleState: "RUNNING",
+  shape: "VM.Standard.E2.1.Micro",
+  availabilityDomain: "XXXX:eu-frankfurt-1-AD-1",
+  compartmentId: "ocid1.tenancy.oc1..example",
+  region: "eu-frankfurt-1",
+  timeCreated: "2026-04-22T20:31:25.145Z",
+};
+
+const componentCases: Array<{
+  name: string;
+  mapper: ComponentBaseMapper;
+  config: Record<string, unknown>;
+  metadata: Array<{ icon: string; label: string }>;
+  minimalMetadata: Array<{ icon: string; label: string }>;
+  emptyFields: string[];
+  fullAssertions: Record<string, string>;
+}> = [
+  {
+    name: "getInstance",
+    mapper: getInstanceMapper,
+    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example" },
+    metadata: [{ icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" }],
+    minimalMetadata: [],
+    emptyFields: ["Instance ID", "Display Name", "State", "Shape", "Region"],
+    fullAssertions: {
+      "Instance ID": fullInstanceOutput.instanceId,
+      "Display Name": fullInstanceOutput.displayName,
+      State: fullInstanceOutput.lifecycleState,
+      Shape: fullInstanceOutput.shape,
+      Region: fullInstanceOutput.region,
+    },
+  },
+  {
+    name: "updateInstance",
+    mapper: updateInstanceMapper,
+    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", displayName: "renamed" },
+    metadata: [
+      { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
+      { icon: "tag", label: "renamed" },
+    ],
+    minimalMetadata: [],
+    emptyFields: ["Instance ID", "Display Name", "State", "Shape", "Region"],
+    fullAssertions: {
+      "Instance ID": fullInstanceOutput.instanceId,
+      "Display Name": fullInstanceOutput.displayName,
+      State: fullInstanceOutput.lifecycleState,
+      Shape: fullInstanceOutput.shape,
+      Region: fullInstanceOutput.region,
+    },
+  },
+  {
+    name: "manageInstancePower",
+    mapper: manageInstancePowerMapper,
+    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
+    metadata: [
+      { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
+      { icon: "zap", label: "STOP" },
+    ],
+    minimalMetadata: [],
+    emptyFields: ["Instance ID", "Display Name", "State", "Region"],
+    fullAssertions: {
+      Action: "STOP",
+      "Instance ID": fullInstanceOutput.instanceId,
+      "Display Name": fullInstanceOutput.displayName,
+      State: fullInstanceOutput.lifecycleState,
+      Region: fullInstanceOutput.region,
+    },
+  },
+  {
+    name: "deleteInstance",
+    mapper: deleteInstanceMapper,
+    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", preserveBootVolume: true },
+    metadata: [
+      { icon: "trash-2", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
+      { icon: "archive", label: "Preserve boot volume" },
+    ],
+    minimalMetadata: [],
+    emptyFields: ["Instance ID", "State"],
+    fullAssertions: {
+      "Instance ID": fullInstanceOutput.instanceId,
+      State: "TERMINATED",
+      "Preserve Boot Volume": "Yes",
+    },
+  },
+];
+
+for (const testCase of componentCases) {
+  describe(`${testCase.name}Mapper.getExecutionDetails`, () => {
+    it("does not throw when outputs is undefined", () => {
+      const ctx = buildDetailsCtx({
+        node: { componentName: `oci.${testCase.name}`, configuration: testCase.config },
+        execution: { outputs: undefined },
+      });
+      expect(() => testCase.mapper.getExecutionDetails(ctx)).not.toThrow();
+    });
+
+    it("does not throw when default array is empty", () => {
+      const ctx = buildDetailsCtx({
+        node: { componentName: `oci.${testCase.name}`, configuration: testCase.config },
+        execution: { outputs: { default: [] } },
+      });
+      expect(() => testCase.mapper.getExecutionDetails(ctx)).not.toThrow();
+    });
+
+    it("returns dashes for expected instance fields when data is empty", () => {
+      const ctx = buildDetailsCtx({
+        node: { componentName: `oci.${testCase.name}`, configuration: {} },
+        execution: { outputs: { default: [buildOutput({})] } },
+      });
+      const details = testCase.mapper.getExecutionDetails(ctx);
+
+      for (const field of testCase.emptyFields) {
+        expect(details[field]).toBe("-");
+      }
+    });
+
+    it("extracts fields from a full output payload", () => {
+      const payload =
+        testCase.name === "deleteInstance"
+          ? { instanceId: fullInstanceOutput.instanceId, lifecycleState: "TERMINATED" }
+          : fullInstanceOutput;
+      const ctx = buildDetailsCtx({
+        node: { componentName: `oci.${testCase.name}`, configuration: testCase.config },
+        execution: { outputs: { default: [buildOutput(payload)] } },
+      });
+      const details = testCase.mapper.getExecutionDetails(ctx);
+
+      for (const [field, value] of Object.entries(testCase.fullAssertions)) {
+        expect(details[field]).toBe(value);
+      }
+    });
+
+    it("includes Executed At when createdAt is present", () => {
+      const ctx = buildDetailsCtx({
+        node: { componentName: `oci.${testCase.name}`, configuration: testCase.config },
+        execution: { outputs: { default: [buildOutput(fullInstanceOutput)] } },
+      });
+      expect(testCase.mapper.getExecutionDetails(ctx)["Executed At"]).not.toBe("-");
+    });
+  });
+
+  describe(`${testCase.name}Mapper.props`, () => {
+    it("returns expected metadata when config fields are set", () => {
+      const props = testCase.mapper.props(
+        buildComponentContext({
+          node: { componentName: `oci.${testCase.name}`, configuration: testCase.config },
+          componentDefinition: { name: `oci.${testCase.name}` },
+        }),
+      );
+
+      expect(props.metadata).toEqual(testCase.metadata);
+    });
+
+    it("returns empty or minimal metadata when config fields are absent", () => {
+      const props = testCase.mapper.props(
+        buildComponentContext({
+          node: { componentName: `oci.${testCase.name}`, configuration: {} },
+          componentDefinition: { name: `oci.${testCase.name}` },
+        }),
+      );
+
+      expect(props.metadata).toEqual(testCase.minimalMetadata);
+    });
+  });
+}
+
+function buildEvent(eventType: string): NonNullable<EventInfo> {
+  return {
+    id: "event-1",
+    createdAt: "2026-04-22T20:34:54.000Z",
+    nodeId: "trigger-1",
+    type: "oci.onInstanceStateChange",
+    data: {
+      eventType,
+      eventTime: "2026-04-22T20:34:54Z",
+      data: {
+        resourceName: "test-instance",
+        resourceId: "ocid1.instance.oc1.eu-frankfurt-1.example",
+        compartmentId: "ocid1.tenancy.oc1..example",
+        compartmentName: "root",
+        availabilityDomain: "XXXX:eu-frankfurt-1-AD-1",
+        additionalDetails: {
+          shape: "VM.Standard.E2.1.Micro",
+        },
+      },
+    },
+  };
+}
+
+function buildTriggerContext(lastEvent?: EventInfo): TriggerRendererContext {
+  return {
+    node: buildNode({ componentName: "oci.onInstanceStateChange", name: "State Change" }),
+    definition: {
+      name: "oci.onInstanceStateChange",
+      label: "On Instance State Change",
+      description: "",
+      icon: "oci",
+      color: "red",
+    },
+    lastEvent,
+  };
+}
+
+describe("onInstanceStateChangeTriggerRenderer", () => {
+  const labels: Record<string, string> = {
+    "com.oraclecloud.computeapi.startinstance.end": "Instance started",
+    "com.oraclecloud.computeapi.stopinstance.end": "Instance stopped",
+    "com.oraclecloud.computeapi.terminateinstance.end": "Instance terminated",
+    "com.oraclecloud.computeapi.resetinstance.end": "Instance reset",
+    "com.oraclecloud.computeapi.softstopinstance.end": "Instance soft-stopped",
+    "com.oraclecloud.computeapi.softresetinstance.end": "Instance soft-reset",
+  };
+
+  for (const [eventType, label] of Object.entries(labels)) {
+    it(`returns ${label} for ${eventType}`, () => {
+      expect(onInstanceStateChangeTriggerRenderer.getTitleAndSubtitle({ event: buildEvent(eventType) }).title).toBe(
+        label,
+      );
+    });
+  }
+
+  it("extracts all root event values", () => {
+    const details = onInstanceStateChangeTriggerRenderer.getRootEventValues({
+      event: buildEvent("com.oraclecloud.computeapi.stopinstance.end"),
+    });
+
+    expect(details["Triggered At"]).toBeDefined();
+    expect(details["Instance Name"]).toBe("test-instance");
+    expect(details["Instance ID"]).toBe("ocid1.instance.oc1.eu-frankfurt-1.example");
+    expect(details["Shape"]).toBe("VM.Standard.E2.1.Micro");
+    expect(details["Availability Domain"]).toBe("XXXX:eu-frankfurt-1-AD-1");
+    expect(details["Compartment"]).toBe("root");
+  });
+
+  it("includes lastEventData when lastEvent is provided", () => {
+    const props = onInstanceStateChangeTriggerRenderer.getTriggerProps(
+      buildTriggerContext(buildEvent("com.oraclecloud.computeapi.stopinstance.end")),
+    );
+
+    expect(props.lastEventData).toMatchObject({
+      title: "Instance stopped",
+      subtitle: "test-instance",
+      state: "triggered",
+      eventId: "event-1",
+    });
+  });
+
+  it("omits lastEventData when lastEvent is absent", () => {
+    const props = onInstanceStateChangeTriggerRenderer.getTriggerProps(buildTriggerContext(undefined));
+    expect(props.lastEventData).toBeUndefined();
+  });
+});
+
+describe("eventStateRegistry", () => {
+  it("maps finished success to fetched for getInstance", () => {
+    expect(eventStateRegistry.getInstance.getState(buildExecution())).toBe("fetched");
+  });
+
+  it("maps finished success to updated for updateInstance", () => {
+    expect(eventStateRegistry.updateInstance.getState(buildExecution())).toBe("updated");
+  });
+
+  it("maps finished success to completed for manageInstancePower", () => {
+    expect(eventStateRegistry.manageInstancePower.getState(buildExecution())).toBe("completed");
+  });
+
+  it("maps finished success to deleted for deleteInstance", () => {
+    expect(eventStateRegistry.deleteInstance.getState(buildExecution())).toBe("deleted");
+  });
+
+  it("maps in-progress executions to running", () => {
+    const execution = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED",
+      resultReason: "RESULT_REASON_UNSPECIFIED",
+    });
+
+    expect(eventStateRegistry.getInstance.getState(execution)).toBe("running");
+    expect(eventStateRegistry.updateInstance.getState(execution)).toBe("running");
+    expect(eventStateRegistry.manageInstancePower.getState(execution)).toBe("running");
+    expect(eventStateRegistry.deleteInstance.getState(execution)).toBe("running");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import React from "react";
 
 import { deleteInstanceMapper } from "./delete_instance";
 import { eventStateRegistry } from "./index";
@@ -254,7 +255,7 @@ for (const testCase of componentCases) {
   });
 }
 
-function buildEvent(eventType: string): NonNullable<EventInfo> {
+function buildEvent(eventType: string, instanceActionType?: string): NonNullable<EventInfo> {
   return {
     id: "event-1",
     createdAt: "2026-04-22T20:34:54.000Z",
@@ -271,6 +272,7 @@ function buildEvent(eventType: string): NonNullable<EventInfo> {
         availabilityDomain: "XXXX:eu-frankfurt-1-AD-1",
         additionalDetails: {
           shape: "VM.Standard.E2.1.Micro",
+          ...(instanceActionType ? { instanceActionType } : {}),
         },
       },
     },
@@ -293,30 +295,42 @@ function buildTriggerContext(lastEvent?: EventInfo): TriggerRendererContext {
 
 describe("onInstanceStateChangeTriggerRenderer", () => {
   const labels: Record<string, string> = {
-    "com.oraclecloud.computeapi.startinstance.end": "Instance started",
-    "com.oraclecloud.computeapi.stopinstance.end": "Instance stopped",
-    "com.oraclecloud.computeapi.terminateinstance.end": "Instance terminated",
-    "com.oraclecloud.computeapi.resetinstance.end": "Instance reset",
-    "com.oraclecloud.computeapi.softstopinstance.end": "Instance soft-stopped",
-    "com.oraclecloud.computeapi.softresetinstance.end": "Instance soft-reset",
+    start: "Instance started",
+    stop: "Instance stopped",
+    reset: "Instance reset",
+    softstop: "Instance soft-stopped",
+    softreset: "Instance soft-reset",
   };
 
-  for (const [eventType, label] of Object.entries(labels)) {
-    it(`returns ${label} for ${eventType}`, () => {
-      expect(onInstanceStateChangeTriggerRenderer.getTitleAndSubtitle({ event: buildEvent(eventType) }).title).toBe(
-        label,
-      );
+  for (const [actionType, label] of Object.entries(labels)) {
+    it(`returns ${label} for ${actionType}`, () => {
+      const { title, subtitle } = onInstanceStateChangeTriggerRenderer.getTitleAndSubtitle({
+        event: buildEvent("com.oraclecloud.computeapi.instanceaction.end", actionType),
+      });
+
+      expect(title).toBe("test-instance");
+      expectReactNodeToContain(subtitle, label);
     });
   }
 
+  it("returns terminate label for terminate event", () => {
+    const { title, subtitle } = onInstanceStateChangeTriggerRenderer.getTitleAndSubtitle({
+      event: buildEvent("com.oraclecloud.computeapi.terminateinstance.end"),
+    });
+
+    expect(title).toBe("test-instance");
+    expectReactNodeToContain(subtitle, "Instance terminated");
+  });
+
   it("extracts all root event values", () => {
     const details = onInstanceStateChangeTriggerRenderer.getRootEventValues({
-      event: buildEvent("com.oraclecloud.computeapi.stopinstance.end"),
+      event: buildEvent("com.oraclecloud.computeapi.instanceaction.end", "stop"),
     });
 
     expect(details["Triggered At"]).toBeDefined();
     expect(details["Instance Name"]).toBe("test-instance");
-    expect(details["Instance ID"]).toBe("ocid1.instance.oc1.eu-frankfurt-1.example");
+    expect(details["Instance ID"]).toBeUndefined();
+    expect(details.Action).toBe("stop");
     expect(details["Shape"]).toBe("VM.Standard.E2.1.Micro");
     expect(details["Availability Domain"]).toBe("XXXX:eu-frankfurt-1-AD-1");
     expect(details["Compartment"]).toBe("root");
@@ -324,15 +338,15 @@ describe("onInstanceStateChangeTriggerRenderer", () => {
 
   it("includes lastEventData when lastEvent is provided", () => {
     const props = onInstanceStateChangeTriggerRenderer.getTriggerProps(
-      buildTriggerContext(buildEvent("com.oraclecloud.computeapi.stopinstance.end")),
+      buildTriggerContext(buildEvent("com.oraclecloud.computeapi.instanceaction.end", "stop")),
     );
 
     expect(props.lastEventData).toMatchObject({
-      title: "Instance stopped",
-      subtitle: "test-instance",
+      title: "test-instance",
       state: "triggered",
       eventId: "event-1",
     });
+    expectReactNodeToContain(props.lastEventData?.subtitle, "Instance stopped");
   });
 
   it("omits lastEventData when lastEvent is absent", () => {
@@ -340,6 +354,19 @@ describe("onInstanceStateChangeTriggerRenderer", () => {
     expect(props.lastEventData).toBeUndefined();
   });
 });
+
+function expectReactNodeToContain(node: React.ReactNode, expected: string) {
+  if (typeof node === "string") {
+    expect(node).toContain(expected);
+    return;
+  }
+
+  if (!React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    throw new Error("Expected React element subtitle");
+  }
+
+  expect(React.Children.toArray(node.props.children)).toContain(expected);
+}
 
 describe("eventStateRegistry", () => {
   it("maps finished success to fetched for getInstance", () => {

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -109,7 +109,7 @@ const componentCases: Array<{
   {
     name: "getInstance",
     mapper: getInstanceMapper,
-    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example" },
+    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example" },
     metadata: [{ icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" }],
     minimalMetadata: [],
     emptyFields: ["Instance ID", "Display Name", "State", "Shape", "Region"],
@@ -124,7 +124,7 @@ const componentCases: Array<{
   {
     name: "updateInstance",
     mapper: updateInstanceMapper,
-    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", displayName: "renamed" },
+    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example", displayName: "renamed" },
     metadata: [
       { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
       { icon: "tag", label: "renamed" },
@@ -142,7 +142,7 @@ const componentCases: Array<{
   {
     name: "manageInstancePower",
     mapper: manageInstancePowerMapper,
-    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
+    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
     metadata: [
       { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
       { icon: "zap", label: "STOP" },
@@ -160,7 +160,7 @@ const componentCases: Array<{
   {
     name: "deleteInstance",
     mapper: deleteInstanceMapper,
-    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", preserveBootVolume: true },
+    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example", preserveBootVolume: true },
     metadata: [
       { icon: "trash-2", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
       { icon: "archive", label: "Preserve boot volume" },

--- a/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/oci.spec.ts
@@ -142,7 +142,7 @@ const componentCases: Array<{
   {
     name: "manageInstancePower",
     mapper: manageInstancePowerMapper,
-    config: { instance: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
+    config: { instanceId: "ocid1.instance.oc1.eu-frankfurt-1.example", action: "STOP" },
     metadata: [
       { icon: "server", label: "ocid1.instance.oc1.eu-frankfurt-1.example" },
       { icon: "zap", label: "STOP" },

--- a/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
@@ -4,6 +4,7 @@ import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } fro
 import type { TriggerProps } from "@/ui/trigger";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import ociIcon from "@/assets/icons/integrations/oci.svg";
+import { compactDetails } from "./base";
 
 interface OciComputeLaunchEvent {
   eventType?: string;
@@ -80,15 +81,3 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     };
   },
 };
-
-function compactDetails(entries: Array<[string, string | undefined]>): Record<string, string> {
-  const details: Record<string, string> = {};
-
-  for (const [key, value] of entries) {
-    if (value) {
-      details[key] = value;
-    }
-  }
-
-  return details;
-}

--- a/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
@@ -44,10 +44,13 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     const envelope = getEventEnvelope(context.event);
     const data = envelope?.data;
     return compactDetails([
-      ["Triggered At", context.event?.createdAt ? new Date(context.event.createdAt).toLocaleString() : undefined],
       [
-        "Event Time",
-        !context.event?.createdAt && envelope?.eventTime ? new Date(envelope.eventTime).toLocaleString() : undefined,
+        "Triggered At",
+        context.event?.createdAt
+          ? new Date(context.event.createdAt).toLocaleString()
+          : envelope?.eventTime
+            ? new Date(envelope.eventTime).toLocaleString()
+            : undefined,
       ],
       ["Instance Name", data?.resourceName],
       ["Instance ID", data?.resourceId],

--- a/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_compute_instance_created.ts
@@ -44,14 +44,7 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     const envelope = getEventEnvelope(context.event);
     const data = envelope?.data;
     return compactDetails([
-      [
-        "Triggered At",
-        context.event?.createdAt
-          ? new Date(context.event.createdAt).toLocaleString()
-          : envelope?.eventTime
-            ? new Date(envelope.eventTime).toLocaleString()
-            : undefined,
-      ],
+      getTimeDetail(context.event, envelope),
       ["Instance Name", data?.resourceName],
       ["Instance ID", data?.resourceId],
       ["Shape", data?.additionalDetails?.shape],
@@ -84,3 +77,18 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     };
   },
 };
+
+function getTimeDetail(
+  event: TriggerEventContext["event"],
+  envelope: OciComputeLaunchEvent | undefined,
+): [string, string | undefined] {
+  if (event?.createdAt) {
+    return ["Triggered At", new Date(event.createdAt).toLocaleString()];
+  }
+
+  if (envelope?.eventTime) {
+    return ["Triggered At", new Date(envelope.eventTime).toLocaleString()];
+  }
+
+  return ["Triggered At", undefined];
+}

--- a/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
@@ -4,6 +4,7 @@ import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } fro
 import type { TriggerProps } from "@/ui/trigger";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import ociIcon from "@/assets/icons/integrations/oci.svg";
+import { compactDetails } from "./base";
 
 interface OciInstanceStateChangeEvent {
   eventType?: string;
@@ -104,16 +105,4 @@ function getTimeDetail(
   }
 
   return ["Triggered At", undefined];
-}
-
-function compactDetails(entries: Array<[string, string | undefined]>): Record<string, string> {
-  const details: Record<string, string> = {};
-
-  for (const [key, value] of entries) {
-    if (value) {
-      details[key] = value;
-    }
-  }
-
-  return details;
 }

--- a/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
@@ -1,11 +1,11 @@
-import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
 import type React from "react";
 import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
 import type { TriggerProps } from "@/ui/trigger";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import ociIcon from "@/assets/icons/integrations/oci.svg";
 
-interface OciComputeLaunchEvent {
+interface OciInstanceStateChangeEvent {
   eventType?: string;
   eventTime?: string;
   data?: {
@@ -21,8 +21,17 @@ interface OciComputeLaunchEvent {
   };
 }
 
-function getEventEnvelope(event: TriggerEventContext["event"]): OciComputeLaunchEvent | undefined {
-  return event?.data as OciComputeLaunchEvent | undefined;
+const eventTypeLabels: Record<string, string> = {
+  "com.oraclecloud.computeapi.startinstance.end": "Instance started",
+  "com.oraclecloud.computeapi.stopinstance.end": "Instance stopped",
+  "com.oraclecloud.computeapi.terminateinstance.end": "Instance terminated",
+  "com.oraclecloud.computeapi.resetinstance.end": "Instance reset",
+  "com.oraclecloud.computeapi.softstopinstance.end": "Instance soft-stopped",
+  "com.oraclecloud.computeapi.softresetinstance.end": "Instance soft-reset",
+};
+
+function getEventEnvelope(event: TriggerEventContext["event"]): OciInstanceStateChangeEvent | undefined {
+  return event?.data as OciInstanceStateChangeEvent | undefined;
 }
 
 function getInstanceName(event: TriggerEventContext["event"]): string {
@@ -30,11 +39,16 @@ function getInstanceName(event: TriggerEventContext["event"]): string {
   return envelope?.data?.resourceName ?? "";
 }
 
-export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
+function getEventTitle(event: TriggerEventContext["event"]): string {
+  const envelope = getEventEnvelope(event);
+  return eventTypeLabels[envelope?.eventType ?? ""] ?? "Instance state changed";
+}
+
+export const onInstanceStateChangeTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
     const name = getInstanceName(context.event);
     return {
-      title: "Compute instance created",
+      title: getEventTitle(context.event),
       subtitle: name || "",
     };
   },
@@ -42,18 +56,14 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
   getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
     const envelope = getEventEnvelope(context.event);
     const data = envelope?.data;
+    const compartment = data?.compartmentName ?? data?.compartmentId;
     return compactDetails([
-      ["Triggered At", context.event?.createdAt ? new Date(context.event.createdAt).toLocaleString() : undefined],
-      [
-        "Event Time",
-        !context.event?.createdAt && envelope?.eventTime ? new Date(envelope.eventTime).toLocaleString() : undefined,
-      ],
+      getTimeDetail(context.event, envelope),
       ["Instance Name", data?.resourceName],
       ["Instance ID", data?.resourceId],
       ["Shape", data?.additionalDetails?.shape],
       ["Availability Domain", data?.availabilityDomain],
-      ["Compartment ID", data?.compartmentId],
-      ["Compartment", data?.compartmentName],
+      ["Compartment", compartment],
     ]);
   },
 
@@ -62,7 +72,7 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     const instanceName = lastEvent ? getInstanceName(lastEvent) : "";
 
     return {
-      title: node.name || definition.label || "On Compute Instance Created",
+      title: node.name || definition.label || "On Instance State Change",
       iconSrc: ociIcon,
       iconSlug: definition.icon || "oci",
       iconColor: getColorClass("black"),
@@ -70,8 +80,8 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
       metadata: [],
       ...(lastEvent && {
         lastEventData: {
-          title: instanceName || "Compute instance created",
-          subtitle: renderTimeAgo(new Date(lastEvent.createdAt)),
+          title: getEventTitle(lastEvent),
+          subtitle: instanceName || renderTimeAgo(new Date(lastEvent.createdAt)),
           receivedAt: new Date(lastEvent.createdAt),
           state: "triggered",
           eventId: lastEvent.id,
@@ -80,6 +90,21 @@ export const onComputeInstanceCreatedTriggerRenderer: TriggerRenderer = {
     };
   },
 };
+
+function getTimeDetail(
+  event: TriggerEventContext["event"],
+  envelope: OciInstanceStateChangeEvent | undefined,
+): [string, string | undefined] {
+  if (event?.createdAt) {
+    return ["Triggered At", new Date(event.createdAt).toLocaleString()];
+  }
+
+  if (envelope?.eventTime) {
+    return ["Event Time", new Date(envelope.eventTime).toLocaleString()];
+  }
+
+  return ["Triggered At", undefined];
+}
 
 function compactDetails(entries: Array<[string, string | undefined]>): Record<string, string> {
   const details: Record<string, string> = {};

--- a/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/on_instance_state_change.ts
@@ -2,7 +2,7 @@ import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
 import type React from "react";
 import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
 import type { TriggerProps } from "@/ui/trigger";
-import { renderTimeAgo } from "@/components/TimeAgo";
+import { renderTimeAgo, renderWithTimeAgo } from "@/components/TimeAgo";
 import ociIcon from "@/assets/icons/integrations/oci.svg";
 import { compactDetails } from "./base";
 
@@ -18,17 +18,21 @@ interface OciInstanceStateChangeEvent {
     additionalDetails?: {
       shape?: string;
       imageId?: string;
+      instanceActionType?: string;
     };
   };
 }
 
-const eventTypeLabels: Record<string, string> = {
-  "com.oraclecloud.computeapi.startinstance.end": "Instance started",
-  "com.oraclecloud.computeapi.stopinstance.end": "Instance stopped",
+const instanceActionTypeLabels: Record<string, string> = {
+  start: "Instance started",
+  stop: "Instance stopped",
+  reset: "Instance reset",
+  softstop: "Instance soft-stopped",
+  softreset: "Instance soft-reset",
+};
+
+const nonActionEventTypeLabels: Record<string, string> = {
   "com.oraclecloud.computeapi.terminateinstance.end": "Instance terminated",
-  "com.oraclecloud.computeapi.resetinstance.end": "Instance reset",
-  "com.oraclecloud.computeapi.softstopinstance.end": "Instance soft-stopped",
-  "com.oraclecloud.computeapi.softresetinstance.end": "Instance soft-reset",
 };
 
 function getEventEnvelope(event: TriggerEventContext["event"]): OciInstanceStateChangeEvent | undefined {
@@ -40,17 +44,29 @@ function getInstanceName(event: TriggerEventContext["event"]): string {
   return envelope?.data?.resourceName ?? "";
 }
 
+function getEventSubtitle(event: TriggerEventContext["event"]): string | React.ReactNode {
+  const title = getEventTitle(event);
+  return title && event?.createdAt
+    ? renderWithTimeAgo(title, new Date(event.createdAt))
+    : title || (event?.createdAt ? renderTimeAgo(new Date(event.createdAt)) : "");
+}
+
 function getEventTitle(event: TriggerEventContext["event"]): string {
   const envelope = getEventEnvelope(event);
-  return eventTypeLabels[envelope?.eventType ?? ""] ?? "Instance state changed";
+  const actionType = envelope?.data?.additionalDetails?.instanceActionType;
+  if (actionType) {
+    return instanceActionTypeLabels[actionType] ?? "Instance state changed";
+  }
+
+  return nonActionEventTypeLabels[envelope?.eventType ?? ""] ?? "Instance state changed";
 }
 
 export const onInstanceStateChangeTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
     const name = getInstanceName(context.event);
     return {
-      title: getEventTitle(context.event),
-      subtitle: name || "",
+      title: name || getEventTitle(context.event),
+      subtitle: getEventSubtitle(context.event),
     };
   },
 
@@ -61,7 +77,7 @@ export const onInstanceStateChangeTriggerRenderer: TriggerRenderer = {
     return compactDetails([
       getTimeDetail(context.event, envelope),
       ["Instance Name", data?.resourceName],
-      ["Instance ID", data?.resourceId],
+      ["Action", data?.additionalDetails?.instanceActionType],
       ["Shape", data?.additionalDetails?.shape],
       ["Availability Domain", data?.availabilityDomain],
       ["Compartment", compartment],
@@ -70,7 +86,6 @@ export const onInstanceStateChangeTriggerRenderer: TriggerRenderer = {
 
   getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
     const { node, definition, lastEvent } = context;
-    const instanceName = lastEvent ? getInstanceName(lastEvent) : "";
 
     return {
       title: node.name || definition.label || "On Instance State Change",
@@ -81,8 +96,7 @@ export const onInstanceStateChangeTriggerRenderer: TriggerRenderer = {
       metadata: [],
       ...(lastEvent && {
         lastEventData: {
-          title: getEventTitle(lastEvent),
-          subtitle: instanceName || renderTimeAgo(new Date(lastEvent.createdAt)),
+          ...onInstanceStateChangeTriggerRenderer.getTitleAndSubtitle({ event: lastEvent }),
           receivedAt: new Date(lastEvent.createdAt),
           state: "triggered",
           eventId: lastEvent.id,

--- a/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
@@ -1,0 +1,78 @@
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { baseMapper } from "./base";
+
+interface UpdateInstanceConfiguration {
+  instanceId?: string;
+  displayName?: string;
+}
+
+interface InstanceOutputData {
+  instanceId?: string;
+  displayName?: string;
+  lifecycleState?: string;
+  shape?: string;
+  availabilityDomain?: string;
+  compartmentId?: string;
+  region?: string;
+  timeCreated?: string;
+  publicIp?: string;
+  privateIp?: string;
+}
+
+type InstanceOutputPayload = OutputPayload & {
+  data?: InstanceOutputData;
+};
+
+function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
+  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
+  const payload = outputs?.default?.[0];
+  if (!payload) return undefined;
+  return (payload.data ?? payload) as InstanceOutputData;
+}
+
+function executedAt(context: ExecutionDetailsContext): string {
+  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
+}
+
+export const updateInstanceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext) {
+    const props = baseMapper.props(context);
+    const config = context.node.configuration as UpdateInstanceConfiguration | undefined;
+    const metadata: MetadataItem[] = [];
+
+    if (config?.instanceId) {
+      metadata.push({ icon: "server", label: config.instanceId });
+    }
+    if (config?.displayName) {
+      metadata.push({ icon: "tag", label: config.displayName });
+    }
+
+    return {
+      ...props,
+      metadata,
+    };
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = getOutputData(context);
+    return {
+      "Executed At": executedAt(context),
+      "Instance ID": data?.instanceId ?? "-",
+      "Display Name": data?.displayName ?? "-",
+      State: data?.lifecycleState ?? "-",
+      Shape: data?.shape ?? "-",
+      Region: data?.region ?? "-",
+    };
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
@@ -9,7 +9,7 @@ import type {
 import { baseMapper } from "./base";
 
 interface UpdateInstanceConfiguration {
-  instanceId?: string;
+  instance?: string;
   displayName?: string;
 }
 
@@ -47,8 +47,8 @@ export const updateInstanceMapper: ComponentBaseMapper = {
     const config = context.node.configuration as UpdateInstanceConfiguration | undefined;
     const metadata: MetadataItem[] = [];
 
-    if (config?.instanceId) {
-      metadata.push({ icon: "server", label: config.instanceId });
+    if (config?.instance) {
+      metadata.push({ icon: "server", label: config.instance });
     }
     if (config?.displayName) {
       metadata.push({ icon: "tag", label: config.displayName });

--- a/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/update_instance.ts
@@ -1,12 +1,6 @@
 import type { MetadataItem } from "@/ui/metadataList";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
-import { baseMapper } from "./base";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { baseMapper, executedAt, getDefaultChannelOutputData } from "./base";
 
 interface UpdateInstanceConfiguration {
   instance?: string;
@@ -24,21 +18,6 @@ interface InstanceOutputData {
   timeCreated?: string;
   publicIp?: string;
   privateIp?: string;
-}
-
-type InstanceOutputPayload = OutputPayload & {
-  data?: InstanceOutputData;
-};
-
-function getOutputData(context: ExecutionDetailsContext): InstanceOutputData | undefined {
-  const outputs = context.execution.outputs as { default?: InstanceOutputPayload[] } | undefined;
-  const payload = outputs?.default?.[0];
-  if (!payload) return undefined;
-  return (payload.data ?? payload) as InstanceOutputData;
-}
-
-function executedAt(context: ExecutionDetailsContext): string {
-  return context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-";
 }
 
 export const updateInstanceMapper: ComponentBaseMapper = {
@@ -65,7 +44,7 @@ export const updateInstanceMapper: ComponentBaseMapper = {
   },
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const data = getOutputData(context);
+    const data = getDefaultChannelOutputData<InstanceOutputData>(context);
     return {
       "Executed At": executedAt(context),
       "Instance ID": data?.instanceId ?? "-",


### PR DESCRIPTION
Closes https://github.com/superplanehq/superplane/issues/4309

This expands the Oracle Cloud Infrastructure integration by adding the following components:
- `oci.deleteInstance`: action
- `oci.onInstanceStateChange`: trigger
- `oci.manageInstancePower`: action
- `oci.updateInstance`: action


### Demo video
