### PR TITLE
feat: add PostHog analytics events for monitoring, debugging and integrations

### DIFF
--- a/web_src/src/hooks/useIntegrations.ts
+++ b/web_src/src/hooks/useIntegrations.ts
@@ -125,7 +125,7 @@ export const useIntegrationResources = (
 };
 
 // Hook to create an integration
-export const useCreateIntegration = (organizationId: string) => {
+export const useCreateIntegration = (organizationId: string, source: "node_configuration" | "integrations_page") => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -141,11 +141,13 @@ export const useCreateIntegration = (organizationId: string) => {
         }),
       );
     },
-    onSuccess: (_, variables) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({
         queryKey: integrationKeys.connected(organizationId),
       });
-      analytics.integrationCreate(variables.integrationName, organizationId);
+      const rawState = data.data?.integration?.status?.state;
+      const status = rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
+      analytics.integrationConnectSubmit(variables.integrationName, source, status, organizationId);
     },
   });
 };
@@ -182,20 +184,22 @@ export const useDeleteIntegration = (organizationId: string, integrationId: stri
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async () => {
-      return await organizationsDeleteIntegration(
+    mutationFn: async (data: { integrationName: string }) => {
+      await organizationsDeleteIntegration(
         withOrganizationHeader({
           path: { id: organizationId, integrationId },
         }),
       );
+      return data;
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: integrationKeys.connected(organizationId),
       });
       queryClient.removeQueries({
         queryKey: integrationKeys.integration(organizationId, integrationId),
       });
+      analytics.integrationDelete(variables.integrationName, organizationId);
     },
   });
 };

--- a/web_src/src/hooks/useIntegrations.ts
+++ b/web_src/src/hooks/useIntegrations.ts
@@ -145,8 +145,7 @@ export const useCreateIntegration = (organizationId: string, source: "node_confi
       queryClient.invalidateQueries({
         queryKey: integrationKeys.connected(organizationId),
       });
-      const rawState = data.data?.integration?.status?.state;
-      const status = rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
+      const status = (data.data?.integration?.status?.state || "pending") as "ready" | "error" | "pending";
       analytics.integrationConnectSubmit(variables.integrationName, source, status, organizationId);
     },
   });

