### PR TITLE
feat: add Cloudflare tunnel components

### DIFF
--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -10,6 +10,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard title="On Load Balancing Health Alert" href="#on-load-balancing-health-alert" description="Trigger when a Cloudflare load balancing pool or origin health state changes" />
+  <LinkCard title="On Tunnel Health" href="#on-tunnel-health" description="Trigger when a Cloudflare Tunnel health notification fires for degradation or recovery" />
 </CardGrid>
 
 ## Actions
@@ -21,6 +22,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Create Monitor" href="#create-monitor" description="Create a Cloudflare load balancing health monitor" />
   <LinkCard title="Create Origin Rule" href="#create-origin-rule" description="Create a rule to override the origin server for matching requests" />
   <LinkCard title="Create Pool" href="#create-pool" description="Create a Cloudflare Load Balancer origin pool" />
+  <LinkCard title="Create Tunnel" href="#create-tunnel" description="Create a new Cloudflare Tunnel (cloudflared) for secure outbound-only connectivity to Cloudflare" />
   <LinkCard title="Delete DNS Record" href="#delete-dns-record" description="Delete a DNS record from a Cloudflare zone" />
   <LinkCard title="Delete KV Namespace" href="#delete-kv-namespace" description="Delete a Cloudflare Workers KV namespace" />
   <LinkCard title="Delete KV Value" href="#delete-kv-value" description="Delete a key from a Cloudflare Workers KV namespace" />
@@ -34,6 +36,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Get Load Balancer" href="#get-load-balancer" description="Retrieve a Cloudflare Load Balancer by ID" />
   <LinkCard title="Get Monitor" href="#get-monitor" description="Retrieve a Cloudflare load balancing health monitor's configuration" />
   <LinkCard title="Get Pool" href="#get-pool" description="Retrieve a Cloudflare Load Balancer origin pool by ID" />
+  <LinkCard title="Get Tunnel" href="#get-tunnel" description="Retrieve configuration and status for a Cloudflare Tunnel by ID" />
   <LinkCard title="Get Worker" href="#get-worker" description="Retrieve metadata and settings for a deployed Worker script" />
   <LinkCard title="Put KV Value" href="#put-kv-value" description="Write a key-value pair to a Cloudflare Workers KV namespace" />
   <LinkCard title="Update DNS Record" href="#update-dns-record" description="Update an existing DNS record in a Cloudflare zone" />
@@ -68,6 +71,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
      - Account / Load Balancing: Monitors and Pools / Edit
      - Account / Notifications / Edit
      - Account / Account Settings / Edit
+     - Account / Cloudflare Tunnel / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
    - **Account Resources**: Include the account containing your load balancers
 5. Click **Continue to summary**, then **Create Token**
@@ -75,7 +79,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Find your Cloudflare Account ID
 
-The **Account ID** is required for KV storage, load balancing monitors/pools, and health alert webhooks.
+The **Account ID** is required for KV storage, load balancing monitors/pools, Cloudflare Tunnels, and health alert webhooks.
 
 1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/)
 2. Select the account that contains your load balancers
@@ -137,6 +141,57 @@ The trigger **title** still prefers an origin name, then pool name, then load ba
   },
   "timestamp": "2026-03-26T19:29:35.841265352Z",
   "type": "cloudflare.loadBalancing.healthAlert"
+}
+```
+
+<a id="on-tunnel-health"></a>
+
+## On Tunnel Health
+
+The On Tunnel Health trigger starts a workflow from Cloudflare `tunnel_health_event` notifications (Cloudflare Tunnel / cloudflared).
+
+### Use Cases
+
+- **Degraded or down**: React when tunnel connectivity drops below healthy thresholds
+- **Recovery**: Resume normal processing when the tunnel returns to a healthy state
+
+### Configuration
+
+- **Tunnel**: Optional. SuperPlane adds this tunnel to the Cloudflare notification policy **and** requires the webhook payload's `tunnel_id` to match (case-insensitive), so a mis-scoped or forged request is less likely to start your workflow. Leave **Tunnel** empty to accept any tunnel on the account (policy and webhook checks both allow any tunnel id present in the payload).
+
+> **Note**: Cloudflare's **Send test** notification may include a sample `tunnel_id` that does not match your real tunnel. With a tunnel selected, that test delivery will not emit until you clear the tunnel filter or use a payload that matches your tunnel id.
+
+### Webhook Setup
+
+SuperPlane provisions a Cloudflare Alerting webhook destination and a notification policy for `tunnel_health_event`. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the `cf-webhook-auth` header before emitting an event.
+
+### Workflow execution details
+
+The trigger **Payload** tab (and expressions such as `$.trigger.data`) use a merged view of the webhook JSON: fields inside `data` are combined with top-level fields (for example `alert_type`, `account_id`) so everything is available in one object.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "account_id": "90ddd046-218b-d375-f20e-9f9082cc0c6d",
+    "alert_name": "tunnel_health_event",
+    "alert_type": "tunnel_health_event",
+    "dashboard_link": "dash.cloudflare.com/aBcD1234efgh567i890j1kl234567m89",
+    "name": "SuperPlane Tunnel Health Alert",
+    "new_status": "TUNNEL_STATUS_TYPE_DEGRADED",
+    "policy_id": "fe9eda012119414084b1c9ffc9a1e2c9",
+    "policy_name": "SuperPlane Tunnel Health Alert",
+    "severity": "INFO",
+    "status_reason": "status change",
+    "text": "A Cloudflare Tunnel in your account has changed its connection status.\nTunnel: tunnel-name (aBcD1234efgh567i890j1kl234567m80) \nNew status: TUNNEL_STATUS_TYPE_DEGRADED (status change)",
+    "timestamp": "2022-10-27T06:00:22Z",
+    "ts": 1778597408,
+    "tunnel_id": "aBcD1234efgh567i890j1kl234567m80",
+    "tunnel_name": "tunnel-name"
+  },
+  "timestamp": "2026-05-12T14:50:14.036687251Z",
+  "type": "cloudflare.tunnel.healthEvent"
 }
 ```
 
@@ -439,6 +494,51 @@ Returns the created origin pool with its assigned ID and full configuration.
   },
   "timestamp": "2026-05-05T06:54:57.198268018Z",
   "type": "cloudflare.pool.created"
+}
+```
+
+<a id="create-tunnel"></a>
+
+## Create Tunnel
+
+The Create Tunnel component provisions a Cloudflare Tunnel under your account.
+
+### Use Cases
+
+- **Expose internal services**: Pair with ingress rules so private origins are reachable through Cloudflare without opening inbound firewall ports
+- **Automation**: Create tunnels as part of environment provisioning
+
+### Configuration
+
+- **Name**: A unique name for the tunnel
+- **Config source**: `cloudflare` (managed in Zero Trust) or `local` (managed via local cloudflared configuration)
+
+### Output
+
+Returns the tunnel resource from the Cloudflare API, including its ID. When Cloudflare returns a connector token, it is included in the output (treat it as a secret).
+
+> **Note**: Deleting a tunnel does not automatically remove all public hostname routes; use Cloudflare Zero Trust or DNS workflows as needed.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "tunnel": {
+      "account_tag": "90ddd046218bd375f20e9f9082cc0c6d",
+      "config_src": "cloudflare",
+      "created_at": "2026-05-12T14:40:05.379813Z",
+      "id": "432c983d-7934-47a8-923f-bfa017eef9c4",
+      "metadata": {},
+      "name": "my-test-tunnel",
+      "status": "inactive",
+      "token": "eyJhIjoiOTBkZGQwNDYyMThiZDM3NWYy...rTE0rM1hHaHhNMEVpa0QvK2RacE0xQUM1N1dHZEVHMHZxS1h4SHV1UER3PT0ifQ=="
+    },
+    "tunnelId": "432c983d-7934-47a8-923f-bfa017eef9c4"
+  },
+  "timestamp": "2026-05-12T14:40:06.391597638Z",
+  "type": "cloudflare.tunnel.created"
 }
 ```
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -30,6 +30,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Monitor" href="#delete-monitor" description="Delete a Cloudflare load balancing health monitor" />
   <LinkCard title="Delete Origin Rule" href="#delete-origin-rule" description="Remove an origin rule" />
   <LinkCard title="Delete Pool" href="#delete-pool" description="Delete a Cloudflare Load Balancer origin pool" />
+  <LinkCard title="Delete Tunnel" href="#delete-tunnel" description="Delete a Cloudflare Tunnel and clean up its connector credentials" />
   <LinkCard title="Delete Worker" href="#delete-worker" description="Delete a Worker script from your Cloudflare account" />
   <LinkCard title="Deploy Worker" href="#deploy-worker" description="Provision a Worker if needed, upload a script version, and deploy it to traffic" />
   <LinkCard title="Get KV Value" href="#get-kv-value" description="Read a value by key from a Cloudflare Workers KV namespace" />
@@ -801,6 +802,41 @@ Emits a confirmation with the account ID and pool ID of the deleted pool.
 }
 ```
 
+<a id="delete-tunnel"></a>
+
+## Delete Tunnel
+
+The Delete Tunnel component permanently removes a Cloudflare Tunnel.
+
+### Use Cases
+
+- **Teardown**: Remove tunnels when an environment is decommissioned
+- **Rotation**: Delete an old tunnel after migrating to a new one
+
+### Configuration
+
+- **Tunnel**: The tunnel ID to delete
+
+### Output
+
+Emits confirmation with the account ID and tunnel ID.
+
+> **Warning**: This operation is irreversible. Active traffic using the tunnel will fail until reconfigured.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "tunnelId": "3c683924-6802-47c9-860a-f27a66e684a2"
+  },
+  "timestamp": "2026-05-12T14:02:15.319225119Z",
+  "type": "cloudflare.tunnel.deleted"
+}
+```
+
 <a id="delete-worker"></a>
 
 ## Delete Worker
@@ -1059,6 +1095,47 @@ Returns the full pool configuration including its origins, enabled state, and he
   },
   "timestamp": "2026-05-05T05:58:40.060373991Z",
   "type": "cloudflare.pool.fetched"
+}
+```
+
+<a id="get-tunnel"></a>
+
+## Get Tunnel
+
+The Get Tunnel component fetches the current state of a Cloudflare Tunnel (cloudflared).
+
+### Use Cases
+
+- **Health and status checks**: Inspect tunnel status in a workflow
+- **Validation**: Confirm a tunnel exists before updating routes or DNS
+
+### Configuration
+
+- **Tunnel**: The tunnel ID to retrieve
+
+### Output
+
+Returns the tunnel object from the Cloudflare API (ID, name, status, config source, timestamps, and related fields).
+
+### Example Output
+
+```json
+{
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "tunnel": {
+      "account_tag": "90ddd046218bd375f20e9f9082cc0c6d",
+      "config_src": "local",
+      "created_at": "2026-05-12T13:59:00.953876Z",
+      "id": "3c683924-6802-47c9-860a-f27a66e684a2",
+      "metadata": {},
+      "name": "my-test-tunnel",
+      "status": "active"
+    },
+    "tunnelId": "3c683924-6802-47c9-860a-f27a66e684a2"
+  },
+  "timestamp": "2026-05-12T14:01:27.023693818Z",
+  "type": "cloudflare.tunnel.fetched"
 }
 ```
 

--- a/pkg/integrations/cloudflare/cfd_tunnel.go
+++ b/pkg/integrations/cloudflare/cfd_tunnel.go
@@ -1,0 +1,130 @@
+package cloudflare
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CFDTunnel is a Cloudflare Tunnel (cloudflared) returned by the account-scoped cfd_tunnel API.
+type CFDTunnel struct {
+	ID         string `json:"id,omitempty"`
+	AccountTag string `json:"account_tag,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Status     string `json:"status,omitempty"`
+	ConfigSrc  string `json:"config_src,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	DeletedAt  string `json:"deleted_at,omitempty"`
+	// Metadata is an object in list/get responses; use RawMessage so unmarshaling accepts any JSON shape.
+	Metadata json.RawMessage `json:"metadata,omitempty"`
+	// Token is returned only when creating a tunnel; treat as sensitive.
+	Token string `json:"token,omitempty"`
+}
+
+// CreateCFDTunnelRequest is the payload for POST /accounts/{account_id}/cfd_tunnel
+type CreateCFDTunnelRequest struct {
+	Name      string `json:"name"`
+	ConfigSrc string `json:"config_src,omitempty"`
+}
+
+// ListCFDTunnels lists Cloudflare Tunnels for an account (non-deleted by default).
+func (c *Client) ListCFDTunnels(accountID string) ([]CFDTunnel, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/cfd_tunnel", c.BaseURL, accountID)
+	responseBody, err := c.execRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool        `json:"success"`
+		Result  []CFDTunnel `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+
+	return response.Result, nil
+}
+
+// GetCFDTunnel retrieves a tunnel by ID.
+func (c *Client) GetCFDTunnel(accountID, tunnelID string) (*CFDTunnel, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/cfd_tunnel/%s", c.BaseURL, accountID, tunnelID)
+	responseBody, err := c.execRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool      `json:"success"`
+		Result  CFDTunnel `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+
+	return &response.Result, nil
+}
+
+// CreateCFDTunnel creates a new Cloudflare Tunnel.
+func (c *Client) CreateCFDTunnel(accountID string, req CreateCFDTunnelRequest) (*CFDTunnel, error) {
+	rawURL := fmt.Sprintf("%s/accounts/%s/cfd_tunnel", c.BaseURL, accountID)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool      `json:"success"`
+		Result  CFDTunnel `json:"result"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return nil, newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+
+	return &response.Result, nil
+}
+
+// DeleteCFDTunnel permanently deletes a tunnel.
+func (c *Client) DeleteCFDTunnel(accountID, tunnelID string) error {
+	rawURL := fmt.Sprintf("%s/accounts/%s/cfd_tunnel/%s", c.BaseURL, accountID, tunnelID)
+	responseBody, err := c.execRequest(http.MethodDelete, rawURL, nil)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+	}
+
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return fmt.Errorf("error parsing response: %v", err)
+	}
+
+	if !response.Success {
+		return newCloudflareAPIError(http.StatusOK, responseBody)
+	}
+
+	return nil
+}

