### PR TITLE
feat: add Cloudflare createPool, getPool, updatePool and deletePool components

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -17,10 +17,10 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
-  <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
-  <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
+  <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
+  <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Origin Rule" href="#update-origin-rule" description="Update an existing origin rule" />
   <LinkCard title="Update Pool" href="#update-pool" description="Update a Cloudflare Load Balancer origin pool's configuration or origin weights" />
@@ -395,6 +395,41 @@ Emits the deleted origin rule on the default channel.
 }
 ```
 
+<a id="delete-pool"></a>
+
+## Delete Pool
+
+The Delete Pool component permanently removes a Cloudflare Load Balancer origin pool.
+
+### Use Cases
+
+- **Blue/green deployments**: Clean up the old (blue) pool after traffic has shifted
+- **Environment teardown**: Remove pools as part of infrastructure cleanup
+
+### Configuration
+
+- **Pool ID**: The origin pool to delete
+
+### Output
+
+Emits a confirmation with the account ID and pool ID of the deleted pool.
+
+> **Warning**: This operation is irreversible. Ensure the pool is not attached to any load balancer before deleting.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
+  },
+  "timestamp": "2026-05-05T05:59:02.93536262Z",
+  "type": "cloudflare.pool.deleted"
+}
+```
+
 <a id="get-kv-value"></a>
 
 ## Get KV Value
@@ -428,79 +463,6 @@ Returns the account ID, namespace ID, key, and the retrieved value string.
   },
   "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.kv.value.fetched"
-}
-```
-
-<a id="put-kv-value"></a>
-
-## Put KV Value
-
-The Put KV Value component writes a key-value pair to a Cloudflare Workers KV namespace.
-
-### Use Cases
-
-- **Feature flags**: Toggle features by writing flag values into KV storage
-- **Cache invalidation**: Store cache keys or version stamps
-- **Dynamic configuration**: Update runtime configuration values from a workflow
-
-### Configuration
-
-- **Namespace**: The ID of the KV namespace to write to
-- **Key**: The key name (up to 512 bytes, printable non-whitespace characters)
-- **Value**: The value to store (up to 25 MiB)
-- **Expiration TTL**: (Optional) Number of seconds until the key expires (minimum 60)
-
-### Output
-
-Emits a confirmation with the account ID, namespace ID, and key that was written.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
-    "key": "my-key",
-    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
-    "written": true
-  },
-  "timestamp": "2026-05-05T06:54:57.198268018Z",
-  "type": "cloudflare.kv.value.put"
-}
-```
-
-<a id="delete-pool"></a>
-
-## Delete Pool
-
-The Delete Pool component permanently removes a Cloudflare Load Balancer origin pool.
-
-### Use Cases
-
-- **Blue/green deployments**: Clean up the old (blue) pool after traffic has shifted
-- **Environment teardown**: Remove pools as part of infrastructure cleanup
-
-### Configuration
-
-- **Pool ID**: The origin pool to delete
-
-### Output
-
-Emits a confirmation with the account ID and pool ID of the deleted pool.
-
-> **Warning**: This operation is irreversible. Ensure the pool is not attached to any load balancer before deleting.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
-    "deleted": true,
-    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
-  },
-  "timestamp": "2026-05-05T05:59:02.93536262Z",
-  "type": "cloudflare.pool.deleted"
 }
 ```
 
@@ -552,6 +514,44 @@ Returns the full pool configuration including its origins, enabled state, and he
   },
   "timestamp": "2026-05-05T05:58:40.060373991Z",
   "type": "cloudflare.pool.fetched"
+}
+```
+
+<a id="put-kv-value"></a>
+
+## Put KV Value
+
+The Put KV Value component writes a key-value pair to a Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Feature flags**: Toggle features by writing flag values into KV storage
+- **Cache invalidation**: Store cache keys or version stamps
+- **Dynamic configuration**: Update runtime configuration values from a workflow
+
+### Configuration
+
+- **Namespace**: The ID of the KV namespace to write to
+- **Key**: The key name (up to 512 bytes, printable non-whitespace characters)
+- **Value**: The value to store (up to 25 MiB)
+- **Expiration TTL**: (Optional) Number of seconds until the key expires (minimum 60)
+
+### Output
+
+Emits a confirmation with the account ID, namespace ID, and key that was written.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "key": "my-key",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "written": true
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.put"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -215,32 +215,29 @@ Returns the created origin pool with its assigned ID and full configuration.
 
 ```json
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "pool": {
-    "description": "Primary origin pool",
-    "enabled": true,
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "minimum_origins": 1,
-    "monitor": "",
-    "name": "primary-pool",
-    "origin_steering": {
-      "policy": "random"
-    },
-    "origins": [
-      {
-        "address": "192.0.2.1",
-        "enabled": true,
-        "name": "app-1",
-        "weight": 1
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-pool",
+      "origin_steering": {
+        "policy": "random"
       },
-      {
-        "address": "192.0.2.2",
-        "enabled": true,
-        "name": "app-2",
-        "weight": 1
-      }
-    ]
-  }
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    }
+  },
+  "timestamp": "2026-05-05T05:57:07.706260875Z",
+  "type": "cloudflare.pool.created"
 }
 ```
 
@@ -498,9 +495,30 @@ Emits a confirmation with the account ID and pool ID of the deleted pool.
 
 ```json
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "deleted": true,
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my deleted pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-deleted-pool",
+      "origin_steering": {
+        "policy": "random"
+      },
+      "origins": [
+        {
+          "address": "138.68.89.169:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    },
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
+  },
+  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "type": "cloudflare.pool.deleted"
 }
 ```
 
@@ -529,27 +547,30 @@ Returns the full pool configuration including its origins, enabled state, and he
 
 ```json
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "pool": {
-    "description": "Primary origin pool",
-    "enabled": true,
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "minimum_origins": 1,
-    "monitor": "",
-    "name": "primary-pool",
-    "origin_steering": {
-      "policy": "random"
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my updated pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-updated-pool",
+      "origin_steering": {
+        "policy": "random"
+      },
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
     },
-    "origins": [
-      {
-        "address": "192.0.2.1",
-        "enabled": true,
-        "name": "app-1",
-        "weight": 1
-      }
-    ]
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "type": "cloudflare.pool.fetched"
 }
 ```
 
@@ -676,33 +697,30 @@ Returns the updated origin pool configuration.
 
 ```json
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "pool": {
-    "description": "Primary origin pool",
-    "enabled": true,
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "minimum_origins": 1,
-    "monitor": "",
-    "name": "primary-pool",
-    "origin_steering": {
-      "policy": "random"
-    },
-    "origins": [
-      {
-        "address": "192.0.2.1",
-        "enabled": true,
-        "name": "app-stable",
-        "weight": 0.9
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my updated pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-updated-pool",
+      "origin_steering": {
+        "policy": "random"
       },
-      {
-        "address": "192.0.2.3",
-        "enabled": true,
-        "name": "app-canary",
-        "weight": 0.1
-      }
-    ]
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    },
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+  "timestamp": "2026-05-05T05:57:59.044021383Z",
+  "type": "cloudflare.pool.updated"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -12,14 +12,18 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record in a Cloudflare zone" />
   <LinkCard title="Create KV Namespace" href="#create-kv-namespace" description="Create a Cloudflare Workers KV namespace" />
   <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
+  <LinkCard title="Create Pool" href="#create-pool" description="Create a Cloudflare Load Balancer origin pool" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
   <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
+  <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
+  <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Origin Rule" href="#update-origin-rule" description="Update an existing origin rule" />
+  <LinkCard title="Update Pool" href="#update-pool" description="Update a Cloudflare Load Balancer origin pool's configuration or origin weights" />
   <LinkCard title="Update Redirect Rule" href="#update-redirect-rule" description="Update a redirect rule in a Cloudflare zone" />
 </CardGrid>
 
@@ -38,6 +42,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
 	 - Account / Workers KV Storage / Edit
+     - Account / Load Balancing: Monitor and Pools / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
@@ -175,6 +180,67 @@ Emits the created origin rule on the default channel.
   },
   "timestamp": "2026-05-06T12:00:00Z",
   "type": "cloudflare.createOriginRule"
+}
+```
+
+<a id="create-pool"></a>
+
+## Create Pool
+
+The Create Pool component creates a new Cloudflare Load Balancer origin pool.
+
+### Use Cases
+
+- **Canary deployments**: Provision a new origin pool for a canary release
+- **Blue/green deployments**: Create the green pool before switching traffic
+- **Multi-region**: Add origin servers in new regions
+
+### Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Name**: A unique, human-readable name for the pool
+- **Description**: Optional description
+- **Origins**: List of origin servers with name, address, enabled flag, weight, optional port, and optional coordinates
+- **Enabled**: Whether the pool is active
+- **Minimum Origins**: Minimum number of healthy origins before marking pool unhealthy
+- **Origin Steering Policy**: How requests are distributed across origins
+- **Monitor**: (Optional) Health monitor to use for origin health checks
+- **Load Shedding**: (Optional) Configure load shedding for the pool
+
+### Output
+
+Returns the created origin pool with its assigned ID and full configuration.
+
+### Example Output
+
+```json
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "pool": {
+    "description": "Primary origin pool",
+    "enabled": true,
+    "id": "17b5962d775c646f3f9725cbc7a53df4",
+    "minimum_origins": 1,
+    "monitor": "",
+    "name": "primary-pool",
+    "origin_steering": {
+      "policy": "random"
+    },
+    "origins": [
+      {
+        "address": "192.0.2.1",
+        "enabled": true,
+        "name": "app-1",
+        "weight": 1
+      },
+      {
+        "address": "192.0.2.2",
+        "enabled": true,
+        "name": "app-2",
+        "weight": 1
+      }
+    ]
+  }
 }
 ```
 
@@ -406,6 +472,87 @@ Emits a confirmation with the account ID, namespace ID, and key that was written
 }
 ```
 
+<a id="delete-pool"></a>
+
+## Delete Pool
+
+The Delete Pool component permanently removes a Cloudflare Load Balancer origin pool.
+
+### Use Cases
+
+- **Blue/green deployments**: Clean up the old (blue) pool after traffic has shifted
+- **Environment teardown**: Remove pools as part of infrastructure cleanup
+
+### Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The origin pool to delete
+
+### Output
+
+Emits a confirmation with the account ID and pool ID of the deleted pool.
+
+> **Warning**: This operation is irreversible. Ensure the pool is not attached to any load balancer before deleting.
+
+### Example Output
+
+```json
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "deleted": true,
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+}
+```
+
+<a id="get-pool"></a>
+
+## Get Pool
+
+The Get Pool component fetches the current state of a Cloudflare Load Balancer origin pool.
+
+### Use Cases
+
+- **Health checks**: Inspect origin health and pool status in a workflow
+- **Pre-flight validation**: Confirm a pool exists before updating it
+- **Audit**: Capture a snapshot of pool configuration at a point in time
+
+### Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The origin pool to retrieve
+
+### Output
+
+Returns the full pool configuration including its origins, enabled state, and health monitor.
+
+### Example Output
+
+```json
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "pool": {
+    "description": "Primary origin pool",
+    "enabled": true,
+    "id": "17b5962d775c646f3f9725cbc7a53df4",
+    "minimum_origins": 1,
+    "monitor": "",
+    "name": "primary-pool",
+    "origin_steering": {
+      "policy": "random"
+    },
+    "origins": [
+      {
+        "address": "192.0.2.1",
+        "enabled": true,
+        "name": "app-1",
+        "weight": 1
+      }
+    ]
+  },
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+}
+```
+
 <a id="update-dns-record"></a>
 
 ## Update DNS Record
@@ -492,6 +639,70 @@ Emits the updated origin rule on the default channel.
   },
   "timestamp": "2026-05-06T12:00:00Z",
   "type": "cloudflare.updateOriginRule"
+}
+```
+
+<a id="update-pool"></a>
+
+## Update Pool
+
+The Update Pool component modifies an existing Cloudflare Load Balancer origin pool.
+
+### Use Cases
+
+- **Canary deployments**: Shift traffic weight from stable to canary origin
+- **Blue/green deployments**: Disable blue origins and enable green origins
+- **Scaling**: Add or remove origin servers dynamically
+- **Health management**: Enable or disable individual origins without removing them
+
+### Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The ID of the pool to update
+- **Origins**: Full list of origin servers with updated weights or enabled status
+- **Name**: Optional new name for the pool
+- **Description**: Optional new description
+- **Enabled**: Enable or disable the entire pool
+- **Minimum Origins**: Minimum number of healthy origins before pool is marked unhealthy
+- **Origin Steering Policy**: How requests are distributed across origins
+- **Monitor**: Health monitor ID for origin health checks
+- **Load Shedding**: Configure load shedding for the pool
+
+### Output
+
+Returns the updated origin pool configuration.
+
+### Example Output
+
+```json
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "pool": {
+    "description": "Primary origin pool",
+    "enabled": true,
+    "id": "17b5962d775c646f3f9725cbc7a53df4",
+    "minimum_origins": 1,
+    "monitor": "",
+    "name": "primary-pool",
+    "origin_steering": {
+      "policy": "random"
+    },
+    "origins": [
+      {
+        "address": "192.0.2.1",
+        "enabled": true,
+        "name": "app-stable",
+        "weight": 0.9
+      },
+      {
+        "address": "192.0.2.3",
+        "enabled": true,
+        "name": "app-canary",
+        "weight": 0.1
+      }
+    ]
+  },
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -197,7 +197,6 @@ The Create Pool component creates a new Cloudflare Load Balancer origin pool.
 
 ### Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Name**: A unique, human-readable name for the pool
 - **Description**: Optional description
 - **Origins**: List of origin servers with name, address, enabled flag, weight, optional port, and optional coordinates
@@ -220,7 +219,7 @@ Returns the created origin pool with its assigned ID and full configuration.
     "pool": {
       "description": "my pool",
       "enabled": true,
-      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "id": "483e85c07a861ae7a8813ef010be7036",
       "minimum_origins": 1,
       "name": "my-pool",
       "origin_steering": {
@@ -228,15 +227,16 @@ Returns the created origin pool with its assigned ID and full configuration.
       },
       "origins": [
         {
-          "address": "192.0.2.1:2015",
-          "enabled": false,
+          "address": "192.0.2.1",
+          "enabled": true,
           "name": "server-1",
+          "port": 2013,
           "weight": 1
         }
       ]
     }
   },
-  "timestamp": "2026-05-05T05:57:07.706260875Z",
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.pool.created"
 }
 ```
@@ -482,7 +482,6 @@ The Delete Pool component permanently removes a Cloudflare Load Balancer origin 
 
 ### Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The origin pool to delete
 
 ### Output
