### PR TITLE
chore: rename hook API endpoints

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -322,13 +322,13 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
-		pbCanvases.Canvases_InvokeNodeExecutionAction_FullMethodName: {
+		pbCanvases.Canvases_InvokeNodeExecutionHook_FullMethodName: {
 			Resource:         "canvases",
 			Action:           "update",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
-		pbCanvases.Canvases_InvokeNodeTriggerAction_FullMethodName: {
+		pbCanvases.Canvases_InvokeNodeTriggerHook_FullMethodName: {
 			Resource:         "canvases",
 			Action:           "update",
 			DomainType:       models.DomainTypeOrganization,

--- a/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_execution_hook.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func InvokeNodeExecutionAction(
+func InvokeNodeExecutionHook(
 	ctx context.Context,
 	authService authorization.Authorization,
 	encryptor crypto.Encryptor,
@@ -29,9 +29,9 @@ func InvokeNodeExecutionAction(
 	orgID uuid.UUID,
 	canvasID uuid.UUID,
 	executionID uuid.UUID,
-	actionName string,
+	hookName string,
 	parameters map[string]any,
-) (*pb.InvokeNodeExecutionActionResponse, error) {
+) (*pb.InvokeNodeExecutionHookResponse, error) {
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
@@ -60,13 +60,13 @@ func InvokeNodeExecutionAction(
 		return nil, fmt.Errorf("node is not a component node")
 	}
 
-	hookProvider, hookDef, err := registry.FindComponentHook(node.Ref.Data().Component.Name, actionName)
+	hookProvider, hookDef, err := registry.FindComponentHook(node.Ref.Data().Component.Name, hookName)
 	if err != nil {
 		return nil, fmt.Errorf("hook not found: %w", err)
 	}
 
 	if hookDef.Type != core.HookTypeUser {
-		return nil, fmt.Errorf("hook '%s' cannot be invoked", actionName)
+		return nil, fmt.Errorf("hook '%s' cannot be invoked", hookName)
 	}
 
 	if err := configuration.ValidateConfiguration(hookDef.Parameters, parameters); err != nil {
@@ -86,7 +86,7 @@ func InvokeNodeExecutionAction(
 	tx := database.Conn()
 	logger := logging.ForExecution(execution, nil)
 	actionCtx := core.ActionHookContext{
-		Name:           actionName,
+		Name:           hookName,
 		Parameters:     parameters,
 		Configuration:  node.Configuration.Data(),
 		HTTP:           registry.HTTPContext(),
@@ -124,5 +124,5 @@ func InvokeNodeExecutionAction(
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
-	return &pb.InvokeNodeExecutionActionResponse{}, nil
+	return &pb.InvokeNodeExecutionHookResponse{}, nil
 }

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func InvokeNodeTriggerAction(
+func InvokeNodeTriggerHook(
 	ctx context.Context,
 	authService authorization.Authorization,
 	encryptor crypto.Encryptor,
@@ -32,7 +32,7 @@ func InvokeNodeTriggerAction(
 	hookName string,
 	parameters map[string]any,
 	webhookBaseURL string,
-) (*pb.InvokeNodeTriggerActionResponse, error) {
+) (*pb.InvokeNodeTriggerHookResponse, error) {
 	userID, userIsSet := authentication.GetUserIdFromMetadata(ctx)
 	if !userIsSet {
 		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
@@ -117,7 +117,7 @@ func InvokeNodeTriggerAction(
 		return nil, status.Errorf(codes.Internal, "failed to create result struct: %v", err)
 	}
 
-	return &pb.InvokeNodeTriggerActionResponse{
+	return &pb.InvokeNodeTriggerHookResponse{
 		Result: resultStruct,
 	}, nil
 }

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -304,7 +304,7 @@ func (s *CanvasService) EmitNodeEvent(ctx context.Context, req *pb.EmitNodeEvent
 	)
 }
 
-func (s *CanvasService) InvokeNodeExecutionAction(ctx context.Context, req *pb.InvokeNodeExecutionActionRequest) (*pb.InvokeNodeExecutionActionResponse, error) {
+func (s *CanvasService) InvokeNodeExecutionHook(ctx context.Context, req *pb.InvokeNodeExecutionHookRequest) (*pb.InvokeNodeExecutionHookResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 
 	canvasID, err := uuid.Parse(req.CanvasId)
@@ -317,7 +317,7 @@ func (s *CanvasService) InvokeNodeExecutionAction(ctx context.Context, req *pb.I
 		return nil, status.Error(codes.InvalidArgument, "invalid execution_id")
 	}
 
-	return canvases.InvokeNodeExecutionAction(
+	return canvases.InvokeNodeExecutionHook(
 		ctx,
 		s.authService,
 		s.encryptor,
@@ -325,12 +325,12 @@ func (s *CanvasService) InvokeNodeExecutionAction(ctx context.Context, req *pb.I
 		uuid.MustParse(organizationID),
 		canvasID,
 		executionID,
-		req.ActionName,
+		req.HookName,
 		req.Parameters.AsMap(),
 	)
 }
 
-func (s *CanvasService) InvokeNodeTriggerAction(ctx context.Context, req *pb.InvokeNodeTriggerActionRequest) (*pb.InvokeNodeTriggerActionResponse, error) {
+func (s *CanvasService) InvokeNodeTriggerHook(ctx context.Context, req *pb.InvokeNodeTriggerHookRequest) (*pb.InvokeNodeTriggerHookResponse, error) {
 	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
 
 	canvasID, err := uuid.Parse(req.CanvasId)
@@ -342,11 +342,11 @@ func (s *CanvasService) InvokeNodeTriggerAction(ctx context.Context, req *pb.Inv
 		return nil, status.Error(codes.InvalidArgument, "node_id is required")
 	}
 
-	if req.ActionName == "" {
-		return nil, status.Error(codes.InvalidArgument, "action_name is required")
+	if req.HookName == "" {
+		return nil, status.Error(codes.InvalidArgument, "hook_name is required")
 	}
 
-	return canvases.InvokeNodeTriggerAction(
+	return canvases.InvokeNodeTriggerHook(
 		ctx,
 		s.authService,
 		s.encryptor,
@@ -354,7 +354,7 @@ func (s *CanvasService) InvokeNodeTriggerAction(ctx context.Context, req *pb.Inv
 		uuid.MustParse(organizationID),
 		canvasID,
 		req.NodeId,
-		req.ActionName,
+		req.HookName,
 		req.Parameters.AsMap(),
 		s.webhookBaseURL,
 	)

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -307,26 +307,26 @@ service Canvases {
     };
   }
 
-  rpc InvokeNodeExecutionAction(InvokeNodeExecutionActionRequest) returns (InvokeNodeExecutionActionResponse) {
+  rpc InvokeNodeExecutionHook(InvokeNodeExecutionHookRequest) returns (InvokeNodeExecutionHookResponse) {
     option (google.api.http) = {
-      post: "/api/v1/canvases/{canvas_id}/executions/{execution_id}/actions/{action_name}"
+      post: "/api/v1/canvases/{canvas_id}/executions/{execution_id}/hooks/{hook_name}"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Invoke execution action";
-      description: "Invokes a custom action on a canvas node execution";
+      summary: "Invoke execution hook";
+      description: "Invokes a custom hook on a canvas node execution";
       tags: "CanvasNodeExecution";
     };
   }
 
-  rpc InvokeNodeTriggerAction(InvokeNodeTriggerActionRequest) returns (InvokeNodeTriggerActionResponse) {
+  rpc InvokeNodeTriggerHook(InvokeNodeTriggerHookRequest) returns (InvokeNodeTriggerHookResponse) {
     option (google.api.http) = {
-      post: "/api/v1/canvases/{canvas_id}/triggers/{node_id}/actions/{action_name}"
+      post: "/api/v1/canvases/{canvas_id}/triggers/{node_id}/hooks/{hook_name}"
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "Invoke trigger action";
-      description: "Invokes a custom action on a canvas node trigger";
+      summary: "Invoke trigger hook";
+      description: "Invokes a custom hook on a canvas node trigger";
       tags: "CanvasNode";
     };
   }
@@ -891,23 +891,23 @@ message CanvasNodeQueueItem {
   google.protobuf.Timestamp created_at = 6;
 }
 
-message InvokeNodeExecutionActionRequest {
+message InvokeNodeExecutionHookRequest {
   string canvas_id = 1;
   string execution_id = 2;
-  string action_name = 3;
+  string hook_name = 3;
   google.protobuf.Struct parameters = 4;
 }
 
-message InvokeNodeExecutionActionResponse {}
+message InvokeNodeExecutionHookResponse {}
 
-message InvokeNodeTriggerActionRequest {
+message InvokeNodeTriggerHookRequest {
   string canvas_id = 1;
   string node_id = 2;
-  string action_name = 3;
+  string hook_name = 3;
   google.protobuf.Struct parameters = 4;
 }
 
-message InvokeNodeTriggerActionResponse {
+message InvokeNodeTriggerHookResponse {
   google.protobuf.Struct result = 1;
 }
 

--- a/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { Puzzle } from "lucide-react";
 import {
-  canvasesInvokeNodeExecutionAction,
+  canvasesInvokeNodeExecutionHook,
   type BlueprintsBlueprint,
   type CanvasesCanvasEvent,
   type CanvasesCanvasNodeExecution,
@@ -416,14 +416,14 @@ export function prepareComponentBaseNode(args: PrepareComponentBaseNodeArgs): Ca
 
 function buildActionContext(queryClient: QueryClient, canvasId: string, nodeId: string): ActionContext {
   return {
-    invokeNodeExecutionAction: async (executionId: string, actionName: string, parameters: unknown) => {
+    invokeNodeExecutionHook: async (executionId: string, hookName: string, parameters: unknown) => {
       try {
-        await canvasesInvokeNodeExecutionAction(
+        await canvasesInvokeNodeExecutionHook(
           withOrganizationHeader({
             path: {
               canvasId,
               executionId,
-              actionName,
+              hookName,
             },
             body: {
               parameters,
@@ -434,7 +434,7 @@ function buildActionContext(queryClient: QueryClient, canvasId: string, nodeId: 
           queryKey: canvasKeys.nodeExecution(canvasId, nodeId),
         });
       } catch (error) {
-        showErrorToast(getApiErrorMessage(error, "failed to invoke action"));
+        showErrorToast(getApiErrorMessage(error, "failed to invoke hook"));
       }
     },
   };

--- a/web_src/src/pages/workflowv2/mappers/approval.ts
+++ b/web_src/src/pages/workflowv2/mappers/approval.ts
@@ -323,7 +323,7 @@ function approvalItemPropsForRecord(
     onApprove: async (comment?: string) => {
       if (!lastExecution?.id) return;
 
-      return context.actions.invokeNodeExecutionAction(lastExecution.id, "approve", {
+      return context.actions.invokeNodeExecutionHook(lastExecution.id, "approve", {
         index: record.index,
         comment: comment,
       });
@@ -331,7 +331,7 @@ function approvalItemPropsForRecord(
     onReject: async (reason: string) => {
       if (!lastExecution?.id) return;
 
-      return context.actions.invokeNodeExecutionAction(lastExecution.id, "reject", {
+      return context.actions.invokeNodeExecutionHook(lastExecution.id, "reject", {
         index: record.index,
         reason: reason,
       });

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/database.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/database.spec.ts
@@ -77,7 +77,7 @@ function buildComponentContext(overrides?: {
     },
     lastExecutions: overrides?.lastExecutions ?? [],
     currentUser: undefined,
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/database_cluster.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/database_cluster.spec.ts
@@ -77,7 +77,7 @@ function buildPropsContext(overrides?: Partial<ComponentBaseContext>): Component
       groups: [],
     },
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
     ...overrides,
   };

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -70,7 +70,7 @@ function makeComponentBaseContext(overrides?: Partial<ComponentBaseContext>): Co
       groups: [],
     },
     actions: {
-      invokeNodeExecutionAction: vi.fn(),
+      invokeNodeExecutionHook: vi.fn(),
     },
     ...overrides,
   };

--- a/web_src/src/pages/workflowv2/mappers/github/run_workflow.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/github/run_workflow.spec.tsx
@@ -33,7 +33,7 @@ function makeContext(configuration: unknown): ComponentBaseContext {
       groups: ["developers"],
     },
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/grafana/alert_rule_mappers.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/grafana/alert_rule_mappers.spec.ts
@@ -51,7 +51,7 @@ function buildComponentContext(componentName: string, nodeOverrides?: Partial<No
     lastExecutions: [],
     currentUser: undefined,
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/grafana/annotations.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/grafana/annotations.spec.ts
@@ -57,7 +57,7 @@ function buildComponentContext(componentName: string, overrides?: { node?: Parti
     lastExecutions: [],
     currentUser: undefined,
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/grafana/dashboard_mappers.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/grafana/dashboard_mappers.spec.ts
@@ -47,7 +47,7 @@ function makeComponentContext(node: NodeInfo, lastExecutions: ExecutionInfo[] = 
     lastExecutions,
     currentUser: undefined,
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/grafana/data_source_mappers.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/grafana/data_source_mappers.spec.ts
@@ -46,7 +46,7 @@ function makeComponentContext(node: NodeInfo): ComponentBaseContext {
     lastExecutions: [],
     currentUser: undefined,
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/grafana/resources.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/grafana/resources.spec.ts
@@ -57,7 +57,7 @@ function buildComponentContext(componentName: string, nodeOverrides?: Partial<No
     lastExecutions: [],
     currentUser: undefined,
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/incident/on_incident_webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/incident/on_incident_webhook.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   canvasesDescribeCanvas,
   canvasesDescribeCanvasVersion,
-  canvasesInvokeNodeTriggerAction,
+  canvasesInvokeNodeTriggerHook,
   canvasesUpdateCanvasVersion,
   type CanvasesCanvas,
   type CanvasesCanvasVersion,
@@ -84,9 +84,9 @@ const SetSigningSecretSection: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     setIsSubmitting(true);
     setSuccess(false);
     try {
-      const invokeResponse = await canvasesInvokeNodeTriggerAction(
+      const invokeResponse = await canvasesInvokeNodeTriggerHook(
         withOrganizationHeader({
-          path: { canvasId, nodeId, actionName: "setSecret" },
+          path: { canvasId, nodeId, hookName: "setSecret" },
           body: { parameters: { webhookSigningSecret: secret } },
         }),
       );

--- a/web_src/src/pages/workflowv2/mappers/logfire/base.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/logfire/base.spec.ts
@@ -76,7 +76,7 @@ function buildComponentBaseContext(overrides?: {
       roles: ["admin"],
       groups: ["developers"],
     },
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/oci/create_compute_instance.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/oci/create_compute_instance.spec.ts
@@ -57,7 +57,7 @@ function buildComponentCtx(nodeOverrides?: Partial<NodeInfo>): ComponentBaseCont
     },
     lastExecutions: [],
     currentUser: undefined,
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/pagerduty/create_incident.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/pagerduty/create_incident.spec.ts
@@ -24,7 +24,7 @@ function makeContext(overrides: Partial<NodeInfo> = {}): ComponentBaseContext {
     componentDefinition: DEFINITION,
     lastExecutions: [],
     currentUser: undefined,
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/safeMappers.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/safeMappers.spec.ts
@@ -58,7 +58,7 @@ function makeComponentBaseContext(overrides?: Partial<ComponentBaseContext>): Co
       groups: ["developers"],
     },
     actions: {
-      invokeNodeExecutionAction: async () => {},
+      invokeNodeExecutionHook: async () => {},
     },
   };
 }

--- a/web_src/src/pages/workflowv2/mappers/servicenow/create_incident.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/servicenow/create_incident.spec.ts
@@ -24,7 +24,7 @@ function makeContext(overrides: Partial<NodeInfo> = {}): ComponentBaseContext {
     componentDefinition: DEFINITION,
     lastExecutions: [],
     currentUser: undefined,
-    actions: { invokeNodeExecutionAction: async () => {} },
+    actions: { invokeNodeExecutionHook: async () => {} },
   };
 }
 

--- a/web_src/src/pages/workflowv2/mappers/timegate.tsx
+++ b/web_src/src/pages/workflowv2/mappers/timegate.tsx
@@ -106,7 +106,7 @@ function getTimeGateCustomField(context: ComponentBaseContext): React.ReactNode 
   return React.createElement(PushThroughHandler, {
     onPushThrough: async () => {
       if (!lastExecution?.id) return;
-      return context.actions.invokeNodeExecutionAction(lastExecution.id, "pushThrough", null);
+      return context.actions.invokeNodeExecutionHook(lastExecution.id, "pushThrough", null);
     },
   });
 }

--- a/web_src/src/pages/workflowv2/mappers/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/types.ts
@@ -126,7 +126,7 @@ export type ComponentBaseContext = {
 };
 
 export type ActionContext = {
-  invokeNodeExecutionAction: (executionId: string, action: string, parameters: unknown) => Promise<void>;
+  invokeNodeExecutionHook: (executionId: string, hook: string, parameters: unknown) => Promise<void>;
 };
 
 export type SubtitleContext = {

--- a/web_src/src/pages/workflowv2/mappers/wait.tsx
+++ b/web_src/src/pages/workflowv2/mappers/wait.tsx
@@ -143,7 +143,7 @@ function getWaitCustomField(context: ComponentBaseContext): React.ReactNode {
   return React.createElement(PushThroughHandler, {
     onPushThrough: async () => {
       if (!lastExecution?.id) return;
-      return context.actions.invokeNodeExecutionAction(lastExecution.id, "pushThrough", null);
+      return context.actions.invokeNodeExecutionHook(lastExecution.id, "pushThrough", null);
     },
   });
 }

--- a/web_src/src/pages/workflowv2/mappers/webhook.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import React from "react";
-import { canvasesInvokeNodeTriggerAction } from "@/api-client";
+import { canvasesInvokeNodeTriggerHook } from "@/api-client";
 import { getColorClass } from "@/lib/colors";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import type {
@@ -246,12 +246,12 @@ const ResetAuthButton: React.FC<{
 
     setIsResetting(true);
     try {
-      const response = await canvasesInvokeNodeTriggerAction(
+      const response = await canvasesInvokeNodeTriggerHook(
         withOrganizationHeader({
           path: {
             canvasId: canvasId,
             nodeId: nodeId,
-            actionName: "resetAuthentication",
+            hookName: "resetAuthentication",
           },
           body: {
             parameters: {},


### PR DESCRIPTION
Now that we have core.Hook (see https://github.com/superplanehq/superplane/pull/4393), we should rename the APIs to use /hooks instead.