### PR TITLE
feat: add global command palette (Cmd/Ctrl+K)

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -28,6 +28,8 @@ import OrganizationDetailAdmin from "./pages/admin/OrganizationDetail";
 import AccountsListAdmin from "./pages/admin/AccountsList";
 import InstallationSettingsAdmin from "./pages/admin/InstallationSettings";
 import ImpersonationBanner from "./components/ImpersonationBanner";
+import { CommandPalette } from "./components/CommandPalette";
+import { useCommandPaletteShortcut } from "./hooks/useCommandPaletteShortcut";
 
 // Create a client
 const queryClient = new QueryClient({
@@ -119,8 +121,10 @@ function AppRouter() {
 }
 
 function OrganizationScope() {
+  const { open, setOpen } = useCommandPaletteShortcut();
   return (
     <PermissionsProvider>
+      <CommandPalette open={open} onOpenChange={setOpen} />
       <Outlet />
     </PermissionsProvider>
   );

--- a/web_src/src/components/CommandPalette/index.tsx
+++ b/web_src/src/components/CommandPalette/index.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Building2, FileCode, Home, LayoutGrid, Plus, Settings, Shield } from "lucide-react";
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { useCanvases } from "@/hooks/useCanvasData";
+import { useAccount } from "@/contexts/AccountContext";
+import { usePermissions } from "@/contexts/PermissionsContext";
+import { analytics } from "@/lib/analytics";
+
+export interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ActionGroup = "navigation" | "canvas" | "action" | "account";
+
+const MAX_CANVASES = 8;
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const orgId = organizationId ?? "";
+  const { account } = useAccount();
+  const { canAct } = usePermissions();
+
+  const { data: canvases = [] } = useCanvases(orgId);
+
+  useEffect(() => {
+    if (open && orgId) {
+      analytics.commandPaletteOpen(orgId);
+    }
+  }, [open, orgId]);
+
+  const run = useCallback(
+    (actionId: string, group: ActionGroup, fn: () => void) => {
+      if (orgId) analytics.commandPaletteAction(actionId, group, orgId);
+      onOpenChange(false);
+      fn();
+    },
+    [onOpenChange, orgId],
+  );
+
+  const recentCanvases = useMemo(() => {
+    return [...canvases]
+      .sort((a, b) => {
+        const aDate = a.metadata?.updatedAt ?? a.metadata?.createdAt ?? "";
+        const bDate = b.metadata?.updatedAt ?? b.metadata?.createdAt ?? "";
+        return bDate.localeCompare(aDate);
+      })
+      .slice(0, MAX_CANVASES);
+  }, [canvases]);
+
+  const canCreate = canAct("canvases", "create");
+  const isInstallationAdmin = !!account?.installation_admin;
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange} title="SuperPlane Command Palette">
+      <CommandInput placeholder="Search canvases or run an action..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Navigation">
+          <CommandItem
+            value="navigation home canvases"
+            onSelect={() => run("navigate_home", "navigation", () => navigate(`/${orgId}`))}
+          >
+            <Home />
+            Home
+            <CommandShortcut>G H</CommandShortcut>
+          </CommandItem>
+          <CommandItem
+            value="navigation templates"
+            onSelect={() => run("navigate_templates", "navigation", () => navigate(`/${orgId}/templates`))}
+          >
+            <FileCode />
+            Templates
+          </CommandItem>
+          <CommandItem
+            value="navigation organization settings"
+            onSelect={() => run("navigate_org_settings", "navigation", () => navigate(`/${orgId}/settings`))}
+          >
+            <Settings />
+            Organization settings
+          </CommandItem>
+          <CommandItem
+            value="navigation switch organization"
+            onSelect={() => run("switch_org", "account", () => navigate(`/`))}
+          >
+            <Building2 />
+            Switch organization
+          </CommandItem>
+          {isInstallationAdmin && (
+            <CommandItem
+              value="navigation admin dashboard"
+              onSelect={() => run("navigate_admin", "navigation", () => navigate(`/admin`))}
+            >
+              <Shield />
+              Admin dashboard
+            </CommandItem>
+          )}
+        </CommandGroup>
+
+        {canCreate && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Actions">
+              <CommandItem
+                value="action create canvas new"
+                onSelect={() => run("create_canvas", "action", () => navigate(`/${orgId}/canvases/new`))}
+              >
+                <Plus />
+                Create canvas
+              </CommandItem>
+            </CommandGroup>
+          </>
+        )}
+
+        {recentCanvases.length > 0 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Canvases">
+              {recentCanvases.map((canvas) => {
+                const id = canvas.metadata?.id;
+                const name = canvas.metadata?.name;
+                if (!id || !name) return null;
+                const description = canvas.metadata?.description ?? "";
+                return (
+                  <CommandItem
+                    key={id}
+                    value={`canvas ${name} ${description} ${id}`}
+                    onSelect={() => run("open_canvas", "canvas", () => navigate(`/${orgId}/canvases/${id}`))}
+                  >
+                    <LayoutGrid />
+                    <span className="truncate">{name}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/web_src/src/hooks/useCommandPaletteShortcut.spec.tsx
+++ b/web_src/src/hooks/useCommandPaletteShortcut.spec.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useCommandPaletteShortcut } from "./useCommandPaletteShortcut";
+
+function Harness() {
+  const { open, setOpen } = useCommandPaletteShortcut();
+  return (
+    <div>
+      <span data-testid="open">{open ? "open" : "closed"}</span>
+      <button onClick={() => setOpen(false)}>close</button>
+      <input data-testid="text-input" />
+      <textarea data-testid="textarea" />
+      <div data-testid="editable" contentEditable="true" />
+      <div data-testid="monaco" className="monaco-editor">
+        <div data-testid="monaco-inner" />
+      </div>
+    </div>
+  );
+}
+
+const stateOf = () => screen.getByTestId("open").textContent;
+
+describe("useCommandPaletteShortcut", () => {
+  it("opens on Cmd+K", () => {
+    render(<Harness />);
+    expect(stateOf()).toBe("closed");
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("open");
+  });
+
+  it("opens on Ctrl+K", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(stateOf()).toBe("open");
+  });
+
+  it("toggles closed when fired again", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("open");
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("closed");
+  });
+
+  it("ignores plain `k` without modifier", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "k" });
+    expect(stateOf()).toBe("closed");
+  });
+
+  it("ignores Cmd+Shift+K and Cmd+Alt+K", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true, shiftKey: true });
+    fireEvent.keyDown(window, { key: "k", metaKey: true, altKey: true });
+    expect(stateOf()).toBe("closed");
+  });
+
+  it.each([
+    ["text-input", "an <input>"],
+    ["textarea", "a <textarea>"],
+    ["editable", "a contenteditable element"],
+    ["monaco-inner", "a Monaco editor"],
+  ])("does not open when focus is in %s (%s)", (testId) => {
+    render(<Harness />);
+    const target = screen.getByTestId(testId);
+    fireEvent.keyDown(target, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("closed");
+  });
+
+  it("still toggles closed from inside an editable element when already open", () => {
+    render(<Harness />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("open");
+    const input = screen.getByTestId("text-input");
+    fireEvent.keyDown(input, { key: "k", metaKey: true });
+    expect(stateOf()).toBe("closed");
+  });
+});

