### PR TITLE
feat: support organization secret refs in HTTP component headers

### DIFF
--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -38,9 +39,16 @@ func init() {
 	registry.RegisterAction("http", &HTTP{})
 }
 
+// Header supports a literal string value or a value resolved from an organization
+// secret (see configuration.SecretKeyRef) with an optional prefix (e.g. "Bearer " for Authorization).
 type Header struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name string `json:"name" mapstructure:"name"`
+	// Value is a plain string, or a map: { "secret", "key", "prefix" } (as in the HTTP component issue example).
+	Value any `json:"value,omitempty" mapstructure:"value"`
+	// Flat form (same as nested value.secret / value.key / value.prefix) for UIs and YAML.
+	Secret string `json:"secret,omitempty" mapstructure:"secret"`
+	Key    string `json:"key,omitempty" mapstructure:"key"`
+	Prefix string `json:"prefix,omitempty" mapstructure:"prefix"`
 }
 
 type KeyValue struct {
@@ -77,6 +85,118 @@ func (s *Spec) GetSuccessCodes() string {
 	}
 
 	return *s.SuccessCodes
+}
+
+func (h *Header) hasSecretKeyRef() bool {
+	if h.Secret != "" && h.Key != "" {
+		return true
+	}
+	if m, ok := h.Value.(map[string]any); ok {
+		secret, _ := m["secret"].(string)
+		k, _ := m["key"].(string)
+		return secret != "" && k != ""
+	}
+	return false
+}
+
+func (h *Header) secretKeyRef() (ref configuration.SecretKeyRef, prefix string) {
+	if h.Secret != "" && h.Key != "" {
+		return configuration.SecretKeyRef{Secret: h.Secret, Key: h.Key}, h.Prefix
+	}
+	if m, ok := h.Value.(map[string]any); ok {
+		secret, _ := m["secret"].(string)
+		k, _ := m["key"].(string)
+		if secret == "" || k == "" {
+			return configuration.SecretKeyRef{}, ""
+		}
+		p, _ := m["prefix"].(string)
+		if p == "" {
+			p = h.Prefix
+		}
+		return configuration.SecretKeyRef{Secret: secret, Key: k}, p
+	}
+	return configuration.SecretKeyRef{}, ""
+}
+
+func (h *Header) validate() error {
+	flatPartial := (h.Secret != "" && h.Key == "") || (h.Secret == "" && h.Key != "")
+	if flatPartial {
+		return fmt.Errorf("header %q: when using an organization secret, both secret and key are required", h.Name)
+	}
+
+	if h.Name == "" {
+		return errors.New("header: name is required for each entry in the list")
+	}
+
+	if h.Value == nil {
+		if h.Secret == "" || h.Key == "" {
+			return fmt.Errorf("header %q: set a value or reference an organization secret with secret and key", h.Name)
+		}
+		return nil
+	}
+
+	switch v := h.Value.(type) {
+	case string:
+		if v == "" {
+			if h.hasSecretKeyRef() {
+				return nil
+			}
+			return fmt.Errorf("header %q: set a value or an organization secret reference (secret and key)", h.Name)
+		}
+		if h.Secret != "" || h.Key != "" {
+			return fmt.Errorf("header %q: use a string value or top-level secret and key, not both", h.Name)
+		}
+		if h.Prefix != "" {
+			return fmt.Errorf("header %q: prefix is only used with organization secret references, not a plain value", h.Name)
+		}
+		return nil
+	case map[string]any:
+		if h.Secret != "" || h.Key != "" {
+			return fmt.Errorf("header %q: use value with secret, key, and optional prefix, or use top-level secret and key, not both", h.Name)
+		}
+		for k := range v {
+			if k != "secret" && k != "key" && k != "prefix" {
+				return fmt.Errorf("header %q: the value object may only include secret, key, and optional prefix", h.Name)
+			}
+		}
+		secret, _ := v["secret"].(string)
+		k, _ := v["key"].(string)
+		if secret == "" || k == "" {
+			return fmt.Errorf("header %q: value.secret and value.key are required for organization secret references in the value object", h.Name)
+		}
+		_, inMap := v["prefix"]
+		if inMap && h.Prefix != "" {
+			return fmt.Errorf("header %q: use either top-level prefix or value.prefix, not both", h.Name)
+		}
+		return nil
+	default:
+		return fmt.Errorf("header %q: value must be a string or an object with secret, key, and optional prefix", h.Name)
+	}
+}
+
+func (h *Header) resolvedValue(secrets core.SecretsContext) (string, error) {
+	if h.hasSecretKeyRef() {
+		if secrets == nil {
+			return "", fmt.Errorf("header %q: organization secrets are not available for this execution", h.Name)
+		}
+		ref, prefix := h.secretKeyRef()
+		if !ref.IsSet() {
+			return "", fmt.Errorf("header %q: secret reference is invalid", h.Name)
+		}
+		keyMaterial, err := secrets.GetKey(ref.Secret, ref.Key)
+		if err != nil {
+			return "", fmt.Errorf("header %q: %w", h.Name, err)
+		}
+		return prefix + string(keyMaterial), nil
+	}
+	if h.Value == nil {
+		return "", nil
+	}
+	s, ok := h.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("header %q: value must be a string when not using a secret", h.Name)
+	}
+	return s, nil
 }
 
 type RetrySpec struct {
@@ -135,7 +255,7 @@ func (e *HTTP) Documentation() string {
 - **URL**: The endpoint to call (supports expressions)
 - **Method**: HTTP method to use
 - **Query Parameters**: Optional URL query parameters
-- **Headers**: Custom HTTP headers (header names cannot use expressions)
+- **Headers**: Custom HTTP headers (header names cannot use expressions). Header values can be a string, or reference an organization secret (name and key) with an optional prefix to prepend (for example a Bearer token prefix for the Authorization header)
 - **Body**: Request body in various formats:
   - **JSON**: Structured JSON payload
   - **Form Data**: URL-encoded form data
@@ -172,6 +292,14 @@ func (e *HTTP) Setup(ctx core.SetupContext) error {
 
 	if spec.Method == "" {
 		return fmt.Errorf("method is required")
+	}
+
+	if spec.Headers != nil {
+		for i := range *spec.Headers {
+			if err := (*spec.Headers)[i].validate(); err != nil {
+				return err
+			}
+		}
 	}
 
 	if spec.ContentType == nil {
@@ -317,8 +445,30 @@ func (e *HTTP) Configuration() []configuration.Field {
 								Name:        "value",
 								Type:        configuration.FieldTypeString,
 								Label:       "Header Value",
-								Required:    true,
+								Required:    false,
+								Description: "Plain text, or leave empty and set organization secret + key below",
 								Placeholder: "application/json",
+							},
+							{
+								Name:        "secret",
+								Type:        configuration.FieldTypeString,
+								Label:       "Secret (name)",
+								Required:    false,
+								Description: "Organization secret name; use with Key for sensitive header values (for example API tokens)",
+							},
+							{
+								Name:        "key",
+								Type:        configuration.FieldTypeString,
+								Label:       "Secret key",
+								Required:    false,
+								Description: "Key within the selected organization secret",
+							},
+							{
+								Name:        "prefix",
+								Type:        configuration.FieldTypeString,
+								Label:       "Prefix",
+								Required:    false,
+								Description: "Optional text before the secret value, such as a Bearer prefix with a trailing space",
 							},
 						},
 					},
@@ -534,7 +684,7 @@ func (e *HTTP) Execute(ctx core.ExecutionContext) error {
 	//
 	// Handle request with retries configured
 	//
-	response, err := e.executeRequest(ctx.Logger, ctx.HTTP, spec)
+	response, err := e.executeRequest(ctx.Logger, ctx.HTTP, ctx.Secrets, spec)
 	if err == nil && e.isSuccessfulResponse(response.StatusCode, spec.GetSuccessCodes()) {
 		return e.processResponse(ctx.Metadata, ctx.ExecutionState, response, spec)
 	}
@@ -576,7 +726,7 @@ func (e *HTTP) Execute(ctx core.ExecutionContext) error {
 }
 
 func (e *HTTP) executeRequestWithoutRetry(ctx core.ExecutionContext, spec Spec) error {
-	response, err := e.executeRequest(ctx.Logger, ctx.HTTP, spec)
+	response, err := e.executeRequest(ctx.Logger, ctx.HTTP, ctx.Secrets, spec)
 	if err != nil {
 		return ctx.ExecutionState.Emit(
 			FailureOutputChannel,
@@ -633,7 +783,7 @@ func (e *HTTP) executeRequestWithoutRetry(ctx core.ExecutionContext, spec Spec) 
 	)
 }
 
-func (e *HTTP) executeRequest(logger *log.Entry, httpCtx core.HTTPContext, spec Spec) (*http.Response, error) {
+func (e *HTTP) executeRequest(logger *log.Entry, httpCtx core.HTTPContext, secrets core.SecretsContext, spec Spec) (*http.Response, error) {
 	var body io.Reader
 	var contentType string
 	var err error
@@ -673,8 +823,13 @@ func (e *HTTP) executeRequest(logger *log.Entry, httpCtx core.HTTPContext, spec 
 	}
 
 	if spec.Headers != nil {
-		for _, header := range *spec.Headers {
-			req.Header.Set(header.Name, header.Value)
+		for i := range *spec.Headers {
+			h := &(*spec.Headers)[i]
+			val, err := h.resolvedValue(secrets)
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set(h.Name, val)
 		}
 	}
 
@@ -899,7 +1054,7 @@ func (e *HTTP) handleRetryRequest(ctx core.ActionHookContext) error {
 		return err
 	}
 
-	resp, err := e.executeRequest(ctx.Logger, ctx.HTTP, spec)
+	resp, err := e.executeRequest(ctx.Logger, ctx.HTTP, ctx.Secrets, spec)
 
 	//
 	// Handle successful scenario

--- a/pkg/components/http/http_test.go
+++ b/pkg/components/http/http_test.go
@@ -20,19 +20,30 @@ import (
 )
 
 func createExecutionContext(config map[string]any) (core.ExecutionContext, *contexts.ExecutionStateContext, *contexts.MetadataContext) {
+	return createExecutionContextWithSecrets(config, nil)
+}
+
+func createExecutionContextWithSecrets(
+	config map[string]any,
+	secrets *contexts.SecretsContext,
+) (core.ExecutionContext, *contexts.ExecutionStateContext, *contexts.MetadataContext) {
 	if _, ok := config["timeoutSeconds"]; !ok {
 		config["timeoutSeconds"] = 1
 	}
 
 	stateCtx := &contexts.ExecutionStateContext{}
 	metadataCtx := &contexts.MetadataContext{}
-	return core.ExecutionContext{
+	exec := core.ExecutionContext{
 		Logger:         log.NewEntry(log.StandardLogger()),
 		Configuration:  config,
 		ExecutionState: stateCtx,
 		Metadata:       metadataCtx,
 		HTTP:           &http.Client{},
-	}, stateCtx, metadataCtx
+	}
+	if secrets != nil {
+		exec.Secrets = secrets
+	}
+	return exec, stateCtx, metadataCtx
 }
 
 func decodeMetadata(t *testing.T, metadataCtx *contexts.MetadataContext) Metadata {
@@ -284,6 +295,85 @@ func TestHTTP__Setup__ValidationErrors(t *testing.T) {
 			err := h.Setup(core.SetupContext{Configuration: tt.config})
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectErr)
+		})
+	}
+}
+
+func TestHTTP__Setup__HeaderValueValidation(t *testing.T) {
+	h := &HTTP{}
+
+	t.Run("partial flat secret is rejected", func(t *testing.T) {
+		err := h.Setup(core.SetupContext{Configuration: map[string]any{
+			"method": "GET",
+			"url":    "https://example.com",
+			"headers": []map[string]any{
+				{"name": "X-Auth", "value": "plain", "secret": "only-name"},
+			},
+		}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both secret and key are required")
+	})
+
+	t.Run("string value and secret is rejected", func(t *testing.T) {
+		err := h.Setup(core.SetupContext{Configuration: map[string]any{
+			"method": "GET",
+			"url":    "https://example.com",
+			"headers": []map[string]any{
+				{"name": "X-Auth", "value": "plain", "secret": "s", "key": "k"},
+			},
+		}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+}
+
+func TestHTTP__Execute__GET_HeaderSecretKeyRef(t *testing.T) {
+	h := &HTTP{}
+	secretStore := &contexts.SecretsContext{Values: map[string][]byte{
+		"my-api-token/token": []byte("secret-token-value"),
+	}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "Bearer secret-token-value", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	for _, name := range []string{"flat secret fields", "nested value object"} {
+		t.Run(name, func(t *testing.T) {
+			var headers any
+			switch name {
+			case "flat secret fields":
+				headers = []map[string]any{{
+					"name":   "Authorization",
+					"value":  "",
+					"secret": "my-api-token",
+					"key":    "token",
+					"prefix": "Bearer ",
+				}}
+			case "nested value object":
+				headers = []map[string]any{{
+					"name": "Authorization",
+					"value": map[string]any{
+						"secret": "my-api-token",
+						"key":    "token",
+						"prefix": "Bearer ",
+					},
+				}}
+			}
+
+			ctx, stateCtx, _ := createExecutionContextWithSecrets(map[string]any{
+				"method":  "GET",
+				"url":     server.URL,
+				"headers": headers,
+			}, secretStore)
+
+			err := h.Execute(ctx)
+			require.NoError(t, err)
+			assert.True(t, stateCtx.Passed)
+			assert.Equal(t, "http.request.finished", stateCtx.Type)
 		})
 	}
 }

--- a/templates/skills/http.md
+++ b/templates/skills/http.md
@@ -1,0 +1,21 @@
+# HTTP component
+
+## Headers and organization secrets
+
+For sensitive header values (for example `Authorization`), do not hardcode tokens in the canvas. Use an organization secret reference:
+
+- **Form / builder fields**: set **Secret (name)** and **Secret key** to the organization secret and key. Optionally set **Prefix** (for example `Bearer ` with a trailing space) so the outgoing header is `Prefix` + secret value.
+- **YAML / canvas**: you can use the same fields at the top level of each header object, or nest under `value`:
+
+```yaml
+headers:
+  - name: Authorization
+    value:
+      secret: my-api-token
+      key: token
+      prefix: "Bearer "
+```
+
+Plain string `value` remains supported for non-secret headers.
+
+Header **names** must be static (no expressions).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#4349**: HTTP request headers can use **organization secret references** (same pattern as SSH) with an optional **prefix** (for example Bearer + space), so auth headers do not need hardcoded tokens.

### Code changes

- Extended `pkg/components/http` `Header` to support:
  - plain string `value` (unchanged)
  - top-level `secret`, `key`, and optional `prefix` (form-friendly)
  - nested `value: { secret, key, prefix? }` (YAML from the issue)
- At execution time, `executeRequest` calls `ctx.Secrets.GetKey` and sets `req.Header` (retries use the same path).
- **Setup** validates header rows (moved before the `contentType == nil` early return so headers are always checked).
- Component **Configuration()** documents the new fields; user-facing **Documentation()** updated.
- Added `templates/skills/http.md` per repository guidelines for AI-assisted components.

### Tests

- `go test ./pkg/components/http/...`

## Review / issue alignment

- **Automated review (#4349)**: followed SSH-style `SecretKeyRef` + `GetKey`, optional prefix, execution-time resolution, unit tests, workflow config schema update, and skill file.
- **shiroyasha**: SSH pattern applied; there is no GraphQL component in this tree—header contract matches the review’s recommendation for a future GraphQL component to reuse the same shape.

Fixes #4349
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a77e593-3407-4e40-9298-9cf5e945d528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a77e593-3407-4e40-9298-9cf5e945d528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

