### PR TITLE
feat: print canvas URL in CLI canvases create and get

### DIFF
--- a/pkg/cli/commands/canvases/create.go
+++ b/pkg/cli/commands/canvases/create.go
@@ -135,7 +135,14 @@ func validateAndPrintCreateResponse(
 	}
 
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
-		_, err := fmt.Fprintf(stdout, "Canvas %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId())
-		return err
+		if _, err := fmt.Fprintf(stdout, "Canvas %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId()); err != nil {
+			return err
+		}
+		if url := BuildCanvasURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
+			if _, err := fmt.Fprintf(stdout, "Canvas URL: %s\n", url); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }

--- a/pkg/cli/commands/canvases/create_test.go
+++ b/pkg/cli/commands/canvases/create_test.go
@@ -21,7 +21,7 @@ func newCanvasCreateServer(t *testing.T) *httptest.Server {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/api/v1/canvases", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"abc-123","name":"my-canvas"}}}`))
+		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"abc-123","name":"my-canvas","organizationId":"org-uuid"}}}`))
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -35,6 +35,38 @@ func TestCreateCommandPrintsCanvasOnSuccess(t *testing.T) {
 	err := (&createCommand{}).Execute(ctx)
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), `Canvas "my-canvas" created (ID: abc-123)`)
+	require.NotContains(t, stdout.String(), "Canvas URL:")
+}
+
+func TestCreateCommandPrintsURLFromResponseOrgID(t *testing.T) {
+	server := newCanvasCreateServer(t)
+	ctx, stdout := newCommandContextWithConfigForTest(t, server, "text", &fakeConfig{
+		url: "https://app.superplane.com",
+	})
+	ctx.Args = []string{"my-canvas"}
+
+	err := (&createCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), `Canvas "my-canvas" created (ID: abc-123)`)
+	require.Contains(t, stdout.String(), "Canvas URL: https://app.superplane.com/org-uuid/canvases/abc-123")
+}
+
+func TestCreateCommandSkipsURLWhenResponseMissingOrgID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"abc-123","name":"my-canvas"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, stdout := newCommandContextWithConfigForTest(t, server, "text", &fakeConfig{
+		url: "https://app.superplane.com",
+	})
+	ctx.Args = []string{"my-canvas"}
+
+	err := (&createCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), `Canvas "my-canvas" created (ID: abc-123)`)
+	require.NotContains(t, stdout.String(), "Canvas URL:")
 }
 
 func TestCreateCommandReturnsJSONOutput(t *testing.T) {

--- a/pkg/cli/commands/canvases/get.go
+++ b/pkg/cli/commands/canvases/get.go
@@ -66,6 +66,9 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		_, _ = fmt.Fprintf(stdout, "ID: %s\n", resource.Metadata.GetId())
 		_, _ = fmt.Fprintf(stdout, "Name: %s\n", resource.Metadata.GetName())
+		if url := BuildCanvasURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
+			_, _ = fmt.Fprintf(stdout, "Canvas URL: %s\n", url)
+		}
 		_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(resource.Spec.GetNodes()))
 		_, err := fmt.Fprintf(stdout, "Edges: %d\n", len(resource.Spec.GetEdges()))
 		return err

--- a/pkg/cli/commands/canvases/get_test.go
+++ b/pkg/cli/commands/canvases/get_test.go
@@ -1,0 +1,72 @@
+package canvases
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testGetCanvasID = "4e9ae08d-0363-40d2-ba2c-5f6389a418d8"
+
+func newCanvasGetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/canvases/"+testGetCanvasID, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"` + testGetCanvasID + `","name":"my-canvas","organizationId":"org-uuid"},"spec":{"nodes":[],"edges":[]}}}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestGetCommandPrintsCanvasOnSuccess(t *testing.T) {
+	server := newCanvasGetServer(t)
+	ctx, stdout := newCreateCommandContextForTest(t, server, "text")
+	ctx.Args = []string{testGetCanvasID}
+
+	err := (&getCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "ID: "+testGetCanvasID)
+	require.Contains(t, stdout.String(), "Name: my-canvas")
+	require.Contains(t, stdout.String(), "Nodes: 0")
+	require.Contains(t, stdout.String(), "Edges: 0")
+	require.NotContains(t, stdout.String(), "Canvas URL:")
+}
+
+func TestGetCommandPrintsURLFromResponseOrgID(t *testing.T) {
+	server := newCanvasGetServer(t)
+	ctx, stdout := newCommandContextWithConfigForTest(t, server, "text", &fakeConfig{
+		url: "https://app.superplane.com",
+	})
+	ctx.Args = []string{testGetCanvasID}
+
+	err := (&getCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "ID: "+testGetCanvasID)
+	require.Contains(t, stdout.String(), "Name: my-canvas")
+	require.Contains(t, stdout.String(), "Canvas URL: https://app.superplane.com/org-uuid/canvases/"+testGetCanvasID)
+	require.Contains(t, stdout.String(), "Nodes: 0")
+	require.Contains(t, stdout.String(), "Edges: 0")
+}
+
+func TestGetCommandSkipsURLWhenResponseMissingOrgID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"canvas":{"metadata":{"id":"` + testGetCanvasID + `","name":"my-canvas"},"spec":{"nodes":[],"edges":[]}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, stdout := newCommandContextWithConfigForTest(t, server, "text", &fakeConfig{
+		url: "https://app.superplane.com",
+	})
+	ctx.Args = []string{testGetCanvasID}
+
+	err := (&getCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "ID: "+testGetCanvasID)
+	require.Contains(t, stdout.String(), "Name: my-canvas")
+	require.NotContains(t, stdout.String(), "Canvas URL:")
+}

--- a/pkg/cli/commands/canvases/helpers_test.go
+++ b/pkg/cli/commands/canvases/helpers_test.go
@@ -1,12 +1,41 @@
 package canvases
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
+
+// fakeConfig is a test stub implementation of core.ConfigContext. The
+// canvas-active accessors are no-ops because the canvas commands under test
+// here do not use them.
+type fakeConfig struct {
+	url string
+}
+
+func (f *fakeConfig) GetActiveCanvas() string               { return "" }
+func (f *fakeConfig) SetActiveCanvas(canvasID string) error { return nil }
+func (f *fakeConfig) GetURL() string                        { return f.url }
+
+// newCommandContextWithConfigForTest builds a command context whose Config is
+// set to the provided stub. Useful for exercising URL output behavior.
+func newCommandContextWithConfigForTest(
+	t *testing.T,
+	server *httptest.Server,
+	outputFormat string,
+	config core.ConfigContext,
+) (core.CommandContext, *bytes.Buffer) {
+	t.Helper()
+
+	ctx, stdout := newCreateCommandContextForTest(t, server, outputFormat)
+	ctx.Config = config
+	return ctx, stdout
+}
 
 func TestFindCurrentUserDraftVersionIDSkipsPublishedVersions(t *testing.T) {
 	server := newAPITestServer(

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -8,9 +8,12 @@ import (
 
 func NewCommand(options core.BindOptions) *cobra.Command {
 	root := &cobra.Command{
-		Use:     "canvases",
-		Short:   "Manage canvases",
-		Long:    core.AgentSkillsHelp(),
+		Use:   "canvases",
+		Short: "Manage canvases",
+		Long: core.AgentSkillsHelp() + `
+
+Canvas URL pattern: {baseURL}/{organizationId}/canvases/{canvasId}
+(e.g. https://app.superplane.com/<organization-id>/canvases/<canvas-id>)`,
 		Aliases: []string{"canvas"},
 	}
 

