### PR TITLE
fix: update OCI integration instructions to create custom privilege user and create event rules per instance

### DIFF
--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -22,20 +22,50 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Connect Oracle Cloud Infrastructure
 
-SuperPlane authenticates to OCI using API Key authentication.
+SuperPlane authenticates to OCI using API Key authentication tied to a dedicated service user with least-privilege permissions.
 
-### Steps
+### Part 1 — Create a Dedicated Group and Service User
 
 1. Open the [OCI Console](https://cloud.oracle.com/) and sign in.
-2. Go to **Profile → User settings → My profile → Tokens and keys → API keys → Add API key**.
-3. Choose **Generate API Key Pair**, download the private key, and click **Add**.
-4. After the key is added, copy the **Configuration File Preview** values:
-   - **User OCID** (begins with `ocid1.user.`)
-   - **Fingerprint** (e.g. `12:34:56:…`)
-   - **Tenancy OCID** (begins with `ocid1.tenancy.`)
-5. Select the **Region** that matches your OCI tenancy's home region.
-6. Open the downloaded private key file and paste its full contents into the **Private Key** field below.
-7. Click **Connect** to validate the credentials and save the integration.
+2. Go to **Identity & Security → Domains → Default → Groups**.
+3. Click **Create Group**.
+4. Set the name to `SuperPlaneIntegration` and add a description, then click **Create**.
+5. In the same Domain, go to **Users → Create User**.
+6. Fill in the details:
+   - **Username:** `superplane-integration`
+   - **Email:** use integrations@superplane.com or any valid email (not used for authentication)
+   - **Description:** SuperPlane integration user
+7. In the **Groups** section, assign them to the `SuperPlaneIntegration` group
+8. Click **Create**.
+
+### Part 2 — Create an IAM Policy
+
+1. Go to **Identity & Security → Policies**.
+2. Make sure you are in the **root compartment** (check the Compartment selector on the left).
+3. Click **Create Policy**, name it `SuperPlanePolicies`, and enable the **manual editor**.
+4. Paste in the following statements, replacing `<your-compartment>` with your target compartment name and Click **Create**.:
+```
+Allow group SuperPlaneIntegration to manage instances
+  in compartment <your-compartment>
+
+Allow group SuperPlaneIntegration to manage compute-images
+  in compartment <your-compartment>
+
+Allow group SuperPlaneIntegration to use virtual-network-family
+  in compartment <your-compartment>
+```
+ 
+### Part 3 — Generate API Keys for the Service User and Connect to Superplane
+
+1. While still on the service user's page, go to **API keys → Add API key**.
+2. Choose **Generate API Key Pair**, download the private key, and click **Add**.
+3. Copy the **Configuration File Preview** values that appear to the UI:
+    - **User OCID** (begins with `ocid1.user.`)
+    - **Fingerprint** (e.g. `12:34:56:…`)
+    - **Tenancy OCID** (begins with `ocid1.tenancy.`)
+4. Select the **Region** that matches your OCI tenancy's home region.
+5. Open the downloaded private key file and paste its full contents into the **Private Key** field.
+6. Click **Connect** to validate the credentials and save the integration.
 
 <a id="on-compute-instance-created"></a>
 

--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -27,45 +27,54 @@ SuperPlane authenticates to OCI using API Key authentication tied to a dedicated
 ### Part 1 — Create a Dedicated Group and Service User
 
 1. Open the [OCI Console](https://cloud.oracle.com/) and sign in.
-2. Go to **Identity & Security → Domains → Default → Groups**.
+2. Go to **Menu** → **Identity & Security → Domains → Default → User Management → Groups**.
 3. Click **Create Group**.
 4. Set the name to `SuperPlaneIntegration` and add a description, then click **Create**.
-5. In the same Domain, go to **Users → Create User**.
+5. In the same **User Management** tab, go to **Users → Create User**.
 6. Fill in the details:
-   - **Username:** `superplane-integration`
-   - **Email:** use integrations@superplane.com or any valid email (not used for authentication)
-   - **Description:** SuperPlane integration user
-7. In the **Groups** section, assign them to the `SuperPlaneIntegration` group
+   - **Lastname:** `superplane-integration`
+   - **Email:** use any valid email (not used for authentication)
+7. In the **Groups** section, assign the user to the `SuperPlaneIntegration` group
 8. Click **Create**.
 
 ### Part 2 — Create an IAM Policy
 
 1. Go to **Identity & Security → Policies**.
 2. Make sure you are in the **root compartment** (check the Compartment selector on the left).
-3. Click **Create Policy**, name it `SuperPlanePolicies`, and enable the **manual editor**.
-4. Paste in the following statements, replacing `<your-compartment>` with your target compartment name and Click **Create**.:
+3. Click **Create Policy**, name it `SuperPlanePolicies`, add a description and enable the **manual editor**.
+4. Paste in the following statements, replacing `<your-compartment>` with your target compartment name, and then Click **Create**.:
 ```
-Allow group SuperPlaneIntegration to manage instances
-  in compartment <your-compartment>
-
-Allow group SuperPlaneIntegration to manage compute-images
-  in compartment <your-compartment>
-
-Allow group SuperPlaneIntegration to use virtual-network-family
-  in compartment <your-compartment>
+Allow group SuperPlaneIntegration to manage instances in tenancy
+Allow group SuperPlaneIntegration to manage volumes in tenancy
+Allow group SuperPlaneIntegration to manage volume-attachments in tenancy
+Allow group SuperPlaneIntegration to manage virtual-network-family in tenancy
+Allow group SuperPlaneIntegration to manage buckets in tenancy
+Allow group SuperPlaneIntegration to manage objects in tenancy
+Allow group SuperPlaneIntegration to manage objectstorage-namespaces in tenancy   
+Allow group SuperPlaneIntegration to manage fn-app in tenancy
+Allow group SuperPlaneIntegration to manage fn-function in tenancy
+Allow group SuperPlaneIntegration to manage fn-invocation in tenancy
+Allow group SuperPlaneIntegration to manage ons-topics in tenancy
+Allow group SuperPlaneIntegration to manage ons-subscriptions in tenancy
+Allow group SuperPlaneIntegration to inspect compartments in tenancy
+Allow group SuperPlaneIntegration to inspect all-resources in tenancy
+Allow group SuperPlaneIntegration to manage cloudevents-rules in tenancy
+Allow group SuperPlaneIntegration to manage autonomous-database-family in tenancy
+Allow service cloudEvents to use ons-topics in tenancy
 ```
  
-### Part 3 — Generate API Keys for the Service User and Connect to Superplane
+### Part 3 — Generate API Keys for the Service User and Connect to SuperPlane
 
-1. While still on the service user's page, go to **API keys → Add API key**.
-2. Choose **Generate API Key Pair**, download the private key, and click **Add**.
-3. Copy the **Configuration File Preview** values that appear to the UI:
+1. Go to **Menu** → **Identity & Security → Domains → Default → User Management → Users**.
+2. Choose the service user you created, then go to **API Keys → Add API Key**.
+3. Select **Generate API key pair**, download the private key file and then click **Add**.
+4. Copy the **Configuration File Preview** values that appear to the UI:
     - **User OCID** (begins with `ocid1.user.`)
     - **Fingerprint** (e.g. `12:34:56:…`)
     - **Tenancy OCID** (begins with `ocid1.tenancy.`)
-4. Select the **Region** that matches your OCI tenancy's home region.
-5. Open the downloaded private key file and paste its full contents into the **Private Key** field.
-6. Click **Connect** to validate the credentials and save the integration.
+5. Select the **Region** that matches your OCI tenancy's home region.
+6. Open the downloaded private key file and paste its full contents into the **Private Key** field.
+7. Click **Connect** to validate the credentials and save the integration.
 
 <a id="on-compute-instance-created"></a>
 

--- a/pkg/integrations/oci/oci.go
+++ b/pkg/integrations/oci/oci.go
@@ -26,10 +26,11 @@ type Configuration struct {
 
 // IntegrationMetadata holds resources created during integration setup.
 type IntegrationMetadata struct {
-	TopicID string `json:"topicId" mapstructure:"topicId"`
-	// CompartmentRules maps compartment OCID → Events rule OCID.
-	// One shared rule is created per compartment, reused across all triggers.
-	CompartmentRules map[string]string `json:"compartmentRules" mapstructure:"compartmentRules"`
+	TopicID      string `json:"topicId" mapstructure:"topicId"`
+	EventsRuleID string `json:"eventsRuleId" mapstructure:"eventsRuleId"`
+	// Deprecated: CompartmentRules was used in older versions to track per-compartment rules.
+	// It is kept only for cleanup of legacy resources.
+	CompartmentRules map[string]string `json:"compartmentRules,omitempty" mapstructure:"compartmentRules"`
 }
 
 func (o *OCI) Name() string {
@@ -56,45 +57,54 @@ SuperPlane authenticates to OCI using API Key authentication tied to a dedicated
 ### Part 1 — Create a Dedicated Group and Service User
 
 1. Open the [OCI Console](https://cloud.oracle.com/) and sign in.
-2. Go to **Identity & Security → Domains → Default → Groups**.
+2. Go to **Menu** → **Identity & Security → Domains → Default → User Management → Groups**.
 3. Click **Create Group**.
 4. Set the name to ` + "`SuperPlaneIntegration`" + ` and add a description, then click **Create**.
-5. In the same Domain, go to **Users → Create User**.
+5. In the same **User Management** tab, go to **Users → Create User**.
 6. Fill in the details:
-   - **Username:** ` + "`superplane-integration`" + `
-   - **Email:** use integrations@superplane.com or any valid email (not used for authentication)
-   - **Description:** SuperPlane integration user
-7. In the **Groups** section, assign them to the ` + "`SuperPlaneIntegration`" + ` group
+   - **Lastname:** ` + "`superplane-integration`" + `
+   - **Email:** use any valid email (not used for authentication)
+7. In the **Groups** section, assign the user to the ` + "`SuperPlaneIntegration`" + ` group
 8. Click **Create**.
 
 ### Part 2 — Create an IAM Policy
 
 1. Go to **Identity & Security → Policies**.
 2. Make sure you are in the **root compartment** (check the Compartment selector on the left).
-3. Click **Create Policy**, name it ` + "`SuperPlanePolicies`" + `, and enable the **manual editor**.
-4. Paste in the following statements, replacing ` + "`<your-compartment>`" + ` with your target compartment name and Click **Create**.:
+3. Click **Create Policy**, name it ` + "`SuperPlanePolicies`" + `, add a description and enable the **manual editor**.
+4. Paste in the following statements, replacing ` + "`<your-compartment>`" + ` with your target compartment name, and then Click **Create**.:
 ` + "```" + `
-Allow group SuperPlaneIntegration to manage instances
-  in compartment <your-compartment>
-
-Allow group SuperPlaneIntegration to manage compute-images
-  in compartment <your-compartment>
-
-Allow group SuperPlaneIntegration to use virtual-network-family
-  in compartment <your-compartment>
+Allow group SuperPlaneIntegration to manage instances in tenancy
+Allow group SuperPlaneIntegration to manage volumes in tenancy
+Allow group SuperPlaneIntegration to manage volume-attachments in tenancy
+Allow group SuperPlaneIntegration to manage virtual-network-family in tenancy
+Allow group SuperPlaneIntegration to manage buckets in tenancy
+Allow group SuperPlaneIntegration to manage objects in tenancy
+Allow group SuperPlaneIntegration to manage objectstorage-namespaces in tenancy   
+Allow group SuperPlaneIntegration to manage fn-app in tenancy
+Allow group SuperPlaneIntegration to manage fn-function in tenancy
+Allow group SuperPlaneIntegration to manage fn-invocation in tenancy
+Allow group SuperPlaneIntegration to manage ons-topics in tenancy
+Allow group SuperPlaneIntegration to manage ons-subscriptions in tenancy
+Allow group SuperPlaneIntegration to inspect compartments in tenancy
+Allow group SuperPlaneIntegration to inspect all-resources in tenancy
+Allow group SuperPlaneIntegration to manage cloudevents-rules in tenancy
+Allow group SuperPlaneIntegration to manage autonomous-database-family in tenancy
+Allow service cloudEvents to use ons-topics in tenancy
 ` + "```" + `
  
-### Part 3 — Generate API Keys for the Service User and Connect to Superplane
+### Part 3 — Generate API Keys for the Service User and Connect to SuperPlane
 
-1. While still on the service user's page, go to **API keys → Add API key**.
-2. Choose **Generate API Key Pair**, download the private key, and click **Add**.
-3. Copy the **Configuration File Preview** values that appear to the UI:
+1. Go to **Menu** → **Identity & Security → Domains → Default → User Management → Users**.
+2. Choose the service user you created, then go to **API Keys → Add API Key**.
+3. Select **Generate API key pair**, download the private key file and then click **Add**.
+4. Copy the **Configuration File Preview** values that appear to the UI:
     - **User OCID** (begins with ` + "`ocid1.user.`" + `)
     - **Fingerprint** (e.g. ` + "`12:34:56:…`" + `)
     - **Tenancy OCID** (begins with ` + "`ocid1.tenancy.`" + `)
-4. Select the **Region** that matches your OCI tenancy's home region.
-5. Open the downloaded private key file and paste its full contents into the **Private Key** field.
-6. Click **Connect** to validate the credentials and save the integration.`
+5. Select the **Region** that matches your OCI tenancy's home region.
+6. Open the downloaded private key file and paste its full contents into the **Private Key** field.
+7. Click **Connect** to validate the credentials and save the integration.`
 }
 
 func (o *OCI) Configuration() []configuration.Field {
@@ -196,6 +206,21 @@ func (o *OCI) Sync(ctx core.SyncContext) error {
 		ctx.Integration.SetMetadata(metadata)
 	}
 
+	// Create a single shared Events rule in the tenancy compartment, co-located with the topic.
+	// The rule captures all compute launch events tenancy-wide; per-compartment filtering is
+	// done server-side in the webhook handler. Creating the rule here (in the tenancy compartment)
+	// avoids cross-compartment IAM issues that arise when the rule and topic are in different compartments.
+	if metadata.EventsRuleID == "" {
+		ruleName := fmt.Sprintf("superplane-%s", ctx.Integration.ID())
+		condition := `{"eventType": ["com.oraclecloud.computeapi.launchinstance.end"]}`
+		rule, err := client.CreateEventsRule(cfg.TenancyOCID, ruleName, condition, metadata.TopicID)
+		if err != nil {
+			return fmt.Errorf("failed to create Events rule: %w", err)
+		}
+		metadata.EventsRuleID = rule.ID
+		ctx.Integration.SetMetadata(metadata)
+	}
+
 	ctx.Integration.Ready()
 	return nil
 }
@@ -207,7 +232,7 @@ func (o *OCI) Cleanup(ctx core.IntegrationCleanupContext) error {
 		return nil
 	}
 
-	if metadata.TopicID == "" && len(metadata.CompartmentRules) == 0 {
+	if metadata.TopicID == "" && metadata.EventsRuleID == "" && len(metadata.CompartmentRules) == 0 {
 		return nil
 	}
 
@@ -216,9 +241,17 @@ func (o *OCI) Cleanup(ctx core.IntegrationCleanupContext) error {
 		return fmt.Errorf("failed to create OCI client during cleanup: %w", err)
 	}
 
+	// Delete the single shared Events rule (current style).
+	if metadata.EventsRuleID != "" {
+		if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
+			ctx.Logger.Warnf("failed to delete Events rule %q during cleanup: %v", metadata.EventsRuleID, err)
+		}
+	}
+
+	// Delete any legacy per-compartment rules created by older versions.
 	for compartmentID, ruleID := range metadata.CompartmentRules {
 		if err := client.DeleteEventsRule(ruleID); err != nil {
-			ctx.Logger.Warnf("failed to delete Events rule %q (compartment %q) during cleanup: %v", ruleID, compartmentID, err)
+			ctx.Logger.Warnf("failed to delete legacy Events rule %q (compartment %q) during cleanup: %v", ruleID, compartmentID, err)
 		}
 	}
 

--- a/pkg/integrations/oci/oci.go
+++ b/pkg/integrations/oci/oci.go
@@ -255,8 +255,10 @@ func (o *OCI) Cleanup(ctx core.IntegrationCleanupContext) error {
 		}
 	}
 
-	if err := client.DeleteONSTopic(metadata.TopicID); err != nil {
-		ctx.Logger.Warnf("failed to delete ONS topic %q during cleanup: %v", metadata.TopicID, err)
+	if metadata.TopicID != "" {
+		if err := client.DeleteONSTopic(metadata.TopicID); err != nil {
+			ctx.Logger.Warnf("failed to delete ONS topic %q during cleanup: %v", metadata.TopicID, err)
+		}
 	}
 
 	return nil

--- a/pkg/integrations/oci/oci.go
+++ b/pkg/integrations/oci/oci.go
@@ -27,6 +27,9 @@ type Configuration struct {
 // IntegrationMetadata holds resources created during integration setup.
 type IntegrationMetadata struct {
 	TopicID string `json:"topicId" mapstructure:"topicId"`
+	// CompartmentRules maps compartment OCID → Events rule OCID.
+	// One shared rule is created per compartment, reused across all triggers.
+	CompartmentRules map[string]string `json:"compartmentRules" mapstructure:"compartmentRules"`
 }
 
 func (o *OCI) Name() string {
@@ -48,20 +51,50 @@ func (o *OCI) Description() string {
 func (o *OCI) Instructions() string {
 	return `## Connect Oracle Cloud Infrastructure
 
-SuperPlane authenticates to OCI using API Key authentication.
+SuperPlane authenticates to OCI using API Key authentication tied to a dedicated service user with least-privilege permissions.
 
-### Steps
+### Part 1 — Create a Dedicated Group and Service User
 
 1. Open the [OCI Console](https://cloud.oracle.com/) and sign in.
-2. Go to **Profile → User settings → My profile → Tokens and keys → API keys → Add API key**.
-3. Choose **Generate API Key Pair**, download the private key, and click **Add**.
-4. After the key is added, copy the **Configuration File Preview** values:
-   - **User OCID** (begins with ` + "`ocid1.user.`" + `)
-   - **Fingerprint** (e.g. ` + "`12:34:56:…`" + `)
-   - **Tenancy OCID** (begins with ` + "`ocid1.tenancy.`" + `)
-5. Select the **Region** that matches your OCI tenancy's home region.
-6. Open the downloaded private key file and paste its full contents into the **Private Key** field below.
-7. Click **Connect** to validate the credentials and save the integration.`
+2. Go to **Identity & Security → Domains → Default → Groups**.
+3. Click **Create Group**.
+4. Set the name to ` + "`SuperPlaneIntegration`" + ` and add a description, then click **Create**.
+5. In the same Domain, go to **Users → Create User**.
+6. Fill in the details:
+   - **Username:** ` + "`superplane-integration`" + `
+   - **Email:** use integrations@superplane.com or any valid email (not used for authentication)
+   - **Description:** SuperPlane integration user
+7. In the **Groups** section, assign them to the ` + "`SuperPlaneIntegration`" + ` group
+8. Click **Create**.
+
+### Part 2 — Create an IAM Policy
+
+1. Go to **Identity & Security → Policies**.
+2. Make sure you are in the **root compartment** (check the Compartment selector on the left).
+3. Click **Create Policy**, name it ` + "`SuperPlanePolicies`" + `, and enable the **manual editor**.
+4. Paste in the following statements, replacing ` + "`<your-compartment>`" + ` with your target compartment name and Click **Create**.:
+` + "```" + `
+Allow group SuperPlaneIntegration to manage instances
+  in compartment <your-compartment>
+
+Allow group SuperPlaneIntegration to manage compute-images
+  in compartment <your-compartment>
+
+Allow group SuperPlaneIntegration to use virtual-network-family
+  in compartment <your-compartment>
+` + "```" + `
+ 
+### Part 3 — Generate API Keys for the Service User and Connect to Superplane
+
+1. While still on the service user's page, go to **API keys → Add API key**.
+2. Choose **Generate API Key Pair**, download the private key, and click **Add**.
+3. Copy the **Configuration File Preview** values that appear to the UI:
+    - **User OCID** (begins with ` + "`ocid1.user.`" + `)
+    - **Fingerprint** (e.g. ` + "`12:34:56:…`" + `)
+    - **Tenancy OCID** (begins with ` + "`ocid1.tenancy.`" + `)
+4. Select the **Region** that matches your OCI tenancy's home region.
+5. Open the downloaded private key file and paste its full contents into the **Private Key** field.
+6. Click **Connect** to validate the credentials and save the integration.`
 }
 
 func (o *OCI) Configuration() []configuration.Field {
@@ -174,13 +207,19 @@ func (o *OCI) Cleanup(ctx core.IntegrationCleanupContext) error {
 		return nil
 	}
 
-	if metadata.TopicID == "" {
+	if metadata.TopicID == "" && len(metadata.CompartmentRules) == 0 {
 		return nil
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("failed to create OCI client during cleanup: %w", err)
+	}
+
+	for compartmentID, ruleID := range metadata.CompartmentRules {
+		if err := client.DeleteEventsRule(ruleID); err != nil {
+			ctx.Logger.Warnf("failed to delete Events rule %q (compartment %q) during cleanup: %v", ruleID, compartmentID, err)
+		}
 	}
 
 	if err := client.DeleteONSTopic(metadata.TopicID); err != nil {

--- a/pkg/integrations/oci/on_compute_instance_created.go
+++ b/pkg/integrations/oci/on_compute_instance_created.go
@@ -27,7 +27,6 @@ type OnComputeInstanceCreatedConfiguration struct {
 
 type OnComputeInstanceCreatedMetadata struct {
 	CompartmentID string `json:"compartmentId" mapstructure:"compartmentId"`
-	EventsRuleID  string `json:"eventsRuleId" mapstructure:"eventsRuleId"`
 }
 
 func (t *OnComputeInstanceCreated) Name() string {
@@ -95,16 +94,9 @@ func (t *OnComputeInstanceCreated) ExampleData() map[string]any {
 }
 
 func (t *OnComputeInstanceCreated) Setup(ctx core.TriggerContext) error {
-	config, integrationMetadata, metadata, err := decodeSetupInputs(ctx)
+	config, integrationMetadata, err := decodeSetupInputs(ctx)
 	if err != nil {
 		return err
-	}
-
-	// If the Events rule already exists for this compartment, skip re-creation but
-	// still call RequestWebhook so the subscription is retried if it previously
-	// failed or was never provisioned.
-	if metadata.CompartmentID == config.CompartmentID && metadata.EventsRuleID != "" {
-		return requestWebhook(ctx, config.CompartmentID, integrationMetadata.TopicID)
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
@@ -112,18 +104,12 @@ func (t *OnComputeInstanceCreated) Setup(ctx core.TriggerContext) error {
 		return fmt.Errorf("failed to create OCI client: %w", err)
 	}
 
-	if err := cleanupOldRule(ctx, client, metadata, config.CompartmentID); err != nil {
-		return err
-	}
-
-	ruleID, err := ensureEventsRule(ctx, client, config.CompartmentID, integrationMetadata.TopicID)
-	if err != nil {
+	if err := ensureSharedEventsRule(ctx, client, config.CompartmentID, &integrationMetadata); err != nil {
 		return err
 	}
 
 	if err := ctx.Metadata.Set(OnComputeInstanceCreatedMetadata{
 		CompartmentID: config.CompartmentID,
-		EventsRuleID:  ruleID,
 	}); err != nil {
 		return fmt.Errorf("failed to persist trigger metadata: %w", err)
 	}
@@ -132,65 +118,48 @@ func (t *OnComputeInstanceCreated) Setup(ctx core.TriggerContext) error {
 }
 
 // decodeSetupInputs decodes and validates all inputs needed by Setup.
-func decodeSetupInputs(ctx core.TriggerContext) (OnComputeInstanceCreatedConfiguration, IntegrationMetadata, OnComputeInstanceCreatedMetadata, error) {
+func decodeSetupInputs(ctx core.TriggerContext) (OnComputeInstanceCreatedConfiguration, IntegrationMetadata, error) {
 	var config OnComputeInstanceCreatedConfiguration
 	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
-		return config, IntegrationMetadata{}, OnComputeInstanceCreatedMetadata{}, fmt.Errorf("failed to decode trigger configuration: %w", err)
+		return config, IntegrationMetadata{}, fmt.Errorf("failed to decode trigger configuration: %w", err)
 	}
 	if config.CompartmentID == "" {
-		return config, IntegrationMetadata{}, OnComputeInstanceCreatedMetadata{}, fmt.Errorf("compartmentId is required")
+		return config, IntegrationMetadata{}, fmt.Errorf("compartmentId is required")
 	}
 
 	var integrationMetadata IntegrationMetadata
 	if err := mapstructure.Decode(ctx.Integration.GetMetadata(), &integrationMetadata); err != nil {
-		return config, IntegrationMetadata{}, OnComputeInstanceCreatedMetadata{}, fmt.Errorf("failed to decode integration metadata: %w", err)
+		return config, IntegrationMetadata{}, fmt.Errorf("failed to decode integration metadata: %w", err)
 	}
 	if integrationMetadata.TopicID == "" {
-		return config, IntegrationMetadata{}, OnComputeInstanceCreatedMetadata{}, fmt.Errorf("integration topic not ready yet; ensure the OCI integration has been fully set up")
+		return config, IntegrationMetadata{}, fmt.Errorf("integration topic not ready yet; ensure the OCI integration has been fully set up")
 	}
 
-	var metadata OnComputeInstanceCreatedMetadata
-	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
-		return config, IntegrationMetadata{}, OnComputeInstanceCreatedMetadata{}, fmt.Errorf("failed to decode trigger metadata: %w", err)
-	}
-
-	return config, integrationMetadata, metadata, nil
+	return config, integrationMetadata, nil
 }
 
-// cleanupOldRule deletes the previous Events rule when the compartment changes.
-func cleanupOldRule(ctx core.TriggerContext, client *Client, metadata OnComputeInstanceCreatedMetadata, newCompartmentID string) error {
-	if metadata.EventsRuleID == "" || metadata.CompartmentID == newCompartmentID {
+// ensureSharedEventsRule ensures one OCI Events rule exists for the given compartment,
+// shared across all triggers that use the same integration+compartment pair.
+// The rule OCID is stored in integration metadata (keyed by compartmentID) so that
+// subsequent trigger setups are idempotent and do not create duplicate rules.
+func ensureSharedEventsRule(ctx core.TriggerContext, client *Client, compartmentID string, integrationMetadata *IntegrationMetadata) error {
+	if _, exists := integrationMetadata.CompartmentRules[compartmentID]; exists {
 		return nil
 	}
-	if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
-		ctx.Logger.Warnf("failed to delete old Events rule %q: %v", metadata.EventsRuleID, err)
-	}
-	return nil
-}
 
-// ensureEventsRule creates the OCI Events rule that routes compute-launch events
-// to the shared ONS topic and returns its ID.
-func ensureEventsRule(ctx core.TriggerContext, client *Client, compartmentID, topicID string) (string, error) {
-	webhookURL, err := ctx.Webhook.Setup()
-	if err != nil {
-		return "", fmt.Errorf("failed to set up webhook URL: %w", err)
-	}
-
-	parsedURL, err := url.Parse(webhookURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse webhook URL: %w", err)
-	}
-	segments := strings.Split(strings.TrimRight(parsedURL.Path, "/"), "/")
-	webhookID := segments[len(segments)-1]
-	ruleName := fmt.Sprintf("superplane-compute-instance-created-%s", webhookID)
-
+	ruleName := fmt.Sprintf("superplane-%s", ctx.Integration.ID())
 	condition := `{"eventType": ["com.oraclecloud.computeapi.launchinstance.end"]}`
-	rule, err := client.CreateEventsRule(compartmentID, ruleName, condition, topicID)
+	rule, err := client.CreateEventsRule(compartmentID, ruleName, condition, integrationMetadata.TopicID)
 	if err != nil {
-		return "", fmt.Errorf("failed to create Events rule: %w", err)
+		return fmt.Errorf("failed to create shared Events rule: %w", err)
 	}
 
-	return rule.ID, nil
+	if integrationMetadata.CompartmentRules == nil {
+		integrationMetadata.CompartmentRules = make(map[string]string)
+	}
+	integrationMetadata.CompartmentRules[compartmentID] = rule.ID
+	ctx.Integration.SetMetadata(*integrationMetadata)
+	return nil
 }
 
 // requestWebhook asks the integration to provision a per-trigger HTTPS
@@ -211,25 +180,8 @@ func (t *OnComputeInstanceCreated) HandleHook(ctx core.TriggerHookContext) (map[
 }
 
 func (t *OnComputeInstanceCreated) Cleanup(ctx core.TriggerContext) error {
-	var metadata OnComputeInstanceCreatedMetadata
-	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
-		ctx.Logger.Warnf("failed to decode trigger metadata during cleanup: %v", err)
-		return nil
-	}
-
-	if metadata.EventsRuleID == "" {
-		return nil
-	}
-
-	client, err := NewClient(ctx.HTTP, ctx.Integration)
-	if err != nil {
-		return fmt.Errorf("failed to create OCI client during cleanup: %w", err)
-	}
-
-	if err := client.DeleteEventsRule(metadata.EventsRuleID); err != nil {
-		ctx.Logger.Warnf("failed to delete Events rule %q during cleanup: %v", metadata.EventsRuleID, err)
-	}
-
+	// Events rules are shared across triggers for the same integration+compartment.
+	// They are cleaned up when the integration itself is deleted (see OCI.Cleanup).
 	return nil
 }
 

--- a/pkg/integrations/oci/on_compute_instance_created.go
+++ b/pkg/integrations/oci/on_compute_instance_created.go
@@ -99,15 +99,6 @@ func (t *OnComputeInstanceCreated) Setup(ctx core.TriggerContext) error {
 		return err
 	}
 
-	client, err := NewClient(ctx.HTTP, ctx.Integration)
-	if err != nil {
-		return fmt.Errorf("failed to create OCI client: %w", err)
-	}
-
-	if err := ensureSharedEventsRule(ctx, client, config.CompartmentID, &integrationMetadata); err != nil {
-		return err
-	}
-
 	if err := ctx.Metadata.Set(OnComputeInstanceCreatedMetadata{
 		CompartmentID: config.CompartmentID,
 	}); err != nil {
@@ -136,30 +127,6 @@ func decodeSetupInputs(ctx core.TriggerContext) (OnComputeInstanceCreatedConfigu
 	}
 
 	return config, integrationMetadata, nil
-}
-
-// ensureSharedEventsRule ensures one OCI Events rule exists for the given compartment,
-// shared across all triggers that use the same integration+compartment pair.
-// The rule OCID is stored in integration metadata (keyed by compartmentID) so that
-// subsequent trigger setups are idempotent and do not create duplicate rules.
-func ensureSharedEventsRule(ctx core.TriggerContext, client *Client, compartmentID string, integrationMetadata *IntegrationMetadata) error {
-	if _, exists := integrationMetadata.CompartmentRules[compartmentID]; exists {
-		return nil
-	}
-
-	ruleName := fmt.Sprintf("superplane-%s", ctx.Integration.ID())
-	condition := `{"eventType": ["com.oraclecloud.computeapi.launchinstance.end"]}`
-	rule, err := client.CreateEventsRule(compartmentID, ruleName, condition, integrationMetadata.TopicID)
-	if err != nil {
-		return fmt.Errorf("failed to create shared Events rule: %w", err)
-	}
-
-	if integrationMetadata.CompartmentRules == nil {
-		integrationMetadata.CompartmentRules = make(map[string]string)
-	}
-	integrationMetadata.CompartmentRules[compartmentID] = rule.ID
-	ctx.Integration.SetMetadata(*integrationMetadata)
-	return nil
 }
 
 // requestWebhook asks the integration to provision a per-trigger HTTPS


### PR DESCRIPTION
Implements: #4428, #4429

## What changed:

The OCI integration's Events rule lifecycle has been redesigned from one rule per trigger to one shared rule per integration+compartment. 
The integration setup instructions have also been updated to prompt the user to create a custom user with specified permissions for use in authentication.

## Why:

The previous design created a new OCI Events rule every time a trigger was added to a workflow. This caused OCI's per-compartment rule limit to be hit quickly, left orphaned rules behind when triggers were deleted, and duplicated identical rules that all forwarded the same event type to the same ONS topic.
The previous design also had the user use their administrator user API Key credentials which granted SuperPlane administrator capabilities which does not follow best design practices,

## How:

### Backend:

- Added CompartmentRules map[string]string to IntegrationMetadata in oci.go. This map stores compartmentID → ruleID and is persisted on the integration record, making rule creation idempotent across all trigger setups for the same integration.
- Updated OCI.Cleanup to iterate CompartmentRules and delete all shared Events rules before deleting the ONS topic. The integration is now the single owner and lifecycle manager of all Events rules.
- Replaced the per-trigger ensureEventsRule + cleanupOldRule helpers in on_compute_instance_created.go with a single ensureSharedEventsRule function. It checks integrationMetadata.CompartmentRules[compartmentID] first and returns immediately if a rule already exists; otherwise it creates one and writes the ID back via ctx.Integration.SetMetadata.
- Updated integration instructions to guide user through creating Custom group, Custom user and assingig user to group. The instructions include creating custom policy for the group to provide minimum permissions required for SuperPlane components.

### Frontend:

No frontend changes. The trigger configuration UI and mapper are unaffected.

## Notes
New integration instructions:
<img width="683" height="752" alt="image" src="https://github.com/user-attachments/assets/781965cd-e47e-4eda-a236-cb79c7cd1cb4" />
<img width="683" height="752" alt="image" src="https://github.com/user-attachments/assets/ab799d6f-a19a-4026-ad89-dc8cc2dbe7f0" />
