### PR TITLE
feat: migrate Claude to new setup flow

### DIFF
--- a/pkg/integrations/claude/claude.go
+++ b/pkg/integrations/claude/claude.go
@@ -11,7 +11,9 @@ import (
 )
 
 func init() {
-	registry.RegisterIntegration("claude", &Claude{})
+	registry.RegisterIntegrationWithOptions("claude", &Claude{}, registry.IntegrationRegistrationOptions{
+		SetupProvider: &SetupProvider{},
+	})
 }
 
 type Claude struct{}
@@ -39,7 +41,7 @@ func (i *Claude) Description() string {
 func (i *Claude) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "apiKey",
+			Name:        SecretAPIKey,
 			Label:       "API Key",
 			Type:        configuration.FieldTypeString,
 			Sensitive:   true,
@@ -74,7 +76,7 @@ func (i *Claude) Sync(ctx core.SyncContext) error {
 		return fmt.Errorf("failed to decode configuration: %v", err)
 	}
 
-	if config.APIKey == "" {
+	if ctx.Integration.LegacySetup() && config.APIKey == "" {
 		return fmt.Errorf("apiKey is required")
 	}
 

--- a/pkg/integrations/claude/claude_test.go
+++ b/pkg/integrations/claude/claude_test.go
@@ -47,29 +47,48 @@ func TestClaude_Configuration(t *testing.T) {
 func TestClaude_Sync(t *testing.T) {
 	logger := logrus.NewEntry(logrus.New())
 
+	modelsOK := func(req *http.Request) *http.Response {
+		if req.URL.Path == "/v1/models" {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"data": [{"id": "claude-2"}]}`)),
+			}
+		}
+		return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}
+	}
+
 	tests := []struct {
-		name          string
-		config        map[string]interface{}
-		mockResponses func(*http.Request) *http.Response
-		expectError   bool
-		expectReady   bool
+		name            string
+		config          map[string]interface{}
+		mockResponses   func(*http.Request) *http.Response
+		expectError     bool
+		expectReady     bool
+		newSetupFlow    bool
+		presetSecretKey string
 	}{
 		{
 			name: "Success",
 			config: map[string]interface{}{
 				"apiKey": "sk-ant-test",
 			},
-			mockResponses: func(req *http.Request) *http.Response {
-				if req.URL.Path == "/v1/models" {
-					return &http.Response{
-						StatusCode: 200,
-						Body:       io.NopCloser(bytes.NewBufferString(`{"data": [{"id": "claude-2"}]}`)),
-					}
-				}
-				return &http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(""))}
-			},
-			expectError: false,
-			expectReady: true,
+			mockResponses: modelsOK,
+			expectError:   false,
+			expectReady:   true,
+		},
+		{
+			name:            "Success new setup flow reads secret from store",
+			newSetupFlow:    true,
+			config:          map[string]interface{}{},
+			presetSecretKey: "sk-ant-from-secret",
+			mockResponses:   modelsOK,
+			expectError:     false,
+			expectReady:     true,
+		},
+		{
+			name:         "New setup flow missing secret",
+			newSetupFlow: true,
+			config:       map[string]interface{}{},
+			expectError:  true,
 		},
 		{
 			name: "Missing API Key",
@@ -98,10 +117,16 @@ func TestClaude_Sync(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &Claude{}
 			integrationCtx := &contexts.IntegrationContext{
+				NewSetupFlow:  tt.newSetupFlow,
 				Configuration: map[string]any{},
 			}
 			if v, ok := tt.config["apiKey"].(string); ok {
 				integrationCtx.Configuration["apiKey"] = v
+			}
+			if tt.presetSecretKey != "" {
+				integrationCtx.CurrentSecrets = map[string]core.IntegrationSecret{
+					"apiKey": {Name: "apiKey", Value: []byte(tt.presetSecretKey)},
+				}
 			}
 
 			var responses []*http.Response

--- a/pkg/integrations/claude/client.go
+++ b/pkg/integrations/claude/client.go
@@ -75,13 +75,24 @@ func NewClient(httpClient core.HTTPContext, ctx core.IntegrationContext) (*Clien
 		return nil, fmt.Errorf("no integration context")
 	}
 
-	apiKey, err := ctx.GetConfig("apiKey")
-	if err != nil {
-		return nil, err
+	var apiKey string
+	var err error
+	if !ctx.LegacySetup() {
+		apiKey, err = ctx.Secrets().Get(SecretAPIKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var raw []byte
+		raw, err = ctx.GetConfig(SecretAPIKey)
+		if err != nil {
+			return nil, err
+		}
+		apiKey = string(raw)
 	}
 
 	return &Client{
-		APIKey:  string(apiKey),
+		APIKey:  apiKey,
 		BaseURL: defaultBaseURL,
 		http:    httpClient,
 	}, nil

--- a/pkg/integrations/claude/client_test.go
+++ b/pkg/integrations/claude/client_test.go
@@ -18,13 +18,15 @@ func TestNewClient(t *testing.T) {
 		name           string
 		integrationCtx *contexts.IntegrationContext
 		expectError    bool
+		wantAPIKey     string
 	}{
 		{
 			name: "Success",
 			integrationCtx: &contexts.IntegrationContext{
-				Configuration: map[string]any{"apiKey": "sk-123"},
+				Configuration: map[string]any{SecretAPIKey: "sk-123"},
 			},
 			expectError: false,
+			wantAPIKey:  "sk-123",
 		},
 		{
 			name:           "Nil Context",
@@ -37,6 +39,17 @@ func TestNewClient(t *testing.T) {
 				Configuration: map[string]any{},
 			},
 			expectError: true,
+		},
+		{
+			name: "New setup flow reads secret",
+			integrationCtx: &contexts.IntegrationContext{
+				NewSetupFlow: true,
+				CurrentSecrets: map[string]core.IntegrationSecret{
+					SecretAPIKey: {Name: SecretAPIKey, Value: []byte("sk-from-secret")},
+				},
+			},
+			expectError: false,
+			wantAPIKey:  "sk-from-secret",
 		},
 	}
 
@@ -60,8 +73,11 @@ func TestNewClient(t *testing.T) {
 				if client == nil {
 					t.Error("expected client, got nil")
 				}
-				if client.APIKey != "sk-123" {
-					t.Errorf("expected API Key 'sk-123', got %s", client.APIKey)
+				if tt.wantAPIKey == "" {
+					t.Fatal("wantAPIKey must be set for success cases")
+				}
+				if client.APIKey != tt.wantAPIKey {
+					t.Errorf("expected API Key %q, got %s", tt.wantAPIKey, client.APIKey)
 				}
 			}
 		})

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -18,6 +18,8 @@ const (
 	anthropicVersionValue      = "2023-06-01"
 	anthropicBetaManagedAgents = "managed-agents-2026-04-01"
 	sessionEventsPageLimit     = "20"
+	// apiKeySecretName matches claude.SecretAPIKey; runagent cannot import claude (import cycle).
+	apiKeySecretName = "apiKey"
 )
 
 type Client struct {
@@ -90,13 +92,24 @@ func NewClient(httpClient core.HTTPContext, ctx core.IntegrationContext) (*Clien
 		return nil, fmt.Errorf("no integration context")
 	}
 
-	apiKey, err := ctx.GetConfig("apiKey")
-	if err != nil {
-		return nil, err
+	var apiKey string
+	var err error
+	if !ctx.LegacySetup() {
+		apiKey, err = ctx.Secrets().Get(apiKeySecretName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var raw []byte
+		raw, err = ctx.GetConfig(apiKeySecretName)
+		if err != nil {
+			return nil, err
+		}
+		apiKey = string(raw)
 	}
 
 	return &Client{
-		APIKey:  string(apiKey),
+		APIKey:  apiKey,
 		BaseURL: defaultBaseURL,
 		http:    httpClient,
 	}, nil

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -54,7 +54,7 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 		},
 	}
 	integrationCtx := &contexts.IntegrationContext{
-		Configuration: map[string]any{"apiKey": "sk-test"},
+		Configuration: map[string]any{apiKeySecretName: "sk-test"},
 	}
 	metadataCtx := &contexts.MetadataContext{}
 	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
@@ -100,7 +100,7 @@ func Test__RunAgent__Execute__schedulesPoll(t *testing.T) {
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
 		},
 	}
-	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}}
+	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{apiKeySecretName: "k"}}
 	metadataCtx := &contexts.MetadataContext{}
 	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 	requestsCtx := &contexts.RequestContext{}
@@ -131,7 +131,7 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"agent.message","content":[{"type":"text","text":"Final"}]},{"type":"agent.message","content":[{"type":"text","text":"Earlier"}]}]}`))},
 		},
 	}
