### PR TITLE
feat: add stdin support for roles and groups CLI commands

### DIFF
--- a/pkg/cli/commands/groups/common.go
+++ b/pkg/cli/commands/groups/common.go
@@ -23,11 +23,20 @@ type groupResource struct {
 	Spec       *openapi_client.GroupsGroupSpec     `json:"spec,omitempty"`
 }
 
-func parseGroupFile(path string) (*groupResource, error) {
-	// #nosec
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource file: %w", err)
+func parseGroupInput(path string, stdin io.Reader) (*groupResource, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		// #nosec
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource file: %w", err)
+		}
 	}
 
 	apiVersion, kind, err := core.ParseYamlResourceHeaders(data)

--- a/pkg/cli/commands/groups/common_test.go
+++ b/pkg/cli/commands/groups/common_test.go
@@ -1,0 +1,56 @@
+package groups
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGroupInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/group.yaml"
+	content := []byte("apiVersion: v1\nkind: Group\nmetadata:\n  name: from-file\nspec:\n  displayName: Test Group\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	resource, err := parseGroupInput(path, strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-file", resource.Metadata.GetName())
+}
+
+func TestParseGroupInputFileRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/group.yaml"
+	content := []byte("apiVersion: v1\nkind: Group\nmetadata:\n  name: from-file\nspec:\n  displayName: Test Group\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	_, err := parseGroupInput(path, strings.NewReader(""))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseGroupInputStdin(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Group\nmetadata:\n  name: from-stdin\nspec:\n  displayName: Test Group\n"
+
+	resource, err := parseGroupInput("-", strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-stdin", resource.Metadata.GetName())
+}
+
+func TestParseGroupInputStdinRejectsUnknownFields(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Group\nmetadata:\n  name: from-stdin\nspec:\n  displayName: Test Group\n  unknown: true\n"
+
+	_, err := parseGroupInput("-", strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseGroupInputStdinEmpty(t *testing.T) {
+	_, err := parseGroupInput("-", strings.NewReader(""))
+	require.Error(t, err)
+}

--- a/pkg/cli/commands/groups/create.go
+++ b/pkg/cli/commands/groups/create.go
@@ -65,7 +65,7 @@ func (c *createCommand) buildGroup(ctx core.CommandContext) (openapi_client.Grou
 			ctx.Cmd.Flags().Changed("role") {
 			return openapi_client.GroupsGroup{}, fmt.Errorf("cannot combine --display-name, --description, or --role with --file")
 		}
-		resource, err := parseGroupFile(filePath)
+		resource, err := parseGroupInput(filePath, ctx.Cmd.InOrStdin())
 		if err != nil {
 			return openapi_client.GroupsGroup{}, err
 		}

--- a/pkg/cli/commands/groups/update.go
+++ b/pkg/cli/commands/groups/update.go
@@ -65,7 +65,7 @@ func (c *updateCommand) buildGroup(ctx core.CommandContext) (string, openapi_cli
 			ctx.Cmd.Flags().Changed("role") {
 			return "", openapi_client.GroupsGroup{}, fmt.Errorf("cannot combine --display-name, --description, or --role with --file")
 		}
-		resource, err := parseGroupFile(filePath)
+		resource, err := parseGroupInput(filePath, ctx.Cmd.InOrStdin())
 		if err != nil {
 			return "", openapi_client.GroupsGroup{}, err
 		}

--- a/pkg/cli/commands/roles/common.go
+++ b/pkg/cli/commands/roles/common.go
@@ -23,11 +23,20 @@ type roleResource struct {
 	Spec       *openapi_client.RolesRoleSpec     `json:"spec,omitempty"`
 }
 
-func parseRoleFile(path string) (*roleResource, error) {
-	// #nosec
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read resource file: %w", err)
+func parseRoleInput(path string, stdin io.Reader) (*roleResource, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from stdin: %w", err)
+		}
+	} else {
+		// #nosec
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource file: %w", err)
+		}
 	}
 
 	apiVersion, kind, err := core.ParseYamlResourceHeaders(data)

--- a/pkg/cli/commands/roles/common_test.go
+++ b/pkg/cli/commands/roles/common_test.go
@@ -1,0 +1,56 @@
+package roles
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRoleInputFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/role.yaml"
+	content := []byte("apiVersion: v1\nkind: Role\nmetadata:\n  name: from-file\nspec:\n  displayName: Test Role\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	resource, err := parseRoleInput(path, strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-file", resource.Metadata.GetName())
+}
+
+func TestParseRoleInputFileRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/role.yaml"
+	content := []byte("apiVersion: v1\nkind: Role\nmetadata:\n  name: from-file\nspec:\n  displayName: Test Role\n  unknown: true\n")
+	require.NoError(t, os.WriteFile(path, content, 0644))
+
+	_, err := parseRoleInput(path, strings.NewReader(""))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseRoleInputStdin(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Role\nmetadata:\n  name: from-stdin\nspec:\n  displayName: Test Role\n"
+
+	resource, err := parseRoleInput("-", strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.Equal(t, "from-stdin", resource.Metadata.GetName())
+}
+
+func TestParseRoleInputStdinRejectsUnknownFields(t *testing.T) {
+	yaml := "apiVersion: v1\nkind: Role\nmetadata:\n  name: from-stdin\nspec:\n  displayName: Test Role\n  unknown: true\n"
+
+	_, err := parseRoleInput("-", strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown field")
+	require.Contains(t, err.Error(), "unknown")
+}
+
+func TestParseRoleInputStdinEmpty(t *testing.T) {
+	_, err := parseRoleInput("-", strings.NewReader(""))
+	require.Error(t, err)
+}

--- a/pkg/cli/commands/roles/create.go
+++ b/pkg/cli/commands/roles/create.go
@@ -26,7 +26,7 @@ func (c *createCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseRoleFile(filePath)
+	resource, err := parseRoleInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/commands/roles/update.go
+++ b/pkg/cli/commands/roles/update.go
@@ -29,7 +29,7 @@ func (c *updateCommand) Execute(ctx core.CommandContext) error {
 		return err
 	}
 
-	resource, err := parseRoleFile(filePath)
+	resource, err := parseRoleInput(filePath, ctx.Cmd.InOrStdin())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Add `-f -` stdin input support to `superplane roles create|update` and `superplane groups create|update`, matching the existing behavior in `superplane secrets create|update`.

## Changes

- Rename `parseRoleFile` → `parseRoleInput(path, stdin)`
- Rename `parseGroupFile` → `parseGroupInput(path, stdin)`
- When `-f` is `-`, read YAML from stdin instead of file
- Add unit tests for file and stdin input paths

## Test plan

- [x] Unit tests for roles (file, stdin, empty stdin, unknown fields)
- [x] Unit tests for groups (file, stdin, empty stdin, unknown fields)
- [ ] CI passes

Closes #4526