### PR TITLE
fix: zoom and interactive controls when switching between runs

### DIFF
--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,16 +1,16 @@
 {
-  "maxAllowedTotalIssues": 712,
+  "maxAllowedTotalIssues": 710,
   "maxAllowedByRule": {
     "complexity": 233,
     "@typescript-eslint/no-explicit-any": 160,
     "@typescript-eslint/no-non-null-asserted-optional-chain": 80,
     "max-lines-per-function": 77,
     "max-statements": 75,
-    "react-hooks/exhaustive-deps": 35,
+    "react-hooks/exhaustive-deps": 33,
     "react-refresh/only-export-components": 23,
     "max-lines": 17,
     "max-params": 6,
     "max-depth": 6
   },
-  "updatedAt": "2026-05-12T19:37:30.702Z"
+  "updatedAt": "2026-05-13T14:19:18.922Z"
 }

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -548,6 +548,7 @@ export function WorkflowPageV2() {
   const [isRunsMode, setIsRunsMode] = useState(() => searchParams.get("view") === "runs");
   const [selectedRunId, setSelectedRunId] = useState<string | null>(() => searchParams.get("run"));
   const [runDetailNodeId, setRunDetailNodeId] = useState<string | null>(null);
+  const [runsFitAllNonce, setRunsFitAllNonce] = useState(0);
   const [runStatusFilters, setRunStatusFilters] = useState<RunStatusFilter[]>([]);
   const runApiFilters = useMemo(() => statusFiltersToApiFilters(runStatusFilters), [runStatusFilters]);
   const infiniteEventsQuery = useInfiniteCanvasEvents(canvasId!, isViewingLiveVersion);
@@ -1928,8 +1929,15 @@ export function WorkflowPageV2() {
       if (!nodeExecutionsMap[execution.nodeId]) {
         nodeExecutionsMap[execution.nodeId] = [];
       }
+      // selectedRun.executions are lightweight refs without `metadata` / `outputs`,
+      // so mappers that need approval records, pushThrough state, etc. can't render
+      // their interactive controls. Hydrate from the live store when available.
+      const fullExecution = visibleNodeExecutionsMap[execution.nodeId]?.find((e) => e.id === execution.id);
       nodeExecutionsMap[execution.nodeId].push({
+        ...(fullExecution || {}),
         ...execution,
+        ...(fullExecution?.metadata ? { metadata: fullExecution.metadata } : {}),
+        ...(fullExecution?.outputs ? { outputs: fullExecution.outputs } : {}),
         rootEvent: selectedRun.rootEvent,
       } as CanvasesCanvasNodeExecution);
     }
@@ -1970,6 +1978,7 @@ export function WorkflowPageV2() {
     canvasId,
     queryClient,
     me,
+    visibleNodeExecutionsMap,
   ]);
 
   const nodes = runCanvasData ? runCanvasData.nodes : nodesWithIntegrationStatus;
@@ -1981,6 +1990,20 @@ export function WorkflowPageV2() {
     runsViewportRef.current = undefined;
     lastRunsViewportKeyRef.current = runsViewportKey;
   }
