### PR TITLE
fix: stop canvas work for deleted orgs

### DIFF
--- a/pkg/models/canvas.go
+++ b/pkg/models/canvas.go
@@ -74,6 +74,14 @@ func queryCanvasWithLiveVersion(tx *gorm.DB) *gorm.DB {
 		)
 }
 
+func withActiveCanvas(tx *gorm.DB, workflowIDColumn string) *gorm.DB {
+	return tx.
+		Joins(fmt.Sprintf("JOIN workflows ON %s = workflows.id", workflowIDColumn)).
+		Joins("JOIN organizations ON workflows.organization_id = organizations.id").
+		Where("workflows.deleted_at IS NULL").
+		Where("organizations.deleted_at IS NULL")
+}
+
 func (c *Canvas) FindNode(id string) (*CanvasNode, error) {
 	var node CanvasNode
 	err := database.Conn().
@@ -328,9 +336,27 @@ func FindCanvasTemplateInTransaction(tx *gorm.DB, id uuid.UUID) (*Canvas, error)
 
 func ListDeletedCanvases() ([]Canvas, error) {
 	var canvases []Canvas
-	err := queryCanvasWithLiveVersion(database.Conn()).
+	err := database.Conn().
+		Model(&Canvas{}).
 		Unscoped().
-		Where("workflows.deleted_at IS NOT NULL").
+		Joins("JOIN workflow_versions live_version ON live_version.id = workflows.live_version_id").
+		Joins("JOIN organizations ON organizations.id = workflows.organization_id").
+		Select(
+			"workflows.id",
+			"workflows.organization_id",
+			"workflows.live_version_id",
+			"workflows.folder_id",
+			"workflows.is_template",
+			"workflows.name",
+			"workflows.created_by",
+			"workflows.created_at",
+			"workflows.updated_at",
+			"COALESCE(workflows.deleted_at, organizations.deleted_at) AS deleted_at",
+			"live_version.description AS description",
+			"live_version.change_management_enabled AS change_management_enabled",
+			"live_version.change_request_approvers AS change_request_approvers",
+		).
+		Where("workflows.deleted_at IS NOT NULL OR organizations.deleted_at IS NOT NULL").
 		Find(&canvases).
 		Error
 
@@ -362,20 +388,26 @@ func LockCanvas(tx *gorm.DB, id uuid.UUID) (*Canvas, error) {
 	err := tx.
 		Unscoped().
 		Model(&Canvas{}).
+		Joins("JOIN organizations ON organizations.id = workflows.organization_id").
 		Select(
 			"workflows.id",
 			"workflows.organization_id",
 			"workflows.live_version_id",
+			"workflows.folder_id",
 			"workflows.is_template",
 			"workflows.name",
 			"workflows.created_by",
 			"workflows.created_at",
 			"workflows.updated_at",
-			"workflows.deleted_at",
+			"COALESCE(workflows.deleted_at, organizations.deleted_at) AS deleted_at",
 		).
-		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+		Clauses(clause.Locking{
+			Strength: "UPDATE",
+			Table:    clause.Table{Name: "workflows"},
+			Options:  "SKIP LOCKED",
+		}).
 		Where("workflows.id = ?", id).
-		Where("workflows.deleted_at IS NOT NULL").
+		Where("workflows.deleted_at IS NOT NULL OR organizations.deleted_at IS NOT NULL").
 		First(&canvas).
 		Error
 

--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -205,10 +205,12 @@ func ListExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime t
 
 func ListPendingCanvasEvents() ([]CanvasEvent, error) {
 	var events []CanvasEvent
-	err := database.Conn().
-		Joins("JOIN workflows ON workflow_events.workflow_id = workflows.id").
-		Where("workflow_events.state = ?", CanvasEventStatePending).
-		Where("workflows.deleted_at IS NULL").
+	query := database.Conn().
+		Table("workflow_events").
+		Select("workflow_events.*").
+		Where("workflow_events.state = ?", CanvasEventStatePending)
+
+	err := withActiveCanvas(query, "workflow_events.workflow_id").
 		Find(&events).
 		Error
 
@@ -222,10 +224,18 @@ func ListPendingCanvasEvents() ([]CanvasEvent, error) {
 func LockCanvasEvent(tx *gorm.DB, id uuid.UUID) (*CanvasEvent, error) {
 	var event CanvasEvent
 
-	err := tx.
-		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-		Where("id = ?", id).
-		Where("state = ?", CanvasEventStatePending).
+	query := tx.
+		Table("workflow_events").
+		Select("workflow_events.*").
+		Clauses(clause.Locking{
+			Strength: "UPDATE",
+			Table:    clause.Table{Name: "workflow_events"},
+			Options:  "SKIP LOCKED",
+		}).
+		Where("workflow_events.id = ?", id).
+		Where("workflow_events.state = ?", CanvasEventStatePending)
+
+	err := withActiveCanvas(query, "workflow_events.workflow_id").
 		First(&event).
 		Error
 

--- a/pkg/models/canvas_node.go
+++ b/pkg/models/canvas_node.go
@@ -182,13 +182,14 @@ func FindCanvasNodesByIDs(tx *gorm.DB, canvasID uuid.UUID, nodeIDs []string) ([]
 
 func ListCanvasNodesReady() ([]CanvasNode, error) {
 	var nodes []CanvasNode
-	err := database.Conn().
+	query := database.Conn().
 		Distinct().
 		Joins("JOIN workflow_node_queue_items ON workflow_nodes.workflow_id = workflow_node_queue_items.workflow_id AND workflow_nodes.node_id = workflow_node_queue_items.node_id").
-		Joins("JOIN workflows ON workflow_nodes.workflow_id = workflows.id").
 		Where("workflow_nodes.state = ?", CanvasNodeStateReady).
 		Where("workflow_nodes.type IN ?", []string{NodeTypeComponent, NodeTypeBlueprint}).
-		Where("workflows.deleted_at IS NULL").
+		Where("workflow_nodes.deleted_at IS NULL")
+
+	err := withActiveCanvas(query, "workflow_nodes.workflow_id").
 		Find(&nodes).
 		Error
 
@@ -217,11 +218,20 @@ func ListReadyTriggers() ([]CanvasNode, error) {
 func LockCanvasNode(tx *gorm.DB, workflowID uuid.UUID, nodeId string) (*CanvasNode, error) {
 	var node CanvasNode
 
-	err := tx.
-		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-		Where("workflow_id = ?", workflowID).
-		Where("node_id = ?", nodeId).
-		Where("state = ?", CanvasNodeStateReady).
+	query := tx.
+		Table("workflow_nodes").
+		Select("workflow_nodes.*").
+		Clauses(clause.Locking{
+			Strength: "UPDATE",
+			Table:    clause.Table{Name: "workflow_nodes"},
+			Options:  "SKIP LOCKED",
+		}).
+		Where("workflow_nodes.workflow_id = ?", workflowID).
+		Where("workflow_nodes.node_id = ?", nodeId).
+		Where("workflow_nodes.state = ?", CanvasNodeStateReady).
+		Where("workflow_nodes.deleted_at IS NULL")
+
+	err := withActiveCanvas(query, "workflow_nodes.workflow_id").
 		First(&node).
 		Error
 

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -132,15 +132,43 @@ func CreatePendingChildExecution(tx *gorm.DB, parent *CanvasNodeExecution, child
 func ListPendingNodeExecutions() ([]CanvasNodeExecution, error) {
 	var executions []CanvasNodeExecution
 	query := database.Conn().
-		Where("state = ?", CanvasNodeExecutionStatePending).
-		Order("created_at DESC")
+		Table("workflow_node_executions").
+		Select("workflow_node_executions.*").
+		Where("workflow_node_executions.state = ?", CanvasNodeExecutionStatePending).
+		Order("workflow_node_executions.created_at DESC")
 
-	err := query.Find(&executions).Error
+	err := withActiveCanvas(query, "workflow_node_executions.workflow_id").
+		Find(&executions).
+		Error
 	if err != nil {
 		return nil, err
 	}
 
 	return executions, nil
+}
+
+func LockPendingNodeExecutionInActiveCanvas(tx *gorm.DB, id uuid.UUID) (*CanvasNodeExecution, error) {
+	var execution CanvasNodeExecution
+
+	query := tx.
+		Table("workflow_node_executions").
+		Select("workflow_node_executions.*").
+		Clauses(clause.Locking{
+			Strength: "UPDATE",
+			Table:    clause.Table{Name: "workflow_node_executions"},
+			Options:  "SKIP LOCKED",
+		}).
+		Where("workflow_node_executions.id = ?", id).
+		Where("workflow_node_executions.state = ?", CanvasNodeExecutionStatePending)
+
+	err := withActiveCanvas(query, "workflow_node_executions.workflow_id").
+		First(&execution).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &execution, nil
 }
 
 func ListNodeExecutions(workflowID uuid.UUID, nodeID string, states []string, results []string, limit int, beforeTime *time.Time) ([]CanvasNodeExecution, error) {

--- a/pkg/models/canvas_node_request.go
+++ b/pkg/models/canvas_node_request.go
@@ -46,9 +46,19 @@ type InvokeAction struct {
 func LockNodeRequest(tx *gorm.DB, id uuid.UUID) (*CanvasNodeRequest, error) {
 	var request CanvasNodeRequest
 
-	err := tx.
-		Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-		Where("id = ?", id).
+	query := tx.
+		Table("workflow_node_requests").
+		Select("workflow_node_requests.*").
+		Joins("JOIN workflow_nodes ON workflow_node_requests.workflow_id = workflow_nodes.workflow_id AND workflow_node_requests.node_id = workflow_nodes.node_id").
+		Clauses(clause.Locking{
+			Strength: "UPDATE",
+			Table:    clause.Table{Name: "workflow_node_requests"},
+			Options:  "SKIP LOCKED",
+		}).
+		Where("workflow_node_requests.id = ?", id).
+		Where("workflow_nodes.deleted_at IS NULL")
+
+	err := withActiveCanvas(query, "workflow_node_requests.workflow_id").
 		First(&request).
 		Error
 
@@ -63,13 +73,15 @@ func ListNodeRequests() ([]CanvasNodeRequest, error) {
 	var requests []CanvasNodeRequest
 
 	now := time.Now()
-	err := database.Conn().
+	query := database.Conn().
+		Table("workflow_node_requests").
+		Select("workflow_node_requests.*").
 		Joins("JOIN workflow_nodes ON workflow_node_requests.workflow_id = workflow_nodes.workflow_id AND workflow_node_requests.node_id = workflow_nodes.node_id").
-		Joins("JOIN workflows ON workflow_node_requests.workflow_id = workflows.id").
 		Where("workflow_node_requests.state = ?", NodeExecutionRequestStatePending).
 		Where("workflow_node_requests.run_at <= ?", now).
-		Where("workflow_nodes.deleted_at IS NULL").
-		Where("workflows.deleted_at IS NULL").
+		Where("workflow_nodes.deleted_at IS NULL")
+
+	err := withActiveCanvas(query, "workflow_node_requests.workflow_id").
 		Find(&requests).
 		Error
 

--- a/pkg/models/webhook.go
+++ b/pkg/models/webhook.go
@@ -108,11 +108,34 @@ func FindWebhookNodes(webhookID uuid.UUID) ([]CanvasNode, error) {
 	return FindWebhookNodesInTransaction(database.Conn(), webhookID)
 }
 
+func FindActiveWebhookNodes(webhookID uuid.UUID) ([]CanvasNode, error) {
+	return FindActiveWebhookNodesInTransaction(database.Conn(), webhookID)
+}
+
 func FindWebhookNodesInTransaction(tx *gorm.DB, webhookID uuid.UUID) ([]CanvasNode, error) {
 	var nodes []CanvasNode
 	err := tx.
 		Where("webhook_id = ?", webhookID).
 		Where("deleted_at IS NULL").
+		Find(&nodes).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
+func FindActiveWebhookNodesInTransaction(tx *gorm.DB, webhookID uuid.UUID) ([]CanvasNode, error) {
+	var nodes []CanvasNode
+	query := tx.
+		Table("workflow_nodes").
+		Select("workflow_nodes.*").
+		Where("workflow_nodes.webhook_id = ?", webhookID).
+		Where("workflow_nodes.deleted_at IS NULL")
+
+	err := withActiveCanvas(query, "workflow_nodes.workflow_id").
 		Find(&nodes).
 		Error
 

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -1059,8 +1059,8 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	nodes, err := models.FindWebhookNodes(webhookID)
-	if err != nil {
+	nodes, err := models.FindActiveWebhookNodes(webhookID)
+	if err != nil || len(nodes) == 0 {
 		http.Error(w, "webhook not found", http.StatusNotFound)
 		return
 	}

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/usage"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -193,6 +195,71 @@ func Test__GRPCGatewayRegistration(t *testing.T) {
 
 	require.Equal(t, "", response.Body.String())
 	require.Equal(t, 200, response.Code)
+}
+
+func Test__HandleWebhook_DoesNotRunNodesForSoftDeletedOrganization(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	signer := jwt.NewSigner("test")
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		signer,
+		support.NewOIDCProvider(),
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	webhookID := uuid.New()
+	webhook := models.Webhook{
+		ID:     webhookID,
+		State:  models.WebhookStateReady,
+		Secret: []byte("secret"),
+	}
+	require.NoError(t, database.Conn().Create(&webhook).Error)
+
+	nodeID := "start-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: nodeID,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+		},
+		[]models.Edge{},
+	)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNode{}).
+		Where("workflow_id = ?", canvas.ID).
+		Where("node_id = ?", nodeID).
+		Update("webhook_id", webhookID).
+		Error)
+
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+
+	response := execRequest(server, requestParams{
+		method: "POST",
+		path:   "/webhooks/" + webhookID.String(),
+		body:   []byte(`{"ok": true}`),
+	})
+
+	require.Equal(t, http.StatusNotFound, response.Code)
+
+	eventCount, err := models.CountCanvasEvents(canvas.ID, nodeID)
+	require.NoError(t, err)
+	assert.Zero(t, eventCount)
 }
 
 type canvasesGatewayStubServer struct {

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -155,6 +155,85 @@ func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 	support.VerifyNodeRequestCount(t, canvas.ID, 0)
 }
 
+func Test__CanvasCleanupWorker_ProcessesWorkflowFromSoftDeletedOrganization(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	worker := NewCanvasCleanupWorker()
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "node-1",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+			{
+				NodeID: "node-2",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	now := time.Now()
+	nodeRequest := models.CanvasNodeRequest{
+		ID:         uuid.New(),
+		WorkflowID: canvas.ID,
+		NodeID:     "node-1",
+		Type:       models.NodeRequestTypeInvokeAction,
+		State:      models.NodeExecutionRequestStatePending,
+		RunAt:      now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "test",
+				Parameters: map[string]any{},
+			},
+		}),
+	}
+	require.NoError(t, database.Conn().Create(&nodeRequest).Error)
+
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+	deletedAtOutsideGracePeriod := time.Now().AddDate(0, 0, -31)
+	require.NoError(t, database.Conn().
+		Unscoped().
+		Model(&models.Organization{}).
+		Where("id = ?", r.Organization.ID).
+		Update("deleted_at", deletedAtOutsideGracePeriod).
+		Error)
+
+	canvases, err := models.ListDeletedCanvases()
+	require.NoError(t, err)
+	require.Len(t, canvases, 1)
+	require.Equal(t, canvas.ID, canvases[0].ID)
+	require.True(t, canvases[0].DeletedAt.Valid)
+
+	require.NoError(t, worker.LockAndProcessCanvas(canvases[0]))
+
+	var canvasCount int64
+	require.NoError(t, database.Conn().Unscoped().Model(&models.Canvas{}).Where("id = ?", canvas.ID).Count(&canvasCount).Error)
+	assert.Equal(t, int64(0), canvasCount)
+
+	nodes, err := models.FindCanvasNodes(canvas.ID)
+	require.NoError(t, err)
+	assert.Empty(t, nodes)
+
+	support.VerifyNodeRequestCount(t, canvas.ID, 0)
+
+	var organizationCount int64
+	require.NoError(t, database.Conn().Unscoped().Model(&models.Organization{}).Where("id = ?", r.Organization.ID).Count(&organizationCount).Error)
+	assert.Equal(t, int64(1), organizationCount)
+}
+
 func Test__CanvasCleanupWorker_ProcessesWorkflowWithWebhook(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -67,6 +67,54 @@ func Test__EventRouter_ProcessRootEvent(t *testing.T) {
 	assert.True(t, queueConsumer.HasReceivedMessage())
 }
 
+func Test__EventRouter_DoesNotRouteEventForSoftDeletedOrganization(t *testing.T) {
+	amqpURL, _ := config.RabbitMQURL()
+
+	router := NewEventRouter(amqpURL)
+	logger := log.NewEntry(log.New())
+	r := support.Setup(t)
+
+	queueConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemCreatedRoutingKey)
+	queueConsumer.Start()
+	defer queueConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger},
+			{NodeID: componentNode, Type: models.NodeTypeComponent},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	event := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+
+	events, err := models.ListPendingCanvasEvents()
+	require.NoError(t, err)
+	for _, pending := range events {
+		assert.NotEqual(t, event.ID, pending.ID)
+	}
+
+	require.NoError(t, router.LockAndProcessEvent(logger, *event))
+
+	updatedEvent, err := models.FindCanvasEvent(event.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasEventStatePending, updatedEvent.State)
+
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
+
+	assert.False(t, queueConsumer.HasReceivedMessage())
+}
+
 func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	amqpURL, _ := config.RabbitMQURL()
 

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	"github.com/google/uuid"
 	"github.com/renderedtext/go-tackle"
@@ -172,8 +171,6 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 	}
 
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		var execution models.CanvasNodeExecution
-
 		//
 		// Try to lock the execution record for update.
 		// If we can't, it means another worker is already processing it.
@@ -193,19 +190,13 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		// Note: We use SKIP LOCKED to avoid waiting on locked records.
 		//
 
-		err := tx.
-			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
-			Where("id = ?", id).
-			Where("state = ?", models.CanvasNodeExecutionStatePending).
-			First(&execution).
-			Error
-
+		execution, err := models.LockPendingNodeExecutionInActiveCanvas(tx, id)
 		if err != nil {
 			w.logger.Debugf("Execution %s already being processed - skipping", id.String())
 			return ErrRecordLocked
 		}
 
-		return w.processNodeExecution(tx, &execution, onNewEvents)
+		return w.processNodeExecution(tx, execution, onNewEvents)
 	})
 
 	if err != nil {

--- a/pkg/workers/node_executor_test.go
+++ b/pkg/workers/node_executor_test.go
@@ -84,6 +84,45 @@ func Test__NodeExecutor_PreventsConcurrentProcessing(t *testing.T) {
 	assert.Equal(t, models.CanvasNodeExecutionResultPassed, updatedExecution.Result)
 }
 
+func Test__NodeExecutor_DoesNotProcessExecutionForSoftDeletedOrganization(t *testing.T) {
+	r := support.Setup(t)
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger, Ref: datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}})},
+			{NodeID: componentNode, Type: models.NodeTypeComponent, Ref: datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}})},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	execution := support.CreateCanvasNodeExecution(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID, nil)
+
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+
+	executions, err := models.ListPendingNodeExecutions()
+	require.NoError(t, err)
+	for _, pending := range executions {
+		assert.NotEqual(t, execution.ID, pending.ID)
+	}
+
+	executor := NewNodeExecutor(r.Encryptor, r.Registry, "http://localhost", "http://localhost", "", r.AuthService)
+	err = executor.LockAndProcessNodeExecution(execution.ID)
+	assert.ErrorIs(t, err, ErrRecordLocked)
+
+	updatedExecution, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStatePending, updatedExecution.State)
+	assert.Empty(t, updatedExecution.Result)
+}
+
 func Test__NodeExecutor_BlueprintNodeExecution(t *testing.T) {
 	r := support.Setup(t)
 

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -106,6 +106,64 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	assert.True(t, queueConsumedConsumer.HasReceivedMessage())
 }
 
+func Test__NodeQueueWorker_DoesNotProcessQueueForSoftDeletedOrganization(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	worker := NewNodeQueueWorker(r.Registry, amqpURL)
+	logger := log.NewEntry(log.New())
+
+	executionConsumer := testconsumer.New(amqpURL, messages.CanvasExecutionRoutingKey)
+	queueConsumedConsumer := testconsumer.New(amqpURL, messages.CanvasQueueItemConsumedRoutingKey)
+	executionConsumer.Start()
+	queueConsumedConsumer.Start()
+	defer executionConsumer.Stop()
+	defer queueConsumedConsumer.Stop()
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger},
+			{NodeID: componentNode, Type: models.NodeTypeComponent, Ref: datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}})},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	support.CreateQueueItem(t, canvas.ID, componentNode, rootEvent.ID, rootEvent.ID)
+
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+
+	nodes, err := models.ListCanvasNodesReady()
+	require.NoError(t, err)
+	for _, node := range nodes {
+		assert.False(t, node.WorkflowID == canvas.ID && node.NodeID == componentNode)
+	}
+
+	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+
+	require.NoError(t, worker.LockAndProcessNode(logger, *node))
+
+	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, executions)
+
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	require.NoError(t, err)
+	assert.Len(t, queueItems, 1)
+
+	assert.False(t, executionConsumer.HasReceivedMessage())
+	assert.False(t, queueConsumedConsumer.HasReceivedMessage())
+}
+
 func Test__NodeQueueWorker_BlueprintNodeQueueIsProcessed(t *testing.T) {
 	r := support.Setup(t)
 	logger := log.NewEntry(log.New())

--- a/pkg/workers/node_request_worker_test.go
+++ b/pkg/workers/node_request_worker_test.go
@@ -607,3 +607,69 @@ func Test__NodeRequestWorker_DoesNotProcessDeletedWorkflowRequests(t *testing.T)
 
 	assert.False(t, executionConsumer.HasReceivedMessage())
 }
