### PR TITLE
fix: allow backing out of SMTP config during installation

### DIFF
--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -185,7 +185,7 @@ func (s *ownerSetupSteps) fillInSMTPDetails(host, port, username, password, from
 	s.session.FillIn(q.Locator(`input[placeholder="noreply@example.com"]`), fromEmail)
 
 	if !useTLS {
-		s.session.Click(q.Locator(`input[type="checkbox"]`))
+		s.session.Click(q.Locator(`#owner-setup-smtp-use-tls`))
 	}
 }
 

--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -40,6 +40,20 @@ func TestOwnerSetupFlow(t *testing.T) {
 		steps.assertOwnerSetupIsNoLongerRequired()
 	})
 
+	t.Run("can skip SMTP after opening SMTP configuration", func(t *testing.T) {
+		steps := &ownerSetupSteps{t: t}
+		steps.start()
+		steps.visitRootPage()
+		steps.assertRedirectedToSetup()
+		steps.visitSetupPage()
+		steps.fillInOwnerDetails("smtp-skip@example.com", "SMTP", "Skip", "Password1")
+		steps.chooseSMTPSetup()
+		steps.finishOwnerSetupWithoutSMTPFromSMTPConfig()
+		steps.assertOwnerAndOrganizationCreated()
+		steps.assertRedirectedToOrganizationHome()
+		steps.assertOwnerSetupIsNoLongerRequired()
+	})
+
 	t.Run("can enable private network access during owner setup", func(t *testing.T) {
 		steps := &ownerSetupSteps{t: t}
 		steps.start()
@@ -145,6 +159,11 @@ func (s *ownerSetupSteps) chooseSMTPSetup() {
 	s.goToPrivateNetworkSettings()
 	s.goToSetupOptions()
 	s.session.Click(q.Text("Set up SMTP"))
+}
+
+func (s *ownerSetupSteps) finishOwnerSetupWithoutSMTPFromSMTPConfig() {
+	s.session.Click(q.Text("Do this later"))
+	s.waitForSetupToComplete()
 }
 
 func (s *ownerSetupSteps) enablePrivateNetworkAccess() {

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -191,12 +191,32 @@ const OwnerSetup: React.FC = () => {
     setStep("smtpPrompt");
   };
 
+  const handlePrivateNetworkBack = () => {
+    setError(null);
+    setFieldErrors({});
+    setStep("owner");
+  };
+
   const handleSkipSMTP = () => {
     submitSetup(false);
   };
 
   const handleEnableSMTP = () => {
+    setError(null);
+    setFieldErrors({});
     setStep("smtpConfig");
+  };
+
+  const handleSMTPPromptBack = () => {
+    setError(null);
+    setFieldErrors({});
+    setStep("privateNetwork");
+  };
+
+  const handleSMTPConfigBack = () => {
+    setError(null);
+    setFieldErrors({});
+    setStep("smtpPrompt");
   };
 
   const handleSubmitSMTP = (e: React.FormEvent) => {
@@ -365,9 +385,14 @@ const OwnerSetup: React.FC = () => {
               </div>
             </div>
 
-            <Button type="button" className="w-full" disabled={loading} onClick={handlePrivateNetworkNext}>
-              Next
-            </Button>
+            <div className="flex gap-3">
+              <Button type="button" variant="outline" disabled={loading} onClick={handlePrivateNetworkBack}>
+                Back
+              </Button>
+              <Button type="button" className="flex-1" disabled={loading} onClick={handlePrivateNetworkNext}>
+                Next
+              </Button>
+            </div>
           </div>
         )}
 
@@ -386,7 +411,10 @@ const OwnerSetup: React.FC = () => {
               </Text>
             </div>
 
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
+              <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPPromptBack}>
+                Back
+              </Button>
               <Button type="button" disabled={loading} onClick={handleEnableSMTP}>
                 Set up SMTP
               </Button>
@@ -513,9 +541,17 @@ const OwnerSetup: React.FC = () => {
               Use TLS (STARTTLS)
             </Label>
 
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? "Saving..." : "Finish setup"}
-            </Button>
+            <div className="flex flex-wrap gap-3">
+              <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPConfigBack}>
+                Back
+              </Button>
+              <Button type="button" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
+                Do this later
+              </Button>
+              <Button type="submit" className="flex-1" disabled={loading}>
+                {loading ? "Saving..." : "Finish setup"}
+              </Button>
+            </div>
           </form>
         )}
       </div>

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
-import { Input, InputGroup } from "../../components/Input/input";
-import { Label } from "@/components/ui/label";
-import { Text } from "../../components/Text/text";
-import { Button } from "../../components/ui/button";
-import { Switch } from "@/ui/switch";
-import superplaneLogo from "../../assets/superplane.svg";
 import { posthog, isPostHogEnabled } from "@/posthog";
 import OwnerSetupSurvey, { type PostHogSurvey } from "./OwnerSetupSurvey";
