### PR TITLE
fix: allow DigitalOcean deletes by name

### DIFF
--- a/docs/components/DigitalOcean.mdx
+++ b/docs/components/DigitalOcean.mdx
@@ -24,11 +24,11 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Load Balancer" href="#create-load-balancer" description="Create a DigitalOcean Load Balancer with forwarding rules and targets" />
   <LinkCard title="Create Snapshot" href="#create-snapshot" description="Create a snapshot of a DigitalOcean Droplet" />
   <LinkCard title="Delete Alert Policy" href="#delete-alert-policy" description="Delete a DigitalOcean monitoring alert policy" />
-  <LinkCard title="Delete App" href="#delete-app" description="Delete a DigitalOcean App Platform application" />
+  <LinkCard title="Delete App" href="#delete-app" description="Delete a DigitalOcean App Platform application by ID or name" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a DigitalOcean domain" />
   <LinkCard title="Delete Data Source" href="#delete-data-source" description="Remove a data source from a DigitalOcean Gradient AI knowledge base" />
   <LinkCard title="Delete Database" href="#delete-database" description="Delete an existing database instance from DigitalOcean" />
-  <LinkCard title="Delete Droplet" href="#delete-droplet" description="Delete a DigitalOcean Droplet by ID" />
+  <LinkCard title="Delete Droplet" href="#delete-droplet" description="Delete a DigitalOcean Droplet by ID or name" />
   <LinkCard title="Delete GPU Droplet" href="#delete-gpu-droplet" description="Delete a DigitalOcean GPU Droplet by ID" />
   <LinkCard title="Delete Knowledge Base" href="#delete-knowledge-base" description="Delete a DigitalOcean Gradient AI knowledge base and optionally its OpenSearch database" />
   <LinkCard title="Delete Load Balancer" href="#delete-load-balancer" description="Delete a DigitalOcean Load Balancer" />
@@ -1014,16 +1014,18 @@ The Delete App component removes a DigitalOcean App Platform application.
 
 ### Configuration
 
-- **App**: The app to delete (required)
+- **App**: The app ID or exact name to delete (required, supports expressions)
 
 ### Output
 
 Returns confirmation of the deleted app including:
 - **appId**: The ID of the deleted app
+- **appName**: The name of the deleted app, when resolved by name
 
 ### Notes
 
 - This operation is idempotent - deleting an already deleted app will succeed
+- Names must match exactly; if multiple apps have the same name, use the app ID
 - All deployments and associated resources will be removed
 - This action cannot be undone
 
@@ -1182,16 +1184,18 @@ The Delete Droplet component permanently deletes a droplet from your DigitalOcea
 
 ### Configuration
 
-- **Droplet**: The droplet to delete (required, supports expressions)
+- **Droplet**: The droplet ID or exact name to delete (required, supports expressions)
 
 ### Output
 
 Returns information about the deleted droplet:
 - **dropletId**: The ID of the droplet that was deleted
+- **dropletName**: The name of the droplet that was deleted, when resolved by name
 
 ### Important Notes
 
 - This operation is **permanent** and cannot be undone
+- Names must match exactly; if multiple droplets have the same name, use the droplet ID
 - All data on the droplet will be lost
 - The droplet will be shut down if it's running before deletion
 - Any snapshots of the droplet will remain in your account
