### PR TITLE
fix: validate UUIDs and fix typo in RemoveUser

### DIFF
--- a/pkg/grpc/actions/organizations/remove_user.go
+++ b/pkg/grpc/actions/organizations/remove_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -13,6 +14,14 @@ import (
 )
 
 func RemoveUser(ctx context.Context, authService authorization.Authorization, orgID, userID string) (*pb.RemoveUserResponse, error) {
+	if _, err := uuid.Parse(orgID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid organization ID")
+	}
+
+	if _, err := uuid.Parse(userID); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid user ID")
+	}
+
 	user, err := models.FindActiveUserByID(orgID, userID)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, "user not found")
@@ -34,8 +43,8 @@ func RemoveUser(ctx context.Context, authService authorization.Authorization, or
 	//
 	roles, err := authService.GetUserRolesForOrg(user.ID.String(), orgID)
 	if err != nil {
-		log.Errorf("Error determing user roles for %s: %v", user.ID.String(), err)
-		return nil, status.Error(codes.Internal, "error determing user roles")
+		log.Errorf("Error determining user roles for %s: %v", user.ID.String(), err)
+		return nil, status.Error(codes.Internal, "error determining user roles")
 	}
 
 	for _, role := range roles {

--- a/pkg/grpc/actions/organizations/remove_user_test.go
+++ b/pkg/grpc/actions/organizations/remove_user_test.go
@@ -23,6 +23,24 @@ func Test_RemoveUser(t *testing.T) {
 	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 	orgID := r.Organization.ID.String()
 
+	t.Run("invalid org ID -> error", func(t *testing.T) {
+		_, err := RemoveUser(ctx, r.AuthService, "not-a-uuid", uuid.NewString())
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "invalid organization ID", s.Message())
+	})
+
+	t.Run("invalid user ID -> error", func(t *testing.T) {
+		_, err := RemoveUser(ctx, r.AuthService, orgID, "not-a-uuid")
+		require.Error(t, err)
+		s, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+		assert.Equal(t, "invalid user ID", s.Message())
+	})
+
 	t.Run("user not found -> error", func(t *testing.T) {
 		_, err := RemoveUser(ctx, r.AuthService, orgID, uuid.NewString())
 		require.Error(t, err)


### PR DESCRIPTION
 ## Summary

  - Add `uuid.Parse` validation for `orgID` and `userID` in `RemoveUser`, returning `codes.InvalidArgument` on bad input — consistent with the pattern used
  throughout the `organizations` package (e.g. `update_integration_property.go`, `list_integration_resources.go`)
  - Fix typo in the gRPC error response: `"error determing user roles"` → `"error determining user roles"` (this was user-visible via the status message)
  - Add test cases covering both invalid-UUID inputs

  ## Test plan

  - [ ] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/organizations/...` passes (110 tests)