### PR TITLE
fix: add optimistic feedback for canvas folder updates

### DIFF
--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -1,7 +1,31 @@
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import type { CanvasesCanvas } from "@/api-client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { canvasKeys } from "@/hooks/useCanvasData";
+const { canvasFoldersUpdateCanvasFolder } = vi.hoisted(() => ({
+  canvasFoldersUpdateCanvasFolder: vi.fn(),
+}));
+
+vi.mock("../api-client/sdk.gen", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    canvasFoldersUpdateCanvasFolder,
+  };
+});
+
+import { canvasKeys, useUpdateCanvasFolderMembership } from "@/hooks/useCanvasData";
+
+type TestCanvasFolder = {
+  metadata?: { id?: string };
+  spec?: {
+    title?: string;
+    backgroundColor?: string;
+    canvases?: Array<{ id?: string }>;
+  };
+};
 
 describe("canvasKeys.nodeExecution", () => {
   it("omits a trailing undefined when limit is not provided", () => {
@@ -24,5 +48,136 @@ describe("canvasKeys.nodeExecution", () => {
     });
 
     expect(queryClient.getQueryState(cachedKey)?.isInvalidated).toBe(true);
+  });
+});
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeCanvas(id: string, folderId?: string): CanvasesCanvas {
+  return {
+    metadata: {
+      id,
+      name: id,
+      folderId,
+    },
+    spec: {},
+  } as CanvasesCanvas;
+}
+
+function makeFolder(id: string, canvasIds: string[] = []): TestCanvasFolder {
+  return {
+    metadata: { id },
+    spec: {
+      title: id,
+      backgroundColor: "blue",
+      canvases: canvasIds.map((canvasId) => ({ id: canvasId })),
+    },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function getCanvasFolderId(queryClient: QueryClient, organizationId: string, canvasId: string) {
+  const canvases = queryClient.getQueryData<CanvasesCanvas[]>(canvasKeys.list(organizationId)) || [];
+  const canvas = canvases.find((item) => item.metadata?.id === canvasId);
+  return (canvas?.metadata as { folderId?: string } | undefined)?.folderId;
+}
+
+function getFolderCanvasIds(queryClient: QueryClient, organizationId: string, folderId: string) {
+  const folders = queryClient.getQueryData<TestCanvasFolder[]>(canvasKeys.folderList(organizationId)) || [];
+  const folder = folders.find((item) => item.metadata?.id === folderId);
+  return folder?.spec?.canvases?.map((canvas) => canvas.id) || [];
+}
+
+describe("useUpdateCanvasFolderMembership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("optimistically moves canvases between folders before the request finishes", async () => {
+    const organizationId = "org-123";
+    const queryClient = createQueryClient();
+    const deferred = createDeferred<unknown>();
+    canvasFoldersUpdateCanvasFolder.mockReturnValue(deferred.promise);
+
+    queryClient.setQueryData(canvasKeys.list(organizationId), [
+      makeCanvas("canvas-1", "folder-1"),
+      makeCanvas("canvas-2", "folder-2"),
+    ]);
+    queryClient.setQueryData(canvasKeys.folderList(organizationId), [
+      makeFolder("folder-1", ["canvas-1"]),
+      makeFolder("folder-2", ["canvas-2"]),
+    ]);
+
+    const { result } = renderHook(() => useUpdateCanvasFolderMembership(organizationId), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const mutation = result.current.mutateAsync({
+      folderId: "folder-2",
+      title: "Deployments",
+      backgroundColor: "green",
+      canvasIds: ["canvas-2", "canvas-1"],
+    });
+
+    await waitFor(() => {
+      expect(getCanvasFolderId(queryClient, organizationId, "canvas-1")).toBe("folder-2");
+    });
+    expect(getFolderCanvasIds(queryClient, organizationId, "folder-1")).toEqual([]);
+    expect(getFolderCanvasIds(queryClient, organizationId, "folder-2")).toEqual(["canvas-2", "canvas-1"]);
+
+    deferred.resolve({});
+    await mutation;
+  });
+
+  it("rolls back optimistic folder membership on request failure", async () => {
+    const organizationId = "org-123";
+    const queryClient = createQueryClient();
+    canvasFoldersUpdateCanvasFolder.mockRejectedValue(new Error("request failed"));
+
+    queryClient.setQueryData(canvasKeys.list(organizationId), [makeCanvas("canvas-1", "folder-1")]);
+    queryClient.setQueryData(canvasKeys.folderList(organizationId), [
+      makeFolder("folder-1", ["canvas-1"]),
+      makeFolder("folder-2"),
+    ]);
+
+    const { result } = renderHook(() => useUpdateCanvasFolderMembership(organizationId), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        folderId: "folder-2",
+        title: "Deployments",
+        backgroundColor: "green",
+        canvasIds: ["canvas-1"],
+      }),
+    ).rejects.toThrow("request failed");
+
+    expect(getCanvasFolderId(queryClient, organizationId, "canvas-1")).toBe("folder-1");
+    expect(getFolderCanvasIds(queryClient, organizationId, "folder-1")).toEqual(["canvas-1"]);
+    expect(getFolderCanvasIds(queryClient, organizationId, "folder-2")).toEqual([]);
   });
 });

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -629,16 +629,107 @@ export const useDeleteCanvasFolder = (organizationId: string) => {
   });
 };
 