--- a/pkg/integrations/cloudflare/cfd_tunnel_test.go
+++ b/pkg/integrations/cloudflare/cfd_tunnel_test.go
@@ -1,0 +1,45 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ListCFDTunnels__UnmarshalsMetadataObject(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": [
+						{
+							"id": "tun-1",
+							"name": "edge",
+							"metadata": {"user_visible": true, "team": "net"}
+						}
+					]
+				}`)),
+			},
+		},
+	}
+
+	client := &Client{
+		Token:   "tok",
+		http:    httpContext,
+		BaseURL: baseURL,
+	}
+
+	tunnels, err := client.ListCFDTunnels("acc123")
+	require.NoError(t, err)
+	require.Len(t, tunnels, 1)
+	assert.Equal(t, "tun-1", tunnels[0].ID)
+	assert.Equal(t, "edge", tunnels[0].Name)
+	assert.JSONEq(t, `{"user_visible": true, "team": "net"}`, string(tunnels[0].Metadata))
+}

--- a/pkg/integrations/cloudflare/client.go
+++ b/pkg/integrations/cloudflare/client.go
@@ -217,6 +217,8 @@ type NotificationPolicyFilters struct {
 	PoolID      []string `json:"pool_id,omitempty"`
 	NewHealth   []string `json:"new_health,omitempty"`
 	EventSource []string `json:"event_source,omitempty"`
+	TunnelID    []string `json:"tunnel_id,omitempty"`
+	NewStatus   []string `json:"new_status,omitempty"`
 }
 
 type NotificationPolicyResponse struct {

--- a/pkg/integrations/cloudflare/cloudflare.go
+++ b/pkg/integrations/cloudflare/cloudflare.go
@@ -106,6 +106,31 @@ func resolveWorkerScriptMetadata(ctx core.SetupContext, accountID, scriptID stri
 	return ctx.Metadata.Set(meta)
 }
 
+type TunnelNodeMetadata struct {
+	TunnelName string `json:"tunnelName"`
+}
+
+func resolveTunnelMetadata(ctx core.SetupContext, accountID, tunnelID string) error {
+	meta := TunnelNodeMetadata{}
+	if strings.Contains(tunnelID, "{{") || strings.Contains(accountID, "{{") {
+		meta.TunnelName = tunnelID
+	} else {
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+		tunnel, err := client.GetCFDTunnel(accountID, tunnelID)
+		if err != nil {
+			return fmt.Errorf("failed to get tunnel: %w", err)
+		}
+		meta.TunnelName = tunnel.Name
+		if meta.TunnelName == "" {
+			meta.TunnelName = tunnelID
+		}
+	}
+	return ctx.Metadata.Set(meta)
+}
+
 func resolvePoolMetadata(ctx core.SetupContext, accountID, poolID string) error {
 	meta := PoolNodeMetadata{}
 	if strings.Contains(poolID, "{{") || strings.Contains(accountID, "{{") {
@@ -172,6 +197,7 @@ func (c *Cloudflare) Instructions() string {
      - Account / Load Balancing: Monitors and Pools / Edit
      - Account / Notifications / Edit
      - Account / Account Settings / Edit
+     - Account / Cloudflare Tunnel / Edit
    - **Zone Resources**: Include / All zones _(or select specific zones)_
    - **Account Resources**: Include the account containing your load balancers
 5. Click **Continue to summary**, then **Create Token**
@@ -179,7 +205,7 @@ func (c *Cloudflare) Instructions() string {
 
 ## Find your Cloudflare Account ID
 
-The **Account ID** is required for KV storage, load balancing monitors/pools, and health alert webhooks.
+The **Account ID** is required for KV storage, load balancing monitors/pools, Cloudflare Tunnels, and health alert webhooks.
 
 1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/)
 2. Select the account that contains your load balancers
@@ -206,7 +232,7 @@ func (c *Cloudflare) Configuration() []configuration.Field {
 			Label:       "Account ID",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Cloudflare account ID. Required for KV storage, load balancing monitors/pools, and alerting webhooks.",
+			Description: "Cloudflare account ID. Required for KV storage, load balancing monitors/pools, Cloudflare Tunnels, and alerting webhooks.",
 			Placeholder: "e.g. 01a7362d577a6c3019a474fd6f485823",
 		},
 	}
@@ -242,12 +268,16 @@ func (c *Cloudflare) Actions() []core.Action {
 		&GetWorker{},
 		&DeleteWorker{},
 		&UpdateWorkerRoute{},
+		&CreateTunnel{},
+		&GetTunnel{},
+		&DeleteTunnel{},
 	}
 }
 
 func (c *Cloudflare) Triggers() []core.Trigger {
 	return []core.Trigger{
 		&OnLoadBalancingHealthAlert{},
+		&OnTunnelHealth{},
 	}
 }
 
@@ -574,6 +604,42 @@ func (c *Cloudflare) ListResources(resourceType string, ctx core.ListResourcesCo
 			})
 		}
 		return resources, nil
+
+	case "tunnel":
+		accountID := ctx.Parameters["accountId"]
+		if accountID == "" {
+			accountID = accountIDFromIntegration(ctx.Integration)
+		}
+		if accountID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		tunnels, err := client.ListCFDTunnels(accountID)
+		if err != nil {
+			return nil, fmt.Errorf("error listing tunnels: %w", err)
+		}
+
+		var out []core.IntegrationResource
+		for _, t := range tunnels {
+			if t.ID == "" {
+				continue
+			}
+			name := t.Name
+			if name == "" {
+				name = t.ID
+			}
+			out = append(out, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   t.ID,
+			})
+		}
+		return out, nil
 
 	default:
 		return []core.IntegrationResource{}, nil

--- a/pkg/integrations/cloudflare/create_tunnel.go
+++ b/pkg/integrations/cloudflare/create_tunnel.go
@@ -110,6 +110,10 @@ func (c *CreateTunnel) Setup(ctx core.SetupContext) error {
 		return errors.New("name is required")
 	}
 
+	if normalizeTunnelConfigSrc(spec.ConfigSrc) == "" {
+		return fmt.Errorf("configSrc must be cloudflare or local")
+	}
+
 	return nil
 }
 

--- a/pkg/integrations/cloudflare/create_tunnel.go
+++ b/pkg/integrations/cloudflare/create_tunnel.go
@@ -1,0 +1,197 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const CreateTunnelPayloadType = "cloudflare.tunnel.created"
+
+type CreateTunnel struct{}
+
+type CreateTunnelSpec struct {
+	AccountID string `json:"accountId"`
+	Name      string `json:"name"`
+	ConfigSrc string `json:"configSrc"`
+}
+
+func (c *CreateTunnel) Name() string {
+	return "cloudflare.createTunnel"
+}
+
+func (c *CreateTunnel) Label() string {
+	return "Create Tunnel"
+}
+
+func (c *CreateTunnel) Description() string {
+	return "Create a new Cloudflare Tunnel (cloudflared) for secure outbound-only connectivity to Cloudflare"
+}
+
+func (c *CreateTunnel) Documentation() string {
+	return `The Create Tunnel component provisions a Cloudflare Tunnel under your account.
+
+## Use Cases
+
+- **Expose internal services**: Pair with ingress rules so private origins are reachable through Cloudflare without opening inbound firewall ports
+- **Automation**: Create tunnels as part of environment provisioning
+
+## Configuration
+
+- **Name**: A unique name for the tunnel
+- **Config source**: ` + "`cloudflare`" + ` (managed in Zero Trust) or ` + "`local`" + ` (managed via local cloudflared configuration)
+
+## Output
+
+Returns the tunnel resource from the Cloudflare API, including its ID. When Cloudflare returns a connector token, it is included in the output (treat it as a secret).
+
+> **Note**: Deleting a tunnel does not automatically remove all public hostname routes; use Cloudflare Zero Trust or DNS workflows as needed.`
+}
+
+func (c *CreateTunnel) Icon() string {
+	return "cloud"
+}
+
+func (c *CreateTunnel) Color() string {
+	return "orange"
+}
+
+func (c *CreateTunnel) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateTunnel) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "name",
+			Label:       "Tunnel Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "A unique name for the Cloudflare Tunnel",
+			Placeholder: "my-app-tunnel",
+		},
+		{
+			Name:        "configSrc",
+			Label:       "Config Source",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Default:     "cloudflare",
+			Description: "Whether tunnel configuration is managed in Cloudflare (remote) or locally in cloudflared",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Cloudflare (remote)", Value: "cloudflare"},
+						{Label: "Local (cloudflared)", Value: "local"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateTunnel) Setup(ctx core.SetupContext) error {
+	spec := CreateTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if strings.TrimSpace(spec.Name) == "" {
+		return errors.New("name is required")
+	}
+
+	return nil
+}
+
+func (c *CreateTunnel) Execute(ctx core.ExecutionContext) error {
+	spec := CreateTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		return errors.New("name is required")
+	}
+
+	configSrc := normalizeTunnelConfigSrc(spec.ConfigSrc)
+	if configSrc == "" {
+		return fmt.Errorf("configSrc must be cloudflare or local")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	tunnel, err := client.CreateCFDTunnel(accountID, CreateCFDTunnelRequest{
+		Name:      name,
+		ConfigSrc: configSrc,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create tunnel: %w", err)
+	}
+
+	result := map[string]any{
+		"tunnel":    tunnel,
+		"accountId": accountID,
+		"tunnelId":  tunnel.ID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		CreateTunnelPayloadType,
+		[]any{result},
+	)
+}
+
+func (c *CreateTunnel) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateTunnel) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateTunnel) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateTunnel) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateTunnel) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateTunnel) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func normalizeTunnelConfigSrc(value string) string {
+	v := strings.TrimSpace(strings.ToLower(value))
+	switch v {
+	case "", "cloudflare":
+		return "cloudflare"
+	case "local":
+		return "local"
+	default:
+		return ""
+	}
+}

--- a/pkg/integrations/cloudflare/delete_tunnel.go
+++ b/pkg/integrations/cloudflare/delete_tunnel.go
@@ -1,0 +1,157 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const DeleteTunnelPayloadType = "cloudflare.tunnel.deleted"
+
+type DeleteTunnel struct{}
+
+type DeleteTunnelSpec struct {
+	AccountID string `json:"accountId"`
+	Tunnel    string `json:"tunnel"`
+}
+
+func (c *DeleteTunnel) Name() string {
+	return "cloudflare.deleteTunnel"
+}
+
+func (c *DeleteTunnel) Label() string {
+	return "Delete Tunnel"
+}
+
+func (c *DeleteTunnel) Description() string {
+	return "Delete a Cloudflare Tunnel and clean up its connector credentials"
+}
+
+func (c *DeleteTunnel) Documentation() string {
+	return `The Delete Tunnel component permanently removes a Cloudflare Tunnel.
+
+## Use Cases
+
+- **Teardown**: Remove tunnels when an environment is decommissioned
+- **Rotation**: Delete an old tunnel after migrating to a new one
+
+## Configuration
+
+- **Tunnel**: The tunnel ID to delete
+
+## Output
+
+Emits confirmation with the account ID and tunnel ID.
+
+> **Warning**: This operation is irreversible. Active traffic using the tunnel will fail until reconfigured.`
+}
+
+func (c *DeleteTunnel) Icon() string {
+	return "cloud"
+}
+
+func (c *DeleteTunnel) Color() string {
+	return "orange"
+}
+
+func (c *DeleteTunnel) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteTunnel) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "tunnel",
+			Label:       "Tunnel",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Cloudflare Tunnel to delete",
+			Placeholder: "Select a tunnel",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "tunnel",
+				},
+			},
+		},
+	}
+}
+
+func (c *DeleteTunnel) Setup(ctx core.SetupContext) error {
+	spec := DeleteTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Tunnel == "" {
+		return errors.New("tunnel is required")
+	}
+
+	return resolveTunnelMetadata(ctx, accountID, spec.Tunnel)
+}
+
+func (c *DeleteTunnel) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.DeleteCFDTunnel(accountID, spec.Tunnel); err != nil {
+		return fmt.Errorf("failed to delete tunnel: %w", err)
+	}
+
+	result := map[string]any{
+		"accountId": accountID,
+		"tunnelId":  spec.Tunnel,
+		"deleted":   true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		DeleteTunnelPayloadType,
+		[]any{result},
+	)
+}
+
+func (c *DeleteTunnel) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteTunnel) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteTunnel) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteTunnel) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteTunnel) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteTunnel) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/example.go
+++ b/pkg/integrations/cloudflare/example.go
@@ -266,3 +266,43 @@ var exampleOutputUpdateWorkerRoute map[string]any
 func (u *UpdateWorkerRoute) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateWorkerRouteOnce, exampleOutputUpdateWorkerRouteBytes, &exampleOutputUpdateWorkerRoute)
 }
+
+//go:embed example_output_create_tunnel.json
+var exampleOutputCreateTunnelBytes []byte
+
+var exampleOutputCreateTunnelOnce sync.Once
+var exampleOutputCreateTunnel map[string]any
+
+func (c *CreateTunnel) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateTunnelOnce, exampleOutputCreateTunnelBytes, &exampleOutputCreateTunnel)
+}
+
+//go:embed example_output_get_tunnel.json
+var exampleOutputGetTunnelBytes []byte
+
+var exampleOutputGetTunnelOnce sync.Once
+var exampleOutputGetTunnel map[string]any
+
+func (c *GetTunnel) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetTunnelOnce, exampleOutputGetTunnelBytes, &exampleOutputGetTunnel)
+}
+
+//go:embed example_output_delete_tunnel.json
+var exampleOutputDeleteTunnelBytes []byte
+
+var exampleOutputDeleteTunnelOnce sync.Once
+var exampleOutputDeleteTunnel map[string]any
+
+func (c *DeleteTunnel) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteTunnelOnce, exampleOutputDeleteTunnelBytes, &exampleOutputDeleteTunnel)
+}
+
+//go:embed example_data_on_tunnel_health.json
+var exampleDataOnTunnelHealthBytes []byte
+
+var exampleDataOnTunnelHealthOnce sync.Once
+var exampleDataOnTunnelHealth map[string]any
+
+func (t *OnTunnelHealth) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleDataOnTunnelHealthOnce, exampleDataOnTunnelHealthBytes, &exampleDataOnTunnelHealth)
+}

--- a/pkg/integrations/cloudflare/example_data_on_tunnel_health.json
+++ b/pkg/integrations/cloudflare/example_data_on_tunnel_health.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "account_id": "01a7362d577a6c3019a474fd6f485823",
+    "alert_type": "tunnel_health_event",
+    "tunnel_id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
+    "tunnel_name": "api-staging",
+    "new_status": "Degraded"
+  },
+  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "type": "cloudflare.tunnel.healthEvent"
+}

--- a/pkg/integrations/cloudflare/example_data_on_tunnel_health.json
+++ b/pkg/integrations/cloudflare/example_data_on_tunnel_health.json
@@ -1,11 +1,21 @@
 {
   "data": {
-    "account_id": "01a7362d577a6c3019a474fd6f485823",
+    "account_id": "90ddd046-218b-d375-f20e-9f9082cc0c6d",
+    "alert_name": "tunnel_health_event",
     "alert_type": "tunnel_health_event",
-    "tunnel_id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
-    "tunnel_name": "api-staging",
-    "new_status": "Degraded"
+    "dashboard_link": "dash.cloudflare.com/aBcD1234efgh567i890j1kl234567m89",
+    "name": "SuperPlane Tunnel Health Alert",
+    "new_status": "TUNNEL_STATUS_TYPE_DEGRADED",
+    "policy_id": "fe9eda012119414084b1c9ffc9a1e2c9",
+    "policy_name": "SuperPlane Tunnel Health Alert",
+    "severity": "INFO",
+    "status_reason": "status change",
+    "text": "A Cloudflare Tunnel in your account has changed its connection status.\nTunnel: tunnel-name (aBcD1234efgh567i890j1kl234567m80) \nNew status: TUNNEL_STATUS_TYPE_DEGRADED (status change)",
+    "timestamp": "2022-10-27T06:00:22Z",
+    "ts": 1778597408,
+    "tunnel_id": "aBcD1234efgh567i890j1kl234567m80",
+    "tunnel_name": "tunnel-name"
   },
-  "timestamp": "2026-03-26T19:29:35.841265352Z",
+  "timestamp": "2026-05-12T14:50:14.036687251Z",
   "type": "cloudflare.tunnel.healthEvent"
 }

--- a/pkg/integrations/cloudflare/example_output_create_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_create_tunnel.json
@@ -1,0 +1,12 @@
+{
+  "tunnel": {
+    "id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
+    "account_tag": "01a7362d577a6c3019a474fd6f485823",
+    "name": "api-staging",
+    "status": "inactive",
+    "config_src": "cloudflare",
+    "created_at": "2026-03-01T12:00:00Z"
+  },
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f"
+}

--- a/pkg/integrations/cloudflare/example_output_create_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_create_tunnel.json
@@ -1,12 +1,18 @@
 {
-  "tunnel": {
-    "id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
-    "account_tag": "01a7362d577a6c3019a474fd6f485823",
-    "name": "api-staging",
-    "status": "inactive",
-    "config_src": "cloudflare",
-    "created_at": "2026-03-01T12:00:00Z"
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "tunnel": {
+      "account_tag": "90ddd046218bd375f20e9f9082cc0c6d",
+      "config_src": "cloudflare",
+      "created_at": "2026-05-12T14:40:05.379813Z",
+      "id": "432c983d-7934-47a8-923f-bfa017eef9c4",
+      "metadata": {},
+      "name": "my-test-tunnel",
+      "status": "inactive",
+      "token": "eyJhIjoiOTBkZGQwNDYyMThiZDM3NWYy...rTE0rM1hHaHhNMEVpa0QvK2RacE0xQUM1N1dHZEVHMHZxS1h4SHV1UER3PT0ifQ=="
+    },
+    "tunnelId": "432c983d-7934-47a8-923f-bfa017eef9c4"
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f"
+  "timestamp": "2026-05-12T14:40:06.391597638Z",
+  "type": "cloudflare.tunnel.created"
 }

--- a/pkg/integrations/cloudflare/example_output_delete_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_delete_tunnel.json
@@ -1,0 +1,5 @@
+{
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
+  "deleted": true
+}

--- a/pkg/integrations/cloudflare/example_output_delete_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_delete_tunnel.json
@@ -1,5 +1,9 @@
 {
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
-  "deleted": true
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "deleted": true,
+    "tunnelId": "3c683924-6802-47c9-860a-f27a66e684a2"
+  },
+  "timestamp": "2026-05-12T14:02:15.319225119Z",
+  "type": "cloudflare.tunnel.deleted"
 }

--- a/pkg/integrations/cloudflare/example_output_get_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_get_tunnel.json
@@ -1,12 +1,17 @@
 {
-  "tunnel": {
-    "id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
-    "account_tag": "01a7362d577a6c3019a474fd6f485823",
-    "name": "api-staging",
-    "status": "healthy",
-    "config_src": "cloudflare",
-    "created_at": "2026-03-01T12:00:00Z"
+  "data": {
+    "accountId": "90ddd046218bd375f20e9f9082cc0c6d",
+    "tunnel": {
+      "account_tag": "90ddd046218bd375f20e9f9082cc0c6d",
+      "config_src": "local",
+      "created_at": "2026-05-12T13:59:00.953876Z",
+      "id": "3c683924-6802-47c9-860a-f27a66e684a2",
+      "metadata": {},
+      "name": "my-test-tunnel",
+      "status": "active"
+    },
+    "tunnelId": "3c683924-6802-47c9-860a-f27a66e684a2"
   },
-  "accountId": "01a7362d577a6c3019a474fd6f485823",
-  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f"
+  "timestamp": "2026-05-12T14:01:27.023693818Z",
+  "type": "cloudflare.tunnel.fetched"
 }

--- a/pkg/integrations/cloudflare/example_output_get_tunnel.json
+++ b/pkg/integrations/cloudflare/example_output_get_tunnel.json
@@ -1,0 +1,12 @@
+{
+  "tunnel": {
+    "id": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f",
+    "account_tag": "01a7362d577a6c3019a474fd6f485823",
+    "name": "api-staging",
+    "status": "healthy",
+    "config_src": "cloudflare",
+    "created_at": "2026-03-01T12:00:00Z"
+  },
+  "accountId": "01a7362d577a6c3019a474fd6f485823",
+  "tunnelId": "f70ff0a7-6f32-4385-8c15-199f8d7a2d0f"
+}

--- a/pkg/integrations/cloudflare/get_tunnel.go
+++ b/pkg/integrations/cloudflare/get_tunnel.go
@@ -1,0 +1,156 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetTunnelPayloadType = "cloudflare.tunnel.fetched"
+
+type GetTunnel struct{}
+
+type GetTunnelSpec struct {
+	AccountID string `json:"accountId"`
+	Tunnel    string `json:"tunnel"`
+}
+
+func (c *GetTunnel) Name() string {
+	return "cloudflare.getTunnel"
+}
+
+func (c *GetTunnel) Label() string {
+	return "Get Tunnel"
+}
+
+func (c *GetTunnel) Description() string {
+	return "Retrieve configuration and status for a Cloudflare Tunnel by ID"
+}
+
+func (c *GetTunnel) Documentation() string {
+	return `The Get Tunnel component fetches the current state of a Cloudflare Tunnel (cloudflared).
+
+## Use Cases
+
+- **Health and status checks**: Inspect tunnel status in a workflow
+- **Validation**: Confirm a tunnel exists before updating routes or DNS
+
+## Configuration
+
+- **Tunnel**: The tunnel ID to retrieve
+
+## Output
+
+Returns the tunnel object from the Cloudflare API (ID, name, status, config source, timestamps, and related fields).`
+}
+
+func (c *GetTunnel) Icon() string {
+	return "cloud"
+}
+
+func (c *GetTunnel) Color() string {
+	return "orange"
+}
+
+func (c *GetTunnel) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetTunnel) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "tunnel",
+			Label:       "Tunnel",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The Cloudflare Tunnel to retrieve",
+			Placeholder: "Select a tunnel",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "tunnel",
+				},
+			},
+		},
+	}
+}
+
+func (c *GetTunnel) Setup(ctx core.SetupContext) error {
+	spec := GetTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	if spec.Tunnel == "" {
+		return errors.New("tunnel is required")
+	}
+
+	return resolveTunnelMetadata(ctx, accountID, spec.Tunnel)
+}
+
+func (c *GetTunnel) Execute(ctx core.ExecutionContext) error {
+	spec := GetTunnelSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	accountID := resolveAccountID(spec.AccountID, ctx.Integration)
+	if accountID == "" {
+		return errors.New("accountId is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	tunnel, err := client.GetCFDTunnel(accountID, spec.Tunnel)
+	if err != nil {
+		return fmt.Errorf("failed to get tunnel: %v", err)
+	}
+
+	result := map[string]any{
+		"tunnel":    tunnel,
+		"accountId": accountID,
+		"tunnelId":  spec.Tunnel,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetTunnelPayloadType,
+		[]any{result},
+	)
+}
+
+func (c *GetTunnel) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetTunnel) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetTunnel) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetTunnel) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetTunnel) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetTunnel) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudflare/get_tunnel_test.go
+++ b/pkg/integrations/cloudflare/get_tunnel_test.go
@@ -1,0 +1,215 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetTunnel__Setup(t *testing.T) {
+	component := &GetTunnel{}
+
+	t.Run("missing accountId returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "",
+				"tunnel":    "tun123",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "accountId is required")
+	})
+
+	t.Run("missing tunnel returns error", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"tunnel":    "",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.ErrorContains(t, err, "tunnel is required")
+	})
+
+	t.Run("expression tunnel id is accepted without API call", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"tunnel":    "{{ $.trigger.data.tunnelId }}",
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves tunnel name", func(t *testing.T) {
+		ctx := core.SetupContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"tunnel":    "tun123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"success": true,
+							"result": {"id": "tun123", "name": "edge-tunnel"}
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiToken": "token123"},
+			},
+			Metadata: &contexts.MetadataContext{},
+		}
+
+		err := component.Setup(ctx)
+		require.NoError(t, err)
+
+		meta, ok := ctx.Metadata.(*contexts.MetadataContext)
+		require.True(t, ok)
+		tunnelMeta, ok := meta.Metadata.(TunnelNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "edge-tunnel", tunnelMeta.TunnelName)
+	})
+}
+
+func Test__GetTunnel__Execute(t *testing.T) {
+	component := &GetTunnel{}
+
+	t.Run("successful get emits result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {
+							"id": "tun123",
+							"name": "edge-tunnel",
+							"status": "healthy",
+							"config_src": "cloudflare"
+						}
+					}`)),
+				},
+			},
+		}
+
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken": "token123",
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{
+			KVs: make(map[string]string),
+		}
+
+		ctx := core.ExecutionContext{
+			Configuration: map[string]any{
+				"accountId": "acc123",
+				"tunnel":    "tun123",
+			},
+			HTTP:           httpContext,
+			Integration:    integrationCtx,
+			ExecutionState: execState,
+		}
+
+		err := component.Execute(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, execState.Passed)
+		assert.Equal(t, "default", execState.Channel)
+		assert.Equal(t, "cloudflare.tunnel.fetched", execState.Type)
+		assert.Len(t, execState.Payloads, 1)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/cfd_tunnel/tun123", httpContext.Requests[0].URL.String())
+		assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+	})
+}
+
+func Test__CreateTunnel__Execute(t *testing.T) {
+	component := &CreateTunnel{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"success": true,
+					"result": {
+						"id": "new-tun",
+						"name": "my-tunnel",
+						"status": "inactive",
+						"config_src": "cloudflare"
+					}
+				}`)),
+			},
+		},
+	}
+
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"accountId": "acc123",
+			"name":      "my-tunnel",
+			"configSrc": "cloudflare",
+		},
+		HTTP: httpContext,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "tok"},
+		},
+		ExecutionState: execState,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, CreateTunnelPayloadType, execState.Type)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	assert.Equal(t, "https://api.cloudflare.com/client/v4/accounts/acc123/cfd_tunnel", httpContext.Requests[0].URL.String())
+}
+
+func Test__DeleteTunnel__Execute(t *testing.T) {
+	component := &DeleteTunnel{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true}`)),
+			},
+		},
+	}
+
+	execState := &contexts.ExecutionStateContext{KVs: make(map[string]string)}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"accountId": "acc123",
+			"tunnel":    "tun123",
+		},
+		HTTP: httpContext,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{"apiToken": "tok"},
+		},
+		ExecutionState: execState,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DeleteTunnelPayloadType, execState.Type)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/cfd_tunnel/tun123")
+}

