### PR TITLE
feat: add MCP server scaffold with read-only tools

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log"
+
+	"github.com/superplanehq/superplane/pkg/mcp"
+)
+
+const version = "dev"
+
+func main() {
+	if err := mcp.StartServer(version); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/markbates/goth v1.81.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.3
+	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/nulab/autog v0.11.0
 	github.com/playwright-community/playwright-go v0.5200.1
 	github.com/renderedtext/go-tackle v0.0.0-20251117195301-3a303949d759
@@ -59,11 +60,15 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.11 // indirect
 	github.com/googleapis/gax-go/v2 v2.17.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/google/go-github/v84 v84.0.0/go.mod h1:WwYL1z1ajRdlaPszjVu/47x1L0PXuk
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -434,6 +436,8 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -495,6 +499,10 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
@@ -534,6 +542,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/cli/commands/mcp/root.go
+++ b/pkg/cli/commands/mcp/root.go
@@ -1,0 +1,21 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/mcp"
+)
+
+// NewCommand creates the mcp command
+func NewCommand(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Start the SuperPlane MCP server",
+		Long:  "Start the Model Context Protocol (MCP) server for SuperPlane. The server runs on stdio transport and provides read-only tools for canvases, integrations, and secrets.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mcp.StartServer(version)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -16,6 +16,7 @@ import (
 	groups "github.com/superplanehq/superplane/pkg/cli/commands/groups"
 	index "github.com/superplanehq/superplane/pkg/cli/commands/index"
 	integrations "github.com/superplanehq/superplane/pkg/cli/commands/integrations"
+	mcp "github.com/superplanehq/superplane/pkg/cli/commands/mcp"
 	members "github.com/superplanehq/superplane/pkg/cli/commands/members"
 	organizations "github.com/superplanehq/superplane/pkg/cli/commands/organizations"
 	queue "github.com/superplanehq/superplane/pkg/cli/commands/queue"
@@ -62,6 +63,7 @@ func init() {
 	RootCmd.AddCommand(groups.NewCommand(options))
 	RootCmd.AddCommand(index.NewCommand(options))
 	RootCmd.AddCommand(integrations.NewCommand(options))
+	RootCmd.AddCommand(mcp.NewCommand(Version))
 	RootCmd.AddCommand(members.NewCommand(options))
 	RootCmd.AddCommand(organizations.NewCommand(options))
 	RootCmd.AddCommand(queue.NewCommand(options))

--- a/pkg/mcp/auth.go
+++ b/pkg/mcp/auth.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+const (
+	defaultAPIURL           = "http://localhost:8000"
+	configKeyContexts       = "contexts"
+	configKeyCurrentContext = "currentContext"
+)
+
+type Config struct {
+	BaseURL  string
+	APIToken string
+}
+
+type configContext struct {
+	URL            string  `json:"url" yaml:"url"`
+	Organization   string  `json:"organization" yaml:"organization"`
+	OrganizationID string  `json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
+	APIToken       string  `json:"apiToken" yaml:"apiToken"`
+	Canvas         *string `json:"canvas,omitempty" yaml:"canvas,omitempty"`
+}
+
+// LoadConfig reads configuration from ~/.superplane.yaml or environment variables
+func LoadConfig() (*Config, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find home directory: %w", err)
+	}
+
+	v := viper.New()
+	v.AddConfigPath(home)
+	v.SetConfigName(".superplane")
+	v.SetEnvPrefix("SUPERPLANE")
+	v.AutomaticEnv()
+
+	// Try to read config file (it's ok if it doesn't exist)
+	_ = v.ReadInConfig()
+
+	// First check environment variables
+	apiToken := os.Getenv("SUPERPLANE_API_TOKEN")
+	baseURL := os.Getenv("SUPERPLANE_API_URL")
+
+	// If not in env vars, try to get from config file
+	if apiToken == "" {
+		if currentContext, ok := getCurrentContext(v); ok {
+			apiToken = currentContext.APIToken
+			if baseURL == "" {
+				baseURL = currentContext.URL
+			}
+		}
+	}
+
+	// Default to localhost if no URL configured
+	if baseURL == "" {
+		baseURL = defaultAPIURL
+	}
+
+	if apiToken == "" {
+		return nil, fmt.Errorf("API token not found. Set SUPERPLANE_API_TOKEN env var or run 'superplane connect'")
+	}
+
+	return &Config{
+		BaseURL:  baseURL,
+		APIToken: apiToken,
+	}, nil
+}
+
+// getCurrentContext reads the current context from viper config
+func getCurrentContext(v *viper.Viper) (configContext, bool) {
+	var contexts []configContext
+	if err := v.UnmarshalKey(configKeyContexts, &contexts); err != nil {
+		return configContext{}, false
+	}
+
+	if len(contexts) == 0 {
+		return configContext{}, false
+	}
+
+	currentSelector := v.GetString(configKeyCurrentContext)
+	if currentSelector == "" {
+		return configContext{}, false
+	}
+
+	for _, context := range contexts {
+		if contextSelector(context) == currentSelector {
+			return context, true
+		}
+	}
+
+	return configContext{}, false
+}
+
+// contextSelector generates a unique selector for a context
+func contextSelector(context configContext) string {
+	context = normalizeContext(context)
+	id := context.OrganizationID
+	if id == "" {
+		id = context.Organization
+	}
+	return fmt.Sprintf("%s/%s", context.URL, id)
+}
+
+// normalizeContext normalizes the fields in a config context
+func normalizeContext(context configContext) configContext {
+	context.URL = normalizeBaseURL(context.URL)
+	context.Organization = strings.TrimSpace(context.Organization)
+	context.OrganizationID = strings.TrimSpace(context.OrganizationID)
+	context.APIToken = strings.TrimSpace(context.APIToken)
+	return context
+}
+
+// normalizeBaseURL trims whitespace and trailing slashes
+func normalizeBaseURL(raw string) string {
+	baseURL := strings.TrimSpace(raw)
+	return strings.TrimRight(baseURL, "/")
+}
+
+// NewAPIClient creates an authenticated openapi_client
+func NewAPIClient(config *Config) *openapi_client.APIClient {
+	apiConfig := openapi_client.NewConfiguration()
+
+	apiConfig.Servers = openapi_client.ServerConfigurations{
+		{
+			URL: config.BaseURL,
+		},
+	}
+
+	if config.APIToken != "" {
+		apiConfig.DefaultHeader["Authorization"] = "Bearer " + config.APIToken
+	}
+
+	apiConfig.HTTPClient = &http.Client{
+		Timeout: time.Second * 30,
+	}
+
+	return openapi_client.NewAPIClient(apiConfig)
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/mcp/tools"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// StartServer initializes and starts the MCP server
+func StartServer(version string) error {
+	config, err := LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	apiClient := NewAPIClient(config)
+
+	s := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "superplane",
+			Version: version,
+		},
+		nil,
+	)
+
+	// Register tools
+	if err := registerTools(context.Background(), s, apiClient); err != nil {
+		return fmt.Errorf("failed to register tools: %w", err)
+	}
+
+	// Connect using stdio transport
+	ctx := context.Background()
+	transport := &mcp.StdioTransport{}
+	_, err = s.Connect(ctx, transport, nil)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+
+	// Block forever - the server will handle requests on stdio
+	select {}
+}
+
+// registerTools registers all MCP tools
+func registerTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// Canvas tools
+	if err := tools.RegisterCanvasTools(ctx, s, apiClient); err != nil {
+		return fmt.Errorf("failed to register canvas tools: %w", err)
+	}
+
+	// Integration tools
+	if err := tools.RegisterIntegrationTools(ctx, s, apiClient); err != nil {
+		return fmt.Errorf("failed to register integration tools: %w", err)
+	}
+
+	// Secret tools
+	if err := tools.RegisterSecretTools(ctx, s, apiClient); err != nil {
+		return fmt.Errorf("failed to register secret tools: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/mcp/tools/canvases.go
+++ b/pkg/mcp/tools/canvases.go
@@ -1,0 +1,119 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+	"gopkg.in/yaml.v3"
+)
+
+// RegisterCanvasTools registers canvas-related MCP tools
+func RegisterCanvasTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// list_canvases tool
+	listCanvasesHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListCanvases(ctx, apiClient)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "list_canvases",
+		Description: "List all canvases in the organization. Returns canvas ID and name.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+	}, listCanvasesHandler)
+
+	// describe_canvas tool
+	describeCanvasHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			CanvasID string `json:"canvas_id"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+		return handleDescribeCanvas(ctx, apiClient, args.CanvasID)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "describe_canvas",
+		Description: "Get full details of a specific canvas including its current version YAML configuration.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"canvas_id":{"type":"string","description":"The ID of the canvas to describe"}},"required":["canvas_id"]}`),
+	}, describeCanvasHandler)
+
+	return nil
+}
+
+// handleListCanvases lists all canvases
+func handleListCanvases(ctx context.Context, apiClient *openapi_client.APIClient) (*mcp.CallToolResult, error) {
+	response, _, err := apiClient.CanvasAPI.CanvasesListCanvases(ctx).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list canvases: %w", err)
+	}
+
+	canvases := response.GetCanvases()
+	results := make([]map[string]any, 0, len(canvases))
+
+	for _, canvas := range canvases {
+		metadata := canvas.GetMetadata()
+
+		result := map[string]any{
+			"id":   metadata.GetId(),
+			"name": metadata.GetName(),
+		}
+
+		if metadata.HasCreatedAt() {
+			result["created_at"] = metadata.GetCreatedAt()
+		}
+
+		results = append(results, result)
+	}
+
+	content, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}
+
+// handleDescribeCanvas describes a single canvas with full details
+func handleDescribeCanvas(ctx context.Context, apiClient *openapi_client.APIClient, canvasID string) (*mcp.CallToolResult, error) {
+	response, _, err := apiClient.CanvasAPI.CanvasesDescribeCanvas(ctx, canvasID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe canvas: %w", err)
+	}
+
+	canvas := response.GetCanvas()
+	metadata := canvas.GetMetadata()
+	spec := canvas.GetSpec()
+
+	result := map[string]any{
+		"id":   metadata.GetId(),
+		"name": metadata.GetName(),
+	}
+
+	if metadata.HasCreatedAt() {
+		result["created_at"] = metadata.GetCreatedAt()
+	}
+
+	if metadata.HasUpdatedAt() {
+		result["updated_at"] = metadata.GetUpdatedAt()
+	}
+
+	// Include the full YAML spec
+	specYAML, err := yaml.Marshal(spec)
+	if err == nil {
+		result["spec_yaml"] = string(specYAML)
+	}
+
+	content, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}

