### PR TITLE
feat: add Cloudflare worker components

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -28,15 +28,19 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Monitor" href="#delete-monitor" description="Delete a Cloudflare load balancing health monitor" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
+  <LinkCard title="Delete Worker" href="#delete-worker" description="Delete a Worker script from your Cloudflare account" />
+  <LinkCard title="Deploy Worker" href="#deploy-worker" description="Upload a Worker script and deploy a new version to production traffic" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Get Load Balancer" href="#get-load-balancer" description="Retrieve a Cloudflare Load Balancer by ID" />
   <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
+  <LinkCard title="Get Worker" href="#get-worker" description="Retrieve metadata and settings for a deployed Worker script" />
   <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Load Balancer" href="#update-load-balancer" description="Update a Cloudflare Load Balancer's steering policy, pool weights, or session affinity" />
   <LinkCard title="Update Origin Rule" href="#update-origin-rule" description="Update an existing origin rule" />
   <LinkCard title="Update Pool" href="#update-pool" description="Update a Cloudflare Load Balancer origin pool's configuration or origin weights" />
   <LinkCard title="Update Redirect Rule" href="#update-redirect-rule" description="Update a redirect rule in a Cloudflare zone" />
+  <LinkCard title="Update Worker Route" href="#update-worker-route" description="Create or update a zone route that maps a URL pattern to a Worker script" />
 </CardGrid>
 
 ## Instructions
