### PR TITLE
fix: normalize GraphQL component icon color in sidebar

### DIFF
--- a/web_src/src/assets/icons/graphql.svg
+++ b/web_src/src/assets/icons/graphql.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
-  <path d="M16 3.5 27 10v12L16 28.5 5 22V10L16 3.5Z" stroke="#111827" stroke-width="2.25" stroke-linejoin="round"/>
-  <path d="M16 3.5v25M5 10l22 12M27 10 5 22" stroke="#111827" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="16" cy="3.5" r="2.5" fill="#111827"/>
-  <circle cx="27" cy="10" r="2.5" fill="#111827"/>
-  <circle cx="27" cy="22" r="2.5" fill="#111827"/>
-  <circle cx="16" cy="28.5" r="2.5" fill="#111827"/>
-  <circle cx="5" cy="22" r="2.5" fill="#111827"/>
-  <circle cx="5" cy="10" r="2.5" fill="#111827"/>
+  <path d="M16 3.5 27 10v12L16 28.5 5 22V10L16 3.5Z" stroke="#6B7280" stroke-width="2.25" stroke-linejoin="round"/>
+  <path d="M16 3.5v25M5 10l22 12M27 10 5 22" stroke="#6B7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="16" cy="3.5" r="2.5" fill="#6B7280"/>
+  <circle cx="27" cy="10" r="2.5" fill="#6B7280"/>
+  <circle cx="27" cy="22" r="2.5" fill="#6B7280"/>
+  <circle cx="16" cy="28.5" r="2.5" fill="#6B7280"/>
+  <circle cx="5" cy="22" r="2.5" fill="#6B7280"/>
+  <circle cx="5" cy="10" r="2.5" fill="#6B7280"/>
 </svg>

--- a/web_src/src/ui/BuildingBlocksSidebar/CategorySection.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/CategorySection.spec.tsx
@@ -78,6 +78,62 @@ describe("CategorySection", () => {
     expect(container.querySelector('[data-slot="item-group"]')).toBeInTheDocument();
   });
 
+  it("renders the graphql block icon as an img element", () => {
+    const category: BuildingBlockCategory = {
+      name: "Core",
+      blocks: [
+        {
+          name: "graphql.request",
+          label: "GraphQL Request",
+          type: "component",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <CategorySection
+        category={category}
+        integrations={[]}
+        showIntegrationSetupStatus={false}
+        canvasZoom={1}
+        isDraggingRef={{ current: false }}
+        setHoveredBlock={() => {}}
+        dragPreviewRef={{ current: null }}
+      />,
+    );
+
+    expect(screen.getByText("GraphQL Request")).toBeInTheDocument();
+    expect(container.querySelector("img[alt='GraphQL Request']")).toBeInTheDocument();
+  });
+
+  it("renders non-graphql core blocks without a custom img icon", () => {
+    const category: BuildingBlockCategory = {
+      name: "Core",
+      blocks: [
+        {
+          name: "filter",
+          label: "Filter",
+          type: "component",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <CategorySection
+        category={category}
+        integrations={[]}
+        showIntegrationSetupStatus={false}
+        canvasZoom={1}
+        isDraggingRef={{ current: false }}
+        setHoveredBlock={() => {}}
+        dragPreviewRef={{ current: null }}
+      />,
+    );
+
+    expect(screen.getByText("Filter")).toBeInTheDocument();
+    expect(container.querySelector("img[alt='Filter']")).not.toBeInTheDocument();
+  });
+
   it("renders the ItemGroup for a non-Core category after it is manually opened", () => {
     const category = createCategory("Email");
 


### PR DESCRIPTION
Fixes [issue](https://github.com/superplanehq/superplane/issues/4483)

- The GraphQL icon SVG used hardcoded #111827 (gray-900) for all strokes
and fills, making it visibly darker than other core components (Filter,
If, Merge, HTTP Request) which render Lucide icons at text-gray-500
(#6B7280). Updated the SVG to use #6B7280 to match.

- Added tests to CategorySection to cover the two rendering paths:
graphql blocks render via <img> (SVG icon), non-graphql blocks render
via a Lucide icon component.