### PR TITLE
docs: fix broken links to e2e-tests.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - One-shot backend tests: `make test` (Golang).
 - Targeted backend tests: `make test PKG_TEST_PACKAGES=./pkg/workers`
 - Targeted E2E tests: `make e2e E2E_TEST_PACKAGES=./test/e2e/workflows`
-- For E2E test authoring, see [docs/development/e2e_tests.md](docs/development/e2e_tests.md)
+- For E2E test authoring, see [docs/contributing/e2e-tests.md](docs/contributing/e2e-tests.md)
 - After updating UI code, always run `make check.build.ui` to verify everything is correct
 - After editing JS code, always run `make format.js` to make sure that the files are consistently formatted
 - After editing Golang code, always run `make format.go` to make sure that files are consistently formatted

--- a/docs/contributing/integrations.md
+++ b/docs/contributing/integrations.md
@@ -548,7 +548,7 @@ After implementing your integration:
 1. **Build and format**: Run `make format.go && make lint && make check.build.app`
 2. **Test the backend**: Run `make test`
 3. **Test the UI**: Run `make check.build.ui`
-4. **E2E tests**: Consider adding E2E tests (see [e2e_tests.md](e2e_tests.md))
+4. **E2E tests**: Consider adding E2E tests (see [e2e-tests.md](e2e-tests.md))
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

Two markdown links pointed at file paths that do not exist:

- `AGENTS.md` linked to `docs/development/e2e_tests.md`. The `docs/development/` directory does not exist; the actual file lives at `docs/contributing/e2e-tests.md`.
- `docs/contributing/integrations.md` linked to a sibling `e2e_tests.md` (underscore) when the filename is `e2e-tests.md` (dash).

Both links now resolve correctly.

## Test plan

- [x] `ls docs/contributing/e2e-tests.md` confirms the target exists
- [x] `grep -n "e2e_tests\|e2e-tests" AGENTS.md docs/contributing/integrations.md` shows both pointers updated
- [x] No code, build, or test impact (docs-only change)