### PR TITLE
fix: remove nested data envelope from memory read output

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -657,23 +657,21 @@ The Read Memory component looks up values from canvas-level memory storage.
 ```json
 {
   "data": {
-    "data": {
-      "count": 1,
-      "emitMode": "allAtOnce",
-      "matches": {
+    "count": 1,
+    "emitMode": "allAtOnce",
+    "matches": {
+      "creator": "igor",
+      "pull_request": 123
+    },
+    "namespace": "machines",
+    "resultMode": "latest",
+    "values": [
+      {
         "creator": "igor",
-        "pull_request": 123
-      },
-      "namespace": "machines",
-      "resultMode": "latest",
-      "values": [
-        {
-          "creator": "igor",
-          "pull_request": 123,
-          "sandbox_id": "sbx-001"
-        }
-      ]
-    }
+        "pull_request": 123,
+        "sandbox_id": "sbx-001"
+      }
+    ]
   },
   "timestamp": "2026-02-28T00:00:00Z",
   "type": "memory.read"

--- a/pkg/components/readmemory/example_output.json
+++ b/pkg/components/readmemory/example_output.json
@@ -1,23 +1,21 @@
 {
   "type": "memory.read",
   "data": {
-    "data": {
-      "namespace": "machines",
-      "resultMode": "latest",
-      "emitMode": "allAtOnce",
-      "matches": {
+    "namespace": "machines",
+    "resultMode": "latest",
+    "emitMode": "allAtOnce",
+    "matches": {
+      "creator": "igor",
+      "pull_request": 123
+    },
+    "values": [
+      {
         "creator": "igor",
-        "pull_request": 123
-      },
-      "values": [
-        {
-          "creator": "igor",
-          "pull_request": 123,
-          "sandbox_id": "sbx-001"
-        }
-      ],
-      "count": 1
-    }
+        "pull_request": 123,
+        "sandbox_id": "sbx-001"
+      }
+    ],
+    "count": 1
   },
   "timestamp": "2026-02-28T00:00:00Z"
 }

--- a/pkg/components/readmemory/read_memory.go
+++ b/pkg/components/readmemory/read_memory.go
@@ -311,16 +311,14 @@ func buildPayloads(spec Spec, matches map[string]any, values []any) []any {
 		payloads := make([]any, 0, len(values))
 		for i, value := range values {
 			payloads = append(payloads, map[string]any{
-				"data": map[string]any{
-					"namespace":  spec.Namespace,
-					"matches":    matches,
-					"resultMode": spec.ResultMode,
-					"emitMode":   spec.EmitMode,
-					"values":     []any{value},
-					"count":      1,
-					"index":      i,
-					"totalCount": len(values),
-				},
+				"namespace":  spec.Namespace,
+				"matches":    matches,
+				"resultMode": spec.ResultMode,
+				"emitMode":   spec.EmitMode,
+				"values":     []any{value},
+				"count":      1,
+				"index":      i,
+				"totalCount": len(values),
 			})
 		}
 		return payloads
@@ -328,14 +326,12 @@ func buildPayloads(spec Spec, matches map[string]any, values []any) []any {
 
 	return []any{
 		map[string]any{
-			"data": map[string]any{
-				"namespace":  spec.Namespace,
-				"matches":    matches,
-				"resultMode": spec.ResultMode,
-				"emitMode":   spec.EmitMode,
-				"values":     values,
-				"count":      len(values),
-			},
+			"namespace":  spec.Namespace,
+			"matches":    matches,
+			"resultMode": spec.ResultMode,
+			"emitMode":   spec.EmitMode,
+			"values":     values,
+			"count":      len(values),
 		},
 	}
 }

--- a/pkg/components/readmemory/read_memory_test.go
+++ b/pkg/components/readmemory/read_memory_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -80,6 +81,18 @@ func TestReadMemoryExecute(t *testing.T) {
 		assert.Equal(t, PayloadType, execState.Type)
 		assert.Len(t, execState.Payloads, 1)
 
+		payload, ok := execState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		data, ok := payload["data"].(map[string]any)
+		require.True(t, ok)
+		assert.NotContains(t, data, "data")
+		assert.Equal(t, "machines", data["namespace"])
+		assert.Equal(t, map[string]any{"creator": "igor", "pull_request": 123}, data["matches"])
+		assert.Equal(t, ResultModeAll, data["resultMode"])
+		assert.Equal(t, EmitModeAllAtOnce, data["emitMode"])
+		assert.Equal(t, memoryCtx.values, data["values"])
+		assert.Equal(t, 1, data["count"])
+
 		assert.Equal(
 			t,
 			map[string]any{
@@ -151,6 +164,16 @@ func TestReadMemoryExecute(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, ChannelNameFound, execState.Channel)
 		assert.Len(t, execState.Payloads, 2)
+
+		firstPayload, ok := execState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		firstData, ok := firstPayload["data"].(map[string]any)
+		require.True(t, ok)
+		assert.NotContains(t, firstData, "data")
+		assert.Equal(t, []any{memoryCtx.values[0]}, firstData["values"])
+		assert.Equal(t, 1, firstData["count"])
+		assert.Equal(t, 0, firstData["index"])
+		assert.Equal(t, 2, firstData["totalCount"])
 	})
 
 	t.Run("emits notFound channel when there are no matches", func(t *testing.T) {

--- a/templates/canvases/health-check-monitor.yaml
+++ b/templates/canvases/health-check-monitor.yaml
@@ -67,7 +67,7 @@ spec:
       name: "Was previously healthy?"
       type: "TYPE_ACTION"
       configuration:
-        expression: '$["Read previous status"].data.data.values[0].lastStatus == "ok"'
+        expression: '$["Read previous status"].data.values[0].lastStatus == "ok"'
       position:
         x: 2014
         "y": 396
@@ -79,7 +79,7 @@ spec:
       configuration:
         recipients: []
         subject: "Endpoint is down (status {{ $[\"Health check request\"].data.status }})"
-        body: "Your health check just started failing. SuperPlane only sends this when the endpoint transitions from healthy to failing, not on every failed check.\n\nStatus code: {{ $[\"Health check request\"].data.status }}\nChecked at: {{ $[\"Check every 10 minutes\"].data.calendar.hour }}:{{ $[\"Check every 10 minutes\"].data.calendar.minute }} on {{ $[\"Check every 10 minutes\"].data.calendar.month }} {{ $[\"Check every 10 minutes\"].data.calendar.day }}, {{ $[\"Check every 10 minutes\"].data.calendar.year }}\n\nApproximate time healthy before this failure: {{ len($[\"Read previous status\"].data.data.values) > 0 ? string(int((now().Unix() - int($[\"Read previous status\"].data.data.values[0].lastHealthyAtUnix)) / 60)) + \" minutes\" : \"unknown (no prior successful check in memory)\" }}"
+        body: "Your health check just started failing. SuperPlane only sends this when the endpoint transitions from healthy to failing, not on every failed check.\n\nStatus code: {{ $[\"Health check request\"].data.status }}\nChecked at: {{ $[\"Check every 10 minutes\"].data.calendar.hour }}:{{ $[\"Check every 10 minutes\"].data.calendar.minute }} on {{ $[\"Check every 10 minutes\"].data.calendar.month }} {{ $[\"Check every 10 minutes\"].data.calendar.day }}, {{ $[\"Check every 10 minutes\"].data.calendar.year }}\n\nApproximate time healthy before this failure: {{ len($[\"Read previous status\"].data.values) > 0 ? string(int((now().Unix() - int($[\"Read previous status\"].data.values[0].lastHealthyAtUnix)) / 60)) + \" minutes\" : \"unknown (no prior successful check in memory)\" }}"
       position:
         x: 2638
         "y": 396


### PR DESCRIPTION
Closes #3370 

## Summary
- Removes the extra inner `data` wrapper from `readMemory` outputs so expressions use `node.data.values[...]`.
- Updates the read memory example output and health check template expressions to match the corrected output shape.
- Adds test coverage to prevent `data.data` nesting from returning.

## Test plan
- `go test ./pkg/components/readmemory`