### PR TITLE
feat: add canvas folders backend

### DIFF
--- a/.go-coverage-baseline.json
+++ b/.go-coverage-baseline.json
@@ -1,9 +1,9 @@
 {
-  "minTotalCoverage": 44.6,
+  "minTotalCoverage": 44.7,
   "minCoverageByPackage": {
     "pkg/authentication": 6.3,
     "pkg/authorization": 52.4,
-    "pkg/cli": 27.8,
+    "pkg/cli": 44.4,
     "pkg/cli/commands/canvases": 35.9,
     "pkg/cli/commands/canvases/models": 100,
     "pkg/cli/commands/events": 39.1,
@@ -29,13 +29,13 @@
     "pkg/grpc/actions/agents": 44,
     "pkg/grpc/actions/auth": 80.8,
     "pkg/grpc/actions/blueprints": 0,
-    "pkg/grpc/actions/canvases": 62.1,
+    "pkg/grpc/actions/canvases": 62.6,
     "pkg/grpc/actions/canvases/changesets": 84.7,
-    "pkg/grpc/actions/canvases/layout": 63.4,
+    "pkg/grpc/actions/canvases/layout": 63.1,
     "pkg/grpc/actions/integrations": 0,
     "pkg/grpc/actions/me": 54.2,
     "pkg/grpc/actions/messages": 0,
-    "pkg/grpc/actions/organizations": 67.2,
+    "pkg/grpc/actions/organizations": 67,
     "pkg/grpc/actions/secrets": 42.6,
     "pkg/grpc/actions/serviceaccounts": 5.5,
     "pkg/grpc/actions/triggers": 84.6,
@@ -44,13 +44,13 @@
     "pkg/jwt": 55.3,
     "pkg/lint/examplepayloads": 84.6,
     "pkg/logging": 0,
-    "pkg/models": 9.8,
-    "pkg/networkpolicy": 82.1,
+    "pkg/models": 8.7,
+    "pkg/networkpolicy": 87.9,
     "pkg/oidc": 70.4,
     "pkg/public": 51.9,
     "pkg/public/middleware": 46.4,
     "pkg/public/ws": 0,
-    "pkg/registry": 82.6,
+    "pkg/registry": 82.9,
     "pkg/retry": 0,
     "pkg/secrets": 62.5,
     "pkg/server": 0,
@@ -61,8 +61,8 @@
     "pkg/utils": 20,
     "pkg/web": 82.1,
     "pkg/widgets/annotation": 0,
-    "pkg/workers": 41,
-    "pkg/workers/contexts": 46.4,
+    "pkg/workers": 42.2,
+    "pkg/workers/contexts": 45.9,
     "pkg/workers/eventdistributer": 0
   },
   "ignoredPackagePrefixes": [
@@ -73,5 +73,5 @@
     "pkg/triggers",
     "pkg/web/assets"
   ],
-  "updatedAt": "2026-05-03T23:40:42Z"
+  "updatedAt": "2026-05-07T12:45:18Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -353,8 +353,8 @@ check.components.docs:
 	$(COMPOSE) run --rm app bash -c "go run scripts/generate_components_docs.go"
 	git diff --exit-code docs/components
 
-MODULES := authorization,organizations,integrations,secrets,users,groups,roles,me,configuration,components,actions,triggers,widgets,blueprints,canvases,service_accounts,agents,usage,private/agents
-REST_API_MODULES := authorization,organizations,integrations,secrets,users,groups,roles,me,configuration,actions,triggers,widgets,blueprints,canvases,service_accounts,agents
+MODULES := authorization,organizations,integrations,secrets,users,groups,roles,me,configuration,components,actions,triggers,widgets,blueprints,canvases,canvas_folders,service_accounts,agents,usage,private/agents
+REST_API_MODULES := authorization,organizations,integrations,secrets,users,groups,roles,me,configuration,actions,triggers,widgets,blueprints,canvases,canvas_folders,service_accounts,agents
 compose.setup:
 	@touch agent/.env
 

--- a/db/migrations/20260506152447_add-canvas-folders.up.sql
+++ b/db/migrations/20260506152447_add-canvas-folders.up.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.canvas_folders (
+  id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+  organization_id uuid NOT NULL,
+  title character varying(128) NOT NULL,
+  background_color character varying(32) NOT NULL DEFAULT 'blue',
+  sort_order bigint NOT NULL,
+  created_at timestamp without time zone NOT NULL,
+  updated_at timestamp without time zone NOT NULL,
+  CONSTRAINT canvas_folders_pkey PRIMARY KEY (id),
+  CONSTRAINT canvas_folders_organization_id_title_key UNIQUE (organization_id, title),
+  CONSTRAINT canvas_folders_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE,
+  CONSTRAINT canvas_folders_background_color_check CHECK (background_color IN ('blue', 'green', 'purple', 'yellow', 'slate', 'orange'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_folders_organization_id_title
+  ON public.canvas_folders (organization_id, title);
+
+ALTER TABLE public.workflows
+  ADD COLUMN IF NOT EXISTS folder_id uuid;
+
+ALTER TABLE public.workflows
+  ADD CONSTRAINT workflows_folder_id_fkey
+  FOREIGN KEY (folder_id) REFERENCES public.canvas_folders(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_workflows_folder_id
+  ON public.workflows (folder_id);
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -194,6 +194,22 @@ CREATE TABLE public.blueprints (
 
 
 --
+-- Name: canvas_folders; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.canvas_folders (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    organization_id uuid NOT NULL,
+    title character varying(128) NOT NULL,
+    background_color character varying(32) DEFAULT 'blue'::character varying NOT NULL,
+    sort_order bigint NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    CONSTRAINT canvas_folders_background_color_check CHECK (((background_color)::text = ANY ((ARRAY['blue'::character varying, 'green'::character varying, 'purple'::character varying, 'yellow'::character varying, 'slate'::character varying, 'orange'::character varying])::text[])))
+);
+
+
+--
 -- Name: canvas_memories; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -642,7 +658,8 @@ CREATE TABLE public.workflows (
     created_by uuid,
     deleted_at timestamp without time zone,
     is_template boolean DEFAULT false NOT NULL,
-    live_version_id uuid NOT NULL
+    live_version_id uuid NOT NULL,
+    folder_id uuid
 );
 
 
@@ -771,6 +788,22 @@ ALTER TABLE ONLY public.blueprints
 
 ALTER TABLE ONLY public.blueprints
     ADD CONSTRAINT blueprints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canvas_folders canvas_folders_organization_id_title_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_folders
+    ADD CONSTRAINT canvas_folders_organization_id_title_key UNIQUE (organization_id, title);
+
+
+--
+-- Name: canvas_folders canvas_folders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_folders
+    ADD CONSTRAINT canvas_folders_pkey PRIMARY KEY (id);
 
 
 --
@@ -1166,6 +1199,13 @@ CREATE INDEX idx_blueprints_organization_id ON public.blueprints USING btree (or
 
 
 --
+-- Name: idx_canvas_folders_organization_id_title; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_canvas_folders_organization_id_title ON public.canvas_folders USING btree (organization_id, title);
+
+
+--
 -- Name: idx_canvas_memories_canvas_namespace; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1453,6 +1493,13 @@ CREATE INDEX idx_workflows_deleted_at ON public.workflows USING btree (deleted_a
 
 
 --
+-- Name: idx_workflows_folder_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_workflows_folder_id ON public.workflows USING btree (folder_id);
+
+
+--
 -- Name: idx_workflows_is_template; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1557,6 +1604,14 @@ ALTER TABLE ONLY public.app_installation_subscriptions
 
 ALTER TABLE ONLY public.app_installations
     ADD CONSTRAINT app_installations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: canvas_folders canvas_folders_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.canvas_folders
+    ADD CONSTRAINT canvas_folders_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
 
 
 --
@@ -1896,6 +1951,14 @@ ALTER TABLE ONLY public.workflow_versions
 
 
 --
+-- Name: workflows workflows_folder_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflows
+    ADD CONSTRAINT workflows_folder_id_fkey FOREIGN KEY (folder_id) REFERENCES public.canvas_folders(id) ON DELETE SET NULL;
+
+
+--
 -- Name: workflows workflows_live_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1935,7 +1998,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260430211005	f
+20260506152447	f
 \.
 
 

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -12,6 +12,7 @@ import (
 	pbActions "github.com/superplanehq/superplane/pkg/protos/actions"
 	pbAgents "github.com/superplanehq/superplane/pkg/protos/agents"
 	pbBlueprints "github.com/superplanehq/superplane/pkg/protos/blueprints"
+	pbCanvasFolders "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
 	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
 	pbGroups "github.com/superplanehq/superplane/pkg/protos/groups"
 	pbIntegrations "github.com/superplanehq/superplane/pkg/protos/integrations"
@@ -260,6 +261,31 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 			Action:           "delete",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: defaultResourceResolver,
+		},
+		pbCanvasFolders.CanvasFolders_ListCanvasFolders_FullMethodName: {
+			Resource:   "canvases",
+			Action:     "read",
+			DomainType: models.DomainTypeOrganization,
+		},
+		pbCanvasFolders.CanvasFolders_CreateCanvasFolder_FullMethodName: {
+			Resource:   "canvases",
+			Action:     "update",
+			DomainType: models.DomainTypeOrganization,
+		},
+		pbCanvasFolders.CanvasFolders_UpdateCanvasFolder_FullMethodName: {
+			Resource:   "canvases",
+			Action:     "update",
+			DomainType: models.DomainTypeOrganization,
+		},
+		pbCanvasFolders.CanvasFolders_UpdateCanvasFolderPosition_FullMethodName: {
+			Resource:   "canvases",
+			Action:     "update",
+			DomainType: models.DomainTypeOrganization,
+		},
+		pbCanvasFolders.CanvasFolders_DeleteCanvasFolder_FullMethodName: {
+			Resource:   "canvases",
+			Action:     "update",
+			DomainType: models.DomainTypeOrganization,
 		},
 		pbCanvases.Canvases_ListNodeExecutions_FullMethodName: {
 			Resource:         "canvases",

--- a/pkg/grpc/actions/canvases/publish_canvas_version_test.go
+++ b/pkg/grpc/actions/canvases/publish_canvas_version_test.go
@@ -158,6 +158,41 @@ func Test__PublishCanvasVersion(t *testing.T) {
 		assert.Equal(t, draftVersionID, canvas.LiveVersionID.String())
 	})
 
+	t.Run("draft version -> preserves canvas folder assignment", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		canvasID := createCanvasWithNoopNode(ctx, t, r, "publish-draft-in-folder")
+		disableChangeManagementForCanvas(t, r, canvasID)
+
+		createVersionResponse, err := CreateCanvasVersion(ctx, r.Organization.ID.String(), canvasID)
+		require.NoError(t, err)
+		draftVersionID := createVersionResponse.Version.Metadata.Id
+
+		require.NoError(t, database.Conn().
+			Model(&models.CanvasVersion{}).
+			Where("id = ?", uuid.MustParse(draftVersionID)).
+			Update("name", "publish-draft-in-folder-renamed").
+			Error)
+
+		folder, err := models.CreateCanvasFolder(r.Organization.ID, "Publish Folder", models.CanvasFolderColorBlue)
+		require.NoError(t, err)
+
+		_, err = models.UpdateCanvasFolderMembership(r.Organization.ID, uuid.MustParse(canvasID), &folder.ID)
+		require.NoError(t, err)
+
+		_, err = PublishCanvasVersion(
+			ctx,
+			r.Encryptor, r.Registry,
+			r.Organization.ID.String(), canvasID, draftVersionID,
+			testWebhookBaseURL, r.AuthService,
+		)
+		require.NoError(t, err)
+
+		canvas, err := models.FindCanvas(r.Organization.ID, uuid.MustParse(canvasID))
+		require.NoError(t, err)
+		require.NotNil(t, canvas.CanvasFolderID)
+		assert.Equal(t, folder.ID, *canvas.CanvasFolderID)
+	})
+
 	t.Run("change management enabled -> direct publish blocked", func(t *testing.T) {
 		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 		canvasID := createCanvasWithNoopNode(ctx, t, r, "publish-cm-enabled")

--- a/pkg/grpc/actions/canvases/serialization.go
+++ b/pkg/grpc/actions/canvases/serialization.go
@@ -83,6 +83,11 @@ func SerializeCanvas(canvas *models.Canvas, includeStatus bool, user *models.Use
 		createdBy = &pb.UserRef{Id: user.ID.String(), Name: user.Name}
 	}
 
+	canvasFolderID := ""
+	if canvas.CanvasFolderID != nil {
+		canvasFolderID = canvas.CanvasFolderID.String()
+	}
+
 	if !includeStatus {
 		return &pb.Canvas{
 			Metadata: &pb.Canvas_Metadata{
@@ -94,6 +99,7 @@ func SerializeCanvas(canvas *models.Canvas, includeStatus bool, user *models.Use
 				UpdatedAt:      timestamppb.New(*canvas.UpdatedAt),
 				CreatedBy:      createdBy,
 				IsTemplate:     canvas.IsTemplate,
+				FolderId:       canvasFolderID,
 			},
 			Spec: &pb.Canvas_Spec{
 				Nodes:            serializedNodes,
@@ -146,6 +152,7 @@ func SerializeCanvas(canvas *models.Canvas, includeStatus bool, user *models.Use
 			UpdatedAt:      timestamppb.New(*canvas.UpdatedAt),
 			CreatedBy:      createdBy,
 			IsTemplate:     canvas.IsTemplate,
+			FolderId:       canvasFolderID,
 		},
 		Spec: &pb.Canvas_Spec{
 			Nodes:            serializedNodes,

--- a/pkg/grpc/actions/canvases/update_canvas.go
+++ b/pkg/grpc/actions/canvases/update_canvas.go
@@ -137,6 +137,7 @@ func lockCanvasForUpdate(tx *gorm.DB, organizationUUID, canvasID uuid.UUID) (*mo
 			"id",
 			"organization_id",
 			"live_version_id",
+			"folder_id",
 			"is_template",
 			"name",
 			"created_by",

--- a/pkg/grpc/actions/canvasfolders/canvas_folder_errors.go
+++ b/pkg/grpc/actions/canvasfolders/canvas_folder_errors.go
@@ -1,0 +1,31 @@
+package canvasfolders
+
+import (
+	"errors"
+
+	"github.com/superplanehq/superplane/pkg/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+func canvasFolderErrorToStatus(err error, internalMessage string) error {
+	switch {
+	case errors.Is(err, models.ErrCanvasFolderTitleRequired):
+		return status.Error(codes.InvalidArgument, "canvas folder title is required")
+	case errors.Is(err, models.ErrCanvasFolderTitleTooLong):
+		return status.Error(codes.InvalidArgument, "canvas folder title must be 128 characters or less")
+	case errors.Is(err, models.ErrCanvasFolderInvalidBackgroundColor):
+		return status.Error(codes.InvalidArgument, "invalid canvas folder background color")
+	case errors.Is(err, models.ErrCanvasFolderInvalidMoveDirection):
+		return status.Error(codes.InvalidArgument, "invalid canvas folder move direction")
+	case errors.Is(err, models.ErrCanvasFolderTitleAlreadyExists):
+		return status.Error(codes.AlreadyExists, "canvas folder with the same title already exists")
+	case errors.Is(err, models.ErrCanvasFolderCanvasNotFound):
+		return status.Error(codes.NotFound, "canvas not found")
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return status.Error(codes.NotFound, "canvas folder not found")
+	default:
+		return status.Error(codes.Internal, internalMessage)
+	}
+}

--- a/pkg/grpc/actions/canvasfolders/canvas_folder_errors_test.go
+++ b/pkg/grpc/actions/canvasfolders/canvas_folder_errors_test.go
@@ -1,0 +1,17 @@
+package canvasfolders
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__CanvasFolderErrorToStatus__UsesOperationSpecificInternalMessage(t *testing.T) {
+	err := canvasFolderErrorToStatus(errors.New("unexpected failure"), "failed to delete canvas folder")
+
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Equal(t, "failed to delete canvas folder", status.Convert(err).Message())
+}

--- a/pkg/grpc/actions/canvasfolders/create_canvas_folder.go
+++ b/pkg/grpc/actions/canvasfolders/create_canvas_folder.go
@@ -1,0 +1,31 @@
+package canvasfolders
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func CreateCanvasFolder(_ context.Context, organizationID string, folder *pb.CanvasFolder) (*pb.CreateCanvasFolderResponse, error) {
+	if folder == nil || folder.Spec == nil {
+		return nil, status.Error(codes.InvalidArgument, "canvas folder is required")
+	}
+
+	organizationUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	createdFolder, err := models.CreateCanvasFolder(organizationUUID, folder.Spec.Title, folder.Spec.BackgroundColor)
+	if err != nil {
+		return nil, canvasFolderErrorToStatus(err, "failed to create canvas folder")
+	}
+
+	return &pb.CreateCanvasFolderResponse{
+		Folder: SerializeCanvasFolder(createdFolder),
+	}, nil
+}

--- a/pkg/grpc/actions/canvasfolders/create_canvas_folder_test.go
+++ b/pkg/grpc/actions/canvasfolders/create_canvas_folder_test.go
@@ -1,0 +1,77 @@
+package canvasfolders
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__CreateCanvasFolder__CreatesFolder(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	createResponse, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{
+			Title:           "  Production  ",
+			BackgroundColor: models.CanvasFolderColorGreen,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, createResponse.Folder)
+	require.NotNil(t, createResponse.Folder.Metadata)
+	require.NotNil(t, createResponse.Folder.Spec)
+	assert.Equal(t, "Production", createResponse.Folder.Spec.Title)
+	assert.Equal(t, models.CanvasFolderColorGreen, createResponse.Folder.Spec.BackgroundColor)
+}
+
+func Test__CreateCanvasFolder__Validation(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	_, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "   "},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{
+			Title:           "Invalid color",
+			BackgroundColor: "red-800",
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{
+			Title: strings.Repeat("a", 129),
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func Test__CreateCanvasFolder__RejectsDuplicateTitles(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	folder := &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Deployments"},
+	}
+
+	_, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), folder)
+	require.NoError(t, err)
+
+	_, err = CreateCanvasFolder(ctx, r.Organization.ID.String(), folder)
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+}

--- a/pkg/grpc/actions/canvasfolders/delete_canvas_folder.go
+++ b/pkg/grpc/actions/canvasfolders/delete_canvas_folder.go
@@ -1,0 +1,29 @@
+package canvasfolders
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func DeleteCanvasFolder(_ context.Context, organizationID, id string) (*pb.DeleteCanvasFolderResponse, error) {
+	organizationUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	folderID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas folder id: %v", err)
+	}
+
+	if err := models.DeleteCanvasFolder(organizationUUID, folderID); err != nil {
+		return nil, canvasFolderErrorToStatus(err, "failed to delete canvas folder")
+	}
+
+	return &pb.DeleteCanvasFolderResponse{}, nil
+}

--- a/pkg/grpc/actions/canvasfolders/delete_canvas_folder_test.go
+++ b/pkg/grpc/actions/canvasfolders/delete_canvas_folder_test.go
@@ -1,0 +1,64 @@
+package canvasfolders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__DeleteCanvasFolder__DeletesFolder(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	createResponse, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Production"},
+	})
+	require.NoError(t, err)
+
+	_, err = DeleteCanvasFolder(ctx, r.Organization.ID.String(), createResponse.Folder.Metadata.Id)
+	require.NoError(t, err)
+
+	listResponse, err := ListCanvasFolders(ctx, r.Organization.ID.String())
+	require.NoError(t, err)
+	assert.Empty(t, listResponse.Folders)
+}
+
+func Test__DeleteCanvasFolder__FreesCanvases(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	folderResponse, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Temporary"},
+	})
+	require.NoError(t, err)
+	folderID := folderResponse.Folder.Metadata.Id
+
+	_, err = UpdateCanvasFolder(
+		ctx,
+		r.Organization.ID.String(),
+		folderID,
+		&pb.CanvasFolder{
+			Spec: &pb.CanvasFolder_Spec{
+				Title:           "Temporary",
+				BackgroundColor: models.CanvasFolderColorBlue,
+				Canvases:        []*pb.CanvasRef{{Id: canvas.ID.String()}},
+			},
+		},
+		true,
+	)
+	require.NoError(t, err)
+
+	_, err = DeleteCanvasFolder(ctx, r.Organization.ID.String(), folderID)
+	require.NoError(t, err)
+
+	persistedCanvas, err := models.FindCanvas(r.Organization.ID, uuid.MustParse(canvas.ID.String()))
+	require.NoError(t, err)
+	assert.Nil(t, persistedCanvas.CanvasFolderID)
+}

--- a/pkg/grpc/actions/canvasfolders/list_canvas_folders.go
+++ b/pkg/grpc/actions/canvasfolders/list_canvas_folders.go
@@ -1,0 +1,29 @@
+package canvasfolders
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func ListCanvasFolders(_ context.Context, organizationID string) (*pb.ListCanvasFoldersResponse, error) {
+	organizationUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	folders, err := models.ListCanvasFolders(organizationUUID)
+	if err != nil {
+		log.Errorf("failed to list canvas folders for organization %s: %v", organizationID, err)
+		return nil, status.Error(codes.Internal, "failed to list canvas folders")
+	}
+
+	return &pb.ListCanvasFoldersResponse{
+		Folders: SerializeCanvasFolders(folders),
+	}, nil
+}

--- a/pkg/grpc/actions/canvasfolders/list_canvas_folders_test.go
+++ b/pkg/grpc/actions/canvasfolders/list_canvas_folders_test.go
@@ -1,0 +1,47 @@
+package canvasfolders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__ListCanvasFolders__AreOrganizationScoped(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+	otherOrganization := support.CreateOrganization(t, r, r.User)
+
+	_, err := CreateCanvasFolder(ctx, otherOrganization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Other org"},
+	})
+	require.NoError(t, err)
+
+	listResponse, err := ListCanvasFolders(ctx, r.Organization.ID.String())
+	require.NoError(t, err)
+	assert.Empty(t, listResponse.Folders)
+}
+
+func Test__ListCanvasFolders__UsesManualOrderWithNewestFirstByDefault(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	firstFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "First"},
+	})
+	require.NoError(t, err)
+
+	secondFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Second"},
+	})
+	require.NoError(t, err)
+
+	listResponse, err := ListCanvasFolders(ctx, r.Organization.ID.String())
+	require.NoError(t, err)
+	require.Len(t, listResponse.Folders, 2)
+	assert.Equal(t, secondFolder.Folder.Metadata.Id, listResponse.Folders[0].Metadata.Id)
+	assert.Equal(t, firstFolder.Folder.Metadata.Id, listResponse.Folders[1].Metadata.Id)
+}

--- a/pkg/grpc/actions/canvasfolders/serialization.go
+++ b/pkg/grpc/actions/canvasfolders/serialization.go
@@ -1,0 +1,44 @@
+package canvasfolders
+
+import (
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func SerializeCanvasFolders(folders []models.CanvasFolder) []*pb.CanvasFolder {
+	protoFolders := make([]*pb.CanvasFolder, len(folders))
+	for i, folder := range folders {
+		protoFolders[i] = SerializeCanvasFolder(&folder)
+	}
+
+	return protoFolders
+}
+
+func SerializeCanvasFolder(folder *models.CanvasFolder) *pb.CanvasFolder {
+	return &pb.CanvasFolder{
+		Metadata: &pb.CanvasFolder_Metadata{
+			Id:             folder.ID.String(),
+			OrganizationId: folder.OrganizationID.String(),
+			CreatedAt:      timestamppb.New(*folder.CreatedAt),
+			UpdatedAt:      timestamppb.New(*folder.UpdatedAt),
+		},
+		Spec: &pb.CanvasFolder_Spec{
+			Title:           folder.Title,
+			BackgroundColor: folder.BackgroundColor,
+			Canvases:        serializeCanvasRefs(folder.Canvases),
+		},
+	}
+}
+
+func serializeCanvasRefs(canvases []models.Canvas) []*pb.CanvasRef {
+	refs := make([]*pb.CanvasRef, 0, len(canvases))
+
+	for _, canvas := range canvases {
+		refs = append(refs, &pb.CanvasRef{
+			Id: canvas.ID.String(),
+		})
+	}
+
+	return refs
+}

--- a/pkg/grpc/actions/canvasfolders/update_canvas_folder.go
+++ b/pkg/grpc/actions/canvasfolders/update_canvas_folder.go
@@ -1,0 +1,92 @@
+package canvasfolders
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func UpdateCanvasFolder(
+	_ context.Context,
+	organizationID,
+	id string,
+	folder *pb.CanvasFolder,
+	replaceMembership bool,
+) (*pb.UpdateCanvasFolderResponse, error) {
+	organizationUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	folderID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas folder id: %v", err)
+	}
+
+	if folder == nil || folder.Spec == nil {
+		return nil, status.Error(codes.InvalidArgument, "canvas folder is required")
+	}
+
+	updatedFolder, err := updateCanvasFolder(organizationUUID, folderID, folder, replaceMembership)
+	if err != nil {
+		return nil, canvasFolderErrorToStatus(err, "failed to update canvas folder")
+	}
+
+	return &pb.UpdateCanvasFolderResponse{
+		Folder: SerializeCanvasFolder(updatedFolder),
+	}, nil
+}
+
+func updateCanvasFolder(organizationID, folderID uuid.UUID, folder *pb.CanvasFolder, replaceMembership bool) (*models.CanvasFolder, error) {
+	if !replaceMembership {
+		return models.UpdateCanvasFolder(organizationID, folderID, folder.Spec.Title, folder.Spec.BackgroundColor)
+	}
+
+	canvasIDs, err := parseCanvasFolderMembership(folder.Spec.Canvases)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedFolder, affectedCanvases, err := models.UpdateCanvasFolderWithMembership(
+		organizationID,
+		folderID,
+		folder.Spec.Title,
+		folder.Spec.BackgroundColor,
+		canvasIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, canvas := range affectedCanvases {
+		if publishErr := messages.NewCanvasUpdatedMessage(canvas.ID.String(), canvas.OrganizationID.String()).PublishUpdated(); publishErr != nil {
+			log.Errorf("failed to publish canvas updated RabbitMQ message: %v", publishErr)
+		}
+	}
+
+	return updatedFolder, nil
+}
+
+func parseCanvasFolderMembership(canvases []*pb.CanvasRef) ([]uuid.UUID, error) {
+	canvasIDs := make([]uuid.UUID, 0, len(canvases))
+	for _, canvas := range canvases {
+		if canvas == nil {
+			return nil, status.Error(codes.InvalidArgument, "canvas id is required")
+		}
+
+		id, err := uuid.Parse(canvas.Id)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
+		}
+
+		canvasIDs = append(canvasIDs, id)
+	}
+
+	return canvasIDs, nil
+}

--- a/pkg/grpc/actions/canvasfolders/update_canvas_folder_membership_test.go
+++ b/pkg/grpc/actions/canvasfolders/update_canvas_folder_membership_test.go
@@ -1,0 +1,79 @@
+package canvasfolders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__UpdateCanvasFolderMembership__CanBeAssignedAndRemoved(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	otherCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	folderResponse, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Team A", BackgroundColor: models.CanvasFolderColorBlue},
+	})
+	require.NoError(t, err)
+	folderID := folderResponse.Folder.Metadata.Id
+
+	assignResponse, err := UpdateCanvasFolder(
+		ctx,
+		r.Organization.ID.String(),
+		folderID,
+		&pb.CanvasFolder{
+			Spec: &pb.CanvasFolder_Spec{
+				Title:           "Team A",
+				BackgroundColor: models.CanvasFolderColorBlue,
+				Canvases:        []*pb.CanvasRef{{Id: canvas.ID.String()}, {Id: otherCanvas.ID.String()}},
+			},
+		},
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, assignResponse.Folder)
+	require.NotNil(t, assignResponse.Folder.Spec)
+	assert.Len(t, assignResponse.Folder.Spec.Canvases, 2)
+
+	persistedCanvas, err := models.FindCanvas(r.Organization.ID, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, persistedCanvas.CanvasFolderID)
+	assert.Equal(t, folderID, persistedCanvas.CanvasFolderID.String())
+
+	listResponse, err := canvases.ListCanvases(ctx, r.Registry, r.Organization.ID.String(), false)
+	require.NoError(t, err)
+	require.Len(t, listResponse.Canvases, 2)
+	for _, listedCanvas := range listResponse.Canvases {
+		assert.Equal(t, folderID, listedCanvas.Metadata.FolderId)
+	}
+
+	removeResponse, err := UpdateCanvasFolder(
+		ctx,
+		r.Organization.ID.String(),
+		folderID,
+		&pb.CanvasFolder{
+			Spec: &pb.CanvasFolder_Spec{
+				Title:           "Team A",
+				BackgroundColor: models.CanvasFolderColorBlue,
+				Canvases:        []*pb.CanvasRef{{Id: otherCanvas.ID.String()}},
+			},
+		},
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, removeResponse.Folder)
+	require.NotNil(t, removeResponse.Folder.Spec)
+	assert.Len(t, removeResponse.Folder.Spec.Canvases, 1)
+	assert.Equal(t, otherCanvas.ID.String(), removeResponse.Folder.Spec.Canvases[0].Id)
+
+	persistedCanvas, err = models.FindCanvas(r.Organization.ID, canvas.ID)
+	require.NoError(t, err)
+	assert.Nil(t, persistedCanvas.CanvasFolderID)
+}

--- a/pkg/grpc/actions/canvasfolders/update_canvas_folder_position.go
+++ b/pkg/grpc/actions/canvasfolders/update_canvas_folder_position.go
@@ -1,0 +1,41 @@
+package canvasfolders
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func UpdateCanvasFolderPosition(
+	_ context.Context,
+	organizationID,
+	id string,
+	direction pb.UpdateCanvasFolderPositionRequest_Direction,
+) (*pb.UpdateCanvasFolderPositionResponse, error) {
+	organizationUUID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	folderID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas folder id: %v", err)
+	}
+
+	if direction == pb.UpdateCanvasFolderPositionRequest_DIRECTION_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "canvas folder move direction is required")
+	}
+
+	folders, err := models.MoveCanvasFolder(organizationUUID, folderID, direction.String())
+	if err != nil {
+		return nil, canvasFolderErrorToStatus(err, "failed to move canvas folder")
+	}
+
+	return &pb.UpdateCanvasFolderPositionResponse{
+		Folders: SerializeCanvasFolders(folders),
+	}, nil
+}

