### PR TITLE
feat: show who created each service account (#3471)

### DIFF
--- a/pkg/grpc/actions/serviceaccounts/common.go
+++ b/pkg/grpc/actions/serviceaccounts/common.go
@@ -1,12 +1,43 @@
 package serviceaccounts
 
 import (
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
+func enrichServiceAccountCreators(serviceAccountUsers []models.User) (map[uuid.UUID]models.User, error) {
+	seen := make(map[uuid.UUID]struct{})
+	var ids []uuid.UUID
+	for i := range serviceAccountUsers {
+		cb := serviceAccountUsers[i].CreatedBy
+		if cb == nil {
+			continue
+		}
+		if _, ok := seen[*cb]; ok {
+			continue
+		}
+		seen[*cb] = struct{}{}
+		ids = append(ids, *cb)
+	}
+	if len(ids) == 0 {
+		return map[uuid.UUID]models.User{}, nil
+	}
+
+	users, err := models.FindMaybeDeletedUsersByIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+
+	byID := make(map[uuid.UUID]models.User, len(users))
+	for _, u := range users {
+		byID[u.ID] = u
+	}
+	return byID, nil
+}
+
+func serializeServiceAccount(user *models.User, creatorsByID map[uuid.UUID]models.User) *pb.ServiceAccount {
 	sa := &pb.ServiceAccount{
 		Id:             user.ID.String(),
 		Name:           user.Name,
@@ -22,6 +53,18 @@ func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
 
 	if user.CreatedBy != nil {
 		sa.CreatedBy = user.CreatedBy.String()
+		if creatorsByID != nil {
+			if creator, ok := creatorsByID[*user.CreatedBy]; ok {
+				sa.CreatedByUser = &pb.UserRef{
+					Id:   creator.ID.String(),
+					Name: creator.Name,
+				}
+			} else {
+				sa.CreatedByUser = &pb.UserRef{
+					Id: user.CreatedBy.String(),
+				}
+			}
+		}
 	}
 
 	return sa

--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -86,8 +86,13 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Errorf(codes.Internal, "failed to create service account: %v", err)
 	}
 
+	creatorsByID, enrichErr := enrichServiceAccountCreators([]models.User{*sa})
+	if enrichErr != nil {
+		return nil, status.Error(codes.Internal, "failed to create service account")
+	}
+
 	return &pb.CreateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(sa),
+		ServiceAccount: serializeServiceAccount(sa, creatorsByID),
 		Token:          plainToken,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/describe_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/describe_service_account.go
@@ -34,7 +34,12 @@ func DescribeServiceAccount(ctx context.Context, req *pb.DescribeServiceAccountR
 		return nil, status.Error(codes.NotFound, "service account not found")
 	}
 
+	creatorsByID, err := enrichServiceAccountCreators([]models.User{*user})
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to describe service account")
+	}
+
 	return &pb.DescribeServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creatorsByID),
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
+++ b/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
@@ -26,9 +26,14 @@ func ListServiceAccounts(ctx context.Context) (*pb.ListServiceAccountsResponse, 
 		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
+	creatorsByID, err := enrichServiceAccountCreators(users)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to list service accounts")
+	}
+
 	serviceAccounts := make([]*pb.ServiceAccount, len(users))
 	for i := range users {
-		serviceAccounts[i] = serializeServiceAccount(&users[i])
+		serviceAccounts[i] = serializeServiceAccount(&users[i], creatorsByID)
 	}
 
 	return &pb.ListServiceAccountsResponse{

--- a/pkg/grpc/actions/serviceaccounts/update_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/update_service_account.go
@@ -50,7 +50,12 @@ func UpdateServiceAccount(ctx context.Context, req *pb.UpdateServiceAccountReque
 		return nil, status.Error(codes.Internal, "failed to update service account")
 	}
 
+	creatorsByID, enrichErr := enrichServiceAccountCreators([]models.User{*user})
+	if enrichErr != nil {
+		return nil, status.Error(codes.Internal, "failed to update service account")
+	}
+
 	return &pb.UpdateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creatorsByID),
 	}, nil
 }