+import { OwnerStep } from "./ownerSetup/OwnerStep";
+import { PrivateNetworkStep } from "./ownerSetup/PrivateNetworkStep";
+import { SmtpPromptStep } from "./ownerSetup/SmtpPromptStep";
+import { SmtpConfigStep } from "./ownerSetup/SmtpConfigStep";
 
 const OWNER_SETUP_SURVEY_NAME = "Owner Setup Survey";
 
@@ -198,6 +196,7 @@ const OwnerSetup: React.FC = () => {
   };
 
   const handleSkipSMTP = () => {
+    setFieldErrors({});
     submitSetup(false);
   };
 
@@ -232,202 +231,43 @@ const OwnerSetup: React.FC = () => {
     <div className="min-h-screen flex items-center justify-center bg-slate-100 px-4 py-8">
       <div className="max-w-md w-full bg-white dark:bg-gray-900 rounded-lg outline outline-gray-950/10 shadow-sm p-8">
         {step === "owner" && (
-          <div className="text-center mb-8">
-            <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto mb-4 h-8 w-8" />
-            <h4 className="text-xl font-medium text-gray-800 dark:text-white mb-1">Set up owner account</h4>
-            <Text className="text-gray-800 dark:text-gray-300">Create an account for this SuperPlane instance.</Text>
-          </div>
-        )}
-
-        {step === "owner" && (
-          <form onSubmit={handleOwnerNext} className="space-y-4">
-            {error && (
-              <div className="p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-                <Text className="text-red-700 dark:text-red-400 text-sm">{error}</Text>
-              </div>
-            )}
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <Label className="block text-left mb-2">
-                  First Name <span className="text-gray-800">*</span>
-                </Label>
-                <InputGroup>
-                  <Input
-                    type="text"
-                    value={firstName}
-                    onChange={(e) => setFirstName(e.target.value)}
-                    placeholder="First name"
-                    className={fieldErrors.firstName ? "border-red-500" : ""}
-                  />
-                </InputGroup>
-                {fieldErrors.firstName && (
-                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.firstName}</p>
-                )}
-              </div>
-
-              <div>
-                <Label className="block text-left mb-2">
-                  Last Name <span className="text-gray-800">*</span>
-                </Label>
-                <InputGroup>
-                  <Input
-                    type="text"
-                    value={lastName}
-                    onChange={(e) => setLastName(e.target.value)}
-                    placeholder="Last name"
-                    className={fieldErrors.lastName ? "border-red-500" : ""}
-                  />
-                </InputGroup>
-                {fieldErrors.lastName && (
-                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.lastName}</p>
-                )}
-              </div>
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                Email <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                  className={fieldErrors.email ? "border-red-500" : ""}
-                />
-              </InputGroup>
-              {fieldErrors.email && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.email}</p>}
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                Password <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="Password"
-                  className={fieldErrors.password ? "border-red-500 ph-no-capture" : "ph-no-capture"}
-                />
-              </InputGroup>
-              {fieldErrors.password ? (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.password}</p>
-              ) : (
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  8+ characters, at least 1 number and 1 capital letter
-                </p>
-              )}
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                Confirm Password <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  placeholder="Confirm password"
-                  className={fieldErrors.confirmPassword ? "border-red-500 ph-no-capture" : "ph-no-capture"}
-                />
-              </InputGroup>
-              {fieldErrors.confirmPassword && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.confirmPassword}</p>
-              )}
-            </div>
-
-            <div className="flex justify-end">
-              <Button type="submit" className="w-36" disabled={loading}>
-                {loading ? "Saving..." : "Next"}
-              </Button>
-            </div>
-          </form>
+          <OwnerStep
+            email={email}
+            firstName={firstName}
+            lastName={lastName}
+            password={password}
+            confirmPassword={confirmPassword}
+            loading={loading}
+            error={error}
+            fieldErrors={fieldErrors}
+            onEmailChange={setEmail}
+            onFirstNameChange={setFirstName}
+            onLastNameChange={setLastName}
+            onPasswordChange={setPassword}
+            onConfirmPasswordChange={setConfirmPassword}
+            onNext={handleOwnerNext}
+          />
         )}
 
         {step === "privateNetwork" && (
-          <div className="space-y-6">
-            {error && (
-              <div className="p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-                <Text className="text-red-700 dark:text-red-400 text-sm">{error}</Text>
-              </div>
-            )}
-
-            <div className="text-left">
-              <h4 className="text-lg font-medium text-gray-800 dark:text-white mb-2">Private network access</h4>
-              <Text className="text-gray-800 dark:text-gray-300">
-                Decide whether this SuperPlane instance should be allowed to reach internal services before continuing
-                to email setup.
-              </Text>
-            </div>
-
-            <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left">
-              <div className="flex items-start justify-between gap-6">
-                <div className="max-w-xs">
-                  <Label className="mb-1 block text-sm font-medium text-gray-800">Allow private network targets</Label>
-                  <Text className="text-sm text-gray-600">
-                    Enable this if SuperPlane needs to reach tools inside your VPC, private Kubernetes cluster, or
-                    another closed network. This reduces SSRF protection for private addresses.
-                  </Text>
-                </div>
-
-                <div className="flex items-center gap-3">
-                  <span className="text-xs text-gray-500">{allowPrivateNetworkAccess ? "Enabled" : "Disabled"}</span>
-                  <Switch
-                    data-testid="owner-setup-private-network-switch"
-                    checked={allowPrivateNetworkAccess}
-                    onCheckedChange={setAllowPrivateNetworkAccess}
-                    aria-label="Allow connections to private network tools"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <Button type="button" variant="outline" disabled={loading} onClick={handlePrivateNetworkBack}>
-                Back
-              </Button>
-              <Button type="button" className="ml-auto w-36" disabled={loading} onClick={handlePrivateNetworkNext}>
-                Next
-              </Button>
-            </div>
-          </div>
+          <PrivateNetworkStep
+            allowPrivateNetworkAccess={allowPrivateNetworkAccess}
+            loading={loading}
+            error={error}
+            onAllowPrivateNetworkAccessChange={setAllowPrivateNetworkAccess}
+            onBack={handlePrivateNetworkBack}
+            onNext={handlePrivateNetworkNext}
+          />
         )}
 
         {step === "smtpPrompt" && (
-          <div className="space-y-6">
-            {error && (
-              <div className="p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-                <Text className="text-red-700 dark:text-red-400 text-sm">{error}</Text>
-              </div>
-            )}
-
-            <div className="text-left">
-              <h4 className="text-lg font-medium text-gray-800 dark:text-white mb-2">Set up email delivery?</h4>
-              <Text className="text-gray-800 dark:text-gray-300">
-                Configure SMTP now to receive notifications. You can skip and set it up later.
-              </Text>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPPromptBack}>
-                Back
-              </Button>
-
-              <div className="ml-auto flex flex-wrap justify-end gap-3">
-                <Button type="button" className="w-36" disabled={loading} onClick={handleEnableSMTP}>
-                  Set up SMTP
-                </Button>
-                <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
-                  Do this later
-                </Button>
-              </div>
-            </div>
-          </div>
+          <SmtpPromptStep
+            loading={loading}
+            error={error}
+            onBack={handleSMTPPromptBack}
+            onEnableSMTP={handleEnableSMTP}
+            onSkipSMTP={handleSkipSMTP}
+          />
         )}
 
         {step === "survey" && activeSurvey && pendingOrganizationId && (
@@ -435,131 +275,28 @@ const OwnerSetup: React.FC = () => {
         )}
 
         {step === "smtpConfig" && (
-          <form onSubmit={handleSubmitSMTP} className="space-y-6">
-            {error && (
-              <div className="p-3 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-                <Text className="text-red-700 dark:text-red-400 text-sm">{error}</Text>
-              </div>
-            )}
-
-            <div className="text-left">
-              <h4 className="text-lg font-medium text-gray-800 dark:text-white mb-2">SMTP configuration</h4>
-              <Text className="text-gray-800 dark:text-gray-300">Configure email delivery for this instance.</Text>
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                SMTP Host <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="text"
-                  value={smtpHost}
-                  onChange={(e) => setSmtpHost(e.target.value)}
-                  placeholder="smtp.example.com"
-                  className={fieldErrors.smtpHost ? "border-red-500" : ""}
-                />
-              </InputGroup>
-              {fieldErrors.smtpHost && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpHost}</p>
-              )}
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                SMTP Port <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="text"
-                  value={smtpPort}
-                  onChange={(e) => setSmtpPort(e.target.value)}
-                  placeholder="587"
-                  className={fieldErrors.smtpPort ? "border-red-500" : ""}
-                />
-              </InputGroup>
-              {fieldErrors.smtpPort && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpPort}</p>
-              )}
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">SMTP Username</Label>
-              <InputGroup>
-                <Input
-                  type="text"
-                  value={smtpUsername}
-                  onChange={(e) => setSmtpUsername(e.target.value)}
-                  placeholder="smtp-user"
-                />
-              </InputGroup>
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">SMTP Password</Label>
-              <InputGroup>
-                <Input
-                  type="password"
-                  value={smtpPassword}
-                  onChange={(e) => setSmtpPassword(e.target.value)}
-                  placeholder="SMTP password"
-                  className={fieldErrors.smtpPassword ? "border-red-500 ph-no-capture" : "ph-no-capture"}
-                />
-              </InputGroup>
-              {fieldErrors.smtpPassword && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpPassword}</p>
-              )}
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">From Name</Label>
-              <InputGroup>
-                <Input
-                  type="text"
-                  value={smtpFromName}
-                  onChange={(e) => setSmtpFromName(e.target.value)}
-                  placeholder="SuperPlane"
-                />
-              </InputGroup>
-            </div>
-
-            <div>
-              <Label className="block text-left mb-2">
-                From Email <span className="text-gray-800">*</span>
-              </Label>
-              <InputGroup>
-                <Input
-                  type="email"
-                  value={smtpFromEmail}
-                  onChange={(e) => setSmtpFromEmail(e.target.value)}
-                  placeholder="noreply@example.com"
-                  className={fieldErrors.smtpFromEmail ? "border-red-500" : ""}
-                />
-              </InputGroup>
-              {fieldErrors.smtpFromEmail && (
-                <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpFromEmail}</p>
-              )}
-            </div>
-
-            <Label className="inline-flex items-center gap-2">
-              <input type="checkbox" checked={smtpUseTLS} onChange={(e) => setSmtpUseTLS(e.target.checked)} />
-              Use TLS (STARTTLS)
-            </Label>
-
-            <div className="flex flex-wrap items-center gap-3">
-              <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPConfigBack}>
-                Back
-              </Button>
-              <div className="ml-auto flex flex-wrap justify-end gap-3">
-                <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
-                  Do this later
-                </Button>
-                <Button type="submit" className="w-36" disabled={loading}>
-                  {loading ? "Saving..." : "Finish setup"}
-                </Button>
-              </div>
-            </div>
-          </form>
+          <SmtpConfigStep
+            smtpHost={smtpHost}
+            smtpPort={smtpPort}
+            smtpUsername={smtpUsername}
+            smtpPassword={smtpPassword}
+            smtpFromName={smtpFromName}
+            smtpFromEmail={smtpFromEmail}
+            smtpUseTLS={smtpUseTLS}
+            loading={loading}
+            error={error}
+            fieldErrors={fieldErrors}
+            onSmtpHostChange={setSmtpHost}
+            onSmtpPortChange={setSmtpPort}
+            onSmtpUsernameChange={setSmtpUsername}
+            onSmtpPasswordChange={setSmtpPassword}
+            onSmtpFromNameChange={setSmtpFromName}
+            onSmtpFromEmailChange={setSmtpFromEmail}
+            onSmtpUseTLSChange={setSmtpUseTLS}
+            onBack={handleSMTPConfigBack}
+            onSkipSMTP={handleSkipSMTP}
+            onSubmit={handleSubmitSMTP}
+          />
         )}
       </div>
     </div>

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -341,9 +341,11 @@ const OwnerSetup: React.FC = () => {
               )}
             </div>
 
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? "Saving..." : "Next"}
-            </Button>
+            <div className="flex justify-end">
+              <Button type="submit" className="w-36" disabled={loading}>
+                {loading ? "Saving..." : "Next"}
+              </Button>
+            </div>
           </form>
         )}
 
