### PR TITLE
feat: configurable HMAC signature header for webhook trigger (#4381)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -159,7 +159,7 @@ The Webhook trigger starts a new workflow execution when an HTTP request is rece
 
 ### Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the `X-Signature-256` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in a configurable HTTP header (default: `X-Signature-256`; use `X-Hub-Signature-256` for GitHub webhooks)
 - **Bearer Token**: Require a Bearer token in the `Authorization` header
 - **Header Token**: Require a raw token in a custom header (default: `X-Webhook-Token`)
 - **None (unsafe)**: No authentication (not recommended for production)

--- a/pkg/triggers/webhook/webhook.go
+++ b/pkg/triggers/webhook/webhook.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	MaxEventSize           = 64 * 1024
-	DefaultHeaderTokenName = "X-Webhook-Token"
+	MaxEventSize               = 64 * 1024
+	DefaultHeaderTokenName     = "X-Webhook-Token"
+	DefaultSignatureHeaderName = "X-Signature-256"
 )
 
 func init() {
@@ -30,8 +31,9 @@ type Metadata struct {
 }
 
 type Configuration struct {
-	Authentication string `json:"authentication"`
-	HeaderName     string `json:"headerName" mapstructure:"headerName"`
+	Authentication      string `json:"authentication"`
+	HeaderName          string `json:"headerName" mapstructure:"headerName"`
+	SignatureHeaderName string `json:"signatureHeaderName" mapstructure:"signatureHeaderName"`
 }
 
 func (w *Webhook) Name() string {
@@ -65,7 +67,7 @@ func (w *Webhook) Documentation() string {
 
 ## Authentication Methods
 
-- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in the ` + "`X-Signature-256`" + ` header
+- **Signature (HMAC)**: Verify requests using HMAC-SHA256 signature in a configurable HTTP header (default: ` + "`X-Signature-256`" + `; e.g. ` + "`X-Hub-Signature-256`" + ` for GitHub)
 - **Bearer Token**: Require a Bearer token in the ` + "`Authorization`" + ` header
 - **Header Token**: Require a raw token in a custom header (default: ` + "`X-Webhook-Token`" + `)
 - **None (unsafe)**: No authentication (not recommended for production)
@@ -116,6 +118,20 @@ func (w *Webhook) Configuration() []configuration.Field {
 			},
 		},
 		{
+			Name:        "signatureHeaderName",
+			Label:       "Header",
+			Type:        configuration.FieldTypeString,
+			Default:     DefaultSignatureHeaderName,
+			Placeholder: DefaultSignatureHeaderName,
+			Description: "HTTP header that carries the HMAC-SHA256 signature (sha256= prefix)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "authentication", Values: []string{"signature"}},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "authentication", Values: []string{"signature"}},
+			},
+		},
+		{
 			Name:        "headerName",
 			Label:       "Header Name",
 			Type:        configuration.FieldTypeString,
@@ -143,6 +159,10 @@ func (w *Webhook) Setup(ctx core.TriggerContext) error {
 	err = mapstructure.Decode(ctx.Configuration, &config)
 	if err != nil {
 		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if config.Authentication == "signature" && config.SignatureHeaderName != "" && strings.TrimSpace(config.SignatureHeaderName) == "" {
+		return fmt.Errorf("signature header name cannot be empty")
 	}
 
 	if metadata.URL != "" && metadata.Authentication == config.Authentication {
@@ -242,7 +262,8 @@ func (w *Webhook) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.Webh
 
 	switch config.Authentication {
 	case "signature":
-		signature := ctx.Headers.Get("X-Signature-256")
+		headerName := config.HMACSignatureHeaderName()
+		signature := ctx.Headers.Get(headerName)
 		if signature == "" {
 			return http.StatusForbidden, nil, fmt.Errorf("missing signature header")
 		}
@@ -310,4 +331,13 @@ func (c Configuration) HeaderTokenName() string {
 	}
 
 	return DefaultHeaderTokenName
+}
+
+// HMACSignatureHeaderName returns the HTTP header used for the HMAC signature (HMAC / "signature" auth).
+// When unset in stored configuration, the default matches previous behavior.
+func (c Configuration) HMACSignatureHeaderName() string {
+	if strings.TrimSpace(c.SignatureHeaderName) == "" {
+		return DefaultSignatureHeaderName
+	}
+	return strings.TrimSpace(c.SignatureHeaderName)
 }

--- a/pkg/triggers/webhook/webhook_test.go
+++ b/pkg/triggers/webhook/webhook_test.go
@@ -77,6 +77,25 @@ func Test__Webhook__Setup(t *testing.T) {
 		require.Equal(t, "existing-url", metadata.URL)
 		require.Equal(t, "bearer", metadata.Authentication)
 	})
+
+	t.Run("rejects signature auth with blank signature header name", func(t *testing.T) {
+		webhook := &Webhook{}
+		metadataCtx := &contexts.MetadataContext{Metadata: Metadata{}}
+		webhookCtx := &contexts.NodeWebhookContext{}
+
+		ctx := core.TriggerContext{
+			Configuration: map[string]any{
+				"authentication":      "signature",
+				"signatureHeaderName": "  ",
+			},
+			Metadata: metadataCtx,
+			Webhook:  webhookCtx,
+		}
+
+		err := webhook.Setup(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature header name cannot be empty")
+	})
 }
 
 func Test__Webhook__HandleAction__ResetAuthentication(t *testing.T) {
@@ -151,6 +170,17 @@ func Test__Webhook__HandleAction__ResetAuthentication(t *testing.T) {
 	})
 }
 
+func Test__Configuration__HMACSignatureHeaderName(t *testing.T) {
+	t.Run("returns default when empty or whitespace", func(t *testing.T) {
+		require.Equal(t, DefaultSignatureHeaderName, (Configuration{}).HMACSignatureHeaderName())
+		require.Equal(t, DefaultSignatureHeaderName, (Configuration{SignatureHeaderName: "  "}).HMACSignatureHeaderName())
+	})
+
+	t.Run("trims and returns custom header", func(t *testing.T) {
+		require.Equal(t, "X-Hub-Signature-256", (Configuration{SignatureHeaderName: "  X-Hub-Signature-256  "}).HMACSignatureHeaderName())
+	})
+}
+
 func Test__Webhook__HandleWebhook(t *testing.T) {
 	t.Run("rejects payloads larger than MaxEventSize", func(t *testing.T) {
 		webhook := &Webhook{}
@@ -173,7 +203,9 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 
 	t.Run("rejects missing signature header", func(t *testing.T) {
 		webhook := &Webhook{}
-		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "signature", "secret")
+		ctx, _ := webhookRequestContext([]byte(`{"ok":true}`), "signature", "secret", map[string]any{
+			"signatureHeaderName": "X-Hub-Signature-256",
+		})
 
 		status, _, err := webhook.HandleWebhook(ctx)
 		require.Equal(t, http.StatusForbidden, status)
@@ -219,6 +251,36 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 		require.True(t, ok)
 		require.Contains(t, data, "body")
 		require.Contains(t, data, "headers")
+	})
+
+	t.Run("accepts valid signature on configured custom header (GitHub)", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"foo":"bar"}`)
+		ctx, eventCtx := webhookRequestContext(body, "signature", "secret", map[string]any{
+			"signatureHeaderName": "X-Hub-Signature-256",
+		})
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, eventCtx.Count())
+	})
+
+	t.Run("empty signatureHeaderName in config uses default header", func(t *testing.T) {
+		webhook := &Webhook{}
+		body := []byte(`{"ok":true}`)
+		ctx, _ := webhookRequestContext(body, "signature", "secret", map[string]any{
+			"signatureHeaderName": "   ",
+		})
+		signature := computeSignature("secret", body)
+		ctx.Headers.Set("X-Signature-256", "sha256="+signature)
+
+		status, _, err := webhook.HandleWebhook(ctx)
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, err)
 	})
 
 	t.Run("rejects missing bearer token", func(t *testing.T) {
@@ -332,14 +394,21 @@ func Test__Webhook__HandleWebhook(t *testing.T) {
 	})
 }
 
-func webhookRequestContext(body []byte, authentication string, secret string) (core.WebhookRequestContext, *contexts.EventContext) {
+func webhookRequestContext(body []byte, authentication string, secret string, configExtras ...map[string]any) (core.WebhookRequestContext, *contexts.EventContext) {
 	eventCtx := &contexts.EventContext{}
 	webhookCtx := &contexts.NodeWebhookContext{Secret: secret}
+
+	cfg := map[string]any{"authentication": authentication}
+	for _, extra := range configExtras {
+		for k, v := range extra {
+			cfg[k] = v
+		}
+	}
 
 	return core.WebhookRequestContext{
 		Body:          body,
 		Headers:       http.Header{},
-		Configuration: map[string]any{"authentication": authentication},
+		Configuration: cfg,
 		Webhook:       webhookCtx,
 		Events:        eventCtx,
 	}, eventCtx

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -19,10 +19,13 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast } from "@/lib/toast";
 
 const DEFAULT_HEADER_TOKEN_NAME = "X-Webhook-Token";
+const DEFAULT_SIGNATURE_HEADER_NAME = "X-Signature-256";
 
 interface WebhookConfiguration {
   authentication?: string;
   headerName?: string;
+  /** HTTP header for HMAC signature when authentication is "signature" */
+  signatureHeaderName?: string;
 }
 
 interface WebhookMetadata {
@@ -30,12 +33,12 @@ interface WebhookMetadata {
   authentication?: string;
 }
 
-function formatAuthenticationMethod(auth: string, headerName?: string): string {
+function formatAuthenticationMethod(auth: string, headerName?: string, signatureHeaderName?: string): string {
   switch (auth) {
     case "none":
       return "No authentication";
     case "signature":
-      return "HMAC signature";
+      return `HMAC signature (${signatureHeaderName || DEFAULT_SIGNATURE_HEADER_NAME})`;
     case "bearer":
       return "Bearer token";
     case "header_token":
@@ -140,6 +143,7 @@ export const webhookTriggerRenderer: TriggerRenderer = {
           label: formatAuthenticationMethod(
             metadata?.authentication || configuration?.authentication || "none",
             configuration?.headerName,
+            configuration?.signatureHeaderName,
           ),
         },
       ],
@@ -321,6 +325,7 @@ export const webhookCustomFieldRenderer: CustomFieldRenderer = {
     const config = node.configuration as WebhookConfiguration | undefined;
     const authMethod = config?.authentication || "none";
     const headerName = config?.headerName || DEFAULT_HEADER_TOKEN_NAME;
+    const signatureHeaderName = config?.signatureHeaderName || DEFAULT_SIGNATURE_HEADER_NAME;
     const webhookUrl = metadata?.url || "[URL GENERATED ONCE THE CANVAS IS SAVED]";
 
     // State to track the currently displayed secret
@@ -346,7 +351,7 @@ export SIGNATURE=$(echo -n "$PAYLOAD" \\
   | xxd -p -c 256)
 
 curl -X POST \\
-  -H "X-Signature-256: sha256=$SIGNATURE" \\
+  -H "${signatureHeaderName}: sha256=$SIGNATURE" \\
   -H "Content-Type: application/json" \\
   --data-binary "$PAYLOAD" \\
   ${webhookUrl}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **user-configurable HTTP header** for **Signature (HMAC)** on the generic Webhook trigger, as requested in [#4381](https://github.com/superplanehq/superplane/issues/4381).

- New configuration field `signatureHeaderName` (form label **Header**), default **`X-Signature-256`**, required when **Signature (HMAC)** is selected. Users can set e.g. **`X-Hub-Signature-256`** for GitHub.
- `HandleWebhook` reads the HMAC from the configured header; existing stored configs without the field still behave like today (default `X-Signature-256`).
- **Server-side validation in `Setup`:** if the field is **present but only whitespace**, setup fails (cannot be empty while meaningfully set). **Handler** still treats all-whitespace stored values like missing and falls back to the default, for backward safety.
- Updated trigger documentation string, [docs/components/Core.mdx](docs/components/Core.mdx), and [web_src](web_src/src/pages/workflowv2/mappers/webhook.tsx) curl / metadata (HMAC line uses configured header name).

## Tests

- `go test ./pkg/triggers/webhook/...` (passes in this environment).

> Full `make` UI build was not run here (generated `api-client` / Docker not available in this agent environment); CI will validate the full tree.

## Issue / review feedback

- **@shiroyasha:** Required **Header** under Signature (HMAC), default `X-Signature-256`, non-empty — **implemented** via `signatureHeaderName` + `Setup` validation + `HMACSignatureHeaderName()` default for legacy configs.
- **Agent review (dual-header fallback):** superseded by human direction; this PR uses **configuration** instead of hardcoded fallbacks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9479309-ca1d-4cc1-80d3-15c49f898345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9479309-ca1d-4cc1-80d3-15c49f898345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