@@ -692,6 +696,85 @@ Emits a confirmation with the account ID and pool ID of the deleted pool.
 }
 ```
 
+<a id="delete-worker"></a>
+
+## Delete Worker
+
+The Delete Worker component removes a Worker script.
+
+### Configuration
+
+- **Script name**: Worker to delete.
+- **Force**: When enabled, Cloudflare deletes the script even when blocked by bindings (see Cloudflare API `force` query parameter).
+
+### Output
+
+Emits the account ID and script name that were deleted.
+
+> **Warning**: This operation is irreversible for the Worker script.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "scriptName": "my-worker"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.deleted"
+}
+```
+
+<a id="deploy-worker"></a>
+
+## Deploy Worker
+
+The Deploy Worker component uploads a single-module Worker (`worker.js`) and creates a deployment so that version serves 100% of traffic.
+
+### Script source
+
+- **Inline**: paste the full contents of `worker.js` (ES module exporting `fetch`).
+- **URL**: provide an **https** URL that returns the script body (max 2 MiB).
+
+### Configuration
+
+- **Script name**: Cloudflare Worker script name (used in routes and the dashboard).
+- **Compatibility date** (optional): Workers compatibility date (for example `2024-01-01`). Recommended; if omitted, Cloudflare applies account defaults.
+- **Compatibility flags** (optional): comma- or newline-separated flags (for example `nodejs_compat`).
+- **Deployment message** (optional): annotation stored on the deployment.
+
+### Output
+
+Emits the account ID, script name, new version ID, and deployment object.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deployment": {
+      "created_on": "2026-05-05T12:00:00Z",
+      "id": "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+      "source": "api",
+      "strategy": "percentage",
+      "versions": [
+        {
+          "percentage": 100,
+          "version_id": "18f97339-c287-4872-9bdd-e2135c07ec12"
+        }
+      ]
+    },
+    "scriptName": "my-worker",
+    "versionId": "18f97339-c287-4872-9bdd-e2135c07ec12"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.deployed"
+}
+```
+
 <a id="get-kv-value"></a>
 
 ## Get KV Value
@@ -822,6 +905,52 @@ Returns the full pool configuration including its origins, enabled state, and he
   },
   "timestamp": "2026-05-05T05:58:40.060373991Z",
   "type": "cloudflare.pool.fetched"
+}
+```
+
+<a id="get-worker"></a>
+
+## Get Worker
+
+The Get Worker component loads Workers script **settings** (bindings, compatibility, usage model, etc.) and the list of **deployments** (newest first per Cloudflare).
+
+### Configuration
+
+- **Script name**: The Worker script name in your Cloudflare account.
+
+### Output
+
+Emits `settings` and `deployments` for use in later workflow steps.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deployments": [
+      {
+        "created_on": "2026-05-05T12:00:00Z",
+        "id": "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+        "source": "api",
+        "strategy": "percentage",
+        "versions": [
+          {
+            "percentage": 100,
+            "version_id": "18f97339-c287-4872-9bdd-e2135c07ec12"
+          }
+        ]
+      }
+    ],
+    "scriptName": "my-worker",
+    "settings": {
+      "bindings": [],
+      "compatibility_date": "2024-01-01",
+      "usage_model": "standard"
+    }
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.metadata"
 }
 ```
 
@@ -1130,6 +1259,45 @@ Returns the updated redirect rule with all current configuration.
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
   "type": "cloudflare.redirectRule"
+}
+```
+
+<a id="update-worker-route"></a>
+
+## Update Worker Route
+
+The Update Worker Route component manages **zone routes** for Workers.
+
+### Create vs update
+
+- Leave **Route ID** empty to **create** a new route (`POST /zones/{zone}/workers/routes`).
+- Set **Route ID** to **update** an existing route (`PUT /zones/{zone}/workers/routes/{id}`).
+
+### Configuration
+
+- **Zone**: Cloudflare zone for the route.
+- **Pattern**: URL pattern (for example `example.com/*`).
+- **Script**: Worker script name invoked for matching traffic.
+
+### Output
+
+Emits the route id, pattern, and script returned by the Cloudflare API.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "route": {
+      "id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "pattern": "example.com/*",
+      "script": "my-worker"
+    },
+    "zoneId": "023e105f4ecef8ad9ca31a8372d0c353"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.workerRoute.created"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -29,7 +29,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
   <LinkCard title="Delete Worker" href="#delete-worker" description="Delete a Worker script from your Cloudflare account" />
-  <LinkCard title="Deploy Worker" href="#deploy-worker" description="Upload a Worker script and deploy a new version to production traffic" />
+  <LinkCard title="Deploy Worker" href="#deploy-worker" description="Provision a Worker if needed, upload a script version, and deploy it to traffic" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Get Load Balancer" href="#get-load-balancer" description="Retrieve a Cloudflare Load Balancer by ID" />
   <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
@@ -704,12 +704,12 @@ The Delete Worker component removes a Worker script.
 
 ### Configuration
 
-- **Script name**: Worker to delete.
+- **Worker Script**: Worker to delete (picker lists scripts for the account).
 - **Force**: When enabled, Cloudflare deletes the script even when blocked by bindings (see Cloudflare API `force` query parameter).
 
 ### Output
 
-Emits the account ID and script name that were deleted.
+Emits the account ID and Worker Script that were deleted.
 
 > **Warning**: This operation is irreversible for the Worker script.
 
@@ -720,7 +720,7 @@ Emits the account ID and script name that were deleted.
   "data": {
     "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
     "deleted": true,
-    "scriptName": "my-worker"
+    "workerScript": "my-worker"
   },
   "timestamp": "2026-05-05T12:00:00.000000000Z",
   "type": "cloudflare.worker.deleted"
@@ -731,7 +731,7 @@ Emits the account ID and script name that were deleted.
 
 ## Deploy Worker
 
-The Deploy Worker component uploads a single-module Worker (`worker.js`) and creates a deployment so that version serves 100% of traffic.
+The Deploy Worker component uploads a single-module Worker (`worker.js`) to a **Worker script name** in your account. When **Provision Worker if missing** is enabled (default), it first calls Cloudflare's Create Worker API so a **new** name works without a separate step. After upload, SuperPlane always creates a **deployment** so the new version serves 100% of traffic (`cloudflare.worker.deployed`).
 
 ### Script source
 
@@ -740,9 +740,11 @@ The Deploy Worker component uploads a single-module Worker (`worker.js`) and cre
 
 ### Configuration
 
-- **Script name**: Cloudflare Worker script name (used in routes and the dashboard).
-- **Compatibility date** (optional): Workers compatibility date (for example `2024-01-01`). Recommended; if omitted, Cloudflare applies account defaults.
-- **Compatibility flags** (optional): comma- or newline-separated flags (for example `nodejs_compat`).
+- **Worker script name**: Name of the Worker in your account (same name used in routes and the dashboard). Used for both provisioning and upload.
+- **Provision Worker if missing** (default on): Calls `POST .../workers/workers` with the optional metadata fields in **Provision settings** when that section is visible. If the Worker already exists, the error is ignored and upload continues.
+- **Provision settings** (optional): Tags, Logpush, Observability, Subdomain, Tail consumers — sent only on the provision step when it runs; omit toggles to leave those keys out of the API request.
+- **Compatibility date** (optional): Passed to the **script upload** metadata. If omitted, SuperPlane sends a recent default so Cloudflare treats the upload as a modern module Worker.
+- **Compatibility flags** (optional): comma- or newline-separated flags for the upload metadata.
 - **Deployment message** (optional): annotation stored on the deployment.
 
 ### Output
@@ -916,7 +918,7 @@ The Get Worker component loads Workers script **settings** (bindings, compatibil
 
 ### Configuration
 
-- **Script name**: The Worker script name in your Cloudflare account.
+- **Worker Script**: The Worker script in your Cloudflare account (picker lists scripts for the account).
 
 ### Output
 
@@ -942,15 +944,15 @@ Emits `settings` and `deployments` for use in later workflow steps.
         ]
       }
     ],
-    "scriptName": "my-worker",
     "settings": {
       "bindings": [],
       "compatibility_date": "2024-01-01",
       "usage_model": "standard"
-    }
+    },
+    "workerScript": "my-worker"
   },
   "timestamp": "2026-05-05T12:00:00.000000000Z",
-  "type": "cloudflare.worker.metadata"
+  "type": "cloudflare.worker.fetched"
 }
 ```
 
@@ -1277,7 +1279,7 @@ The Update Worker Route component manages **zone routes** for Workers.
 
 - **Zone**: Cloudflare zone for the route.
 - **Pattern**: URL pattern (for example `example.com/*`).
-- **Script**: Worker script name invoked for matching traffic.
+- **Worker Script**: Worker script invoked for matching traffic (picker lists scripts for the account).
 
 ### Output
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -58,9 +58,12 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
      - Zone / Dynamic Redirect / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
+     - Zone / Workers Routes / Edit
+	 - Zone / Load Balancers / Edit
      - Account / Workers KV Storage / Edit
+     - Account / Workers Scripts / Edit
+     - Account / Workers / Edit
      - Account / Load Balancing: Monitors and Pools / Edit
-     - Zone / Load Balancers / Edit
      - Account / Notifications / Edit
      - Account / Account Settings / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 
@@ -1728,7 +1729,70 @@ func (c *Client) DeleteLoadBalancer(zoneID, lbID string) error {
 	return nil
 }
 
+// WorkerScriptSummary is one script from GET .../workers/scripts (ID is the script name used in upload and route URLs).
+type WorkerScriptSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ListWorkerScripts lists uploaded Worker scripts for an account.
+func (c *Client) ListWorkerScripts(accountID string) ([]WorkerScriptSummary, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts", c.BaseURL, accountID)
+	responseBody, err := c.execRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool                  `json:"success"`
+		Result  []WorkerScriptSummary `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return response.Result, nil
+}
+
 const workerModuleFileName = "worker.js"
+
+// Cloudflare's upload API treats ES module entrypoints correctly when the script part uses a
+// module JavaScript media type. mime/multipart.Writer.CreateFormFile defaults to application/octet-stream,
+// which can surface as validation error 10021 ("Main module must be an ES module").
+const workerModulePartContentType = "application/javascript+module"
+
+// When compatibility_date is omitted, the API falls back to a very old date; set a modern default so
+// module Workers validate consistently.
+const defaultWorkerUploadCompatibilityDate = "2024-01-15"
+
+// CreateWorkerResource provisions a Worker via POST .../workers/workers before the first script upload.
+func (c *Client) CreateWorkerResource(accountID string, body map[string]any) (map[string]any, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/workers", c.BaseURL, accountID)
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling create worker request: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, rawURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool           `json:"success"`
+		Result  map[string]any `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return response.Result, nil
+}
 
 // UploadWorkerScriptVersion uploads a new Worker version using multipart/form-data (POST .../versions).
 func (c *Client) UploadWorkerScriptVersion(accountID, scriptName string, metadata map[string]any, moduleContent string) (string, error) {
@@ -1737,6 +1801,9 @@ func (c *Client) UploadWorkerScriptVersion(accountID, scriptName string, metadat
 	}
 	if _, ok := metadata["main_module"]; !ok {
 		metadata["main_module"] = workerModuleFileName
+	}
+	if v, ok := metadata["compatibility_date"]; !ok || strings.TrimSpace(fmt.Sprint(v)) == "" {
+		metadata["compatibility_date"] = defaultWorkerUploadCompatibilityDate
 	}
 
 	metaBytes, err := json.Marshal(metadata)
@@ -1749,7 +1816,10 @@ func (c *Client) UploadWorkerScriptVersion(accountID, scriptName string, metadat
 	if err := writer.WriteField("metadata", string(metaBytes)); err != nil {
 		return "", fmt.Errorf("error writing metadata field: %w", err)
 	}
-	part, err := writer.CreateFormFile(workerModuleFileName, workerModuleFileName)
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, workerModuleFileName, workerModuleFileName))
+	partHeader.Set("Content-Type", workerModulePartContentType)
+	part, err := writer.CreatePart(partHeader)
 	if err != nil {
 		return "", fmt.Errorf("error creating script form part: %w", err)
 	}

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -1727,3 +1727,255 @@ func (c *Client) DeleteLoadBalancer(zoneID, lbID string) error {
 
 	return nil
 }
+
+const workerModuleFileName = "worker.js"
+
+// UploadWorkerScriptVersion uploads a new Worker version using multipart/form-data (POST .../versions).
+func (c *Client) UploadWorkerScriptVersion(accountID, scriptName string, metadata map[string]any, moduleContent string) (string, error) {
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if _, ok := metadata["main_module"]; !ok {
+		metadata["main_module"] = workerModuleFileName
+	}
+
+	metaBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling worker metadata: %w", err)
+	}
+
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+	if err := writer.WriteField("metadata", string(metaBytes)); err != nil {
+		return "", fmt.Errorf("error writing metadata field: %w", err)
+	}
+	part, err := writer.CreateFormFile(workerModuleFileName, workerModuleFileName)
+	if err != nil {
+		return "", fmt.Errorf("error creating script form part: %w", err)
+	}
+	if _, err := part.Write([]byte(moduleContent)); err != nil {
+		return "", fmt.Errorf("error writing script content: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("error closing multipart writer: %w", err)
+	}
+
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts/%s/versions", c.BaseURL, accountID, url.PathEscape(scriptName))
+	req, err := http.NewRequest(http.MethodPost, rawURL, buf)
+	if err != nil {
+		return "", fmt.Errorf("error building request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error executing request: %w", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading body: %w", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", newCloudflareAPIError(res.StatusCode, responseBody)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  struct {
+			ID string `json:"id"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return "", fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return "", newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	if response.Result.ID == "" {
+		return "", fmt.Errorf("upload response missing version id")
+	}
+	return response.Result.ID, nil
+}
+
+type workerDeploymentRequest struct {
+	Strategy    string                    `json:"strategy"`
+	Versions    []workerDeploymentVersion `json:"versions"`
+	Annotations map[string]string         `json:"annotations,omitempty"`
+}
+
+type workerDeploymentVersion struct {
+	Percentage int    `json:"percentage"`
+	VersionID  string `json:"version_id"`
+}
+
+// CreateWorkerDeployment creates a deployment so the given version serves traffic.
+func (c *Client) CreateWorkerDeployment(accountID, scriptName, versionID string, annotations map[string]string) (map[string]any, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts/%s/deployments", c.BaseURL, accountID, url.PathEscape(scriptName))
+
+	reqBody := workerDeploymentRequest{
+		Strategy: "percentage",
+		Versions: []workerDeploymentVersion{
+			{Percentage: 100, VersionID: versionID},
+		},
+		Annotations: annotations,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling deployment request: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool           `json:"success"`
+		Result  map[string]any `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return response.Result, nil
+}
+
+// GetWorkerSettings returns script settings (bindings, compatibility, etc.).
+func (c *Client) GetWorkerSettings(accountID, scriptName string) (map[string]any, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts/%s/settings", c.BaseURL, accountID, url.PathEscape(scriptName))
+	responseBody, err := c.execRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool           `json:"success"`
+		Result  map[string]any `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return response.Result, nil
+}
+
+// ListWorkerDeployments returns deployments for a script (newest first per API).
+func (c *Client) ListWorkerDeployments(accountID, scriptName string) ([]map[string]any, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts/%s/deployments", c.BaseURL, accountID, url.PathEscape(scriptName))
+	responseBody, err := c.execRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  struct {
+			Deployments []map[string]any `json:"deployments"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return response.Result.Deployments, nil
+}
+
+// DeleteWorkerScript deletes a Worker script from the account.
+func (c *Client) DeleteWorkerScript(accountID, scriptName string, force bool) error {
+	rawURL := fmt.Sprintf("%s/accounts/%s/workers/scripts/%s", c.BaseURL, accountID, url.PathEscape(scriptName))
+	if force {
+		rawURL += "?force=true"
+	}
+	responseBody, err := c.execRequest(http.MethodDelete, rawURL, nil)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return nil
+}
+
+// WorkerRoute is a zone route mapping a pattern to a Worker script name.
+type WorkerRoute struct {
+	ID      string `json:"id"`
+	Pattern string `json:"pattern"`
+	Script  string `json:"script,omitempty"`
+}
+
+type workerRouteRequest struct {
+	Pattern string `json:"pattern"`
+	Script  string `json:"script,omitempty"`
+}
+
+// CreateWorkerRoute creates a zone route for a Worker.
+func (c *Client) CreateWorkerRoute(zoneID, pattern, script string) (*WorkerRoute, error) {
+	rawURL := fmt.Sprintf("%s/zones/%s/workers/routes", c.BaseURL, zoneID)
+
+	body, err := json.Marshal(workerRouteRequest{Pattern: pattern, Script: script})
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling route request: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool        `json:"success"`
+		Result  WorkerRoute `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return &response.Result, nil
+}
+
+// UpdateWorkerRoute updates an existing zone route.
+func (c *Client) UpdateWorkerRoute(zoneID, routeID, pattern, script string) (*WorkerRoute, error) {
+	rawURL := fmt.Sprintf("%s/zones/%s/workers/routes/%s", c.BaseURL, zoneID, routeID)
+
+	body, err := json.Marshal(workerRouteRequest{Pattern: pattern, Script: script})
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling route request: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPut, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool        `json:"success"`
+		Result  WorkerRoute `json:"result"`
+	}
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %w", err)
+	}
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+	return &response.Result, nil
+}

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -73,6 +73,39 @@ type PoolNodeMetadata struct {
 	PoolName string `json:"poolName"`
 }
 
+// WorkerScriptNodeMetadata stores a display label for Worker script integration resources (picker value is script ID).
+type WorkerScriptNodeMetadata struct {
+	ScriptDisplayName string `json:"scriptDisplayName"`
+}
+
+func resolveWorkerScriptMetadata(ctx core.SetupContext, accountID, scriptID string) error {
+	meta := WorkerScriptNodeMetadata{}
+	if strings.Contains(scriptID, "{{") || strings.Contains(accountID, "{{") {
+		meta.ScriptDisplayName = scriptID
+		return ctx.Metadata.Set(meta)
+	}
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	scripts, err := client.ListWorkerScripts(accountID)
+	if err != nil {
+		return fmt.Errorf("failed to list worker scripts: %w", err)
+	}
+	for _, s := range scripts {
+		if s.ID == scriptID {
+			name := s.Name
+			if name == "" {
+				name = s.ID
+			}
+			meta.ScriptDisplayName = name
+			return ctx.Metadata.Set(meta)
+		}
+	}
+	meta.ScriptDisplayName = scriptID
+	return ctx.Metadata.Set(meta)
+}
+
 func resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
 	meta := PoolNodeMetadata{}
 	if strings.Contains(poolID, "{{") || strings.Contains(accountID, "{{") {
@@ -134,6 +167,7 @@ func (c *Cloudflare) Instructions() string {
      - Zone / Workers Routes / Edit
      - Account / Workers KV Storage / Edit
      - Account / Workers Scripts / Edit
+     - Account / Workers / Edit
      - Account / Load Balancing: Monitors and Pools / Edit
      - Zone / Load Balancers / Edit
      - Account / Notifications / Edit
@@ -503,6 +537,39 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 					ID:   fmt.Sprintf("%s/%s", zone.ID, lb.ID),
 				})
 			}
+		}
+		return resources, nil
+
+	case "workerScript":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
+		if accountID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		scripts, err := client.ListWorkerScripts(accountID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing worker scripts: %w", err)
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(scripts))
+		for _, s := range scripts {
+			name := s.Name
+			if name == "" {
+				name = s.ID
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   s.ID,
+			})
 		}
 		return resources, nil
 

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -165,11 +165,11 @@ func (c *Cloudflare) Instructions() string {
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
      - Zone / Workers Routes / Edit
+	 - Zone / Load Balancers / Edit
      - Account / Workers KV Storage / Edit
      - Account / Workers Scripts / Edit
      - Account / Workers / Edit
      - Account / Load Balancing: Monitors and Pools / Edit
-     - Zone / Load Balancers / Edit
      - Account / Notifications / Edit
      - Account / Account Settings / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -131,7 +131,9 @@ func (c *Cloudflare) Instructions() string {
      - Zone / Dynamic Redirect / Edit
      - Zone / Single Redirect / Edit
      - Zone / Origin Rules / Edit
+     - Zone / Workers Routes / Edit
      - Account / Workers KV Storage / Edit
+     - Account / Workers Scripts / Edit
      - Account / Load Balancing: Monitors and Pools / Edit
      - Zone / Load Balancers / Edit
      - Account / Notifications / Edit
@@ -200,6 +202,10 @@ func (c *Cloudflare) Actions() []core.Action {
 		&GetLoadBalancer{},
 		&UpdateLoadBalancer{},
 		&DeleteLoadBalancer{},
+		&DeployWorker{},
+		&GetWorker{},
+		&DeleteWorker{},
+		&UpdateWorkerRoute{},
 	}
 }
 

--- a/pkg/integrations/cloudflare/delete_worker.go
+++ b/pkg/integrations/cloudflare/delete_worker.go
@@ -1,0 +1,160 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteWorker struct{}
+
+type DeleteWorkerSpec struct {
+	AccountID  string `json:"accountId"`
+	ScriptName string `json:"scriptName"`
+	Force      *bool  `json:"force"`
+}
+
+func (d *DeleteWorker) Name() string {
+	return "cloudflare.deleteWorker"
+}
+
+func (d *DeleteWorker) Label() string {
+	return "Delete Worker"
+}
+
+func (d *DeleteWorker) Description() string {
+	return "Delete a Worker script from your Cloudflare account"
+}
+
+func (d *DeleteWorker) Documentation() string {
+	return `The Delete Worker component removes a Worker script.
+
+## Configuration
+
+- **Script name**: Worker to delete.
+- **Force**: When enabled, Cloudflare deletes the script even when blocked by bindings (see Cloudflare API ` + "`force`" + ` query parameter).
+
+## Output
+
+Emits the account ID and script name that were deleted.
+
+> **Warning**: This operation is irreversible for the Worker script.`
+}
+
+func (d *DeleteWorker) Icon() string {
+	return "cloud"
+}
+
+func (d *DeleteWorker) Color() string {
+	return "orange"
+}
+
+func (d *DeleteWorker) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (d *DeleteWorker) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "scriptName",
+			Label:       "Worker script name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Name of the Worker script to delete",
+			Placeholder: "my-worker",
+		},
+		{
+			Name:        "force",
+			Label:       "Force delete",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     false,
+			Description: "Pass Cloudflare force=true when deleting (see Cloudflare Workers API)",
+		},
+	}
+}
+
+func (d *DeleteWorker) Setup(ctx core.SetupContext) error {
+	spec := DeleteWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.ScriptName == "" {
+		return errors.New("scriptName is required")
+	}
+
+	return nil
+}
+
+func (d *DeleteWorker) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	force := false
+	if spec.Force != nil {
+		force = *spec.Force
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.DeleteWorkerScript(accountID, spec.ScriptName, force); err != nil {
+		return fmt.Errorf("failed to delete worker: %w", err)
+	}
+
+	result := map[string]any{
+		"accountId":  accountID,
+		"scriptName": spec.ScriptName,
+		"deleted":    true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.worker.deleted",
+		[]any{result},
+	)
+}
+
+func (d *DeleteWorker) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (d *DeleteWorker) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (d *DeleteWorker) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (d *DeleteWorker) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (d *DeleteWorker) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (d *DeleteWorker) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/delete_worker.go
+++ b/pkg/integrations/cloudflare/delete_worker.go
@@ -14,9 +14,9 @@ import (
 type DeleteWorker struct{}
 
 type DeleteWorkerSpec struct {
-	AccountID  string `json:"accountId"`
-	ScriptName string `json:"scriptName"`
-	Force      *bool  `json:"force"`
+	AccountID    string `json:"accountId"`
+	WorkerScript string `json:"workerScript"`
+	Force        *bool  `json:"force"`
 }
 
 func (d *DeleteWorker) Name() string {
@@ -36,12 +36,12 @@ func (d *DeleteWorker) Documentation() string {
 
 ## Configuration
 
-- **Script name**: Worker to delete.
+- **Worker Script**: Worker to delete (picker lists scripts for the account).
 - **Force**: When enabled, Cloudflare deletes the script even when blocked by bindings (see Cloudflare API ` + "`force`" + ` query parameter).
 
 ## Output
 
-Emits the account ID and script name that were deleted.
+Emits the account ID and Worker Script that were deleted.
 
 > **Warning**: This operation is irreversible for the Worker script.`
 }
@@ -61,12 +61,23 @@ func (d *DeleteWorker) OutputChannels(configuration any) []core.OutputChannel {
 func (d *DeleteWorker) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "scriptName",
-			Label:       "Worker script name",
-			Type:        configuration.FieldTypeString,
+			Name:        "workerScript",
+			Label:       "Worker Script",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "Name of the Worker script to delete",
-			Placeholder: "my-worker",
+			Description: "The Worker Script to delete",
+			Placeholder: "Select a Worker script",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "workerScript",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
 		},
 		{
 			Name:        "force",
@@ -90,11 +101,11 @@ func (d *DeleteWorker) Setup(ctx core.SetupContext) error {
 		return errors.New("accountId is required")
 	}
 
-	if spec.ScriptName == "" {
-		return errors.New("scriptName is required")
+	if spec.WorkerScript == "" {
+		return errors.New("workerScript is required")
 	}
 
-	return nil
+	return resolveWorkerScriptMetadata(ctx, accountID, spec.WorkerScript)
 }
 
 func (d *DeleteWorker) Execute(ctx core.ExecutionContext) error {
@@ -118,14 +129,14 @@ func (d *DeleteWorker) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	if err := client.DeleteWorkerScript(accountID, spec.ScriptName, force); err != nil {
+	if err := client.DeleteWorkerScript(accountID, spec.WorkerScript, force); err != nil {
 		return fmt.Errorf("failed to delete worker: %w", err)
 	}
 
 	result := map[string]any{
-		"accountId":  accountID,
-		"scriptName": spec.ScriptName,
-		"deleted":    true,
+		"accountId":    accountID,
+		"workerScript": spec.WorkerScript,
+		"deleted":      true,
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/delete_worker_test.go
+++ b/pkg/integrations/cloudflare/delete_worker_test.go
@@ -1,0 +1,82 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteWorker__Setup(t *testing.T) {
+	component := &DeleteWorker{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "",
+				"scriptName": "w",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
+	})
+
+	t.Run("missing scriptName returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
+	})
+
+	t.Run("valid passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+			},
+			Integration: &contexts.IntegrationContext{},
+		}
+		require.NoError(t, component.Setup(ctx))
+	})
+}
+
+func Test__DeleteWorker__Execute(t *testing.T) {
+	component := &DeleteWorker{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true}`)),
+			},
+		},
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token"},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+	ctx := core.ExecutionContext{
+		Configuration: map[string]any{
+			"accountId":  "acc",
+			"scriptName": "gone",
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		ExecutionState: execState,
+	}
+
+	require.NoError(t, component.Execute(ctx))
+	assert.Equal(t, "cloudflare.worker.deleted", execState.Type)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/accounts/acc/workers/scripts/gone")
+}

--- a/pkg/integrations/cloudflare/delete_worker_test.go
+++ b/pkg/integrations/cloudflare/delete_worker_test.go
@@ -18,32 +18,66 @@ func Test__DeleteWorker__Setup(t *testing.T) {
 	t.Run("missing accountId returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "",
-				"scriptName": "w",
+				"accountId":    "",
+				"workerScript": "w",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
 	})
 
-	t.Run("missing scriptName returns error", func(t *testing.T) {
+	t.Run("missing workerScript returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "",
+				"accountId":    "acc",
+				"workerScript": "",
 			},
 		}
-		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
+		require.ErrorContains(t, component.Setup(ctx), "workerScript is required")
 	})
 
-	t.Run("valid passes", func(t *testing.T) {
+	t.Run("expression workerScript skips list API", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
+				"accountId":    "acc",
+				"workerScript": "{{ $.trigger.data.name }}",
 			},
 			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
 		}
 		require.NoError(t, component.Setup(ctx))
+	})
+
+	t.Run("valid configuration resolves script display name", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":    "acc123",
+				"workerScript": "gone",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": [{"id": "gone", "name": "Gone Worker"}]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		scriptMeta, ok := meta.Metadata.(WorkerScriptNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Gone Worker", scriptMeta.ScriptDisplayName)
 	})
 }
 
@@ -66,8 +100,8 @@ func Test__DeleteWorker__Execute(t *testing.T) {
 
 	ctx := core.ExecutionContext{
 		Configuration: map[string]any{
-			"accountId":  "acc",
-			"scriptName": "gone",
+			"accountId":    "acc",
+			"workerScript": "gone",
 		},
 		HTTP:           httpContext,
 		Integration:    integrationCtx,

--- a/pkg/integrations/cloudflare/deploy_worker.go
+++ b/pkg/integrations/cloudflare/deploy_worker.go
@@ -336,6 +336,9 @@ func (d *DeployWorker) Execute(ctx core.ExecutionContext) error {
 		if err != nil {
 			return err
 		}
+		if strings.TrimSpace(body) == "" {
+			return errors.New("script downloaded from scriptUrl is empty")
+		}
 		module = body
 	default:
 		return fmt.Errorf("source must be %q or %q", deployWorkerScriptSourceInline, deployWorkerScriptSourceURL)

--- a/pkg/integrations/cloudflare/deploy_worker.go
+++ b/pkg/integrations/cloudflare/deploy_worker.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -22,15 +23,36 @@ const (
 
 type DeployWorker struct{}
 
+// DeployWorkerProvision holds optional Create Worker metadata when provision runs.
+type DeployWorkerProvision struct {
+	Tags                          string `json:"tags"`
+	Logpush                       *bool  `json:"logpush"`
+	ObservabilityEnabled          *bool  `json:"observabilityEnabled"`
+	ObservabilityHeadSamplingRate string `json:"observabilityHeadSamplingRate"`
+	SubdomainEnabled              *bool  `json:"subdomainEnabled"`
+	SubdomainPreviewsEnabled      *bool  `json:"subdomainPreviewsEnabled"`
+	TailConsumers                 string `json:"tailConsumers"`
+}
+
 type DeployWorkerSpec struct {
-	AccountID          string  `json:"accountId"`
-	ScriptName         string  `json:"scriptName"`
-	Source             string  `json:"source"`
-	InlineCode         *string `json:"inlineCode,omitempty"`
-	ScriptURL          *string `json:"scriptUrl,omitempty"`
-	CompatibilityDate  string  `json:"compatibilityDate"`
-	CompatibilityFlags string  `json:"compatibilityFlags"`
-	DeploymentMessage  string  `json:"deploymentMessage"`
+	AccountID          string                 `json:"accountId"`
+	ScriptName         string                 `json:"scriptName"`
+	ProvisionIfMissing *bool                  `json:"provisionIfMissing"`
+	Provision          *DeployWorkerProvision `json:"provision"`
+	Source             string                 `json:"source"`
+	InlineCode         *string                `json:"inlineCode,omitempty"`
+	ScriptURL          *string                `json:"scriptUrl,omitempty"`
+	CompatibilityDate  string                 `json:"compatibilityDate"`
+	CompatibilityFlags string                 `json:"compatibilityFlags"`
+	DeploymentMessage  string                 `json:"deploymentMessage"`
+}
+
+func deployProvisionArgs(spec DeployWorkerSpec) (tags string, logpush *bool, observabilityEnabled *bool, observabilityHeadSamplingRate string, subdomainEnabled *bool, subdomainPreviewsEnabled *bool, tailConsumers string) {
+	p := spec.Provision
+	if p == nil {
+		return "", nil, nil, "", nil, nil, ""
+	}
+	return p.Tags, p.Logpush, p.ObservabilityEnabled, p.ObservabilityHeadSamplingRate, p.SubdomainEnabled, p.SubdomainPreviewsEnabled, p.TailConsumers
 }
 
 func (d *DeployWorker) Name() string {
@@ -42,11 +64,11 @@ func (d *DeployWorker) Label() string {
 }
 
 func (d *DeployWorker) Description() string {
-	return "Upload a Worker script and deploy a new version to production traffic"
+	return "Provision a Worker if needed, upload a script version, and deploy it to traffic"
 }
 
 func (d *DeployWorker) Documentation() string {
-	return `The Deploy Worker component uploads a single-module Worker (` + "`worker.js`" + `) and creates a deployment so that version serves 100% of traffic.
+	return `The Deploy Worker component uploads a single-module Worker (` + "`worker.js`" + `) to a **Worker script name** in your account. When **Provision Worker if missing** is enabled (default), it first calls Cloudflare's Create Worker API so a **new** name works without a separate step. After upload, SuperPlane always creates a **deployment** so the new version serves 100% of traffic (` + "`cloudflare.worker.deployed`" + `).
 
 ## Script source
 
@@ -55,9 +77,11 @@ func (d *DeployWorker) Documentation() string {
 
 ## Configuration
 
-- **Script name**: Cloudflare Worker script name (used in routes and the dashboard).
-- **Compatibility date** (optional): Workers compatibility date (for example ` + "`2024-01-01`" + `). Recommended; if omitted, Cloudflare applies account defaults.
-- **Compatibility flags** (optional): comma- or newline-separated flags (for example ` + "`nodejs_compat`" + `).
+- **Worker script name**: Name of the Worker in your account (same name used in routes and the dashboard). Used for both provisioning and upload.
+- **Provision Worker if missing** (default on): Calls ` + "`POST .../workers/workers`" + ` with the optional metadata fields in **Provision settings** when that section is visible. If the Worker already exists, the error is ignored and upload continues.
+- **Provision settings** (optional): Tags, Logpush, Observability, Subdomain, Tail consumers — sent only on the provision step when it runs; omit toggles to leave those keys out of the API request.
+- **Compatibility date** (optional): Passed to the **script upload** metadata. If omitted, SuperPlane sends a recent default so Cloudflare treats the upload as a modern module Worker.
+- **Compatibility flags** (optional): comma- or newline-separated flags for the upload metadata.
 - **Deployment message** (optional): annotation stored on the deployment.
 
 ## Output
@@ -78,14 +102,92 @@ func (d *DeployWorker) OutputChannels(configuration any) []core.OutputChannel {
 }
 
 func (d *DeployWorker) Configuration() []configuration.Field {
+	provisionSchema := []configuration.Field{
+		{
+			Name:        "tags",
+			Label:       "Tags",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional tags for the Worker resource, comma- or newline-separated",
+			Placeholder: "team:platform, env:production",
+		},
+		{
+			Name:        "logpush",
+			Label:       "Logpush enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Whether Logpush is enabled (only sent when this toggle is set)",
+		},
+		{
+			Name:        "observabilityEnabled",
+			Label:       "Observability enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "When set, sends an observability object with this enabled flag",
+		},
+		{
+			Name:        "observabilityHeadSamplingRate",
+			Label:       "Observability sampling rate",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional head sampling rate from 0 to 1 (sent inside observability when observability is included)",
+			Placeholder: "1",
+		},
+		{
+			Name:        "subdomainEnabled",
+			Label:       "workers.dev subdomain enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Subdomain enabled flag for the provision request",
+		},
+		{
+			Name:        "subdomainPreviewsEnabled",
+			Label:       "Preview URLs enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Whether preview URLs are enabled for the Worker",
+		},
+		{
+			Name:        "tailConsumers",
+			Label:       "Tail consumer Worker names",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Comma- or newline-separated Worker names that consume logs from this Worker",
+			Placeholder: "my-log-consumer",
+		},
+	}
+
 	return []configuration.Field{
 		{
 			Name:        "scriptName",
 			Label:       "Worker script name",
 			Type:        configuration.FieldTypeString,
 			Required:    true,
-			Description: "Name of the Worker script in your Cloudflare account",
+			Description: "Name of the Worker script in your Cloudflare account (new or existing)",
 			Placeholder: "my-worker",
+		},
+		{
+			Name:        "provisionIfMissing",
+			Label:       "Provision Worker if missing",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "Call Cloudflare Create Worker before upload so a new script name works (ignored if Worker already exists)",
+		},
+		{
+			Name:        "provision",
+			Label:       "Provision settings",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Description: "Optional metadata for Create Worker (only used when provision is enabled)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "provisionIfMissing", Values: []string{"true"}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: provisionSchema,
+				},
+			},
 		},
 		{
 			Name:        "source",
@@ -129,7 +231,7 @@ func (d *DeployWorker) Configuration() []configuration.Field {
 			Label:       "Compatibility date",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Workers compatibility date (YYYY-MM-DD)",
+			Description: "Workers compatibility date for the uploaded script (YYYY-MM-DD)",
 			Placeholder: "2024-01-01",
 		},
 		{
@@ -137,7 +239,7 @@ func (d *DeployWorker) Configuration() []configuration.Field {
 			Label:       "Compatibility flags",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Optional flags, comma- or newline-separated",
+			Description: "Optional flags for the upload, comma- or newline-separated",
 			Placeholder: "nodejs_compat",
 		},
 		{
@@ -148,6 +250,19 @@ func (d *DeployWorker) Configuration() []configuration.Field {
 			Description: "Optional human-readable message stored on the deployment",
 		},
 	}
+}
+
+func (d *DeployWorker) validateObservabilitySamplingRate(rate string) error {
+	if s := strings.TrimSpace(rate); s != "" {
+		rateVal, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("observabilityHeadSamplingRate must be a number between 0 and 1: %w", err)
+		}
+		if rateVal < 0 || rateVal > 1 {
+			return errors.New("observabilityHeadSamplingRate must be between 0 and 1")
+		}
+	}
+	return nil
 }
 
 func (d *DeployWorker) Setup(ctx core.SetupContext) error {
@@ -163,6 +278,12 @@ func (d *DeployWorker) Setup(ctx core.SetupContext) error {
 
 	if strings.TrimSpace(spec.ScriptName) == "" {
 		return errors.New("scriptName is required")
+	}
+
+	if spec.Provision != nil {
+		if err := d.validateObservabilitySamplingRate(spec.Provision.ObservabilityHeadSamplingRate); err != nil {
+			return err
+		}
 	}
 
 	switch spec.Source {
@@ -220,12 +341,12 @@ func (d *DeployWorker) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("source must be %q or %q", deployWorkerScriptSourceInline, deployWorkerScriptSourceURL)
 	}
 
-	metadata := map[string]any{}
+	uploadMeta := map[string]any{}
 	if strings.TrimSpace(spec.CompatibilityDate) != "" {
-		metadata["compatibility_date"] = strings.TrimSpace(spec.CompatibilityDate)
+		uploadMeta["compatibility_date"] = strings.TrimSpace(spec.CompatibilityDate)
 	}
 	if flags := parseCommaOrNewlineList(spec.CompatibilityFlags); len(flags) > 0 {
-		metadata["compatibility_flags"] = flags
+		uploadMeta["compatibility_flags"] = flags
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
@@ -233,7 +354,29 @@ func (d *DeployWorker) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	versionID, err := client.UploadWorkerScriptVersion(accountID, strings.TrimSpace(spec.ScriptName), metadata, module)
+	scriptName := strings.TrimSpace(spec.ScriptName)
+	provision := spec.ProvisionIfMissing == nil || *spec.ProvisionIfMissing
+	if provision {
+		tags, logpush, obsEn, obsRate, subEn, subPrev, tails := deployProvisionArgs(spec)
+		provBody, err := buildWorkerProvisionRequestBody(
+			scriptName,
+			tags,
+			logpush,
+			obsEn,
+			obsRate,
+			subEn,
+			subPrev,
+			tails,
+		)
+		if err != nil {
+			return err
+		}
+		if err := ensureWorkerProvisioned(client, accountID, provBody); err != nil {
+			return fmt.Errorf("failed to provision worker: %w", err)
+		}
+	}
+
+	versionID, err := client.UploadWorkerScriptVersion(accountID, scriptName, uploadMeta, module)
 	if err != nil {
 		return fmt.Errorf("failed to upload worker version: %w", err)
 	}
@@ -243,14 +386,14 @@ func (d *DeployWorker) Execute(ctx core.ExecutionContext) error {
 		annotations = map[string]string{"workers/message": msg}
 	}
 
-	deployment, err := client.CreateWorkerDeployment(accountID, strings.TrimSpace(spec.ScriptName), versionID, annotations)
+	deployment, err := client.CreateWorkerDeployment(accountID, scriptName, versionID, annotations)
 	if err != nil {
 		return fmt.Errorf("failed to create worker deployment: %w", err)
 	}
 
 	result := map[string]any{
 		"accountId":  accountID,
-		"scriptName": strings.TrimSpace(spec.ScriptName),
+		"scriptName": scriptName,
 		"versionId":  versionID,
 		"deployment": deployment,
 	}

--- a/pkg/integrations/cloudflare/deploy_worker.go
+++ b/pkg/integrations/cloudflare/deploy_worker.go
@@ -1,0 +1,339 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const (
+	deployWorkerScriptSourceInline = "inline"
+	deployWorkerScriptSourceURL    = "url"
+	maxWorkerScriptDownloadBytes   = 2 * 1024 * 1024
+)
+
+type DeployWorker struct{}
+
+type DeployWorkerSpec struct {
+	AccountID          string  `json:"accountId"`
+	ScriptName         string  `json:"scriptName"`
+	Source             string  `json:"source"`
+	InlineCode         *string `json:"inlineCode,omitempty"`
+	ScriptURL          *string `json:"scriptUrl,omitempty"`
+	CompatibilityDate  string  `json:"compatibilityDate"`
+	CompatibilityFlags string  `json:"compatibilityFlags"`
+	DeploymentMessage  string  `json:"deploymentMessage"`
+}
+
+func (d *DeployWorker) Name() string {
+	return "cloudflare.deployWorker"
+}
+
+func (d *DeployWorker) Label() string {
+	return "Deploy Worker"
+}
+
+func (d *DeployWorker) Description() string {
+	return "Upload a Worker script and deploy a new version to production traffic"
+}
+
+func (d *DeployWorker) Documentation() string {
+	return `The Deploy Worker component uploads a single-module Worker (` + "`worker.js`" + `) and creates a deployment so that version serves 100% of traffic.
+
+## Script source
+
+- **Inline**: paste the full contents of ` + "`worker.js`" + ` (ES module exporting ` + "`fetch`" + `).
+- **URL**: provide an **https** URL that returns the script body (max 2 MiB).
+
+## Configuration
+
+- **Script name**: Cloudflare Worker script name (used in routes and the dashboard).
+- **Compatibility date** (optional): Workers compatibility date (for example ` + "`2024-01-01`" + `). Recommended; if omitted, Cloudflare applies account defaults.
+- **Compatibility flags** (optional): comma- or newline-separated flags (for example ` + "`nodejs_compat`" + `).
+- **Deployment message** (optional): annotation stored on the deployment.
+
+## Output
+
+Emits the account ID, script name, new version ID, and deployment object.`
+}
+
+func (d *DeployWorker) Icon() string {
+	return "cloud"
+}
+
+func (d *DeployWorker) Color() string {
+	return "orange"
+}
+
+func (d *DeployWorker) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (d *DeployWorker) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "scriptName",
+			Label:       "Worker script name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Name of the Worker script in your Cloudflare account",
+			Placeholder: "my-worker",
+		},
+		{
+			Name:        "source",
+			Label:       "Script source",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Description: "Whether the script is pasted inline or downloaded from a URL",
+			Default:     deployWorkerScriptSourceInline,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Inline", Value: deployWorkerScriptSourceInline},
+						{Label: "URL (https)", Value: deployWorkerScriptSourceURL},
+					},
+				},
+			},
+		},
+		{
+			Name:        "inlineCode",
+			Label:       "Worker script (worker.js)",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "Full ES module source for worker.js (must export fetch)",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "source", Values: []string{deployWorkerScriptSourceInline}},
+			},
+		},
+		{
+			Name:        "scriptUrl",
+			Label:       "Script URL",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "HTTPS URL that returns the worker.js source (max 2 MiB)",
+			Placeholder: "https://example.com/worker.js",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "source", Values: []string{deployWorkerScriptSourceURL}},
+			},
+		},
+		{
+			Name:        "compatibilityDate",
+			Label:       "Compatibility date",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Workers compatibility date (YYYY-MM-DD)",
+			Placeholder: "2024-01-01",
+		},
+		{
+			Name:        "compatibilityFlags",
+			Label:       "Compatibility flags",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional flags, comma- or newline-separated",
+			Placeholder: "nodejs_compat",
+		},
+		{
+			Name:        "deploymentMessage",
+			Label:       "Deployment message",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional human-readable message stored on the deployment",
+		},
+	}
+}
+
+func (d *DeployWorker) Setup(ctx core.SetupContext) error {
+	spec := DeployWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if strings.TrimSpace(spec.ScriptName) == "" {
+		return errors.New("scriptName is required")
+	}
+
+	switch spec.Source {
+	case "", deployWorkerScriptSourceInline:
+		if spec.InlineCode == nil || strings.TrimSpace(*spec.InlineCode) == "" {
+			return errors.New("inlineCode is required when source is inline")
+		}
+	case deployWorkerScriptSourceURL:
+		if spec.ScriptURL == nil || strings.TrimSpace(*spec.ScriptURL) == "" {
+			return errors.New("scriptUrl is required when source is url")
+		}
+	default:
+		return fmt.Errorf("source must be %q or %q", deployWorkerScriptSourceInline, deployWorkerScriptSourceURL)
+	}
+
+	return nil
+}
+
+func (d *DeployWorker) Execute(ctx core.ExecutionContext) error {
+	spec := DeployWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	source := spec.Source
+	if source == "" {
+		source = deployWorkerScriptSourceInline
+	}
+
+	var module string
+	switch source {
+	case deployWorkerScriptSourceInline:
+		if spec.InlineCode == nil {
+			return errors.New("inlineCode is required when source is inline")
+		}
+		module = strings.TrimSpace(*spec.InlineCode)
+		if module == "" {
+			return errors.New("inlineCode is required when source is inline")
+		}
+	case deployWorkerScriptSourceURL:
+		if spec.ScriptURL == nil {
+			return errors.New("scriptUrl is required when source is url")
+		}
+		body, err := fetchWorkerScriptFromHTTPSURL(ctx.HTTP, strings.TrimSpace(*spec.ScriptURL))
+		if err != nil {
+			return err
+		}
+		module = body
+	default:
+		return fmt.Errorf("source must be %q or %q", deployWorkerScriptSourceInline, deployWorkerScriptSourceURL)
+	}
+
+	metadata := map[string]any{}
+	if strings.TrimSpace(spec.CompatibilityDate) != "" {
+		metadata["compatibility_date"] = strings.TrimSpace(spec.CompatibilityDate)
+	}
+	if flags := parseCommaOrNewlineList(spec.CompatibilityFlags); len(flags) > 0 {
+		metadata["compatibility_flags"] = flags
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	versionID, err := client.UploadWorkerScriptVersion(accountID, strings.TrimSpace(spec.ScriptName), metadata, module)
+	if err != nil {
+		return fmt.Errorf("failed to upload worker version: %w", err)
+	}
+
+	var annotations map[string]string
+	if msg := strings.TrimSpace(spec.DeploymentMessage); msg != "" {
+		annotations = map[string]string{"workers/message": msg}
+	}
+
+	deployment, err := client.CreateWorkerDeployment(accountID, strings.TrimSpace(spec.ScriptName), versionID, annotations)
+	if err != nil {
+		return fmt.Errorf("failed to create worker deployment: %w", err)
+	}
+
+	result := map[string]any{
+		"accountId":  accountID,
+		"scriptName": strings.TrimSpace(spec.ScriptName),
+		"versionId":  versionID,
+		"deployment": deployment,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.worker.deployed",
+		[]any{result},
+	)
+}
+
+func fetchWorkerScriptFromHTTPSURL(httpCtx core.HTTPContext, raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return "", fmt.Errorf("scriptUrl must be a valid https URL with a host")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, raw, nil)
+	if err != nil {
+		return "", fmt.Errorf("error building script download request: %w", err)
+	}
+
+	res, err := httpCtx.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error downloading script: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return "", fmt.Errorf("script URL returned status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	limited := io.LimitReader(res.Body, maxWorkerScriptDownloadBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("error reading script body: %w", err)
+	}
+	if len(body) > maxWorkerScriptDownloadBytes {
+		return "", fmt.Errorf("script from URL exceeds maximum size of %d bytes", maxWorkerScriptDownloadBytes)
+	}
+
+	return string(body), nil
+}
+
+func parseCommaOrNewlineList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	parts := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == '\n'
+	})
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func (d *DeployWorker) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (d *DeployWorker) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (d *DeployWorker) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (d *DeployWorker) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (d *DeployWorker) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (d *DeployWorker) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/deploy_worker_test.go
+++ b/pkg/integrations/cloudflare/deploy_worker_test.go
@@ -321,7 +321,7 @@ func Test__DeployWorker__Execute(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
 				{
-					StatusCode: http.StatusOK,
+					StatusCode: http.StatusConflict,
 					Body: io.NopCloser(strings.NewReader(`{
 						"success": false,
 						"errors": [{"code": 10009, "message": "A worker with this name already exists"}]

--- a/pkg/integrations/cloudflare/deploy_worker_test.go
+++ b/pkg/integrations/cloudflare/deploy_worker_test.go
@@ -214,6 +214,39 @@ func Test__DeployWorker__Execute(t *testing.T) {
 		assert.Equal(t, "https://cdn.example.com/worker.js", httpContext.Requests[0].URL.String())
 	})
 
+	t.Run("url source with empty body returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":          "acc123",
+				"scriptName":         "w-empty",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceURL,
+				"scriptUrl":          "https://cdn.example.com/empty.js",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
 	t.Run("provision then upload and deploy calls three endpoints", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{

--- a/pkg/integrations/cloudflare/deploy_worker_test.go
+++ b/pkg/integrations/cloudflare/deploy_worker_test.go
@@ -1,0 +1,192 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeployWorker__Setup(t *testing.T) {
+	component := &DeployWorker{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "",
+				"scriptName": "w",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
+	})
+
+	t.Run("missing scriptName returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
+	})
+
+	t.Run("inline without code returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": "",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "inlineCode is required")
+	})
+
+	t.Run("url without scriptUrl returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+				"source":     deployWorkerScriptSourceURL,
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "scriptUrl is required")
+	})
+
+	t.Run("invalid source returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+				"source":     "invalid",
+				"inlineCode": "x",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "source must be")
+	})
+
+	t.Run("valid inline passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+			},
+			Integration: &contexts.IntegrationContext{},
+		}
+		require.NoError(t, component.Setup(ctx))
+	})
+}
+
+func Test__DeployWorker__Execute(t *testing.T) {
+	component := &DeployWorker{}
+	inline := "export default { fetch() { return new Response('ok'); } };"
+
+	t.Run("successful inline deploy emits and calls APIs", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "ver-1" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "dep-1",
+							"strategy": "percentage",
+							"versions": [{"percentage": 100, "version_id": "ver-1"}]
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":  "acc123",
+				"scriptName": "my-worker",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": inline,
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		require.NoError(t, component.Execute(ctx))
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "cloudflare.worker.deployed", execState.Type)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/accounts/acc123/workers/scripts/my-worker/versions")
+		assert.Equal(t, http.MethodPost, httpContext.Requests[1].Method)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/accounts/acc123/workers/scripts/my-worker/deployments")
+	})
+
+	t.Run("url source downloads then uploads", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(inline)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "ver-2" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "dep-2", "strategy": "percentage" }
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":  "acc123",
+				"scriptName": "w2",
+				"source":     deployWorkerScriptSourceURL,
+				"scriptUrl":  "https://cdn.example.com/worker.js",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		require.NoError(t, component.Execute(ctx))
+		require.Len(t, httpContext.Requests, 3)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+		assert.Equal(t, "https://cdn.example.com/worker.js", httpContext.Requests[0].URL.String())
+	})
+}

--- a/pkg/integrations/cloudflare/deploy_worker_test.go
+++ b/pkg/integrations/cloudflare/deploy_worker_test.go
@@ -18,10 +18,11 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("missing accountId returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "",
-				"scriptName": "w",
-				"source":     deployWorkerScriptSourceInline,
-				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+				"accountId":          "",
+				"scriptName":         "w",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         "export default { fetch() { return new Response('ok'); } };",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
@@ -30,10 +31,11 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("missing scriptName returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "",
-				"source":     deployWorkerScriptSourceInline,
-				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+				"accountId":          "acc",
+				"scriptName":         "",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         "export default { fetch() { return new Response('ok'); } };",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
@@ -42,10 +44,11 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("inline without code returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
-				"source":     deployWorkerScriptSourceInline,
-				"inlineCode": "",
+				"accountId":          "acc",
+				"scriptName":         "w",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         "",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "inlineCode is required")
@@ -54,9 +57,10 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("url without scriptUrl returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
-				"source":     deployWorkerScriptSourceURL,
+				"accountId":          "acc",
+				"scriptName":         "w",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceURL,
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "scriptUrl is required")
@@ -65,10 +69,11 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("invalid source returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
-				"source":     "invalid",
-				"inlineCode": "x",
+				"accountId":          "acc",
+				"scriptName":         "w",
+				"provisionIfMissing": false,
+				"source":             "invalid",
+				"inlineCode":         "x",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "source must be")
@@ -77,14 +82,31 @@ func Test__DeployWorker__Setup(t *testing.T) {
 	t.Run("valid inline passes", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
-				"source":     deployWorkerScriptSourceInline,
-				"inlineCode": "export default { fetch() { return new Response('ok'); } };",
+				"accountId":          "acc",
+				"scriptName":         "w",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         "export default { fetch() { return new Response('ok'); } };",
 			},
 			Integration: &contexts.IntegrationContext{},
 		}
 		require.NoError(t, component.Setup(ctx))
+	})
+
+	t.Run("invalid observability sampling rate returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":          "acc",
+				"scriptName":         "w",
+				"provisionIfMissing": true,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         "export default { fetch() { return new Response('ok'); } };",
+				"provision": map[string]any{
+					"observabilityHeadSamplingRate": "x",
+				},
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "observabilityHeadSamplingRate")
 	})
 }
 
@@ -123,10 +145,11 @@ func Test__DeployWorker__Execute(t *testing.T) {
 
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
-				"accountId":  "acc123",
-				"scriptName": "my-worker",
-				"source":     deployWorkerScriptSourceInline,
-				"inlineCode": inline,
+				"accountId":          "acc123",
+				"scriptName":         "my-worker",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceInline,
+				"inlineCode":         inline,
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,
@@ -174,10 +197,11 @@ func Test__DeployWorker__Execute(t *testing.T) {
 
 		ctx := core.ExecutionContext{
 			Configuration: map[string]any{
-				"accountId":  "acc123",
-				"scriptName": "w2",
-				"source":     deployWorkerScriptSourceURL,
-				"scriptUrl":  "https://cdn.example.com/worker.js",
+				"accountId":          "acc123",
+				"scriptName":         "w2",
+				"provisionIfMissing": false,
+				"source":             deployWorkerScriptSourceURL,
+				"scriptUrl":          "https://cdn.example.com/worker.js",
 			},
 			HTTP:           httpContext,
 			Integration:    integrationCtx,
@@ -188,5 +212,157 @@ func Test__DeployWorker__Execute(t *testing.T) {
 		require.Len(t, httpContext.Requests, 3)
 		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
 		assert.Equal(t, "https://cdn.example.com/worker.js", httpContext.Requests[0].URL.String())
+	})
+
+	t.Run("provision then upload and deploy calls three endpoints", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "wid", "name": "fresh" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "ver-fresh" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "dep-fresh", "strategy": "percentage" }
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":  "acc123",
+				"scriptName": "fresh",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": inline,
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		require.NoError(t, component.Execute(ctx))
+		assert.Equal(t, "cloudflare.worker.deployed", execState.Type)
+		require.Len(t, httpContext.Requests, 3)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/workers/workers")
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/workers/scripts/fresh/versions")
+		assert.Contains(t, httpContext.Requests[2].URL.String(), "/workers/scripts/fresh/deployments")
+	})
+
+	t.Run("provision by default calls workers then upload and deploy", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "wid-1", "name": "new-worker" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "ver-new" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "dep-new", "strategy": "percentage" }
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":  "acc123",
+				"scriptName": "new-worker",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": inline,
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		require.NoError(t, component.Execute(ctx))
+		require.Len(t, httpContext.Requests, 3)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/accounts/acc123/workers/workers")
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/workers/scripts/new-worker/versions")
+		assert.Contains(t, httpContext.Requests[2].URL.String(), "/workers/scripts/new-worker/deployments")
+	})
+
+	t.Run("provision conflict is ignored then upload succeeds", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": false,
+						"errors": [{"code": 10009, "message": "A worker with this name already exists"}]
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "ver-dup" }
+					}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": { "id": "dep-dup", "strategy": "percentage" }
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "token"},
+		}
+		execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId":  "acc123",
+				"scriptName": "existing",
+				"source":     deployWorkerScriptSourceInline,
+				"inlineCode": inline,
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		require.NoError(t, component.Execute(ctx))
+		require.Len(t, httpContext.Requests, 3)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/versions")
 	})
 }

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -206,3 +206,43 @@ var exampleOutputDeleteLoadBalancer map[string]any
 func (c *DeleteLoadBalancer) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteLoadBalancerOnce, exampleOutputDeleteLoadBalancerBytes, &exampleOutputDeleteLoadBalancer)
 }
+
+//go:embed example_output_deploy_worker.json
+var exampleOutputDeployWorkerBytes []byte
+
+var exampleOutputDeployWorkerOnce sync.Once
+var exampleOutputDeployWorker map[string]any
+
+func (d *DeployWorker) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeployWorkerOnce, exampleOutputDeployWorkerBytes, &exampleOutputDeployWorker)
+}
+
+//go:embed example_output_get_worker.json
+var exampleOutputGetWorkerBytes []byte
+
+var exampleOutputGetWorkerOnce sync.Once
+var exampleOutputGetWorker map[string]any
+
+func (g *GetWorker) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetWorkerOnce, exampleOutputGetWorkerBytes, &exampleOutputGetWorker)
+}
+
+//go:embed example_output_delete_worker.json
+var exampleOutputDeleteWorkerBytes []byte
+
+var exampleOutputDeleteWorkerOnce sync.Once
+var exampleOutputDeleteWorker map[string]any
+
+func (d *DeleteWorker) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteWorkerOnce, exampleOutputDeleteWorkerBytes, &exampleOutputDeleteWorker)
+}
+
+//go:embed example_output_update_worker_route.json
+var exampleOutputUpdateWorkerRouteBytes []byte
+
+var exampleOutputUpdateWorkerRouteOnce sync.Once
+var exampleOutputUpdateWorkerRoute map[string]any
+
+func (u *UpdateWorkerRoute) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateWorkerRouteOnce, exampleOutputUpdateWorkerRouteBytes, &exampleOutputUpdateWorkerRoute)
+}

--- a/pkg/integrations/cloudflare/example_output_delete_worker.json
+++ b/pkg/integrations/cloudflare/example_output_delete_worker.json
@@ -2,7 +2,7 @@
   "data": {
     "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
     "deleted": true,
-    "scriptName": "my-worker"
+    "workerScript": "my-worker"
   },
   "timestamp": "2026-05-05T12:00:00.000000000Z",
   "type": "cloudflare.worker.deleted"

--- a/pkg/integrations/cloudflare/example_output_delete_worker.json
+++ b/pkg/integrations/cloudflare/example_output_delete_worker.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "scriptName": "my-worker"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.deleted"
+}

--- a/pkg/integrations/cloudflare/example_output_deploy_worker.json
+++ b/pkg/integrations/cloudflare/example_output_deploy_worker.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deployment": {
+      "created_on": "2026-05-05T12:00:00Z",
+      "id": "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+      "source": "api",
+      "strategy": "percentage",
+      "versions": [
+        {
+          "percentage": 100,
+          "version_id": "18f97339-c287-4872-9bdd-e2135c07ec12"
+        }
+      ]
+    },
+    "scriptName": "my-worker",
+    "versionId": "18f97339-c287-4872-9bdd-e2135c07ec12"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.deployed"
+}

--- a/pkg/integrations/cloudflare/example_output_get_worker.json
+++ b/pkg/integrations/cloudflare/example_output_get_worker.json
@@ -15,7 +15,7 @@
         ]
       }
     ],
-    "scriptName": "my-worker",
+    "workerScript": "my-worker",
     "settings": {
       "bindings": [],
       "compatibility_date": "2024-01-01",
@@ -23,5 +23,5 @@
     }
   },
   "timestamp": "2026-05-05T12:00:00.000000000Z",
-  "type": "cloudflare.worker.metadata"
+  "type": "cloudflare.worker.fetched"
 }

--- a/pkg/integrations/cloudflare/example_output_get_worker.json
+++ b/pkg/integrations/cloudflare/example_output_get_worker.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deployments": [
+      {
+        "created_on": "2026-05-05T12:00:00Z",
+        "id": "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
+        "source": "api",
+        "strategy": "percentage",
+        "versions": [
+          {
+            "percentage": 100,
+            "version_id": "18f97339-c287-4872-9bdd-e2135c07ec12"
+          }
+        ]
+      }
+    ],
+    "scriptName": "my-worker",
+    "settings": {
+      "bindings": [],
+      "compatibility_date": "2024-01-01",
+      "usage_model": "standard"
+    }
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.worker.metadata"
+}

--- a/pkg/integrations/cloudflare/example_output_update_worker_route.json
+++ b/pkg/integrations/cloudflare/example_output_update_worker_route.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "route": {
+      "id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "pattern": "example.com/*",
+      "script": "my-worker"
+    },
+    "zoneId": "023e105f4ecef8ad9ca31a8372d0c353"
+  },
+  "timestamp": "2026-05-05T12:00:00.000000000Z",
+  "type": "cloudflare.workerRoute.created"
+}

--- a/pkg/integrations/cloudflare/get_worker.go
+++ b/pkg/integrations/cloudflare/get_worker.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetWorker struct{}
+
+type GetWorkerSpec struct {
+	AccountID  string `json:"accountId"`
+	ScriptName string `json:"scriptName"`
+}
+
+func (g *GetWorker) Name() string {
+	return "cloudflare.getWorker"
+}
+
+func (g *GetWorker) Label() string {
+	return "Get Worker"
+}
+
+func (g *GetWorker) Description() string {
+	return "Retrieve metadata and settings for a deployed Worker script"
+}
+
+func (g *GetWorker) Documentation() string {
+	return `The Get Worker component loads Workers script **settings** (bindings, compatibility, usage model, etc.) and the list of **deployments** (newest first per Cloudflare).
+
+## Configuration
+
+- **Script name**: The Worker script name in your Cloudflare account.
+
+## Output
+
+Emits ` + "`settings`" + ` and ` + "`deployments`" + ` for use in later workflow steps.`
+}
+
+func (g *GetWorker) Icon() string {
+	return "cloud"
+}
+
+func (g *GetWorker) Color() string {
+	return "orange"
+}
+
+func (g *GetWorker) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetWorker) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "scriptName",
+			Label:       "Worker script name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Name of the Worker script to describe",
+			Placeholder: "my-worker",
+		},
+	}
+}
+
+func (g *GetWorker) Setup(ctx core.SetupContext) error {
+	spec := GetWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.ScriptName == "" {
+		return errors.New("scriptName is required")
+	}
+
+	return nil
+}
+
+func (g *GetWorker) Execute(ctx core.ExecutionContext) error {
+	spec := GetWorkerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	settings, err := client.GetWorkerSettings(accountID, spec.ScriptName)
+	if err != nil {
+		return fmt.Errorf("failed to get worker settings: %w", err)
+	}
+
+	deployments, err := client.ListWorkerDeployments(accountID, spec.ScriptName)
+	if err != nil {
+		return fmt.Errorf("failed to list worker deployments: %w", err)
+	}
+
+	result := map[string]any{
+		"accountId":   accountID,
+		"scriptName":  spec.ScriptName,
+		"settings":    settings,
+		"deployments": deployments,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudflare.worker.metadata",
+		[]any{result},
+	)
+}
+
+func (g *GetWorker) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetWorker) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetWorker) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (g *GetWorker) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (g *GetWorker) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *GetWorker) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/get_worker.go
+++ b/pkg/integrations/cloudflare/get_worker.go
@@ -14,8 +14,8 @@ import (
 type GetWorker struct{}
 
 type GetWorkerSpec struct {
-	AccountID  string `json:"accountId"`
-	ScriptName string `json:"scriptName"`
+	AccountID    string `json:"accountId"`
+	WorkerScript string `json:"workerScript"`
 }
 
 func (g *GetWorker) Name() string {
@@ -35,7 +35,7 @@ func (g *GetWorker) Documentation() string {
 
 ## Configuration
 
-- **Script name**: The Worker script name in your Cloudflare account.
+- **Worker Script**: The Worker script in your Cloudflare account (picker lists scripts for the account).
 
 ## Output
 
@@ -57,12 +57,23 @@ func (g *GetWorker) OutputChannels(configuration any) []core.OutputChannel {
 func (g *GetWorker) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "scriptName",
-			Label:       "Worker script name",
-			Type:        configuration.FieldTypeString,
+			Name:        "workerScript",
+			Label:       "Worker Script",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "Name of the Worker script to describe",
-			Placeholder: "my-worker",
+			Description: "The Worker Script to describe",
+			Placeholder: "Select a Worker script",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "workerScript",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -78,11 +89,11 @@ func (g *GetWorker) Setup(ctx core.SetupContext) error {
 		return errors.New("accountId is required")
 	}
 
-	if spec.ScriptName == "" {
-		return errors.New("scriptName is required")
+	if spec.WorkerScript == "" {
+		return errors.New("workerScript is required")
 	}
 
-	return nil
+	return resolveWorkerScriptMetadata(ctx, accountID, spec.WorkerScript)
 }
 
 func (g *GetWorker) Execute(ctx core.ExecutionContext) error {
@@ -101,26 +112,26 @@ func (g *GetWorker) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	settings, err := client.GetWorkerSettings(accountID, spec.ScriptName)
+	settings, err := client.GetWorkerSettings(accountID, spec.WorkerScript)
 	if err != nil {
 		return fmt.Errorf("failed to get worker settings: %w", err)
 	}
 
-	deployments, err := client.ListWorkerDeployments(accountID, spec.ScriptName)
+	deployments, err := client.ListWorkerDeployments(accountID, spec.WorkerScript)
 	if err != nil {
 		return fmt.Errorf("failed to list worker deployments: %w", err)
 	}
 
 	result := map[string]any{
-		"accountId":   accountID,
-		"scriptName":  spec.ScriptName,
-		"settings":    settings,
-		"deployments": deployments,
+		"accountId":    accountID,
+		"workerScript": spec.WorkerScript,
+		"settings":     settings,
+		"deployments":  deployments,
 	}
 
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
-		"cloudflare.worker.metadata",
+		"cloudflare.worker.fetched",
 		[]any{result},
 	)
 }

--- a/pkg/integrations/cloudflare/get_worker_test.go
+++ b/pkg/integrations/cloudflare/get_worker_test.go
@@ -1,0 +1,92 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetWorker__Setup(t *testing.T) {
+	component := &GetWorker{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "",
+				"scriptName": "w",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
+	})
+
+	t.Run("missing scriptName returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
+	})
+
+	t.Run("valid passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":  "acc",
+				"scriptName": "w",
+			},
+			Integration: &contexts.IntegrationContext{},
+		}
+		require.NoError(t, component.Setup(ctx))
+	})
+}
+
+func Test__GetWorker__Execute(t *testing.T) {
+	component := &GetWorker{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": { "compatibility_date": "2024-01-01", "bindings": [] }
+				}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": { "deployments": [{"id": "d1"}] }
+				}`)),
+			},
+		},
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token"},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+	ctx := core.ExecutionContext{
+		Configuration: map[string]any{
+			"accountId":  "acc",
+			"scriptName": "my-worker",
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		ExecutionState: execState,
+	}
+
+	require.NoError(t, component.Execute(ctx))
+	assert.Equal(t, "cloudflare.worker.metadata", execState.Type)
+	require.Len(t, httpContext.Requests, 2)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/settings")
+	assert.Contains(t, httpContext.Requests[1].URL.String(), "/deployments")
+}

--- a/pkg/integrations/cloudflare/get_worker_test.go
+++ b/pkg/integrations/cloudflare/get_worker_test.go
@@ -18,32 +18,66 @@ func Test__GetWorker__Setup(t *testing.T) {
 	t.Run("missing accountId returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "",
-				"scriptName": "w",
+				"accountId":    "",
+				"workerScript": "w",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
 	})
 
-	t.Run("missing scriptName returns error", func(t *testing.T) {
+	t.Run("missing workerScript returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "",
+				"accountId":    "acc",
+				"workerScript": "",
 			},
 		}
-		require.ErrorContains(t, component.Setup(ctx), "scriptName is required")
+		require.ErrorContains(t, component.Setup(ctx), "workerScript is required")
 	})
 
-	t.Run("valid passes", func(t *testing.T) {
+	t.Run("expression workerScript skips list API", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"accountId":  "acc",
-				"scriptName": "w",
+				"accountId":    "acc",
+				"workerScript": "{{ $.trigger.data.name }}",
 			},
 			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
 		}
 		require.NoError(t, component.Setup(ctx))
+	})
+
+	t.Run("valid configuration resolves script display name", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":    "acc123",
+				"workerScript": "w1",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": [{"id": "w1", "name": "My Worker"}]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		scriptMeta, ok := meta.Metadata.(WorkerScriptNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "My Worker", scriptMeta.ScriptDisplayName)
 	})
 }
 
@@ -76,8 +110,8 @@ func Test__GetWorker__Execute(t *testing.T) {
 
 	ctx := core.ExecutionContext{
 		Configuration: map[string]any{
-			"accountId":  "acc",
-			"scriptName": "my-worker",
+			"accountId":    "acc",
+			"workerScript": "my-worker",
 		},
 		HTTP:           httpContext,
 		Integration:    integrationCtx,
@@ -85,7 +119,7 @@ func Test__GetWorker__Execute(t *testing.T) {
 	}
 
 	require.NoError(t, component.Execute(ctx))
-	assert.Equal(t, "cloudflare.worker.metadata", execState.Type)
+	assert.Equal(t, "cloudflare.worker.fetched", execState.Type)
 	require.Len(t, httpContext.Requests, 2)
 	assert.Contains(t, httpContext.Requests[0].URL.String(), "/settings")
 	assert.Contains(t, httpContext.Requests[1].URL.String(), "/deployments")

--- a/pkg/integrations/cloudflare/update_worker_route.go
+++ b/pkg/integrations/cloudflare/update_worker_route.go
@@ -1,0 +1,215 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type UpdateWorkerRoute struct{}
+
+type UpdateWorkerRouteSpec struct {
+	AccountID string `json:"accountId"`
+	Zone      string `json:"zone"`
+	RouteID   string `json:"routeId"`
+	Pattern   string `json:"pattern"`
+	Script    string `json:"script"`
+}
+
+func (u *UpdateWorkerRoute) Name() string {
+	return "cloudflare.updateWorkerRoute"
+}
+
+func (u *UpdateWorkerRoute) Label() string {
+	return "Update Worker Route"
+}
+
+func (u *UpdateWorkerRoute) Description() string {
+	return "Create or update a zone route that maps a URL pattern to a Worker script"
+}
+
+func (u *UpdateWorkerRoute) Documentation() string {
+	return `The Update Worker Route component manages **zone routes** for Workers.
+
+## Create vs update
+
+- Leave **Route ID** empty to **create** a new route (` + "`POST /zones/{zone}/workers/routes`" + `).
+- Set **Route ID** to **update** an existing route (` + "`PUT /zones/{zone}/workers/routes/{id}`" + `).
+
+## Configuration
+
+- **Zone**: Cloudflare zone for the route.
+- **Pattern**: URL pattern (for example ` + "`example.com/*`" + `).
+- **Script**: Worker script name invoked for matching traffic.
+
+## Output
+
+Emits the route id, pattern, and script returned by the Cloudflare API.`
+}
+
+func (u *UpdateWorkerRoute) Icon() string {
+	return "cloud"
+}
+
+func (u *UpdateWorkerRoute) Color() string {
+	return "orange"
+}
+
+func (u *UpdateWorkerRoute) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (u *UpdateWorkerRoute) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "zone",
+			Label:       "Zone",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Cloudflare zone where the route is created or updated",
+			Placeholder: "Select a zone",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "zone",
+				},
+			},
+		},
+		{
+			Name:        "routeId",
+			Label:       "Route ID",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Existing route ID to update; leave empty to create a new route",
+			Placeholder: "023e105f4ecef8ad9ca31a8372d0c353",
+		},
+		{
+			Name:        "pattern",
+			Label:       "URL pattern",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Pattern to match incoming requests (for example example.com/*)",
+			Placeholder: "example.com/*",
+		},
+		{
+			Name:        "script",
+			Label:       "Worker script name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Name of the Worker script invoked when the route matches",
+			Placeholder: "my-worker",
+		},
+	}
+}
+
+func (u *UpdateWorkerRoute) Setup(ctx core.SetupContext) error {
+	spec := UpdateWorkerRouteSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Zone == "" {
+		return errors.New("zone is required")
+	}
+
+	if strings.TrimSpace(spec.Pattern) == "" {
+		return errors.New("pattern is required")
+	}
+
+	if strings.TrimSpace(spec.Script) == "" {
+		return errors.New("script is required")
+	}
+
+	return nil
+}
+
+func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateWorkerRouteSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Zone == "" {
+		return errors.New("zone is required")
+	}
+
+	pattern := strings.TrimSpace(spec.Pattern)
+	script := strings.TrimSpace(spec.Script)
+	if pattern == "" {
+		return errors.New("pattern is required")
+	}
+	if script == "" {
+		return errors.New("script is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	routeID := strings.TrimSpace(spec.RouteID)
+	var route *WorkerRoute
+	if routeID == "" {
+		route, err = client.CreateWorkerRoute(spec.Zone, pattern, script)
+		if err != nil {
+			return fmt.Errorf("failed to create worker route: %w", err)
+		}
+	} else {
+		route, err = client.UpdateWorkerRoute(spec.Zone, routeID, pattern, script)
+		if err != nil {
+			return fmt.Errorf("failed to update worker route: %w", err)
+		}
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+
+	result := map[string]any{
+		"accountId": accountID,
+		"zoneId":    spec.Zone,
+		"route": map[string]any{
+			"id":      route.ID,
+			"pattern": route.Pattern,
+			"script":  route.Script,
+		},
+	}
+
+	eventType := "cloudflare.workerRoute.created"
+	if routeID != "" {
+		eventType = "cloudflare.workerRoute.updated"
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		eventType,
+		[]any{result},
+	)
+}
+
+func (u *UpdateWorkerRoute) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (u *UpdateWorkerRoute) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (u *UpdateWorkerRoute) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (u *UpdateWorkerRoute) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (u *UpdateWorkerRoute) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (u *UpdateWorkerRoute) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/update_worker_route.go
+++ b/pkg/integrations/cloudflare/update_worker_route.go
@@ -15,11 +15,11 @@ import (
 type UpdateWorkerRoute struct{}
 
 type UpdateWorkerRouteSpec struct {
-	AccountID string `json:"accountId"`
-	Zone      string `json:"zone"`
-	RouteID   string `json:"routeId"`
-	Pattern   string `json:"pattern"`
-	Script    string `json:"script"`
+	AccountID    string `json:"accountId"`
+	Zone         string `json:"zone"`
+	RouteID      string `json:"routeId"`
+	Pattern      string `json:"pattern"`
+	WorkerScript string `json:"workerScript"`
 }
 
 func (u *UpdateWorkerRoute) Name() string {
@@ -46,7 +46,7 @@ func (u *UpdateWorkerRoute) Documentation() string {
 
 - **Zone**: Cloudflare zone for the route.
 - **Pattern**: URL pattern (for example ` + "`example.com/*`" + `).
-- **Script**: Worker script name invoked for matching traffic.
+- **Worker Script**: Worker script invoked for matching traffic (picker lists scripts for the account).
 
 ## Output
 
@@ -97,12 +97,23 @@ func (u *UpdateWorkerRoute) Configuration() []configuration.Field {
 			Placeholder: "example.com/*",
 		},
 		{
-			Name:        "script",
-			Label:       "Worker script name",
-			Type:        configuration.FieldTypeString,
+			Name:        "workerScript",
+			Label:       "Worker Script",
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "Name of the Worker script invoked when the route matches",
-			Placeholder: "my-worker",
+			Description: "The Worker Script invoked when the route matches",
+			Placeholder: "Select a Worker script",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "workerScript",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "accountId",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "accountId"},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -121,11 +132,17 @@ func (u *UpdateWorkerRoute) Setup(ctx core.SetupContext) error {
 		return errors.New("pattern is required")
 	}
 
-	if strings.TrimSpace(spec.Script) == "" {
-		return errors.New("script is required")
+	workerScript := strings.TrimSpace(spec.WorkerScript)
+	if workerScript == "" {
+		return errors.New("workerScript is required")
 	}
 
-	return nil
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	return resolveWorkerScriptMetadata(ctx, accountID, workerScript)
 }
 
 func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
@@ -139,12 +156,12 @@ func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
 	}
 
 	pattern := strings.TrimSpace(spec.Pattern)
-	script := strings.TrimSpace(spec.Script)
+	workerScript := strings.TrimSpace(spec.WorkerScript)
 	if pattern == "" {
 		return errors.New("pattern is required")
 	}
-	if script == "" {
-		return errors.New("script is required")
+	if workerScript == "" {
+		return errors.New("workerScript is required")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
@@ -155,12 +172,12 @@ func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
 	routeID := strings.TrimSpace(spec.RouteID)
 	var route *WorkerRoute
 	if routeID == "" {
-		route, err = client.CreateWorkerRoute(spec.Zone, pattern, script)
+		route, err = client.CreateWorkerRoute(spec.Zone, pattern, workerScript)
 		if err != nil {
 			return fmt.Errorf("failed to create worker route: %w", err)
 		}
 	} else {
-		route, err = client.UpdateWorkerRoute(spec.Zone, routeID, pattern, script)
+		route, err = client.UpdateWorkerRoute(spec.Zone, routeID, pattern, workerScript)
 		if err != nil {
 			return fmt.Errorf("failed to update worker route: %w", err)
 		}
@@ -180,7 +197,7 @@ func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
 
 	eventType := "cloudflare.workerRoute.created"
 	if routeID != "" {
-		eventType = "cloudflare.workerRoute.updated"
+		eventType = "cloudflare.workerRoute.update"
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/update_worker_route.go
+++ b/pkg/integrations/cloudflare/update_worker_route.go
@@ -197,7 +197,7 @@ func (u *UpdateWorkerRoute) Execute(ctx core.ExecutionContext) error {
 
 	eventType := "cloudflare.workerRoute.created"
 	if routeID != "" {
-		eventType = "cloudflare.workerRoute.update"
+		eventType = "cloudflare.workerRoute.updated"
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/cloudflare/update_worker_route_test.go
+++ b/pkg/integrations/cloudflare/update_worker_route_test.go
@@ -15,12 +15,25 @@ import (
 func Test__UpdateWorkerRoute__Setup(t *testing.T) {
 	component := &UpdateWorkerRoute{}
 
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId":    "",
+				"zone":         "z1",
+				"pattern":      "ex.com/*",
+				"workerScript": "w",
+			},
+			Integration: &contexts.IntegrationContext{},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "accountId is required")
+	})
+
 	t.Run("missing zone returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"zone":    "",
-				"pattern": "ex.com/*",
-				"script":  "w",
+				"zone":         "",
+				"pattern":      "ex.com/*",
+				"workerScript": "w",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "zone is required")
@@ -29,32 +42,48 @@ func Test__UpdateWorkerRoute__Setup(t *testing.T) {
 	t.Run("missing pattern returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"zone":    "z1",
-				"pattern": "",
-				"script":  "w",
+				"zone":         "z1",
+				"pattern":      "",
+				"workerScript": "w",
 			},
 		}
 		require.ErrorContains(t, component.Setup(ctx), "pattern is required")
 	})
 
-	t.Run("missing script returns error", func(t *testing.T) {
+	t.Run("missing workerScript returns error", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"zone":    "z1",
-				"pattern": "ex.com/*",
-				"script":  "",
+				"zone":         "z1",
+				"pattern":      "ex.com/*",
+				"workerScript": "",
 			},
 		}
-		require.ErrorContains(t, component.Setup(ctx), "script is required")
+		require.ErrorContains(t, component.Setup(ctx), "workerScript is required")
 	})
 
 	t.Run("valid create shape passes", func(t *testing.T) {
 		ctx := core.SetupContext{
 			Configuration: map[string]any{
-				"zone":    "z1",
-				"pattern": "ex.com/*",
-				"script":  "w",
+				"accountId":    "acc1",
+				"zone":         "z1",
+				"pattern":      "ex.com/*",
+				"workerScript": "w",
 			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": [{"id": "w", "name": "w"}]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token"},
+			},
+			Metadata: &contexts.MetadataContext{},
 		}
 		require.NoError(t, component.Setup(ctx))
 	})
@@ -82,9 +111,9 @@ func Test__UpdateWorkerRoute__Execute__create(t *testing.T) {
 
 	ctx := core.ExecutionContext{
 		Configuration: map[string]any{
-			"zone":    "zone-id",
-			"pattern": "ex.com/*",
-			"script":  "w",
+			"zone":         "zone-id",
+			"pattern":      "ex.com/*",
+			"workerScript": "w",
 		},
 		HTTP:           httpContext,
 		Integration:    integrationCtx,
@@ -120,10 +149,10 @@ func Test__UpdateWorkerRoute__Execute__update(t *testing.T) {
 
 	ctx := core.ExecutionContext{
 		Configuration: map[string]any{
-			"zone":    "zone-id",
-			"routeId": "route-1",
-			"pattern": "ex.com/api/*",
-			"script":  "w2",
+			"zone":         "zone-id",
+			"routeId":      "route-1",
+			"pattern":      "ex.com/api/*",
+			"workerScript": "w2",
 		},
 		HTTP:           httpContext,
 		Integration:    integrationCtx,
@@ -131,7 +160,7 @@ func Test__UpdateWorkerRoute__Execute__update(t *testing.T) {
 	}
 
 	require.NoError(t, component.Execute(ctx))
-	assert.Equal(t, "cloudflare.workerRoute.updated", execState.Type)
+	assert.Equal(t, "cloudflare.workerRoute.update", execState.Type)
 	require.Len(t, httpContext.Requests, 1)
 	assert.Equal(t, http.MethodPut, httpContext.Requests[0].Method)
 	assert.Contains(t, httpContext.Requests[0].URL.String(), "/zones/zone-id/workers/routes/route-1")

--- a/pkg/integrations/cloudflare/update_worker_route_test.go
+++ b/pkg/integrations/cloudflare/update_worker_route_test.go
@@ -160,7 +160,7 @@ func Test__UpdateWorkerRoute__Execute__update(t *testing.T) {
 	}
 
 	require.NoError(t, component.Execute(ctx))
-	assert.Equal(t, "cloudflare.workerRoute.update", execState.Type)
+	assert.Equal(t, "cloudflare.workerRoute.updated", execState.Type)
 	require.Len(t, httpContext.Requests, 1)
 	assert.Equal(t, http.MethodPut, httpContext.Requests[0].Method)
 	assert.Contains(t, httpContext.Requests[0].URL.String(), "/zones/zone-id/workers/routes/route-1")

--- a/pkg/integrations/cloudflare/update_worker_route_test.go
+++ b/pkg/integrations/cloudflare/update_worker_route_test.go
@@ -1,0 +1,138 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateWorkerRoute__Setup(t *testing.T) {
+	component := &UpdateWorkerRoute{}
+
+	t.Run("missing zone returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"zone":    "",
+				"pattern": "ex.com/*",
+				"script":  "w",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "zone is required")
+	})
+
+	t.Run("missing pattern returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"zone":    "z1",
+				"pattern": "",
+				"script":  "w",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "pattern is required")
+	})
+
+	t.Run("missing script returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"zone":    "z1",
+				"pattern": "ex.com/*",
+				"script":  "",
+			},
+		}
+		require.ErrorContains(t, component.Setup(ctx), "script is required")
+	})
+
+	t.Run("valid create shape passes", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"zone":    "z1",
+				"pattern": "ex.com/*",
+				"script":  "w",
+			},
+		}
+		require.NoError(t, component.Setup(ctx))
+	})
+}
+
+func Test__UpdateWorkerRoute__Execute__create(t *testing.T) {
+	component := &UpdateWorkerRoute{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": { "id": "route-1", "pattern": "ex.com/*", "script": "w" }
+				}`)),
+			},
+		},
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token"},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+	ctx := core.ExecutionContext{
+		Configuration: map[string]any{
+			"zone":    "zone-id",
+			"pattern": "ex.com/*",
+			"script":  "w",
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		ExecutionState: execState,
+	}
+
+	require.NoError(t, component.Execute(ctx))
+	assert.Equal(t, "cloudflare.workerRoute.created", execState.Type)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/zones/zone-id/workers/routes")
+}
+
+func Test__UpdateWorkerRoute__Execute__update(t *testing.T) {
+	component := &UpdateWorkerRoute{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": { "id": "route-1", "pattern": "ex.com/api/*", "script": "w2" }
+				}`)),
+			},
+		},
+	}
+
+	integrationCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token"},
+	}
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+
+	ctx := core.ExecutionContext{
+		Configuration: map[string]any{
+			"zone":    "zone-id",
+			"routeId": "route-1",
+			"pattern": "ex.com/api/*",
+			"script":  "w2",
+		},
+		HTTP:           httpContext,
+		Integration:    integrationCtx,
+		ExecutionState: execState,
+	}
+
+	require.NoError(t, component.Execute(ctx))
+	assert.Equal(t, "cloudflare.workerRoute.updated", execState.Type)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodPut, httpContext.Requests[0].Method)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/zones/zone-id/workers/routes/route-1")
+}

--- a/pkg/integrations/cloudflare/worker_provision.go
+++ b/pkg/integrations/cloudflare/worker_provision.go
@@ -69,25 +69,16 @@ func buildWorkerProvisionRequestBody(
 }
 
 // isWorkerProvisionConflict reports whether err indicates the Worker already exists (safe to ignore before upload).
+// We only match on HTTP 409 Conflict, which is the unambiguous signal from Cloudflare that the resource
+// already exists. Broad substring matching on error messages (e.g. "already", "duplicate") is intentionally
+// avoided because it would silently swallow unrelated errors whose messages happen to contain those words
+// (e.g. "Token already revoked", "Quota already exhausted").
 func isWorkerProvisionConflict(err error) bool {
 	var apiErr *CloudflareAPIError
 	if !errors.As(err, &apiErr) {
 		return false
 	}
-	if apiErr.StatusCode == 409 {
-		return true
-	}
-	for _, e := range apiErr.Errors {
-		em := strings.ToLower(e.Message)
-		if strings.Contains(em, "already") {
-			return true
-		}
-		if strings.Contains(em, "duplicate") {
-			return true
-		}
-	}
-	body := strings.ToLower(string(apiErr.Body))
-	return strings.Contains(body, "already exists") || strings.Contains(body, "already exist")
+	return apiErr.StatusCode == 409
 }
 
 func ensureWorkerProvisioned(c *Client, accountID string, body map[string]any) error {

--- a/pkg/integrations/cloudflare/worker_provision.go
+++ b/pkg/integrations/cloudflare/worker_provision.go
@@ -1,0 +1,102 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// buildWorkerProvisionRequestBody builds the JSON body for POST .../workers/workers (Cloudflare Create Worker API).
+func buildWorkerProvisionRequestBody(
+	name string,
+	tags string,
+	logpush *bool,
+	observabilityEnabled *bool,
+	observabilityHeadSamplingRate string,
+	subdomainEnabled *bool,
+	subdomainPreviewsEnabled *bool,
+	tailConsumers string,
+) (map[string]any, error) {
+	body := map[string]any{
+		"name": strings.TrimSpace(name),
+	}
+
+	if tagsList := parseCommaOrNewlineList(tags); len(tagsList) > 0 {
+		body["tags"] = tagsList
+	}
+
+	if logpush != nil {
+		body["logpush"] = *logpush
+	}
+
+	obsIncluded := observabilityEnabled != nil || strings.TrimSpace(observabilityHeadSamplingRate) != ""
+	if obsIncluded {
+		obs := map[string]any{}
+		if observabilityEnabled != nil {
+			obs["enabled"] = *observabilityEnabled
+		}
+		if s := strings.TrimSpace(observabilityHeadSamplingRate); s != "" {
+			rate, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return nil, fmt.Errorf("observabilityHeadSamplingRate: %w", err)
+			}
+			obs["head_sampling_rate"] = rate
+		}
+		body["observability"] = obs
+	}
+
+	if subdomainEnabled != nil || subdomainPreviewsEnabled != nil {
+		sub := map[string]any{}
+		if subdomainEnabled != nil {
+			sub["enabled"] = *subdomainEnabled
+		}
+		if subdomainPreviewsEnabled != nil {
+			sub["previews_enabled"] = *subdomainPreviewsEnabled
+		}
+		body["subdomain"] = sub
+	}
+
+	if names := parseCommaOrNewlineList(tailConsumers); len(names) > 0 {
+		consumers := make([]map[string]string, 0, len(names))
+		for _, n := range names {
+			consumers = append(consumers, map[string]string{"name": n})
+		}
+		body["tail_consumers"] = consumers
+	}
+
+	return body, nil
+}
+
+// isWorkerProvisionConflict reports whether err indicates the Worker already exists (safe to ignore before upload).
+func isWorkerProvisionConflict(err error) bool {
+	var apiErr *CloudflareAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode == 409 {
+		return true
+	}
+	for _, e := range apiErr.Errors {
+		em := strings.ToLower(e.Message)
+		if strings.Contains(em, "already") {
+			return true
+		}
+		if strings.Contains(em, "duplicate") {
+			return true
+		}
+	}
+	body := strings.ToLower(string(apiErr.Body))
+	return strings.Contains(body, "already exists") || strings.Contains(body, "already exist")
+}
+
+func ensureWorkerProvisioned(c *Client, accountID string, body map[string]any) error {
+	_, err := c.CreateWorkerResource(accountID, body)
+	if err == nil {
+		return nil
+	}
+	if isWorkerProvisionConflict(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/integrations/cloudflare/worker_provision_test.go
+++ b/pkg/integrations/cloudflare/worker_provision_test.go
@@ -14,13 +14,31 @@ func Test__isWorkerProvisionConflict(t *testing.T) {
 		assert.True(t, isWorkerProvisionConflict(err))
 	})
 
-	t.Run("already in message", func(t *testing.T) {
+	t.Run("non-409 with 'already' in message is not a conflict", func(t *testing.T) {
 		err := &CloudflareAPIError{
 			StatusCode: http.StatusBadRequest,
 			Errors:     []CloudflareError{{Code: 10009, Message: "A worker with this name already exists"}},
 			Body:       []byte(`{"success":false}`),
 		}
-		assert.True(t, isWorkerProvisionConflict(err))
+		assert.False(t, isWorkerProvisionConflict(err))
+	})
+
+	t.Run("token already revoked is not a conflict", func(t *testing.T) {
+		err := &CloudflareAPIError{
+			StatusCode: http.StatusUnauthorized,
+			Errors:     []CloudflareError{{Code: 9109, Message: "Token already revoked"}},
+			Body:       []byte(`{"success":false}`),
+		}
+		assert.False(t, isWorkerProvisionConflict(err))
+	})
+
+	t.Run("quota already exhausted is not a conflict", func(t *testing.T) {
+		err := &CloudflareAPIError{
+			StatusCode: http.StatusTooManyRequests,
+			Errors:     []CloudflareError{{Code: 10000, Message: "Quota already exhausted"}},
+			Body:       []byte(`{"success":false}`),
+		}
+		assert.False(t, isWorkerProvisionConflict(err))
 	})
 
 	t.Run("unrelated error is not conflict", func(t *testing.T) {

--- a/pkg/integrations/cloudflare/worker_provision_test.go
+++ b/pkg/integrations/cloudflare/worker_provision_test.go
@@ -1,0 +1,38 @@
+package cloudflare
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test__isWorkerProvisionConflict(t *testing.T) {
+	t.Run("409 is conflict", func(t *testing.T) {
+		err := &CloudflareAPIError{StatusCode: http.StatusConflict, Body: []byte(`{}`)}
+		assert.True(t, isWorkerProvisionConflict(err))
+	})
+
+	t.Run("already in message", func(t *testing.T) {
+		err := &CloudflareAPIError{
+			StatusCode: http.StatusBadRequest,
+			Errors:     []CloudflareError{{Code: 10009, Message: "A worker with this name already exists"}},
+			Body:       []byte(`{"success":false}`),
+		}
+		assert.True(t, isWorkerProvisionConflict(err))
+	})
+
+	t.Run("unrelated error is not conflict", func(t *testing.T) {
+		err := &CloudflareAPIError{
+			StatusCode: http.StatusBadRequest,
+			Errors:     []CloudflareError{{Code: 10001, Message: "Invalid request"}},
+			Body:       []byte(`{}`),
+		}
+		assert.False(t, isWorkerProvisionConflict(err))
+	})
+
+	t.Run("non API error", func(t *testing.T) {
+		assert.False(t, isWorkerProvisionConflict(errors.New("network")))
+	})
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -133,6 +133,12 @@ export function deleteLoadBalancerExecutionDetails(context: ExecutionDetailsCont
   return details;
 }
 
+function resolveScriptLabel(data: Record<string, unknown>): string {
+  if (data.workerScript != null) return String(data.workerScript);
+  if (data.scriptName != null) return String(data.scriptName);
+  return "-";
+}
+
 export function getDeployWorkerExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
   const details: Record<string, string> = {};
   if (context.execution.createdAt) {
@@ -143,9 +149,7 @@ export function getDeployWorkerExecutionDetails(context: ExecutionDetailsContext
   if (!data) {
     return details;
   }
-  const script =
-    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
-  details["Script"] = script;
+  details["Script"] = resolveScriptLabel(data);
   return details;
 }
 
@@ -159,9 +163,7 @@ export function getWorkerMetadataExecutionDetails(context: ExecutionDetailsConte
   if (!data) {
     return details;
   }
-  const script =
-    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
-  details["Script"] = script;
+  details["Script"] = resolveScriptLabel(data);
   const deployments = data.deployments as unknown[] | undefined;
   details["Deployments"] = deployments != null ? String(deployments.length) : "-";
   const settings = data.settings as Record<string, unknown> | undefined;
@@ -181,9 +183,7 @@ export function getDeleteWorkerExecutionDetails(context: ExecutionDetailsContext
   if (!data) {
     return details;
   }
-  const script =
-    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
-  details["Script"] = script;
+  details["Script"] = resolveScriptLabel(data);
   if (data.deleted != null) {
     details["Deleted"] = String(data.deleted);
   }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -121,6 +121,76 @@ export function deleteLoadBalancerExecutionDetails(context: ExecutionDetailsCont
   return details;
 }
 
+export function getDeployWorkerExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  if (!data) {
+    return details;
+  }
+  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
+  details["Version ID"] = data.versionId != null ? String(data.versionId) : "-";
+  const deployment = data.deployment as Record<string, unknown> | undefined;
+  if (deployment?.id != null) {
+    details["Deployment ID"] = String(deployment.id);
+  }
+  return details;
+}
+
+export function getWorkerMetadataExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  if (!data) {
+    return details;
+  }
+  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
+  const deployments = data.deployments as unknown[] | undefined;
+  details["Deployments"] = deployments != null ? String(deployments.length) : "-";
+  const settings = data.settings as Record<string, unknown> | undefined;
+  if (settings?.compatibility_date != null) {
+    details["Compatibility date"] = String(settings.compatibility_date);
+  }
+  return details;
+}
+
+export function getDeleteWorkerExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  if (!data) {
+    return details;
+  }
+  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
+  return details;
+}
+
+export function getWorkerRouteExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  const route = data?.route as Record<string, unknown> | undefined;
+  if (!route) {
+    return details;
+  }
+  details["Route ID"] = route.id != null ? String(route.id) : "-";
+  details["Pattern"] = route.pattern != null ? String(route.pattern) : "-";
+  details["Script"] = route.script != null ? String(route.script) : "-";
+  return details;
+}
+
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
   const subtitleDate = execution.updatedAt ?? execution.createdAt;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -13,6 +13,18 @@ import type {
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 
+export type WorkerScriptNodeMetadata = {
+  scriptDisplayName?: string;
+};
+
+/** Prefer backend-resolved display name for Worker script integration resources (value is script id). */
+export function workerScriptDisplayLabel(node: NodeInfo, scriptValue: string | undefined): string {
+  const meta = node.metadata as WorkerScriptNodeMetadata | undefined;
+  const label = meta?.scriptDisplayName?.trim();
+  if (label) return label;
+  return (scriptValue ?? "").trim();
+}
+
 export const baseMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
@@ -131,12 +143,9 @@ export function getDeployWorkerExecutionDetails(context: ExecutionDetailsContext
   if (!data) {
     return details;
   }
-  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
-  details["Version ID"] = data.versionId != null ? String(data.versionId) : "-";
-  const deployment = data.deployment as Record<string, unknown> | undefined;
-  if (deployment?.id != null) {
-    details["Deployment ID"] = String(deployment.id);
-  }
+  const script =
+    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
+  details["Script"] = script;
   return details;
 }
 
@@ -150,7 +159,9 @@ export function getWorkerMetadataExecutionDetails(context: ExecutionDetailsConte
   if (!data) {
     return details;
   }
-  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
+  const script =
+    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
+  details["Script"] = script;
   const deployments = data.deployments as unknown[] | undefined;
   details["Deployments"] = deployments != null ? String(deployments.length) : "-";
   const settings = data.settings as Record<string, unknown> | undefined;
@@ -170,7 +181,12 @@ export function getDeleteWorkerExecutionDetails(context: ExecutionDetailsContext
   if (!data) {
     return details;
   }
-  details["Script"] = data.scriptName != null ? String(data.scriptName) : "-";
+  const script =
+    data.workerScript != null ? String(data.workerScript) : data.scriptName != null ? String(data.scriptName) : "-";
+  details["Script"] = script;
+  if (data.deleted != null) {
+    details["Deleted"] = String(data.deleted);
+  }
   return details;
 }
 
@@ -185,7 +201,6 @@ export function getWorkerRouteExecutionDetails(context: ExecutionDetailsContext)
   if (!route) {
     return details;
   }
-  details["Route ID"] = route.id != null ? String(route.id) : "-";
   details["Pattern"] = route.pattern != null ? String(route.pattern) : "-";
   details["Script"] = route.script != null ? String(route.script) : "-";
   return details;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -2,11 +2,18 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections, getPoolExecutionDetails } from "./base";
+import { baseEventSections } from "./base";
 
 interface CreatePoolConfiguration {
   name?: string;
@@ -30,7 +37,31 @@ export const createPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails: getPoolExecutionDetails,
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const pool = result?.pool as Record<string, unknown> | undefined;
+    if (!pool) return details;
+
+    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+    details["Name"] = pool.name != null ? String(pool.name) : "-";
+
+    if (pool.description != null) {
+      details["Description"] = String(pool.description);
+    }
+
+    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+    return details;
+  },
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_pool.ts
@@ -2,18 +2,11 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  NodeInfo,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections } from "./base";
+import { baseEventSections, getPoolExecutionDetails } from "./base";
 
 interface CreatePoolConfiguration {
   name?: string;
@@ -37,31 +30,7 @@ export const createPoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const details: Record<string, string> = {};
-
-    if (context.execution.createdAt) {
-      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-    }
-
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-    const pool = result?.pool as Record<string, unknown> | undefined;
-    if (!pool) return details;
-
-    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
-    details["Name"] = pool.name != null ? String(pool.name) : "-";
-
-    if (pool.description != null) {
-      details["Description"] = String(pool.description);
-    }
-
-    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
-    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
-    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
-
-    return details;
-  },
+  getExecutionDetails: getPoolExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.spec.ts
@@ -38,11 +38,12 @@ function buildDetailsCtx(overrides?: { execution?: Partial<ExecutionInfo> }): Ex
 }
 
 describe("deleteWorkerMapper.getExecutionDetails", () => {
-  it("includes script name", () => {
-    const data = { scriptName: "gone" };
+  it("includes script name and deleted flag", () => {
+    const data = { workerScript: "gone", deleted: true };
     const outputs = { default: [{ type: "cloudflare.worker.deleted", timestamp: new Date().toISOString(), data }] };
     const details = deleteWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
     expect(details["Script"]).toBe("gone");
+    expect(details["Deleted"]).toBe("true");
   });
 });
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { deleteWorkerMapper } from "./delete_worker";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.deleteWorker",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: { execution?: Partial<ExecutionInfo> }): ExecutionDetailsContext {
+  const node = buildNode();
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+describe("deleteWorkerMapper.getExecutionDetails", () => {
+  it("includes script name", () => {
+    const data = { scriptName: "gone" };
+    const outputs = { default: [{ type: "cloudflare.worker.deleted", timestamp: new Date().toISOString(), data }] };
+    const details = deleteWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
+    expect(details["Script"]).toBe("gone");
+  });
+});
+
+describe("eventStateRegistry.deleteWorker", () => {
+  it("maps finished success to deleted", () => {
+    expect(eventStateRegistry.deleteWorker.getState(buildExecution())).toBe("deleted");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.ts
@@ -1,0 +1,54 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getDeleteWorkerExecutionDetails } from "./base";
+
+interface DeleteWorkerConfiguration {
+  scriptName?: string;
+  force?: boolean;
+}
+
+export const deleteWorkerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getDeleteWorkerExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as DeleteWorkerConfiguration;
+
+  if (configuration?.scriptName) {
+    metadata.push({ icon: "trash-2", label: configuration.scriptName });
+  }
+
+  if (configuration?.force === true) {
+    metadata.push({ icon: "alert-triangle", label: "Force" });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_worker.ts
@@ -6,10 +6,10 @@ import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleConte
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections, getDeleteWorkerExecutionDetails } from "./base";
+import { baseEventSections, getDeleteWorkerExecutionDetails, workerScriptDisplayLabel } from "./base";
 
 interface DeleteWorkerConfiguration {
-  scriptName?: string;
+  workerScript?: string;
   force?: boolean;
 }
 
@@ -42,8 +42,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as DeleteWorkerConfiguration;
 
-  if (configuration?.scriptName) {
-    metadata.push({ icon: "trash-2", label: configuration.scriptName });
+  const scriptLabel = workerScriptDisplayLabel(node, configuration?.workerScript);
+  if (scriptLabel) {
+    metadata.push({ icon: "trash-2", label: scriptLabel });
   }
 
   if (configuration?.force === true) {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+} from "../types";
+import { deployWorkerMapper } from "./deploy_worker";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.deployWorker",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.deployWorker",
+  label: "Deploy Worker",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+describe("deployWorkerMapper.getExecutionDetails", () => {
+  it("includes script and version when data is present", () => {
+    const data = {
+      scriptName: "my-worker",
+      versionId: "ver-1",
+      deployment: { id: "dep-1" },
+    };
+    const outputs = { default: [{ type: "cloudflare.worker.deployed", timestamp: new Date().toISOString(), data }] };
+    const details = deployWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
+    expect(details["Script"]).toBe("my-worker");
+    expect(details["Version ID"]).toBe("ver-1");
+    expect(details["Deployment ID"]).toBe("dep-1");
+  });
+});
+
+describe("deployWorkerMapper.props", () => {
+  it("shows script name and inline in metadata", () => {
+    const props = deployWorkerMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { scriptName: "w", source: "inline" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "code", label: "w" },
+      { icon: "file-text", label: "Inline" },
+    ]);
+  });
+});
+
+describe("eventStateRegistry.deployWorker", () => {
+  it("maps finished success to deployed", () => {
+    expect(eventStateRegistry.deployWorker.getState(buildExecution())).toBe("deployed");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.spec.ts
@@ -67,7 +67,7 @@ function buildPropsContext(overrides?: Partial<ComponentBaseContext>): Component
 }
 
 describe("deployWorkerMapper.getExecutionDetails", () => {
-  it("includes script and version when data is present", () => {
+  it("includes script only when data is present", () => {
     const data = {
       scriptName: "my-worker",
       versionId: "ver-1",
@@ -76,13 +76,13 @@ describe("deployWorkerMapper.getExecutionDetails", () => {
     const outputs = { default: [{ type: "cloudflare.worker.deployed", timestamp: new Date().toISOString(), data }] };
     const details = deployWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
     expect(details["Script"]).toBe("my-worker");
-    expect(details["Version ID"]).toBe("ver-1");
-    expect(details["Deployment ID"]).toBe("dep-1");
+    expect(details["Version ID"]).toBeUndefined();
+    expect(details["Deployment ID"]).toBeUndefined();
   });
 });
 
 describe("deployWorkerMapper.props", () => {
-  it("shows script name and inline in metadata", () => {
+  it("shows at most three chips: name, source, provision", () => {
     const props = deployWorkerMapper.props(
       buildPropsContext({
         node: buildNode({
@@ -93,12 +93,36 @@ describe("deployWorkerMapper.props", () => {
     expect(props.metadata).toEqual([
       { icon: "code", label: "w" },
       { icon: "file-text", label: "Inline" },
+      { icon: "package", label: "Provision on" },
     ]);
+  });
+
+  it("shows provision off when disabled", () => {
+    const props = deployWorkerMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { scriptName: "w", source: "inline", provisionIfMissing: false },
+        }),
+      }),
+    );
+    expect(props.metadata?.[2]).toEqual({ icon: "package", label: "Provision off" });
   });
 });
 
 describe("eventStateRegistry.deployWorker", () => {
-  it("maps finished success to deployed", () => {
-    expect(eventStateRegistry.deployWorker.getState(buildExecution())).toBe("deployed");
+  it("maps deploy output to deployed", () => {
+    const execution = buildExecution({
+      outputs: {
+        default: [
+          {
+            type: "cloudflare.worker.deployed",
+            timestamp: new Date().toISOString(),
+            data: {},
+          },
+        ],
+      },
+    });
+
+    expect(eventStateRegistry.deployWorker.getState(execution)).toBe("deployed");
   });
 });

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.ts
@@ -11,6 +11,8 @@ import { baseEventSections, getDeployWorkerExecutionDetails } from "./base";
 interface DeployWorkerConfiguration {
   scriptName?: string;
   source?: string;
+  provisionIfMissing?: boolean;
+  provision?: Record<string, unknown>;
 }
 
 export const deployWorkerMapper: ComponentBaseMapper = {
@@ -38,6 +40,8 @@ export const deployWorkerMapper: ComponentBaseMapper = {
   },
 };
 
+const maxMetadataItems = 3;
+
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as DeployWorkerConfiguration;
@@ -52,5 +56,8 @@ function metadataList(node: NodeInfo): MetadataItem[] {
     metadata.push({ icon: "file-text", label: "Inline" });
   }
 
-  return metadata;
+  const provisionOn = configuration?.provisionIfMissing !== false;
+  metadata.push({ icon: "package", label: provisionOn ? "Provision on" : "Provision off" });
+
+  return metadata.slice(0, maxMetadataItems);
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/deploy_worker.ts
@@ -1,0 +1,56 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getDeployWorkerExecutionDetails } from "./base";
+
+interface DeployWorkerConfiguration {
+  scriptName?: string;
+  source?: string;
+}
+
+export const deployWorkerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getDeployWorkerExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as DeployWorkerConfiguration;
+
+  if (configuration?.scriptName) {
+    metadata.push({ icon: "code", label: configuration.scriptName });
+  }
+
+  if (configuration?.source === "url") {
+    metadata.push({ icon: "link", label: "From URL" });
+  } else if (configuration?.source === "inline" || configuration?.source === undefined) {
+    metadata.push({ icon: "file-text", label: "Inline" });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
 import { getWorkerMapper } from "./get_worker";
 import { eventStateRegistry } from "./index";
 
@@ -40,15 +40,42 @@ function buildDetailsCtx(overrides?: { execution?: Partial<ExecutionInfo> }): Ex
 describe("getWorkerMapper.getExecutionDetails", () => {
   it("includes deployment count", () => {
     const data = {
-      scriptName: "w",
+      workerScript: "w",
       deployments: [{ id: "d1" }, { id: "d2" }],
       settings: { compatibility_date: "2024-01-01" },
     };
-    const outputs = { default: [{ type: "cloudflare.worker.metadata", timestamp: new Date().toISOString(), data }] };
+    const outputs = { default: [{ type: "cloudflare.worker.fetched", timestamp: new Date().toISOString(), data }] };
     const details = getWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
     expect(details["Script"]).toBe("w");
     expect(details["Deployments"]).toBe("2");
     expect(details["Compatibility date"]).toBe("2024-01-01");
+  });
+});
+
+describe("getWorkerMapper.props metadata", () => {
+  it("prefers resolved script display name from node metadata", () => {
+    const props = getWorkerMapper.props({
+      nodes: [],
+      node: {
+        id: "n1",
+        name: "Node",
+        componentName: "cloudflare.getWorker",
+        isCollapsed: false,
+        configuration: { workerScript: "id-1" },
+        metadata: { scriptDisplayName: "My Worker" },
+      },
+      componentDefinition: {
+        name: "cloudflare.getWorker",
+        label: "Get Worker",
+        description: "",
+        icon: "cloud",
+        color: "orange",
+      },
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    } satisfies ComponentBaseContext);
+    expect(props.metadata).toEqual([{ icon: "code", label: "My Worker" }]);
   });
 });
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { getWorkerMapper } from "./get_worker";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.getWorker",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: { execution?: Partial<ExecutionInfo> }): ExecutionDetailsContext {
+  const node = buildNode();
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+describe("getWorkerMapper.getExecutionDetails", () => {
+  it("includes deployment count", () => {
+    const data = {
+      scriptName: "w",
+      deployments: [{ id: "d1" }, { id: "d2" }],
+      settings: { compatibility_date: "2024-01-01" },
+    };
+    const outputs = { default: [{ type: "cloudflare.worker.metadata", timestamp: new Date().toISOString(), data }] };
+    const details = getWorkerMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
+    expect(details["Script"]).toBe("w");
+    expect(details["Deployments"]).toBe("2");
+    expect(details["Compatibility date"]).toBe("2024-01-01");
+  });
+});
+
+describe("eventStateRegistry.getWorker", () => {
+  it("maps finished success to fetched", () => {
+    expect(eventStateRegistry.getWorker.getState(buildExecution())).toBe("fetched");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.ts
@@ -6,10 +6,10 @@ import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleConte
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections, getWorkerMetadataExecutionDetails } from "./base";
+import { baseEventSections, getWorkerMetadataExecutionDetails, workerScriptDisplayLabel } from "./base";
 
 interface GetWorkerConfiguration {
-  scriptName?: string;
+  workerScript?: string;
 }
 
 export const getWorkerMapper: ComponentBaseMapper = {
@@ -41,8 +41,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as GetWorkerConfiguration;
 
-  if (configuration?.scriptName) {
-    metadata.push({ icon: "code", label: configuration.scriptName });
+  const label = workerScriptDisplayLabel(node, configuration?.workerScript);
+  if (label) {
+    metadata.push({ icon: "code", label });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_worker.ts
@@ -1,0 +1,49 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getWorkerMetadataExecutionDetails } from "./base";
+
+interface GetWorkerConfiguration {
+  scriptName?: string;
+}
+
+export const getWorkerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getWorkerMetadataExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetWorkerConfiguration;
+
+  if (configuration?.scriptName) {
+    metadata.push({ icon: "code", label: configuration.scriptName });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -38,7 +38,7 @@ const updateWorkerRouteStateRegistry: EventStateRegistry = {
     }
     const payloads = execution.outputs?.default as OutputPayload[] | undefined;
     const payloadType = payloads?.[0]?.type;
-    if (payloadType === "cloudflare.workerRoute.update") {
+    if (payloadType === "cloudflare.workerRoute.updated") {
       return "updated";
     }
     return "created";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -38,10 +38,24 @@ const updateWorkerRouteStateRegistry: EventStateRegistry = {
     }
     const payloads = execution.outputs?.default as OutputPayload[] | undefined;
     const payloadType = payloads?.[0]?.type;
-    if (payloadType === "cloudflare.workerRoute.updated") {
+    if (payloadType === "cloudflare.workerRoute.update") {
       return "updated";
     }
     return "created";
+  },
+};
+
+const deployWorkerStateRegistry: EventStateRegistry = {
+  stateMap: {
+    ...DEFAULT_EVENT_STATE_MAP,
+    deployed: DEFAULT_EVENT_STATE_MAP.success,
+  },
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    if (state !== "success") {
+      return state;
+    }
+    return "deployed";
   },
 };
 
@@ -101,7 +115,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getLoadBalancer: buildActionStateRegistry("fetched"),
   updateLoadBalancer: buildActionStateRegistry("updated"),
   deleteLoadBalancer: buildActionStateRegistry("deleted"),
-  deployWorker: buildActionStateRegistry("deployed"),
+  deployWorker: deployWorkerStateRegistry,
   getWorker: buildActionStateRegistry("fetched"),
   deleteWorker: buildActionStateRegistry("deleted"),
   updateWorkerRoute: updateWorkerRouteStateRegistry,

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -1,4 +1,6 @@
-import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type { ComponentBaseMapper, EventStateRegistry, ExecutionInfo, OutputPayload, TriggerRenderer } from "../types";
+import { defaultStateFunction } from "../stateRegistry";
 import { baseMapper } from "./base";
 import { buildActionStateRegistry } from "../utils";
 import { onLoadBalancingHealthAlertTriggerRenderer } from "./on_load_balancing_health_alert";
@@ -18,6 +20,30 @@ import { createLoadBalancerMapper } from "./create_load_balancer";
 import { getLoadBalancerMapper } from "./get_load_balancer";
 import { updateLoadBalancerMapper } from "./update_load_balancer";
 import { deleteLoadBalancerMapper } from "./delete_load_balancer";
+import { deployWorkerMapper } from "./deploy_worker";
+import { getWorkerMapper } from "./get_worker";
+import { deleteWorkerMapper } from "./delete_worker";
+import { updateWorkerRouteMapper } from "./update_worker_route";
+
+const updateWorkerRouteStateRegistry: EventStateRegistry = {
+  stateMap: {
+    ...DEFAULT_EVENT_STATE_MAP,
+    created: DEFAULT_EVENT_STATE_MAP.success,
+    updated: DEFAULT_EVENT_STATE_MAP.success,
+  },
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    if (state !== "success") {
+      return state;
+    }
+    const payloads = execution.outputs?.default as OutputPayload[] | undefined;
+    const payloadType = payloads?.[0]?.type;
+    if (payloadType === "cloudflare.workerRoute.updated") {
+      return "updated";
+    }
+    return "created";
+  },
+};
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
@@ -42,6 +68,10 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getLoadBalancer: getLoadBalancerMapper,
   updateLoadBalancer: updateLoadBalancerMapper,
   deleteLoadBalancer: deleteLoadBalancerMapper,
+  deployWorker: deployWorkerMapper,
+  getWorker: getWorkerMapper,
+  deleteWorker: deleteWorkerMapper,
+  updateWorkerRoute: updateWorkerRouteMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -71,4 +101,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getLoadBalancer: buildActionStateRegistry("fetched"),
   updateLoadBalancer: buildActionStateRegistry("updated"),
   deleteLoadBalancer: buildActionStateRegistry("deleted"),
+  deployWorker: buildActionStateRegistry("deployed"),
+  getWorker: buildActionStateRegistry("fetched"),
+  deleteWorker: buildActionStateRegistry("deleted"),
+  updateWorkerRoute: updateWorkerRouteStateRegistry,
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -2,23 +2,12 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type {
-  ComponentBaseContext,
-  ComponentBaseMapper,
-  ExecutionDetailsContext,
-  NodeInfo,
-  OutputPayload,
-  SubtitleContext,
-} from "../types";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-<<<<<<< HEAD
 import { baseEventSections, getPoolExecutionDetails } from "./base";
 import { getCloudflarePoolName } from "./metadata";
-=======
-import { baseEventSections } from "./base";
->>>>>>> 401fa587 (feat: add worker components)
 
 interface UpdatePoolConfiguration {
   name?: string;
@@ -42,31 +31,7 @@ export const updatePoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const details: Record<string, string> = {};
-
-    if (context.execution.createdAt) {
-      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-    }
-
-    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-    const pool = result?.pool as Record<string, unknown> | undefined;
-    if (!pool) return details;
-
-    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
-    details["Name"] = pool.name != null ? String(pool.name) : "-";
-
-    if (pool.description != null) {
-      details["Description"] = String(pool.description);
-    }
-
-    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
-    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
-    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
-
-    return details;
-  },
+  getExecutionDetails: getPoolExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";
@@ -78,16 +43,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as UpdatePoolConfiguration;
 
-<<<<<<< HEAD
   const label = getCloudflarePoolName(node.metadata) || configuration?.name || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
-=======
-  if (configuration?.name) {
-    metadata.push({ icon: "network", label: configuration.name });
-  } else if (configuration?.pool) {
-    metadata.push({ icon: "network", label: configuration.pool });
->>>>>>> 401fa587 (feat: add worker components)
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -2,12 +2,23 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+<<<<<<< HEAD
 import { baseEventSections, getPoolExecutionDetails } from "./base";
 import { getCloudflarePoolName } from "./metadata";
+=======
+import { baseEventSections } from "./base";
+>>>>>>> 401fa587 (feat: add worker components)
 
 interface UpdatePoolConfiguration {
   name?: string;
@@ -31,7 +42,31 @@ export const updatePoolMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails: getPoolExecutionDetails,
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    const pool = result?.pool as Record<string, unknown> | undefined;
+    if (!pool) return details;
+
+    details["Pool ID"] = pool.id != null ? String(pool.id) : "-";
+    details["Name"] = pool.name != null ? String(pool.name) : "-";
+
+    if (pool.description != null) {
+      details["Description"] = String(pool.description);
+    }
+
+    details["Enabled"] = pool.enabled != null ? String(pool.enabled) : "-";
+    details["Minimum Origins"] = pool.minimum_origins != null ? String(pool.minimum_origins) : "-";
+    details["Number of Origins"] = Array.isArray(pool.origins) ? String(pool.origins.length) : "-";
+
+    return details;
+  },
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";
@@ -43,9 +78,16 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as UpdatePoolConfiguration;
 
+<<<<<<< HEAD
   const label = getCloudflarePoolName(node.metadata) || configuration?.name || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
+=======
+  if (configuration?.name) {
+    metadata.push({ icon: "network", label: configuration.name });
+  } else if (configuration?.pool) {
+    metadata.push({ icon: "network", label: configuration.pool });
+>>>>>>> 401fa587 (feat: add worker components)
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
@@ -70,7 +70,6 @@ describe("updateWorkerRouteMapper.getExecutionDetails", () => {
       default: [{ type: "cloudflare.workerRoute.created", timestamp: new Date().toISOString(), data }],
     };
     const details = updateWorkerRouteMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
-    expect(details["Route ID"]).toBe("r1");
     expect(details["Pattern"]).toBe("ex.com/*");
     expect(details["Script"]).toBe("w");
   });
@@ -81,7 +80,7 @@ describe("updateWorkerRouteMapper.props metadata", () => {
     const props = updateWorkerRouteMapper.props(
       buildPropsContext({
         node: buildNode({
-          configuration: { pattern: "ex.com/*", script: "w" },
+          configuration: { pattern: "ex.com/*", workerScript: "w" },
         }),
       }),
     );
@@ -96,7 +95,7 @@ describe("updateWorkerRouteMapper.props metadata", () => {
     const props = updateWorkerRouteMapper.props(
       buildPropsContext({
         node: buildNode({
-          configuration: { pattern: "ex.com/*", script: "w", routeId: "rid" },
+          configuration: { pattern: "ex.com/*", workerScript: "w", routeId: "rid" },
         }),
       }),
     );
@@ -117,7 +116,7 @@ describe("eventStateRegistry.updateWorkerRoute", () => {
   it("returns updated when payload type is updated", () => {
     const execution = buildExecution({
       outputs: {
-        default: [{ type: "cloudflare.workerRoute.updated", timestamp: new Date().toISOString(), data: {} }],
+        default: [{ type: "cloudflare.workerRoute.update", timestamp: new Date().toISOString(), data: {} }],
       },
     });
     expect(eventStateRegistry.updateWorkerRoute.getState(execution)).toBe("updated");

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
@@ -116,7 +116,7 @@ describe("eventStateRegistry.updateWorkerRoute", () => {
   it("returns updated when payload type is updated", () => {
     const execution = buildExecution({
       outputs: {
-        default: [{ type: "cloudflare.workerRoute.update", timestamp: new Date().toISOString(), data: {} }],
+        default: [{ type: "cloudflare.workerRoute.updated", timestamp: new Date().toISOString(), data: {} }],
       },
     });
     expect(eventStateRegistry.updateWorkerRoute.getState(execution)).toBe("updated");

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+} from "../types";
+import { updateWorkerRouteMapper } from "./update_worker_route";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.updateWorkerRoute",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: { execution?: Partial<ExecutionInfo> }): ExecutionDetailsContext {
+  const node = buildNode();
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.updateWorkerRoute",
+  label: "Update Worker Route",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+describe("updateWorkerRouteMapper.getExecutionDetails", () => {
+  it("reads route from output data", () => {
+    const data = { route: { id: "r1", pattern: "ex.com/*", script: "w" } };
+    const outputs = {
+      default: [{ type: "cloudflare.workerRoute.created", timestamp: new Date().toISOString(), data }],
+    };
+    const details = updateWorkerRouteMapper.getExecutionDetails(buildDetailsCtx({ execution: { outputs } }));
+    expect(details["Route ID"]).toBe("r1");
+    expect(details["Pattern"]).toBe("ex.com/*");
+    expect(details["Script"]).toBe("w");
+  });
+});
+
+describe("updateWorkerRouteMapper.props metadata", () => {
+  it("shows create when routeId is absent", () => {
+    const props = updateWorkerRouteMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pattern: "ex.com/*", script: "w" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([
+      { icon: "route", label: "ex.com/*" },
+      { icon: "code", label: "w" },
+      { icon: "plus", label: "Create" },
+    ]);
+  });
+
+  it("shows update when routeId is set", () => {
+    const props = updateWorkerRouteMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pattern: "ex.com/*", script: "w", routeId: "rid" },
+        }),
+      }),
+    );
+    expect(props.metadata?.[2]).toEqual({ icon: "edit", label: "Update" });
+  });
+});
+
+describe("eventStateRegistry.updateWorkerRoute", () => {
+  it("returns created when payload type is created", () => {
+    const execution = buildExecution({
+      outputs: {
+        default: [{ type: "cloudflare.workerRoute.created", timestamp: new Date().toISOString(), data: {} }],
+      },
+    });
+    expect(eventStateRegistry.updateWorkerRoute.getState(execution)).toBe("created");
+  });
+
+  it("returns updated when payload type is updated", () => {
+    const execution = buildExecution({
+      outputs: {
+        default: [{ type: "cloudflare.workerRoute.updated", timestamp: new Date().toISOString(), data: {} }],
+      },
+    });
+    expect(eventStateRegistry.updateWorkerRoute.getState(execution)).toBe("updated");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.ts
@@ -6,13 +6,13 @@ import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleConte
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections, getWorkerRouteExecutionDetails } from "./base";
+import { baseEventSections, getWorkerRouteExecutionDetails, workerScriptDisplayLabel } from "./base";
 
 interface UpdateWorkerRouteConfiguration {
   zone?: string;
   routeId?: string;
   pattern?: string;
-  script?: string;
+  workerScript?: string;
 }
 
 export const updateWorkerRouteMapper: ComponentBaseMapper = {
@@ -48,8 +48,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
     metadata.push({ icon: "route", label: configuration.pattern });
   }
 
-  if (configuration?.script) {
-    metadata.push({ icon: "code", label: configuration.script });
+  const scriptLabel = workerScriptDisplayLabel(node, configuration?.workerScript);
+  if (scriptLabel) {
+    metadata.push({ icon: "code", label: scriptLabel });
   }
 
   if (configuration?.routeId) {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_worker_route.ts
@@ -1,0 +1,62 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getWorkerRouteExecutionDetails } from "./base";
+
+interface UpdateWorkerRouteConfiguration {
+  zone?: string;
+  routeId?: string;
+  pattern?: string;
+  script?: string;
+}
+
+export const updateWorkerRouteMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getWorkerRouteExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as UpdateWorkerRouteConfiguration;
+
+  if (configuration?.pattern) {
+    metadata.push({ icon: "route", label: configuration.pattern });
+  }
+
+  if (configuration?.script) {
+    metadata.push({ icon: "code", label: configuration.script });
+  }
+
+  if (configuration?.routeId) {
+    metadata.push({ icon: "edit", label: "Update" });
+  } else {
+    metadata.push({ icon: "plus", label: "Create" });
+  }
+
+  return metadata;
+}


### PR DESCRIPTION
Resolves: #4726

## What changed:

Added four new Cloudflare workflow components:
`Deploy Worker (cloudflare.deployWorker)`
`Get Worker (cloudflare.getWorker)`
`Delete Worker (cloudflare.deleteWorker)`
`Update Worker Route (cloudflare.updateWorkerRoute)`

## Why:

To support Cloudflare Workers lifecycle and routing directly in SuperPlane workflows.

## How:

### Backend:

Implemented new client methods in pkg/integrations/cloudflare/client.go for Workers and route endpoints.
Registered actions in pkg/integrations/cloudflare/cloudflare.go and updated token permission guidance.
Added tests

### Frontend:

Added Cloudflare workflow v2 mappers
Registered mappers and event states in web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
Added mapper specs

## Demo
https://youtu.be/rcjTUQ1R5Ss

