### PR TITLE
docs: add payload size limits to HTTP Request component (#4286)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -477,6 +477,15 @@ The component emits the response with:
 - **headers**: Response headers
 - **body**: Parsed response body (JSON if possible, otherwise string)
 
+### Payload Size Limits
+
+Event payloads have a maximum size of **64KB (65,536 bytes)**. If an HTTP response body exceeds this limit, the event will fail with a  error and will not be able to traverse the event graph.
+
+For large data (e.g., GitHub diffs, file contents), consider these alternatives:
+- **Use commit metadata** available in the event context instead of fetching large bodies
+- **Store large data in canvas memory** using the Add Memory component first, then reference it
+- **Delegate to external agents** that can process large payloads independently
+
 ### Example Output
 
 ```json


### PR DESCRIPTION
## Summary

Fixes [#4286](https://github.com/superplanehq/superplane/issues/4286).

Adds a **Payload Size Limits** section to the HTTP Request component documentation explaining the 64KB event payload limit and suggesting alternatives for large data patterns.

## Changes

- Added  subsection to HTTP Request documentation
- Documents the 64KB (65,536 bytes) event payload maximum
- Provides three alternatives for large data: commit metadata, canvas memory, external agents

## Before

The HTTP Request section had no mention of payload size limits.

## After

Clear documentation including the limit, error message example, and recommended workarounds.