### PR TITLE
fix: make webhook cleanup idempotent for missing provider resources

### DIFF
--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -31,6 +32,18 @@ type Client struct {
 	ownerType  string
 	owner      string
 	underlying *github.Client
+}
+
+func IsNotFoundError(err error) bool {
+	var githubErr *github.ErrorResponse
+	if errors.As(err, &githubErr) && githubErr.Response != nil && githubErr.Response.StatusCode == http.StatusNotFound {
+		return true
+	}
+
+	var installationErr *ghinstallation.HTTPError
+	return errors.As(err, &installationErr) &&
+		installationErr.Response != nil &&
+		installationErr.Response.StatusCode == http.StatusNotFound
 }
 
 func (c *Client) FindRepository(repository string) (*github.Repository, error) {

--- a/pkg/integrations/github/webhook_handler.go
+++ b/pkg/integrations/github/webhook_handler.go
@@ -129,6 +129,10 @@ func (h *GitHubWebhookHandler) Cleanup(ctx core.WebhookHandlerContext) error {
 
 	_, err = client.DeleteHook(context.Background(), configuration.Repository, webhook.ID)
 	if err != nil {
+		if common.IsNotFoundError(err) {
+			return nil
+		}
+
 		return fmt.Errorf("error deleting webhook: %v", err)
 	}
 

--- a/pkg/integrations/github/webhook_handler_test.go
+++ b/pkg/integrations/github/webhook_handler_test.go
@@ -1,11 +1,19 @@
 package github
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	"github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
 )
 
 func Test__GitHubWebhookHandler__CompareConfig(t *testing.T) {
@@ -118,4 +126,64 @@ func Test__GitHubWebhookHandler__CompareConfig(t *testing.T) {
 			assert.Equal(t, tc.expectEqual, equal)
 		})
 	}
