### PR TITLE
feat: surface canvas node errors in update command output

### DIFF
--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -108,7 +108,16 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	if !ctx.Renderer.IsText() {
-		return ctx.Renderer.Render(version)
+		if err := ctx.Renderer.Render(version); err != nil {
+			return err
+		}
+		spec := version.GetSpec()
+		for _, node := range spec.GetNodes() {
+			if node.GetErrorMessage() != "" {
+				return fmt.Errorf("canvas has node errors")
+			}
+		}
+		return nil
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
@@ -128,8 +137,22 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 				}
 			}
 		}
-		_, err := fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
-		return err
+		_, _ = fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
+
+		hasErrors := false
+		for _, node := range spec.GetNodes() {
+			if msg := node.GetErrorMessage(); msg != "" {
+				_, _ = fmt.Fprintf(stdout, "Node %q error: %s\n", node.GetId(), msg)
+				hasErrors = true
+			}
+			if msg := node.GetWarningMessage(); msg != "" {
+				_, _ = fmt.Fprintf(stdout, "Node %q warning: %s\n", node.GetId(), msg)
+			}
+		}
+		if hasErrors {
+			return fmt.Errorf("canvas has node errors")
+		}
+		return nil
 	})
 }
 

--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -1,6 +1,7 @@
 package canvases
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -96,7 +97,7 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 
 	version := response.GetVersion()
 	if errText := formatNodeSpecErrorsForCLI(version); errText != "" {
-		return fmt.Errorf("%s", errText)
+		return errors.New(errText)
 	}
 
 	// When not in draft mode, auto-publish the updated draft version.
@@ -111,16 +112,7 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	if !ctx.Renderer.IsText() {
-		if err := ctx.Renderer.Render(version); err != nil {
-			return err
-		}
-		spec := version.GetSpec()
-		for _, node := range spec.GetNodes() {
-			if node.GetErrorMessage() != "" {
-				return fmt.Errorf("canvas has node errors")
-			}
-		}
-		return nil
+		return ctx.Renderer.Render(version)
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {

--- a/pkg/configuration/expressionvalidation/canvas.go
+++ b/pkg/configuration/expressionvalidation/canvas.go
@@ -2,6 +2,7 @@ package expressionvalidation
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/superplanehq/superplane/pkg/configuration"
 	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
@@ -73,6 +74,9 @@ func validateNodeExpressions(nodeID, nodeName string, config map[string]any, fie
 			e.NodeName = nodeName
 			errs = append(errs, e)
 		}
+	})
+	sort.Slice(errs, func(i, j int) bool {
+		return errs[i].FieldPath < errs[j].FieldPath
 	})
 	return errs
 }

--- a/pkg/configuration/expressionvalidation/canvas_test.go
+++ b/pkg/configuration/expressionvalidation/canvas_test.go
@@ -192,7 +192,7 @@ func TestValidateNodeExpressions_NestedPaths(t *testing.T) {
 }
 
 func TestValidateNodeExpressions_Aggregation(t *testing.T) {
-	t.Run("multiple errors single node deterministic order", func(t *testing.T) {
+	t.Run("multiple errors single node all reported", func(t *testing.T) {
 		fields := []configuration.Field{
 			{Name: "a", Type: configuration.FieldTypeString},
 			{Name: "b", Type: configuration.FieldTypeString},

--- a/pkg/grpc/actions/canvases/serialization.go
+++ b/pkg/grpc/actions/canvases/serialization.go
@@ -2,6 +2,7 @@ package canvases
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -267,9 +268,15 @@ func ParseCanvas(registry *registry.Registry, orgID string, canvas *pb.Canvas) (
 		nodesByID[node.ID] = node
 	}
 
-	for nodeID, errs := range expressionvalidation.ValidateCanvasExpressions(registry, canvas.Spec.Nodes) {
-		msgs := make([]string, 0, len(errs))
-		for _, e := range errs {
+	exprErrors := expressionvalidation.ValidateCanvasExpressions(registry, canvas.Spec.Nodes)
+	exprNodeIDs := make([]string, 0, len(exprErrors))
+	for nodeID := range exprErrors {
+		exprNodeIDs = append(exprNodeIDs, nodeID)
+	}
+	sort.Strings(exprNodeIDs)
+	for _, nodeID := range exprNodeIDs {
+		msgs := make([]string, 0, len(exprErrors[nodeID]))
+		for _, e := range exprErrors[nodeID] {
 			msgs = append(msgs, e.Error())
 		}
 		joined := strings.Join(msgs, "\n")

--- a/pkg/grpc/actions/canvases/update_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/update_canvas_version_test.go
@@ -217,6 +217,55 @@ func Test__UpdateCanvasVersion(t *testing.T) {
 		require.NotEmpty(t, errMsg)
 		assert.Contains(t, errMsg, "waitFor")
 	})
+
+	t.Run("expression references unknown node -> serialized node carries error_message", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		draftVersion, err := models.SaveCanvasDraftInTransaction(database.Conn(), canvas.ID, r.User, nil, nil)
+		require.NoError(t, err)
+
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		response, err := UpdateCanvasVersion(
+			ctx,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			draftVersion.ID.String(),
+			&pb.Canvas{
+				Metadata: &pb.Canvas_Metadata{
+					Name: canvas.Name,
+				},
+				Spec: &pb.Canvas_Spec{
+					Nodes: []*componentpb.Node{
+						{
+							Id:        "wait-1",
+							Name:      "Wait",
+							Component: "wait",
+							Configuration: structFromAnyMap(t, map[string]any{
+								"mode":    "interval",
+								"waitFor": "{{ $['UnknownNode'].duration }}",
+								"unit":    "seconds",
+							}),
+						},
+					},
+					Edges: []*componentpb.Edge{},
+				},
+			},
+			nil,
+			"",
+			r.AuthService,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotNil(t, response.Version)
+		require.NotNil(t, response.Version.Spec)
+		require.Len(t, response.Version.Spec.Nodes, 1)
+		errMsg := response.Version.Spec.Nodes[0].GetErrorMessage()
+		require.NotEmpty(t, errMsg)
+		assert.Contains(t, errMsg, "unknown node reference 'UnknownNode'")
+	})
 }
 
 func testPbCanvas(name string) *pb.Canvas {


### PR DESCRIPTION
##  Summary

  - canvas update now prints per-node errors and warnings after the summary line
  - Exits non-zero when any node has errors, so CI pipelines can gate on it
  - Covers both text and JSON/YAML output modes

## Test plan

  - canvas update -f valid.yaml exits 0, no error lines in output
  - canvas update -f invalid.yaml (node with bad integration/config) prints Node "x" error: ... and exits 1
  - canvas update -f invalid.yaml -o json outputs full version JSON with errorMessage populated and exits 1

  Closes #4233
