### PR TITLE
feat: allow secrets create/update to read from stdin with -f

### DIFF
--- a/pkg/cli/commands/secrets/common.go
+++ b/pkg/cli/commands/secrets/common.go
@@ -23,11 +23,20 @@ type secretResource struct {
 	Spec       *openapi_client.SecretsSecretSpec     `json:"spec,omitempty"`
 }
 
-func parseSecretFile(path string) (*secretResource, error) {
-	// #nosec
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource file: %w", err)
+func parseSecretInput(path string, stdin io.Reader) (*secretResource, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		// #nosec
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource file: %w", err)
+		}
 	}
 
 	apiVersion, kind, err := core.ParseYamlResourceHeaders(data)

--- a/pkg/cli/commands/secrets/common_test.go
+++ b/pkg/cli/commands/secrets/common_test.go
@@ -2,19 +2,55 @@ package secrets
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseSecretFileRejectsUnknownFields(t *testing.T) {
+func TestParseSecretInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/secret.yaml"
+	content := []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: from-file\nspec:\n  provider: PROVIDER_LOCAL\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	resource, err := parseSecretInput(path, strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-file", resource.Metadata.GetName())
+}
+
+func TestParseSecretInputFileRejectsUnknownFields(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/secret.yaml"
 	content := []byte("apiVersion: v1\nkind: Secret\nmetadata:\n  name: from-file\nspec:\n  provider: PROVIDER_LOCAL\n  unknown: true\n")
 	require.NoError(t, os.WriteFile(path, content, 0644))
 
-	_, err := parseSecretFile(path)
+	_, err := parseSecretInput(path, strings.NewReader(""))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown field")
 	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseSecretInputStdin(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Secret\nmetadata:\n  name: from-stdin\nspec:\n  provider: PROVIDER_LOCAL\n"
+
+	resource, err := parseSecretInput("-", strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-stdin", resource.Metadata.GetName())
+}
+
+func TestParseSecretInputStdinRejectsUnknownFields(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Secret\nmetadata:\n  name: from-stdin\nspec:\n  provider: PROVIDER_LOCAL\n  unknown: true\n"
+
+	_, err := parseSecretInput("-", strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseSecretInputStdinEmpty(t *testing.T) {
+	_, err := parseSecretInput("-", strings.NewReader(""))
+	require.Error(t, err)
 }

--- a/pkg/cli/commands/secrets/create.go
+++ b/pkg/cli/commands/secrets/create.go
@@ -26,7 +26,7 @@ func (c *createCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseSecretFile(filePath)
+	resource, err := parseSecretInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/commands/secrets/root.go
+++ b/pkg/cli/commands/secrets/root.go
@@ -33,7 +33,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	var createFile string
-	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "filename, directory, or URL to files to use to create the resource")
+	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to resource file, or - to read from stdin")
 	_ = createCmd.MarkFlagRequired("file")
 	core.Bind(createCmd, &createCommand{file: &createFile}, options)
 
@@ -43,7 +43,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	var updateFile string
-	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "filename, directory, or URL to files to use to update the resource")
+	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "path to resource file, or - to read from stdin")
 	_ = updateCmd.MarkFlagRequired("file")
 	core.Bind(updateCmd, &updateCommand{file: &updateFile}, options)
 

--- a/pkg/cli/commands/secrets/update.go
+++ b/pkg/cli/commands/secrets/update.go
@@ -29,7 +29,7 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseSecretFile(filePath)
+	resource, err := parseSecretInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
  ## Summary

  - Extended `secrets create` and `secrets update` to support reading YAML from stdin when `-f -` is passed
  - Updated flag description to document the `-` sentinel
  - Added success-path and stdin-specific test cases to `common_test.go`

  This unblocks non-interactive secret provisioning without any temporary file lifecycle management.

  Closes #4232 