### PR TITLE
feat: add Cloudflare load balancing health monitor management

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -94,6 +94,18 @@ The On Load Balancing Health Alert trigger starts a workflow from Cloudflare Loa
 
 SuperPlane automatically creates a Cloudflare Alerting webhook destination and notification policy for `load_balancing_health_alert`. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the `cf-webhook-auth` header before emitting an event.
 
+### Workflow execution details
+
+In the workflow execution chain, the trigger's **Details** tab lists:
+
+- **Triggered At**: When SuperPlane recorded the webhook event.
+- **Alert Type**: For example `load_balancing_health_alert`.
+- **Event Source**: `pool` or `origin`.
+- **New Health**: The health state in the notification (for example `Unhealthy`).
+- **Pool**: Pool name when Cloudflare sends it; otherwise the pool ID.
+
+The trigger **title** still prefers an origin name, then pool name, then load balancer name when those fields are present in the payload. Use the **Payload** tab (or expressions such as `$.trigger.data`) for every field Cloudflare sends, including **origin name**, **load balancer id/name**, and **account id**.
+
 ### Example Data
 
 ```json

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -17,15 +17,15 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record in a Cloudflare zone" />
   <LinkCard title="Create KV Namespace" href="#create-kv-namespace" description="Create a Cloudflare Workers KV namespace" />
-  <LinkCard title="Create Monitor" href="#create-monitor" description="Create a Cloudflare load balancing health monitor" />
   <LinkCard title="Create Load Balancer" href="#create-load-balancer" description="Create a Cloudflare Load Balancer on a zone, with support for private/public visibility, monitor attachment, and custom rules" />
+  <LinkCard title="Create Monitor" href="#create-monitor" description="Create a Cloudflare load balancing health monitor" />
   <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
   <LinkCard title="Create Pool" href="#create-pool" description="Create a Cloudflare Load Balancer origin pool" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
   <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
-  <LinkCard title="Delete Monitor" href="#delete-monitor" description="Delete a Cloudflare load balancing health monitor" />
   <LinkCard title="Delete Load Balancer" href="#delete-load-balancer" description="Delete a Cloudflare Load Balancer" />
+  <LinkCard title="Delete Monitor" href="#delete-monitor" description="Delete a Cloudflare load balancing health monitor" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
@@ -211,60 +211,6 @@ Returns the created namespace with its assigned ID and title.
 }
 ```
 
-<a id="create-monitor"></a>
-
-## Create Monitor
-
-The Create Monitor component creates a Cloudflare Load Balancing health monitor.
-
-### Use Cases
-
-- **Health checks**: Monitor HTTP, HTTPS, TCP, ICMP, UDP, or SMTP endpoints
-- **Failover**: Attach the new monitor to a pool so unhealthy origins are removed from load balancer rotation
-- **Release safety**: Create monitor definitions as part of load balancing setup automation
-
-### Configuration
-
-- **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
-- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, probe zone, **interval** and **timeout** (seconds; omit both to let Cloudflare pick plan defaults), **retries**, and consecutive thresholds. Plan minimum interval: Pro 60s, Business 15s, Enterprise 10s.
-- **Pool**: Optional pool to attach the created monitor to immediately.
-
-### Output
-
-Emits the created monitor and, when configured, the attached pool.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "accountId": "account_abc123",
-    "monitor": {
-      "consecutive_down": 3,
-      "consecutive_up": 2,
-      "description": "Login page monitor",
-      "expected_codes": "2xx",
-      "id": "monitor_abc123",
-      "interval": 60,
-      "method": "GET",
-      "path": "/health",
-      "retries": 0,
-      "timeout": 5,
-      "type": "https"
-    },
-    "monitorId": "monitor_abc123",
-    "pool": {
-      "id": "pool_xyz789",
-      "monitor": "monitor_abc123",
-      "name": "Production pool"
-    },
-    "poolId": "pool_xyz789"
-  },
-  "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor.created"
-}
-```
-
 <a id="create-load-balancer"></a>
 
 ## Create Load Balancer
@@ -325,6 +271,60 @@ Returns the created load balancer with its assigned ID and full configuration.
   },
   "timestamp": "2026-05-05T13:00:33.465739808Z",
   "type": "cloudflare.loadBalancer.created"
+}
+```
+
+<a id="create-monitor"></a>
+
+## Create Monitor
+
+The Create Monitor component creates a Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Health checks**: Monitor HTTP, HTTPS, TCP, ICMP, UDP, or SMTP endpoints
+- **Failover**: Attach the new monitor to a pool so unhealthy origins are removed from load balancer rotation
+- **Release safety**: Create monitor definitions as part of load balancing setup automation
+
+### Configuration
+
+- **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
+- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, probe zone, **interval** and **timeout** (seconds; omit both to let Cloudflare pick plan defaults), **retries**, and consecutive thresholds. Plan minimum interval: Pro 60s, Business 15s, Enterprise 10s.
+- **Pool**: Optional pool to attach the created monitor to immediately.
+
+### Output
+
+Emits the created monitor and, when configured, the attached pool.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitor": {
+      "consecutive_down": 3,
+      "consecutive_up": 2,
+      "description": "Login page monitor",
+      "expected_codes": "2xx",
+      "id": "monitor_abc123",
+      "interval": 60,
+      "method": "GET",
+      "path": "/health",
+      "retries": 0,
+      "timeout": 5,
+      "type": "https"
+    },
+    "monitorId": "monitor_abc123",
+    "pool": {
+      "id": "pool_xyz789",
+      "monitor": "monitor_abc123",
+      "name": "Production pool"
+    },
+    "poolId": "pool_xyz789"
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor.created"
 }
 ```
 
@@ -549,41 +549,6 @@ Emits a confirmation with the account ID, namespace ID, and key that was deleted
 }
 ```
 
-<a id="delete-monitor"></a>
-
-## Delete Monitor
-
-The Delete Monitor component removes a Cloudflare Load Balancing health monitor.
-
-### Use Cases
-
-- **Cleanup**: Delete monitor definitions when load balancing resources are decommissioned
-- **Rollback**: Remove monitors created during test or migration workflows
-
-### Configuration
-
-- **Monitor**: The monitor to delete.
-- **Force**: Delete even when Cloudflare reports that pools or other resources reference the monitor.
-
-### Output
-
-Emits the deleted monitor ID and any references Cloudflare reported before deletion.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "accountId": "account_abc123",
-    "deleted": true,
-    "monitorId": "monitor_abc123",
-    "references": []
-  },
-  "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor.deleted"
-}
-```
-
 <a id="delete-load-balancer"></a>
 
 ## Delete Load Balancer
@@ -616,6 +581,41 @@ Emits a confirmation with the zone ID and load balancer ID of the deleted load b
   },
   "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.loadBalancer.deleted"
+}
+```
+
+<a id="delete-monitor"></a>
+
+## Delete Monitor
+
+The Delete Monitor component removes a Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Cleanup**: Delete monitor definitions when load balancing resources are decommissioned
+- **Rollback**: Remove monitors created during test or migration workflows
+
+### Configuration
+
+- **Monitor**: The monitor to delete.
+- **Force**: Delete even when Cloudflare reports that pools or other resources reference the monitor.
+
+### Output
+
+Emits the deleted monitor ID and any references Cloudflare reported before deletion.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "deleted": true,
+    "monitorId": "monitor_abc123",
+    "references": []
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor.deleted"
 }
 ```
 
@@ -1132,3 +1132,4 @@ Returns the updated redirect rule with all current configuration.
   "type": "cloudflare.redirectRule"
 }
 ```
+

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -209,7 +209,7 @@ The Create Monitor component creates a Cloudflare Load Balancing health monitor.
 ### Configuration
 
 - **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
-- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, and health threshold settings.
+- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, probe zone, **interval** and **timeout** (seconds; omit both to let Cloudflare pick plan defaults), **retries**, and consecutive thresholds. Plan minimum interval: Pro 60s, Business 15s, Enterprise 10s.
 - **Pool**: Optional pool to attach the created monitor to immediately.
 
 ### Output
@@ -228,11 +228,11 @@ Emits the created monitor and, when configured, the attached pool.
       "description": "Login page monitor",
       "expected_codes": "2xx",
       "id": "monitor_abc123",
-      "interval": 1,
+      "interval": 60,
       "method": "GET",
       "path": "/health",
       "retries": 0,
-      "timeout": 1,
+      "timeout": 5,
       "type": "https"
     },
     "monitorId": "monitor_abc123",

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -6,11 +6,19 @@ Manage Cloudflare zones, rules, and DNS
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
+## Triggers
+
+<CardGrid>
+  <LinkCard title="On Load Balancing Health Alert" href="#on-load-balancing-health-alert" description="Trigger when a Cloudflare load balancing pool or origin health state changes" />
+</CardGrid>
+
 ## Actions
 
 <CardGrid>
   <LinkCard title="Create DNS Record" href="#create-dns-record" description="Create a DNS record in a Cloudflare zone" />
+  <LinkCard title="Create Monitor" href="#create-monitor" description="Create a Cloudflare load balancing health monitor" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
+  <LinkCard title="Delete Monitor" href="#delete-monitor" description="Delete a Cloudflare load balancing health monitor" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Redirect Rule" href="#update-redirect-rule" description="Update a redirect rule in a Cloudflare zone" />
 </CardGrid>
@@ -28,12 +36,68 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
      - Zone / Zone / Read
      - Zone / DNS / Edit
      - Zone / Dynamic Redirect / Edit
-     - Zone / DNS / Edit
+     - Account / Load Balancing: Monitors and Pools / Edit
+     - Account / Notifications / Edit
+     - Account / Account Settings / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
+   - **Account Resources**: Include the account containing your load balancers
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
 
+## Find your Cloudflare Account ID
+
+The **Account ID** is required for load balancing monitors and health alert webhooks.
+
+1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/)
+2. Select the account that contains your load balancers
+3. In the account home page, copy the **Account ID** from the right sidebar
+4. Paste it into the **Account ID** field below
+
+Make sure this is the same account selected in **Account Resources** when creating the API token.
+
 > **Note**: The token is only shown once. Store it securely if needed elsewhere.
+
+<a id="on-load-balancing-health-alert"></a>
+
+## On Load Balancing Health Alert
+
+The On Load Balancing Health Alert trigger starts a workflow from Cloudflare Load Balancing health notifications.
+
+### Use Cases
+
+- **Pool unhealthy**: React when a load balancer pool becomes unhealthy
+- **Origin unhealthy**: Notify or remediate when an endpoint/origin fails health checks
+- **Failover awareness**: Detect health changes that cause Cloudflare to route traffic away from unhealthy pools
+
+### Configuration
+
+- **Pool**: Optional pool filter. Leave empty to listen across pools available to the account.
+- **New Health**: Health states to listen for. Defaults to `Unhealthy`.
+- **Event Source**: Listen for pool events, origin events, or both.
+
+### Webhook Setup
+
+SuperPlane automatically creates a Cloudflare Alerting webhook destination and notification policy for `load_balancing_health_alert`. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the `cf-webhook-auth` header before emitting an event.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "account_id": "account_abc123",
+    "alert_type": "load_balancing_health_alert",
+    "event_source": "origin",
+    "load_balancer_id": "lb_123",
+    "load_balancer_name": "api.example.com",
+    "new_health": "Unhealthy",
+    "origin_name": "api-primary",
+    "pool_id": "pool_xyz789",
+    "pool_name": "Production pool"
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.loadBalancing.healthAlert"
+}
+```
 
 <a id="create-dns-record"></a>
 
@@ -78,6 +142,60 @@ Emits the created DNS record on the default channel. If the zone is not found, t
 }
 ```
 
