### PR TITLE
feat: CLI canvas update dry-run and node validation output

### DIFF
--- a/pkg/cli/commands/canvases/changeset_from_canvas.go
+++ b/pkg/cli/commands/canvases/changeset_from_canvas.go
@@ -1,0 +1,285 @@
+package canvases
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// canvasNodeForChangeset holds the fields needed to diff two canvas specs and
+// build a REST changeset (same semantics as pkg/grpc/actions/canvases/changesets).
+type canvasNodeForChangeset struct {
+	ID            string
+	Name          string
+	Block         string
+	Configuration map[string]interface{}
+	Position      openapi_client.ComponentsPosition
+	IsCollapsed   bool
+	IntegrationID string
+}
+
+func blockNameFromOpenAPINode(node openapi_client.SuperplaneComponentsNode) string {
+	if node.Component != nil && strings.TrimSpace(node.Component.GetName()) != "" {
+		return strings.TrimSpace(node.Component.GetName())
+	}
+	if node.Trigger != nil && strings.TrimSpace(node.Trigger.GetName()) != "" {
+		return strings.TrimSpace(node.Trigger.GetName())
+	}
+	if node.Blueprint != nil && strings.TrimSpace(node.Blueprint.GetId()) != "" {
+		return strings.TrimSpace(node.Blueprint.GetId())
+	}
+	if node.Widget != nil && strings.TrimSpace(node.Widget.GetName()) != "" {
+		return strings.TrimSpace(node.Widget.GetName())
+	}
+	return ""
+}
+
+func positionFromOpenAPINode(n openapi_client.SuperplaneComponentsNode) openapi_client.ComponentsPosition {
+	if n.Position != nil {
+		return *n.Position
+	}
+	p := openapi_client.NewComponentsPosition()
+	p.SetX(0)
+	p.SetY(0)
+	return *p
+}
+
+func nodeFromOpenAPI(n openapi_client.SuperplaneComponentsNode) (canvasNodeForChangeset, error) {
+	id := strings.TrimSpace(n.GetId())
+	if id == "" {
+		return canvasNodeForChangeset{}, fmt.Errorf("node id is required")
+	}
+	block := blockNameFromOpenAPINode(n)
+	if block == "" {
+		return canvasNodeForChangeset{}, fmt.Errorf("block name is required for node %s", id)
+	}
+	pos := positionFromOpenAPINode(n)
+	out := canvasNodeForChangeset{
+		ID:            id,
+		Name:          n.GetName(),
+		Block:         block,
+		Configuration: n.Configuration,
+		Position:      pos,
+		IsCollapsed:   n.GetIsCollapsed(),
+	}
+	if n.Integration != nil {
+		out.IntegrationID = strings.TrimSpace(n.Integration.GetId())
+	}
+	return out, nil
+}
+
+func buildNodeMap(nodes []openapi_client.SuperplaneComponentsNode) (map[string]canvasNodeForChangeset, error) {
+	out := make(map[string]canvasNodeForChangeset, len(nodes))
+	for _, raw := range nodes {
+		node, err := nodeFromOpenAPI(raw)
+		if err != nil {
+			return nil, err
+		}
+		out[node.ID] = node
+	}
+	return out, nil
+}
+
+type canvasEdgeKey struct {
+	SourceID string
+	TargetID string
+	Channel  string
+}
+
+func edgeKey(e openapi_client.SuperplaneComponentsEdge) canvasEdgeKey {
+	return canvasEdgeKey{
+		SourceID: strings.TrimSpace(e.GetSourceId()),
+		TargetID: strings.TrimSpace(e.GetTargetId()),
+		Channel:  strings.TrimSpace(e.GetChannel()),
+	}
+}
+
+func buildEdgeMap(edges []openapi_client.SuperplaneComponentsEdge) map[canvasEdgeKey]openapi_client.SuperplaneComponentsEdge {
+	out := make(map[canvasEdgeKey]openapi_client.SuperplaneComponentsEdge, len(edges))
+	for _, e := range edges {
+		out[edgeKey(e)] = e
+	}
+	return out
+}
+
+func changeNodeForAdd(node canvasNodeForChangeset) openapi_client.CanvasChangesetChangeNode {
+	n := openapi_client.NewCanvasChangesetChangeNode()
+	n.SetId(node.ID)
+	n.SetName(node.Name)
+	n.SetBlock(node.Block)
+	n.SetIsCollapsed(node.IsCollapsed)
+	pos := openapi_client.NewComponentsPosition()
+	pos.SetX(int32(node.Position.GetX()))
+	pos.SetY(int32(node.Position.GetY()))
+	n.SetPosition(*pos)
+	if node.Configuration != nil {
+		n.SetConfiguration(node.Configuration)
+	}
+	if node.IntegrationID != "" {
+		n.SetIntegrationId(node.IntegrationID)
+	}
+	return *n
+}
+
+func changeNodeForUpdate(current, proposed canvasNodeForChangeset) openapi_client.CanvasChangesetChangeNode {
+	n := openapi_client.NewCanvasChangesetChangeNode()
+	n.SetId(proposed.ID)
+	n.SetName(proposed.Name)
+	n.SetBlock(proposed.Block)
+
+	if proposed.Configuration != nil && !reflect.DeepEqual(current.Configuration, proposed.Configuration) {
+		n.SetConfiguration(proposed.Configuration)
+	}
+	if proposed.Position.GetX() != current.Position.GetX() || proposed.Position.GetY() != current.Position.GetY() {
+		pos := openapi_client.NewComponentsPosition()
+		pos.SetX(int32(proposed.Position.GetX()))
+		pos.SetY(int32(proposed.Position.GetY()))
+		n.SetPosition(*pos)
+	}
+	if proposed.IsCollapsed != current.IsCollapsed {
+		n.SetIsCollapsed(proposed.IsCollapsed)
+	}
+	return *n
+}
+
+func changeEdge(e openapi_client.SuperplaneComponentsEdge) openapi_client.CanvasChangesetChangeEdge {
+	out := openapi_client.NewCanvasChangesetChangeEdge()
+	out.SetSourceId(e.GetSourceId())
+	out.SetTargetId(e.GetTargetId())
+	out.SetChannel(e.GetChannel())
+	return *out
+}
+
+// buildCanvasChangesetFromSpecs computes the same changeset the server would use
+// when applying a full canvas snapshot to an existing draft version.
+func buildCanvasChangesetFromSpecs(
+	currentNodes []openapi_client.SuperplaneComponentsNode,
+	currentEdges []openapi_client.SuperplaneComponentsEdge,
+	proposedNodes []openapi_client.SuperplaneComponentsNode,
+	proposedEdges []openapi_client.SuperplaneComponentsEdge,
+) (*openapi_client.CanvasesCanvasChangeset, error) {
+	curN, err := buildNodeMap(currentNodes)
+	if err != nil {
+		return nil, err
+	}
+	propN, err := buildNodeMap(proposedNodes)
+	if err != nil {
+		return nil, err
+	}
+	curE := buildEdgeMap(currentEdges)
+	propE := buildEdgeMap(proposedEdges)
+
+	var changes []openapi_client.CanvasChangesetChange
+
+	for id := range curN {
+		if _, ok := propN[id]; !ok {
+			ch := openapi_client.NewCanvasChangesetChange()
+			ch.SetType(openapi_client.CANVASCHANGESETCHANGETYPE_DELETE_NODE)
+			del := openapi_client.NewCanvasChangesetChangeNode()
+			del.SetId(id)
+			ch.SetNode(*del)
+			changes = append(changes, *ch)
+		}
+	}
+
+	for _, node := range propN {
+		if _, ok := curN[node.ID]; ok {
+			continue
+		}
+		ch := openapi_client.NewCanvasChangesetChange()
+		ch.SetType(openapi_client.CANVASCHANGESETCHANGETYPE_ADD_NODE)
+		add := changeNodeForAdd(node)
+		ch.SetNode(add)
+		changes = append(changes, *ch)
+	}
+
+	for _, proposed := range propN {
+		current, ok := curN[proposed.ID]
+		if !ok {
+			continue
+		}
+		if reflect.DeepEqual(current, proposed) {
+			continue
+		}
+		ch := openapi_client.NewCanvasChangesetChange()
+		ch.SetType(openapi_client.CANVASCHANGESETCHANGETYPE_UPDATE_NODE)
+		ch.SetNode(changeNodeForUpdate(current, proposed))
+		changes = append(changes, *ch)
+	}
+
+	for k, edge := range curE {
+		if _, ok := propE[k]; !ok {
+			ch := openapi_client.NewCanvasChangesetChange()
+			ch.SetType(openapi_client.CANVASCHANGESETCHANGETYPE_DELETE_EDGE)
+			ch.SetEdge(changeEdge(edge))
+			changes = append(changes, *ch)
+		}
+	}
+
+	for k, edge := range propE {
+		if _, ok := curE[k]; !ok {
+			ch := openapi_client.NewCanvasChangesetChange()
+			ch.SetType(openapi_client.CANVASCHANGESETCHANGETYPE_ADD_EDGE)
+			ch.SetEdge(changeEdge(edge))
+			changes = append(changes, *ch)
+		}
+	}
+
+	cs := openapi_client.NewCanvasesCanvasChangeset()
+	cs.SetChanges(changes)
+	return cs, nil
+}
+
+func sortNodeIssuesForDisplay(issues []canvasNodeIssue) {
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].NodeID != issues[j].NodeID {
+			return issues[i].NodeID < issues[j].NodeID
+		}
+		return issues[i].Kind < issues[j].Kind
+	})
+}
+
+type canvasNodeIssue struct {
+	NodeID   string
+	NodeName string
+	Kind     string // "error" or "warning"
+	Message  string
+}
+
+func collectCanvasNodeIssues(spec openapi_client.CanvasesCanvasSpec) []canvasNodeIssue {
+	nodes := spec.GetNodes()
+	out := make([]canvasNodeIssue, 0)
+	for _, n := range nodes {
+		id := strings.TrimSpace(n.GetId())
+		name := strings.TrimSpace(n.GetName())
+		if msg, ok := n.GetErrorMessageOk(); ok && strings.TrimSpace(*msg) != "" {
+			out = append(out, canvasNodeIssue{
+				NodeID:   id,
+				NodeName: name,
+				Kind:     "error",
+				Message:  strings.TrimSpace(*msg),
+			})
+		}
+		if msg, ok := n.GetWarningMessageOk(); ok && strings.TrimSpace(*msg) != "" {
+			out = append(out, canvasNodeIssue{
+				NodeID:   id,
+				NodeName: name,
+				Kind:     "warning",
+				Message:  strings.TrimSpace(*msg),
+			})
+		}
+	}
+	sortNodeIssuesForDisplay(out)
+	return out
+}
+
+func formatNodeIssuesLine(issue canvasNodeIssue) string {
+	label := issue.NodeID
+	if issue.NodeName != "" {
+		label = fmt.Sprintf("%s (%s)", issue.NodeID, issue.NodeName)
+	}
+	return fmt.Sprintf("  - %s [%s]: %s", label, issue.Kind, issue.Message)
+}

