### PR TITLE
fix: include soft-deleted canvases in retention cleanup

### DIFF
--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -195,16 +195,16 @@ func LockExpiredRoutedRootCanvasEventsInTransaction(tx *gorm.DB, referenceTime t
 }
 
 func expiredRoutedRootCanvasEventsQuery(tx *gorm.DB, referenceTime time.Time) *gorm.DB {
-	query := tx.
+	return tx.
 		Table("workflow_events").
 		Select("workflow_events.*").
+		Joins("JOIN workflows ON workflow_events.workflow_id = workflows.id").
+		Joins("JOIN organizations ON workflows.organization_id = organizations.id").
 		Where("organizations.usage_retention_window_days IS NOT NULL").
 		Where("organizations.usage_retention_window_days > 0").
 		Where("workflow_events.execution_id IS NULL").
 		Where("workflow_events.state = ?", CanvasEventStateRouted).
 		Where("workflow_events.created_at + (organizations.usage_retention_window_days * INTERVAL '1 day') < ?", referenceTime.UTC())
-
-	return withActiveCanvas(query, "workflow_events.workflow_id")
 }
 
 func lockCanvasEventsForUpdate(tx *gorm.DB) *gorm.DB {

--- a/pkg/models/canvas_event_test.go
+++ b/pkg/models/canvas_event_test.go
@@ -32,7 +32,7 @@ func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ReturnsMultipleEligibl
 	require.ElementsMatch(t, []uuid.UUID{event1.ID, event2.ID}, canvasEventIDs(events))
 }
 
-func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ExcludesInactiveAndIneligibleEvents(t *testing.T) {
+func Test__LockExpiredRoutedRootCanvasEventsInTransaction_IncludesSoftDeletedCanvasesAndOrganizations(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 
 	org := createOrganization(t)
@@ -48,13 +48,13 @@ func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ExcludesInactiveAndIne
 	createExpiredRootEvent(t, noRetentionCanvas.ID)
 
 	deletedCanvas := createRetentionCanvas(t, org.ID)
-	createExpiredRootEvent(t, deletedCanvas.ID)
+	deletedCanvasEvent := createExpiredRootEvent(t, deletedCanvas.ID)
 	require.NoError(t, database.Conn().Delete(&models.Canvas{}, "id = ?", deletedCanvas.ID).Error)
 
 	deletedOrg := createOrganization(t)
 	cacheRetentionWindow(t, deletedOrg.ID, 30)
 	deletedOrgCanvas := createRetentionCanvas(t, deletedOrg.ID)
-	createExpiredRootEvent(t, deletedOrgCanvas.ID)
+	deletedOrgEvent := createExpiredRootEvent(t, deletedOrgCanvas.ID)
 	require.NoError(t, database.Conn().Delete(&models.Organization{}, "id = ?", deletedOrg.ID).Error)
 
 	queuedRoot := createExpiredRootEvent(t, canvas.ID)
@@ -87,7 +87,7 @@ func Test__LockExpiredRoutedRootCanvasEventsInTransaction_ExcludesInactiveAndIne
 		return err
 	})
 	require.NoError(t, err)
-	require.Equal(t, []uuid.UUID{eligible.ID}, canvasEventIDs(events))
+	require.ElementsMatch(t, []uuid.UUID{eligible.ID, deletedCanvasEvent.ID, deletedOrgEvent.ID}, canvasEventIDs(events))
 }
 
 func createOrganization(t *testing.T) *models.Organization {


### PR DESCRIPTION
## Summary

Updates event retention cleanup to include expired root events from soft-deleted canvases and organizations.

The retention worker still uses the organization retention window to decide eligibility, but no longer skips events only because the canvas or organization is soft-deleted.