+<a id="create-monitor"></a>
+
+## Create Monitor
+
+The Create Monitor component creates a Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Health checks**: Monitor HTTP, HTTPS, TCP, ICMP, UDP, or SMTP endpoints
+- **Failover**: Attach the new monitor to a pool so unhealthy origins are removed from load balancer rotation
+- **Release safety**: Create monitor definitions as part of load balancing setup automation
+
+### Configuration
+
+- **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
+- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, and health threshold settings.
+- **Pool**: Optional pool to attach the created monitor to immediately.
+
+### Output
+
+Emits the created monitor and, when configured, the attached pool.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitor": {
+      "consecutive_down": 3,
+      "consecutive_up": 2,
+      "description": "Login page monitor",
+      "expected_codes": "2xx",
+      "id": "monitor_abc123",
+      "interval": 1,
+      "method": "GET",
+      "path": "/health",
+      "retries": 0,
+      "timeout": 1,
+      "type": "https"
+    },
+    "monitorId": "monitor_abc123",
+    "pool": {
+      "id": "pool_xyz789",
+      "monitor": "monitor_abc123",
+      "name": "Production pool"
+    },
+    "poolId": "pool_xyz789"
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor"
+}
+```
+
 <a id="delete-dns-record"></a>
 
 ## Delete DNS Record
@@ -116,6 +234,41 @@ Emits the deleted DNS record (zoneId, recordId, record) on the default channel. 
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
   "type": "cloudflare.dnsRecord"
+}
+```
+
+<a id="delete-monitor"></a>
+
+## Delete Monitor
+
+The Delete Monitor component removes a Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Cleanup**: Delete monitor definitions when load balancing resources are decommissioned
+- **Rollback**: Remove monitors created during test or migration workflows
+
+### Configuration
+
+- **Monitor**: The monitor to delete.
+- **Force**: Delete even when Cloudflare reports that pools or other resources reference the monitor.
+
+### Output
+
+Emits the deleted monitor ID and any references Cloudflare reported before deletion.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "deleted": true,
+    "monitorId": "monitor_abc123",
+    "references": []
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -244,7 +244,7 @@ Emits the created monitor and, when configured, the attached pool.
     "poolId": "pool_xyz789"
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor"
+  "type": "cloudflare.monitor.created"
 }
 ```
 
@@ -500,7 +500,7 @@ Emits the deleted monitor ID and any references Cloudflare reported before delet
     "references": []
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor"
+  "type": "cloudflare.monitor.deleted"
 }
 ```
 

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -177,7 +177,7 @@ type Pool struct {
 	ID             string          `json:"id,omitempty"`
 	Name           string          `json:"name,omitempty"`
 	Description    string          `json:"description,omitempty"`
-	Enabled        bool            `json:"enabled,omitempty"`
+	Enabled        bool            `json:"enabled"`
 	MinimumOrigins int             `json:"minimum_origins,omitempty"`
 	Monitor        string          `json:"monitor,omitempty"`
 	Origins        []Origin        `json:"origins,omitempty"`

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -27,12 +27,6 @@ type CloudflareError struct {
 	Message string `json:"message"`
 }
 
-type CloudflareResponseInfo struct {
-	Code             int    `json:"code,omitempty"`
-	Message          string `json:"message"`
-	DocumentationURL string `json:"documentation_url,omitempty"`
-}
-
 type CloudflareAPIError struct {
 	StatusCode int
 	Errors     []CloudflareError
@@ -178,8 +172,9 @@ type Pool struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 	// Enabled must not use omitempty: disabled pools must still serialize enabled:false.
-	Enabled        bool            `json:"enabled"`
-	MinimumOrigins int             `json:"minimum_origins,omitempty"`
+	Enabled bool `json:"enabled"`
+	// MinimumOrigins must not use omitempty: 0 is a valid value and must serialize as minimum_origins:0.
+	MinimumOrigins int             `json:"minimum_origins"`
 	Monitor        string          `json:"monitor,omitempty"`
 	Origins        []Origin        `json:"origins,omitempty"`
 	LoadShedding   *LoadShedding   `json:"load_shedding,omitempty"`

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/superplanehq/superplane/pkg/core"
 )
@@ -21,6 +22,12 @@ type Client struct {
 type CloudflareError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+type CloudflareResponseInfo struct {
+	Code             int    `json:"code,omitempty"`
+	Message          string `json:"message"`
+	DocumentationURL string `json:"documentation_url,omitempty"`
 }
 
 type CloudflareAPIError struct {
@@ -106,6 +113,120 @@ type Zone struct {
 	Status string `json:"status"`
 }
 
+type Monitor struct {
+	ID              string              `json:"id,omitempty"`
+	AllowInsecure   *bool               `json:"allow_insecure,omitempty"`
+	ConsecutiveDown *int                `json:"consecutive_down,omitempty"`
+	ConsecutiveUp   *int                `json:"consecutive_up,omitempty"`
+	CreatedOn       string              `json:"created_on,omitempty"`
+	Description     string              `json:"description,omitempty"`
+	ExpectedBody    string              `json:"expected_body,omitempty"`
+	ExpectedCodes   string              `json:"expected_codes,omitempty"`
+	FollowRedirects *bool               `json:"follow_redirects,omitempty"`
+	Header          map[string][]string `json:"header,omitempty"`
+	Interval        *int                `json:"interval,omitempty"`
+	Method          string              `json:"method,omitempty"`
+	ModifiedOn      string              `json:"modified_on,omitempty"`
+	Path            string              `json:"path,omitempty"`
+	Port            *int                `json:"port,omitempty"`
+	ProbeZone       string              `json:"probe_zone,omitempty"`
+	Retries         *int                `json:"retries,omitempty"`
+	Timeout         *int                `json:"timeout,omitempty"`
+	Type            string              `json:"type,omitempty"`
+}
+
+type CreateMonitorRequest struct {
+	AllowInsecure   *bool               `json:"allow_insecure,omitempty"`
+	ConsecutiveDown *int                `json:"consecutive_down,omitempty"`
+	ConsecutiveUp   *int                `json:"consecutive_up,omitempty"`
+	Description     string              `json:"description,omitempty"`
+	ExpectedBody    string              `json:"expected_body,omitempty"`
+	ExpectedCodes   string              `json:"expected_codes,omitempty"`
+	FollowRedirects *bool               `json:"follow_redirects,omitempty"`
+	Header          map[string][]string `json:"header,omitempty"`
+	Interval        *int                `json:"interval,omitempty"`
+	Method          string              `json:"method,omitempty"`
+	Path            string              `json:"path,omitempty"`
+	Port            *int                `json:"port,omitempty"`
+	ProbeZone       string              `json:"probe_zone,omitempty"`
+	Retries         *int                `json:"retries,omitempty"`
+	Timeout         *int                `json:"timeout,omitempty"`
+	Type            string              `json:"type"`
+}
+
+type DeleteMonitorResponse struct {
+	ID string `json:"id,omitempty"`
+}
+
+type MonitorReference struct {
+	ReferenceType string `json:"reference_type,omitempty"`
+	ResourceID    string `json:"resource_id,omitempty"`
+	ResourceName  string `json:"resource_name,omitempty"`
+	ResourceType  string `json:"resource_type,omitempty"`
+}
+
+type Pool struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Monitor string `json:"monitor,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+type AlertingWebhookDestination struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+type CreateAlertingWebhookDestinationRequest struct {
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Secret string `json:"secret,omitempty"`
+}
+
+type CreateNotificationPolicyRequest struct {
+	AlertType   string                       `json:"alert_type"`
+	Enabled     bool                         `json:"enabled"`
+	Mechanisms  NotificationPolicyMechanisms `json:"mechanisms"`
+	Name        string                       `json:"name"`
+	Description string                       `json:"description,omitempty"`
+	Filters     NotificationPolicyFilters    `json:"filters,omitempty"`
+}
+
+type NotificationPolicyMechanisms struct {
+	Email     []NotificationMechanism `json:"email,omitempty"`
+	PagerDuty []NotificationMechanism `json:"pagerduty,omitempty"`
+	Webhooks  []NotificationMechanism `json:"webhooks,omitempty"`
+}
+
+type NotificationMechanism struct {
+	ID string `json:"id,omitempty"`
+}
+
+type NotificationPolicyFilters struct {
+	PoolID      []string `json:"pool_id,omitempty"`
+	NewHealth   []string `json:"new_health,omitempty"`
+	EventSource []string `json:"event_source,omitempty"`
+}
+
+type NotificationPolicyResponse struct {
+	ID string `json:"id,omitempty"`
+}
+
+func accountIDForIntegration(ctx core.IntegrationContext) (string, error) {
+	accountID, err := ctx.GetConfig("accountId")
+	if err != nil {
+		return "", fmt.Errorf("accountId is required")
+	}
+
+	value := strings.TrimSpace(string(accountID))
+	if value == "" {
+		return "", fmt.Errorf("accountId is required")
+	}
+
+	return value, nil
+}
+
 // ListZones retrieves all zones accessible with the API token
 func (c *Client) ListZones() ([]Zone, error) {
 	url := fmt.Sprintf("%s/zones", c.BaseURL)
@@ -129,6 +250,254 @@ func (c *Client) ListZones() ([]Zone, error) {
 	}
 
 	return response.Result, nil
+}
+
+func (c *Client) ListMonitors(accountID string) ([]Monitor, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors", c.BaseURL, accountID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool      `json:"success"`
+		Result  []Monitor `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return response.Result, nil
+}
+
+func (c *Client) GetMonitor(accountID, monitorID string) (*Monitor, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors/%s", c.BaseURL, accountID, monitorID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool    `json:"success"`
+		Result  Monitor `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) CreateMonitor(accountID string, req CreateMonitorRequest) (*Monitor, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool    `json:"success"`
+		Result  Monitor `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) DeleteMonitor(accountID, monitorID string) (*DeleteMonitorResponse, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors/%s", c.BaseURL, accountID, monitorID)
+	responseBody, err := c.execRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool                  `json:"success"`
+		Result  DeleteMonitorResponse `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) ListMonitorReferences(accountID, monitorID string) ([]MonitorReference, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors/%s/references", c.BaseURL, accountID, monitorID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool               `json:"success"`
+		Result  []MonitorReference `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return response.Result, nil
+}
+
+func (c *Client) ListPools(accountID string) ([]Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools", c.BaseURL, accountID)
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Result  []Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return response.Result, nil
+}
+
+func (c *Client) PatchPoolMonitor(accountID, poolID, monitorID string) (*Pool, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools/%s", c.BaseURL, accountID, poolID)
+	body, err := json.Marshal(map[string]string{"monitor": monitorID})
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Result  Pool `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) CreateAlertingWebhookDestination(
+	accountID string,
+	req CreateAlertingWebhookDestinationRequest,
+) (*AlertingWebhookDestination, error) {
+	url := fmt.Sprintf("%s/accounts/%s/alerting/v3/destinations/webhooks", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool                       `json:"success"`
+		Result  AlertingWebhookDestination `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) DeleteAlertingWebhookDestination(accountID, webhookID string) error {
+	url := fmt.Sprintf("%s/accounts/%s/alerting/v3/destinations/webhooks/%s", c.BaseURL, accountID, webhookID)
+	_, err := c.execRequest(http.MethodDelete, url, nil)
+	return err
+}
+
+func (c *Client) CreateNotificationPolicy(
+	accountID string,
+	req CreateNotificationPolicyRequest,
+) (*NotificationPolicyResponse, error) {
+	url := fmt.Sprintf("%s/accounts/%s/alerting/v3/policies", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool                       `json:"success"`
+		Result  NotificationPolicyResponse `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
+func (c *Client) DeleteNotificationPolicy(accountID, policyID string) error {
+	url := fmt.Sprintf("%s/accounts/%s/alerting/v3/policies/%s", c.BaseURL, accountID, policyID)
+	_, err := c.execRequest(http.MethodDelete, url, nil)
+	return err
 }
 
 // DeleteDNSRecord deletes a DNS record by its ID within a zone.

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -174,9 +174,10 @@ type MonitorReference struct {
 }
 
 type Pool struct {
-	ID             string          `json:"id,omitempty"`
-	Name           string          `json:"name,omitempty"`
-	Description    string          `json:"description,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	// Enabled must not use omitempty: disabled pools must still serialize enabled:false.
 	Enabled        bool            `json:"enabled"`
 	MinimumOrigins int             `json:"minimum_origins,omitempty"`
 	Monitor        string          `json:"monitor,omitempty"`

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -52,7 +52,14 @@ func accountIDFromIntegration(ctx core.IntegrationContext) string {
 	}
 	metadata := Metadata{}
 	mapstructure.Decode(ctx.GetMetadata(), &metadata)
-	return metadata.AccountID
+	if id := strings.TrimSpace(metadata.AccountID); id != "" {
+		return id
+	}
+	cfg, err := ctx.GetConfig("accountId")
+	if err != nil || len(cfg) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(string(cfg))
 }
 
 func resolveAccountID(specAccountID string, integration core.IntegrationContext) string {

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
@@ -10,13 +11,14 @@ import (
 )
 
 func init() {
-	registry.RegisterIntegration("cloudflare", &Cloudflare{})
+	registry.RegisterIntegrationWithWebhookHandler("cloudflare", &Cloudflare{}, &CloudflareWebhookHandler{})
 }
 
 type Cloudflare struct{}
 
 type Configuration struct {
-	APIToken string `json:"apiToken"`
+	APIToken  string `json:"apiToken"`
+	AccountID string `json:"accountId"`
 }
 
 type Metadata struct {
@@ -51,10 +53,24 @@ func (c *Cloudflare) Instructions() string {
      - Zone / Zone / Read
      - Zone / DNS / Edit
      - Zone / Dynamic Redirect / Edit
-     - Zone / DNS / Edit
+     - Account / Load Balancing: Monitors and Pools / Edit
+     - Account / Notifications / Edit
+     - Account / Account Settings / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
+   - **Account Resources**: Include the account containing your load balancers
 5. Click **Continue to summary**, then **Create Token**
 6. Copy the token and paste it below
+
+## Find your Cloudflare Account ID
+
+The **Account ID** is required for load balancing monitors and health alert webhooks.
+
+1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/)
+2. Select the account that contains your load balancers
+3. In the account home page, copy the **Account ID** from the right sidebar
+4. Paste it into the **Account ID** field below
+
+Make sure this is the same account selected in **Account Resources** when creating the API token.
 
 > **Note**: The token is only shown once. Store it securely if needed elsewhere.`
 }
@@ -69,6 +85,13 @@ func (c *Cloudflare) Configuration() []configuration.Field {
 			Sensitive:   true,
 			Description: "Cloudflare API Token with appropriate permissions",
 		},
+		{
+			Name:        "accountId",
+			Label:       "Account ID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Cloudflare account ID from the account home page right sidebar. Required for load balancing monitors and alerting webhooks.",
+		},
 	}
 }
 
@@ -78,11 +101,15 @@ func (c *Cloudflare) Actions() []core.Action {
 		&UpdateRedirectRule{},
 		&UpdateDNSRecord{},
 		&DeleteDNSRecord{},
+		&CreateMonitor{},
+		&DeleteMonitor{},
 	}
 }
 
 func (c *Cloudflare) Triggers() []core.Trigger {
-	return []core.Trigger{}
+	return []core.Trigger{
+		&OnLoadBalancingHealthAlert{},
+	}
 }
 
 func (c *Cloudflare) Sync(ctx core.SyncContext) error {
@@ -94,6 +121,10 @@ func (c *Cloudflare) Sync(ctx core.SyncContext) error {
 
 	if configuration.APIToken == "" {
 		return fmt.Errorf("apiToken is required")
+	}
+
+	if strings.TrimSpace(configuration.AccountID) == "" {
+		return fmt.Errorf("accountId is required")
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
@@ -186,6 +217,62 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 					ID:   fmt.Sprintf("%s/%s", zone.ID, record.ID),
 				})
 			}
+		}
+		return resources, nil
+
+	case "monitor":
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		accountID, err := accountIDForIntegration(ctx.Integration)
+		if err != nil {
+			return nil, err
+		}
+
+		monitors, err := client.ListMonitors(accountID)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(monitors))
+		for _, monitor := range monitors {
+			name := monitor.Description
+			if name == "" {
+				name = monitor.ID
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   monitor.ID,
+			})
+		}
+		return resources, nil
+
+	case "pool":
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		accountID, err := accountIDForIntegration(ctx.Integration)
+		if err != nil {
+			return nil, err
+		}
+
+		pools, err := client.ListPools(accountID)
+		if err != nil {
+			return nil, err
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(pools))
+		for _, pool := range pools {
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: pool.Name,
+				ID:   pool.ID,
+			})
 		}
 		return resources, nil
 

--- a/pkg/integrations/cloudflare/cloudflare_test.go
+++ b/pkg/integrations/cloudflare/cloudflare_test.go
@@ -30,6 +30,21 @@ func Test__Cloudflare__Sync(t *testing.T) {
 		require.ErrorContains(t, err, "apiToken is required")
 	})
 
+	t.Run("no accountId -> error", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		err := c.Sync(core.SyncContext{
+			Configuration: integrationCtx.Configuration,
+			Integration:   integrationCtx,
+		})
+
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
 	t.Run("api token -> successful zone list moves app to ready and sets metadata", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
@@ -49,7 +64,8 @@ func Test__Cloudflare__Sync(t *testing.T) {
 
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{
-				"apiToken": "token123",
+				"apiToken":  "token123",
+				"accountId": "account123",
 			},
 		}
 
@@ -82,7 +98,8 @@ func Test__Cloudflare__Sync(t *testing.T) {
 
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{
-				"apiToken": "invalid-token",
+				"apiToken":  "invalid-token",
+				"accountId": "account123",
 			},
 		}
 
@@ -98,6 +115,17 @@ func Test__Cloudflare__Sync(t *testing.T) {
 		assert.Equal(t, "https://api.cloudflare.com/client/v4/zones", httpContext.Requests[0].URL.String())
 		assert.Nil(t, integrationCtx.Metadata)
 	})
+}
+
+func Test__Cloudflare__Configuration(t *testing.T) {
+	c := &Cloudflare{}
+	fields := c.Configuration()
+
+	require.Len(t, fields, 2)
+	assert.Equal(t, "apiToken", fields[0].Name)
+	assert.True(t, fields[0].Required)
+	assert.Equal(t, "accountId", fields[1].Name)
+	assert.True(t, fields[1].Required)
 }
 
 func Test__Cloudflare__ListResources(t *testing.T) {

--- a/pkg/integrations/cloudflare/create_monitor.go
+++ b/pkg/integrations/cloudflare/create_monitor.go
@@ -1,0 +1,528 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const MonitorPayloadType = "cloudflare.monitor"
+
+var (
+	allowedMonitorTypes   = []string{"http", "https", "tcp", "udp_icmp", "icmp_ping", "smtp"}
+	httpMonitorTypes      = []string{"http", "https"}
+	portMonitorTypes      = []string{"http", "https", "tcp", "udp_icmp", "smtp"}
+	allowedMonitorMethods = []string{"GET", "HEAD"}
+)
+
+type CreateMonitor struct{}
+
+type MonitorHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type CreateMonitorSpec struct {
+	Type        string                     `json:"type"`
+	Description string                     `json:"description"`
+	Path        string                     `json:"path"`
+	Port        *int                       `json:"port"`
+	Advanced    *CreateMonitorAdvancedSpec `json:"advanced"`
+	Pool        string                     `json:"pool"`
+
+	// Legacy flat fields are kept for existing saved nodes. New nodes use Advanced.
+	Method          string          `json:"method"`
+	ExpectedCodes   string          `json:"expectedCodes"`
+	ExpectedBody    string          `json:"expectedBody"`
+	Headers         []MonitorHeader `json:"headers"`
+	FollowRedirects *bool           `json:"followRedirects"`
+	AllowInsecure   *bool           `json:"allowInsecure"`
+	ProbeZone       string          `json:"probeZone"`
+	Interval        *int            `json:"interval"`
+	Timeout         *int            `json:"timeout"`
+	Retries         *int            `json:"retries"`
+	ConsecutiveUp   *int            `json:"consecutiveUp"`
+	ConsecutiveDown *int            `json:"consecutiveDown"`
+}
+
+type CreateMonitorAdvancedSpec struct {
+	Method          string          `json:"method"`
+	ExpectedCodes   string          `json:"expectedCodes"`
+	ExpectedBody    string          `json:"expectedBody"`
+	Headers         []MonitorHeader `json:"headers"`
+	FollowRedirects *bool           `json:"followRedirects"`
+	AllowInsecure   *bool           `json:"allowInsecure"`
+	ProbeZone       string          `json:"probeZone"`
+	Interval        *int            `json:"interval"`
+	Timeout         *int            `json:"timeout"`
+	Retries         *int            `json:"retries"`
+	ConsecutiveUp   *int            `json:"consecutiveUp"`
+	ConsecutiveDown *int            `json:"consecutiveDown"`
+}
+
+func (c *CreateMonitor) Name() string {
+	return "cloudflare.createMonitor"
+}
+
+func (c *CreateMonitor) Label() string {
+	return "Create Monitor"
+}
+
+func (c *CreateMonitor) Description() string {
+	return "Create a Cloudflare load balancing health monitor"
+}
+
+func (c *CreateMonitor) Documentation() string {
+	return `The Create Monitor component creates a Cloudflare Load Balancing health monitor.
+
+## Use Cases
+
+- **Health checks**: Monitor HTTP, HTTPS, TCP, ICMP, UDP, or SMTP endpoints
+- **Failover**: Attach the new monitor to a pool so unhealthy origins are removed from load balancer rotation
+- **Release safety**: Create monitor definitions as part of load balancing setup automation
+
+## Configuration
+
+- **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
+- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, and health threshold settings.
+- **Pool**: Optional pool to attach the created monitor to immediately.
+
+## Output
+
+Emits the created monitor and, when configured, the attached pool.`
+}
+
+func (c *CreateMonitor) Icon() string {
+	return "activity"
+}
+
+func (c *CreateMonitor) Color() string {
+	return "orange"
+}
+
+func (c *CreateMonitor) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateMonitor) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "type",
+			Label:    "Type",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "http",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "HTTP", Value: "http"},
+						{Label: "HTTPS", Value: "https"},
+						{Label: "TCP", Value: "tcp"},
+						{Label: "UDP ICMP", Value: "udp_icmp"},
+						{Label: "ICMP Ping", Value: "icmp_ping"},
+						{Label: "SMTP", Value: "smtp"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "description",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Human-readable monitor name",
+			Placeholder: "Login page monitor",
+		},
+		{
+			Name:        "path",
+			Label:       "Path",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Endpoint path to check",
+			Default:     "/",
+			Placeholder: "/health",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "type", Values: httpMonitorTypes},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "type", Values: httpMonitorTypes},
+			},
+		},
+		{
+			Name:        "port",
+			Label:       "Port",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     80,
+			Description: "Port for checks. Required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := 1; return &min }(),
+					Max: func() *int { max := 65535; return &max }(),
+				},
+			},
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "type", Values: portMonitorTypes},
+			},
+		},
+		{
+			Name:        "advanced",
+			Label:       "Advanced Health Check Settings",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Togglable:   true,
+			Description: "Optional method, response validation, headers, redirect, TLS, and health threshold settings",
+			Default: map[string]any{
+				"method":          "GET",
+				"expectedCodes":   "2xx",
+				"followRedirects": true,
+				"allowInsecure":   false,
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: createMonitorAdvancedFields(),
+				},
+			},
+		},
+		{
+			Name:        "pool",
+			Label:       "Attach to Pool",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Togglable:   true,
+			Description: "Optional pool to attach this monitor to after creation",
+			Placeholder: "Select a pool",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "pool",
+				},
+			},
+		},
+	}
+}
+
+func createMonitorAdvancedFields() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "method",
+			Label:       "Method",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Default:     "GET",
+			Description: "HTTP method used for the health check",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "GET", Value: "GET"},
+						{Label: "HEAD", Value: "HEAD"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "expectedCodes",
+			Label:       "Expected Codes",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Default:     "2xx",
+			Description: "Expected HTTP response code or code range",
+			Placeholder: "2xx",
+		},
+		{
+			Name:        "expectedBody",
+			Label:       "Expected Body",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Case-insensitive response body substring expected by Cloudflare",
+		},
+		{
+			Name:        "headers",
+			Label:       "Headers",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "HTTP request headers sent by the monitor",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Header",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{Name: "name", Label: "Name", Type: configuration.FieldTypeString, Required: true},
+							{Name: "value", Label: "Value", Type: configuration.FieldTypeString, Required: true},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "followRedirects",
+			Label:       "Follow Redirects",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "Whether Cloudflare should follow origin redirects",
+		},
+		{
+			Name:        "allowInsecure",
+			Label:       "Allow Insecure HTTPS",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     false,
+			Description: "Do not validate the origin certificate for HTTPS checks",
+		},
+		{
+			Name:        "probeZone",
+			Label:       "Probe Zone",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Zone to emulate while probing",
+			Placeholder: "example.com",
+		},
+		{
+			Name:        "consecutiveUp",
+			Label:       "Consecutive Up",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Description: "Passes needed before marking an origin healthy",
+			TypeOptions: &configuration.TypeOptions{Number: &configuration.NumberTypeOptions{Min: func() *int { min := 0; return &min }()}},
+		},
+		{
+			Name:        "consecutiveDown",
+			Label:       "Consecutive Down",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Description: "Failures needed before marking an origin unhealthy",
+			TypeOptions: &configuration.TypeOptions{Number: &configuration.NumberTypeOptions{Min: func() *int { min := 0; return &min }()}},
+		},
+	}
+}
+
+func (c *CreateMonitor) Setup(ctx core.SetupContext) error {
+	spec := CreateMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	return validateCreateMonitorSpec(spec)
+}
+
+func validateCreateMonitorSpec(spec CreateMonitorSpec) error {
+	monitorType := normalizeMonitorType(spec.Type)
+	if monitorType == "" {
+		return errors.New("type is required")
+	}
+	if !slices.Contains(allowedMonitorTypes, monitorType) {
+		return fmt.Errorf("type must be one of %s", strings.Join(allowedMonitorTypes, ", "))
+	}
+
+	if strings.TrimSpace(spec.Description) == "" {
+		return errors.New("name is required")
+	}
+
+	if slices.Contains(httpMonitorTypes, monitorType) {
+		if strings.TrimSpace(spec.Path) == "" {
+			return errors.New("path is required for HTTP and HTTPS monitors")
+		}
+		method := normalizeMonitorMethod(effectiveMonitorAdvanced(spec).Method)
+		if method != "" && !slices.Contains(allowedMonitorMethods, method) {
+			return fmt.Errorf("method must be one of %s", strings.Join(allowedMonitorMethods, ", "))
+		}
+	}
+
+	if slices.Contains(portMonitorTypes, monitorType) && spec.Port == nil {
+		return fmt.Errorf("port is required for %s monitors", monitorType)
+	}
+
+	if spec.Port != nil && (*spec.Port < 1 || *spec.Port > 65535) {
+		return errors.New("port must be between 1 and 65535")
+	}
+
+	advanced := effectiveMonitorAdvanced(spec)
+	fields := []struct {
+		name  string
+		value *int
+		min   int
+	}{
+		{name: "consecutiveUp", value: advanced.ConsecutiveUp, min: 0},
+		{name: "consecutiveDown", value: advanced.ConsecutiveDown, min: 0},
+	}
+
+	for _, field := range fields {
+		if field.value != nil && *field.value < field.min {
+			return fmt.Errorf("%s must be >= %d", field.name, field.min)
+		}
+	}
+
+	return nil
+}
+
+func (c *CreateMonitor) Execute(ctx core.ExecutionContext) error {
+	spec := CreateMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if err := validateCreateMonitorSpec(spec); err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	monitor, err := client.CreateMonitor(accountID, createMonitorRequest(spec))
+	if err != nil {
+		return fmt.Errorf("failed to create monitor: %w", err)
+	}
+
+	payload := map[string]any{
+		"accountId": accountID,
+		"monitor":   monitor,
+		"monitorId": monitor.ID,
+	}
+
+	if strings.TrimSpace(spec.Pool) != "" {
+		pool, err := client.PatchPoolMonitor(accountID, spec.Pool, monitor.ID)
+		if err != nil {
+			return fmt.Errorf("failed to attach monitor to pool: %w", err)
+		}
+		payload["pool"] = pool
+		payload["poolId"] = spec.Pool
+	}
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, MonitorPayloadType, []any{payload})
+}
+
+func createMonitorRequest(spec CreateMonitorSpec) CreateMonitorRequest {
+	monitorType := normalizeMonitorType(spec.Type)
+	advanced := effectiveMonitorAdvanced(spec)
+	req := CreateMonitorRequest{
+		Type:            monitorType,
+		Description:     strings.TrimSpace(spec.Description),
+		Interval:        monitorIntValue(nil, 1),
+		Timeout:         monitorIntValue(nil, 1),
+		Retries:         monitorIntValue(nil, 0),
+		ConsecutiveUp:   advanced.ConsecutiveUp,
+		ConsecutiveDown: advanced.ConsecutiveDown,
+	}
+
+	if slices.Contains(portMonitorTypes, monitorType) {
+		req.Port = spec.Port
+	}
+
+	if slices.Contains(httpMonitorTypes, monitorType) {
+		req.Method = normalizeMonitorMethod(advanced.Method)
+		if req.Method == "" {
+			req.Method = "GET"
+		}
+		req.Path = strings.TrimSpace(spec.Path)
+		if req.Path == "" {
+			req.Path = "/"
+		}
+		req.ExpectedCodes = strings.TrimSpace(advanced.ExpectedCodes)
+		if req.ExpectedCodes == "" {
+			req.ExpectedCodes = "2xx"
+		}
+		req.ExpectedBody = strings.TrimSpace(advanced.ExpectedBody)
+		req.FollowRedirects = advanced.FollowRedirects
+		if req.FollowRedirects == nil {
+			followRedirects := true
+			req.FollowRedirects = &followRedirects
+		}
+		req.ProbeZone = strings.TrimSpace(advanced.ProbeZone)
+		req.Header = monitorHeadersToMap(advanced.Headers)
+	}
+
+	if monitorType == "https" {
+		req.AllowInsecure = advanced.AllowInsecure
+	}
+
+	return req
+}
+
+func effectiveMonitorAdvanced(spec CreateMonitorSpec) CreateMonitorAdvancedSpec {
+	if spec.Advanced != nil {
+		return *spec.Advanced
+	}
+
+	return CreateMonitorAdvancedSpec{
+		Method:          spec.Method,
+		ExpectedCodes:   spec.ExpectedCodes,
+		ExpectedBody:    spec.ExpectedBody,
+		Headers:         spec.Headers,
+		FollowRedirects: spec.FollowRedirects,
+		AllowInsecure:   spec.AllowInsecure,
+		ProbeZone:       spec.ProbeZone,
+		ConsecutiveUp:   spec.ConsecutiveUp,
+		ConsecutiveDown: spec.ConsecutiveDown,
+	}
+}
+
+func monitorHeadersToMap(headers []MonitorHeader) map[string][]string {
+	result := map[string][]string{}
+	for _, header := range headers {
+		name := strings.TrimSpace(header.Name)
+		value := strings.TrimSpace(header.Value)
+		if name == "" || value == "" {
+			continue
+		}
+		result[name] = append(result[name], value)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func monitorIntValue(value *int, defaultValue int) *int {
+	if value != nil {
+		return value
+	}
+
+	return &defaultValue
+}
+
+func normalizeMonitorType(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeMonitorMethod(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+func (c *CreateMonitor) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateMonitor) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateMonitor) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateMonitor) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateMonitor) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateMonitor) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/create_monitor.go
+++ b/pkg/integrations/cloudflare/create_monitor.go
@@ -15,6 +15,16 @@ import (
 
 const MonitorPayloadType = "cloudflare.monitor"
 
+const (
+	defaultMonitorIntervalSeconds = 60
+	defaultMonitorTimeoutSeconds  = 5
+	defaultMonitorRetries         = 0
+	minMonitorIntervalSeconds     = 10
+	maxMonitorIntervalSeconds     = 86400
+	minMonitorTimeoutSeconds      = 1
+	maxMonitorRetries             = 5
+)
+
 var (
 	allowedMonitorTypes   = []string{"http", "https", "tcp", "udp_icmp", "icmp_ping", "smtp"}
 	httpMonitorTypes      = []string{"http", "https"}
@@ -91,7 +101,7 @@ func (c *CreateMonitor) Documentation() string {
 ## Configuration
 
 - **Name / Type / Path / Port**: Basic monitor settings. Path is required for HTTP and HTTPS monitors. Port is required for HTTP, HTTPS, TCP, UDP ICMP, and SMTP monitors.
-- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, and health threshold settings.
+- **Advanced Health Check Settings**: Optional method, expected response, headers, redirects, TLS, probe zone, **interval** and **timeout** (seconds; omit both to let Cloudflare pick plan defaults), **retries**, and consecutive thresholds. Plan minimum interval: Pro 60s, Business 15s, Enterprise 10s.
 - **Pool**: Optional pool to attach the created monitor to immediately.
 
 ## Output
@@ -184,6 +194,9 @@ func (c *CreateMonitor) Configuration() []configuration.Field {
 				"expectedCodes":   "2xx",
 				"followRedirects": true,
 				"allowInsecure":   false,
+				"interval":        defaultMonitorIntervalSeconds,
+				"timeout":         defaultMonitorTimeoutSeconds,
+				"retries":         defaultMonitorRetries,
 			},
 			TypeOptions: &configuration.TypeOptions{
 				Object: &configuration.ObjectTypeOptions{
@@ -286,6 +299,47 @@ func createMonitorAdvancedFields() []configuration.Field {
 			Placeholder: "example.com",
 		},
 		{
+			Name:        "interval",
+			Label:       "Interval (seconds)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     defaultMonitorIntervalSeconds,
+			Description: "Seconds between health checks. Cloudflare minimums by plan: Pro 60s, Business 15s, Enterprise 10s. Values outside your plan often return a vague API error.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := minMonitorIntervalSeconds; return &min }(),
+					Max: func() *int { max := maxMonitorIntervalSeconds; return &max }(),
+				},
+			},
+		},
+		{
+			Name:        "timeout",
+			Label:       "Timeout (seconds)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     defaultMonitorTimeoutSeconds,
+			Description: "Seconds before marking a check as failed. Must be less than the interval.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := minMonitorTimeoutSeconds; return &min }(),
+				},
+			},
+		},
+		{
+			Name:        "retries",
+			Label:       "Retries",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     defaultMonitorRetries,
+			Description: "Immediate retries after a timeout before marking the origin unhealthy",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := 0; return &min }(),
+					Max: func() *int { max := maxMonitorRetries; return &max }(),
+				},
+			},
+		},
+		{
 			Name:        "consecutiveUp",
 			Label:       "Consecutive Up",
 			Type:        configuration.FieldTypeNumber,
@@ -304,10 +358,50 @@ func createMonitorAdvancedFields() []configuration.Field {
 	}
 }
 
-func (c *CreateMonitor) Setup(ctx core.SetupContext) error {
+func decodeCreateMonitorSpec(configuration any) (CreateMonitorSpec, error) {
 	spec := CreateMonitorSpec{}
-	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
-		return fmt.Errorf("error decoding configuration: %v", err)
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		TagName:          "json",
+		Result:           &spec,
+	})
+	if err != nil {
+		return spec, fmt.Errorf("error configuring decoder: %w", err)
+	}
+
+	if err := dec.Decode(configuration); err != nil {
+		return spec, fmt.Errorf("error decoding configuration: %w", err)
+	}
+
+	return spec, nil
+}
+
+func augmentLoadBalancerMonitorCreateError(err error) error {
+	var apiErr *CloudflareAPIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+
+	for _, e := range apiErr.Errors {
+		msg := strings.ToLower(e.Message)
+		if strings.Contains(msg, "interval") && strings.Contains(msg, "not in range") {
+			return fmt.Errorf(
+				"%w — Cloudflare applies plan-specific minimum intervals for monitors (typically 60s on Pro, 15s on Business, 10s on Enterprise); "+
+					"intervals below your plan minimum produce misleading \"not in range\" errors. "+
+					"If timing fields are omitted, Cloudflare applies account defaults. "+
+					"Confirm Load Balancing is enabled and the integration Account ID matches your balancer account",
+				err,
+			)
+		}
+	}
+
+	return err
+}
+
+func (c *CreateMonitor) Setup(ctx core.SetupContext) error {
+	spec, err := decodeCreateMonitorSpec(ctx.Configuration)
+	if err != nil {
+		return err
 	}
 
 	return validateCreateMonitorSpec(spec)
@@ -360,13 +454,17 @@ func validateCreateMonitorSpec(spec CreateMonitorSpec) error {
 		}
 	}
 
+	if err := validateMonitorTiming(effectiveMonitorAdvanced(spec)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (c *CreateMonitor) Execute(ctx core.ExecutionContext) error {
-	spec := CreateMonitorSpec{}
-	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
-		return fmt.Errorf("error decoding configuration: %v", err)
+	spec, err := decodeCreateMonitorSpec(ctx.Configuration)
+	if err != nil {
+		return err
 	}
 
 	if err := validateCreateMonitorSpec(spec); err != nil {
@@ -385,7 +483,7 @@ func (c *CreateMonitor) Execute(ctx core.ExecutionContext) error {
 
 	monitor, err := client.CreateMonitor(accountID, createMonitorRequest(spec))
 	if err != nil {
-		return fmt.Errorf("failed to create monitor: %w", err)
+		return fmt.Errorf("failed to create monitor: %w", augmentLoadBalancerMonitorCreateError(err))
 	}
 
 	payload := map[string]any{
@@ -412,9 +510,9 @@ func createMonitorRequest(spec CreateMonitorSpec) CreateMonitorRequest {
 	req := CreateMonitorRequest{
 		Type:            monitorType,
 		Description:     strings.TrimSpace(spec.Description),
-		Interval:        monitorIntValue(nil, 1),
-		Timeout:         monitorIntValue(nil, 1),
-		Retries:         monitorIntValue(nil, 0),
+		Interval:        advanced.Interval,
+		Timeout:         advanced.Timeout,
+		Retries:         advanced.Retries,
 		ConsecutiveUp:   advanced.ConsecutiveUp,
 		ConsecutiveDown: advanced.ConsecutiveDown,
 	}
@@ -455,7 +553,17 @@ func createMonitorRequest(spec CreateMonitorSpec) CreateMonitorRequest {
 
 func effectiveMonitorAdvanced(spec CreateMonitorSpec) CreateMonitorAdvancedSpec {
 	if spec.Advanced != nil {
-		return *spec.Advanced
+		out := *spec.Advanced
+		if out.Interval == nil {
+			out.Interval = spec.Interval
+		}
+		if out.Timeout == nil {
+			out.Timeout = spec.Timeout
+		}
+		if out.Retries == nil {
+			out.Retries = spec.Retries
+		}
+		return out
 	}
 
 	return CreateMonitorAdvancedSpec{
@@ -466,9 +574,57 @@ func effectiveMonitorAdvanced(spec CreateMonitorSpec) CreateMonitorAdvancedSpec 
 		FollowRedirects: spec.FollowRedirects,
 		AllowInsecure:   spec.AllowInsecure,
 		ProbeZone:       spec.ProbeZone,
+		Interval:        spec.Interval,
+		Timeout:         spec.Timeout,
+		Retries:         spec.Retries,
 		ConsecutiveUp:   spec.ConsecutiveUp,
 		ConsecutiveDown: spec.ConsecutiveDown,
 	}
+}
+
+func resolvedMonitorTiming(advanced CreateMonitorAdvancedSpec) (interval int, timeout int, retries int) {
+	interval = defaultMonitorIntervalSeconds
+	if advanced.Interval != nil {
+		interval = *advanced.Interval
+	}
+
+	timeout = defaultMonitorTimeoutSeconds
+	if advanced.Timeout != nil {
+		timeout = *advanced.Timeout
+	}
+
+	retries = defaultMonitorRetries
+	if advanced.Retries != nil {
+		retries = *advanced.Retries
+	}
+
+	return interval, timeout, retries
+}
+
+func validateMonitorTiming(advanced CreateMonitorAdvancedSpec) error {
+	if advanced.Interval != nil {
+		if *advanced.Interval < minMonitorIntervalSeconds {
+			return fmt.Errorf("interval must be at least %d seconds", minMonitorIntervalSeconds)
+		}
+		if *advanced.Interval > maxMonitorIntervalSeconds {
+			return fmt.Errorf("interval must be at most %d seconds", maxMonitorIntervalSeconds)
+		}
+	}
+
+	if advanced.Timeout != nil && *advanced.Timeout < minMonitorTimeoutSeconds {
+		return fmt.Errorf("timeout must be at least %d second(s)", minMonitorTimeoutSeconds)
+	}
+
+	if advanced.Retries != nil && (*advanced.Retries < 0 || *advanced.Retries > maxMonitorRetries) {
+		return fmt.Errorf("retries must be between 0 and %d", maxMonitorRetries)
+	}
+
+	interval, timeout, _ := resolvedMonitorTiming(advanced)
+	if timeout >= interval {
+		return fmt.Errorf("timeout (%ds) must be less than interval (%ds)", timeout, interval)
+	}
+
+	return nil
 }
 
 func monitorHeadersToMap(headers []MonitorHeader) map[string][]string {
@@ -485,14 +641,6 @@ func monitorHeadersToMap(headers []MonitorHeader) map[string][]string {
 		return nil
 	}
 	return result
-}
-
-func monitorIntValue(value *int, defaultValue int) *int {
-	if value != nil {
-		return value
-	}
-
-	return &defaultValue
 }
 
 func normalizeMonitorType(value string) string {

--- a/pkg/integrations/cloudflare/create_monitor.go
+++ b/pkg/integrations/cloudflare/create_monitor.go
@@ -13,7 +13,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
-const MonitorPayloadType = "cloudflare.monitor"
+// CreateMonitorPayloadType is the emitted execution payload type (dash0-style: integration.resource.operation).
+const CreateMonitorPayloadType = "cloudflare.monitor.created"
 
 const (
 	defaultMonitorIntervalSeconds = 60
@@ -504,7 +505,7 @@ func (c *CreateMonitor) Execute(ctx core.ExecutionContext) error {
 		payload["poolId"] = spec.Pool
 	}
 
-	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, MonitorPayloadType, []any{payload})
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, CreateMonitorPayloadType, []any{payload})
 }
 
 func createMonitorRequest(spec CreateMonitorSpec) CreateMonitorRequest {

--- a/pkg/integrations/cloudflare/create_monitor.go
+++ b/pkg/integrations/cloudflare/create_monitor.go
@@ -46,20 +46,13 @@ type CreateMonitorSpec struct {
 	Port        *int                       `json:"port"`
 	Advanced    *CreateMonitorAdvancedSpec `json:"advanced"`
 	Pool        string                     `json:"pool"`
-
-	// Legacy flat fields are kept for existing saved nodes. New nodes use Advanced.
-	Method          string          `json:"method"`
-	ExpectedCodes   string          `json:"expectedCodes"`
-	ExpectedBody    string          `json:"expectedBody"`
-	Headers         []MonitorHeader `json:"headers"`
-	FollowRedirects *bool           `json:"followRedirects"`
-	AllowInsecure   *bool           `json:"allowInsecure"`
-	ProbeZone       string          `json:"probeZone"`
-	Interval        *int            `json:"interval"`
-	Timeout         *int            `json:"timeout"`
-	Retries         *int            `json:"retries"`
-	ConsecutiveUp   *int            `json:"consecutiveUp"`
-	ConsecutiveDown *int            `json:"consecutiveDown"`
+	// Flat timing/threshold fields from legacy workflows or alongside partial `advanced`
+	// objects when nested pointers are unset.
+	Interval        *int `json:"interval,omitempty"`
+	Timeout         *int `json:"timeout,omitempty"`
+	Retries         *int `json:"retries,omitempty"`
+	ConsecutiveUp   *int `json:"consecutiveUp,omitempty"`
+	ConsecutiveDown *int `json:"consecutiveDown,omitempty"`
 }
 
 type CreateMonitorAdvancedSpec struct {
@@ -404,7 +397,21 @@ func (c *CreateMonitor) Setup(ctx core.SetupContext) error {
 		return err
 	}
 
-	return validateCreateMonitorSpec(spec)
+	if err := validateCreateMonitorSpec(spec); err != nil {
+		return err
+	}
+
+	poolID := strings.TrimSpace(spec.Pool)
+	if poolID == "" {
+		return nil
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	return resolvePoolMetadata(ctx, accountID, poolID)
 }
 
 func validateCreateMonitorSpec(spec CreateMonitorSpec) error {
@@ -454,11 +461,7 @@ func validateCreateMonitorSpec(spec CreateMonitorSpec) error {
 		}
 	}
 
-	if err := validateMonitorTiming(effectiveMonitorAdvanced(spec)); err != nil {
-		return err
-	}
-
-	return nil
+	return validateMonitorTiming(effectiveMonitorAdvanced(spec))
 }
 
 func (c *CreateMonitor) Execute(ctx core.ExecutionContext) error {
@@ -552,34 +555,26 @@ func createMonitorRequest(spec CreateMonitorSpec) CreateMonitorRequest {
 }
 
 func effectiveMonitorAdvanced(spec CreateMonitorSpec) CreateMonitorAdvancedSpec {
+	var adv CreateMonitorAdvancedSpec
 	if spec.Advanced != nil {
-		out := *spec.Advanced
-		if out.Interval == nil {
-			out.Interval = spec.Interval
-		}
-		if out.Timeout == nil {
-			out.Timeout = spec.Timeout
-		}
-		if out.Retries == nil {
-			out.Retries = spec.Retries
-		}
-		return out
+		adv = *spec.Advanced
 	}
-
-	return CreateMonitorAdvancedSpec{
-		Method:          spec.Method,
-		ExpectedCodes:   spec.ExpectedCodes,
-		ExpectedBody:    spec.ExpectedBody,
-		Headers:         spec.Headers,
-		FollowRedirects: spec.FollowRedirects,
-		AllowInsecure:   spec.AllowInsecure,
-		ProbeZone:       spec.ProbeZone,
-		Interval:        spec.Interval,
-		Timeout:         spec.Timeout,
-		Retries:         spec.Retries,
-		ConsecutiveUp:   spec.ConsecutiveUp,
-		ConsecutiveDown: spec.ConsecutiveDown,
+	if adv.Interval == nil {
+		adv.Interval = spec.Interval
 	}
+	if adv.Timeout == nil {
+		adv.Timeout = spec.Timeout
+	}
+	if adv.Retries == nil {
+		adv.Retries = spec.Retries
+	}
+	if adv.ConsecutiveUp == nil {
+		adv.ConsecutiveUp = spec.ConsecutiveUp
+	}
+	if adv.ConsecutiveDown == nil {
+		adv.ConsecutiveDown = spec.ConsecutiveDown
+	}
+	return adv
 }
 
 func resolvedMonitorTiming(advanced CreateMonitorAdvancedSpec) (interval int, timeout int, retries int) {

--- a/pkg/integrations/cloudflare/create_monitor_test.go
+++ b/pkg/integrations/cloudflare/create_monitor_test.go
@@ -48,7 +48,7 @@ func Test__CreateMonitor__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "port is required")
 	})
 
-	t.Run("stale advanced timing is ignored", func(t *testing.T) {
+	t.Run("advanced interval below Cloudflare minimum fails", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
 				"type":        "https",
@@ -56,14 +56,31 @@ func Test__CreateMonitor__Setup(t *testing.T) {
 				"path":        "/health",
 				"port":        443,
 				"advanced": map[string]any{
-					"interval": 1,
+					"interval": 9,
 					"timeout":  5,
-					"retries":  2,
 				},
 			},
 		})
 
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "interval must be at least")
+	})
+
+	t.Run("advanced timeout must be less than interval", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+				"advanced": map[string]any{
+					"interval": 60,
+					"timeout":  60,
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "timeout")
+		require.ErrorContains(t, err, "must be less than interval")
 	})
 
 	t.Run("valid https monitor passes", func(t *testing.T) {
@@ -112,16 +129,13 @@ func Test__CreateMonitor__Configuration(t *testing.T) {
 	require.NotNil(t, advanced.TypeOptions)
 	require.NotNil(t, advanced.TypeOptions.Object)
 	assert.NotEmpty(t, advanced.TypeOptions.Object.Schema)
-	for _, fieldName := range []string{"interval", "timeout", "retries"} {
-		for _, field := range advanced.TypeOptions.Object.Schema {
-			assert.NotEqual(t, fieldName, field.Name)
-		}
-	}
 
+	names := map[string]bool{}
+	for _, field := range advanced.TypeOptions.Object.Schema {
+		names[field.Name] = true
+	}
 	for _, fieldName := range []string{"interval", "timeout", "retries"} {
-		for _, field := range fields {
-			assert.NotEqual(t, fieldName, field.Name)
-		}
+		assert.True(t, names[fieldName], "advanced schema should include %s", fieldName)
 	}
 }
 
@@ -140,18 +154,15 @@ func Test__CreateMonitor__CreateMonitorRequest(t *testing.T) {
 	assert.Equal(t, 443, *req.Port)
 	assert.Equal(t, "GET", req.Method)
 	assert.Equal(t, "2xx", req.ExpectedCodes)
-	require.NotNil(t, req.Interval)
-	assert.Equal(t, 1, *req.Interval)
-	require.NotNil(t, req.Timeout)
-	assert.Equal(t, 1, *req.Timeout)
-	require.NotNil(t, req.Retries)
-	assert.Equal(t, 0, *req.Retries)
+	assert.Nil(t, req.Interval)
+	assert.Nil(t, req.Timeout)
+	assert.Nil(t, req.Retries)
 	require.NotNil(t, req.FollowRedirects)
 	assert.True(t, *req.FollowRedirects)
 
-	interval := 60
-	timeout := 5
-	retries := 2
+	interval := 120
+	timeout := 8
+	retries := 3
 	req = createMonitorRequest(CreateMonitorSpec{
 		Type:        "https",
 		Description: "API health",
@@ -165,11 +176,11 @@ func Test__CreateMonitor__CreateMonitorRequest(t *testing.T) {
 	})
 
 	require.NotNil(t, req.Interval)
-	assert.Equal(t, 1, *req.Interval)
+	assert.Equal(t, interval, *req.Interval)
 	require.NotNil(t, req.Timeout)
-	assert.Equal(t, 1, *req.Timeout)
+	assert.Equal(t, timeout, *req.Timeout)
 	require.NotNil(t, req.Retries)
-	assert.Equal(t, 0, *req.Retries)
+	assert.Equal(t, retries, *req.Retries)
 }
 
 func Test__CreateMonitor__Execute(t *testing.T) {
@@ -246,6 +257,42 @@ func Test__CreateMonitor__Execute(t *testing.T) {
 		assert.Equal(t, "https", body["type"])
 		assert.Equal(t, "/health", body["path"])
 		assert.Equal(t, "2xx", body["expected_codes"])
+		assert.NotContains(t, body, "interval")
+		assert.NotContains(t, body, "timeout")
+		assert.NotContains(t, body, "retries")
 		assert.Equal(t, map[string]any{"Host": []any{"api.example.com"}}, body["header"])
 	})
+}
+
+func Test__decodeCreateMonitorSpec__weakNumericTypes(t *testing.T) {
+	spec, err := decodeCreateMonitorSpec(map[string]any{
+		"type":        "https",
+		"description": "API health",
+		"path":        "/health",
+		"port":        float64(443),
+		"advanced": map[string]any{
+			"interval": float64(16),
+			"timeout":  float64(5),
+			"retries":  float64(2),
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, spec.Advanced)
+	require.NotNil(t, spec.Advanced.Interval)
+	require.NotNil(t, spec.Advanced.Timeout)
+	require.NotNil(t, spec.Advanced.Retries)
+	assert.Equal(t, 16, *spec.Advanced.Interval)
+	assert.Equal(t, 5, *spec.Advanced.Timeout)
+	assert.Equal(t, 2, *spec.Advanced.Retries)
+}
+
+func Test__augmentLoadBalancerMonitorCreateError(t *testing.T) {
+	apiErr := newCloudflareAPIError(http.StatusBadRequest, []byte(
+		`{"success":false,"errors":[{"code":1002,"message":"interval is not in range [1, 1]: validation failed"}]}`,
+	))
+
+	out := augmentLoadBalancerMonitorCreateError(apiErr)
+	require.ErrorIs(t, out, apiErr)
+	require.Contains(t, out.Error(), "plan-specific")
 }

--- a/pkg/integrations/cloudflare/create_monitor_test.go
+++ b/pkg/integrations/cloudflare/create_monitor_test.go
@@ -95,6 +95,63 @@ func Test__CreateMonitor__Setup(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("optional pool resolves pool name metadata when accountId is configured", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+				"pool":        "pool123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "pool123", "name": "my-pool"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		poolMeta, ok := meta.Metadata.(PoolNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "my-pool", poolMeta.PoolName)
+	})
+
+	t.Run("pool without accountId returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+				"pool":        "pool123",
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "accountId is required")
+	})
 }
 
 func Test__CreateMonitor__Configuration(t *testing.T) {
@@ -224,15 +281,17 @@ func Test__CreateMonitor__Execute(t *testing.T) {
 		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"type":          "https",
-				"description":   "API health",
-				"method":        "GET",
-				"path":          "/health",
-				"port":          443,
-				"expectedCodes": "2xx",
-				"pool":          "pool123",
-				"headers": []map[string]any{
-					{"name": "Host", "value": "api.example.com"},
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+				"pool":        "pool123",
+				"advanced": map[string]any{
+					"method":        "GET",
+					"expectedCodes": "2xx",
+					"headers": []map[string]any{
+						{"name": "Host", "value": "api.example.com"},
+					},
 				},
 			},
 			HTTP: httpContext,
@@ -262,6 +321,73 @@ func Test__CreateMonitor__Execute(t *testing.T) {
 		assert.NotContains(t, body, "retries")
 		assert.Equal(t, map[string]any{"Host": []any{"api.example.com"}}, body["header"])
 	})
+}
+
+func Test__effectiveMonitorAdvanced__mergesFlatLegacyFields(t *testing.T) {
+	t.Run("partial advanced inherits flat consecutive thresholds", func(t *testing.T) {
+		cu := 2
+		cd := 4
+		adv := effectiveMonitorAdvanced(CreateMonitorSpec{
+			Advanced: &CreateMonitorAdvancedSpec{
+				Interval: func() *int { i := 60; return &i }(),
+				Timeout:  func() *int { t := 5; return &t }(),
+			},
+			ConsecutiveUp:   &cu,
+			ConsecutiveDown: &cd,
+		})
+		require.NotNil(t, adv.Interval)
+		require.NotNil(t, adv.ConsecutiveUp)
+		require.NotNil(t, adv.ConsecutiveDown)
+		assert.Equal(t, 60, *adv.Interval)
+		assert.Equal(t, 2, *adv.ConsecutiveUp)
+		assert.Equal(t, 4, *adv.ConsecutiveDown)
+	})
+
+	t.Run("advanced timing overrides flat timing when both set", func(t *testing.T) {
+		adv := effectiveMonitorAdvanced(CreateMonitorSpec{
+			Interval: func() *int { i := 999; return &i }(),
+			Advanced: &CreateMonitorAdvancedSpec{
+				Interval: func() *int { i := 120; return &i }(),
+			},
+		})
+		require.NotNil(t, adv.Interval)
+		assert.Equal(t, 120, *adv.Interval)
+	})
+
+	t.Run("flat fields used when advanced is nil", func(t *testing.T) {
+		adv := effectiveMonitorAdvanced(CreateMonitorSpec{
+			Interval: func() *int { i := 30; return &i }(),
+			Retries:  func() *int { i := 1; return &i }(),
+		})
+		require.NotNil(t, adv.Interval)
+		require.NotNil(t, adv.Retries)
+		assert.Equal(t, 30, *adv.Interval)
+		assert.Equal(t, 1, *adv.Retries)
+	})
+}
+
+func Test__decodeCreateMonitorSpec__flatConsecutiveWithPartialAdvanced(t *testing.T) {
+	spec, err := decodeCreateMonitorSpec(map[string]any{
+		"type":          "https",
+		"description":   "API health",
+		"path":          "/health",
+		"port":          float64(443),
+		"consecutiveUp": float64(2),
+		"advanced": map[string]any{
+			"interval": float64(60),
+			"timeout":  float64(5),
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, spec.ConsecutiveUp)
+	assert.Equal(t, 2, *spec.ConsecutiveUp)
+
+	req := createMonitorRequest(spec)
+	require.NotNil(t, req.ConsecutiveUp)
+	assert.Equal(t, 2, *req.ConsecutiveUp)
+	require.NotNil(t, req.Interval)
+	assert.Equal(t, 60, *req.Interval)
 }
 
 func Test__decodeCreateMonitorSpec__weakNumericTypes(t *testing.T) {

--- a/pkg/integrations/cloudflare/create_monitor_test.go
+++ b/pkg/integrations/cloudflare/create_monitor_test.go
@@ -305,7 +305,7 @@ func Test__CreateMonitor__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.Equal(t, MonitorPayloadType, execState.Type)
+		assert.Equal(t, CreateMonitorPayloadType, execState.Type)
 		require.Len(t, execState.Payloads, 1)
 		require.Len(t, httpContext.Requests, 2)
 		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors", httpContext.Requests[0].URL.String())

--- a/pkg/integrations/cloudflare/create_monitor_test.go
+++ b/pkg/integrations/cloudflare/create_monitor_test.go
@@ -1,0 +1,251 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateMonitor__Setup(t *testing.T) {
+	component := &CreateMonitor{}
+
+	t.Run("missing type returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "type is required")
+	})
+
+	t.Run("http monitor requires path", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"port":        443,
+			},
+		})
+
+		require.ErrorContains(t, err, "path is required")
+	})
+
+	t.Run("tcp monitor requires port", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "tcp",
+				"description": "API health",
+			},
+		})
+
+		require.ErrorContains(t, err, "port is required")
+	})
+
+	t.Run("stale advanced timing is ignored", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+				"advanced": map[string]any{
+					"interval": 1,
+					"timeout":  5,
+					"retries":  2,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("valid https monitor passes", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"type":        "https",
+				"description": "API health",
+				"path":        "/health",
+				"port":        443,
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateMonitor__Configuration(t *testing.T) {
+	component := &CreateMonitor{}
+	fields := component.Configuration()
+
+	requireField := func(name string) configuration.Field {
+		t.Helper()
+		for _, field := range fields {
+			if field.Name == name {
+				return field
+			}
+		}
+
+		t.Fatalf("field %s not found", name)
+		return configuration.Field{}
+	}
+
+	path := requireField("path")
+	assert.Equal(t, "/", path.Default)
+	require.Len(t, path.RequiredConditions, 1)
+	assert.Equal(t, "type", path.RequiredConditions[0].Field)
+	assert.Equal(t, httpMonitorTypes, path.RequiredConditions[0].Values)
+
+	port := requireField("port")
+	require.Len(t, port.RequiredConditions, 1)
+	assert.Equal(t, "type", port.RequiredConditions[0].Field)
+	assert.Equal(t, portMonitorTypes, port.RequiredConditions[0].Values)
+
+	advanced := requireField("advanced")
+	assert.True(t, advanced.Togglable)
+	require.NotNil(t, advanced.TypeOptions)
+	require.NotNil(t, advanced.TypeOptions.Object)
+	assert.NotEmpty(t, advanced.TypeOptions.Object.Schema)
+	for _, fieldName := range []string{"interval", "timeout", "retries"} {
+		for _, field := range advanced.TypeOptions.Object.Schema {
+			assert.NotEqual(t, fieldName, field.Name)
+		}
+	}
+
+	for _, fieldName := range []string{"interval", "timeout", "retries"} {
+		for _, field := range fields {
+			assert.NotEqual(t, fieldName, field.Name)
+		}
+	}
+}
+
+func Test__CreateMonitor__CreateMonitorRequest(t *testing.T) {
+	req := createMonitorRequest(CreateMonitorSpec{
+		Type:        "https",
+		Description: "API health",
+		Path:        "/health",
+		Port:        func() *int { port := 443; return &port }(),
+	})
+
+	assert.Equal(t, "https", req.Type)
+	assert.Equal(t, "API health", req.Description)
+	assert.Equal(t, "/health", req.Path)
+	require.NotNil(t, req.Port)
+	assert.Equal(t, 443, *req.Port)
+	assert.Equal(t, "GET", req.Method)
+	assert.Equal(t, "2xx", req.ExpectedCodes)
+	require.NotNil(t, req.Interval)
+	assert.Equal(t, 1, *req.Interval)
+	require.NotNil(t, req.Timeout)
+	assert.Equal(t, 1, *req.Timeout)
+	require.NotNil(t, req.Retries)
+	assert.Equal(t, 0, *req.Retries)
+	require.NotNil(t, req.FollowRedirects)
+	assert.True(t, *req.FollowRedirects)
+
+	interval := 60
+	timeout := 5
+	retries := 2
+	req = createMonitorRequest(CreateMonitorSpec{
+		Type:        "https",
+		Description: "API health",
+		Path:        "/health",
+		Port:        func() *int { port := 443; return &port }(),
+		Advanced: &CreateMonitorAdvancedSpec{
+			Interval: &interval,
+			Timeout:  &timeout,
+			Retries:  &retries,
+		},
+	})
+
+	require.NotNil(t, req.Interval)
+	assert.Equal(t, 1, *req.Interval)
+	require.NotNil(t, req.Timeout)
+	assert.Equal(t, 1, *req.Timeout)
+	require.NotNil(t, req.Retries)
+	assert.Equal(t, 0, *req.Retries)
+}
+
+func Test__CreateMonitor__Execute(t *testing.T) {
+	component := &CreateMonitor{}
+
+	t.Run("creates monitor and attaches it to pool", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"success": true,
+							"result": {
+								"id": "monitor123",
+								"type": "https",
+								"description": "API health",
+								"path": "/health",
+								"method": "GET",
+								"expected_codes": "2xx"
+							}
+						}
+					`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"success": true,
+							"result": {
+								"id": "pool123",
+								"name": "Production",
+								"monitor": "monitor123"
+							}
+						}
+					`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"type":          "https",
+				"description":   "API health",
+				"method":        "GET",
+				"path":          "/health",
+				"port":          443,
+				"expectedCodes": "2xx",
+				"pool":          "pool123",
+				"headers": []map[string]any{
+					{"name": "Host", "value": "api.example.com"},
+				},
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: execState,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, MonitorPayloadType, execState.Type)
+		require.Len(t, execState.Payloads, 1)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors", httpContext.Requests[0].URL.String())
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/pools/pool123", httpContext.Requests[1].URL.String())
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(httpContext.Requests[0].Body).Decode(&body))
+		assert.Equal(t, "https", body["type"])
+		assert.Equal(t, "/health", body["path"])
+		assert.Equal(t, "2xx", body["expected_codes"])
+		assert.Equal(t, map[string]any{"Host": []any{"api.example.com"}}, body["header"])
+	})
+}

--- a/pkg/integrations/cloudflare/delete_monitor.go
+++ b/pkg/integrations/cloudflare/delete_monitor.go
@@ -1,0 +1,226 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteMonitor struct{}
+
+type DeleteMonitorSpec struct {
+	Monitor string `json:"monitor"`
+	Force   bool   `json:"force"`
+}
+
+// MonitorNodeMetadata stores the resolved monitor identity for workflow canvas UI.
+type MonitorNodeMetadata struct {
+	MonitorID          string `json:"monitorId" mapstructure:"monitorId"`
+	MonitorDescription string `json:"monitorDescription" mapstructure:"monitorDescription"`
+}
+
+func (c *DeleteMonitor) Name() string {
+	return "cloudflare.deleteMonitor"
+}
+
+func (c *DeleteMonitor) Label() string {
+	return "Delete Monitor"
+}
+
+func (c *DeleteMonitor) Description() string {
+	return "Delete a Cloudflare load balancing health monitor"
+}
+
+func (c *DeleteMonitor) Documentation() string {
+	return `The Delete Monitor component removes a Cloudflare Load Balancing health monitor.
+
+## Use Cases
+
+- **Cleanup**: Delete monitor definitions when load balancing resources are decommissioned
+- **Rollback**: Remove monitors created during test or migration workflows
+
+## Configuration
+
+- **Monitor**: The monitor to delete.
+- **Force**: Delete even when Cloudflare reports that pools or other resources reference the monitor.
+
+## Output
+
+Emits the deleted monitor ID and any references Cloudflare reported before deletion.`
+}
+
+func (c *DeleteMonitor) Icon() string {
+	return "activity"
+}
+
+func (c *DeleteMonitor) Color() string {
+	return "orange"
+}
+
+func (c *DeleteMonitor) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteMonitor) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "monitor",
+			Label:       "Monitor",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The load balancing health monitor to delete",
+			Placeholder: "Select a monitor",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "monitor",
+				},
+			},
+		},
+		{
+			Name:        "force",
+			Label:       "Force",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     false,
+			Description: "Delete even when Cloudflare reports references to this monitor",
+		},
+	}
+}
+
+func (c *DeleteMonitor) Setup(ctx core.SetupContext) error {
+	spec := DeleteMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	return resolveMonitorMetadata(ctx, monitorID)
+}
+
+func resolveMonitorMetadata(ctx core.SetupContext, monitorID string) error {
+	if ctx.Metadata == nil || ctx.Integration == nil || ctx.HTTP == nil {
+		return nil
+	}
+
+	id := strings.TrimSpace(monitorID)
+	if strings.Contains(id, "{{") {
+		return ctx.Metadata.Set(MonitorNodeMetadata{
+			MonitorID:          id,
+			MonitorDescription: id,
+		})
+	}
+
+	var existing MonitorNodeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &existing); err == nil && existing.MonitorID == id && existing.MonitorDescription != "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client for monitor metadata: %w", err)
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	monitor, err := client.GetMonitor(accountID, id)
+	if err != nil {
+		return fmt.Errorf("failed to fetch monitor %s for metadata: %w", id, err)
+	}
+
+	desc := strings.TrimSpace(monitor.Description)
+	if desc == "" {
+		desc = id
+	}
+
+	return ctx.Metadata.Set(MonitorNodeMetadata{
+		MonitorID:          id,
+		MonitorDescription: desc,
+	})
+}
+
+func (c *DeleteMonitor) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	references, err := client.ListMonitorReferences(accountID, monitorID)
+	if err != nil {
+		return fmt.Errorf("failed to list monitor references: %w", err)
+	}
+
+	if len(references) > 0 && !spec.Force {
+		return fmt.Errorf("monitor %s is still referenced by %d resource(s); set force to delete anyway", monitorID, len(references))
+	}
+
+	deleted, err := client.DeleteMonitor(accountID, monitorID)
+	if err != nil {
+		return fmt.Errorf("failed to delete monitor: %w", err)
+	}
+
+	deletedID := deleted.ID
+	if deletedID == "" {
+		deletedID = monitorID
+	}
+
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, MonitorPayloadType, []any{
+		map[string]any{
+			"accountId":  accountID,
+			"monitorId":  deletedID,
+			"deleted":    true,
+			"references": references,
+		},
+	})
+}
+
+func (c *DeleteMonitor) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteMonitor) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteMonitor) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteMonitor) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteMonitor) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteMonitor) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/delete_monitor.go
+++ b/pkg/integrations/cloudflare/delete_monitor.go
@@ -12,6 +12,9 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
+// DeleteMonitorPayloadType is the emitted execution payload type (dash0-style: integration.resource.operation).
+const DeleteMonitorPayloadType = "cloudflare.monitor.deleted"
+
 type DeleteMonitor struct{}
 
 type DeleteMonitorSpec struct {
@@ -191,7 +194,7 @@ func (c *DeleteMonitor) Execute(ctx core.ExecutionContext) error {
 		deletedID = monitorID
 	}
 
-	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, MonitorPayloadType, []any{
+	return ctx.ExecutionState.Emit(core.DefaultOutputChannel.Name, DeleteMonitorPayloadType, []any{
 		map[string]any{
 			"accountId":  accountID,
 			"monitorId":  deletedID,

--- a/pkg/integrations/cloudflare/delete_monitor_test.go
+++ b/pkg/integrations/cloudflare/delete_monitor_test.go
@@ -1,0 +1,154 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteMonitor__Setup(t *testing.T) {
+	component := &DeleteMonitor{}
+
+	t.Run("missing monitor returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "monitor is required")
+	})
+
+	t.Run("validation passes without metadata resolution when integration context is absent", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("resolves monitor metadata when integration is available", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"success":true,"result":{"id":"monitor123","description":"Edge health"}}`,
+					)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP:     httpContext,
+			Metadata: metadata,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+
+		var meta MonitorNodeMetadata
+		require.NoError(t, mapstructure.Decode(metadata.Metadata, &meta))
+		assert.Equal(t, "monitor123", meta.MonitorID)
+		assert.Equal(t, "Edge health", meta.MonitorDescription)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(
+			t,
+			"https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123",
+			httpContext.Requests[0].URL.String(),
+		)
+	})
+}
+
+func Test__DeleteMonitor__Execute(t *testing.T) {
+	component := &DeleteMonitor{}
+
+	t.Run("refuses to delete referenced monitor without force", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						{
+							"success": true,
+							"result": [
+								{"resource_type": "pool", "resource_id": "pool123", "resource_name": "Production"}
+							]
+						}
+					`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+
+		require.ErrorContains(t, err, "set force to delete anyway")
+		require.Len(t, httpContext.Requests, 1)
+	})
+
+	t.Run("deletes unreferenced monitor", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": []}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "monitor123"}}`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: execState,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, MonitorPayloadType, execState.Type)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123/references", httpContext.Requests[0].URL.String())
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123", httpContext.Requests[1].URL.String())
+	})
+}

