### PR TITLE
feat: show service account creator with member link (#3471)

### DIFF
--- a/pkg/grpc/actions/serviceaccounts/common.go
+++ b/pkg/grpc/actions/serviceaccounts/common.go
@@ -1,12 +1,13 @@
 package serviceaccounts
 
 import (
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/service_accounts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
+func serializeServiceAccount(user *models.User, creator *models.User) *pb.ServiceAccount {
 	sa := &pb.ServiceAccount{
 		Id:             user.ID.String(),
 		Name:           user.Name,
@@ -20,9 +21,47 @@ func serializeServiceAccount(user *models.User) *pb.ServiceAccount {
 		sa.Description = *user.Description
 	}
 
-	if user.CreatedBy != nil {
-		sa.CreatedBy = user.CreatedBy.String()
+	if creator != nil {
+		sa.CreatedBy = &pb.UserRef{
+			Id:   creator.ID.String(),
+			Name: creator.Name,
+		}
 	}
 
 	return sa
+}
+
+func serializeServiceAccounts(orgID string, users []models.User) ([]*pb.ServiceAccount, error) {
+	userIDs := make([]uuid.UUID, 0)
+	for i := range users {
+		if users[i].CreatedBy != nil {
+			userIDs = append(userIDs, *users[i].CreatedBy)
+		}
+	}
+
+	creators, err := models.FindMaybeDeletedUsersByIDs(userIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	creatorsByID := make(map[string]models.User, len(creators))
+	for _, c := range creators {
+		if c.OrganizationID.String() != orgID {
+			continue
+		}
+		creatorsByID[c.ID.String()] = c
+	}
+
+	out := make([]*pb.ServiceAccount, len(users))
+	for i := range users {
+		var creator *models.User
+		if users[i].CreatedBy != nil {
+			if u, ok := creatorsByID[users[i].CreatedBy.String()]; ok {
+				creator = &u
+			}
+		}
+		out[i] = serializeServiceAccount(&users[i], creator)
+	}
+
+	return out, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -86,8 +86,19 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Errorf(codes.Internal, "failed to create service account: %v", err)
 	}
 
+	var creator *models.User
+	if sa.CreatedBy != nil {
+		creator, err = models.FindMaybeDeletedUserByID(orgID, sa.CreatedBy.String())
+		if err != nil {
+			return nil, status.Error(codes.Internal, "failed to create service account")
+		}
+		if creator.OrganizationID.String() != orgID {
+			creator = nil
+		}
+	}
+
 	return &pb.CreateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(sa),
+		ServiceAccount: serializeServiceAccount(sa, creator),
 		Token:          plainToken,
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/describe_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/describe_service_account.go
@@ -34,7 +34,18 @@ func DescribeServiceAccount(ctx context.Context, req *pb.DescribeServiceAccountR
 		return nil, status.Error(codes.NotFound, "service account not found")
 	}
 
+	var creator *models.User
+	if user.CreatedBy != nil {
+		creator, err = models.FindMaybeDeletedUserByID(orgID, user.CreatedBy.String())
+		if err != nil {
+			return nil, status.Error(codes.Internal, "failed to describe service account")
+		}
+		if creator.OrganizationID.String() != orgID {
+			creator = nil
+		}
+	}
+
 	return &pb.DescribeServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creator),
 	}, nil
 }

--- a/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
+++ b/pkg/grpc/actions/serviceaccounts/list_service_accounts.go
@@ -26,9 +26,9 @@ func ListServiceAccounts(ctx context.Context) (*pb.ListServiceAccountsResponse, 
 		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
-	serviceAccounts := make([]*pb.ServiceAccount, len(users))
-	for i := range users {
-		serviceAccounts[i] = serializeServiceAccount(&users[i])
+	serviceAccounts, err := serializeServiceAccounts(orgID, users)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to list service accounts")
 	}
 
 	return &pb.ListServiceAccountsResponse{

--- a/pkg/grpc/actions/serviceaccounts/update_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/update_service_account.go
@@ -50,7 +50,18 @@ func UpdateServiceAccount(ctx context.Context, req *pb.UpdateServiceAccountReque
 		return nil, status.Error(codes.Internal, "failed to update service account")
 	}
 
+	var creator *models.User
+	if user.CreatedBy != nil {
+		creator, err = models.FindMaybeDeletedUserByID(orgID, user.CreatedBy.String())
+		if err != nil {
+			return nil, status.Error(codes.Internal, "failed to update service account")
+		}
+		if creator.OrganizationID.String() != orgID {
+			creator = nil
+		}
+	}
+
 	return &pb.UpdateServiceAccountResponse{
-		ServiceAccount: serializeServiceAccount(user),
+		ServiceAccount: serializeServiceAccount(user, creator),
 	}, nil
 }

--- a/protos/service_accounts.proto
+++ b/protos/service_accounts.proto
@@ -95,12 +95,17 @@ service ServiceAccounts {
   }
 }
 
+message UserRef {
+  string id = 1;
+  string name = 2;
+}
+
 message ServiceAccount {
   string id = 1;
   string name = 2;
   string description = 3;
   string organization_id = 4;
-  string created_by = 5;
+  UserRef created_by = 5;
   bool has_token = 6;
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -49,12 +49,22 @@ func TestServiceAccounts(t *testing.T) {
 		steps.assertServiceAccountVisibleInList("list-test-bot")
 	})
 
+	t.Run("creator link from list goes to members with anchor", func(t *testing.T) {
+		steps.start()
+		steps.givenServiceAccountExists("creator-link-bot", "Creator link test")
+		steps.visitServiceAccountsPage()
+		steps.assertCreatorLinkVisibleInList("E2E User")
+		steps.clickCreatorLinkFromList()
+		steps.assertMembersPageWithCreatorHash()
+	})
+
 	t.Run("navigating to service account detail", func(t *testing.T) {
 		steps.start()
 		steps.givenServiceAccountExists("detail-test-bot", "For detail test")
 		steps.visitServiceAccountsPage()
 		steps.clickServiceAccountLink("detail-test-bot")
 		steps.assertOnDetailPage("detail-test-bot")
+		steps.assertCreatorLinkVisibleOnDetail("E2E User")
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
@@ -211,6 +221,37 @@ func (s *serviceAccountSteps) assertServiceAccountSavedInDB(name, description, e
 
 func (s *serviceAccountSteps) assertServiceAccountVisibleInList(name string) {
 	s.session.AssertText(name)
+}
+
+func (s *serviceAccountSteps) assertCreatorLinkVisibleInList(displayName string) {
+	page := s.session.Page()
+	link := page.GetByTestId("sa-created-by-link").GetByText(displayName, pw.LocatorGetByTextOptions{Exact: pw.Bool(true)})
+	err := link.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
+}
+
+func (s *serviceAccountSteps) clickCreatorLinkFromList() {
+	page := s.session.Page()
+	err := page.GetByTestId("sa-created-by-link").First().Click()
+	require.NoError(s.t, err)
+	s.session.Sleep(1000)
+}
+
+func (s *serviceAccountSteps) assertMembersPageWithCreatorHash() {
+	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), "e2e@superplane.local")
+	require.NoError(s.t, err)
+
+	page := s.session.Page()
+	url := page.URL()
+	require.Contains(s.t, url, "/settings/members")
+	require.Contains(s.t, url, "#member-"+user.ID.String())
+}
+
+func (s *serviceAccountSteps) assertCreatorLinkVisibleOnDetail(displayName string) {
+	page := s.session.Page()
+	link := page.GetByTestId("sa-created-by-link").GetByText(displayName, pw.LocatorGetByTextOptions{Exact: pw.Bool(true)})
+	err := link.WaitFor(pw.LocatorWaitForOptions{State: pw.WaitForSelectorStateVisible, Timeout: pw.Float(5000)})
+	require.NoError(s.t, err)
 }
 
 func (s *serviceAccountSteps) clickServiceAccountLink(name string) {

--- a/web_src/src/lib/errors.ts
+++ b/web_src/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import type { GooglerpcStatus } from "@/api-client/types.gen";
+import type { GoogleRpcStatus } from "@/api-client/types.gen";
 
 /**
  * Extract error message from API error response
@@ -57,7 +57,7 @@ function getStatusMessage(error: unknown): string | null {
     return null;
   }
 
-  return getNonEmptyString((error as GooglerpcStatus).message);
+  return getNonEmptyString((error as GoogleRpcStatus).message);
 }
 
 function getNonEmptyString(value: unknown): string | null {

--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -372,7 +372,7 @@ export function Members({ organizationId }: MembersProps) {
               </TableHead>
               <TableBody>
                 {getSortedMembers().map((member) => (
-                  <TableRow key={member.id} className="last:[&>td]:border-b-0">
+                  <TableRow key={member.id} id={`member-${member.id}`} className="last:[&>td]:border-b-0 scroll-mt-24">
                     <TableCell>
                       <div className="flex items-center gap-3">
                         <Avatar src={member.avatar} initials={member.initials} className="size-8" />

--- a/web_src/src/pages/organization/settings/ServiceAccountCreatorLink.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountCreatorLink.tsx
@@ -1,0 +1,22 @@
+import { Link } from "@/components/Link/link";
+
+interface ServiceAccountCreatorLinkProps {
+  organizationId: string;
+  createdBy?: { id?: string; name?: string } | null;
+}
+
+export function ServiceAccountCreatorLink({ organizationId, createdBy }: ServiceAccountCreatorLinkProps) {
+  if (!createdBy?.id || !createdBy?.name?.trim()) {
+    return <span className="text-sm text-gray-500 dark:text-gray-400">—</span>;
+  }
+
+  return (
+    <Link
+      href={`/${organizationId}/settings/members#member-${createdBy.id}`}
+      className="cursor-pointer text-sm text-gray-800 !underline underline-offset-2 dark:text-gray-200"
+      data-testid="sa-created-by-link"
+    >
+      {createdBy.name}
+    </Link>
+  );
+}

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -18,6 +18,7 @@ import {
   useDeleteServiceAccount,
   useRegenerateServiceAccountToken,
 } from "@/hooks/useServiceAccounts";
+import { ServiceAccountCreatorLink } from "./ServiceAccountCreatorLink";
 
 interface ServiceAccountDetailProps {
   organizationId: string;
@@ -239,6 +240,10 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
             <dl className="grid grid-cols-2 gap-y-4 text-sm">
               <dt className="text-gray-500 dark:text-gray-400">Description</dt>
               <dd className="text-gray-800 dark:text-white">{serviceAccount.description || "—"}</dd>
+              <dt className="text-gray-500 dark:text-gray-400">Created by</dt>
+              <dd>
+                <ServiceAccountCreatorLink organizationId={organizationId} createdBy={serviceAccount.createdBy} />
+              </dd>
               <dt className="text-gray-500 dark:text-gray-400">Created</dt>
               <dd className="text-gray-800 dark:text-white">{createdAt}</dd>
               <dt className="text-gray-500 dark:text-gray-400">ID</dt>

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -16,6 +16,7 @@ import { Bot, Copy } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useServiceAccounts, useCreateServiceAccount, useDeleteServiceAccount } from "@/hooks/useServiceAccounts";
+import { ServiceAccountCreatorLink } from "./ServiceAccountCreatorLink";
 
 interface ServiceAccountsProps {
   organizationId: string;
@@ -174,6 +175,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                 <TableRow>
                   <TableHeader>Name</TableHeader>
                   <TableHeader>Description</TableHeader>
+                  <TableHeader>Created by</TableHeader>
                   <TableHeader>Token</TableHeader>
                   <TableHeader></TableHeader>
                 </TableRow>
@@ -195,6 +197,9 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">{sa.description || "—"}</span>
+                    </TableCell>
+                    <TableCell>
+                      <ServiceAccountCreatorLink organizationId={organizationId} createdBy={sa.createdBy} />
                     </TableCell>
                     <TableCell>
                       <span className="text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#3471](https://github.com/superplanehq/superplane/issues/3471): service accounts now expose the human creator as structured data and the UI shows **Created by** as a link.

### Backend / API

- `ServiceAccount.created_by` is now a `UserRef` (`id`, `name`) in `protos/service_accounts.proto`, replacing the bare UUID string (per issue discussion and Leonardo review).
- List responses batch-resolve creators with `FindMaybeDeletedUsersByIDs` (no N+1); describe/create/update resolve the creator with `FindMaybeDeletedUserByID` and only populate `created_by` when the creator is in the same organization.

### UI

- Service accounts **list**: new **Created by** column.
- **Detail**: **Created by** row in the metadata block.
- Creator name links to `/{orgId}/settings/members#member-{userId}`; member table rows got stable `id`/`scroll-mt` so the hash highlights the right row.

### Tests / tooling

- E2E: creator link visible on list and detail; clicking from list lands on members with the expected hash.
- Regenerated OpenAPI + web client locally for verification; updated `web_src/src/lib/errors.ts` to use `GoogleRpcStatus` from the regenerated `@hey-api/openapi-ts` output.

## Review alignment

- **Leonardo review**: structured creator ref, batch lookup on list, `FindMaybeDeletedUsersByIDs`, UI columns — addressed.
- **Human feedback (shiroyasha)**: replace UUID with structured field — done; creator **name as a link** — done (links to Members with anchor).

## CI note

Generated artifacts (`pkg/protos`, `api/swagger`, `web_src/src/api-client`) are gitignored; CI should run `make pb.gen`, `make openapi.spec.gen`, and `make openapi.web.client.gen` (or equivalent) so generated code matches this proto change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fa5f387-d8a8-4f4d-b9c0-a49e14ed05bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fa5f387-d8a8-4f4d-b9c0-a49e14ed05bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

