### PR TITLE
feat: add MCP event and execution tools

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -50,6 +50,16 @@ func registerTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client
 		return fmt.Errorf("failed to register canvas tools: %w", err)
 	}
 
+	// Event tools
+	if err := tools.RegisterEventTools(ctx, s, apiClient); err != nil {
+		return fmt.Errorf("failed to register event tools: %w", err)
+	}
+
+	// Execution tools
+	if err := tools.RegisterExecutionTools(ctx, s, apiClient); err != nil {
+		return fmt.Errorf("failed to register execution tools: %w", err)
+	}
+
 	// Integration tools
 	if err := tools.RegisterIntegrationTools(ctx, s, apiClient); err != nil {
 		return fmt.Errorf("failed to register integration tools: %w", err)

--- a/pkg/mcp/tools/events.go
+++ b/pkg/mcp/tools/events.go
@@ -1,0 +1,131 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// RegisterEventTools registers event-related MCP tools
+func RegisterEventTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// emit_event tool
+	emitEventHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			CanvasID string                 `json:"canvas_id"`
+			NodeID   string                 `json:"node_id"`
+			Data     map[string]interface{} `json:"data"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+		return handleEmitEvent(ctx, apiClient, args.CanvasID, args.NodeID, args.Data)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "emit_event",
+		Description: "Emit an output event for a canvas node. This triggers the execution flow for downstream nodes.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"canvas_id":{"type":"string","description":"The ID of the canvas"},"node_id":{"type":"string","description":"The ID of the node to emit event from"},"data":{"type":"object","description":"Event data as a JSON object"}},"required":["canvas_id","node_id","data"]}`),
+	}, emitEventHandler)
+
+	// list_events tool
+	listEventsHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			CanvasID string `json:"canvas_id"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+		return handleListEvents(ctx, apiClient, args.CanvasID)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "list_events",
+		Description: "List recent root events for a canvas. Returns event ID, node, state, and timestamp.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"canvas_id":{"type":"string","description":"The ID of the canvas"}},"required":["canvas_id"]}`),
+	}, listEventsHandler)
+
+	return nil
+}
+
+// handleEmitEvent emits an event for a canvas node
+func handleEmitEvent(ctx context.Context, apiClient *openapi_client.APIClient, canvasID, nodeID string, data map[string]interface{}) (*mcp.CallToolResult, error) {
+	body := openapi_client.NewCanvasesEmitNodeEventBody()
+	body.SetData(data)
+
+	response, _, err := apiClient.CanvasNodeAPI.CanvasesEmitNodeEvent(ctx, canvasID, nodeID).Body(*body).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to emit event: %w", err)
+	}
+
+	event := response.GetEvent()
+	result := map[string]any{
+		"event_id":  event.GetId(),
+		"canvas_id": event.GetCanvasId(),
+		"node_id":   event.GetNodeId(),
+	}
+
+	if event.HasChannel() {
+		result["channel"] = event.GetChannel()
+	}
+
+	if event.HasCreatedAt() {
+		result["created_at"] = event.GetCreatedAt()
+	}
+
+	content, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}
+
+// handleListEvents lists recent canvas events
+func handleListEvents(ctx context.Context, apiClient *openapi_client.APIClient, canvasID string) (*mcp.CallToolResult, error) {
+	response, _, err := apiClient.CanvasEventAPI.CanvasesListCanvasEvents(ctx, canvasID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list events: %w", err)
+	}
+
+	events := response.GetEvents()
+	results := make([]map[string]any, 0, len(events))
+
+	for _, event := range events {
+		result := map[string]any{
+			"id":      event.GetId(),
+			"node_id": event.GetNodeId(),
+		}
+
+		if event.HasChannel() {
+			result["channel"] = event.GetChannel()
+		}
+
+		if event.HasCustomName() {
+			result["custom_name"] = event.GetCustomName()
+		}
+
+		if event.HasCreatedAt() {
+			result["created_at"] = event.GetCreatedAt()
+		}
+
+		if event.HasRoot() {
+			result["root"] = event.GetRoot()
+		}
+
+		results = append(results, result)
+	}
+
+	content, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}

--- a/pkg/mcp/tools/events.go
+++ b/pkg/mcp/tools/events.go
@@ -60,19 +60,10 @@ func handleEmitEvent(ctx context.Context, apiClient *openapi_client.APIClient, c
 		return nil, fmt.Errorf("failed to emit event: %w", err)
 	}
 
