### PR TITLE
fix(canvas): reduce CPU usage when dragging workflow nodes

### DIFF
--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Handle, Position } from "@xyflow/react";
+
+import { useCanvasNodeOverlay } from "../canvasNodeOverlayContext";
 import { getOutputChannels } from "./data";
 import type { BlockConnectionState, BlockEdgeState, BlockProps, CanvasBlockData } from "./types";
 
@@ -253,10 +255,12 @@ export function LeftHandle({
 }: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
   if (shouldHideLeftHandle(data)) return null;
 
-  const hoveredEdge = data._hoveredEdge;
-  const connectingFrom = data._connectingFrom;
+  const overlay = useCanvasNodeOverlay();
+  const hoveredEdge = overlay?.hoveredEdge ?? data._hoveredEdge;
+  const connectingFrom = overlay?.connectingFrom ?? data._connectingFrom;
+  const allEdges = overlay?.allEdges ?? getBlockEdges(data);
   const isAlreadyConnected = isAlreadyConnectedToNode(
-    getBlockEdges(data),
+    allEdges,
     connectingFrom,
     connectingFrom?.nodeId,
     nodeId,
@@ -293,9 +297,10 @@ export function RightHandle({
   if (shouldHideRightHandle(data)) return null;
 
   const channels = getOutputChannels(data);
-  const hoveredEdge = data._hoveredEdge;
-  const connectingFrom = data._connectingFrom;
-  const allEdges = getBlockEdges(data);
+  const overlay = useCanvasNodeOverlay();
+  const hoveredEdge = overlay?.hoveredEdge ?? data._hoveredEdge;
+  const connectingFrom = overlay?.connectingFrom ?? data._connectingFrom;
+  const allEdges = overlay?.allEdges ?? getBlockEdges(data);
 
   if (channels.length === 1) {
     return (

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+
+import { useCanvasNodeOverlay } from "../canvasNodeOverlayContext";
 import { BlockContent } from "./content";
 import { LeftHandle, RightHandle } from "./handles";
 import type { BlockProps } from "./types";
@@ -7,9 +9,12 @@ export type { BlockData, BlockProps } from "./types";
 export type { CanvasBlockData } from "./types";
 
 export const Block = React.memo(function Block(props: BlockProps) {
+  const overlay = useCanvasNodeOverlay();
   const data = props.data;
-  const isHighlighted = data._isHighlighted || false;
-  const hasHighlightedNodes = data._hasHighlightedNodes || false;
+  const nodeId = props.nodeId ?? "";
+  const isHighlighted =
+    (overlay && overlay.highlightedNodeIds.has(nodeId)) || data._isHighlighted || false;
+  const hasHighlightedNodes = overlay?.hasHighlightedNodes || data._hasHighlightedNodes || false;
   const shouldDim = hasHighlightedNodes && !isHighlighted;
   const isConnectionInteractive = props.canvasMode !== "live";
 

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -30,7 +30,7 @@ type BlockHandleType = "source" | "target";
 export interface BlockConnectionState {
   nodeId?: string;
   handleId?: string | null;
-  handleType?: BlockHandleType;
+  handleType?: BlockHandleType | null;
 }
 
 export interface BlockEdgeState {

--- a/web_src/src/ui/CanvasPage/canvasNodeOverlayContext.tsx
+++ b/web_src/src/ui/CanvasPage/canvasNodeOverlayContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, type MouseEvent, type MutableRefObject, type ReactNode } from "react";
+
+import type { BlockConnectionState, BlockEdgeState } from "./Block/types";
+
+/** Callback bundle for custom nodes; lives on a ref so context value can stay stable. */
+export type CanvasNodeRendererCallbacks = {
+  handleNodeClick: (nodeId: string, event?: MouseEvent) => void;
+  onNodeEdit: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onNodeDelete: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onRun: MutableRefObject<((nodeId?: string, initialData?: string) => void) | undefined>;
+  onDuplicate: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onDeactivate: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onTogglePause: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onToggleView: MutableRefObject<((nodeId: string) => void) | undefined>;
+  onAnnotationUpdate: MutableRefObject<
+    | ((
+        nodeId: string,
+        updates: { text?: string; color?: string; width?: number; height?: number; x?: number; y?: number },
+      ) => void)
+    | undefined
+  >;
+  onAnnotationBlur: MutableRefObject<(() => void) | undefined>;
+  runDisabled?: boolean;
+  runDisabledTooltip?: string;
+  showHeader: boolean;
+  hasMultiSelection: boolean;
+  canvasMode: "live" | "edit";
+};
+
+export type CanvasNodeOverlayValue = {
+  callbacksRef: MutableRefObject<CanvasNodeRendererCallbacks>;
+  hoveredEdge: BlockEdgeState | null;
+  connectingFrom: BlockConnectionState | null;
+  allEdges: BlockEdgeState[];
+  highlightedNodeIds: ReadonlySet<string>;
+  hasHighlightedNodes: boolean;
+};
+
+const CanvasNodeOverlayContext = createContext<CanvasNodeOverlayValue | null>(null);
+
+export function CanvasNodeOverlayProvider({
+  value,
+  children,
+}: {
+  value: CanvasNodeOverlayValue;
+  children: ReactNode;
+}) {
+  return <CanvasNodeOverlayContext.Provider value={value}>{children}</CanvasNodeOverlayContext.Provider>;
+}
+
+export function useCanvasNodeOverlay(): CanvasNodeOverlayValue | null {
+  return useContext(CanvasNodeOverlayContext);
+}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -65,6 +65,12 @@ import type { SidebarEvent } from "../componentSidebar/types";
 import { EmitEventModal } from "../EmitEventModal";
 import { IntegrationStatusIndicator, type MissingIntegration } from "../IntegrationStatusIndicator";
 import { Block, type BlockData, type BlockProps, type CanvasBlockData } from "./Block";
+import type { BlockEdgeState } from "./Block/types";
+import {
+  CanvasNodeOverlayProvider,
+  type CanvasNodeRendererCallbacks,
+  useCanvasNodeOverlay,
+} from "./canvasNodeOverlayContext";
 import "./canvas-reset.css";
 import { CustomEdge } from "./CustomEdge";
 import { Header } from "./Header";
@@ -369,26 +375,7 @@ type PendingRunData = {
   initialData?: string;
 };
 
-type CanvasNodeRendererCallbacks = {
-  handleNodeClick: (nodeId: string, event?: React.MouseEvent) => void;
-  onNodeEdit: React.MutableRefObject<CanvasPageProps["onEdit"] | undefined>;
-  onNodeDelete: React.MutableRefObject<CanvasPageProps["onNodeDelete"] | undefined>;
-  onRun: React.MutableRefObject<((nodeId?: string, initialData?: string) => void) | undefined>;
-  onDuplicate: React.MutableRefObject<CanvasPageProps["onDuplicate"] | undefined>;
-  onDeactivate: React.MutableRefObject<CanvasPageProps["onDeactivate"] | undefined>;
-  onTogglePause: React.MutableRefObject<CanvasPageProps["onTogglePause"] | undefined>;
-  onToggleView: React.MutableRefObject<CanvasPageProps["onToggleView"] | undefined>;
-  onAnnotationUpdate: React.MutableRefObject<CanvasPageProps["onAnnotationUpdate"] | undefined>;
-  onAnnotationBlur: React.MutableRefObject<CanvasPageProps["onAnnotationBlur"] | undefined>;
-  runDisabled?: boolean;
-  runDisabledTooltip?: string;
-  showHeader: boolean;
-  hasMultiSelection: boolean;
-  canvasMode: "live" | "edit";
-};
-
 type CanvasBlockNodeData = CanvasBlockData & {
-  _callbacksRef?: React.MutableRefObject<CanvasNodeRendererCallbacks>;
   nodeName?: string;
 };
 
@@ -569,6 +556,11 @@ export class CanvasNodeErrorBoundary extends Component<CanvasNodeErrorBoundaryPr
   }
 }
 
+function stripCanvasOverlayFields(data: CanvasBlockNodeData): CanvasBlockData {
+  const { _hoveredEdge, _connectingFrom, _allEdges, _isHighlighted, _hasHighlightedNodes, ...rest } = data;
+  return rest;
+}
+
 /*
  * nodeTypes must be defined outside of the component to prevent
  * react-flow from remounting the node types on every render.
@@ -578,8 +570,9 @@ const DefaultNodeRenderer = memo(function DefaultNodeRenderer(nodeProps: {
   id: string;
   selected?: boolean;
 }) {
-  const { _callbacksRef, ...blockData } = nodeProps.data;
-  const callbacks = _callbacksRef?.current;
+  const overlay = useCanvasNodeOverlay();
+  const callbacks = overlay?.callbacksRef.current;
+  const blockData = stripCanvasOverlayFields(nodeProps.data);
   const blockProps = buildDefaultNodeBlockProps({
     nodeId: nodeProps.id,
     selected: nodeProps.selected,
@@ -2301,21 +2294,36 @@ function CanvasContent({
     return state.edges?.find((e) => e.id === hoveredEdgeId);
   }, [hoveredEdgeId, state.edges]);
 
-  const nodesWithCallbacks = useMemo(() => {
-    const hasHighlightedNodes = highlightedNodeIds.size > 0;
-    return state.nodes.map((node) => ({
-      ...node,
-      data: {
-        ...node.data,
-        _callbacksRef: callbacksRef,
-        _hoveredEdge: hoveredEdge,
-        _connectingFrom: connectingFrom,
-        _allEdges: state.edges,
-        _isHighlighted: highlightedNodeIds.has(node.id),
-        _hasHighlightedNodes: hasHighlightedNodes,
-      },
-    }));
-  }, [state.nodes, hoveredEdge, connectingFrom, state.edges, highlightedNodeIds]);
+  const blockEdgesForOverlay = useMemo(
+    () =>
+      (state.edges ?? []).map((e) => ({
+        source: e.source,
+        sourceHandle: e.sourceHandle,
+        target: e.target,
+      })),
+    [state.edges],
+  );
+
+  const hoveredBlockEdge = useMemo((): BlockEdgeState | null => {
+    if (!hoveredEdge) return null;
+    return {
+      source: hoveredEdge.source,
+      sourceHandle: hoveredEdge.sourceHandle,
+      target: hoveredEdge.target,
+    };
+  }, [hoveredEdge]);
+
+  const canvasNodeOverlayValue = useMemo(
+    () => ({
+      callbacksRef,
+      hoveredEdge: hoveredBlockEdge,
+      connectingFrom,
+      allEdges: blockEdgesForOverlay,
+      highlightedNodeIds,
+      hasHighlightedNodes: highlightedNodeIds.size > 0,
+    }),
+    [callbacksRef, hoveredBlockEdge, connectingFrom, blockEdgesForOverlay, highlightedNodeIds],
+  );
 
   const edgeTypes = useMemo(
     () => ({
@@ -2428,54 +2436,55 @@ function CanvasContent({
     <div className="h-full w-full relative">
       <div className="h-full">
         <div className="h-full w-full">
-          <ReactFlow
-            nodes={nodesWithCallbacks}
-            edges={styledEdges}
-            nodeTypes={nodeTypes}
-            edgeTypes={edgeTypes}
-            minZoom={MIN_CANVAS_ZOOM}
-            maxZoom={1.5}
-            zoomOnScroll={true}
-            zoomOnPinch={true}
-            zoomOnDoubleClick={false}
-            panOnScroll={true}
-            panOnDrag={true}
-            selectionOnDrag={true}
-            selectionKeyCode={selectionKey}
-            multiSelectionKeyCode={selectionKey}
-            snapToGrid={isSnapToGridEnabled}
-            snapGrid={[48, 48]}
-            panOnScrollSpeed={0.8}
-            nodesDraggable={!isReadOnly}
-            nodesConnectable={isConnectionEditingEnabled}
-            elementsSelectable={true}
-            onNodesChange={handleNodesChange}
-            onEdgesChange={handleEdgesChange}
-            onConnect={isConnectionEditingEnabled ? handleConnect : undefined}
-            onConnectStart={isConnectionEditingEnabled ? handleConnectStart : undefined}
-            onConnectEnd={isConnectionEditingEnabled ? handleConnectEnd : undefined}
-            onDragOver={isReadOnly ? undefined : handleDragOver}
-            onDrop={isReadOnly ? undefined : handleDrop}
-            onMove={handleMove}
-            onInit={handleInit}
-            deleteKeyCode={null}
-            onPaneClick={handlePaneClick}
-            onSelectionStart={() => {
-              setIsSelecting(true);
-              const selected = (stateRef.current.nodes || []).filter((n) => n.selected).map((n) => n.id);
-              previouslySelectedRef.current = new Set(selected);
-            }}
-            onSelectionEnd={() => {
-              setIsSelecting(false);
-              previouslySelectedRef.current = new Set();
-            }}
-            onEdgeMouseEnter={isEditMode ? handleEdgeMouseEnter : undefined}
-            onEdgeMouseLeave={isEditMode ? handleEdgeMouseLeave : undefined}
-            defaultViewport={viewport}
-            fitView={false}
-            style={{ opacity: isInitialized ? 1 : 0 }}
-            className="h-full w-full"
-          >
+          <CanvasNodeOverlayProvider value={canvasNodeOverlayValue}>
+            <ReactFlow
+              nodes={state.nodes}
+              edges={styledEdges}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              minZoom={MIN_CANVAS_ZOOM}
+              maxZoom={1.5}
+              zoomOnScroll={true}
+              zoomOnPinch={true}
+              zoomOnDoubleClick={false}
+              panOnScroll={true}
+              panOnDrag={true}
+              selectionOnDrag={true}
+              selectionKeyCode={selectionKey}
+              multiSelectionKeyCode={selectionKey}
+              snapToGrid={isSnapToGridEnabled}
+              snapGrid={[48, 48]}
+              panOnScrollSpeed={0.8}
+              nodesDraggable={!isReadOnly}
+              nodesConnectable={isConnectionEditingEnabled}
+              elementsSelectable={true}
+              onNodesChange={handleNodesChange}
+              onEdgesChange={handleEdgesChange}
+              onConnect={isConnectionEditingEnabled ? handleConnect : undefined}
+              onConnectStart={isConnectionEditingEnabled ? handleConnectStart : undefined}
+              onConnectEnd={isConnectionEditingEnabled ? handleConnectEnd : undefined}
+              onDragOver={isReadOnly ? undefined : handleDragOver}
+              onDrop={isReadOnly ? undefined : handleDrop}
+              onMove={handleMove}
+              onInit={handleInit}
+              deleteKeyCode={null}
+              onPaneClick={handlePaneClick}
+              onSelectionStart={() => {
+                setIsSelecting(true);
+                const selected = (stateRef.current.nodes || []).filter((n) => n.selected).map((n) => n.id);
+                previouslySelectedRef.current = new Set(selected);
+              }}
+              onSelectionEnd={() => {
+                setIsSelecting(false);
+                previouslySelectedRef.current = new Set();
+              }}
+              onEdgeMouseEnter={isEditMode ? handleEdgeMouseEnter : undefined}
+              onEdgeMouseLeave={isEditMode ? handleEdgeMouseLeave : undefined}
+              defaultViewport={viewport}
+              fitView={false}
+              style={{ opacity: isInitialized ? 1 : 0 }}
+              className="h-full w-full"
+            >
             <Background gap={8} size={2} bgColor="#F1F5F9" color="#d9d9d9ff" />
             <Panel
               position="bottom-left"
@@ -2741,7 +2750,8 @@ function CanvasContent({
                   </div>
                 </ViewportPortal>
               )}
-          </ReactFlow>
+            </ReactFlow>
+          </CanvasNodeOverlayProvider>
         </div>
       </div>
       {showBottomStatusControls ? (

--- a/web_src/src/ui/CanvasPage/useCanvasState.ts
+++ b/web_src/src/ui/CanvasPage/useCanvasState.ts
@@ -1,6 +1,6 @@
 import type { Edge, EdgeChange, Node, NodeChange, NodePositionChange } from "@xyflow/react";
 import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CanvasPageProps } from ".";
 
 export interface CanvasPageState {
@@ -68,16 +68,34 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
     });
   }, [initialNodes]);
 
+  // Re-merge edges from the server when edges or local-only nodes change — not on every node position tick (drag).
+  const localEdgesSyncKey = useMemo(
+    () =>
+      nodes
+        .filter((n) => n.data.isTemplate || n.data.isPendingConnection)
+        .map((n) => `${n.id}:${n.data.isTemplate ? "T" : "P"}`)
+        .sort()
+        .join(","),
+    [nodes],
+  );
+
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+
+  // Depends on `localEdgesSyncKey` (template/pending node set) instead of `nodes` so drag position updates
+  // do not re-merge edges every frame. Reads latest nodes via `nodesRef` when this does run.
   useEffect(() => {
     if (!initialEdges) return;
+
+    const nodesSnapshot = nodesRef.current;
 
     setEdges((currentEdges) => {
       // Preserve edges connected to template or pending connection nodes
       const localOnlyEdges = currentEdges.filter((edge) => {
-        const sourceIsLocal = nodes.some(
+        const sourceIsLocal = nodesSnapshot.some(
           (n) => n.id === edge.source && (n.data.isTemplate || n.data.isPendingConnection),
         );
-        const targetIsLocal = nodes.some(
+        const targetIsLocal = nodesSnapshot.some(
           (n) => n.id === edge.target && (n.data.isTemplate || n.data.isPendingConnection),
         );
         return sourceIsLocal || targetIsLocal;
@@ -86,7 +104,7 @@ export function useCanvasState(props: CanvasPageProps): CanvasPageState {
       // Combine synced edges with local-only edges
       return [...initialEdges, ...localOnlyEdges];
     });
-  }, [initialEdges, nodes]);
+  }, [initialEdges, localEdgesSyncKey]);
 
   // Apply initial collapsed state to nodes
   useEffect(() => {


### PR DESCRIPTION
## The problem

Dragging nodes on the workflow canvas caused high CPU usage. Each drag frame rebuilt overlay data on every node and re-ran the edge sync effect on every `nodes` update, forcing broad React updates and edge remapping.

Related: https://github.com/superplanehq/superplane/issues/4442

## The solution

- Added `CanvasNodeOverlayProvider` / `useCanvasNodeOverlay()` so hover, in-flight connection, edge list for handle logic, execution-chain highlights, and the existing callbacks ref are supplied without cloning `node.data` for every node on every move.
- Pass `state.nodes` directly into React Flow so unchanged nodes keep stable `data` where possible, allowing `memo` on node UI to skip work during drag.
- In `useCanvasState`, derive a `localEdgesSyncKey` from template/pending nodes only and run the edge re-merge effect on `[initialEdges, localEdgesSyncKey]`, using a `nodesRef` snapshot inside the effect so drag-only position updates do not trigger `setEdges` every frame.
- `Block` and handles read overlay from context, with the previous `data._…` fields as fallbacks (e.g. unit tests without a provider).

### Additional implementation notes

- `CanvasNodeRendererCallbacks` lives in `canvasNodeOverlayContext.tsx` to keep types and context together.
- `BlockConnectionState.handleType` allows `null` to match runtime connect state.
- No API, proto, or OpenAPI changes—UI-only performance work.

### Testing notes

- [ ] Drag nodes on a canvas with many nodes; confirm smoother interaction and lower CPU (browser Performance tab / system monitor).
- [ ] Regression: edge hover, new connections, template/pending nodes, execution-chain highlighting, multi-select, read-only canvas.
- [ ] `make format.js` and `make check.build.ui` (or your CI equivalents).

---

Have you done the following:
- [ ] Have you proofread your commits?
- [ ] Did you update the docs, API spec, and README as necessary?