-	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}}
+	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{apiKeySecretName: "k"}}
 	executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 	metadataCtx := &contexts.MetadataContext{
 		Metadata: ExecutionMetadata{

--- a/pkg/integrations/claude/setup_provider.go
+++ b/pkg/integrations/claude/setup_provider.go
@@ -1,0 +1,236 @@
+package claude
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/claude/runagent"
+)
+
+const (
+	SetupStepCapabilitySelection = "capabilitySelection"
+	SetupStepEnterAPIKey         = "enterAPIKey"
+	SetupStepDone                = "done"
+	SecretAPIKey                 = "apiKey"
+)
+
+type SetupProvider struct{}
+
+func (s *SetupProvider) genCapabilities(actions []core.Action, triggers []core.Trigger) []core.Capability {
+	capabilities := []core.Capability{}
+	for _, action := range actions {
+		capabilities = append(capabilities, core.Capability{
+			Type:           core.IntegrationCapabilityTypeAction,
+			Name:           action.Name(),
+			Label:          action.Label(),
+			Description:    action.Description(),
+			Configuration:  action.Configuration(),
+			OutputChannels: action.OutputChannels(nil),
+		})
+	}
+	for _, trigger := range triggers {
+		capabilities = append(capabilities, core.Capability{
+			Type:          core.IntegrationCapabilityTypeTrigger,
+			Name:          trigger.Name(),
+			Label:         trigger.Label(),
+			Description:   trigger.Description(),
+			Configuration: trigger.Configuration(),
+		})
+	}
+
+	return capabilities
+}
+
+func (s *SetupProvider) capabilityDiff(capabilities []string) []string {
+	groups := s.CapabilityGroups()
+
+	diff := []string{}
+	for _, group := range groups {
+		for _, capability := range group.Capabilities {
+			if !slices.Contains(capabilities, capability.Name) {
+				diff = append(diff, capability.Name)
+			}
+		}
+	}
+
+	return diff
+}
+
+func (s *SetupProvider) CapabilityGroups() []core.CapabilityGroup {
+	//
+	// Group capabilities like Semaphore (see semaphore.SetupProvider.CapabilityGroups):
+	// separate user-facing buckets so the picker scales when new actions are added.
+	// — Messages & prompts: single-shot model calls (text, structured output, etc.).
+	// — Agents: session-shaped or long-running work (Run Agent, future thread/webhook nodes).
+	//
+	return []core.CapabilityGroup{
+		{
+			Label: "Messages & prompts",
+			Capabilities: s.genCapabilities(
+				[]core.Action{
+					&TextPrompt{},
+				},
+				nil,
+			),
+		},
+		{
+			Label: "Agents",
+			Capabilities: s.genCapabilities(
+				[]core.Action{
+					&runagent.RunAgent{},
+				},
+				nil,
+			),
+		},
+	}
+}
+
+func (s *SetupProvider) OnCapabilityUpdate(ctx core.CapabilityUpdateContext) (*core.SetupStep, error) {
+	requested, ok := ctx.Changes[core.IntegrationCapabilityStateRequested]
+	if !ok {
+		return nil, errors.New("no requested capabilities")
+	}
+
+	ctx.Capabilities.Enable(requested...)
+	return nil, nil
+}
+
+func (s *SetupProvider) FirstStep(ctx core.SetupStepContext) core.SetupStep {
+	capabilities := []string{}
+	for _, group := range s.CapabilityGroups() {
+		for _, capability := range group.Capabilities {
+			capabilities = append(capabilities, capability.Name)
+		}
+	}
+
+	return core.SetupStep{
+		Type:         core.SetupStepTypeCapabilitySelection,
+		Name:         SetupStepCapabilitySelection,
+		Label:        "Select capabilities",
+		Capabilities: capabilities,
+	}
+}
+
+func (s *SetupProvider) OnStepSubmit(ctx core.SetupStepContext) (*core.SetupStep, error) {
+	switch ctx.Step.Name {
+	case SetupStepCapabilitySelection:
+		return s.onCapabilitySelectionSubmit(ctx)
+	case SetupStepEnterAPIKey:
+		return s.onEnterAPIKeySubmit(ctx.Step.Inputs, ctx)
+	}
+
+	return nil, errors.New("unknown step")
+}
+
+func (s *SetupProvider) onCapabilitySelectionSubmit(ctx core.SetupStepContext) (*core.SetupStep, error) {
+	ctx.Capabilities.Request(ctx.Step.Capabilities...)
+	ctx.Capabilities.Available(s.capabilityDiff(ctx.Step.Capabilities)...)
+
+	return &core.SetupStep{
+		Type:         core.SetupStepTypeInputs,
+		Name:         SetupStepEnterAPIKey,
+		Label:        "Enter Claude API key",
+		Instructions: (&Claude{}).Instructions(),
+		Inputs: []configuration.Field{
+			{
+				Name:        SecretAPIKey,
+				Label:       "API Key",
+				Type:        configuration.FieldTypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Claude API key",
+			},
+		},
+	}, nil
+}
+
+func (s *SetupProvider) OnStepRevert(ctx core.SetupStepContext) error {
+	switch ctx.Step.Name {
+	case SetupStepCapabilitySelection:
+		return s.onCapabilitySelectionRevert(ctx)
+	case SetupStepEnterAPIKey:
+		return s.onEnterAPIKeyRevert(ctx)
+	}
+
+	return errors.New("unknown step")
+}
+
+func (s *SetupProvider) onCapabilitySelectionRevert(ctx core.SetupStepContext) error {
+	ctx.Capabilities.Clear()
+	return nil
+}
+
+func (s *SetupProvider) onEnterAPIKeyRevert(ctx core.SetupStepContext) error {
+	return ctx.Secrets.Delete(SecretAPIKey)
+}
+
+func (s *SetupProvider) OnPropertyUpdate(ctx core.PropertyUpdateContext) (*core.SetupStep, error) {
+	return nil, fmt.Errorf("property updates are not supported for Claude")
+}
+
+func (s *SetupProvider) OnSecretUpdate(ctx core.SecretUpdateContext) (*core.SetupStep, error) {
+	switch ctx.SecretName {
+	case SecretAPIKey:
+		v := strings.TrimSpace(ctx.Value)
+		if v == "" {
+			return nil, fmt.Errorf("value is required")
+		}
+
+		c := &Client{APIKey: v, BaseURL: defaultBaseURL, http: ctx.HTTP}
+		if err := c.Verify(); err != nil {
+			return nil, err
+		}
+
+		return nil, ctx.Secrets.Update(SecretAPIKey, v)
+
+	default:
+		return nil, fmt.Errorf("unknown secret: %s", ctx.SecretName)
+	}
+}
+
+func (s *SetupProvider) onEnterAPIKeySubmit(input any, ctx core.SetupStepContext) (*core.SetupStep, error) {
+	m, ok := input.(map[string]any)
+	if !ok {
+		return nil, errors.New("invalid input")
+	}
+
+	apiKey, ok := m[SecretAPIKey].(string)
+	if !ok {
+		return nil, errors.New("invalid API key")
+	}
+
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return nil, errors.New("API key is required")
+	}
+
+	c := &Client{APIKey: apiKey, BaseURL: defaultBaseURL, http: ctx.HTTP}
+	if err := c.Verify(); err != nil {
+		return nil, err
+	}
+
+	err := ctx.Secrets.Create(core.IntegrationSecretDefinition{
+		Name:        SecretAPIKey,
+		Label:       "API Key",
+		Description: "The Claude API key for this integration",
+		Value:       apiKey,
+		Editable:    true,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error creating secret: %v", err)
+	}
+
+	ctx.Capabilities.Enable(ctx.Capabilities.Requested()...)
+
+	return &core.SetupStep{
+		Type:         core.SetupStepTypeDone,
+		Name:         SetupStepDone,
+		Label:        "Setup complete",
+		Instructions: "Your Claude integration is ready. You can use the selected actions in workflows.",
+	}, nil
+}

--- a/pkg/integrations/claude/setup_provider_test.go
+++ b/pkg/integrations/claude/setup_provider_test.go
@@ -1,0 +1,327 @@
+package claude
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+	"github.com/superplanehq/superplane/test/support/logger"
+)
+
+func Test__Claude__SetupProvider__FirstStep(t *testing.T) {
+	s := &SetupProvider{}
+	step := s.FirstStep(core.SetupStepContext{Logger: logger.DiscardLogger()})
+	assert.Equal(t, core.SetupStepTypeCapabilitySelection, step.Type)
+	assert.Equal(t, SetupStepCapabilitySelection, step.Name)
+	assert.Equal(t, "Select capabilities", step.Label)
+	assert.ElementsMatch(t, []string{"claude.textPrompt", "claude.runAgent"}, step.Capabilities)
+}
+
+func Test__Claude__SetupProvider__CapabilityGroups(t *testing.T) {
+	s := &SetupProvider{}
+	groups := s.CapabilityGroups()
+	require.Len(t, groups, 2)
+
+	assert.Equal(t, "Messages & prompts", groups[0].Label)
+	require.Len(t, groups[0].Capabilities, 1)
+	assert.Equal(t, "claude.textPrompt", groups[0].Capabilities[0].Name)
+
+	assert.Equal(t, "Agents", groups[1].Label)
+	require.Len(t, groups[1].Capabilities, 1)
+	assert.Equal(t, "claude.runAgent", groups[1].Capabilities[0].Name)
+}
+
+func Test__Claude__SetupProvider__OnCapabilityUpdate(t *testing.T) {
+	s := &SetupProvider{}
+	logger := logger.DiscardLogger()
+
+	t.Run("returns error when no requested capabilities entry", func(t *testing.T) {
+		_, err := s.OnCapabilityUpdate(core.CapabilityUpdateContext{
+			Logger:       logger,
+			Changes:      map[core.IntegrationCapabilityState][]string{},
+			Capabilities: &contexts.CapabilityContext{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no requested capabilities")
+	})
+
+	t.Run("delegates Enable for requested capability names", func(t *testing.T) {
+		localCap := &contexts.CapabilityContext{}
+		_, err := s.OnCapabilityUpdate(core.CapabilityUpdateContext{
+			Logger: logger,
+			Changes: map[core.IntegrationCapabilityState][]string{
+				core.IntegrationCapabilityStateRequested: {"claude.textPrompt"},
+			},
+			Capabilities: localCap,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"claude.textPrompt"}, localCap.EnabledCapabilities)
+	})
+}
+
+func Test__Claude__SetupProvider__OnSecretUpdate(t *testing.T) {
+	s := &SetupProvider{}
+	logger := logger.DiscardLogger()
+
+	intCtx := &contexts.IntegrationContext{}
+	secrets := intCtx.Secrets()
+
+	t.Run("unknown secret", func(t *testing.T) {
+		_, err := s.OnSecretUpdate(core.SecretUpdateContext{
+			Logger:     logger,
+			SecretName: "other",
+			Value:      "x",
+			HTTP:       &contexts.HTTPContext{},
+			Secrets:    secrets,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown secret")
+	})
+
+	t.Run("api key required", func(t *testing.T) {
+		_, err := s.OnSecretUpdate(core.SecretUpdateContext{
+			Logger:     logger,
+			SecretName: SecretAPIKey,
+			Value:      "   ",
+			HTTP:       &contexts.HTTPContext{},
+			Secrets:    secrets,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
+	})
+
+	t.Run("verify fails", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad key"}}`)),
+				},
+			},
+		}
+		_, err := s.OnSecretUpdate(core.SecretUpdateContext{
+			Logger:     logger,
+			SecretName: SecretAPIKey,
+			Value:      "sk-invalid",
+			HTTP:       httpCtx,
+			Secrets:    secrets,
+		})
+		require.Error(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.True(t, strings.HasSuffix(httpCtx.Requests[0].URL.Path, "/v1/models"))
+	})
+
+	t.Run("success updates secret", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+				},
+			},
+		}
+		_, err := s.OnSecretUpdate(core.SecretUpdateContext{
+			Logger:     logger,
+			SecretName: SecretAPIKey,
+			Value:      "sk-valid",
+			HTTP:       httpCtx,
+			Secrets:    secrets,
+		})
+		require.NoError(t, err)
+		v, getErr := secrets.Get(SecretAPIKey)
+		require.NoError(t, getErr)
+		assert.Equal(t, "sk-valid", v)
+	})
+}
+
+func Test__Claude__SetupProvider__OnStepSubmit(t *testing.T) {
+	s := &SetupProvider{}
+	logger := logger.DiscardLogger()
+
+	t.Run("unknown step", func(t *testing.T) {
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:   core.StepInfo{Name: "nope"},
+			Logger: logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown step")
+	})
+
+	t.Run("capabilitySelection advances to API key step", func(t *testing.T) {
+		capCtx := &contexts.CapabilityContext{}
+		next, err := s.OnStepSubmit(core.SetupStepContext{
+			Step: core.StepInfo{
+				Name:         SetupStepCapabilitySelection,
+				Capabilities: []string{"claude.textPrompt", "claude.runAgent"},
+			},
+			Logger:       logger,
+			Capabilities: capCtx,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, next)
+		assert.Equal(t, SetupStepEnterAPIKey, next.Name)
+		assert.Equal(t, core.SetupStepTypeInputs, next.Type)
+		assert.Contains(t, next.Instructions, "platform.claude.com")
+		assert.Len(t, next.Inputs, 1)
+		assert.Equal(t, SecretAPIKey, next.Inputs[0].Name)
+	})
+
+	t.Run("enterAPIKey validation", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: "not-a-map"},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         &contexts.HTTPContext{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
+
+		_, err = s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: map[string]any{SecretAPIKey: 1}},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         &contexts.HTTPContext{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid API key")
+
+		_, err = s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: map[string]any{SecretAPIKey: ""}},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         &contexts.HTTPContext{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "API key is required")
+	})
+
+	t.Run("enterAPIKey verify fails", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusBadGateway,
+					Body:       io.NopCloser(strings.NewReader("err")),
+				},
+			},
+		}
+
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: map[string]any{SecretAPIKey: "k"}},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: &contexts.CapabilityContext{},
+			HTTP:         httpCtx,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "request failed")
+		_, getErr := intCtx.Secrets().Get(SecretAPIKey)
+		require.Error(t, getErr, "secret must not be stored when verification fails")
+	})
+
+	t.Run("enterAPIKey success", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+				},
+			},
+		}
+		capCtx := &contexts.CapabilityContext{
+			RequestedCapabilties: []string{"claude.textPrompt", "claude.runAgent"},
+		}
+
+		next, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: map[string]any{SecretAPIKey: "sk-final"}},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: capCtx,
+			HTTP:         httpCtx,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, next)
+		assert.Equal(t, core.SetupStepTypeDone, next.Type)
+		assert.Equal(t, SetupStepDone, next.Name)
+
+		v, getErr := intCtx.Secrets().Get(SecretAPIKey)
+		require.NoError(t, getErr)
+		assert.Equal(t, "sk-final", v)
+		assert.ElementsMatch(t, []string{"claude.textPrompt", "claude.runAgent"}, capCtx.EnabledCapabilities)
+	})
+
+	t.Run("enterAPIKey trims whitespace before storing", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":[]}`)),
+				},
+			},
+		}
+		capCtx := &contexts.CapabilityContext{
+			RequestedCapabilties: []string{"claude.textPrompt"},
+		}
+
+		_, err := s.OnStepSubmit(core.SetupStepContext{
+			Step:         core.StepInfo{Name: SetupStepEnterAPIKey, Inputs: map[string]any{SecretAPIKey: "  sk-trimmed  \t"}},
+			Logger:       logger,
+			Secrets:      intCtx.Secrets(),
+			Capabilities: capCtx,
+			HTTP:         httpCtx,
+		})
+		require.NoError(t, err)
+
+		v, getErr := intCtx.Secrets().Get(SecretAPIKey)
+		require.NoError(t, getErr)
+		assert.Equal(t, "sk-trimmed", v)
+	})
+}
+
+func Test__Claude__SetupProvider__OnStepRevert(t *testing.T) {
+	s := &SetupProvider{}
+	logger := logger.DiscardLogger()
+
+	t.Run("unknown step", func(t *testing.T) {
+		err := s.OnStepRevert(core.SetupStepContext{
+			Step:   core.StepInfo{Name: "x"},
+			Logger: logger,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown step")
+	})
+
+	t.Run("enterAPIKey clears secret", func(t *testing.T) {
+		intCtx := &contexts.IntegrationContext{}
+		require.NoError(t, intCtx.SetSecret(SecretAPIKey, []byte("sek")))
+
+		require.NoError(t, s.OnStepRevert(core.SetupStepContext{
+			Step:    core.StepInfo{Name: SetupStepEnterAPIKey},
+			Logger:  logger,
+			Secrets: intCtx.Secrets(),
+		}))
+		_, err := intCtx.Secrets().Get(SecretAPIKey)
+		require.Error(t, err)
+	})
+}
+
+func Test__Claude__SetupProvider__OnPropertyUpdate(t *testing.T) {
+	s := &SetupProvider{}
+	_, err := s.OnPropertyUpdate(core.PropertyUpdateContext{
+		Logger: logger.DiscardLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}


### PR DESCRIPTION
## Summary

Registers Claude with the same integration setup pattern as Semaphore: capability selection, API key collected in a setup step, stored as an editable secret, validated against Anthropic before completion. Legacy integrations keep using config-based apiKey until fully migrated.

## Behavior
- New setup: `SetupProvider` drives the wizard; key lives in secret storage; Sync no longer requires `apiKey` in decoded configuration.
- Legacy setup: unchanged — `apiKey` still required in config; clients still read via `GetConfig("apiKey")`.


https://github.com/user-attachments/assets/b0df236b-58de-4e08-8fd4-92ade1e4800c