@@ -385,11 +387,11 @@ const OwnerSetup: React.FC = () => {
               </div>
             </div>
 
-            <div className="flex gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <Button type="button" variant="outline" disabled={loading} onClick={handlePrivateNetworkBack}>
                 Back
               </Button>
-              <Button type="button" className="flex-1" disabled={loading} onClick={handlePrivateNetworkNext}>
+              <Button type="button" className="ml-auto w-36" disabled={loading} onClick={handlePrivateNetworkNext}>
                 Next
               </Button>
             </div>
@@ -411,16 +413,19 @@ const OwnerSetup: React.FC = () => {
               </Text>
             </div>
 
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPPromptBack}>
                 Back
               </Button>
-              <Button type="button" disabled={loading} onClick={handleEnableSMTP}>
-                Set up SMTP
-              </Button>
-              <Button type="button" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
-                Do this later
-              </Button>
+
+              <div className="ml-auto flex flex-wrap justify-end gap-3">
+                <Button type="button" className="w-36" disabled={loading} onClick={handleEnableSMTP}>
+                  Set up SMTP
+                </Button>
+                <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
+                  Do this later
+                </Button>
+              </div>
             </div>
           </div>
         )}
@@ -541,16 +546,18 @@ const OwnerSetup: React.FC = () => {
               Use TLS (STARTTLS)
             </Label>
 
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap items-center gap-3">
               <Button type="button" variant="outline" disabled={loading} onClick={handleSMTPConfigBack}>
                 Back
               </Button>
-              <Button type="button" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
-                Do this later
-              </Button>
-              <Button type="submit" className="flex-1" disabled={loading}>
-                {loading ? "Saving..." : "Finish setup"}
-              </Button>
+              <div className="ml-auto flex flex-wrap justify-end gap-3">
+                <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={handleSkipSMTP}>
+                  Do this later
+                </Button>
+                <Button type="submit" className="w-36" disabled={loading}>
+                  {loading ? "Saving..." : "Finish setup"}
+                </Button>
+              </div>
             </div>
           </form>
         )}