--- a/pkg/mcp/tools/canvases_test.go
+++ b/pkg/mcp/tools/canvases_test.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+const testCanvasesListResponse = `{
+	"canvases": [
+		{
+			"metadata": {
+				"id": "canvas-001",
+				"name": "test-canvas",
+				"createdAt": "2025-01-15T10:00:00Z"
+			}
+		}
+	]
+}`
+
+const testCanvasDescribeResponse = `{
+	"canvas": {
+		"metadata": {
+			"id": "canvas-001",
+			"name": "test-canvas",
+			"createdAt": "2025-01-15T10:00:00Z",
+			"updatedAt": "2025-01-16T10:00:00Z"
+		},
+		"spec": {
+			"nodes": [{"id": "node-1"}]
+		}
+	}
+}`
+
+func newTestAPIClient(t *testing.T, handler http.HandlerFunc) *openapi_client.APIClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	config := openapi_client.NewConfiguration()
+	config.Servers = openapi_client.ServerConfigurations{{URL: server.URL}}
+	return openapi_client.NewAPIClient(config)
+}
+
+func TestHandleListCanvases(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testCanvasesListResponse))
+	})
+
+	ctx := context.Background()
+	result, err := handleListCanvases(ctx, apiClient)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var canvases []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &canvases))
+	require.Len(t, canvases, 1)
+	require.Equal(t, "canvas-001", canvases[0]["id"])
+	require.Equal(t, "test-canvas", canvases[0]["name"])
+}
+
+func TestHandleDescribeCanvas(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases/canvas-001", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testCanvasDescribeResponse))
+	})
+
+	ctx := context.Background()
+	result, err := handleDescribeCanvas(ctx, apiClient, "canvas-001")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var canvas map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &canvas))
+	require.Equal(t, "canvas-001", canvas["id"])
+	require.Equal(t, "test-canvas", canvas["name"])
+	require.Contains(t, canvas, "spec_yaml")
+}

