### PR TITLE
fix: add password change flow for email/password accounts

### DIFF
--- a/pkg/models/account.go
+++ b/pkg/models/account.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -20,6 +21,19 @@ type Account struct {
 
 func (a *Account) IsInstallationAdmin() bool {
 	return a.InstallationAdmin
+}
+
+func (a *Account) HasPasswordAuth() (bool, error) {
+	_, err := FindAccountPasswordAuthByAccountID(a.ID)
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func PromoteToInstallationAdmin(accountID string) error {

--- a/pkg/public/middleware/auth.go
+++ b/pkg/public/middleware/auth.go
@@ -474,7 +474,7 @@ func isOwnerSetupAllowedPath(path string) bool {
 
 func isAccountAPIPath(path string) bool {
 	switch path {
-	case "/account", "/account/limits", "/organizations":
+	case "/account", "/account/password", "/account/limits", "/organizations":
 		return true
 	default:
 		return strings.HasPrefix(path, "/api/v1/invite-links/")

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -570,6 +570,7 @@ func (s *Server) InitRouter(additionalMiddlewares ...mux.MiddlewareFunc) {
 	accountRoute := r.NewRoute().Subrouter()
 	accountRoute.Use(middleware.AccountAuthMiddleware(s.jwt))
 	accountRoute.HandleFunc("/account", s.getAccount).Methods("GET")
+	accountRoute.HandleFunc("/account/password", s.changeAccountPassword).Methods("PATCH")
 	accountRoute.HandleFunc("/account/limits", s.getOrganizationCreationStatus).Methods("GET")
 	accountRoute.HandleFunc("/organizations", s.listAccountOrganizations).Methods("GET")
 	accountRoute.HandleFunc("/organizations", s.createOrganization).Methods("POST")
@@ -907,6 +908,7 @@ type AccountResponse struct {
 	Email             string                `json:"email"`
 	AvatarURL         string                `json:"avatar_url"`
 	InstallationAdmin bool                  `json:"installation_admin"`
+	HasPasswordAuth   bool                  `json:"has_password_auth"`
 	Impersonation     *AccountImpersonation `json:"impersonation,omitempty"`
 }
 
@@ -924,12 +926,20 @@ func (s *Server) getAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	hasPasswordAuth, err := account.HasPasswordAuth()
+	if err != nil {
+		log.Errorf("Error checking password auth for account %s: %v", account.Email, err)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
 	accountResponse := AccountResponse{
 		ID:                account.ID.String(),
 		Name:              account.Name,
 		Email:             account.Email,
 		AvatarURL:         getAvatarURL(providers),
 		InstallationAdmin: account.IsInstallationAdmin(),
+		HasPasswordAuth:   hasPasswordAuth,
 	}
 
 	if info, ok := middleware.GetImpersonationFromContext(r.Context()); ok && info.Active {
@@ -941,6 +951,76 @@ func (s *Server) getAccount(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(accountResponse)
+}
+
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
+func (s *Server) changeAccountPassword(w http.ResponseWriter, r *http.Request) {
+	if info, ok := middleware.GetImpersonationFromContext(r.Context()); ok && info.Active {
+		http.Error(w, "Cannot change password while impersonating another account", http.StatusForbidden)
+		return
+	}
+
+	account, ok := middleware.GetAccountFromContext(r.Context())
+	if !ok {
+		http.Error(w, "", http.StatusUnauthorized)
+		return
+	}
+
+	var request ChangePasswordRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if request.CurrentPassword == "" || request.NewPassword == "" {
+		http.Error(w, "Current password and new password are required", http.StatusBadRequest)
+		return
+	}
+
+	hasPasswordAuth, err := account.HasPasswordAuth()
+	if err != nil {
+		log.Errorf("Failed to check password auth for account %s: %v", account.ID, err)
+		http.Error(w, "Failed to update password", http.StatusInternalServerError)
+		return
+	}
+
+	if !hasPasswordAuth {
+		http.Error(w, "Password changes are only available for email/password accounts", http.StatusForbidden)
+		return
+	}
+
+	passwordAuth, err := models.FindAccountPasswordAuthByAccountID(account.ID)
+	if err != nil {
+		log.Errorf("Failed to load password auth for account %s: %v", account.ID, err)
+		http.Error(w, "Failed to update password", http.StatusInternalServerError)
+		return
+	}
+
+	if !crypto.VerifyPassword(passwordAuth.PasswordHash, request.CurrentPassword) {
+		http.Error(w, "Current password is incorrect", http.StatusUnauthorized)
+		return
+	}
+
+	passwordHash, err := crypto.HashPassword(request.NewPassword)
+	if err != nil {
+		log.Errorf("Failed to hash changed password for account %s: %v", account.ID, err)
+		http.Error(w, "Failed to update password", http.StatusInternalServerError)
+		return
+	}
+
+	if err := passwordAuth.UpdatePasswordHash(passwordHash); err != nil {
+		log.Errorf("Failed to update password for account %s: %v", account.ID, err)
+		http.Error(w, "Failed to update password", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) listAccountOrganizations(w http.ResponseWriter, r *http.Request) {

--- a/pkg/public/server_auth_test.go
+++ b/pkg/public/server_auth_test.go
@@ -1,6 +1,8 @@
 package public
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,7 @@ import (
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
@@ -83,7 +86,108 @@ func Test__GetAccount(t *testing.T) {
 		response := httptest.NewRecorder()
 		server.Router.ServeHTTP(response, req)
 		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body AccountResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.False(t, body.HasPasswordAuth)
 	})
+
+	t.Run("authenticated account with password auth -> includes password auth status", func(t *testing.T) {
+		r := support.Setup(t)
+		server, account, token := setupTestServer(r, t)
+		createPasswordAuth(t, account, "old-password")
+
+		req, _ := http.NewRequest(http.MethodGet, "/account", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+		response := httptest.NewRecorder()
+		server.Router.ServeHTTP(response, req)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body AccountResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.True(t, body.HasPasswordAuth)
+	})
+}
+
+func Test__ChangeAccountPassword(t *testing.T) {
+	t.Run("no authenticated account -> unauthorized", func(t *testing.T) {
+		r := support.Setup(t)
+		server, _, _ := setupTestServer(r, t)
+
+		response := changePasswordRequest(t, server, "", "old-password", "new-password")
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+		assert.Empty(t, response.Header().Get("Location"))
+	})
+
+	t.Run("account without password auth -> forbidden", func(t *testing.T) {
+		r := support.Setup(t)
+		server, _, token := setupTestServer(r, t)
+
+		response := changePasswordRequest(t, server, token, "old-password", "new-password")
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("wrong current password -> unauthorized and keeps existing password", func(t *testing.T) {
+		r := support.Setup(t)
+		server, account, token := setupTestServer(r, t)
+		originalHash := createPasswordAuth(t, account, "old-password")
+
+		response := changePasswordRequest(t, server, token, "wrong-password", "new-password")
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+
+		passwordAuth, err := models.FindAccountPasswordAuthByAccountID(account.ID)
+		require.NoError(t, err)
+		assert.Equal(t, originalHash, passwordAuth.PasswordHash)
+		assert.True(t, crypto.VerifyPassword(passwordAuth.PasswordHash, "old-password"))
+		assert.False(t, crypto.VerifyPassword(passwordAuth.PasswordHash, "new-password"))
+	})
+
+	t.Run("valid current password -> updates password", func(t *testing.T) {
+		r := support.Setup(t)
+		server, account, token := setupTestServer(r, t)
+		createPasswordAuth(t, account, "old-password")
+
+		response := changePasswordRequest(t, server, token, "old-password", "new-password")
+		assert.Equal(t, http.StatusNoContent, response.Code)
+
+		passwordAuth, err := models.FindAccountPasswordAuthByAccountID(account.ID)
+		require.NoError(t, err)
+		assert.False(t, crypto.VerifyPassword(passwordAuth.PasswordHash, "old-password"))
+		assert.True(t, crypto.VerifyPassword(passwordAuth.PasswordHash, "new-password"))
+	})
+}
+
+func createPasswordAuth(t *testing.T, account *models.Account, password string) string {
+	t.Helper()
+
+	hash, err := crypto.HashPassword(password)
+	require.NoError(t, err)
+
+	_, err = models.CreateAccountPasswordAuth(account.ID, hash)
+	require.NoError(t, err)
+
+	return hash
+}
+
+func changePasswordRequest(t *testing.T, server *Server, token string, currentPassword string, newPassword string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body, err := json.Marshal(ChangePasswordRequest{
+		CurrentPassword: currentPassword,
+		NewPassword:     newPassword,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPatch, "/account/password", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+	}
+
+	response := httptest.NewRecorder()
+	server.Router.ServeHTTP(response, req)
+	return response
 }
 
 func Test__ListAccountOrganizations(t *testing.T) {

--- a/web_src/src/contexts/AccountContext.tsx
+++ b/web_src/src/contexts/AccountContext.tsx
@@ -12,6 +12,7 @@ interface Account {
   email: string;
   avatar_url: string;
   installation_admin: boolean;
+  has_password_auth: boolean;
   impersonation?: AccountImpersonation;
 }
 

--- a/web_src/src/pages/organization/settings/Profile.tsx
+++ b/web_src/src/pages/organization/settings/Profile.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { type FormEvent, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { meRegenerateToken } from "@/api-client/sdk.gen";
+import { useAccount } from "@/contexts/AccountContext";
 import { Avatar } from "@/components/Avatar/avatar";
 import { Heading } from "@/components/Heading/heading";
 import { Icon } from "@/components/Icon";
@@ -18,6 +19,7 @@ export function Profile() {
   usePageTitle(["Profile"]);
   const queryClient = useQueryClient();
   const organizationId = useOrganizationId();
+  const { account } = useAccount();
   const { data: user, isLoading: loading, error: meError } = useMe();
   const [actionError, setActionError] = useState<string | null>(null);
   const [token, setToken] = useState<string>("");
@@ -127,6 +129,8 @@ export function Profile() {
           </div>
         </div>
 
+        {account?.has_password_auth && !account.impersonation?.active && <PasswordSection />}
+
         <Heading level={2} className="text-lg text-left font-medium text-gray-800 dark:text-white mb-0">
           API Token
         </Heading>
@@ -200,5 +204,108 @@ export function Profile() {
         </div>
       </div>
     </div>
+  );
+}
+
+function PasswordSection() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [changingPassword, setChangingPassword] = useState(false);
+
+  const handleChangePassword = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      showErrorToast("Enter your current password and a new password.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      showErrorToast("New passwords do not match.");
+      return;
+    }
+
+    try {
+      setChangingPassword(true);
+      const response = await fetch("/account/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || "Failed to update password");
+      }
+
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      showSuccessToast("Password updated.");
+    } catch (err) {
+      showErrorToast(err instanceof Error ? err.message : "Failed to update password.");
+    } finally {
+      setChangingPassword(false);
+    }
+  };
+
+  return (
+    <>
+      <Heading level={2} className="text-lg text-left font-medium text-gray-800 dark:text-white mb-0">
+        Password
+      </Heading>
+      <Text className="text-gray-800 text-left dark:text-gray-400 text-sm">
+        Update the password used for email sign-in.
+      </Text>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 p-6">
+        <form className="max-w-sm space-y-4" onSubmit={handleChangePassword}>
+          <div className="space-y-1.5">
+            <Text className="text-sm text-left font-medium text-gray-800 dark:text-gray-300">Current Password</Text>
+            <Input
+              type="password"
+              value={currentPassword}
+              onChange={(event) => setCurrentPassword(event.target.value)}
+              className="ph-no-capture"
+              autoComplete="current-password"
+              disabled={changingPassword}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Text className="text-sm text-left font-medium text-gray-800 dark:text-gray-300">New Password</Text>
+            <Input
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              className="ph-no-capture"
+              autoComplete="new-password"
+              disabled={changingPassword}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Text className="text-sm text-left font-medium text-gray-800 dark:text-gray-300">Confirm New Password</Text>
+            <Input
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              className="ph-no-capture"
+              autoComplete="new-password"
+              disabled={changingPassword}
+            />
+          </div>
+
+          <LoadingButton type="submit" loading={changingPassword} loadingText="Updating..." className="mt-2">
+            Update Password
+          </LoadingButton>
+        </form>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #4650 by adding a self-service password change flow for accounts that use email/password authentication.

## Core changes

- Adds `PATCH /account/password` for account-session password updates.
- Requires the current password before writing a new password hash.
- Blocks password changes while impersonating another account.
- Exposes `has_password_auth` on `/account` so the UI only shows the password form for eligible accounts.
- Adds a Profile settings password section that matches the existing settings page style.
- Adds backend regression coverage for unauthenticated, non-password, wrong-password, and successful password-change cases.

## Behavior / invariants

- Password changes are available only to accounts with password auth records.
- The current password must verify before the stored hash is replaced.
- Impersonation sessions cannot change another account password.

## Validation

- `make format.js`
- `npm run build`
- `npx eslint src/pages/organization/settings/Profile.tsx src/contexts/AccountContext.tsx`
- `go test ./pkg/public -run '^$'`
- `go test ./pkg/models -run '^$'`
- `go build cmd/server/main.go`
