### PR TITLE
feat(setup): allow skipping SMTP setup

### DIFF
--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -21,6 +21,7 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.visitSetupPage()
 		steps.fillInOwnerDetailsAndSubmit("owner@example.com", "Owner", "User", "Password1")
 		steps.assertOwnerAndOrganizationCreated()
+		steps.assertSMTPNotConfigured()
 		steps.assertRedirectedToOrganizationHome()
 		steps.assertOwnerSetupIsNoLongerRequired()
 	})
@@ -54,6 +55,21 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.assertOwnerAndOrganizationCreated()
 		steps.assertPrivateNetworkAccessEnabled()
 		steps.assertRedirectedToOrganizationHome()
+	})
+
+	t.Run("can skip SMTP setup from the SMTP configuration step", func(t *testing.T) {
+		steps := &ownerSetupSteps{t: t}
+		steps.start()
+		steps.visitRootPage()
+		steps.assertRedirectedToSetup()
+		steps.visitSetupPage()
+		steps.fillInOwnerDetails("skip-smtp-config-owner@example.com", "Skip", "SMTP", "Password1")
+		steps.chooseSMTPSetup()
+		steps.skipSMTPConfig()
+		steps.assertOwnerAndOrganizationCreated()
+		steps.assertSMTPNotConfigured()
+		steps.assertRedirectedToOrganizationHome()
+		steps.assertOwnerSetupIsNoLongerRequired()
 	})
 
 	t.Run("can login with email and password after owner setup", func(t *testing.T) {
@@ -175,6 +191,11 @@ func (s *ownerSetupSteps) submitSMTPSetup() {
 	s.waitForSetupToComplete()
 }
 
+func (s *ownerSetupSteps) skipSMTPConfig() {
+	s.session.Click(q.Text("Skip"))
+	s.waitForSetupToComplete()
+}
+
 func (s *ownerSetupSteps) waitForSetupToComplete() {
 	// Poll for up to 10 seconds, checking every 200ms
 	for i := 0; i < 50; i++ {
@@ -222,6 +243,13 @@ func (s *ownerSetupSteps) assertRedirectedToOrganizationHome() {
 func (s *ownerSetupSteps) assertOwnerSetupIsNoLongerRequired() {
 	required := middleware.IsOwnerSetupRequired()
 	assert.False(s.t, required, "owner setup should no longer be required after completion")
+}
+
+func (s *ownerSetupSteps) assertSMTPNotConfigured() {
+	var count int64
+	err := database.Conn().Model(&models.EmailSettings{}).Where("provider = ?", models.EmailProviderSMTP).Count(&count).Error
+	assert.NoError(s.t, err, "count email settings")
+	assert.Equal(s.t, int64(0), count, "expected SMTP settings to not be configured")
 }
 
 func (s *ownerSetupSteps) assertPrivateNetworkAccessEnabled() {

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -480,9 +480,14 @@ const OwnerSetup: React.FC = () => {
               Use TLS (STARTTLS)
             </Label>
 
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? "Saving..." : "Finish setup"}
-            </Button>
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" className="flex-1" disabled={loading} onClick={handleSkipSMTP}>
+                Skip
+              </Button>
+              <Button type="submit" className="flex-1" disabled={loading}>
+                {loading ? "Saving..." : "Finish setup"}
+              </Button>
+            </div>
           </form>
         )}
       </div>


### PR DESCRIPTION
# What changed

Now you can skip the SMTP set up from the "SMTP setup screen"

<img width="664" height="1004" alt="image" src="https://github.com/user-attachments/assets/45fc77e0-fd9b-4f7c-9bbe-952c4d03dd5f" />


# Why

I've miss-clicked on "Set up SMTP" and was not able to skip it, so I had no way of amend my mistake. I've found that a workaround was to refresh the webpage and start all over, but it's not a nice UX 

# How

Since it's a small change and I didn't ask for permission first, I've tried to leave the smallest footprint possible by reusing the preexisting function `handleSkipSMTP`

I've also noticed that there are better ways to do the wizard with form libraries like `react-hook-form`, and doing validation with something like `zod`. We can discuss this as future enhancements

# Related issues

Kind of related to https://github.com/superplanehq/superplane/issues/1742 , but not exactly the same issue

# No breaking changes
