### PR TITLE
fix: persist Building Blocks sidebar filter toggles

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -7,7 +7,11 @@ import { getBackgroundColorClass } from "@/lib/colors";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/ui/dropdownMenu";
 import { Search, Settings2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY } from "../CanvasPage";
+import {
+  COMPONENT_SIDEBAR_CONNECTED_ON_TOP_STORAGE_KEY,
+  COMPONENT_SIDEBAR_SHOW_SETUP_STATUS_STORAGE_KEY,
+  COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY,
+} from "../CanvasPage";
 import { ComponentBase } from "../componentBase";
 import { CategorySection } from "./CategorySection";
 import { findFirstVisibleBlock, type TypeFilter } from "./filter";
@@ -102,12 +106,34 @@ function OpenBuildingBlocksSidebar({
   const [isResizing, setIsResizing] = useState(false);
   const [hoveredBlock, setHoveredBlock] = useState<BuildingBlock | null>(null);
   const dragPreviewRef = useRef<HTMLDivElement>(null);
-  const [showIntegrationSetupStatus, setShowIntegrationSetupStatus] = useState(true);
-  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(false);
+  const [showIntegrationSetupStatus, setShowIntegrationSetupStatus] = useState(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+
+    const saved = window.localStorage.getItem(COMPONENT_SIDEBAR_SHOW_SETUP_STATUS_STORAGE_KEY);
+    return saved === null ? true : saved === "true";
+  });
+  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    const saved = window.localStorage.getItem(COMPONENT_SIDEBAR_CONNECTED_ON_TOP_STORAGE_KEY);
+    return saved === "true";
+  });
 
   useEffect(() => {
     localStorage.setItem(COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
   }, [sidebarWidth]);
+
+  useEffect(() => {
+    localStorage.setItem(COMPONENT_SIDEBAR_SHOW_SETUP_STATUS_STORAGE_KEY, String(showIntegrationSetupStatus));
+  }, [showIntegrationSetupStatus]);
+
+  useEffect(() => {
+    localStorage.setItem(COMPONENT_SIDEBAR_CONNECTED_ON_TOP_STORAGE_KEY, String(showConnectedIntegrationsOnTop));
+  }, [showConnectedIntegrationsOnTop]);
 
   useEffect(() => {
     if (!searchInputRef.current) {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -344,6 +344,8 @@ export interface CanvasPageProps {
 
 export const CANVAS_SIDEBAR_STORAGE_KEY = "canvasSidebarOpen";
 export const COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY = "componentSidebarWidth";
+export const COMPONENT_SIDEBAR_SHOW_SETUP_STATUS_STORAGE_KEY = "componentSidebarShowSetupStatus";
+export const COMPONENT_SIDEBAR_CONNECTED_ON_TOP_STORAGE_KEY = "componentSidebarConnectedOnTop";
 export const CONSOLE_OPEN_STORAGE_KEY = "consoleOpen";
 export const CONSOLE_HEIGHT_STORAGE_KEY = "consoleHeight";
 


### PR DESCRIPTION
Closes #4370

## Summary

The `Connected Integrations on Top` and `Show integration setup status` toggles in the Building Blocks sidebar reset whenever the sidebar remounts — selecting a component, opening the sidebar again, or navigating away and back. The issue references the connected-on-top filter; the setup-status toggle sits in the same dropdown and exhibits the same problem, so this PR persists both for consistency.

## Implementation

Both toggles are now hydrated from `localStorage` on mount and written back on every change, matching the pattern already used for `sidebarWidth` in the same component:

- `componentSidebarShowSetupStatus` — default `true`
- `componentSidebarConnectedOnTop` — default `false`

Key constants are exported from `ui/CanvasPage/index.tsx` next to the existing `COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY`. SSR-safe (`typeof window === "undefined"` guard) like the existing width init.

## Verification

- `tsc --noEmit -p .` clean.
- Existing `filter.spec.ts` and `CategorySection.spec.tsx` still pass (15 tests).
- `npm run lint:budget` totals are unchanged from `main`.
- DCO sign-off included.