### PR TITLE
test: added unit tests for invite link and list invitations actions

### DIFF
--- a/pkg/grpc/actions/organizations/invite_link_test.go
+++ b/pkg/grpc/actions/organizations/invite_link_test.go
@@ -1,0 +1,99 @@
+package organizations
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__GetInviteLink(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("returns existing invite link for organization", func(t *testing.T) {
+		response, err := GetInviteLink(r.Organization.ID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.InviteLink)
+		assert.Equal(t, r.Organization.ID.String(), response.InviteLink.OrganizationId)
+		assert.NotEmpty(t, response.InviteLink.Token)
+		assert.True(t, response.InviteLink.Enabled)
+	})
+
+	t.Run("creates invite link when none exists for organization", func(t *testing.T) {
+		// Use an org UUID that has no existing invite link
+		newOrgID := uuid.New()
+
+		response, err := GetInviteLink(newOrgID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.InviteLink)
+		assert.Equal(t, newOrgID.String(), response.InviteLink.OrganizationId)
+		assert.NotEmpty(t, response.InviteLink.Token)
+		assert.True(t, response.InviteLink.Enabled)
+
+		// Calling it again returns the same link
+		response2, err := GetInviteLink(newOrgID.String())
+		require.NoError(t, err)
+		assert.Equal(t, response.InviteLink.Token, response2.InviteLink.Token)
+	})
+}
+
+func Test__UpdateInviteLink(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("disables invite link", func(t *testing.T) {
+		response, err := UpdateInviteLink(r.Organization.ID.String(), false)
+		require.NoError(t, err)
+		require.NotNil(t, response.InviteLink)
+		assert.False(t, response.InviteLink.Enabled)
+		assert.Equal(t, r.Organization.ID.String(), response.InviteLink.OrganizationId)
+	})
+
+	t.Run("re-enables invite link", func(t *testing.T) {
+		// Disable first, then re-enable
+		_, err := UpdateInviteLink(r.Organization.ID.String(), false)
+		require.NoError(t, err)
+
+		response, err := UpdateInviteLink(r.Organization.ID.String(), true)
+		require.NoError(t, err)
+		require.NotNil(t, response.InviteLink)
+		assert.True(t, response.InviteLink.Enabled)
+	})
+
+	t.Run("invite link not found -> error", func(t *testing.T) {
+		_, err := UpdateInviteLink(uuid.New().String(), true)
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, s.Code())
+		assert.Equal(t, "invite link not found", s.Message())
+	})
+}
+
+func Test__ResetInviteLink(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("resets token to a new value", func(t *testing.T) {
+		original, err := models.FindInviteLinkByOrganizationID(r.Organization.ID.String())
+		require.NoError(t, err)
+
+		response, err := ResetInviteLink(r.Organization.ID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.InviteLink)
+		assert.Equal(t, r.Organization.ID.String(), response.InviteLink.OrganizationId)
+		assert.NotEqual(t, original.Token.String(), response.InviteLink.Token, "token should change after reset")
+	})
+
+	t.Run("invite link not found -> error", func(t *testing.T) {
+		_, err := ResetInviteLink(uuid.New().String())
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.NotFound, s.Code())
+		assert.Equal(t, "invite link not found", s.Message())
+	})
+}

--- a/pkg/grpc/actions/organizations/list_invitations_test.go
+++ b/pkg/grpc/actions/organizations/list_invitations_test.go
@@ -1,0 +1,59 @@
+package organizations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__ListInvitations(t *testing.T) {
+	r := support.Setup(t)
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	orgID := r.Organization.ID.String()
+
+	t.Run("returns empty list when no pending invitations", func(t *testing.T) {
+		response, err := ListInvitations(ctx, orgID)
+		require.NoError(t, err)
+		assert.Empty(t, response.Invitations)
+	})
+
+	t.Run("returns only pending invitations", func(t *testing.T) {
+		// Create a pending invitation
+		_, err := CreateInvitation(ctx, r.AuthService, orgID, "pending@example.com")
+		require.NoError(t, err)
+
+		// Create an account with an accepted invitation
+		account, err := models.CreateAccount(support.RandomName("account")+"@example.com", support.RandomName("user"))
+		require.NoError(t, err)
+		_, err = CreateInvitation(ctx, r.AuthService, orgID, account.Email)
+		require.NoError(t, err)
+
+		response, err := ListInvitations(ctx, orgID)
+		require.NoError(t, err)
+		require.Len(t, response.Invitations, 1)
+		assert.Equal(t, "pending@example.com", response.Invitations[0].Email)
+		assert.Equal(t, models.InvitationStatePending, response.Invitations[0].State)
+		assert.Equal(t, orgID, response.Invitations[0].OrganizationId)
+	})
+
+	t.Run("removed invitation no longer appears in list", func(t *testing.T) {
+		pending, err := models.ListInvitationsInState(orgID, models.InvitationStatePending)
+		require.NoError(t, err)
+		require.NotEmpty(t, pending)
+		invitation := pending[0]
+
+		_, err = RemoveInvitation(ctx, r.AuthService, orgID, invitation.ID.String())
+		require.NoError(t, err)
+
+		response, err := ListInvitations(ctx, orgID)
+		require.NoError(t, err)
+		for _, inv := range response.Invitations {
+			assert.NotEqual(t, invitation.ID.String(), inv.Id)
+		}
+	})
+}


### PR DESCRIPTION
Added unit tests for invite link and list invitations actions
This PR adds unit test coverage for two previously untested organization actions:

`invite_link` - tests for generating and validating invite links
`list_invitations` - tests for listing pending invitations

Tests follow the existing patterns in the codebase.