### PR TITLE
feat: add Cloudflare load balancing health monitor management

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -30,10 +30,12 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
   <LinkCard title="Get Load Balancer" href="#get-load-balancer" description="Retrieve a Cloudflare Load Balancer by ID" />
+  <LinkCard title="Get Monitor" href="#get-monitor" description="Retrieve a Cloudflare load balancing health monitor's configuration" />
   <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
   <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
   <LinkCard title="Update Load Balancer" href="#update-load-balancer" description="Update a Cloudflare Load Balancer's steering policy, pool weights, or session affinity" />
+  <LinkCard title="Update Monitor" href="#update-monitor" description="Update a Cloudflare load balancing health monitor's configuration" />
   <LinkCard title="Update Origin Rule" href="#update-origin-rule" description="Update an existing origin rule" />
   <LinkCard title="Update Pool" href="#update-pool" description="Update a Cloudflare Load Balancer origin pool's configuration or origin weights" />
   <LinkCard title="Update Redirect Rule" href="#update-redirect-rule" description="Update a redirect rule in a Cloudflare zone" />
@@ -774,6 +776,53 @@ Returns the full load balancer configuration including pools, steering policy, a
 }
 ```
 
+<a id="get-monitor"></a>
+
+## Get Monitor
+
+The Get Monitor component fetches the current configuration of a Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Pre-flight validation**: Confirm a monitor exists and inspect its configuration before modifying it
+- **Audit**: Capture a snapshot of monitor settings at a point in time
+- **Workflow data**: Expose monitor configuration as payload data for downstream nodes
+
+### Configuration
+
+- **Monitor**: The health monitor to retrieve
+
+### Output
+
+Returns the full monitor configuration including type, path, port, intervals, and health thresholds.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitor": {
+      "consecutive_down": 3,
+      "consecutive_up": 2,
+      "description": "Login page monitor",
+      "expected_codes": "2xx",
+      "id": "monitor_abc123",
+      "interval": 60,
+      "method": "GET",
+      "path": "/health",
+      "port": 443,
+      "retries": 0,
+      "timeout": 5,
+      "type": "https"
+    },
+    "monitorId": "monitor_abc123"
+  },
+  "timestamp": "2026-05-11T10:00:00.000000000Z",
+  "type": "cloudflare.monitor.fetched"
+}
+```
+
 <a id="get-pool"></a>
 
 ## Get Pool
@@ -965,6 +1014,56 @@ Returns the updated load balancer configuration.
   },
   "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.loadBalancer.updated"
+}
+```
+
+<a id="update-monitor"></a>
+
+## Update Monitor
+
+The Update Monitor component modifies an existing Cloudflare Load Balancing health monitor.
+
+### Use Cases
+
+- **Adjust thresholds**: Change health check intervals, timeouts, or consecutive up/down counts
+- **Change protocol**: Switch a monitor from HTTP to HTTPS or TCP
+- **Update endpoint**: Modify the path or port being checked
+- **Tune headers**: Add or remove request headers sent during health checks
+
+### Configuration
+
+- **Monitor**: The health monitor to update (required)
+- **Type / Description / Path / Port**: Override basic monitor settings. Only toggled fields are applied.
+- **Advanced Health Check Settings**: Override method, expected response, headers, redirect, TLS, and timing thresholds.
+
+### Output
+
+Returns the updated monitor configuration after the change is applied.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitor": {
+      "consecutive_down": 3,
+      "consecutive_up": 2,
+      "description": "Updated login page monitor",
+      "expected_codes": "2xx",
+      "id": "monitor_abc123",
+      "interval": 30,
+      "method": "GET",
+      "path": "/healthz",
+      "port": 443,
+      "retries": 2,
+      "timeout": 5,
+      "type": "https"
+    },
+    "monitorId": "monitor_abc123"
+  },
+  "timestamp": "2026-05-11T10:00:00.000000000Z",
+  "type": "cloudflare.monitor.updated"
 }
 ```
 

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -382,6 +382,35 @@ func (c *Client) ListMonitorReferences(accountID, monitorID string) ([]MonitorRe
 	return response.Result, nil
 }
 
