### PR TITLE
feat: add Cloudflare createKVNamespace, deleteKVNamespace, putKValue, getKVValue and deleteKVValue components

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -10,12 +10,12 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record in a Cloudflare zone" />
-  <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
   <LinkCard title="Create KV Namespace" href="#create-kv-namespace" description="Create a Cloudflare Workers KV namespace" />
+  <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
-  <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
+  <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
@@ -93,6 +93,43 @@ Emits the created DNS record on the default channel. If the zone is not found, t
 }
 ```
 
+<a id="create-kv-namespace"></a>
+
+## Create KV Namespace
+
+The Create KV Namespace component creates a new Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Feature flags**: Provision a dedicated namespace to store feature flag state
+- **Session storage**: Create a namespace for application session data
+- **Configuration store**: Set up a namespace for dynamic configuration values
+
+### Configuration
+
+- **Title**: A human-readable name for the namespace (must be unique per account)
+
+### Output
+
+Returns the created namespace with its assigned ID and title.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespace": {
+      "id": "0f2ac74b498b48028cb68387c421e279",
+      "supports_url_encoding": true,
+      "title": "my-kv-namespace"
+    }
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.namespace.created"
+}
+```
+
 <a id="create-origin-rule"></a>
 
 ## Create Origin Rule
@@ -140,43 +177,6 @@ Emits the created origin rule on the default channel.
 }
 ```
 
-<a id="create-kv-namespace"></a>
-
-## Create KV Namespace
-
-The Create KV Namespace component creates a new Cloudflare Workers KV namespace.
-
-### Use Cases
-
-- **Feature flags**: Provision a dedicated namespace to store feature flag state
-- **Session storage**: Create a namespace for application session data
-- **Configuration store**: Set up a namespace for dynamic configuration values
-
-### Configuration
-
-- **Title**: A human-readable name for the namespace (must be unique per account)
-
-### Output
-
-Returns the created namespace with its assigned ID and title.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
-    "namespace": {
-      "id": "0f2ac74b498b48028cb68387c421e279",
-      "supports_url_encoding": true,
-      "title": "my-kv-namespace"
-    }
-  },
-  "timestamp": "2026-05-05T06:54:57.198268018Z",
-  "type": "cloudflare.kv.namespace.created"
-}
-```
-
 <a id="delete-dns-record"></a>
 
 ## Delete DNS Record
@@ -215,44 +215,6 @@ Emits the deleted DNS record (zoneId, recordId, record) on the default channel. 
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
   "type": "cloudflare.dnsRecord"
-}
-```
-
-<a id="delete-origin-rule"></a>
-
-## Delete Origin Rule
-
-The Delete Origin Rule component removes a Cloudflare origin rule from a zone.
-
-### Configuration
-
-- **Rule**: Select the origin rule to delete
-
-### Output
-
-Emits the deleted origin rule on the default channel.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "rule": {
-      "action": "route",
-      "action_parameters": {
-        "origin": {
-          "host": "api-origin.example.com"
-        }
-      },
-      "description": "Route API requests",
-      "enabled": true,
-      "expression": "starts_with(http.request.uri.path, \"/api/\")",
-      "id": "rule123"
-    },
-    "zoneId": "zone123"
-  },
-  "timestamp": "2026-05-06T12:00:00Z",
-  "type": "cloudflare.deleteOriginRule"
 }
 ```
 
@@ -328,6 +290,44 @@ Emits a confirmation with the account ID, namespace ID, and key that was deleted
   },
   "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.kv.value.deleted"
+}
+```
+
+<a id="delete-origin-rule"></a>
+
+## Delete Origin Rule
+
+The Delete Origin Rule component removes a Cloudflare origin rule from a zone.
+
+### Configuration
+
+- **Rule**: Select the origin rule to delete
+
+### Output
+
+Emits the deleted origin rule on the default channel.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "rule": {
+      "action": "route",
+      "action_parameters": {
+        "origin": {
+          "host": "api-origin.example.com"
+        }
+      },
+      "description": "Route API requests",
+      "enabled": true,
+      "expression": "starts_with(http.request.uri.path, \"/api/\")",
+      "id": "rule123"
+    },
+    "zoneId": "zone123"
+  },
+  "timestamp": "2026-05-06T12:00:00Z",
+  "type": "cloudflare.deleteOriginRule"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -11,8 +11,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record in a Cloudflare zone" />
   <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
+  <LinkCard title="Create KV Namespace" href="#create-kv-namespace" description="Create a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
+  <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
+  <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
+  <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
+  <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Origin Rule" href="#update-origin-rule" description="Update an existing origin rule" />
   <LinkCard title="Update Redirect Rule" href="#update-redirect-rule" description="Update a redirect rule in a Cloudflare zone" />
@@ -29,9 +34,9 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
    - **Token name**: SuperPlane Integration
    - **Permissions** (click "+ Add more" to add each):
      - Zone / Zone / Read
-     - Zone / DNS / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
+	 - Account / Workers KV Storage / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
@@ -128,6 +133,43 @@ Emits the created origin rule on the default channel.
 }
 ```
 
