### PR TITLE
fix: batch event retention cleanup

### DIFF
--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -170,26 +170,17 @@ func CountRootCanvasEvents(canvasID uuid.UUID) (int64, error) {
 	return count, nil
 }
 
-func ListExpiredRoutedRootCanvasEvents(referenceTime time.Time, limit int) ([]CanvasEvent, error) {
-	return ListExpiredRoutedRootCanvasEventsInTransaction(database.Conn(), referenceTime, limit)
-}
-
-func ListExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime time.Time, limit int) ([]CanvasEvent, error) {
+func LockExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime time.Time, limit int) ([]CanvasEvent, error) {
 	var events []CanvasEvent
 
-	query := tx.
-		Table("workflow_events").
-		Select("workflow_events.*").
-		Joins("JOIN workflows ON workflow_events.workflow_id = workflows.id").
-		Joins("JOIN organizations ON workflows.organization_id = organizations.id").
-		Where("organizations.deleted_at IS NULL").
-		Where("organizations.usage_retention_window_days IS NOT NULL").
-		Where("organizations.usage_retention_window_days > 0").
-		Where("workflows.deleted_at IS NULL").
-		Where("workflow_events.execution_id IS NULL").
-		Where("workflow_events.state = ?", CanvasEventStateRouted).
-		Where("workflow_events.created_at + (organizations.usage_retention_window_days * INTERVAL '1 day') < ?", referenceTime.UTC()).
-		Order("workflow_events.created_at ASC")
+	query := expiredRoutedRootCanvasEventsQuery(tx, referenceTime).
+		Scopes(
+			lockCanvasEventsForUpdate,
+			withoutRootEventQueueItems,
+			withoutActiveRootEventExecutions,
+			withoutPendingRootEventRequests,
+			oldestCanvasEventsFirst,
+		)
 
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -201,6 +192,64 @@ func ListExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime t
 	}
 
 	return events, nil
