### PR TITLE
feat: configurable HMAC header for Webhook trigger (#4381)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -159,7 +159,7 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature in a configurable header (default: `X-Signature-256`; set to `X-Hub-Signature-256` for GitHub webhooks)
+- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -159,7 +159,7 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` header
+- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature in a configurable header (default: `X-Signature-256`; set to `X-Hub-Signature-256` for GitHub webhooks)
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)

--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -16,6 +16,7 @@ import (
 const (
 	MaxEventSize           = 64 * 1024
 	DefaultHeaderTokenName = "X-Webhook-Token"
+	DefaultSignatureHeader = "X-Signature-256"
 )
 
 func init() {
@@ -30,8 +31,9 @@ type Metadata struct {
 }
 
 type Configuration struct {
-	Authentication string `json:"authentication"`
-	HeaderName     string `json:"headerName" mapstructure:"headerName"`
+	Authentication  string `json:"authentication"`
+	HeaderName      string `json:"headerName" mapstructure:"headerName"`
+	SignatureHeader string `json:"signatureHeader" mapstructure:"signatureHeader"`
 }
 
 func (w *Webhook) Name() string {
@@ -65,7 +67,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header
+- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature in a configurable header (default: ` + "`X-Signature-256`" + `; e.g. use ` + "`X-Hub-Signature-256`" + ` for GitHub)
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -96,6 +98,7 @@ func (w *Webhook) Color() string {
 }
 
 func (w *Webhook) Configuration() []configuration.Field {
+	signatureHeaderStringMin := 1
 	return []configuration.Field{
 
 		{
@@ -112,6 +115,25 @@ func (w *Webhook) Configuration() []configuration.Field {
 						{Label: "Header Token", Value: "header_token"},
 						{Label: "None (unsafe)", Value: "none"},
 					},
+				},
+			},
+		},
+		{
+			Name:        "signatureHeader",
+			Label:       "Header",
+			Type:        configuration.FieldTypeString,
+			Default:     DefaultSignatureHeader,
+			Placeholder: DefaultSignatureHeader,
+			Description: "HTTP header that contains the HMAC signature (values such as " + DefaultSignatureHeader + " or X-Hub-Signature-256)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "authentication", Values: []string{"signature"}},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "authentication", Values: []string{"signature"}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				String: &configuration.StringTypeOptions{
+					MinLength: &signatureHeaderStringMin,
 				},
 			},
 		},
@@ -242,7 +264,11 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		signature := ctx.Headers.Get("X-Signature-256")
+		if config.SignatureHeader != "" && strings.TrimSpace(config.SignatureHeader) == "" {
+			return http.StatusBadRequest, nil, fmt.Errorf("signature header name cannot be empty")
+		}
+		headerName := config.SignatureHeaderName()
+		signature := ctx.Headers.Get(headerName)
 		if signature == "" {
 			return http.StatusForbidden, nil, fmt.Errorf("missing signature header")
 		}
@@ -310,4 +336,15 @@ func (c Configuration) HeaderTokenName() string {
 	}
 
 	return DefaultHeaderTokenName
+}
+
+// SignatureHeaderName returns the HTTP header to read the HMAC from.
+// It defaults to DefaultSignatureHeader when unset, empty, or only whitespace, so
+// existing workflows that omit the field keep prior behavior.
+func (c Configuration) SignatureHeaderName() string {
+	if strings.TrimSpace(c.SignatureHeader) == "" {
+		return DefaultSignatureHeader
+	}
+
+	return strings.TrimSpace(c.SignatureHeader)
 }

--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	MaxEventSize           = 64 * 1024
-	DefaultHeaderTokenName = "X-Webhook-Token"
-	DefaultSignatureHeader = "X-Signature-256"
+	MaxEventSize             = 64 * 1024
+	DefaultHeaderTokenName   = "X-Webhook-Token"
+	DefaultSignatureHeader   = "X-Signature-256"
+	MinSignatureHeaderLength = 1
 )
 
 func init() {
@@ -67,7 +68,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature in a configurable header (default: ` + "`X-Signature-256`" + `; e.g. use ` + "`X-Hub-Signature-256`" + ` for GitHub)
+- **Signature (HMAC)**: Verify requests using an HMAC-SHA256 signature
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -98,7 +99,6 @@ func (w *Webhook) Color() string {
 }
 
 func (w *Webhook) Configuration() []configuration.Field {
-	signatureHeaderStringMin := 1
 	return []configuration.Field{
 
 		{
@@ -124,17 +124,12 @@ func (w *Webhook) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Default:     DefaultSignatureHeader,
 			Placeholder: DefaultSignatureHeader,
-			Description: "HTTP header that contains the HMAC signature (values such as " + DefaultSignatureHeader + " or X-Hub-Signature-256)",
+			Description: "HTTP header that contains the HMAC signature",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "authentication", Values: []string{"signature"}},
 			},
 			RequiredConditions: []configuration.RequiredCondition{
 				{Field: "authentication", Values: []string{"signature"}},
-			},
-			TypeOptions: &configuration.TypeOptions{
-				String: &configuration.StringTypeOptions{
-					MinLength: &signatureHeaderStringMin,
-				},
 			},
 		},
 		{
@@ -264,9 +259,6 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		if config.SignatureHeader != "" && strings.TrimSpace(config.SignatureHeader) == "" {
-			return http.StatusBadRequest, nil, fmt.Errorf("signature header name cannot be empty")
-		}
 		headerName := config.SignatureHeaderName()
 		signature := ctx.Headers.Get(headerName)
 		if signature == "" {
@@ -338,9 +330,6 @@ func (c Configuration) HeaderTokenName() string {
 	return DefaultHeaderTokenName
 }
 
-// SignatureHeaderName returns the HTTP header to read the HMAC from.
-// It defaults to DefaultSignatureHeader when unset, empty, or only whitespace, so
-// existing workflows that omit the field keep prior behavior.
 func (c Configuration) SignatureHeaderName() string {
 	if strings.TrimSpace(c.SignatureHeader) == "" {
 		return DefaultSignatureHeader

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -8,23 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
-
-func Test__Webhook__Configuration__Validation(t *testing.T) {
-	webhook := &Webhook{}
-	fields := webhook.Configuration()
-
-	t.Run("signature mode accepts configured header", func(t *testing.T) {
-		err := configuration.ValidateConfiguration(fields, map[string]any{
-			"authentication":  "signature",
-			"signatureHeader": "X-Hub-Signature-256",
-		})
-		require.NoError(t, err)
-	})
-}
 
 func Test__Webhook__Setup(t *testing.T) {
 	t.Run("sets metadata when missing", func(t *testing.T) {
@@ -191,32 +177,6 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 
 		status, _, err := webhook.HandleWebhook(ctx)
 		require.Equal(t, http.StatusForbidden, status)
-		require.Error(t, err)
-	})
-
-	t.Run("rejects missing custom signature header", func(t *testing.T) {
-		webhook := &Webhook{}
-		ctx, _ := webhookRequestContextWithConfig(
-			[]byte(`{"ok":true}`),
-			map[string]any{"authentication": "signature", "signatureHeader": "X-Hub-Signature-256"},
-			"secret",
-		)
-
-		status, _, err := webhook.HandleWebhook(ctx)
-		require.Equal(t, http.StatusForbidden, status)
-		require.Error(t, err)
-	})
-
-	t.Run("rejects blank-only configured signature header", func(t *testing.T) {
-		webhook := &Webhook{}
-		ctx, _ := webhookRequestContextWithConfig(
-			[]byte(`{"ok":true}`),
-			map[string]any{"authentication": "signature", "signatureHeader": "   "},
-			"secret",
-		)
-
-		status, _, err := webhook.HandleWebhook(ctx)
-		require.Equal(t, http.StatusBadRequest, status)
 		require.Error(t, err)
 	})
 

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -8,9 +8,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
+
+func Test__Webhook__Configuration__Validation(t *testing.T) {
+	webhook := &Webhook{}
+	fields := webhook.Configuration()
+
+	t.Run("signature mode accepts configured header", func(t *testing.T) {
+		err := configuration.ValidateConfiguration(fields, map[string]any{
+			"authentication":  "signature",
+			"signatureHeader": "X-Hub-Signature-256",
+		})
+		require.NoError(t, err)
+	})
+}
 
 func Test__Webhook__Setup(t *testing.T) {
 	t.Run("sets metadata when missing", func(t *testing.T) {
@@ -180,6 +194,32 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("rejects missing custom signature header", func(t *testing.T) {
+		webhook := &Webhook{}
+		ctx, _ := webhookRequestContextWithConfig(
+			[]byte(`{"ok":true}`),
+			map[string]any{"authentication": "signature", "signatureHeader": "X-Hub-Signature-256"},
+			"secret",
+		)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusForbidden, status)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects blank-only configured signature header", func(t *testing.T) {
+		webhook := &Webhook{}
+		ctx, _ := webhookRequestContextWithConfig(
+			[]byte(`{"ok":true}`),
+			map[string]any{"authentication": "signature", "signatureHeader": "   "},
+			"secret",
+		)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Error(t, err)
+	})
+
 	t.Run("rejects invalid signature format", func(t *testing.T) {
 		webhook := &Webhook{}
 		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "signature", "secret")
@@ -219,6 +259,23 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.True(t, ok)
 		require.Contains(t, data, "body")
 		require.Contains(t, data, "headers")
+	})
+
+	t.Run("accepts valid signature on configured header e.g. GitHub", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContextWithConfig(
+			body,
+			map[string]any{"authentication": "signature", "signatureHeader": "X-Hub-Signature-256"},
+			"secret",
+		)
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+		require.Equal(t, 1, eventCtx.Count())
 	})
 
 	t.Run("rejects missing bearer token", func(t *testing.T) {
@@ -333,13 +390,17 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 }
 
 func webhookRequestContext(body []byte, authentication string, secret string) (core.WebhookRequestContext, *contexts.EventContext) {
+	return webhookRequestContextWithConfig(body, map[string]any{"authentication": authentication}, secret)
+}
+
+func webhookRequestContextWithConfig(body []byte, configuration map[string]any, secret string) (core.WebhookRequestContext, *contexts.EventContext) {
 	eventCtx := &contexts.EventContext{}
 	webhookCtx := &contexts.NodeWebhookContext{Secret: secret}
 
 	return core.WebhookRequestContext{
 		Body:          body,
 		Headers:       http.Header{},
-		Configuration: map[string]any{"authentication": authentication},
+		Configuration: configuration,
 		Webhook:       webhookCtx,
 		Events:        eventCtx,
 	}, eventCtx

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -19,10 +19,12 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast } from "@/lib/toast";
 
 const DEFAULT_HEADER_TOKEN_NAME = "X-Webhook-Token";
+const DEFAULT_SIGNATURE_HEADER = "X-Signature-256";
 
 interface WebhookConfiguration {
   authentication?: string;
   headerName?: string;
+  signatureHeader?: string;
 }
 
 interface WebhookMetadata {
@@ -30,16 +32,19 @@ interface WebhookMetadata {
   authentication?: string;
 }
 
-function formatAuthenticationMethod(auth: string, headerName?: string): string {
+function formatAuthenticationMethod(
+  auth: string,
+  options?: { headerName?: string; signatureHeader?: string },
+): string {
   switch (auth) {
     case "none":
       return "No authentication";
     case "signature":
-      return "HMAC signature";
+      return `HMAC signature (${options?.signatureHeader || DEFAULT_SIGNATURE_HEADER})`;
     case "bearer":
       return "Bearer token";
     case "header_token":
-      return `Header token (${headerName || DEFAULT_HEADER_TOKEN_NAME})`;
+      return `Header token (${options?.headerName || DEFAULT_HEADER_TOKEN_NAME})`;
     default:
       return "Unknown authentication";
   }
@@ -139,7 +144,10 @@ export const webhookTriggerRenderer: TriggerRenderer = {
           icon: "shield-check",
           label: formatAuthenticationMethod(
             metadata?.authentication || configuration?.authentication || "none",
-            configuration?.headerName,
+            {
+              headerName: configuration?.headerName,
+              signatureHeader: configuration?.signatureHeader,
+            },
           ),
         },
       ],
@@ -321,6 +329,7 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
     const config = node.configuration as WebhookConfiguration | undefined;
     const authMethod = config?.authentication || "none";
     const headerName = config?.headerName || DEFAULT_HEADER_TOKEN_NAME;
+    const signatureHeaderName = config?.signatureHeader?.trim() || DEFAULT_SIGNATURE_HEADER;
     const webhookUrl = metadata?.url || "[URL GENERATED ONCE THE CANVAS IS SAVED]";
 
     // State to track the currently displayed secret
@@ -346,7 +355,7 @@ export SIGNATURE=$(echo -n "$PAYLOAD" \\
   | xxd -p -c 256)
 
 curl -X POST \\
-  -H "X-Signature-256: sha256=$SIGNATURE" \\
+  -H "${signatureHeaderName}: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
   --data-binary "$PAYLOAD" \\
   ${webhookUrl}`;

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -32,10 +32,7 @@ interface WebhookMetadata {
   authentication?: string;
 }
 
-function formatAuthenticationMethod(
-  auth: string,
-  options?: { headerName?: string; signatureHeader?: string },
-): string {
+function formatAuthenticationMethod(auth: string, options?: { headerName?: string; signatureHeader?: string }): string {
   switch (auth) {
     case "none":
       return "No authentication";
@@ -142,13 +139,10 @@ export const webhookTriggerRenderer: TriggerRenderer = {
         },
         {
           icon: "shield-check",
-          label: formatAuthenticationMethod(
-            metadata?.authentication || configuration?.authentication || "none",
-            {
-              headerName: configuration?.headerName,
-              signatureHeader: configuration?.signatureHeader,
-            },
-          ),
+          label: formatAuthenticationMethod(metadata?.authentication || configuration?.authentication || "none", {
+            headerName: configuration?.headerName,
+            signatureHeader: configuration?.signatureHeader,
+          }),
         },
       ],
     };

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -19,10 +19,12 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast } from "@/lib/toast";
 
 const DEFAULT_HEADER_TOKEN_NAME = "X-Webhook-Token";
+const DEFAULT_SIGNATURE_HEADER = "X-Signature-256";
 
 interface WebhookConfiguration {
   authentication?: string;
   headerName?: string;
+  signatureHeader?: string;
 }
 
 interface WebhookMetadata {
@@ -30,16 +32,19 @@ interface WebhookMetadata {
   authentication?: string;
 }
 
-function formatAuthenticationMethod(auth: string, headerName?: string): string {
+function formatAuthenticationMethod(
+  auth: string,
+  options?: { headerName?: string; signatureHeader?: string },
+): string {
   switch (auth) {
     case "none":
       return "No authentication";
     case "signature":
-      return "HMAC signature";
+      return `HMAC signature (${options?.signatureHeader || DEFAULT_SIGNATURE_HEADER})`;
     case "bearer":
       return "Bearer token";
     case "header_token":
-      return `Header token (${headerName || DEFAULT_HEADER_TOKEN_NAME})`;
+      return `Header token (${options?.headerName || DEFAULT_HEADER_TOKEN_NAME})`;
     default:
       return "Unknown authentication";
   }
@@ -139,7 +144,10 @@ export const webhookTriggerRenderer: TriggerRenderer = {
           icon: "shield-check",
           label: formatAuthenticationMethod(
             metadata?.authentication || configuration?.authentication || "none",
-            configuration?.headerName,
+            {
+              headerName: configuration?.headerName,
+              signatureHeader: configuration?.signatureHeader,
+            },
           ),
         },
       ],
@@ -321,6 +329,7 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
     const config = node.configuration as WebhookConfiguration | undefined;
     const authMethod = config?.authentication || "none";
     const headerName = config?.headerName || DEFAULT_HEADER_TOKEN_NAME;
+    const signatureHeaderName = config?.signatureHeader?.trim() || DEFAULT_SIGNATURE_HEADER;
     const webhookUrl = metadata?.url || "[URL GENERATED ONCE THE CANVAS IS SAVED]";
 
     // State to track the currently displayed secret
@@ -336,7 +345,10 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
       switch (authMethod) {
         case "signature":
           title = "HMAC Signature Authentication";
-          description = "Use HMAC SHA-256 signature to authenticate your webhook requests.";
+          description =
+            "Use HMAC SHA-256 signature to authenticate your webhook requests. The signature must be sent in the configured header (for example " +
+            DEFAULT_SIGNATURE_HEADER +
+            " or X-Hub-Signature-256 for GitHub).";
           signatureKey = secret || "<your-signature-key>";
           code = `export SIGNATURE_KEY="${signatureKey}"
 export PAYLOAD='{"hello":"world"}'
@@ -346,7 +358,7 @@ export SIGNATURE=$(echo -n "$PAYLOAD" \\
   | xxd -p -c 256)
 
 curl -X POST \\
-  -H "X-Signature-256: sha256=$SIGNATURE" \\
+  -H "${signatureHeaderName}: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
   --data-binary "$PAYLOAD" \\
   ${webhookUrl}`;

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -19,12 +19,10 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast } from "@/lib/toast";
 
 const DEFAULT_HEADER_TOKEN_NAME = "X-Webhook-Token";
-const DEFAULT_SIGNATURE_HEADER = "X-Signature-256";
 
 interface WebhookConfiguration {
   authentication?: string;
   headerName?: string;
-  signatureHeader?: string;
 }
 
 interface WebhookMetadata {
@@ -32,19 +30,16 @@ interface WebhookMetadata {
   authentication?: string;
 }
 
-function formatAuthenticationMethod(
-  auth: string,
-  options?: { headerName?: string; signatureHeader?: string },
-): string {
+function formatAuthenticationMethod(auth: string, headerName?: string): string {
   switch (auth) {
     case "none":
       return "No authentication";
     case "signature":
-      return `HMAC signature (${options?.signatureHeader || DEFAULT_SIGNATURE_HEADER})`;
+      return "HMAC signature";
     case "bearer":
       return "Bearer token";
     case "header_token":
-      return `Header token (${options?.headerName || DEFAULT_HEADER_TOKEN_NAME})`;
+      return `Header token (${headerName || DEFAULT_HEADER_TOKEN_NAME})`;
     default:
       return "Unknown authentication";
   }
@@ -144,10 +139,7 @@ export const webhookTriggerRenderer: TriggerRenderer = {
           icon: "shield-check",
           label: formatAuthenticationMethod(
             metadata?.authentication || configuration?.authentication || "none",
-            {
-              headerName: configuration?.headerName,
-              signatureHeader: configuration?.signatureHeader,
-            },
+            configuration?.headerName,
           ),
         },
       ],
@@ -329,7 +321,6 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
     const config = node.configuration as WebhookConfiguration | undefined;
     const authMethod = config?.authentication || "none";
     const headerName = config?.headerName || DEFAULT_HEADER_TOKEN_NAME;
-    const signatureHeaderName = config?.signatureHeader?.trim() || DEFAULT_SIGNATURE_HEADER;
     const webhookUrl = metadata?.url || "[URL GENERATED ONCE THE CANVAS IS SAVED]";
 
     // State to track the currently displayed secret
@@ -345,10 +336,7 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
       switch (authMethod) {
         case "signature":
           title = "HMAC Signature Authentication";
-          description =
-            "Use HMAC SHA-256 signature to authenticate your webhook requests. The signature must be sent in the configured header (for example " +
-            DEFAULT_SIGNATURE_HEADER +
-            " or X-Hub-Signature-256 for GitHub).";
+          description = "Use HMAC SHA-256 signature to authenticate your webhook requests.";
           signatureKey = secret || "<your-signature-key>";
           code = `export SIGNATURE_KEY="${signatureKey}"
 export PAYLOAD='{"hello":"world"}'
@@ -358,7 +346,7 @@ export SIGNATURE=$(echo -n "$PAYLOAD" \\
   | xxd -p -c 256)
 
 curl -X POST \\
-  -H "${signatureHeaderName}: sha256=$SIGNATURE" \\
+  -H "X-Signature-256: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
   --data-binary "$PAYLOAD" \\
   ${webhookUrl}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the product direction from [issue #4381](https://github.com/superplanehq/superplane/issues/4381): when **Signature (HMAC)** is selected on the **Webhook** trigger, users can set a required **Header** field (default `X-Signature-256`) to match the sending system (e.g. `X-Hub-Signature-256` for GitHub). Existing workflows that omit the field still resolve to the previous default at runtime.

## Changes

- **Backend** (`pkg/triggers/webhook`): new `signatureHeader` configuration field, `DefaultSignatureHeader` constant, `Configuration()` field with visibility/required for `signature` mode, and `HandleWebhook` reads the signature from the configured header. Rejects a stored value that is only whitespace (400) so the header is never empty in practice.
- **Tests**: validation + handle-webhook cases for custom header (e.g. GitHub) and blank-header rejection; refactored test helper for custom config maps.
- **UI** (`webhook.tsx`): curl example and trigger subtitle use the configured header; documentation text updated.
- **Docs** (`docs/components/Core.mdx`): HMAC line updated to mention configurable header and GitHub.

## Testing

- `go test ./pkg/triggers/webhook/...` (local; full `pkg/...` requires DB in this environment for unrelated packages)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04779d03-b9c7-4ddc-a984-340d36874822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04779d03-b9c7-4ddc-a984-340d36874822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