+<a id="create-kv-namespace"></a>
+
+## Create KV Namespace
+
+The Create KV Namespace component creates a new Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Feature flags**: Provision a dedicated namespace to store feature flag state
+- **Session storage**: Create a namespace for application session data
+- **Configuration store**: Set up a namespace for dynamic configuration values
+
+### Configuration
+
+- **Title**: A human-readable name for the namespace (must be unique per account)
+
+### Output
+
+Returns the created namespace with its assigned ID and title.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespace": {
+      "id": "0f2ac74b498b48028cb68387c421e279",
+      "supports_url_encoding": true,
+      "title": "my-kv-namespace"
+    }
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.namespace.created"
+}
+```
+
 <a id="delete-dns-record"></a>
 
 ## Delete DNS Record
@@ -204,6 +246,155 @@ Emits the deleted origin rule on the default channel.
   },
   "timestamp": "2026-05-06T12:00:00Z",
   "type": "cloudflare.deleteOriginRule"
+}
+```
+
+<a id="delete-kv-namespace"></a>
+
+## Delete KV Namespace
+
+The Delete KV Namespace component permanently removes a Cloudflare Workers KV namespace and all of its key-value pairs.
+
+### Use Cases
+
+- **Environment teardown**: Remove namespaces as part of infrastructure cleanup
+- **Pipeline cleanup**: Delete temporary namespaces created during a workflow
+
+### Configuration
+
+- **Namespace**: The KV namespace to delete
+
+### Output
+
+Emits a confirmation with the account ID, namespace ID, and a deleted flag.
+
+> **Warning**: This operation is irreversible. All keys stored in the namespace will be permanently deleted.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "namespace": {
+      "id": "8cc7c421092f456389b23bac8c6b609c"
+    }
+  },
+  "timestamp": "2026-05-07T05:56:34.511115884Z",
+  "type": "cloudflare.kv.namespace.deleted"
+}
+```
+
+<a id="delete-kv-value"></a>
+
+## Delete KV Value
+
+The Delete KV Value component removes a key-value pair from a Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Cleanup**: Remove stale keys as part of a teardown workflow
+- **Feature flag rollback**: Delete a flag to revert to default behaviour
+- **Session invalidation**: Remove session keys to force re-authentication
+
+### Configuration
+
+- **Namespace**: The ID of the KV namespace to delete from
+- **Key**: The key to delete
+
+### Output
+
+Emits a confirmation with the account ID, namespace ID, and key that was deleted.
+
+> **Warning**: This operation is irreversible. The key and its value will be permanently removed.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "key": "my-key",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279"
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.deleted"
+}
+```
+
+<a id="get-kv-value"></a>
+
+## Get KV Value
+
+The Get KV Value component reads a value by key from a Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Feature flag checks**: Read a feature flag value before proceeding
+- **Configuration lookup**: Retrieve dynamic configuration at workflow runtime
+- **Audit**: Capture the current value of a key as part of a pipeline snapshot
+
+### Configuration
+
+- **Namespace**: The ID of the KV namespace to read from
+- **Key**: The key to retrieve
+
+### Output
+
+Returns the account ID, namespace ID, key, and the retrieved value string.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "key": "my-key",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "value": "my-value"
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.fetched"
+}
+```
+
+<a id="put-kv-value"></a>
+
+## Put KV Value
+
+The Put KV Value component writes a key-value pair to a Cloudflare Workers KV namespace.
+
+### Use Cases
+
+- **Feature flags**: Toggle features by writing flag values into KV storage
+- **Cache invalidation**: Store cache keys or version stamps
+- **Dynamic configuration**: Update runtime configuration values from a workflow
+
+### Configuration
+
+- **Namespace**: The ID of the KV namespace to write to
+- **Key**: The key name (up to 512 bytes, printable non-whitespace characters)
+- **Value**: The value to store (up to 25 MiB)
+- **Expiration TTL**: (Optional) Number of seconds until the key expires (minimum 60)
+
+### Output
+
+Emits a confirmation with the account ID, namespace ID, and key that was written.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "key": "my-key",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "written": true
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.put"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -41,6 +41,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
 
+## Account ID (optional)
+
+The Account ID is required for KV storage components.
+
+1. On the account overview page, click on the **ellipsis (...)** next to the **Add** button and select **Copy Account ID**
+2. Paste the Account ID below
+
 > **Note**: The token is only shown once. Store it securely if needed elsewhere.
 
 <a id="create-dns-record"></a>

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -34,6 +34,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
    - **Token name**: SuperPlane Integration
    - **Permissions** (click "+ Add more" to add each):
      - Zone / Zone / Read
+	 - Zone / DNS / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
 	 - Account / Workers KV Storage / Edit

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -712,7 +712,7 @@ func (c *Client) CreateKVNamespace(accountID string, req CreateKVNamespaceReques
 	}
 
 	if !kvResponse.Success {
-		return nil, fmt.Errorf("API returned success=false")
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return &kvResponse.Result, nil
@@ -737,7 +737,7 @@ func (c *Client) GetKVNamespace(accountID, namespaceID string) (*KVNamespace, er
 	}
 
 	if !response.Success {
-		return nil, fmt.Errorf("API returned success=false")
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return &response.Result, nil
@@ -792,7 +792,7 @@ func (c *Client) PutKVValue(accountID, namespaceID, key, value string, expiratio
 	}
 
 	if !response.Success {
-		return fmt.Errorf("API returned success=false")
+		return newCloudflareAPIError(res.StatusCode, responseBody)
 	}
 
 	return nil
@@ -846,7 +846,7 @@ func (c *Client) DeleteKVValue(accountID, namespaceID, key string) error {
 	}
 
 	if !deleteResponse.Success {
-		return fmt.Errorf("API returned success=false")
+		return newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return nil
@@ -876,7 +876,7 @@ func (c *Client) ListKVNamespaces(accountID string) ([]KVNamespace, error) {
 	}
 
 	if !response.Success {
-		return nil, fmt.Errorf("API returned success=false")
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return response.Result, nil
@@ -901,7 +901,7 @@ func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
 	}
 
 	if !response.Success {
-		return nil, fmt.Errorf("API returned success=false")
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return response.Result, nil
@@ -925,7 +925,7 @@ func (c *Client) DeleteKVNamespace(accountID, namespaceID string) error {
 	}
 
 	if !response.Success {
-		return fmt.Errorf("API returned success=false")
+		return newCloudflareAPIError(http.StatusOK, responseBody)
 	}
 
 	return nil

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 
 	"github.com/superplanehq/superplane/pkg/core"
@@ -670,4 +671,218 @@ func (c *Client) CreateDNSRecord(zoneID string, req CreateDNSRecordRequest) (*DN
 	}
 
 	return &response.Result, nil
+}
+
+// ---- Workers KV types ----
+
+// KVNamespace represents a Cloudflare Workers KV namespace
+type KVNamespace struct {
+	ID                  string `json:"id"`
+	Title               string `json:"title"`
+	SupportsURLEncoding *bool  `json:"supports_url_encoding,omitempty"`
+}
+
+// CreateKVNamespaceRequest is the payload for creating a KV namespace
+type CreateKVNamespaceRequest struct {
+	Title string `json:"title"`
+}
+
+// CreateKVNamespace creates a new Workers KV namespace under a Cloudflare account
+func (c *Client) CreateKVNamespace(accountID string, req CreateKVNamespaceRequest) (*KVNamespace, error) {
+	kvURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, kvURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var kvResponse struct {
+		Success bool        `json:"success"`
+		Result  KVNamespace `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &kvResponse); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !kvResponse.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &kvResponse.Result, nil
+}
+
+// GetKVNamespace retrieves a single Workers KV namespace by ID
+func (c *Client) GetKVNamespace(accountID, namespaceID string) (*KVNamespace, error) {
+	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s", c.BaseURL, accountID, namespaceID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Result KVNamespace `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &response.Result, nil
+}
+
+// PutKVValue writes a key-value pair to a Workers KV namespace using multipart/form-data
+func (c *Client) PutKVValue(accountID, namespaceID, key, value string, expirationTTL *int) error {
+	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+	if err := writer.WriteField("value", value); err != nil {
+		return fmt.Errorf("error writing value field: %v", err)
+	}
+	writer.Close()
+
+	req, err := http.NewRequest(http.MethodPut, rawURL, buf)
+	if err != nil {
+		return fmt.Errorf("error building request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+
+	if expirationTTL != nil {
+		q := req.URL.Query()
+		q.Set("expiration_ttl", fmt.Sprintf("%d", *expirationTTL))
+		req.URL.RawQuery = q.Encode()
+	}
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("error executing request: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("error reading body: %v", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return newCloudflareAPIError(res.StatusCode, responseBody)
+	}
+
+	return nil
+}
+
+// GetKVValue retrieves the value for a key from a Workers KV namespace.
+// The Cloudflare API returns the raw value as the response body (not a JSON envelope).
+func (c *Client) GetKVValue(accountID, namespaceID, key string) (string, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("error building request: %v", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error executing request: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading body: %v", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", newCloudflareAPIError(res.StatusCode, responseBody)
+	}
+
+	return string(responseBody), nil
+}
+
+// DeleteKVValue deletes a key-value pair from a Workers KV namespace
+func (c *Client) DeleteKVValue(accountID, namespaceID, key string) error {
+	kvURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+
+	responseBody, err := c.execRequest(http.MethodDelete, kvURL, nil)
+	if err != nil {
+		return err
+	}
+
+	var deleteResponse struct {
+		Success bool `json:"success"`
+	}
+
+	if err := json.Unmarshal(responseBody, &deleteResponse); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !deleteResponse.Success {
+		return fmt.Errorf("API returned success=false")
+	}
+
+	return nil
+}
+
+// KVKey represents a single key in a Workers KV namespace
+type KVKey struct {
+	Name string `json:"name"`
+}
+
+// ListKVNamespaces returns all Workers KV namespaces for an account
+func (c *Client) ListKVNamespaces(accountID string) ([]KVNamespace, error) {
+	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces?per_page=100", c.BaseURL, accountID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Result []KVNamespace `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return response.Result, nil
+}
+
+// ListKVKeys returns all keys in a Workers KV namespace
+func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
+	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/keys?limit=1000", c.BaseURL, accountID, namespaceID)
+
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Result []KVKey `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return response.Result, nil
+}
+
+// DeleteKVNamespace deletes a Workers KV namespace
+func (c *Client) DeleteKVNamespace(accountID, namespaceID string) error {
+	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s", c.BaseURL, accountID, namespaceID)
+
+	_, err := c.execRequest(http.MethodDelete, url, nil)
+	return err
 }

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -739,7 +740,7 @@ func (c *Client) GetKVNamespace(accountID, namespaceID string) (*KVNamespace, er
 
 // PutKVValue writes a key-value pair to a Workers KV namespace using multipart/form-data
 func (c *Client) PutKVValue(accountID, namespaceID, key, value string, expirationTTL *int) error {
-	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, url.PathEscape(key))
 
 	buf := &bytes.Buffer{}
 	writer := multipart.NewWriter(buf)
@@ -783,7 +784,7 @@ func (c *Client) PutKVValue(accountID, namespaceID, key, value string, expiratio
 // GetKVValue retrieves the value for a key from a Workers KV namespace.
 // The Cloudflare API returns the raw value as the response body (not a JSON envelope).
 func (c *Client) GetKVValue(accountID, namespaceID, key string) (string, error) {
-	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+	rawURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, url.PathEscape(key))
 
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
 	if err != nil {
@@ -812,7 +813,7 @@ func (c *Client) GetKVValue(accountID, namespaceID, key string) (string, error) 
 
 // DeleteKVValue deletes a key-value pair from a Workers KV namespace
 func (c *Client) DeleteKVValue(accountID, namespaceID, key string) error {
-	kvURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, key)
+	kvURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/values/%s", c.BaseURL, accountID, namespaceID, url.PathEscape(key))
 
 	responseBody, err := c.execRequest(http.MethodDelete, kvURL, nil)
 	if err != nil {

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -859,52 +859,90 @@ type KVKey struct {
 
 // ListKVNamespaces returns all Workers KV namespaces for an account
 func (c *Client) ListKVNamespaces(accountID string) ([]KVNamespace, error) {
-	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces?per_page=100", c.BaseURL, accountID)
+	var all []KVNamespace
+	cursor := ""
 
-	responseBody, err := c.execRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
+	for {
+		pageURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces?per_page=100", c.BaseURL, accountID)
+		if cursor != "" {
+			pageURL += "&cursor=" + cursor
+		}
+
+		responseBody, err := c.execRequest(http.MethodGet, pageURL, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var response struct {
+			Success    bool          `json:"success"`
+			Result     []KVNamespace `json:"result"`
+			ResultInfo struct {
+				Cursor string `json:"cursor"`
+			} `json:"result_info"`
+		}
+
+		if err := json.Unmarshal(responseBody, &response); err != nil {
+			return nil, fmt.Errorf("error parsing response: %v", err)
+		}
+
+		if !response.Success {
+			return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+		}
+
+		all = append(all, response.Result...)
+
+		if response.ResultInfo.Cursor == "" {
+			break
+		}
+
+		cursor = response.ResultInfo.Cursor
 	}
 
-	var response struct {
-		Success bool          `json:"success"`
-		Result  []KVNamespace `json:"result"`
-	}
-
-	if err := json.Unmarshal(responseBody, &response); err != nil {
-		return nil, fmt.Errorf("error parsing response: %v", err)
-	}
-
-	if !response.Success {
-		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
-	}
-
-	return response.Result, nil
+	return all, nil
 }
 
 // ListKVKeys returns all keys in a Workers KV namespace
 func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
-	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/keys?limit=1000", c.BaseURL, accountID, namespaceID)
+	var all []KVKey
+	cursor := ""
 
-	responseBody, err := c.execRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
+	for {
+		pageURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/keys?limit=1000", c.BaseURL, accountID, namespaceID)
+		if cursor != "" {
+			pageURL += "&cursor=" + cursor
+		}
+
+		responseBody, err := c.execRequest(http.MethodGet, pageURL, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var response struct {
+			Success    bool    `json:"success"`
+			Result     []KVKey `json:"result"`
+			ResultInfo struct {
+				Cursor string `json:"cursor"`
+			} `json:"result_info"`
+		}
+
+		if err := json.Unmarshal(responseBody, &response); err != nil {
+			return nil, fmt.Errorf("error parsing response: %v", err)
+		}
+
+		if !response.Success {
+			return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+		}
+
+		all = append(all, response.Result...)
+
+		if response.ResultInfo.Cursor == "" {
+			break
+		}
+
+		cursor = response.ResultInfo.Cursor
 	}
 
-	var response struct {
-		Success bool    `json:"success"`
-		Result  []KVKey `json:"result"`
-	}
-
-	if err := json.Unmarshal(responseBody, &response); err != nil {
-		return nil, fmt.Errorf("error parsing response: %v", err)
-	}
-
-	if !response.Success {
-		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
-	}
-
-	return response.Result, nil
+	return all, nil
 }
 
 // DeleteKVNamespace deletes a Workers KV namespace

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -783,6 +783,18 @@ func (c *Client) PutKVValue(accountID, namespaceID, key, value string, expiratio
 		return newCloudflareAPIError(res.StatusCode, responseBody)
 	}
 
+	var response struct {
+		Success bool `json:"success"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API returned success=false")
+	}
+
 	return nil
 }
 

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -865,7 +865,7 @@ func (c *Client) ListKVNamespaces(accountID string) ([]KVNamespace, error) {
 	for {
 		pageURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces?per_page=100", c.BaseURL, accountID)
 		if cursor != "" {
-			pageURL += "&cursor=" + cursor
+			pageURL += "&cursor=" + url.QueryEscape(cursor)
 		}
 
 		responseBody, err := c.execRequest(http.MethodGet, pageURL, nil)
@@ -909,7 +909,7 @@ func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
 	for {
 		pageURL := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s/keys?limit=1000", c.BaseURL, accountID, namespaceID)
 		if cursor != "" {
-			pageURL += "&cursor=" + cursor
+			pageURL += "&cursor=" + url.QueryEscape(cursor)
 		}
 
 		responseBody, err := c.execRequest(http.MethodGet, pageURL, nil)

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -728,11 +728,16 @@ func (c *Client) GetKVNamespace(accountID, namespaceID string) (*KVNamespace, er
 	}
 
 	var response struct {
-		Result KVNamespace `json:"result"`
+		Success bool        `json:"success"`
+		Result  KVNamespace `json:"result"`
 	}
 
 	if err := json.Unmarshal(responseBody, &response); err != nil {
 		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
 	}
 
 	return &response.Result, nil
@@ -850,11 +855,16 @@ func (c *Client) ListKVNamespaces(accountID string) ([]KVNamespace, error) {
 	}
 
 	var response struct {
-		Result []KVNamespace `json:"result"`
+		Success bool          `json:"success"`
+		Result  []KVNamespace `json:"result"`
 	}
 
 	if err := json.Unmarshal(responseBody, &response); err != nil {
 		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
 	}
 
 	return response.Result, nil
@@ -870,11 +880,16 @@ func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
 	}
 
 	var response struct {
-		Result []KVKey `json:"result"`
+		Success bool    `json:"success"`
+		Result  []KVKey `json:"result"`
 	}
 
 	if err := json.Unmarshal(responseBody, &response); err != nil {
 		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
 	}
 
 	return response.Result, nil
@@ -884,6 +899,22 @@ func (c *Client) ListKVKeys(accountID, namespaceID string) ([]KVKey, error) {
 func (c *Client) DeleteKVNamespace(accountID, namespaceID string) error {
 	url := fmt.Sprintf("%s/accounts/%s/storage/kv/namespaces/%s", c.BaseURL, accountID, namespaceID)
 
-	_, err := c.execRequest(http.MethodDelete, url, nil)
-	return err
+	responseBody, err := c.execRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API returned success=false")
+	}
+
+	return nil
 }

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -16,11 +17,49 @@ func init() {
 type Cloudflare struct{}
 
 type Configuration struct {
-	APIToken string `json:"apiToken"`
+	APIToken  string `json:"apiToken"`
+	AccountID string `json:"accountId"`
 }
 
 type Metadata struct {
-	Zones []Zone `json:"zones"`
+	Zones     []Zone `json:"zones"`
+	AccountID string `json:"accountId"`
+}
+
+type KVNodeMetadata struct {
+	NamespaceName string `json:"namespaceName"`
+	KeyName       string `json:"keyName"`
+}
+
+func resolveKVNamespaceMetadata(ctx core.SetupContext, accountID, namespaceID string) (string, error) {
+	if strings.Contains(namespaceID, "{{") {
+		return namespaceID, nil
+	}
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return "", fmt.Errorf("failed to create client: %w", err)
+	}
+	ns, err := client.GetKVNamespace(accountID, namespaceID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get KV namespace: %w", err)
+	}
+	return ns.Title, nil
+}
+
+func accountIDFromIntegration(ctx core.IntegrationContext) string {
+	if ctx == nil {
+		return ""
+	}
+	metadata := Metadata{}
+	mapstructure.Decode(ctx.GetMetadata(), &metadata)
+	return metadata.AccountID
+}
+
+func resolveAccountID(specAccountID string, integration core.IntegrationContext) string {
+	if specAccountID != "" {
+		return specAccountID
+	}
+	return accountIDFromIntegration(integration)
 }
 
 func (c *Cloudflare) Name() string {
@@ -49,9 +88,9 @@ func (c *Cloudflare) Instructions() string {
    - **Token name**: SuperPlane Integration
    - **Permissions** (click "+ Add more" to add each):
      - Zone / Zone / Read
-     - Zone / DNS / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
+	 - Account / Workers KV Storage / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
@@ -69,6 +108,14 @@ func (c *Cloudflare) Configuration() []configuration.Field {
 			Sensitive:   true,
 			Description: "Cloudflare API Token with appropriate permissions",
 		},
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Cloudflare account ID. Required for workers, pool and monitor components. Find it in the Cloudflare home page under actions for the account.",
+			Placeholder: "e.g. 01a7362d577a6c3019a474fd6f485823",
+		},
 	}
 }
 
@@ -81,6 +128,11 @@ func (c *Cloudflare) Actions() []core.Action {
 		&UpdateDNSRecord{},
 		&DeleteDNSRecord{},
 		&DeleteOriginRule{},
+		&CreateKVNamespace{},
+		&PutKVValue{},
+		&GetKVValue{},
+		&DeleteKVValue{},
+		&DeleteKVNamespace{},
 	}
 }
 