+}
+
+func expiredRoutedRootCanvasEventsQuery(tx *gorm.DB, referenceTime time.Time) *gorm.DB {
+	query := tx.
+		Table("workflow_events").
+		Select("workflow_events.*").
+		Where("organizations.usage_retention_window_days IS NOT NULL").
+		Where("organizations.usage_retention_window_days > 0").
+		Where("workflow_events.execution_id IS NULL").
+		Where("workflow_events.state = ?", CanvasEventStateRouted).
+		Where("workflow_events.created_at + (organizations.usage_retention_window_days * INTERVAL '1 day') < ?", referenceTime.UTC())
+
+	return withActiveCanvas(query, "workflow_events.workflow_id")
+}
+
+func lockCanvasEventsForUpdate(tx *gorm.DB) *gorm.DB {
+	return tx.Clauses(clause.Locking{
+		Strength: "UPDATE",
+		Table:    clause.Table{Name: "workflow_events"},
+		Options:  "SKIP LOCKED",
+	})
+}
+
+func withoutRootEventQueueItems(tx *gorm.DB) *gorm.DB {
+	return tx.Where(`
+		NOT EXISTS (
+			SELECT 1
+			FROM workflow_node_queue_items
+			WHERE workflow_node_queue_items.root_event_id = workflow_events.id
+		)
+	`)
+}
+
+func withoutActiveRootEventExecutions(tx *gorm.DB) *gorm.DB {
+	return tx.Where(`
+		NOT EXISTS (
+			SELECT 1
+			FROM workflow_node_executions
+			WHERE workflow_node_executions.root_event_id = workflow_events.id
+			AND workflow_node_executions.state IN ?
+		)
+	`, []string{CanvasNodeExecutionStatePending, CanvasNodeExecutionStateStarted})
+}
+
+func withoutPendingRootEventRequests(tx *gorm.DB) *gorm.DB {
+	return tx.Where(`
+		NOT EXISTS (
+			SELECT 1
+			FROM workflow_node_requests
+			JOIN workflow_node_executions ON workflow_node_requests.execution_id = workflow_node_executions.id
+			WHERE workflow_node_executions.root_event_id = workflow_events.id
+			AND workflow_node_requests.state = ?
+		)
+	`, NodeExecutionRequestStatePending)
+}
+
+func oldestCanvasEventsFirst(tx *gorm.DB) *gorm.DB {
+	return tx.Order("workflow_events.created_at ASC")
 }
 
 func ListPendingCanvasEvents() ([]CanvasEvent, error) {
@@ -246,34 +295,40 @@ func LockCanvasEvent(tx *gorm.DB, id uuid.UUID) (*CanvasEvent, error) {
 	return &event, nil
 }
 
-func LockExpiredRoutedRootCanvasEvent(tx *gorm.DB, id uuid.UUID, referenceTime time.Time) (*CanvasEvent, error) {
-	var event CanvasEvent
-
-	err := tx.
-		Table("workflow_events").
-		Select("workflow_events.*").
-		Joins("JOIN workflows ON workflow_events.workflow_id = workflows.id").
-		Joins("JOIN organizations ON workflows.organization_id = organizations.id").
-		Clauses(clause.Locking{
-			Strength: "UPDATE",
-			Table:    clause.Table{Name: "workflow_events"},
-			Options:  "SKIP LOCKED",
-		}).
-		Where("workflow_events.id = ?", id).
-		Where("organizations.deleted_at IS NULL").
-		Where("organizations.usage_retention_window_days IS NOT NULL").
-		Where("organizations.usage_retention_window_days > 0").
-		Where("workflows.deleted_at IS NULL").
-		Where("workflow_events.execution_id IS NULL").
-		Where("workflow_events.state = ?", CanvasEventStateRouted).
-		Where("workflow_events.created_at + (organizations.usage_retention_window_days * INTERVAL '1 day') < ?", referenceTime.UTC()).
-		First(&event).
-		Error
-	if err != nil {
-		return nil, err
+func DeleteRootCanvasEventChainsInTransaction(tx *gorm.DB, rootEventIDs []uuid.UUID) error {
+	if len(rootEventIDs) == 0 {
+		return nil
 	}
 
-	return &event, nil
+	var executionIDs []uuid.UUID
+	err := tx.
+		Model(&CanvasNodeExecution{}).
+		Where("root_event_id IN ?", rootEventIDs).
+		Pluck("id", &executionIDs).
+		Error
+	if err != nil {
+		return err
+	}
+
+	if len(executionIDs) > 0 {
+		if err := tx.Where("execution_id IN ?", executionIDs).Delete(&CanvasNodeRequest{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Where("execution_id IN ?", executionIDs).Delete(&CanvasNodeExecutionKV{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Where("execution_id IN ?", executionIDs).Delete(&CanvasEvent{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Where("root_event_id IN ?", rootEventIDs).Delete(&CanvasNodeExecution{}).Error; err != nil {
+			return err
+		}
+	}
+
+	return tx.Where("id IN ?", rootEventIDs).Delete(&CanvasEvent{}).Error
 }
 
 func (e *CanvasEvent) Routed() error {

--- a/pkg/models/canvas_event_test.go
+++ b/pkg/models/canvas_event_test.go
@@ -1,0 +1,275 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ReturnsMultipleEligibleEvents(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	org := createOrganization(t)
+	cacheRetentionWindow(t, org.ID, 30)
+	canvas := createRetentionCanvas(t, org.ID)
+	event1 := createExpiredRootEvent(t, canvas.ID)
+	event2 := createExpiredRootEvent(t, canvas.ID)
+
+	var events []models.CanvasEvent
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		var err error
+		events, err = models.LockExpiredRoutedRootCanvasEventsInTransaction(tx, time.Now(), 10)
+		return err
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uuid.UUID{event1.ID, event2.ID}, canvasEventIDs(events))
+}
+
+func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ExcludesInactiveAndIneligibleEvents(t *testing.T) {
+	require.NoError(t, database.TruncateTables())
+
+	org := createOrganization(t)
+	cacheRetentionWindow(t, org.ID, 30)
+	canvas := createRetentionCanvas(t, org.ID)
+	eligible := createExpiredRootEvent(t, canvas.ID)
+
+	withinRetention := createRootEvent(t, canvas.ID)
+	updateRootEventAgeAndState(t, withinRetention.ID, 29, models.CanvasEventStateRouted)
+
+	noRetentionOrg := createOrganization(t)
+	noRetentionCanvas := createRetentionCanvas(t, noRetentionOrg.ID)
+	createExpiredRootEvent(t, noRetentionCanvas.ID)
+
+	deletedCanvas := createRetentionCanvas(t, org.ID)
+	createExpiredRootEvent(t, deletedCanvas.ID)
+	require.NoError(t, database.Conn().Delete(&models.Canvas{}, "id = ?", deletedCanvas.ID).Error)
+
+	deletedOrg := createOrganization(t)
+	cacheRetentionWindow(t, deletedOrg.ID, 30)
+	deletedOrgCanvas := createRetentionCanvas(t, deletedOrg.ID)
+	createExpiredRootEvent(t, deletedOrgCanvas.ID)
+	require.NoError(t, database.Conn().Delete(&models.Organization{}, "id = ?", deletedOrg.ID).Error)
+
+	queuedRoot := createExpiredRootEvent(t, canvas.ID)
+	createQueueItem(t, canvas.ID, "component", queuedRoot.ID, queuedRoot.ID)
+
+	activeRoot := createExpiredRootEvent(t, canvas.ID)
+	activeExecution := createExecution(t, canvas.ID, "component", activeRoot.ID, activeRoot.ID)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNodeExecution{}).
+		Where("id = ?", activeExecution.ID).
+		Update("state", models.CanvasNodeExecutionStateStarted).
+		Error)
+
+	pendingRequestRoot := createExpiredRootEvent(t, canvas.ID)
+	pendingRequestExecution := createExecution(t, canvas.ID, "component", pendingRequestRoot.ID, pendingRequestRoot.ID)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNodeExecution{}).
+		Where("id = ?", pendingRequestExecution.ID).
+		Updates(map[string]any{
+			"state":  models.CanvasNodeExecutionStateFinished,
+			"result": models.CanvasNodeExecutionResultPassed,
+		}).
+		Error)
+	createNodeRequest(t, canvas.ID, "component", pendingRequestExecution.ID, models.NodeExecutionRequestStatePending)
+
+	var events []models.CanvasEvent
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		var err error
+		events, err = models.LockExpiredRoutedRootCanvasEventsInTransaction(tx, time.Now(), 20)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{eligible.ID}, canvasEventIDs(events))
+}
+
+func createOrganization(t *testing.T) *models.Organization {
+	t.Helper()
+
+	org, err := models.CreateOrganization("org-"+uuid.NewString(), "test org")
+	require.NoError(t, err)
+	return org
+}
+
+func createRetentionCanvas(t *testing.T, orgID uuid.UUID) *models.Canvas {
+	t.Helper()
+
+	now := time.Now()
+	versionID := uuid.New()
+	canvas := models.Canvas{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		LiveVersionID:  &versionID,
+		Name:           "canvas-" + uuid.NewString(),
+		CreatedAt:      &now,
+		UpdatedAt:      &now,
+	}
+
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&canvas).Error; err != nil {
+			return err
+		}
+
+		nodes := []models.CanvasNode{
+			{
+				WorkflowID: canvas.ID,
+				NodeID:     "trigger",
+				Type:       models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: "start"},
+				}),
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			},
+			{
+				WorkflowID: canvas.ID,
+				NodeID:     "component",
+				Type:       models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			},
+		}
+
+		if err := tx.Create(&nodes).Error; err != nil {
+			return err
+		}
+
+		version := models.CanvasVersion{
+			ID:          versionID,
+			WorkflowID:  canvas.ID,
+			State:       models.CanvasVersionStatePublished,
+			Name:        canvas.Name,
+			Description: "test canvas",
+			PublishedAt: &now,
+			Nodes:       datatypes.NewJSONSlice([]models.Node{}),
+			Edges:       datatypes.NewJSONSlice([]models.Edge{}),
+			CreatedAt:   &now,
+			UpdatedAt:   &now,
+		}
+
+		return tx.Create(&version).Error
+	}))
+
+	return &canvas
+}
+
+func createExpiredRootEvent(t *testing.T, canvasID uuid.UUID) *models.CanvasEvent {
+	t.Helper()
+
+	event := createRootEvent(t, canvasID)
+	updateRootEventAgeAndState(t, event.ID, 31, models.CanvasEventStateRouted)
+	return event
+}
+
+func createRootEvent(t *testing.T, canvasID uuid.UUID) *models.CanvasEvent {
+	t.Helper()
+
+	now := time.Now()
+	event := models.CanvasEvent{
+		WorkflowID: canvasID,
+		NodeID:     "trigger",
+		Channel:    "default",
+		Data:       datatypes.NewJSONType[any](map[string]any{"key": "value"}),
+		State:      models.CanvasEventStatePending,
+		CreatedAt:  &now,
+	}
+
+	require.NoError(t, database.Conn().Clauses(clause.Returning{}).Create(&event).Error)
+	return &event
+}
+
+func updateRootEventAgeAndState(t *testing.T, id uuid.UUID, daysAgo int, state string) {
+	t.Helper()
+
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasEvent{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"state":      state,
+			"created_at": time.Now().AddDate(0, 0, -daysAgo),
+		}).
+		Error)
+}
+
+func cacheRetentionWindow(t *testing.T, orgID uuid.UUID, retentionWindowDays int32) {
+	t.Helper()
+
+	require.NoError(t, models.MarkOrganizationUsageLimitsSynced(orgID.String(), &retentionWindowDays, time.Now()))
+}
+
+func createNodeRequest(t *testing.T, canvasID uuid.UUID, nodeID string, executionID uuid.UUID, state string) {
+	t.Helper()
+
+	now := time.Now()
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvasID,
+		NodeID:      nodeID,
+		ExecutionID: &executionID,
+		State:       state,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{ActionName: "test", Parameters: map[string]any{}},
+		}),
+		RunAt:     now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	require.NoError(t, database.Conn().Create(&request).Error)
+}
+
+func createQueueItem(t *testing.T, canvasID uuid.UUID, nodeID string, rootEventID uuid.UUID, eventID uuid.UUID) {
+	t.Helper()
+
+	now := time.Now()
+	queueItem := models.CanvasNodeQueueItem{
+		ID:          uuid.New(),
+		WorkflowID:  canvasID,
+		NodeID:      nodeID,
+		RootEventID: rootEventID,
+		EventID:     eventID,
+		CreatedAt:   &now,
+	}
+
+	require.NoError(t, database.Conn().Create(&queueItem).Error)
+}
+
+func createExecution(t *testing.T, canvasID uuid.UUID, nodeID string, rootEventID uuid.UUID, eventID uuid.UUID) *models.CanvasNodeExecution {
+	t.Helper()
+
+	now := time.Now()
+	execution := models.CanvasNodeExecution{
+		ID:            uuid.New(),
+		WorkflowID:    canvasID,
+		NodeID:        nodeID,
+		RootEventID:   rootEventID,
+		EventID:       eventID,
+		State:         models.CanvasNodeExecutionStatePending,
+		Configuration: datatypes.NewJSONType(map[string]any{}),
+		CreatedAt:     &now,
+		UpdatedAt:     &now,
+	}
+
+	require.NoError(t, database.Conn().Create(&execution).Error)
+	return &execution
+}
+
+func canvasEventIDs(events []models.CanvasEvent) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.ID)
+	}
+
+	return ids
+}