--- a/pkg/mcp/tools/integrations.go
+++ b/pkg/mcp/tools/integrations.go
@@ -1,0 +1,90 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// RegisterIntegrationTools registers integration-related MCP tools
+func RegisterIntegrationTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// list_integrations tool
+	listIntegrationsHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListIntegrations(ctx, apiClient)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "list_integrations",
+		Description: "List all connected integrations in the organization.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+	}, listIntegrationsHandler)
+
+	return nil
+}
+
+// handleListIntegrations lists all connected integrations
+func handleListIntegrations(ctx context.Context, apiClient *openapi_client.APIClient) (*mcp.CallToolResult, error) {
+	// First get the current user to find organization ID
+	me, _, err := apiClient.MeAPI.MeMe(ctx).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	if !me.User.HasOrganizationId() {
+		return nil, fmt.Errorf("organization id not found for authenticated user")
+	}
+
+	orgID := me.User.GetOrganizationId()
+
+	// Get connected integrations
+	connectedResponse, _, err := apiClient.OrganizationAPI.OrganizationsListIntegrations(ctx, orgID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list integrations: %w", err)
+	}
+
+	// Get available integration definitions for labels and descriptions
+	availableResponse, _, err := apiClient.IntegrationAPI.IntegrationsListIntegrations(ctx).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list available integrations: %w", err)
+	}
+
+	integrationsByName := make(map[string]openapi_client.IntegrationsIntegrationDefinition)
+	for _, integration := range availableResponse.GetIntegrations() {
+		integrationsByName[integration.GetName()] = integration
+	}
+
+	connected := connectedResponse.GetIntegrations()
+	results := make([]map[string]any, 0, len(connected))
+
+	for _, integration := range connected {
+		metadata := integration.GetMetadata()
+		status := integration.GetStatus()
+		integrationName := metadata.GetIntegrationName()
+
+		result := map[string]any{
+			"id":               metadata.GetId(),
+			"name":             metadata.GetName(),
+			"integration_name": integrationName,
+			"state":            status.GetState(),
+		}
+
+		if definition, found := integrationsByName[integrationName]; found {
+			result["label"] = definition.GetLabel()
+			result["description"] = definition.GetDescription()
+		}
+
+		results = append(results, result)
+	}
+
+	content, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}

