### PR TITLE
chore: render large expression numbers without scientific notation

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -1,9 +1,11 @@
 package contexts
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -234,7 +236,7 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 			return ""
 		}
 
-		return fmt.Sprintf("%v", value)
+		return formatTemplateExpressionValue(value)
 	})
 
 	if err != nil {
@@ -242,6 +244,19 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 	}
 
 	return result, nil
+}
+
+func formatTemplateExpressionValue(value any) string {
+	switch v := value.(type) {
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case json.Number:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {

--- a/pkg/workers/contexts/node_configuration_builder_expr_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_expr_test.go
@@ -1,6 +1,7 @@
 package contexts
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,4 +16,56 @@ func TestNodeConfigurationBuilder_ResolveExpression_DateWithTimezoneOption(t *te
 	out, err := b.ResolveTemplateExpressions(`{{ date("2026-03-17T01:02:03Z").Add(duration("1ns")).Format("2006-01-02T15:04:05.999999999Z07:00") }}`)
 	require.NoError(t, err)
 	require.Equal(t, "2026-03-17T01:02:03.000000001Z", out)
+}
+
+func TestNodeConfigurationBuilder_ResolveTemplateExpressions_FormatsLargeFloatIDsWithoutScientificNotation(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithRootPayload(map[string]any{
+			"dropletId": float64(566712522),
+		}).
+		WithInput(map[string]any{
+			"source": map[string]any{
+				"data": map[string]any{
+					"id": float64(566712522),
+				},
+			},
+		})
+
+	t.Run("root payload large integer", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ root().dropletId }}`)
+		require.NoError(t, err)
+		require.Equal(t, "566712522", out)
+	})
+
+	t.Run("previous payload large integer", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ previous().data.id }}`)
+		require.NoError(t, err)
+		require.Equal(t, "566712522", out)
+	})
+
+	t.Run("embedded URL", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`https://api.digitalocean.com/v2/droplets/{{ root().dropletId }}`)
+		require.NoError(t, err)
+		require.Equal(t, "https://api.digitalocean.com/v2/droplets/566712522", out)
+	})
+}
+
+func TestNodeConfigurationBuilder_ResolveTemplateExpressions_FormatsNonIntegerNumbers(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithRootPayload(map[string]any{
+			"weight": float64(0.1),
+			"rawID":  json.Number("566712522"),
+		})
+
+	t.Run("fractional float", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ root().weight }}`)
+		require.NoError(t, err)
+		require.Equal(t, "0.1", out)
+	})
+
+	t.Run("json number", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ root().rawID }}`)
+		require.NoError(t, err)
+		require.Equal(t, "566712522", out)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes expression template rendering for large numeric IDs so values like `566712522` no longer become scientific notation such as `5.66712522e+08`.

## Changes

- Format `float64`, `float32`, and `json.Number` expression results as decimal strings during template interpolation
- Keep existing string-template behavior unchanged for other value types
- Add no-DB regression tests for root payloads, previous payloads, embedded URLs, fractional floats, and `json.Number`

## Testing

```sh
go test -count=1 ./pkg/workers/contexts -run 'TestNodeConfigurationBuilder_ResolveTemplateExpressions|TestNodeConfigurationBuilder_ResolveExpression_DateWithTimezoneOption'
docker compose -f docker-compose.dev.yml exec app go test -count=1 ./pkg/workers/contexts
docker compose -f docker-compose.dev.yml exec app go test -count=1 ./pkg/grpc/actions/canvases -run 'Test__EmitNodeEvent'
go test -count=1 ./pkg/components/addmemory ./pkg/components/readmemory ./pkg/components/updatememory ./pkg/components/upsertmemory
go test -count=1 ./pkg/integrations/digitalocean
go test -count=1 ./pkg/integrations/grafana -run 'Test.*Time|Test.*Query'
```

Closes https://github.com/superplanehq/superplane/issues/4345