### PR TITLE
feat: catch syntax canvas expression errors at save time

### DIFF
--- a/.go-coverage-baseline.json
+++ b/.go-coverage-baseline.json
@@ -20,7 +20,7 @@
     "pkg/cli/core": 46.1,
     "pkg/config": 0,
     "pkg/configuration": 26.2,
-    "pkg/configuration/expressionvalidation": 70,
+    "pkg/configuration/expressionvalidation": 71.5,
     "pkg/crypto": 53.7,
     "pkg/database": 0,
     "pkg/exprruntime": 36.4,
@@ -29,7 +29,7 @@
     "pkg/grpc/actions/agents": 44,
     "pkg/grpc/actions/auth": 80.8,
     "pkg/grpc/actions/blueprints": 0,
-    "pkg/grpc/actions/canvases": 58,
+    "pkg/grpc/actions/canvases": 61.5,
     "pkg/grpc/actions/canvases/changesets": 84.4,
     "pkg/grpc/actions/canvases/layout": 63.4,
     "pkg/grpc/actions/integrations": 0,
@@ -62,7 +62,7 @@
     "pkg/web": 82.1,
     "pkg/widgets/annotation": 0,
     "pkg/workers": 39.5,
-    "pkg/workers/contexts": 42.5,
+    "pkg/workers/contexts": 41.5,
     "pkg/workers/eventdistributer": 0
   },
   "ignoredPackagePrefixes": [

--- a/.go-coverage-baseline.json
+++ b/.go-coverage-baseline.json
@@ -20,6 +20,7 @@
     "pkg/cli/core": 46.1,
     "pkg/config": 0,
     "pkg/configuration": 26.2,
+    "pkg/configuration/expressionvalidation": 70,
     "pkg/crypto": 53.7,
     "pkg/database": 0,
     "pkg/exprruntime": 36.4,
@@ -28,7 +29,7 @@
     "pkg/grpc/actions/agents": 44,
     "pkg/grpc/actions/auth": 80.8,
     "pkg/grpc/actions/blueprints": 0,
-    "pkg/grpc/actions/canvases": 59.7,
+    "pkg/grpc/actions/canvases": 58,
     "pkg/grpc/actions/canvases/changesets": 84.4,
     "pkg/grpc/actions/canvases/layout": 63.4,
     "pkg/grpc/actions/integrations": 0,
@@ -72,5 +73,5 @@
     "pkg/triggers",
     "pkg/web/assets"
   ],
-  "updatedAt": "2026-04-26T12:05:18Z"
+  "updatedAt": "2026-04-28T00:00:00Z"
 }

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -935,12 +935,12 @@ The Wait component pauses workflow execution for a specified duration or until a
 
 - **Interval**: Wait for a fixed duration (seconds, minutes, or hours)
   - Supports expressions for dynamic wait times
-  - Example: `{{$.retry_delay}}` or `{{$.status == "urgent" ? 0 : 30}}`
+  - Example: `{{$['Node Name'].data.retry_delay}}` or `{{$['Node Name'].data.status == "urgent" ? 0 : 30}}`
   
 - **Countdown**: Wait until a specific date/time is reached
   - Supports ISO 8601 date formats
   - Supports expressions for dynamic target times
-  - Example: `{{$.release_date}}` or `{{$.run_time + duration("48h")}}`
+  - Example: `{{$['Node Name'].data.release_date}}` or `{{$['Node Name'].data.run_time + duration("48h")}}`
 
 ### Behavior
 