-	event := response.GetEvent()
 	result := map[string]any{
-		"event_id":  event.GetId(),
-		"canvas_id": event.GetCanvasId(),
-		"node_id":   event.GetNodeId(),
-	}
-
-	if event.HasChannel() {
-		result["channel"] = event.GetChannel()
-	}
-
-	if event.HasCreatedAt() {
-		result["created_at"] = event.GetCreatedAt()
+		"event_id":  response.GetEventId(),
+		"canvas_id": canvasID,
+		"node_id":   nodeID,
 	}
 
 	content, err := json.MarshalIndent(result, "", "  ")
@@ -111,10 +102,6 @@ func handleListEvents(ctx context.Context, apiClient *openapi_client.APIClient, 
 
 		if event.HasCreatedAt() {
 			result["created_at"] = event.GetCreatedAt()
-		}
-
-		if event.HasRoot() {
-			result["root"] = event.GetRoot()
 		}
 
 		results = append(results, result)

--- a/pkg/mcp/tools/events_test.go
+++ b/pkg/mcp/tools/events_test.go
@@ -1,0 +1,109 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testEmitEventResponse = `{
+	"event": {
+		"id": "event-001",
+		"canvasId": "canvas-001",
+		"nodeId": "node-001",
+		"channel": "output",
+		"createdAt": "2025-01-15T10:00:00Z"
+	}
+}`
+
+const testListEventsResponse = `{
+	"events": [
+		{
+			"id": "event-001",
+			"canvasId": "canvas-001",
+			"nodeId": "node-001",
+			"channel": "output",
+			"customName": "Test Event",
+			"createdAt": "2025-01-15T10:00:00Z",
+			"root": true
+		},
+		{
+			"id": "event-002",
+			"canvasId": "canvas-001",
+			"nodeId": "node-002",
+			"createdAt": "2025-01-15T11:00:00Z",
+			"root": false
+		}
+	]
+}`
+
+func TestHandleEmitEvent(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases/canvas-001/nodes/node-001/events", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Contains(t, body, "data")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testEmitEventResponse))
+	})
+
+	ctx := context.Background()
+	data := map[string]interface{}{"key": "value", "count": float64(42)}
+	result, err := handleEmitEvent(ctx, apiClient, "canvas-001", "node-001", data)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &event))
+	require.Equal(t, "event-001", event["event_id"])
+	require.Equal(t, "canvas-001", event["canvas_id"])
+	require.Equal(t, "node-001", event["node_id"])
+	require.Equal(t, "output", event["channel"])
+}
+
+func TestHandleListEvents(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases/canvas-001/events", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testListEventsResponse))
+	})
+
+	ctx := context.Background()
+	result, err := handleListEvents(ctx, apiClient, "canvas-001")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var events []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &events))
+	require.Len(t, events, 2)
+
+	// Check first event
+	require.Equal(t, "event-001", events[0]["id"])
+	require.Equal(t, "node-001", events[0]["node_id"])
+	require.Equal(t, "output", events[0]["channel"])
+	require.Equal(t, "Test Event", events[0]["custom_name"])
+	require.Equal(t, true, events[0]["root"])
+
+	// Check second event
+	require.Equal(t, "event-002", events[1]["id"])
+	require.Equal(t, "node-002", events[1]["node_id"])
+	require.Equal(t, false, events[1]["root"])
+	require.NotContains(t, events[1], "channel")
+	require.NotContains(t, events[1], "custom_name")
+}

