### PR TITLE
feat: show service account creator on list and detail (#3471)

### DIFF
--- a/pkg/grpc/actions/serviceaccounts/common.go
+++ b/pkg/grpc/actions/serviceaccounts/common.go
@@ -1,28 +1,60 @@
 package serviceaccounts
 
 import (
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
-	sa := &pb.ServiceAccount{
-		Id:             user.ID.String(),
-		Name:           user.Name,
-		OrganizationId: user.OrganizationID.String(),
-		HasToken:       user.TokenHash != "",
-		CreatedAt:      timestamppb.New(user.CreatedAt),
-		UpdatedAt:      timestamppb.New(user.UpdatedAt),
+func serializeServiceAccount(sa *models.User, creator *models.User) *pb.ServiceAccount {
+	out := &pb.ServiceAccount{
+		Id:             sa.ID.String(),
+		Name:           sa.Name,
+		OrganizationId: sa.OrganizationID.String(),
+		HasToken:       sa.TokenHash != "",
+		CreatedAt:      timestamppb.New(sa.CreatedAt),
+		UpdatedAt:      timestamppb.New(sa.UpdatedAt),
 	}
 
-	if user.Description != nil {
-		sa.Description = *user.Description
+	if sa.Description != nil {
+		out.Description = *sa.Description
 	}
 
-	if user.CreatedBy != nil {
-		sa.CreatedBy = user.CreatedBy.String()
+	out.CreatedByUser = creatorRefFromUser(creator)
+
+	return out
+}
+
+func creatorRefFromUser(creator *models.User) *pb.UserRef {
+	if creator == nil {
+		return nil
 	}
 
-	return sa
+	name := creator.Name
+	if creator.DeletedAt.Valid {
+		name = name + " (removed)"
+	}
+
+	return &pb.UserRef{
+		Id:   creator.ID.String(),
+		Name: name,
+	}
+}
+
+func distinctCreatedByIDs(users []models.User) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{})
+	var ids []uuid.UUID
+	for i := range users {
+		if users[i].CreatedBy == nil {
+			continue
+		}
+		id := *users[i].CreatedBy
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -86,8 +86,17 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Errorf(codes.Internal, "failed to create service account: %v", err)
 	}
 
+	creators, err := models.FindMaybeDeletedUsersByIDs([]uuid.UUID{createdByUUID})
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creator")
+	}
+	var creator *models.User
+	if len(creators) > 0 {
+		creator = &creators[0]
+	}
+
 	return &pb.CreateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(sa),
+		ServiceAccount: serializeServiceAccount(sa, creator),
 		Token:          plainToken,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/describe_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/describe_service_account.go
@@ -3,6 +3,7 @@ package serviceaccounts
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
@@ -34,7 +35,18 @@ func DescribeServiceAccount(ctx context.Context, req *pb.DescribeServiceAccountR
 		return nil, status.Error(codes.NotFound, "service account not found")
 	}
 
+	var creator *models.User
+	if user.CreatedBy != nil {
+		creators, creatorsErr := models.FindMaybeDeletedUsersByIDs([]uuid.UUID{*user.CreatedBy})
+		if creatorsErr != nil {
+			return nil, status.Error(codes.Internal, "failed to load service account creator")
+		}
+		if len(creators) > 0 {
+			creator = &creators[0]
+		}
+	}
+
 	return &pb.DescribeServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creator),
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
+++ b/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
@@ -26,9 +26,26 @@ func ListServiceAccounts(ctx context.Context) (*pb.ListServiceAccountsResponse, 
 		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
+	creatorIDs := distinctCreatedByIDs(users)
+	creators, err := models.FindMaybeDeletedUsersByIDs(creatorIDs)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load service account creators")
+	}
+
+	creatorsByID := make(map[string]models.User, len(creators))
+	for i := range creators {
+		creatorsByID[creators[i].ID.String()] = creators[i]
+	}
+
 	serviceAccounts := make([]*pb.ServiceAccount, len(users))
 	for i := range users {
-		serviceAccounts[i] = serializeServiceAccount(&users[i])
+		var creator *models.User
+		if users[i].CreatedBy != nil {
+			if u, ok := creatorsByID[users[i].CreatedBy.String()]; ok {
+				creator = &u
+			}
+		}
+		serviceAccounts[i] = serializeServiceAccount(&users[i], creator)
 	}
 
 	return &pb.ListServiceAccountsResponse{

--- a/pkg/grpc/actions/serviceaccounts/update_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/update_service_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -50,7 +51,18 @@ func UpdateServiceAccount(ctx context.Context, req *pb.UpdateServiceAccountReque
 		return nil, status.Error(codes.Internal, "failed to update service account")
 	}
 
+	var creator *models.User
+	if user.CreatedBy != nil {
+		creators, creatorsErr := models.FindMaybeDeletedUsersByIDs([]uuid.UUID{*user.CreatedBy})
+		if creatorsErr != nil {
+			return nil, status.Error(codes.Internal, "failed to load service account creator")
+		}
+		if len(creators) > 0 {
+			creator = &creators[0]
+		}
+	}
+
 	return &pb.UpdateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creator),
 	}, nil
 }

