### PR TITLE
fix: preserve native types for pure expressions in JSON body fields

### DIFF
--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -220,6 +220,12 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 		return expression, nil
 	}
 
+	// When the entire value is a single expression with no surrounding text,
+	// return the native type so numbers and booleans are not coerced to strings.
+	if matches := expressionRegex.FindStringSubmatch(expression); matches != nil && matches[0] == expression {
+		return b.ResolveExpression(matches[1])
+	}
+
 	var err error
 
 	result := expressionRegex.ReplaceAllStringFunc(expression, func(match string) string {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -72,8 +72,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, 42, result["count"])
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_RootFunction(t *testing.T) {
@@ -128,8 +128,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_RootFunction(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, 42, result["count"])
 }
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_ByName(t *testing.T) {
@@ -185,8 +185,8 @@ func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root_ByName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "john", result["user"])
 	assert.Equal(t, "login", result["action"])
-	assert.Equal(t, "true", result["success"])
-	assert.Equal(t, "42", result["count"])
+	assert.Equal(t, true, result["success"])
+	assert.Equal(t, 42, result["count"])
 }
 
 func Test_NodeConfigurationBuilder_NodeNameNotUnique_UsesClosestInChain(t *testing.T) {
@@ -1625,4 +1625,72 @@ func Test_NodeConfigurationBuilder_Config_DoesNotOverwriteExistingConfigKey(t *t
 	assert.Equal(t, "https://api.example.com", result["api_url"])
 	assert.Equal(t, "https://api.example.com", result["prev_api_url"])
 	assert.Equal(t, "ok", result["output_status"])
+}
+
+// Test_NodeConfigurationBuilder_NativeTypePreservation verifies that expressions
+// resolving to non-string values (numbers, booleans) preserve their native types
+// instead of being coerced to strings. This is required for HTTP actions that send
+// JSON bodies to APIs expecting numeric or boolean fields (e.g. float64 weights).
+func Test_NodeConfigurationBuilder_NativeTypePreservation(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Name:   triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: componentNode,
+				Name:   componentNode,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEventData := map[string]any{
+		"weight":  0.9,
+		"enabled": true,
+		"count":   42,
+		"label":   "hello",
+	}
+	rootEvent := support.EmitCanvasEventForNodeWithData(t, canvas.ID, triggerNode, "default", nil, rootEventData)
+
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithRootEvent(&rootEvent.ID).
+		WithInput(map[string]any{triggerNode: rootEventData})
+
+	// Expressions that are the entire field value must return the native type.
+	// Expressions embedded inside a larger string must still produce a string.
+	configuration := map[string]any{
+		"weight":        "{{ $[\"" + triggerNode + "\"].weight }}",
+		"enabled":       "{{ $[\"" + triggerNode + "\"].enabled }}",
+		"count":         "{{ $[\"" + triggerNode + "\"].count }}",
+		"label":         "{{ $[\"" + triggerNode + "\"].label }}",
+		"interpolated":  "value is {{ $[\"" + triggerNode + "\"].count }}",
+	}
+
+	result, err := builder.Build(configuration)
+	require.NoError(t, err)
+
+	// Pure expressions: native types preserved.
+	assert.Equal(t, 0.9, result["weight"])
+	assert.Equal(t, true, result["enabled"])
+	assert.Equal(t, 42, result["count"])
+	assert.Equal(t, "hello", result["label"])
+
+	// Expression embedded in text: stringified as before.
+	assert.Equal(t, "value is 42", result["interpolated"])
 }


### PR DESCRIPTION
## Problem

When an HTTP action JSON body field contains a single expression like:

```json
{ "weight": "{{ $[\"Check Env\"].data.result == true ? 0.1 : 0.9 }}" }
```

the expression evaluates correctly to `0.9` (float64), but `ResolveTemplateExpressions` always calls `fmt.Sprintf(\"%v\", value)` via `ReplaceAllStringFunc`, coercing the result to the string `"0.9"`. APIs that expect a numeric field (e.g. Cloudflare Load Balancer `pool_weights`) then reject the request with:

> cannot decode string into field pool_weights, expected float64

Closes #4499

## Root cause

`regexp.ReplaceAllStringFunc` can only return `string`. Every expression result — regardless of its actual type — was formatted as a string before being returned from `ResolveTemplateExpressions`.

## Fix

Added an early-exit path: when the entire field value is a single `{{ … }}` expression with no surrounding text, `ResolveExpression` is called directly and its native return value (`float64`, `bool`, `int`, etc.) is returned unchanged.

Mixed-content fields like `"prefix {{ expr }}"` continue to go through `ReplaceAllStringFunc` and produce strings — no change in behaviour for those cases.

```go
// When the entire value is a single expression with no surrounding text,
// return the native type to preserve numbers, booleans, etc.
if matches := expressionRegex.FindStringSubmatch(expression); matches != nil && matches[0] == expression {
    return b.ResolveExpression(matches[1])
}
```

## Tests

- Updated three existing tests that asserted `"true"` / `"42"` for boolean and integer expressions — those assertions documented the bug; they now assert the correct native types.
- Added `Test_NodeConfigurationBuilder_NativeTypePreservation` which covers the exact scenario from the issue: `float64`, `bool`, `int`, and `string` pure-expression fields, plus one interpolated field to confirm string coercion is still applied there.