### PR TITLE
fix(web): use GraphQL brand color for graphql component icon

### DIFF
--- a/web_src/src/assets/icons/graphql.svg
+++ b/web_src/src/assets/icons/graphql.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="none">
-  <path d="M16 3.5 27 10v12L16 28.5 5 22V10L16 3.5Z" stroke="#111827" stroke-width="2.25" stroke-linejoin="round"/>
-  <path d="M16 3.5v25M5 10l22 12M27 10 5 22" stroke="#111827" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="16" cy="3.5" r="2.5" fill="#111827"/>
-  <circle cx="27" cy="10" r="2.5" fill="#111827"/>
-  <circle cx="27" cy="22" r="2.5" fill="#111827"/>
-  <circle cx="16" cy="28.5" r="2.5" fill="#111827"/>
-  <circle cx="5" cy="22" r="2.5" fill="#111827"/>
-  <circle cx="5" cy="10" r="2.5" fill="#111827"/>
+  <path d="M16 3.5 27 10v12L16 28.5 5 22V10L16 3.5Z" stroke="#E10098" stroke-width="2.25" stroke-linejoin="round"/>
+  <path d="M16 3.5v25M5 10l22 12M27 10 5 22" stroke="#E10098" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="16" cy="3.5" r="2.5" fill="#E10098"/>
+  <circle cx="27" cy="10" r="2.5" fill="#E10098"/>
+  <circle cx="27" cy="22" r="2.5" fill="#E10098"/>
+  <circle cx="16" cy="28.5" r="2.5" fill="#E10098"/>
+  <circle cx="5" cy="22" r="2.5" fill="#E10098"/>
+  <circle cx="5" cy="10" r="2.5" fill="#E10098"/>
 </svg>


### PR DESCRIPTION
## Summary

The GraphQL component icon hardcoded `#111827` (Tailwind gray-900), which made it appear darker than the other core/integration components in the sidebar — the symptom reported in #4483.

This change aligns the GraphQL icon with the rest of the integration logos, which all use their **official brand colors** (e.g. Slack `#e01e5a`, GitHub `#000`, Discord `#5865F2`, GitLab `#e24329`). The [GraphQL Foundation's brand color is `#E10098`](https://graphql.org/brand/).

## Change

- `web_src/src/assets/icons/graphql.svg`: replace 8 occurrences of `#111827` with `#E10098`.

No other files touched. No code logic changes.

## Visual rationale

Before — icon rendered in `#111827` (dark gray-blue), inconsistent with neighboring brand-colored logos.
After — icon renders in `#E10098`, the official GraphQL brand magenta, matching the visual pattern of the other integration icons.

Closes #4483