+}
+
+func Test__GitHubWebhookHandler__Cleanup(t *testing.T) {
+	t.Run("ignores missing hook", func(t *testing.T) {
+		handler := &GitHubWebhookHandler{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpCtx,
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			Webhook: &contexts.WebhookContext{
+				Metadata:      Webhook{ID: 123},
+				Configuration: common.WebhookConfiguration{Repository: "hello"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, http.MethodDelete, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/repos/testhq/hello/hooks/123", httpCtx.Requests[0].URL.Path)
+	})
+
+	t.Run("ignores missing app installation during token refresh", func(t *testing.T) {
+		handler := &GitHubWebhookHandler{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusNotFound, `{"message":"Not Found"}`),
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpCtx,
+			Integration: mocks.IntegrationContextForLegacySetupFlow(githubPrivateKeyPEM(t)),
+			Webhook: &contexts.WebhookContext{
+				Metadata:      Webhook{ID: 123},
+				Configuration: common.WebhookConfiguration{Repository: "hello"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 1)
+		assert.Equal(t, http.MethodPost, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/app/installations/67890/access_tokens", httpCtx.Requests[0].URL.Path)
+	})
+}
+
+func githubPrivateKeyPEM(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
 }

--- a/pkg/integrations/semaphore/common/client.go
+++ b/pkg/integrations/semaphore/common/client.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,20 @@ type Client struct {
 	OrgURL   string
 	APIToken string
 	http     core.HTTPContext
+}
+
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("request got %d code: %s", e.StatusCode, e.Body)
+}
+
+func IsNotFoundError(err error) bool {
+	var httpErr *HTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
 }
 
 func NewClientWithAPIToken(http core.HTTPContext, parameters core.IntegrationPropertyStorageReader, apiToken string) (*Client, error) {
@@ -157,7 +172,7 @@ func (c *Client) execRequest(method, URL string, body io.Reader) ([]byte, error)
 	}
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
-		return nil, fmt.Errorf("request got %d code: %s", res.StatusCode, string(responseBody))
+		return nil, &HTTPError{StatusCode: res.StatusCode, Body: string(responseBody)}
 	}
 
 	return responseBody, nil
@@ -345,7 +360,7 @@ func (c *Client) DeleteNotification(id string) error {
 	notificationURL := fmt.Sprintf("%s/api/v1alpha/notifications/%s", c.OrgURL, id)
 	_, err := c.execRequest(http.MethodDelete, notificationURL, nil)
 	if err != nil {
-		return fmt.Errorf("error deleting notification: %v", err)
+		return fmt.Errorf("error deleting notification: %w", err)
 	}
 
 	return nil
@@ -392,7 +407,7 @@ func (c *Client) DeleteSecret(name string) error {
 	secretURL := fmt.Sprintf("%s/api/v1beta/secrets/%s", c.OrgURL, name)
 	_, err := c.execRequest(http.MethodDelete, secretURL, nil)
 	if err != nil {
-		return fmt.Errorf("error deleting secret: %v", err)
+		return fmt.Errorf("error deleting secret: %w", err)
 	}
 
 	return nil

--- a/pkg/integrations/semaphore/webhook_handler.go
+++ b/pkg/integrations/semaphore/webhook_handler.go
@@ -105,11 +105,16 @@ func (h *SemaphoreWebhookHandler) Cleanup(ctx core.WebhookHandlerContext) error 
 	}
 
 	err = client.DeleteNotification(metadata.Notification.ID)
-	if err != nil {
+	if err != nil && !common.IsNotFoundError(err) {
 		return fmt.Errorf("error deleting notification: %v", err)
 	}
 
-	return client.DeleteSecret(metadata.Secret.Name)
+	err = client.DeleteSecret(metadata.Secret.Name)
+	if err != nil && !common.IsNotFoundError(err) {
+		return err
+	}
+
+	return nil
 }
 
 func upsertSecret(client *common.Client, name string, key []byte) (*common.Secret, error) {

--- a/pkg/integrations/semaphore/webhook_handler_test.go
+++ b/pkg/integrations/semaphore/webhook_handler_test.go
@@ -1,11 +1,16 @@
 package semaphore
 
 import (
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/semaphore/common"
+	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
 func Test__SemaphoreWebhookHandler__CompareConfig(t *testing.T) {
@@ -83,5 +88,79 @@ func Test__SemaphoreWebhookHandler__CompareConfig(t *testing.T) {
 
 			assert.Equal(t, tc.expectEqual, equal)
 		})
+	}
+}
+
+func Test__SemaphoreWebhookHandler__Cleanup(t *testing.T) {
+	t.Run("ignores missing notification and deletes secret", func(t *testing.T) {
+		handler := &SemaphoreWebhookHandler{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				semaphoreResponse(http.StatusNotFound, `{"code":5,"message":"Notification not found"}`),
+				semaphoreResponse(http.StatusNoContent, ""),
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpCtx,
+			Integration: semaphoreIntegrationContext(),
+			Webhook: &contexts.WebhookContext{
+				Metadata: WebhookMetadata{
+					Secret:       WebhookSecretMetadata{Name: "superplane-webhook-secret"},
+					Notification: WebhookNotificationMetadata{ID: "notification-id"},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+		assert.Equal(t, http.MethodDelete, httpCtx.Requests[0].Method)
+		assert.Equal(t, "/api/v1alpha/notifications/notification-id", httpCtx.Requests[0].URL.Path)
+		assert.Equal(t, http.MethodDelete, httpCtx.Requests[1].Method)
+		assert.Equal(t, "/api/v1beta/secrets/superplane-webhook-secret", httpCtx.Requests[1].URL.Path)
+	})
+
+	t.Run("ignores missing secret", func(t *testing.T) {
+		handler := &SemaphoreWebhookHandler{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				semaphoreResponse(http.StatusNoContent, ""),
+				semaphoreResponse(http.StatusNotFound, `{"code":5,"message":"Secret not found"}`),
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpCtx,
+			Integration: semaphoreIntegrationContext(),
+			Webhook: &contexts.WebhookContext{
+				Metadata: WebhookMetadata{
+					Secret:       WebhookSecretMetadata{Name: "superplane-webhook-secret"},
+					Notification: WebhookNotificationMetadata{ID: "notification-id"},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpCtx.Requests, 2)
+	})
+}
+
+func semaphoreIntegrationContext() *contexts.IntegrationContext {
+	return &contexts.IntegrationContext{
+		NewSetupFlow: true,
+		CurrentProperties: map[string]any{
+			"organizationUrl": "https://example.semaphoreci.com",
+		},
+		CurrentSecrets: map[string]core.IntegrationSecret{
+			"apiToken": {Name: "apiToken", Value: []byte("test-token")},
+		},
+	}
+}
+
+func semaphoreResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }


### PR DESCRIPTION
## Summary
- Treat provider 404s during webhook cleanup as already-cleaned-up resources
- Add typed 404 detection for Semaphore cleanup errors
- Handle GitHub missing hook and missing app installation cleanup cases
- Add regression tests for the repeated cleanup failures seen in logs
