### PR TITLE
feat(core): add new integration setup provider interface

### DIFF
--- a/docs/design/integration-setup-flow.md
+++ b/docs/design/integration-setup-flow.md
@@ -1,0 +1,103 @@
+# Integration Setup Flow
+
+This document captures the design behind the new integration setup flow. The core contract lives in `pkg/core/integration_setup_provider.go`, with the current runtime wired through organization integration actions and integration-specific setup providers.
+
+## Goals
+
+- Let each integration own its setup journey instead of forcing all integrations through one static configuration form.
+- Support multi-step setup flows with instructions, input fields, redirects, completion screens, and back navigation.
+- Separate sensitive secrets from user-visible properties.
+- Allow users to request only the capabilities they need, and allow integrations to enable those capabilities only after the required setup work is complete.
+- Re-enter setup when an editable property, editable secret, or newly requested capability requires additional work.
+
+## Core Model
+
+The setup flow is implemented by `core.IntegrationSetupProvider`.
+
+Each provider declares all capabilities available for that integration through `CapabilityGroups()`. A capability is an action or trigger with its label, description, configuration fields, and action output channels. Capability groups are presentation groups for the setup UI and CLI; the persisted state is still tracked per capability.
+
+Each provider also owns the setup state machine:
+
+- `FirstStep(ctx)` returns the initial pending step.
+- `OnStepSubmit(ctx)` handles submitted inputs for the current step and returns the next step.
+- `OnStepRevert(ctx)` rolls back side effects from the last successfully submitted step.
+- `OnPropertyUpdate(ctx)` handles updates to editable user-visible properties.
+- `OnSecretUpdate(ctx)` handles updates to editable sensitive values.
+- `OnCapabilityUpdate(ctx)` handles requests for new capabilities after the integration already exists.
+
+Handlers receive storage and service contexts instead of loading state directly:
+
+- `Properties` stores non-sensitive integration data visible to users.
+- `Secrets` stores sensitive data, encrypted through the integration secret storage.
+- `Capabilities` reads requested capabilities and moves capabilities between states.
+- `HTTP`, `Logger`, `BaseURL`, and `WebhooksBaseURL` provide runtime services needed by setup flows.
+
+## Setup Steps
+
+A setup step is a serializable UI/CLI instruction for what the user should do next.
+
+Step types are:
+
+- `inputs`: display markdown instructions and collect typed `configuration.Field` inputs.
+- `redirectPrompt`: ask the user to continue through an external URL, optionally with form data.
+- `done`: display completion instructions. Submitting a `done` step clears setup state and marks the integration ready.
+
+Every step has a stable machine-readable `Name`, a human-readable `Label`, optional markdown `Instructions`, and type-specific data.
+
+## Persisted State
+
+New-flow integrations store setup-specific data on `models.Integration`:
+
+- `SetupState`: the current pending step plus previous steps.
+- `Properties`: user-visible non-sensitive setup results.
+- `Capabilities`: one state per declared capability.
+
+Secrets are stored separately in `app_installation_secrets` as `models.IntegrationSecret`, so sensitive values are not mixed into regular integration configuration.
+
+The old integration fields, such as `Configuration`, `Metadata`, and `BrowserAction`, still exist for legacy setup. They should become less important as integrations move to `IntegrationSetupProvider`.
+
+## Capability States
+
+Capabilities are tracked with four states:
+
+- `requested`: the user asked for the capability, but setup has not exposed it yet.
+- `enabled`: the capability is available for use.
+- `disabled`: the capability was available but the user manually disabled it.
+- `unavailable`: the integration supports the capability, but it was not requested for this installation.
+
+When a new integration is created through the new flow, requested capability names are validated against the provider's declared capabilities. Requested capabilities start as `requested`; all others start as `unavailable`. The setup provider decides when requested capabilities can be enabled.
+
+For example, Semaphore enables requested capabilities after a valid API token is stored and verified. GitHub can ask the user to update token permissions before newly requested capabilities become available.
+
+## Editing After Setup
+
+Properties and secrets can be marked editable by the provider. When users update editable values, the corresponding provider callback receives the new value.
+
+The provider can either:
+
+- validate and persist the new value without returning a setup step, or
+- return a setup step to restart a focused setup flow.
+
+For example, a secret update can validate a replacement API token before storing it. A property update could require the user to reconnect, select a resource again, or reauthorize externally.
+
+## Updating Capabilities After Setup
+
+Users can update capability states after the integration exists.
+
+Simple enable and disable changes update stored capability states directly. Newly requested capabilities are delegated to `OnCapabilityUpdate`, because the provider may need to validate permissions, collect new credentials, create webhooks, or show instructions before enabling them.
+
+If `OnCapabilityUpdate` returns no step, the handler persists whatever capability states the provider set. If it returns a step, SuperPlane stores a new setup state so the integration can re-enter setup for that capability expansion.
+
+## Provider Responsibilities
+
+An integration setup provider should:
+
+- Declare all actions and triggers in `CapabilityGroups()`.
+- Keep step names stable because they are persisted and used for dispatch.
+- Store user-visible non-sensitive values as properties.
+- Store credentials, tokens, private keys, and webhook secrets as secrets.
+- Mark properties and secrets editable only when updates are supported.
+- Validate external credentials before enabling capabilities.
+- Enable requested capabilities only after setup has completed the required external work.
+- Clean up step side effects in `OnStepRevert`.
+- Return `done` when the user should see a completion screen, or `nil` when setup can finish without one.