--- a/web_src/src/pages/auth/ownerSetup/ErrorBanner.tsx
+++ b/web_src/src/pages/auth/ownerSetup/ErrorBanner.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Text } from "@/components/Text/text";
+
+export const ErrorBanner = ({ message }: { message: string | null }) => {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+      <Text className="text-sm text-red-700 dark:text-red-400">{message}</Text>
+    </div>
+  );
+};

--- a/web_src/src/pages/auth/ownerSetup/ErrorBanner.tsx
+++ b/web_src/src/pages/auth/ownerSetup/ErrorBanner.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Text } from "@/components/Text/text";
 
 export const ErrorBanner = ({ message }: { message: string | null }) => {

--- a/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import superplaneLogo from "@/assets/superplane.svg";
+import { Input, InputGroup } from "@/components/Input/input";
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ErrorBanner } from "./ErrorBanner";
+
+type OwnerStepProps = {
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  confirmPassword: string;
+  loading: boolean;
+  error: string | null;
+  fieldErrors: Record<string, string>;
+  onEmailChange: (value: string) => void;
+  onFirstNameChange: (value: string) => void;
+  onLastNameChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onNext: (event: React.FormEvent) => void;
+};
+
+export const OwnerStep: React.FC<OwnerStepProps> = ({
+  email,
+  firstName,
+  lastName,
+  password,
+  confirmPassword,
+  loading,
+  error,
+  fieldErrors,
+  onEmailChange,
+  onFirstNameChange,
+  onLastNameChange,
+  onPasswordChange,
+  onConfirmPasswordChange,
+  onNext,
+}) => (
+  <>
+    <div className="mb-8 text-center">
+      <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto mb-4 h-8 w-8" />
+      <h4 className="mb-1 text-xl font-medium text-gray-800 dark:text-white">Set up owner account</h4>
+      <Text className="text-gray-800 dark:text-gray-300">Create an account for this SuperPlane instance.</Text>
+    </div>
+    <form onSubmit={onNext} className="space-y-4">
+      <ErrorBanner message={error} />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <Label className="mb-2 block text-left">
+            First Name <span className="text-gray-800">*</span>
+          </Label>
+          <InputGroup>
+            <Input
+              type="text"
+              value={firstName}
+              onChange={(event) => onFirstNameChange(event.target.value)}
+              placeholder="First name"
+              className={fieldErrors.firstName ? "border-red-500" : ""}
+            />
+          </InputGroup>
+          {fieldErrors.firstName && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.firstName}</p>
+          )}
+        </div>
+        <div>
+          <Label className="mb-2 block text-left">
+            Last Name <span className="text-gray-800">*</span>
+          </Label>
+          <InputGroup>
+            <Input
+              type="text"
+              value={lastName}
+              onChange={(event) => onLastNameChange(event.target.value)}
+              placeholder="Last name"
+              className={fieldErrors.lastName ? "border-red-500" : ""}
+            />
+          </InputGroup>
+          {fieldErrors.lastName && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.lastName}</p>
+          )}
+        </div>
+      </div>
+      <div>
+        <Label className="mb-2 block text-left">
+          Email <span className="text-gray-800">*</span>
+        </Label>
+        <InputGroup>
+          <Input
+            type="email"
+            value={email}
+            onChange={(event) => onEmailChange(event.target.value)}
+            placeholder="you@example.com"
+            className={fieldErrors.email ? "border-red-500" : ""}
+          />
+        </InputGroup>
+        {fieldErrors.email && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.email}</p>}
+      </div>
+      <div>
+        <Label className="mb-2 block text-left">
+          Password <span className="text-gray-800">*</span>
+        </Label>
+        <InputGroup>
+          <Input
+            type="password"
+            value={password}
+            onChange={(event) => onPasswordChange(event.target.value)}
+            placeholder="Password"
+            className={fieldErrors.password ? "border-red-500 ph-no-capture" : "ph-no-capture"}
+          />
+        </InputGroup>
+        {fieldErrors.password ? (
+          <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.password}</p>
+        ) : (
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            8+ characters, at least 1 number and 1 capital letter
+          </p>
+        )}
+      </div>
+      <div>
+        <Label className="mb-2 block text-left">
+          Confirm Password <span className="text-gray-800">*</span>
+        </Label>
+        <InputGroup>
+          <Input
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => onConfirmPasswordChange(event.target.value)}
+            placeholder="Confirm password"
+            className={fieldErrors.confirmPassword ? "border-red-500 ph-no-capture" : "ph-no-capture"}
+          />
+        </InputGroup>
+        {fieldErrors.confirmPassword && (
+          <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.confirmPassword}</p>
+        )}
+      </div>
+      <div className="flex justify-end">
+        <Button type="submit" className="w-36" disabled={loading}>
+          {loading ? "Saving..." : "Next"}
+        </Button>
+      </div>
+    </form>
+  </>
+);