--- a/pkg/grpc/actions/canvasfolders/update_canvas_folder_position_test.go
+++ b/pkg/grpc/actions/canvasfolders/update_canvas_folder_position_test.go
@@ -1,0 +1,88 @@
+package canvasfolders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__UpdateCanvasFolderPosition__MovesFolderUpAndDown(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	firstFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "First"},
+	})
+	require.NoError(t, err)
+
+	secondFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Second"},
+	})
+	require.NoError(t, err)
+
+	thirdFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Third"},
+	})
+	require.NoError(t, err)
+
+	moveUpResponse, err := UpdateCanvasFolderPosition(
+		ctx,
+		r.Organization.ID.String(),
+		secondFolder.Folder.Metadata.Id,
+		pb.UpdateCanvasFolderPositionRequest_DIRECTION_UP,
+	)
+	require.NoError(t, err)
+	require.Len(t, moveUpResponse.Folders, 3)
+	assert.Equal(t, []string{
+		secondFolder.Folder.Metadata.Id,
+		thirdFolder.Folder.Metadata.Id,
+		firstFolder.Folder.Metadata.Id,
+	}, []string{
+		moveUpResponse.Folders[0].Metadata.Id,
+		moveUpResponse.Folders[1].Metadata.Id,
+		moveUpResponse.Folders[2].Metadata.Id,
+	})
+
+	moveDownResponse, err := UpdateCanvasFolderPosition(
+		ctx,
+		r.Organization.ID.String(),
+		secondFolder.Folder.Metadata.Id,
+		pb.UpdateCanvasFolderPositionRequest_DIRECTION_DOWN,
+	)
+	require.NoError(t, err)
+	require.Len(t, moveDownResponse.Folders, 3)
+	assert.Equal(t, []string{
+		thirdFolder.Folder.Metadata.Id,
+		secondFolder.Folder.Metadata.Id,
+		firstFolder.Folder.Metadata.Id,
+	}, []string{
+		moveDownResponse.Folders[0].Metadata.Id,
+		moveDownResponse.Folders[1].Metadata.Id,
+		moveDownResponse.Folders[2].Metadata.Id,
+	})
+}
+
+func Test__UpdateCanvasFolderPosition__RejectsMissingDirection(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	folder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Production"},
+	})
+	require.NoError(t, err)
+
+	_, err = UpdateCanvasFolderPosition(
+		ctx,
+		r.Organization.ID.String(),
+		folder.Folder.Metadata.Id,
+		pb.UpdateCanvasFolderPositionRequest_DIRECTION_UNSPECIFIED,
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/pkg/grpc/actions/canvasfolders/update_canvas_folder_test.go
+++ b/pkg/grpc/actions/canvasfolders/update_canvas_folder_test.go
@@ -1,0 +1,75 @@
+package canvasfolders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__UpdateCanvasFolder__UpdatesFolder(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	createResponse, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{
+			Title:           "Production",
+			BackgroundColor: models.CanvasFolderColorGreen,
+		},
+	})
+	require.NoError(t, err)
+
+	updateResponse, err := UpdateCanvasFolder(
+		ctx,
+		r.Organization.ID.String(),
+		createResponse.Folder.Metadata.Id,
+		&pb.CanvasFolder{
+			Spec: &pb.CanvasFolder_Spec{
+				Title:           "Production Ops",
+				BackgroundColor: models.CanvasFolderColorPurple,
+			},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, updateResponse.Folder)
+	require.NotNil(t, updateResponse.Folder.Spec)
+	assert.Equal(t, "Production Ops", updateResponse.Folder.Spec.Title)
+	assert.Equal(t, models.CanvasFolderColorPurple, updateResponse.Folder.Spec.BackgroundColor)
+}
+
+func Test__UpdateCanvasFolder__RejectsDuplicateTitle(t *testing.T) {
+	r := support.Setup(t)
+	ctx := context.Background()
+
+	firstFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Deployments"},
+	})
+	require.NoError(t, err)
+
+	secondFolder, err := CreateCanvasFolder(ctx, r.Organization.ID.String(), &pb.CanvasFolder{
+		Spec: &pb.CanvasFolder_Spec{Title: "Operations"},
+	})
+	require.NoError(t, err)
+
+	_, err = UpdateCanvasFolder(
+		ctx,
+		r.Organization.ID.String(),
+		secondFolder.Folder.Metadata.Id,
+		&pb.CanvasFolder{
+			Spec: &pb.CanvasFolder_Spec{
+				Title:           firstFolder.Folder.Spec.Title,
+				BackgroundColor: models.CanvasFolderColorBlue,
+			},
+		},
+		false,
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+}

