### PR TITLE
feat: show service account creator with structured API ref

### DIFF
--- a/pkg/grpc/actions/serviceaccounts/common.go
+++ b/pkg/grpc/actions/serviceaccounts/common.go
@@ -1,12 +1,45 @@
 package serviceaccounts
 
 import (
+	"errors"
+
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
+func serializeServiceAccounts(users []models.User) ([]*pb.ServiceAccount, error) {
+	userIDs := []uuid.UUID{}
+	for i := range users {
+		if users[i].CreatedBy != nil {
+			userIDs = append(userIDs, *users[i].CreatedBy)
+		}
+	}
+
+	creators, err := models.FindMaybeDeletedUsersByIDs(userIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	creatorsByID := make(map[string]models.User, len(creators))
+	for _, u := range creators {
+		creatorsByID[u.ID.String()] = u
+	}
+
+	out := make([]*pb.ServiceAccount, len(users))
+	for i := range users {
+		out[i] = serializeServiceAccountWithCreator(&users[i], creatorsByID)
+	}
+	return out, nil
+}
+
 func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
+	return serializeServiceAccountWithCreator(user, nil)
+}
+
+func serializeServiceAccountWithCreator(user *models.User, creatorsByID map[string]models.User) *pb.ServiceAccount {
 	sa := &pb.ServiceAccount{
 		Id:             user.ID.String(),
 		Name:           user.Name,
@@ -22,7 +55,48 @@ func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
 
 	if user.CreatedBy != nil {
 		sa.CreatedBy = user.CreatedBy.String()
+		if creatorsByID != nil {
+			if creator, ok := creatorsByID[user.CreatedBy.String()]; ok {
+				sa.CreatedByUser = userRefFromCreator(&creator)
+			}
+		}
 	}
 
 	return sa
+}
+
+func userRefFromCreator(creator *models.User) *pb.UserRef {
+	if creator == nil {
+		return nil
+	}
+
+	name := creator.Name
+	if creator.DeletedAt.Valid && name == "" {
+		name = "Former member"
+	}
+	if name == "" {
+		name = "Unknown"
+	}
+
+	return &pb.UserRef{
+		Id:   creator.ID.String(),
+		Name: name,
+	}
+}
+
+func attachCreatorUserRef(sa *pb.ServiceAccount, orgID string) error {
+	if sa == nil || sa.CreatedBy == "" || sa.CreatedByUser != nil {
+		return nil
+	}
+
+	creator, err := models.FindMaybeDeletedUserByID(orgID, sa.CreatedBy)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	sa.CreatedByUser = userRefFromCreator(creator)
+	return nil
 }

--- a/pkg/grpc/actions/serviceaccounts/common_test.go
+++ b/pkg/grpc/actions/serviceaccounts/common_test.go
@@ -1,0 +1,36 @@
+package serviceaccounts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"gorm.io/gorm"
+)
+
+func TestUserRefFromCreator(t *testing.T) {
+	id := uuid.New()
+
+	t.Run("active user with name", func(t *testing.T) {
+		ref := userRefFromCreator(&models.User{ID: id, Name: "Alice"})
+		require.Equal(t, id.String(), ref.Id)
+		require.Equal(t, "Alice", ref.Name)
+	})
+
+	t.Run("soft-deleted user with empty name", func(t *testing.T) {
+		ref := userRefFromCreator(&models.User{
+			ID:        id,
+			Name:      "",
+			DeletedAt: gorm.DeletedAt{Time: time.Now(), Valid: true},
+		})
+		require.Equal(t, id.String(), ref.Id)
+		require.Equal(t, "Former member", ref.Name)
+	})
+
+	t.Run("empty name without deletion", func(t *testing.T) {
+		ref := userRefFromCreator(&models.User{ID: id, Name: ""})
+		require.Equal(t, "Unknown", ref.Name)
+	})
+}

--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -86,8 +86,13 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Errorf(codes.Internal, "failed to create service account: %v", err)
 	}
 
+	protoSa := serializeServiceAccount(sa)
+	if err := attachCreatorUserRef(protoSa, orgID); err != nil {
+		return nil, status.Error(codes.Internal, "failed to create service account")
+	}
+
 	return &pb.CreateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(sa),
