### PR TITLE
docs: add Dash0 integration setup instructions

### DIFF
--- a/docs/components/Dash0.mdx
+++ b/docs/components/Dash0.mdx
@@ -6,6 +6,17 @@ Connect to Dash0 to query data using Prometheus API
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
+## Instructions
+
+1. In Dash0, open Organization settings > Auth Tokens and create or reuse an auth token for SuperPlane.
+2. Grant the token access to the dataset(s) SuperPlane will work with:
+   - Read/query permissions are enough for connection validation, Query Prometheus, List Issues, and get actions.
+   - Edit or maintain permissions are required for creating, updating, or deleting check rules and synthetic checks.
+   - Log ingestion permissions are required for Send Log Event. If the token is restricted by signal type, allow logs.
+3. Open Organization settings > Endpoints and copy the Prometheus API endpoint for your Dash0 region.
+4. Paste either the full Prometheus API endpoint, such as https://api.us-west-2.aws.dash0.com/api/prometheus, or the regional API base URL, such as https://api.us-west-2.aws.dash0.com.
+5. After the integration is saved, copy the webhook URL from SuperPlane and configure Dash0 alert or synthetic-check notifications to send HTTP POST requests to it.
+
 ## Triggers
 
 <CardGrid>
@@ -1028,4 +1039,3 @@ The Update HTTP Synthetic Check component updates an existing synthetic check in
   "type": "dash0.syntheticCheck.updated"
 }
 ```
-

--- a/pkg/integrations/dash0/dash0.go
+++ b/pkg/integrations/dash0/dash0.go
@@ -28,6 +28,15 @@ type Metadata struct {
 	WebhookURL string `json:"webhookUrl" mapstructure:"webhookUrl"`
 }
 
+const dash0Instructions = `1. In Dash0, open Organization settings > Auth Tokens and create or reuse an auth token for SuperPlane.
+2. Grant the token access to the dataset(s) SuperPlane will work with:
+   - Read/query permissions are enough for connection validation, Query Prometheus, List Issues, and get actions.
+   - Edit or maintain permissions are required for creating, updating, or deleting check rules and synthetic checks.
+   - Log ingestion permissions are required for Send Log Event. If the token is restricted by signal type, allow logs.
+3. Open Organization settings > Endpoints and copy the Prometheus API endpoint for your Dash0 region.
+4. Paste either the full Prometheus API endpoint, such as https://api.us-west-2.aws.dash0.com/api/prometheus, or the regional API base URL, such as https://api.us-west-2.aws.dash0.com.
+5. After the integration is saved, copy the webhook URL from SuperPlane and configure Dash0 alert or synthetic-check notifications to send HTTP POST requests to it.`
+
 func (d *Dash0) Name() string {
 	return "dash0"
 }
@@ -45,7 +54,7 @@ func (d *Dash0) Description() string {
 }
 
 func (d *Dash0) Instructions() string {
-	return ""
+	return dash0Instructions
 }
 
 func (d *Dash0) Configuration() []configuration.Field {
@@ -63,7 +72,7 @@ func (d *Dash0) Configuration() []configuration.Field {
 			Label:       "Prometheus API Base URL",
 			Type:        configuration.FieldTypeString,
 			Required:    true,
-			Description: "Your Dash0 Prometheus API base URL. Find this in Dash0 dashboard: Organization Settings > Endpoints > Prometheus API. You can use either the full endpoint URL (https://api.us-west-2.aws.dash0.com/api/prometheus) or just the base URL (https://api.us-west-2.aws.dash0.com)",
+			Description: "Your Dash0 regional API base URL or full Prometheus API endpoint.",
 			Placeholder: "https://api.us-west-2.aws.dash0.com",
 		},
 	}

--- a/pkg/integrations/dash0/dash0_test.go
+++ b/pkg/integrations/dash0/dash0_test.go
@@ -155,3 +155,14 @@ func Test__Dash0__Sync(t *testing.T) {
 		assert.NotContains(t, httpContext.Requests[0].URL.String(), "/api/prometheus/api/prometheus")
 	})
 }
+
+func Test__Dash0__Instructions(t *testing.T) {
+	instructions := (&Dash0{}).Instructions()
+
+	require.NotEmpty(t, instructions)
+	assert.Contains(t, instructions, "Auth Tokens")
+	assert.Contains(t, instructions, "Read/query permissions")
+	assert.Contains(t, instructions, "Log ingestion permissions")
+	assert.Contains(t, instructions, "Prometheus API endpoint")
+	assert.Contains(t, instructions, "webhook URL")
+}


### PR DESCRIPTION
## Summary
- Closes #4122
- Add Dash0 setup instructions for auth token creation, required permissions, Prometheus endpoint selection, and webhook notification setup.
- Keep the base URL field description focused on accepted URL formats.
- Add a regression test that verifies the integration exposes the expected setup guidance.

## Validation
- `go test -count=1 ./pkg/integrations/dash0`
- `git diff --check origin/main..HEAD`