+func (c *Client) UpdateMonitor(accountID, monitorID string, req CreateMonitorRequest) (*Monitor, error) {
+	url := fmt.Sprintf("%s/accounts/%s/load_balancers/monitors/%s", c.BaseURL, accountID, monitorID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool    `json:"success"`
+		Result  Monitor `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("API returned success=false")
+	}
+
+	return &response.Result, nil
+}
+
 func (c *Client) ListPools(accountID string) ([]Pool, error) {
 	url := fmt.Sprintf("%s/accounts/%s/load_balancers/pools", c.BaseURL, accountID)
 	responseBody, err := c.execRequest(http.MethodGet, url, nil)

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -185,6 +185,8 @@ func (c *Cloudflare) Actions() []core.Action {
 		&UpdateDNSRecord{},
 		&DeleteDNSRecord{},
 		&CreateMonitor{},
+		&GetMonitor{},
+		&UpdateMonitor{},
 		&DeleteMonitor{},
 		&DeleteOriginRule{},
 		&CreateKVNamespace{},

--- a/pkg/integrations/cloudflare/create_monitor.go
+++ b/pkg/integrations/cloudflare/create_monitor.go
@@ -597,7 +597,36 @@ func resolvedMonitorTiming(advanced CreateMonitorAdvancedSpec) (interval int, ti
 	return interval, timeout, retries
 }
 
-func validateMonitorTiming(advanced CreateMonitorAdvancedSpec) error {
+// resolvedMonitorTimingForUpdate overlays advanced timing fields onto the current monitor (or
+// create-style defaults when current is nil), matching mergeMonitorUpdate behavior.
+func resolvedMonitorTimingForUpdate(advanced CreateMonitorAdvancedSpec, current *Monitor) (interval int, timeout int, retries int) {
+	interval = defaultMonitorIntervalSeconds
+	timeout = defaultMonitorTimeoutSeconds
+	retries = defaultMonitorRetries
+	if current != nil {
+		if current.Interval != nil {
+			interval = *current.Interval
+		}
+		if current.Timeout != nil {
+			timeout = *current.Timeout
+		}
+		if current.Retries != nil {
+			retries = *current.Retries
+		}
+	}
+	if advanced.Interval != nil {
+		interval = *advanced.Interval
+	}
+	if advanced.Timeout != nil {
+		timeout = *advanced.Timeout
+	}
+	if advanced.Retries != nil {
+		retries = *advanced.Retries
+	}
+	return interval, timeout, retries
+}
+
+func validateMonitorTimingFields(advanced CreateMonitorAdvancedSpec) error {
 	if advanced.Interval != nil {
 		if *advanced.Interval < minMonitorIntervalSeconds {
 			return fmt.Errorf("interval must be at least %d seconds", minMonitorIntervalSeconds)
@@ -615,12 +644,42 @@ func validateMonitorTiming(advanced CreateMonitorAdvancedSpec) error {
 		return fmt.Errorf("retries must be between 0 and %d", maxMonitorRetries)
 	}
 
-	interval, timeout, _ := resolvedMonitorTiming(advanced)
+	return nil
+}
+
+func validateMonitorTimeoutLessThanInterval(interval, timeout int) error {
 	if timeout >= interval {
 		return fmt.Errorf("timeout (%ds) must be less than interval (%ds)", timeout, interval)
 	}
-
 	return nil
+}
+
+func validateMonitorTiming(advanced CreateMonitorAdvancedSpec) error {
+	if err := validateMonitorTimingFields(advanced); err != nil {
+		return err
+	}
+
+	interval, timeout, _ := resolvedMonitorTiming(advanced)
+	return validateMonitorTimeoutLessThanInterval(interval, timeout)
+}
+
+// validateMonitorTimingForUpdate validates advanced timing for monitor updates. When current is nil
+// (e.g. setup without integration context), the interval/timeout relationship is only checked if both
+// are explicitly set in advanced, since unresolved fields will keep the existing monitor values.
+func validateMonitorTimingForUpdate(advanced CreateMonitorAdvancedSpec, current *Monitor) error {
+	if err := validateMonitorTimingFields(advanced); err != nil {
+		return err
+	}
+
+	if current == nil {
+		if advanced.Interval != nil && advanced.Timeout != nil {
+			return validateMonitorTimeoutLessThanInterval(*advanced.Interval, *advanced.Timeout)
+		}
+		return nil
+	}
+
+	interval, timeout, _ := resolvedMonitorTimingForUpdate(advanced, current)
+	return validateMonitorTimeoutLessThanInterval(interval, timeout)
 }
 
 func monitorHeadersToMap(headers []MonitorHeader) map[string][]string {

--- a/pkg/integrations/cloudflare/delete_monitor.go
+++ b/pkg/integrations/cloudflare/delete_monitor.go
@@ -107,10 +107,12 @@ func (c *DeleteMonitor) Setup(ctx core.SetupContext) error {
 		return errors.New("monitor is required")
 	}
 
-	return resolveMonitorMetadata(ctx, monitorID)
+	return resolveMonitorMetadata(ctx, monitorID, nil)
 }
 
-func resolveMonitorMetadata(ctx core.SetupContext, monitorID string) error {
+// preloaded, when non-nil, is used for node metadata instead of fetching again (e.g. Update Monitor
+// already retrieved the monitor for validation).
+func resolveMonitorMetadata(ctx core.SetupContext, monitorID string, preloaded *Monitor) error {
 	if ctx.Metadata == nil || ctx.Integration == nil || ctx.HTTP == nil {
 		return nil
 	}
@@ -128,19 +130,24 @@ func resolveMonitorMetadata(ctx core.SetupContext, monitorID string) error {
 		return nil
 	}
 
-	client, err := NewClient(ctx.HTTP, ctx.Integration)
-	if err != nil {
-		return fmt.Errorf("failed to create client for monitor metadata: %w", err)
-	}
+	var monitor *Monitor
+	if preloaded != nil {
+		monitor = preloaded
+	} else {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create client for monitor metadata: %w", err)
+		}
 
-	accountID, err := accountIDForIntegration(ctx.Integration)
-	if err != nil {
-		return err
-	}
+		accountID, err := accountIDForIntegration(ctx.Integration)
+		if err != nil {
+			return err
+		}
 
-	monitor, err := client.GetMonitor(accountID, id)
-	if err != nil {
-		return fmt.Errorf("failed to fetch monitor %s for metadata: %w", id, err)
+		monitor, err = client.GetMonitor(accountID, id)
+		if err != nil {
+			return fmt.Errorf("failed to fetch monitor %s for metadata: %w", id, err)
+		}
 	}
 
 	desc := strings.TrimSpace(monitor.Description)

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -19,6 +19,12 @@ var exampleOutputCreateMonitorBytes []byte
 //go:embed example_output_delete_monitor.json
 var exampleOutputDeleteMonitorBytes []byte
 
+//go:embed example_output_get_monitor.json
+var exampleOutputGetMonitorBytes []byte
+
+//go:embed example_output_update_monitor.json
+var exampleOutputUpdateMonitorBytes []byte
+
 //go:embed example_data_on_load_balancing_health_alert.json
 var exampleDataOnLoadBalancingHealthAlertBytes []byte
 
@@ -33,6 +39,12 @@ var exampleOutputCreateMonitor map[string]any
 
 var exampleOutputDeleteMonitorOnce sync.Once
 var exampleOutputDeleteMonitor map[string]any
+
+var exampleOutputGetMonitorOnce sync.Once
+var exampleOutputGetMonitor map[string]any
+
+var exampleOutputUpdateMonitorOnce sync.Once
+var exampleOutputUpdateMonitor map[string]any
 
 var exampleDataOnLoadBalancingHealthAlertOnce sync.Once
 var exampleDataOnLoadBalancingHealthAlert map[string]any
@@ -51,6 +63,14 @@ func (c *CreateMonitor) ExampleOutput() map[string]any {
 
 func (c *DeleteMonitor) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteMonitorOnce, exampleOutputDeleteMonitorBytes, &exampleOutputDeleteMonitor)
+}
+
+func (c *GetMonitor) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetMonitorOnce, exampleOutputGetMonitorBytes, &exampleOutputGetMonitor)
+}
+
+func (c *UpdateMonitor) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateMonitorOnce, exampleOutputUpdateMonitorBytes, &exampleOutputUpdateMonitor)
 }
 
 func (t *OnLoadBalancingHealthAlert) ExampleData() map[string]any {

--- a/pkg/integrations/cloudflare/example_output_get_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_get_monitor.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitorId": "monitor_abc123",
+    "monitor": {
+      "id": "monitor_abc123",
+      "type": "https",
+      "description": "Login page monitor",
+      "method": "GET",
+      "path": "/health",
+      "expected_codes": "2xx",
+      "interval": 60,
+      "timeout": 5,
+      "retries": 0,
+      "consecutive_up": 2,
+      "consecutive_down": 3,
+      "port": 443
+    }
+  },
+  "timestamp": "2026-05-11T10:00:00.000000000Z",
+  "type": "cloudflare.monitor.fetched"
+}

--- a/pkg/integrations/cloudflare/example_output_update_monitor.json
+++ b/pkg/integrations/cloudflare/example_output_update_monitor.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "accountId": "account_abc123",
+    "monitorId": "monitor_abc123",
+    "monitor": {
+      "id": "monitor_abc123",
+      "type": "https",
+      "description": "Updated login page monitor",
+      "method": "GET",
+      "path": "/healthz",
+      "expected_codes": "2xx",
+      "interval": 30,
+      "timeout": 5,
+      "retries": 2,
+      "consecutive_up": 2,
+      "consecutive_down": 3,
+      "port": 443
+    }
+  },
+  "timestamp": "2026-05-11T10:00:00.000000000Z",
+  "type": "cloudflare.monitor.updated"
+}

--- a/pkg/integrations/cloudflare/get_monitor.go
+++ b/pkg/integrations/cloudflare/get_monitor.go
@@ -91,7 +91,7 @@ func (c *GetMonitor) Setup(ctx core.SetupContext) error {
 		return errors.New("monitor is required")
 	}
 
-	return resolveMonitorMetadata(ctx, monitorID)
+	return resolveMonitorMetadata(ctx, monitorID, nil)
 }
 
 func (c *GetMonitor) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/cloudflare/get_monitor.go
+++ b/pkg/integrations/cloudflare/get_monitor.go
@@ -1,0 +1,156 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetMonitorPayloadType = "cloudflare.monitor.fetched"
+
+type GetMonitor struct{}
+
+type GetMonitorSpec struct {
+	Monitor string `json:"monitor"`
+}
+
+func (c *GetMonitor) Name() string {
+	return "cloudflare.getMonitor"
+}
+
+func (c *GetMonitor) Label() string {
+	return "Get Monitor"
+}
+
+func (c *GetMonitor) Description() string {
+	return "Retrieve a Cloudflare load balancing health monitor's configuration"
+}
+
+func (c *GetMonitor) Documentation() string {
+	return `The Get Monitor component fetches the current configuration of a Cloudflare Load Balancing health monitor.
+
+## Use Cases
+
+- **Pre-flight validation**: Confirm a monitor exists and inspect its configuration before modifying it
+- **Audit**: Capture a snapshot of monitor settings at a point in time
+- **Workflow data**: Expose monitor configuration as payload data for downstream nodes
+
+## Configuration
+
+- **Monitor**: The health monitor to retrieve
+
+## Output
+
+Returns the full monitor configuration including type, path, port, intervals, and health thresholds.`
+}
+
+func (c *GetMonitor) Icon() string {
+	return "activity"
+}
+
+func (c *GetMonitor) Color() string {
+	return "orange"
+}
+
+func (c *GetMonitor) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetMonitor) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "monitor",
+			Label:       "Monitor",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The load balancing health monitor to retrieve",
+			Placeholder: "Select a monitor",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "monitor",
+				},
+			},
+		},
+	}
+}
+
+func (c *GetMonitor) Setup(ctx core.SetupContext) error {
+	spec := GetMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	return resolveMonitorMetadata(ctx, monitorID)
+}
+
+func (c *GetMonitor) Execute(ctx core.ExecutionContext) error {
+	spec := GetMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	monitor, err := client.GetMonitor(accountID, monitorID)
+	if err != nil {
+		return fmt.Errorf("failed to get monitor: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetMonitorPayloadType,
+		[]any{map[string]any{
+			"accountId": accountID,
+			"monitor":   monitor,
+			"monitorId": monitorID,
+		}},
+	)
+}
+
+func (c *GetMonitor) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetMonitor) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetMonitor) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetMonitor) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetMonitor) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetMonitor) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/get_monitor_test.go
+++ b/pkg/integrations/cloudflare/get_monitor_test.go
@@ -1,0 +1,157 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetMonitor__Setup(t *testing.T) {
+	component := &GetMonitor{}
+
+	t.Run("missing monitor returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "monitor is required")
+	})
+
+	t.Run("validation passes without metadata resolution when integration context is absent", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("resolves monitor metadata when integration is available", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"success":true,"result":{"id":"monitor123","description":"Edge health"}}`,
+					)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP:     httpContext,
+			Metadata: metadata,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+
+		var meta MonitorNodeMetadata
+		require.NoError(t, mapstructure.Decode(metadata.Metadata, &meta))
+		assert.Equal(t, "monitor123", meta.MonitorID)
+		assert.Equal(t, "Edge health", meta.MonitorDescription)
+	})
+}
+
+func Test__GetMonitor__Execute(t *testing.T) {
+	component := &GetMonitor{}
+
+	t.Run("successful get emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "monitor123",
+							"type": "https",
+							"description": "Login page monitor",
+							"method": "GET",
+							"path": "/health",
+							"expected_codes": "2xx",
+							"interval": 60,
+							"timeout": 5,
+							"retries": 0
+						}
+					}`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: execState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, GetMonitorPayloadType, execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t,
+			"https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123",
+			httpContext.Requests[0].URL.String(),
+		)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false,"errors":[{"message":"Monitor not found"}]}`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get monitor")
+	})
+}

