### PR TITLE
feat: capability selection as a step in new setup flow

### DIFF
--- a/.go-coverage-baseline.json
+++ b/.go-coverage-baseline.json
@@ -1,5 +1,5 @@
 {
-  "minTotalCoverage": 44.5,
+  "minTotalCoverage": 44.6,
   "minCoverageByPackage": {
     "pkg/authentication": 6.3,
     "pkg/authorization": 52.4,
@@ -25,19 +25,19 @@
     "pkg/database": 38.4,
     "pkg/exprruntime": 36.4,
     "pkg/grpc": 0.4,
-    "pkg/grpc/actions": 24.3,
+    "pkg/grpc/actions": 28.1,
     "pkg/grpc/actions/agents": 44,
     "pkg/grpc/actions/auth": 80.8,
     "pkg/grpc/actions/blueprints": 0,
     "pkg/grpc/actions/canvases": 62.1,
     "pkg/grpc/actions/canvases/changesets": 84.7,
-    "pkg/grpc/actions/canvases/layout": 63.1,
+    "pkg/grpc/actions/canvases/layout": 63.4,
     "pkg/grpc/actions/integrations": 0,
     "pkg/grpc/actions/me": 54.2,
     "pkg/grpc/actions/messages": 0,
-    "pkg/grpc/actions/organizations": 67.1,
+    "pkg/grpc/actions/organizations": 67.2,
     "pkg/grpc/actions/secrets": 42.6,
-    "pkg/grpc/actions/serviceaccounts": 0,
+    "pkg/grpc/actions/serviceaccounts": 5.5,
     "pkg/grpc/actions/triggers": 84.6,
     "pkg/grpc/actions/widgets": 0,
     "pkg/impersonation": 100,
@@ -50,7 +50,7 @@
     "pkg/public": 51.9,
     "pkg/public/middleware": 46.4,
     "pkg/public/ws": 0,
-    "pkg/registry": 80.8,
+    "pkg/registry": 82.6,
     "pkg/retry": 0,
     "pkg/secrets": 62.5,
     "pkg/server": 0,
@@ -62,7 +62,7 @@
     "pkg/web": 82.1,
     "pkg/widgets/annotation": 0,
     "pkg/workers": 41,
-    "pkg/workers/contexts": 46.7,
+    "pkg/workers/contexts": 46.4,
     "pkg/workers/eventdistributer": 0
   },
   "ignoredPackagePrefixes": [
@@ -73,5 +73,5 @@
     "pkg/triggers",
     "pkg/web/assets"
   ],
-  "updatedAt": "2026-05-01T21:00:58Z"
+  "updatedAt": "2026-05-03T23:40:42Z"
 }

--- a/pkg/core/integration_setup_provider.go
+++ b/pkg/core/integration_setup_provider.go
@@ -56,9 +56,10 @@ type IntegrationSetupProvider interface {
 type SetupStepType string
 
 const (
-	SetupStepTypeInputs         SetupStepType = "inputs"
-	SetupStepTypeRedirectPrompt SetupStepType = "redirectPrompt"
-	SetupStepTypeDone           SetupStepType = "done"
+	SetupStepTypeInputs              SetupStepType = "inputs"
+	SetupStepTypeCapabilitySelection SetupStepType = "capabilitySelection"
+	SetupStepTypeRedirectPrompt      SetupStepType = "redirectPrompt"
+	SetupStepTypeDone                SetupStepType = "done"
 )
 
 type SetupStep struct {
@@ -67,6 +68,7 @@ type SetupStep struct {
 	Label          string
 	Instructions   string
 	Inputs         []configuration.Field
+	Capabilities   []string
 	RedirectPrompt *RedirectPrompt
 }
 
@@ -106,8 +108,7 @@ type RedirectPrompt struct {
 }
 
 type SetupStepContext struct {
-	Step            string
-	Inputs          any
+	Step            StepInfo
 	IntegrationID   uuid.UUID
 	OrganizationID  string
 	BaseURL         string
@@ -117,6 +118,12 @@ type SetupStepContext struct {
 	Secrets         IntegrationSecretStorage
 	Properties      IntegrationPropertyStorage
 	Capabilities    CapabilityContext
+}
+
+type StepInfo struct {
+	Name         string
+	Inputs       any
+	Capabilities []string
 }
 
 /*
@@ -186,10 +193,11 @@ type IntegrationSecretDefinition struct {
  * They are typed so the different parts of the system can take only the ones they need.
  *
  * They can be in 4 states:
- * - Requested: the capability was requested, but the setup flow did not yet exposed it.
- * - Enabled: the capability is fully available for use.
- * - Disabled: the capability was made available during the setup flow, but has been manually disabled by the user.
- * - Unavailable: the integration itself has the capability available, but the capability was not requested as part of the setup flow.
+ * - Unavailable: capability exists, but was not requested as part of the setup flow, and the user cannot request it anymore.
+ * - Available: capability exists, setup did not expose it yet, but the user can still request it.
+ * - Requested: capability was requested, but setup did not enable it yet.
+ * - Enabled: capability is fully enabled and ready for use.
+ * - Disabled: capability was enabled during the setup flow, but has been manually disabled by the user.
  */
 type IntegrationCapabilityType string
 type IntegrationCapabilityState string
@@ -201,13 +209,18 @@ const (
 	IntegrationCapabilityStateRequested   IntegrationCapabilityState = "requested"
 	IntegrationCapabilityStateEnabled     IntegrationCapabilityState = "enabled"
 	IntegrationCapabilityStateDisabled    IntegrationCapabilityState = "disabled"
+	IntegrationCapabilityStateAvailable   IntegrationCapabilityState = "available"
 	IntegrationCapabilityStateUnavailable IntegrationCapabilityState = "unavailable"
 )
 
 type CapabilityContext interface {
-	Enable(capabilities ...string) error
-	Disable(capabilities ...string) error
-	IsRequested(capabilities ...string) (bool, error)
+	Request(capabilities ...string)
+	Available(capabilities ...string)
+	Unavailable(capabilities ...string)
+	Enable(capabilities ...string)
+	Disable(capabilities ...string)
+	Clear()
+	IsRequested(capabilities ...string) bool
 	Requested() []string
 }
 

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -1142,12 +1142,18 @@ func CapabilityStateToProto(t string) organizationpb.Integration_CapabilityState
 		return organizationpb.Integration_CapabilityState_STATE_ENABLED
 	case string(core.IntegrationCapabilityStateDisabled):
 		return organizationpb.Integration_CapabilityState_STATE_DISABLED
+	case string(core.IntegrationCapabilityStateAvailable):
+		return organizationpb.Integration_CapabilityState_STATE_AVAILABLE
 	}
 	return organizationpb.Integration_CapabilityState_STATE_UNAVAILABLE
 }
 
 func ProtoToCapabilityState(t organizationpb.Integration_CapabilityState_State) string {
 	switch t {
+	case organizationpb.Integration_CapabilityState_STATE_AVAILABLE:
+		return string(core.IntegrationCapabilityStateAvailable)
+	case organizationpb.Integration_CapabilityState_STATE_UNAVAILABLE:
+		return string(core.IntegrationCapabilityStateUnavailable)
 	case organizationpb.Integration_CapabilityState_STATE_REQUESTED:
 		return string(core.IntegrationCapabilityStateRequested)
 	case organizationpb.Integration_CapabilityState_STATE_ENABLED:

--- a/pkg/grpc/actions/common_test.go
+++ b/pkg/grpc/actions/common_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	integrationpb "github.com/superplanehq/superplane/pkg/protos/integrations"
+	organizationpb "github.com/superplanehq/superplane/pkg/protos/organizations"
 )
 
 func TestConfigurationFieldToProto(t *testing.T) {
@@ -95,4 +98,159 @@ func TestConfigurationFieldToProto(t *testing.T) {
 		require.NotNil(t, field2.TypeOptions.List.MaxItems, "expected MaxItems to be set after roundtrip")
 		assert.Equal(t, maxItems, *field2.TypeOptions.List.MaxItems)
 	})
+}
+
+func TestCapabilityStateToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    string
+		expected organizationpb.Integration_CapabilityState_State
+	}{
+		{
+			name:     "requested",
+			state:    string(core.IntegrationCapabilityStateRequested),
+			expected: organizationpb.Integration_CapabilityState_STATE_REQUESTED,
+		},
+		{
+			name:     "enabled",
+			state:    string(core.IntegrationCapabilityStateEnabled),
+			expected: organizationpb.Integration_CapabilityState_STATE_ENABLED,
+		},
+		{
+			name:     "disabled",
+			state:    string(core.IntegrationCapabilityStateDisabled),
+			expected: organizationpb.Integration_CapabilityState_STATE_DISABLED,
+		},
+		{
+			name:     "available",
+			state:    string(core.IntegrationCapabilityStateAvailable),
+			expected: organizationpb.Integration_CapabilityState_STATE_AVAILABLE,
+		},
+		{
+			name:     "unavailable defaults to unavailable",
+			state:    string(core.IntegrationCapabilityStateUnavailable),
+			expected: organizationpb.Integration_CapabilityState_STATE_UNAVAILABLE,
+		},
+		{
+			name:     "unknown defaults to unavailable",
+			state:    "unknown",
+			expected: organizationpb.Integration_CapabilityState_STATE_UNAVAILABLE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, CapabilityStateToProto(tt.state))
+		})
+	}
+}
+
+func TestProtoToCapabilityState(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    organizationpb.Integration_CapabilityState_State
+		expected string
+	}{
+		{
+			name:     "available",
+			state:    organizationpb.Integration_CapabilityState_STATE_AVAILABLE,
+			expected: string(core.IntegrationCapabilityStateAvailable),
+		},
+		{
+			name:     "unavailable",
+			state:    organizationpb.Integration_CapabilityState_STATE_UNAVAILABLE,
+			expected: string(core.IntegrationCapabilityStateUnavailable),
+		},
+		{
+			name:     "requested",
+			state:    organizationpb.Integration_CapabilityState_STATE_REQUESTED,
+			expected: string(core.IntegrationCapabilityStateRequested),
+		},
+		{
+			name:     "enabled",
+			state:    organizationpb.Integration_CapabilityState_STATE_ENABLED,
+			expected: string(core.IntegrationCapabilityStateEnabled),
+		},
+		{
+			name:     "disabled",
+			state:    organizationpb.Integration_CapabilityState_STATE_DISABLED,
+			expected: string(core.IntegrationCapabilityStateDisabled),
+		},
+		{
+			name:     "unknown returns empty string",
+			state:    organizationpb.Integration_CapabilityState_State(99),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ProtoToCapabilityState(tt.state))
+		})
+	}
+}
+
+func TestCapabilityTypeToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      string
+		expected integrationpb.CapabilityDefinition_Type
+	}{
+		{
+			name:     "action",
+			typ:      string(core.IntegrationCapabilityTypeAction),
+			expected: integrationpb.CapabilityDefinition_TYPE_ACTION,
+		},
+		{
+			name:     "trigger",
+			typ:      string(core.IntegrationCapabilityTypeTrigger),
+			expected: integrationpb.CapabilityDefinition_TYPE_TRIGGER,
+		},
+		{
+			name:     "unknown defaults to unknown",
+			typ:      "unknown",
+			expected: integrationpb.CapabilityDefinition_TYPE_UNKNOWN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, CapabilityTypeToProto(tt.typ))
+		})
+	}
+}
+
+func TestProtoToCapabilityType(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      integrationpb.CapabilityDefinition_Type
+		expected string
+	}{
+		{
+			name:     "action",
+			typ:      integrationpb.CapabilityDefinition_TYPE_ACTION,
+			expected: string(core.IntegrationCapabilityTypeAction),
+		},
+		{
+			name:     "trigger",
+			typ:      integrationpb.CapabilityDefinition_TYPE_TRIGGER,
+			expected: string(core.IntegrationCapabilityTypeTrigger),
+		},
+		{
+			name:     "unknown returns empty string",
+			typ:      integrationpb.CapabilityDefinition_TYPE_UNKNOWN,
+			expected: "",
+		},
+		{
+			name:     "unmapped returns empty string",
+			typ:      integrationpb.CapabilityDefinition_Type(99),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ProtoToCapabilityType(tt.typ))
+		})
+	}
 }

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -438,6 +438,8 @@ func ProtoToCapabilityState(s pb.Integration_CapabilityState_State) core.Integra
 		return core.IntegrationCapabilityStateDisabled
 	case pb.Integration_CapabilityState_STATE_REQUESTED:
 		return core.IntegrationCapabilityStateRequested
