### PR TITLE
fix: preserve native type when JSON config field is a single expression

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -220,6 +220,13 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 		return expression, nil
 	}
 
+	// If the entire field value is a single expression, return the raw resolved value
+	// to preserve native types (number, bool, object, array) for JSON serialization.
+	// Without this, fmt.Sprintf coerces everything to a string, breaking numeric/bool APIs.
+	if matches := expressionRegex.FindStringSubmatch(expression); len(matches) == 2 && strings.TrimSpace(expression) == matches[0] {
+		return b.ResolveExpression(matches[1])
+	}
+
 	var err error
 
 	result := expressionRegex.ReplaceAllStringFunc(expression, func(match string) string {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -804,7 +804,7 @@ func Test_NodeConfigurationBuilder_BlueprintLevelNode_Root(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "alice", result["username"])
 	assert.Equal(t, "alice@example.com", result["email"])
-	assert.Equal(t, "30", result["age"])
+	assert.Equal(t, float64(30), result["age"])
 }
 
 func Test_NodeConfigurationBuilder_BlueprintLevelNode_Chain(t *testing.T) {
@@ -1015,8 +1015,8 @@ func Test_NodeConfigurationBuilder_BlueprintLevelNode_Config(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "secret-key-123", result["key"])
 	assert.Equal(t, "https://api.example.com", result["url"])
-	assert.Equal(t, "30", result["timeout"])
-	assert.Equal(t, "3", result["retries"])
+	assert.Equal(t, float64(30), result["timeout"])
+	assert.Equal(t, float64(3), result["retries"])
 	assert.Equal(t, "nested-data", result["nested"])
 	assert.Equal(t, "API: https://api.example.com, Key: secret-key-123", result["combined"])
 }
@@ -1625,4 +1625,61 @@ func Test_NodeConfigurationBuilder_Config_DoesNotOverwriteExistingConfigKey(t *t
 	assert.Equal(t, "https://api.example.com", result["api_url"])
 	assert.Equal(t, "https://api.example.com", result["prev_api_url"])
 	assert.Equal(t, "ok", result["output_status"])
+}
+
+// Test_NodeConfigurationBuilder_SingleExpression_PreservesNativeType validates that when an
+// entire configuration field value is a single expression (e.g. "{{ expr }}"), the resolved
+// value retains its native Go type instead of being coerced to a string via fmt.Sprintf.
+// This is required so that HTTP action JSON bodies containing numeric or boolean fields
+// are serialized correctly (fixes issue #4499).
+func Test_NodeConfigurationBuilder_SingleExpression_PreservesNativeType(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNode := "trigger"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Name:   triggerNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	inputData := map[string]any{
+		"count":   float64(42),
+		"ratio":   float64(3.14),
+		"enabled": true,
+		"label":   "hello",
+	}
+	rootEvent := support.EmitCanvasEventForNodeWithData(t, canvas.ID, triggerNode, "default", nil, inputData)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithRootEvent(&rootEvent.ID).
+		WithInput(map[string]any{triggerNode: inputData})
+
+	configuration := map[string]any{
+		// Single expressions — must preserve native type
+		"count":   "{{ $[\"" + triggerNode + "\"].count }}",
+		"ratio":   "{{ $[\"" + triggerNode + "\"].ratio }}",
+		"enabled": "{{ $[\"" + triggerNode + "\"].enabled }}",
+		// String value — must stay a string
+		"label": "{{ $[\"" + triggerNode + "\"].label }}",
+		// Mixed expression (interpolated) — must remain a string
+		"summary": "count={{ $[\"" + triggerNode + "\"].count }}",
+	}
+
+	result, err := builder.Build(configuration)
+	require.NoError(t, err)
+	assert.Equal(t, float64(42), result["count"])
+	assert.Equal(t, float64(3.14), result["ratio"])
+	assert.Equal(t, true, result["enabled"])
+	assert.Equal(t, "hello", result["label"])
+	assert.Equal(t, "count=42", result["summary"])
 }


### PR DESCRIPTION
## Problem

Closes #4499

When an HTTP action node has a JSON body field whose value is a single template expression — e.g. `"amount": "{{ payload.price }}"` — the resolved value is always coerced to a string via `fmt.Sprintf("%v", value)`. This means numeric and boolean values are serialised as `"42"` or `"true"` instead of `42` or `true`, breaking downstream APIs that expect native JSON types.

## Root Cause

`ResolveTemplateExpressions` uses `expressionRegex.ReplaceAllStringFunc`, which operates exclusively on strings. Even when the expression evaluates to a `float64` or `bool`, the callback must return a `string`, so the native type is lost.

## Fix

Added a fast path before the `ReplaceAllStringFunc` loop: if the entire field value (after trimming whitespace) is exactly one expression, `ResolveExpression` is called directly and its raw `any` result is returned — preserving the native Go type for correct JSON serialisation downstream.

Interpolated strings such as `"count={{ expr }}"` continue to work as before because they contain surrounding text and therefore take the existing string-replacement path.

## Changes

- `pkg/workers/contexts/node_configuration_builder.go` — single-expression fast path in `ResolveTemplateExpressions`
- `pkg/workers/contexts/node_configuration_builder_test.go` — updated three assertions that expected legacy string coercion; added `Test_NodeConfigurationBuilder_SingleExpression_PreservesNativeType` covering numeric, float, boolean, and mixed-interpolation cases