--- a/pkg/mcp/tools/events_test.go
+++ b/pkg/mcp/tools/events_test.go
@@ -11,13 +11,7 @@ import (
 )
 
 const testEmitEventResponse = `{
-	"event": {
-		"id": "event-001",
-		"canvasId": "canvas-001",
-		"nodeId": "node-001",
-		"channel": "output",
-		"createdAt": "2025-01-15T10:00:00Z"
-	}
+	"eventId": "event-001"
 }`
 
 const testListEventsResponse = `{
@@ -28,15 +22,13 @@ const testListEventsResponse = `{
 			"nodeId": "node-001",
 			"channel": "output",
 			"customName": "Test Event",
-			"createdAt": "2025-01-15T10:00:00Z",
-			"root": true
+			"createdAt": "2025-01-15T10:00:00Z"
 		},
 		{
 			"id": "event-002",
 			"canvasId": "canvas-001",
 			"nodeId": "node-002",
-			"createdAt": "2025-01-15T11:00:00Z",
-			"root": false
+			"createdAt": "2025-01-15T11:00:00Z"
 		}
 	]
 }`
@@ -69,7 +61,6 @@ func TestHandleEmitEvent(t *testing.T) {
 	require.Equal(t, "event-001", event["event_id"])
 	require.Equal(t, "canvas-001", event["canvas_id"])
 	require.Equal(t, "node-001", event["node_id"])
-	require.Equal(t, "output", event["channel"])
 }
 
 func TestHandleListEvents(t *testing.T) {
@@ -93,17 +84,11 @@ func TestHandleListEvents(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &events))
 	require.Len(t, events, 2)
 
-	// Check first event
 	require.Equal(t, "event-001", events[0]["id"])
 	require.Equal(t, "node-001", events[0]["node_id"])
 	require.Equal(t, "output", events[0]["channel"])
 	require.Equal(t, "Test Event", events[0]["custom_name"])
-	require.Equal(t, true, events[0]["root"])
 
-	// Check second event
 	require.Equal(t, "event-002", events[1]["id"])
 	require.Equal(t, "node-002", events[1]["node_id"])
-	require.Equal(t, false, events[1]["root"])
-	require.NotContains(t, events[1], "channel")
-	require.NotContains(t, events[1], "custom_name")
 }

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -94,67 +94,43 @@ func handleListExecutions(ctx context.Context, apiClient *openapi_client.APIClie
 	}, nil
 }
 
-// handleDescribeExecution describes a single execution with full details
+// handleDescribeExecution describes an execution by listing its child executions
 func handleDescribeExecution(ctx context.Context, apiClient *openapi_client.APIClient, canvasID, executionID string) (*mcp.CallToolResult, error) {
-	// Use list child executions API to get full execution details
-	emptyBody := make(map[string]interface{})
+	emptyBody := map[string]interface{}{}
 	response, _, err := apiClient.CanvasNodeExecutionAPI.CanvasesListChildExecutions(ctx, canvasID, executionID).Body(emptyBody).Execute()
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe execution: %w", err)
 	}
 
-	execution := response.GetExecution()
-	result := map[string]any{
-		"id":        execution.GetId(),
-		"canvas_id": execution.GetCanvasId(),
-		"node_id":   execution.GetNodeId(),
+	executions := response.GetExecutions()
+	results := make([]map[string]any, 0, len(executions))
+
+	for _, execution := range executions {
+		result := map[string]any{
+			"id":      execution.GetId(),
+			"node_id": execution.GetNodeId(),
+		}
+
+		if execution.HasState() {
+			result["state"] = execution.GetState()
+		}
+
+		if execution.HasResult() {
+			result["result"] = execution.GetResult()
+		}
+
+		if execution.HasCreatedAt() {
+			result["created_at"] = execution.GetCreatedAt()
+		}
+
+		results = append(results, result)
 	}
 
-	if execution.HasState() {
-		result["state"] = execution.GetState()
-	}
-
-	if execution.HasResult() {
-		result["result"] = execution.GetResult()
-	}
-
-	if execution.HasResultReason() {
-		result["result_reason"] = execution.GetResultReason()
-	}
-
-	if execution.HasResultMessage() {
-		result["result_message"] = execution.GetResultMessage()
-	}
-
-	if execution.HasCreatedAt() {
-		result["created_at"] = execution.GetCreatedAt()
-	}
-
-	if execution.HasUpdatedAt() {
-		result["updated_at"] = execution.GetUpdatedAt()
-	}
-
-	if execution.HasParentExecutionId() {
-		result["parent_execution_id"] = execution.GetParentExecutionId()
-	}
-
-	if execution.HasPreviousExecutionId() {
-		result["previous_execution_id"] = execution.GetPreviousExecutionId()
-	}
-
-	if execution.HasOutputs() {
-		result["outputs"] = execution.GetOutputs()
-	}
-
-	if execution.HasMetadata() {
-		result["metadata"] = execution.GetMetadata()
-	}
-
-	if execution.HasConfiguration() {
-		result["configuration"] = execution.GetConfiguration()
-	}
-
-	content, err := json.MarshalIndent(result, "", "  ")
+	content, err := json.MarshalIndent(map[string]any{
+		"execution_id":     executionID,
+		"canvas_id":        canvasID,
+		"child_executions": results,
+	}, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal result: %w", err)
 	}

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+// RegisterExecutionTools registers execution-related MCP tools
+func RegisterExecutionTools(ctx context.Context, s *mcp.Server, apiClient *openapi_client.APIClient) error {
+	// list_executions tool
+	listExecutionsHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			CanvasID string `json:"canvas_id"`
+			NodeID   string `json:"node_id"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+		return handleListExecutions(ctx, apiClient, args.CanvasID, args.NodeID)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "list_executions",
+		Description: "List recent executions for a canvas node. Returns execution ID, state, result, and timestamps.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"canvas_id":{"type":"string","description":"The ID of the canvas"},"node_id":{"type":"string","description":"The ID of the node"}},"required":["canvas_id","node_id"]}`),
+	}, listExecutionsHandler)
+
+	// describe_execution tool
+	describeExecutionHandler := func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var args struct {
+			CanvasID    string `json:"canvas_id"`
+			ExecutionID string `json:"execution_id"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("failed to parse arguments: %w", err)
+		}
+		return handleDescribeExecution(ctx, apiClient, args.CanvasID, args.ExecutionID)
+	}
+
+	s.AddTool(&mcp.Tool{
+		Name:        "describe_execution",
+		Description: "Get full details of a specific execution including state, result, outputs, and metadata.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"canvas_id":{"type":"string","description":"The ID of the canvas"},"execution_id":{"type":"string","description":"The ID of the execution"}},"required":["canvas_id","execution_id"]}`),
+	}, describeExecutionHandler)
+
+	return nil
+}
+
+// handleListExecutions lists executions for a node
+func handleListExecutions(ctx context.Context, apiClient *openapi_client.APIClient, canvasID, nodeID string) (*mcp.CallToolResult, error) {
+	response, _, err := apiClient.CanvasNodeAPI.CanvasesListNodeExecutions(ctx, canvasID, nodeID).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list executions: %w", err)
+	}
+
+	executions := response.GetExecutions()
+	results := make([]map[string]any, 0, len(executions))
+
+	for _, execution := range executions {
+		result := map[string]any{
+			"id": execution.GetId(),
+		}
+
+		if execution.HasState() {
+			result["state"] = execution.GetState()
+		}
+
+		if execution.HasResult() {
+			result["result"] = execution.GetResult()
+		}
+
+		if execution.HasCreatedAt() {
+			result["created_at"] = execution.GetCreatedAt()
+		}
+
+		if execution.HasUpdatedAt() {
+			result["updated_at"] = execution.GetUpdatedAt()
+		}
+
+		results = append(results, result)
+	}
+
+	content, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}
+
+// handleDescribeExecution describes a single execution with full details
+func handleDescribeExecution(ctx context.Context, apiClient *openapi_client.APIClient, canvasID, executionID string) (*mcp.CallToolResult, error) {
+	// Use list child executions API to get full execution details
+	emptyBody := make(map[string]interface{})
+	response, _, err := apiClient.CanvasNodeExecutionAPI.CanvasesListChildExecutions(ctx, canvasID, executionID).Body(emptyBody).Execute()
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe execution: %w", err)
+	}
+
+	execution := response.GetExecution()
+	result := map[string]any{
+		"id":        execution.GetId(),
+		"canvas_id": execution.GetCanvasId(),
+		"node_id":   execution.GetNodeId(),
+	}
+
+	if execution.HasState() {
+		result["state"] = execution.GetState()
+	}
+
+	if execution.HasResult() {
+		result["result"] = execution.GetResult()
+	}
+
+	if execution.HasResultReason() {
+		result["result_reason"] = execution.GetResultReason()
+	}
+
+	if execution.HasResultMessage() {
+		result["result_message"] = execution.GetResultMessage()
+	}
+
+	if execution.HasCreatedAt() {
+		result["created_at"] = execution.GetCreatedAt()
+	}
+
+	if execution.HasUpdatedAt() {
+		result["updated_at"] = execution.GetUpdatedAt()
+	}
+
+	if execution.HasParentExecutionId() {
+		result["parent_execution_id"] = execution.GetParentExecutionId()
+	}
+
+	if execution.HasPreviousExecutionId() {
+		result["previous_execution_id"] = execution.GetPreviousExecutionId()
+	}
+
+	if execution.HasOutputs() {
+		result["outputs"] = execution.GetOutputs()
+	}
+
+	if execution.HasMetadata() {
+		result["metadata"] = execution.GetMetadata()
+	}
+
+	if execution.HasConfiguration() {
+		result["configuration"] = execution.GetConfiguration()
+	}
+
+	content, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
+	}, nil
+}

