### PR TITLE
fix: add accessible labels to icon-only buttons

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/PayloadPreview.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/PayloadPreview.tsx
@@ -54,12 +54,19 @@ export function PayloadPreview({
         <p className={labelClass}>{label}</p>
         <div className="flex items-center gap-1">
           {showCopy && (
-            <button onClick={handleCopy} className="p-1 text-gray-500 hover:text-gray-800">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="p-1 text-gray-500 hover:text-gray-800"
+              aria-label="Copy to clipboard"
+            >
               {copied ? <Check size={iconSize} /> : <Copy size={iconSize} />}
             </button>
           )}
           <button
+            type="button"
             className="p-1 text-gray-500 hover:text-gray-800"
+            aria-label="Expand payload"
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();

--- a/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
+++ b/web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx
@@ -491,19 +491,23 @@ export const SidebarEventItem: React.FC<SidebarEventItemProps> = ({
                 <div className="flex items-center gap-1 absolute right-2 top-4">
                   <SimpleTooltip content={payloadCopied ? "Copied!" : "Copy Link"} hideOnClick={false}>
                     <button
+                      type="button"
                       onClick={() => copyPayloadToClipboard(tabData.payload)}
                       className="p-1 text-gray-500 hover:text-gray-800"
+                      aria-label="Copy payload"
                     >
                       {React.createElement(resolveIcon("copy"), { size: 16 })}
                     </button>
                   </SimpleTooltip>
                   <SimpleTooltip content="Payload">
                     <button
+                      type="button"
                       onClick={() => {
                         setModalPayload(tabData.payload);
                         setIsPayloadModalOpen(true);
                       }}
                       className="p-1 text-gray-500 hover:text-gray-800"
+                      aria-label="Expand payload"
                     >
                       {React.createElement(resolveIcon("maximize-2"), { size: 16 })}
                     </button>

--- a/web_src/src/ui/configurationFieldRenderer/AnyPredicateListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/AnyPredicateListFieldRenderer.tsx
@@ -82,7 +82,13 @@ export const AnyPredicateListFieldRenderer: React.FC<FieldRendererProps> = ({
               />
             )}
           </div>
-          <Button variant="ghost" size="icon" onClick={() => removePredicate(index)} className="mt-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removePredicate(index)}
+            className="mt-1"
+            aria-label="Remove condition"
+          >
             <Trash2 className="h-4 w-4 text-red-500" />
           </Button>
         </div>

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -176,7 +176,13 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
               />
             )}
           </div>
-          <Button variant="ghost" size="icon" onClick={() => removeItem(index)} className="mt-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removeItem(index)}
+            className="mt-1"
+            aria-label="Remove item"
+          >
             <Trash2 className="h-4 w-4 text-red-500" />
           </Button>
         </div>

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -196,12 +196,22 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
           <div className="border rounded-md border-gray-300 dark:border-gray-700 p-2" style={{ height: "200px" }}>
             <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-1">
               <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
-                <button onClick={copyToClipboard} className="p-1 rounded text-gray-500 hover:text-gray-800">
+                <button
+                  type="button"
+                  onClick={copyToClipboard}
+                  className="p-1 rounded text-gray-500 hover:text-gray-800"
+                  aria-label="Copy to clipboard"
+                >
                   {React.createElement(resolveIcon("copy"), { size: 14 })}
                 </button>
               </SimpleTooltip>
               <SimpleTooltip content="Expand">
-                <button onClick={() => setIsModalOpen(true)} className="p-1 text-gray-500 hover:text-gray-800">
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(true)}
+                  className="p-1 text-gray-500 hover:text-gray-800"
+                  aria-label="Expand editor"
+                >
                   {React.createElement(resolveIcon("maximize-2"), { size: 14 })}
                 </button>
               </SimpleTooltip>

--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
@@ -63,12 +63,22 @@ export const TextFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, 
         <div className="border rounded-md border-gray-300 dark:border-gray-700 p-1" style={{ height: "200px" }}>
           <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-1">
             <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
-              <button onClick={copyToClipboard} className="p-1 rounded text-gray-500 hover:text-gray-800">
+              <button
+                type="button"
+                onClick={copyToClipboard}
+                className="p-1 rounded text-gray-500 hover:text-gray-800"
+                aria-label="Copy to clipboard"
+              >
                 {React.createElement(resolveIcon("copy"), { size: 14 })}
               </button>
             </SimpleTooltip>
             <SimpleTooltip content="Expand">
-              <button onClick={() => setIsModalOpen(true)} className="p-1 text-gray-500 hover:text-gray-800">
+              <button
+                type="button"
+                onClick={() => setIsModalOpen(true)}
+                className="p-1 text-gray-500 hover:text-gray-800"
+                aria-label="Expand editor"
+              >
                 {React.createElement(resolveIcon("maximize-2"), { size: 14 })}
               </button>
             </SimpleTooltip>

--- a/web_src/src/ui/configurationFieldRenderer/XMLFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/XMLFieldRenderer.tsx
@@ -89,12 +89,22 @@ export const XMLFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, o
         <div className="border rounded-md border-gray-300 dark:border-gray-700 p-1" style={{ height: "200px" }}>
           <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-1">
             <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
-              <button onClick={copyToClipboard} className="p-1 rounded text-gray-500 hover:text-gray-800">
+              <button
+                type="button"
+                onClick={copyToClipboard}
+                className="p-1 rounded text-gray-500 hover:text-gray-800"
+                aria-label="Copy to clipboard"
+              >
                 {React.createElement(resolveIcon("copy"), { size: 14 })}
               </button>
             </SimpleTooltip>
             <SimpleTooltip content="Expand">
-              <button onClick={() => setIsModalOpen(true)} className="p-1 text-gray-500 hover:text-gray-800">
+              <button
+                type="button"
+                onClick={() => setIsModalOpen(true)}
+                className="p-1 text-gray-500 hover:text-gray-800"
+                aria-label="Expand editor"
+              >
                 {React.createElement(resolveIcon("maximize-2"), { size: 14 })}
               </button>
             </SimpleTooltip>


### PR DESCRIPTION
## Summary
- Add `aria-label` to icon-only copy, expand, and remove buttons across configuration field renderers, PayloadPreview, and SidebarEventItem
- Add explicit `type="button"` to raw `<button>` elements to prevent accidental form submissions

## Files changed
- `web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx`
- `web_src/src/ui/configurationFieldRenderer/AnyPredicateListFieldRenderer.tsx`
- `web_src/src/ui/configurationFieldRenderer/XMLFieldRenderer.tsx`
- `web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx`
- `web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx`
- `web_srocksSidebar/PayloadPreview.tsx`
- `web_src/src/ui/componentSidebar/SidebarEventItem/SidebarEventItem.tsx`

## Test plan
- [x] `prettier --check` passes on all edited files
- [x] No new TypeScript errors introduced (verified with `tsc -b`)
- [x] `make check.build.ui` (requires Docker environment with generated API client)