### PR TITLE
fix: collapse versions sidebar by default on new canvases (#4344)

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -565,18 +565,18 @@ export function WorkflowPageV2() {
   const [isMemoryViewModalOpen, setIsMemoryViewModalOpen] = useState(false);
   const [isVersionControlOpen, setIsVersionControlOpen] = useState(() => {
     if (typeof window === "undefined") {
-      return true;
+      return false;
     }
 
     const stored = window.localStorage.getItem(CANVAS_VERSION_CONTROL_STORAGE_KEY);
     if (stored === null) {
-      return true;
+      return false;
     }
 
     try {
       return JSON.parse(stored) as boolean;
     } catch {
-      return true;
+      return false;
     }
   });
   /** After creating a change request, hide draft Discard until the user enters edit mode again. */


### PR DESCRIPTION
## Summary

Fixes #4344.

The Versions sidebar opened by default for users without a stored preference, taking up screen real estate on new/empty canvases where there's only v1 and nothing to compare.

After this change, the sidebar starts collapsed for fresh users. Users who previously toggled it open keep their stored preference (the localStorage value at `canvas-version-control-open` is read first; the default only applies when nothing is stored).

## Changes

- `web_src/src/pages/workflowv2/index.tsx`: flip the three default-return paths in the `isVersionControlOpen` initializer from `true` to `false` (SSR fallback, no-stored-value, parse-error).

## Test plan

- [x] `make format.js` clean
- [x] Verified existing E2E (`test/e2e/canvas_change_requests_test.go`) is already defensive — it checks for the "Open version control" button and clicks it if visible, so it works under either default
- [x] Grepped for storybook fixtures / specs hardcoding `isVersionControlOpen={true}` — none found
- [ ] Manual: open a new canvas → sidebar should be collapsed; click the toolbar Versions button → opens; reload → stays open (preference persists)