--- a/web_src/src/lib/analytics.spec.ts
+++ b/web_src/src/lib/analytics.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { init, identify, capture, reset } = vi.hoisted(() => ({
   init: vi.fn(),
@@ -158,20 +158,148 @@ describe("analytics", () => {
     });
   });
 
-  it("captures integration create", () => {
-    analytics.integrationCreate("github", "org-123");
-    expect(capture).toHaveBeenCalledWith("integration:integration_create", {
-      integration_type: "github",
-      organization_id: "org-123",
-    });
-  });
-
   it("captures member accept", () => {
     analytics.memberAccept("org-123");
     expect(capture).toHaveBeenCalledWith("settings:member_accept", {
       organization_id: "org-123",
     });
   });
+
+  describe("integration connect events", () => {
+    let dateSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      dateSpy = vi.spyOn(Date, "now");
+    });
+
+    afterEach(() => {
+      dateSpy.mockRestore();
+    });
+
+    it("captures integration connect start from integrations page", () => {
+      analytics.integrationConnectStart("github", "integrations_page", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:connect_start", {
+        integration: "github",
+        source: "integrations_page",
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures integration connect start from node configuration", () => {
+      analytics.integrationConnectStart("slack", "node_configuration", "org-456");
+      expect(capture).toHaveBeenCalledWith("integration:connect_start", {
+        integration: "slack",
+        source: "node_configuration",
+        organization_id: "org-456",
+      });
+    });
+
+    it("captures integration connect submit with duration when start was recorded", () => {
+      dateSpy.mockReturnValueOnce(0).mockReturnValueOnce(3000);
+      analytics.integrationConnectStart("github", "integrations_page", "org-123");
+      analytics.integrationConnectSubmit("github", "integrations_page", "ready", "org-123");
+      expect(capture).toHaveBeenLastCalledWith("integration:connect_submit", {
+        integration: "github",
+        source: "integrations_page",
+        status: "ready",
+        duration_s: 3,
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures integration connect submit with pending status", () => {
+      dateSpy.mockReturnValueOnce(0).mockReturnValueOnce(5000);
+      analytics.integrationConnectStart("github", "node_configuration", "org-123");
+      analytics.integrationConnectSubmit("github", "node_configuration", "pending", "org-123");
+      expect(capture).toHaveBeenLastCalledWith("integration:connect_submit", {
+        integration: "github",
+        source: "node_configuration",
+        status: "pending",
+        duration_s: 5,
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures integration connect submit with error status", () => {
+      dateSpy.mockReturnValueOnce(0).mockReturnValueOnce(2000);
+      analytics.integrationConnectStart("slack", "integrations_page", "org-456");
+      analytics.integrationConnectSubmit("slack", "integrations_page", "error", "org-456");
+      expect(capture).toHaveBeenLastCalledWith("integration:connect_submit", {
+        integration: "slack",
+        source: "integrations_page",
+        status: "error",
+        duration_s: 2,
+        organization_id: "org-456",
+      });
+    });
+
+    it("captures integration connect submit without duration when no start was recorded", () => {
+      analytics.integrationConnectSubmit("github", "integrations_page", "ready", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:connect_submit", {
+        integration: "github",
+        source: "integrations_page",
+        status: "ready",
+        duration_s: undefined,
+        organization_id: "org-123",
+      });
+    });
+
+    it("clears the start time after submit so a second submit has no duration", () => {
+      dateSpy.mockReturnValueOnce(0).mockReturnValueOnce(1000).mockReturnValueOnce(2000);
+      analytics.integrationConnectStart("github", "integrations_page", "org-123");
+      analytics.integrationConnectSubmit("github", "integrations_page", "ready", "org-123");
+      capture.mockClear();
+      analytics.integrationConnectSubmit("github", "integrations_page", "ready", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:connect_submit", {
+        integration: "github",
+        source: "integrations_page",
+        status: "ready",
+        duration_s: undefined,
+        organization_id: "org-123",
+      });
+    });
+  });
+
+  describe("integration configure and delete events", () => {
+    it("captures integration configure open from integrations page with ready status", () => {
+      analytics.integrationConfigureOpen("github", "integrations_page", "ready", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:configure_open", {
+        integration: "github",
+        source: "integrations_page",
+        previous_status: "ready",
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures integration configure open from node configuration with error status", () => {
+      analytics.integrationConfigureOpen("slack", "node_configuration", "error", "org-456");
+      expect(capture).toHaveBeenCalledWith("integration:configure_open", {
+        integration: "slack",
+        source: "node_configuration",
+        previous_status: "error",
+        organization_id: "org-456",
+      });
+    });
+
+    it("captures integration configure open with pending status", () => {
+      analytics.integrationConfigureOpen("github", "integrations_page", "pending", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:configure_open", {
+        integration: "github",
+        source: "integrations_page",
+        previous_status: "pending",
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures integration delete", () => {
+      analytics.integrationDelete("github", "org-123");
+      expect(capture).toHaveBeenCalledWith("integration:integration_delete", {
+        integration: "github",
+        organization_id: "org-123",
+      });
+    });
+  });
+
   describe("run item and error events", () => {
     it("captures canvas run item open", () => {
       analytics.canvasRunItemOpen("digitalocean.detachKnowledgeBase", "success", "org-123");

--- a/web_src/src/lib/analytics.spec.ts
+++ b/web_src/src/lib/analytics.spec.ts
@@ -172,4 +172,43 @@ describe("analytics", () => {
       organization_id: "org-123",
     });
   });
+  describe("run item and error events", () => {
+    it("captures canvas run item open", () => {
+      analytics.canvasRunItemOpen("digitalocean.detachKnowledgeBase", "success", "org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:run_item_open", {
+        node_ref: "digitalocean.detachKnowledgeBase",
+        execution_status: "success",
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures canvas run item tab view - details", () => {
+      analytics.canvasRunItemTabView("details", "org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:run_item_tab_view", { tab: "details", organization_id: "org-123" });
+    });
+
+    it("captures canvas run item tab view - payload", () => {
+      analytics.canvasRunItemTabView("payload", "org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:run_item_tab_view", { tab: "payload", organization_id: "org-123" });
+    });
+
+    it("captures canvas run item tab view - config", () => {
+      analytics.canvasRunItemTabView("config", "org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:run_item_tab_view", { tab: "config", organization_id: "org-123" });
+    });
+
+    it("captures canvas component error", () => {
+      analytics.canvasComponentError("http.request", "timeout after 30s", "org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:component_error", {
+        node_ref: "http.request",
+        error_message: "timeout after 30s",
+        organization_id: "org-123",
+      });
+    });
+
+    it("captures canvas log view", () => {
+      analytics.canvasLogView("org-123");
+      expect(capture).toHaveBeenCalledWith("canvas:log_view", { organization_id: "org-123" });
+    });
+  });
 });

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from "react";
 import { posthog } from "@/posthog";
+import type { OrganizationsIntegration } from "@/api-client";
 // Tracks when a connect form was opened so duration_s can be computed on submit.
 // Keyed by integration name; last-write-wins for the same integration.
 const integrationConnectStartTimes = new Map<string, number>();
@@ -181,3 +183,26 @@ export const analytics = {
     });
   },
 };
+
+export function useIntegrationConfigureOpen(
+  integration: OrganizationsIntegration | undefined,
+  integrationId: string | null | undefined,
+  source: "node_configuration" | "integrations_page",
+  organizationId: string | undefined,
+) {
+  const firedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!integration || !integrationId || !organizationId) return;
+    if (firedRef.current === integrationId) return;
+    const integrationTypeName = integration.spec?.integrationName;
+    if (!integrationTypeName) return;
+    const previousStatus = (integration.status?.state || "pending") as "ready" | "error" | "pending";
+    analytics.integrationConfigureOpen(integrationTypeName, source, previousStatus, organizationId);
+    firedRef.current = integrationId;
+  }, [integration, integrationId, source, organizationId]);
+
+  useEffect(() => {
+    if (!integrationId) firedRef.current = null;
+  }, [integrationId]);
+}

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -108,4 +108,24 @@ export const analytics = {
   orgCreate: (organizationId: string) => {
     posthog.capture("auth:org_create", { organization_id: organizationId });
   },
+
+  canvasRunItemOpen: (nodeRef: string | undefined, executionStatus: string, organizationId: string) => {
+    posthog.capture("canvas:run_item_open", {
+      node_ref: nodeRef,
+      execution_status: executionStatus,
+      organization_id: organizationId,
+    });
+  },
+
+  canvasRunItemTabView: (tab: "details" | "payload" | "config", organizationId: string) => {
+    posthog.capture("canvas:run_item_tab_view", { tab, organization_id: organizationId });
+  },
+
+  canvasComponentError: (nodeRef: string | undefined, errorMessage: string, organizationId: string) => {
+    posthog.capture("canvas:component_error", { node_ref: nodeRef, error_message: errorMessage, organization_id: organizationId });
+  },
+
+  canvasLogView: (organizationId: string) => {
+    posthog.capture("canvas:log_view", { organization_id: organizationId });
+  },
 };

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -1,4 +1,7 @@
 import { posthog } from "@/posthog";