--- a/pkg/cli/commands/canvases/changeset_from_canvas_test.go
+++ b/pkg/cli/commands/canvases/changeset_from_canvas_test.go
@@ -1,0 +1,80 @@
+package canvases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+func nodeComponent(id, name, component string) openapi_client.SuperplaneComponentsNode {
+	n := openapi_client.NewSuperplaneComponentsNode()
+	n.SetId(id)
+	n.SetName(name)
+	comp := openapi_client.NewNodeComponentRef()
+	comp.SetName(component)
+	n.SetComponent(*comp)
+	pos := openapi_client.NewComponentsPosition()
+	pos.SetX(0)
+	pos.SetY(0)
+	n.SetPosition(*pos)
+	return *n
+}
+
+func edge(source, target, channel string) openapi_client.SuperplaneComponentsEdge {
+	e := openapi_client.NewSuperplaneComponentsEdge()
+	e.SetSourceId(source)
+	e.SetTargetId(target)
+	e.SetChannel(channel)
+	return *e
+}
+
+func TestBuildCanvasChangesetFromSpecsEmpty(t *testing.T) {
+	cs, err := buildCanvasChangesetFromSpecs(nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, cs.GetChanges())
+}
+
+func TestBuildCanvasChangesetFromSpecsAddNodeAndEdge(t *testing.T) {
+	a := nodeComponent("a", "A", "noop")
+	b := nodeComponent("b", "B", "noop")
+	current := []openapi_client.SuperplaneComponentsNode{}
+	currentEdges := []openapi_client.SuperplaneComponentsEdge{}
+	proposed := []openapi_client.SuperplaneComponentsNode{a, b}
+	proposedEdges := []openapi_client.SuperplaneComponentsEdge{
+		edge("a", "b", "default"),
+	}
+
+	cs, err := buildCanvasChangesetFromSpecs(current, currentEdges, proposed, proposedEdges)
+	require.NoError(t, err)
+	changes := cs.GetChanges()
+	require.GreaterOrEqual(t, len(changes), 3)
+
+	var addCount, edgeCount int
+	for _, ch := range changes {
+		switch ch.GetType() {
+		case openapi_client.CANVASCHANGESETCHANGETYPE_ADD_NODE:
+			addCount++
+		case openapi_client.CANVASCHANGESETCHANGETYPE_ADD_EDGE:
+			edgeCount++
+		}
+	}
+	require.Equal(t, 2, addCount)
+	require.Equal(t, 1, edgeCount)
+}
+
+func TestCollectCanvasNodeIssues(t *testing.T) {
+	n := nodeComponent("n1", "One", "noop")
+	errMsg := "bad config"
+	n.SetErrorMessage(errMsg)
+	warnMsg := "heads up"
+	n.SetWarningMessage(warnMsg)
+
+	spec := openapi_client.NewCanvasesCanvasSpec()
+	spec.SetNodes([]openapi_client.SuperplaneComponentsNode{n})
+
+	issues := collectCanvasNodeIssues(*spec)
+	require.Len(t, issues, 2)
+	require.Equal(t, "error", issues[0].Kind)
+	require.Equal(t, "warning", issues[1].Kind)
+}

