### PR TITLE
feat: support stdin (-f -) for roles and groups create/update

### DIFF
--- a/pkg/cli/commands/groups/common.go
+++ b/pkg/cli/commands/groups/common.go
@@ -23,11 +23,20 @@ type groupResource struct {
 	Spec       *openapi_client.GroupsGroupSpec     `json:"spec,omitempty"`
 }
 
-func parseGroupFile(path string) (*groupResource, error) {
-	// #nosec
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource file: %w", err)
+func parseGroupInput(path string, stdin io.Reader) (*groupResource, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		// #nosec
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource file: %w", err)
+		}
 	}
 
 	apiVersion, kind, err := core.ParseYamlResourceHeaders(data)

--- a/pkg/cli/commands/groups/common_test.go
+++ b/pkg/cli/commands/groups/common_test.go
@@ -1,0 +1,56 @@
+package groups
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGroupInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/group.yaml"
+	content := []byte("apiVersion: v1\nkind: Group\nmetadata:\n  name: from-file\nspec:\n  displayName: From File\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	resource, err := parseGroupInput(path, strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-file", resource.Metadata.GetName())
+}
+
+func TestParseGroupInputFileRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/group.yaml"
+	content := []byte("apiVersion: v1\nkind: Group\nmetadata:\n  name: from-file\nspec:\n  displayName: From File\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	_, err := parseGroupInput(path, strings.NewReader(""))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseGroupInputStdin(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Group\nmetadata:\n  name: from-stdin\nspec:\n  displayName: From Stdin\n"
+
+	resource, err := parseGroupInput("-", strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-stdin", resource.Metadata.GetName())
+}
+
+func TestParseGroupInputStdinRejectsUnknownFields(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Group\nmetadata:\n  name: from-stdin\nspec:\n  displayName: From Stdin\n  unknown: true\n"
+
+	_, err := parseGroupInput("-", strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseGroupInputStdinEmpty(t *testing.T) {
+	_, err := parseGroupInput("-", strings.NewReader(""))
+	require.Error(t, err)
+}

--- a/pkg/cli/commands/groups/create.go
+++ b/pkg/cli/commands/groups/create.go
@@ -65,7 +65,7 @@ func (c *createCommand) buildGroup(ctx core.CommandContext) (openapi_client.Grou
 			ctx.Cmd.Flags().Changed("role") {
 			return openapi_client.GroupsGroup{}, fmt.Errorf("cannot combine --display-name, --description, or --role with --file")
 		}
-		resource, err := parseGroupFile(filePath)
+		resource, err := parseGroupInput(filePath, ctx.Cmd.InOrStdin())
 		if err != nil {
 			return openapi_client.GroupsGroup{}, err
 		}

--- a/pkg/cli/commands/groups/root.go
+++ b/pkg/cli/commands/groups/root.go
@@ -36,7 +36,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Long:  "Create a group by passing a name positional with --display-name / --description / --role, or by passing --file pointing to a YAML resource definition.",
 		Args:  cobra.MaximumNArgs(1),
 	}
-	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to a YAML file describing the group")
+	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to a YAML file describing the group, or - to read from stdin")
 	createCmd.Flags().StringVar(&createDisplayName, "display-name", "", "group display name")
 	createCmd.Flags().StringVar(&createDescription, "description", "", "group description")
 	createCmd.Flags().StringVar(&createRole, "role", "", "role assigned to members of the group")
@@ -56,7 +56,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Update a group inline or from a file",
 		Args:  cobra.MaximumNArgs(1),
 	}
-	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "path to a YAML file describing the group")
+	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "path to a YAML file describing the group, or - to read from stdin")
 	updateCmd.Flags().StringVar(&updateDisplayName, "display-name", "", "group display name")
 	updateCmd.Flags().StringVar(&updateDescription, "description", "", "group description")
 	updateCmd.Flags().StringVar(&updateRole, "role", "", "role assigned to members of the group")

