### PR TITLE
fix: include custom roles in service account creation dropdown

### DIFF
--- a/pkg/grpc/actions/serviceaccounts/create_service_account.go
+++ b/pkg/grpc/actions/serviceaccounts/create_service_account.go
@@ -2,6 +2,7 @@ package serviceaccounts
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/authentication"
@@ -30,17 +31,16 @@ func CreateServiceAccount(ctx context.Context, req *pb.CreateServiceAccountReque
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
 
-	validRoles := map[string]bool{
-		models.RoleOrgAdmin:  true,
-		models.RoleOrgViewer: true,
-	}
-
 	if req.Role == "" {
 		return nil, status.Error(codes.InvalidArgument, "role is required")
 	}
 
-	if !validRoles[req.Role] {
-		return nil, status.Error(codes.InvalidArgument, "invalid role for service account; must be org_admin or org_viewer")
+	_, err := models.FindRoleMetadata(req.Role, models.DomainTypeOrganization, orgID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Error(codes.InvalidArgument, "invalid role for service account")
+		}
+		return nil, status.Errorf(codes.Internal, "failed to validate role: %v", err)
 	}
 
 	orgUUID, err := uuid.Parse(orgID)

--- a/web_src/src/pages/organization/settings/ServiceAccountRoleSelect.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountRoleSelect.tsx
@@ -1,0 +1,66 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+interface Role {
+  metadata?: {
+    name?: string;
+  };
+  spec?: {
+    displayName?: string;
+    description?: string;
+  };
+}
+
+interface ServiceAccountRoleSelectProps {
+  roles: Role[];
+  role: string;
+  onRoleChange: (value: string) => void;
+  isLoading: boolean;
+}
+
+export function ServiceAccountRoleSelect({
+  roles,
+  role,
+  onRoleChange,
+  isLoading,
+}: ServiceAccountRoleSelectProps) {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-12">
+        <p className="text-gray-500 dark:text-gray-400">Loading roles...</p>
+      </div>
+    );
+  }
+
+  if (roles.length === 0) {
+    return (
+      <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+        <p className="text-sm text-yellow-800 dark:text-yellow-200 font-medium">No roles available</p>
+        <p className="text-yellow-700 dark:text-yellow-300 mt-1 text-sm">
+          Create a role first to assign it to this service account.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Select value={role} onValueChange={onRoleChange}>
+        <SelectTrigger className="w-full" data-testid="sa-create-role">
+          <SelectValue placeholder="Select a role" />
+        </SelectTrigger>
+        <SelectContent>
+          {roles.map((r) => (
+            <SelectItem key={r.metadata?.name} value={r.metadata?.name || ""}>
+              {r.spec?.displayName || r.metadata?.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {role && (
+        <p className="mt-1 text-xs text-gray-500">
+          {roles.find((r) => r.metadata?.name === role)?.spec?.description || ""}
+        </p>
+      )}
+    </>
+  );
+}

--- a/web_src/src/pages/organization/settings/ServiceAccounts.spec.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.spec.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// jsdom doesn't implement scrollIntoView, which Radix Select uses
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockUseOrganizationRoles = vi.fn(() => ({ data: [], isLoading: false }));
+const mockUseServiceAccounts = vi.fn(() => ({ data: [], isLoading: false }));
+const mockUseCreateServiceAccount = vi.fn(() => ({
+  mutateAsync: vi.fn(),
+  isPending: false,
+  reset: vi.fn(),
+  error: null,
+}));
+const mockUseDeleteServiceAccount = vi.fn(() => ({
+  mutateAsync: vi.fn(),
+  isPending: false,
+}));
+const mockUsePermissions = vi.fn(() => ({ canAct: () => true, isLoading: false }));
+
+vi.mock("@/hooks/useOrganizationData", () => ({
+  useOrganizationRoles: (...args: any[]) => mockUseOrganizationRoles(...args),
+}));
+
+vi.mock("@/hooks/useServiceAccounts", () => ({
+  useServiceAccounts: (...args: any[]) => mockUseServiceAccounts(...args),
+  useCreateServiceAccount: (...args: any[]) => mockUseCreateServiceAccount(...args),
+  useDeleteServiceAccount: (...args: any[]) => mockUseDeleteServiceAccount(...args),
+}));
+
+vi.mock("@/contexts/PermissionsContext", () => ({
+  usePermissions: (...args: any[]) => mockUsePermissions(...args),
+  PermissionTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+import { ServiceAccounts } from "./ServiceAccounts";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe("ServiceAccounts", () => {
+  beforeEach(() => {
+    mockUseOrganizationRoles.mockReturnValue({ data: [], isLoading: false });
+    mockUseServiceAccounts.mockReturnValue({ data: [], isLoading: false });
+    mockUseCreateServiceAccount.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+      reset: vi.fn(),
+      error: null,
+    });
+    mockUseDeleteServiceAccount.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+    mockUsePermissions.mockReturnValue({ canAct: () => true, isLoading: false });
+  });
+
+  it("renders without crashing", () => {
+    render(<ServiceAccounts organizationId="test-org" />, { wrapper: Wrapper });
+    expect(screen.getByText("Create Service Account")).toBeInTheDocument();
+  });
+
+  it("shows custom roles in the dropdown", async () => {
+    mockUseOrganizationRoles.mockReturnValue({
+      data: [
+        {
+          metadata: { name: "deployer" },
+          spec: { displayName: "Deployer", description: "Can deploy to production" },
+        },
+        {
+          metadata: { name: "org_admin" },
+          spec: { displayName: "Admin", description: "Full admin access" },
+        },
+        {
+          metadata: { name: "org_viewer" },
+          spec: { displayName: "Viewer", description: "Read-only access" },
+        },
+      ],
+      isLoading: false,
+    });
+
+    render(<ServiceAccounts organizationId="test-org" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByTestId("sa-create-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sa-create-form")).toBeInTheDocument();
+    });
+
+    const roleTrigger = screen.getByTestId("sa-create-role");
+    fireEvent.click(roleTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Deployer" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("option", { name: "Admin" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Viewer" })).toBeInTheDocument();
+  });
+
+  it("shows loading state while roles are loading", async () => {
+    mockUseOrganizationRoles.mockReturnValue({ data: [], isLoading: true });
+
+    render(<ServiceAccounts organizationId="test-org" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByTestId("sa-create-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading roles...")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no roles are available", async () => {
+    mockUseOrganizationRoles.mockReturnValue({ data: [], isLoading: false });
+
+    render(<ServiceAccounts organizationId="test-org" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByTestId("sa-create-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No roles available")).toBeInTheDocument();
+    });
+  });
+});

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -11,11 +11,12 @@ import { Textarea } from "@/components/Textarea/textarea";
 import { usePermissions } from "@/contexts/PermissionsContext";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Bot, Copy } from "lucide-react";