@@ -2843,4 +2847,3 @@ Returns the created or updated DNS record including:
   "type": "digitalocean.dns.record.upserted"
 }
 ```
-

--- a/pkg/integrations/digitalocean/client.go
+++ b/pkg/integrations/digitalocean/client.go
@@ -344,6 +344,25 @@ func (c *Client) ListDroplets() ([]Droplet, error) {
 	return response.Droplets, nil
 }
 
+// ListDropletsByName retrieves droplets that match a specific name
+func (c *Client) ListDropletsByName(name string) ([]Droplet, error) {
+	url := fmt.Sprintf("%s/droplets?name=%s&per_page=200", c.BaseURL, url.QueryEscape(name))
+	responseBody, err := c.execRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Droplets []Droplet `json:"droplets"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return response.Droplets, nil
+}
+
 // DeleteDroplet deletes a droplet by its ID
 func (c *Client) DeleteDroplet(dropletID int) error {
 	url := fmt.Sprintf("%s/droplets/%d", c.BaseURL, dropletID)

--- a/pkg/integrations/digitalocean/delete_app.go
+++ b/pkg/integrations/digitalocean/delete_app.go
@@ -26,7 +26,7 @@ func (d *DeleteApp) Label() string {
 }
 
 func (d *DeleteApp) Description() string {
-	return "Delete a DigitalOcean App Platform application"
+	return "Delete a DigitalOcean App Platform application by ID or name"
 }
 
 func (d *DeleteApp) Documentation() string {
@@ -40,16 +40,18 @@ func (d *DeleteApp) Documentation() string {
 
 ## Configuration
 
-- **App**: The app to delete (required)
+- **App**: The app ID or exact name to delete (required, supports expressions)
 
 ## Output
 
 Returns confirmation of the deleted app including:
 - **appId**: The ID of the deleted app
+- **appName**: The name of the deleted app, when resolved by name
 
 ## Notes
 
 - This operation is idempotent - deleting an already deleted app will succeed
+- Names must match exactly; if multiple apps have the same name, use the app ID
 - All deployments and associated resources will be removed
 - This action cannot be undone`
 }
@@ -74,7 +76,7 @@ func (d *DeleteApp) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
 			Placeholder: "Select an app",
-			Description: "The app to delete",
+			Description: "The app ID or exact name to delete",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: "app",
@@ -95,7 +97,7 @@ func (d *DeleteApp) Setup(ctx core.SetupContext) error {
 		return errors.New("app is required")
 	}
 
-	err = resolveAppMetadata(ctx, spec.App)
+	err = resolveAppDeleteMetadata(ctx, spec.App)
 	if err != nil {
 		return fmt.Errorf("error resolving app metadata: %v", err)
 	}
@@ -115,13 +117,18 @@ func (d *DeleteApp) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	err = client.DeleteApp(spec.App)
+	target, err := resolveAppDeleteTarget(client, spec.App)
+	if err != nil {
+		return fmt.Errorf("failed to resolve app: %w", err)
+	}
+
+	err = client.DeleteApp(target.ID)
 	if err != nil {
 		if doErr, ok := err.(*DOAPIError); ok && doErr.StatusCode == http.StatusNotFound {
 			return ctx.ExecutionState.Emit(
 				core.DefaultOutputChannel.Name,
 				"digitalocean.app.deleted",
-				[]any{map[string]any{"appId": spec.App}},
+				[]any{appDeletedPayload(target)},
 			)
 		}
 		return fmt.Errorf("failed to delete app: %v", err)
@@ -130,7 +137,7 @@ func (d *DeleteApp) Execute(ctx core.ExecutionContext) error {
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"digitalocean.app.deleted",
-		[]any{map[string]any{"appId": spec.App}},
+		[]any{appDeletedPayload(target)},
 	)
 }
 

--- a/pkg/integrations/digitalocean/delete_app_test.go
+++ b/pkg/integrations/digitalocean/delete_app_test.go
@@ -61,6 +61,40 @@ func Test__DeleteApp__Setup(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("valid app name -> no error", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"app": "test-app",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"apps": [
+								{
+									"id": "b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48",
+									"spec": {"name": "test-app"}
+								}
+							]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			Metadata: metadata,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, AppNodeMetadata{
+			AppID:   "b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48",
+			AppName: "test-app",
+		}, metadata.Metadata)
+	})
 }
 
 func Test__DeleteApp__Execute(t *testing.T) {
@@ -94,6 +128,121 @@ func Test__DeleteApp__Execute(t *testing.T) {
 		assert.Equal(t, "default", executionState.Channel)
 		assert.Equal(t, "digitalocean.app.deleted", executionState.Type)
 		assert.Len(t, executionState.Payloads, 1)
+	})
+
+	t.Run("app name -> resolves ID before deletion", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"apps": [
+							{
+								"id": "b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48",
+								"spec": {"name": "test-app"}
+							}
+						]
+					}`)),
+				},
+				{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: map[string]string{},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{"app": "test-app"},
+			HTTP:          httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Len(t, httpContext.Requests, 2)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[1].Method)
+		assert.Contains(t, httpContext.Requests[1].URL.Path, "/apps/b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48")
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)["data"]
+		assert.Equal(t, map[string]any{
+			"appId":   "b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48",
+			"appName": "test-app",
+		}, payload)
+	})
+
+	t.Run("app name not found -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"apps": []}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: map[string]string{},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{"app": "test-app"},
+			HTTP:          httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `app named "test-app" was not found`)
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("duplicate app name -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"apps": [
+							{
+								"id": "b6bdf840-2854-4f87-a9f6-6a0c4dbf3a48",
+								"spec": {"name": "test-app"}
+							},
+							{
+								"id": "24230ad9-ec2a-45dc-84db-b48dd6799f01",
+								"spec": {"name": "test-app"}
+							}
+						]
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: map[string]string{},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{"app": "test-app"},
+			HTTP:          httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "test-token"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `multiple apps named "test-app" found`)
+		assert.False(t, executionState.Passed)
 	})
 
 	t.Run("app not found (404) -> emits success (idempotent)", func(t *testing.T) {

--- a/pkg/integrations/digitalocean/delete_droplet.go
+++ b/pkg/integrations/digitalocean/delete_droplet.go
@@ -26,7 +26,7 @@ func (d *DeleteDroplet) Label() string {
 }
 
 func (d *DeleteDroplet) Description() string {
-	return "Delete a DigitalOcean Droplet by ID"
+	return "Delete a DigitalOcean Droplet by ID or name"
 }
 
 func (d *DeleteDroplet) Documentation() string {
@@ -41,16 +41,18 @@ func (d *DeleteDroplet) Documentation() string {
 
 ## Configuration
 
-- **Droplet**: The droplet to delete (required, supports expressions)
+- **Droplet**: The droplet ID or exact name to delete (required, supports expressions)
 
 ## Output
 
 Returns information about the deleted droplet:
 - **dropletId**: The ID of the droplet that was deleted
+- **dropletName**: The name of the droplet that was deleted, when resolved by name
 
 ## Important Notes
 
 - This operation is **permanent** and cannot be undone
+- Names must match exactly; if multiple droplets have the same name, use the droplet ID
 - All data on the droplet will be lost
 - The droplet will be shut down if it's running before deletion
 - Any snapshots of the droplet will remain in your account`
@@ -75,7 +77,7 @@ func (d *DeleteDroplet) Configuration() []configuration.Field {
 			Label:       "Droplet",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The droplet ID to delete",
+			Description: "The droplet ID or exact name to delete",
 			Placeholder: "Select droplet",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
@@ -98,7 +100,7 @@ func (d *DeleteDroplet) Setup(ctx core.SetupContext) error {
 		return errors.New("droplet is required")
 	}
 
-	err = resolveDropletMetadata(ctx, spec.Droplet)
+	err = resolveDropletDeleteMetadata(ctx, spec.Droplet)
 	if err != nil {
 		return fmt.Errorf("error resolving droplet metadata: %v", err)
 	}
@@ -113,24 +115,24 @@ func (d *DeleteDroplet) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	dropletID, err := parseDropletID(spec.Droplet)
-	if err != nil {
-		return fmt.Errorf("invalid droplet ID %q: %w", spec.Droplet, err)
-	}
-
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return fmt.Errorf("error creating client: %v", err)
 	}
 
-	err = client.DeleteDroplet(dropletID)
+	target, err := resolveDropletDeleteTarget(client, spec.Droplet)
+	if err != nil {
+		return fmt.Errorf("failed to resolve droplet: %w", err)
+	}
+
+	err = client.DeleteDroplet(target.ID)
 	if err != nil {
 		if doErr, ok := err.(*DOAPIError); ok && doErr.StatusCode == http.StatusNotFound {
 			// Droplet already deleted, emit success
 			return ctx.ExecutionState.Emit(
 				core.DefaultOutputChannel.Name,
 				"digitalocean.droplet.deleted",
-				[]any{map[string]any{"dropletId": dropletID}},
+				[]any{dropletDeletedPayload(target)},
 			)
 		}
 		return fmt.Errorf("failed to delete droplet: %v", err)
@@ -139,7 +141,7 @@ func (d *DeleteDroplet) Execute(ctx core.ExecutionContext) error {
 	return ctx.ExecutionState.Emit(
 		core.DefaultOutputChannel.Name,
 		"digitalocean.droplet.deleted",
-		[]any{map[string]any{"dropletId": dropletID}},
+		[]any{dropletDeletedPayload(target)},
 	)
 }
 

--- a/pkg/integrations/digitalocean/delete_droplet_test.go
+++ b/pkg/integrations/digitalocean/delete_droplet_test.go
@@ -74,6 +74,36 @@ func Test__DeleteDroplet__Setup(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("valid droplet name -> no error", func(t *testing.T) {
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"droplet": "test-droplet",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"droplets": [
+								{"id": 98765432, "name": "test-droplet"}
+							]
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken": "test-token",
+				},
+			},
+			Metadata: metadata,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, DropletNodeMetadata{DropletID: 98765432, DropletName: "test-droplet"}, metadata.Metadata)
+	})
 }
 
 func Test__DeleteDroplet__Execute(t *testing.T) {
@@ -153,6 +183,53 @@ func Test__DeleteDroplet__Execute(t *testing.T) {
 		assert.Len(t, executionState.Payloads, 1)
 	})
 
+	t.Run("droplet name -> resolves ID before deletion", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"droplets": [
+							{"id": 98765432, "name": "test-droplet"}
+						]
+					}`)),
+				},
+				{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: map[string]string{},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"droplet": "test-droplet",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken": "test-token",
+				},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Len(t, httpContext.Requests, 2)
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+		assert.Equal(t, "test-droplet", httpContext.Requests[0].URL.Query().Get("name"))
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[1].Method)
+		assert.Contains(t, httpContext.Requests[1].URL.Path, "/droplets/98765432")
+		require.Len(t, executionState.Payloads, 1)
+		payload := executionState.Payloads[0].(map[string]any)["data"]
+		assert.Equal(t, map[string]any{"dropletId": 98765432, "dropletName": "test-droplet"}, payload)
+	})
+
 	t.Run("droplet ID out of int64 range (2^63) in scientific notation string -> returns error", func(t *testing.T) {
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{
@@ -178,7 +255,16 @@ func Test__DeleteDroplet__Execute(t *testing.T) {
 		assert.False(t, executionState.Passed)
 	})
 
-	t.Run("invalid droplet ID format -> returns error", func(t *testing.T) {
+	t.Run("droplet name not found -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"droplets": []}`)),
+				},
+			},
+		}
+
 		integrationCtx := &contexts.IntegrationContext{
 			Configuration: map[string]any{
 				"apiToken": "test-token",
@@ -193,13 +279,50 @@ func Test__DeleteDroplet__Execute(t *testing.T) {
 			Configuration: map[string]any{
 				"droplet": "not-a-number",
 			},
-			HTTP:           &contexts.HTTPContext{},
+			HTTP:           httpContext,
 			Integration:    integrationCtx,
 			ExecutionState: executionState,
 		})
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid droplet")
+		assert.Contains(t, err.Error(), `droplet named "not-a-number" was not found`)
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("duplicate droplet name -> returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"droplets": [
+							{"id": 111, "name": "test-droplet"},
+							{"id": 222, "name": "test-droplet"}
+						]
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{
+			KVs: map[string]string{},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"droplet": "test-droplet",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiToken": "test-token",
+				},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `multiple droplets named "test-droplet" found`)
 		assert.False(t, executionState.Passed)
 	})
 