--- a/pkg/integrations/cloudflare/on_tunnel_health.go
+++ b/pkg/integrations/cloudflare/on_tunnel_health.go
@@ -52,8 +52,9 @@ func (t *OnTunnelHealth) Documentation() string {
 
 ## Configuration
 
-- **Tunnel**: Optional tunnel filter. Leave empty to receive events for any tunnel on the account.
-- **New status**: Which tunnel status transitions should start a workflow. Values are sent to Cloudflare as ` + "`TUNNEL_STATUS_TYPE_*`" + ` enums; webhook payloads may use human-readable names (for example Down) and SuperPlane still matches your selection.
+- **Tunnel**: Optional. SuperPlane adds this tunnel to the Cloudflare notification policy **and** requires the webhook payload's ` + "`tunnel_id`" + ` to match (case-insensitive), so a mis-scoped or forged request is less likely to start your workflow. Leave **Tunnel** empty to accept any tunnel on the account (policy and webhook checks both allow any tunnel id present in the payload).
+
+> **Note**: Cloudflare's **Send test** notification may include a sample ` + "`tunnel_id`" + ` that does not match your real tunnel. With a tunnel selected, that test delivery will not emit until you clear the tunnel filter or use a payload that matches your tunnel id.
 
 ## Webhook Setup
 
@@ -61,7 +62,7 @@ SuperPlane provisions a Cloudflare Alerting webhook destination and a notificati
 
 ## Workflow execution details
 
-The trigger **Payload** tab (and expressions such as ` + "`$.trigger.data`" + `) contain the fields Cloudflare sends, typically including **tunnel id**, **tunnel name**, **new status**, **account id**, and **alert type**.`
+The trigger **Payload** tab (and expressions such as ` + "`$.trigger.data`" + `) use a merged view of the webhook JSON: fields inside ` + "`data`" + ` are combined with top-level fields (for example ` + "`alert_type`" + `, ` + "`account_id`" + `) so everything is available in one object.`
 }
 
 func (t *OnTunnelHealth) Icon() string {
@@ -79,7 +80,7 @@ func (t *OnTunnelHealth) Configuration() []configuration.Field {
 			Label:       "Tunnel",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    false,
-			Description: "Optional tunnel to filter notifications by",
+			Description: "Optional. Scopes the Cloudflare policy and requires matching tunnel_id in the webhook payload (case-insensitive).",
 			Placeholder: "Select a tunnel",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
@@ -249,37 +250,68 @@ func (t *OnTunnelHealth) HandleWebhook(ctx core.WebhookRequestContext) (int, *co
 		return http.StatusOK, nil, nil
 	}
 
-	if err := ctx.Events.Emit(TunnelHealthEventPayloadType, tunnelHealthWebhookEventData(payload)); err != nil {
+	if err := ctx.Events.Emit(TunnelHealthEventPayloadType, tunnelHealthEventPayloadForEmit(payload)); err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
 
 	return http.StatusOK, nil, nil
 }
 
-func tunnelHealthWebhookEventData(payload map[string]any) map[string]any {
-	if nested, ok := payload["data"].(map[string]any); ok && nested != nil {
-		return nested
+// tunnelHealthFlattenPayload merges top-level webhook fields with the nested "data" object
+// (inner keys win on collision). Cloudflare tunnel health notifications often put tunnel fields
+// under "data" while alert_type and account_id sit at the top level.
+func tunnelHealthFlattenPayload(payload map[string]any) map[string]any {
+	out := make(map[string]any, len(payload)+16)
+	for k, v := range payload {
+		if k == "data" {
+			continue
+		}
+		out[k] = v
 	}
-	return payload
+	if inner, ok := payload["data"].(map[string]any); ok && inner != nil {
+		for k, v := range inner {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func tunnelHealthEventPayloadForEmit(payload map[string]any) map[string]any {
+	return tunnelHealthFlattenPayload(payload)
 }
 
 func tunnelHealthPayloadMatchesSpec(spec OnTunnelHealthSpec, payload map[string]any) bool {
-	data := tunnelHealthWebhookEventData(payload)
+	data := tunnelHealthFlattenPayload(payload)
 
 	if spec.Tunnel != "" {
 		tunnelID := strings.TrimSpace(tunnelHealthStringField(data, "tunnel_id", "tunnelId"))
-		if tunnelID != spec.Tunnel {
+		if tunnelID == "" || !strings.EqualFold(tunnelID, spec.Tunnel) {
 			return false
 		}
 	}
 
-	rawStatus := tunnelHealthStringField(data, "new_status", "newStatus", "status")
+	rawStatus := tunnelHealthNormalizeNewStatusRaw(tunnelHealthStringField(data, "new_status", "newStatus", "status"))
 	normalized := tunnelHealthPayloadStatusForMatch(rawStatus)
 	if normalized == "" || !slices.Contains(spec.NewStatus, normalized) {
 		return false
 	}
 
 	return true
+}
+
+func tunnelHealthNormalizeNewStatusRaw(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// e.g. "TUNNEL_STATUS_TYPE_DEGRADED (status change)"
+	if i := strings.Index(raw, " "); i > 0 {
+		prefix := raw[:i]
+		if strings.HasPrefix(prefix, "TUNNEL_STATUS_TYPE_") {
+			return prefix
+		}
+	}
+	return raw
 }
 
 // tunnelHealthPayloadStatusForMatch maps webhook body status (enum or human-readable) to the same

--- a/pkg/integrations/cloudflare/on_tunnel_health.go
+++ b/pkg/integrations/cloudflare/on_tunnel_health.go
@@ -1,0 +1,313 @@
+package cloudflare
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const TunnelHealthEventPayloadType = "cloudflare.tunnel.healthEvent"
+
+// tunnelHealthPolicyStatuses are the only values accepted by Cloudflare's
+// tunnel_health_event notification policy new_status filter (see API / Terraform provider).
+var tunnelHealthPolicyStatuses = []string{
+	"TUNNEL_STATUS_TYPE_HEALTHY",
+	"TUNNEL_STATUS_TYPE_DEGRADED",
+	"TUNNEL_STATUS_TYPE_DOWN",
+}
+
+type OnTunnelHealth struct{}
+
+type OnTunnelHealthSpec struct {
+	Tunnel    string   `json:"tunnel"`
+	NewStatus []string `json:"newStatus"`
+}
+
+func (t *OnTunnelHealth) Name() string {
+	return "cloudflare.onTunnelHealth"
+}
+
+func (t *OnTunnelHealth) Label() string {
+	return "On Tunnel Health"
+}
+
+func (t *OnTunnelHealth) Description() string {
+	return "Trigger when a Cloudflare Tunnel health notification fires for degradation or recovery"
+}
+
+func (t *OnTunnelHealth) Documentation() string {
+	return `The On Tunnel Health trigger starts a workflow from Cloudflare ` + "`tunnel_health_event`" + ` notifications (Cloudflare Tunnel / cloudflared).
+
+## Use Cases
+
+- **Degraded or down**: React when tunnel connectivity drops below healthy thresholds
+- **Recovery**: Resume normal processing when the tunnel returns to a healthy state
+
+## Configuration
+
+- **Tunnel**: Optional tunnel filter. Leave empty to receive events for any tunnel on the account.
+- **New status**: Which tunnel status transitions should start a workflow. Values are sent to Cloudflare as ` + "`TUNNEL_STATUS_TYPE_*`" + ` enums; webhook payloads may use human-readable names (for example Down) and SuperPlane still matches your selection.
+
+## Webhook Setup
+
+SuperPlane provisions a Cloudflare Alerting webhook destination and a notification policy for ` + "`tunnel_health_event`" + `. Cloudflare signs requests with the generated webhook secret and SuperPlane verifies the ` + "`cf-webhook-auth`" + ` header before emitting an event.
+
+## Workflow execution details
+
+The trigger **Payload** tab (and expressions such as ` + "`$.trigger.data`" + `) contain the fields Cloudflare sends, typically including **tunnel id**, **tunnel name**, **new status**, **account id**, and **alert type**.`
+}
+
+func (t *OnTunnelHealth) Icon() string {
+	return "activity"
+}
+
+func (t *OnTunnelHealth) Color() string {
+	return "orange"
+}
+
+func (t *OnTunnelHealth) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "tunnel",
+			Label:       "Tunnel",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional tunnel to filter notifications by",
+			Placeholder: "Select a tunnel",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "tunnel",
+				},
+			},
+		},
+		{
+			Name:        "newStatus",
+			Label:       "New Status",
+			Type:        configuration.FieldTypeMultiSelect,
+			Required:    false,
+			Default:     []string{"TUNNEL_STATUS_TYPE_HEALTHY", "TUNNEL_STATUS_TYPE_DEGRADED", "TUNNEL_STATUS_TYPE_DOWN"},
+			Description: "Tunnel status values to listen for (Cloudflare policy filter)",
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Healthy", Value: "TUNNEL_STATUS_TYPE_HEALTHY"},
+						{Label: "Degraded", Value: "TUNNEL_STATUS_TYPE_DEGRADED"},
+						{Label: "Down", Value: "TUNNEL_STATUS_TYPE_DOWN"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *OnTunnelHealth) Setup(ctx core.TriggerContext) error {
+	spec := OnTunnelHealthSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	normalized, err := normalizeTunnelHealthSpec(spec)
+	if err != nil {
+		return err
+	}
+
+	if err := resolveTunnelHealthTunnelMetadata(ctx, normalized.Tunnel); err != nil {
+		return err
+	}
+
+	return ctx.Integration.RequestWebhook(normalized)
+}
+
+func resolveTunnelHealthTunnelMetadata(ctx core.TriggerContext, tunnelID string) error {
+	tunnelID = strings.TrimSpace(tunnelID)
+	if tunnelID == "" || ctx.Metadata == nil {
+		return nil
+	}
+
+	meta := TunnelNodeMetadata{TunnelName: tunnelID}
+	accountID := accountIDFromIntegration(ctx.Integration)
+	if strings.Contains(tunnelID, "{{") || strings.Contains(accountID, "{{") || accountID == "" {
+		return ctx.Metadata.Set(meta)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	tunnel, err := client.GetCFDTunnel(accountID, tunnelID)
+	if err != nil {
+		return fmt.Errorf("failed to get tunnel: %w", err)
+	}
+
+	meta.TunnelName = tunnel.Name
+	if strings.TrimSpace(meta.TunnelName) == "" {
+		meta.TunnelName = tunnelID
+	}
+	return ctx.Metadata.Set(meta)
+}
+
+func normalizeTunnelHealthSpec(spec OnTunnelHealthSpec) (OnTunnelHealthSpec, error) {
+	if len(spec.NewStatus) == 0 {
+		spec.NewStatus = []string{
+			"TUNNEL_STATUS_TYPE_HEALTHY",
+			"TUNNEL_STATUS_TYPE_DEGRADED",
+			"TUNNEL_STATUS_TYPE_DOWN",
+		}
+	}
+
+	for i, value := range spec.NewStatus {
+		normalized, err := normalizeTunnelHealthPolicyStatus(value)
+		if err != nil {
+			return spec, err
+		}
+		spec.NewStatus[i] = normalized
+	}
+
+	spec.Tunnel = strings.TrimSpace(spec.Tunnel)
+	spec.NewStatus = compactStrings(spec.NewStatus)
+	return spec, nil
+}
+
+// normalizeTunnelHealthPolicyStatus maps UI / legacy human-readable values to Cloudflare's
+// tunnel_health_event new_status filter enums.
+func normalizeTunnelHealthPolicyStatus(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("newStatus value is empty")
+	}
+
+	if slices.Contains(tunnelHealthPolicyStatuses, trimmed) {
+		return trimmed, nil
+	}
+
+	legacy := map[string]string{
+		"healthy":  "TUNNEL_STATUS_TYPE_HEALTHY",
+		"degraded": "TUNNEL_STATUS_TYPE_DEGRADED",
+		"down":     "TUNNEL_STATUS_TYPE_DOWN",
+	}
+	if mapped, ok := legacy[strings.ToLower(trimmed)]; ok {
+		return mapped, nil
+	}
+
+	if strings.EqualFold(trimmed, "inactive") {
+		return "", fmt.Errorf("newStatus Inactive is not supported for Cloudflare tunnel_health_event notification filters")
+	}
+
+	return "", fmt.Errorf("newStatus must be one of %s (or legacy Healthy, Degraded, Down)", strings.Join(tunnelHealthPolicyStatuses, ", "))
+}
+
+func (t *OnTunnelHealth) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (t *OnTunnelHealth) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (t *OnTunnelHealth) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *OnTunnelHealth) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	secretBytes, err := ctx.Webhook.GetSecret()
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	provided := strings.TrimSpace(headerValue(ctx.Headers, "cf-webhook-auth"))
+	if provided == "" {
+		return http.StatusUnauthorized, nil, fmt.Errorf("missing cf-webhook-auth header")
+	}
+
+	if subtle.ConstantTimeCompare([]byte(provided), secretBytes) != 1 {
+		return http.StatusForbidden, nil, fmt.Errorf("invalid cf-webhook-auth header")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(ctx.Body, &payload); err != nil {
+		payload = map[string]any{"raw": string(ctx.Body)}
+	}
+
+	triggerSpec := OnTunnelHealthSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &triggerSpec); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode trigger configuration: %w", err)
+	}
+
+	normalizedSpec, err := normalizeTunnelHealthSpec(triggerSpec)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	if !tunnelHealthPayloadMatchesSpec(normalizedSpec, payload) {
+		return http.StatusOK, nil, nil
+	}
+
+	if err := ctx.Events.Emit(TunnelHealthEventPayloadType, tunnelHealthWebhookEventData(payload)); err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func tunnelHealthWebhookEventData(payload map[string]any) map[string]any {
+	if nested, ok := payload["data"].(map[string]any); ok && nested != nil {
+		return nested
+	}
+	return payload
+}
+
+func tunnelHealthPayloadMatchesSpec(spec OnTunnelHealthSpec, payload map[string]any) bool {
+	data := tunnelHealthWebhookEventData(payload)
+
+	if spec.Tunnel != "" {
+		tunnelID := strings.TrimSpace(tunnelHealthStringField(data, "tunnel_id", "tunnelId"))
+		if tunnelID != spec.Tunnel {
+			return false
+		}
+	}
+
+	rawStatus := tunnelHealthStringField(data, "new_status", "newStatus", "status")
+	normalized := tunnelHealthPayloadStatusForMatch(rawStatus)
+	if normalized == "" || !slices.Contains(spec.NewStatus, normalized) {
+		return false
+	}
+
+	return true
+}
+
+// tunnelHealthPayloadStatusForMatch maps webhook body status (enum or human-readable) to the same
+// policy enum strings stored in OnTunnelHealthSpec.NewStatus.
+func tunnelHealthPayloadStatusForMatch(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if slices.Contains(tunnelHealthPolicyStatuses, raw) {
+		return raw
+	}
+	legacy := map[string]string{
+		"healthy":  "TUNNEL_STATUS_TYPE_HEALTHY",
+		"degraded": "TUNNEL_STATUS_TYPE_DEGRADED",
+		"down":     "TUNNEL_STATUS_TYPE_DOWN",
+	}
+	if mapped, ok := legacy[strings.ToLower(raw)]; ok {
+		return mapped
+	}
+	return ""
+}
+
+func tunnelHealthStringField(data map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := data[key]; ok {
+			return healthAlertFieldString(value)
+		}
+	}
+	return ""
+}

--- a/pkg/integrations/cloudflare/on_tunnel_health_test.go
+++ b/pkg/integrations/cloudflare/on_tunnel_health_test.go
@@ -1,0 +1,111 @@
+package cloudflare
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__OnTunnelHealth__Setup(t *testing.T) {
+	trigger := &OnTunnelHealth{}
+	integration := &contexts.IntegrationContext{}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{
+			"tunnel":    "tun123",
+			"newStatus": []string{"Down"},
+		},
+		Integration: integration,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, integration.WebhookRequests, 1)
+	assert.Equal(t, OnTunnelHealthSpec{
+		Tunnel:    "tun123",
+		NewStatus: []string{"TUNNEL_STATUS_TYPE_DOWN"},
+	}, integration.WebhookRequests[0])
+}
+
+func Test__OnTunnelHealth__HandleWebhook(t *testing.T) {
+	trigger := &OnTunnelHealth{}
+
+	t.Run("emits valid tunnel health payload", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_status":"Down","tunnel_id":"tun123"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"tunnel":    "tun123",
+				"newStatus": []string{"TUNNEL_STATUS_TYPE_DOWN", "TUNNEL_STATUS_TYPE_DEGRADED"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		require.Len(t, events.Payloads, 1)
+		assert.Equal(t, TunnelHealthEventPayloadType, events.Payloads[0].Type)
+	})
+
+	t.Run("skips when tunnel filter does not match", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_status":"Down","tunnel_id":"tun123"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"tunnel":    "other",
+				"newStatus": []string{"TUNNEL_STATUS_TYPE_DOWN"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		assert.Len(t, events.Payloads, 0)
+	})
+}
+
+func Test__OnTunnelHealth__SetupResolvesTunnelMetadata(t *testing.T) {
+	trigger := &OnTunnelHealth{}
+	metadata := &contexts.MetadataContext{}
+	integration := &contexts.IntegrationContext{
+		Configuration: map[string]any{"apiToken": "token123"},
+		Metadata:      Metadata{AccountID: "acc123"},
+	}
+
+	err := trigger.Setup(core.TriggerContext{
+		Configuration: map[string]any{
+			"tunnel": "tun123",
+		},
+		HTTP: &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"success": true,
+						"result": {"id": "tun123", "name": "Edge tunnel"}
+					}`)),
+				},
+			},
+		},
+		Integration: integration,
+		Metadata:    metadata,
+	})
+
+	require.NoError(t, err)
+	tm, ok := metadata.Metadata.(TunnelNodeMetadata)
+	require.True(t, ok)
+	assert.Equal(t, "Edge tunnel", tm.TunnelName)
+}

--- a/pkg/integrations/cloudflare/on_tunnel_health_test.go
+++ b/pkg/integrations/cloudflare/on_tunnel_health_test.go
@@ -56,24 +56,75 @@ func Test__OnTunnelHealth__HandleWebhook(t *testing.T) {
 		assert.Equal(t, TunnelHealthEventPayloadType, events.Payloads[0].Type)
 	})
 
-	t.Run("skips when tunnel filter does not match", func(t *testing.T) {
+	t.Run("skips emit when tunnel_id does not match spec tunnel", func(t *testing.T) {
 		events := &contexts.EventContext{}
 		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
-			Body:    []byte(`{"new_status":"Down","tunnel_id":"tun123"}`),
+			Body: []byte(`{
+				"alert_type": "tunnel_health_event",
+				"data": {
+					"new_status": "TUNNEL_STATUS_TYPE_DEGRADED",
+					"tunnel_id": "wrong-id",
+					"tunnel_name": "tunnel-name"
+				}
+			}`),
 			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
 			Webhook: &contexts.NodeWebhookContext{
 				Secret: "secret123",
 			},
 			Events: events,
 			Configuration: map[string]any{
-				"tunnel":    "other",
-				"newStatus": []string{"TUNNEL_STATUS_TYPE_DOWN"},
+				"tunnel":    "60d33a5d-1228-47e0-813d-a5297cc0624b",
+				"newStatus": []string{"TUNNEL_STATUS_TYPE_DEGRADED"},
 			},
 		})
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, code)
 		assert.Len(t, events.Payloads, 0)
+	})
+
+	t.Run("matches tunnel_id case-insensitively", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body: []byte(`{
+				"data": {
+					"new_status": "TUNNEL_STATUS_TYPE_DEGRADED",
+					"tunnel_id": "60D33A5D-1228-47E0-813D-A5297CC0624B"
+				}
+			}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"tunnel":    "60d33a5d-1228-47e0-813d-a5297cc0624b",
+				"newStatus": []string{"TUNNEL_STATUS_TYPE_DEGRADED"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		require.Len(t, events.Payloads, 1)
+	})
+
+	t.Run("new_status with suffix still matches", func(t *testing.T) {
+		events := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"new_status":"TUNNEL_STATUS_TYPE_DEGRADED (status change)","tunnel_id":"t1"}`),
+			Headers: http.Header{"cf-webhook-auth": []string{"secret123"}},
+			Webhook: &contexts.NodeWebhookContext{
+				Secret: "secret123",
+			},
+			Events: events,
+			Configuration: map[string]any{
+				"newStatus": []string{"TUNNEL_STATUS_TYPE_DEGRADED"},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, code)
+		require.Len(t, events.Payloads, 1)
 	})
 }
 

--- a/pkg/integrations/cloudflare/webhook_handler.go
+++ b/pkg/integrations/cloudflare/webhook_handler.go
@@ -18,59 +18,152 @@ type CloudflareWebhookMetadata struct {
 	NotificationPolicyID string `json:"notificationPolicyId" mapstructure:"notificationPolicyId"`
 }
 
+type cloudflareWebhookKind string
+
+const (
+	cloudflareWebhookKindLoadBalancing cloudflareWebhookKind = "load_balancing_health_alert"
+	cloudflareWebhookKindTunnelHealth  cloudflareWebhookKind = "tunnel_health_event"
+)
+
+type cloudflareWebhookPolicyConfig struct {
+	Kind   cloudflareWebhookKind
+	Load   OnLoadBalancingHealthAlertSpec
+	Tunnel OnTunnelHealthSpec
+}
+
+func decodeCloudflareWebhookPolicyConfig(value any) (cloudflareWebhookPolicyConfig, error) {
+	if isTunnelHealthWebhookConfiguration(value) {
+		tunnel, err := decodeTunnelHealthWebhookConfig(value)
+		if err != nil {
+			return cloudflareWebhookPolicyConfig{}, err
+		}
+		return cloudflareWebhookPolicyConfig{
+			Kind:   cloudflareWebhookKindTunnelHealth,
+			Tunnel: tunnel,
+		}, nil
+	}
+
+	load, err := decodeHealthAlertWebhookConfig(value)
+	if err != nil {
+		return cloudflareWebhookPolicyConfig{}, err
+	}
+
+	return cloudflareWebhookPolicyConfig{
+		Kind: cloudflareWebhookKindLoadBalancing,
+		Load: load,
+	}, nil
+}
+
+func isTunnelHealthWebhookConfiguration(value any) bool {
+	if m, ok := value.(map[string]any); ok {
+		if _, ok := m["newStatus"]; ok {
+			return true
+		}
+		if _, ok := m["tunnel"]; ok {
+			return true
+		}
+		return false
+	}
+
+	var probe struct {
+		NewStatus []string `mapstructure:"newStatus"`
+		Tunnel    string   `mapstructure:"tunnel"`
+	}
+	if err := mapstructure.Decode(value, &probe); err != nil {
+		return false
+	}
+	if len(probe.NewStatus) > 0 {
+		return true
+	}
+	return strings.TrimSpace(probe.Tunnel) != ""
+}
+
 func (h *CloudflareWebhookHandler) CompareConfig(a, b any) (bool, error) {
-	configA, err := decodeHealthAlertWebhookConfig(a)
+	configA, err := decodeCloudflareWebhookPolicyConfig(a)
 	if err != nil {
 		return false, err
 	}
 
-	configB, err := decodeHealthAlertWebhookConfig(b)
+	configB, err := decodeCloudflareWebhookPolicyConfig(b)
 	if err != nil {
 		return false, err
 	}
 
-	return configA.Pool == configB.Pool &&
-		sameStringSet(configA.NewHealth, configB.NewHealth) &&
-		sameStringSet(configA.EventSource, configB.EventSource), nil
+	if configA.Kind != configB.Kind {
+		return false, nil
+	}
+
+	if configA.Kind == cloudflareWebhookKindTunnelHealth {
+		return configA.Tunnel.Tunnel == configB.Tunnel.Tunnel &&
+			sameStringSet(configA.Tunnel.NewStatus, configB.Tunnel.NewStatus), nil
+	}
+
+	return configA.Load.Pool == configB.Load.Pool &&
+		sameStringSet(configA.Load.NewHealth, configB.Load.NewHealth) &&
+		sameStringSet(configA.Load.EventSource, configB.Load.EventSource), nil
 }
 
 func (h *CloudflareWebhookHandler) Merge(current, requested any) (any, bool, error) {
-	currentConfig, err := decodeHealthAlertWebhookConfig(current)
+	currentConfig, err := decodeCloudflareWebhookPolicyConfig(current)
 	if err != nil {
 		return current, false, err
 	}
 
-	requestedConfig, err := decodeHealthAlertWebhookConfig(requested)
+	requestedConfig, err := decodeCloudflareWebhookPolicyConfig(requested)
 	if err != nil {
 		return current, false, err
 	}
 
-	if currentConfig.Pool != requestedConfig.Pool {
-		return currentConfig, false, nil
+	if currentConfig.Kind != requestedConfig.Kind {
+		return current, false, nil
 	}
 
-	merged := currentConfig
-	merged.NewHealth = mergeStringSets(currentConfig.NewHealth, requestedConfig.NewHealth)
-	merged.EventSource = mergeStringSets(currentConfig.EventSource, requestedConfig.EventSource)
+	if currentConfig.Kind == cloudflareWebhookKindTunnelHealth {
+		if currentConfig.Tunnel.Tunnel != requestedConfig.Tunnel.Tunnel {
+			return currentConfig.Tunnel, false, nil
+		}
 
-	changed := !sameStringSet(currentConfig.NewHealth, merged.NewHealth) ||
-		!sameStringSet(currentConfig.EventSource, merged.EventSource)
+		merged := currentConfig.Tunnel
+		merged.NewStatus = mergeStringSets(currentConfig.Tunnel.NewStatus, requestedConfig.Tunnel.NewStatus)
+
+		changed := !sameStringSet(currentConfig.Tunnel.NewStatus, merged.NewStatus)
+		return merged, changed, nil
+	}
+
+	if currentConfig.Load.Pool != requestedConfig.Load.Pool {
+		return currentConfig.Load, false, nil
+	}
+
+	merged := currentConfig.Load
+	merged.NewHealth = mergeStringSets(currentConfig.Load.NewHealth, requestedConfig.Load.NewHealth)
+	merged.EventSource = mergeStringSets(currentConfig.Load.EventSource, requestedConfig.Load.EventSource)
+
+	changed := !sameStringSet(currentConfig.Load.NewHealth, merged.NewHealth) ||
+		!sameStringSet(currentConfig.Load.EventSource, merged.EventSource)
 
 	return merged, changed, nil
 }
 
 func (h *CloudflareWebhookHandler) Setup(ctx core.WebhookHandlerContext) (any, error) {
+	cfg, err := decodeCloudflareWebhookPolicyConfig(ctx.Webhook.GetConfiguration())
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Kind == cloudflareWebhookKindTunnelHealth {
+		return setupTunnelHealthAlertWebhook(ctx, cfg.Tunnel)
+	}
+
+	return setupLoadBalancingHealthAlertWebhook(ctx, cfg.Load)
+}
+
+func setupLoadBalancingHealthAlertWebhook(ctx core.WebhookHandlerContext, config OnLoadBalancingHealthAlertSpec) (any, error) {
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return nil, err
 	}
 
 	accountID, err := accountIDForIntegration(ctx.Integration)
-	if err != nil {
-		return nil, err
-	}
-
-	config, err := decodeHealthAlertWebhookConfig(ctx.Webhook.GetConfiguration())
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +185,7 @@ func (h *CloudflareWebhookHandler) Setup(ctx core.WebhookHandlerContext) (any, e
 	destination, err := client.CreateAlertingWebhookDestination(
 		accountID,
 		CreateAlertingWebhookDestinationRequest{
-			Name:   cloudflareWebhookName(config),
+			Name:   cloudflareLoadBalancingWebhookName(config),
 			URL:    webhookURL,
 			Secret: string(secretBytes),
 		},
@@ -104,7 +197,7 @@ func (h *CloudflareWebhookHandler) Setup(ctx core.WebhookHandlerContext) (any, e
 	policy, err := client.CreateNotificationPolicy(accountID, CreateNotificationPolicyRequest{
 		AlertType:   "load_balancing_health_alert",
 		Enabled:     true,
-		Name:        cloudflareWebhookName(config),
+		Name:        cloudflareLoadBalancingWebhookName(config),
 		Description: "Created by SuperPlane for Cloudflare load balancing health alerts.",
 		Mechanisms: NotificationPolicyMechanisms{
 			Webhooks: []NotificationMechanism{{ID: destination.ID}},
@@ -113,6 +206,68 @@ func (h *CloudflareWebhookHandler) Setup(ctx core.WebhookHandlerContext) (any, e
 			PoolID:      oneOrNil(config.Pool),
 			NewHealth:   config.NewHealth,
 			EventSource: config.EventSource,
+		},
+	})
+	if err != nil {
+		_ = client.DeleteAlertingWebhookDestination(accountID, destination.ID)
+		return nil, fmt.Errorf("failed to create Cloudflare notification policy: %w", err)
+	}
+
+	return CloudflareWebhookMetadata{
+		AccountID:            accountID,
+		DestinationID:        destination.ID,
+		NotificationPolicyID: policy.ID,
+	}, nil
+}
+
+func setupTunnelHealthAlertWebhook(ctx core.WebhookHandlerContext, config OnTunnelHealthSpec) (any, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	accountID, err := accountIDForIntegration(ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	webhookURL := strings.TrimSpace(ctx.Webhook.GetURL())
+	if webhookURL == "" {
+		return nil, fmt.Errorf("webhook URL is empty")
+	}
+
+	secretBytes, err := ctx.Webhook.GetSecret()
+	if err != nil || len(secretBytes) == 0 || strings.TrimSpace(string(secretBytes)) == "" {
+		secret := uuid.NewString()
+		if err := ctx.Webhook.SetSecret([]byte(secret)); err != nil {
+			return nil, fmt.Errorf("failed to set webhook secret: %w", err)
+		}
+		secretBytes = []byte(secret)
+	}
+
+	destination, err := client.CreateAlertingWebhookDestination(
+		accountID,
+		CreateAlertingWebhookDestinationRequest{
+			Name:   cloudflareTunnelHealthWebhookName(config),
+			URL:    webhookURL,
+			Secret: string(secretBytes),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Cloudflare alerting webhook destination: %w", err)
+	}
+
+	policy, err := client.CreateNotificationPolicy(accountID, CreateNotificationPolicyRequest{
+		AlertType:   "tunnel_health_event",
+		Enabled:     true,
+		Name:        cloudflareTunnelHealthWebhookName(config),
+		Description: "Created by SuperPlane for Cloudflare Tunnel health alerts.",
+		Mechanisms: NotificationPolicyMechanisms{
+			Webhooks: []NotificationMechanism{{ID: destination.ID}},
+		},
+		Filters: NotificationPolicyFilters{
+			TunnelID:  oneOrNil(config.Tunnel),
+			NewStatus: config.NewStatus,
 		},
 	})
 	if err != nil {
@@ -170,6 +325,15 @@ func decodeHealthAlertWebhookConfig(value any) (OnLoadBalancingHealthAlertSpec, 
 	return normalizeHealthAlertSpec(config)
 }
 
+func decodeTunnelHealthWebhookConfig(value any) (OnTunnelHealthSpec, error) {
+	config := OnTunnelHealthSpec{}
+	if err := mapstructure.Decode(value, &config); err != nil {
+		return config, fmt.Errorf("failed to decode webhook configuration: %w", err)
+	}
+
+	return normalizeTunnelHealthSpec(config)
+}
+
 func mergeStringSets(a, b []string) []string {
 	result := append([]string{}, a...)
 	for _, value := range b {
@@ -194,12 +358,20 @@ func sameStringSet(a, b []string) bool {
 	return true
 }
 
-func cloudflareWebhookName(config OnLoadBalancingHealthAlertSpec) string {
+func cloudflareLoadBalancingWebhookName(config OnLoadBalancingHealthAlertSpec) string {
 	if config.Pool == "" {
 		return "SuperPlane Load Balancing Health Alert"
 	}
 
 	return fmt.Sprintf("SuperPlane Load Balancing Health Alert - %s", config.Pool)
+}
+
+func cloudflareTunnelHealthWebhookName(config OnTunnelHealthSpec) string {
+	if config.Tunnel == "" {
+		return "SuperPlane Tunnel Health Alert"
+	}
+
+	return fmt.Sprintf("SuperPlane Tunnel Health Alert - %s", config.Tunnel)
 }
 
 func oneOrNil(value string) []string {

--- a/pkg/integrations/cloudflare/webhook_handler_test.go
+++ b/pkg/integrations/cloudflare/webhook_handler_test.go
@@ -63,6 +63,52 @@ func Test__CloudflareWebhookHandler__Setup(t *testing.T) {
 	}, policy["filters"])
 }
 
+func Test__CloudflareWebhookHandler__Setup_TunnelHealth(t *testing.T) {
+	handler := &CloudflareWebhookHandler{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "dest456"}}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"success": true, "result": {"id": "policy456"}}`)),
+			},
+		},
+	}
+
+	metadata, err := handler.Setup(core.WebhookHandlerContext{
+		HTTP: httpContext,
+		Integration: &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiToken":  "token123",
+				"accountId": "account123",
+			},
+		},
+		Webhook: &contexts.WebhookContext{
+			URL:           "https://example.com/webhook-tunnel",
+			Configuration: OnTunnelHealthSpec{Tunnel: "tun123", NewStatus: []string{"TUNNEL_STATUS_TYPE_DOWN"}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, CloudflareWebhookMetadata{
+		AccountID:            "account123",
+		DestinationID:        "dest456",
+		NotificationPolicyID: "policy456",
+	}, metadata)
+	require.Len(t, httpContext.Requests, 2)
+
+	var policy map[string]any
+	require.NoError(t, json.NewDecoder(httpContext.Requests[1].Body).Decode(&policy))
+	assert.Equal(t, "tunnel_health_event", policy["alert_type"])
+	assert.Equal(t, map[string]any{
+		"tunnel_id":  []any{"tun123"},
+		"new_status": []any{"TUNNEL_STATUS_TYPE_DOWN"},
+	}, policy["filters"])
+}
+
 func Test__CloudflareWebhookHandler__Cleanup(t *testing.T) {
 	handler := &CloudflareWebhookHandler{}
 	integration := &contexts.IntegrationContext{
@@ -183,6 +229,24 @@ func Test__CloudflareWebhookHandler__Cleanup(t *testing.T) {
 
 func Test__CloudflareWebhookHandler__CompareConfig(t *testing.T) {
 	handler := &CloudflareWebhookHandler{}
+
+	t.Run("tunnel health config never matches load balancing defaults", func(t *testing.T) {
+		tunnel := map[string]any{"tunnel": "", "newStatus": []string{"Down"}}
+		lb := map[string]any{"pool": "", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"pool", "origin"}}
+
+		ok, err := handler.CompareConfig(tunnel, lb)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("tunnel health legacy Down normalizes equal to API status", func(t *testing.T) {
+		a := map[string]any{"tunnel": "t1", "newStatus": []string{"Down"}}
+		b := map[string]any{"tunnel": "t1", "newStatus": []string{"TUNNEL_STATUS_TYPE_DOWN"}}
+
+		ok, err := handler.CompareConfig(a, b)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
 
 	t.Run("same pool but different newHealth -> not equal", func(t *testing.T) {
 		a := map[string]any{"pool": "pool123", "newHealth": []string{"Unhealthy"}, "eventSource": []string{"pool"}}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -230,22 +230,6 @@ export function getWorkerRouteExecutionDetails(context: ExecutionDetailsContext)
   return details;
 }
 
-export function deleteTunnelExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-  const details: Record<string, string> = {};
-
-  if (context.execution.createdAt) {
-    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
-  }
-
-  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-  const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
-  if (!result) return details;
-
-  details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
-
-  return details;
-}
-
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
   const subtitleDate = execution.updatedAt ?? execution.createdAt;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -92,6 +92,30 @@ export function getPoolExecutionDetails(context: ExecutionDetailsContext): Recor
   return details;
 }
 
+export function getTunnelExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  const tunnel = result?.tunnel as Record<string, unknown> | undefined;
+  if (!tunnel) return details;
+
+  details["Tunnel ID"] = tunnel.id != null ? String(tunnel.id) : "-";
+  details["Name"] = tunnel.name != null ? String(tunnel.name) : "-";
+  if (tunnel.status != null) {
+    details["Status"] = String(tunnel.status);
+  }
+  if (tunnel.config_src != null) {
+    details["Config source"] = String(tunnel.config_src);
+  }
+
+  return details;
+}
+
 export function getLoadBalancerExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
   const details: Record<string, string> = {};
 
@@ -203,6 +227,23 @@ export function getWorkerRouteExecutionDetails(context: ExecutionDetailsContext)
   }
   details["Pattern"] = route.pattern != null ? String(route.pattern) : "-";
   details["Script"] = route.script != null ? String(route.script) : "-";
+  return details;
+}
+
+export function deleteTunnelExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+  const details: Record<string, string> = {};
+
+  if (context.execution.createdAt) {
+    details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+  }
+
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+  if (!result) return details;
+
+  details["Tunnel ID"] = result.tunnelId != null ? String(result.tunnelId) : "-";
+  details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
+
   return details;
 }
 

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -104,7 +104,6 @@ export function getTunnelExecutionDetails(context: ExecutionDetailsContext): Rec
   const tunnel = result?.tunnel as Record<string, unknown> | undefined;
   if (!tunnel) return details;
 
-  details["Tunnel ID"] = tunnel.id != null ? String(tunnel.id) : "-";
   details["Name"] = tunnel.name != null ? String(tunnel.name) : "-";
   if (tunnel.status != null) {
     details["Status"] = String(tunnel.status);
@@ -241,7 +240,6 @@ export function deleteTunnelExecutionDetails(context: ExecutionDetailsContext): 
   const result = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
   if (!result) return details;
 
-  details["Tunnel ID"] = result.tunnelId != null ? String(result.tunnelId) : "-";
   details["Deleted"] = result.deleted != null ? String(result.deleted) : "-";
 
   return details;

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/base.ts
@@ -140,7 +140,8 @@ export function getLoadBalancerExecutionDetails(context: ExecutionDetailsContext
   return details;
 }
 
-export function deleteLoadBalancerExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+/** Execution details for Cloudflare delete actions that emit `{ deleted: boolean }` on the default channel. */
+export function cloudflareDeletedResourceExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
   const details: Record<string, string> = {};
 
   if (context.execution.createdAt) {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/create_tunnel.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/create_tunnel.ts
@@ -1,0 +1,54 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getTunnelExecutionDetails } from "./base";
+
+interface CreateTunnelConfiguration {
+  name?: string;
+  configSrc?: string;
+}
+
+export const createTunnelMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getTunnelExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as CreateTunnelConfiguration;
+
+  if (configuration?.name) {
+    metadata.push({ icon: "network", label: configuration.name });
+  }
+
+  if (configuration?.configSrc) {
+    metadata.push({ icon: "settings", label: configuration.configSrc });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_load_balancer.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_load_balancer.ts
@@ -2,7 +2,7 @@ import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
 import { getBackgroundColorClass } from "@/lib/colors";
 import { getStateMap } from "..";
-import { baseEventSections, deleteLoadBalancerExecutionDetails } from "./base";
+import { baseEventSections, cloudflareDeletedResourceExecutionDetails } from "./base";
 import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
@@ -33,7 +33,7 @@ export const deleteLoadBalancerMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails: deleteLoadBalancerExecutionDetails,
+  getExecutionDetails: cloudflareDeletedResourceExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_tunnel.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_tunnel.ts
@@ -1,0 +1,51 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, deleteTunnelExecutionDetails } from "./base";
+import { getCloudflareTunnelName } from "./metadata";
+
+interface DeleteTunnelConfiguration {
+  tunnel?: string;
+}
+
+export const deleteTunnelMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: deleteTunnelExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as DeleteTunnelConfiguration;
+
+  const label = getCloudflareTunnelName(node.metadata) || configuration?.tunnel;
+  if (label) {
+    metadata.push({ icon: "network", label });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/delete_tunnel.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/delete_tunnel.ts
@@ -6,7 +6,7 @@ import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleConte
 import type { MetadataItem } from "@/ui/metadataList";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
-import { baseEventSections, deleteTunnelExecutionDetails } from "./base";
+import { baseEventSections, cloudflareDeletedResourceExecutionDetails } from "./base";
 import { getCloudflareTunnelName } from "./metadata";
 
 interface DeleteTunnelConfiguration {
@@ -30,7 +30,7 @@ export const deleteTunnelMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails: deleteTunnelExecutionDetails,
+  getExecutionDetails: cloudflareDeletedResourceExecutionDetails,
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
     if (!context.execution.createdAt) return "";

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.spec.ts
@@ -98,7 +98,7 @@ describe("getTunnelMapper.getExecutionDetails", () => {
       },
     });
     const details = getTunnelMapper.getExecutionDetails(ctx);
-    expect(details["Tunnel ID"]).toBe("tun123");
+    expect(details["Tunnel ID"]).toBeUndefined();
     expect(details["Name"]).toBe("edge-tunnel");
     expect(details["Status"]).toBe("healthy");
   });

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+} from "../types";
+import { getTunnelMapper } from "./get_tunnel";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test Node",
+    componentName: "cloudflare.getTunnel",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudflare.tunnel.fetched",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "cloudflare.getTunnel",
+  label: "Get Tunnel",
+  description: "",
+  icon: "cloud",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode(),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+const tunnelOutputData = {
+  tunnel: {
+    id: "tun123",
+    name: "edge-tunnel",
+    status: "healthy",
+    config_src: "cloudflare",
+  },
+  accountId: "acc123",
+};
+
+describe("getTunnelMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getTunnelMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("includes tunnel fields from output", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: { default: [buildOutput(tunnelOutputData)] },
+      },
+    });
+    const details = getTunnelMapper.getExecutionDetails(ctx);
+    expect(details["Tunnel ID"]).toBe("tun123");
+    expect(details["Name"]).toBe("edge-tunnel");
+    expect(details["Status"]).toBe("healthy");
+  });
+});
+
+describe("eventStateRegistry.getTunnel", () => {
+  it("maps finished passed to fetched", () => {
+    expect(eventStateRegistry.getTunnel.getState(buildExecution())).toBe("fetched");
+  });
+});
+
+describe("getTunnelMapper.props", () => {
+  it("returns props without throwing", () => {
+    const props = getTunnelMapper.props(buildPropsContext({}));
+    expect(props.title).toBeDefined();
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/get_tunnel.ts
@@ -1,0 +1,51 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type { ComponentBaseContext, ComponentBaseMapper, NodeInfo, SubtitleContext } from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections, getTunnelExecutionDetails } from "./base";
+import { getCloudflareTunnelName } from "./metadata";
+
+interface GetTunnelConfiguration {
+  tunnel?: string;
+}
+
+export const getTunnelMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudflare";
+
+    return {
+      iconSrc: cloudflareIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails: getTunnelExecutionDetails,
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetTunnelConfiguration;
+
+  const label = getCloudflareTunnelName(node.metadata) || configuration?.tunnel;
+  if (label) {
+    metadata.push({ icon: "network", label });
+  }
+
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -60,6 +60,10 @@ const deployWorkerStateRegistry: EventStateRegistry = {
     return "deployed";
   },
 };
+import { createTunnelMapper } from "./create_tunnel";
+import { getTunnelMapper } from "./get_tunnel";
+import { deleteTunnelMapper } from "./delete_tunnel";
+import { onTunnelHealthTriggerRenderer } from "./on_tunnel_health";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,
@@ -90,10 +94,14 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   getWorker: getWorkerMapper,
   deleteWorker: deleteWorkerMapper,
   updateWorkerRoute: updateWorkerRouteMapper,
+  createTunnel: createTunnelMapper,
+  getTunnel: getTunnelMapper,
+  deleteTunnel: deleteTunnelMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
   onLoadBalancingHealthAlert: onLoadBalancingHealthAlertTriggerRenderer,
+  onTunnelHealth: onTunnelHealthTriggerRenderer,
 };
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
@@ -125,4 +133,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getWorker: buildActionStateRegistry("fetched"),
   deleteWorker: buildActionStateRegistry("deleted"),
   updateWorkerRoute: updateWorkerRouteStateRegistry,
+  createTunnel: buildActionStateRegistry("created"),
+  getTunnel: buildActionStateRegistry("fetched"),
+  deleteTunnel: buildActionStateRegistry("deleted"),
 };

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
@@ -26,6 +26,10 @@ import { deployWorkerMapper } from "./deploy_worker";
 import { getWorkerMapper } from "./get_worker";
 import { deleteWorkerMapper } from "./delete_worker";
 import { updateWorkerRouteMapper } from "./update_worker_route";
+import { createTunnelMapper } from "./create_tunnel";
+import { getTunnelMapper } from "./get_tunnel";
+import { deleteTunnelMapper } from "./delete_tunnel";
+import { onTunnelHealthTriggerRenderer } from "./on_tunnel_health";
 
 const updateWorkerRouteStateRegistry: EventStateRegistry = {
   stateMap: {
@@ -60,10 +64,6 @@ const deployWorkerStateRegistry: EventStateRegistry = {
     return "deployed";
   },
 };
-import { createTunnelMapper } from "./create_tunnel";
-import { getTunnelMapper } from "./get_tunnel";
-import { deleteTunnelMapper } from "./delete_tunnel";
-import { onTunnelHealthTriggerRenderer } from "./on_tunnel_health";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createDnsRecord: baseMapper,

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/metadata.ts
@@ -42,3 +42,10 @@ export function getCloudflareMonitorDisplayLabel(metadata: unknown, monitorId: s
 
   return id;
 }
+
+export function getCloudflareTunnelName(metadata: unknown): string | undefined {
+  const m = metadataRecord(metadata);
+  if (!m) return undefined;
+  const raw = m.tunnelName ?? m.tunnel_name;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { TriggerEventContext, TriggerRendererContext, EventInfo } from "../types";
+import { onTunnelHealthTriggerRenderer } from "./on_tunnel_health";
+
+const definition = {
+  name: "cloudflare.onTunnelHealth",
+  label: "On Tunnel Health",
+  description: "",
+  icon: "activity",
+  color: "orange",
+};
+
+describe("onTunnelHealthTriggerRenderer", () => {
+  it("builds title from event data", () => {
+    const event: EventInfo = {
+      id: "evt-1",
+      createdAt: new Date().toISOString(),
+      nodeId: "node-1",
+      type: "cloudflare.tunnel.healthEvent",
+      data: {
+        tunnel_name: "api",
+        new_status: "Down",
+      },
+    };
+    const context: TriggerEventContext = { event };
+    expect(onTunnelHealthTriggerRenderer.getTitleAndSubtitle(context).title).toContain("api");
+    expect(onTunnelHealthTriggerRenderer.getTitleAndSubtitle(context).title).toContain("Down");
+  });
+
+  it("getRootEventValues includes status", () => {
+    const event: EventInfo = {
+      id: "evt-1",
+      createdAt: new Date().toISOString(),
+      nodeId: "node-1",
+      type: "cloudflare.tunnel.healthEvent",
+      data: { new_status: "Degraded", tunnel_id: "t1" },
+    };
+    const context: TriggerEventContext = { event };
+    const values = onTunnelHealthTriggerRenderer.getRootEventValues(context);
+    expect(values["New Status"]).toBe("Degraded");
+    expect(values.Tunnel).toBe("t1");
+  });
+
+  it("getTriggerProps returns metadata from configuration", () => {
+    const context: TriggerRendererContext = {
+      node: {
+        id: "n1",
+        name: "Tunnel trigger",
+        componentName: "cloudflare.onTunnelHealth",
+        isCollapsed: false,
+        configuration: {
+          newStatus: ["TUNNEL_STATUS_TYPE_DOWN", "TUNNEL_STATUS_TYPE_HEALTHY"],
+        },
+        metadata: {},
+      },
+      definition,
+      lastEvent: undefined,
+    };
+    const props = onTunnelHealthTriggerRenderer.getTriggerProps(context);
+    expect(props.metadata?.some((m) => m.label === "Down, Healthy")).toBe(true);
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.spec.ts
@@ -42,6 +42,24 @@ describe("onTunnelHealthTriggerRenderer", () => {
     expect(values.Tunnel).toBe("t1");
   });
 
+  it("getRootEventValues reads alert_type from merged-style payload", () => {
+    const event: EventInfo = {
+      id: "evt-1",
+      createdAt: new Date().toISOString(),
+      nodeId: "node-1",
+      type: "cloudflare.tunnel.healthEvent",
+      data: {
+        alert_type: "tunnel_health_event",
+        new_status: "TUNNEL_STATUS_TYPE_DEGRADED",
+        tunnel_name: "tunnel-name",
+        tunnel_id: "abc",
+      },
+    };
+    const values = onTunnelHealthTriggerRenderer.getRootEventValues({ event });
+    expect(values["Alert Type"]).toBe("tunnel_health_event");
+    expect(values["New Status"]).toBe("Degraded");
+  });
+
   it("getTriggerProps returns metadata from configuration", () => {
     const context: TriggerRendererContext = {
       node: {

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.ts
@@ -1,0 +1,154 @@
+import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import type { TriggerProps } from "@/ui/trigger";
+import type React from "react";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import { getCloudflareTunnelName } from "./metadata";
+
+interface TunnelHealthConfiguration {
+  tunnel?: string;
+  newStatus?: string[];
+}
+
+interface TunnelHealthEventData {
+  alert_type?: string;
+  new_status?: string;
+  newStatus?: string;
+  tunnel_id?: string;
+  tunnelId?: string;
+  tunnel_name?: string;
+  tunnelName?: string;
+  account_id?: string;
+}
+
+const TUNNEL_HEALTH_STATUS_LABELS: Record<string, string> = {
+  TUNNEL_STATUS_TYPE_HEALTHY: "Healthy",
+  TUNNEL_STATUS_TYPE_DEGRADED: "Degraded",
+  TUNNEL_STATUS_TYPE_DOWN: "Down",
+};
+
+function tunnelHealthStatusDisplay(value: string | undefined): string {
+  const v = value?.trim();
+  if (!v) return "";
+  return TUNNEL_HEALTH_STATUS_LABELS[v] ?? v;
+}
+
+function tunnelHealthStatusesListDisplay(values: string[] | undefined): string {
+  if (!values?.length) return "";
+  return values.map((s) => tunnelHealthStatusDisplay(s)).join(", ");
+}
+
+function parseTunnelHealthEventData(raw: unknown): TunnelHealthEventData | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
+  const envelope = raw as Record<string, unknown>;
+  const nested = envelope["data"];
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as TunnelHealthEventData;
+  }
+  return envelope as TunnelHealthEventData;
+}
+
+export const onTunnelHealthTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
+    const eventData = parseTunnelHealthEventData(context.event?.data);
+
+    return {
+      title: buildEventTitle(eventData),
+      subtitle: context.event?.createdAt ? renderTimeAgo(new Date(context.event.createdAt)) : "",
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = parseTunnelHealthEventData(context.event?.data);
+    const status =
+      tunnelHealthStatusDisplay(eventData?.new_status?.trim()) ||
+      tunnelHealthStatusDisplay(eventData?.newStatus?.trim());
+
+    return {
+      "Triggered At": formatTriggeredAt(context.event?.createdAt),
+      "Alert Type": displayValue(eventData?.alert_type),
+      "New Status": displayValue(status),
+      Tunnel: displayValue(
+        eventData?.tunnel_name || eventData?.tunnelName || eventData?.tunnel_id || eventData?.tunnelId,
+      ),
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
+    const { node, definition, lastEvent } = context;
+    const configuration = node.configuration as TunnelHealthConfiguration | undefined;
+    const metadata = [];
+
+    const tunnelLabel =
+      getCloudflareTunnelName(node.metadata) || getEventTunnelName(lastEvent) || configuration?.tunnel;
+    if (tunnelLabel) {
+      metadata.push({ icon: "server", label: tunnelLabel });
+    }
+
+    if (configuration?.newStatus?.length) {
+      metadata.push({ icon: "activity", label: tunnelHealthStatusesListDisplay(configuration.newStatus) });
+    }
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Cloudflare tunnel health",
+      iconSrc: cloudflareIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata,
+    };
+
+    if (lastEvent) {
+      const eventData = parseTunnelHealthEventData(lastEvent.data);
+      props.lastEventData = {
+        title: buildEventTitle(eventData),
+        subtitle: lastEvent.createdAt ? renderTimeAgo(new Date(lastEvent.createdAt)) : "",
+        receivedAt: new Date(lastEvent.createdAt),
+        state: "triggered",
+        eventId: lastEvent.id,
+      };
+    }
+
+    return props;
+  },
+};
+
+function buildEventTitle(eventData?: TunnelHealthEventData): string {
+  const statusRaw = eventData?.new_status?.trim() || eventData?.newStatus?.trim() || "";
+  const status = tunnelHealthStatusDisplay(statusRaw) || "Status changed";
+  const target =
+    eventData?.tunnel_name?.trim() ||
+    eventData?.tunnelName?.trim() ||
+    eventData?.tunnel_id?.trim() ||
+    eventData?.tunnelId?.trim();
+
+  return [target, status].filter(Boolean).join(" · ");
+}
+
+function getEventTunnelName(eventDataSource?: { data?: unknown }): string | undefined {
+  const eventData = parseTunnelHealthEventData(eventDataSource?.data);
+  return (
+    eventData?.tunnel_name?.trim() ||
+    eventData?.tunnelName?.trim() ||
+    eventData?.tunnel_id?.trim() ||
+    eventData?.tunnelId?.trim() ||
+    undefined
+  );
+}
+
+function displayValue(value?: string): string {
+  return value?.trim() || "-";
+}
+
+function formatTriggeredAt(createdAt?: string): string {
+  if (!createdAt?.trim()) {
+    return "-";
+  }
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return "-";
+  }
+  return parsed.toLocaleString();
+}

--- a/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.ts
+++ b/web_src/src/pages/workflowv2/mappers/cloudflare/on_tunnel_health.ts
@@ -28,6 +28,14 @@ const TUNNEL_HEALTH_STATUS_LABELS: Record<string, string> = {
   TUNNEL_STATUS_TYPE_DOWN: "Down",
 };
 
+function firstTrimmed(values: (string | undefined)[]): string {
+  for (const v of values) {
+    const t = v?.trim();
+    if (t) return t;
+  }
+  return "";
+}
+
 function tunnelHealthStatusDisplay(value: string | undefined): string {
   const v = value?.trim();
   if (!v) return "";
@@ -51,6 +59,40 @@ function parseTunnelHealthEventData(raw: unknown): TunnelHealthEventData | undef
   return envelope as TunnelHealthEventData;
 }
 
+function tunnelHealthNewStatusRawFromEvent(eventData?: TunnelHealthEventData): string {
+  return firstTrimmed([eventData?.new_status, eventData?.newStatus]);
+}
+
+function tunnelLabelFromEventData(eventData?: TunnelHealthEventData): string {
+  return firstTrimmed([eventData?.tunnel_name, eventData?.tunnelName, eventData?.tunnel_id, eventData?.tunnelId]);
+}
+
+function buildTunnelHealthRootEventValues(event: TriggerEventContext["event"]): Record<string, string> {
+  const eventData = parseTunnelHealthEventData(event?.data);
+  const statusRaw = tunnelHealthNewStatusRawFromEvent(eventData);
+  const statusLabel = tunnelHealthStatusDisplay(statusRaw);
+
+  return {
+    "Triggered At": formatTriggeredAt(event?.createdAt),
+    "Alert Type": displayValue(eventData?.alert_type),
+    "New Status": displayValue(statusLabel),
+    Tunnel: displayValue(tunnelLabelFromEventData(eventData)),
+  };
+}
+
+function buildTunnelHealthLastEventData(
+  lastEvent: NonNullable<TriggerRendererContext["lastEvent"]>,
+): TriggerProps["lastEventData"] {
+  const eventData = parseTunnelHealthEventData(lastEvent.data);
+  return {
+    title: buildEventTitle(eventData),
+    subtitle: lastEvent.createdAt ? renderTimeAgo(new Date(lastEvent.createdAt)) : "",
+    receivedAt: new Date(lastEvent.createdAt),
+    state: "triggered",
+    eventId: lastEvent.id,
+  };
+}
+
 export const onTunnelHealthTriggerRenderer: TriggerRenderer = {
   getTitleAndSubtitle: (context: TriggerEventContext): { title: string; subtitle: string | React.ReactNode } => {
     const eventData = parseTunnelHealthEventData(context.event?.data);
@@ -62,35 +104,13 @@ export const onTunnelHealthTriggerRenderer: TriggerRenderer = {
   },
 
   getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
-    const eventData = parseTunnelHealthEventData(context.event?.data);
-    const status =
-      tunnelHealthStatusDisplay(eventData?.new_status?.trim()) ||
-      tunnelHealthStatusDisplay(eventData?.newStatus?.trim());
-
-    return {
-      "Triggered At": formatTriggeredAt(context.event?.createdAt),
-      "Alert Type": displayValue(eventData?.alert_type),
-      "New Status": displayValue(status),
-      Tunnel: displayValue(
-        eventData?.tunnel_name || eventData?.tunnelName || eventData?.tunnel_id || eventData?.tunnelId,
-      ),
-    };
+    return buildTunnelHealthRootEventValues(context.event);
   },
 
   getTriggerProps: (context: TriggerRendererContext): TriggerProps => {
     const { node, definition, lastEvent } = context;
     const configuration = node.configuration as TunnelHealthConfiguration | undefined;
-    const metadata = [];
-
-    const tunnelLabel =
-      getCloudflareTunnelName(node.metadata) || getEventTunnelName(lastEvent) || configuration?.tunnel;
-    if (tunnelLabel) {
-      metadata.push({ icon: "server", label: tunnelLabel });
-    }
-
-    if (configuration?.newStatus?.length) {
-      metadata.push({ icon: "activity", label: tunnelHealthStatusesListDisplay(configuration.newStatus) });
-    }
+    const metadata = buildTunnelHealthTriggerMetadata(node, configuration, lastEvent);
 
     const props: TriggerProps = {
       title: node.name || definition.label || "Cloudflare tunnel health",
@@ -101,41 +121,43 @@ export const onTunnelHealthTriggerRenderer: TriggerRenderer = {
     };
 
     if (lastEvent) {
-      const eventData = parseTunnelHealthEventData(lastEvent.data);
-      props.lastEventData = {
-        title: buildEventTitle(eventData),
-        subtitle: lastEvent.createdAt ? renderTimeAgo(new Date(lastEvent.createdAt)) : "",
-        receivedAt: new Date(lastEvent.createdAt),
-        state: "triggered",
-        eventId: lastEvent.id,
-      };
+      props.lastEventData = buildTunnelHealthLastEventData(lastEvent);
     }
 
     return props;
   },
 };
 
-function buildEventTitle(eventData?: TunnelHealthEventData): string {
-  const statusRaw = eventData?.new_status?.trim() || eventData?.newStatus?.trim() || "";
-  const status = tunnelHealthStatusDisplay(statusRaw) || "Status changed";
-  const target =
-    eventData?.tunnel_name?.trim() ||
-    eventData?.tunnelName?.trim() ||
-    eventData?.tunnel_id?.trim() ||
-    eventData?.tunnelId?.trim();
+function buildTunnelHealthTriggerMetadata(
+  node: TriggerRendererContext["node"],
+  configuration: TunnelHealthConfiguration | undefined,
+  lastEvent: TriggerRendererContext["lastEvent"],
+): { icon: string; label: string }[] {
+  const metadata: { icon: string; label: string }[] = [];
 
+  const tunnelLabel = getCloudflareTunnelName(node.metadata) || getEventTunnelName(lastEvent) || configuration?.tunnel;
+  if (tunnelLabel) {
+    metadata.push({ icon: "server", label: tunnelLabel });
+  }
+
+  if (configuration?.newStatus?.length) {
+    metadata.push({ icon: "activity", label: tunnelHealthStatusesListDisplay(configuration.newStatus) });
+  }
+
+  return metadata;
+}
+
+function buildEventTitle(eventData?: TunnelHealthEventData): string {
+  const statusRaw = tunnelHealthNewStatusRawFromEvent(eventData);
+  const status = tunnelHealthStatusDisplay(statusRaw) || "Status changed";
+  const target = tunnelLabelFromEventData(eventData);
   return [target, status].filter(Boolean).join(" · ");
 }
 
 function getEventTunnelName(eventDataSource?: { data?: unknown }): string | undefined {
   const eventData = parseTunnelHealthEventData(eventDataSource?.data);
-  return (
-    eventData?.tunnel_name?.trim() ||
-    eventData?.tunnelName?.trim() ||
-    eventData?.tunnel_id?.trim() ||
-    eventData?.tunnelId?.trim() ||
-    undefined
-  );
+  const label = tunnelLabelFromEventData(eventData);
+  return label || undefined;
 }
 
 function displayValue(value?: string): string {


### PR DESCRIPTION
Resolves: #4725 

## What changed
Added Cloudflare Tunnel workflow support: Create tunnel, Get tunnel, and Delete tunnel actions, and On tunnel health trigger

## Why
Enable first-class automation around Cloudflare Tunnels (provision, inspect, remove) and reactive workflows when tunnel health changes.

## How:
### Backend:
Implemented new client methods in pkg/integrations/cloudflare/client.go for Tunnel endpoints.
Registered actions in pkg/integrations/cloudflare/cloudflare.go and updated token permission guidance.
Added tests

## Frontend:
Added Cloudflare workflow v2 mappers
Registered mappers and event states in web_src/src/pages/workflowv2/mappers/cloudflare/index.ts
Added mapper specs

## Demo
https://youtu.be/94iuNs68PgA