@@ -109,7 +161,7 @@ func (c *Cloudflare) Sync(ctx core.SyncContext) error {
 		return fmt.Errorf("error listing zones: %v", err)
 	}
 
-	ctx.Integration.SetMetadata(Metadata{Zones: zones})
+	ctx.Integration.SetMetadata(Metadata{Zones: zones, AccountID: configuration.AccountID})
 	ctx.Integration.Ready()
 	return nil
 }
@@ -224,6 +276,65 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 			}
 		}
 		return resources, nil
+
+	case "namespace":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
+		if accountID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		namespaces, err := client.ListKVNamespaces(accountID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing KV namespaces: %w", err)
+		}
+
+		var nsResources []core.IntegrationResource
+		for _, ns := range namespaces {
+			nsResources = append(nsResources, core.IntegrationResource{
+				Type: resourceType,
+				Name: ns.Title,
+				ID:   ns.ID,
+			})
+		}
+		return nsResources, nil
+
+	case "kv_key":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
+		namespaceID := ctx.Parameters["namespace"]
+		if accountID == "" || namespaceID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		keys, err := client.ListKVKeys(accountID, namespaceID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing KV keys: %w", err)
+		}
+
+		var keyResources []core.IntegrationResource
+		for _, key := range keys {
+			keyResources = append(keyResources, core.IntegrationResource{
+				Type: resourceType,
+				Name: key.Name,
+				ID:   key.Name,
+			})
+		}
+		return keyResources, nil
 
 	default:
 		return []core.IntegrationResource{}, nil

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -32,7 +32,7 @@ type KVNodeMetadata struct {
 }
 
 func resolveKVNamespaceMetadata(ctx core.SetupContext, accountID, namespaceID string) (string, error) {
-	if strings.Contains(namespaceID, "{{") {
+	if strings.Contains(namespaceID, "{{") || strings.Contains(accountID, "{{") {
 		return namespaceID, nil
 	}
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -88,6 +88,7 @@ func (c *Cloudflare) Instructions() string {
    - **Token name**: SuperPlane Integration
    - **Permissions** (click "+ Add more" to add each):
      - Zone / Zone / Read
+	 - Zone / DNS / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
 	 - Account / Workers KV Storage / Edit

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -95,6 +95,13 @@ func (c *Cloudflare) Instructions() string {
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
 
+## Account ID (optional)
+
+The Account ID is required for KV storage components.
+
+1. On the account overview page, click on the **ellipsis (...)** next to the **Add** button and select **Copy Account ID**
+2. Paste the Account ID below
+
 > **Note**: The token is only shown once. Store it securely if needed elsewhere.`
 }
 
@@ -113,7 +120,7 @@ func (c *Cloudflare) Configuration() []configuration.Field {
 			Label:       "Account ID",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Cloudflare account ID. Required for workers, pool and monitor components. Find it in the Cloudflare home page under actions for the account.",
+			Description: "Cloudflare account ID.",
 			Placeholder: "e.g. 01a7362d577a6c3019a474fd6f485823",
 		},
 	}

--- a/pkg/integrations/cloudflare/create_kv_namespace.go
+++ b/pkg/integrations/cloudflare/create_kv_namespace.go
@@ -1,0 +1,153 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CreateKVNamespace struct{}
+
+type KVNamespaceNodeMetadata struct {
+	Title string `json:"title"`
+}
+
+type CreateKVNamespaceSpec struct {
+	AccountID string `json:"accountId"`
+	Title     string `json:"title"`
+}
+
+func (c *CreateKVNamespace) Name() string {
+	return "cloudflare.createKVNamespace"
+}
+
+func (c *CreateKVNamespace) Label() string {
+	return "Create KV Namespace"
+}
+
+func (c *CreateKVNamespace) Description() string {
+	return "Create a Cloudflare Workers KV namespace"
+}
+
+func (c *CreateKVNamespace) Documentation() string {
+	return `The Create KV Namespace component creates a new Cloudflare Workers KV namespace.
+
+## Use Cases
+
+- **Feature flags**: Provision a dedicated namespace to store feature flag state
+- **Session storage**: Create a namespace for application session data
+- **Configuration store**: Set up a namespace for dynamic configuration values
+
+## Configuration
+
+- **Title**: A human-readable name for the namespace (must be unique per account)
+
+## Output
+
+Returns the created namespace with its assigned ID and title.`
+}
+
+func (c *CreateKVNamespace) Icon() string {
+	return "cloud"
+}
+
+func (c *CreateKVNamespace) Color() string {
+	return "orange"
+}
+
+func (c *CreateKVNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateKVNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "title",
+			Label:       "Namespace Title",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "A human-readable name for the KV namespace. Must be unique within the account.",
+			Placeholder: "my-kv-namespace",
+		},
+	}
+}
+
+func (c *CreateKVNamespace) Setup(ctx core.SetupContext) error {
+	spec := CreateKVNamespaceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Title == "" {
+		return errors.New("title is required")
+	}
+
+	return nil
+}
+
+func (c *CreateKVNamespace) Execute(ctx core.ExecutionContext) error {
+	spec := CreateKVNamespaceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	ns, err := client.CreateKVNamespace(accountID, CreateKVNamespaceRequest{Title: spec.Title})
+	if err != nil {
+		return fmt.Errorf("failed to create KV namespace: %v", err)
+	}
+
+	result := map[string]any{
+		"namespace": ns,
+		"accountId": accountID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.kv.namespace.created",
+		[]any{result},
+	)
+}
+
+func (c *CreateKVNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateKVNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateKVNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateKVNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateKVNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateKVNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/create_kv_namespace.go
+++ b/pkg/integrations/cloudflare/create_kv_namespace.go
@@ -13,10 +13,6 @@ import (
 
 type CreateKVNamespace struct{}
 
-type KVNamespaceNodeMetadata struct {
-	Title string `json:"title"`
-}
-
 type CreateKVNamespaceSpec struct {
 	AccountID string `json:"accountId"`
 	Title     string `json:"title"`

--- a/pkg/integrations/cloudflare/create_kv_namespace_test.go
+++ b/pkg/integrations/cloudflare/create_kv_namespace_test.go
@@ -1,0 +1,157 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateKVNamespace__Setup(t *testing.T) {
+	component := &CreateKVNamespace{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"title":     "my-namespace",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing title returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"title":     "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "title is required")
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"title": "my-namespace",
+			},
+			Integration: &contexts.IntegrationContext{
+				Metadata: Metadata{AccountID: "acc-from-integration"},
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"title":     "my-namespace",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateKVNamespace__Execute(t *testing.T) {
+	component := &CreateKVNamespace{}
+
+	t.Run("successful create emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "ns123",
+							"title": "my-namespace",
+							"supports_url_encoding": true
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"title":     "my-namespace",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.kv.namespace.created", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/storage/kv/namespaces", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusBadRequest,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Namespace title already exists"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"title":     "my-namespace",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create KV namespace")
+	})
+}

--- a/pkg/integrations/cloudflare/delete_kv_namespace.go
+++ b/pkg/integrations/cloudflare/delete_kv_namespace.go
@@ -1,0 +1,174 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteKVNamespace struct{}
+
+type DeleteKVNamespaceSpec struct {
+	AccountID string `json:"accountId"`
+	Namespace string `json:"namespace"`
+}
+
+func (c *DeleteKVNamespace) Name() string {
+	return "cloudflare.deleteKVNamespace"
+}
+
+func (c *DeleteKVNamespace) Label() string {
+	return "Delete KV Namespace"
+}
+
+func (c *DeleteKVNamespace) Description() string {
+	return "Delete a Cloudflare Workers KV namespace"
+}
+
+func (c *DeleteKVNamespace) Documentation() string {
+	return `The Delete KV Namespace component permanently removes a Cloudflare Workers KV namespace and all of its key-value pairs.
+
+## Use Cases
+
+- **Environment teardown**: Remove namespaces as part of infrastructure cleanup
+- **Pipeline cleanup**: Delete temporary namespaces created during a workflow
+
+## Configuration
+
+- **Namespace**: The KV namespace to delete
+
+## Output
+
+Emits a confirmation with the account ID, namespace ID, and a deleted flag.
+
+> **Warning**: This operation is irreversible. All keys stored in the namespace will be permanently deleted.`
+}
+
+func (c *DeleteKVNamespace) Icon() string {
+	return "cloud"
+}
+
+func (c *DeleteKVNamespace) Color() string {
+	return "orange"
+}
+
+func (c *DeleteKVNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteKVNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The KV namespace to delete",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "namespace",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *DeleteKVNamespace) Setup(ctx core.SetupContext) error {
+	spec := DeleteKVNamespaceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	namespaceName, err := resolveKVNamespaceMetadata(ctx, accountID, spec.Namespace)
+	if err != nil {
+		return err
+	}
+	return ctx.Metadata.Set(KVNodeMetadata{NamespaceName: namespaceName})
+}
+
+func (c *DeleteKVNamespace) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteKVNamespaceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.DeleteKVNamespace(accountID, spec.Namespace); err != nil {
+		return fmt.Errorf("failed to delete KV namespace: %v", err)
+	}
+
+	namespaceName := ""
+	if ctx.NodeMetadata != nil {
+		meta := KVNodeMetadata{}
+		mapstructure.Decode(ctx.NodeMetadata.Get(), &meta)
+		namespaceName = meta.NamespaceName
+	}
+
+	result := map[string]any{
+		"accountId": accountID,
+		"namespace": map[string]any{
+			"id":    spec.Namespace,
+			"title": namespaceName,
+		},
+		"deleted": true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.kv.namespace.deleted",
+		[]any{result},
+	)
+}
+
+func (c *DeleteKVNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteKVNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteKVNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteKVNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteKVNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteKVNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/delete_kv_namespace_test.go
+++ b/pkg/integrations/cloudflare/delete_kv_namespace_test.go
@@ -1,0 +1,175 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteKVNamespace__Setup(t *testing.T) {
+	component := &DeleteKVNamespace{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"namespace": "ns123",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing namespaceId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"namespace": "ns123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+				Metadata:      Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves namespace name", func(t *testing.T) {
+		metaCtx := &contexts.MetadataContext{}
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: metaCtx,
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+		kvMeta, ok := metaCtx.Metadata.(KVNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "My Namespace", kvMeta.NamespaceName)
+	})
+}
+
+func Test__DeleteKVNamespace__Execute(t *testing.T) {
+	component := &DeleteKVNamespace{}
+
+	t.Run("successful delete emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": null}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.kv.namespace.deleted", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/storage/kv/namespaces/ns123", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "namespace not found"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete KV namespace")
+	})
+}

--- a/pkg/integrations/cloudflare/delete_kv_value.go
+++ b/pkg/integrations/cloudflare/delete_kv_value.go
@@ -1,0 +1,199 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteKVValue struct{}
+
+type DeleteKVValueSpec struct {
+	AccountID string `json:"accountId"`
+	Namespace string `json:"namespace"`
+	KVKey     string `json:"kvKey"`
+}
+
+func (c *DeleteKVValue) Name() string {
+	return "cloudflare.deleteKVValue"
+}
+
+func (c *DeleteKVValue) Label() string {
+	return "Delete KV Value"
+}
+
+func (c *DeleteKVValue) Description() string {
+	return "Delete a key from a Cloudflare Workers KV namespace"
+}
+
+func (c *DeleteKVValue) Documentation() string {
+	return `The Delete KV Value component removes a key-value pair from a Cloudflare Workers KV namespace.
+
+## Use Cases
+
+- **Cleanup**: Remove stale keys as part of a teardown workflow
+- **Feature flag rollback**: Delete a flag to revert to default behaviour
+- **Session invalidation**: Remove session keys to force re-authentication
+
+## Configuration
+
+- **Namespace**: The ID of the KV namespace to delete from
+- **Key**: The key to delete
+
+## Output
+
+Emits a confirmation with the account ID, namespace ID, and key that was deleted.
+
+> **Warning**: This operation is irreversible. The key and its value will be permanently removed.`
+}
+
+func (c *DeleteKVValue) Icon() string {
+	return "cloud"
+}
+
+func (c *DeleteKVValue) Color() string {
+	return "orange"
+}
+
+func (c *DeleteKVValue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteKVValue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The KV namespace to delete from",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "namespace",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "kvKey",
+			Label:       "Key",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The key to delete",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "kv_key",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "namespace",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "namespace"},
+						},
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "namespace", Values: []string{"*"}},
+			},
+		},
+	}
+}
+
+func (c *DeleteKVValue) Setup(ctx core.SetupContext) error {
+	spec := DeleteKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if spec.KVKey == "" {
+		return errors.New("key is required")
+	}
+
+	meta := KVNodeMetadata{KeyName: spec.KVKey}
+	namespaceName, err := resolveKVNamespaceMetadata(ctx, accountID, spec.Namespace)
+	if err != nil {
+		return err
+	}
+	meta.NamespaceName = namespaceName
+	return ctx.Metadata.Set(meta)
+}
+
+func (c *DeleteKVValue) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.DeleteKVValue(accountID, spec.Namespace, spec.KVKey); err != nil {
+		return fmt.Errorf("failed to delete KV value: %v", err)
+	}
+
+	result := map[string]any{
+		"accountId":   accountID,
+		"namespaceId": spec.Namespace,
+		"key":         spec.KVKey,
+		"deleted":     true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.kv.value.deleted",
+		[]any{result},
+	)
+}
+
+func (c *DeleteKVValue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteKVValue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteKVValue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteKVValue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteKVValue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteKVValue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/delete_kv_value_test.go
+++ b/pkg/integrations/cloudflare/delete_kv_value_test.go
@@ -1,0 +1,196 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteKVValue__Setup(t *testing.T) {
+	component := &DeleteKVValue{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing namespaceId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "",
+				"kvKey":     "my-key",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("missing key returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "key is required")
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+				Metadata:      Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves namespace name", func(t *testing.T) {
+		metaCtx := &contexts.MetadataContext{}
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: metaCtx,
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+		kvMeta, ok := metaCtx.Metadata.(KVNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "My Namespace", kvMeta.NamespaceName)
+		assert.Equal(t, "my-key", kvMeta.KeyName)
+	})
+}
+
+func Test__DeleteKVValue__Execute(t *testing.T) {
+	component := &DeleteKVValue{}
+
+	t.Run("successful delete emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {}}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.kv.value.deleted", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/storage/kv/namespaces/ns123/values/my-key", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Unauthorized"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete KV value")
+	})
+}

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -46,3 +46,53 @@ var exampleOutputDeleteDNSRecord map[string]any
 func (c *DeleteDNSRecord) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteDNSRecordOnce, exampleOutputDeleteDNSRecordBytes, &exampleOutputDeleteDNSRecord)
 }
+
+//go:embed example_output_create_kv_namespace.json
+var exampleOutputCreateKVNamespaceBytes []byte
+
+var exampleOutputCreateKVNamespaceOnce sync.Once
+var exampleOutputCreateKVNamespace map[string]any
+
+func (c *CreateKVNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateKVNamespaceOnce, exampleOutputCreateKVNamespaceBytes, &exampleOutputCreateKVNamespace)
+}
+
+//go:embed example_output_put_kv_value.json
+var exampleOutputPutKVValueBytes []byte
+
+var exampleOutputPutKVValueOnce sync.Once
+var exampleOutputPutKVValue map[string]any
+
+func (c *PutKVValue) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputPutKVValueOnce, exampleOutputPutKVValueBytes, &exampleOutputPutKVValue)
+}
+
+//go:embed example_output_get_kv_value.json
+var exampleOutputGetKVValueBytes []byte
+
+var exampleOutputGetKVValueOnce sync.Once
+var exampleOutputGetKVValue map[string]any
+
+func (c *GetKVValue) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetKVValueOnce, exampleOutputGetKVValueBytes, &exampleOutputGetKVValue)
+}
+
+//go:embed example_output_delete_kv_value.json
+var exampleOutputDeleteKVValueBytes []byte
+
+var exampleOutputDeleteKVValueOnce sync.Once
+var exampleOutputDeleteKVValue map[string]any
+
+func (c *DeleteKVValue) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteKVValueOnce, exampleOutputDeleteKVValueBytes, &exampleOutputDeleteKVValue)
+}
+
+//go:embed example_output_delete_kv_namespace.json
+var exampleOutputDeleteKVNamespaceBytes []byte
+
+var exampleOutputDeleteKVNamespaceOnce sync.Once
+var exampleOutputDeleteKVNamespace map[string]any
+
+func (c *DeleteKVNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteKVNamespaceOnce, exampleOutputDeleteKVNamespaceBytes, &exampleOutputDeleteKVNamespace)
+}

--- a/pkg/integrations/cloudflare/example_output_create_kv_namespace.json
+++ b/pkg/integrations/cloudflare/example_output_create_kv_namespace.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespace": {
+      "id": "0f2ac74b498b48028cb68387c421e279",
+      "title": "my-kv-namespace",
+      "supports_url_encoding": true
+    }
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.namespace.created"
+}

--- a/pkg/integrations/cloudflare/example_output_delete_kv_namespace.json
+++ b/pkg/integrations/cloudflare/example_output_delete_kv_namespace.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "namespace": {
+      "id": "8cc7c421092f456389b23bac8c6b609c"
+    }
+  },
+  "timestamp": "2026-05-07T05:56:34.511115884Z",
+  "type": "cloudflare.kv.namespace.deleted"
+}

--- a/pkg/integrations/cloudflare/example_output_delete_kv_value.json
+++ b/pkg/integrations/cloudflare/example_output_delete_kv_value.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "key": "my-key",
+    "deleted": true
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.deleted"
+}

--- a/pkg/integrations/cloudflare/example_output_get_kv_value.json
+++ b/pkg/integrations/cloudflare/example_output_get_kv_value.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "key": "my-key",
+    "value": "my-value"
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.fetched"
+}

--- a/pkg/integrations/cloudflare/example_output_put_kv_value.json
+++ b/pkg/integrations/cloudflare/example_output_put_kv_value.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "namespaceId": "0f2ac74b498b48028cb68387c421e279",
+    "key": "my-key",
+    "written": true
+  },
+  "timestamp": "2026-05-05T06:54:57.198268018Z",
+  "type": "cloudflare.kv.value.put"
+}

--- a/pkg/integrations/cloudflare/get_kv_value.go
+++ b/pkg/integrations/cloudflare/get_kv_value.go
@@ -1,0 +1,198 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetKVValue struct{}
+
+type GetKVValueSpec struct {
+	AccountID string `json:"accountId"`
+	Namespace string `json:"namespace"`
+	KVKey     string `json:"kvKey"`
+}
+
+func (c *GetKVValue) Name() string {
+	return "cloudflare.getKVValue"
+}
+
+func (c *GetKVValue) Label() string {
+	return "Get KV Value"
+}
+
+func (c *GetKVValue) Description() string {
+	return "Read a value by key from a Cloudflare Workers KV namespace"
+}
+
+func (c *GetKVValue) Documentation() string {
+	return `The Get KV Value component reads a value by key from a Cloudflare Workers KV namespace.
+
+## Use Cases
+
+- **Feature flag checks**: Read a feature flag value before proceeding
+- **Configuration lookup**: Retrieve dynamic configuration at workflow runtime
+- **Audit**: Capture the current value of a key as part of a pipeline snapshot
+
+## Configuration
+
+- **Namespace**: The ID of the KV namespace to read from
+- **Key**: The key to retrieve
+
+## Output
+
+Returns the account ID, namespace ID, key, and the retrieved value string.`
+}
+
+func (c *GetKVValue) Icon() string {
+	return "cloud"
+}
+
+func (c *GetKVValue) Color() string {
+	return "orange"
+}
+
+func (c *GetKVValue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetKVValue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The KV namespace to read from",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "namespace",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "kvKey",
+			Label:       "Key",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The key to retrieve",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "kv_key",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "namespace",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "namespace"},
+						},
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "namespace", Values: []string{"*"}},
+			},
+		},
+	}
+}
+
+func (c *GetKVValue) Setup(ctx core.SetupContext) error {
+	spec := GetKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if spec.KVKey == "" {
+		return errors.New("key is required")
+	}
+
+	meta := KVNodeMetadata{KeyName: spec.KVKey}
+	namespaceName, err := resolveKVNamespaceMetadata(ctx, accountID, spec.Namespace)
+	if err != nil {
+		return err
+	}
+	meta.NamespaceName = namespaceName
+	return ctx.Metadata.Set(meta)
+}
+
+func (c *GetKVValue) Execute(ctx core.ExecutionContext) error {
+	spec := GetKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	value, err := client.GetKVValue(accountID, spec.Namespace, spec.KVKey)
+	if err != nil {
+		return fmt.Errorf("failed to get KV value: %v", err)
+	}
+
+	result := map[string]any{
+		"accountId":   accountID,
+		"namespaceId": spec.Namespace,
+		"key":         spec.KVKey,
+		"value":       value,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.kv.value.fetched",
+		[]any{result},
+	)
+}
+
+func (c *GetKVValue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetKVValue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetKVValue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetKVValue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetKVValue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetKVValue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/get_kv_value_test.go
+++ b/pkg/integrations/cloudflare/get_kv_value_test.go
@@ -1,0 +1,200 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetKVValue__Setup(t *testing.T) {
+	component := &GetKVValue{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing namespaceId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "",
+				"kvKey":     "my-key",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("missing key returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "key is required")
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+				Metadata:      Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves namespace name", func(t *testing.T) {
+		metaCtx := &contexts.MetadataContext{}
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: metaCtx,
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+		kvMeta, ok := metaCtx.Metadata.(KVNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "My Namespace", kvMeta.NamespaceName)
+		assert.Equal(t, "my-key", kvMeta.KeyName)
+	})
+}
+
+func Test__GetKVValue__Execute(t *testing.T) {
+	component := &GetKVValue{}
+
+	t.Run("successful get emits result with value", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`my-value`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.kv.value.fetched", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		wrapped := execState.Payloads[0].(map[string]any)
+		result := wrapped["data"].(map[string]any)
+		assert.Equal(t, "my-value", result["value"])
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/storage/kv/namespaces/ns123/values/my-key", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "key not found"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"kvKey":     "my-key",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get KV value")
+	})
+}

--- a/pkg/integrations/cloudflare/put_kv_value.go
+++ b/pkg/integrations/cloudflare/put_kv_value.go
@@ -108,6 +108,11 @@ func (c *PutKVValue) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeNumber,
 			Required:    false,
 			Description: "Number of seconds until the key expires. Must be at least 60. Leave empty for no expiration.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := 60; return &min }(),
+				},
+			},
 		},
 	}
 }

--- a/pkg/integrations/cloudflare/put_kv_value.go
+++ b/pkg/integrations/cloudflare/put_kv_value.go
@@ -1,0 +1,203 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type PutKVValue struct{}
+
+type PutKVValueSpec struct {
+	AccountID     string `json:"accountId"`
+	Namespace     string `json:"namespace"`
+	Key           string `json:"key"`
+	Value         string `json:"value"`
+	ExpirationTTL *int   `json:"expirationTtl"`
+}
+
+func (c *PutKVValue) Name() string {
+	return "cloudflare.putKVValue"
+}
+
+func (c *PutKVValue) Label() string {
+	return "Put KV Value"
+}
+
+func (c *PutKVValue) Description() string {
+	return "Write a key-value pair to a Cloudflare Workers KV namespace"
+}
+
+func (c *PutKVValue) Documentation() string {
+	return `The Put KV Value component writes a key-value pair to a Cloudflare Workers KV namespace.
+
+## Use Cases
+
+- **Feature flags**: Toggle features by writing flag values into KV storage
+- **Cache invalidation**: Store cache keys or version stamps
+- **Dynamic configuration**: Update runtime configuration values from a workflow
+
+## Configuration
+
+- **Namespace**: The ID of the KV namespace to write to
+- **Key**: The key name (up to 512 bytes, printable non-whitespace characters)
+- **Value**: The value to store (up to 25 MiB)
+- **Expiration TTL**: (Optional) Number of seconds until the key expires (minimum 60)
+
+## Output
+
+Emits a confirmation with the account ID, namespace ID, and key that was written.`
+}
+
+func (c *PutKVValue) Icon() string {
+	return "cloud"
+}
+
+func (c *PutKVValue) Color() string {
+	return "orange"
+}
+
+func (c *PutKVValue) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *PutKVValue) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "namespace",
+			Label:       "Namespace",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The KV namespace to write to",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "namespace",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "key",
+			Label:       "Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The key name to write (up to 512 bytes, printable non-whitespace characters)",
+			Placeholder: "my-key",
+		},
+		{
+			Name:        "value",
+			Label:       "Value",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The value to store (up to 25 MiB)",
+			Placeholder: "my-value",
+		},
+		{
+			Name:        "expirationTtl",
+			Label:       "Expiration TTL (seconds)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Description: "Number of seconds until the key expires. Must be at least 60. Leave empty for no expiration.",
+		},
+	}
+}
+
+func (c *PutKVValue) Setup(ctx core.SetupContext) error {
+	spec := PutKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if spec.Key == "" {
+		return errors.New("key is required")
+	}
+
+	if spec.Value == "" {
+		return errors.New("value is required")
+	}
+
+	meta := KVNodeMetadata{KeyName: spec.Key}
+	namespaceName, err := resolveKVNamespaceMetadata(ctx, accountID, spec.Namespace)
+	if err != nil {
+		return err
+	}
+	meta.NamespaceName = namespaceName
+	return ctx.Metadata.Set(meta)
+}
+
+func (c *PutKVValue) Execute(ctx core.ExecutionContext) error {
+	spec := PutKVValueSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.PutKVValue(accountID, spec.Namespace, spec.Key, spec.Value, spec.ExpirationTTL); err != nil {
+		return fmt.Errorf("failed to put KV value: %v", err)
+	}
+
+	result := map[string]any{
+		"accountId":   accountID,
+		"namespaceId": spec.Namespace,
+		"key":         spec.Key,
+		"written":     true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.kv.value.put",
+		[]any{result},
+	)
+}
+
+func (c *PutKVValue) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *PutKVValue) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *PutKVValue) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *PutKVValue) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *PutKVValue) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *PutKVValue) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/put_kv_value_test.go
+++ b/pkg/integrations/cloudflare/put_kv_value_test.go
@@ -1,0 +1,217 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__PutKVValue__Setup(t *testing.T) {
+	component := &PutKVValue{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing namespaceId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("missing key returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "",
+				"value":     "my-value",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "key is required")
+	})
+
+	t.Run("missing value returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "",
+			},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "value is required")
+	})
+
+	t.Run("accountId from integration metadata is used as fallback", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+				Metadata:      Metadata{AccountID: "acc-from-integration"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves namespace name", func(t *testing.T) {
+		metaCtx := &contexts.MetadataContext{}
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"success":true,"result":{"id":"ns123","title":"My Namespace"}}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: metaCtx,
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+		kvMeta, ok := metaCtx.Metadata.(KVNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "My Namespace", kvMeta.NamespaceName)
+		assert.Equal(t, "my-key", kvMeta.KeyName)
+	})
+}
+
+func Test__PutKVValue__Execute(t *testing.T) {
+	component := &PutKVValue{}
+
+	t.Run("successful put emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {}}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.kv.value.put", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/storage/kv/namespaces/ns123/values/my-key", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodPut, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "Unauthorized"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to put KV value")
+	})
+}

--- a/pkg/integrations/cloudflare/put_kv_value_test.go
+++ b/pkg/integrations/cloudflare/put_kv_value_test.go
@@ -177,6 +177,44 @@ func Test__PutKVValue__Execute(t *testing.T) {
 		assert.Equal(t, http.MethodPut, httpContext.Requests[0].Method)
 	})
 
+	t.Run("success=false returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": false, "errors": [{"message": "write failed"}]}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"namespace": "ns123",
+				"key":       "my-key",
+				"value":     "my-value",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to put KV value")
+	})
+
 	t.Run("API error returns error", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -52,7 +52,7 @@ export const baseMapper: ComponentBaseMapper = {
   },
 };
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_kv_namespace.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_kv_namespace.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { createKVNamespaceMapper } from "./create_kv_namespace";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.createKVNamespace",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.kv.namespace.created",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.createKVNamespace",
+  label: "Create KV Namespace",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("createKVNamespaceMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => createKVNamespaceMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => createKVNamespaceMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data has no namespace key", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => createKVNamespaceMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts namespace fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              accountId: "acc123",
+              namespace: { id: "ns123", title: "my-namespace" },
+            }),
+          ],
+        },
+      },
+    });
+    const details = createKVNamespaceMapper.getExecutionDetails(ctx);
+    expect(details["Title"]).toBe("my-namespace");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput({ namespace: { id: "ns123", title: "my-namespace" } })],
+        },
+      },
+    });
+    expect(createKVNamespaceMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("createKVNamespaceMapper.props", () => {
+  it("includes namespace title from configuration in metadata", () => {
+    const props = createKVNamespaceMapper.props(
+      buildPropsContext({ node: buildNode({ configuration: { title: "my-namespace" } }) }),
+    );
+    expect(props.metadata).toEqual([{ icon: "database", label: "my-namespace" }]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = createKVNamespaceMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.createKVNamespace", () => {
+  it("maps finished success to created", () => {
+    expect(eventStateRegistry.createKVNamespace.getState(buildExecution())).toBe("created");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.createKVNamespace.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.createKVNamespace.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_kv_namespace.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_kv_namespace.ts
@@ -1,0 +1,71 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
+
+interface CreateKVNamespaceConfiguration {
+  title?: string;
+}
+
+export const createKVNamespaceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext) {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const ns = result?.namespace as Record<string, unknown> | undefined;
+    if (!ns) return details;
+
+    details["Title"] = ns.title != null ? String(ns.title) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as CreateKVNamespaceConfiguration;
+
+  if (configuration?.title) {
+    metadata.push({ icon: "database", label: configuration.title });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_namespace.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_namespace.ts
@@ -1,0 +1,79 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
+
+interface DeleteKVNamespaceConfiguration {
+  namespace?: string;
+}
+
+interface KVNodeMetadata {
+  namespaceName?: string;
+}
+
+export const deleteKVNamespaceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext) {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!result) return details;
+
+    const ns = result.namespace as Record<string, unknown> | undefined;
+    details["Namespace"] =
+      ns?.title != null && String(ns.title) !== "" ? String(ns.title) : ns?.id != null ? String(ns.id) : "-";
+    details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as KVNodeMetadata | undefined;
+  const configuration = node.configuration as DeleteKVNamespaceConfiguration;
+
+  const namespaceLabel = nodeMetadata?.namespaceName || configuration?.namespace;
+  if (namespaceLabel) {
+    metadata.push({ icon: "database", label: namespaceLabel });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_namespace.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_namespace.ts
@@ -52,8 +52,8 @@ export const deleteKVNamespaceMapper: ComponentBaseMapper = {
     if (!result) return details;
 
     const ns = result.namespace as Record<string, unknown> | undefined;
-    details["Namespace"] =
-      ns?.title != null && String(ns.title) !== "" ? String(ns.title) : ns?.id != null ? String(ns.id) : "-";
+    const nsTitle = ns?.title != null ? String(ns.title) : "";
+    details["Namespace"] = nsTitle !== "" ? nsTitle : ns?.id != null ? String(ns.id) : "-";
     details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
 
     return details;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_value.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_value.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { deleteKVValueMapper } from "./delete_kv_value";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.deleteKVValue",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.kv.value.deleted",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.deleteKVValue",
+  label: "Delete KV Value",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("deleteKVValueMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => deleteKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => deleteKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => deleteKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts namespace id, key, and deleted status from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput({ accountId: "acc123", namespaceId: "ns123", key: "my-key", deleted: true })],
+        },
+      },
+    });
+    const details = deleteKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("my-key");
+    expect(details["Deleted"]).toBe("true");
+  });
+
+  it("uses dash placeholders when result fields are missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({})] } },
+    });
+    const details = deleteKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("-");
+    expect(details["Deleted"]).toBe("-");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ namespaceId: "ns123", key: "my-key", deleted: true })] },
+      },
+    });
+    expect(deleteKVValueMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("deleteKVValueMapper.props", () => {
+  it("shows namespaceName and keyName from node metadata", () => {
+    const props = deleteKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          metadata: { namespaceName: "My Namespace", keyName: "my-key" },
+          configuration: { namespace: "ns123", kvKey: "my-key" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "My Namespace" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("falls back to config ids when metadata names are absent", () => {
+    const props = deleteKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: { namespace: "ns123", kvKey: "my-key" } }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "ns123" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = deleteKVValueMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.deleteKVValue", () => {
+  it("maps finished success to deleted", () => {
+    expect(eventStateRegistry.deleteKVValue.getState(buildExecution())).toBe("deleted");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.deleteKVValue.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.deleteKVValue.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_value.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_kv_value.ts
@@ -1,0 +1,84 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
+
+interface DeleteKVValueConfiguration {
+  namespace?: string;
+  kvKey?: string;
+}
+
+interface KVNodeMetadata {
+  namespaceName?: string;
+  keyName?: string;
+}
+
+export const deleteKVValueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext) {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!result) return details;
+
+    details["Key"] = result.key != null ? String(result.key) : "-";
+    details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as KVNodeMetadata | undefined;
+  const configuration = node.configuration as DeleteKVValueConfiguration;
+
+  const namespaceLabel = nodeMetadata?.namespaceName || configuration?.namespace;
+  if (namespaceLabel) {
+    metadata.push({ icon: "database", label: namespaceLabel });
+  }
+
+  const keyLabel = nodeMetadata?.keyName || configuration?.kvKey;
+  if (keyLabel) {
+    metadata.push({ icon: "key", label: keyLabel });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_kv_value.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_kv_value.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { getKVValueMapper } from "./get_kv_value";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.getKVValue",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.kv.value.fetched",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.getKVValue",
+  label: "Get KV Value",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("getKVValueMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => getKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => getKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts namespace id, key, and value from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput({ accountId: "acc123", namespaceId: "ns123", key: "my-key", value: "my-value" })],
+        },
+      },
+    });
+    const details = getKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("my-key");
+    expect(details["Value"]).toBe("my-value");
+  });
+
+  it("uses dash placeholders when result fields are missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({})] } },
+    });
+    const details = getKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("-");
+    expect(details["Value"]).toBe("-");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ namespaceId: "ns123", key: "my-key", value: "val" })] },
+      },
+    });
+    expect(getKVValueMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("getKVValueMapper.props", () => {
+  it("shows namespaceName and keyName from node metadata", () => {
+    const props = getKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          metadata: { namespaceName: "My Namespace", keyName: "my-key" },
+          configuration: { namespace: "ns123", kvKey: "my-key" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "My Namespace" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("falls back to config ids when metadata names are absent", () => {
+    const props = getKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: { namespace: "ns123", kvKey: "my-key" } }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "ns123" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = getKVValueMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.getKVValue", () => {
+  it("maps finished success to fetched", () => {
+    expect(eventStateRegistry.getKVValue.getState(buildExecution())).toBe("fetched");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.getKVValue.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.getKVValue.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_kv_value.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_kv_value.ts
@@ -1,0 +1,84 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
+
+interface GetKVValueConfiguration {
+  namespace?: string;
+  kvKey?: string;
+}
+
+interface KVNodeMetadata {
+  namespaceName?: string;
+  keyName?: string;
+}
+
+export const getKVValueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext) {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!result) return details;
+
+    details["Key"] = result.key != null ? String(result.key) : "-";
+    details["Value"] = result.value != null ? String(result.value) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as KVNodeMetadata | undefined;
+  const configuration = node.configuration as GetKVValueConfiguration;
+
+  const namespaceLabel = nodeMetadata?.namespaceName || configuration?.namespace;
+  if (namespaceLabel) {
+    metadata.push({ icon: "database", label: namespaceLabel });
+  }
+
+  const keyLabel = nodeMetadata?.keyName || configuration?.kvKey;
+  if (keyLabel) {
+    metadata.push({ icon: "key", label: keyLabel });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -2,6 +2,11 @@ import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from ".
 import { baseMapper } from "./base";
 import { buildActionStateRegistry } from "../utils";
 import { originRuleMapper } from "./origin_rule";
+import { createKVNamespaceMapper } from "./create_kv_namespace";
+import { putKVValueMapper } from "./put_kv_value";
+import { getKVValueMapper } from "./get_kv_value";
+import { deleteKVValueMapper } from "./delete_kv_value";
+import { deleteKVNamespaceMapper } from "./delete_kv_namespace";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
@@ -11,6 +16,11 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   updateRedirectRule: baseMapper,
   updateOriginRule: originRuleMapper,
   deleteOriginRule: originRuleMapper,
+  createKVNamespace: createKVNamespaceMapper,
+  putKVValue: putKVValueMapper,
+  getKVValue: getKVValueMapper,
+  deleteKVValue: deleteKVValueMapper,
+  deleteKVNamespace: deleteKVNamespaceMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -23,4 +33,9 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   updateRedirectRule: buildActionStateRegistry("completed"),
   updateOriginRule: buildActionStateRegistry("updated"),
   deleteOriginRule: buildActionStateRegistry("deleted"),
+  createKVNamespace: buildActionStateRegistry("created"),
+  putKVValue: buildActionStateRegistry("success"),
+  getKVValue: buildActionStateRegistry("fetched"),
+  deleteKVValue: buildActionStateRegistry("deleted"),
+  deleteKVNamespace: buildActionStateRegistry("deleted"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/put_kv_value.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/put_kv_value.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { putKVValueMapper } from "./put_kv_value";
+import { eventStateRegistry } from "./index";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.putKVValue",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.kv.value.written",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.putKVValue",
+  label: "Put KV Value",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+// ── getExecutionDetails ───────────────────────────────────────────────────────
+
+describe("putKVValueMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => putKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => putKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when output data is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput({})] } } });
+    expect(() => putKVValueMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("extracts fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput({ accountId: "acc123", namespaceId: "ns123", key: "my-key", written: true })],
+        },
+      },
+    });
+    const details = putKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("my-key");
+    expect(details["Written"]).toBe("true");
+  });
+
+  it("uses dash placeholders when result fields are missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({})] } },
+    });
+    const details = putKVValueMapper.getExecutionDetails(ctx);
+    expect(details["Namespace ID"]).toBeUndefined();
+    expect(details["Key"]).toBe("-");
+    expect(details["Written"]).toBe("-");
+  });
+
+  it("includes executed at timestamp", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput({ namespaceId: "ns123", key: "my-key", written: true })] },
+      },
+    });
+    expect(putKVValueMapper.getExecutionDetails(ctx)["Executed At"]).toBeDefined();
+  });
+});
+
+// ── props ─────────────────────────────────────────────────────────────────────
+
+describe("putKVValueMapper.props", () => {
+  it("shows namespaceName and keyName from node metadata", () => {
+    const props = putKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          metadata: { namespaceName: "My Namespace", keyName: "my-key" },
+          configuration: { namespace: "ns123", key: "my-key" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "My Namespace" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("falls back to config ids when metadata names are absent", () => {
+    const props = putKVValueMapper.props(
+      buildPropsContext({
+        node: buildNode({ configuration: { namespace: "ns123", key: "my-key" } }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "database", label: "ns123" },
+      { icon: "key", label: "my-key" },
+    ]);
+  });
+
+  it("returns empty metadata when configuration is empty", () => {
+    const props = putKVValueMapper.props(buildPropsContext({ node: buildNode({ configuration: {} }) }));
+    expect(props.metadata).toEqual([]);
+  });
+});
+
+// ── eventStateRegistry ────────────────────────────────────────────────────────
+
+describe("eventStateRegistry.putKVValue", () => {
+  it("maps finished success to success", () => {
+    expect(eventStateRegistry.putKVValue.getState(buildExecution())).toBe("success");
+  });
+
+  it("returns running when execution is in progress", () => {
+    const running = buildExecution({
+      state: "STATE_STARTED",
+      result: "RESULT_UNSPECIFIED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_UNSPECIFIED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.putKVValue.getState(running)).toBe("running");
+  });
+
+  it("returns failed when execution fails", () => {
+    const failed = buildExecution({
+      state: "STATE_FINISHED",
+      result: "RESULT_FAILED" as ExecutionInfo["result"],
+      resultReason: "RESULT_REASON_COMPONENT_FAILED" as ExecutionInfo["resultReason"],
+    });
+    expect(eventStateRegistry.putKVValue.getState(failed)).toBe("failed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/put_kv_value.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/put_kv_value.ts
@@ -1,0 +1,84 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./base";
+
+interface PutKVValueConfiguration {
+  namespace?: string;
+  key?: string;
+}
+
+interface KVNodeMetadata {
+  namespaceName?: string;
+  keyName?: string;
+}
+
+export const putKVValueMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext) {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!result) return details;
+
+    details["Key"] = result.key != null ? String(result.key) : "-";
+    details["Written"] = result.written != null ? String(result.written) : "-";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as KVNodeMetadata | undefined;
+  const configuration = node.configuration as PutKVValueConfiguration;
+
+  const namespaceLabel = nodeMetadata?.namespaceName || configuration?.namespace;
+  if (namespaceLabel) {
+    metadata.push({ icon: "database", label: namespaceLabel });
+  }
+
+  const keyLabel = nodeMetadata?.keyName || configuration?.key;
+  if (keyLabel) {
+    metadata.push({ icon: "key", label: keyLabel });
+  }
+
+  return metadata;
+}


### PR DESCRIPTION

Implements: #4454

## What changed:

Added 5 new Cloudflare Workers KV action components: Create KV Namespace, Put KV Value, Get KV Value, Delete KV Value, and Delete KV Namespace.

## Why:

To enable users to manage Cloudflare Workers KV storage directly from SuperPlane workflows.

## How:

### Backend:

- Added 5 new action components in cloudflare: create_kv_namespace.go, put_kv_value.go, get_kv_value.go, delete_kv_value.go, delete_kv_namespace.go, each implementing Setup, Execute, and Describe.
- Extended client.go with new Cloudflare KV API methods.
- Added example output JSON files and registered all 5 components in the Cloudflare integration.
- Added tests

### Frontend:

- Added mapper files for all 5 components under cloudflare, 
- Registered all 5 mappers and their event state registries in index.ts.
- Full spec coverage for all 5 mappers.

## Demo

https://youtu.be/3oRGqikx0z4