### PR TITLE
feat: add curl paste prefill for HTTP component settings

### DIFF
--- a/web_src/src/lib/curlParser.spec.ts
+++ b/web_src/src/lib/curlParser.spec.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { formatCurlCommand, parseCurlCommand } from "@/lib/curlParser";
+
+describe("parseCurlCommand", () => {
+  it("parses a simple GET request", () => {
+    const result = parseCurlCommand("curl https://api.example.com/users");
+
+    expect(result.error).toBeUndefined();
+    expect(result.method).toBe("GET");
+    expect(result.url).toBe("https://api.example.com/users");
+    expect(result.headers).toEqual([]);
+    expect(result.body).toBeUndefined();
+    expect(result.queryParams).toEqual([]);
+  });
+
+  it("parses a POST request with headers and json body", () => {
+    const result = parseCurlCommand(
+      `curl -X POST https://api.example.com/users -H "Content-Type: application/json" -H "Authorization: Bearer token" -d '{"name":"John","meta":{"role":"admin"}}'`,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.method).toBe("POST");
+    expect(result.url).toBe("https://api.example.com/users");
+    expect(result.headers).toEqual([
+      { name: "Content-Type", value: "application/json" },
+      { name: "Authorization", value: "Bearer token" },
+    ]);
+    expect(result.body).toBe('{"name":"John","meta":{"role":"admin"}}');
+  });
+
+  it("extracts query params from URL and decodes encoded values", () => {
+    const result = parseCurlCommand("curl 'https://api.example.com/search?q=superplane&page=2&name=John%20Doe'");
+
+    expect(result.error).toBeUndefined();
+    expect(result.url).toBe("https://api.example.com/search");
+    expect(result.queryParams).toEqual([
+      { key: "q", value: "superplane" },
+      { key: "page", value: "2" },
+      { key: "name", value: "John Doe" },
+    ]);
+  });
+
+  it("supports multiline curl commands with backslash continuations", () => {
+    const result = parseCurlCommand(`curl -X POST https://api.example.com/users \
+      -H "Content-Type: application/json" \
+      --data-raw '{"name":"John Doe"}'`);
+
+    expect(result.error).toBeUndefined();
+    expect(result.method).toBe("POST");
+    expect(result.url).toBe("https://api.example.com/users");
+    expect(result.headers).toEqual([{ name: "Content-Type", value: "application/json" }]);
+    expect(result.body).toBe('{"name":"John Doe"}');
+  });
+
+  it("supports inline and long-form method flags", () => {
+    const inline = parseCurlCommand("curl -XPATCH https://api.example.com/users/1");
+    const longForm = parseCurlCommand("curl --request=DELETE https://api.example.com/users/1");
+
+    expect(inline.error).toBeUndefined();
+    expect(inline.method).toBe("PATCH");
+    expect(longForm.error).toBeUndefined();
+    expect(longForm.method).toBe("DELETE");
+  });
+
+  it("supports different data flag formats", () => {
+    const dataEquals = parseCurlCommand(`curl https://api.example.com/users --data='{"name":"Jane"}'`);
+    const dataBinary = parseCurlCommand(
+      `curl --request POST https://api.example.com/users --data-binary '{"name":"Ana"}'`,
+    );
+
+    expect(dataEquals.error).toBeUndefined();
+    expect(dataEquals.body).toBe('{"name":"Jane"}');
+    expect(dataEquals.method).toBe("POST");
+
+    expect(dataBinary.error).toBeUndefined();
+    expect(dataBinary.body).toBe('{"name":"Ana"}');
+    expect(dataBinary.method).toBe("POST");
+  });
+
+  it("supports single-quoted header values", () => {
+    const result = parseCurlCommand(
+      "curl https://api.example.com/users -H 'X-Trace-Id: abc-123' -H 'X-Note: value:with:colons'",
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.headers).toEqual([
+      { name: "X-Trace-Id", value: "abc-123" },
+      { name: "X-Note", value: "value:with:colons" },
+    ]);
+  });
+
+  it("handles quoted body edge cases", () => {
+    const escapedJson = parseCurlCommand(
+      `curl -X POST https://api.example.com -d '{"nested":"value\\"with\\"quotes"}'`,
+    );
+    const emptyBody = parseCurlCommand(`curl -X POST https://api.example.com -d ""`);
+
+    expect(escapedJson.error).toBeUndefined();
+    expect(escapedJson.body).toBe('{"nested":"value\\"with\\"quotes"}');
+    expect(emptyBody.error).toBeUndefined();
+    expect(emptyBody.body).toBe("");
+  });
+
+  it("handles unmatched quote segments without throwing", () => {
+    const result = parseCurlCommand(`curl https://api.example.com -H "Content-Type: application/json`);
+
+    expect(result.error).toBeUndefined();
+    expect(result.url).toBe("https://api.example.com");
+    expect(result.headers).toEqual([{ name: '"Content-Type', value: "application/json" }]);
+  });
+
+  it("handles URL variants including ports and fragments", () => {
+    const withPort = parseCurlCommand("curl https://api.example.com:8080/users");
+    const withFragment = parseCurlCommand("curl https://api.example.com/page#section");
+    const urlThenMethod = parseCurlCommand("curl https://api.example.com -X GET");
+    const methodThenUrl = parseCurlCommand("curl -X GET https://api.example.com");
+    const localhostOnly = parseCurlCommand("curl localhost");
+
+    expect(withPort.url).toBe("https://api.example.com:8080/users");
+    expect(withFragment.url).toBe("https://api.example.com/page#section");
+    expect(urlThenMethod.url).toBe("https://api.example.com");
+    expect(methodThenUrl.url).toBe("https://api.example.com");
+    expect(localhostOnly.url).toBe("localhost");
+  });
+
+  it("supports additional HTTP methods and normalizes casing", () => {
+    expect(parseCurlCommand("curl -X PUT https://api.example.com/users/1 -d '{}'").method).toBe("PUT");
+    expect(parseCurlCommand("curl -X DELETE https://api.example.com/users/1").method).toBe("DELETE");
+    expect(parseCurlCommand("curl -X PATCH https://api.example.com/users/1 -d '{}'").method).toBe("PATCH");
+    expect(parseCurlCommand("curl -X OPTIONS https://api.example.com").method).toBe("OPTIONS");
+    expect(parseCurlCommand("curl -X HEAD https://api.example.com").method).toBe("HEAD");
+    expect(parseCurlCommand("curl -X post https://api.example.com").method).toBe("POST");
+  });
+
+  it("handles header edge cases including empty and duplicate values", () => {
+    const emptyValue = parseCurlCommand(`curl https://api.example.com -H "X-Empty:"`);
+    const specialChars = parseCurlCommand(`curl https://api.example.com -H "X-Data: value=foo&bar=baz"`);
+    const duplicateHeaders = parseCurlCommand(
+      `curl https://api.example.com -H "X-Custom: value1" -H "X-Custom: value2"`,
+    );
+    const equalsSyntax = parseCurlCommand(`curl https://api.example.com --header="Content-Type: application/json"`);
+
+    expect(emptyValue.headers).toEqual([{ name: "X-Empty", value: "" }]);
+    expect(specialChars.headers).toEqual([{ name: "X-Data", value: "value=foo&bar=baz" }]);
+    expect(duplicateHeaders.headers).toEqual([
+      { name: "X-Custom", value: "value1" },
+      { name: "X-Custom", value: "value2" },
+    ]);
+    expect(equalsSyntax.headers).toEqual([]);
+  });
+
+  it("handles body data edge cases", () => {
+    const multiData = parseCurlCommand(`curl -X POST https://api.example.com -d "part1" -d "part2"`);
+    const dataRawEquals = parseCurlCommand(`curl -X POST https://api.example.com --data-raw='{"test":true}'`);
+    const multilineBody = parseCurlCommand(`curl -X POST https://api.example.com -d "line1\nline2"`);
+
+    expect(multiData.body).toBe("part2");
+    expect(dataRawEquals.body).toBe('{"test":true}');
+    expect(multilineBody.body).toBe("line1\nline2");
+  });
+
+  it("returns an error for non-curl commands", () => {
+    const result = parseCurlCommand("wget https://api.example.com/users");
+
+    expect(result.error).toBe("Not a valid curl command");
+  });
+
+  it("returns an error when required flag values are missing", () => {
+    expect(parseCurlCommand("curl -X").error).toBe("Missing method after -X flag");
+    expect(parseCurlCommand("curl https://api.example.com -H").error).toBe("Missing header after -H flag");
+    expect(parseCurlCommand("curl https://api.example.com -d").error).toBe("Missing body after -d flag");
+  });
+
+  it("returns an error for invalid header format", () => {
+    const result = parseCurlCommand(`curl https://api.example.com/users -H "InvalidHeaderValue"`);
+
+    expect(result.error).toBe("Invalid header format: InvalidHeaderValue");
+  });
+
+  it("handles empty and whitespace-only values safely", () => {
+    expect(parseCurlCommand("").error).toBe("Not a valid curl command");
+    expect(parseCurlCommand("   ").error).toBe("Not a valid curl command");
+  });
+
+  it("handles null and undefined values passed at runtime", () => {
+    const nullInput = parseCurlCommand(null as unknown as string);
+    const undefinedInput = parseCurlCommand(undefined as unknown as string);
+
+    expect(nullInput.error).toBeTypeOf("string");
+    expect(undefinedInput.error).toBeTypeOf("string");
+  });
+
+  it("handles malformed or partial curl commands gracefully", () => {
+    const curlOnly = parseCurlCommand("curl");
+    const withCommonFlags = parseCurlCommand("curl -v -s -L https://api.example.com");
+    const malformedPrefix = parseCurlCommand("curlhttps://api.example.com");
+
+    expect(curlOnly.error).toBeUndefined();
+    expect(curlOnly.url).toBe("");
+    expect(withCommonFlags.error).toBeUndefined();
+    expect(withCommonFlags.url).toBe("https://api.example.com");
+    expect(malformedPrefix.error).toBeUndefined();
+    expect(malformedPrefix.url).toBe("");
+  });
+});
+
+describe("formatCurlCommand", () => {
+  it("formats a parsed result with method headers body and query params", () => {
+    const formatted = formatCurlCommand({
+      method: "POST",
+      url: "https://api.example.com/users",
+      headers: [
+        { name: "Content-Type", value: "application/json" },
+        { name: "Authorization", value: "Bearer token" },
+      ],
+      body: '{"name":"John"}',
+      queryParams: [
+        { key: "page", value: "2" },
+        { key: "name", value: "John Doe" },
+      ],
+    });
+
+    expect(formatted).toBe(
+      'curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer token" -d "{"name":"John"}" https://api.example.com/users?page=2&name=John%20Doe',
+    );
+  });
+
+  it("formats a minimal GET request", () => {
+    const formatted = formatCurlCommand({
+      method: "GET",
+      url: "https://api.example.com/health",
+      headers: [],
+      queryParams: [],
+    });
+
+    expect(formatted).toBe("curl https://api.example.com/health");
+  });
+
+  it("formats special characters and quoted body values", () => {
+    const formatted = formatCurlCommand({
+      method: "POST",
+      url: "https://api.example.com/search",
+      headers: [{ name: "X-Data", value: "a=b&c=d" }],
+      body: '{"key":"value with \\"quotes\\""}',
+      queryParams: [{ key: "q", value: "hello world" }],
+    });
+
+    expect(formatted).toBe(
+      'curl -X POST -H "X-Data: a=b&c=d" -d "{"key":"value with \\"quotes\\""}" https://api.example.com/search?q=hello%20world',
+    );
+  });
+
+  it("handles empty URL and empty optional fields", () => {
+    const formatted = formatCurlCommand({
+      method: "GET",
+      url: "",
+      headers: [],
+      queryParams: [],
+    });
+
+    expect(formatted).toBe("curl");
+  });
+});