@@ -497,27 +496,10 @@ Emits a confirmation with the account ID and pool ID of the deleted pool.
 {
   "data": {
     "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
-    "pool": {
-      "description": "my deleted pool",
-      "enabled": true,
-      "id": "f7be7edc94014415ba06bca7b13c5c5a",
-      "minimum_origins": 1,
-      "name": "my-deleted-pool",
-      "origin_steering": {
-        "policy": "random"
-      },
-      "origins": [
-        {
-          "address": "138.68.89.169:2015",
-          "enabled": false,
-          "name": "server-1",
-          "weight": 1
-        }
-      ]
-    },
+    "deleted": true,
     "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "timestamp": "2026-05-05T05:59:02.93536262Z",
   "type": "cloudflare.pool.deleted"
 }
 ```
@@ -536,7 +518,6 @@ The Get Pool component fetches the current state of a Cloudflare Load Balancer o
 
 ### Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The origin pool to retrieve
 
 ### Output
@@ -678,7 +659,6 @@ The Update Pool component modifies an existing Cloudflare Load Balancer origin p
 
 ### Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The ID of the pool to update
 - **Origins**: Full list of origin servers with updated weights or enabled status
 - **Name**: Optional new name for the pool

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.5","results":[[":web_src/src/pages/workflowv2/mappers/cloudflare/pool.spec.ts",{"duration":0,"failed":true}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.5","results":[[":web_src/src/pages/workflowv2/mappers/cloudflare/pool.spec.ts",{"duration":0,"failed":true}]]}

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -1099,8 +1099,24 @@ func (c *Client) GetPool(accountID, poolID string) (*Pool, error) {
 // DeletePool deletes an origin pool by ID for a given account
 func (c *Client) DeletePool(accountID, poolID string) error {
 	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools/%s", c.BaseURL, accountID, poolID)
-	_, err := c.execRequest(http.MethodDelete, url, nil)
-	return err
+	responseBody, err := c.execRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API returned success=false")
+	}
+
+	return nil
 }
 
 // CreatePoolRequest is the payload for creating a pool

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -971,12 +971,25 @@ func (c *Client) DeleteKVNamespace(accountID, namespaceID string) error {
 
 // ---- Pool types ----
 
+// Coordinates holds geographic coordinates used for proximity steering
+type Coordinates struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 // Origin represents a single origin server in a pool
 type Origin struct {
-	Name    string  `json:"name"`
-	Address string  `json:"address"`
-	Enabled bool    `json:"enabled"`
-	Weight  float64 `json:"weight"`
+	Name        string       `json:"name"`
+	Address     string       `json:"address"`
+	Enabled     bool         `json:"enabled"`
+	Weight      float64      `json:"weight"`
+	Coordinates *Coordinates `json:"coordinates,omitempty"`
+}
+
+// OriginSteering configures how origins within a pool are selected
+type OriginSteering struct {
+	// Policy is one of: "random", "hash", "least_outstanding_requests", "least_connections"
+	Policy string `json:"policy,omitempty"`
 }
 
 // LoadShedding configures load shedding behaviour for a pool
@@ -989,27 +1002,116 @@ type LoadShedding struct {
 
 // Pool represents a Cloudflare Load Balancer origin pool
 type Pool struct {
-	ID                string        `json:"id"`
-	Name              string        `json:"name"`
-	Description       string        `json:"description"`
-	Enabled           bool          `json:"enabled"`
-	MinimumOrigins    int           `json:"minimum_origins"`
-	Monitor           string        `json:"monitor,omitempty"`
-	NotificationEmail string        `json:"notification_email,omitempty"`
-	Origins           []Origin      `json:"origins"`
-	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description"`
+	Enabled        bool            `json:"enabled"`
+	MinimumOrigins int             `json:"minimum_origins"`
+	Monitor        string          `json:"monitor,omitempty"`
+	Origins        []Origin        `json:"origins"`
+	LoadShedding   *LoadShedding   `json:"load_shedding,omitempty"`
+	OriginSteering *OriginSteering `json:"origin_steering,omitempty"`
+}
+
+// PoolMonitor represents a Cloudflare health monitor
+type PoolMonitor struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+}
+
+// ListMonitors lists all health monitors for a Cloudflare account
+func (c *Client) ListMonitors(accountID string) ([]PoolMonitor, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors", c.BaseURL, accountID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool          `json:"success"`
+		Result  []PoolMonitor `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return response.Result, nil
+}
+
+// ListPools lists all origin pools for a Cloudflare account
+func (c *Client) ListPools(accountID string) ([]Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools", c.BaseURL, accountID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Result  []Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return response.Result, nil
+}
+
+// GetPool retrieves an origin pool by ID for a given account
+func (c *Client) GetPool(accountID, poolID string) (*Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools/%s", c.BaseURL, accountID, poolID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+// DeletePool deletes an origin pool by ID for a given account
+func (c *Client) DeletePool(accountID, poolID string) error {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools/%s", c.BaseURL, accountID, poolID)
+	_, err := c.execRequest(http.MethodDelete, url, nil)
+	return err
 }
 
 // CreatePoolRequest is the payload for creating a pool
 type CreatePoolRequest struct {
-	Name              string        `json:"name"`
-	Description       string        `json:"description,omitempty"`
-	Enabled           bool          `json:"enabled"`
-	MinimumOrigins    int           `json:"minimum_origins,omitempty"`
-	Monitor           string        `json:"monitor,omitempty"`
-	NotificationEmail string        `json:"notification_email,omitempty"`
-	Origins           []Origin      `json:"origins"`
-	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+	Name           string          `json:"name"`
+	Description    string          `json:"description,omitempty"`
+	Enabled        bool            `json:"enabled"`
+	MinimumOrigins int             `json:"minimum_origins,omitempty"`
+	Monitor        string          `json:"monitor,omitempty"`
+	Origins        []Origin        `json:"origins"`
+	LoadShedding   *LoadShedding   `json:"load_shedding,omitempty"`
+	OriginSteering *OriginSteering `json:"origin_steering,omitempty"`
 }
 
 // CreatePool creates a new origin pool under a Cloudflare account
@@ -1044,14 +1146,14 @@ func (c *Client) CreatePool(accountID string, req CreatePoolRequest) (*Pool, err
 
 // UpdatePoolRequest is the payload for updating an origin pool
 type UpdatePoolRequest struct {
-	Name              string        `json:"name,omitempty"`
-	Description       string        `json:"description,omitempty"`
-	Enabled           *bool         `json:"enabled,omitempty"`
-	MinimumOrigins    *int          `json:"minimum_origins,omitempty"`
-	Monitor           string        `json:"monitor,omitempty"`
-	NotificationEmail string        `json:"notification_email,omitempty"`
-	Origins           []Origin      `json:"origins,omitempty"`
-	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+	Name           string          `json:"name,omitempty"`
+	Description    string          `json:"description,omitempty"`
+	Enabled        *bool           `json:"enabled,omitempty"`
+	MinimumOrigins *int            `json:"minimum_origins,omitempty"`
+	Monitor        string          `json:"monitor,omitempty"`
+	Origins        []Origin        `json:"origins,omitempty"`
+	LoadShedding   *LoadShedding   `json:"load_shedding,omitempty"`
+	OriginSteering *OriginSteering `json:"origin_steering,omitempty"`
 }
 
 // UpdatePool updates an existing origin pool under a Cloudflare account

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -968,3 +968,118 @@ func (c *Client) DeleteKVNamespace(accountID, namespaceID string) error {
 
 	return nil
 }
+
+// ---- Pool types ----
+
+// Origin represents a single origin server in a pool
+type Origin struct {
+	Name    string  `json:"name"`
+	Address string  `json:"address"`
+	Enabled bool    `json:"enabled"`
+	Weight  float64 `json:"weight"`
+}
+
+// LoadShedding configures load shedding behaviour for a pool
+type LoadShedding struct {
+	DefaultPercent float64 `json:"default_percent"`
+	DefaultPolicy  string  `json:"default_policy"`
+	SessionPercent float64 `json:"session_percent"`
+	SessionPolicy  string  `json:"session_policy"`
+}
+
+// Pool represents a Cloudflare Load Balancer origin pool
+type Pool struct {
+	ID                string        `json:"id"`
+	Name              string        `json:"name"`
+	Description       string        `json:"description"`
+	Enabled           bool          `json:"enabled"`
+	MinimumOrigins    int           `json:"minimum_origins"`
+	Monitor           string        `json:"monitor,omitempty"`
+	NotificationEmail string        `json:"notification_email,omitempty"`
+	Origins           []Origin      `json:"origins"`
+	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+}
+
+// CreatePoolRequest is the payload for creating a pool
+type CreatePoolRequest struct {
+	Name              string        `json:"name"`
+	Description       string        `json:"description,omitempty"`
+	Enabled           bool          `json:"enabled"`
+	MinimumOrigins    int           `json:"minimum_origins,omitempty"`
+	Monitor           string        `json:"monitor,omitempty"`
+	NotificationEmail string        `json:"notification_email,omitempty"`
+	Origins           []Origin      `json:"origins"`
+	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+}
+
+// CreatePool creates a new origin pool under a Cloudflare account
+func (c *Client) CreatePool(accountID string, req CreatePoolRequest) (*Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+// UpdatePoolRequest is the payload for updating an origin pool
+type UpdatePoolRequest struct {
+	Name              string        `json:"name,omitempty"`
+	Description       string        `json:"description,omitempty"`
+	Enabled           *bool         `json:"enabled,omitempty"`
+	MinimumOrigins    *int          `json:"minimum_origins,omitempty"`
+	Monitor           string        `json:"monitor,omitempty"`
+	NotificationEmail string        `json:"notification_email,omitempty"`
+	Origins           []Origin      `json:"origins,omitempty"`
+	LoadShedding      *LoadShedding `json:"load_shedding,omitempty"`
+}
+
+// UpdatePool updates an existing origin pool under a Cloudflare account
+func (c *Client) UpdatePool(accountID, poolID string, req UpdatePoolRequest) (*Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools/%s", c.BaseURL, accountID, poolID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -983,6 +983,7 @@ type Origin struct {
 	Address     string       `json:"address"`
 	Enabled     bool         `json:"enabled"`
 	Weight      float64      `json:"weight"`
+	Port        int          `json:"port,omitempty"`
 	Coordinates *Coordinates `json:"coordinates,omitempty"`
 }
 

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -1124,7 +1124,7 @@ type CreatePoolRequest struct {
 	Name           string          `json:"name"`
 	Description    string          `json:"description,omitempty"`
 	Enabled        bool            `json:"enabled"`
-	MinimumOrigins int             `json:"minimum_origins,omitempty"`
+	MinimumOrigins *int            `json:"minimum_origins,omitempty"`
 	Monitor        string          `json:"monitor,omitempty"`
 	Origins        []Origin        `json:"origins"`
 	LoadShedding   *LoadShedding   `json:"load_shedding,omitempty"`

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -68,7 +68,7 @@ type PoolNodeMetadata struct {
 
 func resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
 	meta := PoolNodeMetadata{}
-	if strings.Contains(poolID, "{{") {
+	if strings.Contains(poolID, "{{") || strings.Contains(accountID, "{{") {
 		meta.PoolName = poolID
 	} else {
 		client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -144,6 +144,8 @@ func (c *Cloudflare) Actions() []core.Action {
 		&DeleteKVNamespace{},
 		&CreatePool{},
 		&UpdatePool{},
+		&GetPool{},
+		&DeletePool{},
 	}
 }
 
@@ -346,6 +348,62 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 			})
 		}
 		return keyResources, nil
+
+	case "monitor":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		monitors, err := client.ListMonitors(accountID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing monitors: %w", err)
+		}
+
+		var resources []core.IntegrationResource
+		for _, m := range monitors {
+			name := m.Description
+			if name == "" {
+				name = m.ID
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   m.ID,
+			})
+		}
+		return resources, nil
+
+	case "pool":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		pools, err := client.ListPools(accountID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing pools: %w", err)
+		}
+
+		var resources []core.IntegrationResource
+		for _, p := range pools {
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: p.Name,
+				ID:   p.ID,
+			})
+		}
+		return resources, nil
 
 	default:
 		return []core.IntegrationResource{}, nil

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -22,7 +22,7 @@ type Configuration struct {
 }
 
 type Metadata struct {
-	Zones     []Zone `json:"zones"`
+	Zones         []Zone `json:"zones"`
 	AccountID string `json:"accountId"`
 }
 
@@ -44,6 +44,27 @@ func resolveKVNamespaceMetadata(ctx core.SetupContext, accountID, namespaceID st
 		return "", fmt.Errorf("failed to get KV namespace: %w", err)
 	}
 	return ns.Title, nil
+}
+
+func accountIDFromIntegration(ctx core.IntegrationContext) string {
+	if ctx == nil {
+		return ""
+	}
+	metadata := Metadata{}
+	mapstructure.Decode(ctx.GetMetadata(), &metadata)
+	return metadata.AccountID
+}
+
+func resolveAccountID(specAccountID string, integration core.IntegrationContext) string {
+	if specAccountID != "" {
+		return specAccountID
+	}
+	return accountIDFromIntegration(integration)
+	AccountID string `json:"accountId"`
+}
+
+type PoolNodeMetadata struct {
+	PoolName string `json:"poolName"`
 }
 
 func accountIDFromIntegration(ctx core.IntegrationContext) string {
@@ -352,6 +373,9 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 	case "monitor":
 		accountID := ctx.Parameters["accountId"]
 		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
+		if accountID == "" {
 			return []core.IntegrationResource{}, nil
 		}
 
@@ -381,6 +405,9 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 
 	case "pool":
 		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
 		if accountID == "" {
 			return []core.IntegrationResource{}, nil
 		}

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -22,7 +22,7 @@ type Configuration struct {
 }
 
 type Metadata struct {
-	Zones         []Zone `json:"zones"`
+	Zones     []Zone `json:"zones"`
 	AccountID string `json:"accountId"`
 }
 
@@ -60,27 +60,10 @@ func resolveAccountID(specAccountID string, integration core.IntegrationContext)
 		return specAccountID
 	}
 	return accountIDFromIntegration(integration)
-	AccountID string `json:"accountId"`
 }
 
 type PoolNodeMetadata struct {
 	PoolName string `json:"poolName"`
-}
-
-func accountIDFromIntegration(ctx core.IntegrationContext) string {
-	if ctx == nil {
-		return ""
-	}
-	metadata := Metadata{}
-	mapstructure.Decode(ctx.GetMetadata(), &metadata)
-	return metadata.AccountID
-}
-
-func resolveAccountID(specAccountID string, integration core.IntegrationContext) string {
-	if specAccountID != "" {
-		return specAccountID
-	}
-	return accountIDFromIntegration(integration)
 }
 
 func resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -92,6 +92,7 @@ func (c *Cloudflare) Instructions() string {
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
 	 - Account / Workers KV Storage / Edit
+     - Account / Load Balancing: Monitor and Pools / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
@@ -141,6 +142,8 @@ func (c *Cloudflare) Actions() []core.Action {
 		&GetKVValue{},
 		&DeleteKVValue{},
 		&DeleteKVNamespace{},
+		&CreatePool{},
+		&UpdatePool{},
 	}
 }
 

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -83,6 +83,24 @@ func resolveAccountID(specAccountID string, integration core.IntegrationContext)
 	return accountIDFromIntegration(integration)
 }
 
+func resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
+	meta := PoolNodeMetadata{}
+	if strings.Contains(poolID, "{{") {
+		meta.PoolName = poolID
+	} else {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		pool, err := client.GetPool(accountID, poolID)
+		if err != nil {
+			return fmt.Errorf("failed to get pool: %w", err)
+		}
+		meta.PoolName = pool.Name
+	}
+	return ctx.Metadata.Set(meta)
+}
+
 func (c *Cloudflare) Name() string {
 	return "cloudflare"
 }

--- a/pkg/integrations/cloudflare/cloudflare_test.go
+++ b/pkg/integrations/cloudflare/cloudflare_test.go
@@ -49,7 +49,8 @@ func Test__Cloudflare__Sync(t *testing.T) {
 
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{
-				"apiToken": "token123",
+				"apiToken":  "token123",
+				"accountId": "acc123",
 			},
 		}
 
@@ -68,6 +69,7 @@ func Test__Cloudflare__Sync(t *testing.T) {
 		assert.Len(t, metadata.Zones, 1)
 		assert.Equal(t, "zone123", metadata.Zones[0].ID)
 		assert.Equal(t, "example.com", metadata.Zones[0].Name)
+		assert.Equal(t, "acc123", metadata.AccountID)
 	})
 
 	t.Run("api token -> failed zone list returns error", func(t *testing.T) {

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -230,12 +230,6 @@ func (c *CreatePool) Configuration() []configuration.Field {
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "monitor",
-					Parameters: []configuration.ParameterRef{
-						{
-							Name:      "accountId",
-							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -25,7 +25,7 @@ type CreatePoolSpec struct {
 	Name                 string            `json:"name"`
 	Description          string            `json:"description"`
 	Enabled              bool              `json:"enabled"`
-	MinimumOrigins       int               `json:"minimumOrigins"`
+	MinimumOrigins       *int              `json:"minimumOrigins"`
 	Monitor              string            `json:"monitor"`
 	Origins              []OriginSpec      `json:"origins"`
 	OriginSteeringPolicy string            `json:"originSteeringPolicy"`

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -1,0 +1,294 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CreatePool struct{}
+
+type CreatePoolSpec struct {
+	AccountID         string       `json:"accountId"`
+	Name              string       `json:"name"`
+	Description       string       `json:"description"`
+	Enabled           bool         `json:"enabled"`
+	MinimumOrigins    int          `json:"minimumOrigins"`
+	Monitor           string       `json:"monitor"`
+	NotificationEmail string       `json:"notificationEmail"`
+	Origins           []OriginSpec `json:"origins"`
+}
+
+type OriginSpec struct {
+	Name    string  `json:"name"`
+	Address string  `json:"address"`
+	Enabled bool    `json:"enabled"`
+	Weight  float64 `json:"weight"`
+}
+
+func (c *CreatePool) Name() string {
+	return "cloudflare.createPool"
+}
+
+func (c *CreatePool) Label() string {
+	return "Create Pool"
+}
+
+func (c *CreatePool) Description() string {
+	return "Create a Cloudflare Load Balancer origin pool"
+}
+
+func (c *CreatePool) Documentation() string {
+	return `The Create Pool component creates a new Cloudflare Load Balancer origin pool.
+
+## Use Cases
+
+- **Canary deployments**: Provision a new origin pool for a canary release
+- **Blue/green deployments**: Create the green pool before switching traffic
+- **Multi-region**: Add origin servers in new regions
+
+## Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Name**: A unique, human-readable name for the pool
+- **Description**: Optional description
+- **Origins**: List of origin servers with name, address, enabled flag, and weight
+- **Enabled**: Whether the pool is active
+- **Minimum Origins**: Minimum number of healthy origins before marking pool unhealthy
+- **Monitor**: (Optional) Health monitor ID to use for origin health checks
+- **Notification Email**: (Optional) Email to notify when pool health changes
+
+## Output
+
+Returns the created origin pool with its assigned ID and full configuration.`
+}
+
+func (c *CreatePool) Icon() string {
+	return "cloud"
+}
+
+func (c *CreatePool) Color() string {
+	return "orange"
+}
+
+func (c *CreatePool) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreatePool) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Cloudflare account ID that owns the pool",
+		},
+		{
+			Name:        "name",
+			Label:       "Pool Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "A unique, human-readable name for the origin pool",
+			Placeholder: "my-origin-pool",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional description of the origin pool",
+		},
+		{
+			Name:        "origins",
+			Label:       "Origins",
+			Type:        configuration.FieldTypeList,
+			Required:    true,
+			Description: "List of origin servers in the pool",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Origin",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:        "name",
+								Label:       "Name",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Description: "Human-readable name for the origin",
+								Placeholder: "origin-1",
+							},
+							{
+								Name:        "address",
+								Label:       "Address",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Description: "IP address or hostname of the origin",
+								Placeholder: "192.0.2.1",
+							},
+							{
+								Name:     "enabled",
+								Label:    "Enabled",
+								Type:     configuration.FieldTypeBool,
+								Required: false,
+								Default:  true,
+							},
+							{
+								Name:        "weight",
+								Label:       "Weight",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Default:     1,
+								Description: "Traffic weight for this origin (0.0–1.0)",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "enabled",
+			Label:       "Enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "Whether the pool is active and receives traffic",
+		},
+		{
+			Name:        "minimumOrigins",
+			Label:       "Minimum Origins",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     1,
+			Description: "Minimum number of healthy origins before the pool is marked as unhealthy",
+		},
+		{
+			Name:        "monitor",
+			Label:       "Monitor ID",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional health monitor ID to attach to this pool",
+		},
+		{
+			Name:        "notificationEmail",
+			Label:       "Notification Email",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Email address to notify when pool health changes",
+			Placeholder: "ops@example.com",
+		},
+	}
+}
+
+func (c *CreatePool) Setup(ctx core.SetupContext) error {
+	spec := CreatePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.AccountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Name == "" {
+		return errors.New("name is required")
+	}
+
+	if len(spec.Origins) == 0 {
+		return errors.New("at least one origin is required")
+	}
+
+	for i, o := range spec.Origins {
+		if o.Name == "" {
+			return fmt.Errorf("origins[%d].name is required", i)
+		}
+		if o.Address == "" {
+			return fmt.Errorf("origins[%d].address is required", i)
+		}
+	}
+
+	return nil
+}
+
+func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
+	spec := CreatePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	origins := make([]Origin, len(spec.Origins))
+	for i, o := range spec.Origins {
+		weight := o.Weight
+		if weight == 0 {
+			weight = 1.0
+		}
+
+		origins[i] = Origin{
+			Name:    o.Name,
+			Address: o.Address,
+			Enabled: o.Enabled,
+			Weight:  weight,
+		}
+	}
+
+	req := CreatePoolRequest{
+		Name:              spec.Name,
+		Description:       spec.Description,
+		Enabled:           spec.Enabled,
+		MinimumOrigins:    spec.MinimumOrigins,
+		Monitor:           spec.Monitor,
+		NotificationEmail: spec.NotificationEmail,
+		Origins:           origins,
+	}
+
+	pool, err := client.CreatePool(spec.AccountID, req)
+	if err != nil {
+		return fmt.Errorf("failed to create pool: %v", err)
+	}
+
+	result := map[string]any{
+		"pool":      pool,
+		"accountId": spec.AccountID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.pool",
+		[]any{result},
+	)
+}
+
+func (c *CreatePool) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreatePool) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreatePool) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreatePool) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreatePool) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreatePool) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -32,14 +32,18 @@ type CreatePoolSpec struct {
 	LoadShedding         *LoadSheddingSpec `json:"loadShedding"`
 }
 
+type CoordinatesSpec struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
 type OriginSpec struct {
-	Name      string   `json:"name"`
-	Address   string   `json:"address"`
-	Enabled   bool     `json:"enabled"`
-	Weight    float64  `json:"weight"`
-	Port      int      `json:"port"`
-	Latitude  *float64 `json:"latitude"`
-	Longitude *float64 `json:"longitude"`
+	Name        string           `json:"name"`
+	Address     string           `json:"address"`
+	Enabled     bool             `json:"enabled"`
+	Weight      float64          `json:"weight"`
+	Port        int              `json:"port"`
+	Coordinates *CoordinatesSpec `json:"coordinates"`
 }
 
 func (c *CreatePool) Name() string {
@@ -167,18 +171,32 @@ func (c *CreatePool) Configuration() []configuration.Field {
 								Description: "Traffic weight for this origin (0.0–1.0)",
 							},
 							{
-								Name:        "latitude",
-								Label:       "Latitude",
-								Type:        configuration.FieldTypeNumber,
+								Name:        "coordinates",
+								Label:       "Coordinates",
+								Type:        configuration.FieldTypeObject,
 								Required:    false,
-								Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
-							},
-							{
-								Name:        "longitude",
-								Label:       "Longitude",
-								Type:        configuration.FieldTypeNumber,
-								Required:    false,
-								Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
+								Togglable:   true,
+								Description: "Geographic coordinates for proximity steering",
+								TypeOptions: &configuration.TypeOptions{
+									Object: &configuration.ObjectTypeOptions{
+										Schema: []configuration.Field{
+											{
+												Name:        "latitude",
+												Label:       "Latitude",
+												Type:        configuration.FieldTypeNumber,
+												Required:    false,
+												Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
+											},
+											{
+												Name:        "longitude",
+												Label:       "Longitude",
+												Type:        configuration.FieldTypeNumber,
+												Required:    false,
+												Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -242,6 +260,7 @@ func (c *CreatePool) Configuration() []configuration.Field {
 			Label:       "Load Shedding",
 			Type:        configuration.FieldTypeObject,
 			Required:    false,
+			Togglable:   true,
 			Description: "Configure load shedding to drop a percentage of traffic to the pool",
 			TypeOptions: &configuration.TypeOptions{
 				Object: &configuration.ObjectTypeOptions{
@@ -352,8 +371,8 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 		}
 
 		var coords *Coordinates
-		if o.Latitude != nil && o.Longitude != nil {
-			coords = &Coordinates{Latitude: *o.Latitude, Longitude: *o.Longitude}
+		if o.Coordinates != nil {
+			coords = &Coordinates{Latitude: o.Coordinates.Latitude, Longitude: o.Coordinates.Longitude}
 		}
 
 		origins[i] = Origin{

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -347,6 +347,9 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 	}
 
 	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -13,22 +13,33 @@ import (
 
 type CreatePool struct{}
 
+type LoadSheddingSpec struct {
+	DefaultPercent float64 `json:"defaultPercent"`
+	DefaultPolicy  string  `json:"defaultPolicy"`
+	SessionPercent float64 `json:"sessionPercent"`
+	SessionPolicy  string  `json:"sessionPolicy"`
+}
+
 type CreatePoolSpec struct {
-	AccountID         string       `json:"accountId"`
-	Name              string       `json:"name"`
-	Description       string       `json:"description"`
-	Enabled           bool         `json:"enabled"`
-	MinimumOrigins    int          `json:"minimumOrigins"`
-	Monitor           string       `json:"monitor"`
-	NotificationEmail string       `json:"notificationEmail"`
-	Origins           []OriginSpec `json:"origins"`
+	AccountID            string            `json:"accountId"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description"`
+	Enabled              bool              `json:"enabled"`
+	MinimumOrigins       int               `json:"minimumOrigins"`
+	Monitor              string            `json:"monitor"`
+	Origins              []OriginSpec      `json:"origins"`
+	OriginSteeringPolicy string            `json:"originSteeringPolicy"`
+	LoadShedding         *LoadSheddingSpec `json:"loadShedding"`
 }
 
 type OriginSpec struct {
-	Name    string  `json:"name"`
-	Address string  `json:"address"`
-	Enabled bool    `json:"enabled"`
-	Weight  float64 `json:"weight"`
+	Name      string   `json:"name"`
+	Address   string   `json:"address"`
+	Enabled   bool     `json:"enabled"`
+	Weight    float64  `json:"weight"`
+	Port      int      `json:"port"`
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
 }
 
 func (c *CreatePool) Name() string {
@@ -57,11 +68,12 @@ func (c *CreatePool) Documentation() string {
 - **Account ID**: The Cloudflare account ID that owns the pool
 - **Name**: A unique, human-readable name for the pool
 - **Description**: Optional description
-- **Origins**: List of origin servers with name, address, enabled flag, and weight
+- **Origins**: List of origin servers with name, address, enabled flag, weight, optional port, and optional coordinates
 - **Enabled**: Whether the pool is active
 - **Minimum Origins**: Minimum number of healthy origins before marking pool unhealthy
-- **Monitor**: (Optional) Health monitor ID to use for origin health checks
-- **Notification Email**: (Optional) Email to notify when pool health changes
+- **Origin Steering Policy**: How requests are distributed across origins
+- **Monitor**: (Optional) Health monitor to use for origin health checks
+- **Load Shedding**: (Optional) Configure load shedding for the pool
 
 ## Output
 
@@ -129,8 +141,15 @@ func (c *CreatePool) Configuration() []configuration.Field {
 								Label:       "Address",
 								Type:        configuration.FieldTypeString,
 								Required:    true,
-								Description: "IP address or hostname of the origin",
+								Description: "IPv4 address or hostname of the origin",
 								Placeholder: "192.0.2.1",
+							},
+							{
+								Name:        "port",
+								Label:       "Port",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Optional port to append to the address (e.g. 8080). Leave empty to use the default.",
 							},
 							{
 								Name:     "enabled",
@@ -146,6 +165,20 @@ func (c *CreatePool) Configuration() []configuration.Field {
 								Required:    false,
 								Default:     1,
 								Description: "Traffic weight for this origin (0.0–1.0)",
+							},
+							{
+								Name:        "latitude",
+								Label:       "Latitude",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
+							},
+							{
+								Name:        "longitude",
+								Label:       "Longitude",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
 							},
 						},
 					},
@@ -169,19 +202,98 @@ func (c *CreatePool) Configuration() []configuration.Field {
 			Description: "Minimum number of healthy origins before the pool is marked as unhealthy",
 		},
 		{
-			Name:        "monitor",
-			Label:       "Monitor ID",
-			Type:        configuration.FieldTypeString,
+			Name:        "originSteeringPolicy",
+			Label:       "Origin Steering Policy",
+			Type:        configuration.FieldTypeSelect,
 			Required:    false,
-			Description: "Optional health monitor ID to attach to this pool",
+			Description: "Determines how requests are distributed across origins",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Random", Value: "random"},
+						{Label: "Hash (URI)", Value: "hash"},
+						{Label: "Least Outstanding Requests", Value: "least_outstanding_requests"},
+						{Label: "Least Connections", Value: "least_connections"},
+					},
+				},
+			},
 		},
 		{
-			Name:        "notificationEmail",
-			Label:       "Notification Email",
-			Type:        configuration.FieldTypeString,
+			Name:        "monitor",
+			Label:       "Monitor",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
-			Description: "Email address to notify when pool health changes",
-			Placeholder: "ops@example.com",
+			Description: "Health monitor to attach to this pool",
+			Placeholder: "Select a monitor",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "monitor",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "loadShedding",
+			Label:       "Load Shedding",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Description: "Configure load shedding to drop a percentage of traffic to the pool",
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: []configuration.Field{
+						{
+							Name:        "defaultPercent",
+							Label:       "Default Percent",
+							Type:        configuration.FieldTypeNumber,
+							Required:    false,
+							Default:     0,
+							Description: "Percentage of traffic to shed from all sessions (0–100)",
+						},
+						{
+							Name:        "defaultPolicy",
+							Label:       "Default Policy",
+							Type:        configuration.FieldTypeSelect,
+							Required:    false,
+							Description: "Policy for shedding default (non-session-affinity) traffic",
+							TypeOptions: &configuration.TypeOptions{
+								Select: &configuration.SelectTypeOptions{
+									Options: []configuration.FieldOption{
+										{Label: "Random", Value: "random"},
+										{Label: "Hash", Value: "hash"},
+									},
+								},
+							},
+						},
+						{
+							Name:        "sessionPercent",
+							Label:       "Session Percent",
+							Type:        configuration.FieldTypeNumber,
+							Required:    false,
+							Default:     0,
+							Description: "Percentage of existing sessions to shed (0–100)",
+						},
+						{
+							Name:        "sessionPolicy",
+							Label:       "Session Policy",
+							Type:        configuration.FieldTypeSelect,
+							Required:    false,
+							Description: "Policy for shedding session-affinity traffic",
+							TypeOptions: &configuration.TypeOptions{
+								Select: &configuration.SelectTypeOptions{
+									Options: []configuration.FieldOption{
+										{Label: "Hash", Value: "hash"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -234,22 +346,49 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 			weight = 1.0
 		}
 
+		address := o.Address
+		if o.Port > 0 {
+			address = fmt.Sprintf("%s:%d", o.Address, o.Port)
+		}
+
+		var coords *Coordinates
+		if o.Latitude != nil && o.Longitude != nil {
+			coords = &Coordinates{Latitude: *o.Latitude, Longitude: *o.Longitude}
+		}
+
 		origins[i] = Origin{
-			Name:    o.Name,
-			Address: o.Address,
-			Enabled: o.Enabled,
-			Weight:  weight,
+			Name:        o.Name,
+			Address:     address,
+			Enabled:     o.Enabled,
+			Weight:      weight,
+			Coordinates: coords,
+		}
+	}
+
+	var originSteering *OriginSteering
+	if spec.OriginSteeringPolicy != "" {
+		originSteering = &OriginSteering{Policy: spec.OriginSteeringPolicy}
+	}
+
+	var loadShedding *LoadShedding
+	if spec.LoadShedding != nil {
+		loadShedding = &LoadShedding{
+			DefaultPercent: spec.LoadShedding.DefaultPercent,
+			DefaultPolicy:  spec.LoadShedding.DefaultPolicy,
+			SessionPercent: spec.LoadShedding.SessionPercent,
+			SessionPolicy:  spec.LoadShedding.SessionPolicy,
 		}
 	}
 
 	req := CreatePoolRequest{
-		Name:              spec.Name,
-		Description:       spec.Description,
-		Enabled:           spec.Enabled,
-		MinimumOrigins:    spec.MinimumOrigins,
-		Monitor:           spec.Monitor,
-		NotificationEmail: spec.NotificationEmail,
-		Origins:           origins,
+		Name:           spec.Name,
+		Description:    spec.Description,
+		Enabled:        spec.Enabled,
+		MinimumOrigins: spec.MinimumOrigins,
+		Monitor:        spec.Monitor,
+		Origins:        origins,
+		OriginSteering: originSteering,
+		LoadShedding:   loadShedding,
 	}
 
 	pool, err := client.CreatePool(spec.AccountID, req)

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -24,7 +24,7 @@ type CreatePoolSpec struct {
 	AccountID            string            `json:"accountId"`
 	Name                 string            `json:"name"`
 	Description          string            `json:"description"`
-	Enabled              bool              `json:"enabled"`
+	Enabled              *bool             `json:"enabled"`
 	MinimumOrigins       *int              `json:"minimumOrigins"`
 	Monitor              string            `json:"monitor"`
 	Origins              []OriginSpec      `json:"origins"`
@@ -394,10 +394,15 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 		}
 	}
 
+	enabled := true
+	if spec.Enabled != nil {
+		enabled = *spec.Enabled
+	}
+
 	req := CreatePoolRequest{
 		Name:           spec.Name,
 		Description:    spec.Description,
-		Enabled:        spec.Enabled,
+		Enabled:        enabled,
 		MinimumOrigins: spec.MinimumOrigins,
 		Monitor:        spec.Monitor,
 		Origins:        origins,

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -418,7 +418,7 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"cloudflare.pool",
+		"cloudflare.pool.created",
 		[]any{result},
 	)
 }

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -99,13 +99,6 @@ func (c *CreatePool) OutputChannels(configuration any) []core.OutputChannel {
 func (c *CreatePool) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "accountId",
-			Label:       "Account ID",
-			Type:        configuration.FieldTypeString,
-			Required:    true,
-			Description: "The Cloudflare account ID that owns the pool",
-		},
-		{
 			Name:        "name",
 			Label:       "Pool Name",
 			Type:        configuration.FieldTypeString,
@@ -156,13 +149,6 @@ func (c *CreatePool) Configuration() []configuration.Field {
 								Description: "Optional port to append to the address (e.g. 8080). Leave empty to use the default.",
 							},
 							{
-								Name:     "enabled",
-								Label:    "Enabled",
-								Type:     configuration.FieldTypeBool,
-								Required: false,
-								Default:  true,
-							},
-							{
 								Name:        "weight",
 								Label:       "Weight",
 								Type:        configuration.FieldTypeNumber,
@@ -198,18 +184,17 @@ func (c *CreatePool) Configuration() []configuration.Field {
 									},
 								},
 							},
+							{
+								Name:     "enabled",
+								Label:    "Enabled",
+								Type:     configuration.FieldTypeBool,
+								Required: false,
+								Default:  true,
+							},
 						},
 					},
 				},
 			},
