### PR TITLE
fix: link URL values in canvas memory

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.spec.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+import { CanvasMemoryModal } from "./CanvasMemoryModal";
+
+const noop = () => {};
+
+function renderModal(entries: CanvasMemoryEntry[]) {
+  return render(<CanvasMemoryModal open={true} onOpenChange={noop} entries={entries} />);
+}
+
+describe("CanvasMemoryModal", () => {
+  it("renders http and https string values as links", () => {
+    renderModal([
+      {
+        id: "memory-1",
+        namespace: "links",
+        values: {
+          docs: "https://docs.superplane.com",
+          webhook: "http://localhost:8000/hooks",
+        },
+      },
+    ]);
+
+    const docsLink = screen.getByRole("link", { name: "https://docs.superplane.com" });
+    expect(docsLink).toHaveAttribute("href", "https://docs.superplane.com");
+    expect(docsLink).toHaveAttribute("target", "_blank");
+
+    const webhookLink = screen.getByRole("link", { name: "http://localhost:8000/hooks" });
+    expect(webhookLink).toHaveAttribute("href", "http://localhost:8000/hooks");
+    expect(webhookLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("keeps non-http values as text", () => {
+    renderModal([
+      {
+        id: "memory-2",
+        namespace: "links",
+        values: {
+          email: "mailto:support@example.com",
+          label: "release notes",
+        },
+      },
+    ]);
+
+    expect(screen.queryByRole("link", { name: "mailto:support@example.com" })).not.toBeInTheDocument();
+    expect(screen.getByText("mailto:support@example.com")).toBeInTheDocument();
+    expect(screen.getByText("release notes")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
 import { Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
 
 export type CanvasMemoryModalProps = {
   open: boolean;
@@ -120,6 +121,34 @@ function formatValue(value: unknown): string {
   }
 }
 
+function getHttpUrl(value: string): string | undefined {
+  if (value.trim() !== value) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function renderValue(value: unknown): ReactNode {
+  const formattedValue = formatValue(value);
+  const url = typeof value === "string" ? getHttpUrl(formattedValue) : undefined;
+
+  if (!url) {
+    return formattedValue;
+  }
+
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline hover:text-blue-800">
+      {formattedValue}
+    </a>
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -164,7 +193,7 @@ function renderNamespaceTable(
                 <tr key={entry.id || index} className="border-b border-slate-950/15">
                   {columns.map((column) => (
                     <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
-                      {formatValue(item[column])}
+                      {renderValue(item[column])}
                     </td>
                   ))}
                   <td className="px-3 py-2 text-right align-middle">
@@ -203,7 +232,7 @@ function renderNamespaceTable(
         <tbody>
           {values.map((entry, index) => (
             <tr key={entry.id || index} className="border-b border-slate-950/15">
-              <td className="px-3 py-2 align-middle font-mono text-xs text-gray-700">{formatValue(entry.values)}</td>
+              <td className="px-3 py-2 align-middle font-mono text-xs text-gray-700">{renderValue(entry.values)}</td>
               <td className="px-3 py-2 text-right align-middle">
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary
- render Canvas Memory string values that are valid http/https URLs as external links
- keep non-http values as plain text
- add CanvasMemoryModal tests for link rendering and non-link values

## Validation
- npm run test:run -- CanvasMemoryModal
- npx prettier --check src/pages/workflowv2/CanvasMemoryModal.tsx src/pages/workflowv2/CanvasMemoryModal.spec.tsx
- npx eslint src/pages/workflowv2/CanvasMemoryModal.tsx src/pages/workflowv2/CanvasMemoryModal.spec.tsx

## Notes
- npm run build is blocked in a fresh checkout because generated web_src/src/api-client artifacts are not present.
- npm run lint:budget currently reports existing repository budget failures outside this change.

Fixes #4361
