### PR TITLE
chore: merge backend Check jobs into one Semaphore job

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,25 +54,9 @@ blocks:
           parallelism: 10
           commands:
             - make test.e2e.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
-        - name: "Check: DB structure"
+        - name: Checks
           commands:
-            - make check.db.structure
-            - make check.db.migrations
-        - name: "Check: Components Docs"
-          commands:
-            - make check.components.docs
-        - name: "Check: Go Format"
-          commands:
-            - make check.format.go
-        - name: "Check: Example Payloads"
-          commands:
-            - make check.example.payloads
-        - name: "Check: Canvas templates"
-          commands:
-            - make check.templates
-        - name: "Check: Generated Artifacts"
-          commands:
-            - make check.generated.artifacts
+            - make check.backend
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,16 +47,26 @@ blocks:
         - name: Lint
           commands:
             - make lint
+
         - name: Unit Tests
           commands:
             - make test.coverage.check
+
         - name: E2E Tests
           parallelism: 10
           commands:
             - make test.e2e.autoparallel INDEX=$SEMAPHORE_JOB_INDEX TOTAL=$SEMAPHORE_JOB_COUNT
+
         - name: Checks
           commands:
-            - make check.backend
+            - make check.db.structure
+            - make check.db.migrations
+            - make check.components.docs
+            - make check.format.go
+            - make check.example.payloads
+            - make check.templates
+            - make check.generated.artifacts 
+
       epilogue:
         always:
           commands:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test.coverage test.license.check test.agent.unit test.agent.setup test.setup test.e2e.ui.setup gen.setup gen.setup.backend gen.setup.ui gen.setup.agent check.generated.artifacts check.templates compose.setup
+.PHONY: lint test test.coverage test.license.check test.agent.unit test.agent.setup test.setup test.e2e.ui.setup gen.setup gen.setup.backend gen.setup.ui gen.setup.agent check.backend check.generated.artifacts check.templates compose.setup
 
 DB_NAME=superplane
 DB_PASSWORD=the-cake-is-a-lie
@@ -125,6 +125,16 @@ format.go:
 
 check.format.go:
 	$(COMPOSE) exec app bash -c "find . -name '*.go' -not -path './tmp/*' -print0 | xargs -0 gofmt -s -l | tee /dev/stderr | if read; then exit 1; else exit 0; fi"
+
+# All backend "Check: *" Semaphore steps (sequential; one CI job for faster prologue, less fan-out)
+check.backend:
+	$(MAKE) check.db.structure
+	$(MAKE) check.db.migrations
+	$(MAKE) check.components.docs
+	$(MAKE) check.format.go
+	$(MAKE) check.example.payloads
+	$(MAKE) check.templates
+	$(MAKE) check.generated.artifacts
 
 format.js:
 	cd web_src && npm run format

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test.coverage test.license.check test.agent.unit test.agent.setup test.setup test.e2e.ui.setup gen.setup gen.setup.backend gen.setup.ui gen.setup.agent check.backend check.generated.artifacts check.templates compose.setup
+.PHONY: lint test test.coverage test.license.check test.agent.unit test.agent.setup test.setup test.e2e.ui.setup gen.setup gen.setup.backend gen.setup.ui gen.setup.agent check.generated.artifacts check.templates compose.setup
 
 DB_NAME=superplane
 DB_PASSWORD=the-cake-is-a-lie
@@ -125,16 +125,6 @@ format.go:
 
 check.format.go:
 	$(COMPOSE) exec app bash -c "find . -name '*.go' -not -path './tmp/*' -print0 | xargs -0 gofmt -s -l | tee /dev/stderr | if read; then exit 1; else exit 0; fi"
-
-# All backend "Check: *" Semaphore steps (sequential; one CI job for faster prologue, less fan-out)
-check.backend:
-	$(MAKE) check.db.structure
-	$(MAKE) check.db.migrations
-	$(MAKE) check.components.docs
-	$(MAKE) check.format.go
-	$(MAKE) check.example.payloads
-	$(MAKE) check.templates
-	$(MAKE) check.generated.artifacts
 
 format.js:
 	cd web_src && npm run format


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #4418.

- **`.semaphore/semaphore.yml`**: In the **Backend Tests** block, replace the six parallel jobs named `Check: …` with a single job **Checks** that runs `make check.backend` once, after the same shared prologue as the rest of the block.
- **`Makefile`**: Add **`check.backend`**, which runs the same `make` targets in the same order the old jobs used (DB structure + migrations, component docs, Go format, example payloads, canvas templates, generated artifacts). Keeps ordering and the full set of commands in the build system as suggested in the automated review.

## Review and issue alignment
- **Agent review (superplane-leonardo)**: Implemented the primary recommendation—merge the six `Check: *` jobs under Backend Tests into one job, with optional `make` aggregation for readability. Did **not** change License, Agent Tests, or Frondend Tests; scope stays the `Check: *` family per the review.
- **Human comments**: There were no human comments on the issue after the review, so there was no conflicting feedback to apply.

**Note:** Semaphore will run the checks **sequentially** in one job instead of six parallel jobs, which is intended; **Lint**, **Unit Tests**, and **E2E** remain separate parallel jobs in the same block.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f818d5f-9e79-46cd-b586-002d54803d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f818d5f-9e79-46cd-b586-002d54803d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