--- a/pkg/workers/event_retention_worker.go
+++ b/pkg/workers/event_retention_worker.go
@@ -2,13 +2,11 @@ package workers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	"gorm.io/gorm"
 
 	"github.com/superplanehq/superplane/pkg/database"
@@ -17,19 +15,18 @@ import (
 )
 
 const (
-	eventRetentionBatchSize = 100
-	eventRetentionEvery     = 1 * time.Minute
+	eventRetentionBatchSize            = 100
+	eventRetentionMaxRootEventsPerTick = 1000
+	eventRetentionEvery                = 1 * time.Minute
 )
 
 type EventRetentionWorker struct {
-	semaphore    *semaphore.Weighted
 	logger       *log.Entry
 	usageService usage.Service
 }
 
 func NewEventRetentionWorker(usageService usage.Service) *EventRetentionWorker {
 	return &EventRetentionWorker{
-		semaphore:    semaphore.NewWeighted(10),
 		logger:       log.WithFields(log.Fields{"worker": "EventRetentionWorker"}),
 		usageService: usageService,
 	}
@@ -57,96 +54,79 @@ func (w *EventRetentionWorker) Start(ctx context.Context) {
 }
 
 func (w *EventRetentionWorker) tick(ctx context.Context) {
+	startedAt := time.Now()
 	referenceTime := time.Now().UTC()
-	rootEvents, err := models.ListExpiredRoutedRootCanvasEvents(referenceTime, eventRetentionBatchSize)
+	deleted, err := w.processRetentionBatches(ctx, referenceTime, eventRetentionMaxRootEventsPerTick)
 	if err != nil {
-		w.logger.Errorf("Error listing expired root events for retention cleanup: %v", err)
+		w.logger.Errorf("Error processing expired root events for retention cleanup: %v", err)
 		return
 	}
 
-	for _, rootEvent := range rootEvents {
-		if err := w.semaphore.Acquire(ctx, 1); err != nil {
-			if ctx.Err() != nil {
-				return
-			}
-
-			w.logger.Errorf("Error acquiring semaphore: %v", err)
-			continue
-		}
-
-		go func(rootEvent models.CanvasEvent, referenceTime time.Time) {
-			defer w.semaphore.Release(1)
-
-			if err := w.LockAndProcessRootEvent(rootEvent, referenceTime); err != nil {
-				w.logger.Errorf("Error processing retained root event %s: %v", rootEvent.ID, err)
-			}
-		}(rootEvent, referenceTime)
+	if deleted == 0 {
+		return
 	}
-}
 
-func (w *EventRetentionWorker) LockAndProcessRootEvent(rootEvent models.CanvasEvent, referenceTime time.Time) error {
-	return database.Conn().Transaction(func(tx *gorm.DB) error {
-		lockedEvent, err := models.LockExpiredRoutedRootCanvasEvent(tx, rootEvent.ID, referenceTime)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				w.logger.Infof("Root event %s already processed or no longer eligible - skipping", rootEvent.ID)
-				return nil
-			}
-
-			return fmt.Errorf("lock expired routed root event %s: %w", rootEvent.ID, err)
-		}
-
-		return w.processRootEvent(tx, *lockedEvent)
+	logger := w.logger.WithFields(log.Fields{
+		"deleted_root_events": deleted,
+		"max_root_events":     eventRetentionMaxRootEventsPerTick,
+		"duration_ms":         time.Since(startedAt).Milliseconds(),
 	})
+
+	if deleted >= eventRetentionMaxRootEventsPerTick {
+		logger.Warn("Event retention cleanup reached the per-tick limit; more expired root events may remain")
+		return
+	}
+
+	logger.Info("Deleted retained root events")
 }
 
-func (w *EventRetentionWorker) processRootEvent(tx *gorm.DB, rootEvent models.CanvasEvent) error {
-	queueItemsCount, err := models.CountNodeQueueItemsForRootEventInTransaction(tx, rootEvent.ID)
-	if err != nil {
-		return fmt.Errorf("count queue items for root event %s: %w", rootEvent.ID, err)
-	}
-
-	if queueItemsCount > 0 {
-		return nil
-	}
-
-	activeExecutionsCount, err := models.CountActiveNodeExecutionsForRootEventInTransaction(tx, rootEvent.ID)
-	if err != nil {
-		return fmt.Errorf("count active executions for root event %s: %w", rootEvent.ID, err)
-	}
-
-	if activeExecutionsCount > 0 {
-		return nil
-	}
-
-	executions, err := models.ListAllExecutionsForRootEventInTransaction(tx, rootEvent.ID)
-	if err != nil {
-		return fmt.Errorf("list executions for root event %s: %w", rootEvent.ID, err)
-	}
-
-	executionIDs := make([]uuid.UUID, 0, len(executions))
-	for _, execution := range executions {
-		executionIDs = append(executionIDs, execution.ID)
-	}
-
-	pendingRequestsCount, err := models.CountPendingRequestsForExecutionsInTransaction(tx, executionIDs)
-	if err != nil {
-		return fmt.Errorf("count pending requests for root event %s: %w", rootEvent.ID, err)
-	}
-
-	if pendingRequestsCount > 0 {
-		return nil
-	}
-
-	if len(executionIDs) > 0 {
-		if err := tx.Where("root_event_id = ?", rootEvent.ID).Delete(&models.CanvasNodeExecution{}).Error; err != nil {
-			return fmt.Errorf("delete executions for root event %s: %w", rootEvent.ID, err)
+func (w *EventRetentionWorker) processRetentionBatches(ctx context.Context, referenceTime time.Time, maxRootEvents int) (int, error) {
+	totalDeleted := 0
+	for totalDeleted < maxRootEvents {
+		if ctx.Err() != nil {
+			return totalDeleted, ctx.Err()
 		}
+
+		limit := min(eventRetentionBatchSize, maxRootEvents-totalDeleted)
+		deleted, err := w.LockAndProcessRootEvents(referenceTime, limit)
+		if err != nil {
+			return totalDeleted, err
+		}
+
+		if deleted == 0 {
+			return totalDeleted, nil
+		}
+
+		totalDeleted += deleted
 	}
 
-	if err := tx.Delete(&rootEvent).Error; err != nil {
-		return fmt.Errorf("delete root event %s: %w", rootEvent.ID, err)
-	}
+	return totalDeleted, nil
+}
 
-	return nil
+func (w *EventRetentionWorker) LockAndProcessRootEvents(referenceTime time.Time, limit int) (int, error) {
+	var deleted int
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		events, err := models.LockExpiredRoutedRootCanvasEventsInTransaction(tx, referenceTime, limit)
+		if err != nil {
+			return fmt.Errorf("lock expired routed root events: %w", err)
+		}
+
+		if len(events) == 0 {
+			return nil
+		}
+
+		rootEventIDs := make([]uuid.UUID, 0, len(events))
+		for _, event := range events {
+			rootEventIDs = append(rootEventIDs, event.ID)
+		}
+
+		if err := models.DeleteRootCanvasEventChainsInTransaction(tx, rootEventIDs); err != nil {
+			return fmt.Errorf("delete root event chains: %w", err)
+		}
+
+		deleted = len(rootEventIDs)
+		return nil
+	})
+
+	return deleted, err
 }

--- a/pkg/workers/event_retention_worker_test.go
+++ b/pkg/workers/event_retention_worker_test.go
@@ -91,10 +91,9 @@ func Test__EventRetentionWorker_SkipsRootEventWithinRetentionWindow(t *testing.T
 		"created_at": time.Now().AddDate(0, 0, -29),
 	}).Error)
 
-	rootEventInDB, err := models.FindCanvasEvent(rootEventRecord.ID)
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
 	require.NoError(t, err)
-
-	require.NoError(t, worker.LockAndProcessRootEvent(*rootEventInDB, time.Now()))
+	require.Equal(t, 0, deleted)
 
 	support.VerifyCanvasEventsCount(t, canvas.ID, 1)
 }
