### PR TITLE
fix(ui): agent trigger z-index obstructs menu dropdown

### DIFF
--- a/web_src/src/ui/CanvasPage/components/AgentSidebarTrigger.tsx
+++ b/web_src/src/ui/CanvasPage/components/AgentSidebarTrigger.tsx
@@ -11,7 +11,7 @@ export function AgentSidebarTrigger({ agentState }: AgentSidebarTriggerProps) {
   const { showAgentSidebarToggle, isAgentSidebarOpen, handleAgentSidebarToggle } = agentState;
 
   return (
-    <div className="relative z-10 flex shrink-0 items-center">
+    <div className="flex shrink-0 items-center">
       {showAgentSidebarToggle && !isAgentSidebarOpen ? (
         <Tooltip>
           <TooltipTrigger asChild>


### PR DESCRIPTION
Fixes #4248

The `AgentSidebarTrigger` component had a `relative z-10` class on its wrapper. This created a new CSS stacking context that competed with the `OrganizationMenuButton` wrapper (which also uses `z-10`). Since the `SecondaryHeader` (containing the agent trigger) appears later in the DOM than the `PageHeader`, its stacking context was painted on top. This caused the agent trigger to obstruct the organization menu's dropdown and capture pointer events in that area, even though the dropdown had a higher internal z-index (`z-50`).

I removed the unnecessary `z-10` and `relative` classes from the `AgentSidebarTrigger` wrapper. This eliminates the competing stacking context, allowing the organization menu's dropdown to correctly render above all content in the second header row.