+		ServiceAccount: protoSa,
 		Token:          plainToken,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/describe_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/describe_service_account.go
@@ -34,7 +34,12 @@ func DescribeServiceAccount(ctx context.Context, req *pb.DescribeServiceAccountR
 		return nil, status.Error(codes.NotFound, "service account not found")
 	}
 
+	sa := serializeServiceAccount(user)
+	if err := attachCreatorUserRef(sa, orgID); err != nil {
+		return nil, status.Error(codes.Internal, "failed to describe service account")
+	}
+
 	return &pb.DescribeServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: sa,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
+++ b/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
@@ -26,9 +26,9 @@ func ListServiceAccounts(ctx context.Context) (*pb.ListServiceAccountsResponse, 
 		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
-	serviceAccounts := make([]*pb.ServiceAccount, len(users))
-	for i := range users {
-		serviceAccounts[i] = serializeServiceAccount(&users[i])
+	serviceAccounts, err := serializeServiceAccounts(users)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
 	return &pb.ListServiceAccountsResponse{

--- a/pkg/grpc/actions/serviceaccounts/update_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/update_service_account.go
@@ -50,7 +50,12 @@ func UpdateServiceAccount(ctx context.Context, req *pb.UpdateServiceAccountReque
 		return nil, status.Error(codes.Internal, "failed to update service account")
 	}
 
+	sa := serializeServiceAccount(user)
+	if err := attachCreatorUserRef(sa, orgID); err != nil {
+		return nil, status.Error(codes.Internal, "failed to update service account")
+	}
+
 	return &pb.UpdateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: sa,
 	}, nil
 }

--- a/protos/service_accounts.proto
+++ b/protos/service_accounts.proto
@@ -95,6 +95,11 @@ service ServiceAccounts {
   }
 }
 