+
+  const runCanvasNodeIdsKey = useMemo(() => {
+    if (!isRunsMode || !runCanvasData) return null;
+    return runCanvasData.nodes
+      .map((n) => n.id)
+      .sort()
+      .join("|");
+  }, [isRunsMode, runCanvasData]);
+
+  useEffect(() => {
+    if (!isRunsMode) return;
+    if (!runCanvasNodeIdsKey) return;
+    setRunsFitAllNonce((n) => n + 1);
+  }, [isRunsMode, runCanvasNodeIdsKey]);
 
   const getSidebarData = useCallback(
     (nodeId: string): SidebarData | null => {
@@ -5660,6 +5683,7 @@ export function WorkflowPageV2() {
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunsMode ? runsViewportRef : viewportRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
+          fitAllRequest={isRunsMode ? runsFitAllNonce : null}
           saveIsPrimary={saveIsPrimary}
           saveButtonHidden={saveButtonHidden}
           saveDisabled={saveDisabled}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -52,6 +52,7 @@ import {
   useDeleteCanvasMemoryEntry,
   useDeleteCanvasVersion,
   usePublishCanvasVersion,
+  useEventExecutions,
   useInfiniteCanvasEvents,
   useInfiniteCanvasRuns,
   useInfiniteCanvasLiveVersions,
@@ -583,6 +584,14 @@ export function WorkflowPageV2() {
     () => runsData.runs.find((run) => run.id === selectedRunId) || null,
     [runsData.runs, selectedRunId],
   );
+  // Prefetch full executions (with metadata/outputs) for the selected run as soon
+  // as the user picks it in the sidebar. Mappers like wait/timegate compute states
+  // such as "pushed through" from execution.outputs, which selectedRun.executions
+  // (lightweight refs) don't carry. The same query backs RunNodeDetailModal, so the
+  // payload tab also opens without a follow-up fetch.
+  const selectedRunRootEventId = selectedRun?.rootEvent?.id ?? null;
+  const selectedRunExecutionsQuery = useEventExecutions(canvasId!, selectedRunRootEventId);
+  const selectedRunFullExecutions = selectedRunExecutionsQuery.data?.executions;
   const canvasEventsResponse = infiniteEventsQuery.data?.pages?.[0];
   const componentIconMap = useMemo(() => {
     const map: Record<string, string> = {};
@@ -1106,7 +1115,10 @@ export function WorkflowPageV2() {
 
     return { nodeExecutionsMap: executionsMap, nodeQueueItemsMap: queueItemsMap, nodeEventsMap: eventsMap };
   }, [storeVersion]);
-  const visibleNodeExecutionsMap = isViewingLiveVersion ? nodeExecutionsMap : {};
+  const visibleNodeExecutionsMap = useMemo(
+    () => (isViewingLiveVersion ? nodeExecutionsMap : {}),
+    [isViewingLiveVersion, nodeExecutionsMap],
+  );
   const visibleNodeQueueItemsMap = isViewingLiveVersion ? nodeQueueItemsMap : {};
   const visibleNodeEventsMap = isViewingLiveVersion ? nodeEventsMap : {};
 
@@ -1929,17 +1941,15 @@ export function WorkflowPageV2() {
       if (!nodeExecutionsMap[execution.nodeId]) {
         nodeExecutionsMap[execution.nodeId] = [];
       }
-      // selectedRun.executions are lightweight refs without `metadata` / `outputs`,
-      // so mappers that need approval records, pushThrough state, etc. can't render
-      // their interactive controls. Hydrate from the live store when available.
-      const fullExecution = visibleNodeExecutionsMap[execution.nodeId]?.find((e) => e.id === execution.id);
-      nodeExecutionsMap[execution.nodeId].push({
-        ...(fullExecution || {}),
-        ...execution,
-        ...(fullExecution?.metadata ? { metadata: fullExecution.metadata } : {}),
-        ...(fullExecution?.outputs ? { outputs: fullExecution.outputs } : {}),
-        rootEvent: selectedRun.rootEvent,
-      } as CanvasesCanvasNodeExecution);
+
+      nodeExecutionsMap[execution.nodeId].push(
+        hydrateRunExecution(
+          execution,
+          selectedRunFullExecutions,
+          visibleNodeExecutionsMap[execution.nodeId],
+          selectedRun.rootEvent,
+        ),
+      );
     }
 
     if (runNodeIds.size === 0) {
@@ -1979,6 +1989,7 @@ export function WorkflowPageV2() {
     queryClient,
     me,
     visibleNodeExecutionsMap,
+    selectedRunFullExecutions,
   ]);
 
   const nodes = runCanvasData ? runCanvasData.nodes : nodesWithIntegrationStatus;
@@ -5974,6 +5985,25 @@ function useExecutionChainData(workflowId: string, queryClient: QueryClient, wor
   );
 
   return { loadExecutionChain };
+}
+
+// Merge a run's lightweight execution ref with the matching full execution (preferred from the
+// prefetched event-executions query, falling back to the live store), so mappers receive metadata
+// (approval records) and outputs (wait/timegate "pushed through" detection).
+function hydrateRunExecution(
+  ref: CanvasesCanvasNodeExecution,
+  prefetched: CanvasesCanvasNodeExecution[] | undefined,
+  storeExecutions: CanvasesCanvasNodeExecution[] | undefined,
+  rootEvent: CanvasesCanvasEvent | undefined,
+): CanvasesCanvasNodeExecution {
+  const full = prefetched?.find((e) => e.id === ref.id) ?? storeExecutions?.find((e) => e.id === ref.id);
+  return {
+    ...(full ?? {}),
+    ...ref,
+    ...(full?.metadata && { metadata: full.metadata }),
+    ...(full?.outputs && { outputs: full.outputs }),
+    rootEvent,
+  } as CanvasesCanvasNodeExecution;
 }
 
 // Helper function to build topological path to find all nodes that should execute before the given target node

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5695,6 +5695,7 @@ export function WorkflowPageV2() {
           viewportRef={isRunsMode ? runsViewportRef : viewportRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
           fitAllRequest={isRunsMode ? runsFitAllNonce : null}
+          runCanvasLoading={isRunsMode && !!selectedRunRootEventId && selectedRunExecutionsQuery.isLoading}
           saveIsPrimary={saveIsPrimary}
           saveButtonHidden={saveButtonHidden}
           saveDisabled={saveDisabled}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -285,6 +285,8 @@ export interface CanvasPageProps {
   onTriggerModalHostReady?: (openModal: (modal: TriggerActionModal) => void) => void;
   initialSidebar?: { isOpen?: boolean; nodeId?: string | null };
   initialFocusNodeId?: string | null;
+  /** Bump this counter to fit all currently-rendered nodes into view (e.g., when run selection changes). */
+  fitAllRequest?: number | null;
 
   // Full history functionality
   getAllHistoryEvents?: (nodeId: string) => SidebarEvent[];
@@ -1239,6 +1241,7 @@ function CanvasPage(props: CanvasPageProps) {
               logEntries={props.logEntries}
               focusRequest={props.focusRequest}
               initialFocusNodeId={props.initialFocusNodeId}
+              fitAllRequest={props.fitAllRequest}
               runsEvents={props.runsEvents}
               runsTotalCount={props.runsTotalCount}
               runsHasNextPage={props.runsHasNextPage}
@@ -1775,6 +1778,7 @@ function CanvasContent({
   logEntries = [],
   focusRequest,
   initialFocusNodeId,
+  fitAllRequest,
   runsEvents,
   runsTotalCount,
   runsHasNextPage,
@@ -1833,6 +1837,7 @@ function CanvasContent({
   logEntries?: LogEntry[];
   focusRequest?: FocusRequest | null;
   initialFocusNodeId?: string | null;
+  fitAllRequest?: number | null;
   runsEvents?: CanvasesCanvasEventWithExecutions[];
   runsTotalCount?: number;
   runsHasNextPage?: boolean;
@@ -2271,6 +2276,18 @@ function CanvasContent({
     },
     [fitView, getViewport, reportZoom, hasFitToViewRef, viewportRef, initialFocusNodeId],
   );
+
+  // Fit all currently-rendered nodes into view whenever the parent bumps `fitAllRequest`.
+  // Wait a microtask so ReactFlow has measured the just-swapped node set (e.g. switching
+  // between runs whose participating nodes have different coordinates) before fitting.
+  useEffect(() => {
+    if (fitAllRequest == null) return;
+    if (!hasFitToViewRef.current) return;
+    const id = window.setTimeout(() => {
+      fitView({ duration: 500, maxZoom: 1.0, padding: 0.2 });
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [fitAllRequest, fitView, hasFitToViewRef]);
 
   const showHeader = !isReadOnly;
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -287,6 +287,8 @@ export interface CanvasPageProps {
   initialFocusNodeId?: string | null;
   /** Bump this counter to fit all currently-rendered nodes into view (e.g., when run selection changes). */
   fitAllRequest?: number | null;
+  /** Shows a loading indicator over the canvas (not the sidebar) while run executions are being fetched. */
+  runCanvasLoading?: boolean;
 
   // Full history functionality
   getAllHistoryEvents?: (nodeId: string) => SidebarEvent[];
@@ -1160,6 +1162,11 @@ function CanvasPage(props: CanvasPageProps) {
         )}
 
         <div className="flex-1 relative">
+          {props.runCanvasLoading && props.headerMode === "runs" ? (
+            <div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-50">
+              <Loader2 className="h-6 w-6 animate-spin text-slate-500" />
+            </div>
+          ) : null}
           {showPreviewFloatingBar || showAwaitingFloatingBar ? (
             <div className="pointer-events-none absolute inset-x-0 top-0 z-[19] flex justify-center pt-3">
               <div


### PR DESCRIPTION
## Summary

  - Canvas now zooms to the focused-node subgraph of the newly selected run when switching runs in the sidebar (was staying on the previous run's viewport, which
  often pointed off-screen for a different node set).
  - Approval, wait push-through, and time-gate push-through controls are now interactive in run view, and `wait`/`timegate` correctly resolve the "pushed through"
  state.
  - Full run executions are prefetched as soon as the user clicks a run row, so mappers receive `metadata`/`outputs` immediately and `RunNodeDetailModal` opens from
  cache.

  ## Why

  `selectedRun.executions` are `CanvasesCanvasNodeExecutionRef` — the succinct shape with no `metadata` or `outputs`. Mappers that gate their custom field on those
  (approval records, wait/timegate `manual_override`) were silently dropping into the inert branch in run view. Switching runs also reused the React Flow viewport
  from the previous run, so a run with different node coordinates would land off-screen.