--- a/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/OwnerStep.tsx
@@ -137,7 +137,7 @@ export const OwnerStep: React.FC<OwnerStepProps> = ({
         )}
       </div>
       <div className="flex justify-end">
-        <Button type="submit" className="w-36" disabled={loading}>
+        <Button type="submit" disabled={loading}>
           {loading ? "Saving..." : "Next"}
         </Button>
       </div>

--- a/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
@@ -59,7 +59,7 @@ export const PrivateNetworkStep: React.FC<PrivateNetworkStepProps> = ({
       <Button type="button" variant="outline" disabled={loading} onClick={onBack}>
         Back
       </Button>
-      <Button type="button" className="ml-auto w-36" disabled={loading} onClick={onNext}>
+      <Button type="button" className="ml-auto" disabled={loading} onClick={onNext}>
         Next
       </Button>
     </div>

--- a/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/PrivateNetworkStep.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/ui/switch";
+import { ErrorBanner } from "./ErrorBanner";
+
+type PrivateNetworkStepProps = {
+  allowPrivateNetworkAccess: boolean;
+  loading: boolean;
+  error: string | null;
+  onAllowPrivateNetworkAccessChange: (checked: boolean) => void;
+  onBack: () => void;
+  onNext: () => void;
+};
+
+export const PrivateNetworkStep: React.FC<PrivateNetworkStepProps> = ({
+  allowPrivateNetworkAccess,
+  loading,
+  error,
+  onAllowPrivateNetworkAccessChange,
+  onBack,
+  onNext,
+}) => (
+  <div className="space-y-6">
+    <ErrorBanner message={error} />
+
+    <div className="text-left">
+      <h4 className="mb-2 text-lg font-medium text-gray-800 dark:text-white">Private network access</h4>
+      <Text className="text-gray-800 dark:text-gray-300">
+        Decide whether this SuperPlane instance should be allowed to reach internal services before continuing to email
+        setup.
+      </Text>
+    </div>
+
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-4 text-left">
+      <div className="flex items-start justify-between gap-6">
+        <div className="max-w-xs">
+          <Label className="mb-1 block text-sm font-medium text-gray-800">Allow private network targets</Label>
+          <Text className="text-sm text-gray-600">
+            Enable this if SuperPlane needs to reach tools inside your VPC, private Kubernetes cluster, or another
+            closed network. This reduces SSRF protection for private addresses.
+          </Text>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-gray-500">{allowPrivateNetworkAccess ? "Enabled" : "Disabled"}</span>
+          <Switch
+            data-testid="owner-setup-private-network-switch"
+            checked={allowPrivateNetworkAccess}
+            onCheckedChange={onAllowPrivateNetworkAccessChange}
+            aria-label="Allow connections to private network tools"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div className="flex flex-wrap items-center gap-3">
+      <Button type="button" variant="outline" disabled={loading} onClick={onBack}>
+        Back
+      </Button>
+      <Button type="button" className="ml-auto w-36" disabled={loading} onClick={onNext}>
+        Next
+      </Button>
+    </div>
+  </div>
+);

--- a/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
@@ -218,10 +218,10 @@ export const SmtpConfigStep: React.FC<SmtpConfigStepProps> = ({
         Back
       </Button>
       <div className="ml-auto flex flex-wrap justify-end gap-3">
-        <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={onSkipSMTP}>
+        <Button type="button" variant="outline" disabled={loading} onClick={onSkipSMTP}>
           Do this later
         </Button>
-        <Button type="submit" className="w-36" disabled={loading}>
+        <Button type="submit" disabled={loading}>
           {loading ? "Saving..." : "Finish setup"}
         </Button>
       </div>

--- a/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
@@ -3,6 +3,7 @@ import { Input, InputGroup } from "@/components/Input/input";
 import { Text } from "@/components/Text/text";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/ui/checkbox";
 import { ErrorBanner } from "./ErrorBanner";
 
 type SmtpConfigStepProps = {
@@ -155,10 +156,14 @@ const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
       )}
     </div>
 
-    <Label className="inline-flex items-center gap-2">
-      <input type="checkbox" checked={smtpUseTLS} onChange={(event) => onSmtpUseTLSChange(event.target.checked)} />
-      Use TLS (STARTTLS)
-    </Label>
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id="owner-setup-smtp-use-tls"
+        checked={smtpUseTLS}
+        onCheckedChange={(checked) => onSmtpUseTLSChange(checked === true)}
+      />
+      <Label htmlFor="owner-setup-smtp-use-tls">Use TLS (STARTTLS)</Label>
+    </div>
   </>
 );
 

--- a/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpConfigStep.tsx
@@ -1,0 +1,225 @@
+import React from "react";
+import { Input, InputGroup } from "@/components/Input/input";
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ErrorBanner } from "./ErrorBanner";
+
+type SmtpConfigStepProps = {
+  smtpHost: string;
+  smtpPort: string;
+  smtpUsername: string;
+  smtpPassword: string;
+  smtpFromName: string;
+  smtpFromEmail: string;
+  smtpUseTLS: boolean;
+  loading: boolean;
+  error: string | null;
+  fieldErrors: Record<string, string>;
+  onSmtpHostChange: (value: string) => void;
+  onSmtpPortChange: (value: string) => void;
+  onSmtpUsernameChange: (value: string) => void;
+  onSmtpPasswordChange: (value: string) => void;
+  onSmtpFromNameChange: (value: string) => void;
+  onSmtpFromEmailChange: (value: string) => void;
+  onSmtpUseTLSChange: (value: boolean) => void;
+  onBack: () => void;
+  onSkipSMTP: () => void;
+  onSubmit: (event: React.FormEvent) => void;
+};
+
+type SmtpConfigFieldsProps = Pick<
+  SmtpConfigStepProps,
+  | "smtpHost"
+  | "smtpPort"
+  | "smtpUsername"
+  | "smtpPassword"
+  | "smtpFromName"
+  | "smtpFromEmail"
+  | "smtpUseTLS"
+  | "fieldErrors"
+  | "onSmtpHostChange"
+  | "onSmtpPortChange"
+  | "onSmtpUsernameChange"
+  | "onSmtpPasswordChange"
+  | "onSmtpFromNameChange"
+  | "onSmtpFromEmailChange"
+  | "onSmtpUseTLSChange"
+>;
+
+const SmtpConfigFields: React.FC<SmtpConfigFieldsProps> = ({
+  smtpHost,
+  smtpPort,
+  smtpUsername,
+  smtpPassword,
+  smtpFromName,
+  smtpFromEmail,
+  smtpUseTLS,
+  fieldErrors,
+  onSmtpHostChange,
+  onSmtpPortChange,
+  onSmtpUsernameChange,
+  onSmtpPasswordChange,
+  onSmtpFromNameChange,
+  onSmtpFromEmailChange,
+  onSmtpUseTLSChange,
+}) => (
+  <>
+    <div>
+      <Label className="mb-2 block text-left">
+        SMTP Host <span className="text-gray-800">*</span>
+      </Label>
+      <InputGroup>
+        <Input
+          type="text"
+          value={smtpHost}
+          onChange={(event) => onSmtpHostChange(event.target.value)}
+          placeholder="smtp.example.com"
+          className={fieldErrors.smtpHost ? "border-red-500" : ""}
+        />
+      </InputGroup>
+      {fieldErrors.smtpHost && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpHost}</p>}
+    </div>
+
+    <div>
+      <Label className="mb-2 block text-left">
+        SMTP Port <span className="text-gray-800">*</span>
+      </Label>
+      <InputGroup>
+        <Input
+          type="text"
+          value={smtpPort}
+          onChange={(event) => onSmtpPortChange(event.target.value)}
+          placeholder="587"
+          className={fieldErrors.smtpPort ? "border-red-500" : ""}
+        />
+      </InputGroup>
+      {fieldErrors.smtpPort && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpPort}</p>}
+    </div>
+
+    <div>
+      <Label className="mb-2 block text-left">SMTP Username</Label>
+      <InputGroup>
+        <Input
+          type="text"
+          value={smtpUsername}
+          onChange={(event) => onSmtpUsernameChange(event.target.value)}
+          placeholder="smtp-user"
+        />
+      </InputGroup>
+    </div>
+
+    <div>
+      <Label className="mb-2 block text-left">SMTP Password</Label>
+      <InputGroup>
+        <Input
+          type="password"
+          value={smtpPassword}
+          onChange={(event) => onSmtpPasswordChange(event.target.value)}
+          placeholder="SMTP password"
+          className={fieldErrors.smtpPassword ? "border-red-500 ph-no-capture" : "ph-no-capture"}
+        />
+      </InputGroup>
+      {fieldErrors.smtpPassword && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpPassword}</p>
+      )}
+    </div>
+
+    <div>
+      <Label className="mb-2 block text-left">From Name</Label>
+      <InputGroup>
+        <Input
+          type="text"
+          value={smtpFromName}
+          onChange={(event) => onSmtpFromNameChange(event.target.value)}
+          placeholder="SuperPlane"
+        />
+      </InputGroup>
+    </div>
+
+    <div>
+      <Label className="mb-2 block text-left">
+        From Email <span className="text-gray-800">*</span>
+      </Label>
+      <InputGroup>
+        <Input
+          type="email"
+          value={smtpFromEmail}
+          onChange={(event) => onSmtpFromEmailChange(event.target.value)}
+          placeholder="noreply@example.com"
+          className={fieldErrors.smtpFromEmail ? "border-red-500" : ""}
+        />
+      </InputGroup>
+      {fieldErrors.smtpFromEmail && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400">{fieldErrors.smtpFromEmail}</p>
+      )}
+    </div>
+
+    <Label className="inline-flex items-center gap-2">
+      <input type="checkbox" checked={smtpUseTLS} onChange={(event) => onSmtpUseTLSChange(event.target.checked)} />
+      Use TLS (STARTTLS)
+    </Label>
+  </>
+);
+
+export const SmtpConfigStep: React.FC<SmtpConfigStepProps> = ({
+  smtpHost,
+  smtpPort,
+  smtpUsername,
+  smtpPassword,
+  smtpFromName,
+  smtpFromEmail,
+  smtpUseTLS,
+  loading,
+  error,
+  fieldErrors,
+  onSmtpHostChange,
+  onSmtpPortChange,
+  onSmtpUsernameChange,
+  onSmtpPasswordChange,
+  onSmtpFromNameChange,
+  onSmtpFromEmailChange,
+  onSmtpUseTLSChange,
+  onBack,
+  onSkipSMTP,
+  onSubmit,
+}) => (
+  <form onSubmit={onSubmit} className="space-y-6">
+    <ErrorBanner message={error} />
+    <div className="text-left">
+      <h4 className="mb-2 text-lg font-medium text-gray-800 dark:text-white">SMTP configuration</h4>
+      <Text className="text-gray-800 dark:text-gray-300">Configure email delivery for this instance.</Text>
+    </div>
+    <SmtpConfigFields
+      smtpHost={smtpHost}
+      smtpPort={smtpPort}
+      smtpUsername={smtpUsername}
+      smtpPassword={smtpPassword}
+      smtpFromName={smtpFromName}
+      smtpFromEmail={smtpFromEmail}
+      smtpUseTLS={smtpUseTLS}
+      fieldErrors={fieldErrors}
+      onSmtpHostChange={onSmtpHostChange}
+      onSmtpPortChange={onSmtpPortChange}
+      onSmtpUsernameChange={onSmtpUsernameChange}
+      onSmtpPasswordChange={onSmtpPasswordChange}
+      onSmtpFromNameChange={onSmtpFromNameChange}
+      onSmtpFromEmailChange={onSmtpFromEmailChange}
+      onSmtpUseTLSChange={onSmtpUseTLSChange}
+    />
+
+    <div className="flex flex-wrap items-center gap-3">
+      <Button type="button" variant="outline" disabled={loading} onClick={onBack}>
+        Back
+      </Button>
+      <div className="ml-auto flex flex-wrap justify-end gap-3">
+        <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={onSkipSMTP}>
+          Do this later
+        </Button>
+        <Button type="submit" className="w-36" disabled={loading}>
+          {loading ? "Saving..." : "Finish setup"}
+        </Button>
+      </div>
+    </div>
+  </form>
+);

