### PR TITLE
fix: accept X-Hub-Signature-256 for webhook HMAC auth

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -159,7 +159,7 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 in the `X-Signature-256` or `X-Hub-Signature-256` header (the latter is what GitHub webhooks send)
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)

--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -16,6 +16,10 @@ import (
 const (
 	MaxEventSize           = 64 * 1024
 	DefaultHeaderTokenName = "X-Webhook-Token"
+	// Signature256Header is the default HMAC-SHA256 signature header for custom webhook clients.
+	Signature256Header = "X-Signature-256"
+	// GitHubSignature256Header is the HMAC-SHA256 signature header GitHub sends for repository and org webhooks.
+	GitHubSignature256Header = "X-Hub-Signature-256"
 )
 
 func init() {
@@ -65,7 +69,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 in the ` + "`X-Signature-256`" + ` or ` + "`X-Hub-Signature-256`" + ` header (GitHub webhooks)
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -242,17 +246,11 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		signature := ctx.Headers.Get("X-Signature-256")
-		if signature == "" {
-			return http.StatusForbidden, nil, fmt.Errorf("missing signature header")
+		verified, err := verifyHMACSignature256Headers(secret, ctx.Body, ctx.Headers)
+		if err != nil {
+			return http.StatusForbidden, nil, err
 		}
-
-		signature = strings.TrimPrefix(signature, "sha256=")
-		if signature == "" {
-			return http.StatusForbidden, nil, fmt.Errorf("invalid signature format")
-		}
-
-		if err := crypto.VerifySignature(secret, ctx.Body, signature); err != nil {
+		if !verified {
 			return http.StatusForbidden, nil, fmt.Errorf("invalid signature")
 		}
 	case "bearer":
@@ -310,4 +308,34 @@ func (c Configuration) HeaderTokenName() string {
 	}
 
 	return DefaultHeaderTokenName
+}
+
+// verifyHMACSignature256Headers checks the raw body against HMAC-SHA256 values from
+// X-Signature-256 and/or X-Hub-Signature-256 (e.g. GitHub webhooks). The sha256= prefix
+// is stripped when present; each non-empty value is tried until one verifies.
+func verifyHMACSignature256Headers(secret, body []byte, headers http.Header) (bool, error) {
+	var values []string
+	for _, name := range []string{Signature256Header, GitHubSignature256Header} {
+		raw := headers.Get(name)
+		if raw == "" {
+			continue
+		}
+		hex := strings.TrimPrefix(raw, "sha256=")
+		if hex == "" {
+			return false, fmt.Errorf("invalid signature format")
+		}
+		values = append(values, hex)
+	}
+
+	if len(values) == 0 {
+		return false, fmt.Errorf("missing signature header")
+	}
+
+	for _, hex := range values {
+		if err := crypto.VerifySignature(secret, body, hex); err == nil {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -221,6 +221,33 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.Contains(t, data, "headers")
 	})
 
+	t.Run("accepts X-Hub-Signature-256 like GitHub webhooks", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret")
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
+	t.Run("uses X-Hub-Signature-256 when X-Signature-256 is wrong", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret")
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Signature-256", "sha256=deadbeef")
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
 	t.Run("rejects missing bearer token", func(t *testing.T) {
 		webhook := &Webhook{}
 		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "bearer", "secret")

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -336,7 +336,8 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
       switch (authMethod) {
         case "signature":
           title = "HMAC Signature Authentication";
-          description = "Use HMAC SHA-256 signature to authenticate your webhook requests.";
+          description =
+            "Use HMAC SHA-256. Send the signature in the X-Signature-256 header, or use GitHub webhooks which send X-Hub-Signature-256 (both are accepted).";
           signatureKey = secret || "<your-signature-key>";
           code = `export SIGNATURE_KEY="${signatureKey}"
 export PAYLOAD='{"hello":"world"}'
@@ -349,7 +350,10 @@ curl -X POST \\
   -H "X-Signature-256: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
   --data-binary "$PAYLOAD" \\
-  ${webhookUrl}`;
+  ${webhookUrl}
+
+# Or configure a GitHub org/repo webhook: GitHub signs with the same HMAC
+# and sets X-Hub-Signature-256: sha256=$SIGNATURE (no client change required).`;
           break;
 
         case "bearer":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The generic **Webhook** trigger with **Signature (HMAC)** only read `X-Signature-256`, while [GitHub webhooks](https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers) send `X-Hub-Signature-256`, so requests were always rejected with 403.

## Changes
- **Backend** (`pkg/triggers/webhook`): For HMAC auth, collect any non-empty `X-Signature-256` and/or `X-Hub-Signature-256` values (after stripping the `sha256=` prefix) and accept the request if any value verifies against the raw body.
- **Tests**: Cover GitHub-style header and the case where `X-Signature-256` is wrong but `X-Hub-Signature-256` is correct.
- **Docs** (`docs/components/Core.mdx`) and **UI** (`web_src/.../webhook.tsx`): Document both headers; curl example and a short GitHub note.

## Testing
- `go test ./pkg/triggers/webhook/...` (local; full `make test` is Docker-based in this environment).

Closes #4381
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f3d0935-bbe4-4add-affd-9fef3345d17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f3d0935-bbe4-4add-affd-9fef3345d17d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

