### PR TITLE
fix(github): enrich onPRComment payload with full pull request

### DIFF
--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -168,6 +168,10 @@ func (c *Client) CreatePullRequest(ctx context.Context, repository string, pullR
 	return c.underlying.PullRequests.Create(ctx, c.owner, repository, pullRequest)
 }
 
+func (c *Client) GetPullRequest(ctx context.Context, repository string, pullNumber int) (*github.PullRequest, *github.Response, error) {
+	return c.underlying.PullRequests.Get(ctx, c.owner, repository, pullNumber)
+}
+
 func (c *Client) CreateStatus(ctx context.Context, repository string, sha string, status github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
 	return c.underlying.Repositories.CreateStatus(ctx, c.owner, repository, sha, status)
 }

--- a/pkg/integrations/github/components/pulls/common.go
+++ b/pkg/integrations/github/components/pulls/common.go
@@ -1,16 +1,23 @@
 package pulls
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/integrations/github/common"
 )
+
+// enrichPRTimeout caps the GitHub API lookup so the webhook handler can finish
+// well before GitHub's ~10s delivery timeout - blowing past it triggers retries
+// and duplicate events.
+const enrichPRTimeout = 7 * time.Second
 
 type prCommentTriggerConfiguration struct {
 	Repository    string `json:"repository" mapstructure:"repository"`
@@ -158,4 +165,71 @@ func extractPRCommentBody(eventType string, data map[string]any) (string, error)
 	}
 
 	return body, nil
+}
+
+// enrichPRPayload best-effort attaches the full PR (head/base SHA, branch refs)
+// to data["pull_request"]. The issue_comment webhook only carries URLs.
+// On any failure we log and return; the caller still emits the original event.
+func enrichPRPayload(ctx core.WebhookRequestContext, data map[string]any, repository string) {
+	if ctx.Integration == nil {
+		return
+	}
+
+	number, ok := extractPRNumber(data)
+	if !ok {
+		ctx.Logger.Warn("Skipping PR payload enrichment - missing PR number in webhook")
+		return
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		ctx.Logger.Warnf("Skipping PR payload enrichment - failed to build GitHub client: %v", err)
+		return
+	}
+
+	apiCtx, cancel := context.WithTimeout(context.Background(), enrichPRTimeout)
+	defer cancel()
+
+	pr, _, err := client.GetPullRequest(apiCtx, repository, number)
+	if err != nil {
+		ctx.Logger.Warnf("Skipping PR payload enrichment - GetPullRequest failed: %v", err)
+		return
+	}
+
+	asMap, err := structToMap(pr)
+	if err != nil {
+		ctx.Logger.Warnf("Skipping PR payload enrichment - failed to encode PR: %v", err)
+		return
+	}
+
+	data["pull_request"] = asMap
+}
+
+func extractPRNumber(data map[string]any) (int, bool) {
+	issue, ok := data["issue"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+
+	switch n := issue["number"].(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	}
+	return 0, false
+}
+
+// structToMap round-trips through JSON so we honor the json tags on
+// *github.PullRequest. mapstructure would key off Go field names instead.
+func structToMap(v any) (map[string]any, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/pkg/integrations/github/components/pulls/on_pr_comment.go
+++ b/pkg/integrations/github/components/pulls/on_pr_comment.go
@@ -47,10 +47,18 @@ Each comment event includes:
 
 SuperPlane passes through the full GitHub webhook payload under data for the issue_comment event type.
 
+For PR-attached comments, SuperPlane also fetches the full pull request from the GitHub API and adds it under ` + "`root().data.pull_request`" + ` so head/base SHA and branch refs are available without an extra API call.
+
+> **Note:** This enrichment is best-effort. If the lookup fails (transient network error, missing permissions), the event is still emitted without the ` + "`pull_request`" + ` field, so downstream expressions referencing those paths should handle missing values.
+
 Common expression paths:
 - PR number: ` + "`root().data.issue.number`" + `
 - PR title: ` + "`root().data.issue.title`" + `
 - PR URL: ` + "`root().data.issue.pull_request.html_url`" + `
+- PR head SHA: ` + "`root().data.pull_request.head.sha`" + `
+- PR head branch: ` + "`root().data.pull_request.head.ref`" + `
+- PR base SHA: ` + "`root().data.pull_request.base.sha`" + `
+- PR base branch: ` + "`root().data.pull_request.base.ref`" + `
 - Comment body: ` + "`root().data.comment.body`" + `
 
 ## Webhook Setup
@@ -130,6 +138,8 @@ func (p *OnPRComment) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.
 		ctx.Logger.Info("Ignoring event - content filter did not match")
 		return http.StatusOK, nil, nil
 	}
+
+	enrichPRPayload(ctx, data, config.Repository)
 
 	if err := ctx.Events.Emit("github.prComment", data); err != nil {
 		ctx.Logger.Errorf("Failed to emit event: %v", err)

--- a/pkg/integrations/github/components/pulls/on_pr_comment_test.go
+++ b/pkg/integrations/github/components/pulls/on_pr_comment_test.go
@@ -188,6 +188,91 @@ func Test__OnPRComment__HandleWebhook(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 0, events.Count())
 	})
