### PR TITLE
feat: show service account creator with structured API and member link

### DIFF
--- a/pkg/cli/core/errors.go
+++ b/pkg/cli/core/errors.go
@@ -44,13 +44,13 @@ func FormatCommandError(err error) error {
 	return fallbackAPIError(apiErr)
 }
 
-func extractGoogleRPCStatus(apiErr *openapi_client.GenericOpenAPIError) *openapi_client.GooglerpcStatus {
+func extractGoogleRPCStatus(apiErr *openapi_client.GenericOpenAPIError) *openapi_client.GoogleRpcStatus {
 	switch model := apiErr.Model().(type) {
-	case *openapi_client.GooglerpcStatus:
+	case *openapi_client.GoogleRpcStatus:
 		if model != nil && !isEmptyRPCStatus(model) {
 			return model
 		}
-	case openapi_client.GooglerpcStatus:
+	case openapi_client.GoogleRpcStatus:
 		if !isEmptyRPCStatus(&model) {
 			return &model
 		}
@@ -61,7 +61,7 @@ func extractGoogleRPCStatus(apiErr *openapi_client.GenericOpenAPIError) *openapi
 		return nil
 	}
 
-	var decoded openapi_client.GooglerpcStatus
+	var decoded openapi_client.GoogleRpcStatus
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		return nil
 	}
@@ -71,14 +71,14 @@ func extractGoogleRPCStatus(apiErr *openapi_client.GenericOpenAPIError) *openapi
 	return &decoded
 }
 
