### PR TITLE
fix: CLI surface node configuration errors after canvas update

### DIFF
--- a/pkg/cli/commands/canvases/update.go
+++ b/pkg/cli/commands/canvases/update.go
@@ -95,6 +95,9 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 	}
 
 	version := response.GetVersion()
+	if errText := formatNodeSpecErrorsForCLI(version); errText != "" {
+		return fmt.Errorf("%s", errText)
+	}
 
 	// When not in draft mode, auto-publish the updated draft version.
 	if !draftMode {
@@ -129,6 +132,12 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 			}
 		}
 		_, err := fmt.Fprintf(stdout, "Integrations: %d\n", len(integrations))
+		if err != nil {
+			return err
+		}
+		if warnText := formatNodeSpecWarningsForCLI(version); warnText != "" {
+			_, err = fmt.Fprint(stdout, warnText)
+		}
 		return err
 	})
 }
@@ -244,4 +253,77 @@ func buildDefaultAutoLayout() openapi_client.CanvasesCanvasAutoLayout {
 	autoLayout.SetAlgorithm(openapi_client.CANVASAUTOLAYOUTALGORITHM_ALGORITHM_HORIZONTAL)
 	autoLayout.SetScope(openapi_client.CANVASAUTOLAYOUTSCOPE_SCOPE_FULL_CANVAS)
 	return autoLayout
+}
+
+// formatNodeSpecErrorsForCLI summarizes node error_message from the API response (blocks execution until fixed).
+func formatNodeSpecErrorsForCLI(version openapi_client.CanvasesCanvasVersion) string {
+	spec, ok := version.GetSpecOk()
+	if !ok || spec == nil {
+		return ""
+	}
+
+	var lines []string
+	for _, node := range spec.GetNodes() {
+		if !node.HasErrorMessage() {
+			continue
+		}
+		msg := strings.TrimSpace(node.GetErrorMessage())
+		if msg == "" {
+			continue
+		}
+		id := node.GetId()
+		name := strings.TrimSpace(node.GetName())
+		if name == "" {
+			name = id
+		}
+		lines = append(lines, fmt.Sprintf("node %s (%s): %s", id, name, msg))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("canvas was saved but the following nodes have configuration errors (error_message on each node):\n")
+	for _, line := range lines {
+		b.WriteString("  - ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func formatNodeSpecWarningsForCLI(version openapi_client.CanvasesCanvasVersion) string {
+	spec, ok := version.GetSpecOk()
+	if !ok || spec == nil {
+		return ""
+	}
+
+	var lines []string
+	for _, node := range spec.GetNodes() {
+		if !node.HasWarningMessage() {
+			continue
+		}
+		msg := strings.TrimSpace(node.GetWarningMessage())
+		if msg == "" {
+			continue
+		}
+		id := node.GetId()
+		name := strings.TrimSpace(node.GetName())
+		if name == "" {
+			name = id
+		}
+		lines = append(lines, fmt.Sprintf("node %s (%s): %s", id, name, msg))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\nNode warnings (warning_message):\n")
+	for _, line := range lines {
+		b.WriteString("  - ")
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/pkg/grpc/actions/canvases/update_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/update_canvas_version_test.go
@@ -168,6 +168,55 @@ func Test__UpdateCanvasVersion(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, s.Code())
 		assert.Contains(t, s.Message(), `source node http-1 does not have output channel "default"`)
 	})
+
+	t.Run("invalid node field type -> serialized node carries error_message", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		draftVersion, err := models.SaveCanvasDraftInTransaction(database.Conn(), canvas.ID, r.User, nil, nil)
+		require.NoError(t, err)
+
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		response, err := UpdateCanvasVersion(
+			ctx,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			draftVersion.ID.String(),
+			&pb.Canvas{
+				Metadata: &pb.Canvas_Metadata{
+					Name: canvas.Name,
+				},
+				Spec: &pb.Canvas_Spec{
+					Nodes: []*componentpb.Node{
+						{
+							Id:        "wait-1",
+							Name:      "Wait",
+							Component: "wait",
+							Configuration: structFromAnyMap(t, map[string]any{
+								"mode":    "interval",
+								"waitFor": 30,
+								"unit":    "seconds",
+							}),
+						},
+					},
+					Edges: []*componentpb.Edge{},
+				},
+			},
+			nil,
+			"",
+			r.AuthService,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotNil(t, response.Version)
+		require.NotNil(t, response.Version.Spec)
+		require.Len(t, response.Version.Spec.Nodes, 1)
+		errMsg := response.Version.Spec.Nodes[0].GetErrorMessage()
+		require.NotEmpty(t, errMsg)
+		assert.Contains(t, errMsg, "waitFor")
+	})
 }
 
 func testPbCanvas(name string) *pb.Canvas {


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/4439

## Description
  This fixes the case where `superplane canvases update` could exit successfully while nodes had invalid configuration (wrong JSON types, 
  etc.). The API already stores validation output on each node as `error_message` (and softer issues as `warning_message`), but the CLI did not
   surface those fields, so broken canvases were easy to miss.
  After a successful update response, the CLI walks `version.spec.nodes` and summarizes `error_message` / `warning_message`. No new fields were
   added to the REST or protobuf responses.
  ### Behavior
  - **Errors (`error_message`)**: command fails with a bullet list (node id, display name, API message). The draft may already be saved; 
  **auto-publish is skipped** when this fires.
  - **Warnings (`warning_message`) only**: command succeeds; in **text** output, an extra “Node warnings” section is printed after the normal 
  summary.
  ### Examples (text UI)
  **1) Configuration errors — command fails (exit ≠ 0)**
  ```text
  canvas was saved but the following nodes have configuration errors (error_message on each node):
    - node wait-1 (Wait): field 'waitFor': must be a string
    - node http-1 (HTTP Request): field 'timeoutSeconds': must be a number
  ```
  **2) No errors, only warnings — command succeeds**
  ```text
  Canvas version updated: 8f3b2c1d-1111-2222-3333-444455556666
  Canvas ID: a1b2c3d4-aaaa-bbbb-cccc-ddddeeeeffff
  Nodes: 4
  Edges: 3
  Integrations: 2
  Node warnings (warning_message):
    - node if-1 (If): <warning text from API>
  ```
  **3) Clean update — command succeeds**
  ```text
  Canvas version updated: 8f3b2c1d-1111-2222-3333-444455556666
  Canvas ID: a1b2c3d4-aaaa-bbbb-cccc-ddddeeeeffff
  Nodes: 4
  Edges: 3
  Integrations: 2
  ```