--- a/protos/service_accounts.proto
+++ b/protos/service_accounts.proto
@@ -95,15 +95,22 @@ service ServiceAccounts {
   }
 }
 
+message UserRef {
+  string id = 1;
+  string name = 2;
+}
+
 message ServiceAccount {
   string id = 1;
   string name = 2;
   string description = 3;
   string organization_id = 4;
-  string created_by = 5;
+  reserved 5;
+  reserved "created_by";
   bool has_token = 6;
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;
+  UserRef created_by_user = 9;
 }
 
 message CreateServiceAccountRequest {

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"strings"
 	"testing"
 
 	pw "github.com/playwright-community/playwright-go"
@@ -47,6 +48,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.givenServiceAccountExists("list-test-bot", "For listing test")
 		steps.visitServiceAccountsPage()
 		steps.assertServiceAccountVisibleInList("list-test-bot")
+		steps.assertCreatedByColumnShowsCreator("list-test-bot", "E2E User")
 	})
 
 	t.Run("navigating to service account detail", func(t *testing.T) {
@@ -55,6 +57,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.visitServiceAccountsPage()
 		steps.clickServiceAccountLink("detail-test-bot")
 		steps.assertOnDetailPage("detail-test-bot")
+		steps.assertCreatorOnDetailPage("E2E User")
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
@@ -211,6 +214,29 @@ func (s *serviceAccountSteps) assertServiceAccountSavedInDB(name, description, e
 
 func (s *serviceAccountSteps) assertServiceAccountVisibleInList(name string) {
 	s.session.AssertText(name)
+}
+
+func (s *serviceAccountSteps) assertCreatedByColumnShowsCreator(serviceAccountName, creatorDisplayName string) {
+	page := s.session.Page()
+	row := page.GetByRole("row").Filter(pw.LocatorFilterOptions{
+		Has: page.GetByTestId("sa-link").GetByText(serviceAccountName, pw.LocatorGetByTextOptions{Exact: pw.Bool(true)}),
+	})
+	creatorLink := row.Locator(`[data-testid^="sa-created-by-"]`)
+	err := creatorLink.First().WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := creatorLink.First().InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorDisplayName, strings.TrimSpace(text))
+}
+
+func (s *serviceAccountSteps) assertCreatorOnDetailPage(creatorDisplayName string) {
+	page := s.session.Page()
+	loc := page.GetByTestId("sa-detail-created-by")
+	err := loc.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := loc.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, creatorDisplayName, strings.TrimSpace(text))
 }
 
 func (s *serviceAccountSteps) clickServiceAccountLink(name string) {

--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { Avatar } from "../../../components/Avatar/avatar";
@@ -95,6 +95,17 @@ export function Members({ organizationId }: MembersProps) {
   const showInviteLinkSection = inviteLinkErrorMessage !== "Not found";
   const inviteLinkEnabled = inviteLink?.enabled ?? false;
   const inviteLinkBusy = updateInviteLinkMutation.isPending || resetInviteLinkMutation.isPending;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash;
+    if (!hash.startsWith("#member-")) return;
+    const id = hash.slice("#member-".length);
+    if (!id) return;
+    requestAnimationFrame(() => {
+      document.getElementById(`member-${id}`)?.scrollIntoView({ block: "center", behavior: "smooth" });
+    });
+  }, [users]);
 
   // Transform users to Member interface format
   const members = useMemo(() => {
@@ -372,7 +383,11 @@ export function Members({ organizationId }: MembersProps) {
               </TableHead>
               <TableBody>
                 {getSortedMembers().map((member) => (
-                  <TableRow key={member.id} className="last:[&>td]:border-b-0">
+                  <TableRow
+                    key={member.id}
+                    id={member.id ? `member-${member.id}` : undefined}
+                    className="last:[&>td]:border-b-0 scroll-mt-24"
+                  >
                     <TableCell>
                       <div className="flex items-center gap-3">
                         <Avatar src={member.avatar} initials={member.initials} className="size-8" />

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -11,7 +11,8 @@ import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { Bot, Copy, ArrowLeft } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import { Link } from "@/components/Link/link";
 import {
   useServiceAccount,
   useUpdateServiceAccount,
@@ -137,14 +138,14 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
   return (
     <div className="space-y-6 pt-6">
       {/* Back button */}
-      <Link
+      <RouterLink
         to={serviceAccountsHref}
         className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 transition"
         aria-label="Back to service accounts"
       >
         <ArrowLeft size={14} />
         Back to service accounts
-      </Link>
+      </RouterLink>
 
       {/* Details */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-800 overflow-hidden">
@@ -239,6 +240,20 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
             <dl className="grid grid-cols-2 gap-y-4 text-sm">
               <dt className="text-gray-500 dark:text-gray-400">Description</dt>
               <dd className="text-gray-800 dark:text-white">{serviceAccount.description || "—"}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created by</dt>
+              <dd className="text-gray-800 dark:text-white">
+                {serviceAccount.createdByUser?.id && serviceAccount.createdByUser?.name ? (
+                  <Link
+                    href={`/${organizationId}/settings/members#member-${serviceAccount.createdByUser.id}`}
+                    className="text-sky-600 hover:underline underline-offset-2"
+                    data-testid="sa-detail-created-by"
+                  >
+                    {serviceAccount.createdByUser.name}
+                  </Link>
+                ) : (
+                  "—"
+                )}
+              </dd>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-800 dark:text-white">{createdAt}</dd>
               <dt className="text-gray-500 dark:text-gray-400">ID</dt>

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -174,6 +174,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                 <TableRow>
                   <TableHeader>Name</TableHeader>
                   <TableHeader>Description</TableHeader>
+                  <TableHeader>Created by</TableHeader>
                   <TableHeader>Token</TableHeader>
                   <TableHeader></TableHeader>
                 </TableRow>
@@ -195,6 +196,19 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">{sa.description || "—"}</span>
+                    </TableCell>
+                    <TableCell>
+                      {sa.createdByUser?.id && sa.createdByUser?.name ? (
+                        <Link
+                          href={`/${organizationId}/settings/members#member-${sa.createdByUser.id}`}
+                          className="text-sm text-sky-600 hover:underline underline-offset-2"
+                          data-testid={`sa-created-by-${sa.id}`}
+                        >
+                          {sa.createdByUser.name}
+                        </Link>
+                      ) : (
+                        <span className="text-sm text-gray-500 dark:text-gray-400">—</span>
+                      )}
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#3471** — show who created each service account — using a **structured creator reference** instead of exposing only a UUID, per the automated review and maintainer feedback.

### API (`protos/service_accounts.proto`)

- Added **`UserRef`** and **`created_by_user`** on **`ServiceAccount`** (id + display name).
- **Reserved** proto **field 5** and the name **`created_by`** so the old plain UUID field is removed cleanly (per shiroyasha: replace with structured data).

### Backend

- **`serializeServiceAccount`** now fills **`created_by_user`** from the resolved creator user.
- **List**: collects distinct `created_by` IDs and loads creators in one query via **`FindMaybeDeletedUsersByIDs`** (no N+1).
- **Describe / create / update**: resolve the creator the same way.
- Soft-deleted creators still appear with **` (removed)`** appended to the name (same spirit as canvas resolution).

### UI

- Service accounts **table**: new **Created by** column; creator name is a **link** to **`/{org}/settings/members#member-{userId}`**.
- **Detail** page: **Created by** row with the same link pattern.
- **Members** page: each row has **`id="member-{userId}"`** and a small **hash scroll** so deep links land on the right row.

### Tests

- E2E: assert **E2E User** appears as creator in the list (for `list-test-bot`) and on the detail page (for `detail-test-bot`).

### Regeneration (CI / local)

Generated artifacts (`pkg/protos`, `api/swagger`, `web_src/src/api-client`) are gitignored. After merging proto changes, run:

`make pb.gen`, `make openapi.spec.gen`, `make openapi.web.client.gen` (per **AGENTS.md**) so CI environments that use Docker regenerate the same outputs.

### Review / issue alignment

- **Automated review**: structured ref + batch user lookup + UI column + E2E — **done**.
- **shiroyasha**: structured replacement for the UUID field + **creator name as a link** — **done** (links to Members with anchor).

Fixes #3471

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c9cc5bf-e118-4f97-947e-eedaa2c8a76e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c9cc5bf-e118-4f97-947e-eedaa2c8a76e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

