### PR TITLE
feat: add eventId() and executionId() expression functions

### DIFF
--- a/agent/skills/expressions.md
+++ b/agent/skills/expressions.md
@@ -33,6 +33,8 @@ The **data-flow** skill describes how `$` is built during a run.
 | `root()` | Root payload that started the run | `root().data.ref` |
 | `previous()` | Immediate upstream node’s payload | `previous().data.status` |
 | `previous(n)` | Walk *n* levels upstream | `previous(2).data.version` |
+| `eventId()` | UUID of the **root** event that started the run (same value across every step in the chain) | `'/canvases/x/runs?event=' + eventId()` |
+| `executionId()` | UUID of the execution evaluating the expression (the current step) | `'/canvases/x/executions/' + executionId()` |
 
 ## Common Expr functions
 

--- a/pkg/configuration/expressionvalidation/validator.go
+++ b/pkg/configuration/expressionvalidation/validator.go
@@ -130,6 +130,14 @@ func checkTopLevelCall(name string, args []ast.Node) error {
 				return fmt.Errorf("previous() depth must be an integer literal")
 			}
 		}
+	case "eventId":
+		if len(args) != 0 {
+			return fmt.Errorf("eventId() takes no arguments, got %d", len(args))
+		}
+	case "executionId":
+		if len(args) != 0 {
+			return fmt.Errorf("executionId() takes no arguments, got %d", len(args))
+		}
 	}
 	return nil
 }
@@ -165,6 +173,8 @@ func compileWithStubEnv(body string, knownNodeNames map[string]struct{}) error {
 		exprruntime.DateFunctionOption(),
 		expr.Function("root", func(params ...any) (any, error) { return nil, nil }),
 		expr.Function("previous", func(params ...any) (any, error) { return nil, nil }),
+		expr.Function("eventId", func(params ...any) (any, error) { return "", nil }),
+		expr.Function("executionId", func(params ...any) (any, error) { return "", nil }),
 	}
 
 	if _, err := expr.Compile(body, opts...); err != nil {

--- a/pkg/configuration/expressionvalidation/validator_test.go
+++ b/pkg/configuration/expressionvalidation/validator_test.go
@@ -55,6 +55,9 @@ func TestValidateExpression_Valid(t *testing.T) {
 		{name: "type conversion", raw: `int($['Build'].count) + 1`, knownNames: []string{"Build"}},
 		{name: "config blueprint placeholder", raw: `config.foo.bar`},
 		{name: "standalone dollar", raw: `$`},
+		{name: "eventId no args", raw: `eventId()`},
+		{name: "executionId no args", raw: `executionId()`},
+		{name: "eventId in url", raw: `'/runs/' + executionId() + '?event=' + eventId()`},
 	})
 }
 
@@ -87,6 +90,8 @@ func TestValidateExpression_BadArity(t *testing.T) {
 		{name: "memory.find no args", raw: `memory.find()`, wantErr: "memory.find() requires a namespace and matches"},
 		{name: "memory.findFirst no args", raw: `memory.findFirst()`, wantErr: "memory.findFirst() requires a namespace and matches"},
 		{name: "memory.find too many", raw: `memory.find('ns', {}, 'extra')`, wantErr: "memory.find() requires a namespace and matches"},
+		{name: "eventId with arg", raw: `eventId(1)`, wantErr: "eventId() takes no arguments"},
+		{name: "executionId with arg", raw: `executionId('x')`, wantErr: "executionId() takes no arguments"},
 	})
 }
 

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -106,9 +106,10 @@ func LockCanvasNodeExecution(tx *gorm.DB, id uuid.UUID) (*CanvasNodeExecution, e
 	return &execution, nil
 }
 