-		},
-		{
-			Name:        "enabled",
-			Label:       "Enabled",
-			Type:        configuration.FieldTypeBool,
-			Required:    false,
-			Default:     true,
-			Description: "Whether the pool is active and receives traffic",
 		},
 		{
 			Name:        "minimumOrigins",
@@ -314,6 +299,14 @@ func (c *CreatePool) Configuration() []configuration.Field {
 				},
 			},
 		},
+		{
+			Name:        "enabled",
+			Label:       "Enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "Whether the pool is active and receives traffic",
+		},
 	}
 }
 
@@ -323,7 +316,8 @@ func (c *CreatePool) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if spec.AccountID == "" {
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
 		return errors.New("accountId is required")
 	}
 
@@ -352,6 +346,8 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
@@ -410,14 +406,14 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 		LoadShedding:   loadShedding,
 	}
 
-	pool, err := client.CreatePool(spec.AccountID, req)
+	pool, err := client.CreatePool(accountID, req)
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %v", err)
 	}
 
 	result := map[string]any{
 		"pool":      pool,
-		"accountId": spec.AccountID,
+		"accountId": accountID,
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/create_pool.go
+++ b/pkg/integrations/cloudflare/create_pool.go
@@ -40,8 +40,8 @@ type CoordinatesSpec struct {
 type OriginSpec struct {
 	Name        string           `json:"name"`
 	Address     string           `json:"address"`
-	Enabled     bool             `json:"enabled"`
-	Weight      float64          `json:"weight"`
+	Enabled     *bool            `json:"enabled"`
+	Weight      *float64         `json:"weight"`
 	Port        int              `json:"port"`
 	Coordinates *CoordinatesSpec `json:"coordinates"`
 }
@@ -69,7 +69,6 @@ func (c *CreatePool) Documentation() string {
 
 ## Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Name**: A unique, human-readable name for the pool
 - **Description**: Optional description
 - **Origins**: List of origin servers with name, address, enabled flag, weight, optional port, and optional coordinates
@@ -356,14 +355,16 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 
 	origins := make([]Origin, len(spec.Origins))
 	for i, o := range spec.Origins {
-		weight := o.Weight
-		if weight == 0 {
-			weight = 1.0
+		weight := 1.0
+		if o.Weight != nil {
+			weight = *o.Weight
 		}
 
 		address := o.Address
-		if o.Port > 0 {
-			address = fmt.Sprintf("%s:%d", o.Address, o.Port)
+
+		enabled := true
+		if o.Enabled != nil {
+			enabled = *o.Enabled
 		}
 
 		var coords *Coordinates
@@ -374,8 +375,9 @@ func (c *CreatePool) Execute(ctx core.ExecutionContext) error {
 		origins[i] = Origin{
 			Name:        o.Name,
 			Address:     address,
-			Enabled:     o.Enabled,
+			Enabled:     enabled,
 			Weight:      weight,
+			Port:        o.Port,
 			Coordinates: coords,
 		}
 	}

--- a/pkg/integrations/cloudflare/create_pool_test.go
+++ b/pkg/integrations/cloudflare/create_pool_test.go
@@ -1,0 +1,208 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreatePool__Setup(t *testing.T) {
+	component := &CreatePool{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"name":      "my-pool",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing name returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("missing origins returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "my-pool",
+				"origins":   []any{},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "at least one origin is required")
+	})
+
+	t.Run("origin missing name returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "my-pool",
+				"origins": []any{
+					map[string]any{"name": "", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "origins[0].name is required")
+	})
+
+	t.Run("origin missing address returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "my-pool",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "origins[0].address is required")
+	})
+
+	t.Run("valid configuration passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "my-pool",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreatePool__Execute(t *testing.T) {
+	component := &CreatePool{}
+
+	t.Run("successful create emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "pool123",
+							"name": "my-pool",
+							"description": "Test pool",
+							"enabled": true,
+							"minimum_origins": 1,
+							"origins": [
+								{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1}
+							]
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":   "acc123",
+				"name":        "my-pool",
+				"description": "Test pool",
+				"enabled":     true,
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/load_balancers/pools", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusBadRequest,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Pool name already exists"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"name":      "my-pool",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1},
+				},
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create pool")
+	})
+}

--- a/pkg/integrations/cloudflare/create_pool_test.go
+++ b/pkg/integrations/cloudflare/create_pool_test.go
@@ -159,7 +159,7 @@ func Test__CreatePool__Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, execState.Passed)
 		assert.Equal(t, "default", execState.Channel)
-		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Equal(t, "cloudflare.pool.created", execState.Type)
 		assert.Len(t, execState.Payloads, 1)
 
 		require.Len(t, httpContext.Requests, 1)

--- a/pkg/integrations/cloudflare/delete_pool.go
+++ b/pkg/integrations/cloudflare/delete_pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -15,7 +16,7 @@ type DeletePool struct{}
 
 type DeletePoolSpec struct {
 	AccountID string `json:"accountId"`
-	PoolID    string `json:"poolId"`
+	Pool      string `json:"pool"`
 }
 
 func (c *DeletePool) Name() string {
@@ -65,14 +66,7 @@ func (c *DeletePool) OutputChannels(configuration any) []core.OutputChannel {
 func (c *DeletePool) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "accountId",
-			Label:       "Account ID",
-			Type:        configuration.FieldTypeString,
-			Required:    true,
-			Description: "The Cloudflare account ID that owns the pool",
-		},
-		{
-			Name:        "poolId",
+			Name:        "pool",
 			Label:       "Pool",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -81,12 +75,6 @@ func (c *DeletePool) Configuration() []configuration.Field {
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "pool",
-					Parameters: []configuration.ParameterRef{
-						{
-							Name:      "accountId",
-							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
-						},
-					},
 				},
 			},
 		},
@@ -99,15 +87,34 @@ func (c *DeletePool) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if spec.AccountID == "" {
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
 		return errors.New("accountId is required")
 	}
 
-	if spec.PoolID == "" {
-		return errors.New("poolId is required")
+	if spec.Pool == "" {
+		return errors.New("pool is required")
 	}
 
-	return nil
+	return c.resolvePoolMetadata(ctx, accountID, spec.Pool)
+}
+
+func (c *DeletePool) resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
+	meta := PoolNodeMetadata{}
+	if strings.Contains(poolID, "{{") {
+		meta.PoolName = poolID
+	} else {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		pool, err := client.GetPool(accountID, poolID)
+		if err != nil {
+			return fmt.Errorf("failed to get pool: %w", err)
+		}
+		meta.PoolName = pool.Name
+	}
+	return ctx.Metadata.Set(meta)
 }
 
 func (c *DeletePool) Execute(ctx core.ExecutionContext) error {
@@ -116,18 +123,20 @@ func (c *DeletePool) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	if err := client.DeletePool(spec.AccountID, spec.PoolID); err != nil {
+	if err := client.DeletePool(accountID, spec.Pool); err != nil {
 		return fmt.Errorf("failed to delete pool: %v", err)
 	}
 
 	result := map[string]any{
-		"accountId": spec.AccountID,
-		"poolId":    spec.PoolID,
+		"accountId": accountID,
+		"poolId":    spec.Pool,
 		"deleted":   true,
 	}
 

--- a/pkg/integrations/cloudflare/delete_pool.go
+++ b/pkg/integrations/cloudflare/delete_pool.go
@@ -1,0 +1,163 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeletePool struct{}
+
+type DeletePoolSpec struct {
+	AccountID string `json:"accountId"`
+	PoolID    string `json:"poolId"`
+}
+
+func (c *DeletePool) Name() string {
+	return "cloudflare.deletePool"
+}
+
+func (c *DeletePool) Label() string {
+	return "Delete Pool"
+}
+
+func (c *DeletePool) Description() string {
+	return "Delete a Cloudflare Load Balancer origin pool"
+}
+
+func (c *DeletePool) Documentation() string {
+	return `The Delete Pool component permanently removes a Cloudflare Load Balancer origin pool.
+
+## Use Cases
+
+- **Blue/green deployments**: Clean up the old (blue) pool after traffic has shifted
+- **Environment teardown**: Remove pools as part of infrastructure cleanup
+
+## Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The origin pool to delete
+
+## Output
+
+Emits a confirmation with the account ID and pool ID of the deleted pool.
+
+> **Warning**: This operation is irreversible. Ensure the pool is not attached to any load balancer before deleting.`
+}
+
+func (c *DeletePool) Icon() string {
+	return "cloud"
+}
+
+func (c *DeletePool) Color() string {
+	return "orange"
+}
+
+func (c *DeletePool) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeletePool) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Cloudflare account ID that owns the pool",
+		},
+		{
+			Name:        "poolId",
+			Label:       "Pool",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The origin pool to delete",
+			Placeholder: "Select a pool",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "pool",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *DeletePool) Setup(ctx core.SetupContext) error {
+	spec := DeletePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.AccountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.PoolID == "" {
+		return errors.New("poolId is required")
+	}
+
+	return nil
+}
+
+func (c *DeletePool) Execute(ctx core.ExecutionContext) error {
+	spec := DeletePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.DeletePool(spec.AccountID, spec.PoolID); err != nil {
+		return fmt.Errorf("failed to delete pool: %v", err)
+	}
+
+	result := map[string]any{
+		"accountId": spec.AccountID,
+		"poolId":    spec.PoolID,
+		"deleted":   true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.pool.deleted",
+		[]any{result},
+	)
+}
+
+func (c *DeletePool) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeletePool) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeletePool) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeletePool) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeletePool) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeletePool) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/delete_pool.go
+++ b/pkg/integrations/cloudflare/delete_pool.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -99,21 +98,7 @@ func (c *DeletePool) Setup(ctx core.SetupContext) error {
 }
 
 func (c *DeletePool) resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