+// Tracks when a connect form was opened so duration_s can be computed on submit.
+// Keyed by integration name; last-write-wins for the same integration.
+const integrationConnectStartTimes = new Map<string, number>();
 
 export const analytics = {
   memberAccept: (organizationId: string) => {
@@ -98,9 +101,15 @@ export const analytics = {
     posthog.capture("canvas:version_publish", { canvas_id: canvasId, organization_id: organizationId });
   },
 
-  integrationCreate: (integrationType: string, organizationId: string) => {
-    posthog.capture("integration:integration_create", {
-      integration_type: integrationType,
+  integrationConnectStart: (
+    integration: string,
+    source: "node_configuration" | "integrations_page",
+    organizationId: string,
+  ) => {
+    integrationConnectStartTimes.set(integration, Date.now());
+    posthog.capture("integration:connect_start", {
+      integration,
+      source,
       organization_id: organizationId,
     });
   },
@@ -131,5 +140,44 @@ export const analytics = {
 
   canvasLogView: (organizationId: string) => {
     posthog.capture("canvas:log_view", { organization_id: organizationId });
+  },
+
+  integrationConnectSubmit: (
+    integration: string,
+    source: "node_configuration" | "integrations_page",
+    status: "ready" | "error" | "pending",
+    organizationId: string,
+  ) => {
+    const startTime = integrationConnectStartTimes.get(integration);
+    const durationS = startTime !== undefined ? (Date.now() - startTime) / 1000 : undefined;
+    integrationConnectStartTimes.delete(integration);
+    posthog.capture("integration:connect_submit", {
+      integration,
+      source,
+      status,
+      duration_ms: durationS,
+      organization_id: organizationId,
+    });
+  },
+
+  integrationConfigureOpen: (
+    integration: string,
+    source: "node_configuration" | "integrations_page",
+    previousStatus: "ready" | "error" | "pending",
+    organizationId: string,
+  ) => {
+    posthog.capture("integration:configure_open", {
+      integration,
+      source,
+      previous_status: previousStatus,
+      organization_id: organizationId,
+    });
+  },
+
+  integrationDelete: (integration: string, organizationId: string) => {
+    posthog.capture("integration:integration_delete", {
+      integration,
+      organization_id: organizationId,
+    });
   },
 };

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -155,7 +155,7 @@ export const analytics = {
       integration,
       source,
       status,
-      duration_ms: durationS,
+      duration_s: durationS,
       organization_id: organizationId,
     });
   },

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -122,7 +122,11 @@ export const analytics = {
   },
 
   canvasComponentError: (nodeRef: string | undefined, errorMessage: string, organizationId: string) => {
-    posthog.capture("canvas:component_error", { node_ref: nodeRef, error_message: errorMessage, organization_id: organizationId });
+    posthog.capture("canvas:component_error", {
+      node_ref: nodeRef,
+      error_message: errorMessage,
+      organization_id: organizationId,
+    });
   },
 
   canvasLogView: (organizationId: string) => {

--- a/web_src/src/pages/organization/settings/IntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationDetails.tsx
@@ -20,10 +20,10 @@ import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { ArrowLeft, CircleX, ExternalLink, Loader2, Plug, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { renderIntegrationMetadata } from "./integrationMetadataRenderers";
-import { analytics } from "@/lib/analytics";
+import { useIntegrationConfigureOpen } from "@/lib/analytics";
 
 interface IntegrationDetailsProps {
   organizationId: string;
@@ -60,17 +60,7 @@ export function IntegrationDetails({ organizationId }: IntegrationDetailsProps) 
     }
   }, [integration]);
 
-  const configureOpenFiredRef = useRef(false);
-  useEffect(() => {
-    if (!integration || configureOpenFiredRef.current) return;
-    const integrationTypeName = integration.spec?.integrationName;
-    if (!integrationTypeName) return;
-    const rawState = integration.status?.state;
-    const previousStatus =
-      rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
-    analytics.integrationConfigureOpen(integrationTypeName, "integrations_page", previousStatus, organizationId);
-    configureOpenFiredRef.current = true;
-  }, [integration, organizationId]);
+  useIntegrationConfigureOpen(integration ?? undefined, integration?.metadata?.id, "integrations_page", organizationId);
 
   useEffect(() => {
     setIntegrationName(integration?.metadata?.name || integration?.spec?.integrationName || "");

--- a/web_src/src/pages/organization/settings/IntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/IntegrationDetails.tsx
@@ -20,9 +20,10 @@ import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { ArrowLeft, CircleX, ExternalLink, Loader2, Plug, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { renderIntegrationMetadata } from "./integrationMetadataRenderers";
+import { analytics } from "@/lib/analytics";
 
 interface IntegrationDetailsProps {
   organizationId: string;
@@ -58,6 +59,18 @@ export function IntegrationDetails({ organizationId }: IntegrationDetailsProps) 
       setConfigLoaded(true);
     }
   }, [integration]);
+
+  const configureOpenFiredRef = useRef(false);
+  useEffect(() => {
+    if (!integration || configureOpenFiredRef.current) return;
+    const integrationTypeName = integration.spec?.integrationName;
+    if (!integrationTypeName) return;
+    const rawState = integration.status?.state;
+    const previousStatus =
+      rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
+    analytics.integrationConfigureOpen(integrationTypeName, "integrations_page", previousStatus, organizationId);
+    configureOpenFiredRef.current = true;
+  }, [integration, organizationId]);
 
   useEffect(() => {
     setIntegrationName(integration?.metadata?.name || integration?.spec?.integrationName || "");
@@ -195,7 +208,7 @@ export function IntegrationDetails({ organizationId }: IntegrationDetailsProps) 
   const handleDelete = async () => {
     if (!canDeleteIntegrations) return;
     try {
-      await deleteMutation.mutateAsync();
+      await deleteMutation.mutateAsync({ integrationName: integration?.spec?.integrationName ?? "" });
       navigate(`/${organizationId}/settings/integrations`);
     } catch {
       showErrorToast("Failed to delete integration");

--- a/web_src/src/pages/organization/settings/Integrations.tsx
+++ b/web_src/src/pages/organization/settings/Integrations.tsx
@@ -23,6 +23,7 @@ import { showErrorToast } from "@/lib/toast";
 import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { IntegrationInstructions } from "@/ui/IntegrationInstructions";
 import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
+import { analytics } from "@/lib/analytics";
 
 interface IntegrationsProps {
   organizationId: string;
@@ -42,7 +43,7 @@ export function Integrations({ organizationId }: IntegrationsProps) {
 
   const { data: availableIntegrations = [], isLoading: loadingAvailable } = useAvailableIntegrations();
   const { data: organizationIntegrations = [], isLoading: loadingInstalled } = useConnectedIntegrations(organizationId);
-  const createIntegrationMutation = useCreateIntegration(organizationId);
+  const createIntegrationMutation = useCreateIntegration(organizationId, "integrations_page");
 
   const isLoading = loadingAvailable || loadingInstalled;
   const integrationNames = useMemo(() => {
@@ -161,6 +162,7 @@ export function Integrations({ organizationId }: IntegrationsProps) {
     setIntegrationName(getNextIntegrationName(integration.name));
     setConfiguration({});
     setIsModalOpen(true);
+    analytics.integrationConnectStart(integration.name ?? "", "integrations_page", organizationId);
   };
   const handleConnect = async () => {
     if (!canCreateIntegrations) return;

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -2632,7 +2632,7 @@ export function WorkflowPageV2() {
     [canvas, allComponents, allTriggers, availableIntegrations, widgets],
   );
 
-  const createIntegrationMutation = useCreateIntegration(organizationId ?? "");
+  const createIntegrationMutation = useCreateIntegration(organizationId ?? "", "node_configuration");
   const [integrationDialogName, setIntegrationDialogName] = useState<string | null>(null);
   const [justConnectedIntegrations, setJustConnectedIntegrations] = useState<Set<string>>(new Set());
 

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1891,6 +1891,22 @@ export function WorkflowPageV2() {
     [handleSidebarChange],
   );
 
+  const handleRunItemOpen = useCallback(
+    (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => {
+      const node = nodeId ? canvas?.spec?.nodes?.find((n) => n.id === nodeId) : undefined;
+      const { nodeRef } = node ? getNodeAnalyticsProps(node, availableIntegrations) : { nodeRef: undefined };
+      analytics.canvasRunItemOpen(nodeRef, executionStatus, organizationId ?? "");
+      if (errorMessage) {
+        analytics.canvasComponentError(nodeRef, errorMessage,organizationId ?? "");
+      }
+    },
+    [canvas, availableIntegrations,organizationId],
+  );
+
+  const handleLogView = useCallback(() => {
+    analytics.canvasLogView(organizationId ?? "");
+  }, [organizationId]);
+
   const buildLiveRunItemFromExecution = useCallback(
     (execution: CanvasesCanvasNodeExecution): LogRunItem => {
       return buildRunItemFromExecution({
@@ -5348,6 +5364,8 @@ export function WorkflowPageV2() {
           getHasMoreQueue={getHasMoreQueue}
           getLoadingMoreQueue={getLoadingMoreQueue}
           onReEmit={canUpdateCanvas && isViewingLiveVersion ? handleReEmit : undefined}
+          onRunItemOpen={isViewingLiveVersion ? handleRunItemOpen : undefined}
+          onLogView={handleLogView}
           loadExecutionChain={loadExecutionChain}
           getExecutionState={getExecutionState}
           workflowNodes={canvas?.spec?.nodes}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1897,10 +1897,10 @@ export function WorkflowPageV2() {
       const { nodeRef } = node ? getNodeAnalyticsProps(node, availableIntegrations) : { nodeRef: undefined };
       analytics.canvasRunItemOpen(nodeRef, executionStatus, organizationId ?? "");
       if (errorMessage) {
-        analytics.canvasComponentError(nodeRef, errorMessage,organizationId ?? "");
+        analytics.canvasComponentError(nodeRef, errorMessage, organizationId ?? "");
       }
     },
-    [canvas, availableIntegrations,organizationId],
+    [canvas, availableIntegrations, organizationId],
   );
 
   const handleLogView = useCallback(() => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -250,6 +250,8 @@ export interface CanvasPageProps {
   onTogglePause?: (nodeId: string) => void;
   onToggleView?: (nodeId: string) => void;
   onReEmit?: (nodeId: string, eventOrExecutionId: string) => void;
+  onRunItemOpen?: (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => void;
+  onLogView?: () => void;
 
   // Building blocks for adding new nodes
   buildingBlocks: BuildingBlockCategory[];
@@ -1219,6 +1221,7 @@ function CanvasPage(props: CanvasPageProps) {
               missingIntegrations={props.missingIntegrations}
               onConnectIntegration={props.onConnectIntegration}
               canCreateIntegrations={props.canCreateIntegrations}
+              onLogView={props.onLogView}
             />
           </ReactFlowProvider>
 
@@ -1239,6 +1242,7 @@ function CanvasPage(props: CanvasPageProps) {
             getHasMoreQueue={props.getHasMoreQueue}
             getLoadingMoreQueue={props.getLoadingMoreQueue}
             onReEmit={props.onReEmit}
+            onRunItemOpen={props.onRunItemOpen}
             loadExecutionChain={props.loadExecutionChain}
             getExecutionState={props.getExecutionState}
             onSidebarClose={handleSidebarClose}
@@ -1294,6 +1298,7 @@ function Sidebar({
   onCancelQueueItem,
   onCancelExecution,
   onReEmit,
+  onRunItemOpen,
   getAllHistoryEvents,
   onLoadMoreHistory,
   getHasMoreHistory,
@@ -1333,6 +1338,7 @@ function Sidebar({
   onCancelQueueItem?: (id: string) => void;
   onCancelExecution?: (executionId: string) => void;
   onReEmit?: (nodeId: string, eventOrExecutionId: string) => void;
+  onRunItemOpen?: (nodeId: string | undefined, executionStatus: string, errorMessage?: string) => void;
   getAllHistoryEvents?: (nodeId: string) => SidebarEvent[];
   onLoadMoreHistory?: (nodeId: string) => void;
   getHasMoreHistory?: (nodeId: string) => boolean;
@@ -1503,6 +1509,15 @@ function Sidebar({
       getHasMoreQueue={() => getHasMoreQueue?.(state.componentSidebar.selectedNodeId!) || false}
       getLoadingMoreQueue={() => getLoadingMoreQueue?.(state.componentSidebar.selectedNodeId!) || false}
       onReEmit={onReEmit}
+      onEventClick={(event) => {
+        if (event.kind === "trigger" || event.kind === "execution") {
+          onRunItemOpen?.(
+            state.componentSidebar.selectedNodeId ?? undefined,
+            event.state ?? "unknown",
+            event.originalExecution?.resultMessage,
+          );
+        }
+      }}
       loadExecutionChain={loadExecutionChain}
       getExecutionState={getExecutionState}
       showSettingsTab={true}
@@ -1745,6 +1760,7 @@ function CanvasContent({
   missingIntegrations,
   onConnectIntegration,
   canCreateIntegrations,
+  onLogView,
 }: {
   state: CanvasPageState;
   onNodeEdit: (nodeId: string) => void;
@@ -1807,6 +1823,7 @@ function CanvasContent({
   missingIntegrations?: MissingIntegration[];
   onConnectIntegration?: (integrationName: string) => void;
   canCreateIntegrations?: boolean;
+  onLogView?: () => void;
 }) {
   const { fitView, screenToFlowPosition, getViewport, getInternalNode } = useReactFlow();
   const { zoom } = useViewport();
@@ -2422,7 +2439,10 @@ function CanvasContent({
   const handleLogButtonClick = useCallback((tab: ConsoleTab) => {
     setConsoleTab(tab);
     setIsLogSidebarOpen(true);
-  }, []);
+    if (tab === "runs") {
+      onLogView?.();
+    }
+  }, [onLogView]);
 
   return (
     <div className="h-full w-full relative">

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2436,13 +2436,16 @@ function CanvasContent({
     );
   }, [logEntries, logSearch]);
 
-  const handleLogButtonClick = useCallback((tab: ConsoleTab) => {
-    setConsoleTab(tab);
-    setIsLogSidebarOpen(true);
-    if (tab === "runs") {
-      onLogView?.();
-    }
-  }, [onLogView]);
+  const handleLogButtonClick = useCallback(
+    (tab: ConsoleTab) => {
+      setConsoleTab(tab);
+      setIsLogSidebarOpen(true);
+      if (tab === "runs") {
+        onLogView?.();
+      }
+    },
+    [onLogView],
+  );
 
   return (
     <div className="h-full w-full relative">

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -41,6 +41,7 @@ import type { EventState, EventStateMap } from "../componentBase";
 import type { ReactNode } from "react";
 import { ExecutionChainPage, HistoryQueuePage, PageHeader } from "./pages";
 import { mapTriggerEventToSidebarEvent } from "@/pages/workflowv2/utils";
+import { analytics } from "@/lib/analytics";
 
 /** Optional create-dialog overrides per integration (two-step API + webhook flow). Key = integration name. */
 const CREATE_INTEGRATION_DIALOG_OPTIONS: Record<
@@ -262,6 +263,7 @@ export const ComponentSidebar = ({
   const [isCreateIntegrationDialogOpen, setIsCreateIntegrationDialogOpen] = useState(false);
   const [configureIntegrationId, setConfigureIntegrationId] = useState<string | null>(null);
   const [configureIntegrationName, setConfigureIntegrationName] = useState("");
+  const configureOpenFiredRef = useRef<string | null>(null);
   // Use autocompleteExampleObj directly - current node is already filtered out upstream
   const resolvedAutocompleteExampleObj = autocompleteExampleObj ?? null;
 
@@ -271,7 +273,7 @@ export const ComponentSidebar = ({
     configureIntegrationId ?? "",
   );
   const updateIntegrationMutation = useUpdateIntegration(domainId ?? "", configureIntegrationId ?? "");
-  const createIntegrationMutation = useCreateIntegration(domainId ?? "");
+  const createIntegrationMutation = useCreateIntegration(domainId ?? "", "node_configuration");
   const configureIntegrationDefinition = useMemo(
     () =>
       configureIntegration?.spec?.integrationName
@@ -307,7 +309,10 @@ export const ComponentSidebar = ({
 
   const handleOpenCreateIntegrationDialog = useCallback(() => {
     setIsCreateIntegrationDialogOpen(true);
-  }, []);
+    if (integrationName && domainId) {
+      analytics.integrationConnectStart(integrationName, "node_configuration", domainId);
+    }
+  }, [integrationName, domainId]);
 
   const handleCloseCreateIntegrationDialog = useCallback(() => {
     setIsCreateIntegrationDialogOpen(false);
@@ -321,6 +326,7 @@ export const ComponentSidebar = ({
     setConfigureIntegrationId(null);
     setConfigureIntegrationName("");
     setConfigureIntegrationConfig({});
+    configureOpenFiredRef.current = null;
     updateIntegrationMutation.reset();
   }, [updateIntegrationMutation]);
 
@@ -378,6 +384,18 @@ export const ComponentSidebar = ({
       setConfigureIntegrationConfig(configureIntegration.spec.configuration);
     }
   }, [configureIntegration?.spec?.configuration]);
+
+  useEffect(() => {
+    if (!configureIntegration || !configureIntegrationId || !domainId) return;
+    if (configureOpenFiredRef.current === configureIntegrationId) return;
+    const integrationTypeName = configureIntegration.spec?.integrationName;
+    if (!integrationTypeName) return;
+    const rawState = configureIntegration.status?.state;
+    const previousStatus =
+      rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
+    analytics.integrationConfigureOpen(integrationTypeName, "node_configuration", previousStatus, domainId);
+    configureOpenFiredRef.current = configureIntegrationId;
+  }, [configureIntegration, configureIntegrationId, domainId]);
 
   useEffect(() => {
     setConfigureIntegrationName(

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -41,7 +41,7 @@ import type { EventState, EventStateMap } from "../componentBase";
 import type { ReactNode } from "react";
 import { ExecutionChainPage, HistoryQueuePage, PageHeader } from "./pages";
 import { mapTriggerEventToSidebarEvent } from "@/pages/workflowv2/utils";
-import { analytics } from "@/lib/analytics";
+import { analytics, useIntegrationConfigureOpen } from "@/lib/analytics";
 
 /** Optional create-dialog overrides per integration (two-step API + webhook flow). Key = integration name. */
 const CREATE_INTEGRATION_DIALOG_OPTIONS: Record<
@@ -263,7 +263,6 @@ export const ComponentSidebar = ({
   const [isCreateIntegrationDialogOpen, setIsCreateIntegrationDialogOpen] = useState(false);
   const [configureIntegrationId, setConfigureIntegrationId] = useState<string | null>(null);
   const [configureIntegrationName, setConfigureIntegrationName] = useState("");
-  const configureOpenFiredRef = useRef<string | null>(null);
   // Use autocompleteExampleObj directly - current node is already filtered out upstream
   const resolvedAutocompleteExampleObj = autocompleteExampleObj ?? null;
 
@@ -282,6 +281,14 @@ export const ComponentSidebar = ({
     [availableIntegrationDefinitions, configureIntegration?.spec?.integrationName],
   );
   const [configureIntegrationConfig, setConfigureIntegrationConfig] = useState<Record<string, unknown>>({});
+
+  useIntegrationConfigureOpen(
+    configureIntegration ?? undefined,
+    configureIntegrationId,
+    "node_configuration",
+    domainId,
+  );
+
   const createIntegrationDefinition = useMemo(
     () => (integrationName ? availableIntegrationDefinitions.find((d) => d.name === integrationName) : undefined),
     [availableIntegrationDefinitions, integrationName],
@@ -326,7 +333,6 @@ export const ComponentSidebar = ({
     setConfigureIntegrationId(null);
     setConfigureIntegrationName("");
     setConfigureIntegrationConfig({});
-    configureOpenFiredRef.current = null;
     updateIntegrationMutation.reset();
   }, [updateIntegrationMutation]);
 
@@ -384,18 +390,6 @@ export const ComponentSidebar = ({
       setConfigureIntegrationConfig(configureIntegration.spec.configuration);
     }
   }, [configureIntegration?.spec?.configuration]);
-
-  useEffect(() => {
-    if (!configureIntegration || !configureIntegrationId || !domainId) return;
-    if (configureOpenFiredRef.current === configureIntegrationId) return;
-    const integrationTypeName = configureIntegration.spec?.integrationName;
-    if (!integrationTypeName) return;
-    const rawState = configureIntegration.status?.state;
-    const previousStatus =
-      rawState === "ready" || rawState === "error" || rawState === "pending" ? rawState : "pending";
-    analytics.integrationConfigureOpen(integrationTypeName, "node_configuration", previousStatus, domainId);
-    configureOpenFiredRef.current = configureIntegrationId;
-  }, [configureIntegration, configureIntegrationId, domainId]);
 
   useEffect(() => {
     setConfigureIntegrationName(

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -866,6 +866,7 @@ export const ComponentSidebar = ({
                       actions={actions}
                       triggers={triggers}
                       onHighlightedNodesChange={onHighlightedNodesChange}
+                      organizationId={domainId}
                     />
                   )}
                 </div>

--- a/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
+++ b/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
@@ -15,6 +15,7 @@ import type { EventState, EventStateMap } from "../../componentBase";
 import type { ChildExecution } from "@/ui/chainItem";
 import { getExecutionDetails } from "@/pages/workflowv2/mappers";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIcons";
+import { analytics } from "@/lib/analytics";
 
 function buildExecutionTabData(
   execution: CanvasesCanvasNodeExecution,
@@ -142,6 +143,7 @@ interface ExecutionChainPageProps {
   actions?: SuperplaneActionsAction[]; // Component metadata
   triggers?: TriggersTrigger[]; // Trigger metadata
   onHighlightedNodesChange?: (nodeIds: Set<string>) => void;
+  organizationId?: string;
 }
 
 export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
@@ -157,6 +159,7 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
   actions = [],
   triggers = [],
   onHighlightedNodesChange,
+  organizationId,
 }) => {
   const [chainItems, setChainItems] = useState<ChainItemData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -202,6 +205,15 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
   }, [triggerEvent, chainItems]);
 
   // Load execution chain data function
+  const handleTabClickCapture = useCallback((e: React.MouseEvent) => {
+    const button = (e.target as HTMLElement).closest("button");
+    if (!button) return;
+    const text = button.textContent?.trim().toLowerCase();
+    if (text === "details") analytics.canvasRunItemTabView("details", organizationId ?? "");
+    else if (text === "payload") analytics.canvasRunItemTabView("payload", organizationId ?? "");
+    else if (text === "config") analytics.canvasRunItemTabView("config", organizationId ?? "");
+  }, [organizationId]);
+
   const loadChainData = useCallback(async () => {
     if (!eventId || !loadExecutionChain) {
       setLoading(false);
@@ -421,7 +433,7 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
     <div className="flex flex-col h-full">
       {/* Scrollable Section with Event and Executions */}
       <div className="flex-1 flex flex-col min-h-0">
-        <div ref={executionsScrollRef} className="flex-1 overflow-y-auto p-4">
+        <div ref={executionsScrollRef} className="flex-1 overflow-y-auto p-4" onClickCapture={handleTabClickCapture}>
           <div className="pb-15">
             {triggerEvent && (
               <div className="mb-6 border-b-1 border-border pb-4">

--- a/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
+++ b/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
@@ -210,7 +210,7 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
       const button = (e.target as HTMLElement).closest("button");
       if (!button) return;
       const text = button.textContent?.trim().toLowerCase();
-      if (["details", "payload", "config"].includes(text)) {
+      if (["details", "payload", "config"].includes(text ?? "")) {
         analytics.canvasRunItemTabView(text as "details" | "payload" | "config", organizationId ?? "");
       }
     },

--- a/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
+++ b/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
@@ -210,9 +210,9 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
       const button = (e.target as HTMLElement).closest("button");
       if (!button) return;
       const text = button.textContent?.trim().toLowerCase();
-      if (text === "details") analytics.canvasRunItemTabView("details", organizationId ?? "");
-      else if (text === "payload") analytics.canvasRunItemTabView("payload", organizationId ?? "");
-      else if (text === "config") analytics.canvasRunItemTabView("config", organizationId ?? "");
+      if (["details", "payload", "config"].includes(text)) {
+        analytics.canvasRunItemTabView(text as "details" | "payload" | "config", organizationId ?? "");
+      }
     },
     [organizationId],
   );

--- a/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
+++ b/web_src/src/ui/componentSidebar/pages/ExecutionChainPage.tsx
@@ -205,14 +205,17 @@ export const ExecutionChainPage: React.FC<ExecutionChainPageProps> = ({
   }, [triggerEvent, chainItems]);
 
   // Load execution chain data function
-  const handleTabClickCapture = useCallback((e: React.MouseEvent) => {
-    const button = (e.target as HTMLElement).closest("button");
-    if (!button) return;
-    const text = button.textContent?.trim().toLowerCase();
-    if (text === "details") analytics.canvasRunItemTabView("details", organizationId ?? "");
-    else if (text === "payload") analytics.canvasRunItemTabView("payload", organizationId ?? "");
-    else if (text === "config") analytics.canvasRunItemTabView("config", organizationId ?? "");
-  }, [organizationId]);
+  const handleTabClickCapture = useCallback(
+    (e: React.MouseEvent) => {
+      const button = (e.target as HTMLElement).closest("button");
+      if (!button) return;
+      const text = button.textContent?.trim().toLowerCase();
+      if (text === "details") analytics.canvasRunItemTabView("details", organizationId ?? "");
+      else if (text === "payload") analytics.canvasRunItemTabView("payload", organizationId ?? "");
+      else if (text === "config") analytics.canvasRunItemTabView("config", organizationId ?? "");
+    },
+    [organizationId],
+  );
 
   const loadChainData = useCallback(async () => {
     if (!eventId || !loadExecutionChain) {


### PR DESCRIPTION
## Overview
This PR adds PostHog tracking events to support monitoring & debugging and integration analytics dashboards. 
These events enable us to understand how users interact with canvas execution results and integrations, 
and where they encounter problems.

## New Events

### Monitoring & Debugging

| Event | Properties | Description |
|-------|-----------|-------------|
| `canvas:run_item_open` | `node_ref`, `execution_status` | User opens a specific run item from the node panel sidebar |
| `canvas:run_item_tab_view` | `tab` (`details` / `payload` / `config`) | User clicks on different tabs in a run |
| `canvas:log_view` | - | User opens run logs |
| `canvas:component_error` | `node_ref`, `error_message` | A component error occurs |

### Integrations

| Event | Properties | Description |
|-------|-----------|-------------|
| `integration:connect_start` | `integration`, `source` | User opens the connection form |
| `integration:connect_submit` | `integration`, `source`, `status`, `duration_s` | User clicks Connect in the form |
| `integration:configure_open` | `integration`, `source`, `previous_status` | User opens Configure on an existing connection |
| `integration:integration_delete` | `integration` | User deletes a connection to an integration |

## Dashboards

### Component Errors Dashboard
Helps us understand how many users encounter errors and whether they investigate them.

Examples:
- How many users encounter component errors and how often
- Which errors are most common and on which nodes
- What % of users who hit an error actually opened a Run Item to inspect it

### Execution Exploration Dashboard
Helps us understand whether users actively explore execution results or only check when something goes wrong.

Examples:
- Do users explore run items routinely or only on failures
- What % of users discover the Payload tab
- How actively users investigate their executions on average

### Integrations Dashboard
Helps us understand which integrations users connect, where setup fails, and which they abandon.

Examples:
- Which integrations are most commonly attempted vs successfully connected
- Where and why integration setup fails
- How many users attempt to fix a failed connection

For full dashboard and trend specifications, see [Analytics Spec](https://gist.github.com/gaga1307/696062a51199eb71c8c2b02dcb6997d3).