-func isEmptyRPCStatus(status *openapi_client.GooglerpcStatus) bool {
+func isEmptyRPCStatus(status *openapi_client.GoogleRpcStatus) bool {
 	if status == nil {
 		return true
 	}
 	return status.Message == nil && status.Code == nil && len(status.Details) == 0
 }
 
-func formatGoogleRPCStatusError(status *openapi_client.GooglerpcStatus) error {
+func formatGoogleRPCStatusError(status *openapi_client.GoogleRpcStatus) error {
 	if status == nil {
 		return nil
 	}
@@ -110,7 +110,7 @@ func formatGoogleRPCStatusError(status *openapi_client.GooglerpcStatus) error {
 	return fmt.Errorf("%s", message)
 }
 
-func appendFieldViolations(base error, status *openapi_client.GooglerpcStatus) error {
+func appendFieldViolations(base error, status *openapi_client.GoogleRpcStatus) error {
 	violations := extractFieldViolations(status)
 	if len(violations) == 0 {
 		return base
@@ -125,7 +125,7 @@ func appendFieldViolations(base error, status *openapi_client.GooglerpcStatus) e
 	return errors.New(sb.String())
 }
 
-func extractFieldViolations(status *openapi_client.GooglerpcStatus) []string {
+func extractFieldViolations(status *openapi_client.GoogleRpcStatus) []string {
 	if status == nil {
 		return nil
 	}

--- a/pkg/cli/core/errors_test.go
+++ b/pkg/cli/core/errors_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFormatGoogleRPCStatusErrorForUsageLimit(t *testing.T) {
 	message := "organization canvas limit exceeded"
-	status := openapi_client.GooglerpcStatus{Message: &message}
+	status := openapi_client.GoogleRpcStatus{Message: &message}
 
 	err := formatGoogleRPCStatusError(&status)
 	require.Error(t, err)
@@ -28,7 +28,7 @@ func TestFormatGoogleRPCStatusErrorForUsageLimit(t *testing.T) {
 
 func TestFormatGoogleRPCStatusErrorSurfacesUnknownMessage(t *testing.T) {
 	message := "something else"
-	status := openapi_client.GooglerpcStatus{Message: &message}
+	status := openapi_client.GoogleRpcStatus{Message: &message}
 
 	err := formatGoogleRPCStatusError(&status)
 	require.Error(t, err)
@@ -107,7 +107,7 @@ func TestFormatGoogleRPCStatusErrorWithGRPCCodePrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			code := tt.code
-			status := openapi_client.GooglerpcStatus{
+			status := openapi_client.GoogleRpcStatus{
 				Code:    &code,
 				Message: &tt.message,
 			}
@@ -122,7 +122,7 @@ func TestFormatGoogleRPCStatusErrorWithGRPCCodePrefix(t *testing.T) {
 func TestFormatGoogleRPCStatusErrorReturnsNilForEmptyMessage(t *testing.T) {
 	message := ""
 	code := int32(3)
-	status := openapi_client.GooglerpcStatus{Message: &message, Code: &code}
+	status := openapi_client.GoogleRpcStatus{Message: &message, Code: &code}
 
 	err := formatGoogleRPCStatusError(&status)
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestFormatGoogleRPCStatusErrorReturnsNilForNilStatus(t *testing.T) {
 func TestFormatGoogleRPCStatusErrorUsageLimitTakesPrecedence(t *testing.T) {
 	message := "organization canvas limit exceeded"
 	code := int32(3)
-	status := openapi_client.GooglerpcStatus{Message: &message, Code: &code}
+	status := openapi_client.GoogleRpcStatus{Message: &message, Code: &code}
 
 	err := formatGoogleRPCStatusError(&status)
 	require.Error(t, err)

--- a/pkg/grpc/actions/serviceaccounts/common.go
+++ b/pkg/grpc/actions/serviceaccounts/common.go
@@ -1,12 +1,66 @@
 package serviceaccounts
 
 import (
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
+func collectDistinctCreatedByIDs(users []models.User) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{})
+	var ids []uuid.UUID
+	for i := range users {
+		if users[i].CreatedBy == nil {
+			continue
+		}
+		id := *users[i].CreatedBy
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func loadCreatedByUsersByID(ids []uuid.UUID) (map[uuid.UUID]models.User, error) {
+	if len(ids) == 0 {
+		return map[uuid.UUID]models.User{}, nil
+	}
+	users, err := models.FindMaybeDeletedUsersByIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[uuid.UUID]models.User, len(users))
+	for i := range users {
+		byID[users[i].ID] = users[i]
+	}
+	return byID, nil
+}
+
+func createdByUserRef(createdBy *uuid.UUID, byID map[uuid.UUID]models.User) *pb.UserRef {
+	if createdBy == nil {
+		return nil
+	}
+	u, ok := byID[*createdBy]
+	name := ""
+	if ok {
+		name = u.Name
+		if name == "" && u.DeletedAt.Valid {
+			name = "Former member"
+		}
+	}
+	if !ok {
+		name = "Unknown user"
+	}
+	return &pb.UserRef{
+		Id:   createdBy.String(),
+		Name: name,
+	}
+}
+
+func serializeServiceAccount(user *models.User, creatorsByID map[uuid.UUID]models.User) *pb.ServiceAccount {
 	sa := &pb.ServiceAccount{
 		Id:             user.ID.String(),
 		Name:           user.Name,
@@ -20,9 +74,7 @@ func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
 		sa.Description = *user.Description
 	}
 
-	if user.CreatedBy != nil {
-		sa.CreatedBy = user.CreatedBy.String()
-	}
+	sa.CreatedByUser = createdByUserRef(user.CreatedBy, creatorsByID)
 
 	return sa
 }

--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -86,8 +86,13 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Errorf(codes.Internal, "failed to create service account: %v", err)
 	}
 
+	creatorsByID, err := loadCreatedByUsersByID(collectDistinctCreatedByIDs([]models.User{*sa}))
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creator")
+	}
+
 	return &pb.CreateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(sa),
+		ServiceAccount: serializeServiceAccount(sa, creatorsByID),
 		Token:          plainToken,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/describe_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/describe_service_account.go
@@ -34,7 +34,12 @@ func DescribeServiceAccount(ctx context.Context, req *pb.DescribeServiceAccountR
 		return nil, status.Error(codes.NotFound, "service account not found")
 	}
 
+	creatorsByID, err := loadCreatedByUsersByID(collectDistinctCreatedByIDs([]models.User{*user}))
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creator")
+	}
+
 	return &pb.DescribeServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creatorsByID),
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
+++ b/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
@@ -26,9 +26,14 @@ func ListServiceAccounts(ctx context.Context) (*pb.ListServiceAccountsResponse, 
 		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
+	creatorsByID, err := loadCreatedByUsersByID(collectDistinctCreatedByIDs(users))
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creators")
+	}
+
 	serviceAccounts := make([]*pb.ServiceAccount, len(users))
 	for i := range users {
-		serviceAccounts[i] = serializeServiceAccount(&users[i])
+		serviceAccounts[i] = serializeServiceAccount(&users[i], creatorsByID)
 	}
 
 	return &pb.ListServiceAccountsResponse{

--- a/pkg/grpc/actions/serviceaccounts/update_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/update_service_account.go
@@ -50,7 +50,12 @@ func UpdateServiceAccount(ctx context.Context, req *pb.UpdateServiceAccountReque
 		return nil, status.Error(codes.Internal, "failed to update service account")
 	}
 
+	creatorsByID, err := loadCreatedByUsersByID(collectDistinctCreatedByIDs([]models.User{*user}))
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creator")
+	}
+
 	return &pb.UpdateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creatorsByID),
 	}, nil
 }

--- a/protos/service_accounts.proto
+++ b/protos/service_accounts.proto
@@ -95,15 +95,21 @@ service ServiceAccounts {
   }
 }
 
+message UserRef {
+  string id = 1;
+  string name = 2;
+}
+
 message ServiceAccount {
   string id = 1;
   string name = 2;
   string description = 3;
   string organization_id = 4;
-  string created_by = 5;
+  reserved 5;
   bool has_token = 6;
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;
+  UserRef created_by_user = 9;
 }
 
 message CreateServiceAccountRequest {

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	pw "github.com/playwright-community/playwright-go"
@@ -47,6 +48,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.givenServiceAccountExists("list-test-bot", "For listing test")
 		steps.visitServiceAccountsPage()
 		steps.assertServiceAccountVisibleInList("list-test-bot")
+		steps.assertServiceAccountCreatorInList("list-test-bot", "E2E User")
 	})
 
 	t.Run("navigating to service account detail", func(t *testing.T) {
@@ -55,6 +57,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.visitServiceAccountsPage()
 		steps.clickServiceAccountLink("detail-test-bot")
 		steps.assertOnDetailPage("detail-test-bot")
+		steps.assertCreatorOnDetailPage("E2E User")
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
@@ -211,6 +214,27 @@ func (s *serviceAccountSteps) assertServiceAccountSavedInDB(name, description, e
 
 func (s *serviceAccountSteps) assertServiceAccountVisibleInList(name string) {
 	s.session.AssertText(name)
+}
+
+func (s *serviceAccountSteps) assertServiceAccountCreatorInList(serviceAccountName, creatorName string) {
+	page := s.session.Page()
+	row := page.Locator(`tr:has([data-testid="sa-link"]:has-text("` + serviceAccountName + `"))`)
+	link := row.GetByTestId("sa-created-by-link")
+	err := link.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := link.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorName, strings.TrimSpace(text))
+}
+
+func (s *serviceAccountSteps) assertCreatorOnDetailPage(creatorName string) {
+	page := s.session.Page()
+	link := page.GetByTestId("sa-detail-created-by-link")
+	err := link.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := link.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorName, strings.TrimSpace(text))
 }
 
 func (s *serviceAccountSteps) clickServiceAccountLink(name string) {

--- a/web_src/src/lib/errors.ts
+++ b/web_src/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import type { GooglerpcStatus } from "@/api-client/types.gen";
+import type { GoogleRpcStatus } from "@/api-client/types.gen";
 
 /**
  * Extract error message from API error response
@@ -57,7 +57,7 @@ function getStatusMessage(error: unknown): string | null {
     return null;
   }
 
-  return getNonEmptyString((error as GooglerpcStatus).message);
+  return getNonEmptyString((error as GoogleRpcStatus).message);
 }
 
 function getNonEmptyString(value: unknown): string | null {

--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -372,7 +372,11 @@ export function Members({ organizationId }: MembersProps) {
               </TableHead>
               <TableBody>
                 {getSortedMembers().map((member) => (
-                  <TableRow key={member.id} className="last:[&>td]:border-b-0">
+                  <TableRow
+                    key={member.id}
+                    id={member.id ? `member-${member.id}` : undefined}
+                    className="last:[&>td]:border-b-0"
+                  >
                     <TableCell>
                       <div className="flex items-center gap-3">
                         <Avatar src={member.avatar} initials={member.initials} className="size-8" />

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -11,7 +11,8 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { Bot, Copy, ArrowLeft } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import { Link } from "@/components/Link/link";
 import {
   useServiceAccount,
   useUpdateServiceAccount,
@@ -137,14 +138,14 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
   return (
     <div className="space-y-6 pt-6">
       {/* Back button */}
-      <Link
+      <RouterLink
         to={serviceAccountsHref}
         className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 transition"
         aria-label="Back to service accounts"
       >
         <ArrowLeft size={14} />
         Back to service accounts
-      </Link>
+      </RouterLink>
 
       {/* Details */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-800 overflow-hidden">
@@ -239,6 +240,20 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
             <dl className="grid grid-cols-2 gap-y-4 text-sm">
               <dt className="text-gray-500 dark:text-gray-400">Description</dt>
               <dd className="text-gray-800 dark:text-white">{serviceAccount.description || "—"}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created by</dt>
+              <dd className="text-gray-800 dark:text-white">
+                {serviceAccount.createdByUser?.id ? (
+                  <Link
+                    href={`/${organizationId}/settings/members#member-${serviceAccount.createdByUser.id}`}
+                    className="font-semibold underline underline-offset-2"
+                    data-testid="sa-detail-created-by-link"
+                  >
+                    {serviceAccount.createdByUser.name || "—"}
+                  </Link>
+                ) : (
+                  "—"
+                )}
+              </dd>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-800 dark:text-white">{createdAt}</dd>
               <dt className="text-gray-500 dark:text-gray-400">ID</dt>

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -174,6 +174,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                 <TableRow>
                   <TableHeader>Name</TableHeader>
                   <TableHeader>Description</TableHeader>
+                  <TableHeader>Created by</TableHeader>
                   <TableHeader>Token</TableHeader>
                   <TableHeader></TableHeader>
                 </TableRow>
@@ -195,6 +196,19 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">{sa.description || "—"}</span>
+                    </TableCell>
+                    <TableCell>
+                      {sa.createdByUser?.id ? (
+                        <Link
+                          href={`/${organizationId}/settings/members#member-${sa.createdByUser.id}`}
+                          className="cursor-pointer text-sm !font-semibold text-gray-800 !underline underline-offset-2"
+                          data-testid="sa-created-by-link"
+                        >
+                          {sa.createdByUser.name || "—"}
+                        </Link>
+                      ) : (
+                        <span className="text-sm text-gray-500 dark:text-gray-400">—</span>
+                      )}
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#3471](https://github.com/superplanehq/superplane/issues/3471): show **who created** each service account with a **human-readable name** and a **link** to the member on the organization members page.

## What changed

- **API (proto):** Added `UserRef` and `created_by_user` on `ServiceAccount`. **Reserved field 5** (legacy `created_by` string) so the wire format uses the structured ref instead of a bare UUID, matching maintainer direction (“replace it with a structured”).
- **Backend:** List, describe, create, and update responses batch-resolve distinct `CreatedBy` user IDs with `FindMaybeDeletedUsersByIDs` (same pattern as canvases), avoiding N+1 on list. Missing FK rows get display name `"Unknown user"`; soft-deleted creators with an empty name use `"Former member"`.
- **UI:** **Created by** column on the service accounts table and a **Created by** row on the detail page. Creator name links to `/{orgId}/settings/members#member-{userId}`. Member table rows now expose `id="member-{id}"` so the hash scrolls to the right row.
- **E2E:** Assert creator name **E2E User** in list (per-row) and on detail.
- **Regeneration note:** After merge, run `make pb.gen`, `make openapi.spec.gen`, `make openapi.web.client.gen` (and `make openapi.client.gen` if needed) so CI-generated artifacts stay in sync. Locally, OpenAPI/web client regeneration renamed `GooglerpcStatus` → `GoogleRpcStatus`; **CLI** (`pkg/cli/core/errors*.go`) and **`web_src/src/lib/errors.ts`** were updated to match.

## Review feedback addressed

- **Automated review:** Structured ref + batch user lookup + list/detail UI + tests — all covered.
- **Human comment (shiroyasha):** Structured creator field (not UUID-only) and **creator name as a link** — done via link to members with anchor.

Closes #3471

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61152048-22ef-48b7-81ef-275ee45f22c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61152048-22ef-48b7-81ef-275ee45f22c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