--- a/pkg/mcp/tools/integrations_test.go
+++ b/pkg/mcp/tools/integrations_test.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testMeResponse = `{
+	"user": {
+		"id": "user-001",
+		"organizationId": "org-001"
+	}
+}`
+
+const testIntegrationsListResponse = `{
+	"integrations": [
+		{
+			"metadata": {
+				"id": "int-001",
+				"name": "my-integration",
+				"integrationName": "github"
+			},
+			"status": {
+				"state": "CONNECTED"
+			}
+		}
+	]
+}`
+
+const testAvailableIntegrationsResponse = `{
+	"integrations": [
+		{
+			"name": "github",
+			"label": "GitHub",
+			"description": "GitHub integration"
+		}
+	]
+}`
+
+func TestHandleListIntegrations(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v1/me":
+			_, _ = w.Write([]byte(testMeResponse))
+		case "/api/v1/organizations/org-001/integrations":
+			require.Equal(t, http.MethodGet, r.Method)
+			_, _ = w.Write([]byte(testIntegrationsListResponse))
+		case "/api/v1/integrations":
+			require.Equal(t, http.MethodGet, r.Method)
+			_, _ = w.Write([]byte(testAvailableIntegrationsResponse))
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	})
+
+	ctx := context.Background()
+	result, err := handleListIntegrations(ctx, apiClient)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var integrations []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &integrations))
+	require.Len(t, integrations, 1)
+	require.Equal(t, "int-001", integrations[0]["id"])
+	require.Equal(t, "my-integration", integrations[0]["name"])
+	require.Equal(t, "github", integrations[0]["integration_name"])
+	require.Equal(t, "CONNECTED", integrations[0]["state"])
+	require.Equal(t, "GitHub", integrations[0]["label"])
+	require.Equal(t, "GitHub integration", integrations[0]["description"])
+}

