### PR TITLE
docs: document event payload size limit and large payload patterns

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -477,6 +477,18 @@ The component emits the response with:
 - **headers**: Response headers
 - **body**: Parsed response body (JSON if possible, otherwise string)
 
+### Payload Size
+
+The serialized event emitted by this component is capped at **64 KiB (65,536 bytes)**, the same limit applied to every event in the graph. The HTTP call itself can return a larger response, but if the resulting event would exceed the limit, the component fails with `event payload too large: <size> bytes (max 65536)`.
+
+When fetching content that may exceed this limit (large diffs, file contents, logs, paginated lists), prefer one of:
+
+- Filter or project the response to the fields downstream nodes actually need.
+- Persist the blob to external storage (S3, GCS, etc.) and emit only the URL or key.
+- Page the request and fan out one event per page, so the work happens in parallel without a single oversized payload.
+
+See [Architecture: Event Size Limits](../contributing/architecture.md#core-event-processing-system) for more on the cap and the surfaces that enforce it.
+
 ### Example Output
 
 ```json

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -44,6 +44,23 @@ The event processing system is the engine that drives workflow execution. It ope
 
 This architecture enables parallel execution of independent workflow branches, reliable event delivery, and scalable processing through worker queues.
 
+**Event Size Limits:**
+
+Every event that flows through the graph is capped at **64 KiB (65,536 bytes)** of serialized JSON payload. The limit applies in three places:
+
+- **Webhook ingress** (`pkg/triggers/webhook/webhook.go`): incoming webhook bodies above the limit are rejected with `413 Request Entity Too Large`.
+- **Public event API** (`pkg/public/server.go`): the same limit is enforced on event submission endpoints.
+- **Event propagation** (`pkg/workers/contexts/event_context.go`): when a component emits an event, the serialized payload is checked against the limit. Components that produce a larger payload fail with `event payload too large: <size> bytes (max 65536)`.
+
+The cap exists to keep queue items, database rows, and downstream component memory usage predictable. Exceeding it is a hard error — the event is not truncated.
+
+**Patterns for handling large payloads:**
+
+- **Store the blob externally, pass a reference**: write the large content (artifact, diff, log) to S3, GCS, or another object store, and emit only the URL or key on the event.
+- **Project the fields you need**: when fetching from an HTTP API that returns a large body, transform or filter the response to keep only the fields downstream nodes actually consume.
+- **Chunk and fan out**: split a large list into several smaller events (one per item or page), and let the graph process them in parallel rather than passing them as a single payload.
+- **Use canvas memory for accumulating state**: persistent state across executions belongs in the canvas memory store (see [Canvas Memory](../components/Core.mdx#add-memory)) rather than being threaded through event payloads.
+
 ## Authentication & Authorization
 
 SuperPlane uses a multi-layered security model to authenticate users and enforce fine-grained permissions.


### PR DESCRIPTION
Closes #4286

## Summary

Adds explicit documentation for the 64 KiB cap on every event in the workflow graph and patterns for working around it.

### Architecture doc (`docs/contributing/architecture.md`)

New **Event Size Limits** subsection under Core Event Processing System. Covers:

- The cap and the three surfaces that enforce it: webhook ingress (`pkg/triggers/webhook/webhook.go`), public event API (`pkg/public/server.go`), event propagation (`pkg/workers/contexts/event_context.go`).
- Why the limit exists (predictable queue/DB/memory usage).
- That it is a hard error, not truncation.
- Patterns for handling large payloads: external blobs, field projection, chunk-and-fan-out, canvas memory.

### HTTP Request component (`docs/components/Core.mdx`)

New **Payload Size** subsection in the HTTP Request component docs, since this is the most common surface to hit the limit (large diff/file/log responses). Includes the exact failure message users will see and a link back to the architecture doc.

## Notes

- Constants verified: `DefaultMaxPayloadSize` and `MaxEventSize` are all `64 * 1024` (`pkg/workers/contexts/common.go:7`, `pkg/triggers/webhook/webhook.go:17`, `pkg/public/server.go:69`).
- Docs-only change, no code touched.
- DCO sign-off included.