### PR TITLE
fix(ui): persist 'Connected integrations on top' filter across remounts

### DIFF
--- a/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { BuildingBlocksSidebar } from "./index";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BuildingBlocksSidebar, SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY } from "./index";
 import type { BuildingBlockCategory } from "./types";
 
 const defaultProps = {
@@ -63,6 +64,48 @@ describe("BuildingBlocksSidebar", () => {
     const { container } = render(<BuildingBlocksSidebar {...defaultProps} isOpen={false} />);
 
     expect(container.querySelector('[data-testid="building-blocks-sidebar"]')).not.toBeInTheDocument();
+  });
+
+  describe("'Connected integrations on top' filter persistence", () => {
+    beforeEach(() => {
+      window.localStorage.removeItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY);
+    });
+
+    afterEach(() => {
+      window.localStorage.removeItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY);
+    });
+
+    it("defaults to off when no preference is stored", async () => {
+      const user = userEvent.setup();
+      render(<BuildingBlocksSidebar {...defaultProps} />);
+
+      await user.click(screen.getByLabelText("Sidebar settings"));
+
+      const checkbox = await screen.findByRole("menuitemcheckbox", { name: "Connected integrations on top" });
+      expect(checkbox).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("writes the preference to localStorage when toggled on", async () => {
+      const user = userEvent.setup();
+      render(<BuildingBlocksSidebar {...defaultProps} />);
+
+      await user.click(screen.getByLabelText("Sidebar settings"));
+      await user.click(await screen.findByRole("menuitemcheckbox", { name: "Connected integrations on top" }));
+
+      expect(window.localStorage.getItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY)).toBe("true");
+    });
+
+    it("hydrates the toggle from localStorage on mount so the preference survives remounts", async () => {
+      window.localStorage.setItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY, "true");
+      const user = userEvent.setup();
+
+      render(<BuildingBlocksSidebar {...defaultProps} />);
+
+      await user.click(screen.getByLabelText("Sidebar settings"));
+
+      const checkbox = await screen.findByRole("menuitemcheckbox", { name: "Connected integrations on top" });
+      expect(checkbox).toHaveAttribute("aria-checked", "true");
+    });
   });
 
   describe("Enter-to-submit", () => {

--- a/web_src/src/ui/BuildingBlocksSidebar/index.tsx
+++ b/web_src/src/ui/BuildingBlocksSidebar/index.tsx
@@ -16,6 +16,8 @@ import type { BuildingBlock, BuildingBlockCategory } from "./types";
 export type { AgentContext, AgentMode } from "@/components/AgentSidebar/agentChat";
 export type { BuildingBlock, BuildingBlockCategory } from "./types";
 
+export const SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY = "buildingBlocksSidebar:showConnectedIntegrationsOnTop";
+
 export interface BuildingBlocksSidebarProps {
   isOpen: boolean;
   onToggle: (open: boolean) => void;
@@ -103,11 +105,20 @@ function OpenBuildingBlocksSidebar({
   const [hoveredBlock, setHoveredBlock] = useState<BuildingBlock | null>(null);
   const dragPreviewRef = useRef<HTMLDivElement>(null);
   const [showIntegrationSetupStatus, setShowIntegrationSetupStatus] = useState(true);
-  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(false);
+  const [showConnectedIntegrationsOnTop, setShowConnectedIntegrationsOnTop] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.localStorage.getItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY) === "true";
+  });
 
   useEffect(() => {
     localStorage.setItem(COMPONENT_SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
   }, [sidebarWidth]);
+
+  useEffect(() => {
+    localStorage.setItem(SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY, String(showConnectedIntegrationsOnTop));
+  }, [showConnectedIntegrationsOnTop]);
 
   useEffect(() => {
     if (!searchInputRef.current) {


### PR DESCRIPTION
## Summary

Closes #4370.

The **Connected integrations on top** toggle in the *Add Component* sidebar (`BuildingBlocksSidebar`) was held in `useState(false)`, which is reset on every remount — most visibly, every time the sidebar is reopened after picking a component. Users who turned it on had to re-enable it every time they came back to the picker.

This change persists the preference to `localStorage`, following the same pattern that's already used for `sidebarWidth` in this same component. The toggle now survives both remounts and full page reloads.

## What changed

`web_src/src/ui/BuildingBlocksSidebar/index.tsx`
- New exported storage key `SHOW_CONNECTED_INTEGRATIONS_ON_TOP_STORAGE_KEY = "buildingBlocksSidebar:showConnectedIntegrationsOnTop"`
- `useState` lazy initializer reads from `localStorage` (SSR-safe via `typeof window` guard)
- New `useEffect` writes the boolean back on change

The diff mirrors the existing `sidebarWidth` localStorage pattern in the same file (initializer + persistence effect), so there's nothing new to learn structurally.

## Tests

`web_src/src/ui/BuildingBlocksSidebar/index.spec.tsx` — three new tests under a `'Connected integrations on top' filter persistence` block:

1. **Defaults to off when no preference is stored.**
2. **Writes the preference to localStorage when toggled on.**
3. **Hydrates the toggle from localStorage on mount** — covers the remount case from the issue.

The dropdown menu uses Radix UI, which needs real pointer events, so the new tests use `@testing-library/user-event` (already a project dependency) instead of `fireEvent`. `beforeEach` / `afterEach` clear the storage key to keep tests isolated.

All 11 tests in the file pass:
```
Test Files  1 passed (1)
     Tests  11 passed (11)
```

`npm run build` and `npm run lint:budget` both clean.

## Note on a related toggle

The `Show integration setup status` checkbox right above this one has the same in-memory-only state pattern, so it'll have the same drift if the user ever turns it off. I left it alone here because it isn't called out in #4370 and its default-on behavior likely masks it for most users — happy to either extend this PR or open a follow-up if you'd like that one persisted too.