### PR TITLE
feat: Secrets() and Properties() in IntegrationContext

### DIFF
--- a/pkg/core/integration.go
+++ b/pkg/core/integration.go
@@ -191,6 +191,13 @@ type IntegrationCleanupContext struct {
 type IntegrationContext interface {
 
 	//
+	// Whether the integration is using the legacy setup flow.
+	//
+	LegacySetup() bool
+	Properties() IntegrationPropertyStorage
+	Secrets() IntegrationSecretStorage
+
+	//
 	// Control the metadata and config of the integration
 	//
 	ID() uuid.UUID

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -135,11 +135,6 @@ func setupIntegration(registry *registry.Registry, setupProvider core.Integratio
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, newIntegration)
-		if err != nil {
-			return err
-		}
-
 		newIntegration.Capabilities = initialCapabilities
 		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), newIntegration.Capabilities)
 		firstStep := setupProvider.FirstStep(core.SetupStepContext{
@@ -148,7 +143,7 @@ func setupIntegration(registry *registry.Registry, setupProvider core.Integratio
 			HTTP:           registry.HTTPContext(),
 			Properties:     contexts.NewIntegrationPropertyStorage(newIntegration),
 			Capabilities:   capabilityCtx,
-			Secrets:        secretStorage,
+			Secrets:        contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, newIntegration),
 		})
 
 		setupState := datatypes.NewJSONType(models.SetupState{

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -83,8 +83,7 @@ func CreateIntegrationWithUsage(
 	})
 
 	//
-	// If the integration implementation supports the new flow,
-	// and the user has requested to use it, we use the new flow.
+	// If the integration implementation supports the new flow, use it.
 	//
 	if registry.SupportsNewSetupFlow(integrationName) {
 		newIntegration, err := models.CreateIntegration(integrationID, org, integrationName, name, nil)

--- a/pkg/grpc/actions/organizations/next_integration_setup_step.go
+++ b/pkg/grpc/actions/organizations/next_integration_setup_step.go
@@ -95,11 +95,6 @@ func submitStep(registry *registry.Registry, integration *models.Integration, ba
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration)
-		if err != nil {
-			return err
-		}
-
 		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities)
 		nextStep, err := setupProvider.OnStepSubmit(core.SetupStepContext{
 			Step:            setupState.CurrentStep.Name,
@@ -110,7 +105,7 @@ func submitStep(registry *registry.Registry, integration *models.Integration, ba
 			OrganizationID:  integration.OrganizationID.String(),
 			HTTP:            registry.HTTPContext(),
 			Properties:      contexts.NewIntegrationPropertyStorage(integration),
-			Secrets:         secretStorage,
+			Secrets:         contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration),
 			Capabilities:    capabilityCtx,
 		})
 

--- a/pkg/grpc/actions/organizations/previous_integration_setup_step.go
+++ b/pkg/grpc/actions/organizations/previous_integration_setup_step.go
@@ -66,13 +66,7 @@ func PreviousIntegrationSetupStep(ctx context.Context, registry *registry.Regist
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration)
-		if err != nil {
-			return err
-		}
-
 		stepToRevert := setupState.PreviousSteps[len(setupState.PreviousSteps)-1]
-
 		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities)
 		ctx := core.SetupStepContext{
 			Step:           stepToRevert.Name,
@@ -80,7 +74,7 @@ func PreviousIntegrationSetupStep(ctx context.Context, registry *registry.Regist
 			OrganizationID: orgID,
 			HTTP:           registry.HTTPContext(),
 			Properties:     contexts.NewIntegrationPropertyStorage(integration),
-			Secrets:        secretStorage,
+			Secrets:        contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration),
 			Capabilities:   capabilityCtx,
 		}
 

--- a/pkg/grpc/actions/organizations/update_integration.go
+++ b/pkg/grpc/actions/organizations/update_integration.go
@@ -48,6 +48,10 @@ func UpdateIntegration(
 		return nil, status.Errorf(codes.NotFound, "integration not found: %v", err)
 	}
 
+	if !isLegacySetup(instance) {
+		return nil, status.Errorf(codes.InvalidArgument, "integration %s is not a legacy setup", instance.ID.String())
+	}
+
 	if name != "" && name != instance.InstallationName {
 		existing, err := models.FindIntegrationByName(org, name)
 		if err == nil && existing.ID != instance.ID {

--- a/pkg/grpc/actions/organizations/update_integration_capabilities.go
+++ b/pkg/grpc/actions/organizations/update_integration_capabilities.go
@@ -214,18 +214,13 @@ func handleRequestingCapabilties(tx *gorm.DB, registry *registry.Registry, integ
 		return fmt.Errorf("failed to get setup provider: %v", err)
 	}
 
-	secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration)
-	if err != nil {
-		return err
-	}
-
 	capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities)
 	nextStep, err := setupProvider.OnCapabilityUpdate(core.CapabilityUpdateContext{
 		Logger:       logging.ForIntegration(*integration),
 		Changes:      map[core.IntegrationCapabilityState][]string{core.IntegrationCapabilityStateRequested: capabilities},
 		HTTP:         registry.HTTPContext(),
 		Properties:   contexts.NewIntegrationPropertyStorage(integration),
-		Secrets:      secretStorage,
+		Secrets:      contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration),
 		Capabilities: capabilityCtx,
 	})
 

--- a/pkg/grpc/actions/organizations/update_integration_property.go
+++ b/pkg/grpc/actions/organizations/update_integration_property.go
@@ -56,17 +56,12 @@ func UpdateIntegrationProperty(
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration)
-		if err != nil {
-			return err
-		}
-
 		setupStep, err := setupProvider.OnPropertyUpdate(core.PropertyUpdateContext{
 			PropertyName: propertyName,
 			Value:        value,
 			Logger:       logrus.WithField("integration_id", integration.ID),
 			HTTP:         registry.HTTPContext(),
-			Secrets:      secretStorage,
+			Secrets:      contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration),
 			Properties:   contexts.NewIntegrationPropertyStorage(integration),
 			Capabilities: contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities),
 		})

--- a/pkg/grpc/actions/organizations/update_integration_secret.go
+++ b/pkg/grpc/actions/organizations/update_integration_secret.go
@@ -56,17 +56,12 @@ func UpdateIntegrationSecret(
 	}
 
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		secretStorage, err := contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration)
-		if err != nil {
-			return err
-		}
-
 		setupStep, err := setupProvider.OnSecretUpdate(core.SecretUpdateContext{
 			SecretName:   secretName,
 			Value:        value,
 			Logger:       logrus.WithField("integration_id", integration.ID),
 			HTTP:         registry.HTTPContext(),
-			Secrets:      secretStorage,
+			Secrets:      contexts.NewIntegrationSecretStorage(tx, registry.Encryptor, integration),
 			Properties:   contexts.NewIntegrationPropertyStorage(integration),
 			Capabilities: contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities),
 		})

--- a/pkg/integrations/aws/aws_test.go
+++ b/pkg/integrations/aws/aws_test.go
@@ -74,7 +74,6 @@ func Test__AWS__Sync(t *testing.T) {
 				"region":                 "us-east-1",
 				"sessionDurationSeconds": 3600,
 			},
-			Secrets:       map[string]core.IntegrationSecret{},
 			BrowserAction: &core.BrowserAction{},
 		}
 
