### PR TITLE
fix: update integration capabilities saving method to include updated_at timestamp

### DIFF
--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -684,7 +684,11 @@ func (s *Server) HandleIntegrationRequest(w http.ResponseWriter, r *http.Request
 	})
 
 	integrationInstance.Capabilities = capabilityCtx.States()
-	err = database.Conn().Save(&integrationInstance).Error
+
+	err = database.Conn().Model(&models.Integration{ID: integrationInstance.ID}).Select("capabilities").Updates(map[string]any{
+		"capabilities": integrationInstance.Capabilities,
+		"updated_at":   time.Now(),
+	}).Error
 	if err != nil {
 		http.Error(w, "integration not found", http.StatusNotFound)
 		return


### PR DESCRIPTION
Problem
When multiple HTTP requests are received simultaneously for a single integration (e.g., GitHub App installation webhook + setup redirect), concurrent [database.Conn().Save()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) calls on the integration record can cause last-write-wins races. The second request overwrites changes made by the first, losing data.

Real-world example (GitHub integration):

User installs GitHub App → /setup request saves [AppInstallationID](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and sets state to Ready
GitHub sends installation webhook → [/webhook](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) request processes and updates metadata
Without synchronization, the webhook's Save() can overwrite the setup request's changes, causing the installation to appear incomplete
Root Cause
The HTTP request handler in [server.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) loads an integration record, processes it via [integration.HandleRequest()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), updates the capabilities, then saves the entire integration record with [database.Conn().Save(&integrationInstance)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

In concurrent scenarios, this full-record save overwrites any parallel changes to metadata, properties, or secrets made by other handlers without any isolation guarantees.

Solution
Replace the full Save() with a targeted column update that only persists the capabilities field:

Why this works:

The [Select("capabilities")](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) directive tells GORM to update only that column
Concurrent requests can now safely modify metadata/properties/secrets without interference
Each handler persists its own changes to its specific fields
Capabilities remain isolated and correctly updated per-request
Scope & Trade-offs
Minimal change: Only affects integration HTTP request handling path
Backward compatible: Doesn't change the integration's public API or behavior
Opt-in fix: Other race conditions (e.g., between setup and webhook processing) still require stronger mechanisms like row-level locking or async request queueing (future work)
Testing
Existing tests pass (full record save behavior not directly tested)
Manual integration workflow unchanged (GitHub App install, Slack setup, etc.)
Future: Add concurrency test that simulates parallel webhook + setup requests
Follow-up Work
For stronger guarantees, consider:

Row-level locking (FOR UPDATE SKIP LOCKED) for critical sections
Async request processing for most webhooks (enqueue → worker processes later)
Optimistic concurrency control (version fields to detect conflicts)