### PR TITLE
fix(errors-console): show full error message text in the list

### DIFF
--- a/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
+++ b/web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx
@@ -118,7 +118,7 @@ function ErrorItemRow({
           <span>{label}</span>
         </div>
         {item.execution.resultMessage && (
-          <span className="text-xs text-red-600 truncate max-w-[300px]">{item.execution.resultMessage}</span>
+          <span className="text-xs text-red-600 break-words">{item.execution.resultMessage}</span>
         )}
       </div>
       {onAcknowledgeErrors && item.execution.id && (


### PR DESCRIPTION
## Summary

Shows the full error message in the errors console instead of truncating it.

**Before:** Error messages truncated to `max-w-[300px]` with `truncate` class.

**After:** Full error message displayed with `break-words` to show all text.

## Changes

- `web_src/src/pages/workflowv2/ErrorsConsoleContent.tsx`: Changed className from `truncate max-w-[300px]` to `break-words`