--- a/pkg/integrations/cloudflare/update_monitor.go
+++ b/pkg/integrations/cloudflare/update_monitor.go
@@ -174,13 +174,28 @@ func (c *UpdateMonitor) Setup(ctx core.SetupContext) error {
 		return errors.New("port must be between 1 and 65535")
 	}
 
+	var preloaded *Monitor
 	if spec.Advanced != nil {
-		if err := validateMonitorTiming(*spec.Advanced); err != nil {
+		if ctx.HTTP != nil && ctx.Integration != nil && !strings.Contains(monitorID, "{{") {
+			client, err := NewClient(ctx.HTTP, ctx.Integration)
+			if err != nil {
+				return fmt.Errorf("failed to create client for monitor validation: %w", err)
+			}
+			accountID, err := accountIDForIntegration(ctx.Integration)
+			if err != nil {
+				return err
+			}
+			preloaded, err = client.GetMonitor(accountID, monitorID)
+			if err != nil {
+				return fmt.Errorf("failed to fetch monitor for validation: %w", err)
+			}
+		}
+		if err := validateMonitorTimingForUpdate(*spec.Advanced, preloaded); err != nil {
 			return err
 		}
 	}
 
-	return resolveMonitorMetadata(ctx, monitorID)
+	return resolveMonitorMetadata(ctx, monitorID, preloaded)
 }
 
 func isAllowedMonitorType(t string) bool {

--- a/pkg/integrations/cloudflare/update_monitor.go
+++ b/pkg/integrations/cloudflare/update_monitor.go
@@ -1,0 +1,339 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const UpdateMonitorPayloadType = "cloudflare.monitor.updated"
+
+type UpdateMonitor struct{}
+
+type UpdateMonitorSpec struct {
+	Monitor     string                     `json:"monitor"`
+	Type        string                     `json:"type"`
+	Description string                     `json:"description"`
+	Path        *string                    `json:"path,omitempty"`
+	Port        *int                       `json:"port,omitempty"`
+	Advanced    *CreateMonitorAdvancedSpec `json:"advanced,omitempty"`
+}
+
+func (c *UpdateMonitor) Name() string {
+	return "cloudflare.updateMonitor"
+}
+
+func (c *UpdateMonitor) Label() string {
+	return "Update Monitor"
+}
+
+func (c *UpdateMonitor) Description() string {
+	return "Update a Cloudflare load balancing health monitor's configuration"
+}
+
+func (c *UpdateMonitor) Documentation() string {
+	return `The Update Monitor component modifies an existing Cloudflare Load Balancing health monitor.
+
+## Use Cases
+
+- **Adjust thresholds**: Change health check intervals, timeouts, or consecutive up/down counts
+- **Change protocol**: Switch a monitor from HTTP to HTTPS or TCP
+- **Update endpoint**: Modify the path or port being checked
+- **Tune headers**: Add or remove request headers sent during health checks
+
+## Configuration
+
+- **Monitor**: The health monitor to update (required)
+- **Type / Description / Path / Port**: Override basic monitor settings. Only toggled fields are applied.
+- **Advanced Health Check Settings**: Override method, expected response, headers, redirect, TLS, and timing thresholds.
+
+## Output
+
+Returns the updated monitor configuration after the change is applied.`
+}
+
+func (c *UpdateMonitor) Icon() string {
+	return "activity"
+}
+
+func (c *UpdateMonitor) Color() string {
+	return "orange"
+}
+
+func (c *UpdateMonitor) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateMonitor) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "monitor",
+			Label:       "Monitor",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The load balancing health monitor to update",
+			Placeholder: "Select a monitor",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "monitor",
+				},
+			},
+		},
+		{
+			Name:        "description",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+			Description: "New human-readable name for the monitor",
+			Placeholder: "Login page monitor",
+		},
+		{
+			Name:      "type",
+			Label:     "Type",
+			Type:      configuration.FieldTypeSelect,
+			Required:  false,
+			Togglable: true,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "HTTP", Value: "http"},
+						{Label: "HTTPS", Value: "https"},
+						{Label: "TCP", Value: "tcp"},
+						{Label: "UDP ICMP", Value: "udp_icmp"},
+						{Label: "ICMP Ping", Value: "icmp_ping"},
+						{Label: "SMTP", Value: "smtp"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "path",
+			Label:       "Path",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+			Description: "New endpoint path to check (HTTP and HTTPS only)",
+			Placeholder: "/health",
+		},
+		{
+			Name:        "port",
+			Label:       "Port",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Togglable:   true,
+			Description: "New port for health checks",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: func() *int { min := 1; return &min }(),
+					Max: func() *int { max := 65535; return &max }(),
+				},
+			},
+		},
+		{
+			Name:        "advanced",
+			Label:       "Advanced Health Check Settings",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Togglable:   true,
+			Description: "Override method, response validation, headers, redirect, TLS, and health threshold settings",
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: createMonitorAdvancedFields(),
+				},
+			},
+		},
+	}
+}
+
+func (c *UpdateMonitor) Setup(ctx core.SetupContext) error {
+	spec := UpdateMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	if spec.Type != "" {
+		monitorType := normalizeMonitorType(spec.Type)
+		if !isAllowedMonitorType(monitorType) {
+			return fmt.Errorf("type must be one of %s", strings.Join(allowedMonitorTypes, ", "))
+		}
+	}
+
+	if spec.Port != nil && (*spec.Port < 1 || *spec.Port > 65535) {
+		return errors.New("port must be between 1 and 65535")
+	}
+
+	if spec.Advanced != nil {
+		if err := validateMonitorTiming(*spec.Advanced); err != nil {
+			return err
+		}
+	}
+
+	return resolveMonitorMetadata(ctx, monitorID)
+}
+
+func isAllowedMonitorType(t string) bool {
+	for _, allowed := range allowedMonitorTypes {
+		if t == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *UpdateMonitor) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateMonitorSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	monitorID := strings.TrimSpace(spec.Monitor)
+	if monitorID == "" {
+		return errors.New("monitor is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	current, err := client.GetMonitor(accountID, monitorID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch current monitor: %w", err)
+	}
+
+	req := mergeMonitorUpdate(current, spec)
+
+	monitor, err := client.UpdateMonitor(accountID, monitorID, req)
+	if err != nil {
+		return fmt.Errorf("failed to update monitor: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		UpdateMonitorPayloadType,
+		[]any{map[string]any{
+			"accountId": accountID,
+			"monitor":   monitor,
+			"monitorId": monitorID,
+		}},
+	)
+}
+
+// mergeMonitorUpdate overlays user-specified fields onto the current monitor state.
+// Cloudflare's monitor update endpoint is PUT (full replacement), so we fetch first.
+func mergeMonitorUpdate(current *Monitor, spec UpdateMonitorSpec) CreateMonitorRequest {
+	req := CreateMonitorRequest{
+		Type:            current.Type,
+		Description:     current.Description,
+		Method:          current.Method,
+		Path:            current.Path,
+		ExpectedCodes:   current.ExpectedCodes,
+		ExpectedBody:    current.ExpectedBody,
+		Header:          current.Header,
+		FollowRedirects: current.FollowRedirects,
+		AllowInsecure:   current.AllowInsecure,
+		ProbeZone:       current.ProbeZone,
+		Interval:        current.Interval,
+		Timeout:         current.Timeout,
+		Retries:         current.Retries,
+		ConsecutiveUp:   current.ConsecutiveUp,
+		ConsecutiveDown: current.ConsecutiveDown,
+		Port:            current.Port,
+	}
+
+	if spec.Type != "" {
+		req.Type = normalizeMonitorType(spec.Type)
+	}
+	if spec.Description != "" {
+		req.Description = strings.TrimSpace(spec.Description)
+	}
+	if spec.Path != nil {
+		req.Path = strings.TrimSpace(*spec.Path)
+	}
+	if spec.Port != nil {
+		req.Port = spec.Port
+	}
+
+	if spec.Advanced != nil {
+		adv := spec.Advanced
+		if adv.Method != "" {
+			req.Method = normalizeMonitorMethod(adv.Method)
+		}
+		if adv.ExpectedCodes != "" {
+			req.ExpectedCodes = strings.TrimSpace(adv.ExpectedCodes)
+		}
+		if adv.ExpectedBody != "" {
+			req.ExpectedBody = strings.TrimSpace(adv.ExpectedBody)
+		}
+		if len(adv.Headers) > 0 {
+			req.Header = monitorHeadersToMap(adv.Headers)
+		}
+		if adv.FollowRedirects != nil {
+			req.FollowRedirects = adv.FollowRedirects
+		}
+		if adv.AllowInsecure != nil {
+			req.AllowInsecure = adv.AllowInsecure
+		}
+		if adv.ProbeZone != "" {
+			req.ProbeZone = strings.TrimSpace(adv.ProbeZone)
+		}
+		if adv.Interval != nil {
+			req.Interval = adv.Interval
+		}
+		if adv.Timeout != nil {
+			req.Timeout = adv.Timeout
+		}
+		if adv.Retries != nil {
+			req.Retries = adv.Retries
+		}
+		if adv.ConsecutiveUp != nil {
+			req.ConsecutiveUp = adv.ConsecutiveUp
+		}
+		if adv.ConsecutiveDown != nil {
+			req.ConsecutiveDown = adv.ConsecutiveDown
+		}
+	}
+
+	return req
+}
+
+func (c *UpdateMonitor) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateMonitor) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateMonitor) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *UpdateMonitor) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *UpdateMonitor) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdateMonitor) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/update_monitor_test.go
+++ b/pkg/integrations/cloudflare/update_monitor_test.go
@@ -1,0 +1,230 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateMonitor__Setup(t *testing.T) {
+	component := &UpdateMonitor{}
+
+	t.Run("missing monitor returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+		})
+
+		require.ErrorContains(t, err, "monitor is required")
+	})
+
+	t.Run("invalid type returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"type":    "ftp",
+			},
+		})
+
+		require.ErrorContains(t, err, "type must be one of")
+	})
+
+	t.Run("invalid port returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"port":    99999,
+			},
+		})
+
+		require.ErrorContains(t, err, "port must be between 1 and 65535")
+	})
+
+	t.Run("advanced interval below minimum returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"advanced": map[string]any{
+					"interval": 5,
+					"timeout":  3,
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "interval must be at least")
+	})
+
+	t.Run("validation passes without metadata resolution when integration context is absent", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdateMonitor__Execute(t *testing.T) {
+	component := &UpdateMonitor{}
+
+	t.Run("updates monitor by fetching current state then PUT", func(t *testing.T) {
+		currentMonitor := `{
+			"success": true,
+			"result": {
+				"id": "monitor123",
+				"type": "https",
+				"description": "Old name",
+				"method": "GET",
+				"path": "/health",
+				"expected_codes": "2xx",
+				"interval": 60,
+				"timeout": 5,
+				"retries": 0,
+				"port": 443
+			}
+		}`
+		updatedMonitor := `{
+			"success": true,
+			"result": {
+				"id": "monitor123",
+				"type": "https",
+				"description": "New name",
+				"method": "GET",
+				"path": "/health",
+				"expected_codes": "2xx",
+				"interval": 60,
+				"timeout": 5,
+				"retries": 0,
+				"port": 443
+			}
+		}`
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(currentMonitor))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(updatedMonitor))},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor":     "monitor123",
+				"description": "New name",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: execState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, UpdateMonitorPayloadType, execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 2)
+		assert.Equal(t,
+			"https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123",
+			httpContext.Requests[0].URL.String(),
+		)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+		assert.Equal(t,
+			"https://api.cloudflare.com/client/v4/accounts/account123/load_balancers/monitors/monitor123",
+			httpContext.Requests[1].URL.String(),
+		)
+		assert.Equal(t, http.MethodPut, httpContext.Requests[1].Method)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(httpContext.Requests[1].Body).Decode(&body))
+		assert.Equal(t, "New name", body["description"])
+		assert.Equal(t, "https", body["type"])
+	})
+
+	t.Run("preserves current fields not specified in spec", func(t *testing.T) {
+		currentMonitor := `{
+			"success": true,
+			"result": {
+				"id": "monitor123",
+				"type": "https",
+				"description": "Old name",
+				"path": "/original",
+				"expected_codes": "2xx",
+				"interval": 60,
+				"timeout": 5
+			}
+		}`
+		updatedMonitor := `{"success": true, "result": {"id": "monitor123", "type": "https", "description": "Old name", "path": "/new-path"}}`
+
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(currentMonitor))},
+				{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(updatedMonitor))},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		newPath := "/new-path"
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"path":    newPath,
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: execState,
+		})
+
+		require.NoError(t, err)
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(httpContext.Requests[1].Body).Decode(&body))
+		assert.Equal(t, "/new-path", body["path"])
+		assert.Equal(t, "Old name", body["description"])
+	})
+
+	t.Run("API error on fetch returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"success":false,"errors":[{"message":"Monitor not found"}]}`)),
+				},
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+			ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch current monitor")
+	})
+}

