### PR TITLE
feat(cli): canvases update uses only --file; resolve id from active canvas

### DIFF
--- a/pkg/cli/commands/canvases/change_requests.go
+++ b/pkg/cli/commands/canvases/change_requests.go
@@ -191,7 +191,7 @@ func (c *changeRequestCreateCommand) Execute(ctx core.CommandContext) error {
 			return err
 		}
 		if versionID == "" {
-			return fmt.Errorf("no draft version found; run `superplane canvases update %s --draft ...` first", canvasID)
+			return fmt.Errorf("no draft version found; run `superplane canvases update --file <canvas.yaml> --draft ...` first")
 		}
 	}
 

--- a/pkg/cli/commands/canvases/file_loader.go
+++ b/pkg/cli/commands/canvases/file_loader.go
@@ -3,6 +3,7 @@ package canvases
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/superplanehq/superplane/pkg/cli/commands/canvases/models"
 	"github.com/superplanehq/superplane/pkg/cli/core"
@@ -42,15 +43,48 @@ func loadCanvasForCreateFromFile(filePath string) (openapi_client.CanvasesCanvas
 	return models.CanvasFromCanvas(*resource), resource.AutoLayout, nil
 }
 
-func loadCanvasFromFile(filePath string) (string, openapi_client.CanvasesCanvas, error) {
+func loadCanvasFromFile(ctx core.CommandContext, filePath string) (string, openapi_client.CanvasesCanvas, error) {
 	resource, err := parseCanvasResourceFromFile(filePath, "update")
 	if err != nil {
 		return "", openapi_client.CanvasesCanvas{}, err
 	}
 
-	if resource.Metadata == nil || resource.Metadata.Id == nil || resource.Metadata.GetId() == "" {
-		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf("canvas metadata.id is required for update")
+	fileCanvasID := ""
+	if resource.Metadata != nil && resource.Metadata.Id != nil {
+		fileCanvasID = strings.TrimSpace(resource.Metadata.GetId())
 	}
 
-	return resource.Metadata.GetId(), models.CanvasFromCanvas(*resource), nil
+	activeCanvasID := ""
+	if ctx.Config != nil {
+		activeCanvasID = strings.TrimSpace(ctx.Config.GetActiveCanvas())
+	}
+	if activeCanvasID != "" {
+		resolved, resolveErr := findCanvasID(ctx, ctx.API, activeCanvasID)
+		if resolveErr != nil {
+			return "", openapi_client.CanvasesCanvas{}, resolveErr
+		}
+		activeCanvasID = resolved
+	}
+
+	if fileCanvasID != "" && activeCanvasID != "" && fileCanvasID != activeCanvasID {
+		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf(
+			"canvas metadata.id %q does not match the active canvas %q; clear the active canvas or fix metadata.id",
+			fileCanvasID, activeCanvasID)
+	}
+
+	canvasID := fileCanvasID
+	if canvasID == "" {
+		canvasID = activeCanvasID
+	}
+	if canvasID == "" {
+		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf(
+			"canvas metadata.id is required in the file when no active canvas is set; set one with `superplane canvases active` or add metadata.id to the YAML")
+	}
+
+	canvas := models.CanvasFromCanvas(*resource)
+	meta := canvas.GetMetadata()
+	meta.SetId(canvasID)
+	canvas.SetMetadata(meta)
+
+	return canvasID, canvas, nil
 }

--- a/pkg/cli/commands/canvases/file_loader_test.go
+++ b/pkg/cli/commands/canvases/file_loader_test.go
@@ -5,8 +5,21 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
+
+type testCanvasConfig struct {
+	activeCanvas string
+}
+
+func (c testCanvasConfig) GetActiveCanvas() string {
+	return c.activeCanvas
+}
+
+func (c testCanvasConfig) SetActiveCanvas(string) error {
+	return nil
+}
 
 func TestLoadCanvasForCreateFromFilePreservesPositionAndMetadata(t *testing.T) {
 	t.Helper()
@@ -108,7 +121,7 @@ autoLayout:
 	}
 }
 
-func TestLoadCanvasFromFileRequiresMetadataIDForUpdate(t *testing.T) {
+func TestLoadCanvasFromFileRequiresMetadataIDOrActiveCanvas(t *testing.T) {
 	t.Helper()
 
 	filePath := filepath.Join(t.TempDir(), "canvas.yaml")
@@ -125,11 +138,75 @@ spec:
 		t.Fatalf("failed to write temp canvas: %v", err)
 	}
 
-	_, _, err := loadCanvasFromFile(filePath)
+	ctx := core.CommandContext{Config: testCanvasConfig{}}
+	_, _, err := loadCanvasFromFile(ctx, filePath)
 	if err == nil {
-		t.Fatalf("expected metadata.id validation error")
+		t.Fatalf("expected validation error when metadata.id and active canvas are unset")
 	}
-	if err.Error() != "canvas metadata.id is required for update" {
+	want := "canvas metadata.id is required in the file when no active canvas is set; set one with `superplane canvases active` or add metadata.id to the YAML"
+	if err.Error() != want {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadCanvasFromFileUsesActiveCanvasWhenMetadataIDMissing(t *testing.T) {
+	t.Helper()
+
+	activeID := "4e9ae08d-0363-40d2-ba2c-5f6389a418d8"
+	filePath := filepath.Join(t.TempDir(), "canvas.yaml")
+	raw := []byte(`
+apiVersion: v1
+kind: Canvas
+metadata:
+  name: parse-check
+spec:
+  nodes: []
+  edges: []
+`)
+	if err := os.WriteFile(filePath, raw, 0o600); err != nil {
+		t.Fatalf("failed to write temp canvas: %v", err)
+	}
+
+	ctx := core.CommandContext{Config: testCanvasConfig{activeCanvas: activeID}}
+	canvasID, canvas, err := loadCanvasFromFile(ctx, filePath)
+	if err != nil {
+		t.Fatalf("loadCanvasFromFile returned error: %v", err)
+	}
+	if canvasID != activeID {
+		t.Fatalf("expected canvas id %q, got %q", activeID, canvasID)
+	}
+	if canvas.GetMetadata().GetId() != activeID {
+		t.Fatalf("expected metadata id on canvas to be set to %q, got %q", activeID, canvas.GetMetadata().GetId())
+	}
+}
+
+func TestLoadCanvasFromFileRejectsMetadataIDMismatchWithActiveCanvas(t *testing.T) {
+	t.Helper()
+
+	activeID := "4e9ae08d-0363-40d2-ba2c-5f6389a418d8"
+	fileID := "5f9ae08d-0363-40d2-ba2c-5f6389a418d8"
+	filePath := filepath.Join(t.TempDir(), "canvas.yaml")
+	raw := []byte(`
+apiVersion: v1
+kind: Canvas
+metadata:
+  id: ` + fileID + `
+  name: parse-check
+spec:
+  nodes: []
+  edges: []
+`)
+	if err := os.WriteFile(filePath, raw, 0o600); err != nil {
+		t.Fatalf("failed to write temp canvas: %v", err)
+	}
+
+	ctx := core.CommandContext{Config: testCanvasConfig{activeCanvas: activeID}}
+	_, _, err := loadCanvasFromFile(ctx, filePath)
+	if err == nil {
+		t.Fatalf("expected id mismatch error")
+	}
+	want := `canvas metadata.id "` + fileID + `" does not match the active canvas "` + activeID + `"; clear the active canvas or fix metadata.id`
+	if err.Error() != want {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -71,9 +71,9 @@ AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
 	var updateAutoLayoutScope string
 	var updateAutoLayoutNodes []string
 	updateCmd := &cobra.Command{
-		Use:   "update [name-or-id]",
+		Use:   "update",
 		Short: "Update a canvas from a file",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.NoArgs,
 	}
 	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "filename, directory, or URL to files to use to update the resource")
 	updateCmd.Flags().BoolVar(&updateDraft, "draft", false, "keep the update as a draft instead of auto-publishing (required when change management is enabled)")

--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -146,17 +146,12 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		err      error
 	)
 
-	if filePath != "" {
-		canvasID, canvas, err = loadCanvasFromFile(filePath)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		canvasID, canvas, err = loadCanvasFromExisting(ctx)
-		if err != nil {
-			return err
-		}
+	if filePath == "" {
+		return fmt.Errorf("--file is required")
+	}
+	canvasID, canvas, err = loadCanvasFromFile(ctx, filePath)
+	if err != nil {
+		return err
 	}
 
 	cmContext, err := resolveChangeManagementContext(ctx, canvasID)
@@ -246,35 +241,6 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		_, err := fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
 		return err
 	})
-}
-
-func loadCanvasFromExisting(ctx core.CommandContext) (string, openapi_client.CanvasesCanvas, error) {
-	if len(ctx.Args) > 1 {
-		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf("update accepts at most one positional argument")
-	}
-
-	target := ""
-	if len(ctx.Args) == 1 {
-		target = ctx.Args[0]
-	} else if ctx.Config != nil {
-		target = strings.TrimSpace(ctx.Config.GetActiveCanvas())
-	}
-
-	if target == "" {
-		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf("either --file or <name-or-id> (or an active canvas) is required")
-	}
-
-	canvasID, err := findCanvasID(ctx, ctx.API, target)
-	if err != nil {
-		return "", openapi_client.CanvasesCanvas{}, err
-	}
-
-	canvas, err := describeCanvasByID(ctx, canvasID)
-	if err != nil {
-		return "", openapi_client.CanvasesCanvas{}, err
-	}
-
-	return canvasID, canvas, nil
 }
 
 func parseAutoLayout(value string, scopeValue string, nodeIDs []string) (*openapi_client.CanvasesCanvasAutoLayout, error) {

--- a/pkg/cli/commands/canvases/update_test.go
+++ b/pkg/cli/commands/canvases/update_test.go
@@ -60,6 +60,18 @@ func (s *apiTestServer) AssertCalls(t *testing.T, calls []string) {
 	require.Len(t, s.expectations, 0, "unused request expectations")
 }
 
+func TestUpdateRequiresFileFlag(t *testing.T) {
+	t.Helper()
+
+	ctx, _ := newCreateCommandContextForTest(t, nil, "text")
+	emptyFile := ""
+	draft := false
+
+	err := (&updateCommand{file: &emptyFile, draft: &draft}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--file is required")
+}
+
 func TestBuildDefaultAutoLayoutUsesFullCanvas(t *testing.T) {
 	autoLayout := buildDefaultAutoLayout()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [superplanehq/superplane#4231](https://github.com/superplanehq/superplane/issues/4231): `superplane canvases update` no longer takes a positional `<name-or-id>` and **requires `--file` / `-f`**.

When the YAML omits `metadata.id`, the canvas is resolved from the **active canvas** (`superplane canvases active`). The resolved UUID is set on the canvas payload sent to the API so portable specs work without embedding an id in every file. If both `metadata.id` and an active canvas are set, they **must match** or the command errors with a clear message.

## Review / issue alignment

- **Issue body:** Removes the confusing `[id-or-name]` positional; update is `superplane canvases update -f <path>`.
- **Human comment (@lucaspin):** “should not accept a `<name-or-id>` parameter. It should only use the YAML” — addressed by `cobra.NoArgs` and requiring `--file`. Portable YAML without `metadata.id` is supported **only** when an active canvas is configured (documented in the file-loader error string), so agents do not need a positional target.
- **No separate bot/agent review** was present on the issue beyond the two human comments above.

## Testing

- Added/updated unit tests in `pkg/cli/commands/canvases` for `--file` requirement, active-canvas resolution, and id/active mismatch.
- Full `go test` / `make test` was not run in this environment because `pkg/openapi_client` is gitignored/generated and Docker is unavailable here; CI should run the normal test pipeline.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0b57965-3613-4c85-92b7-c60e7d08c14f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0b57965-3613-4c85-92b7-c60e7d08c14f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