--- a/protos/service_accounts.proto
+++ b/protos/service_accounts.proto
@@ -104,6 +104,12 @@ message ServiceAccount {
   bool has_token = 6;
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;
+  UserRef created_by_user = 9;
+}
+
+message UserRef {
+  string id = 1;
+  string name = 2;
 }
 
 message CreateServiceAccountRequest {

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	pw "github.com/playwright-community/playwright-go"
@@ -47,6 +48,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.givenServiceAccountExists("list-test-bot", "For listing test")
 		steps.visitServiceAccountsPage()
 		steps.assertServiceAccountVisibleInList("list-test-bot")
+		steps.assertCreatorShownForServiceAccount("list-test-bot", "E2E User")
 	})
 
 	t.Run("navigating to service account detail", func(t *testing.T) {
@@ -55,6 +57,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.visitServiceAccountsPage()
 		steps.clickServiceAccountLink("detail-test-bot")
 		steps.assertOnDetailPage("detail-test-bot")
+		steps.assertDetailPageShowsCreator("E2E User")
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
@@ -211,6 +214,27 @@ func (s *serviceAccountSteps) assertServiceAccountSavedInDB(name, description, e
 
 func (s *serviceAccountSteps) assertServiceAccountVisibleInList(name string) {
 	s.session.AssertText(name)
+}
+
+func (s *serviceAccountSteps) assertCreatorShownForServiceAccount(saName, creatorDisplay string) {
+	page := s.session.Page()
+	row := page.Locator("tr").Filter(pw.LocatorFilterOptions{HasText: saName}).First()
+	cell := row.GetByTestId("sa-created-by")
+	err := cell.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := cell.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorDisplay, strings.TrimSpace(text))
+}
+
+func (s *serviceAccountSteps) assertDetailPageShowsCreator(creatorDisplay string) {
+	page := s.session.Page()
+	cell := page.GetByTestId("sa-detail-created-by")
+	err := cell.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := cell.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorDisplay, strings.TrimSpace(text))
 }
 
 func (s *serviceAccountSteps) clickServiceAccountLink(name string) {

--- a/web_src/src/lib/serviceAccounts.test.ts
+++ b/web_src/src/lib/serviceAccounts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { serviceAccountCreatorLabel } from "./serviceAccounts";
+
+describe("serviceAccountCreatorLabel", () => {
+  it("returns creator name when present", () => {
+    expect(
+      serviceAccountCreatorLabel({
+        createdBy: "uuid-1",
+        createdByUser: { id: "uuid-1", name: "Alice" },
+      }),
+    ).toBe("Alice");
+  });
+
+  it("returns Unknown when creator id exists but name is missing", () => {
+    expect(
+      serviceAccountCreatorLabel({
+        createdBy: "uuid-1",
+        createdByUser: { id: "uuid-1" },
+      }),
+    ).toBe("Unknown");
+  });
+
+  it("returns em dash when no creator", () => {
+    expect(serviceAccountCreatorLabel({})).toBe("—");
+  });
+});

--- a/web_src/src/lib/serviceAccounts.ts
+++ b/web_src/src/lib/serviceAccounts.ts
@@ -1,0 +1,14 @@
+/** Human-readable label for the user who created a service account (API: createdBy + createdByUser). */
+export function serviceAccountCreatorLabel(serviceAccount: {
+  createdBy?: string;
+  createdByUser?: { id?: string; name?: string };
+}): string {
+  const trimmedName = serviceAccount.createdByUser?.name?.trim();
+  if (trimmedName) {
+    return trimmedName;
+  }
+  if (serviceAccount.createdByUser?.id || serviceAccount.createdBy) {
+    return "Unknown";
+  }
+  return "—";
+}

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -18,6 +18,7 @@ import {
   useDeleteServiceAccount,
   useRegenerateServiceAccountToken,
 } from "@/hooks/useServiceAccounts";
+import { serviceAccountCreatorLabel } from "@/lib/serviceAccounts";
 
 interface ServiceAccountDetailProps {
   organizationId: string;
@@ -132,6 +133,7 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
   }
 
   const createdAt = serviceAccount.createdAt ? new Date(serviceAccount.createdAt).toLocaleDateString() : "—";
+  const createdByLabel = serviceAccountCreatorLabel(serviceAccount);
   const serviceAccountsHref = `/${organizationId}/settings/service-accounts`;
 
   return (
@@ -239,6 +241,10 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
             <dl className="grid grid-cols-2 gap-y-4 text-sm">
               <dt className="text-gray-500 dark:text-gray-400">Description</dt>
               <dd className="text-gray-800 dark:text-white">{serviceAccount.description || "—"}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created by</dt>
+              <dd className="text-gray-800 dark:text-white" data-testid="sa-detail-created-by">
+                {createdByLabel}
+              </dd>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-800 dark:text-white">{createdAt}</dd>
               <dt className="text-gray-500 dark:text-gray-400">ID</dt>

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -16,6 +16,7 @@ import { Bot, Copy } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useServiceAccounts, useCreateServiceAccount, useDeleteServiceAccount } from "@/hooks/useServiceAccounts";
+import { serviceAccountCreatorLabel } from "@/lib/serviceAccounts";
 
 interface ServiceAccountsProps {
   organizationId: string;
@@ -174,6 +175,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                 <TableRow>
                   <TableHeader>Name</TableHeader>
                   <TableHeader>Description</TableHeader>
+                  <TableHeader>Created by</TableHeader>
                   <TableHeader>Token</TableHeader>
                   <TableHeader></TableHeader>
                 </TableRow>
@@ -195,6 +197,11 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">{sa.description || "—"}</span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-sm text-gray-500 dark:text-gray-400" data-testid="sa-created-by">
+                        {serviceAccountCreatorLabel(sa)}
+                      </span>
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3471.

- **API:** Extended `ServiceAccount` in `protos/service_accounts.proto` with optional `created_by_user` (`UserRef`: id + name). Kept existing `created_by` UUID for compatibility.
- **Backend:** `pkg/grpc/actions/serviceaccounts` now collects distinct `CreatedBy` IDs, loads creators in one query via `models.FindMaybeDeletedUsersByIDs`, and attaches `created_by_user` on list, describe, create, and update responses (no N+1 on list).
- **UI:** Service accounts table has a **Created by** column; detail page shows **Created by** in the metadata block. Uses `createdByUser.name` when present, **Unknown** when the creator UUID is set but the user row is missing, and **—** when there is no creator.
- **Tests:** Vitest for `serviceAccountCreatorLabel`; Playwright E2E asserts creator **E2E User** in list and detail for DB-seeded service accounts.

## Review feedback (#3471 Leonardo review)

The review recommended adding a nested ref (like canvases), batch user lookup with `FindMaybeDeletedUsersByIDs`, regenerating OpenAPI/web client, updating list + detail UI, and optional E2E. This PR implements those items. **Regeneration:** In this environment Docker was unavailable, so I ran `protoc`, OpenAPI merge, and `openapi-ts` locally to validate the pipeline; CI with `make pb.gen` / `make openapi.*` should be run to refresh all generated artifacts consistently.

## Human comments

No human comments were posted on the issue after the agent review; nothing additional to reconcile.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d493a934-bcb1-49ce-bb7a-e8b541b139f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d493a934-bcb1-49ce-bb7a-e8b541b139f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

