### PR TITLE
feat: preview template payload on hover in Manual Run trigger

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/start.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start.tsx
@@ -12,6 +12,7 @@ import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
+import { PayloadTooltip } from "@/ui/componentBase/PayloadTooltip";
 
 interface StartTemplate {
   name: string;
@@ -109,12 +110,14 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
       <div className="px-2 py-1.5 flex flex-col gap-1.5">
         {templates.map((template, index) => (
           <div key={index} className="flex items-center justify-between min-w-0">
-            <div className="flex items-center min-w-0 flex-1">
-              <div className="w-4 h-4 mr-2 flex-shrink-0">
-                <Play size={16} className="text-gray-500" />
+            <PayloadTooltip title={template.name || "Payload"} value={template.payload}>
+              <div className="flex items-center min-w-0 flex-1 cursor-help" data-testid="start-template-row">
+                <div className="w-4 h-4 mr-2 flex-shrink-0">
+                  <Play size={16} className="text-gray-500" />
+                </div>
+                <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
               </div>
-              <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
-            </div>
+            </PayloadTooltip>
             {context?.onRun && (
               <Button
                 size="sm"


### PR DESCRIPTION
Closes #2810

## Summary

Manual Run templates currently surface only their name and a Run button. When several templates share similar names (or when a user is just verifying before triggering), there is no way to confirm the payload short of opening the configuration. This PR adds a hover preview on the template row that shows the configured payload as formatted JSON.

## Implementation

- Wraps the icon + name part of each row in `PayloadTooltip` (the same component already used to surface component spec previews in `ui/componentBase/index.tsx`).
- The Run button stays outside the tooltip, so hovering Run does not open the preview.
- Adds a `cursor-help` class on the wrapped area so the affordance is discoverable.
- `data-testid="start-template-row"` added on the wrapped row for future tests.

## Notes

- No new dependency: `PayloadTooltip` is the existing pattern (Tippy + Monaco).
- 200 ms tooltip delay (Tippy default in `PayloadTooltip`) prevents accidental triggers from neighbouring hovers.
- `tsc --noEmit` clean. `npm run lint:budget` totals are unchanged from `main` (the pre-existing `react-refresh/only-export-components` and `max-lines` budgets are over before this change too).
- DCO sign-off included.