--- a/pkg/integrations/digitalocean/delete_lookup.go
+++ b/pkg/integrations/digitalocean/delete_lookup.go
@@ -1,0 +1,202 @@
+package digitalocean
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type dropletDeleteTarget struct {
+	ID   int
+	Name string
+}
+
+type appDeleteTarget struct {
+	ID   string
+	Name string
+}
+
+func resolveDropletDeleteTarget(client *Client, droplet string) (dropletDeleteTarget, error) {
+	value := strings.TrimSpace(droplet)
+	if value == "" {
+		return dropletDeleteTarget{}, errors.New("droplet is required")
+	}
+
+	id, err := parseDropletID(value)
+	if err == nil {
+		return dropletDeleteTarget{ID: id}, nil
+	}
+
+	if !errors.Is(err, errInvalidDropletID) {
+		return dropletDeleteTarget{}, fmt.Errorf("invalid droplet ID %q: %w", droplet, err)
+	}
+
+	return resolveDropletDeleteTargetByName(client, value)
+}
+
+func resolveDropletDeleteTargetByName(client *Client, name string) (dropletDeleteTarget, error) {
+	droplets, err := client.ListDropletsByName(name)
+	if err != nil {
+		return dropletDeleteTarget{}, fmt.Errorf("failed to list droplets for name lookup: %w", err)
+	}
+
+	matches := make([]Droplet, 0, 1)
+	for _, droplet := range droplets {
+		if droplet.Name == name {
+			matches = append(matches, droplet)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return dropletDeleteTarget{}, fmt.Errorf("droplet named %q was not found", name)
+	case 1:
+		return dropletDeleteTarget{ID: matches[0].ID, Name: matches[0].Name}, nil
+	default:
+		return dropletDeleteTarget{}, fmt.Errorf("multiple droplets named %q found; use the droplet ID", name)
+	}
+}
+
+func resolveDropletDeleteMetadata(ctx core.SetupContext, droplet string) error {
+	value := strings.TrimSpace(droplet)
+	if strings.Contains(value, "{{") {
+		return ctx.Metadata.Set(DropletNodeMetadata{DropletName: value})
+	}
+
+	var existing DropletNodeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &existing); err == nil {
+		if existing.DropletName != "" && existing.DropletName == value {
+			return nil
+		}
+		if existing.DropletID != 0 && fmt.Sprintf("%d", existing.DropletID) == value && existing.DropletName != "" {
+			return nil
+		}
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client for metadata resolution: %w", err)
+	}
+
+	target, err := resolveDropletDeleteTarget(client, value)
+	if err != nil {
+		return err
+	}
+
+	if target.Name == "" {
+		droplet, err := client.GetDroplet(target.ID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch droplet %d for metadata: %w", target.ID, err)
+		}
+		target.Name = droplet.Name
+	}
+
+	return ctx.Metadata.Set(DropletNodeMetadata{
+		DropletID:   target.ID,
+		DropletName: target.Name,
+	})
+}
+
+func dropletDeletedPayload(target dropletDeleteTarget) map[string]any {
+	payload := map[string]any{"dropletId": target.ID}
+	if target.Name != "" {
+		payload["dropletName"] = target.Name
+	}
+	return payload
+}
+
+func resolveAppDeleteTarget(client *Client, app string) (appDeleteTarget, error) {
+	value := strings.TrimSpace(app)
+	if value == "" {
+		return appDeleteTarget{}, errors.New("app is required")
+	}
+
+	if _, err := uuid.Parse(value); err == nil {
+		return appDeleteTarget{ID: value}, nil
+	}
+
+	return resolveAppDeleteTargetByName(client, value)
+}
+
+func resolveAppDeleteTargetByName(client *Client, name string) (appDeleteTarget, error) {
+	apps, err := client.ListApps()
+	if err != nil {
+		return appDeleteTarget{}, fmt.Errorf("failed to list apps for name lookup: %w", err)
+	}
+
+	matches := make([]App, 0, 1)
+	for _, app := range apps {
+		if getAppName(app) == name {
+			matches = append(matches, app)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return appDeleteTarget{}, fmt.Errorf("app named %q was not found", name)
+	case 1:
+		return appDeleteTarget{ID: matches[0].ID, Name: getAppName(matches[0])}, nil
+	default:
+		return appDeleteTarget{}, fmt.Errorf("multiple apps named %q found; use the app ID", name)
+	}
+}
+
+func resolveAppDeleteMetadata(ctx core.SetupContext, app string) error {
+	value := strings.TrimSpace(app)
+	if strings.Contains(value, "{{") {
+		return ctx.Metadata.Set(AppNodeMetadata{AppName: value})
+	}
+
+	var existing AppNodeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &existing); err == nil {
+		if existing.AppName != "" && existing.AppName == value {
+			return nil
+		}
+		if existing.AppID != "" && existing.AppID == value && existing.AppName != "" {
+			return nil
+		}
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client for metadata resolution: %w", err)
+	}
+
+	target, err := resolveAppDeleteTarget(client, value)
+	if err != nil {
+		return err
+	}
+
+	if target.Name == "" {
+		app, err := client.GetApp(target.ID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch app %q for metadata: %w", target.ID, err)
+		}
+		target.Name = getAppName(*app)
+	}
+
+	return ctx.Metadata.Set(AppNodeMetadata{
+		AppID:   target.ID,
+		AppName: target.Name,
+	})
+}
+
+func appDeletedPayload(target appDeleteTarget) map[string]any {
+	payload := map[string]any{"appId": target.ID}
+	if target.Name != "" {
+		payload["appName"] = target.Name
+	}
+	return payload
+}
+
+func getAppName(app App) string {
+	if app.Spec != nil && app.Spec.Name != "" {
+		return app.Spec.Name
+	}
+
+	return app.ID
+}

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/delete_app.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/delete_app.ts
@@ -64,7 +64,7 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   if (nodeMetadata?.appName) {
     metadata.push({ icon: "trash-2", label: nodeMetadata.appName });
   } else if (configuration?.app) {
-    metadata.push({ icon: "trash-2", label: `App ID: ${configuration.app}` });
+    metadata.push({ icon: "trash-2", label: `App: ${configuration.app}` });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/delete_droplet.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/delete_droplet.ts
@@ -63,8 +63,8 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 
   if (nodeMetadata?.dropletName) {
     metadata.push({ icon: "trash-2", label: nodeMetadata.dropletName });
-  } else if (configuration?.dropletId) {
-    metadata.push({ icon: "trash-2", label: `Droplet ID: ${configuration.dropletId}` });
+  } else if (configuration?.droplet) {
+    metadata.push({ icon: "trash-2", label: `Droplet: ${configuration.droplet}` });
   }
 
   return metadata;

--- a/web_src/src/pages/workflowv2/mappers/digitalocean/types.ts
+++ b/web_src/src/pages/workflowv2/mappers/digitalocean/types.ts
@@ -13,7 +13,7 @@ export interface GetDropletConfiguration {
 }
 
 export interface DeleteDropletConfiguration {
-  dropletId: string;
+  droplet: string;
 }
 
 export interface ManageDropletPowerConfiguration {


### PR DESCRIPTION
## Summary
- Closes #4348
- Allow `digitalocean.deleteDroplet` and `digitalocean.deleteApp` to accept exact resource names in addition to IDs.
- Resolve names to IDs at execution time and fail on ambiguous matches.
- Update metadata, docs, and workflow mapper labels for ID-or-name delete targets.

## Validation
- `go test -count=1 ./pkg/integrations/digitalocean`
- `npm exec prettier -- --write src/pages/workflowv2/mappers/digitalocean/delete_app.ts src/pages/workflowv2/mappers/digitalocean/delete_droplet.ts src/pages/workflowv2/mappers/digitalocean/types.ts`
- `git diff --check origin/main..HEAD`