### PR TITLE
fix: poll integration redirect setup state

### DIFF
--- a/web_src/src/hooks/useIntegrations.ts
+++ b/web_src/src/hooks/useIntegrations.ts
@@ -84,8 +84,15 @@ export const useConnectedIntegrations = (organizationId: string, options?: { ena
   });
 };
 
+type UseIntegrationOptions = {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+  refetchIntervalInBackground?: boolean;
+  staleTime?: number;
+};
+
 // Hook to fetch a single integration
-export const useIntegration = (organizationId: string, integrationId: string) => {
+export const useIntegration = (organizationId: string, integrationId: string, options?: UseIntegrationOptions) => {
   return useQuery({
     queryKey: integrationKeys.integration(organizationId, integrationId),
     queryFn: async () => {
@@ -96,9 +103,11 @@ export const useIntegration = (organizationId: string, integrationId: string) =>
       );
       return response.data?.integration || null;
     },
-    staleTime: 2 * 60 * 1000, // 2 minutes
+    staleTime: options?.staleTime ?? 2 * 60 * 1000, // 2 minutes
     gcTime: 5 * 60 * 1000, // 5 minutes
-    enabled: !!organizationId && !!integrationId,
+    enabled: !!organizationId && !!integrationId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval,
+    refetchIntervalInBackground: options?.refetchIntervalInBackground,
   });
 };
 

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.spec.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import type * as SdkGen from "@/api-client/sdk.gen";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IntegrationSetup } from ".";
 
 const { integrationsListIntegrations, organizationsDescribeIntegration, organizationsListIntegrations } = vi.hoisted(
@@ -24,7 +24,9 @@ vi.mock("@/api-client/sdk.gen", async (importOriginal) => {
   };
 });
 