--- a/web_src/src/pages/auth/ownerSetup/SmtpPromptStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpPromptStep.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Text } from "@/components/Text/text";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "./ErrorBanner";
+
+type SmtpPromptStepProps = {
+  loading: boolean;
+  error: string | null;
+  onBack: () => void;
+  onEnableSMTP: () => void;
+  onSkipSMTP: () => void;
+};
+
+export const SmtpPromptStep: React.FC<SmtpPromptStepProps> = ({ loading, error, onBack, onEnableSMTP, onSkipSMTP }) => (
+  <div className="space-y-6">
+    <ErrorBanner message={error} />
+
+    <div className="text-left">
+      <h4 className="mb-2 text-lg font-medium text-gray-800 dark:text-white">Set up email delivery?</h4>
+      <Text className="text-gray-800 dark:text-gray-300">
+        Configure SMTP now to receive notifications. You can skip and set it up later.
+      </Text>
+    </div>
+
+    <div className="flex flex-wrap items-center gap-3">
+      <Button type="button" variant="outline" disabled={loading} onClick={onBack}>
+        Back
+      </Button>
+
+      <div className="ml-auto flex flex-wrap justify-end gap-3">
+        <Button type="button" className="w-36" disabled={loading} onClick={onEnableSMTP}>
+          Set up SMTP
+        </Button>
+        <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={onSkipSMTP}>
+          Do this later
+        </Button>
+      </div>
+    </div>
+  </div>
+);