+type UpdateCanvasFolderMembershipInput = {
+  folderId: string;
+  title: string;
+  backgroundColor: CanvasFolderColor;
+  canvasIds: string[];
+};
+
+type CanvasMetadataWithFolder = CanvasesCanvas["metadata"] & {
+  folderId?: string;
+};
+
+function updateCanvasListFolderMembership(
+  canvases: CanvasesCanvas[] | undefined,
+  data: UpdateCanvasFolderMembershipInput,
+) {
+  if (!canvases) {
+    return canvases;
+  }
+
+  const targetCanvasIds = new Set(data.canvasIds);
+
+  return canvases.map((canvas) => {
+    const metadata = canvas.metadata as CanvasMetadataWithFolder | undefined;
+    const canvasId = metadata?.id;
+    if (!canvasId) {
+      return canvas;
+    }
+
+    if (targetCanvasIds.has(canvasId)) {
+      return {
+        ...canvas,
+        metadata: {
+          ...metadata,
+          folderId: data.folderId,
+        },
+      };
+    }
+
+    if (metadata.folderId !== data.folderId) {
+      return canvas;
+    }
+
+    return {
+      ...canvas,
+      metadata: {
+        ...metadata,
+        folderId: undefined,
+      },
+    };
+  });
+}
+
+function updateCanvasFolderListMembership(
+  folders: CanvasFoldersCanvasFolder[] | undefined,
+  data: UpdateCanvasFolderMembershipInput,
+) {
+  if (!folders) {
+    return folders;
+  }
+
+  const targetCanvasIds = new Set(data.canvasIds);
+
+  return folders.map((folder) => {
+    const folderId = folder.metadata?.id;
+    if (!folderId) {
+      return folder;
+    }
+
+    if (folderId === data.folderId) {
+      return {
+        ...folder,
+        spec: {
+          ...folder.spec,
+          title: data.title,
+          backgroundColor: data.backgroundColor,
+          canvases: data.canvasIds.map((id) => ({ id })),
+        },
+      };
+    }
+
+    const canvases = folder.spec?.canvases || [];
+    const nextCanvases = canvases.filter((canvas) => !canvas.id || !targetCanvasIds.has(canvas.id));
+    if (nextCanvases.length === canvases.length) {
+      return folder;
+    }
+
+    return {
+      ...folder,
+      spec: {
+        ...folder.spec,
+        canvases: nextCanvases,
+      },
+    };
+  });
+}
+
 export const useUpdateCanvasFolderMembership = (organizationId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: {
-      folderId: string;
-      title: string;
-      backgroundColor: CanvasFolderColor;
-      canvasIds: string[];
-    }) => {
+    mutationFn: async (data: UpdateCanvasFolderMembershipInput) => {
       return await canvasFoldersUpdateCanvasFolder(
         withOrganizationHeader({
           organizationId,
@@ -656,7 +747,37 @@ export const useUpdateCanvasFolderMembership = (organizationId: string) => {
         }),
       );
     },
-    onSuccess: () => {
+    onMutate: async (data) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: canvasKeys.list(organizationId) }),
+        queryClient.cancelQueries({ queryKey: canvasKeys.folderList(organizationId) }),
+      ]);
+
+      const previousCanvases = queryClient.getQueryData<CanvasesCanvas[]>(canvasKeys.list(organizationId));
+      const previousFolders = queryClient.getQueryData<CanvasFoldersCanvasFolder[]>(
+        canvasKeys.folderList(organizationId),
+      );
+
+      queryClient.setQueryData(canvasKeys.list(organizationId), (current: CanvasesCanvas[] | undefined) =>
+        updateCanvasListFolderMembership(current, data),
+      );
+      queryClient.setQueryData(
+        canvasKeys.folderList(organizationId),
+        (current: CanvasFoldersCanvasFolder[] | undefined) => updateCanvasFolderListMembership(current, data),
+      );
+
+      return { previousCanvases, previousFolders };
+    },
+    onError: (_error, _data, context) => {
+      if (context?.previousCanvases) {
+        queryClient.setQueryData(canvasKeys.list(organizationId), context.previousCanvases);
+      }
+
+      if (context?.previousFolders) {
+        queryClient.setQueryData(canvasKeys.folderList(organizationId), context.previousFolders);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.folderList(organizationId) });
     },

