### PR TITLE
feat: inject short-lived scoped CLI credentials into agent sessions

### DIFF
--- a/db/migrations/20260512210222_add-agent-session-api-token.down.sql
+++ b/db/migrations/20260512210222_add-agent-session-api-token.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_sessions DROP COLUMN IF EXISTS api_token;
+ALTER TABLE agent_sessions DROP COLUMN IF EXISTS api_token_expires_at;

--- a/db/migrations/20260512210222_add-agent-session-api-token.up.sql
+++ b/db/migrations/20260512210222_add-agent-session-api-token.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_sessions ADD COLUMN api_token TEXT;
+ALTER TABLE agent_sessions ADD COLUMN api_token_expires_at TIMESTAMPTZ;

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -3,21 +3,49 @@ package agents
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/superplanehq/superplane/pkg/jwt"
 	pb "github.com/superplanehq/superplane/pkg/protos/agents"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const agentTokenTTL = 1 * time.Hour
+
 // Service implements the agent business logic.
 type Service struct {
-	Client *Client
-	Store  *Store
+	Client    *Client
+	Store     *Store
+	JWTSigner *jwt.Signer
+	BaseURL   string // SuperPlane API base URL for CLI config
 }
 
-func NewService(client *Client, store *Store) *Service {
-	return &Service{Client: client, Store: store}
+func NewService(client *Client, store *Store, jwtSigner *jwt.Signer, baseURL string) *Service {
+	return &Service{
+		Client:    client,
+		Store:     store,
+		JWTSigner: jwtSigner,
+		BaseURL:   baseURL,
+	}
+}
+
+// GenerateAgentToken creates a short-lived scoped token for the agent CLI.
+func (s *Service) GenerateAgentToken(orgID, userID string) (string, time.Time, error) {
+	expiresAt := time.Now().Add(agentTokenTTL)
+
+	token, err := s.JWTSigner.GenerateScopedToken(jwt.ScopedTokenClaims{
+		Subject: userID,
+		OrgID:   orgID,
+		Purpose: "agent",
+		Scopes:  []string{"canvases:read", "canvases:write", "integrations:read", "components:read"},
+	}, agentTokenTTL)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generate agent token: %w", err)
+	}
+
+	return token, expiresAt, nil
 }
 
 // CreateAgentChat returns the existing session or creates a new one.
@@ -25,7 +53,11 @@ func (s *Service) CreateAgentChat(ctx context.Context, orgID, userID, canvasID s
 	// Check if session already exists
 	existing, err := s.Store.FindSession(orgID, userID, canvasID)
 	if err == nil {
-		_ = existing
+		// Refresh token if expired or missing
+		if err := s.refreshTokenIfNeeded(existing); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to refresh agent token: %v", err)
+		}
+
 		return &pb.CreateAgentChatResponse{
 			Url: fmt.Sprintf("/api/v1/agents/chats/%s/stream", canvasID),
 		}, nil
@@ -38,9 +70,19 @@ func (s *Service) CreateAgentChat(ctx context.Context, orgID, userID, canvasID s
 	}
 
 	// Store it
-	_, err = s.Store.CreateSession(orgID, userID, canvasID, session.ID)
+	stored, err := s.Store.CreateSession(orgID, userID, canvasID, session.ID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to store session: %v", err)
+	}
+
+	// Generate and store scoped token
+	token, expiresAt, err := s.GenerateAgentToken(orgID, userID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to generate agent token: %v", err)
+	}
+
+	if err := s.Store.UpdateAPIToken(stored.ID, token, expiresAt); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to store agent token: %v", err)
 	}
 
 	return &pb.CreateAgentChatResponse{
@@ -48,11 +90,35 @@ func (s *Service) CreateAgentChat(ctx context.Context, orgID, userID, canvasID s
 	}, nil
 }
 