@@ -127,10 +126,9 @@ func Test__EventRetentionWorker_SkipsRootEventWithoutCachedRetentionWindow(t *te
 		"created_at": time.Now().AddDate(0, 0, -31),
 	}).Error)
 
-	rootEventInDB, err := models.FindCanvasEvent(rootEventRecord.ID)
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
 	require.NoError(t, err)
-
-	require.NoError(t, worker.LockAndProcessRootEvent(*rootEventInDB, time.Now()))
+	require.Equal(t, 0, deleted)
 
 	support.VerifyCanvasEventsCount(t, canvas.ID, 1)
 }
@@ -203,15 +201,160 @@ func Test__EventRetentionWorker_CleansExpiredCompletedRootEventChain(t *testing.
 	}
 	require.NoError(t, database.Conn().Create(&request).Error)
 
-	rootEventInDB, err := models.FindCanvasEvent(rootEvent.ID)
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
 	require.NoError(t, err)
-
-	require.NoError(t, worker.LockAndProcessRootEvent(*rootEventInDB, time.Now()))
+	require.Equal(t, 1, deleted)
 
 	support.VerifyCanvasEventsCount(t, canvas.ID, 0)
 	support.VerifyNodeExecutionsCount(t, canvas.ID, 0)
 	support.VerifyNodeExecutionKVCount(t, canvas.ID, 0)
 	support.VerifyNodeRequestCount(t, canvas.ID, 0)