-	meta := PoolNodeMetadata{}
-	if strings.Contains(poolID, "{{") {
-		meta.PoolName = poolID
-	} else {
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return fmt.Errorf("failed to create client: %w", err)
-		}
-		pool, err := client.GetPool(accountID, poolID)
-		if err != nil {
-			return fmt.Errorf("failed to get pool: %w", err)
-		}
-		meta.PoolName = pool.Name
-	}
-	return ctx.Metadata.Set(meta)
+	return resolvePoolMetadata(ctx, accountID, poolID)
 }
 
 func (c *DeletePool) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/cloudflare/delete_pool.go
+++ b/pkg/integrations/cloudflare/delete_pool.go
@@ -41,7 +41,6 @@ func (c *DeletePool) Documentation() string {
 
 ## Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The origin pool to delete
 
 ## Output
@@ -124,6 +123,9 @@ func (c *DeletePool) Execute(ctx core.ExecutionContext) error {
 	}
 
 	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {

--- a/pkg/integrations/cloudflare/delete_pool_test.go
+++ b/pkg/integrations/cloudflare/delete_pool_test.go
@@ -19,7 +19,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -32,20 +32,20 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "",
+				"pool":    "",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
-		require.ErrorContains(t, err, "poolId is required")
+		require.ErrorContains(t, err, "pool is required")
 	})
 
 	t.Run("expression poolId is accepted without API call", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "{{ $.trigger.data.poolId }}",
+				"pool":    "{{ $.trigger.data.poolId }}",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -57,7 +57,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"poolId": "{{ $.trigger.data.poolId }}",
+				"pool": "{{ $.trigger.data.poolId }}",
 			},
 			Integration: &contexts.IntegrationContext{
 				Metadata: Metadata{AccountID: "acc-from-integration"},
@@ -73,7 +73,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
@@ -129,7 +129,7 @@ func Test__DeletePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,
@@ -172,7 +172,7 @@ func Test__DeletePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,

--- a/pkg/integrations/cloudflare/delete_pool_test.go
+++ b/pkg/integrations/cloudflare/delete_pool_test.go
@@ -21,6 +21,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 				"accountId": "",
 				"poolId":    "pool123",
 			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
@@ -33,22 +34,72 @@ func Test__DeletePool__Setup(t *testing.T) {
 				"accountId": "acc123",
 				"poolId":    "",
 			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.ErrorContains(t, err, "poolId is required")
 	})
 
-	t.Run("valid configuration passes", func(t *testing.T) {
+	t.Run("expression poolId is accepted without API call", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "{{ $.trigger.data.poolId }}",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"poolId": "{{ $.trigger.data.poolId }}",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves pool name", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
 				"poolId":    "pool123",
 			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "pool123", "name": "my-pool"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		poolMeta, ok := meta.Metadata.(PoolNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "my-pool", poolMeta.PoolName)
 	})
 }
 

--- a/pkg/integrations/cloudflare/delete_pool_test.go
+++ b/pkg/integrations/cloudflare/delete_pool_test.go
@@ -19,7 +19,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -32,7 +32,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "",
+				"pool":      "",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -45,7 +45,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "{{ $.trigger.data.poolId }}",
+				"pool":      "{{ $.trigger.data.poolId }}",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -73,7 +73,7 @@ func Test__DeletePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
@@ -129,7 +129,7 @@ func Test__DeletePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,
@@ -172,7 +172,7 @@ func Test__DeletePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,

--- a/pkg/integrations/cloudflare/delete_pool_test.go
+++ b/pkg/integrations/cloudflare/delete_pool_test.go
@@ -1,0 +1,136 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeletePool__Setup(t *testing.T) {
+	component := &DeletePool{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing poolId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "poolId is required")
+	})
+
+	t.Run("valid configuration passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__DeletePool__Execute(t *testing.T) {
+	component := &DeletePool{}
+
+	t.Run("successful delete emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "pool123"}}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.pool.deleted", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/load_balancers/pools/pool123", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Pool is in use"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete pool")
+	})
+}

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -116,3 +116,23 @@ var exampleOutputUpdatePool map[string]any
 func (c *UpdatePool) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdatePoolOnce, exampleOutputUpdatePoolBytes, &exampleOutputUpdatePool)
 }
+
+//go:embed example_output_get_pool.json
+var exampleOutputGetPoolBytes []byte
+
+var exampleOutputGetPoolOnce sync.Once
+var exampleOutputGetPool map[string]any
+
+func (c *GetPool) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetPoolOnce, exampleOutputGetPoolBytes, &exampleOutputGetPool)
+}
+
+//go:embed example_output_delete_pool.json
+var exampleOutputDeletePoolBytes []byte
+
+var exampleOutputDeletePoolOnce sync.Once
+var exampleOutputDeletePool map[string]any
+
+func (c *DeletePool) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeletePoolOnce, exampleOutputDeletePoolBytes, &exampleOutputDeletePool)
+}

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -96,3 +96,23 @@ var exampleOutputDeleteKVNamespace map[string]any
 func (c *DeleteKVNamespace) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteKVNamespaceOnce, exampleOutputDeleteKVNamespaceBytes, &exampleOutputDeleteKVNamespace)
 }
+
+//go:embed example_output_create_pool.json
+var exampleOutputCreatePoolBytes []byte
+
+var exampleOutputCreatePoolOnce sync.Once
+var exampleOutputCreatePool map[string]any
+
+func (c *CreatePool) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreatePoolOnce, exampleOutputCreatePoolBytes, &exampleOutputCreatePool)
+}
+
+//go:embed example_output_update_pool.json
+var exampleOutputUpdatePoolBytes []byte
+
+var exampleOutputUpdatePoolOnce sync.Once
+var exampleOutputUpdatePool map[string]any
+
+func (c *UpdatePool) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdatePoolOnce, exampleOutputUpdatePoolBytes, &exampleOutputUpdatePool)
+}

--- a/pkg/integrations/cloudflare/example_output_create_pool.json
+++ b/pkg/integrations/cloudflare/example_output_create_pool.json
@@ -4,7 +4,7 @@
     "pool": {
       "description": "my pool",
       "enabled": true,
-      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "id": "483e85c07a861ae7a8813ef010be7036",
       "minimum_origins": 1,
       "name": "my-pool",
       "origin_steering": {
@@ -12,14 +12,15 @@
       },
       "origins": [
         {
-          "address": "192.0.2.1:2015",
-          "enabled": false,
+          "address": "192.0.2.1",
+          "enabled": true,
           "name": "server-1",
+          "port": 2013,
           "weight": 1
         }
       ]
     }
   },
-  "timestamp": "2026-05-05T05:57:07.706260875Z",
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.pool.created"
 }

