### PR TITLE
fix: error nodes now create failed executions instead of silently swallowing events

### DIFF
--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -140,6 +140,11 @@ func (w *EventRouter) Consume(delivery tackle.Delivery) error {
 func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.CanvasEvent) error {
 	var createdQueueItems []models.CanvasNodeQueueItem
 	var execution *models.CanvasNodeExecution
+	var newFailedExecutions []*models.CanvasNodeExecution
+	onNewFailedExecutions := func(executions ...*models.CanvasNodeExecution) {
+		newFailedExecutions = append(newFailedExecutions, executions...)
+	}
+
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		event, err := models.LockCanvasEvent(tx, event.ID)
 		if err != nil {
@@ -147,7 +152,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 			return nil
 		}
 
-		createdQueueItems, execution, err = w.processEvent(tx, logger, event)
+		createdQueueItems, execution, err = w.processEvent(tx, logger, event, onNewFailedExecutions)
 		if err != nil {
 			return err
 		}
@@ -177,10 +182,20 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 		).Publish()
 	}
 
+	for _, e := range newFailedExecutions {
+		if e != nil {
+			messages.NewCanvasExecutionMessage(
+				e.WorkflowID.String(),
+				e.ID.String(),
+				e.NodeID,
+			).Publish()
+		}
+	}
+
 	return nil
 }
 
-func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, *models.CanvasNodeExecution, error) {
+func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models.CanvasEvent, onNewFailedExecutions func(...*models.CanvasNodeExecution)) ([]models.CanvasNodeQueueItem, *models.CanvasNodeExecution, error) {
 	canvas, err := models.FindCanvasWithoutOrgScopeInTransaction(tx, event.WorkflowID)
 	if err != nil {
 		return nil, nil, err
@@ -192,7 +207,7 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 	}
 
 	if event.ExecutionID == nil {
-		queueItems, err := w.processRootEvent(tx, canvas, liveEdges, event)
+		queueItems, err := w.processRootEvent(tx, canvas, liveEdges, event, onNewFailedExecutions)
 		return queueItems, nil, err
 	}
 
@@ -202,10 +217,10 @@ func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models
 	}
 
 	if execution.ParentExecutionID != nil {
-		return w.processChildExecutionEvent(tx, logger, canvas, execution, event)
+		return w.processChildExecutionEvent(tx, logger, canvas, execution, event, onNewFailedExecutions)
 	}
 
-	queueItems, err := w.processExecutionEvent(tx, logger, canvas, liveEdges, execution, event)
+	queueItems, err := w.processExecutionEvent(tx, logger, canvas, liveEdges, execution, event, onNewFailedExecutions)
 	return queueItems, execution, err
 }
 
@@ -220,7 +235,7 @@ func findOutgoingEdges(edges []models.Edge, sourceID string, channel string) []m
 	return matches
 }
 
