### PR TITLE
fix: autocomplete dropdown clipped in Monaco editor input fields

### DIFF
--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -254,7 +254,6 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
                   renderValidationDecorations: "off",
                   overflowWidgetsDomNode: document.body,
                 }}
-
               />
             </div>
           </DialogContent>

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -252,7 +252,9 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
                   ...editorOptions,
                   automaticLayout: true,
                   renderValidationDecorations: "off",
+                  overflowWidgetsDomNode: document.body,
                 }}
+
               />
             </div>
           </DialogContent>


### PR DESCRIPTION
Closes #1804 

What: The autocomplete/suggestions dropdown in Monaco editor input fields was being cropped and cut off, making it difficult to see or select options.

Where: Affects component configuration fields across the Monarch editor sidebar — any component using these fields   
(e.g. HTTP request nodes, and others). 

Why: The expanded editor modal has overflow constraints that clip Monaco's suggestion widgets, which are rendered    relative to the editor container by default.

Fix: Added overflowWidgetsDomNode: document.body to the Monaco options object in the expanded editor modal inside    
ObjectFieldRenderer.tsx. This tells Monaco to mount overflow widgets (autocomplete dropdowns, hover cards, etc.) on
document.body instead of the clipped container, so they render above all other elements without being cut off. 