-func CreatePendingChildExecution(tx *gorm.DB, parent *CanvasNodeExecution, childNodeID string, config map[string]any) (*CanvasNodeExecution, error) {
+func CreatePendingChildExecution(tx *gorm.DB, parent *CanvasNodeExecution, childNodeID string, config map[string]any, id uuid.UUID) (*CanvasNodeExecution, error) {
 	now := time.Now()
 	execution := CanvasNodeExecution{
+		ID:                  id,
 		WorkflowID:          parent.WorkflowID,
 		RootEventID:         parent.RootEventID,
 		EventID:             parent.EventID,

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -22,6 +22,7 @@ type NodeConfigurationBuilder struct {
 	tx                  *gorm.DB
 	workflowID          uuid.UUID
 	nodeID              string
+	currentExecutionID  *uuid.UUID
 	previousExecutionID *uuid.UUID
 	rootEventID         *uuid.UUID
 	rootPayload         any
@@ -60,6 +61,19 @@ func (b *NodeConfigurationBuilder) WithRootPayload(payload any) *NodeConfigurati
 func (b *NodeConfigurationBuilder) WithPreviousExecution(previousExecutionID *uuid.UUID) *NodeConfigurationBuilder {
 	b.previousExecutionID = previousExecutionID
 	return b
+}
+
+func (b *NodeConfigurationBuilder) WithCurrentExecution(currentExecutionID *uuid.UUID) *NodeConfigurationBuilder {
+	b.currentExecutionID = currentExecutionID
+	return b
+}
+
+// SetCurrentExecution rebinds the executionId() return value after the builder
+// has been wired into a long-lived context. ProcessQueueContext uses this to
+// switch ctx.Expressions from the pre-generated ID to the actual execution
+// once FindExecutionByKV resolves to a different existing row.
+func (b *NodeConfigurationBuilder) SetCurrentExecution(currentExecutionID *uuid.UUID) {
+	b.currentExecutionID = currentExecutionID
 }
 
 func (b *NodeConfigurationBuilder) WithInput(input any) *NodeConfigurationBuilder {
@@ -291,6 +305,24 @@ func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, er
 			}
 
 			return b.resolvePreviousPayload(depth)
+		}),
+		expr.Function("eventId", func(params ...any) (any, error) {
+			if len(params) != 0 {
+				return nil, fmt.Errorf("eventId() takes no arguments")
+			}
+			if b.rootEventID == nil {
+				return nil, fmt.Errorf("eventId() is not available in this context")
+			}
+			return b.rootEventID.String(), nil
+		}),
+		expr.Function("executionId", func(params ...any) (any, error) {
+			if len(params) != 0 {
+				return nil, fmt.Errorf("executionId() takes no arguments")
+			}
+			if b.currentExecutionID == nil {
+				return nil, fmt.Errorf("executionId() is not available in this context")
+			}
+			return b.currentExecutionID.String(), nil
 		}),
 	}
 

--- a/pkg/workers/contexts/node_configuration_builder_expr_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_expr_test.go
@@ -16,3 +16,54 @@ func TestNodeConfigurationBuilder_ResolveExpression_DateWithTimezoneOption(t *te
 	require.NoError(t, err)
 	require.Equal(t, "2026-03-17T01:02:03.000000001Z", out)
 }
+
+func TestNodeConfigurationBuilder_ResolveExpression_EventId(t *testing.T) {
+	eventID := uuid.New()
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithInput(map[string]any{}).
+		WithRootEvent(&eventID)
+
+	out, err := b.ResolveExpression("eventId()")
+	require.NoError(t, err)
+	require.Equal(t, eventID.String(), out)
+}
+
+func TestNodeConfigurationBuilder_ResolveExpression_EventIdNotAvailable(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).WithInput(map[string]any{})
+
+	_, err := b.ResolveExpression("eventId()")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "eventId() is not available in this context")
+}
+
+func TestNodeConfigurationBuilder_ResolveExpression_ExecutionId(t *testing.T) {
+	executionID := uuid.New()
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithInput(map[string]any{}).
+		WithCurrentExecution(&executionID)
+
+	out, err := b.ResolveExpression("executionId()")
+	require.NoError(t, err)
+	require.Equal(t, executionID.String(), out)
+}
+
+func TestNodeConfigurationBuilder_ResolveExpression_ExecutionIdNotAvailable(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).WithInput(map[string]any{})
+
+	_, err := b.ResolveExpression("executionId()")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "executionId() is not available in this context")
+}
+
+func TestNodeConfigurationBuilder_ResolveTemplateExpressions_RunIdentifiersInUrlTemplate(t *testing.T) {
+	eventID := uuid.New()
+	executionID := uuid.New()
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithInput(map[string]any{}).
+		WithRootEvent(&eventID).
+		WithCurrentExecution(&executionID)
+
+	out, err := b.ResolveTemplateExpressions("/canvases/x/runs/{{ executionId() }}?event={{ eventId() }}")
+	require.NoError(t, err)
+	require.Equal(t, "/canvases/x/runs/"+executionID.String()+"?event="+eventID.String(), out)
+}

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -43,9 +43,18 @@ func BuildProcessQueueContext(
 		return nil, err
 	}
 