--- a/pkg/cli/commands/canvases/dry_run.go
+++ b/pkg/cli/commands/canvases/dry_run.go
@@ -1,0 +1,74 @@
+package canvases
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+func validateCanvasUpdateDryRun(
+	ctx core.CommandContext,
+	canvasID string,
+	proposedCanvas openapi_client.CanvasesCanvas,
+	targetVersionID string,
+) error {
+	current, err := describeCanvasVersionByID(ctx, canvasID, targetVersionID)
+	if err != nil {
+		return err
+	}
+	if current.Spec == nil {
+		return fmt.Errorf("current draft version has no spec")
+	}
+	proposedSpec := proposedCanvas.GetSpec()
+
+	changeset, err := buildCanvasChangesetFromSpecs(
+		current.Spec.GetNodes(),
+		current.Spec.GetEdges(),
+		proposedSpec.GetNodes(),
+		proposedSpec.GetEdges(),
+	)
+	if err != nil {
+		return err
+	}
+	if len(changeset.GetChanges()) == 0 {
+		if !ctx.Renderer.IsText() {
+			return ctx.Renderer.Render(map[string]any{
+				"valid":   true,
+				"message": "no changes compared to the current draft",
+			})
+		}
+		return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+			_, err := fmt.Fprintln(stdout, "Dry-run: no changes compared to the current draft.")
+			return err
+		})
+	}
+
+	body := openapi_client.NewCanvasesValidateCanvasVersionChangesetBody()
+	body.SetChangeset(*changeset)
+
+	resp, _, err := ctx.API.CanvasVersionAPI.
+		CanvasesValidateCanvasVersionChangeset(ctx.Context, canvasID, targetVersionID).
+		Body(*body).
+		Execute()
+	if err != nil {
+		return err
+	}
+
+	version := resp.GetVersion()
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(map[string]any{
+			"valid":   true,
+			"version": version,
+		})
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		if err := writeCanvasUpdateSuccessSummary(stdout, version); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintln(stdout, "Dry-run: validation succeeded (nothing was saved).")
+		return err
+	})
+}

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -67,22 +67,29 @@ AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
 
 	var updateFile string
 	var updateDraft bool
