### PR TITLE
fix: require --file for canvases update without positional id

### DIFF
--- a/pkg/cli/commands/canvases/change_requests.go
+++ b/pkg/cli/commands/canvases/change_requests.go
@@ -191,7 +191,7 @@ func (c *changeRequestCreateCommand) Execute(ctx core.CommandContext) error {
 			return err
 		}
 		if versionID == "" {
-			return fmt.Errorf("no draft version found; run `superplane canvases update %s --draft ...` first", canvasID)
+			return fmt.Errorf("no draft version found; run `superplane canvases update -f <path-to-yaml> --draft ...` first")
 		}
 	}
 

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -71,11 +71,12 @@ AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
 	var updateAutoLayoutScope string
 	var updateAutoLayoutNodes []string
 	updateCmd := &cobra.Command{
-		Use:   "update [name-or-id]",
+		Use:   "update",
 		Short: "Update a canvas from a file",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.NoArgs,
 	}
 	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "filename, directory, or URL to files to use to update the resource")
+	_ = updateCmd.MarkFlagRequired("file")
 	updateCmd.Flags().BoolVar(&updateDraft, "draft", false, "keep the update as a draft instead of auto-publishing (required when change management is enabled)")
 	updateCmd.Flags().StringVar(&updateAutoLayout, "auto-layout", "", "automatically arrange the canvas (supported: horizontal, disable)")
 	updateCmd.Flags().StringVar(&updateAutoLayoutScope, "auto-layout-scope", "", "scope for auto layout (full-canvas, connected-component)")

--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -140,23 +140,13 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	}
 	draftMode := c.draft != nil && *c.draft
 
-	var (
-		canvasID string
-		canvas   openapi_client.CanvasesCanvas
-		err      error
-	)
+	if filePath == "" {
+		return fmt.Errorf("--file is required")
+	}
 
-	if filePath != "" {
-		canvasID, canvas, err = loadCanvasFromFile(filePath)
-		if err != nil {
-			return err
-		}
-
-	} else {
-		canvasID, canvas, err = loadCanvasFromExisting(ctx)
-		if err != nil {
-			return err
-		}
+	canvasID, canvas, err := loadCanvasFromFile(filePath)
+	if err != nil {
+		return err
 	}
 
 	cmContext, err := resolveChangeManagementContext(ctx, canvasID)
@@ -248,35 +238,6 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	})
 }
 
-func loadCanvasFromExisting(ctx core.CommandContext) (string, openapi_client.CanvasesCanvas, error) {
-	if len(ctx.Args) > 1 {
-		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf("update accepts at most one positional argument")
-	}
-
-	target := ""
-	if len(ctx.Args) == 1 {
-		target = ctx.Args[0]
-	} else if ctx.Config != nil {
-		target = strings.TrimSpace(ctx.Config.GetActiveCanvas())
-	}
-
-	if target == "" {
-		return "", openapi_client.CanvasesCanvas{}, fmt.Errorf("either --file or <name-or-id> (or an active canvas) is required")
-	}
-
-	canvasID, err := findCanvasID(ctx, ctx.API, target)
-	if err != nil {
-		return "", openapi_client.CanvasesCanvas{}, err
-	}
-
-	canvas, err := describeCanvasByID(ctx, canvasID)
-	if err != nil {
-		return "", openapi_client.CanvasesCanvas{}, err
-	}
-
-	return canvasID, canvas, nil
-}
-
 func parseAutoLayout(value string, scopeValue string, nodeIDs []string) (*openapi_client.CanvasesCanvasAutoLayout, error) {
 	normalizedValue := strings.ToLower(strings.TrimSpace(value))
 	switch normalizedValue {
@@ -340,18 +301,6 @@ func autoLayoutFlagsWereSet(ctx core.CommandContext) bool {
 	}
 
 	return flags.Changed("auto-layout") || flags.Changed("auto-layout-scope") || flags.Changed("auto-layout-node")
-}
-
-func describeCanvasByID(ctx core.CommandContext, canvasID string) (openapi_client.CanvasesCanvas, error) {
-	response, _, err := ctx.API.CanvasAPI.CanvasesDescribeCanvas(ctx.Context, canvasID).Execute()
-	if err != nil {
-		return openapi_client.CanvasesCanvas{}, err
-	}
-	if response.Canvas == nil {
-		return openapi_client.CanvasesCanvas{}, fmt.Errorf("canvas %q not found", canvasID)
-	}
-
-	return *response.Canvas, nil
 }
 
 func buildDefaultAutoLayout() openapi_client.CanvasesCanvasAutoLayout {

--- a/pkg/cli/commands/canvases/update_test.go
+++ b/pkg/cli/commands/canvases/update_test.go
@@ -60,6 +60,22 @@ func (s *apiTestServer) AssertCalls(t *testing.T, calls []string) {
 	require.Len(t, s.expectations, 0, "unused request expectations")
 }
 
+func TestUpdateRequiresFile(t *testing.T) {
+	t.Helper()
+
+	draft := false
+	ctx, _ := newCreateCommandContextForTest(t, nil, "text")
+
+	err := (&updateCommand{file: nil, draft: &draft}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--file is required")
+
+	empty := ""
+	err = (&updateCommand{file: &empty, draft: &draft}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--file is required")
+}
+
 func TestBuildDefaultAutoLayoutUsesFullCanvas(t *testing.T) {
 	autoLayout := buildDefaultAutoLayout()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [superplanehq/superplane#4231](https://github.com/superplanehq/superplane/issues/4231): `superplane canvases update` now only accepts canvas YAML via `--file` / `-f` (no `[name-or-id]` positional). The canvas to update is identified solely by `metadata.id` in the YAML, matching the issue and **lucaspin**’s comment that the command should not accept `<name-or-id>` and should only use the YAML.

## Changes

- `pkg/cli/commands/canvases/root.go`: `Use: "update"`, `Args: cobra.NoArgs`, `MarkFlagRequired("file")`.
- `pkg/cli/commands/canvases/update.go`: always load from file; removed `loadCanvasFromExisting` and unused `describeCanvasByID`.
- `pkg/cli/commands/canvases/change_requests.go`: error hint updated to `superplane canvases update -f <path-to-yaml> --draft ...`.
- `pkg/cli/commands/canvases/update_test.go`: `TestUpdateRequiresFile` for missing/empty `--file`.

## Review / comments

- **Human (lucaspin)**: addressed by removing the positional argument and requiring YAML-only update via `--file`.
- **Human (shiroyasha)**: clarification only; no conflicting direction.

## Testing

- Added unit test for `--file` requirement.
- Full `go test ./pkg/cli/commands/canvases/...` was not runnable in this agent environment (generated `openapi_client` package absent from the checkout); CI should run the full suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0c58d63-7078-4c28-9862-ce6208be4817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0c58d63-7078-4c28-9862-ce6208be4817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

