### PR TITLE
fix: improve approval notification email button styling (#3442)

### DIFF
--- a/pkg/services/email_test.go
+++ b/pkg/services/email_test.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderNotificationEmailHTML_withURLLabel_omitsDuplicateInlineURL(t *testing.T) {
+	repoTemplates := filepath.Join("..", "..", "templates")
+
+	html, err := renderEmailTemplate(repoTemplates, "notification.html", NotificationTemplateData{
+		Title:    "Approval needed",
+		Body:     "Please review the pending approval.",
+		URL:      "https://app.superplane.com/approvals/123",
+		URLLabel: "Open approval",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, html, `href="https://app.superplane.com/approvals/123"`)
+	assert.Contains(t, html, "Open approval")
+	assert.NotContains(t, strings.TrimSpace(html), "https://app.superplane.com/approvals/123</a>")
+	assert.NotContains(t, html, ">https://app.superplane.com/approvals/123<")
+}
+
+func TestRenderNotificationEmailHTML_withoutURLLabel_keepsInlineURL(t *testing.T) {
+	repoTemplates := filepath.Join("..", "..", "templates")
+
+	html, err := renderEmailTemplate(repoTemplates, "notification.html", NotificationTemplateData{
+		Title:    "Notice",
+		Body:     "Something happened.",
+		URL:      "https://example.com/page",
+		URLLabel: "",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, html, `href="https://example.com/page"`)
+	assert.Contains(t, html, ">https://example.com/page<")
+	assert.Contains(t, html, "Open in SuperPlane")
+}

--- a/pkg/workers/notification_email_consumer_test.go
+++ b/pkg/workers/notification_email_consumer_test.go
@@ -59,7 +59,7 @@ func Test__NotificationEmailConsumer(t *testing.T) {
 			Title:          "Approval needed",
 			Body:           "Please review the pending approval.",
 			Url:            "https://app.superplane.com/approvals/123",
-			UrlLabel:       "Review approval",
+			UrlLabel:       "Open approval",
 			Emails:         []string{groupUser.GetEmail(), "external@example.com"},
 			Groups:         []string{groupName},
 			Roles:          []string{models.RoleOrgAdmin},
@@ -82,6 +82,6 @@ func Test__NotificationEmailConsumer(t *testing.T) {
 		assert.Equal(t, "Approval needed", sentEmails[0].Title)
 		assert.Equal(t, "Please review the pending approval.", sentEmails[0].Body)
 		assert.Equal(t, "https://app.superplane.com/approvals/123", sentEmails[0].URL)
-		assert.Equal(t, "Review approval", sentEmails[0].URLLabel)
+		assert.Equal(t, "Open approval", sentEmails[0].URLLabel)
 	})
 }

--- a/templates/email/notification.html
+++ b/templates/email/notification.html
@@ -69,7 +69,7 @@
             font-size: 0.95rem;
             line-height: 1.5;
             color: #1f2937;
-            margin: 0 0 24px;
+            margin: 0 0 20px;
             white-space: pre-line;
         }
         @media (prefers-color-scheme: dark) {
@@ -86,24 +86,41 @@
                 color: #93c5fd;
             }
         }
+        .cta-wrap {
+            margin: 4px 0 0;
+        }
         .action-btn {
             display: inline-block;
-            padding: 8px 16px;
-            border-radius: 5px;
-            background: #1f2937;
-            color: #f3f4f6;
+            padding: 14px 28px;
+            border-radius: 8px;
+            background: #2563eb;
+            color: #ffffff;
             text-decoration: none;
             font-weight: 600;
             font-size: 0.95rem;
+            line-height: 1.35;
+            border: 1px solid #1d4ed8;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
         }
         @media (prefers-color-scheme: dark) {
             .action-btn {
-                background: #f3f4f6;
-                color: #1f2937;
+                background: #3b82f6;
+                color: #0f172a;
+                border-color: #60a5fa;
+                box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
             }
         }
         .action-btn:hover {
-            opacity: 0.9;
+            filter: brightness(1.05);
+        }
+        .action-btn:focus-visible {
+            outline: 2px solid #93c5fd;
+            outline-offset: 3px;
+        }
+        @media (prefers-color-scheme: dark) {
+            .action-btn:focus-visible {
+                outline-color: #bfdbfe;
+            }
         }
         .footer {
             margin-top: 20px;
@@ -121,13 +138,15 @@
         </div>
         <h1 class="title">{{.Title}}</h1>
         <p class="body">{{.Body}}
-            {{if .URL}}
+            {{if and .URL (not .URLLabel)}}
             <br><br>
             <a href="{{.URL}}">{{.URL}}</a>
             {{end}}
         </p>
         {{if .URL}}
-        <a class="action-btn" href="{{.URL}}">{{if .URLLabel}}{{.URLLabel}}{{else}}Open in SuperPlane{{end}}</a>
+        <div class="cta-wrap">
+            <a class="action-btn" href="{{.URL}}">{{if .URLLabel}}{{.URLLabel}}{{else}}Open in SuperPlane{{end}}</a>
+        </div>
         {{end}}
         <div class="footer">This notification was sent by SuperPlane.</div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [#3442](https://github.com/superplanehq/superplane/issues/3442) (sub-standard visuals for the approval notification email button).

### Changes

- **`templates/email/notification.html`**
  - Refreshed `.action-btn`: stronger primary styling (blue palette), larger padding, 8px radius, subtle border/shadow, dark-mode variants, `:focus-visible` outline for keyboard users.
  - Wrapped the CTA in `.cta-wrap` with tighter spacing relative to the body.
  - **Reduced redundancy:** when both `URL` and `URLLabel` are set, the raw URL is no longer duplicated as an inline link in the body paragraph—the CTA carries the link. When there is no label, behavior is unchanged (inline URL + default “Open in SuperPlane” button).
- **`pkg/services/email_test.go`**: Tests that render the real repo template and assert the conditional inline URL behavior.
- **`pkg/workers/notification_email_consumer_test.go`**: Updated fixture label to `"Open approval"` to match production approval notifications (per issue review).

### Review alignment

Following the [automated issue review](https://github.com/superplanehq/superplane/issues/3442#issuecomment-4338415634): primary CSS refresh for the button, omit duplicate inline URL when a labeled CTA is present, plain-text `notification.txt` unchanged (URL still included for accessibility). No human comments were posted on the issue.

### Testing

- `go test ./pkg/services -run TestRenderNotification -count=1` (passes locally).
- Full `make test` / `make lint` were not run here because Docker is unavailable in this environment; CI should validate the full suite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ef1f9f-3679-46f4-94c5-f0969c4139f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ef1f9f-3679-46f4-94c5-f0969c4139f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