+}
+
+func Test__EventRetentionWorker_CleansMultipleExpiredCompletedRootEventChains(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	worker := NewEventRetentionWorker(&fakeEventRetentionUsageService{enabled: true})
+	cacheOrganizationRetentionWindowDays(t, r.Organization.ID, 30)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "trigger",
+				Type:   models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: "start"},
+				}),
+			},
+			{
+				NodeID: "component",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	createExpiredCompletedRootEventChain(t, canvas.ID)
+	createExpiredCompletedRootEventChain(t, canvas.ID)
+
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted)
+
+	support.VerifyCanvasEventsCount(t, canvas.ID, 0)
+	support.VerifyNodeExecutionsCount(t, canvas.ID, 0)
+	support.VerifyNodeExecutionKVCount(t, canvas.ID, 0)
+	support.VerifyNodeRequestCount(t, canvas.ID, 0)
+}
+
+func Test__EventRetentionWorker_DoesNotDeleteUnrelatedCanvasData(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	worker := NewEventRetentionWorker(&fakeEventRetentionUsageService{enabled: true})
+	cacheOrganizationRetentionWindowDays(t, r.Organization.ID, 30)
+
+	eligibleCanvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "trigger",
+				Type:   models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: "start"},
+				}),
+			},
+			{
+				NodeID: "component",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	unrelatedCanvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "trigger",
+				Type:   models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: "start"},
+				}),
+			},
+			{
+				NodeID: "component",
+				Type:   models.NodeTypeComponent,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Component: &models.ComponentRef{Name: "noop"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	createExpiredCompletedRootEventChain(t, eligibleCanvas.ID)
+	createCompletedRootEventChain(t, unrelatedCanvas.ID, 1)
+
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+
+	support.VerifyCanvasEventsCount(t, eligibleCanvas.ID, 0)
+	support.VerifyNodeExecutionsCount(t, eligibleCanvas.ID, 0)
+	support.VerifyNodeExecutionKVCount(t, eligibleCanvas.ID, 0)
+	support.VerifyNodeRequestCount(t, eligibleCanvas.ID, 0)
+
+	support.VerifyCanvasEventsCount(t, unrelatedCanvas.ID, 2)
+	support.VerifyNodeExecutionsCount(t, unrelatedCanvas.ID, 1)
+	support.VerifyNodeExecutionKVCount(t, unrelatedCanvas.ID, 1)
+	support.VerifyNodeRequestCount(t, unrelatedCanvas.ID, 1)
+}
+
+func Test__EventRetentionWorker_RespectsMaxRootEventsPerTick(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	worker := NewEventRetentionWorker(&fakeEventRetentionUsageService{enabled: true})
+	cacheOrganizationRetentionWindowDays(t, r.Organization.ID, 30)
+
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: "trigger",
+				Type:   models.NodeTypeTrigger,
+				Ref: datatypes.NewJSONType(models.NodeRef{
+					Trigger: &models.TriggerRef{Name: "start"},
+				}),
+			},
+		},
+		[]models.Edge{},
+	)
+
+	createExpiredRootEventForWorker(t, canvas.ID)
+	createExpiredRootEventForWorker(t, canvas.ID)
+
+	deleted, err := worker.processRetentionBatches(context.Background(), time.Now(), 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+	support.VerifyCanvasEventsCount(t, canvas.ID, 1)
 }
 
 func Test__EventRetentionWorker_SkipsRootEventWithQueuedWork(t *testing.T) {
@@ -251,10 +394,9 @@ func Test__EventRetentionWorker_SkipsRootEventWithQueuedWork(t *testing.T) {
 	}).Error)
 	support.CreateQueueItem(t, canvas.ID, "component", rootEvent.ID, rootEvent.ID)
 
