### PR TITLE
fix: stop merge queue items from retrying on expression errors

### DIFF
--- a/pkg/components/merge/merge.go
+++ b/pkg/components/merge/merge.go
@@ -294,7 +294,7 @@ func (m *Merge) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, erro
 	if spec.StopIfExpression != "" {
 		out, err := ctx.Expressions.Run(spec.StopIfExpression)
 		if err != nil {
-			return nil, err
+			return m.failStopExpression(executionCtx, md, err.Error())
 		}
 
 		//
@@ -303,18 +303,7 @@ func (m *Merge) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, erro
 		//
 		stopEarly, ok := out.(bool)
 		if !ok {
-			md.StopEarly = true
-			err := executionCtx.Metadata.Set(md)
-			if err != nil {
-				return nil, err
-			}
-
-			err = executionCtx.ExecutionState.Fail("error", fmt.Sprintf("stop expression must evaluate to boolean, got %T: %v", out, out))
-			if err != nil {
-				return nil, err
-			}
-
-			return &executionCtx.ID, nil
+			return m.failStopExpression(executionCtx, md, fmt.Sprintf("stop expression must evaluate to boolean, got %T: %v", out, out))
 		}
 
 		//
@@ -342,6 +331,21 @@ func (m *Merge) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, erro
 			"merge.finished",
 			[]any{md},
 		)
+	}
+
+	return &executionCtx.ID, nil
+}
+
+func (m *Merge) failStopExpression(executionCtx *core.ExecutionContext, md *ExecutionMetadata, message string) (*uuid.UUID, error) {
+	md.StopEarly = true
+	err := executionCtx.Metadata.Set(md)
+	if err != nil {
+		return nil, err
+	}
+
+	err = executionCtx.ExecutionState.Fail("error", message)
+	if err != nil {
+		return nil, err
 	}
 
 	return &executionCtx.ID, nil

--- a/pkg/components/merge/merge_test.go
+++ b/pkg/components/merge/merge_test.go
@@ -105,6 +105,35 @@ func Test_Merge_BadStopIfExpression(t *testing.T) {
 	steps.AssertQueueIsEmpty()
 }
 
+func Test_Merge_StopIfExpressionEvaluationError(t *testing.T) {
+	steps := NewMergeTestSteps(t)
+	steps.CreateWorkflow()
+
+	steps.SetMergeConfiguration(map[string]any{
+		"stopIfExpression": "$[\"missing-node\"].result == \"fail\"",
+	})
+
+	steps.CreateEventsWithData(
+		map[string]any{"result": "fail"},
+		map[string]any{"result": "ok"},
+	)
+	steps.CreateQueueItems()
+
+	m := &Merge{}
+
+	steps.ProcessFirstEventExpectFinish(m)
+	steps.AssertNodeExecutionCount(1)
+	steps.AssertExecutionFailedWithError("node name missing-node not found in execution chain")
+	steps.AssertNodeIsAllowedToProcessNextQueueItem()
+
+	steps.ProcessSecondEventExpectNoFinish(m)
+	steps.AssertNodeExecutionCount(1)
+	steps.AssertExecutionFinished()
+	steps.AssertNodeIsAllowedToProcessNextQueueItem()
+
+	steps.AssertQueueIsEmpty()
+}
+
 func Test_Merge_StopIfExpression_SourceNodeReference(t *testing.T) {
 	steps := NewMergeTestSteps(t)
 


### PR DESCRIPTION
## Summary
Fixes an infinite retry loop in the merge component when `stopIfExpression` fails during evaluation.

## What was happening
1. `NodeQueueWorker` picked up a queue item for a merge node.
2. The merge component dequeued the queue item.
3. The merge component evaluated `stopIfExpression`.
4. The expression failed because it referenced a node that was not in the execution chain.
5. `ProcessQueueItem` returned that error.
6. Because processing runs inside a DB transaction, returning the error rolled back the whole transaction.
7. The queue item deletion was rolled back too.
8. The same queue item stayed in the queue and was picked up again every worker tick.

## Fix
- Treat merge stop-expression evaluation errors as failed merge executions.
- Mark