--- a/pkg/integrations/cloudflare/example_output_create_pool.json
+++ b/pkg/integrations/cloudflare/example_output_create_pool.json
@@ -1,28 +1,25 @@
 {
-  "pool": {
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "name": "primary-pool",
-    "description": "Primary origin pool",
-    "enabled": true,
-    "minimum_origins": 1,
-    "monitor": "",
-    "origins": [
-      {
-        "name": "app-1",
-        "address": "192.0.2.1",
-        "enabled": true,
-        "weight": 1
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-pool",
+      "origin_steering": {
+        "policy": "random"
       },
-      {
-        "name": "app-2",
-        "address": "192.0.2.2",
-        "enabled": true,
-        "weight": 1
-      }
-    ],
-    "origin_steering": {
-      "policy": "random"
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
     }
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823"
+  "timestamp": "2026-05-05T05:57:07.706260875Z",
+  "type": "cloudflare.pool.created"
 }

--- a/pkg/integrations/cloudflare/example_output_create_pool.json
+++ b/pkg/integrations/cloudflare/example_output_create_pool.json
@@ -1,0 +1,26 @@
+{
+  "pool": {
+    "id": "17b5962d775c646f3f9725cbc7a53df4",
+    "name": "primary-pool",
+    "description": "Primary origin pool",
+    "enabled": true,
+    "minimum_origins": 1,
+    "monitor": "",
+    "notification_email": "",
+    "origins": [
+      {
+        "name": "app-1",
+        "address": "192.0.2.1",
+        "enabled": true,
+        "weight": 1
+      },
+      {
+        "name": "app-2",
+        "address": "192.0.2.2",
+        "enabled": true,
+        "weight": 1
+      }
+    ]
+  },
+  "accountId": "01a7362d577a6c3019a474fd6f485823"
+}

--- a/pkg/integrations/cloudflare/example_output_delete_pool.json
+++ b/pkg/integrations/cloudflare/example_output_delete_pool.json
@@ -1,0 +1,5 @@
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4",
+  "deleted": true
+}

--- a/pkg/integrations/cloudflare/example_output_delete_pool.json
+++ b/pkg/integrations/cloudflare/example_output_delete_pool.json
@@ -1,26 +1,9 @@
 {
   "data": {
     "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
-    "pool": {
-      "description": "my deleted pool",
-      "enabled": true,
-      "id": "f7be7edc94014415ba06bca7b13c5c5a",
-      "minimum_origins": 1,
-      "name": "my-deleted-pool",
-      "origin_steering": {
-        "policy": "random"
-      },
-      "origins": [
-        {
-          "address": "138.68.89.169:2015",
-          "enabled": false,
-          "name": "server-1",
-          "weight": 1
-        }
-      ]
-    },
+    "deleted": true,
     "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "timestamp": "2026-05-05T05:59:02.93536262Z",
   "type": "cloudflare.pool.deleted"
 }

--- a/pkg/integrations/cloudflare/example_output_delete_pool.json
+++ b/pkg/integrations/cloudflare/example_output_delete_pool.json
@@ -1,5 +1,26 @@
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4",
-  "deleted": true
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my deleted pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-deleted-pool",
+      "origin_steering": {
+        "policy": "random"
+      },
+      "origins": [
+        {
+          "address": "138.68.89.169:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    },
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
+  },
+  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "type": "cloudflare.pool.deleted"
 }

--- a/pkg/integrations/cloudflare/example_output_get_pool.json
+++ b/pkg/integrations/cloudflare/example_output_get_pool.json
@@ -12,17 +12,12 @@
         "address": "192.0.2.1",
         "enabled": true,
         "weight": 1
-      },
-      {
-        "name": "app-2",
-        "address": "192.0.2.2",
-        "enabled": true,
-        "weight": 1
       }
     ],
     "origin_steering": {
       "policy": "random"
     }
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823"
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
 }

--- a/pkg/integrations/cloudflare/example_output_get_pool.json
+++ b/pkg/integrations/cloudflare/example_output_get_pool.json
@@ -1,23 +1,26 @@
 {
-  "pool": {
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "name": "primary-pool",
-    "description": "Primary origin pool",
-    "enabled": true,
-    "minimum_origins": 1,
-    "monitor": "",
-    "origins": [
-      {
-        "name": "app-1",
-        "address": "192.0.2.1",
-        "enabled": true,
-        "weight": 1
-      }
-    ],
-    "origin_steering": {
-      "policy": "random"
-    }
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my updated pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-updated-pool",
+      "origin_steering": {
+        "policy": "random"
+      },
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    },
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+  "timestamp": "2026-05-05T05:58:40.060373991Z",
+  "type": "cloudflare.pool.fetched"
 }

--- a/pkg/integrations/cloudflare/example_output_update_pool.json
+++ b/pkg/integrations/cloudflare/example_output_update_pool.json
@@ -1,0 +1,27 @@
+{
+  "pool": {
+    "id": "17b5962d775c646f3f9725cbc7a53df4",
+    "name": "primary-pool",
+    "description": "Primary origin pool",
+    "enabled": true,
+    "minimum_origins": 1,
+    "monitor": "",
+    "notification_email": "",
+    "origins": [
+      {
+        "name": "app-stable",
+        "address": "192.0.2.1",
+        "enabled": true,
+        "weight": 0.9
+      },
+      {
+        "name": "app-canary",
+        "address": "192.0.2.3",
+        "enabled": true,
+        "weight": 0.1
+      }
+    ]
+  },
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+}

--- a/pkg/integrations/cloudflare/example_output_update_pool.json
+++ b/pkg/integrations/cloudflare/example_output_update_pool.json
@@ -1,29 +1,26 @@
 {
-  "pool": {
-    "id": "17b5962d775c646f3f9725cbc7a53df4",
-    "name": "primary-pool",
-    "description": "Primary origin pool",
-    "enabled": true,
-    "minimum_origins": 1,
-    "monitor": "",
-    "origins": [
-      {
-        "name": "app-stable",
-        "address": "192.0.2.1",
-        "enabled": true,
-        "weight": 0.9
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "pool": {
+      "description": "my updated pool",
+      "enabled": true,
+      "id": "f7be7edc94014415ba06bca7b13c5c5a",
+      "minimum_origins": 1,
+      "name": "my-updated-pool",
+      "origin_steering": {
+        "policy": "random"
       },
-      {
-        "name": "app-canary",
-        "address": "192.0.2.3",
-        "enabled": true,
-        "weight": 0.1
-      }
-    ],
-    "origin_steering": {
-      "policy": "random"
-    }
+      "origins": [
+        {
+          "address": "192.0.2.1:2015",
+          "enabled": false,
+          "name": "server-1",
+          "weight": 1
+        }
+      ]
+    },
+    "poolId": "f7be7edc94014415ba06bca7b13c5c5a"
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "poolId": "17b5962d775c646f3f9725cbc7a53df4"
+  "timestamp": "2026-05-05T05:57:59.044021383Z",
+  "type": "cloudflare.pool.updated"
 }

--- a/pkg/integrations/cloudflare/example_output_update_pool.json
+++ b/pkg/integrations/cloudflare/example_output_update_pool.json
@@ -6,7 +6,6 @@
     "enabled": true,
     "minimum_origins": 1,
     "monitor": "",
-    "notification_email": "",
     "origins": [
       {
         "name": "app-stable",
@@ -20,7 +19,10 @@
         "enabled": true,
         "weight": 0.1
       }
-    ]
+    ],
+    "origin_steering": {
+      "policy": "random"
+    }
   },
   "accountId": "01a7362d577a6c3019a474fd6f485823",
   "poolId": "17b5962d775c646f3f9725cbc7a53df4"

--- a/pkg/integrations/cloudflare/get_pool.go
+++ b/pkg/integrations/cloudflare/get_pool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -15,7 +16,7 @@ type GetPool struct{}
 
 type GetPoolSpec struct {
 	AccountID string `json:"accountId"`
-	PoolID    string `json:"poolId"`
+	Pool      string `json:"pool"`
 }
 
 func (c *GetPool) Name() string {
@@ -64,14 +65,7 @@ func (c *GetPool) OutputChannels(configuration any) []core.OutputChannel {
 func (c *GetPool) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "accountId",
-			Label:       "Account ID",
-			Type:        configuration.FieldTypeString,
-			Required:    true,
-			Description: "The Cloudflare account ID that owns the pool",
-		},
-		{
-			Name:        "poolId",
+			Name:        "pool",
 			Label:       "Pool",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -80,12 +74,6 @@ func (c *GetPool) Configuration() []configuration.Field {
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "pool",
-					Parameters: []configuration.ParameterRef{
-						{
-							Name:      "accountId",
-							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
-						},
-					},
 				},
 			},
 		},
@@ -98,15 +86,34 @@ func (c *GetPool) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if spec.AccountID == "" {
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
 		return errors.New("accountId is required")
 	}
 
-	if spec.PoolID == "" {
-		return errors.New("poolId is required")
+	if spec.Pool == "" {
+		return errors.New("pool is required")
 	}
 
-	return nil
+	return c.resolvePoolMetadata(ctx, accountID, spec.Pool)
+}
+
+func (c *GetPool) resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
+	meta := PoolNodeMetadata{}
+	if strings.Contains(poolID, "{{") {
+		meta.PoolName = poolID
+	} else {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		pool, err := client.GetPool(accountID, poolID)
+		if err != nil {
+			return fmt.Errorf("failed to get pool: %w", err)
+		}
+		meta.PoolName = pool.Name
+	}
+	return ctx.Metadata.Set(meta)
 }
 
 func (c *GetPool) Execute(ctx core.ExecutionContext) error {
@@ -115,20 +122,22 @@ func (c *GetPool) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	pool, err := client.GetPool(spec.AccountID, spec.PoolID)
+	pool, err := client.GetPool(accountID, spec.Pool)
 	if err != nil {
 		return fmt.Errorf("failed to get pool: %v", err)
 	}
 
 	result := map[string]any{
 		"pool":      pool,
-		"accountId": spec.AccountID,
-		"poolId":    spec.PoolID,
+		"accountId": accountID,
+		"poolId":    spec.Pool,
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/get_pool.go
+++ b/pkg/integrations/cloudflare/get_pool.go
@@ -142,7 +142,7 @@ func (c *GetPool) Execute(ctx core.ExecutionContext) error {
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"cloudflare.pool",
+		"cloudflare.pool.fetched",
 		[]any{result},
 	)
 }

--- a/pkg/integrations/cloudflare/get_pool.go
+++ b/pkg/integrations/cloudflare/get_pool.go
@@ -42,7 +42,6 @@ func (c *GetPool) Documentation() string {
 
 ## Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The origin pool to retrieve
 
 ## Output

--- a/pkg/integrations/cloudflare/get_pool.go
+++ b/pkg/integrations/cloudflare/get_pool.go
@@ -1,0 +1,163 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetPool struct{}
+
+type GetPoolSpec struct {
+	AccountID string `json:"accountId"`
+	PoolID    string `json:"poolId"`
+}
+
+func (c *GetPool) Name() string {
+	return "cloudflare.getPool"
+}
+
+func (c *GetPool) Label() string {
+	return "Get Pool"
+}
+
+func (c *GetPool) Description() string {
+	return "Retrieve a Cloudflare Load Balancer origin pool by ID"
+}
+
+func (c *GetPool) Documentation() string {
+	return `The Get Pool component fetches the current state of a Cloudflare Load Balancer origin pool.
+
+## Use Cases
+
+- **Health checks**: Inspect origin health and pool status in a workflow
+- **Pre-flight validation**: Confirm a pool exists before updating it
+- **Audit**: Capture a snapshot of pool configuration at a point in time
+
+## Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The origin pool to retrieve
+
+## Output
+
+Returns the full pool configuration including its origins, enabled state, and health monitor.`
+}
+
+func (c *GetPool) Icon() string {
+	return "cloud"
+}
+
+func (c *GetPool) Color() string {
+	return "orange"
+}
+
+func (c *GetPool) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetPool) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Cloudflare account ID that owns the pool",
+		},
+		{
+			Name:        "poolId",
+			Label:       "Pool",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The origin pool to retrieve",
+			Placeholder: "Select a pool",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "pool",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *GetPool) Setup(ctx core.SetupContext) error {
+	spec := GetPoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.AccountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.PoolID == "" {
+		return errors.New("poolId is required")
+	}
+
+	return nil
+}
+
+func (c *GetPool) Execute(ctx core.ExecutionContext) error {
+	spec := GetPoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	pool, err := client.GetPool(spec.AccountID, spec.PoolID)
+	if err != nil {
+		return fmt.Errorf("failed to get pool: %v", err)
+	}
+
+	result := map[string]any{
+		"pool":      pool,
+		"accountId": spec.AccountID,
+		"poolId":    spec.PoolID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.pool",
+		[]any{result},
+	)
+}
+
+func (c *GetPool) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetPool) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetPool) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetPool) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetPool) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetPool) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/get_pool.go
+++ b/pkg/integrations/cloudflare/get_pool.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -98,21 +97,7 @@ func (c *GetPool) Setup(ctx core.SetupContext) error {
 }
 
 func (c *GetPool) resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
-	meta := PoolNodeMetadata{}
-	if strings.Contains(poolID, "{{") {
-		meta.PoolName = poolID
-	} else {
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return fmt.Errorf("failed to create client: %w", err)
-		}
-		pool, err := client.GetPool(accountID, poolID)
-		if err != nil {
-			return fmt.Errorf("failed to get pool: %w", err)
-		}
-		meta.PoolName = pool.Name
-	}
-	return ctx.Metadata.Set(meta)
+	return resolvePoolMetadata(ctx, accountID, poolID)
 }
 
 func (c *GetPool) Execute(ctx core.ExecutionContext) error {
@@ -122,6 +107,9 @@ func (c *GetPool) Execute(ctx core.ExecutionContext) error {
 	}
 
 	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {

--- a/pkg/integrations/cloudflare/get_pool_test.go
+++ b/pkg/integrations/cloudflare/get_pool_test.go
@@ -19,7 +19,7 @@ func Test__GetPool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -32,20 +32,20 @@ func Test__GetPool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "",
+				"pool":      "",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
-		require.ErrorContains(t, err, "poolId is required")
+		require.ErrorContains(t, err, "pool is required")
 	})
 
 	t.Run("expression poolId is accepted without API call", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "{{ $.trigger.data.poolId }}",
+				"pool":      "{{ $.trigger.data.poolId }}",
 			},
 			Metadata: &contexts.MetadataContext{},
 		}
@@ -57,7 +57,7 @@ func Test__GetPool__Setup(t *testing.T) {
 	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"poolId": "{{ $.trigger.data.poolId }}",
+				"pool": "{{ $.trigger.data.poolId }}",
 			},
 			Integration: &contexts.IntegrationContext{
 				Metadata: Metadata{AccountID: "acc-from-integration"},
@@ -73,7 +73,7 @@ func Test__GetPool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP: &contexts.HTTPContext{
 				Responses: []*http.Response{
@@ -141,7 +141,7 @@ func Test__GetPool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,
@@ -153,7 +153,7 @@ func Test__GetPool__Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, execState.Passed)
 		assert.Equal(t, "default", execState.Channel)
-		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Equal(t, "cloudflare.pool.fetched", execState.Type)
 		assert.Len(t, execState.Payloads, 1)
 
 		require.Len(t, httpContext.Requests, 1)
@@ -184,7 +184,7 @@ func Test__GetPool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,

--- a/pkg/integrations/cloudflare/get_pool_test.go
+++ b/pkg/integrations/cloudflare/get_pool_test.go
@@ -1,0 +1,148 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetPool__Setup(t *testing.T) {
+	component := &GetPool{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing poolId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "poolId is required")
+	})
+
+	t.Run("valid configuration passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetPool__Execute(t *testing.T) {
+	component := &GetPool{}
+
+	t.Run("successful get emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "pool123",
+							"name": "my-pool",
+							"description": "Test pool",
+							"enabled": true,
+							"minimum_origins": 1,
+							"origins": [
+								{"name": "o1", "address": "1.2.3.4", "enabled": true, "weight": 1}
+							]
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/load_balancers/pools/pool123", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Pool not found"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get pool")
+	})
+}

--- a/pkg/integrations/cloudflare/get_pool_test.go
+++ b/pkg/integrations/cloudflare/get_pool_test.go
@@ -21,6 +21,7 @@ func Test__GetPool__Setup(t *testing.T) {
 				"accountId": "",
 				"poolId":    "pool123",
 			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
@@ -33,22 +34,72 @@ func Test__GetPool__Setup(t *testing.T) {
 				"accountId": "acc123",
 				"poolId":    "",
 			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.ErrorContains(t, err, "poolId is required")
 	})
 
-	t.Run("valid configuration passes", func(t *testing.T) {
+	t.Run("expression poolId is accepted without API call", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "{{ $.trigger.data.poolId }}",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"poolId": "{{ $.trigger.data.poolId }}",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves pool name", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
 				"poolId":    "pool123",
 			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "pool123", "name": "my-pool"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		poolMeta, ok := meta.Metadata.(PoolNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "my-pool", poolMeta.PoolName)
 	})
 }
 

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -111,6 +111,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Origins",
 			Type:        configuration.FieldTypeList,
 			Required:    false,
