### PR TITLE
fix: include memory.find and memory.findFirst in expression autocomplete

### DIFF
--- a/web_src/src/components/AutoCompleteInput/core.spec.ts
+++ b/web_src/src/components/AutoCompleteInput/core.spec.ts
@@ -40,6 +40,27 @@ describe("getSuggestions", () => {
     expect(suggestions.some((item) => item.label === "trim")).toBe(true);
   });
 
+  it("suggests memory.find and memory.findFirst by prefix", () => {
+    const suggestions = getSuggestions("mem", 3, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toContain("memory.find");
+    expect(labels).toContain("memory.findFirst");
+  });
+
+  it("suggests memory methods after memory dot", () => {
+    const suggestions = getSuggestions("memory.", "memory.".length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toContain("find");
+    expect(labels).toContain("findFirst");
+  });
+
+  it("filters memory methods by member prefix", () => {
+    const suggestions = getSuggestions("memory.findF", "memory.findF".length, {});
+    const labels = suggestions.map((item) => item.label);
+    expect(labels).toContain("findFirst");
+    expect(labels).not.toContain("find");
+  });
+
   it("suggests root() payload fields after dot", () => {
     const suggestions = getSuggestions("root().", "root().".length, {
       __root: { github: { ref: "main" }, user: "alice" },

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -74,6 +74,21 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
       "Returns the payload from the immediate predecessor that emitted this event. Provide depth to walk upstream.",
     example: "previous(2).data.image.version",
   },
+  // Memory
+  {
+    name: "memory.find",
+    snippet: 'memory.find(${1:"namespace"}, ${2:{key: "value"\\}})',
+    description:
+      "Returns all canvas memory entries in the given namespace whose fields match every key/value in the matches map.",
+    example: 'memory.find("machines", {sandbox_id: "12121"})',
+  },
+  {
+    name: "memory.findFirst",
+    snippet: 'memory.findFirst(${1:"namespace"}, ${2:{key: "value"\\}})',
+    description:
+      "Returns the first canvas memory entry in the given namespace whose fields match every key/value in the matches map, or nil if none match.",
+    example: 'memory.findFirst("machines", {creator: "igor"}).sandbox_id',
+  },
   // String
   {
     name: "trim",
@@ -528,6 +543,30 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
   },
 ] as const;
 
+type MemoryMethod = {
+  name: string;
+  snippet: string;
+  description: string;
+  example: string;
+};
+
+const MEMORY_METHODS: readonly MemoryMethod[] = [
+  {
+    name: "find",
+    snippet: 'find(${1:"namespace"}, ${2:{key: "value"\\}})',
+    description:
+      "Returns all canvas memory entries in the given namespace whose fields match every key/value in the matches map.",
+    example: 'memory.find("machines", {sandbox_id: "12121"})',
+  },
+  {
+    name: "findFirst",
+    snippet: 'findFirst(${1:"namespace"}, ${2:{key: "value"\\}})',
+    description:
+      "Returns the first canvas memory entry in the given namespace whose fields match every key/value in the matches map, or nil if none match.",
+    example: 'memory.findFirst("machines", {creator: "igor"}).sandbox_id',
+  },
+] as const;
+
 export function getSuggestions<TGlobals extends Record<string, unknown>>(
   text: string,
   cursor: number,
@@ -608,6 +647,20 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
             description: m.description,
           }));
       }
+    }
+
+    // Handle memory namespace method suggestions (e.g., memory.find)
+    if (!isFunctionCall && baseExpr === "memory") {
+      return MEMORY_METHODS.filter((m) => m.name.toLowerCase().startsWith(mp) && mp !== m.name.toLowerCase())
+        .slice(0, limit)
+        .map((m) => ({
+          label: m.name,
+          kind: "function" as const,
+          insertText: m.snippet,
+          detail: "function",
+          description: m.description,
+          example: m.example,
+        }));
     }
 
     const resolvableBase = isFunctionCall ? baseExpr : extractTailPathExpression(baseExpr);


### PR DESCRIPTION
## Summary
- Adds `memory.find` and `memory.findFirst` to the expression autocomplete suggestion engine so they appear when typing the `mem` / `memory` prefix.
- Adds dot-completion for `memory.` so the `find` and `findFirst` methods show up after the dot, with snippet placeholders for the namespace and matches arguments.
- Adds unit tests covering both prefix and dot-completion paths.

Closes #4200

## Test plan
- [x] `npx vitest run src/components/AutoCompleteInput/core.spec.ts` (19 tests passing, including the 3 new ones)
- [x] `npx tsc --noEmit -p .` (no errors)
- [x] `npx prettier --check` on modified files
- [ ] Manual UI smoke test in the expression editor: typing `mem` and `memory.` shows the new suggestions