+
+	t.Run("PR comment payload is enriched with head/base details", func(t *testing.T) {
+		body := []byte(`{"action":"created","issue":{"pull_request":{"url":"https://api.github.com/repos/testhq/test/pulls/1"},"number":1},"comment":{"body":"/deploy"}}`)
+		headers := signedHeaders(body, "test-secret", eventType)
+
+		integrationCtx := mocks.IntegrationContextForNewSetupFlow()
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"number": 1,
+					"head": {"sha": "abc123", "ref": "feature-branch"},
+					"base": {"sha": "def456", "ref": "main"}
+				}`),
+			},
+		}
+
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    body,
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+			Configuration: map[string]any{
+				"repository": "test",
+			},
+			Webhook:     &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Events:      events,
+			Integration: integrationCtx,
+			HTTP:        httpCtx,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, events.Count())
+
+		payload, ok := events.Payloads[0].Data.(map[string]any)
+		require.True(t, ok)
+
+		pr, ok := payload["pull_request"].(map[string]any)
+		require.True(t, ok, "expected enriched pull_request on payload, got %v", payload)
+
+		head, ok := pr["head"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "abc123", head["sha"])
+		assert.Equal(t, "feature-branch", head["ref"])
+
+		base, ok := pr["base"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "def456", base["sha"])
+		assert.Equal(t, "main", base["ref"])
+	})
+
+	t.Run("event still emits when GitHub API call fails", func(t *testing.T) {
+		body := []byte(`{"action":"created","issue":{"pull_request":{"url":"https://api.github.com/repos/testhq/test/pulls/1"},"number":1},"comment":{"body":"/deploy"}}`)
+		headers := signedHeaders(body, "test-secret", eventType)
+
+		integrationCtx := mocks.IntegrationContextForNewSetupFlow()
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusInternalServerError, `{"message":"oops"}`),
+			},
+		}
+
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    body,
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+			Configuration: map[string]any{
+				"repository": "test",
+			},
+			Webhook:     &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Events:      events,
+			Integration: integrationCtx,
+			HTTP:        httpCtx,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, events.Count())
+
+		payload, ok := events.Payloads[0].Data.(map[string]any)
+		require.True(t, ok)
+		_, hasEnriched := payload["pull_request"]
+		assert.False(t, hasEnriched, "expected no pull_request when API fails")
+	})
 }
 
 func Test__OnPRComment__Setup(t *testing.T) {


### PR DESCRIPTION
Closes #4352.

## Problem

`github.onPRComment` is wired to GitHub's `issue_comment` webhook. That payload only carries URLs under `data.issue.pull_request`, no `head.sha` and no `head.ref`. Slash-command flows like `/deploy` end up with two annoying workarounds: stash the SHA in Canvas Memory during an `onPullRequest` event and read it back, or `git fetch origin pull/<n>/head` to dodge the missing branch name.

## Fix

Right after the signature/event/action/content-filter checks pass and we know we're going to emit, look the PR up via the GitHub API and attach the full object at `data["pull_request"]`. Downstream nodes can now read `data.pull_request.head.sha`, `data.pull_request.head.ref`, etc. directly.

Best-effort by design: if there's no integration on the request, no PR number on the payload, the client can't be built, the API call errors, or the marshal fails — we log a warning and emit the original event. Never drop the webhook silently.

A few small things worth calling out:

- The enriched data goes to a new top-level key (`data.pull_request`) instead of overwriting the existing minimal `data.issue.pull_request`. Keeps existing expressions like `data.issue.pull_request.html_url` working.
- 7s timeout on the API call so we don't get anywhere near GitHub's ~10s webhook delivery deadline. Going past that triggers retries and duplicate events.
- Added `GetPullRequest` to the common client; placed it next to `CreatePullRequest` to match the existing grouping.

## Tests

Two new tests on top of the existing ones:

1. Successful enrichment — mock GitHub API returns a PR, assert `data.pull_request.head.sha` / `head.ref` / `base.sha` / `base.ref` show up on the emitted payload.
2. Degraded mode — API returns 500, assert the event still emits and `data.pull_request` is absent.

Existing tests (which don't pass an `Integration`) keep passing because of the `ctx.Integration == nil` early-out. `go test ./pkg/integrations/github/...` is green.