### PR TITLE
feat: hide columns in canvas memory table

### DIFF
--- a/web_src/src/hooks/useCanvasMemoryColumnVisibility.spec.ts
+++ b/web_src/src/hooks/useCanvasMemoryColumnVisibility.spec.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  canvasMemoryHiddenColumnsStorageKey,
+  useCanvasMemoryColumnVisibility,
+} from "@/hooks/useCanvasMemoryColumnVisibility";
+
+const canvasId = "canvas-1";
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useCanvasMemoryColumnVisibility", () => {
+  it("starts with all columns visible when nothing is stored", () => {
+    const { result } = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns", ["a", "b", "c"]));
+    expect(result.current.visibleColumns).toEqual(["a", "b", "c"]);
+    expect(result.current.hidden.size).toBe(0);
+  });
+
+  it("hydrates hidden columns from localStorage", () => {
+    window.localStorage.setItem(canvasMemoryHiddenColumnsStorageKey(canvasId), JSON.stringify({ ns: ["b"] }));
+    const { result } = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns", ["a", "b", "c"]));
+    expect(result.current.visibleColumns).toEqual(["a", "c"]);
+    expect(result.current.hidden.has("b")).toBe(true);
+  });
+
+  it("toggles a column and persists to localStorage", () => {
+    const { result } = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns", ["a", "b", "c"]));
+
+    act(() => result.current.toggle("b"));
+    expect(result.current.visibleColumns).toEqual(["a", "c"]);
+    expect(JSON.parse(window.localStorage.getItem(canvasMemoryHiddenColumnsStorageKey(canvasId))!)).toEqual({
+      ns: ["b"],
+    });
+
+    act(() => result.current.toggle("b"));
+    expect(result.current.visibleColumns).toEqual(["a", "b", "c"]);
+    expect(window.localStorage.getItem(canvasMemoryHiddenColumnsStorageKey(canvasId))).toBeNull();
+  });
+
+  it("hideAll hides every column; showAll restores them", () => {
+    const { result } = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns", ["a", "b"]));
+
+    act(() => result.current.hideAll());
+    expect(result.current.visibleColumns).toEqual([]);
+    expect(result.current.hidden.size).toBe(2);
+
+    act(() => result.current.showAll());
+    expect(result.current.visibleColumns).toEqual(["a", "b"]);
+    expect(result.current.hidden.size).toBe(0);
+  });
+
+  it("does not clobber other namespaces in the same canvas", () => {
+    const nsA = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns-a", ["a", "b"]));
+    const nsB = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns-b", ["x", "y"]));
+
+    act(() => nsA.result.current.toggle("a"));
+    act(() => nsB.result.current.toggle("y"));
+
+    const stored = JSON.parse(window.localStorage.getItem(canvasMemoryHiddenColumnsStorageKey(canvasId))!);
+    expect(stored).toEqual({ "ns-a": ["a"], "ns-b": ["y"] });
+  });
+
+  it("ignores malformed stored values", () => {
+    window.localStorage.setItem(canvasMemoryHiddenColumnsStorageKey(canvasId), "not json");
+    const { result } = renderHook(() => useCanvasMemoryColumnVisibility(canvasId, "ns", ["a", "b"]));
+    expect(result.current.visibleColumns).toEqual(["a", "b"]);
+  });
+});

