### PR TITLE
fix: make organization user removal resilient to partial failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ We welcome your bug reports, ideas for improvement, and focused PRs.
 - Read the **[Contributing Guide](CONTRIBUTING.md)** to get started.
 - Issues: use GitHub issues for bugs and feature requests.
 
+### Consistency Note (Organization Membership)
+
+When removing a user from an organization, SuperPlane removes the user's organization roles and then soft-deletes the user. If role removal fails, user deletion is not performed, and any roles removed earlier in the same operation are restored.
+
+Traduccion al espanol: Al remover un usuario de una organizacion, SuperPlane elimina primero los roles de organizacion del usuario y luego aplica un borrado logico del usuario. Si la eliminacion de roles falla, el borrado del usuario no se ejecuta y cualquier rol eliminado previamente en la misma operacion se restaura.
+
 ## License
 
 Apache License 2.0. See `LICENSE`.

--- a/pkg/grpc/actions/organizations/remove_user.go
+++ b/pkg/grpc/actions/organizations/remove_user.go
@@ -28,28 +28,38 @@ func RemoveUser(ctx context.Context, authService authorization.Authorization, or
 		return nil, status.Error(codes.FailedPrecondition, "cannot remove the last organization owner")
 	}
 
-	//
-	// TODO: this should all be inside of a transaction
-	// Remove organization roles
-	//
 	roles, err := authService.GetUserRolesForOrg(user.ID.String(), orgID)
 	if err != nil {
-		log.Errorf("Error determing user roles for %s: %v", user.ID.String(), err)
-		return nil, status.Error(codes.Internal, "error determing user roles")
+		log.Errorf("Error determining user roles for %s: %v", user.ID.String(), err)
+		return nil, status.Error(codes.Internal, "error determining user roles")
 	}
 
+	removedRoles := make([]string, 0, len(roles))
 	for _, role := range roles {
 		err = authService.RemoveRole(user.ID.String(), role.Name, orgID, models.DomainTypeOrganization)
 		if err != nil {
 			log.Errorf("Error removing role %s for %s: %v", role.Name, user.ID.String(), err)
+			restoreRoles(authService, user.ID.String(), orgID, removedRoles)
 			return nil, status.Error(codes.Internal, "error removing role")
 		}
+
+		removedRoles = append(removedRoles, role.Name)
 	}
 
 	err = user.Delete()
 	if err != nil {
+		restoreRoles(authService, user.ID.String(), orgID, removedRoles)
 		return nil, status.Error(codes.Internal, "error deleting user")
 	}
 
 	return &pb.RemoveUserResponse{}, nil
+}
+
+func restoreRoles(authService authorization.Authorization, userID, orgID string, roles []string) {
+	for _, roleName := range roles {
+		err := authService.AssignRole(userID, roleName, orgID, models.DomainTypeOrganization)
+		if err != nil {
+			log.Errorf("Error restoring role %s for %s after rollback attempt: %v", roleName, userID, err)
+		}
+	}
 }

--- a/pkg/grpc/actions/organizations/remove_user_test.go
+++ b/pkg/grpc/actions/organizations/remove_user_test.go
@@ -2,12 +2,14 @@ package organizations
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
@@ -68,4 +70,54 @@ func Test_RemoveUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, roles, 0)
 	})
+
+	t.Run("role removal failure -> user remains active with original roles", func(t *testing.T) {
+		newUser := support.CreateUser(t, r, r.Organization.ID)
+
+		rolesBefore, err := r.AuthService.GetUserRolesForOrg(newUser.ID.String(), orgID)
+		require.NoError(t, err)
+		require.NotEmpty(t, rolesBefore)
+
+		failingRole := rolesBefore[0].Name
+		mockAuth := &removeUserAuthService{
+			Authorization:   r.AuthService,
+			failOnRoleName:  failingRole,
+			removeRoleError: errors.New("forced remove role error"),
+		}
+
+		_, err = RemoveUser(ctx, mockAuth, orgID, newUser.ID.String())
+		require.Error(t, err)
+
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+		assert.Equal(t, "error removing role", s.Message())
+
+		_, err = models.FindActiveUserByID(orgID, newUser.ID.String())
+		require.NoError(t, err)
+
+		rolesAfter, err := r.AuthService.GetUserRolesForOrg(newUser.ID.String(), orgID)
+		require.NoError(t, err)
+		require.NotEmpty(t, rolesAfter)
+
+		roleNamesAfter := make([]string, 0, len(rolesAfter))
+		for _, role := range rolesAfter {
+			roleNamesAfter = append(roleNamesAfter, role.Name)
+		}
+		assert.Contains(t, roleNamesAfter, failingRole)
+	})
+}
+
+type removeUserAuthService struct {
+	authorization.Authorization
+	failOnRoleName  string
+	removeRoleError error
+}
+
+func (m *removeUserAuthService) RemoveRole(userID, role, domainID string, domainType string) error {
+	if m.removeRoleError != nil && role == m.failOnRoleName {
+		return m.removeRoleError
+	}
+
+	return m.Authorization.RemoveRole(userID, role, domainID, domainType)
 }


### PR DESCRIPTION
This PR improves organization user removal by making it resilient to partial failures.

When a user is removed from an organization, the system now keeps authorization and membership state consistent. If role removal fails, the operation stops and any roles removed earlier in the same request are restored. If user soft-deletion fails after roles were removed, those roles are also restored.

The change also includes a typo fix in internal error messages (determing -> determining) and adds regression test coverage for the role-removal failure path.

Additionally, the README now includes a consistency note about this behavior in English, with an extra Spanish translation.

