### PR TITLE
Remove commands from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,6 @@
 
 ## Build, Test, and Development Commands
 
-- Setup dev environment: `make dev.setup`
-- Run server: `make dev.start` - UI at http://localhost:8000
-- One-shot backend tests: `make test` (Golang).
-- Targeted backend tests: `make test PKG_TEST_PACKAGES=./pkg/workers`
-- Targeted E2E tests: `make e2e E2E_TEST_PACKAGES=./test/e2e/workflows`
 - For E2E test authoring, see [docs/contributing/e2e-tests.md](docs/contributing/e2e-tests.md)
 - After updating UI code, always run `make check.build.ui` to verify everything is correct
 - After editing JS code, always run `make format.js` to make sure that the files are consistently formatted


### PR DESCRIPTION
Agent harnesses are usually good at discovering and running scripts on their own. Listing them in agents.md often just wastes tokens and can increase hallucinations.

agents.md should be used to steer behavior when the agent makes recurring mistakes, not to map out the entire application structure or all scripts, unless those are consistently being misinterpreted.