--- a/pkg/integrations/cloudflare/delete_monitor_test.go
+++ b/pkg/integrations/cloudflare/delete_monitor_test.go
@@ -146,7 +146,7 @@ func Test__DeleteMonitor__Execute(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.Equal(t, MonitorPayloadType, execState.Type)
+		assert.Equal(t, DeleteMonitorPayloadType, execState.Type)
 		require.Len(t, httpContext.Requests, 2)
 		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123/references", httpContext.Requests[0].URL.String())
 		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123", httpContext.Requests[1].URL.String())

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -13,11 +13,29 @@ var exampleOutputUpdateRedirectRuleBytes []byte
 //go:embed example_output_create_dns_record.json
 var exampleOutputCreateDNSRecordBytes []byte
 
+//go:embed example_output_create_monitor.json
+var exampleOutputCreateMonitorBytes []byte
+
+//go:embed example_output_delete_monitor.json
+var exampleOutputDeleteMonitorBytes []byte
+
+//go:embed example_data_on_load_balancing_health_alert.json
+var exampleDataOnLoadBalancingHealthAlertBytes []byte
+
 var exampleOutputUpdateRedirectRuleOnce sync.Once
 var exampleOutputUpdateRedirectRule map[string]any
 
 var exampleOutputCreateDNSRecordOnce sync.Once
 var exampleOutputCreateDNSRecord map[string]any
+
+var exampleOutputCreateMonitorOnce sync.Once
+var exampleOutputCreateMonitor map[string]any
+
+var exampleOutputDeleteMonitorOnce sync.Once
+var exampleOutputDeleteMonitor map[string]any
+
+var exampleDataOnLoadBalancingHealthAlertOnce sync.Once
+var exampleDataOnLoadBalancingHealthAlert map[string]any
 
 func (c *CreateDNSRecord) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateDNSRecordOnce, exampleOutputCreateDNSRecordBytes, &exampleOutputCreateDNSRecord)