+
+func Test__NodeRequestWorker_DoesNotProcessSoftDeletedOrganizationRequests(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	executionConsumer := testconsumer.New(amqpURL, messages.CanvasExecutionRoutingKey)
+	executionConsumer.Start()
+	defer executionConsumer.Stop()
+
+	worker := NewNodeRequestWorker(r.Encryptor, r.Registry, "", r.AuthService)
+	triggerNode := "trigger-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNode,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "schedule"}}),
+				Configuration: datatypes.NewJSONType(map[string]any{
+					"type":         "days",
+					"daysInterval": 1,
+					"hour":         12,
+					"minute":       0,
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	request := models.CanvasNodeRequest{
+		ID:         uuid.New(),
+		WorkflowID: canvas.ID,
+		NodeID:     triggerNode,
+		Type:       models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{
+				ActionName: "emitEvent",
+				Parameters: map[string]any{},
+			},
+		}),
+		State: models.NodeExecutionRequestStatePending,
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+
+	require.NoError(t, models.SoftDeleteOrganization(r.Organization.ID.String()))
+
+	requests, err := models.ListNodeRequests()
+	require.NoError(t, err)
+	for _, pending := range requests {
+		assert.NotEqual(t, request.ID, pending.ID)
+	}
+
+	require.NoError(t, worker.LockAndProcessRequest(request))
+
+	var updatedRequest models.CanvasNodeRequest
+	require.NoError(t, database.Conn().Where("id = ?", request.ID).First(&updatedRequest).Error)
+	assert.Equal(t, models.NodeExecutionRequestStatePending, updatedRequest.State)
+
+	eventCount, err := models.CountCanvasEvents(canvas.ID, triggerNode)
+	require.NoError(t, err)
+	assert.Zero(t, eventCount)
+	assert.False(t, executionConsumer.HasReceivedMessage())
+}


### PR DESCRIPTION
## Summary

This stops canvases from continuing to run after their organization has been soft-deleted.

Workers now ignore queued work, events, executions, node requests, and webhook deliveries for canvases whose organization is deleted. The canvas cleanup worker also treats canvases in deleted orgs as cleanup candidates after the org grace period, even if the canvas itself was not soft-deleted.