--- a/pkg/mcp/tools/secrets.go
+++ b/pkg/mcp/tools/secrets.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// RegisterSecretTools registers secret-related MCP tools
+func RegisterSecretTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// list_secrets tool
+	listSecretsHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListSecrets(ctx, apiClient)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "list_secrets",
+		Description: "List all available secrets in the organization. Returns secret names only, not values.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+	}, listSecretsHandler)
+
+	return nil
+}
+
+// handleListSecrets lists all secrets (names only, no values)
+func handleListSecrets(ctx context.Context, apiClient *openapi_client.APIClient) (*mcp.CallToolResult, error) {
+	// First get the current user to find organization ID
+	me, _, err := apiClient.MeAPI.MeMe(ctx).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	if !me.User.HasOrganizationId() {
+		return nil, fmt.Errorf("organization id not found for authenticated user")
+	}
+
+	orgID := me.User.GetOrganizationId()
+
+	// Get secrets
+	response, _, err := apiClient.SecretAPI.
+		SecretsListSecrets(ctx).
+		DomainType(string(openapi_client.AUTHORIZATIONDOMAINTYPE_DOMAIN_TYPE_ORGANIZATION)).
+		DomainId(orgID).
+		Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	secrets := response.GetSecrets()
+	results := make([]map[string]any, 0, len(secrets))
+
+	for _, secret := range secrets {
+		metadata := secret.GetMetadata()
+
+		result := map[string]any{
+			"id":   metadata.GetId(),
+			"name": metadata.GetName(),
+		}
+
+		if metadata.HasCreatedAt() {
+			result["created_at"] = metadata.GetCreatedAt()
+		}
+
+		results = append(results, result)
+	}
+
+	content, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}

--- a/pkg/mcp/tools/secrets_test.go
+++ b/pkg/mcp/tools/secrets_test.go
@@ -1,0 +1,57 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecretsListResponse = `{
+	"secrets": [
+		{
+			"metadata": {
+				"id": "secret-001",
+				"name": "my-secret",
+				"createdAt": "2025-01-15T10:00:00Z"
+			}
+		}
+	]
+}`
+
+func TestHandleListSecrets(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v1/me":
+			_, _ = w.Write([]byte(testMeResponse))
+		case "/api/v1/secrets":
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, "DOMAIN_TYPE_ORGANIZATION", r.URL.Query().Get("domainType"))
+			require.Equal(t, "org-001", r.URL.Query().Get("domainId"))
+			_, _ = w.Write([]byte(testSecretsListResponse))
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	})
+
+	ctx := context.Background()
+	result, err := handleListSecrets(ctx, apiClient)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var secrets []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &secrets))
+	require.Len(t, secrets, 1)
+	require.Equal(t, "secret-001", secrets[0]["id"])
+	require.Equal(t, "my-secret", secrets[0]["name"])
+	require.Contains(t, secrets[0], "created_at")
+}


### PR DESCRIPTION
Adds MCP server infrastructure with 4 read-only tools (list_canvases, describe_canvas, list_integrations, list_secrets). Uses official Go MCP SDK, reuses existing openapi_client. 788 lines, 13 files.