+			Togglable:   true,
 			Description: "Updated list of origin servers. When provided, replaces the current list.",
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
@@ -157,18 +158,32 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 								Description: "Traffic weight for this origin (0.0–1.0)",
 							},
 							{
-								Name:        "latitude",
-								Label:       "Latitude",
-								Type:        configuration.FieldTypeNumber,
+								Name:        "coordinates",
+								Label:       "Coordinates",
+								Type:        configuration.FieldTypeObject,
 								Required:    false,
-								Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
-							},
-							{
-								Name:        "longitude",
-								Label:       "Longitude",
-								Type:        configuration.FieldTypeNumber,
-								Required:    false,
-								Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
+								Togglable:   true,
+								Description: "Geographic coordinates for proximity steering",
+								TypeOptions: &configuration.TypeOptions{
+									Object: &configuration.ObjectTypeOptions{
+										Schema: []configuration.Field{
+											{
+												Name:        "latitude",
+												Label:       "Latitude",
+												Type:        configuration.FieldTypeNumber,
+												Required:    false,
+												Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
+											},
+											{
+												Name:        "longitude",
+												Label:       "Longitude",
+												Type:        configuration.FieldTypeNumber,
+												Required:    false,
+												Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -180,6 +195,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Pool Name",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
+			Togglable:   true,
 			Description: "New name for the pool (optional)",
 		},
 		{
@@ -187,6 +203,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Description",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
+			Togglable:   true,
 			Description: "New description for the pool (optional)",
 		},
 		{
@@ -194,6 +211,8 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Enabled",
 			Type:        configuration.FieldTypeBool,
 			Required:    false,
+			Togglable:   true,
+			Default:     true,
 			Description: "Enable or disable the pool",
 		},
 		{
@@ -201,6 +220,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Minimum Origins",
 			Type:        configuration.FieldTypeNumber,
 			Required:    false,
+			Togglable:   true,
 			Description: "Minimum number of healthy origins before the pool is marked as unhealthy",
 		},
 		{
@@ -208,6 +228,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Origin Steering Policy",
 			Type:        configuration.FieldTypeSelect,
 			Required:    false,
+			Togglable:   true,
 			Description: "Determines how requests are distributed across origins",
 			TypeOptions: &configuration.TypeOptions{
 				Select: &configuration.SelectTypeOptions{
@@ -225,6 +246,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Monitor",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
+			Togglable:   true,
 			Description: "Health monitor to attach to this pool",
 			Placeholder: "Select a monitor",
 			TypeOptions: &configuration.TypeOptions{
@@ -244,6 +266,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Load Shedding",
 			Type:        configuration.FieldTypeObject,
 			Required:    false,
+			Togglable:   true,
 			Description: "Configure load shedding to drop a percentage of traffic to the pool",
 			TypeOptions: &configuration.TypeOptions{
 				Object: &configuration.ObjectTypeOptions{
@@ -376,8 +399,8 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 			}
 
 			var coords *Coordinates
-			if o.Latitude != nil && o.Longitude != nil {
-				coords = &Coordinates{Latitude: *o.Latitude, Longitude: *o.Longitude}
+			if o.Coordinates != nil {
+				coords = &Coordinates{Latitude: o.Coordinates.Latitude, Longitude: o.Coordinates.Longitude}
 			}
 
 			origins[i] = Origin{

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -237,12 +237,6 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "monitor",
-					Parameters: []configuration.ParameterRef{
-						{
-							Name:      "accountId",
-							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -417,7 +417,7 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"cloudflare.pool",
+		"cloudflare.pool.updated",
 		[]any{result},
 	)
 }

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -14,15 +14,16 @@ import (
 type UpdatePool struct{}
 
 type UpdatePoolSpec struct {
-	AccountID         string       `json:"accountId"`
-	PoolID            string       `json:"poolId"`
-	Name              string       `json:"name"`
-	Description       string       `json:"description"`
-	Enabled           *bool        `json:"enabled"`
-	MinimumOrigins    *int         `json:"minimumOrigins"`
-	Monitor           string       `json:"monitor"`
-	NotificationEmail string       `json:"notificationEmail"`
-	Origins           []OriginSpec `json:"origins"`
+	AccountID            string            `json:"accountId"`
+	PoolID               string            `json:"poolId"`
+	Name                 string            `json:"name"`
+	Description          string            `json:"description"`
+	Enabled              *bool             `json:"enabled"`
+	MinimumOrigins       *int              `json:"minimumOrigins"`
+	Monitor              string            `json:"monitor"`
+	Origins              []OriginSpec      `json:"origins"`
+	OriginSteeringPolicy string            `json:"originSteeringPolicy"`
+	LoadShedding         *LoadSheddingSpec `json:"loadShedding"`
 }
 
 func (c *UpdatePool) Name() string {
@@ -56,8 +57,9 @@ func (c *UpdatePool) Documentation() string {
 - **Description**: Optional new description
 - **Enabled**: Enable or disable the entire pool
 - **Minimum Origins**: Minimum number of healthy origins before pool is marked unhealthy
+- **Origin Steering Policy**: How requests are distributed across origins
 - **Monitor**: Health monitor ID for origin health checks
-- **Notification Email**: Email to notify on health changes
+- **Load Shedding**: Configure load shedding for the pool
 
 ## Output
 
@@ -87,10 +89,22 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "poolId",
-			Label:       "Pool ID",
-			Type:        configuration.FieldTypeString,
+			Label:       "Pool",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The ID of the origin pool to update",
+			Description: "The origin pool to update",
+			Placeholder: "Select a pool",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "pool",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
 		},
 		{
 			Name:        "origins",
@@ -117,8 +131,15 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 								Label:       "Address",
 								Type:        configuration.FieldTypeString,
 								Required:    true,
-								Description: "IP address or hostname of the origin",
+								Description: "IPv4 address or hostname of the origin",
 								Placeholder: "192.0.2.1",
+							},
+							{
+								Name:        "port",
+								Label:       "Port",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Optional port to append to the address (e.g. 8080). Leave empty to use the default.",
 							},
 							{
 								Name:     "enabled",
@@ -134,6 +155,20 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 								Required:    false,
 								Default:     1,
 								Description: "Traffic weight for this origin (0.0–1.0)",
+							},
+							{
+								Name:        "latitude",
+								Label:       "Latitude",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Geographic latitude for proximity steering (e.g. 51.5074)",
+							},
+							{
+								Name:        "longitude",
+								Label:       "Longitude",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Description: "Geographic longitude for proximity steering (e.g. -0.1278)",
 							},
 						},
 					},
@@ -169,18 +204,98 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Description: "Minimum number of healthy origins before the pool is marked as unhealthy",
 		},
 		{
-			Name:        "monitor",
-			Label:       "Monitor ID",
-			Type:        configuration.FieldTypeString,
+			Name:        "originSteeringPolicy",
+			Label:       "Origin Steering Policy",
+			Type:        configuration.FieldTypeSelect,
 			Required:    false,
-			Description: "Health monitor ID to attach to this pool",
+			Description: "Determines how requests are distributed across origins",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Random", Value: "random"},
+						{Label: "Hash (URI)", Value: "hash"},
+						{Label: "Least Outstanding Requests", Value: "least_outstanding_requests"},
+						{Label: "Least Connections", Value: "least_connections"},
+					},
+				},
+			},
 		},
 		{
-			Name:        "notificationEmail",
-			Label:       "Notification Email",
-			Type:        configuration.FieldTypeString,
+			Name:        "monitor",
+			Label:       "Monitor",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
-			Description: "Email address to notify when pool health changes",
+			Description: "Health monitor to attach to this pool",
+			Placeholder: "Select a monitor",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "monitor",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "loadShedding",
+			Label:       "Load Shedding",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Description: "Configure load shedding to drop a percentage of traffic to the pool",
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: []configuration.Field{
+						{
+							Name:        "defaultPercent",
+							Label:       "Default Percent",
+							Type:        configuration.FieldTypeNumber,
+							Required:    false,
+							Default:     0,
+							Description: "Percentage of traffic to shed from all sessions (0–100)",
+						},
+						{
+							Name:        "defaultPolicy",
+							Label:       "Default Policy",
+							Type:        configuration.FieldTypeSelect,
+							Required:    false,
+							Description: "Policy for shedding default (non-session-affinity) traffic",
+							TypeOptions: &configuration.TypeOptions{
+								Select: &configuration.SelectTypeOptions{
+									Options: []configuration.FieldOption{
+										{Label: "Random", Value: "random"},
+										{Label: "Hash", Value: "hash"},
+									},
+								},
+							},
+						},
+						{
+							Name:        "sessionPercent",
+							Label:       "Session Percent",
+							Type:        configuration.FieldTypeNumber,
+							Required:    false,
+							Default:     0,
+							Description: "Percentage of existing sessions to shed (0–100)",
+						},
+						{
+							Name:        "sessionPolicy",
+							Label:       "Session Policy",
+							Type:        configuration.FieldTypeSelect,
+							Required:    false,
+							Description: "Policy for shedding session-affinity traffic",
+							TypeOptions: &configuration.TypeOptions{
+								Select: &configuration.SelectTypeOptions{
+									Options: []configuration.FieldOption{
+										{Label: "Hash", Value: "hash"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -222,13 +337,29 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
+	var originSteering *OriginSteering
+	if spec.OriginSteeringPolicy != "" {
+		originSteering = &OriginSteering{Policy: spec.OriginSteeringPolicy}
+	}
+
+	var loadShedding *LoadShedding
+	if spec.LoadShedding != nil {
+		loadShedding = &LoadShedding{
+			DefaultPercent: spec.LoadShedding.DefaultPercent,
+			DefaultPolicy:  spec.LoadShedding.DefaultPolicy,
+			SessionPercent: spec.LoadShedding.SessionPercent,
+			SessionPolicy:  spec.LoadShedding.SessionPolicy,
+		}
+	}
+
 	req := UpdatePoolRequest{
-		Name:              spec.Name,
-		Description:       spec.Description,
-		Enabled:           spec.Enabled,
-		MinimumOrigins:    spec.MinimumOrigins,
-		Monitor:           spec.Monitor,
-		NotificationEmail: spec.NotificationEmail,
+		Name:           spec.Name,
+		Description:    spec.Description,
+		Enabled:        spec.Enabled,
+		MinimumOrigins: spec.MinimumOrigins,
+		Monitor:        spec.Monitor,
+		OriginSteering: originSteering,
+		LoadShedding:   loadShedding,
 	}
 
 	if len(spec.Origins) > 0 {
@@ -239,11 +370,22 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 				weight = 1.0
 			}
 
+			address := o.Address
+			if o.Port > 0 {
+				address = fmt.Sprintf("%s:%d", o.Address, o.Port)
+			}
+
+			var coords *Coordinates
+			if o.Latitude != nil && o.Longitude != nil {
+				coords = &Coordinates{Latitude: *o.Latitude, Longitude: *o.Longitude}
+			}
+
 			origins[i] = Origin{
-				Name:    o.Name,
-				Address: o.Address,
-				Enabled: o.Enabled,
-				Weight:  weight,
+				Name:        o.Name,
+				Address:     address,
+				Enabled:     o.Enabled,
+				Weight:      weight,
+				Coordinates: coords,
 			}
 		}
 

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -342,6 +342,9 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 	}
 
 	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -15,7 +15,7 @@ type UpdatePool struct{}
 
 type UpdatePoolSpec struct {
 	AccountID            string            `json:"accountId"`
-	PoolID               string            `json:"poolId"`
+	Pool                 string            `json:"pool"`
 	Name                 string            `json:"name"`
 	Description          string            `json:"description"`
 	Enabled              *bool             `json:"enabled"`
@@ -81,14 +81,7 @@ func (c *UpdatePool) OutputChannels(configuration any) []core.OutputChannel {
 func (c *UpdatePool) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "accountId",
-			Label:       "Account ID",
-			Type:        configuration.FieldTypeString,
-			Required:    true,
-			Description: "The Cloudflare account ID that owns the pool",
-		},
-		{
-			Name:        "poolId",
+			Name:        "pool",
 			Label:       "Pool",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
@@ -97,12 +90,6 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "pool",
-					Parameters: []configuration.ParameterRef{
-						{
-							Name:      "accountId",
-							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
-						},
-					},
 				},
 			},
 		},
@@ -211,7 +198,6 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Enabled",
 			Type:        configuration.FieldTypeBool,
 			Required:    false,
-			Togglable:   true,
 			Default:     true,
 			Description: "Enable or disable the pool",
 		},
@@ -329,12 +315,13 @@ func (c *UpdatePool) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if spec.AccountID == "" {
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
 		return errors.New("accountId is required")
 	}
 
-	if spec.PoolID == "" {
-		return errors.New("poolId is required")
+	if spec.Pool == "" {
+		return errors.New("pool is required")
 	}
 
 	for i, o := range spec.Origins {
@@ -354,6 +341,8 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
@@ -415,15 +404,15 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 		req.Origins = origins
 	}
 
-	pool, err := client.UpdatePool(spec.AccountID, spec.PoolID, req)
+	pool, err := client.UpdatePool(accountID, spec.Pool, req)
 	if err != nil {
 		return fmt.Errorf("failed to update pool: %v", err)
 	}
 
 	result := map[string]any{
 		"pool":      pool,
-		"accountId": spec.AccountID,
-		"poolId":    spec.PoolID,
+		"accountId": accountID,
+		"poolId":    spec.Pool,
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -50,7 +50,6 @@ func (c *UpdatePool) Documentation() string {
 
 ## Configuration
 
-- **Account ID**: The Cloudflare account ID that owns the pool
 - **Pool ID**: The ID of the pool to update
 - **Origins**: Full list of origin servers with updated weights or enabled status
 - **Name**: Optional new name for the pool
@@ -377,14 +376,16 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 	if len(spec.Origins) > 0 {
 		origins := make([]Origin, len(spec.Origins))
 		for i, o := range spec.Origins {
-			weight := o.Weight
-			if weight == 0 {
-				weight = 1.0
+			weight := 1.0
+			if o.Weight != nil {
+				weight = *o.Weight
 			}
 
 			address := o.Address
-			if o.Port > 0 {
-				address = fmt.Sprintf("%s:%d", o.Address, o.Port)
+
+			enabled := true
+			if o.Enabled != nil {
+				enabled = *o.Enabled
 			}
 
 			var coords *Coordinates
@@ -395,8 +396,9 @@ func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
 			origins[i] = Origin{
 				Name:        o.Name,
 				Address:     address,
-				Enabled:     o.Enabled,
+				Enabled:     enabled,
 				Weight:      weight,
+				Port:        o.Port,
 				Coordinates: coords,
 			}
 		}

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -326,7 +326,11 @@ func (c *UpdatePool) Setup(ctx core.SetupContext) error {
 		}
 	}
 
-	return nil
+	return c.resolvePoolMetadata(ctx, accountID, spec.Pool)
+}
+
+func (c *UpdatePool) resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
+	return resolvePoolMetadata(ctx, accountID, poolID)
 }
 
 func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -197,6 +197,7 @@ func (c *UpdatePool) Configuration() []configuration.Field {
 			Label:       "Enabled",
 			Type:        configuration.FieldTypeBool,
 			Required:    false,
+			Togglable:   true,
 			Default:     true,
 			Description: "Enable or disable the pool",
 		},

--- a/pkg/integrations/cloudflare/update_pool.go
+++ b/pkg/integrations/cloudflare/update_pool.go
@@ -1,0 +1,293 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type UpdatePool struct{}
+
+type UpdatePoolSpec struct {
+	AccountID         string       `json:"accountId"`
+	PoolID            string       `json:"poolId"`
+	Name              string       `json:"name"`
+	Description       string       `json:"description"`
+	Enabled           *bool        `json:"enabled"`
+	MinimumOrigins    *int         `json:"minimumOrigins"`
+	Monitor           string       `json:"monitor"`
+	NotificationEmail string       `json:"notificationEmail"`
+	Origins           []OriginSpec `json:"origins"`
+}
+
+func (c *UpdatePool) Name() string {
+	return "cloudflare.updatePool"
+}
+
+func (c *UpdatePool) Label() string {
+	return "Update Pool"
+}
+
+func (c *UpdatePool) Description() string {
+	return "Update a Cloudflare Load Balancer origin pool's configuration or origin weights"
+}
+
+func (c *UpdatePool) Documentation() string {
+	return `The Update Pool component modifies an existing Cloudflare Load Balancer origin pool.
+
+## Use Cases
+
+- **Canary deployments**: Shift traffic weight from stable to canary origin
+- **Blue/green deployments**: Disable blue origins and enable green origins
+- **Scaling**: Add or remove origin servers dynamically
+- **Health management**: Enable or disable individual origins without removing them
+
+## Configuration
+
+- **Account ID**: The Cloudflare account ID that owns the pool
+- **Pool ID**: The ID of the pool to update
+- **Origins**: Full list of origin servers with updated weights or enabled status
+- **Name**: Optional new name for the pool
+- **Description**: Optional new description
+- **Enabled**: Enable or disable the entire pool
+- **Minimum Origins**: Minimum number of healthy origins before pool is marked unhealthy
+- **Monitor**: Health monitor ID for origin health checks
+- **Notification Email**: Email to notify on health changes
+
+## Output
+
+Returns the updated origin pool configuration.`
+}
+
+func (c *UpdatePool) Icon() string {
+	return "cloud"
+}
+
+func (c *UpdatePool) Color() string {
+	return "orange"
+}
+
+func (c *UpdatePool) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdatePool) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The Cloudflare account ID that owns the pool",
+		},
+		{
+			Name:        "poolId",
+			Label:       "Pool ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The ID of the origin pool to update",
+		},
+		{
+			Name:        "origins",
+			Label:       "Origins",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Updated list of origin servers. When provided, replaces the current list.",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Origin",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:        "name",
+								Label:       "Name",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Description: "Human-readable name for the origin",
+								Placeholder: "origin-1",
+							},
+							{
+								Name:        "address",
+								Label:       "Address",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Description: "IP address or hostname of the origin",
+								Placeholder: "192.0.2.1",
+							},
+							{
+								Name:     "enabled",
+								Label:    "Enabled",
+								Type:     configuration.FieldTypeBool,
+								Required: false,
+								Default:  true,
+							},
+							{
+								Name:        "weight",
+								Label:       "Weight",
+								Type:        configuration.FieldTypeNumber,
+								Required:    false,
+								Default:     1,
+								Description: "Traffic weight for this origin (0.0–1.0)",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "name",
+			Label:       "Pool Name",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "New name for the pool (optional)",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "New description for the pool (optional)",
+		},
+		{
+			Name:        "enabled",
+			Label:       "Enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Enable or disable the pool",
+		},
+		{
+			Name:        "minimumOrigins",
+			Label:       "Minimum Origins",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Description: "Minimum number of healthy origins before the pool is marked as unhealthy",
+		},
+		{
+			Name:        "monitor",
+			Label:       "Monitor ID",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Health monitor ID to attach to this pool",
+		},
+		{
+			Name:        "notificationEmail",
+			Label:       "Notification Email",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Email address to notify when pool health changes",
+		},
+	}
+}
+
+func (c *UpdatePool) Setup(ctx core.SetupContext) error {
+	spec := UpdatePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.AccountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.PoolID == "" {
+		return errors.New("poolId is required")
+	}
+
+	for i, o := range spec.Origins {
+		if o.Name == "" {
+			return fmt.Errorf("origins[%d].name is required", i)
+		}
+		if o.Address == "" {
+			return fmt.Errorf("origins[%d].address is required", i)
+		}
+	}
+
+	return nil
+}
+
+func (c *UpdatePool) Execute(ctx core.ExecutionContext) error {
+	spec := UpdatePoolSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	req := UpdatePoolRequest{
+		Name:              spec.Name,
+		Description:       spec.Description,
+		Enabled:           spec.Enabled,
+		MinimumOrigins:    spec.MinimumOrigins,
+		Monitor:           spec.Monitor,
+		NotificationEmail: spec.NotificationEmail,
+	}
+
+	if len(spec.Origins) > 0 {
+		origins := make([]Origin, len(spec.Origins))
+		for i, o := range spec.Origins {
+			weight := o.Weight
+			if weight == 0 {
+				weight = 1.0
+			}
+
+			origins[i] = Origin{
+				Name:    o.Name,
+				Address: o.Address,
+				Enabled: o.Enabled,
+				Weight:  weight,
+			}
+		}
+
+		req.Origins = origins
+	}
+
+	pool, err := client.UpdatePool(spec.AccountID, spec.PoolID, req)
+	if err != nil {
+		return fmt.Errorf("failed to update pool: %v", err)
+	}
+
+	result := map[string]any{
+		"pool":      pool,
+		"accountId": spec.AccountID,
+		"poolId":    spec.PoolID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.pool",
+		[]any{result},
+	)
+}
+
+func (c *UpdatePool) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdatePool) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdatePool) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *UpdatePool) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *UpdatePool) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdatePool) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/update_pool_test.go
+++ b/pkg/integrations/cloudflare/update_pool_test.go
@@ -19,7 +19,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 		}
 
@@ -31,7 +31,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "",
+				"pool":      "",
 			},
 		}
 
@@ -43,7 +43,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 				"origins": []any{
 					map[string]any{"name": "o1", "address": "", "enabled": true, "weight": 1},
 				},
@@ -58,7 +58,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 			},
 		}
 