--- a/web_src/src/lib/curlParser.ts
+++ b/web_src/src/lib/curlParser.ts
@@ -1,0 +1,243 @@
+/**
+ * Parses curl commands and extracts HTTP method, URL, headers, body, and parameters.
+ * Supports common curl formats like:
+ *  - curl -X POST https://api.example.com/users -H "Content-Type: application/json" -d '{"name":"John"}'
+ *  - curl -X GET https://api.example.com/users?param1=value1
+ *  - curl -H "Authorization: Bearer token" -H "Content-Type: application/json" https://api.example.com/users -d '{"name":"John"}'
+ */
+export interface CurlParseResult {
+  method: string;
+  url: string;
+  headers: Array<{ name: string; value: string }>;
+  body?: string;
+  queryParams: Array<{ key: string; value: string }>;
+  error?: string;
+}
+
+/**
+ * Parses a curl command string
+ * @param curlCommand The curl command to parse
+ * @returns CurlParseResult with parsed components or error
+ */
+export function parseCurlCommand(curlCommand: string): CurlParseResult {
+  const result: CurlParseResult = {
+    method: "GET",
+    url: "",
+    headers: [],
+    queryParams: [],
+  };
+
+  try {
+    // Remove leading and trailing whitespace
+    const command = curlCommand.replace(/\\\r?\n/g, " ").trim();
+
+    if (!command.startsWith("curl")) {
+      throw new Error("Not a valid curl command");
+    }
+
+    // Split by spaces, but respect quoted strings
+    const parts = splitCurlCommand(command);
+
+    // Extract options and arguments
+    let i = 1; // Start after 'curl'
+    let currentMethod = "GET";
+    let currentUrl = "";
+    const headers: Array<{ name: string; value: string }> = [];
+    let body: string | undefined;
+    let queryParams: Array<{ key: string; value: string }> = [];
+
+    while (i < parts.length) {
+      const part = parts[i];
+
+      // Handle method specification
+      if (part === "-X" || part === "--request") {
+        if (i + 1 < parts.length) {
+          currentMethod = stripShellQuotes(parts[i + 1]).toUpperCase();
+          i += 2;
+        } else {
+          throw new Error("Missing method after -X flag");
+        }
+      } else if (part.startsWith("-X") && part.length > 2) {
+        currentMethod = stripShellQuotes(part.slice(2)).toUpperCase();
+        i++;
+      } else if (part.startsWith("--request=")) {
+        currentMethod = stripShellQuotes(part.slice("--request=".length)).toUpperCase();
+        i++;
+      }
+      // Handle headers
+      else if (part === "-H" || part === "--header") {
+        if (i + 1 < parts.length) {
+          const header = stripShellQuotes(parts[i + 1]);
+          const colonIndex = header.indexOf(":");
+          if (colonIndex !== -1) {
+            const name = header.substring(0, colonIndex).trim();
+            const value = header.substring(colonIndex + 1).trim();
+            headers.push({ name, value });
+          } else {
+            throw new Error(`Invalid header format: ${header}`);
+          }
+          i += 2;
+        } else {
+          throw new Error("Missing header after -H flag");
+        }
+      }
+      // Handle body data
+      else if (part === "-d" || part === "--data" || part === "--data-raw") {
+        if (i + 1 < parts.length) {
+          body = stripShellQuotes(parts[i + 1]);
+          i += 2;
+        } else {
+          throw new Error("Missing body after -d flag");
+        }
+      }
+      // Handle POST data from file
+      else if (part === "--data-binary") {
+        if (i + 1 < parts.length) {
+          body = stripShellQuotes(parts[i + 1]);
+          i += 2;
+        } else {
+          throw new Error("Missing body after --data-binary flag");
+        }
+      } else if (part.startsWith("--data=") || part.startsWith("--data-raw=")) {
+        const [, value = ""] = part.split("=", 2);
+        body = stripShellQuotes(value);
+        i++;
+      }
+      // Handle URL (last argument without flag)
+      else if (!part.startsWith("-") && currentUrl === "") {
+        currentUrl = stripShellQuotes(part);
+        i++;
+      }
+      // Handle query parameters from URL
+      else if (part.startsWith("-") && part.includes("?")) {
+        // This handles cases like `-H "Accept: application/json?param=value"`
+        // But we'll process this more carefully in the URL parsing
+        i++;
+      } else {
+        i++;
+      }
+    }
+
+    // Extract URL and query parameters if present
+    if (currentUrl) {
+      const [url, searchParamsStr] = currentUrl.split("?", 2);
+      currentUrl = url;
+      if (searchParamsStr) {
+        const urlSearchParams = new URLSearchParams(searchParamsStr);
+        const params: Array<{ key: string; value: string }> = [];
+        for (const [key, value] of urlSearchParams.entries()) {
+          params.push({ key, value });
+        }
+        queryParams = params;
+      }
+    }
+
+    // Default to POST if body is specified but no method
+    if (body && currentMethod === "GET") {
+      currentMethod = "POST";
+    }
+
+    result.method = currentMethod;
+    result.url = currentUrl;
+    result.headers = headers;
+    result.body = body;
+    result.queryParams = queryParams;
+  } catch (error) {
+    result.error = (error as Error).message || "Failed to parse curl command";
+  }
+
+  return result;
+}
+
+/**
+ * Splits a curl command while respecting quoted strings that might contain spaces
+ * @param command The curl command to split
+ * @returns Array of command parts
+ */
+function splitCurlCommand(command: string): string[] {
+  const parts: string[] = [];
+  let currentPart = "";
+  let inQuotes = false;
+  let quoteChar = "";
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (!inQuotes && (char === '"' || char === "'")) {
+      inQuotes = true;
+      quoteChar = char;
+      currentPart += char;
+    } else if (inQuotes && char === quoteChar) {
+      inQuotes = false;
+      quoteChar = "";
+      currentPart += char;
+    } else if (!inQuotes && char === " ") {
+      if (currentPart) {
+        parts.push(currentPart);
+        currentPart = "";
+      }
+    } else {
+      currentPart += char;
+    }
+  }
+
+  // Add the final part if it exists
+  if (currentPart) {
+    parts.push(currentPart);
+  }
+
+  return parts;
+}
+
+function stripShellQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+/**
+ * Format a parsed curl result back into a curl command string
+ * @param parseResult The parsed curl result
+ * @returns Formatted curl command
+ */
+export function formatCurlCommand(parseResult: CurlParseResult): string {
+  const parts = ["curl"];
+
+  // Add method
+  if (parseResult.method && parseResult.method !== "GET") {
+    parts.push("-X", parseResult.method);
+  }
+
+  // Add headers
+  for (const header of parseResult.headers) {
+    parts.push("-H", `"${header.name}: ${header.value}"`);
+  }
+
+  // Add body if present
+  if (parseResult.body) {
+    parts.push("-d", `"${parseResult.body}"`);
+  }
+
+  // Add URL
+  if (parseResult.url) {
+    // Add query parameters
+    if (parseResult.queryParams && parseResult.queryParams.length > 0) {
+      let urlWithParams = parseResult.url;
+      const queryParamsString = parseResult.queryParams
+        .map((param) => `${encodeURIComponent(param.key)}=${encodeURIComponent(param.value)}`)
+        .join("&");
+      urlWithParams += `?${queryParamsString}`;
+      parts.push(urlWithParams);
+    } else {
+      parts.push(parseResult.url);
+    }
+  }
+
+  return parts.join(" ");
+}

