### PR TITLE
Add Docker prerequisite to Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A few concrete things teams build with SuperPlane:
 
 ## Quick start
 
+**Prerequisites:** Docker installed on your system.
+
 Run the latest demo container:
 
 ```


### PR DESCRIPTION
The Quick Start section assumes Docker is installed but doesn't explicitly state this as a requirement. This can be confusing for users unfamiliar with Docker or those setting up SuperPlane for the first time.
Added a "Prerequisites" note at the beginning of the Quick Start section to make the Docker requirement clear before users attempt to run the demo container.