### PR TITLE
fix(workflow): show full failed execution messages in console lists

### DIFF
--- a/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
+++ b/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
@@ -10,6 +10,7 @@ import { cn, resolveIcon } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIcons";
 import type { SidebarEvent } from "@/ui/componentSidebar/types";
 import { findNode, getStatusBadgeProps, resolveNodeIconSlug } from "@/pages/workflowv2/lib/canvas-runs";
+import { WORKFLOW_CONSOLE_FAILED_MESSAGE_CLASSNAME } from "@/pages/workflowv2/constants";
 import { buildTriggerSidebarEvent } from "./utils";
 
 function NodeIcon({
@@ -94,7 +95,7 @@ function ErrorItemRow({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-4 py-1.5 min-h-8",
+        "flex items-start gap-2 px-4 py-1.5 min-h-8",
         isClickable && "cursor-pointer hover:bg-gray-50 transition-colors",
       )}
       role={isClickable ? "button" : undefined}
@@ -107,10 +108,10 @@ function ErrorItemRow({
         }
       }}
     >
-      <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center">
+      <div className="flex-shrink-0 w-4 h-4 flex items-center justify-center pt-0.5">
         <NodeIcon node={item.node} componentIconMap={componentIconMap} />
       </div>
-      <div className="flex flex-1 items-center gap-2 min-w-0">
+      <div className="flex flex-1 items-start gap-2 min-w-0">
         <span className="text-xs text-gray-700 truncate">{nodeName}</span>
         <div
           className={`uppercase text-[10px] py-[1.5px] px-[5px] font-semibold rounded flex items-center tracking-wide justify-center text-white ${badgeColor}`}
@@ -118,13 +119,15 @@ function ErrorItemRow({
           <span>{label}</span>
         </div>
         {item.execution.resultMessage && (
-          <span className="text-xs text-red-600 truncate max-w-[300px]">{item.execution.resultMessage}</span>
+          <span className={WORKFLOW_CONSOLE_FAILED_MESSAGE_CLASSNAME} title={item.execution.resultMessage}>
+            {item.execution.resultMessage}
+          </span>
         )}
       </div>
       {onAcknowledgeErrors && item.execution.id && (
         <AcknowledgeButton executionId={item.execution.id} onAcknowledgeErrors={onAcknowledgeErrors} />
       )}
-      <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap">
+      <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap pt-0.5">
         {item.execution.createdAt ? <TimeAgo date={item.execution.createdAt} /> : ""}
       </span>
     </div>

--- a/web_src/src/pages/workflowv2/components/RunsConsoleContent/ExecutionRow.tsx
+++ b/web_src/src/pages/workflowv2/components/RunsConsoleContent/ExecutionRow.tsx
@@ -1,7 +1,6 @@
 import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/api-client";
 import { TimeAgo } from "@/components/TimeAgo";
-import { cn } from "@/lib/utils";
-import { handleKeyboardActivation } from "@/lib/utils";
+import { cn, handleKeyboardActivation } from "@/lib/utils";
 import { RUNS_CONSOLE_BADGE_COL } from "./constants";
 import { StatusBadge } from "./StatusBadge";
 import { NodeIcon } from "./NodeIcon";
@@ -10,6 +9,7 @@ import {
   resolveExecutionDisplayStatus,
   resolveNodeIconSlug,
 } from "@/pages/workflowv2/lib/canvas-runs";
+import { WORKFLOW_CONSOLE_FAILED_MESSAGE_CLASSNAME } from "@/pages/workflowv2/constants";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIcons";
 
 export function ExecutionRow({
@@ -35,7 +35,7 @@ export function ExecutionRow({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-4 py-1.5 pl-11 border-t border-gray-200 min-h-8",
+        "flex items-start gap-2 px-4 py-1.5 pl-11 border-t border-gray-200 min-h-8",
         onSelect && "cursor-pointer hover:bg-gray-100 transition-colors",
       )}
       role={onSelect ? "button" : undefined}
@@ -43,19 +43,23 @@ export function ExecutionRow({
       onClick={onSelect}
       onKeyDown={onSelect ? (e) => handleKeyboardActivation(e, onSelect) : undefined}
     >
-      <div className="flex-shrink-0 w-3.5 h-3.5 flex items-center justify-center">
+      <div className="flex-shrink-0 w-3.5 h-3.5 flex items-center justify-center pt-0.5">
         <NodeIcon iconSrc={iconSrc} iconSlug={iconSlug} alt={nodeName} size={13} className="text-gray-400" />
       </div>
-      <div className="flex flex-1 items-center gap-2 min-w-0">
+      <div className="flex flex-1 items-start gap-2 min-w-0 pt-0.5">
         <div className={RUNS_CONSOLE_BADGE_COL}>
           <StatusBadge status={status} />
         </div>
         <span className="text-xs text-gray-700 truncate">{nodeName}</span>
         {duration && <span className="text-xs text-gray-500 tabular-nums">{duration}</span>}
       </div>
-      {errorMessage && <span className="text-xs text-red-600 truncate max-w-[300px]">{errorMessage}</span>}
+      {errorMessage && (
+        <span className={WORKFLOW_CONSOLE_FAILED_MESSAGE_CLASSNAME} title={errorMessage}>
+          {errorMessage}
+        </span>
+      )}
       {execution.createdAt && (
-        <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap">
+        <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap pt-0.5">
           <TimeAgo date={execution.createdAt} />
         </span>
       )}

--- a/web_src/src/pages/workflowv2/constants.ts
+++ b/web_src/src/pages/workflowv2/constants.ts
@@ -1,0 +1,3 @@
+/** Failed execution `resultMessage` in Runs / Errors console rows: full text, word-wrapped, scrolls when very long. */
+export const WORKFLOW_CONSOLE_FAILED_MESSAGE_CLASSNAME =
+  "text-xs text-red-600 whitespace-normal break-words max-w-[300px] max-h-24 overflow-y-auto min-w-0";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes truncated `resultMessage` text in the workflow **Runs** and **Errors** console rows (including SSH failures shown in the issue screenshot). Messages now wrap, use a bounded height with vertical scroll for very long output, and include a native `title` for quick full-text access on hover.

## Issue

Closes https://github.com/superplanehq/superplane/issues/3337

## Review feedback (automated issue review)

The review identified `truncate max-w-[300px]` on failed execution messages in:

- `web_src/src/pages/workflowv2/components/RunsConsoleContent/ExecutionRow.tsx`
- `web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx`

**Addressed:** Both locations now use a shared class constant (`web_src/src/pages/workflowv2/constants.ts`) with `whitespace-normal`, `break-words`, `max-w-[300px]`, `max-h-24`, and `overflow-y-auto`, plus `title={...}`. Rows use `items-start` and light top padding so icons and timestamps align when the error block grows.

**Human comments:** None on the issue after the bot review; no additional overrides.

## Optional follow-up from review

ChainItem detail-row truncation for stdout/stderr was noted as optional; this PR does not change that scope.

## Testing

- `npx prettier --write` on the touched files
- `make check.build.ui` / `make test` were not runnable in this environment (`docker` unavailable). CI should run the full UI build and Go tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-129f829f-331f-4b1c-8b84-eb7eacbbd310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-129f829f-331f-4b1c-8b84-eb7eacbbd310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

