### PR TITLE
fix: handle stop expression evaluation errors in Merge component

### DIFF
--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -292,29 +292,25 @@ func (m *Merge) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, erro
 	// configs created before the toggle will still work if they have an expression.
 	//
 	if spec.StopIfExpression != "" {
-		out, err := ctx.Expressions.Run(spec.StopIfExpression)
-		if err != nil {
-			return nil, err
+		failWithError := func(message string) (*uuid.UUID, error) {
+			md.StopEarly = true
+			if err := executionCtx.Metadata.Set(md); err != nil {
+				return nil, err
+			}
+			if err := executionCtx.ExecutionState.Fail("error", message); err != nil {
+				return nil, err
+			}
+			return &executionCtx.ID, nil
 		}
 
-		//
-		// If the stop expression does not evaluate to a boolean value,
-		// we fail the execution and mark the merge as stopped early.
-		//
+		out, err := ctx.Expressions.Run(spec.StopIfExpression)
+		if err != nil {
+			return failWithError(fmt.Sprintf("stop expression evaluation failed: %v", err))
+		}
+
 		stopEarly, ok := out.(bool)
 		if !ok {
-			md.StopEarly = true
-			err := executionCtx.Metadata.Set(md)
-			if err != nil {
-				return nil, err
-			}
-
-			err = executionCtx.ExecutionState.Fail("error", fmt.Sprintf("stop expression must evaluate to boolean, got %T: %v", out, out))
-			if err != nil {
-				return nil, err
-			}
-
-			return &executionCtx.ID, nil
+			return failWithError(fmt.Sprintf("stop expression must evaluate to boolean, got %T: %v", out, out))
 		}
 
 		//
@@ -323,8 +319,7 @@ func (m *Merge) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, erro
 		//
 		if stopEarly {
 			md.StopEarly = true
-			err := executionCtx.Metadata.Set(md)
-			if err != nil {
+			if err := executionCtx.Metadata.Set(md); err != nil {
 				return nil, err
 			}
 

--- a/pkg/components/merge/merge_test.go
+++ b/pkg/components/merge/merge_test.go
@@ -105,6 +105,32 @@ func Test_Merge_BadStopIfExpression(t *testing.T) {
 	steps.AssertQueueIsEmpty()
 }
 
+func Test_Merge_StopIfExpression_EvaluationError(t *testing.T) {
+	steps := NewMergeTestSteps(t)
+	steps.CreateWorkflow()
+
+	steps.SetMergeConfiguration(map[string]any{
+		"stopIfExpression": `$["process-1"].metrics.lastOutcome == "Critical" || $["process-1"].result[0].value != "0"`,
+	})
+
+	steps.CreateEventsWithData(
+		map[string]any{"metrics": map[string]any{"lastOutcome": "Healthy"}},
+		map[string]any{"result": []any{map[string]any{"value": "0"}}},
+	)
+	steps.CreateQueueItems()
+
+	m := &Merge{}
+
+	steps.ProcessFirstEventExpectFinish(m)
+	steps.AssertNodeExecutionCount(1)
+	steps.AssertExecutionFailedWithErrorContains("stop expression evaluation failed")
+	steps.AssertNodeIsAllowedToProcessNextQueueItem()
+
+	// Subsequent events on the same merge must be dequeued without re-failing.
+	steps.ProcessSecondEventExpectNoFinish(m)
+	steps.AssertQueueIsEmpty()
+}
+
 func Test_Merge_StopIfExpression_SourceNodeReference(t *testing.T) {
 	steps := NewMergeTestSteps(t)
 
@@ -558,6 +584,15 @@ func (s *MergeTestSteps) AssertExecutionFailedWithError(errorMessage string) {
 	assert.Equal(s.t, models.CanvasNodeExecutionResultFailed, execution.Result)
 	assert.Equal(s.t, "error", execution.ResultReason)
 	assert.Equal(s.t, errorMessage, execution.ResultMessage)
+}
+
+func (s *MergeTestSteps) AssertExecutionFailedWithErrorContains(substring string) {
+	var execution models.CanvasNodeExecution
+	require.NoError(s.t, s.Tx.Where("node_id = ?", s.MergeNode.NodeID).First(&execution).Error)
+	assert.Equal(s.t, models.CanvasNodeExecutionStateFinished, execution.State)
+	assert.Equal(s.t, models.CanvasNodeExecutionResultFailed, execution.Result)
+	assert.Equal(s.t, "error", execution.ResultReason)
+	assert.Contains(s.t, execution.ResultMessage, substring)
 }
 
 // AssertExecutionFailed checks that the execution finished and emitted to the fail channel.


### PR DESCRIPTION
## What                                                   

  When a Merge node's conditional stop expression fails to evaluate against an incoming event (e.g. nil field access when two upstream sources emit different shapes), the merge now finishes the execution on the `fail` channel with a clear error message instead of silently blocking the queue.                        
   
  Fixes #4482.                                                                                                                                                                                                                                                                                                              
                                                            
  ## Why                                                                                                                                                                                                                                                                                                                    
                                                            
  Per the issue: when the stop expression hits a missing field, expression evaluation returns an error. Previously, `Merge.ProcessQueueItem` propagated that error up; the queue worker wraps `processNode` in a database transaction, so the propagated error rolled back the dequeue along with everything else. The same 
  item was retried indefinitely, no execution was recorded, and no error surfaced to the user. The only recovery was manually canceling queue items from the UI.
                                                                                                                                                                                                                                                                                                                            
  ## How                                                                                                                                                                                                                                                                                                                    
   
  In `pkg/components/merge/merge.go`, when `ctx.Expressions.Run` returns an error we now mirror the existing branch that handles non-boolean expression output: mark the merge metadata as `StopEarly`, call `ExecutionState.Fail("error", ...)` with the underlying evaluation error, and return `nil` as the error so the 
  surrounding transaction commits.                          
                                                                                                                                                                                                                                                                                                                            
  This treats expression evaluation failure as a valid `fail` channel outcome (the expression cannot reasonably be evaluated against this input), not as a transient error to retry.                                                                                                                                        
   
  While mirroring the new error branch, the existing non-boolean branch shared the exact same "mark stopEarly + persist metadata + fail execution" sequence. Extracted both into a local `failWithError` closure inside the stop-expression block to keep the three stop causes legible at a glance.                        
                                                            
  ### Alternatives considered                                                                                                                                                                                                                                                                                               
                                                            
  - **Make field access nil-safe globally** (option 1 in the issue): would require changing `ResolveExpression`, which is shared by every component. Out of scope and risks masking legitimate expression bugs elsewhere.                                                                                                   
  - **Rely on short-circuit evaluation** (option 2 in the issue): `expr` already short-circuits `||`. In the issue's example the LHS evaluates to `false`, so the RHS is still evaluated and crashes — short-circuit does not help here.
                                                                                                                                                                                                                                                                                                                            
  ## Test plan                                              
                                                                                                                                                                                                                                                                                                                            
  - [x] Added `Test_Merge_StopIfExpression_EvaluationError` in `pkg/components/merge/merge_test.go` reproducing the issue scenario (two sources with different shapes, expression accessing a missing path). Test fails on `main` and passes with this fix.                                                                 
  - [x] `make format.go`, `make lint`, `make check.build.app` clean.
  - [x] `make test PKG_TEST_PACKAGES=./pkg/components/merge` — all 6 tests green.  