### PR TITLE
fix: preserve edges when canvas node IDs are regenerated

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -39,6 +39,7 @@ type CanvasPublisher struct {
 	draft      *models.CanvasVersion
 	changeset  *pb.CanvasChangeset
 	finalNodes map[string]models.Node
+	renamedIDs map[string]string
 
 	//
 	// All nodes in the workflow, including deleted ones.
@@ -122,6 +123,7 @@ func NewCanvasPublisher(tx *gorm.DB, draft *models.CanvasVersion, liveVersion *m
 		draft:      draft,
 		changeset:  changeset,
 		allNodes:   allNodesMap,
+		renamedIDs: make(map[string]string),
 	}, nil
 }
 
@@ -137,13 +139,34 @@ func (p *CanvasPublisher) Publish(ctx context.Context) error {
 		finalNodes = append(finalNodes, node)
 	}
 
-	finalEdges := p.filterEdgesForExistingNodes(p.draft.Edges)
+	finalEdges := p.filterEdgesForExistingNodes(p.edgesWithRenamedNodeIDs(p.draft.Edges))
 	err := models.PromoteToLiveInTransaction(p.tx, p.draft, finalNodes, finalEdges)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (p *CanvasPublisher) edgesWithRenamedNodeIDs(edges []models.Edge) []models.Edge {
+	if len(p.renamedIDs) == 0 {
+		return edges
+	}
+
+	updatedEdges := make([]models.Edge, len(edges))
+	copy(updatedEdges, edges)
+
+	for i := range updatedEdges {
+		if renamedSource, ok := p.renamedIDs[updatedEdges[i].SourceID]; ok {
+			updatedEdges[i].SourceID = renamedSource
+		}
+
+		if renamedTarget, ok := p.renamedIDs[updatedEdges[i].TargetID]; ok {
+			updatedEdges[i].TargetID = renamedTarget
+		}
+	}
+
+	return updatedEdges
 }
 
 func (p *CanvasPublisher) filterEdgesForExistingNodes(edges []models.Edge) []models.Edge {
@@ -462,6 +485,7 @@ func (p *CanvasPublisher) ensureNewNodeID(node models.Node) string {
 	//
 	newNodeID := models.GenerateUniqueNodeID(node, reservedIDs)
 	delete(p.finalNodes, node.ID)
+	p.renamedIDs[node.ID] = newNodeID
 	node.ID = newNodeID
 	p.finalNodes[newNodeID] = node
 	return newNodeID

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -555,6 +555,70 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.True(t, versionHasNewID)
 	})
 
+	t.Run("add trigger with conflicting id rewrites connected edge source", func(t *testing.T) {
+		r := support.Setup(t)
+
+		canvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				componentCanvasNode("node-a", "Node A", "noop", map[string]any{"value": "before"}),
+			},
+			nil,
+		)
+
+		conflictingID := "pr-opened"
+		legacyNode := componentCanvasNode(conflictingID, "Legacy Trigger", "noop", map[string]any{"value": "legacy"})
+		legacyNode.WorkflowID = canvas.ID
+		legacyNode.State = models.CanvasNodeStateReady
+		require.NoError(t, database.Conn().Create(&legacyNode).Error)
+		require.NoError(t, database.Conn().Delete(&legacyNode).Error)
+
+		draft, err := models.SaveCanvasDraftInTransaction(
+			database.Conn(),
+			canvas.ID,
+			r.User,
+			[]models.Node{
+				componentNode("node-a", "Node A", "noop", map[string]any{"value": "before"}),
+				triggerNode(conflictingID, "PR Opened", "schedule", map[string]any{
+					"type":            "minutes",
+					"minutesInterval": 1,
+				}),
+			},
+			[]models.Edge{
+				{SourceID: conflictingID, TargetID: "node-a", Channel: "default"},
+			},
+		)
+		require.NoError(t, err)
+
+		liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), canvas.ID)
+		require.NoError(t, err)
+		publisher, err := NewCanvasPublisher(database.Conn(), draft, liveVersion, canvasPublisherOptions(r))
+		require.NoError(t, err)
+
+		err = publisher.Publish(context.Background())
+		require.NoError(t, err)
+
+		activeNodes, err := models.FindCanvasNodes(canvas.ID)
+		require.NoError(t, err)
+		index := slices.IndexFunc(activeNodes, func(node models.CanvasNode) bool {
+			return node.Name == "PR Opened"
+		})
+		require.True(t, index != -1, "expected added trigger with conflicting ID")
+
+		addedTrigger := activeNodes[index]
+		require.NotEqual(t, conflictingID, addedTrigger.NodeID)
+
+		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			datatypes.NewJSONSlice([]models.Edge{{SourceID: addedTrigger.NodeID, TargetID: "node-a", Channel: "default"}}),
+			publishedVersion.Edges,
+		)
+	})
+
 	t.Run("add node with conflicting id and setup error does not duplicate final nodes", func(t *testing.T) {
 		r := support.Setup(t)
 


### PR DESCRIPTION
## Summary

Fixes canvas publishing so edges are updated when a node ID is regenerated due to an existing deleted node ID conflict.

Closes: https://github.com/superplanehq/superplane/issues/4347