@@ -91,12 +90,15 @@ func Test__AWS__Sync(t *testing.T) {
 		assert.Equal(t, "ready", integrationCtx.State)
 		assert.Nil(t, integrationCtx.BrowserAction)
 
-		require.Contains(t, integrationCtx.Secrets, "accessKeyId")
-		require.Contains(t, integrationCtx.Secrets, "secretAccessKey")
-		require.Contains(t, integrationCtx.Secrets, "sessionToken")
-		assert.Equal(t, []byte("AKIA_TEST"), integrationCtx.Secrets["accessKeyId"].Value)
-		assert.Equal(t, []byte("secret"), integrationCtx.Secrets["secretAccessKey"].Value)
-		assert.Equal(t, []byte("token"), integrationCtx.Secrets["sessionToken"].Value)
+		secret, err := integrationCtx.Secrets().Get("accessKeyId")
+		require.NoError(t, err)
+		assert.Equal(t, "AKIA_TEST", secret)
+		secret, err = integrationCtx.Secrets().Get("secretAccessKey")
+		require.NoError(t, err)
+		assert.Equal(t, "secret", secret)
+		secret, err = integrationCtx.Secrets().Get("sessionToken")
+		require.NoError(t, err)
+		assert.Equal(t, "token", secret)
 
 		metadata, ok := integrationCtx.Metadata.(common.IntegrationMetadata)
 		require.True(t, ok)
@@ -142,7 +144,7 @@ func Test__AWS__Sync(t *testing.T) {
 				"region":                 "us-east-1",
 				"sessionDurationSeconds": 3600,
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("AKIA_TEST")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token1")},
@@ -194,12 +196,15 @@ func Test__AWS__Sync(t *testing.T) {
 		//
 		// Session token is refreshed.
 		//
-		require.Contains(t, integrationCtx.Secrets, "accessKeyId")
-		require.Contains(t, integrationCtx.Secrets, "secretAccessKey")
-		require.Contains(t, integrationCtx.Secrets, "sessionToken")
-		assert.Equal(t, []byte("AKIA_TEST"), integrationCtx.Secrets["accessKeyId"].Value)
-		assert.Equal(t, []byte("secret"), integrationCtx.Secrets["secretAccessKey"].Value)
-		assert.Equal(t, []byte("token2"), integrationCtx.Secrets["sessionToken"].Value)
+		secret, err := integrationCtx.Secrets().Get("accessKeyId")
+		require.NoError(t, err)
+		assert.Equal(t, "AKIA_TEST", secret)
+		secret, err = integrationCtx.Secrets().Get("secretAccessKey")
+		require.NoError(t, err)
+		assert.Equal(t, "secret", secret)
+		secret, err = integrationCtx.Secrets().Get("sessionToken")
+		require.NoError(t, err)
+		assert.Equal(t, "token2", secret)
 
 		metadata, ok := integrationCtx.Metadata.(common.IntegrationMetadata)
 		require.True(t, ok)
@@ -226,10 +231,8 @@ func Test__AWS__ListResources(t *testing.T) {
 
 	t.Run("lambda.function without credentials returns error", func(t *testing.T) {
 		_, err := a.ListResources("lambda.function", core.ListResourcesContext{
-			Logger: logrus.NewEntry(logrus.New()),
-			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{},
-			},
+			Logger:      logrus.NewEntry(logrus.New()),
+			Integration: &contexts.IntegrationContext{},
 		})
 
 		require.ErrorContains(t, err, "AWS session credentials are missing")
@@ -237,7 +240,7 @@ func Test__AWS__ListResources(t *testing.T) {
 
 	t.Run("lambda.function without region returns error", func(t *testing.T) {
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -272,7 +275,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -317,7 +320,7 @@ func Test__AWS__ListResources(t *testing.T) {
 
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -358,7 +361,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -399,7 +402,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -443,7 +446,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -471,7 +474,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		_, err := a.ListResources("ec2.image", core.ListResourcesContext{
 			Integration: &contexts.IntegrationContext{
 				Metadata: common.IntegrationMetadata{},
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -512,7 +515,7 @@ func Test__AWS__ListResources(t *testing.T) {
 					AccountID: "123456789012",
 				},
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -562,7 +565,7 @@ func Test__AWS__ListResources(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/copy_package_versions_test.go
+++ b/pkg/integrations/aws/codeartifact/copy_package_versions_test.go
@@ -80,7 +80,7 @@ func TestCopyPackageVersions_Execute(t *testing.T) {
 				"format": "npm", "package": "pkg", "versions": "1.0.0",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credentials")
@@ -109,7 +109,7 @@ func TestCopyPackageVersions_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/create_repository_test.go
+++ b/pkg/integrations/aws/codeartifact/create_repository_test.go
@@ -84,7 +84,7 @@ func TestCreateRepository_Execute(t *testing.T) {
 				"region": "us-east-1", "domain": "my-domain", "repository": "my-repo",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credentials")
@@ -110,7 +110,7 @@ func TestCreateRepository_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/delete_package_versions_test.go
+++ b/pkg/integrations/aws/codeartifact/delete_package_versions_test.go
@@ -58,7 +58,7 @@ func TestDeletePackageVersions_Execute(t *testing.T) {
 				"versions": "1.0.0",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credentials")
@@ -85,7 +85,7 @@ func TestDeletePackageVersions_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/delete_repository_test.go
+++ b/pkg/integrations/aws/codeartifact/delete_repository_test.go
@@ -91,9 +91,7 @@ func TestDeleteRepository_Execute(t *testing.T) {
 				"repository": "my-repo",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{},
-			},
+			Integration:    &contexts.IntegrationContext{},
 		})
 
 		require.Error(t, err)
@@ -130,7 +128,7 @@ func TestDeleteRepository_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/dispose_package_versions_test.go
+++ b/pkg/integrations/aws/codeartifact/dispose_package_versions_test.go
@@ -58,7 +58,7 @@ func TestDisposePackageVersions_Execute(t *testing.T) {
 				"versions": "1.0.0",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credentials")
@@ -85,7 +85,7 @@ func TestDisposePackageVersions_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codeartifact/update_package_versions_status_test.go
+++ b/pkg/integrations/aws/codeartifact/update_package_versions_status_test.go
@@ -89,7 +89,7 @@ func TestUpdatePackageVersionsStatus_Execute(t *testing.T) {
 				"versions": "1.0.0", "targetStatus": "Archived",
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "credentials")
@@ -118,7 +118,7 @@ func TestUpdatePackageVersionsStatus_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codepipeline/get_pipeline_execution_test.go
+++ b/pkg/integrations/aws/codepipeline/get_pipeline_execution_test.go
@@ -83,7 +83,7 @@ func Test__GetPipelineExecution__Execute(t *testing.T) {
 				"pipeline":  "my-pipeline",
 				"execution": "a1b2c3d4-5678-90ab-cdef-111122223333",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 		require.ErrorContains(t, err, "AWS session credentials are missing")
@@ -129,7 +129,7 @@ func Test__GetPipelineExecution__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codepipeline/get_pipeline_test.go
+++ b/pkg/integrations/aws/codepipeline/get_pipeline_test.go
@@ -69,7 +69,7 @@ func Test__GetPipeline__Execute(t *testing.T) {
 				"region":   "us-east-1",
 				"pipeline": "my-pipeline",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 		require.ErrorContains(t, err, "AWS session credentials are missing")
@@ -119,7 +119,7 @@ func Test__GetPipeline__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/codepipeline/retry_stage_execution_test.go
+++ b/pkg/integrations/aws/codepipeline/retry_stage_execution_test.go
@@ -117,7 +117,7 @@ func Test__RetryStageExecution__Execute(t *testing.T) {
 				"pipelineExecution": "old-exec-123",
 				"retryMode":         "FAILED_ACTIONS",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 		require.ErrorContains(t, err, "AWS session credentials are missing")
@@ -144,7 +144,7 @@ func Test__RetryStageExecution__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 		})
 
@@ -174,7 +174,7 @@ func Test__RetryStageExecution__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 		})
 

--- a/pkg/integrations/aws/codepipeline/run_pipeline_test.go
+++ b/pkg/integrations/aws/codepipeline/run_pipeline_test.go
@@ -92,7 +92,7 @@ func Test__RunPipeline__Setup(t *testing.T) {
 			Metadata: &contexts.MetadataContext{Metadata: map[string]any{}},
 			HTTP:     httpCtx,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 		})
 
@@ -115,8 +115,8 @@ func Test__RunPipeline__Setup(t *testing.T) {
 
 		metadataCtx := &contexts.MetadataContext{Metadata: map[string]any{}}
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets:  validSecrets(),
-			Metadata: map[string]any{},
+			CurrentSecrets: validSecrets(),
+			Metadata:       map[string]any{},
 		}
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
@@ -165,7 +165,7 @@ func Test__RunPipeline__Execute(t *testing.T) {
 					},
 				},
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -192,8 +192,8 @@ func Test__RunPipeline__Execute(t *testing.T) {
 		}
 		requestCtx := &contexts.RequestContext{}
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets:  validSecrets(),
-			Metadata: map[string]any{},
+			CurrentSecrets: validSecrets(),
+			Metadata:       map[string]any{},
 		}
 
 		err := component.Execute(core.ExecutionContext{
@@ -477,7 +477,7 @@ func Test__RunPipeline__Poll(t *testing.T) {
 			},
 			HTTP: httpCtx,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			Requests:       requestCtx,
@@ -519,7 +519,7 @@ func Test__RunPipeline__Poll(t *testing.T) {
 			},
 			HTTP: httpCtx,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 			ExecutionState: execState,
 			Requests:       &contexts.RequestContext{},
@@ -575,7 +575,7 @@ func Test__RunPipeline__Poll(t *testing.T) {
 			},
 			HTTP: httpCtx,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 			ExecutionState: execState,
 			Requests:       &contexts.RequestContext{},
@@ -893,7 +893,7 @@ func Test__RunPipeline__ListPipelines(t *testing.T) {
 	t.Run("missing credentials -> error", func(t *testing.T) {
 		_, err := ListPipelines(core.ListResourcesContext{
 			Parameters:  map[string]string{"region": "us-east-1"},
-			Integration: &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration: &contexts.IntegrationContext{},
 		}, "codepipeline.pipeline")
 
 		require.ErrorContains(t, err, "AWS session credentials are missing")
@@ -918,7 +918,7 @@ func Test__RunPipeline__ListPipelines(t *testing.T) {
 			Parameters: map[string]string{"region": "us-east-1"},
 			HTTP:       httpCtx,
 			Integration: &contexts.IntegrationContext{
-				Secrets: validSecrets(),
+				CurrentSecrets: validSecrets(),
 			},
 		}, "codepipeline.pipeline")
 

--- a/pkg/integrations/aws/ec2/copy_image_test.go
+++ b/pkg/integrations/aws/ec2/copy_image_test.go
@@ -238,7 +238,7 @@ func Test__CopyImage__OnIntegrationMessage(t *testing.T) {
 		err := component.OnIntegrationMessage(core.IntegrationMessageContext{
 			Logger: log.NewEntry(log.New()),
 			Integration: &contexts.IntegrationContext{
-				Secrets: testIntegrationWithCredentials().Secrets,
+				CurrentSecrets: testIntegrationWithCredentials().CurrentSecrets,
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{

--- a/pkg/integrations/aws/ec2/create_image_test.go
+++ b/pkg/integrations/aws/ec2/create_image_test.go
@@ -138,7 +138,7 @@ func Test__CreateImage__Execute(t *testing.T) {
 			Metadata:       metadata,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -228,7 +228,7 @@ func Test__CreateImage__OnIntegrationMessage(t *testing.T) {
 		err := component.OnIntegrationMessage(core.IntegrationMessageContext{
 			Logger: log.NewEntry(log.New()),
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ec2/get_image_test.go
+++ b/pkg/integrations/aws/ec2/get_image_test.go
@@ -61,7 +61,7 @@ func Test__GetImage__Execute(t *testing.T) {
 				"region":  "us-east-1",
 				"imageId": "ami-123",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -129,7 +129,7 @@ func Test__GetImage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -205,7 +205,7 @@ func Test__GetImage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ec2/image_operation_helpers_test.go
+++ b/pkg/integrations/aws/ec2/image_operation_helpers_test.go
@@ -12,7 +12,7 @@ import (
 
 func testIntegrationWithCredentials() *contexts.IntegrationContext {
 	return &contexts.IntegrationContext{
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 			"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 			"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecr/get_image_scan_findings_test.go
+++ b/pkg/integrations/aws/ecr/get_image_scan_findings_test.go
@@ -89,7 +89,7 @@ func Test__GetImageScanFindings__Execute(t *testing.T) {
 				"repository": "backend",
 				"imageTag":   "latest",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -121,7 +121,7 @@ func Test__GetImageScanFindings__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecr/get_image_test.go
+++ b/pkg/integrations/aws/ecr/get_image_test.go
@@ -89,7 +89,7 @@ func Test__GetImage__Execute(t *testing.T) {
 				"repository": "backend",
 				"imageTag":   "latest",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -127,7 +127,7 @@ func Test__GetImage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecr/on_image_push_test.go
+++ b/pkg/integrations/aws/ecr/on_image_push_test.go
@@ -45,7 +45,7 @@ func Test__OnImagePush__Setup(t *testing.T) {
 					Rules: map[string]common.EventBridgeRuleMetadata{},
 				},
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -108,7 +108,7 @@ func Test__OnImagePush__Setup(t *testing.T) {
 					},
 				},
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecr/on_image_scan_test.go
+++ b/pkg/integrations/aws/ecr/on_image_scan_test.go
@@ -45,7 +45,7 @@ func Test__OnImageScan__Setup(t *testing.T) {
 					Rules: map[string]common.EventBridgeRuleMetadata{},
 				},
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -104,7 +104,7 @@ func Test__OnImageScan__Setup(t *testing.T) {
 					},
 				},
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecr/scan_image_test.go
+++ b/pkg/integrations/aws/ecr/scan_image_test.go
@@ -81,7 +81,7 @@ func Test__ScanImage__Execute(t *testing.T) {
 				"repository": "backend",
 				"imageTag":   "latest",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -117,7 +117,7 @@ func Test__ScanImage__Execute(t *testing.T) {
 			Requests:       requests,
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -171,7 +171,7 @@ func Test__ScanImage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -230,7 +230,7 @@ func Test__ScanImage__HandleHook(t *testing.T) {
 				},
 			},
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -271,7 +271,7 @@ func Test__ScanImage__HandleHook(t *testing.T) {
 				},
 			},
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecs/describe_service_test.go
+++ b/pkg/integrations/aws/ecs/describe_service_test.go
@@ -89,7 +89,7 @@ func Test__DescribeService__Execute(t *testing.T) {
 				"cluster": "demo",
 				"service": "web",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -139,7 +139,7 @@ func Test__DescribeService__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecs/run_task_test.go
+++ b/pkg/integrations/aws/ecs/run_task_test.go
@@ -746,14 +746,14 @@ func Test__RunTask__OnIntegrationMessage(t *testing.T) {
 
 func setupIntegrationContext(eventBridge *common.EventBridgeMetadata) *contexts.IntegrationContext {
 	return &contexts.IntegrationContext{
-		Metadata: common.IntegrationMetadata{EventBridge: eventBridge},
-		Secrets:  map[string]core.IntegrationSecret{},
+		Metadata:       common.IntegrationMetadata{EventBridge: eventBridge},
+		CurrentSecrets: map[string]core.IntegrationSecret{},
 	}
 }
 
 func validIntegrationContext() *contexts.IntegrationContext {
 	return &contexts.IntegrationContext{
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 			"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 			"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/ecs/stop_task_test.go
+++ b/pkg/integrations/aws/ecs/stop_task_test.go
@@ -145,7 +145,7 @@ func Test__StopTask__Execute(t *testing.T) {
 				"cluster": "demo",
 				"task":    "arn:aws:ecs:us-east-1:123456789012:task/demo/abc",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -352,14 +352,14 @@ func Test__StopTask__OnIntegrationMessage(t *testing.T) {
 
 func setupStopTaskIntegrationContext(eventBridge *common.EventBridgeMetadata) *contexts.IntegrationContext {
 	return &contexts.IntegrationContext{
-		Metadata: common.IntegrationMetadata{EventBridge: eventBridge},
-		Secrets:  map[string]core.IntegrationSecret{},
+		Metadata:       common.IntegrationMetadata{EventBridge: eventBridge},
+		CurrentSecrets: map[string]core.IntegrationSecret{},
 	}
 }
 
 func validStopTaskIntegrationContext() *contexts.IntegrationContext {
 	return &contexts.IntegrationContext{
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 			"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 			"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/lambda/run_function_test.go
+++ b/pkg/integrations/aws/lambda/run_function_test.go
@@ -83,7 +83,6 @@ func Test__RunFunction__Execute(t *testing.T) {
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			Integration: &contexts.IntegrationContext{
 				Configuration: map[string]any{"region": "us-east-1"},
-				Secrets:       map[string]core.IntegrationSecret{},
 			},
 		})
 
@@ -109,7 +108,7 @@ func Test__RunFunction__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
 				Configuration: map[string]any{"region": " "},
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -155,7 +154,7 @@ func Test__RunFunction__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
 				Configuration: map[string]any{"region": "us-east-1"},
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -196,7 +195,7 @@ func Test__RunFunction__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
 				Configuration: map[string]any{"region": "us-east-1"},
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/route53/create_record_test.go
+++ b/pkg/integrations/aws/route53/create_record_test.go
@@ -125,9 +125,7 @@ func TestCreateRecord_Execute(t *testing.T) {
 				"values":       []string{"1.2.3.4"},
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{},
-			},
+			Integration:    &contexts.IntegrationContext{},
 		})
 
 		require.Error(t, err)
@@ -169,7 +167,7 @@ func TestCreateRecord_Execute(t *testing.T) {
 			Metadata:       metadata,
 			Requests:       requests,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -222,7 +220,7 @@ func TestCreateRecord_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -273,7 +271,7 @@ func TestCreateRecord_Execute(t *testing.T) {
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -315,7 +313,7 @@ func TestCreateRecord_Execute(t *testing.T) {
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -372,7 +370,7 @@ func TestCreateRecord_HandleHook(t *testing.T) {
 				},
 			},
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -415,7 +413,7 @@ func TestCreateRecord_HandleHook(t *testing.T) {
 				},
 			},
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/route53/delete_record_test.go
+++ b/pkg/integrations/aws/route53/delete_record_test.go
@@ -95,9 +95,7 @@ func TestDeleteRecord_Execute(t *testing.T) {
 				"values":       []string{"1.2.3.4"},
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{},
-			},
+			Integration:    &contexts.IntegrationContext{},
 		})
 
 		require.Error(t, err)
@@ -139,7 +137,7 @@ func TestDeleteRecord_Execute(t *testing.T) {
 			Metadata:       metadata,
 			Requests:       requests,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -189,7 +187,7 @@ func TestDeleteRecord_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -240,7 +238,7 @@ func TestDeleteRecord_Execute(t *testing.T) {
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/route53/upsert_record_test.go
+++ b/pkg/integrations/aws/route53/upsert_record_test.go
@@ -95,9 +95,7 @@ func TestUpsertRecord_Execute(t *testing.T) {
 				"values":       []string{"1.2.3.4"},
 			},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
-			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{},
-			},
+			Integration:    &contexts.IntegrationContext{},
 		})
 
 		require.Error(t, err)
@@ -139,7 +137,7 @@ func TestUpsertRecord_Execute(t *testing.T) {
 			Metadata:       metadata,
 			Requests:       requests,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -189,7 +187,7 @@ func TestUpsertRecord_Execute(t *testing.T) {
 			ExecutionState: execState,
 			HTTP:           httpContext,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/create_topic_test.go
+++ b/pkg/integrations/aws/sns/create_topic_test.go
@@ -68,7 +68,7 @@ func Test__CreateTopic__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/delete_topic_test.go
+++ b/pkg/integrations/aws/sns/delete_topic_test.go
@@ -49,7 +49,7 @@ func Test__DeleteTopic__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/get_subscription_test.go
+++ b/pkg/integrations/aws/sns/get_subscription_test.go
@@ -77,7 +77,7 @@ func Test__GetSubscription__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/get_topic_test.go
+++ b/pkg/integrations/aws/sns/get_topic_test.go
@@ -106,7 +106,7 @@ func Test__GetTopic__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/on_topic_message_test.go
+++ b/pkg/integrations/aws/sns/on_topic_message_test.go
@@ -48,7 +48,7 @@ func Test__OnTopicMessage__Setup(t *testing.T) {
 
 		metadataContext := &contexts.MetadataContext{}
 		integration := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -93,7 +93,7 @@ func Test__OnTopicMessage__Setup(t *testing.T) {
 		}
 
 		integration := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 				"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 				"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sns/publish_message_test.go
+++ b/pkg/integrations/aws/sns/publish_message_test.go
@@ -118,7 +118,7 @@ func Test__PublishMessage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
@@ -161,7 +161,7 @@ func Test__PublishMessage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: executionState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sqs/create_queue_test.go
+++ b/pkg/integrations/aws/sqs/create_queue_test.go
@@ -75,7 +75,7 @@ func Test__CreateQueue__Execute(t *testing.T) {
 				"region":    "us-east-1",
 				"queueName": "my-queue",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -107,7 +107,7 @@ func Test__CreateQueue__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sqs/delete_queue_test.go
+++ b/pkg/integrations/aws/sqs/delete_queue_test.go
@@ -75,7 +75,7 @@ func Test__DeleteQueue__Execute(t *testing.T) {
 				"region": "us-east-1",
 				"queue":  "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -101,7 +101,7 @@ func Test__DeleteQueue__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sqs/get_queue_test.go
+++ b/pkg/integrations/aws/sqs/get_queue_test.go
@@ -75,7 +75,7 @@ func Test__GetQueue__Execute(t *testing.T) {
 				"region": "us-east-1",
 				"queue":  "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -114,7 +114,7 @@ func Test__GetQueue__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sqs/purge_queue_test.go
+++ b/pkg/integrations/aws/sqs/purge_queue_test.go
@@ -75,7 +75,7 @@ func Test__PurgeQueue__Execute(t *testing.T) {
 				"region": "us-east-1",
 				"queue":  "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -101,7 +101,7 @@ func Test__PurgeQueue__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/aws/sqs/send_message_test.go
+++ b/pkg/integrations/aws/sqs/send_message_test.go
@@ -97,7 +97,7 @@ func Test__SendMessage__Execute(t *testing.T) {
 				"format": SendMessageFormatText,
 				"text":   "hello world",
 			},
-			Integration:    &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}},
+			Integration:    &contexts.IntegrationContext{},
 			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
 		})
 
@@ -133,7 +133,7 @@ func Test__SendMessage__Execute(t *testing.T) {
 			HTTP:           httpContext,
 			ExecutionState: execState,
 			Integration: &contexts.IntegrationContext{
-				Secrets: map[string]core.IntegrationSecret{
+				CurrentSecrets: map[string]core.IntegrationSecret{
 					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
 					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
 					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},

--- a/pkg/integrations/dockerhub/client_test.go
+++ b/pkg/integrations/dockerhub/client_test.go
@@ -23,7 +23,7 @@ func Test__DockerHub__NewClient(t *testing.T) {
 
 	t.Run("valid configuration -> client created", func(t *testing.T) {
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				accessTokenSecretName: {Name: accessTokenSecretName, Value: []byte("token")},
 			},
 		}
@@ -52,7 +52,7 @@ func Test__DockerHub__ListRepositories(t *testing.T) {
 	}
 
 	integrationCtx := &contexts.IntegrationContext{
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			accessTokenSecretName: {Name: accessTokenSecretName, Value: []byte("token")},
 		},
 	}

--- a/pkg/integrations/dockerhub/get_image_tag_test.go
+++ b/pkg/integrations/dockerhub/get_image_tag_test.go
@@ -75,7 +75,7 @@ func Test__GetImageTag__Execute(t *testing.T) {
 
 	err := component.Execute(core.ExecutionContext{
 		Integration: &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				accessTokenSecretName: {Name: accessTokenSecretName, Value: []byte("token")},
 			},
 		},

--- a/pkg/integrations/dockerhub/on_image_push_test.go
+++ b/pkg/integrations/dockerhub/on_image_push_test.go
@@ -39,7 +39,7 @@ func Test__OnImagePush__Setup(t *testing.T) {
 
 		metadata := &contexts.MetadataContext{}
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				accessTokenSecretName: {Name: accessTokenSecretName, Value: []byte("token")},
 			},
 		}

--- a/pkg/integrations/gcp/cloudbuild_setup_test.go
+++ b/pkg/integrations/gcp/cloudbuild_setup_test.go
@@ -67,7 +67,7 @@ func TestHandleEnsureCloudBuildCreatesTopicAndSubscription(t *testing.T) {
 			ProjectID:  "demo-project",
 			AuthMethod: gcpcommon.AuthMethodWIF,
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			gcpcommon.SecretNameAccessToken: {
 				Name:  gcpcommon.SecretNameAccessToken,
 				Value: []byte("test-access-token"),
@@ -90,13 +90,13 @@ func TestHandleEnsureCloudBuildCreatesTopicAndSubscription(t *testing.T) {
 	require.NoError(t, mapstructure.Decode(integrationCtx.GetMetadata(), &metadata))
 	assert.Equal(t, expectedSubscriptionID, metadata.CloudBuildSubscription)
 
-	secret, ok := integrationCtx.Secrets[CloudBuildSecretName]
-	require.True(t, ok)
-	assert.NotEmpty(t, secret.Value)
+	secret, err := integrationCtx.Secrets().Get(CloudBuildSecretName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, secret)
 	assert.Equal(t, "projects/demo-project/topics/cloud-builds", subscriptionRequestBody.Topic)
 	assert.Equal(
 		t,
-		"https://superplane.example/api/v1/integrations/"+integrationID+"/cloud-build-events?token="+string(secret.Value),
+		"https://superplane.example/api/v1/integrations/"+integrationID+"/cloud-build-events?token="+secret,
 		subscriptionRequestBody.PushConfig.PushEndpoint,
 	)
 }

--- a/pkg/integrations/gcp/common/credentials_test.go
+++ b/pkg/integrations/gcp/common/credentials_test.go
@@ -31,7 +31,7 @@ func Test_AuthMethodFromMetadata(t *testing.T) {
 
 func Test_TokenSourceFromIntegration(t *testing.T) {
 	t.Run("no credentials returns error", func(t *testing.T) {
-		ctx := &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}}
+		ctx := &contexts.IntegrationContext{}
 		_, err := TokenSourceFromIntegration(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no GCP credentials found")
@@ -39,7 +39,7 @@ func Test_TokenSourceFromIntegration(t *testing.T) {
 
 	t.Run("WIF with access token returns token source", func(t *testing.T) {
 		ctx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				SecretNameAccessToken: {Name: SecretNameAccessToken, Value: []byte("wif-access-token")},
 			},
 			Metadata: map[string]any{"authMethod": AuthMethodWIF},
@@ -56,7 +56,7 @@ func Test_TokenSourceFromIntegration(t *testing.T) {
 	t.Run("WIF with expired token in metadata returns error", func(t *testing.T) {
 		expired := time.Now().Add(-time.Hour).Format(time.RFC3339)
 		ctx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				SecretNameAccessToken: {Name: SecretNameAccessToken, Value: []byte("tok")},
 			},
 			Metadata: map[string]any{
@@ -71,7 +71,7 @@ func Test_TokenSourceFromIntegration(t *testing.T) {
 
 	t.Run("service account key with invalid JSON returns error", func(t *testing.T) {
 		ctx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				SecretNameServiceAccountKey: {Name: SecretNameServiceAccountKey, Value: []byte(`{invalid`)},
 			},
 			Metadata: map[string]any{"authMethod": AuthMethodServiceAccountKey},
@@ -85,7 +85,7 @@ func Test_TokenSourceFromIntegration(t *testing.T) {
 func Test_CredentialsFromIntegration(t *testing.T) {
 	t.Run("delegates to TokenSource and returns credentials", func(t *testing.T) {
 		ctx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				SecretNameAccessToken: {Name: SecretNameAccessToken, Value: []byte("tok")},
 			},
 			Metadata: map[string]any{"authMethod": AuthMethodWIF},
@@ -97,7 +97,7 @@ func Test_CredentialsFromIntegration(t *testing.T) {
 	})
 
 	t.Run("error from TokenSource is propagated", func(t *testing.T) {
-		ctx := &contexts.IntegrationContext{Secrets: map[string]core.IntegrationSecret{}}
+		ctx := &contexts.IntegrationContext{}
 		_, err := CredentialsFromIntegration(ctx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no GCP credentials found")

--- a/pkg/integrations/gitlab/client_test.go
+++ b/pkg/integrations/gitlab/client_test.go
@@ -42,7 +42,7 @@ func Test__Client__NewClient(t *testing.T) {
 				"authType": AuthTypeAppOAuth,
 				"groupId":  "group-456",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				OAuthAccessToken: {Name: OAuthAccessToken, Value: []byte("oauth-token-123")},
 			},
 		}

--- a/pkg/integrations/gitlab/gitlab_test.go
+++ b/pkg/integrations/gitlab/gitlab_test.go
@@ -161,7 +161,7 @@ func Test__GitLab__Sync(t *testing.T) {
 				"clientId":     "id",
 				"clientSecret": "secret",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				OAuthAccessToken:  {Name: OAuthAccessToken, Value: []byte("access-token")},
 				OAuthRefreshToken: {Name: OAuthRefreshToken, Value: []byte("refresh-token")},
 			},
@@ -204,7 +204,7 @@ func Test__GitLab__Sync(t *testing.T) {
 				"clientId":     "id",
 				"clientSecret": "secret",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				OAuthAccessToken: {Name: OAuthAccessToken, Value: []byte("existing-access-token")},
 			},
 		}
@@ -274,7 +274,7 @@ func Test__GitLab__HandleRequest(t *testing.T) {
 				"baseUrl":      "https://gitlab.com",
 				"authType":     AuthTypeAppOAuth,
 			},
-			Secrets: make(map[string]core.IntegrationSecret),
+			CurrentSecrets: make(map[string]core.IntegrationSecret),
 		}
 
 		recorder := httptest.NewRecorder()
@@ -342,7 +342,7 @@ func Test__GitLab__HandleRequest(t *testing.T) {
 					"clientSecret": "secret",
 					"baseUrl":      "https://gitlab.com",
 				},
-				Secrets: make(map[string]core.IntegrationSecret),
+				CurrentSecrets: make(map[string]core.IntegrationSecret),
 			}
 
 			mockHTTP := &contexts.HTTPContext{

--- a/pkg/integrations/honeycomb/create_event_test.go
+++ b/pkg/integrations/honeycomb/create_event_test.go
@@ -74,7 +74,6 @@ func Test__CreateEvent__Execute(t *testing.T) {
 				"managementKey": "keyid:secret",
 				"site":          "api.honeycomb.io",
 			},
-			Secrets: map[string]core.IntegrationSecret{},
 		}
 
 		err := component.Execute(core.ExecutionContext{
@@ -104,7 +103,7 @@ func Test__CreateEvent__Execute(t *testing.T) {
 				"managementKey": "keyid:secret",
 				"site":          "api.honeycomb.io",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				secretNameIngestKey: {Name: secretNameIngestKey, Value: []byte("test-ingest-key")},
 			},
 		}
@@ -136,7 +135,7 @@ func Test__CreateEvent__Execute(t *testing.T) {
 				"managementKey": "keyid:secret",
 				"site":          "api.honeycomb.io",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				secretNameIngestKey: {Name: secretNameIngestKey, Value: []byte("test-ingest-key")},
 			},
 		}
@@ -188,7 +187,7 @@ func Test__CreateEvent__Execute(t *testing.T) {
 				"managementKey": "keyid:secret",
 				"site":          "api.honeycomb.io",
 			},
-			Secrets: map[string]core.IntegrationSecret{
+			CurrentSecrets: map[string]core.IntegrationSecret{
 				secretNameIngestKey: {Name: secretNameIngestKey, Value: []byte("test-ingest-key")},
 			},
 		}

--- a/pkg/integrations/honeycomb/honeycomb_test.go
+++ b/pkg/integrations/honeycomb/honeycomb_test.go
@@ -143,7 +143,6 @@ func Test__Honeycomb__Sync(t *testing.T) {
 				"teamSlug":        "myteam",
 				"environmentSlug": "production",
 			},
-			Secrets: map[string]core.IntegrationSecret{},
 		}
 
 		environmentsBody := `{
@@ -216,12 +215,12 @@ func Test__Honeycomb__Sync(t *testing.T) {
 
 		assert.Len(t, httpCtx.Requests, 7)
 
-		cfgSecret, ok := integrationCtx.Secrets[secretNameConfigurationKey]
-		require.True(t, ok)
-		assert.Equal(t, []byte("cfg-secret-value"), cfgSecret.Value)
+		configurationKey, err := integrationCtx.Secrets().Get(secretNameConfigurationKey)
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-secret-value", configurationKey)
 
-		ingestSecret, ok := integrationCtx.Secrets[secretNameIngestKey]
-		require.True(t, ok)
-		assert.Equal(t, []byte("ingestkey-idingest-secret-value"), ingestSecret.Value)
+		ingestKey, err := integrationCtx.Secrets().Get(secretNameIngestKey)
+		require.NoError(t, err)
+		assert.Equal(t, "ingestkey-idingest-secret-value", ingestKey)
 	})
 }

--- a/pkg/integrations/logfire/logfire_test.go
+++ b/pkg/integrations/logfire/logfire_test.go
@@ -47,7 +47,6 @@ func Test__Logfire__Sync__Success(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_key_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	err := integration.Sync(core.SyncContext{
@@ -63,9 +62,6 @@ func Test__Logfire__Sync__Success(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "acme-org", metadata.ExternalOrganizationID)
 	assert.True(t, metadata.SupportsQueryAPI)
-
-	assert.Empty(t, integrationCtx.Secrets)
-
 	require.Len(t, httpCtx.Requests, 1)
 }
 
@@ -84,7 +80,6 @@ func Test__Logfire__Sync__Fail_InvalidAPIKey(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_key_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	err := integration.Sync(core.SyncContext{
@@ -116,7 +111,6 @@ func Test__Logfire__Sync__PreservesWebhookSetupFromMetadata(t *testing.T) {
 		Metadata: map[string]any{
 			"supportsWebhookSetup": true,
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	err := integration.Sync(core.SyncContext{
@@ -155,7 +149,6 @@ func Test__Logfire__ListResources__Projects(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_key_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	resources, err := integration.ListResources("project", core.ListResourcesContext{
@@ -183,7 +176,6 @@ func Test__Logfire__ListResources__Alerts__MissingProjectId_ReturnsEmptyNoError(
 		Configuration: map[string]any{
 			"apiKey": "lf_api_key_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	resources, err := integration.ListResources("alert", core.ListResourcesContext{
@@ -205,7 +197,6 @@ func Test__Logfire__ListResources__Alerts__WithProjectId_Undefined_ReturnsEmptyN
 		Configuration: map[string]any{
 			"apiKey": "lf_api_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	resources, err := integration.ListResources("alert", core.ListResourcesContext{
@@ -230,7 +221,6 @@ func Test__Logfire__ListResources__Alerts__WithProjectId_Null_ReturnsEmptyNoErro
 		Configuration: map[string]any{
 			"apiKey": "lf_api_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	resources, err := integration.ListResources("alert", core.ListResourcesContext{
@@ -265,7 +255,6 @@ func Test__Logfire__ListResources__Alerts__WithProjectId(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_key_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	resources, err := integration.ListResources("alert", core.ListResourcesContext{

--- a/pkg/integrations/logfire/query_logfire_test.go
+++ b/pkg/integrations/logfire/query_logfire_test.go
@@ -92,7 +92,6 @@ func TestQueryLogfire_Setup_ValidatesProjectSelection(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	metadataCtx := &contexts.MetadataContext{}
@@ -120,9 +119,9 @@ func TestQueryLogfire_Setup_ValidatesProjectSelection(t *testing.T) {
 	assert.Equal(t, "Project 123", meta.Project.Name)
 
 	// Verify per-project secret was stored.
-	secret, ok := integrationCtx.Secrets[readTokenSecretNameForProject("proj_123")]
-	require.True(t, ok)
-	assert.Equal(t, "read_token_new", string(secret.Value))
+	secret, err := integrationCtx.Secrets().Get(readTokenSecretNameForProject("proj_123"))
+	require.NoError(t, err)
+	assert.Equal(t, "read_token_new", secret)
 }
 
 func TestQueryLogfire_Setup_InvalidProject_ReturnsError(t *testing.T) {
@@ -142,7 +141,6 @@ func TestQueryLogfire_Setup_InvalidProject_ReturnsError(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	err := component.Setup(core.SetupContext{
@@ -184,7 +182,7 @@ func TestQueryLogfire_Setup_ReusesExistingToken(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			readTokenSecretNameForProject("proj_123"): {
 				Name:  readTokenSecretNameForProject("proj_123"),
 				Value: []byte("existing_read_token"),
@@ -243,7 +241,7 @@ func TestQueryLogfire_Setup_MigratesLegacyToken(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			readTokenSecretName: {
 				Name:  readTokenSecretName,
 				Value: []byte("legacy_read_token"),
@@ -269,9 +267,9 @@ func TestQueryLogfire_Setup_MigratesLegacyToken(t *testing.T) {
 	require.Len(t, httpCtx.Requests, 2)
 
 	// Verify per-project secret was stored (migration from legacy).
-	secret, ok := integrationCtx.Secrets[readTokenSecretNameForProject("proj_123")]
-	require.True(t, ok)
-	assert.Equal(t, "legacy_read_token", string(secret.Value))
+	secret, err := integrationCtx.Secrets().Get(readTokenSecretNameForProject("proj_123"))
+	require.NoError(t, err)
+	assert.Equal(t, "legacy_read_token", secret)
 
 	// Verify metadata was set.
 	var meta QueryLogfireNodeMetadata
@@ -300,7 +298,7 @@ func TestQueryLogfire_Execute_Success(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			readTokenSecretNameForProject("proj_123"): {
 				Name:  readTokenSecretNameForProject("proj_123"),
 				Value: []byte("read_token_123"),
@@ -349,7 +347,7 @@ func TestQueryLogfire_Execute_FallsBackToLegacyToken(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			readTokenSecretName: {
 				Name:  readTokenSecretName,
 				Value: []byte("legacy_read_token"),
@@ -393,7 +391,6 @@ func TestQueryLogfire_Execute_NoTokenAvailable(t *testing.T) {
 		Configuration: map[string]any{
 			"apiKey": "lf_api_us_123",
 		},
-		Secrets: map[string]core.IntegrationSecret{},
 	}
 
 	err := component.Execute(core.ExecutionContext{

--- a/pkg/integrations/pagerduty/pagerduty_test.go
+++ b/pkg/integrations/pagerduty/pagerduty_test.go
@@ -159,7 +159,6 @@ func Test__Pagerduty__Sync(t *testing.T) {
 				"subdomain": "example",
 				"authType":  AuthTypeAppOAuth,
 			},
-			Secrets: map[string]core.IntegrationSecret{},
 		}
 
 		err := p.Sync(core.SyncContext{
@@ -244,7 +243,6 @@ func Test__Pagerduty__Sync(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{},
 			Configuration: map[string]any{
 				"region":       "us",
 				"subdomain":    "example",
@@ -297,7 +295,6 @@ func Test__Pagerduty__Sync(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{},
 			Configuration: map[string]any{
 				"region":       "us",
 				"subdomain":    "example",
@@ -318,9 +315,9 @@ func Test__Pagerduty__Sync(t *testing.T) {
 		require.Len(t, httpContext.Requests, 2)
 		assert.Equal(t, "https://identity.pagerduty.com/oauth/token", httpContext.Requests[0].URL.String())
 		assert.Equal(t, "https://api.pagerduty.com/services", httpContext.Requests[1].URL.String())
-		secret, ok := integrationCtx.Secrets[AppAccessToken]
-		require.True(t, ok)
-		assert.Equal(t, []byte("access-123"), secret.Value)
+		secret, err := integrationCtx.Secrets().Get(AppAccessToken)
+		require.NoError(t, err)
+		assert.Equal(t, "access-123", secret)
 
 		metadata := integrationCtx.Metadata.(Metadata)
 		assert.Len(t, metadata.Services, 1)

--- a/pkg/integrations/sendgrid/webhook_handler_test.go
+++ b/pkg/integrations/sendgrid/webhook_handler_test.go
@@ -49,7 +49,6 @@ func Test__SendGrid__Setup_EnablesSignedWebhook(t *testing.T) {
 
 	integrationCtx := &contexts.IntegrationContext{
 		Configuration: map[string]any{"apiKey": "sg-test"},
-		Secrets:       map[string]core.IntegrationSecret{},
 	}
 
 	webhookCtx := &testWebhookContext{
@@ -65,9 +64,9 @@ func Test__SendGrid__Setup_EnablesSignedWebhook(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "public-key-from-api", string(webhookCtx.secret))
-	secret, ok := integrationCtx.Secrets[webhookVerificationKeySecret]
-	require.True(t, ok)
-	assert.Equal(t, "public-key-from-api", string(secret.Value))
+	secret, err := integrationCtx.Secrets().Get(webhookVerificationKeySecret)
+	require.NoError(t, err)
+	assert.Equal(t, "public-key-from-api", secret)
 }
 
 func Test__SendGrid__CleanupWebhook_DisablesWebhook(t *testing.T) {
@@ -101,7 +100,6 @@ func Test__SendGrid__CleanupWebhook_DisablesWebhook(t *testing.T) {
 		Webhook: webhookCtx,
 		Integration: &contexts.IntegrationContext{
 			Configuration: map[string]any{"apiKey": "sg-test"},
-			Secrets:       map[string]core.IntegrationSecret{},
 		},
 	})
 
@@ -149,7 +147,6 @@ func Test__SendGrid__CleanupWebhook_SkipsNonHTTPS(t *testing.T) {
 		Webhook: webhookCtx,
 		Integration: &contexts.IntegrationContext{
 			Configuration: map[string]any{"apiKey": "sg-test"},
-			Secrets:       map[string]core.IntegrationSecret{},
 		},
 	})
 

--- a/pkg/integrations/sentry/sentry_test.go
+++ b/pkg/integrations/sentry/sentry_test.go
@@ -134,9 +134,9 @@ func Test__Sentry__Sync(t *testing.T) {
 		assert.Equal(t, "https://sentry.io/api/0/sentry-apps/superplane/", httpContext.Requests[5].URL.String())
 
 		// Sentry rotates the client secret on PUT — verify the new secret was stored automatically.
-		secret, ok := integrationCtx.Secrets["clientSecret"]
-		require.True(t, ok)
-		assert.Equal(t, "new-rotated-secret", string(secret.Value))
+		secret, err := integrationCtx.Secrets().Get("clientSecret")
+		require.NoError(t, err)
+		assert.Equal(t, "new-rotated-secret", secret)
 	})
 
 	t.Run("multiple apps without integration name -> ready with manual webhook prompt", func(t *testing.T) {

--- a/pkg/integrations/servicenow/create_incident_test.go
+++ b/pkg/integrations/servicenow/create_incident_test.go
@@ -20,7 +20,7 @@ func oauthIntegrationContext() *contexts.IntegrationContext {
 			"clientId":     "client-123",
 			"clientSecret": "secret-123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			OAuthAccessToken: {Name: OAuthAccessToken, Value: []byte("access-token-123")},
 		},
 	}

--- a/pkg/integrations/servicenow/list_resources_test.go
+++ b/pkg/integrations/servicenow/list_resources_test.go
@@ -21,7 +21,7 @@ func Test__ServiceNow__ListResources(t *testing.T) {
 			"clientId":     "client-123",
 			"clientSecret": "secret-123",
 		},
-		Secrets: map[string]core.IntegrationSecret{
+		CurrentSecrets: map[string]core.IntegrationSecret{
 			OAuthAccessToken: {Name: OAuthAccessToken, Value: []byte("access-token-123")},
 		},
 	}

--- a/pkg/integrations/servicenow/servicenow_test.go
+++ b/pkg/integrations/servicenow/servicenow_test.go
@@ -36,7 +36,6 @@ func Test__ServiceNow__Sync(t *testing.T) {
 			Configuration: map[string]any{
 				"instanceUrl": "https://dev12345.service-now.com",
 			},
-			Secrets: map[string]core.IntegrationSecret{},
 		}
 
 		err := s.Sync(core.SyncContext{
@@ -114,7 +113,6 @@ func Test__ServiceNow__Sync(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{},
 			Configuration: map[string]any{
 				"instanceUrl":  "https://dev12345.service-now.com",
 				"clientId":     clientID,
@@ -163,7 +161,6 @@ func Test__ServiceNow__Sync(t *testing.T) {
 		}
 
 		integrationCtx := &contexts.IntegrationContext{
-			Secrets: map[string]core.IntegrationSecret{},
 			Configuration: map[string]any{
 				"instanceUrl":  "https://dev12345.service-now.com",
 				"clientId":     clientID,
@@ -183,9 +180,9 @@ func Test__ServiceNow__Sync(t *testing.T) {
 		assert.Equal(t, "https://dev12345.service-now.com/oauth_token.do", httpContext.Requests[0].URL.String())
 		assert.Equal(t, "https://dev12345.service-now.com/api/now/table/incident?sysparm_limit=1", httpContext.Requests[1].URL.String())
 
-		secret, ok := integrationCtx.Secrets[OAuthAccessToken]
-		require.True(t, ok)
-		assert.Equal(t, []byte("access-123"), secret.Value)
+		secret, err := integrationCtx.Secrets().Get(OAuthAccessToken)
+		require.NoError(t, err)
+		assert.Equal(t, "access-123", secret)
 
 		require.Len(t, integrationCtx.ResyncRequests, 1)
 		assert.Equal(t, 900*time.Second, integrationCtx.ResyncRequests[0])

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -25,6 +25,11 @@ type IntegrationContext struct {
 	encryptor   crypto.Encryptor
 	registry    *registry.Registry
 	onNewEvents func([]models.CanvasEvent)
+
+	//
+	// Lazily create a secret storage, when Secrets() used.
+	//
+	secretStorage *IntegrationSecretStorage
 }
 
 func NewIntegrationContext(
@@ -454,4 +459,26 @@ func (c *IntegrationContext) FindSubscription(predicate func(core.IntegrationSub
 	}
 
 	return nil, nil
+}
+
+func (c *IntegrationContext) LegacySetup() bool {
+	return len(c.integration.Capabilities) == 0
+}
+
+func (c *IntegrationContext) Properties() core.IntegrationPropertyStorage {
+	return NewIntegrationPropertyStorage(c.integration)
+}
+
+func (c *IntegrationContext) Secrets() core.IntegrationSecretStorage {
+	if c.secretStorage != nil {
+		return c.secretStorage
+	}
+
+	secretStorage, err := NewIntegrationSecretStorage(c.tx, c.encryptor, c.integration)
+	if err != nil {
+		return nil
+	}
+
+	c.secretStorage = secretStorage
+	return secretStorage
 }

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -474,11 +474,6 @@ func (c *IntegrationContext) Secrets() core.IntegrationSecretStorage {
 		return c.secretStorage
 	}
 
-	secretStorage, err := NewIntegrationSecretStorage(c.tx, c.encryptor, c.integration)
-	if err != nil {
-		return nil
-	}
-
-	c.secretStorage = secretStorage
-	return secretStorage
+	c.secretStorage = NewIntegrationSecretStorage(c.tx, c.encryptor, c.integration)
+	return c.secretStorage
 }

--- a/pkg/workers/contexts/integration_secret_storage.go
+++ b/pkg/workers/contexts/integration_secret_storage.go
@@ -18,19 +18,28 @@ type IntegrationSecretStorage struct {
 	secrets     []models.IntegrationSecret
 }
 
-func NewIntegrationSecretStorage(tx *gorm.DB, encryptor crypto.Encryptor, integration *models.Integration) (*IntegrationSecretStorage, error) {
-	var secrets []models.IntegrationSecret
-	err := tx.Where("installation_id = ?", integration.ID).Find(&secrets).Error
-	if err != nil {
-		return nil, err
-	}
-
+func NewIntegrationSecretStorage(tx *gorm.DB, encryptor crypto.Encryptor, integration *models.Integration) *IntegrationSecretStorage {
 	return &IntegrationSecretStorage{
 		tx:          tx,
 		encryptor:   encryptor,
 		integration: integration,
-		secrets:     secrets,
-	}, nil
+		secrets:     []models.IntegrationSecret{},
+	}
+}
+
+func (s *IntegrationSecretStorage) loadSecrets() error {
+	if len(s.secrets) > 0 {
+		return nil
+	}
+
+	var secrets []models.IntegrationSecret
+	err := s.tx.Where("installation_id = ?", s.integration.ID).Find(&secrets).Error
+	if err != nil {
+		return err
+	}
+
+	s.secrets = secrets
+	return nil
 }
 
 func (s *IntegrationSecretStorage) findSecret(name string) (*models.IntegrationSecret, error) {
@@ -44,6 +53,11 @@ func (s *IntegrationSecretStorage) findSecret(name string) (*models.IntegrationS
 }
 
 func (s *IntegrationSecretStorage) Get(name string) (string, error) {
+	err := s.loadSecrets()
+	if err != nil {
+		return "", err
+	}
+
 	secret, err := s.findSecret(name)
 	if err != nil {
 		return "", err
@@ -63,16 +77,12 @@ func (s *IntegrationSecretStorage) Get(name string) (string, error) {
 }
 
 func (s *IntegrationSecretStorage) Delete(name string) error {
-	_, err := s.findSecret(name)
+	err := s.loadSecrets()
 	if err != nil {
 		return err
 	}
 
-	err = s.tx.
-		Where("installation_id = ? AND name = ?", s.integration.ID, name).
-		Delete(&models.IntegrationSecret{}).
-		Error
-
+	_, err = s.findSecret(name)
 	if err != nil {
 		return err
 	}
@@ -92,7 +102,12 @@ func (s *IntegrationSecretStorage) Create(def core.IntegrationSecretDefinition) 
 		return fmt.Errorf("secret name is required")
 	}
 
-	_, err := s.Get(def.Name)
+	err := s.loadSecrets()
+	if err != nil {
+		return err
+	}
+
+	_, err = s.Get(def.Name)
 	if err == nil {
 		return fmt.Errorf("secret %s already exists", def.Name)
 	}
@@ -140,6 +155,11 @@ func (s *IntegrationSecretStorage) CreateMany(defs []core.IntegrationSecretDefin
 }
 
 func (s *IntegrationSecretStorage) Update(name string, value string) error {
+	err := s.loadSecrets()
+	if err != nil {
+		return err
+	}
+
 	secret, err := s.findSecret(name)
 	if err != nil {
 		return err

--- a/pkg/workers/contexts/integration_secret_storage.go
+++ b/pkg/workers/contexts/integration_secret_storage.go
@@ -3,6 +3,7 @@ package contexts
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/superplanehq/superplane/pkg/core"
@@ -16,6 +17,7 @@ type IntegrationSecretStorage struct {
 	encryptor   crypto.Encryptor
 	integration *models.Integration
 	secrets     []models.IntegrationSecret
+	loaded      bool
 }
 
 func NewIntegrationSecretStorage(tx *gorm.DB, encryptor crypto.Encryptor, integration *models.Integration) *IntegrationSecretStorage {
@@ -28,7 +30,7 @@ func NewIntegrationSecretStorage(tx *gorm.DB, encryptor crypto.Encryptor, integr
 }
 
 func (s *IntegrationSecretStorage) loadSecrets() error {
-	if len(s.secrets) > 0 {
+	if s.loaded {
 		return nil
 	}
 
@@ -39,6 +41,7 @@ func (s *IntegrationSecretStorage) loadSecrets() error {
 	}
 
 	s.secrets = secrets
+	s.loaded = true
 	return nil
 }
 
@@ -87,14 +90,20 @@ func (s *IntegrationSecretStorage) Delete(name string) error {
 		return err
 	}
 
-	for i, secret := range s.secrets {
-		if secret.Name == name {
-			s.secrets = append(s.secrets[:i], s.secrets[i+1:]...)
-			return nil
-		}
+	err = s.tx.
+		Where("installation_id = ? AND name = ?", s.integration.ID, name).
+		Delete(&models.IntegrationSecret{}).
+		Error
+
+	if err != nil {
+		return err
 	}
 
-	return fmt.Errorf("secret %s not found", name)
+	s.secrets = slices.DeleteFunc(s.secrets, func(secret models.IntegrationSecret) bool {
+		return secret.Name == name
+	})
+
+	return nil
 }
 
 func (s *IntegrationSecretStorage) Create(def core.IntegrationSecretDefinition) error {

--- a/pkg/workers/contexts/integration_secret_storage_test.go
+++ b/pkg/workers/contexts/integration_secret_storage_test.go
@@ -129,10 +129,9 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 
 	t.Run("deletes cached and persisted secrets", func(t *testing.T) {
 		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
 		require.NoError(t, storage.Delete("many-two"))
 
-		_, err = storage.Get("many-two")
+		_, err := storage.Get("many-two")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret many-two not found")
 

--- a/pkg/workers/contexts/integration_secret_storage_test.go
+++ b/pkg/workers/contexts/integration_secret_storage_test.go
@@ -30,9 +30,7 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	t.Run("loads and decrypts existing secrets", func(t *testing.T) {
 		seedContextIntegrationSecret(t, integration, "token", "initial-token")
 
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
-
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
 		value, err := storage.Get("token")
 		require.NoError(t, err)
 		assert.Equal(t, "initial-token", value)
@@ -44,10 +42,8 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	})
 
 	t.Run("creates and persists secrets", func(t *testing.T) {
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
-
-		err = storage.Create(core.IntegrationSecretDefinition{
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
+		err := storage.Create(core.IntegrationSecretDefinition{
 			Name:        "created-token",
 			Label:       "Created token",
 			Description: "created by test",
@@ -76,10 +72,8 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	})
 
 	t.Run("rejects empty and duplicate secret names", func(t *testing.T) {
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
-
-		err = storage.Create(core.IntegrationSecretDefinition{Value: "missing-name"})
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
+		err := storage.Create(core.IntegrationSecretDefinition{Value: "missing-name"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret name is required")
 
@@ -89,10 +83,8 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	})
 
 	t.Run("creates many secrets and stops on duplicates", func(t *testing.T) {
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
-
-		err = storage.CreateMany([]core.IntegrationSecretDefinition{
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
+		err := storage.CreateMany([]core.IntegrationSecretDefinition{
 			{Name: "many-one", Value: "1"},
 			{Name: "many-two", Value: "2"},
 		})
@@ -111,9 +103,7 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	})
 
 	t.Run("updates cached and persisted secret value", func(t *testing.T) {
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
-		require.NoError(t, err)
-
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
 		oldValue, err := storage.Get("created-token")
 		require.NoError(t, err)
 
@@ -138,9 +128,8 @@ func Test__IntegrationSecretStorage(t *testing.T) {
 	})
 
 	t.Run("deletes cached and persisted secrets", func(t *testing.T) {
-		storage, err := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
+		storage := NewIntegrationSecretStorage(database.Conn(), crypto.NewNoOpEncryptor(), integration)
 		require.NoError(t, err)
-
 		require.NoError(t, storage.Delete("many-two"))
 
 		_, err = storage.Get("many-two")

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -91,7 +91,7 @@ type IntegrationContext struct {
 	State            string
 	StateDescription string
 	BrowserAction    *core.BrowserAction
-	Secrets          map[string]core.IntegrationSecret
+	CurrentSecrets   map[string]core.IntegrationSecret
 	WebhookRequests  []any
 	ResyncRequests   []time.Duration
 	ActionRequests   []ActionRequest
@@ -114,7 +114,8 @@ func (c *IntegrationContext) ID() uuid.UUID {
 		return uuid.MustParse(c.IntegrationID)
 	}
 
-	return uuid.New()
+	c.IntegrationID = uuid.New().String()
+	return uuid.MustParse(c.IntegrationID)
 }
 
 func (c *IntegrationContext) GetMetadata() any {
@@ -166,16 +167,16 @@ func (c *IntegrationContext) RemoveBrowserAction() {
 }
 
 func (c *IntegrationContext) SetSecret(name string, value []byte) error {
-	if c.Secrets == nil {
-		c.Secrets = make(map[string]core.IntegrationSecret)
+	if c.CurrentSecrets == nil {
+		c.CurrentSecrets = make(map[string]core.IntegrationSecret)
 	}
-	c.Secrets[name] = core.IntegrationSecret{Name: name, Value: value}
+	c.CurrentSecrets[name] = core.IntegrationSecret{Name: name, Value: value}
 	return nil
 }
 
 func (c *IntegrationContext) GetSecrets() ([]core.IntegrationSecret, error) {
-	secrets := make([]core.IntegrationSecret, 0, len(c.Secrets))
-	for _, secret := range c.Secrets {
+	secrets := make([]core.IntegrationSecret, 0, len(c.CurrentSecrets))
+	for _, secret := range c.CurrentSecrets {
 		secrets = append(secrets, secret)
 	}
 	return secrets, nil
@@ -212,6 +213,18 @@ func (c *IntegrationContext) Subscribe(subscription any) (*uuid.UUID, error) {
 	s := Subscription{ID: uuid.New(), Configuration: subscription}
 	c.Subscriptions = append(c.Subscriptions, s)
 	return &s.ID, nil
+}
+
+func (c *IntegrationContext) LegacySetup() bool {
+	return false
+}
+
+func (c *IntegrationContext) Properties() core.IntegrationPropertyStorage {
+	return nil
+}
+
+func (c *IntegrationContext) Secrets() core.IntegrationSecretStorage {
+	return &IntegrationSecretStorage{parentContext: c}
 }
 
 type SubscriptionContext struct {
@@ -416,5 +429,43 @@ func (c *NotificationContext) IsAvailable() bool {
 
 func (c *NotificationContext) Send(title, body, url, urlLabel string, receivers core.NotificationReceivers) error {
 	c.Messages = append(c.Messages, Notification{Title: title, Body: body, URL: url, URLLabel: urlLabel, Receivers: receivers})
+	return nil
+}
+
+type IntegrationSecretStorage struct {
+	parentContext *IntegrationContext
+}
+
+func (s *IntegrationSecretStorage) Get(name string) (string, error) {
+	v, ok := s.parentContext.CurrentSecrets[name]
+	if !ok {
+		return "", fmt.Errorf("secret not found: %s", name)
+	}
+
+	return string(v.Value), nil
+}
+
+func (s *IntegrationSecretStorage) Delete(name string) error {
+	delete(s.parentContext.CurrentSecrets, name)
+	return nil
+}
+
+func (s *IntegrationSecretStorage) Create(def core.IntegrationSecretDefinition) error {
+	s.parentContext.CurrentSecrets[def.Name] = core.IntegrationSecret{Name: def.Name, Value: []byte(def.Value)}
+	return nil
+}
+
+func (s *IntegrationSecretStorage) CreateMany(defs []core.IntegrationSecretDefinition) error {
+	for _, def := range defs {
+		err := s.Create(def)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *IntegrationSecretStorage) Update(name string, value string) error {
+	s.parentContext.CurrentSecrets[name] = core.IntegrationSecret{Name: name, Value: []byte(value)}
 	return nil
 }

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -451,6 +451,10 @@ func (s *IntegrationSecretStorage) Delete(name string) error {
 }
 
 func (s *IntegrationSecretStorage) Create(def core.IntegrationSecretDefinition) error {
+	if len(s.parentContext.CurrentSecrets) == 0 {
+		s.parentContext.CurrentSecrets = make(map[string]core.IntegrationSecret)
+	}
+
 	s.parentContext.CurrentSecrets[def.Name] = core.IntegrationSecret{Name: def.Name, Value: []byte(def.Value)}
 	return nil
 }
@@ -466,6 +470,10 @@ func (s *IntegrationSecretStorage) CreateMany(defs []core.IntegrationSecretDefin
 }
 
 func (s *IntegrationSecretStorage) Update(name string, value string) error {
+	if len(s.parentContext.CurrentSecrets) == 0 {
+		s.parentContext.CurrentSecrets = make(map[string]core.IntegrationSecret)
+	}
+
 	s.parentContext.CurrentSecrets[name] = core.IntegrationSecret{Name: name, Value: []byte(value)}
 	return nil
 }


### PR DESCRIPTION
Adding three new methods in IntegrationContext:
- LegacySetup() - helper function to simplify implementation code until we migrate everything
- Properties() - returns the new IntegrationPropertyStorage interface
- Secrets() - returns the new IntegrationSecretStorage interface. Naming this one Secrets() required updating the integration context we use in tests

---

This is prep work for adding the first implementation for the new flow.