### PR TITLE
fix: Persist building blocks sidebar display settings

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BuildingBlocksSidebar } from "./index";
 import type { BuildingBlockCategory } from "./types";
 
@@ -19,7 +20,19 @@ const coreCategory: BuildingBlockCategory = {
   ],
 };
 
+async function openSidebarSettings(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByLabelText("Sidebar settings"));
+}
+
+function getSidebarSetting(name: string) {
+  return screen.getByRole("menuitemcheckbox", { name });
+}
+
 describe("BuildingBlocksSidebar", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("calls onToggle(false) when close button is clicked while disabled", () => {
     const onToggle = vi.fn();
     render(
@@ -63,6 +76,24 @@ describe("BuildingBlocksSidebar", () => {
     const { container } = render(<BuildingBlocksSidebar {...defaultProps} isOpen={false} />);
 
     expect(container.querySelector('[data-testid="building-blocks-sidebar"]')).not.toBeInTheDocument();
+  });
+
+  it("persists display settings after remounting", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<BuildingBlocksSidebar {...defaultProps} blocks={[coreCategory]} />);
+
+    await openSidebarSettings(user);
+    await user.click(getSidebarSetting("Show integration setup status"));
+    await openSidebarSettings(user);
+    await user.click(getSidebarSetting("Connected integrations on top"));
+
+    unmount();
+
+    render(<BuildingBlocksSidebar {...defaultProps} blocks={[coreCategory]} />);
+
+    await openSidebarSettings(user);
+    expect(getSidebarSetting("Show integration setup status")).toHaveAttribute("aria-checked", "false");
+    expect(getSidebarSetting("Connected integrations on top")).toHaveAttribute("aria-checked", "true");
   });
 
   describe("Enter-to-submit", () => {

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -16,6 +16,42 @@ import type { BuildingBlock, BuildingBlockCategory } from "./types";
 export type { AgentContext, AgentMode } from "@/components/AgentSidebar/agentChat";
 export type { BuildingBlock, BuildingBlockCategory } from "./types";
 
+export const BUILDING_BLOCKS_SIDEBAR_SETTINGS_STORAGE_KEY = "buildingBlocksSidebarSettings";
+
+const DEFAULT_BUILDING_BLOCKS_SIDEBAR_SETTINGS = {
+  showIntegrationSetupStatus: true,
+  showConnectedIntegrationsOnTop: false,
+};
+
+function readBuildingBlocksSidebarSettings() {
+  if (typeof window === "undefined") {
+    return DEFAULT_BUILDING_BLOCKS_SIDEBAR_SETTINGS;
+  }
+
+  const stored = window.localStorage.getItem(BUILDING_BLOCKS_SIDEBAR_SETTINGS_STORAGE_KEY);
+  if (stored === null) {
+    return DEFAULT_BUILDING_BLOCKS_SIDEBAR_SETTINGS;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return DEFAULT_BUILDING_BLOCKS_SIDEBAR_SETTINGS;
+    }
+
+    const settings = parsed as Record<string, unknown>;
+    return {
+      showIntegrationSetupStatus:
+        typeof settings.showIntegrationSetupStatus === "boolean" ? settings.showIntegrationSetupStatus : true,
+      showConnectedIntegrationsOnTop:
+        typeof settings.showConnectedIntegrationsOnTop === "boolean" ? settings.showConnectedIntegrationsOnTop : false,
+    };
+  } catch (error) {
+    console.warn("Failed to parse building blocks sidebar settings from local storage:", error);
+    return DEFAULT_BUILDING_BLOCKS_SIDEBAR_SETTINGS;
+  }
+}
+
 export interface BuildingBlocksSidebarProps {
   isOpen: boolean;
   onToggle: (open: boolean) => void;
@@ -102,12 +138,26 @@ function OpenBuildingBlocksSidebar({
   const [isResizing, setIsResizing] = useState(false);
   const [hoveredBlock, setHoveredBlock] = useState<BuildingBlock | null>(null);
   const dragPreviewRef = useRef<HTMLDivElement>(null);
-  const [showIntegrationSetupStatus, setShowIntegrationSetupStatus] = useState(true);
-  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(false);
+  const [showIntegrationSetupStatus, setShowIntegrationSetupStatus] = useState(
+    () => readBuildingBlocksSidebarSettings().showIntegrationSetupStatus,
+  );
+  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(
+    () => readBuildingBlocksSidebarSettings().showConnectedIntegrationsOnTop,
+  );
 
   useEffect(() => {
     localStorage.setItem(COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
   }, [sidebarWidth]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      BUILDING_BLOCKS_SIDEBAR_SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        showIntegrationSetupStatus,
+        showConnectedIntegrationsOnTop,
+      }),
+    );
+  }, [showIntegrationSetupStatus, showConnectedIntegrationsOnTop]);
 
   useEffect(() => {
     if (!searchInputRef.current) {


### PR DESCRIPTION
## Summary

Persist Building Blocks sidebar display settings across remounts:

- Show integration setup status
- Connected integrations on top

## Validation

- `docker compose -f docker-compose.dev.yml exec app bash -c "cd web_src && npx vitest run src/ui/BuildingBlocksSidebar/index.spec.tsx"`

Closes #4370