--- a/pkg/grpc/canvas_folder_service.go
+++ b/pkg/grpc/canvas_folder_service.go
@@ -1,0 +1,43 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvasfolders"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
+)
+
+type CanvasFolderService struct{}
+
+func NewCanvasFolderService() *CanvasFolderService {
+	return &CanvasFolderService{}
+}
+
+func (s *CanvasFolderService) ListCanvasFolders(ctx context.Context, req *pb.ListCanvasFoldersRequest) (*pb.ListCanvasFoldersResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvasfolders.ListCanvasFolders(ctx, organizationID)
+}
+
+func (s *CanvasFolderService) CreateCanvasFolder(ctx context.Context, req *pb.CreateCanvasFolderRequest) (*pb.CreateCanvasFolderResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvasfolders.CreateCanvasFolder(ctx, organizationID, req.Folder)
+}
+
+func (s *CanvasFolderService) UpdateCanvasFolder(ctx context.Context, req *pb.UpdateCanvasFolderRequest) (*pb.UpdateCanvasFolderResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvasfolders.UpdateCanvasFolder(ctx, organizationID, req.Id, req.Folder, req.ReplaceMembership)
+}
+
+func (s *CanvasFolderService) UpdateCanvasFolderPosition(
+	ctx context.Context,
+	req *pb.UpdateCanvasFolderPositionRequest,
+) (*pb.UpdateCanvasFolderPositionResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvasfolders.UpdateCanvasFolderPosition(ctx, organizationID, req.Id, req.Direction)
+}
+
+func (s *CanvasFolderService) DeleteCanvasFolder(ctx context.Context, req *pb.DeleteCanvasFolderRequest) (*pb.DeleteCanvasFolderResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvasfolders.DeleteCanvasFolder(ctx, organizationID, req.Id)
+}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -17,6 +17,7 @@ import (
 	pbActions "github.com/superplanehq/superplane/pkg/protos/actions"
 	pbAgents "github.com/superplanehq/superplane/pkg/protos/agents"
 	pbBlueprints "github.com/superplanehq/superplane/pkg/protos/blueprints"
+	pbCanvasFolders "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
 	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
 	pbGroups "github.com/superplanehq/superplane/pkg/protos/groups"
 	integrationpb "github.com/superplanehq/superplane/pkg/protos/integrations"
@@ -145,6 +146,9 @@ func RunServer(
 
 	canvasService := NewCanvasService(authService, registry, encryptor, webhooksBaseURL, usageService)
 	pbCanvases.RegisterCanvasesServer(grpcServer, canvasService)
+
+	canvasFolderService := NewCanvasFolderService()
+	pbCanvasFolders.RegisterCanvasFoldersServer(grpcServer, canvasFolderService)
 
 	integrationService := NewIntegrationService(encryptor, registry)
 	integrationpb.RegisterIntegrationsServer(grpcServer, integrationService)

--- a/pkg/models/canvas.go
+++ b/pkg/models/canvas.go
@@ -21,6 +21,7 @@ type Canvas struct {
 	ID             uuid.UUID
 	OrganizationID uuid.UUID
 	LiveVersionID  *uuid.UUID
+	CanvasFolderID *uuid.UUID `gorm:"column:folder_id"`
 	IsTemplate     bool
 	Name           string
 	// The `->` tag marks fields as read-only in GORM. These values are projected

--- a/pkg/models/canvas_folder.go
+++ b/pkg/models/canvas_folder.go
@@ -1,0 +1,550 @@
+package models
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/superplanehq/superplane/pkg/database"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	CanvasFolderColorBlue   = "blue"
+	CanvasFolderColorGreen  = "green"
+	CanvasFolderColorPurple = "purple"
+	CanvasFolderColorYellow = "yellow"
+	CanvasFolderColorSlate  = "slate"
+	CanvasFolderColorOrange = "orange"
+
+	canvasFolderTitleUniqueConstraint = "canvas_folders_organization_id_title_key"
+	canvasFolderTitleMaxLength        = 128
+)
+
+var (
+	ErrCanvasFolderTitleAlreadyExists     = errors.New("canvas folder title already exists")
+	ErrCanvasFolderTitleRequired          = errors.New("canvas folder title is required")
+	ErrCanvasFolderTitleTooLong           = errors.New("canvas folder title is too long")
+	ErrCanvasFolderInvalidBackgroundColor = errors.New("invalid canvas folder background color")
+	ErrCanvasFolderInvalidMoveDirection   = errors.New("invalid canvas folder move direction")
+	ErrCanvasFolderCanvasNotFound         = errors.New("canvas not found")
+)
+
+var CanvasFolderBackgroundColors = []string{
+	CanvasFolderColorBlue,
+	CanvasFolderColorGreen,
+	CanvasFolderColorPurple,
+	CanvasFolderColorYellow,
+	CanvasFolderColorSlate,
+	CanvasFolderColorOrange,
+}
+
+type CanvasFolder struct {
+	ID              uuid.UUID
+	OrganizationID  uuid.UUID
+	Title           string
+	BackgroundColor string
+	SortOrder       int64
+	CreatedAt       *time.Time
+	UpdatedAt       *time.Time
+	Canvases        []Canvas `gorm:"foreignKey:CanvasFolderID"`
+}
+
+func (f *CanvasFolder) TableName() string {
+	return "canvas_folders"
+}
+
+func ListCanvasFolders(organizationID uuid.UUID) ([]CanvasFolder, error) {
+	return ListCanvasFoldersInTransaction(database.Conn(), organizationID)
+}
+
+func ListCanvasFoldersInTransaction(tx *gorm.DB, organizationID uuid.UUID) ([]CanvasFolder, error) {
+	var folders []CanvasFolder
+	err := tx.
+		Preload("Canvases", func(tx *gorm.DB) *gorm.DB {
+			return tx.Order("name ASC").Order("id ASC")
+		}).
+		Where("organization_id = ?", organizationID).
+		Order("sort_order ASC").
+		Order("created_at DESC").
+		Order("id DESC").
+		Find(&folders).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return folders, nil
+}
+
+func FindCanvasFolder(organizationID, id uuid.UUID) (*CanvasFolder, error) {
+	return FindCanvasFolderInTransaction(database.Conn(), organizationID, id)
+}
+
+func FindCanvasFolderInTransaction(tx *gorm.DB, organizationID, id uuid.UUID) (*CanvasFolder, error) {
+	var folder CanvasFolder
+	err := tx.
+		Where("organization_id = ?", organizationID).
+		Where("id = ?", id).
+		First(&folder).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &folder, nil
+}
+
+func CreateCanvasFolder(organizationID uuid.UUID, title, backgroundColor string) (*CanvasFolder, error) {
+	var folder *CanvasFolder
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		createdFolder, err := CreateCanvasFolderInTransaction(tx, organizationID, title, backgroundColor)
+		if err != nil {
+			return err
+		}
+
+		folder = createdFolder
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return folder, nil
+}
+
+func CreateCanvasFolderInTransaction(tx *gorm.DB, organizationID uuid.UUID, title, backgroundColor string) (*CanvasFolder, error) {
+	normalizedTitle, err := normalizeCanvasFolderTitle(title)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedColor, err := normalizeCanvasFolderBackgroundColor(backgroundColor)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := lockOrganizationForCanvasFolderSort(tx, organizationID); err != nil {
+		return nil, err
+	}
+
+	sortOrder, err := nextCanvasFolderSortOrderForCreate(tx, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	folder := &CanvasFolder{
+		ID:              uuid.New(),
+		OrganizationID:  organizationID,
+		Title:           normalizedTitle,
+		BackgroundColor: normalizedColor,
+		SortOrder:       sortOrder,
+		CreatedAt:       &now,
+		UpdatedAt:       &now,
+	}
+
+	if err := tx.Create(folder).Error; err != nil {
+		return nil, mapCanvasFolderTitleUniqueConstraintError(err)
+	}
+
+	return folder, nil
+}
+
+func UpdateCanvasFolder(organizationID, id uuid.UUID, title, backgroundColor string) (*CanvasFolder, error) {
+	return UpdateCanvasFolderInTransaction(database.Conn(), organizationID, id, title, backgroundColor)
+}
+
+func UpdateCanvasFolderWithMembership(
+	organizationID,
+	id uuid.UUID,
+	title,
+	backgroundColor string,
+	canvasIDs []uuid.UUID,
+) (*CanvasFolder, []Canvas, error) {
+	var folder *CanvasFolder
+	var affectedCanvases []Canvas
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		updatedFolder, err := UpdateCanvasFolderInTransaction(tx, organizationID, id, title, backgroundColor)
+		if err != nil {
+			return err
+		}
+
+		canvases, affected, err := ReplaceCanvasFolderMembershipInTransaction(tx, organizationID, id, canvasIDs)
+		if err != nil {
+			return err
+		}
+
+		updatedFolder.Canvases = canvases
+		folder = updatedFolder
+		affectedCanvases = affected
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return folder, affectedCanvases, nil
+}
+
+func UpdateCanvasFolderInTransaction(tx *gorm.DB, organizationID, id uuid.UUID, title, backgroundColor string) (*CanvasFolder, error) {
+	normalizedTitle, err := normalizeCanvasFolderTitle(title)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedColor, err := normalizeCanvasFolderBackgroundColor(backgroundColor)
+	if err != nil {
+		return nil, err
+	}
+
+	folder, err := FindCanvasFolderInTransaction(tx, organizationID, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if folder.Title == normalizedTitle && folder.BackgroundColor == normalizedColor {
+		return folder, nil
+	}
+
+	now := time.Now()
+	folder.Title = normalizedTitle
+	folder.BackgroundColor = normalizedColor
+	folder.UpdatedAt = &now
+	if err := tx.Save(folder).Error; err != nil {
+		return nil, mapCanvasFolderTitleUniqueConstraintError(err)
+	}
+
+	return folder, nil
+}
+
+func DeleteCanvasFolder(organizationID, id uuid.UUID) error {
+	return DeleteCanvasFolderInTransaction(database.Conn(), organizationID, id)
+}
+
+func DeleteCanvasFolderInTransaction(tx *gorm.DB, organizationID, id uuid.UUID) error {
+	result := tx.
+		Where("organization_id = ?", organizationID).
+		Where("id = ?", id).
+		Delete(&CanvasFolder{})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+func MoveCanvasFolder(organizationID, id uuid.UUID, direction string) ([]CanvasFolder, error) {
+	var folders []CanvasFolder
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		updatedFolders, err := MoveCanvasFolderInTransaction(tx, organizationID, id, direction)
+		if err != nil {
+			return err
+		}
+
+		folders = updatedFolders
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return folders, nil
+}
+
+func MoveCanvasFolderInTransaction(tx *gorm.DB, organizationID, id uuid.UUID, direction string) ([]CanvasFolder, error) {
+	if err := lockOrganizationForCanvasFolderSort(tx, organizationID); err != nil {
+		return nil, err
+	}
+
+	var folders []CanvasFolder
+	if err := tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("organization_id = ?", organizationID).
+		Order("sort_order ASC").
+		Order("created_at DESC").
+		Order("id DESC").
+		Find(&folders).
+		Error; err != nil {
+		return nil, err
+	}
+
+	folderIndex := slices.IndexFunc(folders, func(folder CanvasFolder) bool {
+		return folder.ID == id
+	})
+	if folderIndex == -1 {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	targetIndex := folderIndex
+	switch direction {
+	case "DIRECTION_UP":
+		targetIndex = folderIndex - 1
+	case "DIRECTION_DOWN":
+		targetIndex = folderIndex + 1
+	default:
+		return nil, ErrCanvasFolderInvalidMoveDirection
+	}
+
+	if targetIndex < 0 || targetIndex >= len(folders) {
+		return folders, nil
+	}
+
+	now := time.Now()
+	currentFolder := folders[folderIndex]
+	targetFolder := folders[targetIndex]
+
+	if err := tx.
+		Model(&CanvasFolder{}).
+		Where("id = ?", currentFolder.ID).
+		Updates(map[string]any{
+			"sort_order": targetFolder.SortOrder,
+			"updated_at": now,
+		}).
+		Error; err != nil {
+		return nil, err
+	}
+
+	if err := tx.
+		Model(&CanvasFolder{}).
+		Where("id = ?", targetFolder.ID).
+		Updates(map[string]any{
+			"sort_order": currentFolder.SortOrder,
+			"updated_at": now,
+		}).
+		Error; err != nil {
+		return nil, err
+	}
+
+	return ListCanvasFoldersInTransaction(tx, organizationID)
+}
+
+func lockOrganizationForCanvasFolderSort(tx *gorm.DB, organizationID uuid.UUID) error {
+	return tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", organizationID).
+		First(&Organization{}).
+		Error
+}
+
+func UpdateCanvasFolderMembership(organizationID, canvasID uuid.UUID, folderID *uuid.UUID) (*Canvas, error) {
+	var canvas *Canvas
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		updatedCanvas, err := UpdateCanvasFolderMembershipInTransaction(tx, organizationID, canvasID, folderID)
+		if err != nil {
+			return err
+		}
+
+		canvas = updatedCanvas
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return canvas, nil
+}
+
+func UpdateCanvasFolderMembershipInTransaction(tx *gorm.DB, organizationID, canvasID uuid.UUID, folderID *uuid.UUID) (*Canvas, error) {
+	var canvas Canvas
+	if err := tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("organization_id = ?", organizationID).
+		Where("id = ?", canvasID).
+		First(&canvas).
+		Error; err != nil {
+		return nil, err
+	}
+
+	if folderID != nil {
+		if _, err := FindCanvasFolderInTransaction(tx, organizationID, *folderID); err != nil {
+			return nil, err
+		}
+	}
+
+	var folderValue any
+	if folderID != nil {
+		folderValue = *folderID
+	}
+
+	if err := tx.
+		Model(&Canvas{}).
+		Where("organization_id = ?", organizationID).
+		Where("id = ?", canvasID).
+		Updates(map[string]any{
+			"folder_id":  folderValue,
+			"updated_at": time.Now(),
+		}).
+		Error; err != nil {
+		return nil, err
+	}
+
+	return FindCanvasInTransaction(tx, organizationID, canvasID)
+}
+
+func ReplaceCanvasFolderMembershipInTransaction(tx *gorm.DB, organizationID, folderID uuid.UUID, canvasIDs []uuid.UUID) ([]Canvas, []Canvas, error) {
+	if _, err := FindCanvasFolderInTransaction(tx.Clauses(clause.Locking{Strength: "UPDATE"}), organizationID, folderID); err != nil {
+		return nil, nil, err
+	}
+
+	uniqueCanvasIDs := make([]uuid.UUID, 0, len(canvasIDs))
+	for _, id := range canvasIDs {
+		if slices.Contains(uniqueCanvasIDs, id) {
+			continue
+		}
+
+		uniqueCanvasIDs = append(uniqueCanvasIDs, id)
+	}
+
+	var existingCanvases []Canvas
+	if err := tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("organization_id = ?", organizationID).
+		Where("folder_id = ?", folderID).
+		Find(&existingCanvases).
+		Error; err != nil {
+		return nil, nil, err
+	}
+
+	affectedCanvases := make([]Canvas, 0, len(existingCanvases)+len(uniqueCanvasIDs))
+	affectedCanvasIDs := make([]uuid.UUID, 0, len(existingCanvases)+len(uniqueCanvasIDs))
+	for _, canvas := range existingCanvases {
+		affectedCanvases = append(affectedCanvases, canvas)
+		affectedCanvasIDs = append(affectedCanvasIDs, canvas.ID)
+	}
+
+	if len(uniqueCanvasIDs) > 0 {
+		var canvases []Canvas
+		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("organization_id = ?", organizationID).
+			Where("id IN ?", uniqueCanvasIDs).
+			Find(&canvases).
+			Error; err != nil {
+			return nil, nil, err
+		}
+
+		if len(canvases) != len(uniqueCanvasIDs) {
+			return nil, nil, ErrCanvasFolderCanvasNotFound
+		}
+
+		for _, canvas := range canvases {
+			if slices.Contains(affectedCanvasIDs, canvas.ID) {
+				continue
+			}
+
+			affectedCanvases = append(affectedCanvases, canvas)
+			affectedCanvasIDs = append(affectedCanvasIDs, canvas.ID)
+		}
+	}
+
+	now := time.Now()
+	clearQuery := tx.
+		Model(&Canvas{}).
+		Where("organization_id = ?", organizationID).
+		Where("folder_id = ?", folderID)
+
+	if len(uniqueCanvasIDs) > 0 {
+		clearQuery = clearQuery.Where("id NOT IN ?", uniqueCanvasIDs)
+	}
+
+	if err := clearQuery.
+		Updates(map[string]any{
+			"folder_id":  nil,
+			"updated_at": now,
+		}).
+		Error; err != nil {
+		return nil, nil, err
+	}
+
+	if len(uniqueCanvasIDs) > 0 {
+		if err := tx.
+			Model(&Canvas{}).
+			Where("organization_id = ?", organizationID).
+			Where("id IN ?", uniqueCanvasIDs).
+			Updates(map[string]any{
+				"folder_id":  folderID,
+				"updated_at": now,
+			}).
+			Error; err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var canvases []Canvas
+	if err := tx.
+		Where("organization_id = ?", organizationID).
+		Where("folder_id = ?", folderID).
+		Order("name ASC").
+		Order("id ASC").
+		Find(&canvases).
+		Error; err != nil {
+		return nil, nil, err
+	}
+
+	return canvases, affectedCanvases, nil
+}
+
+func normalizeCanvasFolderTitle(title string) (string, error) {
+	normalized := strings.TrimSpace(title)
+	if normalized == "" {
+		return "", ErrCanvasFolderTitleRequired
+	}
+
+	if len(normalized) > canvasFolderTitleMaxLength {
+		return "", ErrCanvasFolderTitleTooLong
+	}
+
+	return normalized, nil
+}
+
+func normalizeCanvasFolderBackgroundColor(backgroundColor string) (string, error) {
+	if backgroundColor == "" {
+		return CanvasFolderColorBlue, nil
+	}
+
+	if !slices.Contains(CanvasFolderBackgroundColors, backgroundColor) {
+		return "", ErrCanvasFolderInvalidBackgroundColor
+	}
+
+	return backgroundColor, nil
+}
+
+func nextCanvasFolderSortOrderForCreate(tx *gorm.DB, organizationID uuid.UUID) (int64, error) {
+	var firstFolder CanvasFolder
+	err := tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("organization_id = ?", organizationID).
+		Order("sort_order ASC").
+		Order("created_at DESC").
+		Order("id DESC").
+		Limit(1).
+		First(&firstFolder).
+		Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return firstFolder.SortOrder - 1, nil
+}
+
+func mapCanvasFolderTitleUniqueConstraintError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.ConstraintName == canvasFolderTitleUniqueConstraint {
+		return ErrCanvasFolderTitleAlreadyExists
+	}
+
+	return err
+}

--- a/pkg/models/canvas_version.go
+++ b/pkg/models/canvas_version.go
@@ -205,6 +205,7 @@ func lockCanvasForVersioningInTransaction(tx *gorm.DB, workflowID uuid.UUID) (*C
 			"id",
 			"organization_id",
 			"live_version_id",
+			"folder_id",
 			"is_template",
 			"name",
 			"created_by",
@@ -242,7 +243,15 @@ func PromoteToLiveInTransaction(tx *gorm.DB, version *CanvasVersion, nodes []Nod
 	canvas.LiveVersionID = &version.ID
 	canvas.Name = version.Name
 	canvas.UpdatedAt = &now
-	return MapCanvasNameUniqueConstraintError(tx.Save(canvas).Error)
+	return MapCanvasNameUniqueConstraintError(tx.
+		Model(&Canvas{}).
+		Where("id = ?", canvas.ID).
+		Updates(map[string]any{
+			"live_version_id": version.ID,
+			"name":            version.Name,
+			"updated_at":      now,
+		}).
+		Error)
 }
 
 func SaveCanvasDraftInTransaction(
@@ -366,7 +375,15 @@ func PublishCanvasDraftInTransaction(
 	canvas.Name = version.Name
 	canvas.UpdatedAt = &now
 
-	if err := tx.Save(canvas).Error; err != nil {
+	if err := tx.
+		Model(&Canvas{}).
+		Where("id = ?", canvas.ID).
+		Updates(map[string]any{
+			"live_version_id": version.ID,
+			"name":            version.Name,
+			"updated_at":      now,
+		}).
+		Error; err != nil {
 		return nil, MapCanvasNameUniqueConstraintError(err)
 	}
 

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -39,6 +39,7 @@ import (
 	pbActions "github.com/superplanehq/superplane/pkg/protos/actions"
 	pbAgents "github.com/superplanehq/superplane/pkg/protos/agents"
 	pbBlueprints "github.com/superplanehq/superplane/pkg/protos/blueprints"
+	pbCanvasFolders "github.com/superplanehq/superplane/pkg/protos/canvas_folders"
 	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
 	pbGroups "github.com/superplanehq/superplane/pkg/protos/groups"
 	pbIntegrations "github.com/superplanehq/superplane/pkg/protos/integrations"
@@ -318,6 +319,11 @@ func (s *Server) RegisterGRPCGateway(grpcServerAddr string) error {
 		return err
 	}
 
+	err = pbCanvasFolders.RegisterCanvasFoldersHandlerFromEndpoint(ctx, grpcGatewayMux, grpcServerAddr, opts)
+	if err != nil {
+		return err
+	}
+
 	err = pbServiceAccounts.RegisterServiceAccountsHandlerFromEndpoint(ctx, grpcGatewayMux, grpcServerAddr, opts)
 	if err != nil {
 		return err
@@ -344,6 +350,7 @@ func (s *Server) RegisterGRPCGateway(grpcServerAddr string) error {
 	s.Router.PathPrefix("/api/v1/groups").Handler(protectedGRPCHandler)
 	s.Router.PathPrefix("/api/v1/roles").Handler(protectedGRPCHandler)
 	s.Router.PathPrefix("/api/v1/canvases").Handler(protectedGRPCHandler)
+	s.Router.PathPrefix("/api/v1/canvas-folders").Handler(protectedGRPCHandler)
 	s.Router.PathPrefix("/api/v1/organizations").Handler(protectedGRPCHandler)
 	s.Router.PathPrefix("/api/v1/invite-links").Handler(protectedAccountGRPCHandler)
 	s.Router.PathPrefix("/api/v1/integrations").Handler(protectedGRPCHandler)

--- a/protos/canvas_folders.proto
+++ b/protos/canvas_folders.proto
@@ -1,0 +1,152 @@
+syntax = "proto3";
+
+package Superplane.CanvasFolders;
+
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+option go_package = "github.com/superplanehq/superplane/pkg/protos/canvas_folders";
+
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Superplane Canvas Folders API";
+    version: "1.0";
+    description: "API for SuperPlane canvas folders";
+    contact: {
+      name: "API Support";
+      email: "support@superplane.com";
+    };
+  };
+  schemes: HTTPS;
+  schemes: HTTP;
+  consumes: "application/json";
+  produces: "application/json";
+};
+
+service CanvasFolders {
+  rpc ListCanvasFolders(ListCanvasFoldersRequest) returns (ListCanvasFoldersResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/canvas-folders"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List canvas folders";
+      description: "Returns all canvas folders for an organization";
+      tags: "CanvasFolder";
+    };
+  }
+
+  rpc CreateCanvasFolder(CreateCanvasFolderRequest) returns (CreateCanvasFolderResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/canvas-folders"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Create canvas folder";
+      description: "Creates a canvas folder";
+      tags: "CanvasFolder";
+    };
+  }
+
+  rpc UpdateCanvasFolder(UpdateCanvasFolderRequest) returns (UpdateCanvasFolderResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/canvas-folders/{id}"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update canvas folder";
+      description: "Updates a canvas folder";
+      tags: "CanvasFolder";
+    };
+  }
+
+  rpc UpdateCanvasFolderPosition(UpdateCanvasFolderPositionRequest) returns (UpdateCanvasFolderPositionResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/canvas-folders/{id}/position"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update canvas folder position";
+      description: "Moves a canvas folder up or down";
+      tags: "CanvasFolder";
+    };
+  }
+
+  rpc DeleteCanvasFolder(DeleteCanvasFolderRequest) returns (DeleteCanvasFolderResponse) {
+    option (google.api.http) = {
+      delete: "/api/v1/canvas-folders/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Delete canvas folder";
+      description: "Deletes a canvas folder without deleting its canvases";
+      tags: "CanvasFolder";
+    };
+  }
+}
+
+message ListCanvasFoldersRequest {}
+
+message ListCanvasFoldersResponse {
+  repeated CanvasFolder folders = 1;
+}
+
+message CreateCanvasFolderRequest {
+  CanvasFolder folder = 1;
+}
+
+message CreateCanvasFolderResponse {
+  CanvasFolder folder = 1;
+}
+
+message UpdateCanvasFolderRequest {
+  string id = 1;
+  CanvasFolder folder = 2;
+  bool replace_membership = 3;
+}
+
+message UpdateCanvasFolderResponse {
+  CanvasFolder folder = 1;
+}
+
+message UpdateCanvasFolderPositionRequest {
+  enum Direction {
+    DIRECTION_UNSPECIFIED = 0;
+    DIRECTION_UP = 1;
+    DIRECTION_DOWN = 2;
+  }
+
+  string id = 1;
+  Direction direction = 2;
+}
+
+message UpdateCanvasFolderPositionResponse {
+  repeated CanvasFolder folders = 1;
+}
+
+message DeleteCanvasFolderRequest {
+  string id = 1;
+}
+
+message DeleteCanvasFolderResponse {}
+
+message CanvasRef {
+  string id = 1;
+}
+
+message CanvasFolder {
+  message Metadata {
+    string id = 1;
+    string organization_id = 2;
+    google.protobuf.Timestamp created_at = 3;
+    google.protobuf.Timestamp updated_at = 4;
+  }
+
+  message Spec {
+    string title = 1;
+    string background_color = 2;
+    repeated CanvasRef canvases = 3;
+  }
+
+  Metadata metadata = 1;
+  Spec spec = 2;
+}

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -632,6 +632,7 @@ message Canvas {
     google.protobuf.Timestamp updated_at = 6;
     UserRef created_by = 7;
     bool is_template = 8;
+    string folder_id = 9;
   }
 
   message ChangeManagement {


### PR DESCRIPTION
## Summary
- add canvas folder models, migrations, and db structure updates
- add gRPC actions/service registration and authorization for canvas folders
- wire folder metadata into canvas serialization and version restore paths

## Stack
- Depends on #4671
- Next: split/canvas-folders-ui

## Validation
- make test PKG_TEST_PACKAGES=./pkg/grpc/actions/canvasfolders
- make lint && make check.build.app