### PR TITLE
fix(expressions): preserve type for single-expression template fields

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -216,32 +216,33 @@ func asAnyMap(value any) (map[string]any, bool) {
 }
 
 func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string) (any, error) {
-	if !expressionRegex.MatchString(expression) {
+	matches := expressionRegex.FindAllStringSubmatchIndex(expression, -1)
+	if len(matches) == 0 {
 		return expression, nil
 	}
 
-	var err error
-
-	result := expressionRegex.ReplaceAllStringFunc(expression, func(match string) string {
-		matches := expressionRegex.FindStringSubmatch(match)
-		if len(matches) != 2 {
-			return match
-		}
-
-		value, e := b.ResolveExpression(matches[1])
-		if e != nil {
-			err = e
-			return ""
-		}
-
-		return fmt.Sprintf("%v", value)
-	})
-
-	if err != nil {
-		return nil, err
+	// When the entire field value is a single {{ ... }} expression, return the
+	// raw result so that numbers, booleans, and objects survive into typed
+	// contexts like JSON request bodies. See issue #4499.
+	if len(matches) == 1 && matches[0][0] == 0 && matches[0][1] == len(expression) {
+		return b.ResolveExpression(expression[matches[0][2]:matches[0][3]])
 	}
 
-	return result, nil
+	// Otherwise the result is a string: stringify each expression and
+	// concatenate with the surrounding text.
+	var sb strings.Builder
+	pos := 0
+	for _, m := range matches {
+		sb.WriteString(expression[pos:m[0]])
+		value, err := b.ResolveExpression(expression[m[2]:m[3]])
+		if err != nil {
+			return nil, err
+		}
+		sb.WriteString(fmt.Sprintf("%v", value))
+		pos = m[1]
+	}
+	sb.WriteString(expression[pos:])
+	return sb.String(), nil
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {

--- a/pkg/workers/contexts/node_configuration_builder_expr_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_expr_test.go
@@ -16,3 +16,75 @@ func TestNodeConfigurationBuilder_ResolveExpression_DateWithTimezoneOption(t *te
 	require.NoError(t, err)
 	require.Equal(t, "2026-03-17T01:02:03.000000001Z", out)
 }
+
+// Regression tests for issue #4499: expressions in JSON body fields resolve
+// to strings, breaking numeric APIs. When the entire field value is a single
+// {{ ... }} expression, the result's type must be preserved so that numbers,
+// booleans, and objects flow through to json.Marshal correctly.
+func TestNodeConfigurationBuilder_ResolveTemplateExpressions_PreservesType(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).WithInput(map[string]any{})
+
+	t.Run("single float expression preserves float64", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ 0.9 }}`)
+		require.NoError(t, err)
+		require.Equal(t, 0.9, out)
+	})
+
+	t.Run("single conditional expression preserves float64", func(t *testing.T) {
+		// Mirrors the issue's Cloudflare LB pool weights example.
+		out, err := b.ResolveTemplateExpressions(`{{ true ? 0.9 : 0.1 }}`)
+		require.NoError(t, err)
+		require.Equal(t, 0.9, out)
+	})
+
+	t.Run("single int expression preserves int", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ 42 }}`)
+		require.NoError(t, err)
+		require.Equal(t, 42, out)
+	})
+
+	t.Run("single bool expression preserves bool", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ 1 == 1 }}`)
+		require.NoError(t, err)
+		require.Equal(t, true, out)
+	})
+
+	t.Run("single map expression preserves map", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ {"x": 1, "y": 2} }}`)
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"x": 1, "y": 2}, out)
+	})
+
+	t.Run("single string expression still returns string", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ "hello" }}`)
+		require.NoError(t, err)
+		require.Equal(t, "hello", out)
+	})
+
+	t.Run("mixed text with expression returns string", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`prefix-{{ 0.9 }}`)
+		require.NoError(t, err)
+		require.Equal(t, "prefix-0.9", out)
+	})
+
+	t.Run("multiple expressions return string", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`{{ 1 }}{{ 2 }}`)
+		require.NoError(t, err)
+		require.Equal(t, "12", out)
+	})
+
+	t.Run("plain text without expression returns string", func(t *testing.T) {
+		out, err := b.ResolveTemplateExpressions(`https://api.example.com`)
+		require.NoError(t, err)
+		require.Equal(t, "https://api.example.com", out)
+	})
+
+	t.Run("surrounding whitespace prevents type preservation", func(t *testing.T) {
+		// Conservative behavior: only the exact single-expression form preserves
+		// type. Anything outside the braces — including whitespace — falls back
+		// to the string-concat path. Keeps the rule simple and predictable.
+		out, err := b.ResolveTemplateExpressions(` {{ 0.9 }} `)
+		require.NoError(t, err)
+		require.Equal(t, " 0.9 ", out)
+	})
+}

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -72,8 +72,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, 42, result["count"])
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_RootFunction(t *testing.T) {
@@ -128,8 +128,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_RootFunction(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, float64(42), result["count"])
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_ByName(t *testing.T) {
@@ -185,8 +185,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_ByName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, 42, result["count"])
 }
 
 func Test_NodeConfigurationBuilder_NodeNameNotUnique_UsesClosestInChain(t *testing.T) {
@@ -448,7 +448,7 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Chain(t *testing.T) {
 	result, err := builder.Build(configuration)
 	require.NoError(t, err)
 	assert.Equal(t, "first", result["from_node1"])
-	assert.Equal(t, "2", result["from_node2"])
+	assert.Equal(t, 2, result["from_node2"])
 }
 
 func Test_NodeConfigurationBuilder_Chain_IncludesParallelUpstreamExecutions(t *testing.T) {
@@ -804,7 +804,7 @@ func Test_NodeConfigurationBuilder_BlueprintLevelNode_Root(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "alice", result["username"])
 	assert.Equal(t, "alice@example.com", result["email"])
-	assert.Equal(t, "30", result["age"])
+	assert.Equal(t, 30, result["age"])
 }
 
 func Test_NodeConfigurationBuilder_BlueprintLevelNode_Chain(t *testing.T) {
@@ -934,7 +934,7 @@ func Test_NodeConfigurationBuilder_BlueprintLevelNode_Chain(t *testing.T) {
 
 	result, err := builder.Build(configuration)
 	require.NoError(t, err)
-	assert.Equal(t, "true", result["processed"])
+	assert.Equal(t, true, result["processed"])
 	assert.Equal(t, "from-first-node", result["value"])
 }
 
@@ -1015,8 +1015,8 @@ func Test_NodeConfigurationBuilder_BlueprintLevelNode_Config(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "secret-key-123", result["key"])
 	assert.Equal(t, "https://api.example.com", result["url"])
-	assert.Equal(t, "30", result["timeout"])
-	assert.Equal(t, "3", result["retries"])
+	assert.Equal(t, float64(30), result["timeout"])
+	assert.Equal(t, float64(3), result["retries"])
 	assert.Equal(t, "nested-data", result["nested"])
 	assert.Equal(t, "API: https://api.example.com, Key: secret-key-123", result["combined"])
 }
@@ -1153,8 +1153,8 @@ func Test_NodeConfigurationBuilder_InputVariable(t *testing.T) {
 	result, err := builder.Build(configuration)
 	require.NoError(t, err)
 	assert.Equal(t, "Alice", result["name"])
-	assert.Equal(t, "25", result["age"])
-	assert.Equal(t, "true", result["active"])
+	assert.Equal(t, 25, result["age"])
+	assert.Equal(t, true, result["active"])
 	assert.Equal(t, "admin", result["role"])
 	assert.Equal(t, "User Alice is 25 years old", result["combined"])
 }


### PR DESCRIPTION
## Summary

Fixes #4499. When a configuration field's value is exactly one `{{ ... }}` expression, the expression's result type is now preserved (numbers stay numbers, booleans stay booleans, objects stay objects).

Previously every expression result was coerced to a string via `fmt.Sprintf("%v", ...)`, which broke any downstream code expecting typed values — most visibly the HTTP component's `json` body, where
expressions like `'{{ count > 5 ? 0.1 : 0.9 }}'` would render as `"0.9"` and trigger `JSON type error: cannot decode string into field, expected float64` from APIs like Cloudflare Load Balancer.

Mixed text (`prefix-{{ x }}`) and multi-expression strings (`{{ a }}{{ b }}`) keep the existing string-concatenation behavior.

## Before / after

```yaml
# HTTP component config
json:
  pool_weights:
    pool-id-1: '{{ $["Check Env"].data.result == true ? 0.1 : 0.9 }}'
```

| | Resolved JSON body |
| --- | --- |
| Before | `{"pool_weights":{"pool-id-1":"0.9"}}` ❌ |
| After  | `{"pool_weights":{"pool-id-1":0.9}}`   ✅ |

## Scope

- `pkg/workers/contexts/node_configuration_builder.go` — refactor  `ResolveTemplateExpressions` to detect the single-expression case  and return the raw result.
- `pkg/workers/contexts/node_configuration_builder_expr_test.go` — new  no-DB regression tests for type preservation across float, int, bool,  map, string; plus the boundary cases (mixed text, multiple expressions, surrounding whitespace).
- `pkg/workers/contexts/node_configuration_builder_test.go` — update  pre-existing `Build()` integration tests that asserted the old  string-coercion behavior. Bool/int fields now correctly assert their  native types; values pulled via `root()` from JSON-stored canvas  events are `float64` after JSON round-trip, which is also asserted.

## Impact

- The two existing callers of `ResolveTemplateExpressions`  (`pkg/workers/contexts/event_context.go`, `pkg/grpc/actions/canvases/emit_node_event.go`) immediately stringify  the result via `fmt.Sprintf("%v", resolved)` for run-title rendering,  so they are unaffected.
- For end users, expressions that were previously stringified now  preserve their type. Anyone relying on that coercion (e.g. a single  `{{ numericId }}` in a string-typed field) can wrap the expression  with `string(...)` or use the mixed-text form `'-{{ x }}'`.

## Related

Adjacent work: #4599 improves number formatting in the multi-expression / string-concat path. Compatible with this PR — they touch different branches of the same function.

## Validation

```sh
make test PKG_TEST_PACKAGES=./pkg/workers/contexts   # 69/69 pass
make format.go
make lint
make check.build.app
```
