### PR TITLE
feat: validate capability state on canvas update

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
@@ -243,18 +243,22 @@ func (p *CanvasPatcher) validateIntegration(node *pb.CanvasChangeset_Change_Node
 		return nil, fmt.Errorf("integration is required for %s", node.GetBlock())
 	}
 
-	integration := node.GetIntegrationId()
-	integrationID, err := uuid.Parse(integration)
+	id := node.GetIntegrationId()
+	integrationID, err := uuid.Parse(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid integration id: %v", err)
 	}
 
-	_, err = models.FindIntegrationInTransaction(p.tx, p.orgID, integrationID)
+	integration, err := models.FindIntegrationInTransaction(p.tx, p.orgID, integrationID)
 	if err != nil {
-		return nil, fmt.Errorf("integration %s not found", node.GetIntegrationId())
+		return nil, fmt.Errorf("integration %s not found", id)
 	}
 
-	return &integration, nil
+	if !integration.HasCapabilityEnabled(node.GetBlock()) {
+		return nil, fmt.Errorf("%s is not enabled for integration %s", node.GetBlock(), integration.InstallationName)
+	}
+
+	return &id, nil
 }
 
 func (p *CanvasPatcher) deleteNode(change *pb.CanvasChangeset_Change) error {

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -818,6 +819,76 @@ func Test__CanvasPatcher(t *testing.T) {
 		})
 		steps.assertHasNodeBlock("node-a", "github.getIssue")
 		steps.assertHasNodeIntegrationID("node-a", integration.ID.String())
+	})
+
+	t.Run("accepts integration component when capability is enabled", func(t *testing.T) {
+		steps := &CanvasPatcherSteps{t: t, registry: r.Registry, orgID: r.Organization.ID}
+		steps.givenCanvasVersion(nil, nil)
+
+		integration := support.CreateIntegrationWithCapabilities(t, r.Organization.ID, []models.CapabilityState{
+			{Name: "github.getIssue", State: core.IntegrationCapabilityStateEnabled},
+		})
+
+		steps.whenHandling(&pb.CanvasChangeset{
+			Changes: []*pb.CanvasChangeset_Change{
+				{
+					Type: pb.CanvasChangeset_Change_ADD_NODE,
+					Node: &pb.CanvasChangeset_Change_Node{
+						Id:            "node-a",
+						Name:          "Node A",
+						Block:         "github.getIssue",
+						IntegrationId: integration.ID.String(),
+						Configuration: structFromMap(t, map[string]any{
+							"repository":  "superplanehq/superplane",
+							"issueNumber": "1",
+						}),
+					},
+				},
+			},
+		}, nil)
+
+		steps.assertNoError()
+		steps.assertNodeCount(1)
+		steps.assertHasNode("node-a", "Node A", map[string]any{
+			"repository":  "superplanehq/superplane",
+			"issueNumber": "1",
+		})
+		steps.assertHasNodeBlock("node-a", "github.getIssue")
+		steps.assertHasNodeIntegrationID("node-a", integration.ID.String())
+	})
+
+	t.Run("integration component with disabled capability -> sets node error without returning error", func(t *testing.T) {
+		steps := &CanvasPatcherSteps{t: t, registry: r.Registry, orgID: r.Organization.ID}
+		steps.givenCanvasVersion(nil, nil)
+
+		integration := support.CreateIntegrationWithCapabilities(t, r.Organization.ID, []models.CapabilityState{
+			{Name: "github.getIssue", State: core.IntegrationCapabilityStateDisabled},
+		})
+
+		steps.whenHandling(&pb.CanvasChangeset{
+			Changes: []*pb.CanvasChangeset_Change{
+				{
+					Type: pb.CanvasChangeset_Change_ADD_NODE,
+					Node: &pb.CanvasChangeset_Change_Node{
+						Id:            "node-a",
+						Name:          "Node A",
+						Block:         "github.getIssue",
+						IntegrationId: integration.ID.String(),
+						Configuration: structFromMap(t, map[string]any{
+							"repository":  "superplanehq/superplane",
+							"issueNumber": "1",
+						}),
+					},
+				},
+			},
+		}, nil)
+
+		steps.assertNoError()
+		steps.assertNodeCount(1)
+		steps.assertHasNodeBlock("node-a", "github.getIssue")
+		steps.assertHasNoNodeIntegrationID("node-a")
+		steps.assertNodeErrorContains("node-a", "github.getIssue is not enabled")
+		steps.assertNodeErrorContains("node-a", integration.InstallationName)
 	})
 }
 