+// refreshTokenIfNeeded regenerates the token if it's expired or missing.
+func (s *Service) refreshTokenIfNeeded(session *ChatSession) error {
+	needsRefresh := session.APIToken == nil ||
+		*session.APIToken == "" ||
+		session.APITokenExpiresAt == nil ||
+		time.Now().After(*session.APITokenExpiresAt)
+
+	if !needsRefresh {
+		return nil
+	}
+
+	token, expiresAt, err := s.GenerateAgentToken(session.OrganizationID, session.UserID)
+	if err != nil {
+		return err
+	}
+
+	return s.Store.UpdateAPIToken(session.ID, token, expiresAt)
+}
+
 // ResumeAgentChat returns the stream URL for an existing session.
 func (s *Service) ResumeAgentChat(ctx context.Context, orgID, userID, canvasID string) (*pb.ResumeAgentChatResponse, error) {
-	_, err := s.Store.FindSession(orgID, userID, canvasID)
+	session, err := s.Store.FindSession(orgID, userID, canvasID)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, "no session found for this canvas")
+	}
+
+	// Refresh token on resume
+	if err := s.refreshTokenIfNeeded(session); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to refresh agent token: %v", err)
 	}
 
 	return &pb.ResumeAgentChatResponse{

--- a/pkg/agents/store.go
+++ b/pkg/agents/store.go
@@ -9,12 +9,14 @@ import (
 
 // ChatSession represents a persisted agent chat session.
 type ChatSession struct {
-	ID                   string    `gorm:"column:id;primaryKey"`
-	OrganizationID       string    `gorm:"column:organization_id"`
-	UserID               string    `gorm:"column:user_id"`
-	CanvasID             string    `gorm:"column:canvas_id"`
-	AnthropicSessionID   string    `gorm:"column:anthropic_session_id"`
-	CreatedAt            time.Time `gorm:"column:created_at"`
+	ID                   string     `gorm:"column:id;primaryKey"`
+	OrganizationID       string     `gorm:"column:organization_id"`
+	UserID               string     `gorm:"column:user_id"`
+	CanvasID             string     `gorm:"column:canvas_id"`
+	AnthropicSessionID   string     `gorm:"column:anthropic_session_id"`
+	APIToken             *string    `gorm:"column:api_token"`
+	APITokenExpiresAt    *time.Time `gorm:"column:api_token_expires_at"`
+	CreatedAt            time.Time  `gorm:"column:created_at"`
 }
 
 func (ChatSession) TableName() string { return "agent_sessions" }
@@ -99,4 +101,12 @@ func (s *Store) ListMessages(sessionID string) ([]ChatMessage, error) {
 		return nil, fmt.Errorf("list messages: %w", err)
 	}
 	return messages, nil
+}
+
+// UpdateAPIToken sets the scoped API token and expiry on a session.
+func (s *Store) UpdateAPIToken(sessionID, token string, expiresAt time.Time) error {
+	return s.db.Model(&ChatSession{}).Where("id = ?", sessionID).Updates(map[string]any{
+		"api_token":            token,
+		"api_token_expires_at": expiresAt,
+	}).Error
 }

--- a/pkg/agents/stream.go
+++ b/pkg/agents/stream.go
@@ -13,12 +13,13 @@ import (
 
 // StreamHandler handles SSE streaming for agent chats.
 type StreamHandler struct {
-	client *Client
-	store  *Store
+	client  *Client
+	store   *Store
+	baseURL string // SuperPlane API URL for CLI config
 }
 
-func NewStreamHandler(client *Client, store *Store) *StreamHandler {
-	return &StreamHandler{client: client, store: store}
+func NewStreamHandler(client *Client, store *Store, baseURL string) *StreamHandler {
+	return &StreamHandler{client: client, store: store, baseURL: baseURL}
 }
 
 // streamRequest is the POST body from the frontend.
@@ -78,11 +79,12 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request, org
 	// Send run_started
 	writeSSE(w, flusher, map[string]any{"type": "run_started", "model": "claude-sonnet-4-6"})
 
-	// Build prompt with canvas context
-	prompt := body.Question
-	if body.AgentContext.Mode == "build" && body.AgentContext.CanvasVersion != "" {
-		prompt = fmt.Sprintf("[Canvas version: %s]\n\n%s", body.AgentContext.CanvasVersion, body.Question)
+	// Build prompt with canvas context and CLI credentials
+	msgCount := 1 // We just stored the current user message
+	if existingMsgs, _ := h.store.ListMessages(session.ID); len(existingMsgs) > 0 {
+		msgCount = len(existingMsgs)
 	}
+	prompt := h.buildPrompt(session, body, canvasID, msgCount)
 
 	// Count existing events before sending (to skip old turns when streaming)
 	existingEvents, _ := h.client.ListEvents(r.Context(), session.AnthropicSessionID, 200)
@@ -229,6 +231,54 @@ func extractText(event Event) string {
 		}
 	}
 	return strings.Join(parts, "")
+}
+
+// buildPrompt constructs the message to send to Anthropic, injecting CLI setup when needed.
+func (h *StreamHandler) buildPrompt(session *ChatSession, body streamRequest, canvasID string, msgCount int) string {
+	var parts []string
+
+	// Inject CLI credentials if token is available and this needs setup
+	if session.APIToken != nil && *session.APIToken != "" {
+		needsSetup := msgCount <= 1 // Only the current user message = first turn
+
+		// Also re-inject if token was recently refreshed
+		tokenRefreshed := session.APITokenExpiresAt != nil &&
+			time.Until(*session.APITokenExpiresAt) > 50*time.Minute // freshly generated = ~1h remaining
+
+		if needsSetup || tokenRefreshed {
+			setup := fmt.Sprintf(`[Agent CLI Setup — run this silently before any SuperPlane commands]
+cat > ~/.superplane.yaml << 'SUPERPLANE_CONFIG_EOF'
+contexts:
+- apiToken: %s
+  organization: %s
+  organizationId: %s
+  url: %s
+currentcontext: %s/%s
+output: text
+SUPERPLANE_CONFIG_EOF`,
+				*session.APIToken,
+				session.OrganizationID,
+				session.OrganizationID,
+				h.baseURL,
+				h.baseURL,
+				session.OrganizationID,
+			)
+			parts = append(parts, setup)
+		}
+	}
+
+	// Add canvas context
+	if canvasID != "" {
+		parts = append(parts, fmt.Sprintf("[Canvas ID: %s]", canvasID))
+	}
+	if body.AgentContext.Mode == "build" && body.AgentContext.CanvasVersion != "" {
+		parts = append(parts, fmt.Sprintf("[Canvas version: %s]", body.AgentContext.CanvasVersion))
+	}
+
+	// Add user question
+	parts = append(parts, body.Question)
+
+	return strings.Join(parts, "\n\n")
 }
 
 func writeSSE(w http.ResponseWriter, flusher http.Flusher, data map[string]any) {

--- a/pkg/agents/stream.go
+++ b/pkg/agents/stream.go
@@ -134,26 +134,31 @@ func (h *StreamHandler) pollAndStream(ctx context.Context, w http.ResponseWriter
 		case <-time.After(2 * time.Second):
 		}
 
-		// Check session status
-		session, err := h.client.GetSession(ctx, sessionID)
-		if err != nil {
-			log.WithError(err).Error("failed to poll session")
-			continue
-		}
-
-		// Get events
+		// Get events first
 		events, err := h.client.ListEvents(ctx, sessionID, 200)
 		if err != nil {
 			log.WithError(err).Error("failed to list events")
 			continue
 		}
 
-		// Stream new events
+		// Stream new events and detect completion from event types
+		sawIdle := false
+		sawFailed := false
 		for _, event := range events.Data {
 			if seenEventIDs[event.ID] {
 				continue
 			}
 			seenEventIDs[event.ID] = true
+
+			// Detect session completion from events themselves
+			if event.Type == "session.status_idle" {
+				sawIdle = true
+				continue
+			}
+			if event.Type == "session.status_failed" {
+				sawFailed = true
+				continue
+			}
 
 			text := h.streamEvent(w, flusher, event)
 			if text != "" {
@@ -161,23 +166,8 @@ func (h *StreamHandler) pollAndStream(ctx context.Context, w http.ResponseWriter
 			}
 		}
 
-		// Check if done
-		if session.Status == "idle" && session.Usage.OutputTokens > 0 {
-			// Final fetch to catch any events that arrived between our list and status check
-			finalEvents, err := h.client.ListEvents(ctx, sessionID, 200)
-			if err == nil {
-				for _, event := range finalEvents.Data {
-					if seenEventIDs[event.ID] {
-						continue
-					}
-					seenEventIDs[event.ID] = true
-					text := h.streamEvent(w, flusher, event)
-					if text != "" {
-						assistantContent += text
-					}
-				}
-			}
-
+		// Only consider done AFTER processing all events in this batch
+		if sawIdle {
 			if assistantContent != "" {
 				writeSSE(w, flusher, map[string]any{"type": "final_answer", "output": assistantContent})
 			}
@@ -186,7 +176,7 @@ func (h *StreamHandler) pollAndStream(ctx context.Context, w http.ResponseWriter
 			return assistantContent
 		}
 
-		if session.Status == "failed" {
+		if sawFailed {
 			writeSSE(w, flusher, map[string]any{"type": "run_failed", "error": "agent session failed"})
 			writeSSE(w, flusher, map[string]any{"type": "done"})
 			return assistantContent

--- a/pkg/agents/stream_test.go
+++ b/pkg/agents/stream_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStreamHandler_MissingQuestion(t *testing.T) {
-	handler := NewStreamHandler(&Client{}, &Store{})
+	handler := NewStreamHandler(&Client{}, &Store{}, "https://app.superplane.com")
 
 	body := `{"question":"","agent_context":{"enabled":true,"mode":"inspect"}}`
 	req := httptest.NewRequest("POST", "/stream", strings.NewReader(body))
@@ -28,7 +28,7 @@ func TestStreamHandler_MissingQuestion(t *testing.T) {
 }
 
 func TestStreamHandler_InvalidJSON(t *testing.T) {
-	handler := NewStreamHandler(&Client{}, &Store{})
+	handler := NewStreamHandler(&Client{}, &Store{}, "https://app.superplane.com")
 
 	req := httptest.NewRequest("POST", "/stream", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -42,7 +42,7 @@ func TestStreamHandler_InvalidJSON(t *testing.T) {
 }
 
 func TestStreamHandler_MethodNotAllowed(t *testing.T) {
-	handler := NewStreamHandler(&Client{}, &Store{})
+	handler := NewStreamHandler(&Client{}, &Store{}, "https://app.superplane.com")
 
 	req := httptest.NewRequest("GET", "/stream", nil)
 	w := httptest.NewRecorder()
@@ -150,5 +150,71 @@ func TestStreamRequest_ParsesCorrectly(t *testing.T) {
 	}
 	if req.AgentContext.CanvasVersion != "v123" {
 		t.Errorf("expected canvas_version=v123, got %q", req.AgentContext.CanvasVersion)
+	}
+}
+
+func TestBuildPrompt_WithToken_FirstMessage(t *testing.T) {
+	token := "test-jwt-token"
+	h := NewStreamHandler(&Client{}, &Store{}, "https://app.superplane.com")
+
+	session := &ChatSession{
+		ID:             "sess-1",
+		OrganizationID: "org-123",
+		APIToken:       &token,
+	}
+
+	body := streamRequest{
+		Question: "List canvases",
+		AgentContext: agentContext{Mode: "build", CanvasVersion: "v42"},
+	}
+
+	prompt := h.buildPrompt(session, body, "canvas-456", 1)
+
+	// Should contain CLI setup with token
+	if !strings.Contains(prompt, "test-jwt-token") {
+		t.Error("expected prompt to contain the API token")
+	}
+	if !strings.Contains(prompt, "org-123") {
+		t.Error("expected prompt to contain org ID")
+	}
+	if !strings.Contains(prompt, "https://app.superplane.com") {
+		t.Error("expected prompt to contain base URL")
+	}
+	if !strings.Contains(prompt, "canvas-456") {
+		t.Error("expected prompt to contain canvas ID")
+	}
+	if !strings.Contains(prompt, "v42") {
+		t.Error("expected prompt to contain canvas version")
+	}
+	if !strings.Contains(prompt, "List canvases") {
+		t.Error("expected prompt to contain user question")
+	}
+}
+
+func TestBuildPrompt_WithoutToken(t *testing.T) {
+	h := NewStreamHandler(&Client{}, &Store{}, "https://app.superplane.com")
+
+	session := &ChatSession{
+		ID:             "sess-1",
+		OrganizationID: "org-123",
+	}
+
+	body := streamRequest{
+		Question: "Hello",
+		AgentContext: agentContext{Mode: "inspect"},
+	}
+
+	prompt := h.buildPrompt(session, body, "canvas-456", 1)
+
+	// Should NOT contain CLI setup
+	if strings.Contains(prompt, "superplane.yaml") {
+		t.Error("expected prompt to NOT contain CLI setup when no token")
+	}
+	// Should still contain canvas ID and question
+	if !strings.Contains(prompt, "canvas-456") {
+		t.Error("expected prompt to contain canvas ID")
+	}
+	if !strings.Contains(prompt, "Hello") {
+		t.Error("expected prompt to contain user question")
 	}
 }

--- a/pkg/public/agent_stream.go
+++ b/pkg/public/agent_stream.go
@@ -13,7 +13,7 @@ import (
 
 // RegisterAgentStreamHandler registers the SSE stream route for agents.
 func (s *Server) RegisterAgentStreamHandler(agentService *agents.Service) {
-	streamHandler := agents.NewStreamHandler(agentService.Client, agentService.Store)
+	streamHandler := agents.NewStreamHandler(agentService.Client, agentService.Store, agentService.BaseURL)
 
 	log.Println("Registering agent stream handler at /api/v1/agents/chats/{canvas_id}/stream")
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -494,7 +494,7 @@ func Start() {
 			os.Getenv("ANTHROPIC_ENVIRONMENT_ID"),
 		)
 		agentStore := agents.NewStore(database.Conn())
-		agentService = agents.NewService(agentClient, agentStore)
+		agentService = agents.NewService(agentClient, agentStore, jwtSigner, baseURL)
 	}
 
 	if os.Getenv("START_PUBLIC_API") == "yes" {


### PR DESCRIPTION
## Summary

Gives the managed agent CLI access to the SuperPlane API by injecting a short-lived scoped JWT token into the Anthropic session.

## How it works

1. **Session creation** → generates a 1h scoped JWT (locked to org, user, purpose `agent`)
2. **First message** → prepends a CLI setup block that writes `~/.superplane.yaml` with the token
3. **Session resume** → auto-refreshes token if expired
4. **Agent runs** → `superplane` CLI commands authenticate with the scoped token

## What the agent sees (first message only)

```
[Agent CLI Setup — run this silently before any SuperPlane commands]
cat > ~/.superplane.yaml << 'SUPERPLANE_CONFIG_EOF'
contexts:
- apiToken: <short-lived-jwt>
  organization: <org-id>
  organizationId: <org-id>
  url: https://app.superplane.com
currentcontext: https://app.superplane.com/<org-id>
output: text
SUPERPLANE_CONFIG_EOF

[Canvas ID: <canvas-id>]
[Canvas version: <version>]

<user's actual question>
```

## Security

- **1h TTL** — token expires quickly, limits blast radius
- **Org-scoped** — can't access other organizations  
- **Server-side injection** — user never sees the token in browser
- **Ephemeral container** — Anthropic destroys it when session ends

## Changes

| File | Change |
|------|--------|
| `db/migrations/20260512210222_*` | Add `api_token` + `api_token_expires_at` columns |
| `pkg/agents/service.go` | Token generation + auto-refresh |
| `pkg/agents/store.go` | Store/retrieve token |
| `pkg/agents/stream.go` | `buildPrompt` injects CLI config |
| `pkg/agents/stream_test.go` | Tests for prompt building with/without token |

## Tests

- `TestBuildPrompt_WithToken_FirstMessage` — verifies CLI setup injected
- `TestBuildPrompt_WithoutToken` — verifies no setup when no token
- All existing tests pass (13 total)
