### PR TITLE
fix(errors-console): show full error message text in the list

### DIFF
--- a/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
+++ b/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
@@ -118,7 +118,7 @@ function ErrorItemRow({
           <span>{label}</span>
         </div>
         {item.execution.resultMessage && (
-          <span className="text-xs text-red-600 truncate max-w-[300px]">{item.execution.resultMessage}</span>
+          <span className="text-xs text-red-600 break-words">{item.execution.resultMessage}</span>
         )}
       </div>
       {onAcknowledgeErrors && item.execution.id && (


### PR DESCRIPTION
## Summary

Fixes error messages in the errors console being truncated to 300px, hiding the full error text needed for debugging.

## What this does

In `web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx`, the error message span in the errors list row was using `truncate max-w-[300px]`. Long error messages (e.g. API error responses with URLs, status codes, validation errors) were cut off mid-word.

Changed to `break-words` — the error message now wraps to full available width while preserving the complete text.

## Changes

- `web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx` — removed `truncate max-w-[300px]`, replaced with `break-words`

Fixes superplanehq/superplane#4163.