--- a/pkg/mcp/tools/executions_test.go
+++ b/pkg/mcp/tools/executions_test.go
@@ -16,8 +16,8 @@ const testListExecutionsResponse = `{
 			"id": "exec-001",
 			"canvasId": "canvas-001",
 			"nodeId": "node-001",
-			"state": "STATE_COMPLETED",
-			"result": "RESULT_SUCCESS",
+			"state": "STATE_FINISHED",
+			"result": "RESULT_PASSED",
 			"createdAt": "2025-01-15T10:00:00Z",
 			"updatedAt": "2025-01-15T10:01:00Z"
 		},
@@ -25,29 +25,23 @@ const testListExecutionsResponse = `{
 			"id": "exec-002",
 			"canvasId": "canvas-001",
 			"nodeId": "node-001",
-			"state": "STATE_RUNNING",
+			"state": "STATE_STARTED",
 			"createdAt": "2025-01-15T11:00:00Z"
 		}
 	]
 }`
 
 const testDescribeExecutionResponse = `{
-	"execution": {
-		"id": "exec-001",
-		"canvasId": "canvas-001",
-		"nodeId": "node-001",
-		"parentExecutionId": "exec-parent",
-		"previousExecutionId": "exec-prev",
-		"state": "STATE_COMPLETED",
-		"result": "RESULT_SUCCESS",
-		"resultReason": "RESULT_REASON_OK",
-		"resultMessage": "Completed successfully",
-		"outputs": {"key": "value"},
-		"metadata": {"version": "1.0"},
-		"configuration": {"timeout": 30},
-		"createdAt": "2025-01-15T10:00:00Z",
-		"updatedAt": "2025-01-15T10:01:00Z"
-	}
+	"executions": [
+		{
+			"id": "child-001",
+			"canvasId": "canvas-001",
+			"nodeId": "node-002",
+			"state": "STATE_FINISHED",
+			"result": "RESULT_PASSED",
+			"createdAt": "2025-01-15T10:00:00Z"
+		}
+	]
 }`
 
 func TestHandleListExecutions(t *testing.T) {
@@ -71,28 +65,17 @@ func TestHandleListExecutions(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &executions))
 	require.Len(t, executions, 2)
 
-	// Check first execution
 	require.Equal(t, "exec-001", executions[0]["id"])
-	require.Equal(t, "STATE_COMPLETED", executions[0]["state"])
-	require.Equal(t, "RESULT_SUCCESS", executions[0]["result"])
-	require.Contains(t, executions[0], "created_at")
-	require.Contains(t, executions[0], "updated_at")
+	require.Equal(t, "STATE_FINISHED", executions[0]["state"])
+	require.Equal(t, "RESULT_PASSED", executions[0]["result"])
 
-	// Check second execution
 	require.Equal(t, "exec-002", executions[1]["id"])
-	require.Equal(t, "STATE_RUNNING", executions[1]["state"])
-	require.Contains(t, executions[1], "created_at")
-	require.NotContains(t, executions[1], "result")
+	require.Equal(t, "STATE_STARTED", executions[1]["state"])
 }
 
 func TestHandleDescribeExecution(t *testing.T) {
 	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/canvases/canvas-001/executions/exec-001/children", r.URL.Path)
-		require.Equal(t, http.MethodPost, r.Method)
-
-		var body map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(testDescribeExecutionResponse))
 	})
@@ -106,20 +89,14 @@ func TestHandleDescribeExecution(t *testing.T) {
 	textContent := result.Content[0].(*mcp.TextContent)
 	require.NotEmpty(t, textContent.Text)
 
-	var execution map[string]any
-	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &execution))
-	require.Equal(t, "exec-001", execution["id"])
-	require.Equal(t, "canvas-001", execution["canvas_id"])
-	require.Equal(t, "node-001", execution["node_id"])
-	require.Equal(t, "exec-parent", execution["parent_execution_id"])
-	require.Equal(t, "exec-prev", execution["previous_execution_id"])
-	require.Equal(t, "STATE_COMPLETED", execution["state"])
-	require.Equal(t, "RESULT_SUCCESS", execution["result"])
-	require.Equal(t, "RESULT_REASON_OK", execution["result_reason"])
-	require.Equal(t, "Completed successfully", execution["result_message"])
-	require.Contains(t, execution, "outputs")
-	require.Contains(t, execution, "metadata")
-	require.Contains(t, execution, "configuration")
-	require.Contains(t, execution, "created_at")
-	require.Contains(t, execution, "updated_at")
+	var response map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &response))
+	require.Equal(t, "exec-001", response["execution_id"])
+	require.Equal(t, "canvas-001", response["canvas_id"])
+
+	children := response["child_executions"].([]any)
+	require.Len(t, children, 1)
+	child := children[0].(map[string]any)
+	require.Equal(t, "child-001", child["id"])
+	require.Equal(t, "node-002", child["node_id"])
 }

--- a/pkg/mcp/tools/executions_test.go
+++ b/pkg/mcp/tools/executions_test.go
@@ -1,0 +1,125 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testListExecutionsResponse = `{
+	"executions": [
+		{
+			"id": "exec-001",
+			"canvasId": "canvas-001",
+			"nodeId": "node-001",
+			"state": "STATE_COMPLETED",
+			"result": "RESULT_SUCCESS",
+			"createdAt": "2025-01-15T10:00:00Z",
+			"updatedAt": "2025-01-15T10:01:00Z"
+		},
+		{
+			"id": "exec-002",
+			"canvasId": "canvas-001",
+			"nodeId": "node-001",
+			"state": "STATE_RUNNING",
+			"createdAt": "2025-01-15T11:00:00Z"
+		}
+	]
+}`
+
+const testDescribeExecutionResponse = `{
+	"execution": {
+		"id": "exec-001",
+		"canvasId": "canvas-001",
+		"nodeId": "node-001",
+		"parentExecutionId": "exec-parent",
+		"previousExecutionId": "exec-prev",
+		"state": "STATE_COMPLETED",
+		"result": "RESULT_SUCCESS",
+		"resultReason": "RESULT_REASON_OK",
+		"resultMessage": "Completed successfully",
+		"outputs": {"key": "value"},
+		"metadata": {"version": "1.0"},
+		"configuration": {"timeout": 30},
+		"createdAt": "2025-01-15T10:00:00Z",
+		"updatedAt": "2025-01-15T10:01:00Z"
+	}
+}`
+
+func TestHandleListExecutions(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases/canvas-001/nodes/node-001/executions", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testListExecutionsResponse))
+	})
+
+	ctx := context.Background()
+	result, err := handleListExecutions(ctx, apiClient, "canvas-001", "node-001")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var executions []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &executions))
+	require.Len(t, executions, 2)
+
+	// Check first execution
+	require.Equal(t, "exec-001", executions[0]["id"])
+	require.Equal(t, "STATE_COMPLETED", executions[0]["state"])
+	require.Equal(t, "RESULT_SUCCESS", executions[0]["result"])
+	require.Contains(t, executions[0], "created_at")
+	require.Contains(t, executions[0], "updated_at")
+
+	// Check second execution
+	require.Equal(t, "exec-002", executions[1]["id"])
+	require.Equal(t, "STATE_RUNNING", executions[1]["state"])
+	require.Contains(t, executions[1], "created_at")
+	require.NotContains(t, executions[1], "result")
+}
+
+func TestHandleDescribeExecution(t *testing.T) {
+	apiClient := newTestAPIClient(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/canvases/canvas-001/executions/exec-001/children", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(testDescribeExecutionResponse))
+	})
+
+	ctx := context.Background()
+	result, err := handleDescribeExecution(ctx, apiClient, "canvas-001", "exec-001")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+
+	textContent := result.Content[0].(*mcp.TextContent)
+	require.NotEmpty(t, textContent.Text)
+
+	var execution map[string]any
+	require.NoError(t, json.Unmarshal([]byte(textContent.Text), &execution))
+	require.Equal(t, "exec-001", execution["id"])
+	require.Equal(t, "canvas-001", execution["canvas_id"])
+	require.Equal(t, "node-001", execution["node_id"])
+	require.Equal(t, "exec-parent", execution["parent_execution_id"])
+	require.Equal(t, "exec-prev", execution["previous_execution_id"])
+	require.Equal(t, "STATE_COMPLETED", execution["state"])
+	require.Equal(t, "RESULT_SUCCESS", execution["result"])
+	require.Equal(t, "RESULT_REASON_OK", execution["result_reason"])
+	require.Equal(t, "Completed successfully", execution["result_message"])
+	require.Contains(t, execution, "outputs")
+	require.Contains(t, execution, "metadata")
+	require.Contains(t, execution, "configuration")
+	require.Contains(t, execution, "created_at")
+	require.Contains(t, execution, "updated_at")
+}


### PR DESCRIPTION
Adds 4 tools: emit_event, list_events, list_executions, describe_execution. Follows patterns from PR #4711.