### PR TITLE
docs: add payload size limits to HTTP Request component (#4286)

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -477,6 +477,15 @@ The component emits the response with:
 - **headers**: Response headers
 - **body**: Parsed response body (JSON if possible, otherwise string)
 
+### Payload Size Limits
+
+Event payloads have a maximum size of **64KB (65,536 bytes)**. If an HTTP response body exceeds this limit, the event will fail with a `"payload too large"` error and will not be able to traverse the event graph.
+
+For large data (e.g., GitHub diffs, file contents), consider these alternatives:
+- **Use commit metadata** available in the event context instead of fetching large bodies
+- **Store large data in canvas memory** using the Add Memory component first, then reference it
+- **Delegate to external agents** that can process large payloads independently
+
 ### Example Output
 
 ```json


### PR DESCRIPTION
## Summary

Adds documentation about the 64KB payload size limit for the HTTP Request component.

**Before:** No mention of size limits.

**After:** New "Payload Size Limits" section documents the 64KB limit and alternatives for large data.

## Changes

- `docs/components/Core.mdx`: Added Payload Size Limits section with alternatives

## Test

Build the docs and verify the new section appears.
