### PR TITLE
feat: add Apps prototype page shell and agent sidebar

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -18,6 +18,7 @@ import OwnerSetup from "./pages/auth/OwnerSetup";
 import { CreateCanvasPage } from "./pages/canvas/CreateCanvasPage";
 import { CanvasSettingsPage } from "./pages/canvas/settings";
 import { TemplatesPage } from "./pages/canvas/TemplatesPage";
+import { AppPrototypePage } from "./pages/apps/AppPrototypePage";
 import { HomePage } from "./pages/home";
 import { OrganizationSettings } from "./pages/organization/settings";
 import { WorkflowPageV2 } from "./pages/workflowv2";
@@ -102,6 +103,7 @@ function AppRouter() {
                   path="canvases/:canvasId/settings"
                   element={withAuthAndPermission(CanvasSettingsPage, "canvases", "update")}
                 />
+                <Route path="apps/:canvasId" element={withAuthAndPermission(AppPrototypePage, "canvases", "read")} />
                 <Route path="canvases/:canvasId" element={withAuthAndPermission(WorkflowPageV2, "canvases", "read")} />
                 <Route path="templates" element={withAuthAndPermission(TemplatesPage, "canvases", "read")} />
                 <Route path="templates/:canvasId" element={withAuthAndPermission(WorkflowPageV2, "canvases", "read")} />

--- a/web_src/src/components/AgentSidebar/AiBuilderChatPanel.tsx
+++ b/web_src/src/components/AgentSidebar/AiBuilderChatPanel.tsx
@@ -5,6 +5,7 @@ import { AiBuilderConversationMessageList } from "./AiBuilderConversationMessage
 import { InputForm } from "./AiBuilderInputForm";
 import { ProposalsList } from "./AiBuilderProposalsList";
 import { type AiBuilderMessage, type AiBuilderProposal, type AiChatSession } from "./agentChat";
+import { cn } from "@/lib/utils";
 import { useApplyOnCmdEnter } from "./useApplyOnCmdEnter";
 import { useDeleteChatSession } from "./useDeleteChatSession";
 
@@ -33,6 +34,9 @@ type AiBuilderChatPanelProps = {
   onSelectChat: (chatId: string) => void;
   onSendPrompt: () => void;
   aiInputRef: RefObject<HTMLTextAreaElement | null>;
+  inputPlacement?: "top" | "bottom";
+  compact?: boolean;
+  showConversationList?: boolean;
 };
 
 export function AiBuilderChatPanel({
@@ -60,6 +64,9 @@ export function AiBuilderChatPanel({
   onSelectChat,
   onSendPrompt,
   aiInputRef,
+  inputPlacement = "top",
+  compact = false,
+  showConversationList = true,
 }: AiBuilderChatPanelProps) {
   const currentChatIdRef = useRef(currentChatId);
   currentChatIdRef.current = currentChatId;
@@ -96,32 +103,51 @@ export function AiBuilderChatPanel({
     <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
       <div className="h-full min-h-0 flex flex-col">
         {isNewChatView ? (
-          <div className="m-3">
-            <InputForm
-              aiInputRef={aiInputRef}
-              aiInput={aiInput}
-              onAiInputChange={onAiInputChange}
-              onSendPrompt={onSendPrompt}
-              disabled={disabled}
-              canvasId={canvasId}
-              isGeneratingResponse={isGeneratingResponse}
-              maxAiInputHeight={maxAiInputHeight}
-              expanded
-            />
+          <div className={cn("flex min-h-0 flex-1 flex-col", compact ? "m-1.5" : "m-3")}>
+            {inputPlacement === "top" ? (
+              <InputForm
+                aiInputRef={aiInputRef}
+                aiInput={aiInput}
+                onAiInputChange={onAiInputChange}
+                onSendPrompt={onSendPrompt}
+                disabled={disabled}
+                canvasId={canvasId}
+                isGeneratingResponse={isGeneratingResponse}
+                maxAiInputHeight={maxAiInputHeight}
+                expanded
+              />
+            ) : null}
 
-            <ConversationList
-              chatSessions={chatSessions}
-              currentChatId={currentChatId}
-              isLoadingChatSessions={isLoadingChatSessions}
-              isGeneratingResponse={isGeneratingResponse}
-              onSelectChat={onSelectChat}
-              onDeleteChat={handleDeleteChatSession}
-              className="flex-1 min-h-0 px-2 py-2 space-y-2"
-              fillAvailable
-            />
+            {showConversationList ? (
+              <ConversationList
+                chatSessions={chatSessions}
+                currentChatId={currentChatId}
+                isLoadingChatSessions={isLoadingChatSessions}
+                isGeneratingResponse={isGeneratingResponse}
+                onSelectChat={onSelectChat}
+                onDeleteChat={handleDeleteChatSession}
+                className={cn("flex-1 min-h-0 space-y-2", compact ? "px-1 py-1" : "px-2 py-2")}
+                fillAvailable
+              />
+            ) : (
+              <div className="flex-1" />
+            )}
+
+            {inputPlacement === "bottom" ? (
+              <InputForm
+                aiInputRef={aiInputRef}
+                aiInput={aiInput}
+                onAiInputChange={onAiInputChange}
+                onSendPrompt={onSendPrompt}
+                disabled={disabled}
+                canvasId={canvasId}
+                isGeneratingResponse={isGeneratingResponse}
+                maxAiInputHeight={maxAiInputHeight}
+              />
+            ) : null}
           </div>
         ) : (
-          <div className="mx-2 mb-2 h-full flex flex-col">
+          <div className={cn("h-full flex flex-col", compact ? "mx-1 mb-1" : "mx-2 mb-2")}>
             <ConversationContent
               aiMessagesContainerRef={aiMessagesContainerRef}
               isLoadingChatMessages={isLoadingChatMessages}

--- a/web_src/src/components/AgentSidebar/AiBuilderInputForm.tsx
+++ b/web_src/src/components/AgentSidebar/AiBuilderInputForm.tsx
@@ -59,7 +59,10 @@ export function InputForm({
     <div className={cn("m-1.5", expanded && "mb-3")}>
       <form
         onSubmit={submitHandler}
-        className={cn("rounded-md border border-slate-300 bg-white p-1.5", expanded && "p-3 shadow-sm")}
+        className={cn(
+          "rounded-md border border-slate-950/15 bg-white p-1.5 hover:border-slate-950/40 focus-within:border-slate-950/40",
+          expanded && "p-3 shadow-sm",
+        )}
       >
         <Textarea
           ref={aiInputRef}

--- a/web_src/src/components/AgentSidebar/index.tsx
+++ b/web_src/src/components/AgentSidebar/index.tsx
@@ -13,9 +13,27 @@ import { useSidebarWidth } from "./useSidebarWidth";
 
 export interface AgentSidebarProps {
   agentState: AgentState;
+  showCloseButton?: boolean;
+  showHeaderBorder?: boolean;
+  showHeader?: boolean;
+  inputPlacement?: "top" | "bottom";
+  compact?: boolean;
+  sidebarWidthStorageKey?: string;
+  defaultWidthPercent?: number;
+  showConversationList?: boolean;
 }
 
-export function AgentSidebar({ agentState }: AgentSidebarProps) {
+export function AgentSidebar({
+  agentState,
+  showCloseButton = true,
+  showHeaderBorder = true,
+  showHeader = true,
+  inputPlacement = "top",
+  compact = false,
+  sidebarWidthStorageKey,
+  defaultWidthPercent,
+  showConversationList = true,
+}: AgentSidebarProps) {
   if (!agentState.showAgentSidebarToggle) {
     return null;
   }
@@ -24,10 +42,32 @@ export function AgentSidebar({ agentState }: AgentSidebarProps) {
     return null;
   }
 
-  return <OpenAgentSidebar agentState={agentState} />;
+  return (
+    <OpenAgentSidebar
+      agentState={agentState}
+      showCloseButton={showCloseButton}
+      showHeaderBorder={showHeaderBorder}
+      showHeader={showHeader}
+      inputPlacement={inputPlacement}
+      compact={compact}
+      sidebarWidthStorageKey={sidebarWidthStorageKey}
+      defaultWidthPercent={defaultWidthPercent}
+      showConversationList={showConversationList}
+    />
+  );
 }
 
-function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
+function OpenAgentSidebar({
+  agentState,
+  showCloseButton,
+  showHeaderBorder,
+  showHeader,
+  inputPlacement,
+  compact,
+  sidebarWidthStorageKey,
+  defaultWidthPercent,
+  showConversationList,
+}: AgentSidebarProps) {
   const { canvasId, organizationId, agentContext, onApplyAiOperations } = agentState;
 
   const aiInputRef = useRef<HTMLTextAreaElement>(null);
@@ -119,10 +159,15 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
 
   return (
     <AgentSidebarContainer
-      onClose={agentState.closeSidebar}
       title={sidebarTitle}
       showBack={currentChatId !== null}
       onBack={handleStartNewChatSession}
+      onClose={agentState.closeSidebar}
+      showCloseButton={showCloseButton ?? true}
+      showHeaderBorder={showHeaderBorder ?? true}
+      showHeader={showHeader ?? true}
+      sidebarWidthStorageKey={sidebarWidthStorageKey}
+      defaultWidthPercent={defaultWidthPercent}
     >
       <AiBuilderChatPanel
         chatSessions={chatSessions}
@@ -149,6 +194,9 @@ function OpenAgentSidebar({ agentState }: AgentSidebarProps) {
         onSelectChat={handleSelectChatSession}
         onSendPrompt={() => void handleSendPrompt()}
         aiInputRef={aiInputRef}
+        inputPlacement={inputPlacement}
+        compact={compact}
+        showConversationList={showConversationList}
       />
     </AgentSidebarContainer>
   );
@@ -162,33 +210,62 @@ function AgentSidebarContainer({
   title,
   showBack,
   onBack,
+  showCloseButton,
+  showHeaderBorder,
+  showHeader,
+  sidebarWidthStorageKey,
+  defaultWidthPercent,
 }: {
   children: React.ReactNode;
   onClose: () => void;
   title: string;
   showBack: boolean;
   onBack: () => void;
+  showCloseButton: boolean;
+  showHeaderBorder: boolean;
+  showHeader: boolean;
+  sidebarWidthStorageKey?: string;
+  defaultWidthPercent?: number;
 }) {
-  const { sidebarRef, isResizing, onResizeMouseDown, sidebarStyle } = useSidebarWidth();
+  const defaultWidthPx =
+    defaultWidthPercent && typeof window !== "undefined"
+      ? Math.round(window.innerWidth * defaultWidthPercent)
+      : undefined;
+  const maxWidthPx =
+    defaultWidthPercent && typeof window !== "undefined" ? Math.round(window.innerWidth * 0.8) : undefined;
+
+  const { sidebarRef, isResizing, onResizeMouseDown, sidebarStyle } = useSidebarWidth({
+    storageKey: sidebarWidthStorageKey,
+    defaultWidthPx,
+    maxWidthPx,
+  });
 
   return (
     <div
       ref={sidebarRef}
-      className="relative border-r border-border shrink-0 h-full z-21 flex flex-col overflow-hidden bg-white"
+      className="relative border-r border-slate-950/10 shrink-0 h-full z-21 flex flex-col overflow-hidden bg-white"
       style={sidebarStyle}
       data-testid="agent-sidebar"
     >
-      <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-b border-border shrink-0 min-w-0">
-        <div className="flex min-w-0 flex-1 items-center gap-1">
-          {showBack ? <BackButton onBack={onBack} /> : null}
-          <h2 className="text-base font-medium min-w-0 flex-1 truncate" title={title}>
-            {title}
-          </h2>
+      {showHeader ? (
+        <div
+          className={`flex items-center justify-between gap-3 px-4 py-2.5 shrink-0 min-w-0 ${
+            showHeaderBorder ? "border-b border-border" : ""
+          }`}
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-1">
+            {showBack ? <BackButton onBack={onBack} /> : null}
+            <h2 className="text-base font-medium min-w-0 flex-1 truncate" title={title}>
+              {title}
+            </h2>
+          </div>
+          {showCloseButton ? (
+            <div className="flex shrink-0 items-center gap-1">
+              <CloseButton onClose={onClose} />
+            </div>
+          ) : null}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <CloseButton onClose={onClose} />
-        </div>
-      </div>
+      ) : null}
 
       <div className="flex flex-1 flex-col min-h-0">{children}</div>
 
@@ -201,18 +278,10 @@ function AgentSidebarResizeHandle({ isResizing, onMouseDown }: { isResizing: boo
   return (
     <div
       onMouseDown={onMouseDown}
-      className={`absolute right-0 top-0 bottom-0 w-4 cursor-ew-resize hover:bg-gray-100 transition-colors flex items-center justify-center group ${
-        isResizing ? "bg-blue-50" : ""
-      }`}
+      className={`absolute right-0 top-0 bottom-0 w-4 hover:cursor-col-resize ${isResizing ? "cursor-col-resize" : ""}`}
       style={{ marginRight: "-8px" }}
       aria-hidden
-    >
-      <div
-        className={`w-2 h-14 rounded-full bg-gray-300 group-hover:bg-gray-800 transition-colors ${
-          isResizing ? "bg-blue-500" : ""
-        }`}
-      />
-    </div>
+    />
   );
 }
 

--- a/web_src/src/components/AgentSidebar/useSidebarWidth.ts
+++ b/web_src/src/components/AgentSidebar/useSidebarWidth.ts
@@ -10,18 +10,32 @@ const DEFAULT_SIDEBAR_WIDTH_PX = 400;
 const SIDEBAR_WIDTH_MIN_PX = 280;
 const SIDEBAR_WIDTH_MAX_PX = 560;
 
-function readInitialSidebarWidthPx(): number {
+type SidebarWidthOptions = {
+  storageKey?: string;
+  defaultWidthPx?: number;
+  minWidthPx?: number;
+  maxWidthPx?: number;
+};
+
+function readInitialSidebarWidthPx(storageKey: string, defaultWidthPx: number): number {
   if (typeof window === "undefined") {
-    return DEFAULT_SIDEBAR_WIDTH_PX;
+    return defaultWidthPx;
   }
 
-  const saved = window.localStorage.getItem(AGENT_SIDEBAR_WIDTH_STORAGE_KEY);
-  return saved ? parseInt(saved, 10) : DEFAULT_SIDEBAR_WIDTH_PX;
+  const saved = window.localStorage.getItem(storageKey);
+  const parsed = saved ? parseInt(saved, 10) : NaN;
+
+  return Number.isFinite(parsed) ? parsed : defaultWidthPx;
 }
 
-export function useSidebarWidth() {
+export function useSidebarWidth({
+  storageKey = AGENT_SIDEBAR_WIDTH_STORAGE_KEY,
+  defaultWidthPx = DEFAULT_SIDEBAR_WIDTH_PX,
+  minWidthPx = SIDEBAR_WIDTH_MIN_PX,
+  maxWidthPx = SIDEBAR_WIDTH_MAX_PX,
+}: SidebarWidthOptions = {}) {
   const sidebarRef = useRef<HTMLDivElement>(null);
-  const [sidebarWidth, setSidebarWidth] = useState(readInitialSidebarWidthPx);
+  const [sidebarWidth, setSidebarWidth] = useState(() => readInitialSidebarWidthPx(storageKey, defaultWidthPx));
   const [isResizing, setIsResizing] = useState(false);
 
   useEffect(() => {
@@ -43,8 +57,8 @@ export function useSidebarWidth() {
   }, []);
 
   useEffect(() => {
-    window.localStorage.setItem(AGENT_SIDEBAR_WIDTH_STORAGE_KEY, String(sidebarWidth));
-  }, [sidebarWidth]);
+    window.localStorage.setItem(storageKey, String(sidebarWidth));
+  }, [sidebarWidth, storageKey]);
 
   const onResizeMouseDown = useCallback((event: ReactMouseEvent) => {
     event.preventDefault();
@@ -59,10 +73,10 @@ export function useSidebarWidth() {
 
       const rect = sidebarRef.current.getBoundingClientRect();
       const newWidth = event.clientX - rect.left;
-      const clampedWidth = Math.max(SIDEBAR_WIDTH_MIN_PX, Math.min(SIDEBAR_WIDTH_MAX_PX, newWidth));
+      const clampedWidth = Math.max(minWidthPx, Math.min(maxWidthPx, newWidth));
       setSidebarWidth(clampedWidth);
     },
-    [isResizing],
+    [isResizing, minWidthPx, maxWidthPx],
   );
 
   const handleResizeMouseUp = useCallback(() => {
@@ -73,7 +87,7 @@ export function useSidebarWidth() {
     if (isResizing) {
       document.addEventListener("mousemove", handleResizeMouseMove);
       document.addEventListener("mouseup", handleResizeMouseUp);
-      document.body.style.cursor = "ew-resize";
+      document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
 
       return () => {

--- a/web_src/src/pages/apps/AppPrototypePage.tsx
+++ b/web_src/src/pages/apps/AppPrototypePage.tsx
@@ -1,0 +1,408 @@
+import { AgentSidebar } from "@/components/AgentSidebar";
+import { useAgentState } from "@/components/AgentSidebar/useAgentState";
+import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import {
+  CANVAS_FOLDER_COLORS,
+  DEFAULT_CANVAS_FOLDER_COLOR,
+  useCanvases,
+  useCanvas,
+  useCanvasFolders,
+  type CanvasFolderColor,
+} from "@/hooks/useCanvasData";
+import { cn } from "@/lib/utils";
+import { Search, Sparkles } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+type AppTab = "dashboard" | "canvas" | "runs" | "data";
+
+type PrototypeCanvas = {
+  metadata?: {
+    id?: string;
+    name?: string;
+    liveVersionId?: string;
+    folderId?: string;
+  };
+};
+
+const APP_TABS: Array<{ id: AppTab; label: string }> = [
+  { id: "dashboard", label: "Dashboard" },
+  { id: "canvas", label: "Canvas" },
+  { id: "runs", label: "Runs" },
+  { id: "data", label: "Data" },
+];
+
+const RECENT_APPS_STORAGE_KEY_PREFIX = "appPrototypeRecentlyOpenedApps";
+const MAX_RECENT_APPS = 20;
+const APP_SWITCHER_FOLDER_DOT_CLASSES: Record<CanvasFolderColor, string> = {
+  blue: "bg-blue-100",
+  green: "bg-green-100",
+  purple: "bg-purple-100",
+  yellow: "bg-yellow-100",
+  slate: "bg-slate-100",
+  orange: "bg-orange-100",
+};
+
+export function AppPrototypePage() {
+  const navigate = useNavigate();
+  const { organizationId = "", canvasId = "" } = useParams<{ organizationId: string; canvasId: string }>();
+  const [activeTab, setActiveTab] = useState<AppTab>("canvas");
+  const [isSwitcherOpen, setIsSwitcherOpen] = useState(false);
+  const [recentAppIds, setRecentAppIds] = useState<string[]>(() => readRecentAppIds(organizationId));
+
+  const { data: canvasData, isLoading: isCanvasLoading } = useCanvas(organizationId, canvasId);
+  const { data: appsData = [], isLoading: isAppsLoading } = useCanvases(organizationId);
+  const { data: canvasFoldersData = [] } = useCanvasFolders(organizationId);
+
+  const canvas = canvasData as PrototypeCanvas | undefined;
+  const appFolderDotClasses = useMemo(() => {
+    const folderColorById = new Map<string, CanvasFolderColor>();
+    const folderColorByCanvasId = new Map<string, CanvasFolderColor>();
+
+    for (const folder of canvasFoldersData) {
+      const folderId = folder.metadata?.id;
+      const folderColor = asCanvasFolderColor(folder.spec?.backgroundColor);
+
+      if (folderId) {
+        folderColorById.set(folderId, folderColor);
+      }
+
+      for (const folderCanvas of folder.spec?.canvases || []) {
+        if (folderCanvas.id) {
+          folderColorByCanvasId.set(folderCanvas.id, folderColor);
+        }
+      }
+    }
+
+    return new Map(
+      (appsData as PrototypeCanvas[])
+        .map((app): [string, string] | null => {
+          const appId = app.metadata?.id;
+          if (!appId) {
+            return null;
+          }
+
+          const folderColor = folderColorByCanvasId.get(appId) || folderColorById.get(app.metadata?.folderId || "");
+
+          return folderColor ? [appId, APP_SWITCHER_FOLDER_DOT_CLASSES[folderColor]] : null;
+        })
+        .filter((entry): entry is [string, string] => entry !== null),
+    );
+  }, [appsData, canvasFoldersData]);
+
+  const apps = useMemo(() => {
+    const recentIndex = new Map(recentAppIds.map((appId, index) => [appId, index]));
+
+    return (appsData as PrototypeCanvas[])
+      .filter((app) => app.metadata?.id && app.metadata?.name)
+      .sort((left, right) => {
+        const leftRecentIndex = recentIndex.get(left.metadata?.id || "") ?? Number.POSITIVE_INFINITY;
+        const rightRecentIndex = recentIndex.get(right.metadata?.id || "") ?? Number.POSITIVE_INFINITY;
+
+        if (leftRecentIndex !== rightRecentIndex) {
+          return leftRecentIndex - rightRecentIndex;
+        }
+
+        return (left.metadata?.name || "").localeCompare(right.metadata?.name || "");
+      });
+  }, [appsData, recentAppIds]);
+
+  const appName = canvas?.metadata?.name || (isCanvasLoading ? "Loading app..." : "Untitled app");
+
+  useEffect(() => {
+    setRecentAppIds(readRecentAppIds(organizationId));
+  }, [organizationId]);
+
+  useEffect(() => {
+    if (!canvasId) {
+      return;
+    }
+
+    setRecentAppIds(markAppRecentlyOpened(organizationId, canvasId));
+  }, [organizationId, canvasId]);
+
+  const agentState = useAgentState({
+    isEditing: false,
+    canvasVersion: canvas?.metadata?.liveVersionId || "",
+    hideAddControls: false,
+    readOnly: false,
+    canvasId,
+    organizationId,
+  });
+
+  const handleSelectApp = (nextCanvasId?: string) => {
+    if (!nextCanvasId) {
+      return;
+    }
+
+    setIsSwitcherOpen(false);
+    navigate(`/${organizationId}/apps/${nextCanvasId}`);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-100 text-slate-950">
+      <AppTopBar
+        organizationId={organizationId}
+        appName={appName}
+        isSwitcherOpen={isSwitcherOpen}
+        onSwitcherOpenChange={setIsSwitcherOpen}
+        apps={apps}
+        appFolderDotClasses={appFolderDotClasses}
+        isAppsLoading={isAppsLoading}
+        activeCanvasId={canvasId}
+        onSelectApp={handleSelectApp}
+      />
+
+      <AppBar activeTab={activeTab} onTabChange={setActiveTab} agentState={agentState} />
+
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <AgentSidebar
+          agentState={agentState}
+          showHeader={false}
+          showCloseButton={false}
+          showHeaderBorder={false}
+          inputPlacement="bottom"
+          compact
+          sidebarWidthStorageKey="appPrototypeAgentSidebarWidth"
+          defaultWidthPercent={0.4}
+          showConversationList={false}
+        />
+
+        <main className="min-w-0 flex-1 overflow-auto">
+          <AppTabContent activeTab={activeTab} />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function AppTopBar({
+  organizationId,
+  appName,
+  isSwitcherOpen,
+  onSwitcherOpenChange,
+  apps,
+  appFolderDotClasses,
+  isAppsLoading,
+  activeCanvasId,
+  onSelectApp,
+}: {
+  organizationId: string;
+  appName: string;
+  isSwitcherOpen: boolean;
+  onSwitcherOpenChange: (open: boolean) => void;
+  apps: PrototypeCanvas[];
+  appFolderDotClasses: Map<string, string>;
+  isAppsLoading: boolean;
+  activeCanvasId: string;
+  onSelectApp: (canvasId?: string) => void;
+}) {
+  const switcherRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isSwitcherOpen) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      switcherRef.current?.querySelector<HTMLInputElement>("[data-slot='command-input']")?.focus();
+    });
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!switcherRef.current?.contains(event.target as Node)) {
+        onSwitcherOpenChange(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onSwitcherOpenChange(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isSwitcherOpen, onSwitcherOpenChange]);
+
+  return (
+    <header className="relative z-30 flex h-9 shrink-0 items-center border-b border-slate-950/10 bg-white px-3">
+      <div className="relative z-30 flex min-w-0 shrink-0 items-center">
+        <OrganizationMenuButton organizationId={organizationId} className="[&_a_img]:h-6 [&_a_img]:w-6" />
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 flex justify-center px-24">
+        <div ref={switcherRef} className="pointer-events-auto relative">
+          <button
+            type="button"
+            onClick={() => onSwitcherOpenChange(!isSwitcherOpen)}
+            className="flex h-6 min-w-0 max-w-md items-center gap-2 rounded-md bg-transparent px-2.5 text-[13px] font-medium text-slate-800 outline outline-1 outline-slate-950/10 transition-colors hover:outline-slate-950/20"
+            aria-label="Switch apps"
+            aria-expanded={isSwitcherOpen}
+          >
+            <Search className="h-3 w-3 shrink-0 text-slate-500" />
+            <span className="truncate">{appName}</span>
+          </button>
+
+          {isSwitcherOpen ? (
+            <AppSwitcherMenu
+              apps={apps}
+              appFolderDotClasses={appFolderDotClasses}
+              isLoading={isAppsLoading}
+              activeCanvasId={activeCanvasId}
+              onSelectApp={onSelectApp}
+            />
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function AppBar({
+  activeTab,
+  onTabChange,
+  agentState,
+}: {
+  activeTab: AppTab;
+  onTabChange: (tab: AppTab) => void;
+  agentState: ReturnType<typeof useAgentState>;
+}) {
+  const agentIsAvailable = agentState.showAgentSidebarToggle;
+  const agentIsOpen = agentState.isAgentSidebarOpen;
+
+  return (
+    <div className="relative flex h-9 shrink-0 items-center border-b border-slate-950/10 bg-white px-3">
+      <div className="relative z-10 flex shrink-0 items-center">
+        <button
+          type="button"
+          disabled={!agentIsAvailable}
+          aria-pressed={agentIsOpen}
+          aria-label={agentIsOpen ? "Close Agent" : "Open Agent"}
+          onClick={() => agentState.handleAgentSidebarOpenChange(!agentIsOpen)}
+          className={cn(
+            "-ml-1 flex h-6 w-6 items-center justify-center rounded-md text-slate-700 transition-colors hover:bg-slate-100 disabled:pointer-events-none disabled:opacity-50",
+            agentIsOpen && "bg-violet-100 text-violet-600 hover:bg-violet-100",
+          )}
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <nav className="pointer-events-none absolute inset-x-0 flex justify-center">
+        <div className="pointer-events-auto flex items-center rounded-md bg-slate-100 p-0.5">
+          {APP_TABS.map((tab) => {
+            const selected = activeTab === tab.id;
+
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => onTabChange(tab.id)}
+                className={cn(
+                  "flex h-6 items-center gap-1.5 rounded px-2.5 text-[13px] font-medium text-slate-600 transition-colors",
+                  selected ? "bg-white text-slate-950 shadow-xs" : "hover:text-slate-950",
+                )}
+                aria-current={selected ? "page" : undefined}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+function AppTabContent({ activeTab }: { activeTab: AppTab }) {
+  return <div className="min-h-full" aria-label={`${activeTab} tab content`} />;
+}
+
+function AppSwitcherMenu({
+  apps,
+  appFolderDotClasses,
+  isLoading,
+  activeCanvasId,
+  onSelectApp,
+}: {
+  apps: PrototypeCanvas[];
+  appFolderDotClasses: Map<string, string>;
+  isLoading: boolean;
+  activeCanvasId: string;
+  onSelectApp: (canvasId?: string) => void;
+}) {
+  return (
+    <Command className="absolute left-1/2 top-[-2px] z-50 h-[280px] w-[480px] -translate-x-1/2 rounded-md border border-slate-950/10 bg-white shadow-lg [&_[cmdk-group-heading]]:font-normal [&_[data-slot=command-input-wrapper]]:h-8 [&_[data-slot=command-input-wrapper]]:border-slate-950/10 [&_[data-slot=command-input-wrapper]]:px-2.5">
+      <CommandInput placeholder="Search Apps..." className="h-8 py-1" />
+      <CommandList className="max-h-none flex-1">
+        <CommandEmpty>{isLoading ? "Loading apps..." : "No apps found."}</CommandEmpty>
+        <CommandGroup heading="Recently opened">
+          {apps.map((app) => {
+            const appId = app.metadata?.id;
+            const appName = app.metadata?.name || "Untitled app";
+            const selected = appId === activeCanvasId;
+            const folderDotClass = appId ? appFolderDotClasses.get(appId) : undefined;
+
+            return (
+              <CommandItem key={appId} value={appName} onSelect={() => onSelectApp(appId)}>
+                <span
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0 rounded-full border border-slate-950/30 bg-white",
+                    folderDotClass,
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="truncate">{appName}</span>
+                {selected ? <span className="ml-auto text-xs text-muted-foreground">Current</span> : null}
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+function recentAppsStorageKey(organizationId: string) {
+  return `${RECENT_APPS_STORAGE_KEY_PREFIX}:${organizationId}`;
+}
+
+function asCanvasFolderColor(value?: string): CanvasFolderColor {
+  return CANVAS_FOLDER_COLORS.includes(value as CanvasFolderColor)
+    ? (value as CanvasFolderColor)
+    : DEFAULT_CANVAS_FOLDER_COLOR;
+}
+
+function readRecentAppIds(organizationId: string) {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const value = window.localStorage.getItem(recentAppsStorageKey(organizationId));
+    const parsed = value ? JSON.parse(value) : [];
+
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function markAppRecentlyOpened(organizationId: string, appId: string) {
+  const recentAppIds = [
+    appId,
+    ...readRecentAppIds(organizationId).filter((recentAppId) => recentAppId !== appId),
+  ].slice(0, MAX_RECENT_APPS);
+
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(recentAppsStorageKey(organizationId), JSON.stringify(recentAppIds));
+  }
+
+  return recentAppIds;
+}

--- a/web_src/src/pages/home/CanvasCardsGrid.tsx
+++ b/web_src/src/pages/home/CanvasCardsGrid.tsx
@@ -71,7 +71,7 @@ function CanvasCard({
   canDeleteCanvases,
   permissionsLoading,
 }: CanvasCardProps) {
-  const canvasHref = `/${organizationId}/canvases/${canvas.id}`;
+  const canvasHref = `/${organizationId}/apps/${canvas.id}`;
   const previewNodes = canvas.nodes || [];
   const previewEdges = canvas.edges || [];
 


### PR DESCRIPTION
Adds a protected /apps/:canvasId route with top bar, app switcher, tab bar, and resizable agent chat sidebar. Home canvas cards navigate to this shell. Agent sidebar supports compact layout, bottom input, configurable width storage, and gray-based dark styling.

db/structure.sql is left unstaged (local schema drift).