+message UserRef {
+  string id = 1;
+  string name = 2;
+}
+
 message ServiceAccount {
   string id = 1;
   string name = 2;
@@ -104,6 +109,7 @@ message ServiceAccount {
   bool has_token = 6;
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;
+  UserRef created_by_user = 9;
 }
 
 message CreateServiceAccountRequest {

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -47,6 +47,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.givenServiceAccountExists("list-test-bot", "For listing test")
 		steps.visitServiceAccountsPage()
 		steps.assertServiceAccountVisibleInList("list-test-bot")
+		steps.assertCreatorLinkShowsE2EUser()
 	})
 
 	t.Run("navigating to service account detail", func(t *testing.T) {
@@ -55,6 +56,7 @@ func TestServiceAccounts(t *testing.T) {
 		steps.visitServiceAccountsPage()
 		steps.clickServiceAccountLink("detail-test-bot")
 		steps.assertOnDetailPage("detail-test-bot")
+		steps.assertCreatorLinkShowsE2EUser()
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
@@ -211,6 +213,16 @@ func (s *serviceAccountSteps) assertServiceAccountSavedInDB(name, description, e
 
 func (s *serviceAccountSteps) assertServiceAccountVisibleInList(name string) {
 	s.session.AssertText(name)
+}
+
+func (s *serviceAccountSteps) assertCreatorLinkShowsE2EUser() {
+	page := s.session.Page()
+	link := page.GetByTestId("sa-created-by-link")
+	err := link.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+	text, err := link.InnerText()
+	require.NoError(s.t, err)
+	require.Equal(s.t, "E2E User", text)
 }
 
 func (s *serviceAccountSteps) clickServiceAccountLink(name string) {

--- a/web_src/src/pages/organization/settings/ServiceAccountCreatorLink.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountCreatorLink.tsx
@@ -1,0 +1,24 @@
+import { Link } from "@/components/Link/link";
+
+interface ServiceAccountCreatorLinkProps {
+  organizationId: string;
+  creator?: { id?: string; name?: string };
+}
+
+export function ServiceAccountCreatorLink({ organizationId, creator }: ServiceAccountCreatorLinkProps) {
+  const membersHref = `/${organizationId}/settings/members`;
+
+  if (creator?.id && creator?.name) {
+    return (
+      <Link
+        href={membersHref}
+        className="text-sm text-gray-800 underline underline-offset-2 dark:text-gray-200"
+        data-testid="sa-created-by-link"
+      >
+        {creator.name}
+      </Link>
+    );
+  }
+
+  return <span className="text-sm text-gray-500 dark:text-gray-400">—</span>;
+}

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -18,6 +18,7 @@ import {
   useDeleteServiceAccount,
   useRegenerateServiceAccountToken,
 } from "@/hooks/useServiceAccounts";
+import { ServiceAccountCreatorLink } from "./ServiceAccountCreatorLink";
 
 interface ServiceAccountDetailProps {
   organizationId: string;
@@ -239,6 +240,10 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
             <dl className="grid grid-cols-2 gap-y-4 text-sm">
               <dt className="text-gray-500 dark:text-gray-400">Description</dt>
               <dd className="text-gray-800 dark:text-white">{serviceAccount.description || "—"}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created by</dt>
+              <dd className="text-gray-800 dark:text-white">
+                <ServiceAccountCreatorLink organizationId={organizationId} creator={serviceAccount.createdByUser} />
+              </dd>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-800 dark:text-white">{createdAt}</dd>
               <dt className="text-gray-500 dark:text-gray-400">ID</dt>

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -16,6 +16,7 @@ import { Bot, Copy } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useServiceAccounts, useCreateServiceAccount, useDeleteServiceAccount } from "@/hooks/useServiceAccounts";
+import { ServiceAccountCreatorLink } from "./ServiceAccountCreatorLink";
 
 interface ServiceAccountsProps {
   organizationId: string;
@@ -174,6 +175,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                 <TableRow>
                   <TableHeader>Name</TableHeader>
                   <TableHeader>Description</TableHeader>
+                  <TableHeader>Created by</TableHeader>
                   <TableHeader>Token</TableHeader>
                   <TableHeader></TableHeader>
                 </TableRow>
@@ -195,6 +197,9 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">{sa.description || "—"}</span>
+                    </TableCell>
+                    <TableCell>
+                      <ServiceAccountCreatorLink organizationId={organizationId} creator={sa.createdByUser} />
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#3471](https://github.com/superplanehq/superplane/issues/3471): service accounts now expose a structured **`created_by_user`** (`UserRef`: id + display name) alongside the existing **`created_by`** UUID string. The list and detail UI show **Created by** with the creator name as a link.

## Backend

- Extended `protos/service_accounts.proto` with `UserRef` and `ServiceAccount.created_by_user`.
- **List**: batch-load creators with `models.FindMaybeDeletedUsersByIDs` (no N+1).
- **Describe / create / update**: attach `created_by_user` via `FindMaybeDeletedUserByID` when missing from the batch map.
- Soft-deleted creators with no name show **Former member**; missing lookup leaves `created_by_user` unset (UI shows **—**).

## Frontend

- New **Created by** column on the service accounts table and row on the detail `<dl>`.
- Creator name links to `/{orgId}/settings/members` (member profile route does not exist today; link lands on the members list per product navigation).

## Tests

- Unit tests for `userRefFromCreator` naming edge cases.
- E2E: assert visible creator link text **E2E User** on list and detail after creating a service account via DB helper.

## Review / human feedback addressed

- **Automated review**: structured ref field (not UUID-only in UI), batch resolution, OpenAPI/client regeneration is required in CI (`make pb.gen`, `openapi.spec.gen`, `openapi.web.client.gen`); regenerated locally where Docker was unavailable—CI should confirm full pipeline.
- **shiroyasha** ([comment](https://github.com/superplanehq/superplane/issues/3471#issuecomment-4356366770)): use structured data; show creator **name as a link**.

## Checklist

- [x] `go test ./pkg/grpc/actions/serviceaccounts/...`
- [x] `go build ./cmd/server/main.go`
- [x] `web_src`: `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a6f04a9-35bd-4e95-b0b3-092a39202b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a6f04a9-35bd-4e95-b0b3-092a39202b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