--- a/web_src/src/pages/auth/ownerSetup/SmtpPromptStep.tsx
+++ b/web_src/src/pages/auth/ownerSetup/SmtpPromptStep.tsx
@@ -28,10 +28,10 @@ export const SmtpPromptStep: React.FC<SmtpPromptStepProps> = ({ loading, error, 
       </Button>
 
       <div className="ml-auto flex flex-wrap justify-end gap-3">
-        <Button type="button" className="w-36" disabled={loading} onClick={onEnableSMTP}>
+        <Button type="button" disabled={loading} onClick={onEnableSMTP}>
           Set up SMTP
         </Button>
-        <Button type="button" className="w-36" variant="outline" disabled={loading} onClick={onSkipSMTP}>
+        <Button type="button" variant="outline" disabled={loading} onClick={onSkipSMTP}>
           Do this later
         </Button>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
During the self-hosted installation wizard, if a user enters the SMTP configuration step, there’s no in-product way to go back or cancel. Using the browser back button resets the entire setup flow.

### What I changed
- Added explicit **Back** navigation in the owner setup wizard so users can move between steps without losing progress.
- Added a **Do this later** (skip SMTP) action in the SMTP configuration step so users can exit SMTP setup safely.
- Adjusted wizard action layout so **Back stays on the left**, and the primary actions stay **right-aligned**.
- Updated right-side actions to **size to content** (instead of fixed width) per review feedback.
- Fixed Bugbot’s note: skipping SMTP now clears stale field validation errors before submitting.
- Refactored the owner setup page into small step components under `web_src/src/pages/auth/ownerSetup/` to keep `OwnerSetup.tsx` under the lint budget thresholds.
- Replaced the raw TLS checkbox with the project `Checkbox` primitive for consistency.
- Updated the owner setup E2E helper to toggle TLS via the Radix checkbox root (`#owner-setup-smtp-use-tls`).

### Notes
- This keeps all wizard state in React state, so navigating between steps does not reset inputs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2d73a43-aa09-4dd9-8a45-436bd28f27e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2d73a43-aa09-4dd9-8a45-436bd28f27e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