@@ -70,7 +70,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 				"origins": []any{
 					map[string]any{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
 					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
@@ -178,7 +178,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"pool":    "pool123",
+				"pool":      "pool123",
 				"name":      "renamed-pool",
 			},
 			HTTP:           httpContext,

--- a/pkg/integrations/cloudflare/update_pool_test.go
+++ b/pkg/integrations/cloudflare/update_pool_test.go
@@ -60,10 +60,31 @@ func Test__UpdatePool__Setup(t *testing.T) {
 				"accountId": "acc123",
 				"pool":      "pool123",
 			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "pool123", "name": "my-pool"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		poolMeta, ok := meta.Metadata.(PoolNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "my-pool", poolMeta.PoolName)
 	})
 
 	t.Run("valid configuration with origins passes", func(t *testing.T) {
@@ -76,10 +97,31 @@ func Test__UpdatePool__Setup(t *testing.T) {
 					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
 				},
 			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "pool123", "name": "my-pool"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
 		}
 
 		err := component.Setup(ctx)
 		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		poolMeta, ok := meta.Metadata.(PoolNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "my-pool", poolMeta.PoolName)
 	})
 }
 

--- a/pkg/integrations/cloudflare/update_pool_test.go
+++ b/pkg/integrations/cloudflare/update_pool_test.go
@@ -1,0 +1,231 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdatePool__Setup(t *testing.T) {
+	component := &UpdatePool{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing poolId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "poolId is required")
+	})
+
+	t.Run("origin missing address returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+				"origins": []any{
+					map[string]any{"name": "o1", "address": "", "enabled": true, "weight": 1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "origins[0].address is required")
+	})
+
+	t.Run("valid configuration without origins passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration with origins passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+				"origins": []any{
+					map[string]any{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
+					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
+				},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdatePool__Execute(t *testing.T) {
+	component := &UpdatePool{}
+
+	t.Run("successful update with origins emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "pool123",
+							"name": "my-pool",
+							"description": "Test pool",
+							"enabled": true,
+							"minimum_origins": 1,
+							"origins": [
+								{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
+								{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1}
+							]
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+				"origins": []any{
+					map[string]any{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
+					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
+				},
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/load_balancers/pools/pool123", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodPatch, httpContext.Requests[0].Method)
+	})
+
+	t.Run("successful update without origins emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "pool123",
+							"name": "renamed-pool",
+							"enabled": true,
+							"minimum_origins": 1,
+							"origins": []
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+				"name":      "renamed-pool",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "cloudflare.pool", execState.Type)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Pool not found"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"poolId":    "pool123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update pool")
+	})
+}

--- a/pkg/integrations/cloudflare/update_pool_test.go
+++ b/pkg/integrations/cloudflare/update_pool_test.go
@@ -19,7 +19,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 		}
 
@@ -31,19 +31,19 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "",
+				"pool":    "",
 			},
 		}
 
 		err := component.Setup(ctx)
-		require.ErrorContains(t, err, "poolId is required")
+		require.ErrorContains(t, err, "pool is required")
 	})
 
 	t.Run("origin missing address returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 				"origins": []any{
 					map[string]any{"name": "o1", "address": "", "enabled": true, "weight": 1},
 				},
@@ -58,7 +58,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 			},
 		}
 
