### PR TITLE
fix: add worker backpressure and cancellation handling

### DIFF
--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -203,14 +203,19 @@ func ListExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime t
 	return events, nil
 }
 
-func ListPendingCanvasEvents() ([]CanvasEvent, error) {
+func ListPendingCanvasEvents(limit int) ([]CanvasEvent, error) {
 	var events []CanvasEvent
-	err := database.Conn().
+	query := database.Conn().
 		Joins("JOIN workflows ON workflow_events.workflow_id = workflows.id").
 		Where("workflow_events.state = ?", CanvasEventStatePending).
 		Where("workflows.deleted_at IS NULL").
-		Find(&events).
-		Error
+		Order("workflow_events.created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&events).Error
 
 	if err != nil {
 		return nil, err

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -180,17 +180,22 @@ func FindCanvasNodesByIDs(tx *gorm.DB, canvasID uuid.UUID, nodeIDs []string) ([]
 	return nodes, nil
 }
 
-func ListCanvasNodesReady() ([]CanvasNode, error) {
+func ListCanvasNodesReady(limit int) ([]CanvasNode, error) {
 	var nodes []CanvasNode
-	err := database.Conn().
+	query := database.Conn().
 		Distinct().
 		Joins("JOIN workflow_node_queue_items ON workflow_nodes.workflow_id = workflow_node_queue_items.workflow_id AND workflow_nodes.node_id = workflow_node_queue_items.node_id").
 		Joins("JOIN workflows ON workflow_nodes.workflow_id = workflows.id").
 		Where("workflow_nodes.state = ?", CanvasNodeStateReady).
 		Where("workflow_nodes.type IN ?", []string{NodeTypeComponent, NodeTypeBlueprint}).
 		Where("workflows.deleted_at IS NULL").
-		Find(&nodes).
-		Error
+		Order("workflow_nodes.created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&nodes).Error
 
 	if err != nil {
 		return nil, err

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -129,11 +129,15 @@ func CreatePendingChildExecution(tx *gorm.DB, parent *CanvasNodeExecution, child
 	return &execution, nil
 }
 
-func ListPendingNodeExecutions() ([]CanvasNodeExecution, error) {
+func ListPendingNodeExecutions(limit int) ([]CanvasNodeExecution, error) {
 	var executions []CanvasNodeExecution
 	query := database.Conn().
 		Where("state = ?", CanvasNodeExecutionStatePending).
-		Order("created_at DESC")
+		Order("created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
 
 	err := query.Find(&executions).Error
 	if err != nil {

--- a/pkg/models/canvas_node_request.go
+++ b/pkg/models/canvas_node_request.go
@@ -46,9 +46,12 @@ type InvokeAction struct {
 func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 	var request CanvasNodeRequest
 
+	now := time.Now()
 	err := tx.
 		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
 		Where("id = ?", id).
+		Where("state = ?", NodeExecutionRequestStatePending).
+		Where("run_at <= ?", now).
 		First(&request).
 		Error
 
@@ -59,19 +62,24 @@ func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 	return &request, nil
 }
 
-func ListNodeRequests() ([]CanvasNodeRequest, error) {
+func ListNodeRequests(limit int) ([]CanvasNodeRequest, error) {
 	var requests []CanvasNodeRequest
 
 	now := time.Now()
-	err := database.Conn().
+	query := database.Conn().
 		Joins("JOIN workflow_nodes ON workflow_node_requests.workflow_id = workflow_nodes.workflow_id AND workflow_node_requests.node_id = workflow_nodes.node_id").
 		Joins("JOIN workflows ON workflow_node_requests.workflow_id = workflows.id").
 		Where("workflow_node_requests.state = ?", NodeExecutionRequestStatePending).
 		Where("workflow_node_requests.run_at <= ?", now).
 		Where("workflow_nodes.deleted_at IS NULL").
 		Where("workflows.deleted_at IS NULL").
-		Find(&requests).
-		Error
+		Order("workflow_node_requests.run_at ASC, workflow_node_requests.created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&requests).Error
 
 	if err != nil {
 		return nil, err

--- a/pkg/models/integration_request.go
+++ b/pkg/models/integration_request.go
@@ -45,9 +45,12 @@ type IntegrationInvokeAction struct {
 func LockIntegrationRequest(tx *gorm.DB, id uuid.UUID) (*IntegrationRequest, error) {
 	var request IntegrationRequest
 
+	now := time.Now()
 	err := tx.
 		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
 		Where("id = ?", id).
+		Where("state = ?", IntegrationRequestStatePending).
+		Where("run_at <= ?", now).
 		First(&request).
 		Error
 	if err != nil {
@@ -57,17 +60,22 @@ func LockIntegrationRequest(tx *gorm.DB, id uuid.UUID) (*IntegrationRequest, err
 	return &request, nil
 }
 
-func ListIntegrationRequests() ([]IntegrationRequest, error) {
+func ListIntegrationRequests(limit int) ([]IntegrationRequest, error) {
 	var requests []IntegrationRequest
 
 	now := time.Now()
-	err := database.Conn().
+	query := database.Conn().
 		Joins("JOIN app_installations ON app_installation_requests.app_installation_id = app_installations.id").
 		Where("app_installation_requests.state = ?", IntegrationRequestStatePending).
 		Where("app_installation_requests.run_at <= ?", now).
 		Where("app_installations.deleted_at IS NULL").
-		Find(&requests).
-		Error
+		Order("app_installation_requests.run_at ASC, app_installation_requests.created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&requests).Error
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/pending_lists_test.go
+++ b/pkg/models/pending_lists_test.go
@@ -1,0 +1,184 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/gorm"
+)
+
+func TestPendingListsRespectLimit(t *testing.T) {
+	t.Run("node executions", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{NodeID: "component", Type: models.NodeTypeComponent},
+		}, []models.Edge{{SourceID: "trigger", TargetID: "component", Channel: "default"}})
+
+		rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+		for range 3 {
+			support.CreateCanvasNodeExecution(t, canvas.ID, "component", rootEvent.ID, rootEvent.ID, nil)
+		}
+
+		executions, err := models.ListPendingNodeExecutions(2)
+		require.NoError(t, err)
+		assert.Len(t, executions, 2)
+	})
+
+	t.Run("canvas events", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+		}, nil)
+
+		for range 3 {
+			support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+		}
+
+		events, err := models.ListPendingCanvasEvents(2)
+		require.NoError(t, err)
+		assert.Len(t, events, 2)
+	})
+
+	t.Run("node requests", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+		}, nil)
+
+		for range 3 {
+			require.NoError(t, database.Conn().Create(&models.CanvasNodeRequest{
+				ID:         uuid.New(),
+				WorkflowID: canvas.ID,
+				NodeID:     "trigger",
+				Type:       models.NodeRequestTypeInvokeAction,
+				State:      models.NodeExecutionRequestStatePending,
+				RunAt:      time.Now().Add(-time.Second),
+			}).Error)
+		}
+
+		requests, err := models.ListNodeRequests(2)
+		require.NoError(t, err)
+		assert.Len(t, requests, 2)
+	})
+
+	t.Run("integration requests", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+		require.NoError(t, err)
+
+		for range 3 {
+			require.NoError(t, database.Conn().Create(&models.IntegrationRequest{
+				ID:                uuid.New(),
+				AppInstallationID: integration.ID,
+				State:             models.IntegrationRequestStatePending,
+				Type:              models.IntegrationRequestTypeSync,
+				RunAt:             time.Now().Add(-time.Second),
+			}).Error)
+		}
+
+		requests, err := models.ListIntegrationRequests(2)
+		require.NoError(t, err)
+		assert.Len(t, requests, 2)
+	})
+
+	t.Run("webhooks", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		for range 3 {
+			require.NoError(t, database.Conn().Create(&models.Webhook{
+				ID:         uuid.New(),
+				State:      models.WebhookStatePending,
+				Secret:     []byte("secret"),
+				MaxRetries: 3,
+			}).Error)
+		}
+
+		webhooks, err := models.ListPendingWebhooks(2)
+		require.NoError(t, err)
+		assert.Len(t, webhooks, 2)
+	})
+
+	t.Run("ready nodes", func(t *testing.T) {
+		r := support.Setup(t)
+		defer r.Close()
+
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+			{NodeID: "trigger", Type: models.NodeTypeTrigger},
+			{NodeID: "component-1", Type: models.NodeTypeComponent},
+			{NodeID: "component-2", Type: models.NodeTypeComponent},
+			{NodeID: "component-3", Type: models.NodeTypeComponent},
+		}, []models.Edge{
+			{SourceID: "trigger", TargetID: "component-1", Channel: "default"},
+			{SourceID: "trigger", TargetID: "component-2", Channel: "default"},
+			{SourceID: "trigger", TargetID: "component-3", Channel: "default"},
+		})
+
+		rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "trigger", "default", nil)
+		support.CreateQueueItem(t, canvas.ID, "component-1", rootEvent.ID, rootEvent.ID)
+		support.CreateQueueItem(t, canvas.ID, "component-2", rootEvent.ID, rootEvent.ID)
+		support.CreateQueueItem(t, canvas.ID, "component-3", rootEvent.ID, rootEvent.ID)
+
+		nodes, err := models.ListCanvasNodesReady(2)
+		require.NoError(t, err)
+		assert.Len(t, nodes, 2)
+	})
+}
+
+func TestLockRequestsSkipStaleRows(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{
+		{NodeID: "trigger", Type: models.NodeTypeTrigger},
+	}, nil)
+
+	nodeRequest := models.CanvasNodeRequest{
+		ID:         uuid.New(),
+		WorkflowID: canvas.ID,
+		NodeID:     "trigger",
+		Type:       models.NodeRequestTypeInvokeAction,
+		State:      models.NodeExecutionRequestStateCompleted,
+		RunAt:      time.Now().Add(-time.Second),
+	}
+	require.NoError(t, database.Conn().Create(&nodeRequest).Error)
+
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		_, err := models.LockNodeRequest(tx, nodeRequest.ID)
+		return err
+	})
+	require.Error(t, err)
+
+	integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+	require.NoError(t, err)
+
+	integrationRequest := models.IntegrationRequest{
+		ID:                uuid.New(),
+		AppInstallationID: integration.ID,
+		Type:              models.IntegrationRequestTypeSync,
+		State:             models.IntegrationRequestStateCompleted,
+		RunAt:             time.Now().Add(-time.Second),
+	}
+	require.NoError(t, database.Conn().Create(&integrationRequest).Error)
+
+	err = database.Conn().Transaction(func(tx *gorm.DB) error {
+		_, err := models.LockIntegrationRequest(tx, integrationRequest.ID)
+		return err
+	})
+	require.Error(t, err)
+}

--- a/pkg/models/webhook.go
+++ b/pkg/models/webhook.go
@@ -123,12 +123,17 @@ func FindWebhookNodesInTransaction(tx *gorm.DB, webhookID uuid.UUID) ([]CanvasNo
 	return nodes, nil
 }
 
-func ListPendingWebhooks() ([]Webhook, error) {
+func ListPendingWebhooks(limit int) ([]Webhook, error) {
 	var webhooks []Webhook
-	err := database.Conn().
+	query := database.Conn().
 		Where("state = ?", WebhookStatePending).
-		Find(&webhooks).
-		Error
+		Order("created_at ASC")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err := query.Find(&webhooks).Error
 
 	if err != nil {
 		return nil, err

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -21,17 +21,19 @@ import (
 )
 
 type EventRouter struct {
-	semaphore   *semaphore.Weighted
-	logger      *log.Entry
-	rabbitMQURL string
-	consumer    *tackle.Consumer
+	semaphore           *semaphore.Weighted
+	logger              *log.Entry
+	maxResourcesPerTick int
+	rabbitMQURL         string
+	consumer            *tackle.Consumer
 }
 
 func NewEventRouter(rabbitMQURL string) *EventRouter {
 	return &EventRouter{
-		semaphore:   semaphore.NewWeighted(25),
-		logger:      log.WithFields(log.Fields{"worker": "EventRouter"}),
-		rabbitMQURL: rabbitMQURL,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		logger:              log.WithFields(log.Fields{"worker": "EventRouter"}),
+		maxResourcesPerTick: defaultWorkerConcurrency,
+		rabbitMQURL:         rabbitMQURL,
 	}
 }
 
@@ -52,7 +54,7 @@ func (w *EventRouter) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			events, err := models.ListPendingCanvasEvents()
+			events, err := models.ListPendingCanvasEvents(w.maxResourcesPerTick)
 			if err != nil {
 				w.logger.Errorf("Error finding canvas nodes ready to be processed: %v", err)
 			}
@@ -61,7 +63,7 @@ func (w *EventRouter) Start(ctx context.Context) {
 
 			for _, event := range events {
 				logger := logging.ForEvent(w.logger, event)
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -69,7 +71,7 @@ func (w *EventRouter) Start(ctx context.Context) {
 				go func(event models.CanvasEvent) {
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessEvent(logger, event); err != nil {
+					if _, err := w.LockAndProcessEvent(logger, event); err != nil {
 						w.logger.Errorf("Error processing event %s: %v", event.ID, err)
 					}
 				}(event)
@@ -99,12 +101,16 @@ func (w *EventRouter) StartRabbitMQConsumer(ctx context.Context) {
 		err := w.consumer.Start(&options, w.Consume)
 		if err != nil {
 			w.logger.Errorf("Error consuming messages from %s: %v", messages.CanvasEventCreatedRoutingKey, err)
-			time.Sleep(5 * time.Second)
+			if !sleepWithContext(ctx, 5*time.Second) {
+				return
+			}
 			continue
 		}
 
 		w.logger.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.CanvasEventCreatedRoutingKey)
-		time.Sleep(5 * time.Second)
+		if !sleepWithContext(ctx, 5*time.Second) {
+			return
+		}
 	}
 }
 
@@ -134,12 +140,14 @@ func (w *EventRouter) Consume(delivery tackle.Delivery) error {
 	}
 
 	logger := logging.ForEvent(w.logger, *event)
-	return w.LockAndProcessEvent(logger, *event)
+	_, err = w.LockAndProcessEvent(logger, *event)
+	return err
 }
 
-func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.CanvasEvent) error {
+func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.CanvasEvent) (bool, error) {
 	var createdQueueItems []models.CanvasNodeQueueItem
 	var execution *models.CanvasNodeExecution
+	processed := false
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		event, err := models.LockCanvasEvent(tx, event.ID)
 		if err != nil {
@@ -147,6 +155,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 			return nil
 		}
 
+		processed = true
 		createdQueueItems, execution, err = w.processEvent(tx, logger, event)
 		if err != nil {
 			return err
@@ -156,7 +165,11 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 	})
 
 	if err != nil {
-		return err
+		return false, err
+	}
+
+	if !processed {
+		return false, nil
 	}
 
 	if len(createdQueueItems) > 0 {
@@ -177,7 +190,7 @@ func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.Canvas
 		).Publish()
 	}
 
-	return nil
+	return true, nil
 }
 
 func (w *EventRouter) processEvent(tx *gorm.DB, logger *log.Entry, event *models.CanvasEvent) ([]models.CanvasNodeQueueItem, *models.CanvasNodeExecution, error) {

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -47,8 +47,9 @@ func Test__EventRouter_ProcessRootEvent(t *testing.T) {
 	// Create the root event for the trigger node, and process it.
 	//
 	event := support.EmitCanvasEventForNode(t, canvas.ID, node1, "default", nil)
-	err := router.LockAndProcessEvent(logger, *event)
+	processed, err := router.LockAndProcessEvent(logger, *event)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Verify event was marked as routed and
@@ -112,8 +113,9 @@ func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	outputEvent := events[0]
-	err = router.LockAndProcessEvent(logger, outputEvent)
+	processed, err := router.LockAndProcessEvent(logger, outputEvent)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	updatedEvent, err := models.FindCanvasEvent(outputEvent.ID)
 	require.NoError(t, err)
@@ -217,8 +219,9 @@ func Test__EventRouter_CustomComponent_RespectsOutputChannels(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	childOutputEvent := events[0]
-	err = router.LockAndProcessEvent(logger, childOutputEvent)
+	processed, err := router.LockAndProcessEvent(logger, childOutputEvent)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	parent, err := models.FindNodeExecution(canvas.ID, parentExecution.ID)
 	require.NoError(t, err)
@@ -319,8 +322,9 @@ func TestEventRouter__CustomComponent_MultipleOutputs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 5)
 	childOutputEvent := events[0]
-	err = router.LockAndProcessEvent(logger, childOutputEvent)
+	processed, err := router.LockAndProcessEvent(logger, childOutputEvent)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	parent, err := models.FindNodeExecution(canvas.ID, parentExecution.ID)
 	require.NoError(t, err)

--- a/pkg/workers/integration_request_worker.go
+++ b/pkg/workers/integration_request_worker.go
@@ -20,22 +20,24 @@ import (
 )
 
 type IntegrationRequestWorker struct {
-	semaphore       *semaphore.Weighted
-	registry        *registry.Registry
-	encryptor       crypto.Encryptor
-	oidcProvider    oidc.Provider
-	baseURL         string
-	webhooksBaseURL string
+	semaphore           *semaphore.Weighted
+	registry            *registry.Registry
+	encryptor           crypto.Encryptor
+	oidcProvider        oidc.Provider
+	baseURL             string
+	webhooksBaseURL     string
+	maxResourcesPerTick int
 }
 
 func NewIntegrationRequestWorker(encryptor crypto.Encryptor, registry *registry.Registry, oidcProvider oidc.Provider, baseURL string, webhooksBaseURL string) *IntegrationRequestWorker {
 	return &IntegrationRequestWorker{
-		encryptor:       encryptor,
-		registry:        registry,
-		oidcProvider:    oidcProvider,
-		baseURL:         baseURL,
-		webhooksBaseURL: webhooksBaseURL,
-		semaphore:       semaphore.NewWeighted(25),
+		encryptor:           encryptor,
+		registry:            registry,
+		oidcProvider:        oidcProvider,
+		baseURL:             baseURL,
+		webhooksBaseURL:     webhooksBaseURL,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		maxResourcesPerTick: defaultWorkerConcurrency,
 	}
 }
 
@@ -48,13 +50,13 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			requests, err := models.ListIntegrationRequests()
+			requests, err := models.ListIntegrationRequests(w.maxResourcesPerTick)
 			if err != nil {
 				w.log("Error finding app installation requests: %v", err)
 			}
 
 			for _, request := range requests {
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -62,7 +64,7 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 				go func(request models.IntegrationRequest) {
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessRequest(request); err != nil {
+					if _, err := w.LockAndProcessRequest(request); err != nil {
 						w.log("Error processing request %s: %v", request.ID, err)
 					}
 				}(request)
@@ -71,16 +73,24 @@ func (w *IntegrationRequestWorker) Start(ctx context.Context) {
 	}
 }
 
-func (w *IntegrationRequestWorker) LockAndProcessRequest(request models.IntegrationRequest) error {
-	return database.Conn().Transaction(func(tx *gorm.DB) error {
+func (w *IntegrationRequestWorker) LockAndProcessRequest(request models.IntegrationRequest) (bool, error) {
+	processed := false
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		r, err := models.LockIntegrationRequest(tx, request.ID)
 		if err != nil {
 			w.log("Request %s already being processed - skipping", request.ID)
 			return nil
 		}
 
+		processed = true
 		return w.processRequest(tx, r)
 	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return processed, nil
 }
 
 func (w *IntegrationRequestWorker) processRequest(tx *gorm.DB, request *models.IntegrationRequest) error {

--- a/pkg/workers/integration_request_worker_test.go
+++ b/pkg/workers/integration_request_worker_test.go
@@ -50,8 +50,9 @@ func Test__IntegrationRequestWorker_Sync(t *testing.T) {
 	//
 	// Lock and process request
 	//
-	err = worker.LockAndProcessRequest(*request)
+	processed, err := worker.LockAndProcessRequest(*request)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Reload request, verify it was completed, and sync was called
@@ -95,7 +96,9 @@ func Test__IntegrationRequestWorker_SyncError(t *testing.T) {
 	//
 	// Process request
 	//
-	require.NoError(t, worker.LockAndProcessRequest(*request))
+	processed, err := worker.LockAndProcessRequest(*request)
+	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Reload request, verify it was completed, and app installation was moved to error state.
@@ -150,8 +153,9 @@ func Test__AppInstallationRequestWorker_InvokeHook(t *testing.T) {
 	//
 	// Lock and process request
 	//
-	err = worker.LockAndProcessRequest(*request)
+	processed, err := worker.LockAndProcessRequest(*request)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Reload request, verify it was completed, and sync was called
@@ -201,7 +205,9 @@ func Test__AppInstallationRequestWorker_InvokeHookError(t *testing.T) {
 	//
 	// Process request
 	//
-	require.NoError(t, worker.LockAndProcessRequest(*request))
+	processed, err := worker.LockAndProcessRequest(*request)
+	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Reload request, verify it was completed, even though the action failed.
@@ -210,4 +216,36 @@ func Test__AppInstallationRequestWorker_InvokeHookError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.IntegrationRequestStateCompleted, request.State)
 	assert.True(t, hookCalled)
+}
+
+func Test__IntegrationRequestWorker_SkipsCompletedRequest(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	worker := NewIntegrationRequestWorker(r.Encryptor, r.Registry, nil, "http://localhost:8000", "http://localhost:8000")
+
+	var syncCalled bool
+	r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+		OnSync: func(ctx core.SyncContext) error {
+			syncCalled = true
+			return nil
+		},
+	})
+
+	integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+	require.NoError(t, err)
+
+	request := models.IntegrationRequest{
+		ID:                uuid.New(),
+		AppInstallationID: integration.ID,
+		State:             models.IntegrationRequestStateCompleted,
+		Type:              models.IntegrationRequestTypeSync,
+		RunAt:             time.Now().Add(-time.Second),
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	processed, err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+	assert.False(t, processed)
+	assert.False(t, syncCalled)
 }

--- a/pkg/workers/limits.go
+++ b/pkg/workers/limits.go
@@ -1,0 +1,20 @@
+package workers
+
+import (
+	"context"
+	"time"
+)
+
+const defaultWorkerConcurrency = 25
+
+func sleepWithContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -32,13 +32,14 @@ import (
 var ErrRecordLocked = errors.New("record locked")
 
 type NodeExecutor struct {
-	encryptor      crypto.Encryptor
-	registry       *registry.Registry
-	authService    authorization.Authorization
-	baseURL        string
-	webhookBaseURL string
-	semaphore      *semaphore.Weighted
-	logger         *logrus.Entry
+	encryptor           crypto.Encryptor
+	registry            *registry.Registry
+	authService         authorization.Authorization
+	baseURL             string
+	webhookBaseURL      string
+	semaphore           *semaphore.Weighted
+	logger              *logrus.Entry
+	maxResourcesPerTick int
 
 	rabbitMQURL string
 	consumer    *tackle.Consumer
@@ -46,14 +47,15 @@ type NodeExecutor struct {
 
 func NewNodeExecutor(encryptor crypto.Encryptor, registry *registry.Registry, baseURL string, webhookBaseURL string, rabbitMQURL string, authService authorization.Authorization) *NodeExecutor {
 	return &NodeExecutor{
-		encryptor:      encryptor,
-		registry:       registry,
-		baseURL:        baseURL,
-		webhookBaseURL: webhookBaseURL,
-		semaphore:      semaphore.NewWeighted(25),
-		logger:         logrus.WithFields(logrus.Fields{"worker": "NodeExecutor"}),
-		rabbitMQURL:    rabbitMQURL,
-		authService:    authService,
+		encryptor:           encryptor,
+		registry:            registry,
+		baseURL:             baseURL,
+		webhookBaseURL:      webhookBaseURL,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		logger:              logrus.WithFields(logrus.Fields{"worker": "NodeExecutor"}),
+		maxResourcesPerTick: defaultWorkerConcurrency,
+		rabbitMQURL:         rabbitMQURL,
+		authService:         authService,
 	}
 }
 
@@ -74,7 +76,7 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			executions, err := models.ListPendingNodeExecutions()
+			executions, err := models.ListPendingNodeExecutions(w.maxResourcesPerTick)
 			if err != nil {
 				w.logger.Errorf("Error finding workflow nodes ready to be processed: %v", err)
 			}
@@ -82,7 +84,7 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 			telemetry.RecordExecutorWorkerNodesCount(context.Background(), len(executions))
 
 			for _, execution := range executions {
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					w.logger.Errorf("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -90,9 +92,11 @@ func (w *NodeExecutor) Start(ctx context.Context) {
 				go func(execution models.CanvasNodeExecution) {
 					defer w.semaphore.Release(1)
 
-					err := w.LockAndProcessNodeExecution(execution.ID)
+					processed, err := w.LockAndProcessNodeExecution(execution.ID)
 					if err == nil {
-						messages.NewCanvasExecutionMessage(execution.WorkflowID.String(), execution.ID.String(), execution.NodeID).Publish()
+						if processed {
+							messages.NewCanvasExecutionMessage(execution.WorkflowID.String(), execution.ID.String(), execution.NodeID).Publish()
+						}
 						return
 					}
 
@@ -128,12 +132,16 @@ func (w *NodeExecutor) StartRabbitMQConsumer(ctx context.Context) {
 		err := w.consumer.Start(&options, w.Consume)
 		if err != nil {
 			w.logger.Errorf("Error consuming messages from %s: %v", messages.CanvasExecutionRoutingKey, err)
-			time.Sleep(5 * time.Second)
+			if !sleepWithContext(ctx, 5*time.Second) {
+				return
+			}
 			continue
 		}
 
 		w.logger.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.CanvasExecutionRoutingKey)
-		time.Sleep(5 * time.Second)
+		if !sleepWithContext(ctx, 5*time.Second) {
+			return
+		}
 	}
 }
 
@@ -151,9 +159,11 @@ func (w *NodeExecutor) Consume(delivery tackle.Delivery) error {
 		return err
 	}
 
-	err = w.LockAndProcessNodeExecution(executionID)
+	processed, err := w.LockAndProcessNodeExecution(executionID)
 	if err == nil {
-		messages.NewCanvasExecutionMessage(data.CanvasId, data.Id, data.NodeId).Publish()
+		if processed {
+			messages.NewCanvasExecutionMessage(data.CanvasId, data.Id, data.NodeId).Publish()
+		}
 		return nil
 	}
 
@@ -165,12 +175,13 @@ func (w *NodeExecutor) Consume(delivery tackle.Delivery) error {
 	return err
 }
 
-func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
+func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) (bool, error) {
 	newEvents := []models.CanvasEvent{}
 	onNewEvents := func(events []models.CanvasEvent) {
 		newEvents = append(newEvents, events...)
 	}
 
+	processed := false
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		var execution models.CanvasNodeExecution
 
@@ -205,18 +216,19 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 			return ErrRecordLocked
 		}
 
+		processed = true
 		return w.processNodeExecution(tx, &execution, onNewEvents)
 	})
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	for _, event := range newEvents {
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
-	return nil
+	return processed, nil
 }
 
 func (w *NodeExecutor) processNodeExecution(tx *gorm.DB, execution *models.CanvasNodeExecution, onNewEvents func([]models.CanvasEvent)) error {

--- a/pkg/workers/node_executor_test.go
+++ b/pkg/workers/node_executor_test.go
@@ -57,12 +57,14 @@ func Test__NodeExecutor_PreventsConcurrentProcessing(t *testing.T) {
 	//
 	go func() {
 		executor1 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-		results <- executor1.LockAndProcessNodeExecution(execution.ID)
+		_, err := executor1.LockAndProcessNodeExecution(execution.ID)
+		results <- err
 	}()
 
 	go func() {
 		executor2 := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-		results <- executor2.LockAndProcessNodeExecution(execution.ID)
+		_, err := executor2.LockAndProcessNodeExecution(execution.ID)
+		results <- err
 	}()
 
 	// Collect results - one should succeed (return nil) and one should get ErrRecordLocked
@@ -147,8 +149,9 @@ func Test__NodeExecutor_BlueprintNodeExecution(t *testing.T) {
 	// and moves the parent execution to started state.
 	//
 	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-	err := executor.LockAndProcessNodeExecution(execution.ID)
+	processed, err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify parent execution moved to started state
 	parentExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
@@ -225,8 +228,9 @@ func Test__NodeExecutor_ComponentNodeWithoutStateChange(t *testing.T) {
 	// The approval component doesn't call Pass() in Execute(), so it should remain in started state.
 	//
 	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-	err = executor.LockAndProcessNodeExecution(execution.ID)
+	processed, err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify execution moved to started state but not finished,
 	// and metadata is updated.
@@ -292,8 +296,9 @@ func Test__NodeExecutor_ComponentNodeWithStateChange(t *testing.T) {
 	// The noop component calls Pass() in Execute(), which should finish the execution.
 	//
 	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-	err := executor.LockAndProcessNodeExecution(execution.ID)
+	processed, err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify execution moved to finished state with passed result
 	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
@@ -373,8 +378,9 @@ func Test__NodeExecutor_BlueprintNodeExecutionFailsWhenConfigurationCannotBeBuil
 	// since this isn't a runtime error, but a configuration error.
 	//
 	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
-	err := executor.LockAndProcessNodeExecution(execution.ID)
+	processed, err := executor.LockAndProcessNodeExecution(execution.ID)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Verify the execution was marked as failed with an error reason.

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -26,9 +26,10 @@ import (
 )
 
 type NodeQueueWorker struct {
-	registry  *registry.Registry
-	semaphore *semaphore.Weighted
-	logger    *log.Entry
+	registry            *registry.Registry
+	semaphore           *semaphore.Weighted
+	logger              *log.Entry
+	maxResourcesPerTick int
 
 	rabbitMQURL string
 	consumer    *tackle.Consumer
@@ -36,10 +37,11 @@ type NodeQueueWorker struct {
 
 func NewNodeQueueWorker(registry *registry.Registry, rabbitMQURL string) *NodeQueueWorker {
 	return &NodeQueueWorker{
-		registry:    registry,
-		rabbitMQURL: rabbitMQURL,
-		semaphore:   semaphore.NewWeighted(25),
-		logger:      log.WithFields(log.Fields{"worker": "NodeQueueWorker"}),
+		registry:            registry,
+		rabbitMQURL:         rabbitMQURL,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		logger:              log.WithFields(log.Fields{"worker": "NodeQueueWorker"}),
+		maxResourcesPerTick: defaultWorkerConcurrency,
 	}
 }
 
@@ -69,7 +71,7 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 			return
 		case <-ticker.C:
 			tickStart := time.Now()
-			nodes, err := models.ListCanvasNodesReady()
+			nodes, err := models.ListCanvasNodesReady(w.maxResourcesPerTick)
 			if err != nil {
 				w.logger.Errorf("Error finding canvas nodes ready to be processed: %v", err)
 			}
@@ -78,7 +80,7 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 
 			for _, node := range nodes {
 				logger := logging.WithNode(w.logger, node)
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					logger.Errorf("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -86,7 +88,7 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 				go func(node models.CanvasNode) {
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessNode(logger, node); err != nil {
+					if _, err := w.LockAndProcessNode(logger, node); err != nil {
 						logger.Errorf("Error processing: %v", err)
 					}
 				}(node)
@@ -116,12 +118,16 @@ func (w *NodeQueueWorker) StartRabbitMQConsumer(ctx context.Context) {
 		err := w.consumer.Start(&options, w.Consume)
 		if err != nil {
 			w.logger.Errorf("Error consuming messages from %s: %v", messages.CanvasQueueItemCreatedRoutingKey, err)
-			time.Sleep(5 * time.Second)
+			if !sleepWithContext(ctx, 5*time.Second) {
+				return
+			}
 			continue
 		}
 
 		w.logger.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.CanvasQueueItemCreatedRoutingKey)
-		time.Sleep(5 * time.Second)
+		if !sleepWithContext(ctx, 5*time.Second) {
+			return
+		}
 	}
 }
 
@@ -157,10 +163,11 @@ func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
 	// Node is ready for processing, let's lock it and process it.
 	//
 	logger := logging.WithNode(w.logger, *node)
-	return w.LockAndProcessNode(logger, *node)
+	_, err = w.LockAndProcessNode(logger, *node)
+	return err
 }
 
-func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.CanvasNode) error {
+func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.CanvasNode) (bool, error) {
 	var executionIDs []*uuid.UUID
 	var queueItem *models.CanvasNodeQueueItem
 
@@ -169,6 +176,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		newEvents = append(newEvents, events...)
 	}
 
+	processed := false
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		n, err := models.LockCanvasNode(tx, node.WorkflowID, node.NodeID)
 		if err != nil {
@@ -176,11 +184,16 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 			return nil
 		}
 
+		processed = true
 		executionIDs, queueItem, err = w.processNode(tx, logger, n, onNewEvents)
 		return err
 	})
 
-	if err == nil {
+	if err != nil {
+		return false, err
+	}
+
+	if processed {
 		if len(executionIDs) > 0 {
 			for _, executionID := range executionIDs {
 				if executionID == nil {
@@ -208,7 +221,7 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		}
 	}
 
-	return err
+	return processed, nil
 }
 
 func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, *models.CanvasNodeQueueItem, error) {

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -81,8 +81,9 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	// - Node state is updated to processing
 	// - Queue item is deleted
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify execution was created with pending state
 	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
@@ -198,8 +199,9 @@ func Test__NodeQueueWorker_BlueprintNodeQueueIsProcessed(t *testing.T) {
 	// - Queue item is deleted
 	//
 	worker := NewNodeQueueWorker(r.Registry, amqpURL)
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify execution was created with pending state
 	executions, err := models.ListNodeExecutions(canvas.ID, blueprintNode, nil, nil, 10, nil)
@@ -304,8 +306,9 @@ func Test__NodeQueueWorker_PicksOldestQueueItem(t *testing.T) {
 	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
 	require.NoError(t, err)
 
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify the execution was created with the oldest event
 	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
@@ -370,8 +373,9 @@ func Test__NodeQueueWorker_EmptyQueue(t *testing.T) {
 	//
 	// Process the node with an empty queue - this should succeed but do nothing.
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify no executions were created
 	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
@@ -430,7 +434,10 @@ func Test__NodeQueueWorker_PreventsConcurrentProcessing(t *testing.T) {
 	// Have two workers call LockAndProcessNode concurrently on the same node.
 	// LockAndProcessNode uses a transaction with SKIP LOCKED, so only one should actually process.
 	//
-	results := make(chan error, 2)
+	results := make(chan struct {
+		processed bool
+		err       error
+	}, 2)
 
 	//
 	// Create two workers and have them try to process the node concurrently.
@@ -438,21 +445,30 @@ func Test__NodeQueueWorker_PreventsConcurrentProcessing(t *testing.T) {
 	go func() {
 		worker1 := NewNodeQueueWorker(r.Registry, amqpURL)
 		logger := log.NewEntry(log.New())
-		results <- worker1.LockAndProcessNode(logger, *node)
+		processed, err := worker1.LockAndProcessNode(logger, *node)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	go func() {
 		worker2 := NewNodeQueueWorker(r.Registry, amqpURL)
 		logger := log.NewEntry(log.New())
-		results <- worker2.LockAndProcessNode(logger, *node)
+		processed, err := worker2.LockAndProcessNode(logger, *node)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	// Collect results - both should succeed (return nil)
 	// because LockAndProcessNode returns nil when it can't acquire the lock
 	result1 := <-results
 	result2 := <-results
-	assert.NoError(t, result1)
-	assert.NoError(t, result2)
+	assert.NoError(t, result1.err)
+	assert.NoError(t, result2.err)
+	assert.Equal(t, 1, processedCount(result1.processed, result2.processed))
 
 	//
 	// Verify only one execution was created (not two).
@@ -539,8 +555,9 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 	// - Node state should remain ready (not updated to processing)
 	// - Queue item should be deleted
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Verify execution was created with finished state and failed result
 	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
@@ -651,8 +668,9 @@ func Test__WorkflowNodeQueueWorker_ConfigurationBuildFailure_PropagateToParent(t
 	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, blueprintNode)
 	require.NoError(t, err)
 
-	err = worker.LockAndProcessNode(logger, *node)
+	processed, err := worker.LockAndProcessNode(logger, *node)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	// Get the parent execution that was created
 	parentExecutions, err := models.ListNodeExecutions(canvas.ID, blueprintNode, nil, nil, 10, nil)
@@ -697,8 +715,9 @@ func Test__WorkflowNodeQueueWorker_ConfigurationBuildFailure_PropagateToParent(t
 	// 1. Create a failed child execution with ParentExecutionID set
 	// 2. Propagate the failure to the parent execution
 	//
-	err = worker.LockAndProcessNode(logger, *childNode)
+	processed, err = worker.LockAndProcessNode(logger, *childNode)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Verify the child execution was created with:

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -25,20 +25,22 @@ import (
 )
 
 type NodeRequestWorker struct {
-	semaphore      *semaphore.Weighted
-	registry       *registry.Registry
-	encryptor      crypto.Encryptor
-	webhookBaseURL string
-	authService    authorization.Authorization
+	semaphore           *semaphore.Weighted
+	registry            *registry.Registry
+	encryptor           crypto.Encryptor
+	webhookBaseURL      string
+	authService         authorization.Authorization
+	maxResourcesPerTick int
 }
 
 func NewNodeRequestWorker(encryptor crypto.Encryptor, registry *registry.Registry, webhookBaseURL string, authService authorization.Authorization) *NodeRequestWorker {
 	return &NodeRequestWorker{
-		encryptor:      encryptor,
-		registry:       registry,
-		webhookBaseURL: webhookBaseURL,
-		semaphore:      semaphore.NewWeighted(25),
-		authService:    authService,
+		encryptor:           encryptor,
+		registry:            registry,
+		webhookBaseURL:      webhookBaseURL,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		authService:         authService,
+		maxResourcesPerTick: defaultWorkerConcurrency,
 	}
 }
 
@@ -53,7 +55,7 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 		case <-ticker.C:
 			tickStart := time.Now()
 
-			requests, err := models.ListNodeRequests()
+			requests, err := models.ListNodeRequests(w.maxResourcesPerTick)
 			if err != nil {
 				w.log("Error finding workflow nodes ready to be processed: %v", err)
 			}
@@ -61,7 +63,7 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 			telemetry.RecordNodeRequestWorkerRequestsCount(context.Background(), len(requests))
 
 			for _, request := range requests {
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -69,11 +71,12 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 				go func(request models.CanvasNodeRequest) {
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessRequest(request); err != nil {
+					processed, err := w.LockAndProcessRequest(request)
+					if err != nil {
 						w.log("Error processing request %s: %v", request.ID, err)
 					}
 
-					if request.ExecutionID != nil {
+					if processed && request.ExecutionID != nil {
 						messages.NewCanvasExecutionMessage(request.WorkflowID.String(), request.ExecutionID.String(), request.NodeID).Publish()
 					}
 				}(request)
@@ -84,12 +87,13 @@ func (w *NodeRequestWorker) Start(ctx context.Context) {
 	}
 }
 
-func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeRequest) error {
+func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeRequest) (bool, error) {
 	newEvents := []models.CanvasEvent{}
 	onNewEvents := func(events []models.CanvasEvent) {
 		newEvents = append(newEvents, events...)
 	}
 
+	processed := false
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		r, err := models.LockNodeRequest(tx, request.ID)
 		if err != nil {
@@ -97,18 +101,23 @@ func (w *NodeRequestWorker) LockAndProcessRequest(request models.CanvasNodeReque
 			return nil
 		}
 
+		processed = true
 		return w.processRequest(tx, r, onNewEvents)
 	})
 
 	if err != nil {
-		return err
+		return false, err
+	}
+
+	if !processed {
+		return false, nil
 	}
 
 	for _, event := range newEvents {
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
-	return nil
+	return true, nil
 }
 
 func (w *NodeRequestWorker) processRequest(tx *gorm.DB, request *models.CanvasNodeRequest, onNewEvents func([]models.CanvasEvent)) error {

--- a/pkg/workers/node_request_worker_hook_probe_test.go
+++ b/pkg/workers/node_request_worker_hook_probe_test.go
@@ -114,8 +114,9 @@ func Test_NodeRequestWorker_InternalHookUsesExecutionSnapshotConfiguration(t *te
 	require.NoError(t, database.Conn().Create(&req).Error)
 
 	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
-	err := worker.LockAndProcessRequest(req)
+	processed, err := worker.LockAndProcessRequest(req)
 	require.NoError(t, err)
+	require.True(t, processed)
 
 	cfg, ok := testHookProbeLastConfiguration().(map[string]any)
 	require.True(t, ok, "hook should receive configuration map")

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -1,7 +1,9 @@
 package workers
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -70,8 +72,9 @@ func Test__NodeRequestWorker_InvokeTriggerAction(t *testing.T) {
 	//
 	// Process the request and verify it completes successfully.
 	//
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	//
 	// Verify the request was marked as completed.
@@ -124,8 +127,9 @@ func Test__NodeRequestWorker_InvokeNodeComponentActionWithoutExecution(t *testin
 	}
 	require.NoError(t, database.Conn().Create(&request).Error)
 
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.Error(t, err)
+	assert.False(t, processed)
 	assert.Contains(t, err.Error(), "hook non-existent-action not found for action noop")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
@@ -186,27 +190,39 @@ func Test__NodeRequestWorker_PreventsConcurrentProcessing(t *testing.T) {
 	// Have two workers call LockAndProcessRequest concurrently on the same request.
 	// LockAndProcessRequest uses a transaction with locking, so only one should actually process.
 	//
-	results := make(chan error, 2)
+	results := make(chan struct {
+		processed bool
+		err       error
+	}, 2)
 
 	//
 	// Create two workers and have them try to process the request concurrently.
 	//
 	go func() {
 		worker1 := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
-		results <- worker1.LockAndProcessRequest(request)
+		processed, err := worker1.LockAndProcessRequest(request)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	go func() {
 		worker2 := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
-		results <- worker2.LockAndProcessRequest(request)
+		processed, err := worker2.LockAndProcessRequest(request)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	// Collect results - both should succeed (return nil)
 	// because LockAndProcessRequest returns nil when it can't acquire the lock
 	result1 := <-results
 	result2 := <-results
-	assert.NoError(t, result1)
-	assert.NoError(t, result2)
+	assert.NoError(t, result1.err)
+	assert.NoError(t, result2.err)
+	assert.Equal(t, 1, processedCount(result1.processed, result2.processed))
 
 	//
 	// Verify the request was marked as completed.
@@ -276,8 +292,9 @@ func Test__NodeRequestWorker_UnsupportedRequestType(t *testing.T) {
 	//
 	// Process the request and verify it returns an error.
 	//
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.Error(t, err)
+	assert.False(t, processed)
 	assert.Contains(t, err.Error(), "unsupported node execution request type")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
@@ -333,8 +350,9 @@ func Test__NodeRequestWorker_MissingInvokeActionSpec(t *testing.T) {
 	//
 	// Process the request and verify it returns an error.
 	//
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.Error(t, err)
+	assert.False(t, processed)
 	assert.Contains(t, err.Error(), "spec is not specified")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
@@ -389,8 +407,9 @@ func Test__NodeRequestWorker_NonExistentTrigger(t *testing.T) {
 	//
 	// Process the request and verify it returns an error.
 	//
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.Error(t, err)
+	assert.False(t, processed)
 	assert.Contains(t, err.Error(), "trigger non-existent-trigger not registered")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
@@ -451,8 +470,9 @@ func Test__NodeRequestWorker_NonExistentAction(t *testing.T) {
 	//
 	// Process the request and verify it returns an error.
 	//
-	err := worker.LockAndProcessRequest(request)
+	processed, err := worker.LockAndProcessRequest(request)
 	require.Error(t, err)
+	assert.False(t, processed)
 	assert.Contains(t, err.Error(), "hook non-existent-action not found for trigger schedule")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
@@ -517,7 +537,7 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
 	//
 	// Verify that ListNodeRequests does not return the request for the deleted node.
 	//
-	requests, err := models.ListNodeRequests()
+	requests, err := models.ListNodeRequests(0)
 	require.NoError(t, err)
 
 	// Check that our request is not in the list
@@ -531,6 +551,106 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedNodeRequests(t *testing.T) {
 	assert.False(t, found, "Request for deleted node should not be returned by ListNodeRequests")
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__NodeRequestWorker_SkipsCompletedRequest(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
+
+	amqpURL, _ := config.RabbitMQURL()
+	executionConsumer := testconsumer.New(amqpURL, messages.CanvasExecutionRoutingKey)
+	executionConsumer.Start()
+	defer executionConsumer.Stop()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "component-1",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	executionID := uuid.New()
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      "component-1",
+		ExecutionID: &executionID,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "emitEvent",
+				Parameters: map[string]interface{}{},
+			},
+		}),
+		State: models.NodeExecutionRequestStateCompleted,
+		RunAt: time.Now().Add(-time.Second),
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	processed, err := worker.LockAndProcessRequest(request)
+	require.NoError(t, err)
+	assert.False(t, processed)
+	assert.False(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__NodeRequestWorker_StartExitsWhenSemaphoreAcquireIsCanceled(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "trigger-1",
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "schedule"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	request := models.CanvasNodeRequest{
+		ID:         uuid.New(),
+		WorkflowID: canvas.ID,
+		NodeID:     "trigger-1",
+		Type:       models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{ActionName: "emitEvent"},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+		RunAt: time.Now().Add(-time.Second),
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	require.NoError(t, worker.semaphore.Acquire(context.Background(), defaultWorkerConcurrency))
+	defer worker.semaphore.Release(defaultWorkerConcurrency)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		worker.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(1100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit after semaphore acquire context was canceled")
+	}
 }
 
 func Test__NodeRequestWorker_DoesNotProcessDeletedWorkflowRequests(t *testing.T) {
@@ -592,7 +712,7 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedWorkflowRequests(t *testing.T)
 	//
 	// Verify that ListNodeRequests does not return the request for the deleted workflow.
 	//
-	requests, err := models.ListNodeRequests()
+	requests, err := models.ListNodeRequests(0)
 	require.NoError(t, err)
 
 	// Check that our request is not in the list

--- a/pkg/workers/webhook_provisioner.go
+++ b/pkg/workers/webhook_provisioner.go
@@ -18,18 +18,20 @@ import (
 )
 
 type WebhookProvisioner struct {
-	semaphore *semaphore.Weighted
-	registry  *registry.Registry
-	encryptor crypto.Encryptor
-	baseURL   string
+	semaphore           *semaphore.Weighted
+	registry            *registry.Registry
+	encryptor           crypto.Encryptor
+	baseURL             string
+	maxResourcesPerTick int
 }
 
 func NewWebhookProvisioner(baseURL string, encryptor crypto.Encryptor, registry *registry.Registry) *WebhookProvisioner {
 	return &WebhookProvisioner{
-		registry:  registry,
-		baseURL:   baseURL,
-		encryptor: encryptor,
-		semaphore: semaphore.NewWeighted(25),
+		registry:            registry,
+		baseURL:             baseURL,
+		encryptor:           encryptor,
+		semaphore:           semaphore.NewWeighted(defaultWorkerConcurrency),
+		maxResourcesPerTick: defaultWorkerConcurrency,
 	}
 }
 
@@ -50,13 +52,13 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			webhooks, err := models.ListPendingWebhooks()
+			webhooks, err := models.ListPendingWebhooks(w.maxResourcesPerTick)
 			if err != nil {
 				w.log("Error finding workflow nodes ready to be processed: %v", err)
 			}
 
 			for _, webhook := range webhooks {
-				if err := w.semaphore.Acquire(context.Background(), 1); err != nil {
+				if err := w.semaphore.Acquire(ctx, 1); err != nil {
 					w.log("Error acquiring semaphore: %v", err)
 					continue
 				}
@@ -64,7 +66,7 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 				go func(webhook models.Webhook) {
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessWebhook(webhook); err != nil {
+					if _, err := w.LockAndProcessWebhook(webhook); err != nil {
 						w.log("Error processing webhook %s: %v", webhook.ID, err)
 					}
 				}(webhook)
@@ -79,16 +81,16 @@ func (w *WebhookProvisioner) Start(ctx context.Context) {
 //   - Phase 1 (short tx): Lock the webhook and set state to "provisioning"
 //   - Phase 2 (no tx): Run the external handler.Setup() call
 //   - Phase 3 (short tx): Set state to "ready" or handle errors
-func (w *WebhookProvisioner) LockAndProcessWebhook(webhook models.Webhook) error {
+func (w *WebhookProvisioner) LockAndProcessWebhook(webhook models.Webhook) (bool, error) {
 	// Phase 1: Lock and mark as provisioning in a short transaction.
 	// Non-integration webhooks are marked ready directly in this phase.
-	lockedWebhook, err := w.lockAndMarkProvisioning(webhook)
+	lockedWebhook, processed, err := w.lockAndMarkProvisioning(webhook)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if lockedWebhook == nil {
 		// Already being processed, no longer pending, or non-integration (already ready).
-		return nil
+		return processed, nil
 	}
 
 	// Phase 2: Run handler.Setup() outside any transaction.
@@ -96,17 +98,18 @@ func (w *WebhookProvisioner) LockAndProcessWebhook(webhook models.Webhook) error
 
 	// Phase 3: Finalize state based on the result.
 	if setupErr != nil {
-		return w.handleProvisioningError(lockedWebhook, setupErr)
+		return true, w.handleProvisioningError(lockedWebhook, setupErr)
 	}
 
-	return w.markReady(lockedWebhook, metadata)
+	return true, w.markReady(lockedWebhook, metadata)
 }
 
 // lockAndMarkProvisioning acquires a row lock and transitions the webhook
 // from "pending" to "provisioning". Returns nil if the webhook was already
 // picked up by another worker.
-func (w *WebhookProvisioner) lockAndMarkProvisioning(webhook models.Webhook) (*models.Webhook, error) {
+func (w *WebhookProvisioner) lockAndMarkProvisioning(webhook models.Webhook) (*models.Webhook, bool, error) {
 	var locked *models.Webhook
+	processed := false
 
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		r, err := models.LockWebhook(tx, webhook.ID)
@@ -114,7 +117,9 @@ func (w *WebhookProvisioner) lockAndMarkProvisioning(webhook models.Webhook) (*m
 			return err
 		}
 
-		// Non-integration webhooks don't need external calls — mark ready directly.
+		// Non-integration webhooks don't need external calls - mark ready directly.
+		processed = true
+
 		if r.AppInstallationID == nil {
 			return r.Ready(tx)
 		}
@@ -129,10 +134,10 @@ func (w *WebhookProvisioner) lockAndMarkProvisioning(webhook models.Webhook) (*m
 
 	if err != nil {
 		w.log("Webhook %s already being processed - skipping", webhook.ID)
-		return nil, nil //nolint:nilerr
+		return nil, false, nil //nolint:nilerr
 	}
 
-	return locked, nil
+	return locked, processed, nil
 }
 
 // runIntegrationSetup calls the external webhook handler outside any

--- a/pkg/workers/webhook_provisioner_test.go
+++ b/pkg/workers/webhook_provisioner_test.go
@@ -41,8 +41,9 @@ func Test__WebhookProvisioner_WithoutAppInstallation(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&webhook).Error)
 
-	err := provisioner.LockAndProcessWebhook(webhook)
+	processed, err := provisioner.LockAndProcessWebhook(webhook)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	updatedWebhook, err := models.FindWebhook(webhookID)
 	require.NoError(t, err)
@@ -84,8 +85,9 @@ func Test__WebhookProvisioner_RetryOnError(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&webhook).Error)
 
-	err = provisioner.LockAndProcessWebhook(webhook)
+	processed, err := provisioner.LockAndProcessWebhook(webhook)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	updatedWebhook, err := models.FindWebhook(webhookID)
 	require.NoError(t, err)
@@ -126,8 +128,9 @@ func Test__WebhookProvisioner_MaxRetriesExceeded(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&webhook).Error)
 
-	err = provisioner.LockAndProcessWebhook(webhook)
+	processed, err := provisioner.LockAndProcessWebhook(webhook)
 	require.NoError(t, err)
+	assert.True(t, processed)
 
 	updatedWebhook, err := models.FindWebhook(webhookID)
 	require.NoError(t, err)
@@ -149,22 +152,34 @@ func Test__WebhookProvisioner_ConcurrentProcessing(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&webhook).Error)
 
-	results := make(chan error, 2)
+	results := make(chan struct {
+		processed bool
+		err       error
+	}, 2)
 
 	go func() {
 		worker1 := NewWebhookProvisioner("https://example.com", r.Encryptor, r.Registry)
-		results <- worker1.LockAndProcessWebhook(webhook)
+		processed, err := worker1.LockAndProcessWebhook(webhook)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	go func() {
 		worker2 := NewWebhookProvisioner("https://example.com", r.Encryptor, r.Registry)
-		results <- worker2.LockAndProcessWebhook(webhook)
+		processed, err := worker2.LockAndProcessWebhook(webhook)
+		results <- struct {
+			processed bool
+			err       error
+		}{processed: processed, err: err}
 	}()
 
 	result1 := <-results
 	result2 := <-results
-	assert.NoError(t, result1)
-	assert.NoError(t, result2)
+	assert.NoError(t, result1.err)
+	assert.NoError(t, result2.err)
+	assert.Equal(t, 1, processedCount(result1.processed, result2.processed))
 
 	updatedWebhook, err := models.FindWebhook(webhookID)
 	require.NoError(t, err)

--- a/pkg/workers/worker_test.go
+++ b/pkg/workers/worker_test.go
@@ -1,0 +1,12 @@
+package workers
+
+func processedCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+
+	return count
+}


### PR DESCRIPTION
## Summary

Adds bounded worker polling and cancellation-aware processing for the main worker loops.

## Changes

- Added shared worker concurrency/batch limit of `25`.
- Added per-tick polling limits to node, event, request, queue, integration, and webhook workers.
- Updated pending list queries to accept limits and use stable oldest-first ordering.
- Made semaphore acquisition use worker context cancellation.
- Made RabbitMQ reconnect sleeps respect cancellation.
- Prevented follow-up messages from being published when stale or already-processed records are skipped.
- Tightened stale request locking for node and integration requests.