### PR TITLE
fix(configuration): add tooltip support for configuration fields

### DIFF
--- a/pkg/configuration/field.go
+++ b/pkg/configuration/field.go
@@ -56,6 +56,7 @@ type Field struct {
 	 */
 	Type        string `json:"type"`
 	Description string `json:"description"`
+	Tooltip     string `json:"tooltip,omitempty"`
 	Required    bool   `json:"required"`
 	Default     any    `json:"default"`
 	Togglable   bool   `json:"togglable"`

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -305,6 +305,10 @@ func ConfigurationFieldToProto(field configuration.Field) *configpb.Field {
 		pbField.Placeholder = &field.Placeholder
 	}
 
+	if field.Tooltip != "" {
+		pbField.Tooltip = &field.Tooltip
+	}
+
 	if len(field.VisibilityConditions) > 0 {
 		pbField.VisibilityConditions = make([]*configpb.VisibilityCondition, len(field.VisibilityConditions))
 		for i, cond := range field.VisibilityConditions {
@@ -640,6 +644,10 @@ func ProtoToConfigurationField(pbField *configpb.Field) configuration.Field {
 
 	if pbField.Togglable != nil {
 		field.Togglable = *pbField.Togglable
+	}
+
+	if pbField.Tooltip != nil {
+		field.Tooltip = *pbField.Tooltip
 	}
 
 	if len(pbField.VisibilityConditions) > 0 {

--- a/pkg/integrations/pagerduty/snooze_incident.go
+++ b/pkg/integrations/pagerduty/snooze_incident.go
@@ -103,7 +103,7 @@ func (c *SnoozeIncident) Configuration() []configuration.Field {
 			Label:       "From Email",
 			Type:        configuration.FieldTypeString,
 			Required:    false,
-			Description: "Email address of a valid PagerDuty user. Required for App OAuth and account-level API tokens, optional for user-level API tokens.",
+			Tooltip:     "Email address of a valid PagerDuty user.",
 			Placeholder: "user@example.com",
 		},
 	}

--- a/protos/configuration.proto
+++ b/protos/configuration.proto
@@ -17,6 +17,7 @@ message Field {
   optional string placeholder = 10;
   optional bool sensitive = 11;
   optional bool togglable = 12;
+  optional string tooltip = 13;
 }
 
 message TypeOptions {

--- a/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx
@@ -57,6 +57,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
     );
   }
 
+  const fieldWithTooltip = field as { tooltip?: string };
   return (
     <AutoCompleteInput
       exampleObj={autocompleteExampleObj ?? null}
@@ -68,7 +69,7 @@ export const StringFieldRenderer: React.FC<FieldRendererProps> = ({
       suffix=" }}"
       inputSize="md"
       showValuePreview
-      quickTip="Tip: type `{{` to start an expression."
+      quickTip={fieldWithTooltip.tooltip ? undefined : "Tip: type `{{` to start an expression."}
       className=""
       data-testid={toTestId(`string-field-${field.name}`)}
       excludedSuggestions={excludedSuggestions}

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
 import type { FieldRendererProps, ValidationError } from "./types";
 import { StringFieldRenderer } from "./StringFieldRenderer";
 import { ExpressionFieldRenderer } from "./ExpressionFieldRenderer";
@@ -264,6 +266,9 @@ export const ConfigurationFieldRenderer = ({
   if (!isVisible) {
     return null;
   }
+
+  const fieldTooltip = (field as { tooltip?: string }).tooltip;
+
   const renderField = () => {
     const commonProps = {
       field,
@@ -440,9 +445,19 @@ export const ConfigurationFieldRenderer = ({
         <div className="flex items-center gap-3">
           {isTogglable && <Switch checked={isEnabled} onCheckedChange={handleToggleChange} />}
           {isEnabled && renderField()}
-          <Label className="text-left cursor-pointer">
+          <Label className="text-left cursor-pointer flex items-center gap-1">
             {field.label || field.name}
             {isRequired && <span className="text-gray-800 ml-1">*</span>}
+            {fieldTooltip && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="size-3.5 shrink-0 text-gray-400 hover:text-gray-600 cursor-default" aria-hidden />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs text-balance">
+                  {fieldTooltip}
+                </TooltipContent>
+              </Tooltip>
+            )}
             {hasFieldError &&
               ((enableRealtimeValidation && isRequired && (value === undefined || value === null || value === "")) ||
                 (!enableRealtimeValidation &&
@@ -469,7 +484,7 @@ export const ConfigurationFieldRenderer = ({
         )}
 
         {/* Display field description */}
-        {field.description && (
+        {field.description && !fieldTooltip && (
           <p className="text-xs text-gray-500 dark:text-gray-400 text-left leading-normal">{field.description}</p>
         )}
       </div>
@@ -481,9 +496,19 @@ export const ConfigurationFieldRenderer = ({
     <div className="space-y-2">
       <div className="flex items-center gap-3">
         {isTogglable && <Switch checked={isEnabled} onCheckedChange={handleToggleChange} />}
-        <Label className="block text-left flex-1 min-w-0">
+        <Label className="flex items-center gap-1 text-left flex-1 min-w-0">
           {field.label || field.name}
           {isRequired && <span className="text-gray-800 ml-1">*</span>}
+          {fieldTooltip && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="size-3.5 shrink-0 text-gray-400 hover:text-gray-600 cursor-default" aria-hidden />
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs text-balance">
+                {fieldTooltip}
+              </TooltipContent>
+            </Tooltip>
+          )}
           {hasFieldError &&
             ((enableRealtimeValidation && isRequired && (value === undefined || value === null || value === "")) ||
               (!enableRealtimeValidation &&
@@ -516,7 +541,7 @@ export const ConfigurationFieldRenderer = ({
       )}
 
       {/* Display field description */}
-      {field.description && (
+      {field.description && !fieldTooltip && (
         <p className="text-xs text-gray-500 dark:text-gray-400 text-left leading-normal">{field.description}</p>
       )}
     </div>


### PR DESCRIPTION
Fix tooltip support for configuration fields (`#1898`)

### Backend (Go)

* Added `optional string tooltip = 13;` to the `Field` message in `protos/configuration.proto`
* Added `Tooltip string \`json:"tooltip,omitempty"``to the`Field`struct in`pkg/configuration/field.go`
* Wired tooltip serialization/deserialization in:

  * `pkg/grpc/actions/common.go`

    * `ConfigurationFieldToProto`
    * `ProtoToConfigurationField`
* Updated PagerDuty integration:

  * `pkg/integrations/pagerduty/snooze_incident.go`
  * Replaced the long `Description` on `fromEmail` with a shorter tooltip:

    * `"Email address of a valid PagerDuty user."`
  * Removed the description text

### Frontend (TypeScript)

* Updated `web_src/src/ui/configurationFieldRenderer/StringFieldRenderer.tsx`

  * `quickTip` is now suppressed when `field.tooltip` is present
  * Prevents rendering the generic `Tip: type {{...}}` helper for tooltip-enabled fields
* Updated `web_src/src/ui/configurationFieldRenderer/index.tsx`

  * Added Info (`ℹ`) icon with shadcn Tooltip support
  * Extracted `fieldTooltip` from the field definition
  * Added tooltip rendering for both boolean and non-boolean labels
  * Suppressed the grey description paragraph when a tooltip is present

### Notes

* No required `*` is shown for `fromEmail`

  * `Required: false`
  * No `RequiredConditions`
  * Satisfies requirement #4 from the issue
* Regenerated generated assets with:

  * `make pb.gen`
  * `make openapi.spec.gen`
  * `make openapi.web.client.gen`

This updates the generated Go proto code, OpenAPI spec, and TypeScript API client so `ConfigurationField` now includes:

```ts
tooltip?: string
```