--- a/pkg/grpc/actions/canvases/serialization.go
+++ b/pkg/grpc/actions/canvases/serialization.go
@@ -352,7 +352,7 @@ func validateNodeRef(registry *registry.Registry, organizationID string, node *c
 	}
 
 	if len(parts) > 1 {
-		err := validateIntegration(organizationID, node.Integration)
+		err := validateIntegration(organizationID, node.Integration, node.Component)
 		if err != nil {
 			return err
 		}
@@ -361,7 +361,7 @@ func validateNodeRef(registry *registry.Registry, organizationID string, node *c
 	return configuration.ValidateConfiguration(configurable.Configuration(), node.Configuration.AsMap())
 }
 
-func validateIntegration(organizationID string, ref *componentpb.IntegrationRef) error {
+func validateIntegration(organizationID string, ref *componentpb.IntegrationRef, component string) error {
 	if ref == nil || ref.Id == nil {
 		return fmt.Errorf("integration is required")
 	}
@@ -376,9 +376,13 @@ func validateIntegration(organizationID string, ref *componentpb.IntegrationRef)
 		return fmt.Errorf("invalid organization ID: %v", err)
 	}
 
-	_, err = models.FindIntegration(orgID, integrationID)
+	integration, err := models.FindIntegration(orgID, integrationID)
 	if err != nil {
 		return fmt.Errorf("integration not found or does not belong to this organization")
+	}
+
+	if !integration.HasCapabilityEnabled(component) {
+		return fmt.Errorf("%s is not enabled for integration %s", component, integration.InstallationName)
 	}
 
 	return nil

--- a/pkg/grpc/actions/canvases/update_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/update_canvas_version_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -217,6 +218,79 @@ func Test__UpdateCanvasVersion(t *testing.T) {
 		require.NotEmpty(t, errMsg)
 		assert.Contains(t, errMsg, "waitFor")
 	})
+
+	t.Run("integration component with enabled capability -> updates without node error", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		draftVersion, err := models.SaveCanvasDraftInTransaction(database.Conn(), canvas.ID, r.User, nil, nil)
+		require.NoError(t, err)
+
+		integration := support.CreateIntegrationWithCapabilities(t, r.Organization.ID, []models.CapabilityState{
+			{Name: "github.getIssue", State: core.IntegrationCapabilityStateEnabled},
+		})
+
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		response, err := UpdateCanvasVersion(
+			ctx,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			draftVersion.ID.String(),
+			testPbCanvasWithGitHubIssueNode(t, canvas.Name, integration.ID.String()),
+			nil,
+			"",
+			r.AuthService,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotNil(t, response.Version)
+		require.NotNil(t, response.Version.Spec)
+		require.Len(t, response.Version.Spec.Nodes, 1)
+
+		node := response.Version.Spec.Nodes[0]
+		assert.Empty(t, node.GetErrorMessage())
+		require.NotNil(t, node.GetIntegration())
+		require.NotNil(t, node.GetIntegration().Id)
+		assert.Equal(t, integration.ID.String(), *node.GetIntegration().Id)
+	})
+
+	t.Run("integration component with disabled capability -> serialized node carries error_message", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		draftVersion, err := models.SaveCanvasDraftInTransaction(database.Conn(), canvas.ID, r.User, nil, nil)
+		require.NoError(t, err)
+
+		integration := support.CreateIntegrationWithCapabilities(t, r.Organization.ID, []models.CapabilityState{
+			{Name: "github.getIssue", State: core.IntegrationCapabilityStateDisabled},
+		})
+
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		response, err := UpdateCanvasVersion(
+			ctx,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			draftVersion.ID.String(),
+			testPbCanvasWithGitHubIssueNode(t, canvas.Name, integration.ID.String()),
+			nil,
+			"",
+			r.AuthService,
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotNil(t, response.Version)
+		require.NotNil(t, response.Version.Spec)
+		require.Len(t, response.Version.Spec.Nodes, 1)
+
+		errMsg := response.Version.Spec.Nodes[0].GetErrorMessage()
+		require.NotEmpty(t, errMsg)
+		assert.Contains(t, errMsg, "github.getIssue is not enabled for integration "+integration.InstallationName)
+		assert.Contains(t, errMsg, integration.InstallationName)
+	})
 }
 
 func testPbCanvas(name string) *pb.Canvas {
@@ -226,6 +300,31 @@ func testPbCanvas(name string) *pb.Canvas {
 		},
 		Spec: &pb.Canvas_Spec{
 			Nodes: []*componentpb.Node{},
+			Edges: []*componentpb.Edge{},
+		},
+	}
+}
+
+func testPbCanvasWithGitHubIssueNode(t *testing.T, name string, integrationID string) *pb.Canvas {
+	return &pb.Canvas{
+		Metadata: &pb.Canvas_Metadata{
+			Name: name,
+		},
+		Spec: &pb.Canvas_Spec{
+			Nodes: []*componentpb.Node{
+				{
+					Id:        "github-issue",
+					Name:      "Get Issue",
+					Component: "github.getIssue",
+					Integration: &componentpb.IntegrationRef{
+						Id: &integrationID,
+					},
+					Configuration: structFromAnyMap(t, map[string]any{
+						"repository":  "superplanehq/superplane",
+						"issueNumber": "1",
+					}),
+				},
+			},
 			Edges: []*componentpb.Edge{},
 		},
 	}

--- a/pkg/grpc/actions/organizations/create_integration.go
+++ b/pkg/grpc/actions/organizations/create_integration.go
@@ -255,7 +255,7 @@ func serializeIntegration(registry *registry.Registry, instance *models.Integrat
 			Metadata:         metadata,
 			UsedIn:           []*pb.Integration_NodeRef{},
 			Capabilities:     serializeCapabilities(registry, instance),
-			LegacySetup:      isLegacySetup(instance),
+			LegacySetup:      instance.IsLegacy(),
 		},
 	}
 
