### PR TITLE
feat: enable empty matchList for read memory component

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -648,12 +648,14 @@ The Read Memory component looks up values from canvas-level memory storage.
 - Retrieve previously stored IDs before cleanup actions
 - Check whether related data already exists
 - Rehydrate context from prior runs
+- Enumerate every record in a namespace (for bulk processing or fan-out)
 
 ### How It Works
 
-1. Reads `namespace`, `resultMode`, `emitMode`, and `matchList` from configuration
-2. Finds memory rows matching all configured key/value pairs
-3. Emits `memory.read` to the `found` or `notFound` channel
+1. Reads `namespace`, `resultMode`, `emitMode`, and optional `matchList` from configuration
+2. When `matchList` is provided, finds memory rows matching all configured key/value pairs
+3. When `matchList` is omitted or empty, returns all rows in the namespace (or the most recently created row when `resultMode = latest`)
+4. Emits `memory.read` to the `found` or `notFound` channel
 
 ### Output Channels
 

--- a/pkg/components/addmemory/add_memory_test.go
+++ b/pkg/components/addmemory/add_memory_test.go
@@ -30,6 +30,14 @@ func (c *canvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	return nil, c.err
 }
 
+func (c *canvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	return []any{}, c.err
+}
+
+func (c *canvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	return nil, c.err
+}
+
 func TestAddMemoryExecute(t *testing.T) {
 	t.Run("adds memory and emits payload", func(t *testing.T) {
 		component := &AddMemory{}

--- a/pkg/components/deletememory/delete_memory_test.go
+++ b/pkg/components/deletememory/delete_memory_test.go
@@ -29,6 +29,14 @@ func (c *canvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	return nil, nil
 }
 
+func (c *canvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	return []any{}, nil
+}
+
+func (c *canvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	return nil, nil
+}
+
 func (c *canvasMemoryContext) Delete(namespace string, matches map[string]any) ([]any, error) {
 	c.deleteCalls++
 	c.namespace = namespace

--- a/pkg/components/readmemory/read_memory.go
+++ b/pkg/components/readmemory/read_memory.go
@@ -59,12 +59,14 @@ func (c *ReadMemory) Documentation() string {
 - Retrieve previously stored IDs before cleanup actions
 - Check whether related data already exists
 - Rehydrate context from prior runs
+- Enumerate every record in a namespace (for bulk processing or fan-out)
 
 ## How It Works
 
-1. Reads ` + "`namespace`" + `, ` + "`resultMode`" + `, ` + "`emitMode`" + `, and ` + "`matchList`" + ` from configuration
-2. Finds memory rows matching all configured key/value pairs
-3. Emits ` + "`memory.read`" + ` to the ` + "`found`" + ` or ` + "`notFound`" + ` channel
+1. Reads ` + "`namespace`" + `, ` + "`resultMode`" + `, ` + "`emitMode`" + `, and optional ` + "`matchList`" + ` from configuration
+2. When ` + "`matchList`" + ` is provided, finds memory rows matching all configured key/value pairs
+3. When ` + "`matchList`" + ` is omitted or empty, returns all rows in the namespace (or the most recently created row when ` + "`resultMode = latest`" + `)
+4. Emits ` + "`memory.read`" + ` to the ` + "`found`" + ` or ` + "`notFound`" + ` channel
 
 ## Output Channels
 
@@ -121,8 +123,9 @@ func (c *ReadMemory) Configuration() []configuration.Field {
 			Name:        "matchList",
 			Label:       "Matches",
 			Type:        configuration.FieldTypeList,
-			Description: "List of exact field/value matches used for lookup",
-			Required:    true,
+			Description: "Optional exact field/value matches used for lookup. When omitted, all rows in the namespace are returned.",
+			Required:    false,
+			Togglable:   true,
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Match",
@@ -193,7 +196,15 @@ func (c *ReadMemory) Execute(ctx core.ExecutionContext) error {
 	matches := buildMatches(spec.MatchList)
 	values := []any{}
 	if spec.ResultMode == ResultModeLatest {
-		value, findErr := ctx.CanvasMemory.FindFirst(spec.Namespace, matches)
+		var (
+			value   any
+			findErr error
+		)
+		if len(matches) == 0 {
+			value, findErr = ctx.CanvasMemory.FindFirstInNamespace(spec.Namespace)
+		} else {
+			value, findErr = ctx.CanvasMemory.FindFirst(spec.Namespace, matches)
+		}
 		if findErr != nil {
 			return fmt.Errorf("failed to read canvas memory: %w", findErr)
 		}
@@ -202,7 +213,11 @@ func (c *ReadMemory) Execute(ctx core.ExecutionContext) error {
 		}
 	} else {
 		var findErr error
-		values, findErr = ctx.CanvasMemory.Find(spec.Namespace, matches)
+		if len(matches) == 0 {
+			values, findErr = ctx.CanvasMemory.FindAll(spec.Namespace)
+		} else {
+			values, findErr = ctx.CanvasMemory.Find(spec.Namespace, matches)
+		}
 		if findErr != nil {
 			return fmt.Errorf("failed to read canvas memory: %w", findErr)
 		}
@@ -265,11 +280,6 @@ func validateSpec(spec Spec) error {
 	}
 	if spec.EmitMode != EmitModeAllAtOnce && spec.EmitMode != EmitModeOneByOne {
 		return fmt.Errorf("emitMode must be either %q or %q", EmitModeAllAtOnce, EmitModeOneByOne)
-	}
-
-	matches := buildMatches(spec.MatchList)
-	if len(matches) == 0 {
-		return fmt.Errorf("at least one memory match is required")
 	}
 
 	return nil

--- a/pkg/components/readmemory/read_memory_test.go
+++ b/pkg/components/readmemory/read_memory_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 type canvasMemoryContext struct {
-	namespace      string
-	matches        map[string]any
-	values         []any
-	first          any
-	findCalls      int
-	findFirstCalls int
-	err            error
+	namespace                 string
+	matches                   map[string]any
+	values                    []any
+	first                     any
+	findCalls                 int
+	findFirstCalls            int
+	findAllCalls              int
+	findFirstInNamespaceCalls int
+	err                       error
 }
 
 func (c *canvasMemoryContext) Add(namespace string, values any) error {
@@ -38,6 +40,24 @@ func (c *canvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	c.findFirstCalls++
 	c.namespace = namespace
 	c.matches = matches
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.first, nil
+}
+
+func (c *canvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	c.findAllCalls++
+	c.namespace = namespace
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.values, nil
+}
+
+func (c *canvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	c.findFirstInNamespaceCalls++
+	c.namespace = namespace
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -220,8 +240,77 @@ func TestReadMemoryExecute(t *testing.T) {
 		assert.Contains(t, err.Error(), "namespace is required")
 	})
 
-	t.Run("returns error when no matches are provided", func(t *testing.T) {
+	t.Run("reads all rows in namespace when matchList is empty", func(t *testing.T) {
 		component := &ReadMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{
+			values: []any{
+				map[string]any{"creator": "igor", "sandbox_id": "sbx-001"},
+				map[string]any{"creator": "alex", "sandbox_id": "sbx-002"},
+			},
+		}
+		execMetadata := &contexts.MetadataContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace": "machines",
+				"matchList": []map[string]any{},
+			},
+			Metadata:       execMetadata,
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, memoryCtx.findCalls)
+		assert.Equal(t, 1, memoryCtx.findAllCalls)
+		assert.Equal(t, "machines", memoryCtx.namespace)
+		assert.Equal(t, ChannelNameFound, execState.Channel)
+
+		payload, ok := execState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		data, ok := payload["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "machines", data["namespace"])
+		assert.Equal(t, map[string]any{}, data["matches"])
+		assert.Equal(t, memoryCtx.values, data["values"])
+		assert.Equal(t, 2, data["count"])
+
+		assert.Equal(t, []string{}, execMetadata.Get().(map[string]any)["fields"])
+		assert.Equal(t, map[string]any{}, execMetadata.Get().(map[string]any)["matches"])
+	})
+
+	t.Run("reads latest row in namespace when matchList is empty", func(t *testing.T) {
+		component := &ReadMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{
+			first: map[string]any{"creator": "igor", "sandbox_id": "sbx-latest"},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":  "machines",
+				"resultMode": ResultModeLatest,
+				"matchList":  []map[string]any{},
+			},
+			Metadata:       &contexts.MetadataContext{},
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 0, memoryCtx.findFirstCalls)
+		assert.Equal(t, 1, memoryCtx.findFirstInNamespaceCalls)
+		assert.Equal(t, "machines", memoryCtx.namespace)
+		assert.Equal(t, ChannelNameFound, execState.Channel)
+	})
+
+	t.Run("emits notFound when matchList is empty and namespace has no rows", func(t *testing.T) {
+		component := &ReadMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{values: []any{}}
 
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
@@ -230,12 +319,13 @@ func TestReadMemoryExecute(t *testing.T) {
 			},
 			Metadata:       &contexts.MetadataContext{},
 			NodeMetadata:   &contexts.MetadataContext{},
-			CanvasMemory:   &canvasMemoryContext{},
-			ExecutionState: &contexts.ExecutionStateContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
 		})
 
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "at least one memory match is required")
+		assert.NoError(t, err)
+		assert.Equal(t, 1, memoryCtx.findAllCalls)
+		assert.Equal(t, ChannelNameNotFound, execState.Channel)
 	})
 
 	t.Run("returns error when reading memory fails", func(t *testing.T) {
@@ -311,15 +401,14 @@ func TestReadMemorySetup(t *testing.T) {
 		assert.Contains(t, err.Error(), "namespace is required")
 	})
 
-	t.Run("missing matches fails", func(t *testing.T) {
+	t.Run("empty matches are allowed", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
 				"namespace": "machines",
 				"matchList": []map[string]any{},
 			},
 		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "at least one memory match is required")
+		assert.NoError(t, err)
 	})
 
 	t.Run("invalid result mode fails", func(t *testing.T) {

--- a/pkg/components/updatememory/update_memory_test.go
+++ b/pkg/components/updatememory/update_memory_test.go
@@ -30,6 +30,14 @@ func (c *canvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	return nil, nil
 }
 
+func (c *canvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	return []any{}, nil
+}
+
+func (c *canvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	return nil, nil
+}
+
 func (c *canvasMemoryContext) Update(namespace string, matches map[string]any, values map[string]any) ([]any, error) {
 	c.updateCalls++
 	c.namespace = namespace

--- a/pkg/components/upsertmemory/upsert_memory_test.go
+++ b/pkg/components/upsertmemory/upsert_memory_test.go
@@ -38,6 +38,14 @@ func (c *canvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	return nil, nil
 }
 
+func (c *canvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	return []any{}, nil
+}
+
+func (c *canvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	return nil, nil
+}
+
 func (c *canvasMemoryContext) Update(namespace string, matches map[string]any, values map[string]any) ([]any, error) {
 	c.updateCalls++
 	c.namespace = namespace

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -75,6 +75,8 @@ type CanvasMemoryContext interface {
 	Add(namespace string, values any) error
 	Find(namespace string, matches map[string]any) ([]any, error)
 	FindFirst(namespace string, matches map[string]any) (any, error)
+	FindAll(namespace string) ([]any, error)
+	FindFirstInNamespace(namespace string) (any, error)
 }
 
 /*

--- a/pkg/models/canvas_memory.go
+++ b/pkg/models/canvas_memory.go
@@ -133,6 +133,27 @@ func FindFirstCanvasMemoryByNamespaceAndMatches(canvasID uuid.UUID, namespace st
 	return FindFirstCanvasMemoryByNamespaceAndMatchesInTransaction(database.Conn(), canvasID, namespace, matches)
 }
 
+func FindFirstCanvasMemoryByNamespaceInTransaction(tx *gorm.DB, canvasID uuid.UUID, namespace string) (*CanvasMemory, error) {
+	var record CanvasMemory
+
+	err := tx.
+		Where("canvas_id = ? AND namespace = ?", canvasID, namespace).
+		Order("created_at DESC").
+		Limit(1).
+		First(&record).
+		Error
+
+	if err != nil {
+		return nil, nil
+	}
+
+	return &record, nil
+}
+
+func FindFirstCanvasMemoryByNamespace(canvasID uuid.UUID, namespace string) (*CanvasMemory, error) {
+	return FindFirstCanvasMemoryByNamespaceInTransaction(database.Conn(), canvasID, namespace)
+}
+
 func DeleteCanvasMemory(canvasID, memoryID uuid.UUID) error {
 	return DeleteCanvasMemoryInTransaction(database.Conn(), canvasID, memoryID)
 }

--- a/pkg/models/canvas_memory.go
+++ b/pkg/models/canvas_memory.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -123,7 +124,10 @@ func FindFirstCanvasMemoryByNamespaceAndMatchesInTransaction(tx *gorm.DB, canvas
 		Error
 
 	if err != nil {
-		return nil, nil
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	return &record, nil
@@ -144,7 +148,10 @@ func FindFirstCanvasMemoryByNamespaceInTransaction(tx *gorm.DB, canvasID uuid.UU
 		Error
 
 	if err != nil {
-		return nil, nil
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
 	}
 
 	return &record, nil

--- a/pkg/workers/contexts/canvas_memory_context.go
+++ b/pkg/workers/contexts/canvas_memory_context.go
@@ -63,6 +63,42 @@ func (c *CanvasMemoryContext) FindFirst(namespace string, matches map[string]any
 	return record.Values.Data(), nil
 }
 
+func (c *CanvasMemoryContext) FindAll(namespace string) ([]any, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	records, err := models.ListCanvasMemoriesByNamespaceInTransaction(c.tx, c.canvasID, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([]any, 0, len(records))
+	for _, record := range records {
+		values = append(values, record.Values.Data())
+	}
+
+	return values, nil
+}
+
+func (c *CanvasMemoryContext) FindFirstInNamespace(namespace string) (any, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required")
+	}
+
+	record, err := models.FindFirstCanvasMemoryByNamespaceInTransaction(c.tx, c.canvasID, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		return nil, nil
+	}
+
+	return record.Values.Data(), nil
+}
+
 func (c *CanvasMemoryContext) Delete(namespace string, matches map[string]any) ([]any, error) {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {

--- a/pkg/workers/contexts/canvas_memory_context_test.go
+++ b/pkg/workers/contexts/canvas_memory_context_test.go
@@ -1,0 +1,95 @@
+package contexts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func Test__CanvasMemoryContext(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "node-1", Name: "node-1", Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{},
+	)
+
+	ctx := NewCanvasMemoryContext(database.Conn(), canvas.ID)
+
+	t.Run("rejects empty namespace", func(t *testing.T) {
+		assert.Error(t, ctx.Add("", map[string]any{"k": "v"}))
+
+		_, err := ctx.Find("", map[string]any{"k": "v"})
+		assert.Error(t, err)
+
+		_, err = ctx.FindFirst("", map[string]any{"k": "v"})
+		assert.Error(t, err)
+
+		_, err = ctx.FindAll("")
+		assert.Error(t, err)
+
+		_, err = ctx.FindFirstInNamespace("")
+		assert.Error(t, err)
+
+		_, err = ctx.Delete("", map[string]any{"k": "v"})
+		assert.Error(t, err)
+
+		_, err = ctx.Update("", map[string]any{"k": "v"}, map[string]any{"x": 1})
+		assert.Error(t, err)
+	})
+
+	t.Run("CRUD and find helpers", func(t *testing.T) {
+		err := ctx.Add("machines", map[string]any{"sandbox_id": "a", "creator": "alice"})
+		require.NoError(t, err)
+		err = ctx.Add("machines", map[string]any{"sandbox_id": "b", "creator": "bob"})
+		require.NoError(t, err)
+
+		all, err := ctx.FindAll("machines")
+		require.NoError(t, err)
+		require.Len(t, all, 2)
+
+		latest, err := ctx.FindFirstInNamespace("machines")
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"sandbox_id": "b", "creator": "bob"}, latest)
+
+		matched, err := ctx.Find("machines", map[string]any{"sandbox_id": "a"})
+		require.NoError(t, err)
+		require.Equal(t, []any{map[string]any{"sandbox_id": "a", "creator": "alice"}}, matched)
+
+		first, err := ctx.FindFirst("machines", map[string]any{"sandbox_id": "a"})
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"sandbox_id": "a", "creator": "alice"}, first)
+
+		updated, err := ctx.Update("machines", map[string]any{"sandbox_id": "b"}, map[string]any{"patched": true})
+		require.NoError(t, err)
+		require.Len(t, updated, 1)
+
+		deleted, err := ctx.Delete("machines", map[string]any{"sandbox_id": "a"})
+		require.NoError(t, err)
+		require.Len(t, deleted, 1)
+
+		remaining, err := ctx.FindAll("machines")
+		require.NoError(t, err)
+		require.Len(t, remaining, 1)
+	})
+
+	t.Run("findFirst and findFirstInNamespace when missing", func(t *testing.T) {
+		missing, err := ctx.FindFirst("empty-ns", map[string]any{"id": "none"})
+		require.NoError(t, err)
+		assert.Nil(t, missing)
+
+		none, err := ctx.FindFirstInNamespace("empty-ns-other")
+		require.NoError(t, err)
+		assert.Nil(t, none)
+	})
+}


### PR DESCRIPTION
This PR makes match list optional for read memory. It was previously required.

<img width="334" height="430" alt="image" src="https://github.com/user-attachments/assets/03f7a617-af02-408c-b7eb-6b64d1734d20" />
<img width="338" height="424" alt="image" src="https://github.com/user-attachments/assets/0153b4aa-e619-42a7-98f1-22717eaf4559" />

### Related Issue

https://github.com/superplanehq/superplane/issues/4350