--- a/web_src/src/hooks/useCanvasMemoryColumnVisibility.ts
+++ b/web_src/src/hooks/useCanvasMemoryColumnVisibility.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type HiddenByNamespace = Record<string, string[]>;
+
+export const CANVAS_MEMORY_HIDDEN_COLUMNS_STORAGE_KEY_PREFIX = "canvasMemoryHiddenColumns";
+
+export function canvasMemoryHiddenColumnsStorageKey(canvasId: string): string {
+  return `${CANVAS_MEMORY_HIDDEN_COLUMNS_STORAGE_KEY_PREFIX}:${canvasId}`;
+}
+
+function readBlob(canvasId: string): HiddenByNamespace {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(canvasMemoryHiddenColumnsStorageKey(canvasId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const result: HiddenByNamespace = {};
+    for (const [namespace, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+        result[namespace] = value as string[];
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function writeBlob(canvasId: string, blob: HiddenByNamespace) {
+  if (typeof window === "undefined") return;
+  try {
+    if (Object.keys(blob).length === 0) {
+      window.localStorage.removeItem(canvasMemoryHiddenColumnsStorageKey(canvasId));
+      return;
+    }
+    window.localStorage.setItem(canvasMemoryHiddenColumnsStorageKey(canvasId), JSON.stringify(blob));
+  } catch {
+    // localStorage may be unavailable or quota-exceeded; preferences are non-critical.
+  }
+}
+
+export type CanvasMemoryColumnVisibility = {
+  hidden: Set<string>;
+  visibleColumns: string[];
+  toggle: (column: string) => void;
+  showAll: () => void;
+  hideAll: () => void;
+};
+
+export function useCanvasMemoryColumnVisibility(
+  canvasId: string,
+  namespace: string,
+  allColumns: string[],
+): CanvasMemoryColumnVisibility {
+  const [hidden, setHidden] = useState<string[]>(() => readBlob(canvasId)[namespace] ?? []);
+
+  useEffect(() => {
+    setHidden(readBlob(canvasId)[namespace] ?? []);
+  }, [canvasId, namespace]);
+
+  const persist = useCallback(
+    (next: string[]) => {
+      const blob = readBlob(canvasId);
+      if (next.length === 0) {
+        delete blob[namespace];
+      } else {
+        blob[namespace] = next;
+      }
+      writeBlob(canvasId, blob);
+      setHidden(next);
+    },
+    [canvasId, namespace],
+  );
+
+  const hiddenSet = useMemo(() => new Set(hidden), [hidden]);
+  const visibleColumns = useMemo(() => allColumns.filter((c) => !hiddenSet.has(c)), [allColumns, hiddenSet]);
+
+  const toggle = useCallback(
+    (column: string) => {
+      const next = hiddenSet.has(column) ? hidden.filter((c) => c !== column) : [...hidden, column];
+      persist(next);
+    },
+    [hidden, hiddenSet, persist],
+  );
+
+  const showAll = useCallback(() => persist([]), [persist]);
+  const hideAll = useCallback(() => persist([...allColumns]), [allColumns, persist]);
+
+  return { hidden: hiddenSet, visibleColumns, toggle, showAll, hideAll };
+}

--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
@@ -1,11 +1,23 @@
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdownMenu";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
-import { Trash2 } from "lucide-react";
+import { useCanvasMemoryColumnVisibility } from "@/hooks/useCanvasMemoryColumnVisibility";
+import { Columns3, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 
 export type CanvasMemoryModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  canvasId: string;
   entries: CanvasMemoryEntry[];
   isLoading?: boolean;
   errorMessage?: string;
@@ -24,6 +36,7 @@ export function CanvasMemoryModal(props: CanvasMemoryModalProps) {
 
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-50">
             <CanvasMemoryModalBody
+              canvasId={props.canvasId}
               entries={props.entries}
               isLoading={props.isLoading}
               errorMessage={props.errorMessage}
@@ -38,6 +51,7 @@ export function CanvasMemoryModal(props: CanvasMemoryModalProps) {
 }
 
 type CanvasMemoryBodyProps = {
+  canvasId: string;
   entries: CanvasMemoryEntry[];
   isLoading?: boolean;
   errorMessage?: string;
@@ -45,7 +59,14 @@ type CanvasMemoryBodyProps = {
   deletingId?: string;
 };
 
-function CanvasMemoryModalBody({ entries, isLoading, errorMessage, onDeleteEntry, deletingId }: CanvasMemoryBodyProps) {
+function CanvasMemoryModalBody({
+  canvasId,
+  entries,
+  isLoading,
+  errorMessage,
+  onDeleteEntry,
+  deletingId,
+}: CanvasMemoryBodyProps) {
   const groupedEntries = entries.reduce<Record<string, CanvasMemoryEntry[]>>((acc, entry) => {
     const namespace = entry.namespace || "(no namespace)";
     if (!acc[namespace]) {
@@ -79,13 +100,14 @@ function CanvasMemoryModalBody({ entries, isLoading, errorMessage, onDeleteEntry
   return (
     <div className="min-h-0 w-full min-w-0 flex-1 overflow-auto">
       {Object.entries(groupedEntries).map(([namespace, values]) => (
-        <div key={namespace} className="m-4 border border-slate-300 rounded-md bg-white">
-          <div className="px-3 py-2 font-mono text-sm text-gray-600 border-b border-slate-300">
-            Namespace: {namespace}
-          </div>
-
-          {renderNamespaceTable(values, onDeleteEntry, deletingId)}
-        </div>
+        <NamespaceCard
+          key={namespace}
+          canvasId={canvasId}
+          namespace={namespace}
+          values={values}
+          onDeleteEntry={onDeleteEntry}
+          deletingId={deletingId}
+        />
       ))}
     </div>
   );
@@ -132,67 +154,195 @@ function collectColumns(items: Record<string, unknown>[]): string[] {
   return Array.from(set);
 }
 
-function renderNamespaceTable(
-  values: CanvasMemoryEntry[],
-  onDeleteEntry?: (memoryId: string) => void,
-  deletingId?: string,
-) {
-  if (values.length === 0) {
-    return <div className="px-3 py-2 text-xs text-gray-500">No items</div>;
-  }
+type NamespaceCardProps = {
+  canvasId: string;
+  namespace: string;
+  values: CanvasMemoryEntry[];
+  onDeleteEntry?: (memoryId: string) => void;
+  deletingId?: string;
+};
 
-  const objectValues = values.map((entry) => entry.values).filter(isRecord) as Record<string, unknown>[];
-  if (objectValues.length === values.length) {
-    const columns = collectColumns(objectValues);
+function NamespaceCard({ canvasId, namespace, values, onDeleteEntry, deletingId }: NamespaceCardProps) {
+  const objectValues = useMemo(
+    () => values.map((entry) => entry.values).filter(isRecord) as Record<string, unknown>[],
+    [values],
+  );
+  const allValuesAreObjects = objectValues.length === values.length && values.length > 0;
+  const allColumns = useMemo(
+    () => (allValuesAreObjects ? collectColumns(objectValues) : []),
+    [allValuesAreObjects, objectValues],
+  );
+
+  const visibility = useCanvasMemoryColumnVisibility(canvasId, namespace, allColumns);
+
+  return (
+    <div className="m-4 border border-slate-300 rounded-md bg-white">
+      <div className="flex items-center justify-between gap-3 border-b border-slate-300 px-3 py-2">
+        <span className="font-mono text-sm text-gray-600">Namespace: {namespace}</span>
+        {allValuesAreObjects && allColumns.length > 0 ? (
+          <ColumnVisibilityMenu
+            allColumns={allColumns}
+            hidden={visibility.hidden}
+            onToggle={visibility.toggle}
+            onShowAll={visibility.showAll}
+            onHideAll={visibility.hideAll}
+          />
+        ) : null}
+      </div>
+
+      {allValuesAreObjects ? (
+        <ObjectNamespaceTable
+          values={values}
+          objectValues={objectValues}
+          visibleColumns={visibility.visibleColumns}
+          totalColumns={allColumns.length}
+          onShowAll={visibility.showAll}
+          onDeleteEntry={onDeleteEntry}
+          deletingId={deletingId}
+        />
+      ) : values.length === 0 ? (
+        <div className="px-3 py-2 text-xs text-gray-500">No items</div>
+      ) : (
+        <RawNamespaceTable values={values} onDeleteEntry={onDeleteEntry} deletingId={deletingId} />
+      )}
+    </div>
+  );
+}
+
+type ColumnVisibilityMenuProps = {
+  allColumns: string[];
+  hidden: Set<string>;
+  onToggle: (column: string) => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+};
+
+function ColumnVisibilityMenu({ allColumns, hidden, onToggle, onShowAll, onHideAll }: ColumnVisibilityMenuProps) {
+  const visibleCount = allColumns.length - hidden.size;
+  const allVisible = hidden.size === 0;
+  const allHidden = hidden.size === allColumns.length;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="h-7 gap-1.5 px-2 text-xs">
+          <Columns3 className="h-3.5 w-3.5" />
+          Columns
+          <span className="text-gray-500">
+            ({visibleCount}/{allColumns.length})
+          </span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-[60vh] min-w-[12rem]">
+        <DropdownMenuLabel className="text-xs font-semibold uppercase text-gray-500">Toggle columns</DropdownMenuLabel>
+        {allColumns.map((column) => (
+          <DropdownMenuCheckboxItem
+            key={column}
+            checked={!hidden.has(column)}
+            onCheckedChange={() => onToggle(column)}
+            onSelect={(event) => event.preventDefault()}
+          >
+            <span className="truncate font-mono text-xs">{column}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled={allVisible} onSelect={onShowAll}>
+          Show all
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={allHidden} onSelect={onHideAll}>
+          Hide all
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type ObjectNamespaceTableProps = {
+  values: CanvasMemoryEntry[];
+  objectValues: Record<string, unknown>[];
+  visibleColumns: string[];
+  totalColumns: number;
+  onShowAll: () => void;
+  onDeleteEntry?: (memoryId: string) => void;
+  deletingId?: string;
+};
+
+function ObjectNamespaceTable({
+  values,
+  objectValues,
+  visibleColumns,
+  totalColumns,
+  onShowAll,
+  onDeleteEntry,
+  deletingId,
+}: ObjectNamespaceTableProps) {
+  if (totalColumns > 0 && visibleColumns.length === 0) {
     return (
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-slate-950/15 bg-slate-50">
-              {columns.map((column) => (
-                <th key={column} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase">
-                  {column}
-                </th>
-              ))}
-              <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {values.map((entry, index) => {
-              const item = objectValues[index];
-              return (
-                <tr key={entry.id || index} className="border-b border-slate-950/15">
-                  {columns.map((column) => (
-                    <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
-                      {formatValue(item[column])}
-                    </td>
-                  ))}
-                  <td className="px-3 py-2 text-right align-middle">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={!onDeleteEntry || !entry.id || deletingId === entry.id}
-                      onClick={() => {
-                        if (entry.id) onDeleteEntry?.(entry.id);
-                      }}
-                      className="text-gray-500 hover:text-red-600"
-                      title="Delete entry"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+      <div className="flex items-center justify-between gap-3 px-3 py-3 text-xs text-gray-500">
+        <span>All columns are hidden.</span>
+        <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onShowAll}>
+          Show all
+        </Button>
       </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto bg-red-500">
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-950/15 bg-slate-50">
+            {visibleColumns.map((column) => (
+              <th key={column} className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase">
+                {column}
+              </th>
+            ))}
+            <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {values.map((entry, index) => {
+            const item = objectValues[index];
+            return (
+              <tr key={entry.id || index} className="border-b border-slate-950/15">
+                {visibleColumns.map((column) => (
+                  <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
+                    {formatValue(item[column])}
+                  </td>
+                ))}
+                <td className="px-3 py-2 text-right align-middle">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={!onDeleteEntry || !entry.id || deletingId === entry.id}
+                    onClick={() => {
+                      if (entry.id) onDeleteEntry?.(entry.id);
+                    }}
+                    className="text-gray-500 hover:text-red-600"
+                    title="Delete entry"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type RawNamespaceTableProps = {
+  values: CanvasMemoryEntry[];
+  onDeleteEntry?: (memoryId: string) => void;
+  deletingId?: string;
+};
+
+function RawNamespaceTable({ values, onDeleteEntry, deletingId }: RawNamespaceTableProps) {
+  return (
+    <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-slate-950/15 bg-slate-50">

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5408,6 +5408,7 @@ export function WorkflowPageV2() {
       <CanvasMemoryModal
         open={isMemoryViewModalOpen}
         onOpenChange={setIsMemoryViewModalOpen}
+        canvasId={canvasId!}
         entries={isViewingDraftVersion ? [] : canvasMemoryEntries}
         isLoading={isViewingDraftVersion ? false : canvasMemoryLoading}
         errorMessage={


### PR DESCRIPTION
## Summary

Adds a per-namespace **Columns** dropdown to the Canvas Memory modal so users can toggle column visibility — useful when a namespace stores many fields but only a few are user-relevant. Closes #4360.

  - New `useCanvasMemoryColumnVisibility(canvasId, namespace, allColumns)` hook backs the menu and persists hidden columns to `localStorage` under `canvasMemoryHiddenColumns:<canvasId>` (per-canvas,
  per-namespace). Stores *hidden* columns rather than visible, so newly added columns appear by default.
  - `CanvasMemoryModal` refactored: extracts `NamespaceCard`, `ObjectNamespaceTable`, `RawNamespaceTable`, and `ColumnVisibilityMenu` out of the previous monolithic `renderNamespaceTable`.
  - The Columns menu only renders for object-shaped namespaces; raw/scalar namespaces still render the single-column "Value" view, untouched.
  - When all columns are hidden, the table swaps to an "All columns are hidden." inline prompt with a "Show all" action so the table can't dead-end.
  - Drive-by: removes a leftover `bg-red-500` debug class on the raw-values wrapper that was bleeding through to scalar namespaces.

  ## Test plan

  - [x] `vitest` covers the new hook: hydration, toggle, hideAll/showAll, multi-namespace isolation, malformed-storage tolerance — 6/6 passing.
  - [x] `make check.build.ui` (tsc -b + vite build) passes.
  - [x] Manually verified in dev:
    - 10-column `environments` namespace toggles work; counter updates `(visible/total)`.
    - Hidden columns persist across hard reload via `localStorage`.
    - "Hide all" → empty-state with inline "Show all" → restored.
    - Toggles in one namespace don't affect others.
    - Non-object namespace (`raw_notes`) renders the single-column view with no Columns button.
<img width="1318" height="799" alt="Screenshot 2026-04-26 at 1 00 21 PM" src="https://github.com/user-attachments/assets/66876944-baa6-47b2-ac37-4021f6f91926" />
<img width="1318" height="799" alt="Screenshot 2026-04-26 at 1 00 38 PM" src="https://github.com/user-attachments/assets/0594d9af-24d7-4cf6-bbc2-6837d8e58d85" />

Closes #4360.