+	case pb.Integration_CapabilityState_STATE_AVAILABLE:
+		return core.IntegrationCapabilityStateAvailable
 	}
 	return core.IntegrationCapabilityStateUnavailable
 }

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -525,5 +525,9 @@ func sanitizeConfigurationIfNeeded(integration core.Integration, config map[stri
 }
 
 func isLegacySetup(integration *models.Integration) bool {
+	if integration.SetupState != nil {
+		return false
+	}
+
 	return len(integration.Capabilities) == 0
 }

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -29,7 +29,7 @@ import (
 )
 
 func CreateIntegration(ctx context.Context, registry *registry.Registry, oidcProvider oidc.Provider, baseURL string, webhooksBaseURL string, orgID string, integrationName, name string, appConfig *structpb.Struct) (*pb.CreateIntegrationResponse, error) {
-	return CreateIntegrationWithUsage(ctx, nil, registry, oidcProvider, baseURL, webhooksBaseURL, orgID, integrationName, name, appConfig, nil)
+	return CreateIntegrationWithUsage(ctx, nil, registry, oidcProvider, baseURL, webhooksBaseURL, orgID, integrationName, name, appConfig)
 }
 
 func CreateIntegrationWithUsage(
@@ -42,7 +42,6 @@ func CreateIntegrationWithUsage(
 	orgID string,
 	integrationName, name string,
 	appConfig *structpb.Struct,
-	capabilities []string,
 ) (*pb.CreateIntegrationResponse, error) {
 	integration, err := registry.GetIntegration(integrationName)
 	if err != nil {
@@ -97,7 +96,7 @@ func CreateIntegrationWithUsage(
 			return nil, status.Errorf(codes.Internal, "failed to get setup provider: %v", err)
 		}
 
-		return setupIntegration(registry, setupProvider, newIntegration, capabilities)
+		return setupIntegration(registry, setupProvider, newIntegration)
 	}
 
 	//
@@ -126,16 +125,10 @@ func allCapabilities(setupProvider core.IntegrationSetupProvider) []core.Capabil
 	return capabilities
 }
 
-func setupIntegration(registry *registry.Registry, setupProvider core.IntegrationSetupProvider, newIntegration *models.Integration, capabilities []string) (*pb.CreateIntegrationResponse, error) {
+func setupIntegration(registry *registry.Registry, setupProvider core.IntegrationSetupProvider, newIntegration *models.Integration) (*pb.CreateIntegrationResponse, error) {
 	logrus.Infof("setting up integration %s", newIntegration.ID)
 
-	initialCapabilities, err := initialCapabilityStates(allCapabilities(setupProvider), capabilities)
-	if err != nil {
-		return nil, err
-	}
-
-	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		newIntegration.Capabilities = initialCapabilities
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), newIntegration.Capabilities)
 		firstStep := setupProvider.FirstStep(core.SetupStepContext{
 			IntegrationID:  newIntegration.ID,
@@ -166,36 +159,6 @@ func setupIntegration(registry *registry.Registry, setupProvider core.Integratio
 	}
 
 	return &pb.CreateIntegrationResponse{Integration: proto}, nil
-}
-
-func initialCapabilityStates(definitions []core.Capability, requestedCapabilities []string) ([]models.CapabilityState, error) {
-	definitionsByName := map[string]core.Capability{}
-	for _, definition := range definitions {
-		definitionsByName[definition.Name] = definition
-	}
-
-	requested := map[string]bool{}
-	for _, capability := range requestedCapabilities {
-		if _, ok := definitionsByName[capability]; !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "capability %s not found", capability)
-		}
-		requested[capability] = true
-	}
-
-	states := make([]models.CapabilityState, 0, len(definitions))
-	for _, definition := range definitions {
-		state := core.IntegrationCapabilityStateUnavailable
-		if requested[definition.Name] {
-			state = core.IntegrationCapabilityStateRequested
-		}
-
-		states = append(states, models.CapabilityState{
-			Name:  definition.Name,
-			State: state,
-		})
-	}
-
-	return states, nil
 }
 
 func syncIntegration(
@@ -322,11 +285,11 @@ func serializeIntegration(registry *registry.Registry, instance *models.Integrat
 		}
 
 		if state.CurrentStep != nil {
-			proto.Status.SetupState.CurrentStep = serializeNextStep(*state.CurrentStep)
+			proto.Status.SetupState.CurrentStep = serializeStep(*state.CurrentStep)
 		}
 
 		for _, step := range state.PreviousSteps {
-			proto.Status.SetupState.PreviousSteps = append(proto.Status.SetupState.PreviousSteps, serializeNextStep(step))
+			proto.Status.SetupState.PreviousSteps = append(proto.Status.SetupState.PreviousSteps, serializeStep(step))
 		}
 	}
 
@@ -371,9 +334,9 @@ func integrationParameterValueToString(value any) string {
 	return string(encoded)
 }
 
-func serializeNextStep(step core.SetupStep) *pb.Integration_SetupStepDefinition {
+func serializeStep(step core.SetupStep) *pb.Integration_SetupStepDefinition {
 	def := &pb.Integration_SetupStepDefinition{
-		Type:         serializeNextStepType(step.Type),
+		Type:         serializeStepType(step.Type),
 		Name:         step.Name,
 		Label:        step.Label,
 		Instructions: step.Instructions,
@@ -392,15 +355,21 @@ func serializeNextStep(step core.SetupStep) *pb.Integration_SetupStepDefinition 
 		}
 	}
 
+	if len(step.Capabilities) > 0 {
+		def.Capabilities = step.Capabilities
+	}
+
 	return def
 }
 
-func serializeNextStepType(stepType core.SetupStepType) pb.Integration_SetupStepDefinition_Type {
+func serializeStepType(stepType core.SetupStepType) pb.Integration_SetupStepDefinition_Type {
 	switch stepType {
 	case core.SetupStepTypeInputs:
 		return pb.Integration_SetupStepDefinition_INPUTS
 	case core.SetupStepTypeRedirectPrompt:
 		return pb.Integration_SetupStepDefinition_REDIRECT_PROMPT
+	case core.SetupStepTypeCapabilitySelection:
+		return pb.Integration_SetupStepDefinition_CAPABILITY_SELECTION
 	case core.SetupStepTypeDone:
 		return pb.Integration_SetupStepDefinition_DONE
 	default:
@@ -481,8 +450,8 @@ func CapabilityStateToProto(t core.IntegrationCapabilityState) pb.Integration_Ca
 		return pb.Integration_CapabilityState_STATE_DISABLED
 	case core.IntegrationCapabilityStateRequested:
 		return pb.Integration_CapabilityState_STATE_REQUESTED
-	case core.IntegrationCapabilityStateUnavailable:
-		return pb.Integration_CapabilityState_STATE_UNAVAILABLE
+	case core.IntegrationCapabilityStateAvailable:
+		return pb.Integration_CapabilityState_STATE_AVAILABLE
 	}
 	return pb.Integration_CapabilityState_STATE_UNAVAILABLE
 }

--- a/pkg/grpc/actions/organizations/create_integration_test.go
+++ b/pkg/grpc/actions/organizations/create_integration_test.go
@@ -285,7 +285,6 @@ func Test__CreateIntegration(t *testing.T) {
 			"github",
 			name,
 			appConfig,
-			[]string{},
 		)
 		require.Error(t, err)
 		s, ok := status.FromError(err)

--- a/pkg/grpc/actions/organizations/next_integration_setup_step.go
+++ b/pkg/grpc/actions/organizations/next_integration_setup_step.go
@@ -3,12 +3,15 @@ package organizations
 import (
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/workers/contexts"
@@ -21,7 +24,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func NextIntegrationSetupStep(ctx context.Context, registry *registry.Registry, baseURL, webhooksBaseURL, orgID, id string, inputs *structpb.Struct) (*pb.NextIntegrationSetupStepResponse, error) {
+func NextIntegrationSetupStep(
+	ctx context.Context,
+	registry *registry.Registry,
+	baseURL, webhooksBaseURL,
+	orgID, id string,
+	inputs *structpb.Struct,
+	capabilities []string,
+) (*pb.NextIntegrationSetupStepResponse, error) {
 	org, err := uuid.Parse(orgID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid organization ID")
@@ -59,7 +69,7 @@ func NextIntegrationSetupStep(ctx context.Context, registry *registry.Registry, 
 		return clearIntegrationSetupState(registry, integration)
 	}
 
-	return submitStep(registry, integration, baseURL, webhooksBaseURL, &setupState, inputs)
+	return submitStep(registry, integration, baseURL, webhooksBaseURL, &setupState, inputs, capabilities)
 }
 
 func getStepInputs(inputs *structpb.Struct) map[string]any {
@@ -88,19 +98,40 @@ func clearIntegrationSetupState(registry *registry.Registry, integration *models
 	}, nil
 }
 
-func submitStep(registry *registry.Registry, integration *models.Integration, baseURL, webhooksBaseURL string, setupState *models.SetupState, inputs *structpb.Struct) (*pb.NextIntegrationSetupStepResponse, error) {
+func submitStep(
+	registry *registry.Registry,
+	integration *models.Integration,
+	baseURL,
+	webhooksBaseURL string,
+	setupState *models.SetupState,
+	inputs *structpb.Struct,
+	capabilities []string,
+) (*pb.NextIntegrationSetupStepResponse, error) {
 	setupProvider, err := registry.GetSetupProvider(integration.AppName)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to get setup provider")
 	}
 
+	allCapabilities := allCapabilities(setupProvider)
+
+	//
+	// Verify that the requested capabilities are valid.
+	//
+	if len(capabilities) > 0 {
+		for _, capability := range capabilities {
+			if !slices.ContainsFunc(allCapabilities, func(c core.Capability) bool { return c.Name == capability }) {
+				return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid capability: %s", capability))
+			}
+		}
+	}
+
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
-		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities)
+		capabilityCtx := contexts.NewCapabilityContext(allCapabilities, integration.Capabilities)
 		nextStep, err := setupProvider.OnStepSubmit(core.SetupStepContext{
-			Step:            setupState.CurrentStep.Name,
+			Logger:          logging.ForIntegration(*integration),
+			Step:            core.StepInfo{Name: setupState.CurrentStep.Name, Inputs: getStepInputs(inputs), Capabilities: capabilities},
 			BaseURL:         baseURL,
 			WebhooksBaseURL: webhooksBaseURL,
-			Inputs:          getStepInputs(inputs),
 			IntegrationID:   integration.ID,
 			OrganizationID:  integration.OrganizationID.String(),
 			HTTP:            registry.HTTPContext(),

--- a/pkg/grpc/actions/organizations/next_integration_setup_step_test.go
+++ b/pkg/grpc/actions/organizations/next_integration_setup_step_test.go
@@ -28,7 +28,7 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 			return core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_one"}
 		},
 		OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
-			switch ctx.Step {
+			switch ctx.Step.Name {
 			case "step_one":
 				return &core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_two"}, nil
 
@@ -44,7 +44,7 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 	baseURL := "http://localhost"
 
 	t.Run("invalid organization ID -> invalid argument", func(t *testing.T) {
-		_, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, "not-a-uuid", uuid.NewString(), nil)
+		_, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, "not-a-uuid", uuid.NewString(), nil, nil)
 		require.Error(t, err)
 		s, ok := status.FromError(err)
 		require.True(t, ok)
@@ -52,7 +52,7 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 	})
 
 	t.Run("integration not found -> not found", func(t *testing.T) {
-		_, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), uuid.NewString(), nil)
+		_, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), uuid.NewString(), nil, nil)
 		require.Error(t, err)
 		s, ok := status.FromError(err)
 		require.True(t, ok)
@@ -75,14 +75,14 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Integration)
 
-		afterOne, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil)
+		afterOne, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, afterOne.Integration)
 		require.NotNil(t, afterOne.Integration.Status.SetupState)
 		require.NotNil(t, afterOne.Integration.Status.SetupState.CurrentStep)
 		assert.Equal(t, "step_two", afterOne.Integration.Status.SetupState.CurrentStep.Name)
 
-		afterTwo, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil)
+		afterTwo, err := NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, afterTwo.Integration)
 
@@ -118,7 +118,7 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Integration)
 