--- a/web_src/src/hooks/useCommandPaletteShortcut.ts
+++ b/web_src/src/hooks/useCommandPaletteShortcut.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  return !!target.closest('input, textarea, select, [contenteditable="true"], .monaco-editor');
+};
+
+export interface UseCommandPaletteShortcutResult {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export function useCommandPaletteShortcut(): UseCommandPaletteShortcutResult {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "k" || !(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+        return;
+      }
+      if (!open && isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      setOpen((prev) => !prev);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  return { open, setOpen };
+}

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -10,6 +10,22 @@ export const analytics = {
     posthog.capture("settings:member_accept", { organization_id: organizationId });
   },
 
+  commandPaletteOpen: (organizationId: string) => {
+    posthog.capture("command_palette:open", { organization_id: organizationId });
+  },
+
+  commandPaletteAction: (
+    actionId: string,
+    group: "navigation" | "canvas" | "action" | "account",
+    organizationId: string,
+  ) => {
+    posthog.capture("command_palette:action", {
+      action_id: actionId,
+      group,
+      organization_id: organizationId,
+    });
+  },
+
   canvasCreate: (
     canvasId: string,
     organizationId: string,


### PR DESCRIPTION
## 📋 Summary

SuperPlane already ships `cmdk` and the shadcn `<Command*>` primitives, but never exposes them as a global palette — power users have no keyboard-first way to navigate between canvases, settings, and admin surfaces inside an organization. This PR mounts a global Cmd/Ctrl+K command palette inside the org-scoped route shell. It adds zero new dependencies, gates each action through the existing `PermissionsContext`, and emits PostHog telemetry so we can measure adoption before investing in deeper commands (run replay, AI canvas generation, jump-to-secret).

## 🔄 Changes

### ✨ New feature

- `web_src/src/components/CommandPalette/index.tsx` — new component built on `components/ui/command` (`CommandDialog` + `CommandList`/`CommandGroup`/`CommandItem`). Three groups:
  - **Navigation:** Home, Templates, Organization settings, Switch organization, Admin (only when `account.installation_admin`).
  - **Actions:** Create canvas (gated on `canvases:create` via `PermissionsContext.canAct`).
  - **Canvases:** top 8 sorted by `metadata.updatedAt || createdAt`, click → `/<orgId>/canvases/<id>`. Live data via the existing `useCanvases(orgId)` hook.
- `web_src/src/hooks/useCommandPaletteShortcut.ts` — Cmd+K / Ctrl+K toggle hook. Mirrors the suppression contract of `useBuildingBlocksShortcut`: ignores keydown when focus is in `<input>`, `<textarea>`, `<select>`, contenteditable, or a Monaco editor. Exception: when the palette is already open, the shortcut still toggles closed from any field so users aren't trapped. Rejects Shift+ and Alt+ combinations to avoid clashing with browser shortcuts.
- `web_src/src/App.tsx` — mounts `<CommandPalette>` inside `OrganizationScope` so it inherits `organizationId` from the URL and the `PermissionsContext` provider. Inert on `/login`, `/setup`, `/admin`, and the org-select screen, which is the intended scope.

### 📊 Telemetry

- `web_src/src/lib/analytics.ts` — adds `analytics.commandPaletteOpen(organizationId)` and `analytics.commandPaletteAction(actionId, group, organizationId)`. Events:
  - `command_palette:open` — fired once per dialog open
  - `command_palette:action` — `{ action_id, group, organization_id }` where `group ∈ "navigation" | "canvas" | "action" | "account"`

### 🧪 Tests

- `web_src/src/hooks/useCommandPaletteShortcut.spec.tsx` — 10 tests covering Cmd+K, Ctrl+K, toggle behavior, suppression in all four editable contexts (input, textarea, contenteditable, Monaco), modifier rejection (Shift, Alt), and the "still toggles closed from inside an input when already open" exception.

## 🧪 Testing

- [x] Unit tests added — 10 passing in `useCommandPaletteShortcut.spec.tsx`
- [x] Lint passes on touched files (`eslint`)
- [x] Prettier passes on touched files
- [x] TypeScript: no new errors introduced (pre-existing `@/api-client` errors stem from the generated SDK, fixed by `make openapi.web.client.gen`)
- [ ] Manual: visit `/<orgId>`, press Cmd/Ctrl+K, confirm palette opens with three groups
- [ ] Manual: type a canvas name → Enter → navigates to `/<orgId>/canvases/<id>`
- [ ] Manual: focus a text input, press Cmd+K, confirm palette does **not** open
- [ ] Manual: open the canvas YAML modal (Monaco), press Cmd+K, confirm palette does **not** open
- [ ] Manual: open palette, focus the search input, press Cmd+K, confirm palette **closes** (toggle-from-open exception)
- [ ] Manual: as a role without `canvases:create`, confirm "Create canvas" is hidden
- [ ] Manual: as a non-`installation_admin`, confirm "Admin dashboard" is hidden
- [ ] PostHog: `command_palette:open` and `command_palette:action` events appear with expected payload

## 📸 Screenshots

*To be attached during manual review — empty state, canvas search results, permission-gated state.*

## 🔗 Related

- Branch does not match a `<user>/<ticket>-<desc>` convention — no Linear ticket linked.
- Builds on existing primitives in `web_src/src/components/ui/command.tsx` and `web_src/src/ui/command/index.tsx`.
- Mirrors keyboard suppression contract from `web_src/src/ui/CanvasPage/useBuildingBlocksShortcut.ts`.

### Out of scope (suggested follow-ups, each its own PR)

- Run-from-step / rerun-with-payload action surfaced inside an open canvas.
- AI-assisted canvas generation entry point ("Generate canvas from description").
- Jump-to-secret / jump-to-integration commands.
- Recently-used scoring instead of pure `updatedAt` sort.
