### PR TITLE
fix: accept X-Hub-Signature-256 for webhook HMAC (GitHub)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -159,7 +159,7 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` or `X-Hub-Signature-256` header
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)

--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -16,6 +16,11 @@ import (
 const (
 	MaxEventSize           = 64 * 1024
 	DefaultHeaderTokenName = "X-Webhook-Token"
+	// HMACSignatureHeaderName is the primary header for HMAC-SHA256 verification.
+	HMACSignatureHeaderName = "X-Signature-256"
+	// HubSignature256HeaderName is the header GitHub (and other providers) use for the same
+	// sha256=... HMAC value.
+	HubSignature256HeaderName = "X-Hub-Signature-256"
 )
 
 func init() {
@@ -65,7 +70,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` or ` + "`X-Hub-Signature-256`" + ` header (GitHub uses the latter)
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -242,7 +247,7 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		signature := ctx.Headers.Get("X-Signature-256")
+		signature := hmacSignatureFromHeaders(ctx.Headers)
 		if signature == "" {
 			return http.StatusForbidden, nil, fmt.Errorf("missing signature header")
 		}
@@ -310,4 +315,15 @@ func (c Configuration) HeaderTokenName() string {
 	}
 
 	return DefaultHeaderTokenName
+}
+
+// hmacSignatureFromHeaders returns the sha256=... HMAC value from a supported header.
+// X-Signature-256 is checked first, then X-Hub-Signature-256 (GitHub).
+func hmacSignatureFromHeaders(h http.Header) string {
+	for _, name := range []string{HMACSignatureHeaderName, HubSignature256HeaderName} {
+		if s := h.Get(name); s != "" {
+			return s
+		}
+	}
+	return ""
 }

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -221,6 +221,33 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.Contains(t, data, "headers")
 	})
 
+	t.Run("accepts X-Hub-Signature-256 for GitHub-style webhooks", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret")
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
+	t.Run("prefers X-Signature-256 when both HMAC headers are set", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, _ := webhookRequestContext(body, "signature", "secret")
+		correct := computeSignature("secret", body)
+		wrong := computeSignature("wrong", body)
+		ctx.Headers.Set("X-Signature-256", "sha256="+correct)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+wrong)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+	})
+
 	t.Run("rejects missing bearer token", func(t *testing.T) {
 		webhook := &Webhook{}
 		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "bearer", "secret")

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -336,7 +336,8 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
       switch (authMethod) {
         case "signature":
           title = "HMAC Signature Authentication";
-          description = "Use HMAC SHA-256 signature to authenticate your webhook requests.";
+          description =
+            "Use HMAC SHA-256 signature to authenticate your webhook requests. You can use X-Signature-256 or X-Hub-Signature-256 (e.g. GitHub sends the latter).";
           signatureKey = secret || "<your-signature-key>";
           code = `export SIGNATURE_KEY="${signatureKey}"
 export PAYLOAD='{"hello":"world"}'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Webhook trigger with **Signature (HMAC)** only read `X-Signature-256`. GitHub (and some other providers) send the same `sha256=...` value in **`X-Hub-Signature-256`**, which caused verification to fail with 403.

## Changes

- When HMAC auth is enabled, accept the signature from **`X-Signature-256`** or **`X-Hub-Signature-256`**, preferring the former if both are set.
- Document the behavior in the trigger docs, Core component docs, and the workflow mapper copy for the sample curl.

## Testing

- `go test ./pkg/triggers/webhook/...`

Closes #4381
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f41928ff-448c-42fc-b8af-4b98e69ce7e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f41928ff-448c-42fc-b8af-4b98e69ce7e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