-import { useState } from "react";
+import { ServiceAccountRoleSelect } from "./ServiceAccountRoleSelect";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useServiceAccounts, useCreateServiceAccount, useDeleteServiceAccount } from "@/hooks/useServiceAccounts";
+import { useOrganizationRoles } from "@/hooks/useOrganizationData";
 
 interface ServiceAccountsProps {
   organizationId: string;
@@ -28,7 +29,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [role, setRole] = useState("org_viewer");
+  const [role, setRole] = useState("");
   const [newToken, setNewToken] = useState<string | null>(null);
   const canCreate = canAct("service_accounts", "create");
   const canDelete = canAct("service_accounts", "delete");
@@ -36,12 +37,31 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
   const { data: serviceAccounts = [], isLoading } = useServiceAccounts(organizationId);
   const createMutation = useCreateServiceAccount(organizationId);
   const deleteMutation = useDeleteServiceAccount(organizationId);
+  const { data: roles = [], isLoading: loadingRoles } = useOrganizationRoles(organizationId);
+
+  const sortedRoles = useMemo(() => {
+    const defaultRoles = new Set(["org_admin", "org_owner", "org_viewer"]);
+    const customRoles = roles
+      .filter((r) => !defaultRoles.has(r.metadata?.name || ""))
+      .sort((a, b) => (a.spec?.displayName || "").localeCompare(b.spec?.displayName || ""));
+    const baseRoles = roles
+      .filter((r) => defaultRoles.has(r.metadata?.name || ""))
+      .sort((a, b) => (a.spec?.displayName || "").localeCompare(b.spec?.displayName || ""));
+
+    return [...customRoles, ...baseRoles];
+  }, [roles]);
+
+  useEffect(() => {
+    if (sortedRoles.length > 0 && !role) {
+      setRole(sortedRoles[0].metadata?.name || "");
+    }
+  }, [sortedRoles, role]);
 
   const handleCreateClick = () => {
     if (!canCreate) return;
     setName("");
     setDescription("");
-    setRole("org_viewer");
+    setRole("");
     setNewToken(null);
     setIsCreateModalOpen(true);
   };
@@ -50,7 +70,7 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
     setIsCreateModalOpen(false);
     setName("");
     setDescription("");
-    setRole("org_viewer");
+    setRole("");
     setNewToken(null);
     createMutation.reset();
   };