--- a/pkg/core/integration_setup_provider.go
+++ b/pkg/core/integration_setup_provider.go
@@ -112,6 +112,7 @@ type SetupStepContext struct {
 	OrganizationID  string
 	BaseURL         string
 	WebhooksBaseURL string
+	Logger          *log.Entry
 	HTTP            HTTPContext
 	Secrets         IntegrationSecretStorage
 	Properties      IntegrationPropertyStorage
@@ -176,7 +177,7 @@ type IntegrationSecretDefinition struct {
 	Name        string
 	Label       string
 	Description string
-	Value       []byte
+	Value       string
 	Editable    bool
 }
 

--- a/pkg/core/integration_setup_provider.go
+++ b/pkg/core/integration_setup_provider.go
@@ -1,0 +1,225 @@
+package core
+
+import (
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+/*
+ * IntegrationSetupProvider is the contract for an integration to provide its setup flow.
+ * Any changes to this interface should be documented in docs/design/integration-setup-flow.md.
+ */
+type IntegrationSetupProvider interface {
+
+	//
+	// All the capabilities supported by the integration.
+	// The grouping is a presentation matter, and per-integration states
+	// are still tracked per capability.
+	//
+	CapabilityGroups() []CapabilityGroup
+
+	//
+	// Generate the first step of the setup flow.
+	//
+	FirstStep(ctx SetupStepContext) SetupStep
+
+	//
+	// Called when the user submits the current pending step.
+	//
+	OnStepSubmit(ctx SetupStepContext) (*SetupStep, error)
+
+	//
+	// Called when the user reverts the last successfully submitted step.
+	//
+	OnStepRevert(ctx SetupStepContext) error
+
+	//
+	// Called when the user updates a property.
+	// A property update might trigger a new setup flow.
+	//
+	OnPropertyUpdate(ctx PropertyUpdateContext) (*SetupStep, error)
+
+	//
+	// Called when the user updates a secret.
+	// A secret update might trigger a new setup flow.
+	//
+	OnSecretUpdate(ctx SecretUpdateContext) (*SetupStep, error)
+
+	//
+	// Called when the user requests new capabilities
+	// from an already setup integration.
+	//
+	OnCapabilityUpdate(ctx CapabilityUpdateContext) (*SetupStep, error)
+}
+
+type SetupStepType string
+
+const (
+	SetupStepTypeInputs         SetupStepType = "inputs"
+	SetupStepTypeRedirectPrompt SetupStepType = "redirectPrompt"
+	SetupStepTypeDone           SetupStepType = "done"
+)
+
+type SetupStep struct {
+	Type           SetupStepType
+	Name           string
+	Label          string
+	Instructions   string
+	Inputs         []configuration.Field
+	RedirectPrompt *RedirectPrompt
+}
+
+type PropertyUpdateContext struct {
+	PropertyName string
+	Value        string
+	Logger       *log.Entry
+	HTTP         HTTPContext
+	Secrets      IntegrationSecretStorage
+	Properties   IntegrationPropertyStorage
+	Capabilities CapabilityContext
+}
+
+type SecretUpdateContext struct {
+	SecretName   string
+	Value        string
+	Logger       *log.Entry
+	HTTP         HTTPContext
+	Secrets      IntegrationSecretStorage
+	Properties   IntegrationPropertyStorage
+	Capabilities CapabilityContext
+}
+
+type CapabilityUpdateContext struct {
+	Changes      map[IntegrationCapabilityState][]string
+	Logger       *log.Entry
+	HTTP         HTTPContext
+	Secrets      IntegrationSecretStorage
+	Properties   IntegrationPropertyStorage
+	Capabilities CapabilityContext
+}
+
+type RedirectPrompt struct {
+	URL      string
+	Method   string
+	FormData map[string]string
+}
+
+type SetupStepContext struct {
+	Step            string
+	Inputs          any
+	IntegrationID   uuid.UUID
+	OrganizationID  string
+	BaseURL         string
+	WebhooksBaseURL string
+	HTTP            HTTPContext
+	Secrets         IntegrationSecretStorage
+	Properties      IntegrationPropertyStorage
+	Capabilities    CapabilityContext
+}
+
+/*
+ * Properties is non-sensitive information exposed by the setup flow to the user.
+ * They can be editable or not. If they are editable, OnPropertyUpdate() is called when the user updates it.
+ * They are also typed, so the display layers (UI, CLI) can render them accordingly.
+ */
+type IntegrationPropertyType string
+
+const (
+	IntegrationPropertyTypeString IntegrationPropertyType = "string"
+)
+
+type IntegrationPropertyDefinition struct {
+	Type        IntegrationPropertyType `json:"type"`
+	Name        string                  `json:"name"`
+	Label       string                  `json:"label"`
+	Description string                  `json:"description"`
+	Value       any                     `json:"value"`
+	Editable    bool                    `json:"editable"`
+}
+
+type IntegrationPropertyStorageReader interface {
+	Get(name string) (any, error)
+	GetString(name string) (string, error)
+}
+
+type IntegrationPropertyStorage interface {
+	IntegrationPropertyStorageReader
+
+	Delete(names ...string) error
+	Create(def IntegrationPropertyDefinition) error
+	CreateMany(defs []IntegrationPropertyDefinition) error
+}
+
+type IntegrationSecretStorageReader interface {
+	Get(name string) (string, error)
+}
+
+/*
+ * Secrets are sensitive information managed by the integration.
+ * In some cases, this comes from the user, as a step input.
+ * In other cases, this comes from the setup flow itself.
+ * Secrets can be editable or not. If they are editable, OnSecretUpdate() is called when the user updates it.
+ *
+ * This is context that the integration receives as part of the setup flow for managing them.
+ */
+type IntegrationSecretStorage interface {
+	IntegrationSecretStorageReader
+
+	Delete(name string) error
+	Create(def IntegrationSecretDefinition) error
+	CreateMany(defs []IntegrationSecretDefinition) error
+	Update(name string, value string) error
+}
+
+type IntegrationSecretDefinition struct {
+	Name        string
+	Label       string
+	Description string
+	Value       []byte
+	Editable    bool
+}
+
+/*
+ * Capabilities are the "features" that the integration provides.
+ * They are typed so the different parts of the system can take only the ones they need.
+ *
+ * They can be in 4 states:
+ * - Requested: the capability was requested, but the setup flow did not yet exposed it.
+ * - Enabled: the capability is fully available for use.
+ * - Disabled: the capability was made available during the setup flow, but has been manually disabled by the user.
+ * - Unavailable: the integration itself has the capability available, but the capability was not requested as part of the setup flow.
+ */
+type IntegrationCapabilityType string
+type IntegrationCapabilityState string
+
+const (
+	IntegrationCapabilityTypeAction  IntegrationCapabilityType = "action"
+	IntegrationCapabilityTypeTrigger IntegrationCapabilityType = "trigger"
+
+	IntegrationCapabilityStateRequested   IntegrationCapabilityState = "requested"
+	IntegrationCapabilityStateEnabled     IntegrationCapabilityState = "enabled"
+	IntegrationCapabilityStateDisabled    IntegrationCapabilityState = "disabled"
+	IntegrationCapabilityStateUnavailable IntegrationCapabilityState = "unavailable"
+)
+
+type CapabilityContext interface {
+	Enable(capabilities ...string) error
+	Disable(capabilities ...string) error
+	IsRequested(capabilities ...string) (bool, error)
+	Requested() []string
+}
+
+type CapabilityGroup struct {
+	Label        string
+	Capabilities []Capability
+}
+
+type Capability struct {
+	Type           IntegrationCapabilityType `json:"type"`
+	Name           string                    `json:"name"`
+	Label          string                    `json:"label"`
+	Description    string                    `json:"description"`
+	Configuration  []configuration.Field     `json:"configuration"`
+	OutputChannels []OutputChannel           `json:"outputChannels"`
+}


### PR DESCRIPTION
Bootstrapping the new integration setup, by introducing the new core interfaces that will drive them. Details about them is in the [docs/design/integration-setup-flow.md](https://github.com/superplanehq/superplane/pull/4507/changes#diff-2a56f768f12e474dcf13cc3ed2a6fd6a595c63346539e255b997c6b0b6b25775) document in this pull request. More details on how this will be rolled out is in [this Discord message](https://discord.com/channels/1409914582239023200/1496902863866171392/1499416794765459487).