-function renderIntegrationSetup() {
+type TestInitialEntry = string | { pathname: string; state?: unknown };
+
+function renderIntegrationSetup(initialEntry: TestInitialEntry = "/org-123/settings/integrations/setup/github") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -34,11 +36,15 @@ function renderIntegrationSetup() {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/org-123/settings/integrations/setup/github"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route
             path="/:organizationId/settings/integrations/setup/:integrationName"
             element={<IntegrationSetup organizationId="org-123" />}
+          />
+          <Route
+            path="/:organizationId/settings/integrations/:integrationId"
+            element={<div data-testid="integration-details">Integration details</div>}
           />
         </Routes>
       </MemoryRouter>
@@ -57,6 +63,10 @@ describe("PreCreateIntegrationSetup", () => {
     organizationsDescribeIntegration.mockResolvedValue({ data: { integration: null } });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("lets users clear the default instance name before typing a replacement", async () => {
     const user = userEvent.setup();
     renderIntegrationSetup();
@@ -68,5 +78,61 @@ describe("PreCreateIntegrationSetup", () => {
     await user.type(input, "production");
 
     expect(input).toHaveValue("production");
+  });
+
+  it("polls redirect prompt setup state and navigates when setup completes", async () => {
+    organizationsDescribeIntegration
+      .mockResolvedValueOnce({
+        data: {
+          integration: {
+            metadata: {
+              id: "integration-123",
+              name: "github",
+              integrationName: "github",
+              updatedAt: "2026-05-06T20:32:18Z",
+            },
+            status: {
+              state: "pending",
+              setupState: {
+                currentStep: {
+                  name: "create-github-app",
+                  type: "REDIRECT_PROMPT",
+                  label: "Create GitHub App",
+                  instructions: "Create the GitHub App in GitHub, then return to SuperPlane.",
+                  redirectPrompt: {
+                    url: "https://github.com/settings/apps/new",
+                    method: "GET",
+                  },
+                },
+                previousSteps: [],
+              },
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          integration: {
+            metadata: {
+              id: "integration-123",
+              name: "github",
+              integrationName: "github",
+              updatedAt: "2026-05-06T20:33:18Z",
+            },
+            status: {
+              state: "ready",
+            },
+          },
+        },
+      });
+
+    renderIntegrationSetup({
+      pathname: "/org-123/settings/integrations/setup/github",
+      state: { integrationId: "integration-123" },
+    });
+
+    expect(await screen.findByRole("button", { name: /continue/i })).toBeInTheDocument();
+    await waitFor(() => expect(organizationsDescribeIntegration).toHaveBeenCalledTimes(2), { timeout: 5000 });
+    await waitFor(() => expect(screen.getByTestId("integration-details")).toBeInTheDocument());
   });
 });

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts
@@ -40,6 +40,17 @@ export function useIntegrationSetupController(organizationId: string) {
   });
   const progress = useIntegrationSetupProgress(state.createdIntegration, metadata.integrationLabel);
   useSyncSelectedCapabilitiesForStep(progress.currentStep, state.setSelectedCapabilities);
+  const redirectPromptDescribe = useRedirectPromptDescribe(
+    organizationId,
+    state.createdIntegration,
+    progress.currentStep,
+  );
+  useRedirectPromptDescribeSync(
+    state.createdIntegration,
+    progress.currentStep,
+    redirectPromptDescribe.data,
+    state.setCreatedIntegration,
+  );
   const mutations = useIntegrationSetupMutations(organizationId, state.createdIntegration);
   const actions = useIntegrationSetupActions({
     route,
@@ -214,6 +225,51 @@ function getCapabilitySelectionOfferKey(currentStep: IntegrationSetupStepDefinit
 
 function getCapabilitiesFromOfferKey(offerKey: string) {
   return (JSON.parse(offerKey) as { capabilities: string[] }).capabilities;
+}
+
+function useRedirectPromptDescribe(
+  organizationId: string,
+  createdIntegration: OrganizationsIntegration | null,
+  currentStep: IntegrationSetupStepDefinition | null,
+) {
+  const integrationId = createdIntegration?.metadata?.id ?? "";
+  const shouldPoll = currentStep?.type === "REDIRECT_PROMPT" && integrationId !== "";
+
+  return useIntegration(organizationId, integrationId, {
+    enabled: shouldPoll,
+    staleTime: 0,
+    refetchInterval: shouldPoll ? 2000 : false,
+    refetchIntervalInBackground: true,
+  });
+}
+
+function useRedirectPromptDescribeSync(
+  createdIntegration: OrganizationsIntegration | null,
+  currentStep: IntegrationSetupStepDefinition | null,
+  redirectPromptDescribe: OrganizationsIntegration | null | undefined,
+  setCreatedIntegration: Dispatch<SetStateAction<OrganizationsIntegration | null>>,
+) {
+  const lastRedirectPromptDescribeKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (currentStep?.type !== "REDIRECT_PROMPT") {
+      lastRedirectPromptDescribeKey.current = null;
+      return;
+    }
+
+    const createdIntegrationId = createdIntegration?.metadata?.id;
+    if (!createdIntegrationId || redirectPromptDescribe?.metadata?.id !== createdIntegrationId) {
+      return;
+    }
+
+    const describeKey = getResumeDescribeStateKey(redirectPromptDescribe);
+    if (lastRedirectPromptDescribeKey.current === describeKey) {
+      return;
+    }
+
+    lastRedirectPromptDescribeKey.current = describeKey;
+    setCreatedIntegration(redirectPromptDescribe);
+  }, [createdIntegration, currentStep, redirectPromptDescribe, setCreatedIntegration]);
 }
 
 function useIntegrationSetupProgress(createdIntegration: OrganizationsIntegration | null, integrationLabel: string) {


### PR DESCRIPTION
## Summary
- Closes #4666
- Poll describe integration while setup is on a redirect prompt step.
- Apply polled setup state to the existing setup controller so completed redirects advance without a manual refresh.
- Add coverage for redirect prompt polling through completion navigation.

## Validation
- `npm exec prettier -- --write src/hooks/useIntegrations.ts src/pages/organization/settings/components/IntegrationSetup/useIntegrationSetupController.ts src/pages/organization/settings/components/IntegrationSetup/PreCreateIntegrationSetup.spec.tsx`
- `git diff --check origin/main..HEAD`