### PR TITLE
docs(agent): add canvas-memory skill and memory() to expressions

### DIFF
--- a/agent/skills/canvas-memory.md
+++ b/agent/skills/canvas-memory.md
@@ -1,0 +1,56 @@
+# Canvas Memory
+
+Canvas Memory provides persistent key-value storage scoped to the canvas. Use it to share state across nodes, accumulate values across runs, or cache expensive lookups.
+
+## Components
+
+### addMemory
+
+Stores a new value for a key. Fails if the key already exists — use `upsertMemory` if you want create-or-update semantics.
+
+```yaml
+type: addMemory
+key: "{{ $['Trigger'].run_id }}"
+value: "{{ $['Trigger'].payload | toJSON }}"
+```
+
+### readMemory
+
+Reads the current value for a key. Emits on the `found` channel if the key exists, `not_found` otherwise. You can also reference memory values inline using the `memory()` expression function (see [expressions.md](expressions.md)).
+
+```yaml
+type: readMemory
+key: "last_deployed_sha"
+```
+
+Channels: `found`, `not_found`
+
+### upsertMemory
+
+Creates the key if it does not exist; updates it if it does.
+
+```yaml
+type: upsertMemory
+key: "deploy_count"
+value: "{{ int(memory('deploy_count')) + 1 }}"
+```
+
+### deleteMemory
+
+Removes a key. No-ops silently if the key does not exist.
+
+```yaml
+type: deleteMemory
+key: "{{ $['Trigger'].run_id }}"
+```
+
+## Using memory() in expressions
+
+The `memory()` function reads a Canvas Memory key inline without a dedicated `readMemory` node:
+
+```
+{{ memory("last_deployed_sha") }}
+{{ memory("deploy_count") != nil ? int(memory("deploy_count")) : 0 }}
+```
+
+Returns `nil` if the key does not exist. See [expressions.md](expressions.md) for the full expression reference.

--- a/agent/skills/expressions.md
+++ b/agent/skills/expressions.md
@@ -33,6 +33,9 @@ The **data-flow** skill describes how `$` is built during a run.
 | `root()` | Root payload that started the run | `root().data.ref` |
 | `previous()` | Immediate upstream node’s payload | `previous().data.status` |
 | `previous(n)` | Walk *n* levels upstream | `previous(2).data.version` |
+| `memory(key)` | Read a value from Canvas Memory; returns `nil` if the key does not exist | `memory("last_deployed_sha")` |
+
+See the **canvas-memory** skill for the full Canvas Memory component reference (`addMemory`, `readMemory`, `upsertMemory`, `deleteMemory`).
 
 ## Common Expr functions
 


### PR DESCRIPTION
- Add agent/skills/canvas-memory.md documenting addMemory, readMemory, upsertMemory, and deleteMemory components with YAML examples and channel behaviour (found/not_found).
- Add memory(key) row to the SuperPlane functions table in expressions.md with a cross-reference to the new canvas-memory skill.

Closes #4351 (partial) - documents missing Canvas Memory components Closes #4200 (partial) - memory() now appears in the expression reference