@@ -25,6 +43,18 @@ func (c *CreateDNSRecord) ExampleOutput() map[string]any {
 
 func (c *UpdateRedirectRule) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateRedirectRuleOnce, exampleOutputUpdateRedirectRuleBytes, &exampleOutputUpdateRedirectRule)
+}
+
+func (c *CreateMonitor) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateMonitorOnce, exampleOutputCreateMonitorBytes, &exampleOutputCreateMonitor)
+}
+
+func (c *DeleteMonitor) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteMonitorOnce, exampleOutputDeleteMonitorBytes, &exampleOutputDeleteMonitor)
+}
+
+func (t *OnLoadBalancingHealthAlert) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnLoadBalancingHealthAlertOnce, exampleDataOnLoadBalancingHealthAlertBytes, &exampleDataOnLoadBalancingHealthAlert)
 }
 
 //go:embed example_output_update_dns_record.json

--- a/pkg/integrations/cloudflare/example_data_on_load_balancing_health_alert.json
+++ b/pkg/integrations/cloudflare/example_data_on_load_balancing_health_alert.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "account_id": "account_abc123",
+    "alert_type": "load_balancing_health_alert",
+    "event_source": "origin",
+    "new_health": "Unhealthy",
+    "pool_id": "pool_xyz789",
+    "pool_name": "Production pool",
+    "origin_name": "api-primary",
+    "load_balancer_id": "lb_123",
+    "load_balancer_name": "api.example.com"
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.loadBalancing.healthAlert"
+}

--- a/pkg/integrations/cloudflare/example_output_create_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_create_monitor.json
@@ -9,8 +9,8 @@
       "method": "GET",
       "path": "/health",
       "expected_codes": "2xx",
-      "interval": 1,
-      "timeout": 1,
+      "interval": 60,
+      "timeout": 5,
       "retries": 0,
       "consecutive_up": 2,
       "consecutive_down": 3

--- a/pkg/integrations/cloudflare/example_output_create_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_create_monitor.json
@@ -23,5 +23,5 @@
     }
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor"
+  "type": "cloudflare.monitor.created"
 }

