### PR TITLE
chore: render run button on agent created manual run components

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ComponentBase } from "@/ui/componentBase";
@@ -121,6 +121,32 @@ describe("workflow v2 edit-mode action affordances", () => {
     render(<Trigger {...props} canvasMode="live" onRun={vi.fn()} />);
 
     expect(screen.getByTestId("start-template-run")).toBeInTheDocument();
+  });
+
+  it("keeps start trigger run buttons visible when live runs are disabled", () => {
+    const onRun = vi.fn();
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+    });
+
+    render(
+      <Trigger
+        {...props}
+        canvasMode="live"
+        onRun={onRun}
+        runDisabled
+        runDisabledTooltip="Save canvas changes before running"
+      />,
+    );
+
+    const runButton = screen.getByTestId("start-template-run");
+    expect(runButton).toBeDisabled();
+    expect(screen.getByLabelText("Save canvas changes before running")).toBeInTheDocument();
+
+    fireEvent.click(runButton);
+
+    expect(onRun).not.toHaveBeenCalled();
   });
 
   it("disables approval actions in edit mode", () => {

--- a/web_src/src/pages/workflowv2/mappers/safeMappers.ts
+++ b/web_src/src/pages/workflowv2/mappers/safeMappers.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { ComponentBaseProps, CustomFieldRunContext } from "@/ui/componentBase";
 import type { TriggerProps } from "@/ui/trigger";
 import type {
   ComponentBaseContext,
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 
 type UnknownRecord = Record<string, unknown>;
+type CustomFieldFunction = (onRun?: () => void, context?: CustomFieldRunContext) => React.ReactNode;
 
 export const CANVAS_NODE_FALLBACK_MESSAGE = "Can't display";
 
@@ -84,9 +85,9 @@ function sanitizeCustomField(
   mapperName: string,
 ): ComponentBaseProps["customField"] {
   if (typeof customField === "function") {
-    return (onRun, nodeId) => {
+    return (onRun, context) => {
       try {
-        return sanitizeReactNodeValue(customField(onRun, nodeId));
+        return sanitizeReactNodeValue(customField(onRun, context));
       } catch (error) {
         console.error(`[SafeMapper] Component mapper "${mapperName}" threw in customField():`, error);
         return null;
@@ -225,10 +226,10 @@ function buildLastEventData(lastEventData: unknown, fallbackTitle: string): Trig
 
 function normalizeTriggerCustomField(customField: unknown): ComponentBaseProps["customField"] {
   if (typeof customField === "function") {
-    return (onRun, nodeId) => {
+    return (onRun, context) => {
       try {
-        const fn = customField as (onRun?: () => void, nodeId?: string) => React.ReactNode;
-        return sanitizeReactNodeValue(fn(onRun, nodeId));
+        const fn = customField as CustomFieldFunction;
+        return sanitizeReactNodeValue(fn(onRun, context));
       } catch (error) {
         console.error("[SafeMapper] Trigger customField() threw:", error);
         return null;

--- a/web_src/src/pages/workflowv2/mappers/start.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start.tsx
@@ -1,6 +1,7 @@
 import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
 import type {
   TriggerRenderer,
+  CustomFieldRendererContext,
   CustomFieldRenderer,
   NodeInfo,
   TriggerRendererContext,
@@ -11,6 +12,7 @@ import { flattenObject } from "@/lib/utils";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Play } from "lucide-react";
 
 interface StartTemplate {
@@ -38,27 +40,25 @@ export const startTriggerRenderer: TriggerRenderer = {
     const { node, definition, lastEvent } = context;
     const nodeId = node.id;
 
-    // Create customField as a function that will receive onRun when ComponentBase renders it
-    // We'll create a wrapper that captures nodeId and allows passing initialData
-    const customField = (onRunBase?: () => void) => {
-      if (!onRunBase) {
-        return startCustomFieldRenderer.render(node);
-      }
+    const customField = (
+      onRunBase?: () => void,
+      runContext?: { runDisabled?: boolean; runDisabledTooltip?: string },
+    ) => {
+      const onRun = onRunBase
+        ? (initialData?: string) => {
+            (window as any).__pendingRunData = { nodeId, initialData };
+            onRunBase();
+            setTimeout(() => {
+              delete (window as any).__pendingRunData;
+            }, 100);
+          }
+        : undefined;
 
-      // Create a wrapper onRun that can accept initialData
-      // Store initialData temporarily in window and trigger the base onRun
-      // handleNodeRun will check for this data
-      const onRunWithContext = (initialData?: string) => {
-        // Store initialData temporarily and trigger the run
-        (window as any).__pendingRunData = { nodeId, initialData };
-        onRunBase();
-        // Clear after a short delay to allow handleNodeRun to read it
-        setTimeout(() => {
-          delete (window as any).__pendingRunData;
-        }, 100);
-      };
-
-      return startCustomFieldRenderer.render(node, { onRun: onRunWithContext });
+      return startCustomFieldRenderer.render(node, {
+        onRun,
+        runDisabled: runContext?.runDisabled,
+        runDisabledTooltip: runContext?.runDisabledTooltip,
+      });
     };
 
     const props: TriggerProps = {
@@ -90,7 +90,7 @@ export const startTriggerRenderer: TriggerRenderer = {
  * This is only used internally by startTriggerRenderer, not registered in the global registry
  */
 const startCustomFieldRenderer: CustomFieldRenderer = {
-  render: (node: NodeInfo, context?: { onRun?: (initialData?: string) => void }): React.ReactNode => {
+  render: (node: NodeInfo, context?: CustomFieldRendererContext): React.ReactNode => {
     const config = node.configuration as StartConfiguration;
     const templates = config?.templates || [];
 
@@ -99,10 +99,47 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
     }
 
     const handleRun = (template: StartTemplate) => {
-      if (context?.onRun) {
+      if (context?.onRun && !context.runDisabled) {
         const payloadString = JSON.stringify(template.payload, null, 2);
         context.onRun(payloadString);
       }
+    };
+
+    const renderRunButton = (template: StartTemplate) => {
+      if (!context?.onRun) {
+        return null;
+      }
+
+      const button = (
+        <Button
+          size="sm"
+          data-testid="start-template-run"
+          disabled={context.runDisabled}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            handleRun(template);
+          }}
+          className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
+        >
+          Run
+        </Button>
+      );
+
+      if (!context.runDisabled || !context.runDisabledTooltip) {
+        return button;
+      }
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div aria-label={context.runDisabledTooltip} className="inline-flex flex-shrink-0">
+              {button}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>{context.runDisabledTooltip}</TooltipContent>
+        </Tooltip>
+      );
     };
 
     return (
@@ -115,20 +152,7 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
               </div>
               <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
             </div>
-            {context?.onRun && (
-              <Button
-                size="sm"
-                data-testid="start-template-run"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleRun(template);
-                }}
-                className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
-              >
-                Run
-              </Button>
-            )}
+            {renderRunButton(template)}
           </div>
         ))}
       </div>

--- a/web_src/src/pages/workflowv2/mappers/start.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start.tsx
@@ -7,6 +7,7 @@ import type {
   TriggerRendererContext,
   TriggerEventContext,
 } from "./types";
+import type { CustomFieldRunContext } from "@/ui/componentBase";
 import type { TriggerProps } from "@/ui/trigger";
 import { flattenObject } from "@/lib/utils";
 import { renderTimeAgo } from "@/components/TimeAgo";
@@ -22,6 +23,14 @@ interface StartTemplate {
 
 interface StartConfiguration {
   templates?: StartTemplate[];
+}
+
+function runWithPendingData(nodeId: string, initialData: string | undefined, onRun: () => void): void {
+  window.__pendingRunData = { nodeId, initialData };
+  onRun();
+  setTimeout(() => {
+    delete window.__pendingRunData;
+  }, 100);
 }
 
 /**
@@ -40,26 +49,11 @@ export const startTriggerRenderer: TriggerRenderer = {
     const { node, definition, lastEvent } = context;
     const nodeId = node.id;
 
-    const customField = (
-      onRunBase?: () => void,
-      runContext?: { runDisabled?: boolean; runDisabledTooltip?: string },
-    ) => {
-      const onRun = onRunBase
-        ? (initialData?: string) => {
-            (window as any).__pendingRunData = { nodeId, initialData };
-            onRunBase();
-            setTimeout(() => {
-              delete (window as any).__pendingRunData;
-            }, 100);
-          }
-        : undefined;
-
-      return startCustomFieldRenderer.render(node, {
-        onRun,
-        runDisabled: runContext?.runDisabled,
-        runDisabledTooltip: runContext?.runDisabledTooltip,
+    const customField = (onRunBase?: () => void, runContext?: CustomFieldRunContext) =>
+      startCustomFieldRenderer.render(node, {
+        onRun: onRunBase ? (initialData?: string) => runWithPendingData(nodeId, initialData, onRunBase) : undefined,
+        ...runContext,
       });
-    };
 
     const props: TriggerProps = {
       title: node.name || definition.label || "Unnamed trigger",

--- a/web_src/src/pages/workflowv2/mappers/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/types.ts
@@ -178,6 +178,8 @@ export interface EventStateRegistry {
  */
 export interface CustomFieldRendererContext {
   onRun?: (initialData?: string) => void;
+  runDisabled?: boolean;
+  runDisabledTooltip?: string;
   /** Full integration object when editing an app trigger/component (e.g. for incident webhook status) */
   integration?: OrganizationsIntegration;
 }

--- a/web_src/src/ui/componentBase/index.tsx
+++ b/web_src/src/ui/componentBase/index.tsx
@@ -198,6 +198,11 @@ export interface EventSection {
   handleComponent?: React.ReactNode;
 }
 
+export interface CustomFieldRunContext {
+  runDisabled?: boolean;
+  runDisabledTooltip?: string;
+}
+
 export interface ComponentBaseProps extends ComponentActionsProps {
   iconSrc?: string;
   iconSlug?: string;
@@ -214,7 +219,7 @@ export interface ComponentBaseProps extends ComponentActionsProps {
   selected?: boolean;
   metadata?: MetadataItem[];
   /** Custom content rendered on the node */
-  customField?: React.ReactNode | ((onRun?: () => void, nodeId?: string) => React.ReactNode);
+  customField?: React.ReactNode | ((onRun?: () => void, context?: CustomFieldRunContext) => React.ReactNode);
   /** Where to render customField: "before" (before events) or "after" (after events, default) */
   customFieldPosition?: "before" | "after";
   /** Whether the custom field should only be shown in live mode */
@@ -277,9 +282,9 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
   const safeCustomFieldVisibility = customFieldVisibility === "live-only" ? "live-only" : "always";
   const safeCustomField = React.useMemo(() => {
     if (typeof customField === "function") {
-      return (onRunHandler?: () => void, nodeId?: string) => {
+      return (onRunHandler?: () => void, context?: CustomFieldRunContext) => {
         try {
-          return customField(onRunHandler, nodeId) ?? null;
+          return customField(onRunHandler, context) ?? null;
         } catch (renderError) {
           console.error("[ComponentBase] customField threw during render:", renderError);
           return null;
@@ -322,12 +327,19 @@ export const ComponentBase: React.FC<ComponentBaseProps> = ({
     safeEventSections && safeEventSections.length > 0
       ? (resolvedEventStateMap[compactEventState] || resolvedEventStateMap.neutral).badgeColor
       : undefined;
-  const customFieldOnRun = canvasMode === "edit" || runDisabled ? undefined : onRun;
+  const customFieldOnRun = canvasMode === "edit" ? undefined : onRun;
+  const customFieldRunContext = React.useMemo(
+    () => ({
+      runDisabled,
+      runDisabledTooltip: _runDisabledTooltip,
+    }),
+    [runDisabled, _runDisabledTooltip],
+  );
   const renderedCustomField =
     safeCustomFieldVisibility === "live-only" && canvasMode === "edit"
       ? null
       : typeof safeCustomField === "function"
-        ? safeCustomField(customFieldOnRun)
+        ? safeCustomField(customFieldOnRun, customFieldRunContext)
         : safeCustomField || null;
 
   return (


### PR DESCRIPTION
**Summary**

Fixes Manual Run templates not showing a `Run` button when the canvas is in Live Canvas but run actions are disabled.

**What changed**

- Keeps Manual Run template actions visible in live mode even when `runDisabled` is true.
- Renders the `Run` button disabled with the existing tooltip pattern used elsewhere in the app.
- Preserves edit-mode behaviour where Manual Run template buttons stay hidden.
- Adds regression coverage for live-mode disabled Manual Run templates.

**Verification**

- Reproduced the old behaviour with mocked backend canvas data: Manual Run and template were visible, but no `Run` button rendered.
- Applied the fix and verified the same mocked canvas shows a disabled `Run` button with tooltip text.
- Ran:
  - `make format.js`
  - `npm run test:run -- src/pages/workflowv2/mappers/editModeActions.spec.tsx`
  - `make check.build.ui`
  
Closes https://github.com/superplanehq/superplane/issues/4250