### PR TITLE
feat: render canvas memory urls as clickable links

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.spec.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CanvasMemoryModal } from "./CanvasMemoryModal";
+
+describe("CanvasMemoryModal", () => {
+  it("renders URL values as clickable links", () => {
+    render(
+      <CanvasMemoryModal
+        open
+        onOpenChange={() => {}}
+        entries={[
+          {
+            id: "memory-1",
+            namespace: "ephemeral-environments",
+            values: {
+              url: "https://preview.example.com",
+              pr_url: "https://github.com/org/repo/pull/49",
+            },
+          },
+        ]}
+      />,
+    );
+
+    const previewLink = screen.getByRole("link", { name: "https://preview.example.com" });
+    expect(previewLink).toHaveAttribute("href", "https://preview.example.com");
+    expect(previewLink).toHaveAttribute("target", "_blank");
+    expect(previewLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    const prLink = screen.getByRole("link", { name: "https://github.com/org/repo/pull/49" });
+    expect(prLink).toHaveAttribute("href", "https://github.com/org/repo/pull/49");
+  });
+
+  it("keeps non-URL values as plain text", () => {
+    render(
+      <CanvasMemoryModal
+        open
+        onOpenChange={() => {}}
+        entries={[
+          {
+            id: "memory-2",
+            namespace: "ephemeral-environments",
+            values: {
+              status: "ready",
+              hostname: "preview.internal",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("ready")).toBeInTheDocument();
+    expect(screen.getByText("preview.internal")).toBeInTheDocument();
+
+    const statusCell = screen.getByText("ready").closest("td");
+    expect(statusCell).not.toBeNull();
+    expect(within(statusCell as HTMLElement).queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+import { isUrl } from "@/lib/utils";
+import type { ReactNode } from "react";
 import { Trash2 } from "lucide-react";
 
 export type CanvasMemoryModalProps = {
@@ -132,6 +134,24 @@ function collectColumns(items: Record<string, unknown>[]): string[] {
   return Array.from(set);
 }
 
+function renderValue(value: unknown): ReactNode {
+  const formattedValue = formatValue(value);
+  if (typeof value !== "string" || !isUrl(value)) {
+    return formattedValue;
+  }
+
+  return (
+    <a
+      href={value}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+    >
+      {formattedValue}
+    </a>
+  );
+}
+
 function renderNamespaceTable(
   values: CanvasMemoryEntry[],
   onDeleteEntry?: (memoryId: string) => void,
@@ -164,7 +184,7 @@ function renderNamespaceTable(
                 <tr key={entry.id || index} className="border-b border-slate-950/15">
                   {columns.map((column) => (
                     <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
-                      {formatValue(item[column])}
+                      {renderValue(item[column])}
                     </td>
                   ))}
                   <td className="px-3 py-2 text-right align-middle">
@@ -192,7 +212,7 @@ function renderNamespaceTable(
   }
 
   return (
-    <div className="overflow-x-auto bg-red-500">
+    <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-slate-950/15 bg-slate-50">
@@ -203,7 +223,7 @@ function renderNamespaceTable(
         <tbody>
           {values.map((entry, index) => (
             <tr key={entry.id || index} className="border-b border-slate-950/15">
-              <td className="px-3 py-2 align-middle font-mono text-xs text-gray-700">{formatValue(entry.values)}</td>
+              <td className="px-3 py-2 align-middle font-mono text-xs text-gray-700">{renderValue(entry.values)}</td>
               <td className="px-3 py-2 text-right align-middle">
                 <Button
                   type="button"


### PR DESCRIPTION
Closes #4361

<img width="1705" height="1333" alt="image" src="https://github.com/user-attachments/assets/dfa1576c-8aca-41c3-8478-751e6f5182fa" />

## Summary

* Canvas memory now renders HTTP/HTTPS string values as clickable links instead of plain text.
* The modal reuses the shared URL helper from the frontend utilities for the URL check.
* External link styling in the canvas memory modal is aligned with the project’s link colors.
* Added frontend tests covering both URL rendering and non-URL plain text rendering.
* Removed an unintended pre-existing red background from the scalar Canvas Memory row renderer. The red styling was introduced with the modal’s initial implementation, was not tied to any error state, and made normal string memory entries look broken (screenshot below, before removing it).

<img width="1705" height="1333" alt="image copy" src="https://github.com/user-attachments/assets/80c125e2-303a-4268-b1e0-b876c4c3b737" />