--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -213,7 +213,7 @@ func (m *Merge) Configuration() []configuration.Field {
 			Label:       "Stop if",
 			Type:        configuration.FieldTypeExpression,
 			Description: "When true, stop waiting and finish immediately.",
-			Placeholder: "e.g. $.result == 'fail'",
+			Placeholder: "e.g. $['Node Name'].data.result == 'fail'",
 			Required:    false,
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{

--- a/pkg/components/wait/wait.go
+++ b/pkg/components/wait/wait.go
@@ -66,12 +66,12 @@ func (w *Wait) Documentation() string {
 
 - **Interval**: Wait for a fixed duration (seconds, minutes, or hours)
   - Supports expressions for dynamic wait times
-  - Example: ` + "`{{$.retry_delay}}`" + ` or ` + "`{{$.status == \"urgent\" ? 0 : 30}}`" + `
+  - Example: ` + "`{{$['Node Name'].data.retry_delay}}`" + ` or ` + "`{{$['Node Name'].data.status == \"urgent\" ? 0 : 30}}`" + `
   
 - **Countdown**: Wait until a specific date/time is reached
   - Supports ISO 8601 date formats
   - Supports expressions for dynamic target times
-  - Example: ` + "`{{$.release_date}}`" + ` or ` + "`{{$.run_time + duration(\"48h\")}}`" + `
+  - Example: ` + "`{{$['Node Name'].data.release_date}}`" + ` or ` + "`{{$['Node Name'].data.run_time + duration(\"48h\")}}`" + `
 
 ## Behavior
 
@@ -128,7 +128,7 @@ func (w *Wait) Configuration() []configuration.Field {
 			Name:        "waitFor",
 			Label:       "Wait for...",
 			Type:        configuration.FieldTypeString,
-			Description: "Component will wait for a fixed amount of time before emitting the event forward.\n\nSupports expressions and expects integer.\n\nExample expressions:\n{{$.wait_time}}\n{{$.wait_time + 5}}\n{{$.status == \"urgent\" ? 0 : 30}}",
+			Description: "Component will wait for a fixed amount of time before emitting the event forward.\n\nSupports expressions and expects integer.\n\nExample expressions:\n{{$['Node Name'].data.wait_time}}\n{{$['Node Name'].data.wait_time + 5}}\n{{$['Node Name'].data.status == \"urgent\" ? 0 : 30}}",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "mode", Values: []string{ModeInterval}},
 			},
@@ -172,7 +172,7 @@ func (w *Wait) Configuration() []configuration.Field {
 			Name:        "waitUntil",
 			Label:       "Wait until",
 			Type:        configuration.FieldTypeString,
-			Description: "Component will countdown until the provided date/time before emitting an event forward.\n\nSupports expressions and expects date in [ISO 8601](https://www.timestamp-converter.com/) format.\n\nExample expressions:\n{{$.run_time}}\n{{$.run_time.In(timezone(\"UTC\"))}}\n{{$.run_time + duration(\"48h\")}}",
+			Description: "Component will countdown until the provided date/time before emitting an event forward.\n\nSupports expressions and expects date in [ISO 8601](https://www.timestamp-converter.com/) format.\n\nExample expressions:\n{{$['Node Name'].data.run_time}}\n{{$['Node Name'].data.run_time.In(timezone(\"UTC\"))}}\n{{$['Node Name'].data.run_time + duration(\"48h\")}}",
 			VisibilityConditions: []configuration.VisibilityCondition{
 				{Field: "mode", Values: []string{ModeCountdown}},
 			},

--- a/pkg/configuration/expressionvalidation/canvas.go
+++ b/pkg/configuration/expressionvalidation/canvas.go
@@ -1,0 +1,109 @@
+package expressionvalidation
+
+import (
+	"fmt"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+// ExpressionError describes a single static validation failure for one
+// expression inside a node's configuration.
+type ExpressionError struct {
+	NodeID     string
+	NodeName   string
+	FieldPath  string
+	Expression string
+	Err        error
+}
+
+func (e *ExpressionError) Error() string {
+	return fmt.Sprintf("field %q: expression %q: %s", e.FieldPath, e.Expression, e.Err.Error())
+}
+
+// ValidateCanvasExpressions runs static expression validation across every
+// node's configuration. Errors are returned per node ID; an empty result means
+// nothing failed.
+func ValidateCanvasExpressions(reg *registry.Registry, nodes []*componentpb.Node) map[string][]ExpressionError {
+	results := map[string][]ExpressionError{}
+	if len(nodes) == 0 {
+		return results
+	}
+
+	knownNodeNames := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		if n == nil || n.Name == "" {
+			continue
+		}
+		knownNodeNames[n.Name] = struct{}{}
+	}
+
+	for _, node := range nodes {
+		if node == nil || node.Configuration == nil {
+			continue
+		}
+
+		fields := schemaForNode(reg, node)
+		errs := validateNodeExpressions(node.Id, node.Name, node.Configuration.AsMap(), fields, knownNodeNames)
+		if len(errs) > 0 {
+			results[node.Id] = errs
+		}
+	}
+
+	return results
+}
+
+func schemaForNode(reg *registry.Registry, node *componentpb.Node) []configuration.Field {
+	if reg == nil || node.Component == "" {
+		return nil
+	}
+	configurable, err := reg.FindConfigurableComponent(node.Component)
+	if err != nil {
+		return nil
+	}
+	return configurable.Configuration()
+}
+
+func validateNodeExpressions(nodeID, nodeName string, config map[string]any, fields []configuration.Field, knownNodeNames map[string]struct{}) []ExpressionError {
+	var errs []ExpressionError
+	walkConfiguration(config, fields, func(fieldPath, fieldType, value string) {
+		for _, e := range validateString(fieldPath, fieldType, value, knownNodeNames) {
+			e.NodeID = nodeID
+			e.NodeName = nodeName
+			errs = append(errs, e)
+		}
+	})
+	return errs
+}
+
+func validateString(fieldPath, fieldType, value string, knownNodeNames map[string]struct{}) []ExpressionError {
+	matches := configuration.ExpressionPlaceholderRegex.FindAllString(value, -1)
+
+	// FieldTypeExpression values without {{ }} framing flow through
+	// NodeConfigurationBuilder.Build() as literal strings — bare identifiers
+	// like "default" or "ok" never reach expr.Compile at runtime — so we skip
+	// the strict identifier check here. Syntax errors and unknown node
+	// references are still caught.
+	if len(matches) == 0 {
+		if fieldType == configuration.FieldTypeExpression {
+			if err := ValidateBareExpression(value, knownNodeNames); err != nil {
+				return []ExpressionError{{FieldPath: fieldPath, Expression: value, Err: err}}
+			}
+		}
+		return nil
+	}
+
+	var errs []ExpressionError
+	for _, match := range matches {
+		body := match[2 : len(match)-2]
+		if err := ValidateExpression(body, knownNodeNames); err != nil {
+			errs = append(errs, ExpressionError{
+				FieldPath:  fieldPath,
+				Expression: match,
+				Err:        err,
+			})
+		}
+	}
+	return errs
+}

--- a/pkg/configuration/expressionvalidation/canvas_test.go
+++ b/pkg/configuration/expressionvalidation/canvas_test.go
@@ -1,0 +1,246 @@
+package expressionvalidation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+func knownSet(names ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
+func assertOneError(t *testing.T, errs []ExpressionError, wantPath, wantMsg string) {
+	t.Helper()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %+v", len(errs), errs)
+	}
+	if errs[0].FieldPath != wantPath {
+		t.Fatalf("expected FieldPath %q, got %q", wantPath, errs[0].FieldPath)
+	}
+	if !strings.Contains(errs[0].Err.Error(), wantMsg) {
+		t.Fatalf("expected error containing %q, got: %v", wantMsg, errs[0].Err)
+	}
+}
+
+func TestValidateNodeExpressions_FieldTypes(t *testing.T) {
+	t.Run("string with embedded expr", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "command", Type: configuration.FieldTypeString}}
+		errs := validateNodeExpressions("n1", "Deploy", map[string]any{
+			"command": "echo {{ $['Missing'].x }}",
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "command", "unknown node reference 'Missing'")
+	})
+
+	t.Run("text with mixed text and expression", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "message", Type: configuration.FieldTypeText}}
+		errs := validateNodeExpressions("n1", "Notify", map[string]any{
+			"message": `My value: {{ "dsadasd" + invalid() }}`,
+		}, fields, knownSet())
+		assertOneError(t, errs, "message", "compile error")
+	})
+
+	t.Run("text with multiple placeholders one broken", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "message", Type: configuration.FieldTypeText}}
+		errs := validateNodeExpressions("n1", "Notify", map[string]any{
+			"message": "{{ $['Build'].x }} and {{ $['Missing'].y }}",
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "message", "unknown node reference 'Missing'")
+	})
+
+	t.Run("expression bare literals pass", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
+		for _, raw := range []string{"true", "default", "ok", "down", "1 + 2", `"plain"`, `$["Build"].x + 1`} {
+			errs := validateNodeExpressions("n1", "Mem", map[string]any{
+				"value": raw,
+			}, fields, knownSet("Build"))
+			if len(errs) != 0 {
+				t.Fatalf("expected no errors for %q, got %+v", raw, errs)
+			}
+		}
+	})
+
+	t.Run("expression bare syntax error caught", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
+		errs := validateNodeExpressions("n1", "Mem", map[string]any{
+			"value": `$["Build"].data.calendar.day asdadasd 2313312`,
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "value", "syntax error")
+	})
+
+	t.Run("expression bare unknown node ref caught", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
+		errs := validateNodeExpressions("n1", "Mem", map[string]any{
+			"value": `$["Missing"].x`,
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "value", "unknown node reference 'Missing'")
+	})
+
+	t.Run("expression placeholder content validated", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
+		errs := validateNodeExpressions("n1", "Mem", map[string]any{
+			"value": "{{ $['Missing'].x }}",
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "value", "unknown node reference 'Missing'")
+	})
+
+	t.Run("expression valid placeholder passes", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
+		errs := validateNodeExpressions("n1", "Mem", map[string]any{
+			"value": "{{ int(now().Unix()) }}",
+		}, fields, knownSet())
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %+v", errs)
+		}
+	})
+}
+
+func TestValidateNodeExpressions_NestedPaths(t *testing.T) {
+	t.Run("nested object schema", func(t *testing.T) {
+		fields := []configuration.Field{
+			{
+				Name: "body",
+				Type: configuration.FieldTypeObject,
+				TypeOptions: &configuration.TypeOptions{
+					Object: &configuration.ObjectTypeOptions{
+						Schema: []configuration.Field{
+							{
+								Name: "headers",
+								Type: configuration.FieldTypeObject,
+								TypeOptions: &configuration.TypeOptions{
+									Object: &configuration.ObjectTypeOptions{
+										Schema: []configuration.Field{
+											{Name: "auth", Type: configuration.FieldTypeString},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		errs := validateNodeExpressions("n1", "Call", map[string]any{
+			"body": map[string]any{
+				"headers": map[string]any{
+					"auth": "Bearer {{ $['Missing'].token }}",
+				},
+			},
+		}, fields, knownSet("Build"))
+		assertOneError(t, errs, "body.headers.auth", "unknown node reference 'Missing'")
+	})
+
+	t.Run("list of objects", func(t *testing.T) {
+		fields := []configuration.Field{
+			{
+				Name: "items",
+				Type: configuration.FieldTypeList,
+				TypeOptions: &configuration.TypeOptions{
+					List: &configuration.ListTypeOptions{
+						ItemDefinition: &configuration.ListItemDefinition{
+							Type: configuration.FieldTypeObject,
+							Schema: []configuration.Field{
+								{Name: "url", Type: configuration.FieldTypeString},
+							},
+						},
+					},
+				},
+			},
+		}
+		errs := validateNodeExpressions("n1", "Fetch", map[string]any{
+			"items": []any{
+				map[string]any{"url": "ok"},
+				map[string]any{"url": "ok"},
+				map[string]any{"url": "{{ root( }}"},
+			},
+		}, fields, knownSet())
+		assertOneError(t, errs, "items[2].url", "syntax error")
+	})
+
+	t.Run("list of strings", func(t *testing.T) {
+		fields := []configuration.Field{
+			{
+				Name: "items",
+				Type: configuration.FieldTypeList,
+				TypeOptions: &configuration.TypeOptions{
+					List: &configuration.ListTypeOptions{
+						ItemDefinition: &configuration.ListItemDefinition{Type: configuration.FieldTypeString},
+					},
+				},
+			},
+		}
+		errs := validateNodeExpressions("n1", "Fetch", map[string]any{
+			"items": []any{"{{ $['Missing'].x }}"},
+		}, fields, knownSet())
+		assertOneError(t, errs, "items[0]", "unknown node reference 'Missing'")
+	})
+
+	t.Run("key not in schema still walked", func(t *testing.T) {
+		fields := []configuration.Field{}
+		errs := validateNodeExpressions("n1", "Free", map[string]any{
+			"extra": map[string]any{
+				"unknown": "{{ $['Missing'].x }}",
+			},
+		}, fields, knownSet())
+		assertOneError(t, errs, "extra.unknown", "unknown node reference 'Missing'")
+	})
+}
+
+func TestValidateNodeExpressions_Aggregation(t *testing.T) {
+	t.Run("multiple errors single node deterministic order", func(t *testing.T) {
+		fields := []configuration.Field{
+			{Name: "a", Type: configuration.FieldTypeString},
+			{Name: "b", Type: configuration.FieldTypeString},
+			{Name: "c", Type: configuration.FieldTypeString},
+		}
+		errs := validateNodeExpressions("n1", "Multi", map[string]any{
+			"a": "{{ $['M1'].x }}",
+			"b": "{{ $['M2'].x }}",
+			"c": "{{ $['M3'].x }}",
+		}, fields, knownSet())
+		if len(errs) != 3 {
+			t.Fatalf("expected 3 errors, got %+v", errs)
+		}
+		paths := make(map[string]bool, 3)
+		for _, e := range errs {
+			paths[e.FieldPath] = true
+		}
+		for _, p := range []string{"a", "b", "c"} {
+			if !paths[p] {
+				t.Fatalf("missing FieldPath %q in errors: %+v", p, errs)
+			}
+		}
+	})
+}
+
+func TestValidateNodeExpressions_Edge(t *testing.T) {
+	t.Run("nil configuration emits no errors", func(t *testing.T) {
+		errs := validateNodeExpressions("n1", "Empty", nil, nil, knownSet())
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %+v", errs)
+		}
+	})
+
+	t.Run("empty placeholder rejected", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "command", Type: configuration.FieldTypeString}}
+		errs := validateNodeExpressions("n1", "Empty", map[string]any{
+			"command": "{{   }}",
+		}, fields, knownSet())
+		assertOneError(t, errs, "command", "expression body is empty")
+	})
+
+	t.Run("non-expression value not validated", func(t *testing.T) {
+		fields := []configuration.Field{{Name: "command", Type: configuration.FieldTypeString}}
+		errs := validateNodeExpressions("n1", "Plain", map[string]any{
+			"command": "hello world",
+		}, fields, knownSet())
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %+v", errs)
+		}
+	})
+}

--- a/pkg/configuration/expressionvalidation/references.go
+++ b/pkg/configuration/expressionvalidation/references.go
@@ -1,0 +1,54 @@
+package expressionvalidation
+
+import (
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
+)
+
+// ParseReferencedNodes returns the names referenced via $['Name']
+// inside the given expression body, in source order.
+func ParseReferencedNodes(expression string) ([]string, error) {
+	tree, err := parser.Parse(expression)
+	if err != nil {
+		return nil, err
+	}
+
+	collector := &nodeReferenceCollector{seen: make(map[string]struct{})}
+	ast.Walk(&tree.Node, collector)
+	return collector.identifiers, nil
+}
+
+type nodeReferenceCollector struct {
+	identifiers []string
+	seen        map[string]struct{}
+}
+
+func (c *nodeReferenceCollector) Visit(node *ast.Node) {
+	member, ok := (*node).(*ast.MemberNode)
+	if !ok {
+		return
+	}
+
+	root, ok := member.Node.(*ast.IdentifierNode)
+	if !ok || root.Value != "$" {
+		return
+	}
+
+	switch property := member.Property.(type) {
+	case *ast.StringNode:
+		c.add(property.Value)
+	case *ast.IdentifierNode:
+		c.add(property.Value)
+	}
+}
+
+func (c *nodeReferenceCollector) add(value string) {
+	if value == "" {
+		return
+	}
+	if _, ok := c.seen[value]; ok {
+		return
+	}
+	c.seen[value] = struct{}{}
+	c.identifiers = append(c.identifiers, value)
+}

--- a/pkg/configuration/expressionvalidation/validator.go
+++ b/pkg/configuration/expressionvalidation/validator.go
@@ -19,12 +19,7 @@ func ValidateExpression(raw string, knownNodeNames map[string]struct{}) error {
 		return err
 	}
 
-	body := strings.TrimSpace(raw)
-	if err := compileWithStubEnv(body, knownNodeNames); err != nil {
-		return err
-	}
-
-	return nil
+	return compileWithStubEnv(strings.TrimSpace(raw), knownNodeNames)
 }
 
 // ValidateBareExpression checks the same expression body but skips the strict

--- a/pkg/configuration/expressionvalidation/validator.go
+++ b/pkg/configuration/expressionvalidation/validator.go
@@ -1,0 +1,179 @@
+package expressionvalidation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/parser"
+	"github.com/superplanehq/superplane/pkg/exprruntime"
+)
+
+// ValidateExpression checks a {{ ... }} placeholder body for syntax errors,
+// unknown node references, function arity mistakes, and unresolved identifiers.
+// Returns nil for a valid expression.
+func ValidateExpression(raw string, knownNodeNames map[string]struct{}) error {
+	if err := validateExpressionAST(raw, knownNodeNames); err != nil {
+		return err
+	}
+
+	body := strings.TrimSpace(raw)
+	if err := compileWithStubEnv(body, knownNodeNames); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateBareExpression checks the same expression body but skips the strict
+// compile-time identifier resolution. Use it for FieldTypeExpression values
+// without {{ }} framing: at runtime those flow through as literal strings
+// unless a component explicitly evaluates them, so identifiers like "default"
+// or "ok" are valid literal payloads, while obvious syntax errors and unknown
+// node references still need to be caught.
+func ValidateBareExpression(raw string, knownNodeNames map[string]struct{}) error {
+	return validateExpressionAST(raw, knownNodeNames)
+}
+
+func validateExpressionAST(raw string, knownNodeNames map[string]struct{}) error {
+	body := strings.TrimSpace(raw)
+	if body == "" {
+		return fmt.Errorf("expression body is empty")
+	}
+
+	tree, err := parser.Parse(body)
+	if err != nil {
+		return fmt.Errorf("syntax error: %s", firstLine(err.Error()))
+	}
+
+	if err := checkNodeReferences(&tree.Node, knownNodeNames); err != nil {
+		return err
+	}
+
+	return checkFunctionCalls(&tree.Node)
+}
+
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx != -1 {
+		return s[:idx]
+	}
+	return s
+}
+
+func checkNodeReferences(node *ast.Node, knownNodeNames map[string]struct{}) error {
+	refs, err := collectNodeReferences(node)
+	if err != nil {
+		return err
+	}
+	for _, name := range refs {
+		if _, ok := knownNodeNames[name]; !ok {
+			return fmt.Errorf("unknown node reference '%s'", name)
+		}
+	}
+	return nil
+}
+
+func collectNodeReferences(node *ast.Node) ([]string, error) {
+	collector := &nodeReferenceCollector{seen: make(map[string]struct{})}
+	ast.Walk(node, collector)
+	return collector.identifiers, nil
+}
+
+type callChecker struct {
+	err error
+}
+
+func (c *callChecker) Visit(node *ast.Node) {
+	if c.err != nil {
+		return
+	}
+	call, ok := (*node).(*ast.CallNode)
+	if !ok {
+		return
+	}
+
+	switch callee := call.Callee.(type) {
+	case *ast.IdentifierNode:
+		c.err = checkTopLevelCall(callee.Value, call.Arguments)
+	case *ast.MemberNode:
+		root, rootOK := callee.Node.(*ast.IdentifierNode)
+		prop, propOK := callee.Property.(*ast.StringNode)
+		if !rootOK || !propOK {
+			return
+		}
+		if root.Value == "memory" {
+			c.err = checkMemoryCall(prop.Value, call.Arguments)
+		}
+	}
+}
+
+func checkFunctionCalls(node *ast.Node) error {
+	checker := &callChecker{}
+	ast.Walk(node, checker)
+	return checker.err
+}
+
+func checkTopLevelCall(name string, args []ast.Node) error {
+	switch name {
+	case "root":
+		if len(args) != 0 {
+			return fmt.Errorf("root() takes no arguments, got %d", len(args))
+		}
+	case "previous":
+		if len(args) > 1 {
+			return fmt.Errorf("previous() accepts zero or one argument, got %d", len(args))
+		}
+		if len(args) == 1 {
+			switch arg := args[0].(type) {
+			case *ast.IntegerNode:
+				if arg.Value < 1 {
+					return fmt.Errorf("previous() depth must be >= 1, got %d", arg.Value)
+				}
+			case *ast.StringNode, *ast.FloatNode, *ast.BoolNode, *ast.NilNode:
+				return fmt.Errorf("previous() depth must be an integer literal")
+			}
+		}
+	}
+	return nil
+}
+
+func checkMemoryCall(method string, args []ast.Node) error {
+	switch method {
+	case "find", "findFirst":
+		if len(args) != 2 {
+			return fmt.Errorf("memory.%s() requires a namespace and matches, got %d arguments", method, len(args))
+		}
+	}
+	return nil
+}
+
+func compileWithStubEnv(body string, knownNodeNames map[string]struct{}) error {
+	dollar := make(map[string]any, len(knownNodeNames))
+	for name := range knownNodeNames {
+		dollar[name] = map[string]any{}
+	}
+
+	memoryStub := func(params ...any) (any, error) { return nil, nil }
+	env := map[string]any{
+		"$":      dollar,
+		"memory": map[string]any{"find": memoryStub, "findFirst": memoryStub},
+		"config": map[string]any{},
+	}
+
+	opts := []expr.Option{
+		expr.Env(env),
+		expr.AsAny(),
+		expr.WithContext("ctx"),
+		expr.Timezone(time.UTC.String()),
+		exprruntime.DateFunctionOption(),
+		expr.Function("root", func(params ...any) (any, error) { return nil, nil }),
+		expr.Function("previous", func(params ...any) (any, error) { return nil, nil }),
+	}
+
+	if _, err := expr.Compile(body, opts...); err != nil {
+		return fmt.Errorf("compile error: %s", firstLine(err.Error()))
+	}
+	return nil
+}

--- a/pkg/configuration/expressionvalidation/validator_test.go
+++ b/pkg/configuration/expressionvalidation/validator_test.go
@@ -1,0 +1,98 @@
+package expressionvalidation
+
+import (
+	"strings"
+	"testing"
+)
+
+type exprCase struct {
+	name       string
+	raw        string
+	knownNames []string
+	wantErr    string // empty == valid; otherwise substring expected in err.Error()
+}
+
+func runExprCases(t *testing.T, group string, cases []exprCase) {
+	t.Helper()
+	t.Run(group, func(t *testing.T) {
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				known := make(map[string]struct{}, len(tc.knownNames))
+				for _, n := range tc.knownNames {
+					known[n] = struct{}{}
+				}
+				err := ValidateExpression(tc.raw, known)
+				if tc.wantErr == "" {
+					if err != nil {
+						t.Fatalf("expected no error, got: %v", err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+			})
+		}
+	})
+}
+
+func TestValidateExpression_Valid(t *testing.T) {
+	runExprCases(t, "valid", []exprCase{
+		{name: "bracket node ref", raw: `$['Build'].artifact`, knownNames: []string{"Build"}},
+		{name: "name with space and percent", raw: `$['Deploy 10%'].status`, knownNames: []string{"Deploy 10%"}},
+		{name: "root call", raw: `root().data.ref`},
+		{name: "previous no args", raw: `previous()`},
+		{name: "previous with int", raw: `previous(2)`},
+		{name: "memory find", raw: `memory.find('users', {id: 1})`},
+		{name: "memory findFirst", raw: `memory.findFirst('users', {id: 1})`},
+		{name: "string builtins chain", raw: `lower(trim($['Build'].name))`, knownNames: []string{"Build"}},
+		{name: "now builtin", raw: `now()`},
+		{name: "date builtin", raw: `date('2026-01-01')`},
+		{name: "type conversion", raw: `int($['Build'].count) + 1`, knownNames: []string{"Build"}},
+		{name: "config blueprint placeholder", raw: `config.foo.bar`},
+		{name: "standalone dollar", raw: `$`},
+	})
+}
+
+func TestValidateExpression_Syntax(t *testing.T) {
+	runExprCases(t, "syntax", []exprCase{
+		{name: "unclosed paren", raw: `root(`, wantErr: "syntax error"},
+		{name: "unclosed bracket", raw: `$[`, wantErr: "syntax error"},
+		{name: "trailing dot", raw: `$['Build'].`, knownNames: []string{"Build"}, wantErr: "syntax error"},
+		{name: "incomplete binary", raw: `1 +`, wantErr: "syntax error"},
+		{name: "unterminated string", raw: `'unterminated`, wantErr: "syntax error"},
+		{name: "empty body", raw: `   `, wantErr: "expression body is empty"},
+	})
+}
+
+func TestValidateExpression_UnknownNodeRef(t *testing.T) {
+	runExprCases(t, "unknown_node_ref", []exprCase{
+		{name: "bracket missing", raw: `$['Missing'].x`, knownNames: []string{"Build"}, wantErr: "unknown node reference 'Missing'"},
+		{name: "one valid one missing", raw: `$['Build'].x + $['AlsoMissing'].y`, knownNames: []string{"Build"}, wantErr: "unknown node reference 'AlsoMissing'"},
+	})
+}
+
+func TestValidateExpression_BadArity(t *testing.T) {
+	runExprCases(t, "bad_arity", []exprCase{
+		{name: "root with int", raw: `root(1)`, wantErr: "root() takes no arguments"},
+		{name: "root with string", raw: `root('x')`, wantErr: "root() takes no arguments"},
+		{name: "previous too many", raw: `previous(1, 2)`, wantErr: "previous() accepts zero or one argument"},
+		{name: "previous string literal", raw: `previous('a')`, wantErr: "previous() depth must be an integer literal"},
+		{name: "previous float literal", raw: `previous(1.5)`, wantErr: "previous() depth must be an integer literal"},
+		{name: "memory.find missing matches", raw: `memory.find('ns')`, wantErr: "memory.find() requires a namespace and matches"},
+		{name: "memory.find no args", raw: `memory.find()`, wantErr: "memory.find() requires a namespace and matches"},
+		{name: "memory.findFirst no args", raw: `memory.findFirst()`, wantErr: "memory.findFirst() requires a namespace and matches"},
+		{name: "memory.find too many", raw: `memory.find('ns', {}, 'extra')`, wantErr: "memory.find() requires a namespace and matches"},
+	})
+}
+
+func TestValidateExpression_UnknownIdentifier(t *testing.T) {
+	runExprCases(t, "unknown_identifier", []exprCase{
+		{name: "bare identifier", raw: `unknownThing`, wantErr: "compile error"},
+		{name: "wrong case memory", raw: `Memory.find('ns', {})`, wantErr: "compile error"},
+	})
+}

--- a/pkg/configuration/expressionvalidation/walker.go
+++ b/pkg/configuration/expressionvalidation/walker.go
@@ -1,0 +1,119 @@
+package expressionvalidation
+
+import (
+	"fmt"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+// stringVisitor receives every string leaf reachable from a configuration map,
+// along with the field type derived from the schema (or empty when the value
+// lies outside the schema).
+type stringVisitor func(fieldPath, fieldType, value string)
+
+// walkConfiguration traverses a configuration map and calls visit for each
+// string leaf. Schema-aware where possible: keys present in fields recurse
+// using the field's declared structure (object schemas, list item definitions);
+// keys outside the schema fall through to a generic recursion.
+func walkConfiguration(config map[string]any, fields []configuration.Field, visit stringVisitor) {
+	fieldsByName := make(map[string]configuration.Field, len(fields))
+	for _, f := range fields {
+		fieldsByName[f.Name] = f
+	}
+
+	for key, value := range config {
+		if field, ok := fieldsByName[key]; ok {
+			walkFieldValue(key, field, value, visit)
+			continue
+		}
+		walkUntypedValue(key, value, visit)
+	}
+}
+
+func walkFieldValue(path string, field configuration.Field, value any, visit stringVisitor) {
+	switch field.Type {
+	case configuration.FieldTypeObject:
+		if field.TypeOptions != nil && field.TypeOptions.Object != nil && len(field.TypeOptions.Object.Schema) > 0 {
+			if obj, ok := asAnyMap(value); ok {
+				walkConfiguration(obj, field.TypeOptions.Object.Schema, func(p, t, v string) {
+					visit(path+"."+p, t, v)
+				})
+				return
+			}
+		}
+		walkUntypedValue(path, value, visit)
+
+	case configuration.FieldTypeList:
+		var itemDef *configuration.ListItemDefinition
+		if field.TypeOptions != nil && field.TypeOptions.List != nil {
+			itemDef = field.TypeOptions.List.ItemDefinition
+		}
+		if list, ok := value.([]any); ok {
+			walkList(path, list, itemDef, visit)
+			return
+		}
+		walkUntypedValue(path, value, visit)
+
+	default:
+		if str, ok := value.(string); ok {
+			visit(path, field.Type, str)
+			return
+		}
+		walkUntypedValue(path, value, visit)
+	}
+}
+
+func walkList(path string, list []any, itemDef *configuration.ListItemDefinition, visit stringVisitor) {
+	for i, item := range list {
+		itemPath := fmt.Sprintf("%s[%d]", path, i)
+		if itemDef != nil && itemDef.Type == configuration.FieldTypeObject && len(itemDef.Schema) > 0 {
+			if obj, ok := asAnyMap(item); ok {
+				walkConfiguration(obj, itemDef.Schema, func(p, t, v string) {
+					visit(itemPath+"."+p, t, v)
+				})
+				continue
+			}
+		}
+		if itemDef != nil && itemDef.Type != "" && itemDef.Type != configuration.FieldTypeObject {
+			if str, ok := item.(string); ok {
+				visit(itemPath, itemDef.Type, str)
+				continue
+			}
+		}
+		walkUntypedValue(itemPath, item, visit)
+	}
+}
+
+func walkUntypedValue(path string, value any, visit stringVisitor) {
+	switch v := value.(type) {
+	case string:
+		visit(path, "", v)
+	case map[string]any:
+		for key, child := range v {
+			walkUntypedValue(path+"."+key, child, visit)
+		}
+	case map[string]string:
+		for key, child := range v {
+			visit(path+"."+key, "", child)
+		}
+	case []any:
+		for i, child := range v {
+			walkUntypedValue(fmt.Sprintf("%s[%d]", path, i), child, visit)
+		}
+	}
+}
+
+func asAnyMap(value any) (map[string]any, bool) {
+	switch v := value.(type) {
+	case map[string]any:
+		return v, true
+	case map[string]string:
+		out := make(map[string]any, len(v))
+		for k, vv := range v {
+			out[k] = vv
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}

--- a/pkg/configuration/validation.go
+++ b/pkg/configuration/validation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-var expressionPlaceholderRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
+var ExpressionPlaceholderRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
 
 func ValidateConfiguration(fields []Field, config map[string]any) error {
 	for _, field := range fields {
@@ -253,9 +253,9 @@ func validateDaysOfWeek(_ Field, value any) error {
 func validateObject(field Field, value any) error {
 	if text, ok := value.(string); ok {
 		normalized := text
-		hasExpressions := expressionPlaceholderRegex.MatchString(text)
+		hasExpressions := ExpressionPlaceholderRegex.MatchString(text)
 		if hasExpressions {
-			normalized = expressionPlaceholderRegex.ReplaceAllString(text, "{}")
+			normalized = ExpressionPlaceholderRegex.ReplaceAllString(text, "{}")
 		}
 
 		var parsed any

--- a/pkg/grpc/actions/canvases/serialization.go
+++ b/pkg/grpc/actions/canvases/serialization.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/configuration/expressionvalidation"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases/changesets"
@@ -264,6 +265,19 @@ func ParseCanvas(registry *registry.Registry, orgID string, canvas *pb.Canvas) (
 	nodesByID := make(map[string]models.Node, len(nodes))
 	for _, node := range nodes {
 		nodesByID[node.ID] = node
+	}
+
+	for nodeID, errs := range expressionvalidation.ValidateCanvasExpressions(registry, canvas.Spec.Nodes) {
+		msgs := make([]string, 0, len(errs))
+		for _, e := range errs {
+			msgs = append(msgs, e.Error())
+		}
+		joined := strings.Join(msgs, "\n")
+		if existing, ok := nodeValidationErrors[nodeID]; ok {
+			nodeValidationErrors[nodeID] = existing + "\n" + joined
+		} else {
+			nodeValidationErrors[nodeID] = joined
+		}
 	}
 
 	for i, edge := range canvas.Spec.Edges {

--- a/pkg/integrations/render/cancel_deploy.go
+++ b/pkg/integrations/render/cancel_deploy.go
@@ -105,7 +105,7 @@ func (c *CancelDeploy) Configuration() []configuration.Field {
 			Label:       "Deploy ID",
 			Type:        configuration.FieldTypeString,
 			Required:    true,
-			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Placeholder: "e.g., dep-... or {{$['Node Name'].data.deployId}}",
 			Description: "Render deploy ID to cancel",
 		},
 	}

--- a/pkg/integrations/render/get_deploy.go
+++ b/pkg/integrations/render/get_deploy.go
@@ -81,7 +81,7 @@ func (c *GetDeploy) Configuration() []configuration.Field {
 			Label:       "Deploy ID",
 			Type:        configuration.FieldTypeString,
 			Required:    true,
-			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Placeholder: "e.g., dep-... or {{$['Node Name'].data.deployId}}",
 			Description: "Render deploy ID to retrieve",
 		},
 	}

--- a/pkg/integrations/render/rollback_deploy.go
+++ b/pkg/integrations/render/rollback_deploy.go
@@ -106,7 +106,7 @@ func (c *RollbackDeploy) Configuration() []configuration.Field {
 			Label:       "Deploy ID",
 			Type:        configuration.FieldTypeString,
 			Required:    true,
-			Placeholder: "e.g., dep-... or {{$.event.data.deployId}}",
+			Placeholder: "e.g., dep-... or {{$['Node Name'].data.deployId}}",
 			Description: "Deploy ID to roll back to",
 		},
 	}

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -8,10 +8,9 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr"
-	"github.com/expr-lang/expr/ast"
-	"github.com/expr-lang/expr/parser"
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/configuration/expressionvalidation"
 	"github.com/superplanehq/superplane/pkg/exprruntime"
 	"github.com/superplanehq/superplane/pkg/models"
 	"gorm.io/gorm"
@@ -246,7 +245,7 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {
-	referencedNodes, err := parseReferencedNodes(expression)
+	referencedNodes, err := expressionvalidation.ParseReferencedNodes(expression)
 	if err != nil {
 		return "", err
 	}
@@ -1021,56 +1020,4 @@ func (b *NodeConfigurationBuilder) listUpstreamNodeIDs() ([]string, error) {
 	}
 	sort.Strings(ids)
 	return ids, nil
-}
-
-func parseReferencedNodes(expression string) ([]string, error) {
-	tree, err := parser.Parse(expression)
-	if err != nil {
-		return nil, err
-	}
-
-	collector := &nodeReferenceCollector{
-		seen: make(map[string]struct{}),
-	}
-
-	ast.Walk(&tree.Node, collector)
-
-	return collector.identifiers, nil
-}
-
-type nodeReferenceCollector struct {
-	identifiers []string
-	seen        map[string]struct{}
-}
-
-func (c *nodeReferenceCollector) Visit(node *ast.Node) {
-	member, ok := (*node).(*ast.MemberNode)
-	if !ok {
-		return
-	}
-
-	root, ok := member.Node.(*ast.IdentifierNode)
-	if !ok || root.Value != "$" {
-		return
-	}
-
-	switch property := member.Property.(type) {
-	case *ast.StringNode:
-		c.add(property.Value)
-	case *ast.IdentifierNode:
-		c.add(property.Value)
-	}
-}
-
-func (c *nodeReferenceCollector) add(value string) {
-	if value == "" {
-		return
-	}
-
-	if _, ok := c.seen[value]; ok {
-		return
-	}
-
-	c.seen[value] = struct{}{}
-	c.identifiers = append(c.identifiers, value)
 }


### PR DESCRIPTION
## Problem

  Expression mistakes in node configurations (`{{ $['Wrong Name'].x }}`, `{{ root( }}`, trailing junk like `$['X'].y asdadasd   
  1234`) only surfaced at runtime when a node executed. Agent loops became publish → run → fail → fix instead of save → see
  error → fix.                                                                                                                  
                                                                  
  ## What this does

  Adds a static validation pass during canvas create/update. Runs inside `ParseCanvas` (so it covers both create and update) and
   folds errors into the existing per-node `ErrorMessage` aggregation — same pattern `validateNodeRef` already uses.
                                                                                                                                
  ## What's caught                                                

  | Field | Value | Result |
  |---|---|---|
  | `String` / `Text` | `echo {{ $['Missing'].x }}` | ✗ unknown node reference 'Missing' |
  | `String` / `Text` | `Hi {{ root( }}` | ✗ syntax error: unexpected token EOF |                                               
  | `String` / `Text` | `My value: {{ "x" + invalid() }}` | ✗ compile error: unknown name invalid |
  | Any field | `{{   }}` | ✗ expression body is empty |                                                                        
  | Any field | `{{ root(1) }}` | ✗ root() takes no arguments |   
  | Any field | `{{ previous('a') }}` | ✗ previous() depth must be an integer literal |                                         
  | Any field | `{{ memory.find('ns') }}` | ✗ memory.find() requires a namespace and matches |
  | `Expression` | `$["Build"].day asdadasd 2313312` | ✗ syntax error: unexpected token Identifier("asdadasd") |                
  | `Expression` | `$["Missing"].x` | ✗ unknown node reference 'Missing' |                                                      
                                                                                                                                
  ## What's deliberately not caught                                                                                             
                                                                  
  `FieldTypeExpression` values without `{{ }}` framing flow through `Build()` as literal strings (`ResolveTemplateExpressions`  
  short-circuits when no `{{ }}` is present, see `pkg/workers/contexts/node_configuration_builder.go`). The dominant runtime
  pattern — memory components storing literals like `value: "default"` or `value: "ok"` — keeps these as plain strings; they    
  never reach `expr.Compile`. So bare-value identifiers are not strictly compile-checked:

  | Field | Value | Result |                                                                                                    
  |---|---|---|
  | `Expression` | `default`, `ok`, `down`, `1 + 2`, `"plain"` | ✓ pass (literal at runtime) |                                  
  | `Expression` | `$["Build"].x + 1` | ✓ pass (valid bare expression) |
                                                                                                                                
  Trade-off: `if expression: "undefinedThing"` (which the `if` component *does* compile at runtime) won't be caught statically. 
  Syntax errors and unknown node references in the same field still are.                                                        
                                                                                                                                
  Property paths inside payloads (`$['X'].data.foo`) and runtime-only graph reachability are out of scope — those need real     
  payloads/edges.
                                                                                                                                
                                                                                                       
                                                                  
  Wired in:                                                                                                                     
  - `pkg/grpc/actions/canvases/serialization.go` — hook in `ParseCanvas` after `nodesByID` is built; errors fold into
  `nodeValidationErrors`.                                                                                                       
  - `pkg/configuration/validation.go` — `ExpressionPlaceholderRegex` exported so the new package and `validateObject` share one
  regex.                                                                                                                        
  - `pkg/workers/contexts/node_configuration_builder.go` — uses the moved `ParseReferencedNodes`.
                                                                                                                               
  
<img width="1118" height="634" alt="image" src="https://github.com/user-attachments/assets/c64af749-fe96-4193-994a-c0a9ce027d82" />

  
<img width="1332" height="700" alt="image" src="https://github.com/user-attachments/assets/f349ff03-ce15-4200-bdc3-50b1aa85fcf6" />
<img width="1322" height="660" alt="image" src="https://github.com/user-attachments/assets/f12594fd-406f-48dd-9375-f26250cb9b61" />