@@ -522,12 +522,4 @@ func sanitizeConfigurationIfNeeded(integration core.Integration, config map[stri
 	}
 
 	return sanitized
-}
-
-func isLegacySetup(integration *models.Integration) bool {
-	if integration.SetupState != nil {
-		return false
-	}
-
-	return len(integration.Capabilities) == 0
 }

--- a/pkg/grpc/actions/organizations/update_integration.go
+++ b/pkg/grpc/actions/organizations/update_integration.go
@@ -48,7 +48,7 @@ func UpdateIntegration(
 		return nil, status.Errorf(codes.NotFound, "integration not found: %v", err)
 	}
 
-	if !isLegacySetup(instance) {
+	if !instance.IsLegacy() {
 		return nil, status.Errorf(codes.InvalidArgument, "integration %s is not a legacy setup", instance.ID.String())
 	}
 

--- a/pkg/models/integration.go
+++ b/pkg/models/integration.go
@@ -386,3 +386,25 @@ func (a *Integration) CreateActionRequest(tx *gorm.DB, actionName string, parame
 		}),
 	}).Error
 }
+
+func (a *Integration) IsLegacy() bool {
+	if a.SetupState != nil {
+		return false
+	}
+
+	return len(a.Capabilities) == 0
+}
+
+func (a *Integration) HasCapabilityEnabled(name string) bool {
+	if a.IsLegacy() {
+		return true
+	}
+
+	for _, capability := range a.Capabilities {
+		if capability.Name == name && capability.State == core.IntegrationCapabilityStateEnabled {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -463,11 +463,7 @@ func (c *IntegrationContext) FindSubscription(predicate func(core.IntegrationSub
 }
 
 func (c *IntegrationContext) LegacySetup() bool {
-	if c.integration.SetupState != nil {
-		return false
-	}
-
-	return len(c.integration.Capabilities) == 0
+	return c.integration.IsLegacy()
 }
 
 func (c *IntegrationContext) Properties() core.IntegrationPropertyStorage {

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -151,6 +151,29 @@ func CreateSecret(t *testing.T, r *ResourceRegistry, secretData map[string]strin
 	return secret, nil
 }
 
+func CreateIntegrationWithCapabilities(
+	t require.TestingT,
+	organizationID uuid.UUID,
+	capabilities []models.CapabilityState,
+) *models.Integration {
+	integration, err := models.CreateIntegration(
+		uuid.New(),
+		organizationID,
+		"github",
+		RandomName("integration"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, database.Conn().
+		Model(integration).
+		Update("capabilities", datatypes.NewJSONSlice(capabilities)).
+		Error)
+
+	integration.Capabilities = datatypes.NewJSONSlice(capabilities)
+	return integration
+}
+
 func RandomName(prefix string) string {
 	return prefix + "-" + uuid.New().String()
 }


### PR DESCRIPTION
When using a component from an integration set up using the new flow, we should check if the component is enabled for use. Integrations already set up using the old flow will keep working as usual.