--- a/pkg/cli/commands/groups/update.go
+++ b/pkg/cli/commands/groups/update.go
@@ -65,7 +65,7 @@ func (c *updateCommand) buildGroup(ctx core.CommandContext) (string, openapi_cli
 			ctx.Cmd.Flags().Changed("role") {
 			return "", openapi_client.GroupsGroup{}, fmt.Errorf("cannot combine --display-name, --description, or --role with --file")
 		}
-		resource, err := parseGroupFile(filePath)
+		resource, err := parseGroupInput(filePath, ctx.Cmd.InOrStdin())
 		if err != nil {
 			return "", openapi_client.GroupsGroup{}, err
 		}

--- a/pkg/cli/commands/roles/common.go
+++ b/pkg/cli/commands/roles/common.go
@@ -23,11 +23,20 @@ type roleResource struct {
 	Spec       *openapi_client.RolesRoleSpec     `json:"spec,omitempty"`
 }
 
-func parseRoleFile(path string) (*roleResource, error) {
-	// #nosec
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource file: %w", err)
+func parseRoleInput(path string, stdin io.Reader) (*roleResource, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		// #nosec
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource file: %w", err)
+		}
 	}
 
 	apiVersion, kind, err := core.ParseYamlResourceHeaders(data)

--- a/pkg/cli/commands/roles/common_test.go
+++ b/pkg/cli/commands/roles/common_test.go
@@ -1,0 +1,56 @@
+package roles
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRoleInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/role.yaml"
+	content := []byte("apiVersion: v1\nkind: Role\nmetadata:\n  name: from-file\nspec:\n  displayName: From File\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	resource, err := parseRoleInput(path, strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-file", resource.Metadata.GetName())
+}
+
+func TestParseRoleInputFileRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/role.yaml"
+	content := []byte("apiVersion: v1\nkind: Role\nmetadata:\n  name: from-file\nspec:\n  displayName: From File\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	_, err := parseRoleInput(path, strings.NewReader(""))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseRoleInputStdin(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Role\nmetadata:\n  name: from-stdin\nspec:\n  displayName: From Stdin\n"
+
+	resource, err := parseRoleInput("-", strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-stdin", resource.Metadata.GetName())
+}
+
+func TestParseRoleInputStdinRejectsUnknownFields(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Role\nmetadata:\n  name: from-stdin\nspec:\n  displayName: From Stdin\n  unknown: true\n"
+
+	_, err := parseRoleInput("-", strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseRoleInputStdinEmpty(t *testing.T) {
+	_, err := parseRoleInput("-", strings.NewReader(""))
+	require.Error(t, err)
+}

--- a/pkg/cli/commands/roles/create.go
+++ b/pkg/cli/commands/roles/create.go
@@ -26,7 +26,7 @@ func (c *createCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseRoleFile(filePath)
+	resource, err := parseRoleInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/commands/roles/root.go
+++ b/pkg/cli/commands/roles/root.go
@@ -32,7 +32,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Create a role from a file",
 		Args:  cobra.NoArgs,
 	}
-	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to a YAML file describing the role")
+	createCmd.Flags().StringVarP(&createFile, "file", "f", "", "path to a YAML file describing the role, or - to read from stdin")
 	_ = createCmd.MarkFlagRequired("file")
 	core.Bind(createCmd, &createCommand{file: &createFile}, options)
 
@@ -42,7 +42,7 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 		Short: "Update a role from a file",
 		Args:  cobra.NoArgs,
 	}
-	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "path to a YAML file describing the role")
+	updateCmd.Flags().StringVarP(&updateFile, "file", "f", "", "path to a YAML file describing the role, or - to read from stdin")
 	_ = updateCmd.MarkFlagRequired("file")
 	core.Bind(updateCmd, &updateCommand{file: &updateFile}, options)
 

--- a/pkg/cli/commands/roles/update.go
+++ b/pkg/cli/commands/roles/update.go
@@ -29,7 +29,7 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseRoleFile(filePath)
+	resource, err := parseRoleInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Extends the `-f -` / stdin input path that already exists for `superplane secrets create|update` to `roles` and `groups` create/update, so resource YAML can be piped or read from memory without a filesystem path.

## Why

`roles` and `groups` still read `-f` only via `os.ReadFile`. Scripts, CI pipelines, and agents that emit YAML on stdout cannot use the same `... | superplane ... -f -` workflow as secrets — creating an inconsistency in CLI behavior across org resource commands.

## How

- `pkg/cli/commands/roles/common.go`: renamed `parseRoleFile(path)` → `parseRoleInput(path, stdin io.Reader)`, adding `-` path check that reads from `stdin` instead of the filesystem
- `pkg/cli/commands/groups/common.go`: same rename and stdin support for `parseGroupInput`
- Updated `create.go` and `update.go` in both packages to pass `ctx.Cmd.InOrStdin()`
- Updated `-f` flag descriptions in `root.go` for both packages to document `- to read from stdin`
- Added `common_test.go` for both packages with 5 tests each, mirroring `pkg/cli/commands/secrets/common_test.go`:
  - file path read
  - file path rejects unknown fields
  - stdin read
  - stdin rejects unknown fields
  - empty stdin returns error

## Related issues

Closes #4526