@@ -70,7 +70,7 @@ func Test__UpdatePool__Setup(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 				"origins": []any{
 					map[string]any{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
 					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
@@ -122,7 +122,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 				"origins": []any{
 					map[string]any{"name": "stable", "address": "1.2.3.4", "enabled": true, "weight": 0.9},
 					map[string]any{"name": "canary", "address": "1.2.3.5", "enabled": true, "weight": 0.1},
@@ -138,7 +138,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, execState.Passed)
 		assert.Equal(t, "default", execState.Channel)
-		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Equal(t, "cloudflare.pool.updated", execState.Type)
 		assert.Len(t, execState.Payloads, 1)
 
 		require.Len(t, httpContext.Requests, 1)
@@ -178,7 +178,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":    "pool123",
 				"name":      "renamed-pool",
 			},
 			HTTP:           httpContext,
@@ -190,7 +190,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.True(t, execState.Passed)
-		assert.Equal(t, "cloudflare.pool", execState.Type)
+		assert.Equal(t, "cloudflare.pool.updated", execState.Type)
 	})
 
 	t.Run("API error returns error", func(t *testing.T) {
@@ -216,7 +216,7 @@ func Test__UpdatePool__Execute(t *testing.T) {
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
 				"accountId": "acc123",
-				"poolId":    "pool123",
+				"pool":      "pool123",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -52,6 +52,32 @@ export const baseMapper: ComponentBaseMapper = {
   },
 };
 
+export function getPoolExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  const pool = result?.pool as Record<string, unknown> | undefined;
+  if (!pool) return details;
+
+  details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+  details["Name"] = pool.name != null ? String(pool.name) : "-";
+
+  if (pool.description != null) {
+    details["Description"] = String(pool.description);
+  }
+
+  details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+  details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+  details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+  return details;
+}
+
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
   const subtitleDate = execution.updatedAt ?? execution.createdAt;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -53,19 +53,20 @@ export const baseMapper: ComponentBaseMapper = {
 };
 
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
-  const eventSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const eventState = getState(componentName)(execution);
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle,
-      eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
-    },
-  ];
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
+
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -54,7 +54,8 @@ export const baseMapper: ComponentBaseMapper = {
 
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const subtitleDate = execution.updatedAt ?? execution.createdAt;
+  const eventSubtitle = subtitleDate ? renderTimeAgo(new Date(subtitleDate)) : "";
   const eventState = getState(componentName)(execution);
 
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.spec.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { createPoolMapper } from "./create_pool";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.createPool",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.pool",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.createPool",
+  label: "Create Pool",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+const poolOutputData = {
+  pool: {
+    id: "pool123",
+    name: "primary-pool",
+    description: "Primary origin pool",
+    enabled: true,
+    minimum_origins: 1,
+    origins: [
+      { name: "origin-1", address: "1.2.3.4", enabled: true, weight: 1 },
+      { name: "origin-2", address: "5.6.7.8", enabled: true, weight: 1 },
+    ],
+  },
+  accountId: "acc123",
+};
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("createPoolMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => createPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => createPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data has no pool key", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => createPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts pool fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    const details = createPoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("pool123");
+    expect(details["Name"]).toBe("primary-pool");
+    expect(details["Description"]).toBe("Primary origin pool");
+    expect(details["Enabled"]).toBe("true");
+    expect(details["Minimum Origins"]).toBe("1");
+    expect(details["Number of Origins"]).toBe("2");
+  });
+
+  it("omits description when it is absent", () => {
+    const data = { pool: { id: "p1", name: "my-pool", enabled: true, minimum_origins: 1, origins: [] } };
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(data)] } },
+    });
+    expect(createPoolMapper.getExecutionDetails(ctx)["Description"]).toBeUndefined();
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    expect(createPoolMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("createPoolMapper.props", () => {
+  it("includes pool name from configuration in metadata", () => {
+    const props = createPoolMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { name: "my-pool", enabled: true } }) }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "network", label: "my-pool" },
+      { icon: "check-circle", label: "Enabled" },
+    ]);
+  });
+
+  it("shows disabled icon when enabled is false", () => {
+    const props = createPoolMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { name: "my-pool", enabled: false } }) }),
+    );
+    expect(props.metadata).toContainEqual({ icon: "circle", label: "Disabled" });
+  });
+
+  it("omits enabled item when enabled is not set", () => {
+    const props = createPoolMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { name: "my-pool" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "my-pool" }]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = createPoolMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.createPool", () => {
+  it("maps finished success to created", () => {
+    expect(eventStateRegistry.createPool.getState(buildExecution())).toBe("created");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.createPool.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.createPool.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -88,17 +88,20 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const eventState = getState(componentName)(execution);
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
-    },
-  ];
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
+
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -1,12 +1,11 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -14,6 +13,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
 
 interface CreatePoolConfiguration {
   name?: string;
@@ -87,21 +87,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
-  const eventState = getState(componentName)(execution);
-
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  if (!rootTriggerNode || !execution.rootEvent?.id) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  if (!rootTriggerRenderer) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-  }
-
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -1,0 +1,104 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface CreatePoolConfiguration {
+  name?: string;
+  enabled?: boolean;
+}
+
+export const createPoolMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    const pool = result?.pool as Record<string, any> | undefined;
+    if (!pool) return details;
+
+    details["Pool ID"] = pool.id?.toString() || "-";
+    details["Name"] = pool.name || "-";
+
+    if (pool.description) {
+      details["Description"] = pool.description;
+    }
+
+    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as CreatePoolConfiguration;
+
+  if (configuration?.name) {
+    metadata.push({ icon: "network", label: configuration.name });
+  }
+
+  if (configuration?.enabled != null) {
+    metadata.push({
+      icon: configuration.enabled ? "check-circle" : "circle",
+      label: configuration.enabled ? "Enabled" : "Disabled",
+    });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -86,4 +86,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   return metadata;
 }
-

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -37,7 +37,7 @@ export const createPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+  getExecutionDetails(context: ExecutionDetailsContext) {
     const details: Record<string, string> = {};
 
     if (context.execution.createdAt) {
@@ -45,15 +45,15 @@ export const createPoolMapper: ComponentBaseMapper = {
     }
 
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
-    const pool = result?.pool as Record<string, any> | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const pool = result?.pool as Record<string, unknown> | undefined;
     if (!pool) return details;
 
-    details["Pool ID"] = pool.id?.toString() || "-";
-    details["Name"] = pool.name || "-";
+    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+    details["Name"] = pool.name != null ? String(pool.name) : "-";
 
-    if (pool.description) {
-      details["Description"] = pool.description;
+    if (pool.description != null) {
+      details["Description"] = String(pool.description);
     }
 
     details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -2,18 +2,11 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  NodeInfo,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections } from "./base";
+import { baseEventSections, getPoolExecutionDetails } from "./base";
 
 interface CreatePoolConfiguration {
   name?: string;
@@ -37,31 +30,7 @@ export const createPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext) {
-    const details: Record<string, string> = {};
-
-    if (context.execution.createdAt) {
-      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-    }
-
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-    const pool = result?.pool as Record<string, unknown> | undefined;
-    if (!pool) return details;
-
-    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
-    details["Name"] = pool.name != null ? String(pool.name) : "-";
-
-    if (pool.description != null) {
-      details["Description"] = String(pool.description);
-    }
-
-    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
-    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
-    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
-
-    return details;
-  },
+  getExecutionDetails: getPoolExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { deletePoolMapper } from "./delete_pool";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.deletePool",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.pool",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.deletePool",
+  label: "Delete Pool",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("deletePoolMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => deletePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => deletePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => deletePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts pool id and deleted status from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput({ poolId: "pool123", accountId: "acc123", deleted: true })],
+        },
+      },
+    });
+    const details = deletePoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("pool123");
+    expect(details["Deleted"]).toBe("true");
+  });
+
+  it("uses dash placeholders when result fields are missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({})] } },
+    });
+    const details = deletePoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("-");
+    expect(details["Deleted"]).toBe("-");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ poolId: "pool123", deleted: true })] },
+      },
+    });
+    expect(deletePoolMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("deletePoolMapper.props", () => {
+  it("prefers pool name from node metadata", () => {
+    const props = deletePoolMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pool: "pool-id" },
+          metadata: { poolName: "My Pool" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "My Pool" }]);
+  });
+
+  it("falls back to pool id from configuration when metadata is absent", () => {
+    const props = deletePoolMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pool: "pool-id" },
+          metadata: {},
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "pool-id" }]);
+  });
+
+  it("returns empty metadata when both metadata and configuration are empty", () => {
+    const props = deletePoolMapper.props(buildPropsContext({ node: buildNode({ configuration: {}, metadata: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.deletePool", () => {
+  it("maps finished success to deleted", () => {
+    expect(eventStateRegistry.deletePool.getState(buildExecution())).toBe("deleted");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.deletePool.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.deletePool.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -75,4 +75,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   return metadata;
 }
-

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -16,7 +16,11 @@ import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 
 interface DeletePoolConfiguration {
-  poolId?: string;
+  pool?: string;
+}
+
+interface DeletePoolNodeMetadata {
+  poolName?: string;
 }
 
 export const deletePoolMapper: ComponentBaseMapper = {
@@ -61,10 +65,12 @@ export const deletePoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as DeletePoolNodeMetadata | undefined;
   const configuration = node.configuration as DeletePoolConfiguration;
 
-  if (configuration?.poolId) {
-    metadata.push({ icon: "network", label: configuration.poolId });
+  const label = nodeMetadata?.poolName || configuration?.pool;
+  if (label) {
+    metadata.push({ icon: "network", label });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -1,0 +1,87 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface DeletePoolConfiguration {
+  poolId?: string;
+}
+
+export const deletePoolMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    if (!result) return details;
+
+    details["Pool ID"] = result.poolId?.toString() || "-";
+    details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as DeletePoolConfiguration;
+
+  if (configuration?.poolId) {
+    metadata.push({ icon: "network", label: configuration.poolId });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -1,12 +1,11 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -14,6 +13,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
 
 interface DeletePoolConfiguration {
   pool?: string;
@@ -76,21 +76,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
-  const eventState = getState(componentName)(execution);
-
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  if (!rootTriggerNode || !execution.rootEvent?.id) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  if (!rootTriggerRenderer) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-  }
-
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -77,17 +77,20 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const eventState = getState(componentName)(execution);
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
-    },
-  ];
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
+
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -48,7 +48,7 @@ export const deletePoolMapper: ComponentBaseMapper = {
     }
 
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
     if (!result) return details;
 
     details["Pool ID"] = result.poolId?.toString() || "-";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -40,7 +40,7 @@ export const deletePoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+  getExecutionDetails(context: ExecutionDetailsContext) {
     const details: Record<string, string> = {};
 
     if (context.execution.createdAt) {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.spec.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { getPoolMapper } from "./get_pool";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.getPool",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.pool",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.getPool",
+  label: "Get Pool",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+const poolOutputData = {
+  pool: {
+    id: "pool123",
+    name: "primary-pool",
+    description: "Primary origin pool",
+    enabled: true,
+    minimum_origins: 1,
+    origins: [
+      { name: "origin-1", address: "1.2.3.4", enabled: true, weight: 1 },
+      { name: "origin-2", address: "5.6.7.8", enabled: true, weight: 1 },
+    ],
+  },
+  accountId: "acc123",
+};
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("getPoolMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => getPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data has no pool key", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => getPoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts all pool fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    const details = getPoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("pool123");
+    expect(details["Name"]).toBe("primary-pool");
+    expect(details["Description"]).toBe("Primary origin pool");
+    expect(details["Enabled"]).toBe("true");
+    expect(details["Minimum Origins"]).toBe("1");
+    expect(details["Number of Origins"]).toBe("2");
+  });
+
+  it("uses dash placeholders when pool fields are missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({ pool: {} })] } },
+    });
+    const details = getPoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("-");
+    expect(details["Name"]).toBe("-");
+    expect(details["Enabled"]).toBe("-");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    expect(getPoolMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("getPoolMapper.props", () => {
+  it("prefers pool name from node metadata", () => {
+    const props = getPoolMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pool: "pool-id" },
+          metadata: { poolName: "Resolved Name" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "Resolved Name" }]);
+  });
+
+  it("falls back to pool id from configuration when metadata is absent", () => {
+    const props = getPoolMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: { pool: "pool-id" }, metadata: {} }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "pool-id" }]);
+  });
+
+  it("returns empty metadata when both metadata and configuration are empty", () => {
+    const props = getPoolMapper.props(buildPropsContext({ node: buildNode({ configuration: {}, metadata: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.getPool", () => {
+  it("maps finished success to fetched", () => {
+    expect(eventStateRegistry.getPool.getState(buildExecution())).toBe("fetched");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.getPool.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.getPool.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -1,12 +1,11 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -14,6 +13,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
 
 interface GetPoolConfiguration {
   pool?: string;
@@ -85,21 +85,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
-  const eventState = getState(componentName)(execution);
-
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  if (!rootTriggerNode || !execution.rootEvent?.id) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  if (!rootTriggerRenderer) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-  }
-
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -16,7 +16,11 @@ import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 
 interface GetPoolConfiguration {
-  poolId?: string;
+  pool?: string;
+}
+
+interface GetPoolNodeMetadata {
+  poolName?: string;
 }
 
 export const getPoolMapper: ComponentBaseMapper = {
@@ -70,10 +74,12 @@ export const getPoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as GetPoolNodeMetadata | undefined;
   const configuration = node.configuration as GetPoolConfiguration;
 
-  if (configuration?.poolId) {
-    metadata.push({ icon: "network", label: configuration.poolId });
+  const label = nodeMetadata?.poolName || configuration?.pool;
+  if (label) {
+    metadata.push({ icon: "network", label });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -84,4 +84,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   return metadata;
 }
-

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -48,15 +48,15 @@ export const getPoolMapper: ComponentBaseMapper = {
     }
 
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
-    const pool = result?.pool as Record<string, any> | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const pool = result?.pool as Record<string, unknown> | undefined;
     if (!pool) return details;
 
-    details["Pool ID"] = pool.id?.toString() || "-";
-    details["Name"] = pool.name || "-";
+    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+    details["Name"] = pool.name != null ? String(pool.name) : "-";
 
-    if (pool.description) {
-      details["Description"] = pool.description;
+    if (pool.description != null) {
+      details["Description"] = String(pool.description);
     }
 
     details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -40,7 +40,7 @@ export const getPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+  getExecutionDetails(context: ExecutionDetailsContext) {
     const details: Record<string, string> = {};
 
     if (context.execution.createdAt) {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -1,0 +1,96 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface GetPoolConfiguration {
+  poolId?: string;
+}
+
+export const getPoolMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    const pool = result?.pool as Record<string, any> | undefined;
+    if (!pool) return details;
+
+    details["Pool ID"] = pool.id?.toString() || "-";
+    details["Name"] = pool.name || "-";
+
+    if (pool.description) {
+      details["Description"] = pool.description;
+    }
+
+    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetPoolConfiguration;
+
+  if (configuration?.poolId) {
+    metadata.push({ icon: "network", label: configuration.poolId });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -2,18 +2,11 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  NodeInfo,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections } from "./base";
+import { baseEventSections, getPoolExecutionDetails } from "./base";
 
 interface GetPoolConfiguration {
   pool?: string;
@@ -40,31 +33,7 @@ export const getPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext) {
-    const details: Record<string, string> = {};
-
-    if (context.execution.createdAt) {
-      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-    }
-
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-    const pool = result?.pool as Record<string, unknown> | undefined;
-    if (!pool) return details;
-
-    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
-    details["Name"] = pool.name != null ? String(pool.name) : "-";
-
-    if (pool.description != null) {
-      details["Description"] = String(pool.description);
-    }
-
-    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
-    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
-    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
-
-    return details;
-  },
+  getExecutionDetails: getPoolExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -86,17 +86,20 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const eventState = getState(componentName)(execution);
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
-    },
-  ];
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
+
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -8,6 +8,9 @@ import { getKVValueMapper } from "./get_kv_value";
 import { deleteKVValueMapper } from "./delete_kv_value";
 import { deleteKVNamespaceMapper } from "./delete_kv_namespace";
 import { createPoolMapper } from "./create_pool";
+import { getPoolMapper } from "./get_pool";
+import { deletePoolMapper } from "./delete_pool";
+import { updatePoolMapper } from "./update_pool";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
@@ -23,9 +26,9 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   deleteKVValue: deleteKVValueMapper,
   deleteKVNamespace: deleteKVNamespaceMapper,
   createPool: createPoolMapper,
-  updatePool: baseMapper,
-  getPool: baseMapper,
-  deletePool: baseMapper,
+  updatePool: updatePoolMapper,
+  getPool: getPoolMapper,
+  deletePool: deletePoolMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -21,6 +21,8 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getKVValue: getKVValueMapper,
   deleteKVValue: deleteKVValueMapper,
   deleteKVNamespace: deleteKVNamespaceMapper,
+  createPool: baseMapper,
+  updatePool: baseMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -38,4 +40,6 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getKVValue: buildActionStateRegistry("fetched"),
   deleteKVValue: buildActionStateRegistry("deleted"),
   deleteKVNamespace: buildActionStateRegistry("deleted"),
+  createPool: buildActionStateRegistry("completed"),
+  updatePool: buildActionStateRegistry("completed"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -46,8 +46,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getKVValue: buildActionStateRegistry("fetched"),
   deleteKVValue: buildActionStateRegistry("deleted"),
   deleteKVNamespace: buildActionStateRegistry("deleted"),
-  createPool: buildActionStateRegistry("completed"),
-  updatePool: buildActionStateRegistry("completed"),
-  getPool: buildActionStateRegistry("completed"),
-  deletePool: buildActionStateRegistry("completed"),
+  createPool: buildActionStateRegistry("created"),
+  updatePool: buildActionStateRegistry("updated"),
+  getPool: buildActionStateRegistry("fetched"),
+  deletePool: buildActionStateRegistry("deleted"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -7,6 +7,7 @@ import { putKVValueMapper } from "./put_kv_value";
 import { getKVValueMapper } from "./get_kv_value";
 import { deleteKVValueMapper } from "./delete_kv_value";
 import { deleteKVNamespaceMapper } from "./delete_kv_namespace";
+import { createPoolMapper } from "./create_pool";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
@@ -21,8 +22,10 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getKVValue: getKVValueMapper,
   deleteKVValue: deleteKVValueMapper,
   deleteKVNamespace: deleteKVNamespaceMapper,
-  createPool: baseMapper,
+  createPool: createPoolMapper,
   updatePool: baseMapper,
+  getPool: baseMapper,
+  deletePool: baseMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -42,4 +45,6 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   deleteKVNamespace: buildActionStateRegistry("deleted"),
   createPool: buildActionStateRegistry("completed"),
   updatePool: buildActionStateRegistry("completed"),
+  getPool: buildActionStateRegistry("completed"),
+  deletePool: buildActionStateRegistry("completed"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { eventStateRegistry } from "./index";
+import { updatePoolMapper } from "./update_pool";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.updatePool",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.pool",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.updatePool",
+  label: "Update Pool",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+const poolOutputData = {
+  pool: {
+    id: "pool123",
+    name: "primary-pool",
+    description: "Primary origin pool",
+    enabled: true,
+    minimum_origins: 1,
+    origins: [
+      { name: "origin-1", address: "1.2.3.4", enabled: true, weight: 1 },
+      { name: "origin-2", address: "5.6.7.8", enabled: true, weight: 1 },
+    ],
+  },
+  accountId: "acc123",
+};
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("updatePoolMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => updatePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => updatePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data has no pool key", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => updatePoolMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts pool fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    const details = updatePoolMapper.getExecutionDetails(ctx);
+    expect(details["Pool ID"]).toBe("pool123");
+    expect(details["Name"]).toBe("primary-pool");
+    expect(details["Description"]).toBe("Primary origin pool");
+    expect(details["Enabled"]).toBe("true");
+    expect(details["Minimum Origins"]).toBe("1");
+    expect(details["Number of Origins"]).toBe("2");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(poolOutputData)] } },
+    });
+    expect(updatePoolMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("updatePoolMapper.props", () => {
+  it("shows pool name from configuration when set", () => {
+    const props = updatePoolMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { name: "my-pool", pool: "pool-id" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "my-pool" }]);
+  });
+
+  it("falls back to pool id when name is absent", () => {
+    const props = updatePoolMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { pool: "pool-id" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "pool-id" }]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = updatePoolMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.updatePool", () => {
+  it("maps finished success to updated", () => {
+    expect(eventStateRegistry.updatePool.getState(buildExecution())).toBe("updated");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.updatePool.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.updatePool.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -83,17 +83,20 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
+  const eventState = getState(componentName)(execution);
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
-    },
-  ];
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
+
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -2,18 +2,11 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  NodeInfo,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections } from "./base";
+import { baseEventSections, getPoolExecutionDetails } from "./base";
 
 interface UpdatePoolConfiguration {
   name?: string;
@@ -41,31 +34,7 @@ export const updatePoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext) {
-    const details: Record<string, string> = {};
-
-    if (context.execution.createdAt) {
-      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-    }
-
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-    const pool = result?.pool as Record<string, unknown> | undefined;
-    if (!pool) return details;
-
-    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
-    details["Name"] = pool.name != null ? String(pool.name) : "-";
-
-    if (pool.description != null) {
-      details["Description"] = String(pool.description);
-    }
-
-    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
-    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
-    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
-
-    return details;
-  },
+  getExecutionDetails: getPoolExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -1,12 +1,11 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -14,6 +13,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
 
 interface UpdatePoolConfiguration {
   name?: string;
@@ -82,21 +82,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const eventSubtitle = execution.createdAt ? renderTimeAgo(new Date(execution.createdAt)) : "";
-  const eventState = getState(componentName)(execution);
-
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  if (!rootTriggerNode || !execution.rootEvent?.id) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  if (!rootTriggerRenderer) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-  }
-
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -81,4 +81,3 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   return metadata;
 }
-

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -37,7 +37,7 @@ export const updatePoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+  getExecutionDetails(context: ExecutionDetailsContext) {
     const details: Record<string, string> = {};
 
     if (context.execution.createdAt) {
@@ -45,15 +45,15 @@ export const updatePoolMapper: ComponentBaseMapper = {
     }
 
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
-    const pool = result?.pool as Record<string, any> | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const pool = result?.pool as Record<string, unknown> | undefined;
     if (!pool) return details;
 
-    details["Pool ID"] = pool.id?.toString() || "-";
-    details["Name"] = pool.name || "-";
+    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+    details["Name"] = pool.name != null ? String(pool.name) : "-";
 
-    if (pool.description) {
-      details["Description"] = pool.description;
+    if (pool.description != null) {
+      details["Description"] = String(pool.description);
     }
 
     details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -17,7 +17,7 @@ import { renderTimeAgo } from "@/components/TimeAgo";
 
 interface UpdatePoolConfiguration {
   name?: string;
-  poolId?: string;
+  pool?: string;
 }
 
 export const updatePoolMapper: ComponentBaseMapper = {
@@ -75,8 +75,8 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   if (configuration?.name) {
     metadata.push({ icon: "network", label: configuration.name });
-  } else if (configuration?.poolId) {
-    metadata.push({ icon: "network", label: configuration.poolId });
+  } else if (configuration?.pool) {
+    metadata.push({ icon: "network", label: configuration.pool });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -20,6 +20,10 @@ interface UpdatePoolConfiguration {
   pool?: string;
 }
 
+interface UpdatePoolNodeMetadata {
+  poolName?: string;
+}
+
 export const updatePoolMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
@@ -71,12 +75,12 @@ export const updatePoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as UpdatePoolNodeMetadata | undefined;
   const configuration = node.configuration as UpdatePoolConfiguration;
 
-  if (configuration?.name) {
-    metadata.push({ icon: "network", label: configuration.name });
-  } else if (configuration?.pool) {
-    metadata.push({ icon: "network", label: configuration.pool });
+  const label = nodeMetadata?.poolName || configuration?.pool;
+  if (label) {
+    metadata.push({ icon: "network", label });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -78,7 +78,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const nodeMetadata = node.metadata as UpdatePoolNodeMetadata | undefined;
   const configuration = node.configuration as UpdatePoolConfiguration;
 
-  const label = nodeMetadata?.poolName || configuration?.pool;
+  const label = nodeMetadata?.poolName || configuration?.name || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
   }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -1,0 +1,99 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface UpdatePoolConfiguration {
+  name?: string;
+  poolId?: string;
+}
+
+export const updatePoolMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    const pool = result?.pool as Record<string, any> | undefined;
+    if (!pool) return details;
+
+    details["Pool ID"] = pool.id?.toString() || "-";
+    details["Name"] = pool.name || "-";
+
+    if (pool.description) {
+      details["Description"] = pool.description;
+    }
+
+    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as UpdatePoolConfiguration;
+
+  if (configuration?.name) {
+    metadata.push({ icon: "network", label: configuration.name });
+  } else if (configuration?.poolId) {
+    metadata.push({ icon: "network", label: configuration.poolId });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent! });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}


### PR DESCRIPTION
Implements: #4500 

## What changed:

Added four Cloudflare Load Balancer pool components — createPool, updatePool, getPool, and deletePool — along with their frontend card and details page mappers.

## Why:

To enable users to manage Cloudflare Load Balancer origin pools directly from SuperPlane workflows, supporting use cases like blue/green deployments, canary releases, and multi-region origin management.

## How:

### Backend:

- Added CreatePool, UpdatePool, GetPool, and DeletePool action components under cloudflare
- Added ListMonitors and ListPools methods to the Cloudflare API client, along with GetPool and DeletePool
- Registered GetPool and DeletePool in cloudflare.go Actions() and added "monitor" and "pool" cases to ListResources()
- Added example output JSON files and ExampleOutput() methods for all four components
- Added tests for all four components

### Frontend:

- Created dedicated mapper files for all four components under cloudflare
- Wired all four mappers into the Cloudflare index.ts component and event state registries

## Demo:
https://youtu.be/k276-NasEVQ