### PR TITLE
fix: use component-defined color for GraphQL mapper

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/graphql.ts
+++ b/web_src/src/pages/workflowv2/mappers/graphql.ts
@@ -190,7 +190,7 @@ export const graphqlMapper: ComponentBaseMapper = {
     return {
       iconSrc: graphqlIcon,
       iconSlug: context.componentDefinition.icon || "network",
-      iconColor: getColorClass("black"),
+      iconColor: getColorClass(context.componentDefinition.color),
       collapsed: context.node.isCollapsed,
       collapsedBackground: "bg-white",
       title:


### PR DESCRIPTION
## What changed
Changed the GraphQL mapper to use the component's defined color instead of hardcoded black.

## Why
The GraphQL component was appearing darker than other core components because the mapper was using `getColorClass("black")` instead of using the component's defined color (`violet`).

## How
Updated `web_src/src/pages/workflowv2/mappers/graphql.ts` to use `getColorClass(context.componentDefinition.color)` which matches the pattern used by other integration components.

Closes #4483