### PR TITLE
feat: update canvas append handles

### DIFF
--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@xyflow/react", () => ({
@@ -187,10 +187,13 @@ describe("Block fallback rendering", () => {
   });
 
   it("shows an append connector button for end nodes in edit mode", () => {
+    const onAppendFromNode = vi.fn();
+
     render(
       <Block
         canvasMode="edit"
         nodeId="end-node"
+        onAppendFromNode={onAppendFromNode}
         data={{
           label: "End node",
           state: "pending",
@@ -206,7 +209,9 @@ describe("Block fallback rendering", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Add next component" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add next component" }));
+
+    expect(onAppendFromNode).toHaveBeenCalledWith("end-node", "default");
   });
 
   it("highlights the append connector source handle during compatible connection drags", () => {
@@ -237,10 +242,13 @@ describe("Block fallback rendering", () => {
   });
 
   it("shows append connector buttons for unconnected output channels", () => {
+    const onAppendFromNode = vi.fn();
+
     render(
       <Block
         canvasMode="edit"
         nodeId="router-node"
+        onAppendFromNode={onAppendFromNode}
         data={{
           label: "Router",
           state: "pending",
@@ -257,6 +265,9 @@ describe("Block fallback rendering", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Add next component (success)" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add next component (failure)" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add next component (failure)" }));
+
+    expect(onAppendFromNode).toHaveBeenCalledWith("router-node", "failure");
   });
 });

--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -166,11 +166,97 @@ describe("Block fallback rendering", () => {
             iconSlug: "box",
             collapsed: false,
           },
+          _allEdges: [
+            {
+              source: "component-node",
+              sourceHandle: "default",
+              target: "next-node",
+            },
+            {
+              source: "prev-node",
+              sourceHandle: "default",
+              target: "component-node",
+            },
+          ],
         }}
       />,
     );
 
     expect(screen.getByTestId("handle-target-default")).toHaveAttribute("data-pointer-events", "none");
     expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-pointer-events", "none");
+  });
+
+  it("shows an append connector button for end nodes in edit mode", () => {
+    render(
+      <Block
+        canvasMode="edit"
+        nodeId="end-node"
+        data={{
+          label: "End node",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+          component: {
+            title: "End node",
+            iconSlug: "box",
+            collapsed: false,
+          },
+          _allEdges: [{ source: "prev-node", sourceHandle: "default", target: "end-node" }],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add next component" })).toBeInTheDocument();
+  });
+
+  it("highlights the append connector source handle during compatible connection drags", () => {
+    render(
+      <Block
+        canvasMode="edit"
+        nodeId="end-node"
+        data={{
+          label: "End node",
+          state: "pending",
+          type: "component",
+          outputChannels: ["default"],
+          component: {
+            title: "End node",
+            iconSlug: "box",
+            collapsed: false,
+          },
+          _connectingFrom: {
+            nodeId: "target-node",
+            handleType: "target",
+          },
+          _allEdges: [{ source: "prev-node", sourceHandle: "default", target: "end-node" }],
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("handle-source-default")).toHaveAttribute("data-highlighted", "true");
+  });
+
+  it("shows append connector buttons for unconnected output channels", () => {
+    render(
+      <Block
+        canvasMode="edit"
+        nodeId="router-node"
+        data={{
+          label: "Router",
+          state: "pending",
+          type: "component",
+          outputChannels: ["success", "failure"],
+          component: {
+            title: "Router",
+            iconSlug: "box",
+            collapsed: false,
+          },
+          _allEdges: [{ source: "router-node", sourceHandle: "success", target: "success-node" }],
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Add next component (success)" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add next component (failure)" })).toBeInTheDocument();
   });
 });

--- a/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
@@ -1,0 +1,34 @@
+import { Plus } from "lucide-react";
+import type React from "react";
+
+export const APPEND_CONNECTOR_COLOR = "#C9D5E1";
+
+const APPEND_HANDLE_STYLE: React.CSSProperties = {
+  width: 24,
+  height: 24,
+  borderRadius: 100,
+  border: `3px solid ${APPEND_CONNECTOR_COLOR}`,
+  background: "white",
+  pointerEvents: "auto",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#94A3B8",
+};
+
+export function AppendHandleButton({ label, style }: { label: string; style: React.CSSProperties }) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className="sp-append-source-handle hover:text-slate-500"
+      style={{
+        ...APPEND_HANDLE_STYLE,
+        ...style,
+      }}
+    >
+      <Plus aria-hidden="true" className="h-4 w-4" strokeWidth={3} />
+    </button>
+  );
+}

--- a/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
@@ -1,5 +1,6 @@
 import { Plus } from "lucide-react";
 import type React from "react";
+import type { BlockProps } from "./types";
 
 export const APPEND_CONNECTOR_COLOR = "#C9D5E1";
 
@@ -17,12 +18,35 @@ const APPEND_HANDLE_STYLE: React.CSSProperties = {
   color: "#94A3B8",
 };
 
-export function AppendHandleButton({ label, style }: { label: string; style: React.CSSProperties }) {
+const APPEND_PREVIEW_DOT_STYLE: React.CSSProperties = {
+  width: 12,
+  height: 12,
+  borderRadius: 100,
+  border: `3px solid ${APPEND_CONNECTOR_COLOR}`,
+  background: "transparent",
+};
+
+export type AppendFromNodeHandler = NonNullable<BlockProps["onAppendFromNode"]>;
+
+export function AppendHandleButton({
+  label,
+  onClick,
+  style,
+}: {
+  label: string;
+  onClick: () => void | Promise<void>;
+  style: React.CSSProperties;
+}) {
   return (
     <button
       type="button"
       aria-label={label}
       className="sp-append-source-handle hover:text-slate-500"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void onClick();
+      }}
       style={{
         ...APPEND_HANDLE_STYLE,
         ...style,
@@ -30,5 +54,59 @@ export function AppendHandleButton({ label, style }: { label: string; style: Rea
     >
       <Plus aria-hidden="true" className="h-4 w-4" strokeWidth={3} />
     </button>
+  );
+}
+
+export function AppendHandlePreview({
+  style,
+  connectorTop = "50%",
+  containerOffsetY = 0,
+}: {
+  style: React.CSSProperties;
+  connectorTop?: number | string;
+  containerOffsetY?: number;
+}) {
+  const previewStemLength = 44;
+  const previewConnectorSize = 12;
+  const previewContainerGap = 12;
+  const previewContainerLeft = previewStemLength + previewConnectorSize / 2 + previewContainerGap;
+
+  return (
+    <div className="sp-append-source-preview" style={style}>
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: connectorTop,
+          width: previewStemLength,
+          height: 3,
+          transform: "translateY(-50%)",
+          backgroundColor: APPEND_CONNECTOR_COLOR,
+          borderRadius: 999,
+        }}
+      />
+      <div
+        style={{
+          ...APPEND_PREVIEW_DOT_STYLE,
+          position: "absolute",
+          left: previewStemLength + previewConnectorSize / 2,
+          top: connectorTop,
+          transform: "translate(-50%, -50%)",
+          pointerEvents: "none",
+        }}
+      />
+      <div
+        style={{
+          marginLeft: previewContainerLeft,
+          marginTop: containerOffsetY,
+          width: "23rem",
+          height: 96,
+          borderRadius: 8,
+          background: "white",
+          outline: "1px solid rgb(15 23 42 / 0.15)",
+          opacity: 0.6,
+        }}
+      />
+    </div>
   );
 }

--- a/web_src/src/ui/CanvasPage/Block/connectionState.ts
+++ b/web_src/src/ui/CanvasPage/Block/connectionState.ts
@@ -1,0 +1,20 @@
+import type { BlockConnectionState, BlockEdgeState } from "./types";
+
+export function isAlreadyConnectedToNode(
+  edges: BlockEdgeState[],
+  connection: BlockConnectionState | undefined,
+  sourceNodeId: string | undefined,
+  targetNodeId: string | undefined,
+  sourceHandle?: string | null,
+) {
+  if (!connection || !sourceNodeId || !targetNodeId) {
+    return false;
+  }
+
+  return edges.some(
+    (edge) =>
+      edge.source === sourceNodeId &&
+      edge.sourceHandle === (sourceHandle ?? connection.handleId) &&
+      edge.target === targetNodeId,
+  );
+}

--- a/web_src/src/ui/CanvasPage/Block/handleStyle.ts
+++ b/web_src/src/ui/CanvasPage/Block/handleStyle.ts
@@ -1,0 +1,9 @@
+import type React from "react";
+
+export const HANDLE_STYLE = {
+  width: 12,
+  height: 12,
+  borderRadius: 100,
+  border: "3px solid #C9D5E1",
+  background: "transparent",
+} satisfies React.CSSProperties;

--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -1,37 +1,59 @@
-import React from "react";
 import { Handle, Position } from "@xyflow/react";
+import { APPEND_CONNECTOR_COLOR, AppendHandleButton } from "./appendHandle";
+import { isAlreadyConnectedToNode } from "./connectionState";
 import { getOutputChannels } from "./data";
+import { HANDLE_STYLE } from "./handleStyle";
+import { MultiRightHandle } from "./multiRightHandle";
 import type { BlockConnectionState, BlockEdgeState, BlockProps, CanvasBlockData } from "./types";
-
-const HANDLE_STYLE = {
-  width: 12,
-  height: 12,
-  borderRadius: 100,
-  border: "3px solid #C9D5E1",
-  background: "transparent",
-};
-
-function isAlreadyConnectedToNode(
-  edges: BlockEdgeState[],
-  connection: BlockConnectionState | undefined,
-  sourceNodeId: string | undefined,
-  targetNodeId: string | undefined,
-  sourceHandle?: string | null,
-) {
-  if (!connection || !sourceNodeId || !targetNodeId) {
-    return false;
-  }
-
-  return edges.some(
-    (edge) =>
-      edge.source === sourceNodeId &&
-      edge.sourceHandle === (sourceHandle ?? connection.handleId) &&
-      edge.target === targetNodeId,
-  );
-}
 
 function getBlockEdges(data: CanvasBlockData): BlockEdgeState[] {
   return data._allEdges || [];
+}
+
+function getNodeConnectionStats(edges: BlockEdgeState[], nodeId?: string) {
+  if (!nodeId) {
+    return { hasIncoming: false, hasOutgoing: false };
+  }
+
+  return {
+    hasIncoming: edges.some((edge) => edge.target === nodeId),
+    hasOutgoing: edges.some((edge) => edge.source === nodeId),
+  };
+}
+
+function isDisconnectedNode(stats: { hasIncoming: boolean; hasOutgoing: boolean }) {
+  return !stats.hasIncoming && !stats.hasOutgoing;
+}
+
+function shouldHideInactiveLeftHandle(
+  isConnectionInteractive: boolean,
+  stats: { hasIncoming: boolean; hasOutgoing: boolean },
+) {
+  return !isConnectionInteractive && isDisconnectedNode(stats);
+}
+
+function getLeftHandleHighlight({
+  isConnectionInteractive,
+  hoveredEdge,
+  connectingFrom,
+  nodeId,
+  isAlreadyConnected,
+}: {
+  isConnectionInteractive: boolean;
+  hoveredEdge?: BlockEdgeState;
+  connectingFrom?: BlockConnectionState;
+  nodeId?: string;
+  isAlreadyConnected: boolean;
+}) {
+  if (!isConnectionInteractive) {
+    return false;
+  }
+
+  if (hoveredEdge && hoveredEdge.target === nodeId) {
+    return true;
+  }
+
+  return connectingFrom?.nodeId !== nodeId && connectingFrom?.handleType === "source" && !isAlreadyConnected;
 }
 
 function shouldHideLeftHandle(data: CanvasBlockData) {
@@ -109,140 +131,66 @@ function SingleRightHandle({
   );
 }
 
-function getChannelHighlightResolver(args: {
-  hoveredEdge?: BlockEdgeState;
-  connectingFrom?: BlockConnectionState;
-  nodeId?: string;
-  allEdges: BlockEdgeState[];
-}) {
-  const { hoveredEdge, connectingFrom, nodeId, allEdges } = args;
-
-  return (channel: string) => {
-    const isAlreadyConnected = isAlreadyConnectedToNode(
-      allEdges,
-      connectingFrom,
-      nodeId,
-      connectingFrom?.nodeId,
-      channel,
-    );
-
-    return (
-      (hoveredEdge && hoveredEdge.source === nodeId && hoveredEdge.sourceHandle === channel) ||
-      (connectingFrom && connectingFrom.nodeId === nodeId && connectingFrom.handleId === channel) ||
-      (connectingFrom &&
-        connectingFrom.nodeId !== nodeId &&
-        connectingFrom.handleType === "target" &&
-        !isAlreadyConnected)
-    );
-  };
-}
-
-function MultiRightHandle({
-  channels,
+function EndNodeAppendConnector({
+  channel,
   hoveredEdge,
   connectingFrom,
   nodeId,
   allEdges,
   isConnectionInteractive,
 }: {
-  channels: string[];
+  channel: string;
   hoveredEdge?: BlockEdgeState;
   connectingFrom?: BlockConnectionState;
   nodeId?: string;
   allEdges: BlockEdgeState[];
   isConnectionInteractive: boolean;
 }) {
-  const getChannelHighlight = getChannelHighlightResolver({
-    hoveredEdge,
-    connectingFrom,
-    nodeId,
-    allEdges,
-  });
-
-  const channelSpacing = 24;
-  const handleSize = 12;
-  const edgeColor = "#C9D5E1";
-  const trunkLength = 16;
-  const branchEndX = trunkLength + 24;
-  const labelStartX = branchEndX + 4;
-  const lineEndX = branchEndX + 62;
-  const handleGap = 4;
-  const handleLeftX = lineEndX + handleGap;
-  const totalHeight = (channels.length - 1) * channelSpacing;
-  const svgHeight = totalHeight + 40;
-  const svgCenterY = svgHeight / 2;
-  const channelPositions = channels.map((channel, index) => ({
-    channel,
-    offsetY: (index - (channels.length - 1) / 2) * channelSpacing,
-    isHighlighted: isConnectionInteractive && getChannelHighlight(channel),
-  }));
+  const isHighlighted =
+    isConnectionInteractive &&
+    getSingleChannelHighlight({
+      hoveredEdge,
+      connectingFrom,
+      nodeId,
+      channel,
+      allEdges,
+    });
 
   return (
-    <div
-      className="absolute"
-      style={{
-        left: "100%",
-        top: 0,
-        bottom: 0,
-        pointerEvents: "none",
-      }}
-    >
-      <svg
-        width={lineEndX}
-        height={svgHeight}
+    <>
+      <Handle
+        type="source"
+        position={Position.Right}
+        id={channel}
+        style={{
+          ...HANDLE_STYLE,
+          right: -21,
+          top: 13,
+          pointerEvents: "auto",
+          transform: "none",
+        }}
+        className={isHighlighted ? "highlighted" : undefined}
+      />
+      <div
         style={{
           position: "absolute",
-          left: 0,
-          top: `calc(50% - ${svgCenterY}px)`,
-          overflow: "visible",
+          right: -63,
+          top: 17,
+          width: 42,
+          height: 3,
+          backgroundColor: APPEND_CONNECTOR_COLOR,
+          pointerEvents: "none",
         }}
-      >
-        <line x1={0} y1={svgCenterY} x2={trunkLength} y2={svgCenterY} stroke={edgeColor} strokeWidth={3} />
-
-        {channelPositions.map(({ channel, offsetY }) => {
-          const y = svgCenterY + offsetY;
-          return (
-            <g key={channel}>
-              <line x1={trunkLength} y1={svgCenterY} x2={branchEndX} y2={y} stroke={edgeColor} strokeWidth={3} />
-              <line x1={branchEndX} y1={y} x2={lineEndX} y2={y} stroke={edgeColor} strokeWidth={3} />
-            </g>
-          );
-        })}
-      </svg>
-
-      {channelPositions.map(({ channel, offsetY, isHighlighted }) => (
-        <React.Fragment key={channel}>
-          <span
-            className="text-xs font-medium whitespace-nowrap absolute bg-slate-100"
-            style={{
-              left: labelStartX,
-              top: `calc(50% + ${offsetY}px)`,
-              transform: "translateY(-50%)",
-              color: "#8B9AAC",
-              lineHeight: `${handleSize}px`,
-              paddingLeft: 4,
-              paddingRight: 4,
-            }}
-          >
-            {channel}
-          </span>
-
-          <Handle
-            type="source"
-            position={Position.Right}
-            id={channel}
-            style={{
-              ...HANDLE_STYLE,
-              left: handleLeftX,
-              top: `calc(50% + ${offsetY}px)`,
-              transform: "translateY(-50%)",
-              pointerEvents: isConnectionInteractive ? "auto" : "none",
-            }}
-            className={isHighlighted ? "highlighted" : undefined}
-          />
-        </React.Fragment>
-      ))}
-    </div>
+      />
+      <AppendHandleButton
+        label="Add next component"
+        style={{
+          right: -87,
+          top: 6,
+          position: "absolute",
+        }}
+      />
+    </>
   );
 }
 
@@ -251,24 +199,31 @@ export function LeftHandle({
   nodeId,
   isConnectionInteractive = true,
 }: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
+  const allEdges = getBlockEdges(data);
+  const connectionStats = getNodeConnectionStats(allEdges, nodeId);
+
+  if (shouldHideInactiveLeftHandle(isConnectionInteractive, connectionStats)) {
+    return null;
+  }
+
   if (shouldHideLeftHandle(data)) return null;
 
   const hoveredEdge = data._hoveredEdge;
   const connectingFrom = data._connectingFrom;
   const isAlreadyConnected = isAlreadyConnectedToNode(
-    getBlockEdges(data),
+    allEdges,
     connectingFrom,
     connectingFrom?.nodeId,
     nodeId,
     connectingFrom?.handleId,
   );
-  const isHighlighted =
-    isConnectionInteractive &&
-    ((hoveredEdge && hoveredEdge.target === nodeId) ||
-      (connectingFrom &&
-        connectingFrom.nodeId !== nodeId &&
-        connectingFrom.handleType === "source" &&
-        !isAlreadyConnected));
+  const isHighlighted = getLeftHandleHighlight({
+    isConnectionInteractive,
+    hoveredEdge,
+    connectingFrom,
+    nodeId,
+    isAlreadyConnected,
+  });
 
   return (
     <Handle
@@ -290,12 +245,32 @@ export function RightHandle({
   nodeId,
   isConnectionInteractive = true,
 }: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
+  const allEdges = getBlockEdges(data);
+  const { hasIncoming, hasOutgoing } = getNodeConnectionStats(allEdges, nodeId);
+  const isDisconnected = isDisconnectedNode({ hasIncoming, hasOutgoing });
+
+  if (!isConnectionInteractive && (!hasOutgoing || isDisconnected)) {
+    return null;
+  }
+
   if (shouldHideRightHandle(data)) return null;
 
   const channels = getOutputChannels(data);
   const hoveredEdge = data._hoveredEdge;
   const connectingFrom = data._connectingFrom;
-  const allEdges = getBlockEdges(data);
+
+  if (isConnectionInteractive && !hasOutgoing && channels.length === 1) {
+    return (
+      <EndNodeAppendConnector
+        channel={channels[0]}
+        hoveredEdge={hoveredEdge}
+        connectingFrom={connectingFrom}
+        nodeId={nodeId}
+        allEdges={allEdges}
+        isConnectionInteractive={isConnectionInteractive}
+      />
+    );
+  }
 
   if (channels.length === 1) {
     return (

--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -1,5 +1,10 @@
 import { Handle, Position } from "@xyflow/react";
-import { APPEND_CONNECTOR_COLOR, AppendHandleButton } from "./appendHandle";
+import {
+  APPEND_CONNECTOR_COLOR,
+  AppendHandleButton,
+  AppendHandlePreview,
+  type AppendFromNodeHandler,
+} from "./appendHandle";
 import { isAlreadyConnectedToNode } from "./connectionState";
 import { getOutputChannels } from "./data";
 import { HANDLE_STYLE } from "./handleStyle";
@@ -132,20 +137,26 @@ function SingleRightHandle({
 }
 
 function EndNodeAppendConnector({
+  nodeId,
   channel,
+  onAppendFromNode,
   hoveredEdge,
   connectingFrom,
-  nodeId,
   allEdges,
   isConnectionInteractive,
 }: {
+  nodeId?: string;
   channel: string;
+  onAppendFromNode?: AppendFromNodeHandler;
   hoveredEdge?: BlockEdgeState;
   connectingFrom?: BlockConnectionState;
-  nodeId?: string;
   allEdges: BlockEdgeState[];
   isConnectionInteractive: boolean;
 }) {
+  if (!nodeId || !onAppendFromNode) {
+    return null;
+  }
+
   const isHighlighted =
     isConnectionInteractive &&
     getSingleChannelHighlight({
@@ -184,11 +195,20 @@ function EndNodeAppendConnector({
       />
       <AppendHandleButton
         label="Add next component"
+        onClick={() => onAppendFromNode(nodeId, channel)}
         style={{
           right: -87,
           top: 6,
           position: "absolute",
         }}
+      />
+      <AppendHandlePreview
+        style={{
+          position: "absolute",
+          left: "calc(100% + 85px)",
+          top: 0,
+        }}
+        connectorTop={18}
       />
     </>
   );
@@ -244,7 +264,8 @@ export function RightHandle({
   data,
   nodeId,
   isConnectionInteractive = true,
-}: Pick<BlockProps, "data" | "nodeId"> & { isConnectionInteractive?: boolean }) {
+  onAppendFromNode,
+}: Pick<BlockProps, "data" | "nodeId" | "onAppendFromNode"> & { isConnectionInteractive?: boolean }) {
   const allEdges = getBlockEdges(data);
   const { hasIncoming, hasOutgoing } = getNodeConnectionStats(allEdges, nodeId);
   const isDisconnected = isDisconnectedNode({ hasIncoming, hasOutgoing });
@@ -259,13 +280,14 @@ export function RightHandle({
   const hoveredEdge = data._hoveredEdge;
   const connectingFrom = data._connectingFrom;
 
-  if (isConnectionInteractive && !hasOutgoing && channels.length === 1) {
+  if (isConnectionInteractive && !hasOutgoing && channels.length === 1 && onAppendFromNode) {
     return (
       <EndNodeAppendConnector
+        nodeId={nodeId}
         channel={channels[0]}
+        onAppendFromNode={onAppendFromNode}
         hoveredEdge={hoveredEdge}
         connectingFrom={connectingFrom}
-        nodeId={nodeId}
         allEdges={allEdges}
         isConnectionInteractive={isConnectionInteractive}
       />
@@ -293,6 +315,7 @@ export function RightHandle({
       nodeId={nodeId}
       allEdges={allEdges}
       isConnectionInteractive={isConnectionInteractive}
+      onAppendFromNode={onAppendFromNode}
     />
   );
 }

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -17,7 +17,12 @@ export const Block = React.memo(function Block(props: BlockProps) {
     <div className={`relative w-fit ${shouldDim ? "opacity-30" : ""}`} onClick={(e) => props.onClick?.(e)}>
       <LeftHandle data={data} nodeId={props.nodeId} isConnectionInteractive={isConnectionInteractive} />
       <BlockContent {...props} />
-      <RightHandle data={data} nodeId={props.nodeId} isConnectionInteractive={isConnectionInteractive} />
+      <RightHandle
+        data={data}
+        nodeId={props.nodeId}
+        isConnectionInteractive={isConnectionInteractive}
+        onAppendFromNode={props.onAppendFromNode}
+      />
     </div>
   );
 });

--- a/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { Handle, Position } from "@xyflow/react";
-import { APPEND_CONNECTOR_COLOR, AppendHandleButton } from "./appendHandle";
+import {
+  APPEND_CONNECTOR_COLOR,
+  AppendHandleButton,
+  AppendHandlePreview,
+  type AppendFromNodeHandler,
+} from "./appendHandle";
 import { isAlreadyConnectedToNode } from "./connectionState";
 import { HANDLE_STYLE } from "./handleStyle";
 import type { BlockConnectionState, BlockEdgeState } from "./types";
@@ -151,6 +156,7 @@ function MultiRightChannelControl({
   isHighlighted,
   isConnectionInteractive,
   canAppend,
+  onAppend,
 }: {
   layout: MultiRightHandleLayout;
   channel: string;
@@ -158,6 +164,7 @@ function MultiRightChannelControl({
   isHighlighted: boolean | undefined;
   isConnectionInteractive: boolean;
   canAppend: boolean;
+  onAppend: () => void | Promise<void>;
 }) {
   return (
     <React.Fragment>
@@ -206,12 +213,22 @@ function MultiRightChannelControl({
           />
           <AppendHandleButton
             label={`Add next component (${channel})`}
+            onClick={onAppend}
             style={{
               left: layout.handleLeftX + 32,
               top: `calc(50% + ${offsetY}px)`,
               transform: "translateY(-50%)",
               position: "absolute",
             }}
+          />
+          <AppendHandlePreview
+            style={{
+              position: "absolute",
+              left: layout.handleLeftX + 52,
+              top: `calc(50% + ${offsetY}px)`,
+              transform: "translateY(-50%)",
+            }}
+            containerOffsetY={54}
           />
         </>
       ) : null}
@@ -226,6 +243,7 @@ export function MultiRightHandle({
   nodeId,
   allEdges,
   isConnectionInteractive,
+  onAppendFromNode,
 }: {
   channels: string[];
   hoveredEdge?: BlockEdgeState;
@@ -233,6 +251,7 @@ export function MultiRightHandle({
   nodeId?: string;
   allEdges: BlockEdgeState[];
   isConnectionInteractive: boolean;
+  onAppendFromNode?: AppendFromNodeHandler;
 }) {
   const getChannelHighlight = getChannelHighlightResolver({
     hoveredEdge,
@@ -254,7 +273,7 @@ export function MultiRightHandle({
       <MultiRightHandleLines layout={layout} channels={channelPositions} />
 
       {channelPositions.map(({ channel, offsetY, isHighlighted, hasOutgoingForChannel }) => {
-        const canAppend = isConnectionInteractive && !hasOutgoingForChannel;
+        const canAppend = isConnectionInteractive && !!nodeId && !!onAppendFromNode && !hasOutgoingForChannel;
 
         return (
           <MultiRightChannelControl
@@ -265,6 +284,7 @@ export function MultiRightHandle({
             isHighlighted={isHighlighted}
             isConnectionInteractive={isConnectionInteractive}
             canAppend={canAppend}
+            onAppend={() => (nodeId ? onAppendFromNode?.(nodeId, channel) : undefined)}
           />
         );
       })}

--- a/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
@@ -1,0 +1,273 @@
+import React from "react";
+import { Handle, Position } from "@xyflow/react";
+import { APPEND_CONNECTOR_COLOR, AppendHandleButton } from "./appendHandle";
+import { isAlreadyConnectedToNode } from "./connectionState";
+import { HANDLE_STYLE } from "./handleStyle";
+import type { BlockConnectionState, BlockEdgeState } from "./types";
+
+const MULTI_HANDLE_CHANNEL_SPACING = 34;
+
+type MultiRightHandleLayout = {
+  handleSize: number;
+  labelStartX: number;
+  lineEndX: number;
+  handleLeftX: number;
+  trunkLength: number;
+  branchEndX: number;
+  svgHeight: number;
+  svgCenterY: number;
+};
+
+type ChannelPosition = {
+  channel: string;
+  offsetY: number;
+  isHighlighted: boolean | undefined;
+  hasOutgoingForChannel: boolean;
+};
+
+function getChannelHighlightResolver(args: {
+  hoveredEdge?: BlockEdgeState;
+  connectingFrom?: BlockConnectionState;
+  nodeId?: string;
+  allEdges: BlockEdgeState[];
+}) {
+  const { hoveredEdge, connectingFrom, nodeId, allEdges } = args;
+
+  return (channel: string) => {
+    const isAlreadyConnected = isAlreadyConnectedToNode(
+      allEdges,
+      connectingFrom,
+      nodeId,
+      connectingFrom?.nodeId,
+      channel,
+    );
+
+    return (
+      (hoveredEdge && hoveredEdge.source === nodeId && hoveredEdge.sourceHandle === channel) ||
+      (connectingFrom && connectingFrom.nodeId === nodeId && connectingFrom.handleId === channel) ||
+      (connectingFrom &&
+        connectingFrom.nodeId !== nodeId &&
+        connectingFrom.handleType === "target" &&
+        !isAlreadyConnected)
+    );
+  };
+}
+
+function getMultiRightHandleLayout(channelCount: number): MultiRightHandleLayout {
+  const trunkLength = 16;
+  const branchEndX = trunkLength + 24;
+  const lineEndX = branchEndX + 62;
+  const handleGap = 4;
+  const totalHeight = (channelCount - 1) * MULTI_HANDLE_CHANNEL_SPACING;
+  const svgHeight = totalHeight + 40;
+
+  return {
+    handleSize: 12,
+    labelStartX: branchEndX + 4,
+    lineEndX,
+    handleLeftX: lineEndX + handleGap,
+    trunkLength,
+    branchEndX,
+    svgHeight,
+    svgCenterY: svgHeight / 2,
+  };
+}
+
+function getChannelPositions({
+  channels,
+  allEdges,
+  nodeId,
+  isConnectionInteractive,
+  getChannelHighlight,
+}: {
+  channels: string[];
+  allEdges: BlockEdgeState[];
+  nodeId?: string;
+  isConnectionInteractive: boolean;
+  getChannelHighlight: (channel: string) => boolean | undefined;
+}): ChannelPosition[] {
+  return channels.map((channel, index) => ({
+    channel,
+    offsetY: (index - (channels.length - 1) / 2) * MULTI_HANDLE_CHANNEL_SPACING,
+    isHighlighted: isConnectionInteractive && getChannelHighlight(channel),
+    hasOutgoingForChannel: allEdges.some(
+      (edge) => edge.source === nodeId && (edge.sourceHandle ?? "default") === channel,
+    ),
+  }));
+}
+
+function MultiRightHandleLines({ layout, channels }: { layout: MultiRightHandleLayout; channels: ChannelPosition[] }) {
+  return (
+    <svg
+      width={layout.lineEndX}
+      height={layout.svgHeight}
+      style={{
+        position: "absolute",
+        left: 0,
+        top: `calc(50% - ${layout.svgCenterY}px)`,
+        overflow: "visible",
+      }}
+    >
+      <line
+        x1={0}
+        y1={layout.svgCenterY}
+        x2={layout.trunkLength}
+        y2={layout.svgCenterY}
+        stroke={APPEND_CONNECTOR_COLOR}
+        strokeWidth={3}
+      />
+
+      {channels.map(({ channel, offsetY }) => {
+        const y = layout.svgCenterY + offsetY;
+        return (
+          <g key={channel}>
+            <line
+              x1={layout.trunkLength}
+              y1={layout.svgCenterY}
+              x2={layout.branchEndX}
+              y2={y}
+              stroke={APPEND_CONNECTOR_COLOR}
+              strokeWidth={3}
+            />
+            <line
+              x1={layout.branchEndX}
+              y1={y}
+              x2={layout.lineEndX}
+              y2={y}
+              stroke={APPEND_CONNECTOR_COLOR}
+              strokeWidth={3}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function MultiRightChannelControl({
+  layout,
+  channel,
+  offsetY,
+  isHighlighted,
+  isConnectionInteractive,
+  canAppend,
+}: {
+  layout: MultiRightHandleLayout;
+  channel: string;
+  offsetY: number;
+  isHighlighted: boolean | undefined;
+  isConnectionInteractive: boolean;
+  canAppend: boolean;
+}) {
+  return (
+    <React.Fragment>
+      <span
+        className="text-xs font-medium whitespace-nowrap absolute bg-slate-100"
+        style={{
+          left: layout.labelStartX,
+          top: `calc(50% + ${offsetY}px)`,
+          transform: "translateY(-50%)",
+          color: "#8B9AAC",
+          lineHeight: `${layout.handleSize}px`,
+          paddingLeft: 4,
+          paddingRight: 4,
+        }}
+      >
+        {channel}
+      </span>
+
+      <Handle
+        type="source"
+        position={Position.Right}
+        id={channel}
+        style={{
+          ...HANDLE_STYLE,
+          left: layout.handleLeftX,
+          top: `calc(50% + ${offsetY}px)`,
+          transform: "translateY(-50%)",
+          pointerEvents: isConnectionInteractive ? "auto" : "none",
+        }}
+        className={isHighlighted ? "highlighted" : undefined}
+      />
+
+      {canAppend ? (
+        <>
+          <div
+            style={{
+              position: "absolute",
+              left: layout.handleLeftX + 12,
+              top: `calc(50% + ${offsetY}px)`,
+              transform: "translateY(-50%)",
+              width: 24,
+              height: 3,
+              backgroundColor: APPEND_CONNECTOR_COLOR,
+              pointerEvents: "none",
+            }}
+          />
+          <AppendHandleButton
+            label={`Add next component (${channel})`}
+            style={{
+              left: layout.handleLeftX + 32,
+              top: `calc(50% + ${offsetY}px)`,
+              transform: "translateY(-50%)",
+              position: "absolute",
+            }}
+          />
+        </>
+      ) : null}
+    </React.Fragment>
+  );
+}
+
+export function MultiRightHandle({
+  channels,
+  hoveredEdge,
+  connectingFrom,
+  nodeId,
+  allEdges,
+  isConnectionInteractive,
+}: {
+  channels: string[];
+  hoveredEdge?: BlockEdgeState;
+  connectingFrom?: BlockConnectionState;
+  nodeId?: string;
+  allEdges: BlockEdgeState[];
+  isConnectionInteractive: boolean;
+}) {
+  const getChannelHighlight = getChannelHighlightResolver({
+    hoveredEdge,
+    connectingFrom,
+    nodeId,
+    allEdges,
+  });
+  const layout = getMultiRightHandleLayout(channels.length);
+  const channelPositions = getChannelPositions({
+    channels,
+    allEdges,
+    nodeId,
+    isConnectionInteractive,
+    getChannelHighlight,
+  });
+
+  return (
+    <div className="absolute" style={{ left: "100%", top: 0, bottom: 0, pointerEvents: "none" }}>
+      <MultiRightHandleLines layout={layout} channels={channelPositions} />
+
+      {channelPositions.map(({ channel, offsetY, isHighlighted, hasOutgoingForChannel }) => {
+        const canAppend = isConnectionInteractive && !hasOutgoingForChannel;
+
+        return (
+          <MultiRightChannelControl
+            key={channel}
+            layout={layout}
+            channel={channel}
+            offsetY={offsetY}
+            isHighlighted={isHighlighted}
+            isConnectionInteractive={isConnectionInteractive}
+            canAppend={canAppend}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -73,5 +73,6 @@ export interface BlockProps extends ComponentActionsProps {
     updates: { text?: string; color?: string; width?: number; height?: number; x?: number; y?: number },
   ) => void;
   onAnnotationBlur?: () => void;
+  onAppendFromNode?: (nodeId: string, sourceHandleId?: string | null) => void | Promise<void>;
   onClick?: (e: MouseEvent) => void;
 }

--- a/web_src/src/ui/CanvasPage/canvas-reset.css
+++ b/web_src/src/ui/CanvasPage/canvas-reset.css
@@ -110,6 +110,16 @@
   border-color: #A1AEC0 !important;
 }
 
+.sp-canvas .sp-append-source-preview {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.sp-canvas .sp-append-source-handle:hover + .sp-append-source-preview {
+  opacity: 1;
+}
+
 .sp-canvas .edge-label {
   opacity: 0;
   pointer-events: none;

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -6,7 +6,14 @@ import type { BlockData } from "./Block";
 
 const { captureException, reactFlowPropsRef } = vi.hoisted(() => ({
   captureException: vi.fn(),
-  reactFlowPropsRef: { current: null as null | Record<string, (...args: unknown[]) => unknown> },
+  reactFlowPropsRef: {
+    current: null as null | {
+      nodes?: unknown;
+      onConnectStart?: (...args: unknown[]) => unknown;
+      onConnectEnd?: (...args: unknown[]) => unknown;
+      onPaneClick?: (...args: unknown[]) => unknown;
+    },
+  },
 }));
 
 vi.mock("@/sentry", () => ({
@@ -23,8 +30,8 @@ vi.mock("@/sentry", () => ({
 vi.mock("@xyflow/react", () => ({
   Background: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Panel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  ReactFlow: (props: { children?: ReactNode }) => {
-    reactFlowPropsRef.current = props as unknown as Record<string, (...args: unknown[]) => unknown>;
+  ReactFlow: (props: { children?: ReactNode; nodes?: unknown }) => {
+    reactFlowPropsRef.current = props;
     return <div>{props.children}</div>;
   },
   ReactFlowProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -33,6 +40,9 @@ vi.mock("@xyflow/react", () => ({
   useReactFlow: vi.fn(() => ({
     fitView: vi.fn(),
     screenToFlowPosition: vi.fn((position) => position),
+    getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 1 })),
+    setViewport: vi.fn(),
+    getInternalNode: vi.fn(),
     zoomTo: vi.fn(),
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
@@ -189,5 +199,63 @@ describe("CanvasPage connection drop", () => {
 
     expect(onPlaceholderAdd).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("building-blocks-sidebar")).toBeInTheDocument();
+  });
+
+  it("creates a placeholder when appending from an end-node connector", () => {
+    const onPlaceholderAdd = vi.fn(async () => "placeholder-node");
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          nodes={[
+            {
+              id: "source-node",
+              position: { x: 100, y: 200 },
+              width: 240,
+              data: {
+                label: "Source",
+                state: "pending",
+                type: "component",
+                outputChannels: ["default"],
+                component: {
+                  title: "Source",
+                  iconSlug: "box",
+                  collapsed: false,
+                },
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          activeCanvasVersionId="draft-version"
+          onMemoryOpen={vi.fn()}
+          onYamlOpen={vi.fn()}
+          onEdgeCreate={vi.fn()}
+          onPlaceholderAdd={onPlaceholderAdd}
+        />
+      </MemoryRouter>,
+    );
+
+    const nodes = reactFlowPropsRef.current?.nodes as Array<{
+      data: {
+        _callbacksRef?: {
+          current?: {
+            onAppendFromNode?: (nodeId: string, sourceHandleId?: string | null) => void;
+          };
+        };
+      };
+    }>;
+
+    act(() => {
+      nodes[0].data._callbacksRef?.current?.onAppendFromNode?.("source-node", "default");
+    });
+
+    expect(onPlaceholderAdd).toHaveBeenCalledWith({
+      position: { x: 640, y: 200 },
+      sourceNodeId: "source-node",
+      sourceHandleId: "default",
+    });
   });
 });

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -374,6 +374,7 @@ type PendingRunData = {
 
 type CanvasNodeRendererCallbacks = {
   handleNodeClick: (nodeId: string, event?: React.MouseEvent) => void;
+  onAppendFromNode?: (nodeId: string, sourceHandleId?: string | null) => void | Promise<void>;
   onNodeEdit: React.MutableRefObject<CanvasPageProps["onEdit"] | undefined>;
   onNodeDelete: React.MutableRefObject<CanvasPageProps["onNodeDelete"] | undefined>;
   onRun: React.MutableRefObject<((nodeId: string) => void) | undefined>;
@@ -529,6 +530,7 @@ function buildInteractiveNodeBlockProps(
   return {
     showHeader: callbacks.showHeader && !callbacks.hasMultiSelection,
     canvasMode: callbacks.canvasMode,
+    onAppendFromNode: callbacks.onAppendFromNode,
     onClick: (event) => callbacks.handleNodeClick(nodeId, event),
     onEdit: getNodeAction(callbacks.onNodeEdit, nodeId),
     onDelete: getNodeAction(callbacks.onNodeDelete, nodeId),
@@ -1895,7 +1897,7 @@ function CanvasContent({
   canCreateIntegrations?: boolean;
   onLogView?: () => void;
 }) {
-  const { fitView, screenToFlowPosition, getViewport, getInternalNode } = useReactFlow();
+  const { fitView, screenToFlowPosition, getViewport, getInternalNode, setViewport } = useReactFlow();
   const { zoom } = useViewport();
   const isReadOnly = readOnly ?? false;
 
@@ -2311,9 +2313,54 @@ function CanvasContent({
 
   const hasMultiSelection = multiSelectedNodes.length >= 2;
 
+  const handleAppendFromNode = useCallback(
+    (sourceNodeId: string, sourceHandleId?: string | null) => {
+      if (isReadOnly || !onConnectionDropInEmptySpace) {
+        return;
+      }
+
+      const sourceNode = stateRef.current.nodes?.find((node) => node.id === sourceNodeId);
+      if (!sourceNode) {
+        return;
+      }
+
+      const sourceWidth = sourceNode.width ?? 240;
+      const appendGapX = 300;
+      const appendAlignmentY = 30;
+      const placeholderPosition = {
+        x: sourceNode.position.x + sourceWidth + appendGapX,
+        y: sourceNode.position.y + appendAlignmentY,
+      };
+
+      const currentViewport = getViewport();
+      const canvasWidth =
+        typeof document === "undefined" ? 0 : (document.querySelector(".react-flow")?.clientWidth ?? window.innerWidth);
+      const rightSidebarSafeArea = 560;
+      const placeholderEstimatedWidth = 420;
+      const viewportBuffer = 48;
+      const placeholderRightScreenX =
+        (placeholderPosition.x + placeholderEstimatedWidth) * currentViewport.zoom + currentViewport.x;
+      const maxVisibleScreenX = canvasWidth - rightSidebarSafeArea - viewportBuffer;
+
+      if (canvasWidth > 0 && placeholderRightScreenX > maxVisibleScreenX) {
+        const overflow = placeholderRightScreenX - maxVisibleScreenX;
+        const nextViewport = { ...currentViewport, x: currentViewport.x - overflow };
+        setViewport(nextViewport, { duration: 180 });
+        viewportRef.current = nextViewport;
+      }
+
+      onConnectionDropInEmptySpace(placeholderPosition, {
+        nodeId: sourceNodeId,
+        handleId: sourceHandleId ?? "default",
+      });
+    },
+    [getViewport, isReadOnly, onConnectionDropInEmptySpace, setViewport, viewportRef],
+  );
+
   // Store callback handlers in a ref so they can be accessed without being in node data
   const callbacksRef = useRef({
     handleNodeClick,
+    onAppendFromNode: handleAppendFromNode,
     onNodeEdit: onNodeEditRef,
     onNodeDelete: onNodeDeleteRef,
     onRun: onRunRef,
@@ -2331,6 +2378,7 @@ function CanvasContent({
   });
   callbacksRef.current = {
     handleNodeClick,
+    onAppendFromNode: handleAppendFromNode,
     onNodeEdit: onNodeEditRef,
     onNodeDelete: onNodeDeleteRef,
     onRun: onRunRef,


### PR DESCRIPTION
## Summary
- replace available append targets with Plus-icon handle controls
- extract multi-output handle rendering for clearer handle layout
- add Block tests for end-node and unconnected-channel append handles

## Validation
- make format.js
- make check.lint.ui
- make check.build.ui
- cd web_src && npm run test -- CanvasPage/Block.spec.tsx