-	rootEventInDB, err := models.FindCanvasEvent(rootEvent.ID)
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
 	require.NoError(t, err)
-
-	require.NoError(t, worker.LockAndProcessRootEvent(*rootEventInDB, time.Now()))
+	require.Equal(t, 0, deleted)
 
 	support.VerifyCanvasEventsCount(t, canvas.ID, 1)
 	support.VerifyNodeQueueCount(t, canvas.ID, 1)
@@ -320,12 +462,72 @@ func Test__EventRetentionWorker_SkipsRootEventWithPendingRequest(t *testing.T) {
 	}
 	require.NoError(t, database.Conn().Create(&request).Error)
 
-	rootEventInDB, err := models.FindCanvasEvent(rootEvent.ID)
+	deleted, err := worker.LockAndProcessRootEvents(time.Now(), eventRetentionBatchSize)
 	require.NoError(t, err)
-
-	require.NoError(t, worker.LockAndProcessRootEvent(*rootEventInDB, time.Now()))
+	require.Equal(t, 0, deleted)
 
 	support.VerifyCanvasEventsCount(t, canvas.ID, 1)
 	support.VerifyNodeExecutionsCount(t, canvas.ID, 1)
 	support.VerifyNodeRequestCount(t, canvas.ID, 1)
+}
+
+func createExpiredCompletedRootEventChain(t *testing.T, canvasID uuid.UUID) {
+	t.Helper()
+
+	createCompletedRootEventChain(t, canvasID, 31)
+}
+
+func createCompletedRootEventChain(t *testing.T, canvasID uuid.UUID, daysAgo int) {
+	t.Helper()
+
+	rootEvent := createRootEventForWorker(t, canvasID, daysAgo)
+	execution := support.CreateCanvasNodeExecution(t, canvasID, "component", rootEvent.ID, rootEvent.ID, nil)
+	require.NoError(t, database.Conn().Model(&models.CanvasNodeExecution{}).Where("id = ?", execution.ID).Updates(map[string]any{
+		"state":      models.CanvasNodeExecutionStateFinished,
+		"result":     models.CanvasNodeExecutionResultPassed,
+		"created_at": time.Now().AddDate(0, 0, -daysAgo),
+		"updated_at": time.Now().AddDate(0, 0, -daysAgo),
+	}).Error)
+
+	childEvent := support.EmitCanvasEventForNode(t, canvasID, "component", "default", &execution.ID)
+	require.NoError(t, database.Conn().Model(&models.CanvasEvent{}).Where("id = ?", childEvent.ID).Updates(map[string]any{
+		"state":      models.CanvasEventStateRouted,
+		"created_at": time.Now().AddDate(0, 0, -daysAgo),
+	}).Error)
+
+	require.NoError(t, models.CreateNodeExecutionKVInTransaction(database.Conn(), canvasID, "component", execution.ID, "test-key", "test-value"))
+
+	request := models.CanvasNodeRequest{
+		ID:          uuid.New(),
+		WorkflowID:  canvasID,
+		NodeID:      "component",
+		ExecutionID: &execution.ID,
+		State:       models.NodeExecutionRequestStateCompleted,
+		Type:        models.NodeRequestTypeInvokeAction,
+		Spec: datatypes.NewJSONType(models.NodeExecutionRequestSpec{
+			InvokeAction: &models.InvokeAction{ActionName: "test", Parameters: map[string]any{}},
+		}),
+		RunAt:     time.Now().AddDate(0, 0, -daysAgo),
+		CreatedAt: time.Now().AddDate(0, 0, -daysAgo),
+		UpdatedAt: time.Now().AddDate(0, 0, -daysAgo),
+	}
+	require.NoError(t, database.Conn().Create(&request).Error)
+}
+
+func createExpiredRootEventForWorker(t *testing.T, canvasID uuid.UUID) *models.CanvasEvent {
+	t.Helper()
+
+	return createRootEventForWorker(t, canvasID, 31)
+}
+
+func createRootEventForWorker(t *testing.T, canvasID uuid.UUID, daysAgo int) *models.CanvasEvent {
+	t.Helper()
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvasID, "trigger", "default", nil)
+	require.NoError(t, database.Conn().Model(&models.CanvasEvent{}).Where("id = ?", rootEvent.ID).Updates(map[string]any{
+		"state":      models.CanvasEventStateRouted,
+		"created_at": time.Now().AddDate(0, 0, -daysAgo),
+	}).Error)
+
+	return rootEvent
 }


### PR DESCRIPTION
## Summary
Batch event retention cleanup so the worker locks and deletes eligible root event chains in groups instead of one root event per transaction.

This keeps the same safety checks for active work, but reduces repeated queries and transaction overhead when there is retention backlog.
