### PR TITLE
fix: prevent external cleanup failures from blocking workers

### DIFF
--- a/pkg/workers/webhook_cleanup_worker.go
+++ b/pkg/workers/webhook_cleanup_worker.go
@@ -105,7 +105,7 @@ func (w *WebhookCleanupWorker) processAppInstallationWebhook(tx *gorm.DB, webhoo
 	})
 
 	if err != nil {
-		return err
+		w.log("Best-effort cleanup failed for webhook %s: %v", webhook.ID, err)
 	}
 
 	return tx.Unscoped().Delete(webhook).Error

--- a/pkg/workers/webhook_cleanup_worker_test.go
+++ b/pkg/workers/webhook_cleanup_worker_test.go
@@ -1,0 +1,83 @@
+package workers
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"github.com/superplanehq/superplane/test/support/impl"
+	"gorm.io/gorm"
+)
+
+func Test__WebhookCleanupWorker_DeletesWebhookWhenProviderCleanupFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	cleanupCalls := 0
+	worker, webhookID := setupWebhookCleanupWorker(t, r, func(ctx core.WebhookHandlerContext) error {
+		cleanupCalls++
+		return errors.New("provider unavailable")
+	})
+
+	err := worker.LockAndProcessWebhook(models.Webhook{ID: webhookID})
+	require.NoError(t, err)
+
+	assertWebhookHardDeleted(t, webhookID)
+	assert.Equal(t, 1, cleanupCalls)
+}
+
+func setupWebhookCleanupWorker(
+	t *testing.T,
+	r *support.ResourceRegistry,
+	cleanupFunc func(ctx core.WebhookHandlerContext) error,
+) (*WebhookCleanupWorker, uuid.UUID) {
+	t.Helper()
+
+	r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{})
+	r.Registry.WebhookHandlers["dummy"] = impl.NewDummyWebhookHandler(impl.DummyWebhookHandlerOptions{
+		CleanupFunc: cleanupFunc,
+	})
+
+	integration, err := models.CreateIntegration(
+		uuid.New(),
+		r.Organization.ID,
+		"dummy",
+		support.RandomName("integration"),
+		nil,
+	)
+	require.NoError(t, err)
+
+	now := time.Now()
+	webhook := models.Webhook{
+		ID:                uuid.New(),
+		State:             models.WebhookStateReady,
+		Secret:            []byte("encrypted-secret"),
+		AppInstallationID: &integration.ID,
+		RetryCount:        3,
+		MaxRetries:        3,
+		CreatedAt:         &now,
+	}
+	require.NoError(t, database.Conn().Create(&webhook).Error)
+	require.NoError(t, database.Conn().Delete(&webhook).Error)
+
+	return NewWebhookCleanupWorker(r.Encryptor, r.Registry, "https://example.com"), webhook.ID
+}
+
+func assertWebhookHardDeleted(t *testing.T, webhookID uuid.UUID) {
+	t.Helper()
+
+	var webhook models.Webhook
+	err := database.Conn().
+		Unscoped().
+		Where("id = ?", webhookID).
+		First(&webhook).
+		Error
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}


### PR DESCRIPTION
## Summary
- Make webhook cleanup best-effort so provider cleanup failures do not block local webhook deletion
- Treat provider 404s as already-cleaned-up resources for GitHub and Semaphore cleanup
- Prevent soft-deleted webhooks from indefinitely blocking integration cleanup
- Add regression tests for missing provider resources and failed external cleanup