--- a/pkg/integrations/cloudflare/example_output_create_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_create_monitor.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitorId": "monitor_abc123",
+    "monitor": {
+      "id": "monitor_abc123",
+      "type": "https",
+      "description": "Login page monitor",
+      "method": "GET",
+      "path": "/health",
+      "expected_codes": "2xx",
+      "interval": 1,
+      "timeout": 1,
+      "retries": 0,
+      "consecutive_up": 2,
+      "consecutive_down": 3
+    },
+    "poolId": "pool_xyz789",
+    "pool": {
+      "id": "pool_xyz789",
+      "name": "Production pool",
+      "monitor": "monitor_abc123"
+    }
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor"
+}

--- a/pkg/integrations/cloudflare/example_output_delete_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_delete_monitor.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitorId": "monitor_abc123",
+    "deleted": true,
+    "references": []
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.monitor"
+}

--- a/pkg/integrations/cloudflare/example_output_delete_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_delete_monitor.json
@@ -6,5 +6,5 @@
     "references": []
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
-  "type": "cloudflare.monitor"
+  "type": "cloudflare.monitor.deleted"
 }

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
@@ -271,18 +271,25 @@ func (t *OnLoadBalancingHealthAlert) HandleWebhook(ctx core.WebhookRequestContex
 		return http.StatusOK, nil, nil
 	}
 
-	if err := ctx.Events.Emit(LoadBalancingHealthAlertPayloadType, payload); err != nil {
+	if err := ctx.Events.Emit(LoadBalancingHealthAlertPayloadType, healthAlertWebhookEventData(payload)); err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
 
 	return http.StatusOK, nil, nil
 }
 
-func healthAlertPayloadMatchesSpec(spec OnLoadBalancingHealthAlertSpec, payload map[string]any) bool {
-	data := payload
+// healthAlertWebhookEventData returns the object stored on the workflow event. Cloudflare may POST either
+// flat alert fields or the same fields nested under a top-level "data" key; matching uses the same unwrap
+// rule as healthAlertPayloadMatchesSpec.
+func healthAlertWebhookEventData(payload map[string]any) map[string]any {
 	if nested, ok := payload["data"].(map[string]any); ok && nested != nil {
-		data = nested
+		return nested
 	}
+	return payload
+}
+
+func healthAlertPayloadMatchesSpec(spec OnLoadBalancingHealthAlertSpec, payload map[string]any) bool {
+	data := healthAlertWebhookEventData(payload)
 
 	if spec.Pool != "" {
 		if strings.TrimSpace(healthAlertFieldString(data["pool_id"])) != spec.Pool {

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
@@ -57,7 +57,19 @@ func (t *OnLoadBalancingHealthAlert) Documentation() string {
 
 ## Webhook Setup
 
-SuperPlane automatically creates a Cloudflare Alerting webhook destination and notification policy for ` + "`load_balancing_health_alert`" + `. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the ` + "`cf-webhook-auth`" + ` header before emitting an event.`
+SuperPlane automatically creates a Cloudflare Alerting webhook destination and notification policy for ` + "`load_balancing_health_alert`" + `. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the ` + "`cf-webhook-auth`" + ` header before emitting an event.
+
+## Workflow execution details
+
+In the workflow execution chain, the trigger's **Details** tab lists:
+
+- **Triggered At**: When SuperPlane recorded the webhook event.
+- **Alert Type**: For example ` + "`load_balancing_health_alert`" + `.
+- **Event Source**: ` + "`pool`" + ` or ` + "`origin`" + `.
+- **New Health**: The health state in the notification (for example ` + "`Unhealthy`" + `).
+- **Pool**: Pool name when Cloudflare sends it; otherwise the pool ID.
+
+The trigger **title** still prefers an origin name, then pool name, then load balancer name when those fields are present in the payload. Use the **Payload** tab (or expressions such as ` + "`$.trigger.data`" + `) for every field Cloudflare sends, including **origin name**, **load balancer id/name**, and **account id**.`
 }
 
 func (t *OnLoadBalancingHealthAlert) Icon() string {

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
@@ -216,11 +216,62 @@ func (t *OnLoadBalancingHealthAlert) HandleWebhook(ctx core.WebhookRequestContex
 		payload = map[string]any{"raw": string(ctx.Body)}
 	}
 
+	triggerSpec := OnLoadBalancingHealthAlertSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &triggerSpec); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode trigger configuration: %w", err)
+	}
+
+	normalizedSpec, err := normalizeHealthAlertSpec(triggerSpec)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	if !healthAlertPayloadMatchesSpec(normalizedSpec, payload) {
+		return http.StatusOK, nil, nil
+	}
+
 	if err := ctx.Events.Emit(LoadBalancingHealthAlertPayloadType, payload); err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
 
 	return http.StatusOK, nil, nil
+}
+
+func healthAlertPayloadMatchesSpec(spec OnLoadBalancingHealthAlertSpec, payload map[string]any) bool {
+	data := payload
+	if nested, ok := payload["data"].(map[string]any); ok && nested != nil {
+		data = nested
+	}
+
+	if spec.Pool != "" {
+		if strings.TrimSpace(healthAlertFieldString(data["pool_id"])) != spec.Pool {
+			return false
+		}
+	}
+
+	newHealth := normalizeOneOf(healthAlertFieldString(data["new_health"]), loadBalancingHealthValues)
+	if newHealth == "" || !slices.Contains(spec.NewHealth, newHealth) {
+		return false
+	}
+
+	eventSource := normalizeOneOf(healthAlertFieldString(data["event_source"]), loadBalancingEventSources)
+	if eventSource == "" || !slices.Contains(spec.EventSource, eventSource) {
+		return false
+	}
+
+	return true
+}
+
+func healthAlertFieldString(value any) string {
+	if value == nil {
+		return ""
+	}
+	s, ok := value.(string)
+	if ok {
+		return s
+	}
+
+	return fmt.Sprint(value)
 }
 
 func headerValue(headers http.Header, name string) string {

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
@@ -1,0 +1,239 @@
+package cloudflare
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const LoadBalancingHealthAlertPayloadType = "cloudflare.loadBalancing.healthAlert"
+
+var (
+	loadBalancingHealthValues = []string{"Healthy", "Unhealthy"}
+	loadBalancingEventSources = []string{"pool", "origin"}
+)
+
+type OnLoadBalancingHealthAlert struct{}
+
+type OnLoadBalancingHealthAlertSpec struct {
+	Pool        string   `json:"pool"`
+	NewHealth   []string `json:"newHealth"`
+	EventSource []string `json:"eventSource"`
+}
+
+func (t *OnLoadBalancingHealthAlert) Name() string {
+	return "cloudflare.onLoadBalancingHealthAlert"
+}
+
+func (t *OnLoadBalancingHealthAlert) Label() string {
+	return "On Load Balancing Health Alert"
+}
+
+func (t *OnLoadBalancingHealthAlert) Description() string {
+	return "Trigger when a Cloudflare load balancing pool or origin health state changes"
+}
+
+func (t *OnLoadBalancingHealthAlert) Documentation() string {
+	return `The On Load Balancing Health Alert trigger starts a workflow from Cloudflare Load Balancing health notifications.
+
+## Use Cases
+
+- **Pool unhealthy**: React when a load balancer pool becomes unhealthy
+- **Origin unhealthy**: Notify or remediate when an endpoint/origin fails health checks
+- **Failover awareness**: Detect health changes that cause Cloudflare to route traffic away from unhealthy pools
+
+## Configuration
+
+- **Pool**: Optional pool filter. Leave empty to listen across pools available to the account.
+- **New Health**: Health states to listen for. Defaults to ` + "`Unhealthy`" + `.
+- **Event Source**: Listen for pool events, origin events, or both.
+
+## Webhook Setup
+
+SuperPlane automatically creates a Cloudflare Alerting webhook destination and notification policy for ` + "`load_balancing_health_alert`" + `. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the ` + "`cf-webhook-auth`" + ` header before emitting an event.`
+}
+
+func (t *OnLoadBalancingHealthAlert) Icon() string {
+	return "activity"
+}
+
+func (t *OnLoadBalancingHealthAlert) Color() string {
+	return "orange"
+}
+
+func (t *OnLoadBalancingHealthAlert) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "pool",
+			Label:       "Pool",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional load balancing pool to filter alerts by",
+			Placeholder: "Select a pool",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "pool",
+				},
+			},
+		},
+		{
+			Name:        "newHealth",
+			Label:       "New Health",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    false,
+			Default:     []string{"Unhealthy"},
+			Description: "Health states to listen for",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Healthy", Value: "Healthy"},
+						{Label: "Unhealthy", Value: "Unhealthy"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "eventSource",
+			Label:       "Event Source",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    false,
+			Default:     []string{"pool", "origin"},
+			Description: "Cloudflare health event sources to listen for",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Pool", Value: "pool"},
+						{Label: "Origin", Value: "origin"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *OnLoadBalancingHealthAlert) Setup(ctx core.TriggerContext) error {
+	spec := OnLoadBalancingHealthAlertSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	normalized, err := normalizeHealthAlertSpec(spec)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(normalized)
+}
+
+func normalizeHealthAlertSpec(spec OnLoadBalancingHealthAlertSpec) (OnLoadBalancingHealthAlertSpec, error) {
+	if len(spec.NewHealth) == 0 {
+		spec.NewHealth = []string{"Unhealthy"}
+	}
+	if len(spec.EventSource) == 0 {
+		spec.EventSource = []string{"pool", "origin"}
+	}
+
+	for i, value := range spec.NewHealth {
+		normalized := normalizeOneOf(value, loadBalancingHealthValues)
+		if normalized == "" {
+			return spec, fmt.Errorf("newHealth must contain only %s", strings.Join(loadBalancingHealthValues, ", "))
+		}
+		spec.NewHealth[i] = normalized
+	}
+
+	for i, value := range spec.EventSource {
+		normalized := normalizeOneOf(value, loadBalancingEventSources)
+		if normalized == "" {
+			return spec, fmt.Errorf("eventSource must contain only %s", strings.Join(loadBalancingEventSources, ", "))
+		}
+		spec.EventSource[i] = normalized
+	}
+
+	spec.Pool = strings.TrimSpace(spec.Pool)
+	spec.NewHealth = compactStrings(spec.NewHealth)
+	spec.EventSource = compactStrings(spec.EventSource)
+	return spec, nil
+}
+
+func normalizeOneOf(value string, allowed []string) string {
+	trimmed := strings.TrimSpace(value)
+	for _, option := range allowed {
+		if strings.EqualFold(trimmed, option) {
+			return option
+		}
+	}
+	return ""
+}
+
+func compactStrings(values []string) []string {
+	result := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || slices.Contains(result, value) {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func (t *OnLoadBalancingHealthAlert) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (t *OnLoadBalancingHealthAlert) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (t *OnLoadBalancingHealthAlert) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *OnLoadBalancingHealthAlert) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	secretBytes, err := ctx.Webhook.GetSecret()
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	provided := strings.TrimSpace(headerValue(ctx.Headers, "cf-webhook-auth"))
+	if provided == "" {
+		return http.StatusUnauthorized, nil, fmt.Errorf("missing cf-webhook-auth header")
+	}
+
+	if subtle.ConstantTimeCompare([]byte(provided), secretBytes) != 1 {
+		return http.StatusForbidden, nil, fmt.Errorf("invalid cf-webhook-auth header")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(ctx.Body, &payload); err != nil {
+		payload = map[string]any{"raw": string(ctx.Body)}
+	}
+
+	if err := ctx.Events.Emit(LoadBalancingHealthAlertPayloadType, payload); err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func headerValue(headers http.Header, name string) string {
+	if value := headers.Get(name); value != "" {
+		return value
+	}
+
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) || len(values) == 0 {
+			continue
+		}
+		return values[0]
+	}
+
+	return ""
+}

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert.go
@@ -129,7 +129,36 @@ func (t *OnLoadBalancingHealthAlert) Setup(ctx core.TriggerContext) error {
 		return err
 	}
 
+	if err := resolveHealthAlertPoolMetadata(ctx, normalized.Pool); err != nil {
+		return err
+	}
+
 	return ctx.Integration.RequestWebhook(normalized)
+}
+
+func resolveHealthAlertPoolMetadata(ctx core.TriggerContext, poolID string) error {
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" || ctx.Metadata == nil {
+		return nil
+	}
+
+	meta := PoolNodeMetadata{PoolName: poolID}
+	accountID := accountIDFromIntegration(ctx.Integration)
+	if strings.Contains(poolID, "{{") || strings.Contains(accountID, "{{") || accountID == "" {
+		return ctx.Metadata.Set(meta)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	pool, err := client.GetPool(accountID, poolID)
+	if err != nil {
+		return fmt.Errorf("failed to get pool: %w", err)
+	}
+
+	meta.PoolName = pool.Name
+	return ctx.Metadata.Set(meta)
 }
 
 func normalizeHealthAlertSpec(spec OnLoadBalancingHealthAlertSpec) (OnLoadBalancingHealthAlertSpec, error) {

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
@@ -63,4 +63,72 @@ func Test__OnLoadBalancingHealthAlert__HandleWebhook(t *testing.T) {
 		require.Len(t, events.Payloads, 1)
 		assert.Equal(t, LoadBalancingHealthAlertPayloadType, events.Payloads[0].Type)
 	})
+
+	t.Run("skips emit when pool filter does not match payload", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_health":"Unhealthy","event_source":"origin","pool_id":"pool123"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"pool":        "other-pool",
+				"newHealth":   []string{"Unhealthy"},
+				"eventSource": []string{"origin"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Empty(t, events.Payloads)
+	})
+
+	t.Run("skips emit when new_health not allowed by trigger", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_health":"Healthy","event_source":"origin","pool_id":"pool123"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"newHealth":   []string{"Unhealthy"},
+				"eventSource": []string{"origin"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Empty(t, events.Payloads)
+	})
+
+	t.Run("matches nested data envelope", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body: []byte(`{
+				"data": {
+					"new_health": "Unhealthy",
+					"event_source": "pool",
+					"pool_id": "pool123"
+				}
+			}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"pool":        "pool123",
+				"newHealth":   []string{"Unhealthy"},
+				"eventSource": []string{"pool"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		require.Len(t, events.Payloads, 1)
+	})
 }

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
@@ -166,5 +166,12 @@ func Test__OnLoadBalancingHealthAlert__HandleWebhook(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, code)
 		require.Len(t, events.Payloads, 1)
+		emitted, ok := events.Payloads[0].Data.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Unhealthy", emitted["new_health"])
+		assert.Equal(t, "pool", emitted["event_source"])
+		assert.Equal(t, "pool123", emitted["pool_id"])
+		_, hasEnvelope := emitted["data"]
+		assert.False(t, hasEnvelope)
 	})
 }

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
@@ -1,7 +1,9 @@
 package cloudflare
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +32,40 @@ func Test__OnLoadBalancingHealthAlert__Setup(t *testing.T) {
 		NewHealth:   []string{"Unhealthy"},
 		EventSource: []string{"pool"},
 	}, integration.WebhookRequests[0])
+}
+
+func Test__OnLoadBalancingHealthAlert__SetupResolvesPoolMetadata(t *testing.T) {
+	trigger := &OnLoadBalancingHealthAlert{}
+	metadata := &contexts.MetadataContext{}
+	integration := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token123"},
+		Metadata:      Metadata{AccountID: "acc123"},
+	}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{
+			"pool": "pool123",
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {"id": "pool123", "name": "Production pool"}
+					}`)),
+				},
+			},
+		},
+		Integration: integration,
+		Metadata:    metadata,
+	})
+
+	require.NoError(t, err)
+	poolMeta, ok := metadata.Metadata.(PoolNodeMetadata)
+	require.True(t, ok)
+	assert.Equal(t, "Production pool", poolMeta.PoolName)
+	require.Len(t, integration.WebhookRequests, 1)
 }
 
 func Test__OnLoadBalancingHealthAlert__HandleWebhook(t *testing.T) {

--- a/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
+++ b/pkg/integrations/cloudflare/on_load_balancing_health_alert_test.go
@@ -1,0 +1,66 @@
+package cloudflare
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnLoadBalancingHealthAlert__Setup(t *testing.T) {
+	trigger := &OnLoadBalancingHealthAlert{}
+	integration := &contexts.IntegrationContext{}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{
+			"pool":        "pool123",
+			"newHealth":   []string{"Unhealthy"},
+			"eventSource": []string{"pool"},
+		},
+		Integration: integration,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, integration.WebhookRequests, 1)
+	assert.Equal(t, OnLoadBalancingHealthAlertSpec{
+		Pool:        "pool123",
+		NewHealth:   []string{"Unhealthy"},
+		EventSource: []string{"pool"},
+	}, integration.WebhookRequests[0])
+}
+
+func Test__OnLoadBalancingHealthAlert__HandleWebhook(t *testing.T) {
+	trigger := &OnLoadBalancingHealthAlert{}
+
+	t.Run("rejects missing auth header", func(t *testing.T) {
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Headers: http.Header{},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+		})
+
+		require.ErrorContains(t, err, "missing cf-webhook-auth")
+		assert.Equal(t, http.StatusUnauthorized, code)
+	})
+
+	t.Run("emits valid alert payload", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_health":"Unhealthy","event_source":"origin","pool_id":"pool123"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		require.Len(t, events.Payloads, 1)
+		assert.Equal(t, LoadBalancingHealthAlertPayloadType, events.Payloads[0].Type)
+	})
+}

--- a/pkg/integrations/cloudflare/pool_json_test.go
+++ b/pkg/integrations/cloudflare/pool_json_test.go
@@ -16,3 +16,22 @@ func TestPoolMarshalJSON_IncludesEnabledWhenFalse(t *testing.T) {
 
 	assert.Contains(t, string(raw), `"enabled":false`)
 }
+
+func TestPoolMarshalJSON_IncludesMinimumOriginsWhenZero(t *testing.T) {
+	pool := Pool{Name: "pool-a", Enabled: true, MinimumOrigins: 0}
+
+	raw, err := json.Marshal(pool)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(raw), `"minimum_origins":0`)
+}
+
+func TestCreatePoolRequestMarshalJSON_IncludesMinimumOriginsWhenZero(t *testing.T) {
+	z := 0
+	req := CreatePoolRequest{Name: "pool-a", Enabled: true, Origins: []Origin{}, MinimumOrigins: &z}
+
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(raw), `"minimum_origins":0`)
+}

--- a/pkg/integrations/cloudflare/pool_json_test.go
+++ b/pkg/integrations/cloudflare/pool_json_test.go
@@ -1,0 +1,18 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoolMarshalJSON_IncludesEnabledWhenFalse(t *testing.T) {
+	pool := Pool{Name: "disabled-pool", Enabled: false}
+
+	raw, err := json.Marshal(pool)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(raw), `"enabled":false`)
+}