--- a/pkg/cli/commands/canvases/urls.go
+++ b/pkg/cli/commands/canvases/urls.go
@@ -1,0 +1,27 @@
+package canvases
+
+import (
+	"fmt"
+
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+// BuildCanvasURL composes the canonical web URL for a canvas. Returns "" when
+// the context, base URL, organization id, or canvas id is missing so callers
+// can omit the URL output without erroring.
+//
+// orgID and canvasID should come from the API response (canvas metadata)
+// rather than the local CLI context, so the URL stays correct even if the
+// active context drifts.
+func BuildCanvasURL(ctx core.CommandContext, orgID, canvasID string) string {
+	if ctx.Config == nil || orgID == "" || canvasID == "" {
+		return ""
+	}
+
+	baseURL := ctx.Config.GetURL()
+	if baseURL == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s/canvases/%s", baseURL, orgID, canvasID)
+}

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -307,3 +307,7 @@ func (c *CurrentContext) SetActiveCanvas(canvasID string) error {
 	_, err := UpsertContext(c.context)
 	return err
 }
+
+func (c *CurrentContext) GetURL() string {
+	return c.context.URL
+}

--- a/pkg/cli/core/command.go
+++ b/pkg/cli/core/command.go
@@ -31,6 +31,7 @@ type CommandContext struct {
 type ConfigContext interface {
 	GetActiveCanvas() string
 	SetActiveCanvas(canvasID string) error
+	GetURL() string
 }
 
 // IsInteractive returns true when stdin is a terminal,


### PR DESCRIPTION
## Summary

- `superplane canvases create` and `superplane canvases get` now print a
  `Canvas URL: ...` line on text output, so users (and bots) don't have to
  reconstruct the canvas URL from the org id and canvas id by hand.
- `superplane canvases --help` now documents the URL pattern
  `{baseURL}/{organizationId}/canvases/{canvasId}` so it's discoverable.
- The URL is sourced from the API response's `metadata.organizationId`
  (canonical owner) and the active context's base URL. It is omitted when
  either is missing rather than printing a guess.

Closes #4319.

## Out of scope (intentionally)

The original issue also suggested a few things I deliberately left out to
keep this small and focused:

- **No `url` field in JSON/YAML output.** Bots already get
  `metadata.organizationId` and `metadata.id` in responses; composing the
  URL is one f-string. Adding a top-level `url` to the canvas resource
  shape would be a Kubernetes-style convention break for marginal gain.
- **No URL in `canvases list`.** Not asked for; users can `get` a canvas
  if they need its URL.
- **No dedicated docs page.** The pattern is the SPA route, the CLI
  prints it, and `--help` documents it. A standalone docs page would be
  ~60 lines for a 3-segment URL.
- **No self-hosted dual-host config.** The CLI assumes the web UI lives
  at the same host as the API (true for cloud and standard self-hosted).
  If split-host self-hosted ever becomes a real ask, adding a second
  field is a small isolated change.

## Test plan

- [x] `make test PKG_TEST_PACKAGES=./pkg/cli/...`
- [x] `superplane canvases create my-canvas` prints `Canvas URL: ...`
- [x] `superplane canvases get <id>` prints `Canvas URL: ...`
- [x] Both URLs open the canvas in the web UI on cloud
- [x] `--output json` and `--output yaml` are unchanged (no `url` field)
- [x] `superplane canvases --help` shows the URL pattern