--- a/web_src/src/pages/workflowv2/mappers/httpCurl.tsx
+++ b/web_src/src/pages/workflowv2/mappers/httpCurl.tsx
@@ -1,0 +1,8 @@
+import type { CustomFieldRenderer, CustomFieldRendererContext, NodeInfo } from "@/pages/workflowv2/mappers/types";
+import { HttpCurlCustomField } from "./httpCurlCustomField";
+
+export const httpCurlCustomFieldRenderer: CustomFieldRenderer = {
+  render: (node: NodeInfo, context?: CustomFieldRendererContext) => {
+    return <HttpCurlCustomField node={node} context={context} />;
+  },
+};

--- a/web_src/src/pages/workflowv2/mappers/httpCurlCustomField.tsx
+++ b/web_src/src/pages/workflowv2/mappers/httpCurlCustomField.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from "react";
+import { parseCurlCommand, type CurlParseResult } from "@/lib/curlParser";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { CustomFieldRendererContext, NodeInfo } from "@/pages/workflowv2/mappers/types";
+
+type HttpCurlCustomFieldProps = {
+  node: NodeInfo;
+  context?: CustomFieldRendererContext;
+};
+
+export function HttpCurlCustomField({ node: _node, context: _context }: HttpCurlCustomFieldProps) {
+  const [curlInput, setCurlInput] = useState("");
+  const [parseResult, setParseResult] = useState<CurlParseResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isParsing, setIsParsing] = useState(false);
+
+  useEffect(() => {
+    if (!curlInput.trim()) {
+      setParseResult(null);
+      setError(null);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsParsing(true);
+      try {
+        const result = parseCurlCommand(curlInput);
+        setParseResult(result);
+        setError(result.error ?? null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to parse curl command");
+        setParseResult(null);
+      } finally {
+        setIsParsing(false);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [curlInput]);
+
+  const handleAutoPopulate = useCallback(() => {
+    // Placeholder until node configuration wiring is implemented.
+  }, []);
+
+  return (
+    <div className="mt-4 rounded-md border bg-white">
+      <div className="border-b px-4 py-3">
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <span>Import from cURL</span>
+          <Badge variant="secondary" className="text-xs">
+            Beta
+          </Badge>
+        </h3>
+      </div>
+      <div className="space-y-4 p-4">
+        <div>
+          <Label htmlFor="curl-input">Paste curl command</Label>
+          <Textarea
+            id="curl-input"
+            placeholder={`curl -X POST https://api.example.com/users -H "Content-Type: application/json" -d '{"name":"John"}'`}
+            className="mt-2 font-mono text-xs"
+            value={curlInput}
+            onChange={(event) => setCurlInput(event.target.value)}
+            disabled={isParsing}
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Paste your curl command here to automatically populate HTTP configuration fields.
+          </p>
+        </div>
+
+        {isParsing && (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-gray-500" />
+            <span>Parsing curl command...</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>
+        )}
+
+        {parseResult && !parseResult.error && (
+          <div className="space-y-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h4 className="font-medium">Parsed Result</h4>
+                <p className="mt-1 text-sm text-gray-600">
+                  Method: <span className="rounded bg-gray-100 px-1 font-mono">{parseResult.method}</span> | URL:{" "}
+                  <span className="max-w-xs truncate rounded bg-gray-100 px-1 font-mono">{parseResult.url}</span>
+                </p>
+              </div>
+              <Button size="sm" onClick={handleAutoPopulate} variant="outline" className="text-xs">
+                Auto-populate
+              </Button>
+            </div>
+
+            {parseResult.headers.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium">Headers</h4>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {parseResult.headers.map((header) => (
+                    <Badge key={`${header.name}-${header.value}`} variant="secondary" className="text-xs">
+                      {header.name}: {header.value}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {parseResult.queryParams.length > 0 && (
+              <div>
+                <h4 className="text-sm font-medium">Query Params</h4>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {parseResult.queryParams.map((param) => (
+                    <Badge key={`${param.key}-${param.value}`} variant="secondary" className="text-xs">
+                      {param.key}: {param.value}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {parseResult.body && (
+              <div>
+                <h4 className="text-sm font-medium">Body</h4>
+                <p className="mt-1 max-h-20 overflow-auto rounded bg-gray-100 p-2 font-mono text-xs">
+                  {parseResult.body}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="pt-2">
+          <p className="text-xs text-gray-500">
+            <strong>Supported curl formats:</strong> curl -X POST https://api.example.com/users -H "Content-Type:
+            application/json" -d '{"{"}name":"John"{"}"}'
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/mappers/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/index.ts
@@ -212,7 +212,6 @@ import {
   triggerRenderers as dockerhubTriggerRenderers,
   eventStateRegistry as dockerhubEventStateRegistry,
 } from "./dockerhub";
-
 import {
   componentMappers as honeycombComponentMappers,
   triggerRenderers as honeycombTriggerRenderers,

--- a/web_src/src/pages/workflowv2/mappers/start.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start.tsx
@@ -12,6 +12,7 @@ import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
+import { PayloadTooltip } from "@/ui/componentBase/PayloadTooltip";
 
 interface StartTemplate {
   name: string;
@@ -109,12 +110,14 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
       <div className="px-2 py-1.5 flex flex-col gap-1.5">
         {templates.map((template, index) => (
           <div key={index} className="flex items-center justify-between min-w-0">
-            <div className="flex items-center min-w-0 flex-1">
-              <div className="w-4 h-4 mr-2 flex-shrink-0">
-                <Play size={16} className="text-gray-500" />
+            <PayloadTooltip title={template.name} value={template.payload} contentType="json">
+              <div className="flex items-center min-w-0 flex-1">
+                <div className="w-4 h-4 mr-2 flex-shrink-0">
+                  <Play size={16} className="text-gray-500" />
+                </div>
+                <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
               </div>
-              <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
-            </div>
+            </PayloadTooltip>
             {context?.onRun && (
               <Button
                 size="sm"

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -10,6 +10,8 @@ import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { TextFieldRenderer } from "@/ui/configurationFieldRenderer/TextFieldRenderer";
+import { parseCurlCommand } from "@/lib/curlParser";
 import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -39,6 +41,7 @@ interface SettingsTabProps {
   domainId?: string;
   domainType?: AuthorizationDomainType;
   customField?: (configuration: Record<string, unknown>) => ReactNode;
+  componentType?: string;
   integrationName?: string;
   integrationRef?: ComponentsIntegrationRef;
   integrations?: OrganizationsIntegration[];
@@ -64,9 +67,9 @@ function buildAutosaveSnapshot(
     nodeName,
     integrationRef: integrationRef
       ? {
-          id: integrationRef.id || "",
-          name: integrationRef.name || "",
-        }
+        id: integrationRef.id || "",
+        name: integrationRef.name || "",
+      }
       : null,
   });
 }
@@ -82,6 +85,7 @@ export function SettingsTab({
   domainId,
   domainType,
   customField,
+  componentType,
   integrationName,
   integrationRef,
   integrations = [],
@@ -107,6 +111,13 @@ export function SettingsTab({
   const [showValidation, setShowValidation] = useState(false);
   const [selectedIntegration, setSelectedIntegration] = useState<ComponentsIntegrationRef | undefined>(integrationRef);
   const [isSaving, setIsSaving] = useState(false);
+  const [curlInput, setCurlInput] = useState("");
+  const [curlParseFeedback, setCurlParseFeedback] = useState<{
+    type: "error" | "warning" | "success";
+    message: string;
+    method?: string;
+    url?: string;
+  } | null>(null);
   const savingRef = useRef(false);
   const autosaveTimerRef = useRef<number | null>(null);
   const autosaveBaselineSnapshotRef = useRef(buildAutosaveSnapshot(configuration || {}, nodeName, integrationRef));
@@ -252,6 +263,8 @@ export function SettingsTab({
     setSelectedIntegration(integrationRef);
     setValidationErrors(new Set());
     setShowValidation(false);
+    setCurlInput("");
+    setCurlParseFeedback(null);
   }, [configuration, nodeName, defaultValuesWithoutToggles, filterVisibleFields, integrationRef]);
 
   // Auto-select the first installation if none is selected or selection is invalid
@@ -285,6 +298,7 @@ export function SettingsTab({
   }, [integrationsOfType, selectedIntegration, nodeConfiguration, currentNodeName]);
 
   const shouldShowConfiguration = true;
+  const isHttpComponent = componentType === "http";
   const shouldAutosaveOnChangeByFieldType = useCallback((fieldType: ConfigurationField["type"] | undefined) => {
     // Text-like editors save on blur; discrete/destructive controls save on change.
     if (!fieldType) {
@@ -404,6 +418,115 @@ export function SettingsTab({
     }, 300);
   }, [configurationSaveMode, isReadOnly]);
 
+  const mapCurlBodyToConfig = useCallback((body: string) => {
+    const emptyBodyConfig = { json: undefined, text: undefined, xml: undefined, formData: undefined };
+    const trimmedBody = body.trim();
+
+    if (!trimmedBody) {
+      return {};
+    }
+
+    const looksLikeJson =
+      (trimmedBody.startsWith("{") && trimmedBody.endsWith("}")) ||
+      (trimmedBody.startsWith("[") && trimmedBody.endsWith("]"));
+
+    if (looksLikeJson) {
+      try {
+        return { ...emptyBodyConfig, contentType: "application/json", json: JSON.parse(trimmedBody) };
+      } catch {
+        return { ...emptyBodyConfig, contentType: "text/plain", text: body };
+      }
+    }
+
+    if (trimmedBody.startsWith("<")) {
+      return { ...emptyBodyConfig, contentType: "application/xml", xml: body };
+    }
+
+    if (trimmedBody.includes("=")) {
+      const safeDecodeURIComponent = (value: string): string => {
+        try {
+          return decodeURIComponent(value);
+        } catch {
+          return value;
+        }
+      };
+      const formData = trimmedBody
+        .split("&")
+        .map((pair) => {
+          const [rawKey, rawValue = ""] = pair.split("=", 2);
+          return { key: safeDecodeURIComponent(rawKey || ""), value: safeDecodeURIComponent(rawValue) };
+        })
+        .filter((item) => item.key);
+      return { ...emptyBodyConfig, contentType: "application/x-www-form-urlencoded", formData };
+    }
+
+    return { ...emptyBodyConfig, contentType: "text/plain", text: body };
+  }, []);
+
+  const handleParseCurl = useCallback(() => {
+    const parsed = parseCurlCommand(curlInput);
+    if (parsed.error) {
+      setCurlParseFeedback({ type: "error", message: parsed.error });
+      return;
+    }
+
+    const supportedMethods = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+    const nextMethod = supportedMethods.has(parsed.method) ? parsed.method : undefined;
+
+    const contentTypeHeader = parsed.headers.find((h) => h.name.toLowerCase() === "content-type")?.value.toLowerCase();
+
+    const knownContentTypes = [
+      "application/json",
+      "application/xml",
+      "text/plain",
+      "application/x-www-form-urlencoded",
+    ];
+    const contentTypeFromHeader = knownContentTypes.find((ct) => contentTypeHeader?.includes(ct));
+
+    const bodyConfig = parsed.body ? mapCurlBodyToConfig(parsed.body) : {};
+
+    setNodeConfiguration((prev) =>
+      filterVisibleFields({
+        ...prev,
+        ...(nextMethod && { method: nextMethod }),
+        ...(parsed.url && { url: parsed.url }),
+        ...(contentTypeFromHeader && { contentType: contentTypeFromHeader }),
+        headers: parsed.headers,
+        queryParams: parsed.queryParams,
+        ...bodyConfig,
+      }),
+    );
+
+    requestAutosave();
+
+    if (!nextMethod && parsed.method) {
+      setCurlParseFeedback({
+        type: "warning",
+        message: `Parsed curl, but method "${parsed.method}" is not supported by this form. Filled remaining fields.`,
+        method: parsed.method,
+        url: parsed.url,
+      });
+      return;
+    }
+
+    const parsedParts = [
+      parsed.url && "URL",
+      nextMethod && "method",
+      parsed.headers.length > 0 && "headers",
+      parsed.queryParams.length > 0 && "query params",
+      parsed.body && "body",
+    ].filter(Boolean) as string[];
+
+    setCurlParseFeedback({
+      type: "success",
+      method: nextMethod,
+      url: parsed.url,
+      message: parsedParts.length
+        ? `Parsed and populated: ${parsedParts.join(", ")}. Please review before saving.`
+        : "Parsed curl command, but no supported fields were detected.",
+    });
+  }, [curlInput, filterVisibleFields, mapCurlBodyToConfig, requestAutosave]);
+
   // Flush unsaved changes on unmount (e.g. when user switches away from the Settings tab)
   useEffect(() => {
     if (configurationSaveMode !== "auto") {
@@ -516,6 +639,74 @@ export function SettingsTab({
             </div>
           );
         })()}
+        {isHttpComponent && (
+          <div
+            className={`border-t border-gray-200 dark:border-gray-700 pt-6 space-y-2 ${isReadOnly ? "pointer-events-none opacity-60" : ""}`}
+          >
+            {curlParseFeedback?.method || curlParseFeedback?.url ? (
+              <p className="text-xs text-gray-600 dark:text-gray-400">
+                {curlParseFeedback.method && (
+                  <>
+                    Method:{" "}
+                    <span className="rounded bg-gray-100 dark:bg-gray-800 px-1 font-mono">
+                      {curlParseFeedback.method}
+                    </span>
+                  </>
+                )}
+                {curlParseFeedback.method && curlParseFeedback.url && " | "}
+                {curlParseFeedback.url && (
+                  <>
+                    URL:{" "}
+                    <span className="rounded bg-gray-100 dark:bg-gray-800 px-1 font-mono max-w-[200px] inline-block overflow-hidden text-ellipsis whitespace-nowrap align-bottom">
+                      {curlParseFeedback.url}
+                    </span>
+                  </>
+                )}
+              </p>
+            ) : null}
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Paste a curl command to auto-populate HTTP configuration fields.
+            </p>
+            <TextFieldRenderer
+              field={{
+                name: "curlImport",
+                label: "Paste curl",
+                type: "text",
+              }}
+              value={curlInput}
+              onChange={(value) => {
+                setCurlInput(typeof value === "string" ? value : "");
+                setCurlParseFeedback(null);
+              }}
+              autocompleteExampleObj={resolvedAutocompleteExampleObj}
+              size="xs"
+            />
+
+            <div className="flex justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleParseCurl}
+                disabled={isReadOnly || curlInput.trim().length === 0}
+              >
+                Parse curl
+              </Button>
+            </div>
+            {curlParseFeedback && (
+              <p
+                className={`text-xs ${curlParseFeedback.type === "error"
+                    ? "text-red-600"
+                    : curlParseFeedback.type === "warning"
+                      ? "text-amber-700"
+                      : "text-green-700"
+                  }`}
+              >
+                {curlParseFeedback.message}
+              </p>
+            )}
+          </div>
+        )}
 
         {/* Integration section — one container, three states: Connect / error or incomplete / ready */}
         {integrationName && (
@@ -616,13 +807,12 @@ export function SettingsTab({
 
                       const integrationStatusCard = (
                         <div
-                          className={`border border-gray-300 dark:border-gray-700 rounded-md bg-stripe-diagonal p-3 flex items-center justify-between gap-4 ${
-                            selectedIntegrationFull.status?.state === "ready"
+                          className={`border border-gray-300 dark:border-gray-700 rounded-md bg-stripe-diagonal p-3 flex items-center justify-between gap-4 ${selectedIntegrationFull.status?.state === "ready"
                               ? "bg-green-100 dark:bg-green-950/30"
                               : selectedIntegrationFull.status?.state === "error"
                                 ? "bg-red-100 dark:bg-red-950/30"
                                 : "bg-orange-100 dark:bg-orange-950/30"
-                          }`}
+                            }`}
                         >
                           <div className="flex items-center gap-2 min-w-0">
                             <IntegrationIcon
@@ -641,17 +831,16 @@ export function SettingsTab({
                           </div>
                           <div className="flex items-center gap-2 flex-shrink-0">
                             <span
-                              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                                selectedIntegrationFull.status?.state === "ready"
+                              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${selectedIntegrationFull.status?.state === "ready"
                                   ? "border border-green-950/15 bg-green-100 text-green-800 dark:border-green-950/15 dark:bg-green-900/30 dark:text-green-400"
                                   : selectedIntegrationFull.status?.state === "error"
                                     ? "border border-red-950/15 bg-red-100 text-red-800 dark:border-red-950/15 dark:bg-red-900/30 dark:text-red-400"
                                     : "border border-orange-950/15 bg-orange-100 text-yellow-800 dark:border-orange-950/15 dark:bg-orange-950/30 dark:text-yellow-400"
-                              }`}
+                                }`}
                             >
                               {selectedIntegrationFull.status?.state
                                 ? selectedIntegrationFull.status.state.charAt(0).toUpperCase() +
-                                  selectedIntegrationFull.status.state.slice(1)
+                                selectedIntegrationFull.status.state.slice(1)
                                 : "Unknown"}
                             </span>
                             {selectedIntegrationFull.metadata?.id && onOpenConfigureIntegrationDialog && (

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -664,9 +664,8 @@ export function SettingsTab({
                 )}
               </p>
             ) : null}
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Paste a curl command to auto-populate HTTP configuration fields.
-            </p>
+            <Label className="block text-left">Paste curl</Label>
+
             <TextFieldRenderer
               field={{
                 name: "curlImport",
@@ -681,7 +680,9 @@ export function SettingsTab({
               autocompleteExampleObj={resolvedAutocompleteExampleObj}
               size="xs"
             />
-
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Paste a curl command to auto-populate HTTP configuration fields.
+            </p>
             <div className="flex justify-end">
               <Button
                 type="button"

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -748,6 +748,7 @@ export const ComponentSidebar = ({
                   nodeId={nodeId}
                   nodeName={nodeName}
                   nodeLabel={nodeLabel}
+                  componentType={blockName}
                   configuration={nodeConfiguration}
                   configurationFields={nodeConfigurationFields}
                   onSave={onNodeConfigSave || (() => {})}

--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
@@ -6,13 +6,21 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/compone
 import { SimpleTooltip } from "../componentSidebar/SimpleTooltip";
 import { useMonacoExpressionAutocomplete } from "./useMonacoExpressionAutocomplete";
 
-export const TextFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange, autocompleteExampleObj }) => {
+export const TextFieldRenderer: React.FC<FieldRendererProps> = ({
+  field,
+  value,
+  onChange,
+  autocompleteExampleObj,
+  size = "md",
+}) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
   const { handleEditorMount } = useMonacoExpressionAutocomplete({
     autocompleteExampleObj,
     languageId: "plaintext",
   });
+
+  const editorHeight = size === "xs" ? "56px" : size === "sm" ? "100px" : "200px";
 
   const copyToClipboard = () => {
     const textToCopy = (value as string) || "";
@@ -60,7 +68,7 @@ export const TextFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, 
   return (
     <>
       <div className="flex flex-col gap-2 relative">
-        <div className="border rounded-md border-gray-300 dark:border-gray-700 p-1" style={{ height: "200px" }}>
+        <div className="border rounded-md border-gray-300 dark:border-gray-700 p-1" style={{ height: editorHeight }}>
           <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-1">
             <SimpleTooltip content={copied ? "Copied!" : "Copy"} hideOnClick={false}>
               <button onClick={copyToClipboard} className="p-1 rounded text-gray-500 hover:text-gray-800">

--- a/web_src/src/ui/configurationFieldRenderer/types.ts
+++ b/web_src/src/ui/configurationFieldRenderer/types.ts
@@ -21,4 +21,6 @@ export interface FieldRendererProps {
   autocompleteExampleObj?: Record<string, unknown> | null;
   allowExpressions?: boolean;
   excludedSuggestions?: string[];
+  /** Controls the editor height. "xs" = 56px, "sm" = 100px, "md" = 200px (default). */
+  size?: "xs" | "sm" | "md";
 }


### PR DESCRIPTION

**Summary**
Adds a new “Paste curl” input flow in the component settings sidebar for HTTP components.
Parses pasted curl commands and pre-fills HTTP config fields (method, URL, headers, query params, and body content mapping).
Improves UX feedback for curl parsing (success/warning/error states plus parsed method/URL preview).


**Why**
Reduces manual setup effort for HTTP actions by letting users reuse existing curl snippets.
Lowers configuration errors when translating API examples into workflow settings.
Speeds up onboarding for common API integration tasks.

**Test Plan**

- [ ]  Paste a valid curl with -X, URL, headers, and JSON body; verify fields are correctly populated.
- [ ]  Paste malformed/partial curl and verify warning/error feedback is shown without corrupting existing config.
- [ ]  Confirm behavior is only shown for HTTP components and respects read-only mode.


<img width="2549" height="1256" alt="Screenshot 2026-04-28 at 16 22 00" src="https://github.com/user-attachments/assets/1cc375d0-18f4-46de-8890-c52c73c78b54" />
