### PR TITLE
fix: update ngrok install snippet to support Linux and Windows

### DIFF
--- a/docs/contributing/connecting-to-3rdparty-services-from-development.md
+++ b/docs/contributing/connecting-to-3rdparty-services-from-development.md
@@ -11,7 +11,7 @@ Install [ngrok](https://ngrok.com/):
 # Install ngrok (choose your OS)
 
 # macOS
-brew install ngrok/ngrok/ngrok
+brew install ngrok
 
 # Linux (Debian/Ubuntu)
 curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc \

--- a/docs/contributing/connecting-to-3rdparty-services-from-development.md
+++ b/docs/contributing/connecting-to-3rdparty-services-from-development.md
@@ -8,13 +8,23 @@ expose it via a tunnel so external services can deliver webhooks.
 
 Install [ngrok](https://ngrok.com/):
 
-```bash
-# Install (macOS)
-brew install ngrok
+# Install ngrok (choose your OS)
 
-# Authenticate
+# macOS
+brew install ngrok/ngrok/ngrok
+
+# Linux (Debian/Ubuntu)
+curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+  | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
+  && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" \
+  | sudo tee /etc/apt/sources.list.d/ngrok.list \
+  && sudo apt update && sudo apt install ngrok
+
+# Windows (via Chocolatey)
+choco install ngrok
+
+# Authenticate (all platforms)
 ngrok config add-authtoken YOUR_AUTH_TOKEN
-```
 
 ### 2. Start ngrok Tunnel
 

--- a/docs/contributing/connecting-to-3rdparty-services-from-development.md
+++ b/docs/contributing/connecting-to-3rdparty-services-from-development.md
@@ -91,3 +91,4 @@ The AWS integration uses OpenID Connect. When running locally, AWS IAM needs an 
 
 - **Webhooks not received:** Check `WEBHOOKS_BASE_URL`, ensure the tunnel is running, and that the third-party service uses the correct webhook URL.
 - **AWS "Could not connect":** Restart SuperPlane with the tunnel URL as base; confirm `/.well-known/openid-configuration` returns the right issuer; try the Provider URL with a trailing slash; keep the tunnel running. If trycloudflare.com is blocked, use ngrok (paid avoids interstitial) or another tunnel.
+


### PR DESCRIPTION
The ngrok installation snippet in the contributing docs only showed 
the macOS `brew install` command, which does not work on Linux or Windows.

Added install instructions for Linux (apt) and Windows (Chocolatey) 
so developers on all platforms can follow the local development guide.