### PR TITLE
feat(canvas-memory): make URL values clickable in the memory table

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+import { Fragment } from "react";
 import { Trash2 } from "lucide-react";
 
 export type CanvasMemoryModalProps = {
@@ -108,8 +109,24 @@ function ZeroState() {
   );
 }
 
-function formatValue(value: unknown): string {
+function isUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://");
+}
+
+function formatValue(value: unknown): string | React.ReactElement {
   if (typeof value === "string") {
+    if (isUrl(value)) {
+      return (
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:text-blue-800 underline"
+        >
+          {value}
+        </a>
+      );
+    }
     return value;
   }
 
@@ -162,11 +179,14 @@ function renderNamespaceTable(
               const item = objectValues[index];
               return (
                 <tr key={entry.id || index} className="border-b border-slate-950/15">
-                  {columns.map((column) => (
-                    <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
-                      {formatValue(item[column])}
-                    </td>
-                  ))}
+                  {columns.map((column) => {
+                    const formatted = formatValue(item[column]);
+                    return (
+                      <td key={`${index}-${column}`} className="px-3 py-2 align-middle font-mono text-xs text-gray-700">
+                        {typeof formatted === "string" ? formatted : <Fragment key={column}>{formatted}</Fragment>}
+                      </td>
+                    );
+                  })}
                   <td className="px-3 py-2 text-right align-middle">
                     <Button
                       type="button"


### PR DESCRIPTION
## Summary

Auto-detects values starting with `http://` or `https://` in the Canvas Memory table and renders them as clickable hyperlinks instead of plain text.

## What this does

For dashboards storing `url` (preview link) and `pr_url` (GitHub PR link) in canvas memory, the preview URL and PR link are now directly clickable — turning the memory modal into a usable dashboard.

## Changes

- `web_src/src/pages/workflowv2/CanvasMemoryModal.tsx`:
  - Added `isUrl()` helper to detect `http://`/`https://` prefixed strings
  - Modified `formatValue()` to return an `<a>` element for URL strings, plain text otherwise
  - Updated table cell rendering to handle both string and React element returns

## No breaking changes

- No schema changes
- No storage changes
- Non-URL values render identically to before
- URLs open in a new tab with `rel="noopener noreferrer"`

Fixes superplanehq/superplane#4361.