-		nextResponse, err := NextIntegrationSetupStep(ctx3, r3.Registry, baseURL, baseURL, r3.Organization.ID.String(), resp.Integration.Metadata.Id, nil)
+		nextResponse, err := NextIntegrationSetupStep(ctx3, r3.Registry, baseURL, baseURL, r3.Organization.ID.String(), resp.Integration.Metadata.Id, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, nextResponse.Integration)
 

--- a/pkg/grpc/actions/organizations/next_integration_setup_step_test.go
+++ b/pkg/grpc/actions/organizations/next_integration_setup_step_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/organizations"
 	"github.com/superplanehq/superplane/test/support"
 	"github.com/superplanehq/superplane/test/support/impl"
 	"google.golang.org/grpc/codes"
@@ -89,6 +90,52 @@ func Test__NextIntegrationSetupStep(t *testing.T) {
 		stored, err := models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
 		require.NoError(t, err)
 		assert.Nil(t, stored.SetupState)
+	})
+
+	t.Run("capability selection with invalid capability -> invalid argument", func(t *testing.T) {
+		r4 := support.Setup(t)
+		ctx4 := authentication.SetUserIdInMetadata(context.Background(), r4.User.String())
+		onStepSubmitCalled := false
+
+		r4.Registry.AppEnv = "development"
+		r4.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{})
+		r4.Registry.SetupProviders["dummy"] = impl.NewDummyIntegrationSetupProvider(impl.DummyIntegrationSetupProviderOptions{
+			CapabilityGroups: []core.CapabilityGroup{{Capabilities: []core.Capability{{Name: "feat"}}}},
+			FirstStep: func(ctx core.SetupStepContext) core.SetupStep {
+				return core.SetupStep{Type: core.SetupStepTypeCapabilitySelection, Name: "select_capabilities", Capabilities: []string{"feat"}}
+			},
+			OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
+				onStepSubmitCalled = true
+				return nil, nil
+			},
+		})
+
+		resp, err := CreateIntegration(
+			ctx4,
+			r4.Registry,
+			nil,
+			"http://localhost",
+			"http://localhost",
+			r4.Organization.ID.String(),
+			"dummy",
+			support.RandomName("installation"),
+			nil,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.Integration)
+		require.NotNil(t, resp.Integration.Status.SetupState)
+		require.NotNil(t, resp.Integration.Status.SetupState.CurrentStep)
+		assert.Equal(t, "select_capabilities", resp.Integration.Status.SetupState.CurrentStep.Name)
+		assert.Equal(t, pb.Integration_SetupStepDefinition_CAPABILITY_SELECTION, resp.Integration.Status.SetupState.CurrentStep.Type)
+
+		_, err = NextIntegrationSetupStep(ctx4, r4.Registry, baseURL, baseURL, r4.Organization.ID.String(), resp.Integration.Metadata.Id, nil, []string{"invalid-capability"})
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "invalid capability: invalid-capability", s.Message())
+		assert.False(t, onStepSubmitCalled)
 	})
 
 	t.Run("done step clears setup and marks ready", func(t *testing.T) {

--- a/pkg/grpc/actions/organizations/previous_integration_setup_step.go
+++ b/pkg/grpc/actions/organizations/previous_integration_setup_step.go
@@ -69,7 +69,7 @@ func PreviousIntegrationSetupStep(ctx context.Context, registry *registry.Regist
 		stepToRevert := setupState.PreviousSteps[len(setupState.PreviousSteps)-1]
 		capabilityCtx := contexts.NewCapabilityContext(allCapabilities(setupProvider), integration.Capabilities)
 		ctx := core.SetupStepContext{
-			Step:           stepToRevert.Name,
+			Step:           core.StepInfo{Name: stepToRevert.Name},
 			IntegrationID:  integration.ID,
 			OrganizationID: orgID,
 			HTTP:           registry.HTTPContext(),

--- a/pkg/grpc/actions/organizations/previous_integration_setup_step_test.go
+++ b/pkg/grpc/actions/organizations/previous_integration_setup_step_test.go
@@ -31,7 +31,7 @@ func Test__PreviousIntegrationSetupStep(t *testing.T) {
 			return core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_one"}
 		},
 		OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
-			switch ctx.Step {
+			switch ctx.Step.Name {
 			case "step_one":
 				return &core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_two"}, nil
 
@@ -85,7 +85,7 @@ func Test__PreviousIntegrationSetupStep(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Integration)
 
-		_, err = NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil)
+		_, err = NextIntegrationSetupStep(ctx, r.Registry, baseURL, baseURL, r.Organization.ID.String(), resp.Integration.Metadata.Id, nil, nil)
 		require.NoError(t, err)
 
 		back, err := PreviousIntegrationSetupStep(ctx, r.Registry, r.Organization.ID.String(), resp.Integration.Metadata.Id)

--- a/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
@@ -32,7 +32,7 @@ func Test__UpdateIntegrationCapabilities(t *testing.T) {
 			return core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_one"}
 		},
 		OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
-			switch ctx.Step {
+			switch ctx.Step.Name {
 			case "step_one":
 				return &core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_two"}, nil
 

--- a/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_capabilities_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/organizations"
 	"github.com/superplanehq/superplane/test/support"
 	"github.com/superplanehq/superplane/test/support/impl"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gorm.io/datatypes"
 )
 
 func Test__UpdateIntegrationCapabilities(t *testing.T) {
@@ -93,12 +95,17 @@ func Test__UpdateIntegrationCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Integration)
 
+		//
+		// Capability must have been exposed by the integration setup provider.
+		// Here, we mock that, by setting the capability state to unavailable directly.
+		//
 		stored, err := models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
 		require.NoError(t, err)
-		require.Len(t, stored.Capabilities, 1)
-		current := stored.Capabilities[0].State
+		newStates := []models.CapabilityState{{Name: "feat", State: core.IntegrationCapabilityStateUnavailable}}
+		stored.Capabilities = datatypes.NewJSONSlice(newStates)
+		require.NoError(t, database.Conn().Save(stored).Error)
 
-		pbState := CapabilityStateToProto(current)
+		pbState := CapabilityStateToProto(core.IntegrationCapabilityStateUnavailable)
 		_, err = UpdateIntegrationCapabilities(
 			ctx,
 			r.Registry,
@@ -131,6 +138,16 @@ func Test__UpdateIntegrationCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Integration)
 
+		//
+		// Capability must have been exposed by the integration setup provider.
+		// Here, we mock that, by setting the capability state to unavailable directly.
+		//
+		stored, err := models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
+		require.NoError(t, err)
+		newStates := []models.CapabilityState{{Name: "feat", State: core.IntegrationCapabilityStateUnavailable}}
+		stored.Capabilities = datatypes.NewJSONSlice(newStates)
+		require.NoError(t, database.Conn().Save(stored).Error)
+
 		updateResponse, err := UpdateIntegrationCapabilities(
 			ctx,
 			r.Registry,
@@ -143,7 +160,7 @@ func Test__UpdateIntegrationCapabilities(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, updateResponse.Integration)
 
-		stored, err := models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
+		stored, err = models.FindIntegration(r.Organization.ID, uuid.MustParse(resp.Integration.Metadata.Id))
 		require.NoError(t, err)
 		require.Len(t, stored.Capabilities, 1)
 		assert.Equal(t, core.IntegrationCapabilityStateEnabled, stored.Capabilities[0].State)

--- a/pkg/grpc/actions/organizations/update_integration_property_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_property_test.go
@@ -33,7 +33,7 @@ func Test__UpdateIntegrationProperty(t *testing.T) {
 			return core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_one"}
 		},
 		OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
-			switch ctx.Step {
+			switch ctx.Step.Name {
 			case "step_one":
 				return &core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_two"}, nil
 

--- a/pkg/grpc/actions/organizations/update_integration_secret_test.go
+++ b/pkg/grpc/actions/organizations/update_integration_secret_test.go
@@ -30,7 +30,7 @@ func Test__UpdateIntegrationSecret(t *testing.T) {
 			return core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_one"}
 		},
 		OnStepSubmit: func(ctx core.SetupStepContext) (*core.SetupStep, error) {
-			switch ctx.Step {
+			switch ctx.Step.Name {
 			case "step_one":
 				return &core.SetupStep{Type: core.SetupStepTypeInputs, Name: "step_two"}, nil
 

--- a/pkg/grpc/organization_service.go
+++ b/pkg/grpc/organization_service.go
@@ -185,7 +185,6 @@ func (s *OrganizationService) CreateIntegration(ctx context.Context, req *pb.Cre
 		req.IntegrationName,
 		req.Name,
 		req.Configuration,
-		req.Capabilities,
 	)
 }
 
@@ -216,7 +215,7 @@ func (s *OrganizationService) DeleteIntegration(ctx context.Context, req *pb.Del
 
 func (s *OrganizationService) NextIntegrationSetupStep(ctx context.Context, req *pb.NextIntegrationSetupStepRequest) (*pb.NextIntegrationSetupStepResponse, error) {
 	orgID := ctx.Value(authorization.DomainIdContextKey).(string)
-	return organizations.NextIntegrationSetupStep(ctx, s.registry, s.baseURL, s.webhooksBaseURL, orgID, req.IntegrationId, req.Inputs)
+	return organizations.NextIntegrationSetupStep(ctx, s.registry, s.baseURL, s.webhooksBaseURL, orgID, req.IntegrationId, req.Inputs, req.Capabilities)
 }
 
 func (s *OrganizationService) PreviousIntegrationSetupStep(ctx context.Context, req *pb.PreviousIntegrationSetupStepRequest) (*pb.PreviousIntegrationSetupStepResponse, error) {

--- a/pkg/integrations/semaphore/setup_provider.go
+++ b/pkg/integrations/semaphore/setup_provider.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -14,7 +15,17 @@ import (
 	"github.com/superplanehq/superplane/pkg/integrations/semaphore/components"
 )
 
-type SetupProvider struct{}
+const (
+	SetupStepCapabilitySelection = "capabilitySelection"
+	SetupStepSelectOrganization  = "selectOrganization"
+	SetupStepEnterAPIToken       = "enterAPIToken"
+	SetupStepDone                = "done"
+)
+
+const (
+	PropertyOrganizationURL = "organizationUrl"
+	SecretAPIToken          = "apiToken"
+)
 
 //go:embed templates/organization-url-instructions.tpl
 var organizationURLInstructionsTemplate []byte
@@ -24,6 +35,8 @@ var apiTokenInstructionsTemplate []byte
 
 //go:embed templates/setup-complete.tpl
 var setupCompleteTemplate []byte
+
+type SetupProvider struct{}
 
 func (s *SetupProvider) genCapabilities(actions []core.Action, triggers []core.Trigger) []core.Capability {
 	capabilities := []core.Capability{}
@@ -48,6 +61,24 @@ func (s *SetupProvider) genCapabilities(actions []core.Action, triggers []core.T
 	}
 
 	return capabilities
+}
+
+/*
+ * Returns all the capabilities, minus the ones being passed in.
+ */
+func (s *SetupProvider) capabilityDiff(capabilities []string) []string {
+	groups := s.CapabilityGroups()
+
+	diff := []string{}
+	for _, group := range groups {
+		for _, capability := range group.Capabilities {
+			if !slices.Contains(capabilities, capability.Name) {
+				diff = append(diff, capability.Name)
+			}
+		}
+	}
+
+	return diff
 }
 
 func (s *SetupProvider) CapabilityGroups() []core.CapabilityGroup {
@@ -77,18 +108,56 @@ func (s *SetupProvider) OnCapabilityUpdate(ctx core.CapabilityUpdateContext) (*c
 		return nil, errors.New("no requested capabilities")
 	}
 
-	ctx.Logger.Infof("requested capabilities: %v", requested)
-	return nil, ctx.Capabilities.Enable(requested...)
+	ctx.Capabilities.Enable(requested...)
+	return nil, nil
 }
 
 func (s *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
+	capabilities := []string{}
+	for _, group := range s.CapabilityGroups() {
+		for _, capability := range group.Capabilities {
+			capabilities = append(capabilities, capability.Name)
+		}
+	}
+
 	return core.SetupStep{
+		Type:         core.SetupStepTypeCapabilitySelection,
+		Name:         SetupStepCapabilitySelection,
+		Label:        "Select capabilities",
+		Capabilities: capabilities,
+	}
+}
+
+func (s *SetupProvider) OnStepSubmit(ctx core.SetupStepContext) (*core.SetupStep, error) {
+	switch ctx.Step.Name {
+	case SetupStepCapabilitySelection:
+		return s.onCapabilitySelectionSubmit(ctx)
+	case SetupStepSelectOrganization:
+		return s.onSelectOrganizationSubmit(ctx.Step.Inputs, ctx)
+	case SetupStepEnterAPIToken:
+		return s.onEnterAPITokenSubmit(ctx.Step.Inputs, ctx)
+	}
+
+	return nil, errors.New("unknown step")
+}
+
+func (s *SetupProvider) onCapabilitySelectionSubmit(ctx core.SetupStepContext) (*core.SetupStep, error) {
+
+	//
+	// We move the requested capabilities to the REQUESTED state,
+	// and the not requested ones to the AVAILABLE state,
+	// since they were not requested yet, but they could be later on.
+	//
+	ctx.Capabilities.Request(ctx.Step.Capabilities...)
+	ctx.Capabilities.Available(s.capabilityDiff(ctx.Step.Capabilities)...)
+
+	return &core.SetupStep{
 		Type:  core.SetupStepTypeInputs,
-		Name:  "selectOrganization",
+		Name:  SetupStepSelectOrganization,
 		Label: "What is your Semaphore Organization URL?",
 		Inputs: []configuration.Field{
 			{
-				Name:     "organizationUrl",
+				Name:     PropertyOrganizationURL,
 				Label:    "Semaphore Organization URL",
 				Type:     configuration.FieldTypeString,
 				Required: true,
@@ -96,37 +165,33 @@ func (s *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
 			},
 		},
 		Instructions: string(organizationURLInstructionsTemplate),
-	}
-}
-
-func (s *SetupProvider) OnStepSubmit(ctx core.SetupStepContext) (*core.SetupStep, error) {
-	switch ctx.Step {
-	case "selectOrganization":
-		return s.onSelectOrganizationSubmit(ctx.Inputs, ctx)
-	case "enterAPIToken":
-		return s.onEnterAPITokenSubmit(ctx.Inputs, ctx)
-	}
-
-	return nil, errors.New("unknown step")
+	}, nil
 }
 
 func (s *SetupProvider) OnStepRevert(ctx core.SetupStepContext) error {
-	switch ctx.Step {
-	case "selectOrganization":
+	switch ctx.Step.Name {
+	case SetupStepCapabilitySelection:
+		return s.onCapabilitySelectionRevert(ctx)
+	case SetupStepSelectOrganization:
 		return s.onSelectOrganizationRevert(ctx)
-	case "enterAPIToken":
+	case SetupStepEnterAPIToken:
 		return s.onEnterAPITokenRevert(ctx)
 	}
 
 	return errors.New("unknown step")
 }
 
+func (s *SetupProvider) onCapabilitySelectionRevert(ctx core.SetupStepContext) error {
+	ctx.Capabilities.Clear()
+	return nil
+}
+
 func (s *SetupProvider) onSelectOrganizationRevert(ctx core.SetupStepContext) error {
-	return ctx.Properties.Delete("organizationUrl")
+	return ctx.Properties.Delete(PropertyOrganizationURL)
 }
 
 func (s *SetupProvider) onEnterAPITokenRevert(ctx core.SetupStepContext) error {
-	return ctx.Secrets.Delete("apiToken")
+	return ctx.Secrets.Delete(SecretAPIToken)
 }
 
 func (s *SetupProvider) OnPropertyUpdate(ctx core.PropertyUpdateContext) (*core.SetupStep, error) {
@@ -135,7 +200,7 @@ func (s *SetupProvider) OnPropertyUpdate(ctx core.PropertyUpdateContext) (*core.
 
 func (s *SetupProvider) OnSecretUpdate(ctx core.SecretUpdateContext) (*core.SetupStep, error) {
 	switch ctx.SecretName {
-	case "apiToken":
+	case SecretAPIToken:
 		v := strings.TrimSpace(ctx.Value)
 		if v == "" {
 			return nil, fmt.Errorf("value is required")
@@ -158,7 +223,7 @@ func (s *SetupProvider) OnSecretUpdate(ctx core.SecretUpdateContext) (*core.Setu
 			return nil, fmt.Errorf("error listing projects: %v", err)
 		}
 
-		return nil, ctx.Secrets.Update("apiToken", v)
+		return nil, ctx.Secrets.Update(SecretAPIToken, v)
 
 	default:
 		return nil, fmt.Errorf("unknown secret: %s", ctx.SecretName)
@@ -171,7 +236,7 @@ func (s *SetupProvider) onSelectOrganizationSubmit(inputs any, ctx core.SetupSte
 		return nil, errors.New("invalid input")
 	}
 
-	organizationURL, ok := m["organizationUrl"].(string)
+	organizationURL, ok := m[PropertyOrganizationURL].(string)
 	if !ok {
 		return nil, errors.New("invalid organization URL")
 	}
@@ -185,7 +250,7 @@ func (s *SetupProvider) onSelectOrganizationSubmit(inputs any, ctx core.SetupSte
 	// so once it's set, you cannot change it.
 	//
 	err := ctx.Properties.Create(core.IntegrationPropertyDefinition{
-		Name:        "organizationUrl",
+		Name:        PropertyOrganizationURL,
 		Label:       "Organization URL",
 		Description: "The URL of the Semaphore organization you are connected",
 		Type:        configuration.FieldTypeString,
@@ -213,11 +278,11 @@ func (s *SetupProvider) onSelectOrganizationSubmit(inputs any, ctx core.SetupSte
 
 	return &core.SetupStep{
 		Type:  core.SetupStepTypeInputs,
-		Name:  "enterAPIToken",
+		Name:  SetupStepEnterAPIToken,
 		Label: "Enter Semaphore API token",
 		Inputs: []configuration.Field{
 			{
-				Name:      "apiToken",
+				Name:      SecretAPIToken,
 				Label:     "API Token",
 				Type:      configuration.FieldTypeString,
 				Required:  true,
@@ -234,7 +299,7 @@ func (s *SetupProvider) onEnterAPITokenSubmit(input any, ctx core.SetupStepConte
 		return nil, errors.New("invalid input")
 	}
 
-	apiToken, ok := m["apiToken"].(string)
+	apiToken, ok := m[SecretAPIToken].(string)
 	if !ok {
 		return nil, errors.New("invalid API token")
 	}
@@ -248,7 +313,7 @@ func (s *SetupProvider) onEnterAPITokenSubmit(input any, ctx core.SetupStepConte
 	// so we store it as an editable secret.
 	//
 	err := ctx.Secrets.Create(core.IntegrationSecretDefinition{
-		Name:        "apiToken",
+		Name:        SecretAPIToken,
 		Label:       "API Token",
 		Description: "The API token for the Semaphore organization",
 		Value:       apiToken,
@@ -276,11 +341,7 @@ func (s *SetupProvider) onEnterAPITokenSubmit(input any, ctx core.SetupStepConte
 		return nil, fmt.Errorf("error listing projects: %v", err)
 	}
 
-	err = ctx.Capabilities.Enable(ctx.Capabilities.Requested()...)
-	if err != nil {
-		return nil, fmt.Errorf("error enabling capability group: %v", err)
-	}
-
+	ctx.Capabilities.Enable(ctx.Capabilities.Requested()...)
 	url, err := ctx.Properties.GetString("organizationUrl")
 	if err != nil {
 		return nil, fmt.Errorf("error getting organization URL: %v", err)

--- a/pkg/integrations/semaphore/setup_provider_test.go
+++ b/pkg/integrations/semaphore/setup_provider_test.go
@@ -135,7 +135,7 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 
 	t.Run("unknown step", func(t *testing.T) {
 		_, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:   "nope",
+			Step:   core.StepInfo{Name: "nope"},
 			Logger: logger,
 		})
 		require.Error(t, err)
@@ -143,35 +143,26 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 	})
 
 	t.Run("selectOrganization validation", func(t *testing.T) {
-		base := core.SetupStepContext{
-			Step:       "selectOrganization",
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization, Inputs: "not-a-map"},
 			Logger:     logger,
 			Properties: &contexts.IntegrationPropertyStorage{},
-		}
-
-		_, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:       base.Step,
-			Logger:     base.Logger,
-			Properties: base.Properties,
-			Inputs:     "not-a-map",
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid input")
 
 		_, err = s.OnStepSubmit(core.SetupStepContext{
-			Step:       base.Step,
-			Logger:     base.Logger,
-			Properties: base.Properties,
-			Inputs:     map[string]any{"organizationUrl": 42},
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization, Inputs: map[string]any{"organizationUrl": 42}},
+			Logger:     logger,
+			Properties: &contexts.IntegrationPropertyStorage{},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid organization URL")
 
 		_, err = s.OnStepSubmit(core.SetupStepContext{
-			Step:       base.Step,
-			Logger:     base.Logger,
-			Properties: base.Properties,
-			Inputs:     map[string]any{"organizationUrl": ""},
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization, Inputs: map[string]any{"organizationUrl": ""}},
+			Logger:     logger,
+			Properties: &contexts.IntegrationPropertyStorage{},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "organization URL is required")
@@ -181,10 +172,9 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 		props := contexts.NewIntegrationPropertyStorage()
 		orgURL := "https://org.semaphoreci.com"
 		next, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:       "selectOrganization",
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization, Inputs: map[string]any{"organizationUrl": orgURL}},
 			Logger:     logger,
 			Properties: props,
-			Inputs:     map[string]any{"organizationUrl": orgURL},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, next)
@@ -205,47 +195,35 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 			Value: "https://example.semaphoreci.com",
 		}))
 
-		base := core.SetupStepContext{
-			Step:         "enterAPIToken",
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIToken, Inputs: 123},
 			Logger:       logger,
 			Properties:   props,
 			Secrets:      intCtx.Secrets(),
 			Capabilities: &contexts.CapabilityContext{},
 			HTTP:         &contexts.HTTPContext{},
-		}
-
-		_, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:         base.Step,
-			Logger:       base.Logger,
-			Properties:   base.Properties,
-			Secrets:      base.Secrets,
-			Capabilities: base.Capabilities,
-			HTTP:         base.HTTP,
-			Inputs:       123,
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid input")
 
 		_, err = s.OnStepSubmit(core.SetupStepContext{
-			Step:         base.Step,
-			Logger:       base.Logger,
-			Properties:   base.Properties,
-			Secrets:      base.Secrets,
-			Capabilities: base.Capabilities,
-			HTTP:         base.HTTP,
-			Inputs:       map[string]any{"apiToken": 1},
+			Step:         core.StepInfo{Name: SetupStepEnterAPIToken, Inputs: map[string]any{"apiToken": 1}},
+			Logger:       logger,
+			Properties:   props,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         &contexts.HTTPContext{},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid API token")
 
 		_, err = s.OnStepSubmit(core.SetupStepContext{
-			Step:         base.Step,
-			Logger:       base.Logger,
-			Properties:   base.Properties,
-			Secrets:      base.Secrets,
-			Capabilities: base.Capabilities,
-			HTTP:         base.HTTP,
-			Inputs:       map[string]any{"apiToken": ""},
+			Step:         core.StepInfo{Name: SetupStepEnterAPIToken, Inputs: map[string]any{"apiToken": ""}},
+			Logger:       logger,
+			Properties:   props,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         &contexts.HTTPContext{},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "API token is required")
@@ -268,13 +246,12 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 		}
 
 		_, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:         "enterAPIToken",
+			Step:         core.StepInfo{Name: SetupStepEnterAPIToken, Inputs: map[string]any{"apiToken": "t"}},
 			Logger:       logger,
 			Properties:   props,
 			Secrets:      intCtx.Secrets(),
 			Capabilities: &contexts.CapabilityContext{},
 			HTTP:         httpCtx,
-			Inputs:       map[string]any{"apiToken": "t"},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error listing projects")
@@ -301,13 +278,12 @@ func Test__Semaphore__SetupProvider__OnStepSubmit(t *testing.T) {
 		}
 
 		next, err := s.OnStepSubmit(core.SetupStepContext{
-			Step:         "enterAPIToken",
+			Step:         core.StepInfo{Name: SetupStepEnterAPIToken, Inputs: map[string]any{"apiToken": "final-token"}},
 			Logger:       logger,
 			Properties:   props,
 			Secrets:      intCtx.Secrets(),
 			Capabilities: capCtx,
 			HTTP:         httpCtx,
-			Inputs:       map[string]any{"apiToken": "final-token"},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, next)
@@ -327,7 +303,10 @@ func Test__Semaphore__SetupProvider__OnStepRevert(t *testing.T) {
 	logger := logger.DiscardLogger()
 
 	t.Run("unknown step", func(t *testing.T) {
-		err := s.OnStepRevert(core.SetupStepContext{Step: "x", Logger: logger})
+		err := s.OnStepRevert(core.SetupStepContext{
+			Step:   core.StepInfo{Name: "x"},
+			Logger: logger,
+		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown step")
 	})
@@ -339,7 +318,7 @@ func Test__Semaphore__SetupProvider__OnStepRevert(t *testing.T) {
 			Value: "https://example.semaphoreci.com",
 		}))
 		require.NoError(t, s.OnStepRevert(core.SetupStepContext{
-			Step:       "selectOrganization",
+			Step:       core.StepInfo{Name: SetupStepSelectOrganization},
 			Logger:     logger,
 			Properties: props,
 		}))
@@ -352,7 +331,7 @@ func Test__Semaphore__SetupProvider__OnStepRevert(t *testing.T) {
 		require.NoError(t, intCtx.SetSecret("apiToken", []byte("sek")))
 
 		require.NoError(t, s.OnStepRevert(core.SetupStepContext{
-			Step:    "enterAPIToken",
+			Step:    core.StepInfo{Name: SetupStepEnterAPIToken},
 			Logger:  logger,
 			Secrets: intCtx.Secrets(),
 		}))

--- a/pkg/models/integration.go
+++ b/pkg/models/integration.go
@@ -53,8 +53,9 @@ type SetupState struct {
 }
 
 type CapabilityState struct {
-	Name  string                          `json:"name"`
-	State core.IntegrationCapabilityState `json:"state"`
+	Name   string                          `json:"name"`
+	State  core.IntegrationCapabilityState `json:"state"`
+	Reason *string                         `json:"reason,omitempty"`
 }
 
 func (a *Integration) TableName() string {

--- a/pkg/workers/contexts/capability_context.go
+++ b/pkg/workers/contexts/capability_context.go
@@ -1,8 +1,6 @@
 package contexts
 
 import (
-	"fmt"
-
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/models"
 )
@@ -18,7 +16,7 @@ func NewCapabilityContext(definitions []core.Capability, states []models.Capabil
 		definitionsMap[definition.Name] = definition
 	}
 
-	statesMap := make(map[string]models.CapabilityState)
+	statesMap := map[string]models.CapabilityState{}
 	for _, state := range states {
 		statesMap[state.Name] = state
 	}
@@ -37,45 +35,49 @@ func (c *CapabilityContext) States() []models.CapabilityState {
 	return states
 }
 
-func (c *CapabilityContext) Enable(capabilities ...string) error {
+func (c *CapabilityContext) updateState(newState core.IntegrationCapabilityState, capabilities ...string) {
 	for _, capability := range capabilities {
-		_, ok := c.definitions[capability]
-		if !ok {
-			return fmt.Errorf("capability %s not found", capability)
-		}
-
-		c.states[capability] = models.CapabilityState{Name: capability, State: core.IntegrationCapabilityStateEnabled}
+		c.states[capability] = models.CapabilityState{Name: capability, State: newState}
 	}
-
-	return nil
 }
 
-func (c *CapabilityContext) Disable(capabilities ...string) error {
-	for _, capability := range capabilities {
-		_, ok := c.definitions[capability]
-		if !ok {
-			return fmt.Errorf("capability %s not found", capability)
-		}
-
-		c.states[capability] = models.CapabilityState{Name: capability, State: core.IntegrationCapabilityStateDisabled}
-	}
-
-	return nil
+func (c *CapabilityContext) Request(capabilities ...string) {
+	c.updateState(core.IntegrationCapabilityStateRequested, capabilities...)
 }
 
-func (c *CapabilityContext) IsRequested(capabilities ...string) (bool, error) {
+func (c *CapabilityContext) Enable(capabilities ...string) {
+	c.updateState(core.IntegrationCapabilityStateEnabled, capabilities...)
+}
+
+func (c *CapabilityContext) Disable(capabilities ...string) {
+	c.updateState(core.IntegrationCapabilityStateDisabled, capabilities...)
+}
+
+func (c *CapabilityContext) Available(capabilities ...string) {
+	c.updateState(core.IntegrationCapabilityStateAvailable, capabilities...)
+}
+
+func (c *CapabilityContext) Unavailable(capabilities ...string) {
+	c.updateState(core.IntegrationCapabilityStateUnavailable, capabilities...)
+}
+
+func (c *CapabilityContext) Clear() {
+	c.states = map[string]models.CapabilityState{}
+}
+
+func (c *CapabilityContext) IsRequested(capabilities ...string) bool {
 	for _, capability := range capabilities {
 		v, ok := c.states[capability]
 		if !ok {
-			return false, fmt.Errorf("capability %s not found", capability)
+			return false
 		}
 
 		if v.State != core.IntegrationCapabilityStateRequested {
-			return false, nil
+			return false
 		}
 	}
 
-	return true, nil
+	return true
 }
 
 func (c *CapabilityContext) Requested() []string {

--- a/pkg/workers/contexts/capability_context_test.go
+++ b/pkg/workers/contexts/capability_context_test.go
@@ -23,25 +23,12 @@ func Test__CapabilityContext(t *testing.T) {
 			{Name: "rollback", State: core.IntegrationCapabilityStateEnabled},
 		})
 
-		require.NoError(t, ctx.Enable("deploy"))
-		require.NoError(t, ctx.Disable("rollback"))
+		ctx.Enable("deploy")
+		ctx.Disable("rollback")
 
 		states := ctx.States()
 		assertCapabilityState(t, states, "deploy", core.IntegrationCapabilityStateEnabled)
 		assertCapabilityState(t, states, "rollback", core.IntegrationCapabilityStateDisabled)
-	})
-
-	t.Run("rejects unknown capabilities on enable and disable", func(t *testing.T) {
-		ctx := NewCapabilityContext(definitions, nil)
-
-		err := ctx.Enable("missing")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "capability missing not found")
-
-		err = ctx.Disable("missing")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "capability missing not found")
-		assert.Empty(t, ctx.States())
 	})
 
 	t.Run("checks requested capabilities", func(t *testing.T) {
@@ -51,18 +38,9 @@ func Test__CapabilityContext(t *testing.T) {
 			{Name: "promote", State: core.IntegrationCapabilityStateRequested},
 		})
 
-		requested, err := ctx.IsRequested("deploy", "promote")
-		require.NoError(t, err)
-		assert.True(t, requested)
-
-		requested, err = ctx.IsRequested("deploy", "rollback")
-		require.NoError(t, err)
-		assert.False(t, requested)
-
-		requested, err = ctx.IsRequested("missing")
-		require.Error(t, err)
-		assert.False(t, requested)
-		assert.Contains(t, err.Error(), "capability missing not found")
+		assert.True(t, ctx.IsRequested("deploy", "promote"))
+		assert.False(t, ctx.IsRequested("deploy", "rollback"))
+		assert.False(t, ctx.IsRequested("missing"))
 	})
 
 	t.Run("returns requested capability names", func(t *testing.T) {

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -462,6 +462,10 @@ func (c *IntegrationContext) FindSubscription(predicate func(core.IntegrationSub
 }
 
 func (c *IntegrationContext) LegacySetup() bool {
+	if c.integration.SetupState != nil {
+		return false
+	}
+
 	return len(c.integration.Capabilities) == 0
 }
 

--- a/protos/organizations.proto
+++ b/protos/organizations.proto
@@ -549,7 +549,6 @@ message CreateIntegrationRequest {
   string name = 2;
   string integration_name = 3;
   google.protobuf.Struct configuration = 4;
-  repeated string capabilities = 5;
 }
 
 message CreateIntegrationResponse {
@@ -603,6 +602,7 @@ message NextIntegrationSetupStepRequest {
   string id = 1;
   string integration_id = 2;
   google.protobuf.Struct inputs = 3;
+  repeated string capabilities = 4;
 }
 
 message NextIntegrationSetupStepResponse {
@@ -703,7 +703,8 @@ message Integration {
       UNKNOWN = 0;
       INPUTS = 1;
       REDIRECT_PROMPT = 2;
-      DONE = 3;
+      CAPABILITY_SELECTION = 3;
+      DONE = 4;
     }
 
     message RedirectPrompt {
@@ -718,36 +719,47 @@ message Integration {
     string instructions = 4;
     repeated Configuration.Field inputs = 5;
     RedirectPrompt redirect_prompt = 6;
+    repeated string capabilities = 7;
   }
 
   message CapabilityState {
     enum State {
+
       //
-      // The integration itself has the capability available,
-      // but the capability was not requested as part of the setup flow.
+      // The integration has the capability available,
+      // but the integration setup did not expose it,
+      // and the user cannot request it anymore.
       //
       STATE_UNAVAILABLE = 0;
+
+      //
+      // THe integration has the capability available,
+      // but the integration setup did not expose it yet.
+      // The user can still request it, though.
+      //
+      STATE_AVAILABLE = 1;
 
       //
       // The capability was requested,
       // but the setup flow did not yet exposed the capability requested.
       //
-      STATE_REQUESTED = 1;
+      STATE_REQUESTED = 2;
 
       //
       // The capability is fully available for use.
       //
-      STATE_ENABLED = 2;
+      STATE_ENABLED = 3;
 
       //
       // The capability was made available during the setup flow,
       // but has been manually disabled by the user.
       //
-      STATE_DISABLED = 3;
+      STATE_DISABLED = 4;
     }
 
     string name = 1;
     State state = 2;
+    optional string reason = 3;
   }
 
   message NodeRef {

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -537,29 +537,49 @@ func (s *IntegrationPropertyStorage) CreateMany(defs []core.IntegrationPropertyD
 }
 
 type CapabilityContext struct {
-	RequestedCapabilties []string
-	EnabledCapabilities  []string
-	DisabledCapabilities []string
+	RequestedCapabilties    []string
+	EnabledCapabilities     []string
+	DisabledCapabilities    []string
+	AvailableCapabilities   []string
+	UnavailableCapabilities []string
 }
 
-func (c *CapabilityContext) Enable(capabilities ...string) error {
+func (c *CapabilityContext) Request(capabilities ...string) {
+	c.RequestedCapabilties = append(c.RequestedCapabilties, capabilities...)
+}
+
+func (c *CapabilityContext) Enable(capabilities ...string) {
 	c.EnabledCapabilities = append(c.EnabledCapabilities, capabilities...)
-	return nil
 }
 
-func (c *CapabilityContext) Disable(capabilities ...string) error {
+func (c *CapabilityContext) Disable(capabilities ...string) {
 	c.DisabledCapabilities = append(c.DisabledCapabilities, capabilities...)
-	return nil
 }
 
-func (c *CapabilityContext) IsRequested(capabilities ...string) (bool, error) {
+func (c *CapabilityContext) Available(capabilities ...string) {
+	c.AvailableCapabilities = append(c.AvailableCapabilities, capabilities...)
+}
+
+func (c *CapabilityContext) Unavailable(capabilities ...string) {
+	c.UnavailableCapabilities = append(c.UnavailableCapabilities, capabilities...)
+}
+
+func (c *CapabilityContext) Clear() {
+	c.RequestedCapabilties = []string{}
+	c.EnabledCapabilities = []string{}
+	c.DisabledCapabilities = []string{}
+	c.AvailableCapabilities = []string{}
+	c.UnavailableCapabilities = []string{}
+}
+
+func (c *CapabilityContext) IsRequested(capabilities ...string) bool {
 	for _, capability := range capabilities {
 		if !slices.Contains(c.RequestedCapabilties, capability) {
-			return false, nil
+			return false
 		}
 	}
 
-	return true, nil
+	return true
 }
 
 func (c *CapabilityContext) Requested() []string {

--- a/web_src/src/hooks/useIntegrations.ts
+++ b/web_src/src/hooks/useIntegrations.ts
@@ -170,12 +170,13 @@ export const useNextIntegrationSetupStep = (organizationId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: { integrationId: string; inputs?: Record<string, unknown> }) => {
+    mutationFn: async (data: { integrationId: string; inputs?: Record<string, unknown>; capabilities?: string[] }) => {
       return await organizationsNextIntegrationSetupStep(
         withOrganizationHeader({
           path: { id: organizationId, integrationId: data.integrationId },
           body: {
             inputs: data.inputs,
+            capabilities: data.capabilities,
           },
         }),
       );

--- a/web_src/src/lib/capabilities.ts
+++ b/web_src/src/lib/capabilities.ts
@@ -35,6 +35,20 @@ export type CapabilityGroupSection = {
 };
 
 /**
+ * Returns capability definitions offered by a setup step (by name), preserving {@link defsSorted} order.
+ */
+export function capabilityDefinitionsForStepOffer(
+  defsSorted: IntegrationsCapabilityDefinition[],
+  offeredNames: string[] | undefined,
+): IntegrationsCapabilityDefinition[] {
+  const allowed = new Set((offeredNames ?? []).filter(Boolean));
+  if (allowed.size === 0) {
+    return [];
+  }
+  return defsSorted.filter((def) => Boolean(def.name) && allowed.has(def.name!));
+}
+
+/**
  * Groups capability names using {@link IntegrationsIntegrationDefinition.capabilityGroups} when present.
  * Otherwise returns a single section with label "" and every defined capability name.
  */

--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/CapabilitySection.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/CapabilitySection.tsx
@@ -101,7 +101,7 @@ export function CapabilitySection({
                             Enable
                           </Button>
                         ) : null}
-                        {effectiveState === "STATE_UNAVAILABLE" ? (
+                        {effectiveState === "STATE_AVAILABLE" ? (
                           <Button
                             type="button"
                             variant="outline"

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySection.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySection.tsx
@@ -9,23 +9,23 @@ function getCapabilitySelectionDotClass(selected: boolean) {
   return selected ? "bg-green-500" : "bg-gray-400 dark:bg-gray-500";
 }
 
-export interface PreCreateCapabilitySectionProps {
+export interface CapabilitySectionProps {
   section: CapabilityGroupSection;
   capabilityByName: Map<string, IntegrationsCapabilityDefinition>;
   selectedCapabilities: ReadonlySet<string>;
   onToggleCapability: (capabilityName: string) => void;
   onToggleCapabilityGroup: (capabilityNames: string[]) => void;
-  isCreatePending: boolean;
+  selectionDisabled: boolean;
 }
 
-export function PreCreateCapabilitySection({
+export function CapabilitySection({
   section,
   capabilityByName,
   selectedCapabilities,
   onToggleCapability,
   onToggleCapabilityGroup,
-  isCreatePending,
-}: PreCreateCapabilitySectionProps) {
+  selectionDisabled,
+}: CapabilitySectionProps) {
   const groupState = section.label ? getGroupToggleState(section.names, selectedCapabilities) : undefined;
   const selectedInSection = section.names.filter((name) => selectedCapabilities.has(name)).length;
   const groupIcon =
@@ -46,7 +46,7 @@ export function PreCreateCapabilitySection({
       {section.label ? (
         <button
           type="button"
-          disabled={isCreatePending}
+          disabled={selectionDisabled}
           aria-label={
             groupState === "all"
               ? `Remove all selections from ${section.label}`
@@ -54,11 +54,11 @@ export function PreCreateCapabilitySection({
           }
           className={cn(
             "flex w-full cursor-pointer flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3 text-left transition-colors hover:bg-gray-100 dark:border-gray-800 dark:bg-gray-800/50 dark:hover:bg-gray-800",
-            isCreatePending && "!cursor-not-allowed opacity-70 hover:bg-gray-50 dark:hover:bg-gray-800/50",
+            selectionDisabled && "!cursor-not-allowed opacity-70 hover:bg-gray-50 dark:hover:bg-gray-800/50",
           )}
           onClick={() => onToggleCapabilityGroup(section.names)}
           onKeyDown={(event) => {
-            if (isCreatePending) {
+            if (selectionDisabled) {
               return;
             }
             if (event.key === "Enter" || event.key === " ") {
@@ -93,13 +93,13 @@ export function PreCreateCapabilitySection({
                   key={capabilityName}
                   className={cn(
                     "transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:focus-visible:ring-offset-gray-900",
-                    isCreatePending
+                    selectionDisabled
                       ? "cursor-not-allowed opacity-70"
                       : "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/60",
                   )}
                   onClick={() => onToggleCapability(capabilityName)}
                   onKeyDown={(event) => {
-                    if (isCreatePending) {
+                    if (selectionDisabled) {
                       return;
                     }
                     if (event.key === "Enter" || event.key === " ") {
@@ -107,7 +107,7 @@ export function PreCreateCapabilitySection({
                       onToggleCapability(capabilityName);
                     }
                   }}
-                  tabIndex={isCreatePending ? -1 : 0}
+                  tabIndex={selectionDisabled ? -1 : 0}
                   aria-selected={checked}
                   aria-label={`${checked ? "Selected" : "Not selected"}: ${capabilityName}. Press Enter or Space to toggle.`}
                 >

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySelection.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySelection.tsx
@@ -1,26 +1,26 @@
 import type { IntegrationsCapabilityDefinition } from "@/api-client";
 import type { CapabilityGroupSection } from "@/lib/capabilities";
-import { PreCreateCapabilitySection } from "./PreCreateCapabilitySection";
+import { CapabilitySection } from "./CapabilitySection";
 
-export interface PreCreateCapabilitySelectionProps {
+export interface CapabilitySelectionProps {
   integrationCapabilities: IntegrationsCapabilityDefinition[];
   capabilitySections: CapabilityGroupSection[];
   capabilityByName: Map<string, IntegrationsCapabilityDefinition>;
   selectedCapabilities: ReadonlySet<string>;
   onToggleCapability: (capabilityName: string) => void;
   onToggleCapabilityGroup: (capabilityNames: string[]) => void;
-  isCreatePending: boolean;
+  selectionDisabled: boolean;
 }
 
-export function PreCreateCapabilitySelection({
+export function CapabilitySelection({
   integrationCapabilities,
   capabilitySections,
   capabilityByName,
   selectedCapabilities,
   onToggleCapability,
   onToggleCapabilityGroup,
-  isCreatePending,
-}: PreCreateCapabilitySelectionProps) {
+  selectionDisabled,
+}: CapabilitySelectionProps) {
   if (integrationCapabilities.length === 0) {
     return null;
   }
@@ -34,14 +34,14 @@ export function PreCreateCapabilitySelection({
       </p>
       <div className="space-y-4">
         {capabilitySections.map((section) => (
-          <PreCreateCapabilitySection
+          <CapabilitySection
             key={section.key}
             section={section}
             capabilityByName={capabilityByName}
             selectedCapabilities={selectedCapabilities}
             onToggleCapability={onToggleCapability}
             onToggleCapabilityGroup={onToggleCapabilityGroup}
-            isCreatePending={isCreatePending}
+            selectionDisabled={selectionDisabled}
           />
         ))}
       </div>

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySelectionStep.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/CapabilitySelectionStep.tsx
@@ -1,0 +1,115 @@
+import type {
+  IntegrationSetupStepDefinition,
+  IntegrationsCapabilityDefinition,
+  IntegrationsIntegrationDefinition,
+} from "@/api-client";
+import { Button } from "@/components/ui/button";
+import {
+  buildIntegrationCapabilityGroupSections,
+  capabilityDefinitionsForStepOffer,
+  type CapabilityGroupSection,
+} from "@/lib/capabilities";
+import { useMemo } from "react";
+import { Instructions } from "./Instructions";
+import { CapabilitySelection } from "./CapabilitySelection";
+import { ArrowLeft, MoveRight } from "lucide-react";
+
+function capabilityByNameFromDefinitions(defs: IntegrationsCapabilityDefinition[]) {
+  const map = new Map<string, IntegrationsCapabilityDefinition>();
+  for (const capability of defs) {
+    if (capability.name) {
+      map.set(capability.name, capability);
+    }
+  }
+  return map;
+}
+
+interface CapabilitySelectionStepProps {
+  step: IntegrationSetupStepDefinition;
+  integrationDefinition: IntegrationsIntegrationDefinition | undefined;
+  integrationCapabilities: IntegrationsCapabilityDefinition[];
+  selectedCapabilities: ReadonlySet<string>;
+  onBack?: () => void;
+  onToggleCapability: (capabilityName: string) => void;
+  onToggleCapabilityGroup: (capabilityNames: string[]) => void;
+  onSubmit: () => void;
+  isReverting?: boolean;
+  isSubmitting?: boolean;
+}
+
+export function CapabilitySelectionStep({
+  step,
+  integrationDefinition,
+  integrationCapabilities,
+  selectedCapabilities,
+  onBack,
+  onToggleCapability,
+  onToggleCapabilityGroup,
+  onSubmit,
+  isReverting,
+  isSubmitting,
+}: CapabilitySelectionStepProps) {
+  const offeredDefinitions = useMemo(
+    () => capabilityDefinitionsForStepOffer(integrationCapabilities, step.capabilities),
+    [integrationCapabilities, step.capabilities],
+  );
+
+  const capabilitySections: CapabilityGroupSection[] = useMemo(
+    () => buildIntegrationCapabilityGroupSections(integrationDefinition, offeredDefinitions),
+    [integrationDefinition, offeredDefinitions],
+  );
+
+  const capabilityByName = useMemo(() => capabilityByNameFromDefinitions(offeredDefinitions), [offeredDefinitions]);
+
+  const selectionDisabled = Boolean(isSubmitting || isReverting);
+  const hasInstructions = Boolean(step.instructions?.trim());
+  const mustPickOne = offeredDefinitions.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <CapabilitySelection
+        integrationCapabilities={offeredDefinitions}
+        capabilitySections={capabilitySections}
+        capabilityByName={capabilityByName}
+        selectedCapabilities={selectedCapabilities}
+        onToggleCapability={onToggleCapability}
+        onToggleCapabilityGroup={onToggleCapabilityGroup}
+        selectionDisabled={selectionDisabled}
+      />
+
+      <div className="flex w-fit max-w-full items-center gap-4 pt-2">
+        {onBack ? (
+          <Button
+            type="button"
+            variant="link"
+            onClick={onBack}
+            disabled={selectionDisabled}
+            className="group h-auto shrink-0 gap-1.5 px-0 py-1 font-normal hover:!no-underline"
+          >
+            <ArrowLeft
+              aria-hidden
+              className="size-4 shrink-0 transition-transform duration-200 ease-out group-hover:-translate-x-1 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
+            />
+            {isReverting ? "Going back..." : "Previous"}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          onClick={() => void onSubmit()}
+          disabled={selectionDisabled || (mustPickOne && selectedCapabilities.size === 0)}
+          className="group justify-center gap-2 text-sm !px-7 hover:!bg-primary"
+        >
+          {isSubmitting ? "Saving..." : "Next"}
+          <MoveRight
+            aria-hidden
+            className="size-4 shrink-0 transition-transform duration-200 ease-out group-hover:translate-x-1 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
+          />
+        </Button>
+      </div>
+
+      {hasInstructions ? <hr className="my-8 border-0 border-t border-gray-300 dark:border-gray-600" /> : null}
+
+      <Instructions description={step.instructions} />
+    </div>
+  );
+}

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/CurrentStep.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/CurrentStep.tsx
@@ -1,5 +1,10 @@
-import type { IntegrationSetupStepDefinition } from "@/api-client";
+import type {
+  IntegrationSetupStepDefinition,
+  IntegrationsCapabilityDefinition,
+  IntegrationsIntegrationDefinition,
+} from "@/api-client";
 import { openRedirectPrompt } from "@/lib/integrations";
+import { CapabilitySelectionStep } from "./CapabilitySelectionStep";
 import { DoneStep } from "./DoneStep";
 import { InputsStep } from "./InputsStep";
 import { RedirectPromptStep } from "./RedirectPromptStep";
@@ -13,6 +18,11 @@ interface CurrentStepProps {
   onBack?: () => void;
   isSubmitting: boolean;
   isReverting: boolean;
+  integrationDefinition: IntegrationsIntegrationDefinition | undefined;
+  integrationCapabilities: IntegrationsCapabilityDefinition[];
+  selectedCapabilities: ReadonlySet<string>;
+  onToggleCapability: (capabilityName: string) => void;
+  onToggleCapabilityGroup: (capabilityNames: string[]) => void;
 }
 
 export function CurrentStep({
@@ -24,6 +34,11 @@ export function CurrentStep({
   onBack,
   isSubmitting,
   isReverting,
+  integrationDefinition,
+  integrationCapabilities,
+  selectedCapabilities,
+  onToggleCapability,
+  onToggleCapabilityGroup,
 }: CurrentStepProps) {
   if (!currentStep) {
     return null;
@@ -36,6 +51,23 @@ export function CurrentStep({
         step={currentStep}
         values={values}
         onChange={onChange}
+        onSubmit={onSubmit}
+        onBack={onBack}
+        isSubmitting={isSubmitting}
+        isReverting={isReverting}
+      />
+    );
+  }
+
+  if (currentStep.type === "CAPABILITY_SELECTION") {
+    return (
+      <CapabilitySelectionStep
+        step={currentStep}
+        integrationDefinition={integrationDefinition}
+        integrationCapabilities={integrationCapabilities}
+        selectedCapabilities={selectedCapabilities}
+        onToggleCapability={onToggleCapability}
+        onToggleCapabilityGroup={onToggleCapabilityGroup}
         onSubmit={onSubmit}
         onBack={onBack}
         isSubmitting={isSubmitting}

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
@@ -1,21 +1,12 @@
-import type { IntegrationsCapabilityDefinition } from "@/api-client";
 import { Info, MoveRight } from "lucide-react";
-import type { CapabilityGroupSection } from "@/lib/capabilities";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { PreCreateCapabilitySelection } from "./PreCreateCapabilitySelection";
 
 export interface PreCreateIntegrationSetupProps {
   instanceName: string;
   onInstanceNameChange: (value: string) => void;
   integrationName: string;
-  integrationCapabilities: IntegrationsCapabilityDefinition[];
-  capabilitySections: CapabilityGroupSection[];
-  capabilityByName: Map<string, IntegrationsCapabilityDefinition>;
-  selectedCapabilities: ReadonlySet<string>;
-  onToggleCapability: (capabilityName: string) => void;
-  onToggleCapabilityGroup: (capabilityNames: string[]) => void;
   isCreatePending: boolean;
   onCreate: () => void;
 }
@@ -24,12 +15,6 @@ export function PreCreateIntegrationSetup({
   instanceName,
   onInstanceNameChange,
   integrationName,
-  integrationCapabilities,
-  capabilitySections,
-  capabilityByName,
-  selectedCapabilities,
-  onToggleCapability,
-  onToggleCapabilityGroup,
   isCreatePending,
   onCreate,
 }: PreCreateIntegrationSetupProps) {
@@ -52,31 +37,18 @@ export function PreCreateIntegrationSetup({
         <div className="flex gap-3 rounded-md border border-gray-300 bg-gray-50 p-3 text-sm leading-relaxed text-gray-600 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-400">
           <Info className="mt-0.5 size-4 shrink-0 text-gray-500 dark:text-gray-500" aria-hidden />
           <p className="min-w-0">
-            You can connect the same integration type more than once—for different environments, namespaces, or
-            organizations. Use a name that identifies this connection.
+            You can connect the same integration provider more than once - for accessing different environments, namespaces, or organizations.
+            <br />
+            Use a name that identifies this connection uniquely.
           </p>
         </div>
       </div>
-
-      <PreCreateCapabilitySelection
-        integrationCapabilities={integrationCapabilities}
-        capabilitySections={capabilitySections}
-        capabilityByName={capabilityByName}
-        selectedCapabilities={selectedCapabilities}
-        onToggleCapability={onToggleCapability}
-        onToggleCapabilityGroup={onToggleCapabilityGroup}
-        isCreatePending={isCreatePending}
-      />
 
       <div className="flex w-fit max-w-full items-center gap-4 pt-2">
         <Button
           type="button"
           onClick={() => void onCreate()}
-          disabled={
-            isCreatePending ||
-            !instanceName.trim() ||
-            (integrationCapabilities.length > 0 && selectedCapabilities.size === 0)
-          }
+          disabled={isCreatePending || !instanceName.trim()}
           className="group justify-center gap-2 text-sm !px-7 hover:!bg-primary"
         >
           {isCreatePending ? "Creating..." : "Next"}

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
@@ -37,7 +37,8 @@ export function PreCreateIntegrationSetup({
         <div className="flex gap-3 rounded-md border border-gray-300 bg-gray-50 p-3 text-sm leading-relaxed text-gray-600 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-400">
           <Info className="mt-0.5 size-4 shrink-0 text-gray-500 dark:text-gray-500" aria-hidden />
           <p className="min-w-0">
-            You can connect the same integration provider more than once - for accessing different environments, namespaces, or organizations.
+            You can connect the same integration provider more than once - for accessing different environments,
+            namespaces, or organizations.
             <br />
             Use a name that identifies this connection uniquely.
           </p>

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/SetupCard.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/SetupCard.tsx
@@ -1,9 +1,9 @@
 import type {
   IntegrationSetupStepDefinition,
   IntegrationsCapabilityDefinition,
+  IntegrationsIntegrationDefinition,
   OrganizationsIntegration,
 } from "@/api-client";
-import type { CapabilityGroupSection } from "@/lib/capabilities";
 import { Alert, AlertDescription, AlertTitle } from "@/ui/alert";
 import { getApiErrorMessage } from "@/lib/errors";
 import { CurrentStep } from "./CurrentStep";
@@ -18,9 +18,8 @@ interface SetupCardProps {
   showSetupStepBack: boolean;
   instanceName: string;
   integrationName: string;
+  integrationDefinition: IntegrationsIntegrationDefinition | undefined;
   integrationCapabilities: IntegrationsCapabilityDefinition[];
-  capabilitySections: CapabilityGroupSection[];
-  capabilityByName: Map<string, IntegrationsCapabilityDefinition>;
   selectedCapabilities: ReadonlySet<string>;
   isCreatePending: boolean;
   isSubmitting: boolean;
@@ -43,9 +42,8 @@ export function SetupCard({
   showSetupStepBack,
   instanceName,
   integrationName,
+  integrationDefinition,
   integrationCapabilities,
-  capabilitySections,
-  capabilityByName,
   selectedCapabilities,
   isCreatePending,
   isSubmitting,
@@ -72,12 +70,6 @@ export function SetupCard({
           instanceName={instanceName}
           onInstanceNameChange={onInstanceNameChange}
           integrationName={integrationName}
-          integrationCapabilities={integrationCapabilities}
-          capabilitySections={capabilitySections}
-          capabilityByName={capabilityByName}
-          selectedCapabilities={selectedCapabilities}
-          onToggleCapability={onToggleCapability}
-          onToggleCapabilityGroup={onToggleCapabilityGroup}
           isCreatePending={isCreatePending}
           onCreate={onCreate}
         />
@@ -91,6 +83,11 @@ export function SetupCard({
           onBack={showSetupStepBack ? onSetupStepBack : undefined}
           isSubmitting={isSubmitting}
           isReverting={isReverting}
+          integrationDefinition={integrationDefinition}
+          integrationCapabilities={integrationCapabilities}
+          selectedCapabilities={selectedCapabilities}
+          onToggleCapability={onToggleCapability}
+          onToggleCapabilityGroup={onToggleCapabilityGroup}
         />
       )}
     </div>

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/SetupView.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/SetupView.tsx
@@ -40,9 +40,8 @@ export function SetupView({ setup }: SetupViewProps) {
       showSetupStepBack={progress.showSetupStepBack}
       instanceName={state.instanceName}
       integrationName={route.integrationName}
+      integrationDefinition={metadata.integrationDefinition}
       integrationCapabilities={metadata.integrationCapabilities}
-      capabilitySections={metadata.capabilitySections}
-      capabilityByName={metadata.capabilityByName}
       selectedCapabilities={state.selectedCapabilities}
       isCreatePending={mutations.createMutation.isPending}
       isSubmitting={mutations.submitStepMutation.isPending}

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
@@ -8,6 +8,7 @@ import type {
 } from "./useIntegrationSetupController";
 import { showErrorToast } from "@/lib/toast";
 import { getGroupToggleState } from "./lib";
+import type { IntegrationSetupStepDefinitionType } from "@/api-client";
 
 interface SetupActionsParams {
   route: IntegrationSetupRoute;
@@ -150,6 +151,19 @@ interface CurrentStepActionParams {
   mutations: Pick<IntegrationSetupMutations, "submitStepMutation" | "revertStepMutation">;
 }
 
+function submitStepBody(type: IntegrationSetupStepDefinitionType, state: IntegrationSetupState) {
+  switch (type) {
+    case "INPUTS":
+      return {
+        inputs: state.stepInputs,
+      };
+  }
+
+  return {
+    capabilities: Array.from(state.selectedCapabilities),
+  };
+}
+
 function useSubmitCurrentStepAction({ state, progress, mutations }: CurrentStepActionParams) {
   return useCallback(async () => {
     const integrationId = state.createdIntegration?.metadata?.id;
@@ -172,9 +186,7 @@ function useSubmitCurrentStepAction({ state, progress, mutations }: CurrentStepA
     try {
       const response = await mutations.submitStepMutation.mutateAsync({
         integrationId,
-        inputs: progress.currentStep.type === "INPUTS" ? state.stepInputs : undefined,
-        capabilities:
-          progress.currentStep.type === "CAPABILITY_SELECTION" ? Array.from(state.selectedCapabilities) : undefined,
+        ...submitStepBody(progress.currentStep.type!, state),
       });
       state.setCreatedIntegration(response.data?.integration || null);
       state.setStepInputs({});

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
@@ -1,7 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback } from "react";
 import type {
-  IntegrationSetupMetadata,
   IntegrationSetupMutations,
   IntegrationSetupProgress,
   IntegrationSetupRoute,
@@ -14,14 +13,15 @@ interface SetupActionsParams {
   route: IntegrationSetupRoute;
   state: IntegrationSetupState;
   progress: IntegrationSetupProgress;
-  metadata: IntegrationSetupMetadata;
   mutations: IntegrationSetupMutations;
 }
 
-export function useIntegrationSetupActions({ route, state, progress, metadata, mutations }: SetupActionsParams) {
-  const handleCreateIntegration = useCreateIntegrationHandler({ route, state, metadata, mutations });
+export function useIntegrationSetupActions({ route, state, progress, mutations }: SetupActionsParams) {
+  const handleCreateIntegration = useCreateIntegrationHandler({ route, state, mutations });
   const capabilityToggles = useCapabilitySelectionActions({
     createMutation: mutations.createMutation,
+    submitStepMutation: mutations.submitStepMutation,
+    revertStepMutation: mutations.revertStepMutation,
     setSelectedCapabilities: state.setSelectedCapabilities,
   });
   const handleStepInputChange = useStepInputChange(state.setStepInputs);
@@ -48,11 +48,10 @@ export function useIntegrationSetupActions({ route, state, progress, metadata, m
 interface CreateIntegrationHandlerParams {
   route: IntegrationSetupRoute;
   state: IntegrationSetupState;
-  metadata: IntegrationSetupMetadata;
   mutations: Pick<IntegrationSetupMutations, "createMutation">;
 }
 
-function useCreateIntegrationHandler({ route, state, metadata, mutations }: CreateIntegrationHandlerParams) {
+function useCreateIntegrationHandler({ route, state, mutations }: CreateIntegrationHandlerParams) {
   return useCallback(async () => {
     const trimmedName = state.instanceName.trim();
     if (!trimmedName) {
@@ -60,34 +59,35 @@ function useCreateIntegrationHandler({ route, state, metadata, mutations }: Crea
       return;
     }
 
-    if (metadata.integrationCapabilities.length > 0 && state.selectedCapabilities.size === 0) {
-      showErrorToast("Select at least one capability");
-      return;
-    }
-
     try {
       const response = await mutations.createMutation.mutateAsync({
         integrationName: route.integrationName,
         name: trimmedName,
-        capabilities: Array.from(state.selectedCapabilities),
       });
       state.setCreatedIntegration(response.data?.integration || null);
       state.setStepInputs({});
     } catch {
       // Error is shown by inline alert.
     }
-  }, [route.integrationName, state, metadata.integrationCapabilities, mutations.createMutation]);
+  }, [route.integrationName, state, mutations.createMutation]);
 }
 
 interface CapabilitySelectionActionsParams {
   createMutation: IntegrationSetupMutations["createMutation"];
+  submitStepMutation: IntegrationSetupMutations["submitStepMutation"];
+  revertStepMutation: IntegrationSetupMutations["revertStepMutation"];
   setSelectedCapabilities: Dispatch<SetStateAction<Set<string>>>;
 }
 
-function useCapabilitySelectionActions({ createMutation, setSelectedCapabilities }: CapabilitySelectionActionsParams) {
+function useCapabilitySelectionActions({
+  createMutation,
+  submitStepMutation,
+  revertStepMutation,
+  setSelectedCapabilities,
+}: CapabilitySelectionActionsParams) {
   const toggleCapabilitySelection = useCallback(
     (capabilityName: string) => {
-      if (createMutation.isPending) {
+      if (createMutation.isPending || submitStepMutation.isPending || revertStepMutation.isPending) {
         return;
       }
 
@@ -101,19 +101,24 @@ function useCapabilitySelectionActions({ createMutation, setSelectedCapabilities
         return next;
       });
     },
-    [createMutation, setSelectedCapabilities],
+    [createMutation.isPending, submitStepMutation.isPending, revertStepMutation.isPending, setSelectedCapabilities],
   );
 
   const toggleCapabilityGroup = useCallback(
     (capabilityNames: string[]) => {
-      if (createMutation.isPending || capabilityNames.length === 0) {
+      if (
+        createMutation.isPending ||
+        submitStepMutation.isPending ||
+        revertStepMutation.isPending ||
+        capabilityNames.length === 0
+      ) {
         return;
       }
 
       setSelectedCapabilities((previous) => {
-        const state = getGroupToggleState(capabilityNames, previous);
+        const groupState = getGroupToggleState(capabilityNames, previous);
         const next = new Set(previous);
-        if (state === "all") {
+        if (groupState === "all") {
           capabilityNames.forEach((name) => next.delete(name));
         } else {
           capabilityNames.forEach((name) => next.add(name));
@@ -121,7 +126,7 @@ function useCapabilitySelectionActions({ createMutation, setSelectedCapabilities
         return next;
       });
     },
-    [createMutation, setSelectedCapabilities],
+    [createMutation.isPending, submitStepMutation.isPending, revertStepMutation.isPending, setSelectedCapabilities],
   );
 
   return {
@@ -156,10 +161,20 @@ function useSubmitCurrentStepAction({ state, progress, mutations }: CurrentStepA
       return;
     }
 
+    if (progress.currentStep.type === "CAPABILITY_SELECTION") {
+      const offered = progress.currentStep.capabilities ?? [];
+      if (offered.length > 0 && state.selectedCapabilities.size === 0) {
+        showErrorToast("Select at least one capability");
+        return;
+      }
+    }
+
     try {
       const response = await mutations.submitStepMutation.mutateAsync({
         integrationId,
         inputs: progress.currentStep.type === "INPUTS" ? state.stepInputs : undefined,
+        capabilities:
+          progress.currentStep.type === "CAPABILITY_SELECTION" ? Array.from(state.selectedCapabilities) : undefined,
       });
       state.setCreatedIntegration(response.data?.integration || null);
       state.setStepInputs({});
@@ -236,7 +251,9 @@ function useSetupStepBackAction({ state, progress, mutations, handleRevertCurren
     }
 
     if (
-      !window.confirm("Remove this partially configured integration? You'll return to naming and capability selection.")
+      !window.confirm(
+        "Remove this partially configured integration? You'll return to naming and can start setup again.",
+      )
     ) {
       return;
     }

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupActions.ts
@@ -157,11 +157,14 @@ function submitStepBody(type: IntegrationSetupStepDefinitionType, state: Integra
       return {
         inputs: state.stepInputs,
       };
+
+    case "CAPABILITY_SELECTION":
+      return {
+        capabilities: Array.from(state.selectedCapabilities),
+      };
   }
 
-  return {
-    capabilities: Array.from(state.selectedCapabilities),
-  };
+  return {};
 }
 
 function useSubmitCurrentStepAction({ state, progress, mutations }: CurrentStepActionParams) {

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
@@ -1,5 +1,5 @@
 import type {
-  IntegrationsCapabilityDefinition,
+  IntegrationSetupStepDefinition,
   IntegrationsIntegrationDefinition,
   OrganizationsIntegration,
 } from "@/api-client";
@@ -16,7 +16,6 @@ import {
   useNextIntegrationSetupStep,
   usePreviousIntegrationSetupStep,
 } from "@/hooks/useIntegrations";
-import { buildIntegrationCapabilityGroupSections } from "@/lib/capabilities";
 import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { useIntegrationSetupActions } from "./useIntegrationSetupActions";
 import { applyResumeDescribeIfChanged, canRevertSetupStep, getCurrentSetupStep, getNextIntegrationName } from "./lib";
@@ -35,18 +34,17 @@ export function useIntegrationSetupController(organizationId: string) {
   });
   const state = useIntegrationSetupLocalState({
     integrationName: route.integrationName,
-    integrationCapabilities: metadata.integrationCapabilities,
     existingIntegrationNames: metadata.existingIntegrationNames,
     setupIntegrationId: route.setupIntegrationId,
     resumeIntegrationDescribe: queries.resumeIntegrationDescribe,
   });
   const progress = useIntegrationSetupProgress(state.createdIntegration, metadata.integrationLabel);
+  useSyncSelectedCapabilitiesForStep(progress.currentStep, state.setSelectedCapabilities);
   const mutations = useIntegrationSetupMutations(organizationId, state.createdIntegration);
   const actions = useIntegrationSetupActions({
     route,
     state,
     progress,
-    metadata,
     mutations,
   });
 
@@ -119,11 +117,6 @@ function useIntegrationSetupMetadata({
     () => getIntegrationCapabilities(integrationDefinition),
     [integrationDefinition],
   );
-  const capabilitySections = useMemo(
-    () => buildIntegrationCapabilityGroupSections(integrationDefinition, integrationCapabilities),
-    [integrationDefinition, integrationCapabilities],
-  );
-  const capabilityByName = useMemo(() => getCapabilityByName(integrationCapabilities), [integrationCapabilities]);
   const existingIntegrationNames = useMemo(
     () => getExistingIntegrationNames(connectedIntegrations),
     [connectedIntegrations],
@@ -133,15 +126,12 @@ function useIntegrationSetupMetadata({
     integrationDefinition,
     integrationLabel,
     integrationCapabilities,
-    capabilitySections,
-    capabilityByName,
     existingIntegrationNames,
   };
 }
 
 interface IntegrationSetupLocalStateParams {
   integrationName: string;
-  integrationCapabilities: IntegrationsCapabilityDefinition[];
   existingIntegrationNames: Set<string>;
   setupIntegrationId?: string;
   resumeIntegrationDescribe?: OrganizationsIntegration | null;
@@ -149,7 +139,6 @@ interface IntegrationSetupLocalStateParams {
 
 function useIntegrationSetupLocalState({
   integrationName,
-  integrationCapabilities,
   existingIntegrationNames,
   setupIntegrationId,
   resumeIntegrationDescribe,
@@ -170,7 +159,6 @@ function useIntegrationSetupLocalState({
   );
 
   useResetSetupState(integrationName, lastResumeDescribeKey, setters);
-  useDefaultSelectedCapabilities(createdIntegration, integrationCapabilities, setSelectedCapabilities);
   useDefaultInstanceName(instanceName, integrationName, existingIntegrationNames, setInstanceName);
   useResumeIntegrationDescribe(setupIntegrationId, resumeIntegrationDescribe, lastResumeDescribeKey, setters);
 
@@ -184,6 +172,24 @@ function useIntegrationSetupLocalState({
     selectedCapabilities,
     setSelectedCapabilities,
   };
+}
+
+function useSyncSelectedCapabilitiesForStep(
+  currentStep: IntegrationSetupStepDefinition | null,
+  setSelectedCapabilities: Dispatch<SetStateAction<Set<string>>>,
+) {
+  const offerKey =
+    currentStep?.type === "CAPABILITY_SELECTION"
+      ? `${currentStep.name ?? ""}:${(currentStep.capabilities ?? []).join(",")}`
+      : "";
+
+  useEffect(() => {
+    if (!offerKey || currentStep?.type !== "CAPABILITY_SELECTION") {
+      return;
+    }
+    const names = (currentStep.capabilities ?? []).filter((n): n is string => Boolean(n));
+    setSelectedCapabilities(new Set(names));
+  }, [offerKey, currentStep, setSelectedCapabilities]);
 }
 
 function useIntegrationSetupProgress(createdIntegration: OrganizationsIntegration | null, integrationLabel: string) {
@@ -244,26 +250,6 @@ function useResetSetupState(
     setters.setInstanceName("");
     setters.setSelectedCapabilities(new Set());
   }, [integrationName, lastResumeDescribeKey, setters]);
-}
-
-function useDefaultSelectedCapabilities(
-  createdIntegration: OrganizationsIntegration | null,
-  integrationCapabilities: IntegrationsCapabilityDefinition[],
-  setSelectedCapabilities: Dispatch<SetStateAction<Set<string>>>,
-) {
-  useEffect(() => {
-    if (createdIntegration) {
-      return;
-    }
-
-    setSelectedCapabilities((current) => {
-      if (current.size > 0) {
-        return current;
-      }
-
-      return new Set(integrationCapabilities.map((capability) => capability.name).filter(Boolean) as string[]);
-    });
-  }, [integrationCapabilities, createdIntegration, setSelectedCapabilities]);
 }
 
 function useDefaultInstanceName(
@@ -328,16 +314,6 @@ function getIntegrationCapabilities(integrationDefinition?: IntegrationsIntegrat
   return [...(integrationDefinition?.capabilities || [])]
     .filter((capability) => Boolean(capability.name))
     .sort((left, right) => left.label!.localeCompare(right.label!));
-}
-
-function getCapabilityByName(integrationCapabilities: IntegrationsCapabilityDefinition[]) {
-  const map = new Map<string, IntegrationsCapabilityDefinition>();
-  for (const capability of integrationCapabilities) {
-    if (capability.name) {
-      map.set(capability.name, capability);
-    }
-  }
-  return map;
 }
 
 function getExistingIntegrationNames(connectedIntegrations: OrganizationsIntegration[]) {

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
@@ -178,18 +178,30 @@ function useSyncSelectedCapabilitiesForStep(
   currentStep: IntegrationSetupStepDefinition | null,
   setSelectedCapabilities: Dispatch<SetStateAction<Set<string>>>,
 ) {
-  const offerKey =
-    currentStep?.type === "CAPABILITY_SELECTION"
-      ? `${currentStep.name ?? ""}:${(currentStep.capabilities ?? []).join(",")}`
-      : "";
+  const offerKey = getCapabilitySelectionOfferKey(currentStep);
 
   useEffect(() => {
-    if (!offerKey || currentStep?.type !== "CAPABILITY_SELECTION") {
+    if (!offerKey) {
       return;
     }
-    const names = (currentStep.capabilities ?? []).filter((n): n is string => Boolean(n));
+    const names = getCapabilitiesFromOfferKey(offerKey);
     setSelectedCapabilities(new Set(names));
-  }, [offerKey, currentStep, setSelectedCapabilities]);
+  }, [offerKey, setSelectedCapabilities]);
+}
+
+function getCapabilitySelectionOfferKey(currentStep: IntegrationSetupStepDefinition | null) {
+  if (currentStep?.type !== "CAPABILITY_SELECTION") {
+    return "";
+  }
+
+  return JSON.stringify({
+    name: currentStep.name ?? "",
+    capabilities: (currentStep.capabilities ?? []).filter((name): name is string => Boolean(name)),
+  });
+}
+
+function getCapabilitiesFromOfferKey(offerKey: string) {
+  return (JSON.parse(offerKey) as { capabilities: string[] }).capabilities;
 }
 
 function useIntegrationSetupProgress(createdIntegration: OrganizationsIntegration | null, integrationLabel: string) {


### PR DESCRIPTION
Right now, the setup flow initiates after the user chooses the capabilities they want. This assumes all capabilities are selectable for all possible flows, which is not the case. For example, for the GitHub integration, the `github.getWorkflowUsage` component can only be used if you are connected to an organization, and not a user account. Therefore, it should not be offered at all as a possible capability if you are connected to a user account.

---

This pull request moves capability offering and selection into the setup flow as well. Capability selection becomes a new kind of step, so it can be placed as the first step, or later down the flow. This allows integration implementations to properly control which capabilities to offer for selection depending on flow chosen by the user.
