### PR TITLE
fix: allow replacing default integration instance name

### DIFF
--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.spec.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.spec.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type * as SdkGen from "@/api-client/sdk.gen";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IntegrationSetup } from ".";
+
+const { integrationsListIntegrations, organizationsDescribeIntegration, organizationsListIntegrations } = vi.hoisted(
+  () => ({
+    integrationsListIntegrations: vi.fn(),
+    organizationsDescribeIntegration: vi.fn(),
+    organizationsListIntegrations: vi.fn(),
+  }),
+);
+
+vi.mock("@/api-client/sdk.gen", async (importOriginal) => {
+  const actual = await importOriginal<typeof SdkGen>();
+  return {
+    ...actual,
+    integrationsListIntegrations,
+    organizationsDescribeIntegration,
+    organizationsListIntegrations,
+  };
+});
+
+function renderIntegrationSetup() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/org-123/settings/integrations/setup/github"]}>
+        <Routes>
+          <Route
+            path="/:organizationId/settings/integrations/setup/:integrationName"
+            element={<IntegrationSetup organizationId="org-123" />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("PreCreateIntegrationSetup", () => {
+  beforeEach(() => {
+    integrationsListIntegrations.mockResolvedValue({
+      data: {
+        integrations: [{ name: "github", label: "GitHub", capabilities: [] }],
+      },
+    });
+    organizationsListIntegrations.mockResolvedValue({ data: { integrations: [] } });
+    organizationsDescribeIntegration.mockResolvedValue({ data: { integration: null } });
+  });
+
+  it("lets users clear the default instance name before typing a replacement", async () => {
+    const user = userEvent.setup();
+    renderIntegrationSetup();
+
+    const input = await screen.findByLabelText("Name");
+    await waitFor(() => expect(input).toHaveValue("github"));
+
+    await user.clear(input);
+    await user.type(input, "production");
+
+    expect(input).toHaveValue("production");
+  });
+});

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.tsx
@@ -29,7 +29,7 @@ export function PreCreateIntegrationSetup({
             id="integration-instance-name"
             value={instanceName}
             onChange={(event) => onInstanceNameChange(event.target.value)}
-            placeholder={`${integrationName}-integration`}
+            placeholder={`${integrationName} integration`}
             autoComplete="off"
             className="h-9 w-72 max-w-full"
           />

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
@@ -4,7 +4,7 @@ import type {
   OrganizationsIntegration,
 } from "@/api-client";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import {
@@ -144,27 +144,39 @@ function useIntegrationSetupLocalState({
   resumeIntegrationDescribe,
 }: IntegrationSetupLocalStateParams) {
   const lastResumeDescribeKey = useRef<string | null>(null);
+  const hasEditedInstanceName = useRef(false);
   const [instanceName, setInstanceName] = useState("");
+  const handleInstanceNameChange = useCallback((value: string) => {
+    hasEditedInstanceName.current = true;
+    setInstanceName(value);
+  }, []);
   const [createdIntegration, setCreatedIntegration] = useState<OrganizationsIntegration | null>(null);
   const [stepInputs, setStepInputs] = useState<Record<string, unknown>>({});
   const [selectedCapabilities, setSelectedCapabilities] = useState<Set<string>>(new Set());
   const setters = useMemo(
     () => ({
       setCreatedIntegration,
+      hasEditedInstanceName,
       setInstanceName,
       setSelectedCapabilities,
       setStepInputs,
     }),
-    [],
+    [hasEditedInstanceName],
   );
 
   useResetSetupState(integrationName, lastResumeDescribeKey, setters);
-  useDefaultInstanceName(instanceName, integrationName, existingIntegrationNames, setInstanceName);
+  useDefaultInstanceName(
+    instanceName,
+    integrationName,
+    existingIntegrationNames,
+    hasEditedInstanceName,
+    setInstanceName,
+  );
   useResumeIntegrationDescribe(setupIntegrationId, resumeIntegrationDescribe, lastResumeDescribeKey, setters);
 
   return {
     instanceName,
-    setInstanceName,
+    setInstanceName: handleInstanceNameChange,
     createdIntegration,
     setCreatedIntegration,
     stepInputs,
@@ -245,6 +257,7 @@ export type IntegrationSetupMutations = ReturnType<typeof useIntegrationSetupMut
 
 interface ResetStateSetters {
   setCreatedIntegration: Dispatch<SetStateAction<OrganizationsIntegration | null>>;
+  hasEditedInstanceName: MutableRefObject<boolean>;
   setInstanceName: Dispatch<SetStateAction<string>>;
   setSelectedCapabilities: Dispatch<SetStateAction<Set<string>>>;
   setStepInputs: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -257,6 +270,7 @@ function useResetSetupState(
 ) {
   useEffect(() => {
     lastResumeDescribeKey.current = null;
+    setters.hasEditedInstanceName.current = false;
     setters.setCreatedIntegration(null);
     setters.setStepInputs({});
     setters.setInstanceName("");
@@ -268,15 +282,16 @@ function useDefaultInstanceName(
   instanceName: string,
   integrationName: string,
   existingIntegrationNames: Set<string>,
+  hasEditedInstanceName: MutableRefObject<boolean>,
   setInstanceName: Dispatch<SetStateAction<string>>,
 ) {
   useEffect(() => {
-    if (instanceName || !integrationName) {
+    if (instanceName || !integrationName || hasEditedInstanceName.current) {
       return;
     }
 
     setInstanceName(getNextIntegrationName(integrationName, existingIntegrationNames));
-  }, [instanceName, integrationName, existingIntegrationNames, setInstanceName]);
+  }, [instanceName, integrationName, existingIntegrationNames, hasEditedInstanceName, setInstanceName]);
 }
 
 function useResumeIntegrationDescribe(
@@ -290,6 +305,7 @@ function useResumeIntegrationDescribe(
       setters.setCreatedIntegration(describe);
       setters.setStepInputs({});
       setters.setSelectedCapabilities(new Set());
+      setters.hasEditedInstanceName.current = true;
       setters.setInstanceName(describe.metadata?.name || describe.metadata?.integrationName || "");
     });
   }, [setupIntegrationId, resumeIntegrationDescribe, lastResumeDescribeKey, setters]);


### PR DESCRIPTION
## Summary

- Prevent the integration setup default instance name from being reinserted after the user clears the field.
- Track user edits separately from automatic default initialization.
- Add a Vitest regression covering clearing the default name and typing a replacement.