--- a/web_src/src/pages/home/CanvasFolderSubmenu.tsx
+++ b/web_src/src/pages/home/CanvasFolderSubmenu.tsx
@@ -1,5 +1,5 @@
 import type { CanvasFoldersCanvasFolder } from "@/api-client";
-import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { Input } from "@/components/Input/input";
 import { Text } from "@/components/Text/text";
 import {
@@ -33,6 +33,9 @@ interface CanvasFolderSubmenuProps {
   canUpdateCanvases: boolean;
 }
 
+type CreateCanvasFolderMutation = ReturnType<typeof useCreateCanvasFolder>;
+type UpdateCanvasFolderMembershipMutation = ReturnType<typeof useUpdateCanvasFolderMembership>;
+
 export function CanvasFolderSubmenu({
   canvas,
   canvasFolders,
@@ -46,96 +49,50 @@ export function CanvasFolderSubmenu({
   const queryClient = useQueryClient();
   const folderActionLabel = canvas.canvasFolderId ? "Move to Folder" : "Add to Folder";
   const isDuplicateNewFolderTitle = hasDuplicateFolderTitle(canvasFolders, newFolderTitle);
+  const isCreatingFolder = createCanvasFolderMutation.isPending;
+  const isUpdatingMembership = updateCanvasFolderMembershipMutation.isPending;
 
-  const handleAssignToFolder = async (folderId: string) => {
-    if (!canUpdateCanvases || folderId === canvas.canvasFolderId) return;
-
-    const folder = canvasFolders.find((canvasFolder) => canvasFolder.id === folderId);
-    if (!folder) {
-      showErrorToast("Folder not found");
-      return;
-    }
-
-    try {
-      await updateCanvasFolderMembershipMutation.mutateAsync({
-        folderId: folder.id,
-        title: folder.title,
-        backgroundColor: folder.backgroundColor,
-        canvasIds: addCanvasToFolder(folder.canvasIds, canvas.id),
-      });
-    } catch (error) {
-      showErrorToast(getApiErrorMessage(error, "Failed to add canvas to folder"));
-    }
-  };
-
-  const handleRemoveFromFolder = async () => {
-    if (!canUpdateCanvases || !canvas.canvasFolderId) return;
-
-    const folder = canvasFolders.find((canvasFolder) => canvasFolder.id === canvas.canvasFolderId);
-    if (!folder) {
-      showErrorToast("Folder not found");
-      return;
-    }
-
-    try {
-      await updateCanvasFolderMembershipMutation.mutateAsync({
-        folderId: folder.id,
-        title: folder.title,
-        backgroundColor: folder.backgroundColor,
-        canvasIds: removeCanvasFromFolder(folder.canvasIds, canvas.id),
-      });
-    } catch (error) {
-      showErrorToast(getApiErrorMessage(error, "Failed to remove canvas from folder"));
-    }
-  };
-
-  const handleCreateFolder = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (!canUpdateCanvases) return;
-
-    const title = newFolderTitle.trim();
-    if (!title) return;
-
-    if (isDuplicateNewFolderTitle) {
-      showErrorToast("Folder name already exists");
-      return;
-    }
-
-    let responseFolderId: string | undefined;
-    try {
-      const response = await createCanvasFolderMutation.mutateAsync({ title, backgroundColor: newFolderColor });
-      responseFolderId = response.data?.folder?.metadata?.id;
-    } catch (error) {
-      showErrorToast(getApiErrorMessage(error, "Failed to create folder"));
-      return;
-    }
-
-    try {
-      const folderId = await resolveCreatedFolderId(queryClient, organizationId, title, responseFolderId);
-
-      await updateCanvasFolderMembershipMutation.mutateAsync({
-        folderId,
-        title,
-        backgroundColor: newFolderColor,
-        canvasIds: [canvas.id],
-      });
-    } catch (error) {
-      setNewFolderTitle("");
-      setNewFolderColor(DEFAULT_CANVAS_FOLDER_COLOR);
-      showErrorToast(getFolderCreatedAssignmentErrorMessage(error));
-      return;
-    }
-
+  const resetNewFolderForm = () => {
     setNewFolderTitle("");
     setNewFolderColor(DEFAULT_CANVAS_FOLDER_COLOR);
-    showSuccessToast("Folder created");
   };
+
+  const handleAssignToFolder = (folderId: string) =>
+    assignCanvasToFolder({
+      canvas,
+      canvasFolders,
+      folderId,
+      canUpdateCanvases,
+      updateCanvasFolderMembershipMutation,
+    });
+
+  const handleRemoveFromFolder = () =>
+    removeCanvasFromFolder({
+      canvas,
+      canvasFolders,
+      canUpdateCanvases,
+      updateCanvasFolderMembershipMutation,
+    });
+
+  const handleCreateFolder = (event: FormEvent<HTMLFormElement>) =>
+    createFolderAndAssignCanvas({
+      event,
+      canvasId: canvas.id,
+      title: newFolderTitle,
+      backgroundColor: newFolderColor,
+      organizationId,
+      queryClient,
+      canUpdateCanvases,
+      isDuplicateTitle: isDuplicateNewFolderTitle,
+      createCanvasFolderMutation,
+      updateCanvasFolderMembershipMutation,
+      onReset: resetNewFolderForm,
+    });
 
   return (
     <>
       <DropdownMenuSub>
-        <DropdownMenuSubTrigger disabled={!canUpdateCanvases}>
+        <DropdownMenuSubTrigger disabled={!canUpdateCanvases || isCreatingFolder || isUpdatingMembership}>
           <FolderPlus size={16} />
           {folderActionLabel}
         </DropdownMenuSubTrigger>
@@ -143,7 +100,7 @@ export function CanvasFolderSubmenu({
           <CanvasFolderList
             canvas={canvas}
             canvasFolders={canvasFolders}
-            isUpdatingMembership={updateCanvasFolderMembershipMutation.isPending}
+            isUpdatingMembership={isUpdatingMembership}
             onAssignToFolder={(folderId) => void handleAssignToFolder(folderId)}
           />
           <CreateCanvasFolderForm
@@ -151,7 +108,8 @@ export function CanvasFolderSubmenu({
             backgroundColor={newFolderColor}
             isDuplicateTitle={isDuplicateNewFolderTitle}
             canUpdateCanvases={canUpdateCanvases}
-            isCreatingFolder={createCanvasFolderMutation.isPending}
+            isCreatingFolder={isCreatingFolder}
+            isUpdatingMembership={isUpdatingMembership}
             onTitleChange={setNewFolderTitle}
             onColorChange={setNewFolderColor}
             onSubmit={handleCreateFolder}
@@ -162,7 +120,7 @@ export function CanvasFolderSubmenu({
       <RemoveFromFolderItem
         canvasFolderId={canvas.canvasFolderId}
         canUpdateCanvases={canUpdateCanvases}
-        isUpdatingMembership={updateCanvasFolderMembershipMutation.isPending}
+        isUpdatingMembership={isUpdatingMembership}
         onRemoveFromFolder={() => void handleRemoveFromFolder()}
       />
     </>
@@ -172,6 +130,140 @@ export function CanvasFolderSubmenu({
 function hasDuplicateFolderTitle(canvasFolders: CanvasFolderData[], title: string) {
   const normalizedTitle = title.trim().toLowerCase();
   return canvasFolders.some((folder) => folder.title.trim().toLowerCase() === normalizedTitle);
+}
+
+async function assignCanvasToFolder({
+  canvas,
+  canvasFolders,
+  folderId,
+  canUpdateCanvases,
+  updateCanvasFolderMembershipMutation,
+}: {
+  canvas: CanvasCardData;
+  canvasFolders: CanvasFolderData[];
+  folderId: string;
+  canUpdateCanvases: boolean;
+  updateCanvasFolderMembershipMutation: UpdateCanvasFolderMembershipMutation;
+}) {
+  if (!canUpdateCanvases || folderId === canvas.canvasFolderId) return;
+
+  const folder = canvasFolders.find((canvasFolder) => canvasFolder.id === folderId);
+  if (!folder) {
+    showErrorToast("Folder not found");
+    return;
+  }
+
+  try {
+    await updateCanvasFolderMembershipMutation.mutateAsync({
+      folderId: folder.id,
+      title: folder.title,
+      backgroundColor: folder.backgroundColor,
+      canvasIds: addCanvasToFolder(folder.canvasIds, canvas.id),
+    });
+  } catch (error) {
+    showErrorToast(getApiErrorMessage(error, "Failed to add canvas to folder"));
+  }
+}
+
+async function removeCanvasFromFolder({
+  canvas,
+  canvasFolders,
+  canUpdateCanvases,
+  updateCanvasFolderMembershipMutation,
+}: {
+  canvas: CanvasCardData;
+  canvasFolders: CanvasFolderData[];
+  canUpdateCanvases: boolean;
+  updateCanvasFolderMembershipMutation: UpdateCanvasFolderMembershipMutation;
+}) {
+  if (!canUpdateCanvases || !canvas.canvasFolderId) return;
+
+  const folder = canvasFolders.find((canvasFolder) => canvasFolder.id === canvas.canvasFolderId);
+  if (!folder) {
+    showErrorToast("Folder not found");
+    return;
+  }
+
+  try {
+    await updateCanvasFolderMembershipMutation.mutateAsync({
+      folderId: folder.id,
+      title: folder.title,
+      backgroundColor: folder.backgroundColor,
+      canvasIds: removeCanvasId(folder.canvasIds, canvas.id),
+    });
+  } catch (error) {
+    showErrorToast(getApiErrorMessage(error, "Failed to remove canvas from folder"));
+  }
+}
+
+async function createFolderAndAssignCanvas({
+  event,
+  canvasId,
+  title,
+  backgroundColor,
+  organizationId,
+  queryClient,
+  canUpdateCanvases,
+  isDuplicateTitle,
+  createCanvasFolderMutation,
+  updateCanvasFolderMembershipMutation,
+  onReset,
+}: {
+  event: FormEvent<HTMLFormElement>;
+  canvasId: string;
+  title: string;
+  backgroundColor: CanvasFolderColor;
+  organizationId: string;
+  queryClient: QueryClient;
+  canUpdateCanvases: boolean;
+  isDuplicateTitle: boolean;
+  createCanvasFolderMutation: CreateCanvasFolderMutation;
+  updateCanvasFolderMembershipMutation: UpdateCanvasFolderMembershipMutation;
+  onReset: () => void;
+}) {
+  event.preventDefault();
+  event.stopPropagation();
+  const trimmedTitle = title.trim();
+  if (!canUpdateCanvases || !trimmedTitle) return;
+
+  if (isDuplicateTitle) {
+    showErrorToast("Folder name already exists");
+    return;
+  }
+
+  const createdFolder = await createCanvasFolder(trimmedTitle, backgroundColor, createCanvasFolderMutation);
+  if (!createdFolder.ok) return;
+
+  try {
+    const folderId = await resolveCreatedFolderId(queryClient, organizationId, trimmedTitle, createdFolder.folderId);
+    await updateCanvasFolderMembershipMutation.mutateAsync({
+      folderId,
+      title: trimmedTitle,
+      backgroundColor,
+      canvasIds: [canvasId],
+    });
+  } catch (error) {
+    onReset();
+    showErrorToast(getFolderCreatedAssignmentErrorMessage(error));
+    return;
+  }
+
+  onReset();
+  showSuccessToast("Folder created");
+}
+
+async function createCanvasFolder(
+  title: string,
+  backgroundColor: CanvasFolderColor,
+  createCanvasFolderMutation: CreateCanvasFolderMutation,
+) {
+  try {
+    const response = await createCanvasFolderMutation.mutateAsync({ title, backgroundColor });
+    return { ok: true as const, folderId: response.data?.folder?.metadata?.id };
+  } catch (error) {
+    showErrorToast(getApiErrorMessage(error, "Failed to create folder"));
+    return { ok: false as const };
+  }
 }
 
 async function resolveCreatedFolderId(
@@ -202,7 +294,7 @@ function addCanvasToFolder(canvasIds: string[], canvasId: string) {
   return canvasIds.includes(canvasId) ? canvasIds : [...canvasIds, canvasId];
 }
 
-function removeCanvasFromFolder(canvasIds: string[], canvasId: string) {
+function removeCanvasId(canvasIds: string[], canvasId: string) {
   return canvasIds.filter((id) => id !== canvasId);
 }
 
@@ -274,6 +366,7 @@ function CreateCanvasFolderForm({
   isDuplicateTitle,
   canUpdateCanvases,
   isCreatingFolder,
+  isUpdatingMembership,
   onTitleChange,
   onColorChange,
   onSubmit,
@@ -283,10 +376,14 @@ function CreateCanvasFolderForm({
   isDuplicateTitle: boolean;
   canUpdateCanvases: boolean;
   isCreatingFolder: boolean;
+  isUpdatingMembership: boolean;
   onTitleChange: (title: string) => void;
   onColorChange: (color: CanvasFolderColor) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }) {
+  const isSaving = isCreatingFolder || isUpdatingMembership;
+  const loadingText = isCreatingFolder ? "Creating..." : "Adding...";
+
   return (
     <form className="space-y-3 p-3" onSubmit={onSubmit} onClick={(event) => event.stopPropagation()}>
       <Input
@@ -296,20 +393,26 @@ function CreateCanvasFolderForm({
         placeholder="New folder name"
         className="h-8"
         maxLength={128}
-        disabled={!canUpdateCanvases || isCreatingFolder}
+        disabled={!canUpdateCanvases || isSaving}
       />
       {isDuplicateTitle ? (
         <Text className="text-xs text-red-600 dark:text-red-300">Folder name already exists</Text>
       ) : null}
-      <CanvasFolderColorPicker selectedColor={backgroundColor} onColorChange={onColorChange} />
-      <Button
+      <CanvasFolderColorPicker
+        selectedColor={backgroundColor}
+        onColorChange={onColorChange}
+        isColorDisabled={() => isSaving}
+      />
+      <LoadingButton
         type="submit"
         size="sm"
         className="w-full"
-        disabled={!title.trim() || isDuplicateTitle || isCreatingFolder}
+        disabled={!title.trim() || isDuplicateTitle || isSaving}
+        loading={isSaving}
+        loadingText={loadingText}
       >
         Create Folder
-      </Button>
+      </LoadingButton>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- Add optimistic cache updates when moving canvases into or out of folders
- Add localized pending states for creating a folder and assigning a canvas
- Add tests for optimistic folder membership updates and rollback

