### PR TITLE
fix: expand append connector handle hitbox

### DIFF
--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@xyflow/react", () => ({
@@ -7,17 +8,22 @@ vi.mock("@xyflow/react", () => ({
     id,
     className,
     style,
+    children,
   }: {
     type: string;
     id?: string;
     className?: string;
     style?: { pointerEvents?: string };
+    children?: React.ReactNode;
   }) => (
     <div
       data-testid={`handle-${type}-${id || "default"}`}
-      data-highlighted={className === "highlighted" ? "true" : "false"}
+      data-highlighted={className?.includes("highlighted") ? "true" : "false"}
       data-pointer-events={style?.pointerEvents || "auto"}
-    />
+      data-class-name={className}
+    >
+      {children}
+    </div>
   ),
   Position: {
     Left: "left",

--- a/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/appendHandle.tsx
@@ -1,8 +1,12 @@
+import { Handle, Position } from "@xyflow/react";
 import { Plus } from "lucide-react";
 import type React from "react";
+import { HANDLE_STYLE } from "./handleStyle";
 import type { BlockProps } from "./types";
 
 export const APPEND_CONNECTOR_COLOR = "#C9D5E1";
+const APPEND_SOURCE_LINE_WIDTH = 42;
+const APPEND_SOURCE_BUTTON_LEFT = 54;
 
 const APPEND_HANDLE_STYLE: React.CSSProperties = {
   width: 24,
@@ -27,6 +31,76 @@ const APPEND_PREVIEW_DOT_STYLE: React.CSSProperties = {
 };
 
 export type AppendFromNodeHandler = NonNullable<BlockProps["onAppendFromNode"]>;
+
+function getAppendSourceHandleClassName(isHighlighted: boolean | undefined) {
+  return isHighlighted ? "sp-append-source-hitbox highlighted" : "sp-append-source-hitbox";
+}
+
+export function AppendSourceHandle({
+  channel,
+  label,
+  isHighlighted,
+  onAppend,
+  style,
+  lineWidth = APPEND_SOURCE_LINE_WIDTH,
+  buttonLeft = APPEND_SOURCE_BUTTON_LEFT,
+  buttonTop = -7,
+}: {
+  channel: string;
+  label: string;
+  isHighlighted: boolean | undefined;
+  onAppend: () => void | Promise<void>;
+  style: React.CSSProperties;
+  lineWidth?: number;
+  buttonLeft?: number;
+  buttonTop?: number;
+}) {
+  const handleStyle: React.CSSProperties & { "--sp-append-source-hitbox-width": string } = {
+    ...HANDLE_STYLE,
+    "--sp-append-source-hitbox-width": `${buttonLeft + 24}px`,
+    pointerEvents: "auto",
+    ...style,
+  };
+
+  return (
+    <Handle
+      type="source"
+      position={Position.Right}
+      id={channel}
+      className={getAppendSourceHandleClassName(isHighlighted)}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void onAppend();
+      }}
+      style={handleStyle}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: 12,
+          top: "50%",
+          width: lineWidth,
+          height: 3,
+          transform: "translateY(-50%)",
+          backgroundColor: APPEND_CONNECTOR_COLOR,
+          pointerEvents: "none",
+        }}
+      />
+      <AppendHandleButton
+        label={label}
+        onClick={onAppend}
+        style={{
+          left: buttonLeft,
+          top: buttonTop,
+          position: "absolute",
+          pointerEvents: "none",
+        }}
+      />
+    </Handle>
+  );
+}
 
 export function AppendHandleButton({
   label,

--- a/web_src/src/ui/CanvasPage/Block/handles.tsx
+++ b/web_src/src/ui/CanvasPage/Block/handles.tsx
@@ -1,10 +1,5 @@
 import { Handle, Position } from "@xyflow/react";
-import {
-  APPEND_CONNECTOR_COLOR,
-  AppendHandleButton,
-  AppendHandlePreview,
-  type AppendFromNodeHandler,
-} from "./appendHandle";
+import { AppendHandlePreview, AppendSourceHandle, type AppendFromNodeHandler } from "./appendHandle";
 import { isAlreadyConnectedToNode } from "./connectionState";
 import { getOutputChannels } from "./data";
 import { HANDLE_STYLE } from "./handleStyle";
@@ -169,37 +164,15 @@ function EndNodeAppendConnector({
 
   return (
     <>
-      <Handle
-        type="source"
-        position={Position.Right}
-        id={channel}
+      <AppendSourceHandle
+        channel={channel}
+        label="Add next component"
+        onAppend={() => onAppendFromNode(nodeId, channel)}
+        isHighlighted={isHighlighted}
         style={{
-          ...HANDLE_STYLE,
           right: -21,
           top: 13,
-          pointerEvents: "auto",
           transform: "none",
-        }}
-        className={isHighlighted ? "highlighted" : undefined}
-      />
-      <div
-        style={{
-          position: "absolute",
-          right: -63,
-          top: 17,
-          width: 42,
-          height: 3,
-          backgroundColor: APPEND_CONNECTOR_COLOR,
-          pointerEvents: "none",
-        }}
-      />
-      <AppendHandleButton
-        label="Add next component"
-        onClick={() => onAppendFromNode(nodeId, channel)}
-        style={{
-          right: -87,
-          top: 6,
-          position: "absolute",
         }}
       />
       <AppendHandlePreview

--- a/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
+++ b/web_src/src/ui/CanvasPage/Block/multiRightHandle.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Handle, Position } from "@xyflow/react";
 import {
   APPEND_CONNECTOR_COLOR,
-  AppendHandleButton,
   AppendHandlePreview,
+  AppendSourceHandle,
   type AppendFromNodeHandler,
 } from "./appendHandle";
 import { isAlreadyConnectedToNode } from "./connectionState";
@@ -183,42 +183,20 @@ function MultiRightChannelControl({
         {channel}
       </span>
 
-      <Handle
-        type="source"
-        position={Position.Right}
-        id={channel}
-        style={{
-          ...HANDLE_STYLE,
-          left: layout.handleLeftX,
-          top: `calc(50% + ${offsetY}px)`,
-          transform: "translateY(-50%)",
-          pointerEvents: isConnectionInteractive ? "auto" : "none",
-        }}
-        className={isHighlighted ? "highlighted" : undefined}
-      />
-
       {canAppend ? (
         <>
-          <div
-            style={{
-              position: "absolute",
-              left: layout.handleLeftX + 12,
-              top: `calc(50% + ${offsetY}px)`,
-              transform: "translateY(-50%)",
-              width: 24,
-              height: 3,
-              backgroundColor: APPEND_CONNECTOR_COLOR,
-              pointerEvents: "none",
-            }}
-          />
-          <AppendHandleButton
+          <AppendSourceHandle
+            channel={channel}
             label={`Add next component (${channel})`}
-            onClick={onAppend}
+            onAppend={onAppend}
+            isHighlighted={isHighlighted}
+            lineWidth={24}
+            buttonLeft={32}
+            buttonTop={-6}
             style={{
-              left: layout.handleLeftX + 32,
+              left: layout.handleLeftX,
               top: `calc(50% + ${offsetY}px)`,
               transform: "translateY(-50%)",
-              position: "absolute",
             }}
           />
           <AppendHandlePreview
@@ -231,7 +209,21 @@ function MultiRightChannelControl({
             containerOffsetY={54}
           />
         </>
-      ) : null}
+      ) : (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={channel}
+          style={{
+            ...HANDLE_STYLE,
+            left: layout.handleLeftX,
+            top: `calc(50% + ${offsetY}px)`,
+            transform: "translateY(-50%)",
+            pointerEvents: isConnectionInteractive ? "auto" : "none",
+          }}
+          className={isHighlighted ? "highlighted" : undefined}
+        />
+      )}
     </React.Fragment>
   );
 }

--- a/web_src/src/ui/CanvasPage/canvas-reset.css
+++ b/web_src/src/ui/CanvasPage/canvas-reset.css
@@ -90,6 +90,13 @@
   pointer-events: auto;
 }
 
+.sp-canvas .react-flow__handle.sp-append-source-hitbox::before {
+  left: 0;
+  width: var(--sp-append-source-hitbox-width, 78px);
+  height: 30px;
+  transform: translateY(-50%);
+}
+
 .sp-canvas.sp-canvas-live .react-flow__handle::before {
   pointer-events: none;
 }
@@ -117,6 +124,10 @@
 }
 
 .sp-canvas .sp-append-source-handle:hover + .sp-append-source-preview {
+  opacity: 1;
+}
+
+.sp-canvas .react-flow__handle.sp-append-source-hitbox:hover + .sp-append-source-preview {
   opacity: 1;
 }
 


### PR DESCRIPTION
This updates canvas append handles so the visible connector affordance behaves like the actual connection handle.

The append connector line and plus button are now rendered inside the React Flow source handle, making the whole visible append control part of the connection hitbox. Dragging from the append line or plus icon now starts a connection, and dragging an input handle onto those visible append controls can complete the connection more intuitively.

This applies to both single-output end nodes and multi-output channel append handles.

**Changes**
- Added a reusable `AppendSourceHandle` wrapper for append connector handles.
- Moved append line and plus button visuals inside the React Flow source handle.
- Extended the append source handle pseudo-hitbox to cover the visible line/button area.
- Kept existing click-to-append behavior.
- Updated the Block test mock to render React Flow handle children and support combined class names.