@@ -289,16 +309,12 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
                   <Label className="text-gray-800 dark:text-gray-100 mb-2">
                     Role <span className="text-red-500">*</span>
                   </Label>
-                  <Select value={role} onValueChange={setRole}>
-                    <SelectTrigger className="w-full" data-testid="sa-create-role">
-                      <SelectValue placeholder="Select a role" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="org_viewer">Viewer</SelectItem>
-                      <SelectItem value="org_admin">Admin</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <p className="mt-1 text-xs text-gray-500">Determines what this service account can access.</p>
+                  <ServiceAccountRoleSelect
+                    roles={sortedRoles}
+                    role={role}
+                    onRoleChange={setRole}
+                    isLoading={loadingRoles}
+                  />
                 </div>
               </div>
 


### PR DESCRIPTION
## Fixes
Closes #4674

## Problem
The service account creation flow had **two hardcoded bottlenecks** that blocked custom roles:

1. **Frontend:**  
   The Role dropdown was hardcoded to only:
   - `org_viewer`
   - `org_admin`

   This made custom roles invisible to users.

2. **Backend:**  
   The API rejected any role except `org_admin` or `org_viewer`, so even if custom roles appeared in the dropdown, service account creation failed with:
   > `invalid role for service account`

## Solution

### Frontend
- Fetch organization roles dynamically using `useOrganizationRoles`
- Replace hardcoded `<SelectItem>`s with dynamic mapping from API
- List custom roles **first** to match the existing UX in `CreateGroupPage.tsx` and the Roles table
- Follow with default roles (Admin, Owner, Viewer), sorted alphabetically
- Extract role selection UI into a dedicated `ServiceAccountRoleSelect` component
- Add loading state (`Loading roles...`) while roles are being fetched
- Add empty state guidance when no roles exist
- Display role descriptions below the select when available

### Backend
- Replace hardcoded role validation in `create_service_account.go`
- Validate roles dynamically using `FindRoleMetadata`
- Accept **any valid organization role** (default + custom)
- Add proper error handling:
  - `400` for invalid roles
  - `500` for database/internal errors

## Files Changed

| File | Change |
|------|--------|
| `ServiceAccounts.tsx` | Dynamic role dropdown, custom roles listed first |
| `ServiceAccountRoleSelect.tsx` | **New** — Extracted reusable role selection component |
| `ServiceAccounts.spec.tsx` | **New** — Unit tests covering loading, empty, and custom role states |
| `create_service_account.go` | **Backend** — Role validation via database lookup instead of hardcoded map |

## Verification

- [x] Unit tests pass (4/4)
- [x] Custom roles appear in dropdown and can be successfully assigned
- [x] Existing default roles (Admin, Owner, Viewer) continue to work
- [x] Backend accepts custom roles (verified via API)
- [x] No TypeScript errors in frontend files

<img width="1362" height="850" alt="service-account-table" src="https://github.com/user-attachments/assets/9187490d-89d0-4b86-8a04-8b0f9e259a71" />
<img width="1426" height="857" alt="custom-service-account-slug" src="https://github.com/user-attachments/assets/b437c862-5573-4cfb-8719-b9788608a975" />
<img width="952" height="457" alt="custom-service-account-created" src="https://github.com/user-attachments/assets/1455e9d4-62a5-42ff-9936-0f983e6fd0c7" />
<img width="1874" height="864" alt="custom-service-account" src="https://github.com/user-attachments/assets/3b778877-af68-4922-99c7-ce1e546235d3" />
<img width="1891" height="860" alt="roles" src="https://github.com/user-attachments/assets/8676434b-19ca-4ba1-911d-cb6cc47105e5" />