--- a/pkg/integrations/cloudflare/update_monitor_test.go
+++ b/pkg/integrations/cloudflare/update_monitor_test.go
@@ -60,6 +60,84 @@ func Test__UpdateMonitor__Setup(t *testing.T) {
 		require.ErrorContains(t, err, "interval must be at least")
 	})
 
+	t.Run("advanced timeout only uses fetched monitor interval for relationship check", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"success":true,"result":{"id":"monitor123","description":"LB","interval":120,"timeout":5}}`,
+					)),
+				},
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"advanced": map[string]any{
+					"timeout": 70,
+				},
+			},
+			HTTP:     httpContext,
+			Metadata: &contexts.MetadataContext{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 1)
+	})
+
+	t.Run("advanced timeout only passes without integration when relationship cannot be checked", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"advanced": map[string]any{
+					"timeout": 70,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("advanced timeout rejected when it is not less than fetched monitor interval", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"success":true,"result":{"id":"monitor123","description":"LB","interval":60,"timeout":5}}`,
+					)),
+				},
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"monitor": "monitor123",
+				"advanced": map[string]any{
+					"timeout": 70,
+				},
+			},
+			HTTP:     httpContext,
+			Metadata: &contexts.MetadataContext{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken":  "token123",
+					"accountId": "account123",
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "timeout (70s) must be less than interval (60s)")
+	})
+
 	t.Run("validation passes without metadata resolution when integration context is absent", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_monitor.ts
@@ -8,7 +8,7 @@ import type {
   SubtitleContext,
 } from "../types";
 import { baseMapper, firstOutputData } from "./base";
-import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
+import { getCloudflareMonitorDisplayLabel } from "./metadata";
 
 interface DeleteMonitorConfiguration {
   monitor?: string;
@@ -38,7 +38,9 @@ export const deleteMonitorMapper: ComponentBaseMapper = {
       return details;
     }
 
-    details["Monitor"] = output.monitorId ? resolvedMonitorDisplayLabel(context.node.metadata, output.monitorId) : "-";
+    details["Monitor"] = output.monitorId
+      ? getCloudflareMonitorDisplayLabel(context.node.metadata, output.monitorId)
+      : "-";
     details["Deleted"] = output.deleted ? "Yes" : "No";
 
     if (output.references) {
@@ -61,7 +63,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   if (monitorId) {
     metadata.push({
       icon: "trash-2",
-      label: resolvedMonitorDisplayLabel(node.metadata, monitorId),
+      label: getCloudflareMonitorDisplayLabel(node.metadata, monitorId),
     });
   }
 
@@ -70,20 +72,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-/** Prefer Cloudflare monitor description when node metadata matches the monitor id (see Setup resolver). */
-function resolvedMonitorDisplayLabel(metadata: unknown, monitorId: string): string {
-  const id = monitorId.trim();
-  if (!id) {
-    return "-";
-  }
-
-  const resolvedId = getCloudflareMonitorId(metadata);
-  const resolvedDesc = getCloudflareMonitorDescription(metadata);
-  if (resolvedId === id && resolvedDesc) {
-    return resolvedDesc;
-  }
-
-  return id;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_monitor.ts
@@ -8,7 +8,7 @@ import type {
   SubtitleContext,
 } from "../types";
 import { baseMapper, firstOutputData } from "./base";
-import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
+import { getCloudflareMonitorDisplayLabel } from "./metadata";
 
 interface GetMonitorConfiguration {
   monitor?: string;
@@ -70,22 +70,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   if (monitorId) {
     metadata.push({
       icon: "activity",
-      label: resolvedMonitorLabel(node.metadata, monitorId),
+      label: getCloudflareMonitorDisplayLabel(node.metadata, monitorId),
     });
   }
 
   return metadata;
-}
-
-function resolvedMonitorLabel(metadata: unknown, monitorId: string): string {
-  const id = monitorId.trim();
-  if (!id) return "-";
-
-  const resolvedId = getCloudflareMonitorId(metadata);
-  const resolvedDesc = getCloudflareMonitorDescription(metadata);
-  if (resolvedId === id && resolvedDesc) {
-    return resolvedDesc;
-  }
-
-  return id;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_monitor.ts
@@ -1,0 +1,91 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import { baseMapper, firstOutputData } from "./base";
+import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
+
+interface GetMonitorConfiguration {
+  monitor?: string;
+}
+
+interface GetMonitorOutput {
+  accountId?: string;
+  monitorId?: string;
+  monitor?: {
+    id?: string;
+    type?: string;
+    description?: string;
+    path?: string;
+    port?: number;
+    method?: string;
+    interval?: number;
+    timeout?: number;
+    retries?: number;
+  };
+}
+
+export const getMonitorMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return {
+      ...baseMapper.props(context),
+      metadata: metadataList(context.node),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
+    const output = firstOutputData(context.execution.outputs) as GetMonitorOutput | undefined;
+
+    if (!output?.monitor) {
+      return details;
+    }
+
+    const m = output.monitor;
+    if (m.description) details["Name"] = m.description;
+    if (m.type) details["Type"] = m.type.toUpperCase();
+    if (m.path) details["Path"] = m.path;
+    if (m.port != null) details["Port"] = String(m.port);
+    if (m.interval != null) details["Interval"] = `${m.interval}s`;
+    if (m.timeout != null) details["Timeout"] = `${m.timeout}s`;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as GetMonitorConfiguration | undefined;
+  const metadata: MetadataItem[] = [];
+
+  const monitorId = configuration?.monitor?.trim();
+  if (monitorId) {
+    metadata.push({
+      icon: "activity",
+      label: resolvedMonitorLabel(node.metadata, monitorId),
+    });
+  }
+
+  return metadata;
+}
+
+function resolvedMonitorLabel(metadata: unknown, monitorId: string): string {
+  const id = monitorId.trim();
+  if (!id) return "-";
+
+  const resolvedId = getCloudflareMonitorId(metadata);
+  const resolvedDesc = getCloudflareMonitorDescription(metadata);
+  if (resolvedId === id && resolvedDesc) {
+    return resolvedDesc;
+  }
+
+  return id;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -4,6 +4,8 @@ import { buildActionStateRegistry } from "../utils";
 import { onLoadBalancingHealthAlertTriggerRenderer } from "./on_load_balancing_health_alert";
 import { createMonitorMapper } from "./create_monitor";
 import { deleteMonitorMapper } from "./delete_monitor";
+import { getMonitorMapper } from "./get_monitor";
+import { updateMonitorMapper } from "./update_monitor";
 import { originRuleMapper } from "./origin_rule";
 import { createKVNamespaceMapper } from "./create_kv_namespace";
 import { putKVValueMapper } from "./put_kv_value";
@@ -22,6 +24,8 @@ import { deleteLoadBalancerMapper } from "./delete_load_balancer";
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
   createMonitor: createMonitorMapper,
+  getMonitor: getMonitorMapper,
+  updateMonitor: updateMonitorMapper,
   createOriginRule: originRuleMapper,
   updateDNSRecord: baseMapper,
   deleteDnsRecord: baseMapper,
@@ -51,6 +55,8 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createDnsRecord: buildActionStateRegistry("completed"),
   createMonitor: buildActionStateRegistry("created"),
+  getMonitor: buildActionStateRegistry("fetched"),
+  updateMonitor: buildActionStateRegistry("updated"),
   createOriginRule: buildActionStateRegistry("created"),
   updateDNSRecord: buildActionStateRegistry("completed"),
   deleteDnsRecord: buildActionStateRegistry("completed"),

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
@@ -28,3 +28,17 @@ export function getCloudflareMonitorDescription(metadata: unknown): string | und
   const raw = m.monitorDescription ?? m.monitor_description;
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
+
+/** Prefer Cloudflare monitor description when node metadata matches the monitor id (see Setup resolver). */
+export function getCloudflareMonitorDisplayLabel(metadata: unknown, monitorId: string): string {
+  const id = monitorId.trim();
+  if (!id) return "-";
+
+  const resolvedId = getCloudflareMonitorId(metadata);
+  const resolvedDesc = getCloudflareMonitorDescription(metadata);
+  if (resolvedId === id && resolvedDesc) {
+    return resolvedDesc;
+  }
+
+  return id;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_monitor.ts
@@ -8,7 +8,7 @@ import type {
   SubtitleContext,
 } from "../types";
 import { baseMapper, firstOutputData } from "./base";
-import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
+import { getCloudflareMonitorDisplayLabel } from "./metadata";
 
 interface UpdateMonitorConfiguration {
   monitor?: string;
@@ -74,7 +74,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   if (monitorId) {
     metadata.push({
       icon: "activity",
-      label: resolvedMonitorLabel(node.metadata, monitorId),
+      label: getCloudflareMonitorDisplayLabel(node.metadata, monitorId),
     });
   }
 
@@ -87,17 +87,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-function resolvedMonitorLabel(metadata: unknown, monitorId: string): string {
-  const id = monitorId.trim();
-  if (!id) return "-";
-
-  const resolvedId = getCloudflareMonitorId(metadata);
-  const resolvedDesc = getCloudflareMonitorDescription(metadata);
-  if (resolvedId === id && resolvedDesc) {
-    return resolvedDesc;
-  }
-
-  return id;
 }

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/update_monitor.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/update_monitor.ts
@@ -1,0 +1,103 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type { MetadataItem } from "@/ui/metadataList";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import { baseMapper, firstOutputData } from "./base";
+import { getCloudflareMonitorDescription, getCloudflareMonitorId } from "./metadata";
+
+interface UpdateMonitorConfiguration {
+  monitor?: string;
+  description?: string;
+  type?: string;
+  path?: string;
+  port?: number;
+  advanced?: Record<string, unknown>;
+}
+
+interface UpdateMonitorOutput {
+  accountId?: string;
+  monitorId?: string;
+  monitor?: {
+    id?: string;
+    type?: string;
+    description?: string;
+    path?: string;
+    port?: number;
+    interval?: number;
+    timeout?: number;
+    retries?: number;
+  };
+}
+
+export const updateMonitorMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return {
+      ...baseMapper.props(context),
+      metadata: metadataList(context.node),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details = baseMapper.getExecutionDetails(context) as Record<string, string>;
+    const output = firstOutputData(context.execution.outputs) as UpdateMonitorOutput | undefined;
+
+    if (!output?.monitor) {
+      return details;
+    }
+
+    const m = output.monitor;
+    if (m.description) details["Name"] = m.description;
+    if (m.type) details["Type"] = m.type.toUpperCase();
+    if (m.path) details["Path"] = m.path;
+    if (m.port != null) details["Port"] = String(m.port);
+    if (m.interval != null) details["Interval"] = `${m.interval}s`;
+    if (m.timeout != null) details["Timeout"] = `${m.timeout}s`;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext) {
+    return baseMapper.subtitle(context);
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as UpdateMonitorConfiguration | undefined;
+  const metadata: MetadataItem[] = [];
+
+  const monitorId = configuration?.monitor?.trim();
+  if (monitorId) {
+    metadata.push({
+      icon: "activity",
+      label: resolvedMonitorLabel(node.metadata, monitorId),
+    });
+  }
+
+  if (configuration?.description) {
+    metadata.push({ icon: "pencil", label: configuration.description });
+  }
+
+  if (configuration?.type) {
+    metadata.push({ icon: "radio", label: configuration.type.toUpperCase() });
+  }
+
+  return metadata;
+}
+
+function resolvedMonitorLabel(metadata: unknown, monitorId: string): string {
+  const id = monitorId.trim();
+  if (!id) return "-";
+
+  const resolvedId = getCloudflareMonitorId(metadata);
+  const resolvedDesc = getCloudflareMonitorDescription(metadata);
+  if (resolvedId === id && resolvedDesc) {
+    return resolvedDesc;
+  }
+
+  return id;
+}


### PR DESCRIPTION
## What changed:
- Introduced new Cloudflare components: OrderCertificatePack, DeleteCertificatePack, and PurgeCache.
- Updated the Cloudflare API client to support certificate pack ordering, certificate pack deletion, and cache purge operations.
- Added example outputs and frontend workflow mappers for the new components.

## Why:
To expand the Cloudflare integration so users can manage SSL/TLS certificate packs and purge cached content directly from SuperPlane workflows.

## How:
- Implemented request and response structures for the new Cloudflare operations.
- Registered the new actions in the Cloudflare integration.
- Added frontend component mappers and example outputs for workflow configuration and display.
