### PR TITLE
fix: make SuperPlane agent skills discoverable in CLI

### DIFF
--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -10,6 +10,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "canvases",
 		Short:   "Manage canvases",
+		Long:    core.AgentSkillsHelp(),
 		Aliases: []string{"canvas"},
 	}
 
@@ -46,7 +47,12 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create [canvas-name]",
 		Short: "Create a canvas",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Create a canvas by name or from a file.
+
+AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
+- ` + core.SkillsInstallCommand("superplane-canvas-builder") + `
+- ` + core.SkillsInstallCommand("superplane-cli"),
+		Args: cobra.MaximumNArgs(1),
 	}
 	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "filename, directory, or URL to files to use to create the resource")
 	createCmd.Flags().StringVar(&createAutoLayout, "auto-layout", "", "automatically arrange the canvas (supported: horizontal, disable)")

--- a/pkg/cli/commands/secrets/root.go
+++ b/pkg/cli/commands/secrets/root.go
@@ -29,6 +29,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a secret",
+		Long:  core.AgentSkillsHelp(),
 		Args:  cobra.NoArgs,
 	}
 	var createFile string

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -51,6 +51,10 @@ func (c *ConnectCommand) Execute(ctx core.CommandContext) error {
 	if ctx.Renderer.IsText() {
 		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 			_, err := fmt.Fprintf(stdout, "Connected to %q (%s)\n", orgName, baseURL)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(stdout, "%s\n", core.AgentSkillsHint())
 			return err
 		})
 	}

--- a/pkg/cli/core/agent_skills.go
+++ b/pkg/cli/core/agent_skills.go
@@ -1,0 +1,17 @@
+package core
+
+const SkillsRepository = "superplanehq/skills"
+
+func SkillsInstallCommand(skill string) string {
+	return "npx skills add " + SkillsRepository + " --skill " + skill
+}
+
+func AgentSkillsHint() string {
+	return "Tip (AI agents): install SuperPlane skills: " + SkillsInstallCommand("superplane-cli")
+}
+
+func AgentSkillsHelp() string {
+	return `AI agents: SuperPlane skills are available to guide correct YAML formats, field names, and workflows.
+Install: ` + SkillsInstallCommand("superplane-cli") + `
+More skills: superplane-canvas-builder, superplane-monitor`
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -39,7 +39,7 @@ var OutputFormat string
 var RootCmd = &cobra.Command{
 	Use:   "superplane",
 	Short: "SuperPlane command line interface",
-	Long:  `SuperPlane CLI - Command line interface for the SuperPlane API`,
+	Long:  "SuperPlane CLI - Command line interface for the SuperPlane API\n\n" + core.AgentSkillsHelp(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if !Verbose {
 			log.SetOutput(io.Discard)

--- a/pkg/cli/whoami.go
+++ b/pkg/cli/whoami.go
@@ -54,6 +54,7 @@ func (w *whoamiCommand) Execute(ctx core.CommandContext) error {
 			_, _ = fmt.Fprintf(stdout, "Organization ID: %s\n", response.User.GetOrganizationId())
 			_, _ = fmt.Fprintf(stdout, "Organization: %s\n", organizationLabel)
 			_, _ = fmt.Fprintf(stdout, "Change Management: %s\n", changeManagementLabel)
+			_, _ = fmt.Fprintf(stdout, "\n%s\n", core.AgentSkillsHint())
 			return nil
 		})
 	}


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/pull/4379

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds an explicit “AI agents: install SuperPlane skills” discovery hint to the most common first-touch CLI surfaces.

## Changes
- `superplane connect` (text output) prints a tip to install `superplane-cli` skill after a successful connection.
- `superplane whoami` (text output) prints the same tip.
- `superplane --help` now includes a short “AI agents” section with the install command and additional skills to look for.
- `superplane canvases --help` and `superplane canvases create --help` reference the canvas-builder + CLI skills for canonical YAML shapes/wiring.
- `superplane secrets create --help` references the CLI skill.

## Notes
- JSON/YAML render outputs are unchanged (tip is text-mode only).
- Local compilation verified for `./pkg/cli/...`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af663b4-e91c-4504-ae92-821714c22e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af663b4-e91c-4504-ae92-821714c22e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