+	var updateDryRun bool
 	var updateAutoLayout string
 	var updateAutoLayoutScope string
 	var updateAutoLayoutNodes []string
 	updateCmd := &cobra.Command{
 		Use:   "update [name-or-id]",
 		Short: "Update a canvas from a file",
-		Args:  cobra.MaximumNArgs(1),
+		Long: `Update a canvas from a file.
+
+Use --draft --dry-run to validate YAML against your current draft without saving
+(useful for CI and agent loops). Dry-run calls the same server-side validation as apply.`,
+		Args: cobra.MaximumNArgs(1),
 	}
 	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "filename, directory, or URL to files to use to update the resource")
 	updateCmd.Flags().BoolVar(&updateDraft, "draft", false, "keep the update as a draft instead of auto-publishing (required when change management is enabled)")
+	updateCmd.Flags().BoolVar(&updateDryRun, "dry-run", false, "validate the update against your draft without persisting (requires --draft)")
 	updateCmd.Flags().StringVar(&updateAutoLayout, "auto-layout", "", "automatically arrange the canvas (supported: horizontal, disable)")
 	updateCmd.Flags().StringVar(&updateAutoLayoutScope, "auto-layout-scope", "", "scope for auto layout (full-canvas, connected-component)")
 	updateCmd.Flags().StringArrayVar(&updateAutoLayoutNodes, "auto-layout-node", nil, "node id seed for auto layout (repeatable)")
 	core.Bind(updateCmd, &updateCommand{
 		file:            &updateFile,
 		draft:           &updateDraft,
+		dryRun:          &updateDryRun,
 		autoLayout:      &updateAutoLayout,
 		autoLayoutScope: &updateAutoLayoutScope,
 		autoLayoutNodes: &updateAutoLayoutNodes,

--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -12,6 +12,7 @@ import (
 type updateCommand struct {
 	file            *string
 	draft           *bool
+	dryRun          *bool
 	autoLayout      *string
 	autoLayoutScope *string
 	autoLayoutNodes *[]string
@@ -139,6 +140,13 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		autoLayoutNodeIDs = append(autoLayoutNodeIDs, *c.autoLayoutNodes...)
 	}
 	draftMode := c.draft != nil && *c.draft
+	dryRun := c.dryRun != nil && *c.dryRun
+	if dryRun && !draftMode {
+		return fmt.Errorf("--dry-run requires --draft (validation runs against your draft without publishing)")
+	}
+	if dryRun && filePath == "" {
+		return fmt.Errorf("--dry-run requires --file")
+	}
 
 	var (
 		canvasID string
@@ -157,6 +165,24 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if dryRun {
+		cmContext, err := resolveChangeManagementContext(ctx, canvasID)
+		if err != nil {
+			return err
+		}
+		if cmContext.changeManagementEnabled && !draftMode {
+			return fmt.Errorf("change management is enabled for this canvas; use --draft to update your draft version, then publish with `superplane canvases change-requests create`")
+		}
+		targetVersionID, err := findCurrentUserDraftVersionID(ctx, canvasID)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(targetVersionID) == "" {
+			return fmt.Errorf("no draft version found to validate against; run `superplane canvases update --file <path> --draft` once to create a draft, then use --dry-run")
+		}
+		return validateCanvasUpdateDryRun(ctx, canvasID, canvas, targetVersionID)
 	}
 
 	cmContext, err := resolveChangeManagementContext(ctx, canvasID)
@@ -227,25 +253,38 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
-		metadata := version.GetMetadata()
-		spec := version.GetSpec()
+		return writeCanvasUpdateSuccessSummary(stdout, version)
+	})
+}
 
-		_, _ = fmt.Fprintf(stdout, "Canvas version updated: %s\n", metadata.GetId())
-		_, _ = fmt.Fprintf(stdout, "Canvas ID: %s\n", metadata.GetCanvasId())
-		_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(spec.GetNodes()))
-		_, _ = fmt.Fprintf(stdout, "Edges: %d\n", len(spec.GetEdges()))
+func writeCanvasUpdateSuccessSummary(stdout io.Writer, version openapi_client.CanvasesCanvasVersion) error {
+	metadata := version.GetMetadata()
+	spec := version.GetSpec()
 
-		integrations := make(map[string]struct{})
-		for _, node := range spec.GetNodes() {
-			if ref, ok := node.GetIntegrationOk(); ok && ref != nil {
-				if id := ref.GetId(); id != "" {
-					integrations[id] = struct{}{}
-				}
+	_, _ = fmt.Fprintf(stdout, "Canvas version updated: %s\n", metadata.GetId())
+	_, _ = fmt.Fprintf(stdout, "Canvas ID: %s\n", metadata.GetCanvasId())
+	_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(spec.GetNodes()))
+	_, _ = fmt.Fprintf(stdout, "Edges: %d\n", len(spec.GetEdges()))
+
+	integrations := make(map[string]struct{})
+	for _, node := range spec.GetNodes() {
+		if ref, ok := node.GetIntegrationOk(); ok && ref != nil {
+			if id := ref.GetId(); id != "" {
+				integrations[id] = struct{}{}
 			}
 		}
-		_, err := fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
-		return err
-	})
+	}
+	_, _ = fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
+
+	issues := collectCanvasNodeIssues(spec)
+	if len(issues) == 0 {
+		return nil
+	}
+	_, _ = fmt.Fprintln(stdout, "Node issues from validation:")
+	for _, issue := range issues {
+		_, _ = fmt.Fprintln(stdout, formatNodeIssuesLine(issue))
+	}
+	return nil
 }
 
 func loadCanvasFromExisting(ctx core.CommandContext) (string, openapi_client.CanvasesCanvas, error) {

--- a/pkg/cli/commands/canvases/update_test.go
+++ b/pkg/cli/commands/canvases/update_test.go
@@ -418,6 +418,94 @@ func TestUpdateFromFileDisableChangeManagementFailsWhenOrganizationEnforcesIt(t 
 	})
 }
 