+	//
+	// Pre-generate the execution UUID so that expressions resolved against the
+	// node configuration can reference executionId() before the row is inserted.
+	// The same value is then assigned in CreateExecution below so the resolved
+	// config matches the row that ends up in the database.
+	//
+	executionID := uuid.New()
+
 	configBuilder := NewNodeConfigurationBuilder(tx, queueItem.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&queueItem.RootEventID).
+		WithCurrentExecution(&executionID).
 		WithPreviousExecution(event.ExecutionID).
 		WithInput(map[string]any{event.NodeID: event.Data.Data()})
 	if len(configFields) > 0 {
@@ -75,6 +84,7 @@ func BuildProcessQueueContext(
 	builder := NewNodeConfigurationBuilder(tx, queueItem.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&queueItem.RootEventID).
+		WithCurrentExecution(&executionID).
 		WithInput(map[string]any{event.NodeID: event.Data.Data()})
 	if event.ExecutionID != nil {
 		builder = builder.WithPreviousExecution(event.ExecutionID)
@@ -95,6 +105,7 @@ func BuildProcessQueueContext(
 		now := time.Now()
 
 		execution := models.CanvasNodeExecution{
+			ID:                  executionID,
 			WorkflowID:          queueItem.WorkflowID,
 			NodeID:              node.NodeID,
 			RootEventID:         queueItem.RootEventID,
@@ -238,6 +249,22 @@ func BuildProcessQueueContext(
 
 			return nil, err
 		}
+
+		//
+		// Rebind ctx.Expressions to the existing execution. Components like Merge
+		// reuse a previously-created execution via FindExecutionByKV and then
+		// evaluate stop expressions through ctx.Expressions; without rebinding,
+		// executionId() would return the unused pre-generated ID instead of the
+		// row that's actually in the database.
+		//
+		// NOTE: ctx.Configuration is NOT rebuilt here — it was resolved up front
+		// against the pre-generated UUID. Today no Merge config field templates
+		// executionId() outside the stop expression, but a future component that
+		// adds such a field on the existing-execution branch would need to also
+		// re-resolve ctx.Configuration (or read the existing execution's stored
+		// configuration) to keep the two consistent.
+		//
+		builder.SetCurrentExecution(&execution.ID)
 
 		orgUUID := uuid.Nil
 		orgID := ""

--- a/pkg/workers/contexts/process_queue_context_test.go
+++ b/pkg/workers/contexts/process_queue_context_test.go
@@ -1,0 +1,147 @@
+package contexts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
+)
+
+func Test__BuildProcessQueueContext__ResolvesExecutionIdToCreatedExecution(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNodeID := "trigger-1"
+	componentNodeID := "component-1"
+	canvas, nodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNodeID,
+				Name:   triggerNodeID,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: componentNodeID,
+				Name:   componentNodeID,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+				Configuration: datatypes.NewJSONType(map[string]any{
+					"runUrl": "/canvases/x/runs/{{ executionId() }}?event={{ eventId() }}",
+				}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNodeID, TargetID: componentNodeID, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNodeID, "default", nil)
+	queueItem := support.CreateQueueItem(t, canvas.ID, componentNodeID, rootEvent.ID, rootEvent.ID)
+
+	var componentNode *models.CanvasNode
+	for i, n := range nodes {
+		if n.NodeID == componentNodeID {
+			componentNode = &nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, componentNode)
+
+	ctx, err := BuildProcessQueueContext(nil, database.Conn(), componentNode, queueItem, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+
+	resolvedConfig, ok := ctx.Configuration.(map[string]any)
+	require.True(t, ok, "expected Configuration to be a map after resolution")
+	resolvedURL, ok := resolvedConfig["runUrl"].(string)
+	require.True(t, ok, "expected runUrl to be a string after resolution")
+	assert.Contains(t, resolvedURL, "/canvases/x/runs/")
+	assert.Contains(t, resolvedURL, "?event="+rootEvent.ID.String())
+
+	executionCtx, err := ctx.CreateExecution()
+	require.NoError(t, err)
+	require.NotNil(t, executionCtx)
+
+	expected := "/canvases/x/runs/" + executionCtx.ID.String() + "?event=" + rootEvent.ID.String()
+	assert.Equal(t, expected, resolvedURL,
+		"resolved executionId() must match the created execution's actual ID")
+}
+
+func Test__BuildProcessQueueContext__RebindsExpressionsToExistingExecutionAfterFindByKV(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	triggerNodeID := "trigger-1"
+	mergeNodeID := "merge-1"
+	canvas, nodes := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: triggerNodeID,
+				Name:   triggerNodeID,
+				Type:   models.NodeTypeTrigger,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+			},
+			{
+				NodeID: mergeNodeID,
+				Name:   mergeNodeID,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "merge"}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: triggerNodeID, TargetID: mergeNodeID, Channel: "default"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNodeID, "default", nil)
+	queueItem := support.CreateQueueItem(t, canvas.ID, mergeNodeID, rootEvent.ID, rootEvent.ID)
+
+	var mergeNode *models.CanvasNode
+	for i, n := range nodes {
+		if n.NodeID == mergeNodeID {
+			mergeNode = &nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, mergeNode)
+
+	existingExecution := support.CreateNodeExecutionWithConfiguration(
+		t, canvas.ID, mergeNodeID, rootEvent.ID, rootEvent.ID, nil, map[string]any{},
+	)
+	require.NoError(t, models.CreateNodeExecutionKVInTransaction(
+		database.Conn(), canvas.ID, mergeNodeID, existingExecution.ID, "merge_group", "g1",
+	))
+
+	ctx, err := BuildProcessQueueContext(nil, database.Conn(), mergeNode, queueItem, nil, nil)
+	require.NoError(t, err)
+
+	preBindResult, err := ctx.Expressions.Run("executionId()")
+	require.NoError(t, err)
+	preBindID, ok := preBindResult.(string)
+	require.True(t, ok)
+	assert.NotEqual(t, existingExecution.ID.String(), preBindID,
+		"before FindExecutionByKV, ctx.Expressions returns the pre-generated id")
+
+	executionCtx, err := ctx.FindExecutionByKV("merge_group", "g1")
+	require.NoError(t, err)
+	require.NotNil(t, executionCtx)
+	assert.Equal(t, existingExecution.ID, executionCtx.ID)
+
+	postBindResult, err := ctx.Expressions.Run("executionId()")
+	require.NoError(t, err)
+	postBindID, ok := postBindResult.(string)
+	require.True(t, ok)
+	assert.Equal(t, existingExecution.ID.String(), postBindID,
+		"after FindExecutionByKV, ctx.Expressions must rebind to the existing execution's id")
+}

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -251,9 +251,17 @@ func (w *NodeExecutor) executeBlueprintNode(tx *gorm.DB, execution *models.Canva
 	// since this means the first node has improper configuration,
 	// and the user should be aware of this.
 	//
+	//
+	// Pre-generate the child execution UUID so executionId() in the child node's
+	// configuration resolves to the same row we will insert below via
+	// CreatePendingChildExecution.
+	//
+	childExecutionID := uuid.New()
+
 	configBuilder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&execution.RootEventID).
+		WithCurrentExecution(&childExecutionID).
 		WithPreviousExecution(&execution.ID).
 		ForBlueprintNode(node).
 		WithInput(map[string]any{inputEvent.NodeID: input})
@@ -283,7 +291,7 @@ func (w *NodeExecutor) executeBlueprintNode(tx *gorm.DB, execution *models.Canva
 		return nil
 	}
 
-	_, err = models.CreatePendingChildExecution(tx, execution, firstNode.ID, config)
+	_, err = models.CreatePendingChildExecution(tx, execution, firstNode.ID, config, childExecutionID)
 	if err != nil {
 		return fmt.Errorf("failed to create child execution: %w", err)
 	}
@@ -355,6 +363,7 @@ func (w *NodeExecutor) executeActionNode(tx *gorm.DB, execution *models.CanvasNo
 	builder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&execution.RootEventID).
+		WithCurrentExecution(&execution.ID).
 		WithInput(map[string]any{inputEvent.NodeID: input})
 	if execution.PreviousExecutionID != nil {
 		builder = builder.WithPreviousExecution(execution.PreviousExecutionID)

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -728,6 +728,7 @@ func Test__WorkflowNodeQueueWorker_ConfigurationBuildFailure_PropagateToParent(t
 		&parentExecution,
 		"noop1",
 		map[string]any{},
+		uuid.New(),
 	)
 	require.NoError(t, err)
 

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -74,6 +74,18 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
       "Returns the payload from the immediate predecessor that emitted this event. Provide depth to walk upstream.",
     example: "previous(2).data.image.version",
   },
+  {
+    name: "eventId",
+    snippet: "eventId()",
+    description: "UUID of the event that triggered the run. Useful for building deep links from notifications.",
+    example: "'/canvases/x/runs?event=' + eventId()",
+  },
+  {
+    name: "executionId",
+    snippet: "executionId()",
+    description: "UUID of the execution evaluating the expression. Useful for linking to a specific run step.",
+    example: "'/canvases/x/executions/' + executionId()",
+  },
   // String
   {
     name: "trim",

--- a/web_src/src/lib/exprEvaluator.ts
+++ b/web_src/src/lib/exprEvaluator.ts
@@ -889,6 +889,12 @@ function evaluate(node: ASTNode, context: Record<string, unknown>): unknown {
           return null;
         };
       }
+      if (node.name === "eventId") {
+        return () => (typeof context.__eventId === "string" ? context.__eventId : "");
+      }
+      if (node.name === "executionId") {
+        return () => (typeof context.__executionId === "string" ? context.__executionId : "");
+      }
       if (node.name in BUILTIN_FUNCTIONS) {
         return BUILTIN_FUNCTIONS[node.name];
       }


### PR DESCRIPTION
 ## What

Adds two new SuperPlane expression functions usable in canvas YAML configuration via `{{ ... }}` templates:

- `eventId()` — UUID of the **root** event that started the run, stable across every step in the chain.
- `executionId()` — UUID of the execution evaluating the expression (the current step).

Both take zero arguments and return strings, suited for templating into URLs and notification payloads:

```yaml
config:
body: "Run failed: https://app.superplane.com/canvases/x/runs/{{ executionId() }}?event={{ eventId() }}"
```

## Why

Per #4290, deep links from YAML-only notifications (Slack messages, HTTP webhooks, GitHub comments, etc.) had no way to reference the exact run. The expression environment exposed `root()`, `$['Node']`, `previous()`, and helpers, but no run identifiers — so users were stuck linking to the stable canvas URL plus external commit/PR/dashboard URLs.

## How

The runtime side is straightforward: register two new `expr.Function`s alongside `root()` and `previous()`, with matching arity checks and stubs in the validator.

The interesting part is timing — action node configurations are resolved *before* the execution row is inserted. To make `executionId()` resolve to the same UUID that ends up in the database:

1. Pre-generate the execution UUID at config-resolution time (`uuid.New()` in `BuildProcessQueueContext` for queued action nodes, in `executeBlueprintNode` for blueprint children).
2. Thread it through the builder so `executionId()` can read it.
3. Assign it as the row ID when the execution is inserted.

When a Merge component reuses an existing execution via `FindExecutionByKV`, the long-lived `ctx.Expressions` builder is rebound to the existing execution's ID so stop expressions like `{{ executionId() }}` resolve to the persisted row, not the unused pre-generated UUID.

## Reading the diff

The four commits split the work into independently-reviewable chapters:

1. **`feat: add eventId() and executionId() expression functions`** — the two new functions on the builder, the validator surface, and unit tests.
2. **`feat: pre-generate execution UUID at queue-time config resolution`** — the headline action-node path plus integration tests for both the happy path and the Merge `FindExecutionByKV` rebind.
3. **`feat: pre-generate child execution UUID in blueprint configuration`** — the same pre-generation pattern for blueprint children, plus the one-line caller update for the changed `CreatePendingChildExecution` signature.
4. **`feat: surface eventId() and executionId() in the editor and docs`** — agent skill docs, autocomplete entries, and live-preview evaluator handlers.

## Tests

- Unit tests for both functions: success, missing-context errors, validator arity failures.
- Integration test in `process_queue_context_test.go` proving the resolved `runUrl` template matches the persisted execution ID end-to-end.
- Integration test for the Merge `FindExecutionByKV` rebind path (asserts pre-bind ≠ existing execution ID, post-bind equals it).
- Existing `node_queue_worker_test.go` updated to the new `CreatePendingChildExecution` signature (only existing caller).

## Breaking changes

None user-visible. `models.CreatePendingChildExecution` gained an `id uuid.UUID` parameter; the only existing caller is updated in this PR.

## Known limitation (follow-up)

`eventId()` and `executionId()` are not available in trigger `customName` templates — the customName builder is invoked with no event or execution ID at resolution time. A `customName: "{{ eventId() }}"` will persist `"Failed to resolve run title: eventId() is not available in this context"` as the run title (a sharp edge in the existing customName error path, not a regression introduced here).

Fixing this requires pre-generating the trigger event UUID and softening `fetchRootEvent`'s `gorm.ErrRecordNotFound` handling so `root()` keeps using its `rootPayload` fallback. Out of scope for this PR — happy to follow up.

## Refs

Refs #4290
