### PR TITLE
fix: accept X-Hub-Signature-256 for webhook HMAC auth

### DIFF
--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -16,6 +16,8 @@ import (
 const (
 	MaxEventSize           = 64 * 1024
 	DefaultHeaderTokenName = "X-Webhook-Token"
+	SignatureHeader        = "X-Signature-256"
+	GitHubSignatureHeader  = "X-Hub-Signature-256"
 )
 
 func init() {
@@ -65,7 +67,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header (the GitHub-compatible ` + "`X-Hub-Signature-256`" + ` header is also accepted)
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -242,7 +244,10 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		signature := ctx.Headers.Get("X-Signature-256")
+		signature := ctx.Headers.Get(SignatureHeader)
+		if signature == "" {
+			signature = ctx.Headers.Get(GitHubSignatureHeader)
+		}
 		if signature == "" {
 			return http.StatusForbidden, nil, fmt.Errorf("missing signature header")
 		}

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -221,6 +221,43 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.Contains(t, data, "headers")
 	})
 
+	t.Run("accepts valid signature via X-Hub-Signature-256 header", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret")
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
+	t.Run("rejects invalid signature in X-Hub-Signature-256 header", func(t *testing.T) {
+		webhook := &Webhook{}
+		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "signature", "secret")
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256=invalid")
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusForbidden, status)
+		require.Error(t, err)
+	})
+
+	t.Run("prefers X-Signature-256 over X-Hub-Signature-256", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret")
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Signature-256", "sha256="+signature)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256=invalid")
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
 	t.Run("rejects missing bearer token", func(t *testing.T) {
 		webhook := &Webhook{}
 		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "bearer", "secret")


### PR DESCRIPTION
## Summary

- Webhook HMAC auth previously only read the signature from `X-Signature-256`; GitHub sends it in `X-Hub-Signature-256`, so every GitHub webhook with signature auth failed with a 403.
- Fall back to `X-Hub-Signature-256` when `X-Signature-256` is absent, so GitHub webhooks work out of the box without breaking senders using the original header.
- Documentation updated to mention both accepted headers.

Closes #4381

## Test plan

- [x] `pkg/triggers/webhook` unit tests pass (`docker compose run --rm --no-deps app go test -count=1 ./pkg/triggers/webhook/...`)
- [x] New tests cover: valid signature via `X-Hub-Signature-256`, invalid signature via `X-Hub-Signature-256`, and precedence (`X-Signature-256` wins when both are present)
- [x] Existing "missing signature" / invalid-format / invalid-signature / valid-via-`X-Signature-256` cases still pass
- [ ] Manual: point a real GitHub webhook (signature auth) at a SuperPlane webhook trigger and confirm a test delivery now returns 200