+func TestUpdateDryRunRequiresDraftFlag(t *testing.T) {
+	canvasID := "4e9ae08d-0363-40d2-ba2c-5f6389a418d8"
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "canvas.yaml")
+	content := []byte(
+		"apiVersion: v1\n" +
+			"kind: Canvas\n" +
+			"metadata:\n" +
+			"  id: " + canvasID + "\n" +
+			"  name: dry-run-test\n" +
+			"spec:\n" +
+			"  nodes: []\n" +
+			"  edges: []\n",
+	)
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+
+	draft := false
+	dryRun := true
+	file := filePath
+	ctx, _ := newCreateCommandContextForTest(t, nil, "text")
+
+	err := (&updateCommand{file: &file, draft: &draft, dryRun: &dryRun}).Execute(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--dry-run requires --draft")
+}
+
+func TestUpdateDryRunNoChangesAgainstDraft(t *testing.T) {
+	canvasID := "4e9ae08d-0363-40d2-ba2c-5f6389a418d8"
+	versionID := "ver-draft-1"
+
+	server := newAPITestServer(
+		t,
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/canvases/" + canvasID,
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"` + canvasID + `","name":"dry-run"},"spec":{"changeManagement":{"enabled":false}}}}`))
+			},
+		},
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/canvases/" + canvasID + "/versions",
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"versions":[{"metadata":{"id":"` + versionID + `","canvasId":"` + canvasID + `","isPublished":false}}]}`))
+			},
+		},
+		requestExpectation{
+			method: http.MethodGet,
+			path:   "/api/v1/canvases/" + canvasID + "/versions/" + versionID,
+			handle: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"version":{"metadata":{"id":"` + versionID + `","canvasId":"` + canvasID + `"},"spec":{"nodes":[],"edges":[]}}}`))
+			},
+		},
+	)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "canvas.yaml")
+	content := []byte(
+		"apiVersion: v1\n" +
+			"kind: Canvas\n" +
+			"metadata:\n" +
+			"  id: " + canvasID + "\n" +
+			"  name: dry-run-test\n" +
+			"spec:\n" +
+			"  nodes: []\n" +
+			"  edges: []\n",
+	)
+	require.NoError(t, os.WriteFile(filePath, content, 0o644))
+
+	file := filePath
+	draft := true
+	dryRun := true
+	ctx, stdout := newCreateCommandContextForTest(t, server.server, "text")
+
+	err := (&updateCommand{file: &file, draft: &draft, dryRun: &dryRun}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "Dry-run: no changes")
+
+	server.AssertCalls(t, []string{
+		http.MethodGet + " /api/v1/canvases/" + canvasID,
+		http.MethodGet + " /api/v1/canvases/" + canvasID + "/versions",
+		http.MethodGet + " /api/v1/canvases/" + canvasID + "/versions/" + versionID,
+	})
+}
+
 func writeTestCanvasFileWithChangeManagementEnabled(t *testing.T, canvasID string, enabled bool) string {
 	t.Helper()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub #4233 by improving how the CLI surfaces server-side canvas validation, without adding new backend endpoints.

- **`superplane canvases update --file <path> --draft --dry-run`** — Builds the same kind of changeset as a full snapshot apply, then calls the existing **`PATCH /api/v1/canvases/{canvasId}/versions/{versionId}/validate`** endpoint so nothing is persisted. Requires an existing user draft (no draft auto-creation in dry-run). Skips change-management side-effect mutations during dry-run.
- **Richer success output** — After a normal `update`, text output now lists **per-node `errorMessage` / `warningMessage`** from the returned version when the server attached them (aligned with the discussion in #4233 about exposing node errors in CLI output).

## Human comment (#4233)

Contributor feedback suggested **better CLI surfacing of validation/node errors** instead of a new validate/dry-run API. This PR follows that: it reuses the existing validate endpoint for `--dry-run` and prints node issues on successful updates.

## Tests

- `go test ./pkg/cli/commands/canvases/...`
- `go vet ./pkg/cli/commands/canvases/...`

CI in this repo typically regenerates ignored artifacts (`pkg/openapi_client`); the implementation uses the generated OpenAPI client types already expected by the CLI.

Fixes #4233
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6fa84e9-2c65-45c5-b8dc-ebd74893a963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6fa84e9-2c65-45c5-b8dc-ebd74893a963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