--- a/pkg/integrations/cloudflare/webhook_handler.go
+++ b/pkg/integrations/cloudflare/webhook_handler.go
@@ -147,13 +147,13 @@ func (h *CloudflareWebhookHandler) Cleanup(ctx core.WebhookHandlerContext) error
 	}
 
 	if metadata.NotificationPolicyID != "" {
-		if err := client.DeleteNotificationPolicy(accountID, metadata.NotificationPolicyID); err != nil {
+		if err := client.DeleteNotificationPolicy(accountID, metadata.NotificationPolicyID); err != nil && !isCloudflareNotFound(err) {
 			return fmt.Errorf("failed to delete Cloudflare notification policy: %w", err)
 		}
 	}
 
 	if metadata.DestinationID != "" {
-		if err := client.DeleteAlertingWebhookDestination(accountID, metadata.DestinationID); err != nil {
+		if err := client.DeleteAlertingWebhookDestination(accountID, metadata.DestinationID); err != nil && !isCloudflareNotFound(err) {
 			return fmt.Errorf("failed to delete Cloudflare alerting webhook destination: %w", err)
 		}
 	}

--- a/pkg/integrations/cloudflare/webhook_handler.go
+++ b/pkg/integrations/cloudflare/webhook_handler.go
@@ -1,0 +1,210 @@
+package cloudflare
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type CloudflareWebhookHandler struct{}
+
+type CloudflareWebhookMetadata struct {
+	AccountID            string `json:"accountId" mapstructure:"accountId"`
+	DestinationID        string `json:"destinationId" mapstructure:"destinationId"`
+	NotificationPolicyID string `json:"notificationPolicyId" mapstructure:"notificationPolicyId"`
+}
+
+func (h *CloudflareWebhookHandler) CompareConfig(a, b any) (bool, error) {
+	configA, err := decodeHealthAlertWebhookConfig(a)
+	if err != nil {
+		return false, err
+	}
+
+	configB, err := decodeHealthAlertWebhookConfig(b)
+	if err != nil {
+		return false, err
+	}
+
+	return configA.Pool == configB.Pool, nil
+}
+
+func (h *CloudflareWebhookHandler) Merge(current, requested any) (any, bool, error) {
+	currentConfig, err := decodeHealthAlertWebhookConfig(current)
+	if err != nil {
+		return current, false, err
+	}
+
+	requestedConfig, err := decodeHealthAlertWebhookConfig(requested)
+	if err != nil {
+		return current, false, err
+	}
+
+	if currentConfig.Pool != requestedConfig.Pool {
+		return currentConfig, false, nil
+	}
+
+	merged := currentConfig
+	merged.NewHealth = mergeStringSets(currentConfig.NewHealth, requestedConfig.NewHealth)
+	merged.EventSource = mergeStringSets(currentConfig.EventSource, requestedConfig.EventSource)
+
+	changed := !sameStringSet(currentConfig.NewHealth, merged.NewHealth) ||
+		!sameStringSet(currentConfig.EventSource, merged.EventSource)
+
+	return merged, changed, nil
+}
+
+func (h *CloudflareWebhookHandler) Setup(ctx core.WebhookHandlerContext) (any, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := decodeHealthAlertWebhookConfig(ctx.Webhook.GetConfiguration())
+	if err != nil {
+		return nil, err
+	}
+
+	webhookURL := strings.TrimSpace(ctx.Webhook.GetURL())
+	if webhookURL == "" {
+		return nil, fmt.Errorf("webhook URL is empty")
+	}
+
+	secretBytes, err := ctx.Webhook.GetSecret()
+	if err != nil || len(secretBytes) == 0 || strings.TrimSpace(string(secretBytes)) == "" {
+		secret := uuid.NewString()
+		if err := ctx.Webhook.SetSecret([]byte(secret)); err != nil {
+			return nil, fmt.Errorf("failed to set webhook secret: %w", err)
+		}
+		secretBytes = []byte(secret)
+	}
+
+	destination, err := client.CreateAlertingWebhookDestination(
+		accountID,
+		CreateAlertingWebhookDestinationRequest{
+			Name:   cloudflareWebhookName(config),
+			URL:    webhookURL,
+			Secret: string(secretBytes),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Cloudflare alerting webhook destination: %w", err)
+	}
+
+	policy, err := client.CreateNotificationPolicy(accountID, CreateNotificationPolicyRequest{
+		AlertType:   "load_balancing_health_alert",
+		Enabled:     true,
+		Name:        cloudflareWebhookName(config),
+		Description: "Created by SuperPlane for Cloudflare load balancing health alerts.",
+		Mechanisms: NotificationPolicyMechanisms{
+			Webhooks: []NotificationMechanism{{ID: destination.ID}},
+		},
+		Filters: NotificationPolicyFilters{
+			PoolID:      oneOrNil(config.Pool),
+			NewHealth:   config.NewHealth,
+			EventSource: config.EventSource,
+		},
+	})
+	if err != nil {
+		_ = client.DeleteAlertingWebhookDestination(accountID, destination.ID)
+		return nil, fmt.Errorf("failed to create Cloudflare notification policy: %w", err)
+	}
+
+	return CloudflareWebhookMetadata{
+		AccountID:            accountID,
+		DestinationID:        destination.ID,
+		NotificationPolicyID: policy.ID,
+	}, nil
+}
+
+func (h *CloudflareWebhookHandler) Cleanup(ctx core.WebhookHandlerContext) error {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	metadata := CloudflareWebhookMetadata{}
+	if err := mapstructure.Decode(ctx.Webhook.GetMetadata(), &metadata); err != nil {
+		return nil
+	}
+
+	accountID := strings.TrimSpace(metadata.AccountID)
+	if accountID == "" {
+		accountID, err = accountIDForIntegration(ctx.Integration)
+		if err != nil {
+			return nil
+		}
+	}
+
+	if metadata.NotificationPolicyID != "" {
+		if err := client.DeleteNotificationPolicy(accountID, metadata.NotificationPolicyID); err != nil {
+			return fmt.Errorf("failed to delete Cloudflare notification policy: %w", err)
+		}
+	}
+
+	if metadata.DestinationID != "" {
+		if err := client.DeleteAlertingWebhookDestination(accountID, metadata.DestinationID); err != nil {
+			return fmt.Errorf("failed to delete Cloudflare alerting webhook destination: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func decodeHealthAlertWebhookConfig(value any) (OnLoadBalancingHealthAlertSpec, error) {
+	config := OnLoadBalancingHealthAlertSpec{}
+	if err := mapstructure.Decode(value, &config); err != nil {
+		return config, fmt.Errorf("failed to decode webhook configuration: %w", err)
+	}
+
+	return normalizeHealthAlertSpec(config)
+}
+
+func mergeStringSets(a, b []string) []string {
+	result := append([]string{}, a...)
+	for _, value := range b {
+		if !slices.Contains(result, value) {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, value := range a {
+		if !slices.Contains(b, value) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func cloudflareWebhookName(config OnLoadBalancingHealthAlertSpec) string {
+	if config.Pool == "" {
+		return "SuperPlane Load Balancing Health Alert"
+	}
+
+	return fmt.Sprintf("SuperPlane Load Balancing Health Alert - %s", config.Pool)
+}
+
+func oneOrNil(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+
+	return []string{value}
+}

--- a/pkg/integrations/cloudflare/webhook_handler.go
+++ b/pkg/integrations/cloudflare/webhook_handler.go
@@ -29,7 +29,9 @@ func (h *CloudflareWebhookHandler) CompareConfig(a, b any) (bool, error) {
 		return false, err
 	}
 
-	return configA.Pool == configB.Pool, nil
+	return configA.Pool == configB.Pool &&
+		sameStringSet(configA.NewHealth, configB.NewHealth) &&
+		sameStringSet(configA.EventSource, configB.EventSource), nil
 }
 
 func (h *CloudflareWebhookHandler) Merge(current, requested any) (any, bool, error) {

--- a/pkg/integrations/cloudflare/webhook_handler_test.go
+++ b/pkg/integrations/cloudflare/webhook_handler_test.go
@@ -62,3 +62,46 @@ func Test__CloudflareWebhookHandler__Setup(t *testing.T) {
 		"event_source": []any{"origin"},
 	}, policy["filters"])
 }
+
+func Test__CloudflareWebhookHandler__CompareConfig(t *testing.T) {
+	handler := &CloudflareWebhookHandler{}
+
+	t.Run("same pool but different newHealth -> not equal", func(t *testing.T) {
+		a := map[string]any{"pool": "pool123", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"pool"}}
+		b := map[string]any{"pool": "pool123", "newHealth": []string{"Healthy"}, "eventSource": []string{"pool"}}
+
+		ok, err := handler.CompareConfig(a, b)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("same pool but different eventSource -> not equal", func(t *testing.T) {
+		a := map[string]any{"pool": "pool123", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"pool"}}
+		b := map[string]any{"pool": "pool123", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"origin"}}
+
+		ok, err := handler.CompareConfig(a, b)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("matching filters including defaults -> equal", func(t *testing.T) {
+		a := map[string]any{"pool": "", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"pool", "origin"}}
+		b := map[string]any{}
+
+		ok, err := handler.CompareConfig(a, b)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("identical normalized configs -> equal", func(t *testing.T) {
+		spec := OnLoadBalancingHealthAlertSpec{
+			Pool:        "pool123",
+			NewHealth:   []string{"Unhealthy"},
+			EventSource: []string{"origin"},
+		}
+
+		ok, err := handler.CompareConfig(spec, spec)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}

--- a/pkg/integrations/cloudflare/webhook_handler_test.go
+++ b/pkg/integrations/cloudflare/webhook_handler_test.go
@@ -63,6 +63,124 @@ func Test__CloudflareWebhookHandler__Setup(t *testing.T) {
 	}, policy["filters"])
 }
 
+func Test__CloudflareWebhookHandler__Cleanup(t *testing.T) {
+	handler := &CloudflareWebhookHandler{}
+	integration := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"apiToken":  "token123",
+			"accountId": "account123",
+		},
+	}
+	metadata := map[string]any{
+		"accountId":            "account123",
+		"notificationPolicyId": "policy123",
+		"destinationId":        "dest123",
+	}
+
+	t.Run("deletes policy then destination", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))},
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpContext,
+			Integration: integration,
+			Webhook:     &contexts.WebhookContext{Metadata: metadata},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/alerting/v3/policies/policy123")
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "/alerting/v3/destinations/webhooks/dest123")
+	})
+
+	t.Run("404 on policy delete still deletes destination", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false,"errors":[{"code":1003,"message":"not found"}]}`)),
+				},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))},
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpContext,
+			Integration: integration,
+			Webhook:     &contexts.WebhookContext{Metadata: metadata},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 2)
+	})
+
+	t.Run("404 on destination delete succeeds", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))},
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false,"errors":[{"code":1003}]}`)),
+				},
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpContext,
+			Integration: integration,
+			Webhook:     &contexts.WebhookContext{Metadata: metadata},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("non-404 error on policy fails cleanup before destination", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusBadGateway,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false}`)),
+				},
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpContext,
+			Integration: integration,
+			Webhook:     &contexts.WebhookContext{Metadata: metadata},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notification policy")
+		require.Len(t, httpContext.Requests, 1)
+	})
+
+	t.Run("non-404 error on destination fails cleanup", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))},
+				{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false}`)),
+				},
+			},
+		}
+
+		err := handler.Cleanup(core.WebhookHandlerContext{
+			HTTP:        httpContext,
+			Integration: integration,
+			Webhook:     &contexts.WebhookContext{Metadata: metadata},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "alerting webhook destination")
+	})
+}
+
 func Test__CloudflareWebhookHandler__CompareConfig(t *testing.T) {
 	handler := &CloudflareWebhookHandler{}
 

--- a/pkg/integrations/cloudflare/webhook_handler_test.go
+++ b/pkg/integrations/cloudflare/webhook_handler_test.go
@@ -1,0 +1,64 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CloudflareWebhookHandler__Setup(t *testing.T) {
+	handler := &CloudflareWebhookHandler{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "dest123"}}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "policy123"}}`)),
+			},
+		},
+	}
+
+	metadata, err := handler.Setup(core.WebhookHandlerContext{
+		HTTP: httpContext,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken":  "token123",
+				"accountId": "account123",
+			},
+		},
+		Webhook: &contexts.WebhookContext{
+			URL:           "https://example.com/webhook",
+			Configuration: OnLoadBalancingHealthAlertSpec{Pool: "pool123", NewHealth: []string{"Unhealthy"}, EventSource: []string{"origin"}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, CloudflareWebhookMetadata{
+		AccountID:            "account123",
+		DestinationID:        "dest123",
+		NotificationPolicyID: "policy123",
+	}, metadata)
+	require.Len(t, httpContext.Requests, 2)
+	assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/alerting/v3/destinations/webhooks", httpContext.Requests[0].URL.String())
+	assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/account123/alerting/v3/policies", httpContext.Requests[1].URL.String())
+
+	var policy map[string]any
+	require.NoError(t, json.NewDecoder(httpContext.Requests[1].Body).Decode(&policy))
+	assert.Equal(t, "load_balancing_health_alert", policy["alert_type"])
+	assert.Equal(t, true, policy["enabled"])
+	assert.Equal(t, map[string]any{
+		"pool_id":      []any{"pool123"},
+		"new_health":   []any{"Unhealthy"},
+		"event_source": []any{"origin"},
+	}, policy["filters"])
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -53,7 +53,7 @@ export const baseMapper: ComponentBaseMapper = {
 };
 
 /** First payload `data` from the default output channel (workflow execution outputs). */
-export function firstDefaultChannelOutputData(outputs: unknown): unknown {
+export function firstOutputData(outputs: unknown): unknown {
   const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
   return outputMap?.default?.[0]?.data;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -52,6 +52,12 @@ export const baseMapper: ComponentBaseMapper = {
   },
 };
 
+/** First payload `data` from the default output channel (workflow execution outputs). */
+export function firstDefaultChannelOutputData(outputs: unknown): unknown {
+  const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
+  return outputMap?.default?.[0]?.data;
+}
+
 export function getPoolExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
   const details: Record<string, string> = {};
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -35,10 +35,6 @@ export const baseMapper: ComponentBaseMapper = {
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
     const payload = outputs?.default?.[0];
 
-    if (payload?.type) {
-      details["Event Type"] = payload.type;
-    }
-
     if (payload?.timestamp) {
       details["Emitted At"] = new Date(payload.timestamp).toLocaleString();
     }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -3,6 +3,7 @@ import type { MetadataItem } from "@/ui/metadataList";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
+  ExecutionInfo,
   ExecutionDetailsContext,
   NodeInfo,
   SubtitleContext,
@@ -35,7 +36,6 @@ interface CreateMonitorOutput {
     description?: string;
     path?: string;
     port?: number;
-    expected_codes?: string;
   };
   pool?: {
     id?: string;
@@ -47,7 +47,7 @@ export const createMonitorMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     return {
       ...baseMapper.props(context),
-      metadata: metadataList(context.node),
+      metadata: metadataList(context.node, context.lastExecutions[0]),
     };
   },
 
@@ -63,7 +63,7 @@ export const createMonitorMapper: ComponentBaseMapper = {
   },
 };
 
-function metadataList(node: NodeInfo): MetadataItem[] {
+function metadataList(node: NodeInfo, lastExecution?: ExecutionInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
   const configuration = node.configuration as CreateMonitorConfiguration | undefined;
 
@@ -82,7 +82,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   const poolId = configuration?.pool?.trim();
   if (poolId) {
-    const poolLabel = getCloudflarePoolName(node.metadata) || poolId;
+    const poolLabel = getCloudflarePoolName(node.metadata) || getPoolNameFromExecution(lastExecution) || poolId;
     metadata.push({ icon: "server", label: `Pool: ${poolLabel}` });
   }
 
@@ -93,13 +93,18 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
+function getPoolNameFromExecution(execution?: ExecutionInfo): string | undefined {
+  const output = firstOutputData(execution?.outputs) as CreateMonitorOutput | undefined;
+  const name = output?.pool?.name?.trim();
+  return name || undefined;
+}
+
 function outputDetails(output: CreateMonitorOutput): Record<string, string> {
   return compactDetails({
     Name: output.monitor?.description || "-",
     Type: output.monitor?.type?.toUpperCase() || "-",
     Path: output.monitor?.path,
     Port: output.monitor?.port != null ? String(output.monitor.port) : undefined,
-    "Expected Codes": output.monitor?.expected_codes,
     Pool: output.pool?.name || output.poolId,
   });
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -1,7 +1,14 @@
 import type { ComponentBaseProps } from "@/ui/componentBase";
 import type { MetadataItem } from "@/ui/metadataList";
-import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
 import { baseMapper, firstOutputData } from "./base";
+import { getCloudflarePoolName } from "./metadata";
 
 interface CreateMonitorConfiguration {
   description?: string;
@@ -10,15 +17,10 @@ interface CreateMonitorConfiguration {
   port?: number;
   pool?: string;
   advanced?: Record<string, unknown>;
-
-  // Legacy flat fields.
-  method?: string;
-  expectedCodes?: string;
-  headers?: unknown[];
-  expectedBody?: string;
-  followRedirects?: boolean;
-  allowInsecure?: boolean;
-  probeZone?: string;
+  /** Legacy flat fields saved before nested `advanced` was standard */
+  interval?: number;
+  timeout?: number;
+  retries?: number;
   consecutiveUp?: number;
   consecutiveDown?: number;
 }
@@ -45,7 +47,7 @@ export const createMonitorMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     return {
       ...baseMapper.props(context),
-      metadata: metadataList(context.node.configuration as CreateMonitorConfiguration | undefined),
+      metadata: metadataList(context.node),
     };
   },
 
@@ -61,8 +63,9 @@ export const createMonitorMapper: ComponentBaseMapper = {
   },
 };
 
-function metadataList(configuration?: CreateMonitorConfiguration): MetadataItem[] {
+function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as CreateMonitorConfiguration | undefined;
 
   if (configuration?.description) {
     metadata.push({ icon: "activity", label: configuration.description });
@@ -77,11 +80,13 @@ function metadataList(configuration?: CreateMonitorConfiguration): MetadataItem[
     metadata.push({ icon: "link", label: target });
   }
 
-  if (configuration?.pool) {
-    metadata.push({ icon: "server", label: `Pool: ${configuration.pool}` });
+  const poolId = configuration?.pool?.trim();
+  if (poolId) {
+    const poolLabel = getCloudflarePoolName(node.metadata) || poolId;
+    metadata.push({ icon: "server", label: `Pool: ${poolLabel}` });
   }
 
-  if (hasAdvancedSettings(configuration)) {
+  if (createMonitorShowsAdvancedBadge(configuration)) {
     metadata.push({ icon: "settings", label: "Advanced health check settings" });
   }
 
@@ -134,28 +139,41 @@ function monitorTarget(configuration?: CreateMonitorConfiguration): string {
   return "";
 }
 
-function hasAdvancedSettings(configuration?: CreateMonitorConfiguration): boolean {
+function createMonitorShowsAdvancedBadge(configuration?: CreateMonitorConfiguration): boolean {
+  if (advancedObjectHasSettings(configuration?.advanced)) {
+    return true;
+  }
   if (!configuration) {
     return false;
   }
+  const legacyKeys: (keyof CreateMonitorConfiguration)[] = [
+    "interval",
+    "timeout",
+    "retries",
+    "consecutiveUp",
+    "consecutiveDown",
+  ];
+  return legacyKeys.some(
+    (key) => typeof configuration[key] === "number" && !Number.isNaN(configuration[key] as number),
+  );
+}
 
-  if (configuration.advanced && Object.keys(configuration.advanced).length > 0) {
-    return true;
+function advancedObjectHasSettings(adv: Record<string, unknown> | undefined): boolean {
+  if (!adv || typeof adv !== "object") {
+    return false;
   }
 
-  const adv = configuration.advanced;
-  return Boolean(
-    configuration.method ||
-      configuration.expectedCodes ||
-      configuration.expectedBody ||
-      configuration.headers?.length ||
-      configuration.followRedirects != null ||
-      configuration.allowInsecure != null ||
-      configuration.probeZone ||
-      configuration.consecutiveUp != null ||
-      configuration.consecutiveDown != null ||
-      typeof adv?.interval === "number" ||
-      typeof adv?.timeout === "number" ||
-      typeof adv?.retries === "number",
-  );
+  return Object.values(adv).some(advancedValuePresent);
+}
+
+function advancedValuePresent(value: unknown): boolean {
+  if (value === undefined || value === null || value === "") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return true;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -90,7 +90,6 @@ function metadataList(configuration?: CreateMonitorConfiguration): MetadataItem[
 
 function outputDetails(output: CreateMonitorOutput): Record<string, string> {
   return compactDetails({
-    "Monitor ID": output.monitorId || output.monitor?.id || "-",
     Name: output.monitor?.description || "-",
     Type: output.monitor?.type?.toUpperCase() || "-",
     Path: output.monitor?.path,

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -1,7 +1,7 @@
 import type { ComponentBaseProps } from "@/ui/componentBase";
 import type { MetadataItem } from "@/ui/metadataList";
 import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
-import { baseMapper, firstDefaultChannelOutputData } from "./base";
+import { baseMapper, firstOutputData } from "./base";
 
 interface CreateMonitorConfiguration {
   description?: string;
@@ -51,7 +51,7 @@ export const createMonitorMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
-    const output = firstDefaultChannelOutputData(context.execution.outputs) as CreateMonitorOutput | undefined;
+    const output = firstOutputData(context.execution.outputs) as CreateMonitorOutput | undefined;
 
     return output ? { ...details, ...outputDetails(output) } : details;
   },

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -1,7 +1,7 @@
 import type { ComponentBaseProps } from "@/ui/componentBase";
 import type { MetadataItem } from "@/ui/metadataList";
 import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
-import { baseMapper } from "./base";
+import { baseMapper, firstDefaultChannelOutputData } from "./base";
 
 interface CreateMonitorConfiguration {
   description?: string;
@@ -51,7 +51,7 @@ export const createMonitorMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
-    const output = firstOutputData(context.execution.outputs) as CreateMonitorOutput | undefined;
+    const output = firstDefaultChannelOutputData(context.execution.outputs) as CreateMonitorOutput | undefined;
 
     return output ? { ...details, ...outputDetails(output) } : details;
   },
@@ -144,6 +144,7 @@ function hasAdvancedSettings(configuration?: CreateMonitorConfiguration): boolea
     return true;
   }
 
+  const adv = configuration.advanced;
   return Boolean(
     configuration.method ||
       configuration.expectedCodes ||
@@ -153,11 +154,9 @@ function hasAdvancedSettings(configuration?: CreateMonitorConfiguration): boolea
       configuration.allowInsecure != null ||
       configuration.probeZone ||
       configuration.consecutiveUp != null ||
-      configuration.consecutiveDown != null,
+      configuration.consecutiveDown != null ||
+      typeof adv?.interval === "number" ||
+      typeof adv?.timeout === "number" ||
+      typeof adv?.retries === "number",
   );
-}
-
-function firstOutputData(outputs: unknown): unknown {
-  const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
-  return outputMap?.default?.[0]?.data;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_monitor.ts
@@ -1,0 +1,163 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type { ComponentBaseContext, ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../types";
+import { baseMapper } from "./base";
+
+interface CreateMonitorConfiguration {
+  description?: string;
+  type?: string;
+  path?: string;
+  port?: number;
+  pool?: string;
+  advanced?: Record<string, unknown>;
+
+  // Legacy flat fields.
+  method?: string;
+  expectedCodes?: string;
+  headers?: unknown[];
+  expectedBody?: string;
+  followRedirects?: boolean;
+  allowInsecure?: boolean;
+  probeZone?: string;
+  consecutiveUp?: number;
+  consecutiveDown?: number;
+}
+
+interface CreateMonitorOutput {
+  accountId?: string;
+  monitorId?: string;
+  poolId?: string;
+  monitor?: {
+    id?: string;
+    type?: string;
+    description?: string;
+    path?: string;
+    port?: number;
+    expected_codes?: string;
+  };
+  pool?: {
+    id?: string;
+    name?: string;
+  };
+}
+
+export const createMonitorMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return {
+      ...baseMapper.props(context),
+      metadata: metadataList(context.node.configuration as CreateMonitorConfiguration | undefined),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
+    const output = firstOutputData(context.execution.outputs) as CreateMonitorOutput | undefined;
+
+    return output ? { ...details, ...outputDetails(output) } : details;
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+};
+
+function metadataList(configuration?: CreateMonitorConfiguration): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+
+  if (configuration?.description) {
+    metadata.push({ icon: "activity", label: configuration.description });
+  }
+
+  if (configuration?.type) {
+    metadata.push({ icon: "radio", label: configuration.type.toUpperCase() });
+  }
+
+  const target = monitorTarget(configuration);
+  if (target) {
+    metadata.push({ icon: "link", label: target });
+  }
+
+  if (configuration?.pool) {
+    metadata.push({ icon: "server", label: `Pool: ${configuration.pool}` });
+  }
+
+  if (hasAdvancedSettings(configuration)) {
+    metadata.push({ icon: "settings", label: "Advanced health check settings" });
+  }
+
+  return metadata;
+}
+
+function outputDetails(output: CreateMonitorOutput): Record<string, string> {
+  return compactDetails({
+    "Monitor ID": output.monitorId || output.monitor?.id || "-",
+    Name: output.monitor?.description || "-",
+    Type: output.monitor?.type?.toUpperCase() || "-",
+    Path: output.monitor?.path,
+    Port: output.monitor?.port != null ? String(output.monitor.port) : undefined,
+    "Expected Codes": output.monitor?.expected_codes,
+    Pool: output.pool?.name || output.poolId,
+  });
+}
+
+function compactDetails(values: Record<string, string | undefined>): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      details[key] = value;
+    }
+  }
+
+  return details;
+}
+
+function monitorTarget(configuration?: CreateMonitorConfiguration): string {
+  if (!configuration) {
+    return "";
+  }
+
+  const path = configuration.path?.trim();
+  const port = configuration.port;
+
+  if (path && port != null) {
+    return `${path} · Port ${port}`;
+  }
+
+  if (path) {
+    return path;
+  }
+
+  if (port != null) {
+    return `Port ${port}`;
+  }
+
+  return "";
+}
+
+function hasAdvancedSettings(configuration?: CreateMonitorConfiguration): boolean {
+  if (!configuration) {
+    return false;
+  }
+
+  if (configuration.advanced && Object.keys(configuration.advanced).length > 0) {
+    return true;
+  }
+
+  return Boolean(
+    configuration.method ||
+      configuration.expectedCodes ||
+      configuration.expectedBody ||
+      configuration.headers?.length ||
+      configuration.followRedirects != null ||
+      configuration.allowInsecure != null ||
+      configuration.probeZone ||
+      configuration.consecutiveUp != null ||
+      configuration.consecutiveDown != null,
+  );
+}
+
+function firstOutputData(outputs: unknown): unknown {
+  const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
+  return outputMap?.default?.[0]?.data;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -8,15 +8,11 @@ import type {
   SubtitleContext,
 } from "../types";
 import { baseMapper, firstOutputData } from "./base";
+import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
 
 interface DeleteMonitorConfiguration {
   monitor?: string;
   force?: boolean;
-}
-
-interface DeleteMonitorNodeMetadata {
-  monitorId?: string;
-  monitorDescription?: string;
 }
 
 interface DeleteMonitorOutput {
@@ -59,15 +55,13 @@ export const deleteMonitorMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const configuration = node.configuration as DeleteMonitorConfiguration | undefined;
-  const nodeMetadata = node.metadata as DeleteMonitorNodeMetadata | undefined;
   const metadata: MetadataItem[] = [];
 
   const monitorId = configuration?.monitor?.trim();
   if (monitorId) {
-    const display =
-      nodeMetadata?.monitorId === monitorId && nodeMetadata.monitorDescription?.trim()
-        ? nodeMetadata.monitorDescription.trim()
-        : monitorId;
+    const resolvedId = getCloudflareMonitorId(node.metadata);
+    const resolvedDesc = getCloudflareMonitorDescription(node.metadata);
+    const display = resolvedId === monitorId && resolvedDesc ? resolvedDesc : monitorId;
     metadata.push({ icon: "trash-2", label: display });
   }
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -7,7 +7,7 @@ import type {
   NodeInfo,
   SubtitleContext,
 } from "../types";
-import { baseMapper } from "./base";
+import { baseMapper, firstDefaultChannelOutputData } from "./base";
 
 interface DeleteMonitorConfiguration {
   monitor?: string;
@@ -36,7 +36,7 @@ export const deleteMonitorMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
-    const output = firstOutputData(context.execution.outputs) as DeleteMonitorOutput | undefined;
+    const output = firstDefaultChannelOutputData(context.execution.outputs) as DeleteMonitorOutput | undefined;
 
     if (!output) {
       return details;
@@ -76,9 +76,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-function firstOutputData(outputs: unknown): unknown {
-  const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
-  return outputMap?.default?.[0]?.data;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -38,7 +38,7 @@ export const deleteMonitorMapper: ComponentBaseMapper = {
       return details;
     }
 
-    details["Monitor ID"] = output.monitorId || "-";
+    details["Monitor"] = output.monitorId ? resolvedMonitorDisplayLabel(context.node.metadata, output.monitorId) : "-";
     details["Deleted"] = output.deleted ? "Yes" : "No";
 
     if (output.references) {
@@ -59,10 +59,10 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   const monitorId = configuration?.monitor?.trim();
   if (monitorId) {
-    const resolvedId = getCloudflareMonitorId(node.metadata);
-    const resolvedDesc = getCloudflareMonitorDescription(node.metadata);
-    const display = resolvedId === monitorId && resolvedDesc ? resolvedDesc : monitorId;
-    metadata.push({ icon: "trash-2", label: display });
+    metadata.push({
+      icon: "trash-2",
+      label: resolvedMonitorDisplayLabel(node.metadata, monitorId),
+    });
   }
 
   if (configuration?.force) {
@@ -70,4 +70,20 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
+}
+
+/** Prefer Cloudflare monitor description when node metadata matches the monitor id (see Setup resolver). */
+function resolvedMonitorDisplayLabel(metadata: unknown, monitorId: string): string {
+  const id = monitorId.trim();
+  if (!id) {
+    return "-";
+  }
+
+  const resolvedId = getCloudflareMonitorId(metadata);
+  const resolvedDesc = getCloudflareMonitorDescription(metadata);
+  if (resolvedId === id && resolvedDesc) {
+    return resolvedDesc;
+  }
+
+  return id;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -7,7 +7,7 @@ import type {
   NodeInfo,
   SubtitleContext,
 } from "../types";
-import { baseMapper, firstDefaultChannelOutputData } from "./base";
+import { baseMapper, firstOutputData } from "./base";
 
 interface DeleteMonitorConfiguration {
   monitor?: string;
@@ -36,7 +36,7 @@ export const deleteMonitorMapper: ComponentBaseMapper = {
 
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
-    const output = firstDefaultChannelOutputData(context.execution.outputs) as DeleteMonitorOutput | undefined;
+    const output = firstOutputData(context.execution.outputs) as DeleteMonitorOutput | undefined;
 
     if (!output) {
       return details;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -1,0 +1,84 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import { baseMapper } from "./base";
+
+interface DeleteMonitorConfiguration {
+  monitor?: string;
+  force?: boolean;
+}
+
+interface DeleteMonitorNodeMetadata {
+  monitorId?: string;
+  monitorDescription?: string;
+}
+
+interface DeleteMonitorOutput {
+  accountId?: string;
+  monitorId?: string;
+  deleted?: boolean;
+  references?: unknown[];
+}
+
+export const deleteMonitorMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return {
+      ...baseMapper.props(context),
+      metadata: metadataList(context.node),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
+    const output = firstOutputData(context.execution.outputs) as DeleteMonitorOutput | undefined;
+
+    if (!output) {
+      return details;
+    }
+
+    details["Monitor ID"] = output.monitorId || "-";
+    details["Deleted"] = output.deleted ? "Yes" : "No";
+
+    if (output.references) {
+      details["References"] = String(output.references.length);
+    }
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as DeleteMonitorConfiguration | undefined;
+  const nodeMetadata = node.metadata as DeleteMonitorNodeMetadata | undefined;
+  const metadata: MetadataItem[] = [];
+
+  const monitorId = configuration?.monitor?.trim();
+  if (monitorId) {
+    const display =
+      nodeMetadata?.monitorId === monitorId && nodeMetadata.monitorDescription?.trim()
+        ? nodeMetadata.monitorDescription.trim()
+        : monitorId;
+    metadata.push({ icon: "trash-2", label: display });
+  }
+
+  if (configuration?.force) {
+    metadata.push({ icon: "shield-alert", label: "Force delete" });
+  }
+
+  return metadata;
+}
+
+function firstOutputData(outputs: unknown): unknown {
+  const outputMap = outputs as { default?: Array<{ data?: unknown }> } | undefined;
+  return outputMap?.default?.[0]?.data;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.spec.ts
@@ -142,6 +142,18 @@ describe("deletePoolMapper.props", () => {
     expect(props.metadata).toEqual([{ icon: "network", label: "My Pool" }]);
   });
 
+  it("prefers pool name from snake_case node metadata keys", () => {
+    const props = deletePoolMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: { pool: "pool-id" },
+          metadata: { pool_name: "My Pool" },
+        }),
+      }),
+    );
+    expect(props.metadata).toEqual([{ icon: "network", label: "My Pool" }]);
+  });
+
   it("falls back to pool id from configuration when metadata is absent", () => {
     const props = deletePoolMapper.props(
       buildPropsContext({

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_pool.ts
@@ -14,13 +14,10 @@ import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { baseEventSections } from "./base";
+import { getCloudflarePoolName } from "./metadata";
 
 interface DeletePoolConfiguration {
   pool?: string;
-}
-
-interface DeletePoolNodeMetadata {
-  poolName?: string;
 }
 
 export const deletePoolMapper: ComponentBaseMapper = {
@@ -65,10 +62,9 @@ export const deletePoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
-  const nodeMetadata = node.metadata as DeletePoolNodeMetadata | undefined;
   const configuration = node.configuration as DeletePoolConfiguration;
 
-  const label = nodeMetadata?.poolName || configuration?.pool;
+  const label = getCloudflarePoolName(node.metadata) || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
   }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_pool.ts
@@ -7,13 +7,10 @@ import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { baseEventSections, getPoolExecutionDetails } from "./base";
+import { getCloudflarePoolName } from "./metadata";
 
 interface GetPoolConfiguration {
   pool?: string;
-}
-
-interface GetPoolNodeMetadata {
-  poolName?: string;
 }
 
 export const getPoolMapper: ComponentBaseMapper = {
@@ -43,10 +40,9 @@ export const getPoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
-  const nodeMetadata = node.metadata as GetPoolNodeMetadata | undefined;
   const configuration = node.configuration as GetPoolConfiguration;
 
-  const label = nodeMetadata?.poolName || configuration?.pool;
+  const label = getCloudflarePoolName(node.metadata) || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
   }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -1,19 +1,28 @@
 import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
 import { baseMapper } from "./base";
 import { buildActionStateRegistry } from "../utils";
+import { onLoadBalancingHealthAlertTriggerRenderer } from "./on_load_balancing_health_alert";
+import { createMonitorMapper } from "./create_monitor";
+import { deleteMonitorMapper } from "./delete_monitor";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
+  createMonitor: createMonitorMapper,
   updateDNSRecord: baseMapper,
   deleteDnsRecord: baseMapper,
+  deleteMonitor: deleteMonitorMapper,
   updateRedirectRule: baseMapper,
 };
 
-export const triggerRenderers: Record<string, TriggerRenderer> = {};
+export const triggerRenderers: Record<string, TriggerRenderer> = {
+  onLoadBalancingHealthAlert: onLoadBalancingHealthAlertTriggerRenderer,
+};
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createDnsRecord: buildActionStateRegistry("completed"),
+  createMonitor: buildActionStateRegistry("completed"),
   updateDNSRecord: buildActionStateRegistry("completed"),
   deleteDnsRecord: buildActionStateRegistry("completed"),
+  deleteMonitor: buildActionStateRegistry("completed"),
   updateRedirectRule: buildActionStateRegistry("completed"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -42,11 +42,11 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createDnsRecord: buildActionStateRegistry("completed"),
-  createMonitor: buildActionStateRegistry("completed"),
+  createMonitor: buildActionStateRegistry("created"),
   createOriginRule: buildActionStateRegistry("created"),
   updateDNSRecord: buildActionStateRegistry("completed"),
   deleteDnsRecord: buildActionStateRegistry("completed"),
-  deleteMonitor: buildActionStateRegistry("completed"),
+  deleteMonitor: buildActionStateRegistry("deleted"),
   updateRedirectRule: buildActionStateRegistry("completed"),
   updateOriginRule: buildActionStateRegistry("updated"),
   deleteOriginRule: buildActionStateRegistry("deleted"),

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
@@ -1,0 +1,30 @@
+/**
+ * Canvas node metadata is stored as a Struct/map and may arrive as camelCase
+ * or snake_case depending on serialization. Normalize reads here.
+ */
+
+function metadataRecord(metadata: unknown): Record<string, unknown> | undefined {
+  if (!metadata || typeof metadata !== "object") return undefined;
+  return metadata as Record<string, unknown>;
+}
+
+export function getCloudflarePoolName(metadata: unknown): string | undefined {
+  const m = metadataRecord(metadata);
+  if (!m) return undefined;
+  const raw = m.poolName ?? m.pool_name;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+export function getCloudflareMonitorId(metadata: unknown): string | undefined {
+  const m = metadataRecord(metadata);
+  if (!m) return undefined;
+  const raw = m.monitorId ?? m.monitor_id;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+export function getCloudflareMonitorDescription(metadata: unknown): string | undefined {
+  const m = metadataRecord(metadata);
+  if (!m) return undefined;
+  const raw = m.monitorDescription ?? m.monitor_description;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
@@ -41,15 +41,130 @@ describe("Cloudflare monitor component mappers", () => {
           expectedCodes: "2xx",
         },
       },
+      metadata: {
+        poolName: "Production",
+      },
     };
 
     expect(createMonitorMapper.props(baseContext(node)).metadata).toEqual([
       { icon: "activity", label: "Login monitor" },
       { icon: "radio", label: "HTTP" },
       { icon: "link", label: "/health · Port 80" },
-      { icon: "server", label: "Pool: pool123" },
+      { icon: "server", label: "Pool: Production" },
       { icon: "settings", label: "Advanced health check settings" },
     ]);
+  });
+
+  it("reads resolved pool name when metadata uses snake_case keys", () => {
+    const node: NodeInfo = {
+      id: "node-pool-snake",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "Probe",
+        type: "tcp",
+        port: 443,
+        pool: "501ca97551554e91623f1bcfecb6deee",
+      },
+      metadata: {
+        pool_name: "Production pool",
+      },
+    };
+
+    expect(createMonitorMapper.props(baseContext(node)).metadata).toContainEqual({
+      icon: "server",
+      label: "Pool: Production pool",
+    });
+  });
+
+  it("falls back to pool id in metadata when node metadata has no pool name", () => {
+    const node: NodeInfo = {
+      id: "node-pool-id-only",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "M",
+        type: "tcp",
+        port: 443,
+        pool: "501ca97551554e91623f1bcfecb6deee",
+      },
+    };
+
+    expect(createMonitorMapper.props(baseContext(node)).metadata).toContainEqual({
+      icon: "server",
+      label: "Pool: 501ca97551554e91623f1bcfecb6deee",
+    });
+  });
+
+  it("shows advanced badge when advanced.interval is set", () => {
+    const node: NodeInfo = {
+      id: "node-advanced-interval",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "Probe",
+        type: "tcp",
+        port: 443,
+        advanced: { interval: 120 },
+      },
+    };
+
+    expect(createMonitorMapper.props(baseContext(node)).metadata).toContainEqual({
+      icon: "settings",
+      label: "Advanced health check settings",
+    });
+  });
+
+  it("shows advanced badge for legacy flat timing fields without nested advanced", () => {
+    const node: NodeInfo = {
+      id: "node-legacy-flat",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "Probe",
+        type: "https",
+        path: "/",
+        port: 443,
+        interval: 90,
+        retries: 0,
+      },
+    };
+
+    expect(createMonitorMapper.props(baseContext(node)).metadata).toContainEqual({
+      icon: "settings",
+      label: "Advanced health check settings",
+    });
+  });
+
+  it("reads monitor description from snake_case metadata keys", () => {
+    const node: NodeInfo = {
+      id: "node-monitor-snake",
+      name: "Delete Cloudflare monitor",
+      componentName: "cloudflare.deleteMonitor",
+      isCollapsed: false,
+      configuration: {
+        monitor: "monitor123",
+      },
+      metadata: {
+        monitor_id: "monitor123",
+        monitor_description: "Edge health",
+      },
+    };
+
+    expect(
+      deleteMonitorMapper.props(
+        baseContext(node, {
+          ...DEFINITION,
+          name: "cloudflare.deleteMonitor",
+          label: "Delete Monitor",
+          icon: "trash-2",
+        }),
+      ).metadata,
+    ).toContainEqual({ icon: "trash-2", label: "Edge health" });
   });
 
   it("shows delete monitor configuration metadata using resolved description when present", () => {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { ComponentBaseContext, ComponentDefinition, NodeInfo } from "../types";
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
 import { createMonitorMapper } from "./create_monitor";
 import { deleteMonitorMapper } from "./delete_monitor";
 
@@ -11,17 +18,64 @@ const DEFINITION: ComponentDefinition = {
   color: "orange",
 };
 
-function baseContext(node: NodeInfo, definition: ComponentDefinition = DEFINITION): ComponentBaseContext {
+function baseContext(
+  node: NodeInfo,
+  definition: ComponentDefinition = DEFINITION,
+  lastExecutions: ExecutionInfo[] = [],
+): ComponentBaseContext {
   return {
     nodes: [node],
     node,
     componentDefinition: definition,
-    lastExecutions: [],
+    lastExecutions,
     currentUser: undefined,
     actions: {
       invokeNodeExecutionHook: async () => undefined,
     },
   };
+}
+
+const DELETE_MONITOR_DEFINITION: ComponentDefinition = {
+  ...DEFINITION,
+  name: "cloudflare.deleteMonitor",
+  label: "Delete Monitor",
+  icon: "trash-2",
+};
+
+function buildDeleteMonitorOutputPayload(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.monitor.deleted",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildDeleteMonitorDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-del",
+    name: "Delete Cloudflare monitor",
+    componentName: "cloudflare.deleteMonitor",
+    isCollapsed: false,
+    configuration: { monitor: "monitor123" },
+    ...overrides?.node,
+  };
+  const execution: ExecutionInfo = {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides?.execution,
+  };
+  return { nodes: [node], node, execution };
 }
 
 describe("Cloudflare monitor component mappers", () => {
@@ -98,6 +152,39 @@ describe("Cloudflare monitor component mappers", () => {
     });
   });
 
+  it("uses pool name from latest create monitor execution output when node metadata is absent", () => {
+    const node: NodeInfo = {
+      id: "node-pool-output",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "M",
+        type: "tcp",
+        port: 443,
+        pool: "501ca97551554e91623f1bcfecb6deee",
+      },
+    };
+
+    const execution = {
+      outputs: {
+        default: [
+          {
+            data: {
+              poolId: "501ca97551554e91623f1bcfecb6deee",
+              pool: { id: "501ca97551554e91623f1bcfecb6deee", name: "Production pool" },
+            },
+          },
+        ],
+      },
+    } as unknown as ExecutionInfo;
+
+    expect(createMonitorMapper.props(baseContext(node, DEFINITION, [execution])).metadata).toContainEqual({
+      icon: "server",
+      label: "Pool: Production pool",
+    });
+  });
+
   it("shows advanced badge when advanced.interval is set", () => {
     const node: NodeInfo = {
       id: "node-advanced-interval",
@@ -155,16 +242,10 @@ describe("Cloudflare monitor component mappers", () => {
       },
     };
 
-    expect(
-      deleteMonitorMapper.props(
-        baseContext(node, {
-          ...DEFINITION,
-          name: "cloudflare.deleteMonitor",
-          label: "Delete Monitor",
-          icon: "trash-2",
-        }),
-      ).metadata,
-    ).toContainEqual({ icon: "trash-2", label: "Edge health" });
+    expect(deleteMonitorMapper.props(baseContext(node, DELETE_MONITOR_DEFINITION)).metadata).toContainEqual({
+      icon: "trash-2",
+      label: "Edge health",
+    });
   });
 
   it("shows delete monitor configuration metadata using resolved description when present", () => {
@@ -183,16 +264,7 @@ describe("Cloudflare monitor component mappers", () => {
       },
     };
 
-    expect(
-      deleteMonitorMapper.props(
-        baseContext(node, {
-          ...DEFINITION,
-          name: "cloudflare.deleteMonitor",
-          label: "Delete Monitor",
-          icon: "trash-2",
-        }),
-      ).metadata,
-    ).toEqual([
+    expect(deleteMonitorMapper.props(baseContext(node, DELETE_MONITOR_DEFINITION)).metadata).toEqual([
       { icon: "trash-2", label: "Edge health" },
       { icon: "shield-alert", label: "Force delete" },
     ]);
@@ -213,15 +285,56 @@ describe("Cloudflare monitor component mappers", () => {
     expect(
       deleteMonitorMapper.props(
         baseContext(node, {
-          ...DEFINITION,
-          name: "cloudflare.deleteMonitor",
-          label: "Delete Monitor",
-          icon: "trash-2",
+          ...DELETE_MONITOR_DEFINITION,
         }),
       ).metadata,
     ).toEqual([
       { icon: "trash-2", label: "monitor123" },
       { icon: "shield-alert", label: "Force delete" },
     ]);
+  });
+});
+
+describe("deleteMonitorMapper.getExecutionDetails", () => {
+  it("shows resolved monitor description under Monitor when metadata matches output id", () => {
+    const ctx = buildDeleteMonitorDetailsCtx({
+      node: {
+        metadata: { monitorId: "monitor123", monitorDescription: "Edge health" },
+        configuration: { monitor: "monitor123" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildDeleteMonitorOutputPayload({
+              accountId: "acc",
+              monitorId: "monitor123",
+              deleted: true,
+              references: [],
+            }),
+          ],
+        },
+      },
+    });
+    const details = deleteMonitorMapper.getExecutionDetails(ctx);
+    expect(details["Monitor"]).toBe("Edge health");
+    expect(details["Monitor ID"]).toBeUndefined();
+    expect(details["Deleted"]).toBe("Yes");
+    expect(details["References"]).toBe("0");
+  });
+
+  it("falls back to monitor id in execution details when metadata is absent", () => {
+    const ctx = buildDeleteMonitorDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildDeleteMonitorOutputPayload({
+              monitorId: "monitor-xyz",
+              deleted: true,
+            }),
+          ],
+        },
+      },
+    });
+    expect(deleteMonitorMapper.getExecutionDetails(ctx)["Monitor"]).toBe("monitor-xyz");
   });
 });

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/monitor_components.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { ComponentBaseContext, ComponentDefinition, NodeInfo } from "../types";
+import { createMonitorMapper } from "./create_monitor";
+import { deleteMonitorMapper } from "./delete_monitor";
+
+const DEFINITION: ComponentDefinition = {
+  name: "cloudflare.createMonitor",
+  label: "Create Monitor",
+  description: "",
+  icon: "activity",
+  color: "orange",
+};
+
+function baseContext(node: NodeInfo, definition: ComponentDefinition = DEFINITION): ComponentBaseContext {
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: definition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: {
+      invokeNodeExecutionHook: async () => undefined,
+    },
+  };
+}
+
+describe("Cloudflare monitor component mappers", () => {
+  it("shows create monitor configuration metadata", () => {
+    const node: NodeInfo = {
+      id: "node-1",
+      name: "Create Cloudflare monitor",
+      componentName: "cloudflare.createMonitor",
+      isCollapsed: false,
+      configuration: {
+        description: "Login monitor",
+        type: "http",
+        path: "/health",
+        port: 80,
+        pool: "pool123",
+        advanced: {
+          expectedCodes: "2xx",
+        },
+      },
+    };
+
+    expect(createMonitorMapper.props(baseContext(node)).metadata).toEqual([
+      { icon: "activity", label: "Login monitor" },
+      { icon: "radio", label: "HTTP" },
+      { icon: "link", label: "/health · Port 80" },
+      { icon: "server", label: "Pool: pool123" },
+      { icon: "settings", label: "Advanced health check settings" },
+    ]);
+  });
+
+  it("shows delete monitor configuration metadata using resolved description when present", () => {
+    const node: NodeInfo = {
+      id: "node-2",
+      name: "Delete Cloudflare monitor",
+      componentName: "cloudflare.deleteMonitor",
+      isCollapsed: false,
+      configuration: {
+        monitor: "monitor123",
+        force: true,
+      },
+      metadata: {
+        monitorId: "monitor123",
+        monitorDescription: "Edge health",
+      },
+    };
+
+    expect(
+      deleteMonitorMapper.props(
+        baseContext(node, {
+          ...DEFINITION,
+          name: "cloudflare.deleteMonitor",
+          label: "Delete Monitor",
+          icon: "trash-2",
+        }),
+      ).metadata,
+    ).toEqual([
+      { icon: "trash-2", label: "Edge health" },
+      { icon: "shield-alert", label: "Force delete" },
+    ]);
+  });
+
+  it("falls back to configured monitor id when node metadata is absent or stale", () => {
+    const node: NodeInfo = {
+      id: "node-2",
+      name: "Delete Cloudflare monitor",
+      componentName: "cloudflare.deleteMonitor",
+      isCollapsed: false,
+      configuration: {
+        monitor: "monitor123",
+        force: true,
+      },
+    };
+
+    expect(
+      deleteMonitorMapper.props(
+        baseContext(node, {
+          ...DEFINITION,
+          name: "cloudflare.deleteMonitor",
+          label: "Delete Monitor",
+          icon: "trash-2",
+        }),
+      ).metadata,
+    ).toEqual([
+      { icon: "trash-2", label: "monitor123" },
+      { icon: "shield-alert", label: "Force delete" },
+    ]);
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { onLoadBalancingHealthAlertTriggerRenderer } from "./on_load_balancing_health_alert";
+import type { ComponentDefinition, EventInfo, NodeInfo, TriggerEventContext, TriggerRendererContext } from "../types";
+
+const NODE: NodeInfo = {
+  id: "node-1",
+  name: "Cloudflare Health",
+  componentName: "cloudflare.onLoadBalancingHealthAlert",
+  isCollapsed: false,
+  configuration: {
+    pool: "pool123",
+    newHealth: ["Unhealthy"],
+  },
+  metadata: {},
+};
+
+const DEFINITION: ComponentDefinition = {
+  name: "cloudflare.onLoadBalancingHealthAlert",
+  label: "On Load Balancing Health Alert",
+  description: "",
+  icon: "activity",
+  color: "orange",
+};
+
+const EVENT: EventInfo = {
+  id: "event-1",
+  createdAt: new Date().toISOString(),
+  data: {
+    alert_type: "load_balancing_health_alert",
+    event_source: "origin",
+    new_health: "Unhealthy",
+    pool_id: "pool123",
+    pool_name: "Production pool",
+    origin_name: "api-primary",
+    load_balancer_name: "api.example.com",
+  },
+  nodeId: "node-1",
+  type: "cloudflare.loadBalancing.healthAlert",
+};
+
+describe("onLoadBalancingHealthAlertTriggerRenderer", () => {
+  it("builds title and root event values from Cloudflare health alert payload", () => {
+    const context: TriggerEventContext = { event: EVENT };
+
+    expect(onLoadBalancingHealthAlertTriggerRenderer.getTitleAndSubtitle(context).title).toBe(
+      "api-primary · origin · Unhealthy",
+    );
+
+    expect(onLoadBalancingHealthAlertTriggerRenderer.getRootEventValues(context)).toEqual({
+      "Alert Type": "load_balancing_health_alert",
+      "Event Source": "origin",
+      "New Health": "Unhealthy",
+      Pool: "Production pool",
+      Origin: "api-primary",
+      "Load Balancer": "api.example.com",
+    });
+  });
+
+  it("includes configured pool and health metadata", () => {
+    const context: TriggerRendererContext = {
+      node: NODE,
+      definition: DEFINITION,
+      lastEvent: EVENT,
+    };
+
+    const props = onLoadBalancingHealthAlertTriggerRenderer.getTriggerProps(context);
+
+    expect(props.metadata).toEqual([
+      { icon: "server", label: "pool123" },
+      { icon: "activity", label: "Unhealthy" },
+    ]);
+    expect(props.lastEventData?.title).toBe("api-primary · origin · Unhealthy");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
@@ -66,9 +66,24 @@ describe("onLoadBalancingHealthAlertTriggerRenderer", () => {
     const props = onLoadBalancingHealthAlertTriggerRenderer.getTriggerProps(context);
 
     expect(props.metadata).toEqual([
-      { icon: "server", label: "pool123" },
+      { icon: "server", label: "Production pool" },
       { icon: "activity", label: "Unhealthy" },
     ]);
     expect(props.lastEventData?.title).toBe("api-primary · origin · Unhealthy");
+  });
+
+  it("prefers resolved pool name from node metadata", () => {
+    const context: TriggerRendererContext = {
+      node: { ...NODE, metadata: { poolName: "Resolved pool" } },
+      definition: DEFINITION,
+      lastEvent: undefined,
+    };
+
+    const props = onLoadBalancingHealthAlertTriggerRenderer.getTriggerProps(context);
+
+    expect(props.metadata).toEqual([
+      { icon: "server", label: "Resolved pool" },
+      { icon: "activity", label: "Unhealthy" },
+    ]);
   });
 });

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.spec.ts
@@ -24,18 +24,25 @@ const DEFINITION: ComponentDefinition = {
 
 const EVENT: EventInfo = {
   id: "event-1",
-  createdAt: new Date().toISOString(),
+  createdAt: "2026-03-26T19:29:35.841Z",
   data: {
     alert_type: "load_balancing_health_alert",
     event_source: "origin",
     new_health: "Unhealthy",
     pool_id: "pool123",
     pool_name: "Production pool",
-    origin_name: "api-primary",
-    load_balancer_name: "api.example.com",
   },
   nodeId: "node-1",
   type: "cloudflare.loadBalancing.healthAlert",
+};
+
+const EVENT_WITH_ORIGIN: EventInfo = {
+  ...EVENT,
+  data: {
+    ...(EVENT.data as object),
+    origin_name: "api-primary",
+    load_balancer_name: "api.example.com",
+  },
 };
 
 describe("onLoadBalancingHealthAlertTriggerRenderer", () => {
@@ -43,17 +50,39 @@ describe("onLoadBalancingHealthAlertTriggerRenderer", () => {
     const context: TriggerEventContext = { event: EVENT };
 
     expect(onLoadBalancingHealthAlertTriggerRenderer.getTitleAndSubtitle(context).title).toBe(
-      "api-primary · origin · Unhealthy",
+      "Production pool · origin · Unhealthy",
     );
 
     expect(onLoadBalancingHealthAlertTriggerRenderer.getRootEventValues(context)).toEqual({
+      "Triggered At": new Date(EVENT.createdAt).toLocaleString(),
       "Alert Type": "load_balancing_health_alert",
       "Event Source": "origin",
       "New Health": "Unhealthy",
       Pool: "Production pool",
-      Origin: "api-primary",
-      "Load Balancer": "api.example.com",
     });
+  });
+
+  it("prefers origin_name in the title when the payload includes it (Details tab unchanged)", () => {
+    const context: TriggerEventContext = { event: EVENT_WITH_ORIGIN };
+
+    expect(onLoadBalancingHealthAlertTriggerRenderer.getTitleAndSubtitle(context).title).toBe(
+      "api-primary · origin · Unhealthy",
+    );
+
+    expect(onLoadBalancingHealthAlertTriggerRenderer.getRootEventValues(context)).toEqual({
+      "Triggered At": new Date(EVENT_WITH_ORIGIN.createdAt).toLocaleString(),
+      "Alert Type": "load_balancing_health_alert",
+      "Event Source": "origin",
+      "New Health": "Unhealthy",
+      Pool: "Production pool",
+    });
+  });
+
+  it("shows dash for Triggered At when createdAt is missing", () => {
+    const values = onLoadBalancingHealthAlertTriggerRenderer.getRootEventValues({
+      event: { ...EVENT, createdAt: "   " },
+    });
+    expect(values["Triggered At"]).toBe("-");
   });
 
   it("includes configured pool and health metadata", () => {
@@ -61,6 +90,22 @@ describe("onLoadBalancingHealthAlertTriggerRenderer", () => {
       node: NODE,
       definition: DEFINITION,
       lastEvent: EVENT,
+    };
+
+    const props = onLoadBalancingHealthAlertTriggerRenderer.getTriggerProps(context);
+
+    expect(props.metadata).toEqual([
+      { icon: "server", label: "Production pool" },
+      { icon: "activity", label: "Unhealthy" },
+    ]);
+    expect(props.lastEventData?.title).toBe("Production pool · origin · Unhealthy");
+  });
+
+  it("prefers origin_name for lastEventData title when the payload includes it", () => {
+    const context: TriggerRendererContext = {
+      node: NODE,
+      definition: DEFINITION,
+      lastEvent: EVENT_WITH_ORIGIN,
     };
 
     const props = onLoadBalancingHealthAlertTriggerRenderer.getTriggerProps(context);

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
@@ -22,9 +22,22 @@ interface HealthAlertEventData {
   load_balancer_name?: string;
 }
 
+/** Cloudflare may send alert fields at the top level or under a `data` object; backend now normalizes on emit, but unwrap here for older executions. */
+function parseHealthAlertEventData(raw: unknown): HealthAlertEventData | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const envelope = raw as Record<string, unknown>;
+  const nested = envelope["data"];
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as HealthAlertEventData;
+  }
+  return envelope as HealthAlertEventData;
+}
+
 export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
-    const eventData = context.event?.data as HealthAlertEventData;
+    const eventData = parseHealthAlertEventData(context.event?.data);
 
     return {
       title: buildEventTitle(eventData),
@@ -33,7 +46,7 @@ export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
   },
 
   getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
-    const eventData = context.event?.data as HealthAlertEventData;
+    const eventData = parseHealthAlertEventData(context.event?.data);
 
     return {
       "Triggered At": formatTriggeredAt(context.event?.createdAt),
@@ -67,7 +80,7 @@ export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
     };
 
     if (lastEvent) {
-      const eventData = lastEvent.data as HealthAlertEventData;
+      const eventData = parseHealthAlertEventData(lastEvent.data);
       props.lastEventData = {
         title: buildEventTitle(eventData),
         subtitle: lastEvent.createdAt ? renderTimeAgo(new Date(lastEvent.createdAt)) : "",
@@ -91,7 +104,7 @@ function buildEventTitle(eventData?: HealthAlertEventData): string {
 }
 
 function getEventPoolName(eventDataSource?: { data?: unknown }): string | undefined {
-  const eventData = eventDataSource?.data as HealthAlertEventData | undefined;
+  const eventData = parseHealthAlertEventData(eventDataSource?.data);
   return eventData?.pool_name?.trim() || undefined;
 }
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
@@ -36,12 +36,11 @@ export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
     const eventData = context.event?.data as HealthAlertEventData;
 
     return {
+      "Triggered At": formatTriggeredAt(context.event?.createdAt),
       "Alert Type": displayValue(eventData?.alert_type),
       "Event Source": displayValue(eventData?.event_source),
       "New Health": displayValue(eventData?.new_health),
       Pool: displayValue(eventData?.pool_name || eventData?.pool_id),
-      Origin: displayValue(eventData?.origin_name),
-      "Load Balancer": displayValue(eventData?.load_balancer_name),
     };
   },
 
@@ -98,4 +97,15 @@ function getEventPoolName(eventDataSource?: { data?: unknown }): string | undefi
 
 function displayValue(value?: string): string {
   return value?.trim() || "-";
+}
+
+function formatTriggeredAt(createdAt?: string): string {
+  if (!createdAt?.trim()) {
+    return "-";
+  }
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return "-";
+  }
+  return parsed.toLocaleString();
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
@@ -4,6 +4,7 @@ import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
 import type { TriggerProps } from "@/ui/trigger";
 import type React from "react";
 import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import { getCloudflarePoolName } from "./metadata";
 
 interface HealthAlertConfiguration {
   pool?: string;
@@ -49,8 +50,9 @@ export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
     const configuration = node.configuration as HealthAlertConfiguration | undefined;
     const metadata = [];
 
-    if (configuration?.pool) {
-      metadata.push({ icon: "server", label: configuration.pool });
+    const poolLabel = getCloudflarePoolName(node.metadata) || getEventPoolName(lastEvent) || configuration?.pool;
+    if (poolLabel) {
+      metadata.push({ icon: "server", label: poolLabel });
     }
 
     if (configuration?.newHealth?.length) {
@@ -87,6 +89,11 @@ function buildEventTitle(eventData?: HealthAlertEventData): string {
     eventData?.origin_name?.trim() || eventData?.pool_name?.trim() || eventData?.load_balancer_name?.trim();
 
   return [target, source, health].filter(Boolean).join(" · ");
+}
+
+function getEventPoolName(eventDataSource?: { data?: unknown }): string | undefined {
+  const eventData = eventDataSource?.data as HealthAlertEventData | undefined;
+  return eventData?.pool_name?.trim() || undefined;
 }
 
 function displayValue(value?: string): string {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_load_balancing_health_alert.ts
@@ -1,0 +1,94 @@
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import type { TriggerProps } from "@/ui/trigger";
+import type React from "react";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+
+interface HealthAlertConfiguration {
+  pool?: string;
+  newHealth?: string[];
+  eventSource?: string[];
+}
+
+interface HealthAlertEventData {
+  alert_type?: string;
+  event_source?: string;
+  new_health?: string;
+  pool_id?: string;
+  pool_name?: string;
+  origin_name?: string;
+  load_balancer_name?: string;
+}
+
+export const onLoadBalancingHealthAlertTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
+    const eventData = context.event?.data as HealthAlertEventData;
+
+    return {
+      title: buildEventTitle(eventData),
+      subtitle: context.event?.createdAt ? renderTimeAgo(new Date(context.event.createdAt)) : "",
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = context.event?.data as HealthAlertEventData;
+
+    return {
+      "Alert Type": displayValue(eventData?.alert_type),
+      "Event Source": displayValue(eventData?.event_source),
+      "New Health": displayValue(eventData?.new_health),
+      Pool: displayValue(eventData?.pool_name || eventData?.pool_id),
+      Origin: displayValue(eventData?.origin_name),
+      "Load Balancer": displayValue(eventData?.load_balancer_name),
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
+    const { node, definition, lastEvent } = context;
+    const configuration = node.configuration as HealthAlertConfiguration | undefined;
+    const metadata = [];
+
+    if (configuration?.pool) {
+      metadata.push({ icon: "server", label: configuration.pool });
+    }
+
+    if (configuration?.newHealth?.length) {
+      metadata.push({ icon: "activity", label: configuration.newHealth.join(", ") });
+    }
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Cloudflare health alert",
+      iconSrc: cloudflareIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata,
+    };
+
+    if (lastEvent) {
+      const eventData = lastEvent.data as HealthAlertEventData;
+      props.lastEventData = {
+        title: buildEventTitle(eventData),
+        subtitle: lastEvent.createdAt ? renderTimeAgo(new Date(lastEvent.createdAt)) : "",
+        receivedAt: new Date(lastEvent.createdAt),
+        state: "triggered",
+        eventId: lastEvent.id,
+      };
+    }
+
+    return props;
+  },
+};
+
+function buildEventTitle(eventData?: HealthAlertEventData): string {
+  const health = eventData?.new_health?.trim() || "Health changed";
+  const source = eventData?.event_source?.trim();
+  const target =
+    eventData?.origin_name?.trim() || eventData?.pool_name?.trim() || eventData?.load_balancer_name?.trim();
+
+  return [target, source, health].filter(Boolean).join(" · ");
+}
+
+function displayValue(value?: string): string {
+  return value?.trim() || "-";
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_pool.ts
@@ -7,14 +7,11 @@ import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { baseEventSections, getPoolExecutionDetails } from "./base";
+import { getCloudflarePoolName } from "./metadata";
 
 interface UpdatePoolConfiguration {
   name?: string;
   pool?: string;
-}
-
-interface UpdatePoolNodeMetadata {
-  poolName?: string;
 }
 
 export const updatePoolMapper: ComponentBaseMapper = {
@@ -44,10 +41,9 @@ export const updatePoolMapper: ComponentBaseMapper = {
 
 function metadataList(node: NodeInfo): MetadataItem[] {
   const metadata: MetadataItem[] = [];
-  const nodeMetadata = node.metadata as UpdatePoolNodeMetadata | undefined;
   const configuration = node.configuration as UpdatePoolConfiguration;
 
-  const label = nodeMetadata?.poolName || configuration?.name || configuration?.pool;
+  const label = getCloudflarePoolName(node.metadata) || configuration?.name || configuration?.pool;
   if (label) {
     metadata.push({ icon: "network", label });
   }


### PR DESCRIPTION
### What changed:

- Added new Cloudflare Load Balancing workflow components:
- Create Monitor (cloudflare.createMonitor)
- Delete Monitor (cloudflare.deleteMonitor)
- On Load Balancing Health Alert (cloudflare.onLoadBalancingHealthAlert)

### Why:
To support Cloudflare Load Balancing health monitor management and health alert automation directly in SuperPlane workflows.

### How:
Backend:

- Implemented account-level Cloudflare API methods in pkg/integrations/cloudflare/client.go for monitors, pools, monitor references, alerting webhook destinations, and notification policies.
- Registered monitor actions and the health alert trigger in pkg/integrations/cloudflare/cloudflare.go.
- Added Cloudflare webhook handler setup/cleanup for load_balancing_health_alert notification policies.
- Added Account ID configuration and setup instructions.
- Added example outputs/data and regenerated component docs.
- Added tests for create monitor, delete monitor, health alert trigger handling, webhook setup/cleanup, and Cloudflare integration configuration.

### Frontend:

- Added Cloudflare workflow v2 mappers for Create Monitor and Delete Monitor.
- Added trigger renderer for On Load Balancing Health Alert.
- Registered mappers, trigger renderer, and event states in web_src/src/pages/workflowv2/mappers/cloudflare/index.ts.
- Added mapper specs for monitor metadata and health alert rendering.
- 