-func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges []models.Edge, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, error) {
+func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges []models.Edge, event *models.CanvasEvent, onNewFailedExecutions func(...*models.CanvasNodeExecution)) ([]models.CanvasNodeQueueItem, error) {
 	now := time.Now()
 
 	w.logger.Infof("Processing root event %s", event.ID)
@@ -234,6 +249,11 @@ func (w *EventRouter) processRootEvent(tx *gorm.DB, canvas *models.Canvas, edges
 		}
 
 		if targetNode.State == models.CanvasNodeStateError {
+			executions, err := w.createFailedExecutionForErrorNode(tx, targetNode, event.ID, event.ID, nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			onNewFailedExecutions(executions...)
 			continue
 		}
 
@@ -267,6 +287,7 @@ func (w *EventRouter) processExecutionEvent(
 	edges []models.Edge,
 	execution *models.CanvasNodeExecution,
 	event *models.CanvasEvent,
+	onNewFailedExecutions func(...*models.CanvasNodeExecution),
 ) ([]models.CanvasNodeQueueItem, error) {
 	now := time.Now()
 
@@ -282,6 +303,11 @@ func (w *EventRouter) processExecutionEvent(
 		}
 
 		if targetNode.State == models.CanvasNodeStateError {
+			failedExecutions, err := w.createFailedExecutionForErrorNode(tx, targetNode, execution.RootEventID, event.ID, &execution.ID, nil)
+			if err != nil {
+				return nil, err
+			}
+			onNewFailedExecutions(failedExecutions...)
 			continue
 		}
 
@@ -303,7 +329,66 @@ func (w *EventRouter) processExecutionEvent(
 	return createdQueueItems, event.RoutedInTransaction(tx)
 }
 
-func (w *EventRouter) processChildExecutionEvent(tx *gorm.DB, logger *log.Entry, canvas *models.Canvas, execution *models.CanvasNodeExecution, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, *models.CanvasNodeExecution, error) {
+// createFailedExecutionForErrorNode creates a FINISHED/FAILED execution for a node that is in error
+// state, returning the child execution and (if applicable) the parent execution that was also failed.
+// This mirrors the behavior of handleNodeConfigurationError in NodeQueueWorker.
+func (w *EventRouter) createFailedExecutionForErrorNode(
+	tx *gorm.DB,
+	node *models.CanvasNode,
+	rootEventID uuid.UUID,
+	eventID uuid.UUID,
+	previousExecutionID *uuid.UUID,
+	parentExecutionID *uuid.UUID,
+) ([]*models.CanvasNodeExecution, error) {
+	errorMsg := ""
+	if node.StateReason != nil {
+		errorMsg = *node.StateReason
+	}
+
+	now := time.Now()
+	execution := models.CanvasNodeExecution{
+		WorkflowID:          node.WorkflowID,
+		NodeID:              node.NodeID,
+		RootEventID:         rootEventID,
+		EventID:             eventID,
+		PreviousExecutionID: previousExecutionID,
+		ParentExecutionID:   parentExecutionID,
+		State:               models.CanvasNodeExecutionStateFinished,
+		Configuration:       node.Configuration,
+		Result:              models.CanvasNodeExecutionResultFailed,
+		ResultReason:        models.CanvasNodeExecutionResultReasonError,
+		ResultMessage:       errorMsg,
+		CreatedAt:           &now,
+		UpdatedAt:           &now,
+	}
+
+	if err := tx.Create(&execution).Error; err != nil {
+		return nil, err
+	}
+
+	//
+	// If this is a child execution (inside a blueprint node),
+	// propagate the failure to the parent execution and return both,
+	// so callers can publish execution messages for both.
+	// Mirrors handleNodeConfigurationError in NodeQueueWorker.
+	//
+	if parentExecutionID == nil {
+		return []*models.CanvasNodeExecution{&execution}, nil
+	}
+
+	parent, err := models.FindNodeExecutionInTransaction(tx, node.WorkflowID, *parentExecutionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := parent.FailInTransaction(tx, models.CanvasNodeExecutionResultReasonError, errorMsg); err != nil {
+		return nil, err
+	}
+
+	return []*models.CanvasNodeExecution{&execution, parent}, nil
+}
+
+func (w *EventRouter) processChildExecutionEvent(tx *gorm.DB, logger *log.Entry, canvas *models.Canvas, execution *models.CanvasNodeExecution, event *models.CanvasEvent, onNewFailedExecutions func(...*models.CanvasNodeExecution)) ([]models.CanvasNodeQueueItem, *models.CanvasNodeExecution, error) {
 	parentExecution, err := models.FindNodeExecutionInTransaction(tx, canvas.ID, *execution.ParentExecutionID)
 	if err != nil {
 		logger.Errorf("Error finding parent execution: %v", err)
@@ -374,6 +459,12 @@ func (w *EventRouter) processChildExecutionEvent(tx *gorm.DB, logger *log.Entry,
 		}
 
 		if targetNode.State == models.CanvasNodeStateError {
+			failedExecutions, err := w.createFailedExecutionForErrorNode(tx, targetNode, execution.RootEventID, event.ID, &execution.ID, execution.ParentExecutionID)
+			if err != nil {
+				logger.Errorf("Error creating failed execution for error node: %v", err)
+				return nil, nil, err
+			}
+			onNewFailedExecutions(failedExecutions...)
 			continue
 		}
 

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
@@ -329,6 +330,164 @@ func TestEventRouter__CustomComponent_MultipleOutputs(t *testing.T) {
 	parentOutputEvents, err := models.ListCanvasEvents(canvas.ID, customComponentNode, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, filterEventsByChannel(parentOutputEvents, "default"), 5)
+
+	assert.True(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__EventRouter_ProcessRootEvent_ErrorNode_CreatesFailedExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+
+	executionConsumer := testconsumer.New(amqpURL, messages.CanvasExecutionRoutingKey)
+	executionConsumer.Start()
+	defer executionConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	errorNode := "component-error"
+	errorMsg := "field 'timeoutSeconds': must be a number"
+
+	canvas, createdNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger},
+			{NodeID: errorNode, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: errorNode, Channel: "default"},
+		},
+	)
+
+	// Put the target node into error state (simulating a validation error)
+	var targetNode models.CanvasNode
+	for _, n := range createdNodes {
+		if n.NodeID == errorNode {
+			targetNode = n
+			break
+		}
+	}
+	require.NoError(t, database.Conn().Model(&targetNode).Updates(map[string]any{
+		"state":        models.CanvasNodeStateError,
+		"state_reason": errorMsg,
+	}).Error)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	err := router.LockAndProcessEvent(logger, *event)
+	require.NoError(t, err)
+
+	// Event should be marked routed
+	updatedEvent, err := models.FindCanvasEvent(event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasEventStateRouted, updatedEvent.State)
+
+	// No queue items should be created for the error node
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, errorNode, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
+
+	// A failed execution must exist for the error node
+	executions, err := models.ListNodeExecutions(canvas.ID, errorNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+	exec := executions[0]
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, exec.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, exec.Result)
+	assert.Equal(t, models.CanvasNodeExecutionResultReasonError, exec.ResultReason)
+	assert.Equal(t, errorMsg, exec.ResultMessage)
+	assert.Equal(t, event.ID, exec.RootEventID)
+	assert.Equal(t, event.ID, exec.EventID)
+	assert.Nil(t, exec.PreviousExecutionID)
+
+	// An execution message must be published so the system records the failure
+	assert.True(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__EventRouter_ProcessExecutionEvent_ErrorNode_CreatesFailedExecution(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+
+	executionConsumer := testconsumer.New(amqpURL, messages.CanvasExecutionRoutingKey)
+	executionConsumer.Start()
+	defer executionConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	goodNode := "component-1"
+	errorNode := "component-error"
+	errorMsg := "field 'timeoutSeconds': must be a number"
+
+	canvas, createdNodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger},
+			{NodeID: goodNode, Type: models.NodeTypeComponent},
+			{NodeID: errorNode, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: goodNode, Channel: "default"},
+			{SourceID: goodNode, TargetID: errorNode, Channel: "default"},
+		},
+	)
+
+	// Put the target node into error state
+	var targetNode models.CanvasNode
+	for _, n := range createdNodes {
+		if n.NodeID == errorNode {
+			targetNode = n
+			break
+		}
+	}
+	require.NoError(t, database.Conn().Model(&targetNode).Updates(map[string]any{
+		"state":        models.CanvasNodeStateError,
+		"state_reason": errorMsg,
+	}).Error)
+
+	// Create a root event and an execution for goodNode that emits on "default"
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, goodNode, rootEvent.ID, rootEvent.ID, nil)
+	_, err := execution.Pass(map[string][]any{"default": {map[string]any{}}})
+	require.NoError(t, err)
+
+	// Get the output event emitted by goodNode
+	events, err := models.ListCanvasEvents(canvas.ID, goodNode, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	outputEvent := events[0]
+
+	err = router.LockAndProcessEvent(logger, outputEvent)
+	require.NoError(t, err)
+
+	// Output event should be routed
+	updatedEvent, err := models.FindCanvasEvent(outputEvent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasEventStateRouted, updatedEvent.State)
+
+	// No queue items for the error node
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, errorNode, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
+
+	// A failed execution must exist with PreviousExecutionID pointing to the upstream execution
+	executions, err := models.ListNodeExecutions(canvas.ID, errorNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+	exec := executions[0]
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, exec.State)
+	assert.Equal(t, models.CanvasNodeExecutionResultFailed, exec.Result)
+	assert.Equal(t, models.CanvasNodeExecutionResultReasonError, exec.ResultReason)
+	assert.Equal(t, errorMsg, exec.ResultMessage)
+	assert.Equal(t, rootEvent.ID, exec.RootEventID)
+	assert.Equal(t, outputEvent.ID, exec.EventID)
+	require.NotNil(t, exec.PreviousExecutionID)
+	assert.Equal(t, execution.ID, *exec.PreviousExecutionID)
 
 	assert.True(t, executionConsumer.HasReceivedMessage())
 }


### PR DESCRIPTION
## Problem

When an execution reaches a canvas node with `errorMessage` (i.e. `state = error`), the `EventRouter` silently skipped it — no failed execution was created, nothing appeared in the execution trace, and the chain stopped with no indication of why.

## Change

`EventRouter` now creates a `FINISHED/FAILED` `CanvasNodeExecution` for any target node in error state instead of silently continuing. The `resultMessage` is set from the node's `StateReason`.

This applies across all three routing paths:
- `processRootEvent` — root trigger events
- `processExecutionEvent` — standard upstream execution events
- `processChildExecutionEvent` — child (blueprint) execution events

For child executions, the failure is also propagated to the parent blueprint execution, consistent with how `handleNodeConfigurationError` works in `NodeQueueWorker`.

An execution message is published after the transaction so the failure is visible in the trace.

## Test

Added two integration tests in `event_router_test.go`:
- `Test__EventRouter_ProcessRootEvent_ErrorNode_CreatesFailedExecution` — verifies a failed execution is created with the correct `resultMessage` when a root event routes to an error node
- `Test__EventRouter_ProcessExecutionEvent_ErrorNode_CreatesFailedExecution` — verifies the same for upstream execution events, including correct `PreviousExecutionID` linkage

Closes #4440