### PR TITLE
feat: surface unpublished-draft choice on canvas Edit button

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5059,6 +5059,33 @@ export function WorkflowPageV2() {
     handleUseVersion(liveCanvasVersionId);
   }, [handleUseVersion, isRunsMode, isViewingLiveVersion, liveCanvasVersionId]);
 
+  const handleDiscardDraftAndStartEdit = useCallback(async () => {
+    if (!canUpdateCanvas) {
+      showErrorToast("You don't have permission to edit this canvas");
+      return;
+    }
+    if (isTemplate) {
+      showErrorToast("Template canvases are read-only");
+      return;
+    }
+
+    const draftId = latestDraftVersion?.metadata?.id;
+    if (draftId) {
+      try {
+        await deleteCanvasVersionMutation.mutateAsync(draftId);
+      } catch (error) {
+        const message =
+          (error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+          (error as { message?: string })?.message ||
+          "Failed to discard draft";
+        showErrorToast(message);
+        return;
+      }
+    }
+
+    await handleCreateVersion();
+  }, [canUpdateCanvas, isTemplate, latestDraftVersion, deleteCanvasVersionMutation, handleCreateVersion]);
+
   const handleResetDraftChanges = useCallback(async () => {
     if (!organizationId || !canvasId) {
       return;
@@ -5707,6 +5734,8 @@ export function WorkflowPageV2() {
           onDiscardVersion={handleResetDraftChanges}
           discardVersionDisabled={resetDraftDisabled}
           discardVersionDisabledTooltip={resetDraftDisabledTooltip}
+          onDiscardDraftAndStartEdit={handleDiscardDraftAndStartEdit}
+          unpublishedDraftUpdatedAt={latestDraftVersion?.metadata?.updatedAt || latestDraftVersion?.metadata?.createdAt}
           headerMode={headerMode}
           onEnterEditMode={handleEnterEditModeFromHeader}
           enterEditModeDisabled={toggleEditModeDisabled}

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "../button";
 import { AgentSidebarTrigger } from "./components/AgentSidebarTrigger";
 import { CanvasModeToggle } from "./components/CanvasModeToggle";
+import { EnterEditDraftDropdown } from "./components/EnterEditDraftDropdown";
 
 type HeaderMode = "default" | "version-live" | "version-edit" | "runs";
 
@@ -39,6 +40,10 @@ interface HeaderProps {
   publishVersionLabel?: string;
   /** When true, shows the Discard control next to Publish in version edit mode (draft differs from live). */
   hasUnpublishedDraftChanges?: boolean;
+  /** ISO timestamp of the existing unpublished draft, used to label "Last edited X" in the Edit dropdown. */
+  unpublishedDraftUpdatedAt?: string;
+  /** Discard the existing draft and start a new edit session from live. Shown in the Edit dropdown when a draft exists. */
+  onDiscardDraftAndStartEdit?: () => void;
   /** Canvas settings route requires `canvases:update`; hide the menu when the user cannot update. */
   showCanvasSettingsMenu?: boolean;
   isVersionControlOpen?: boolean;
@@ -167,9 +172,13 @@ function SecondaryHeaderActions({
   onExitEditMode,
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
+  unpublishedDraftUpdatedAt,
+  onDiscardDraftAndStartEdit,
 }: HeaderProps) {
   const showVersionControlTrigger = mode === "version-live" && !!onOpenVersionControl;
   const showEditButton = mode === "version-live" && !!onEnterEditMode;
+  const showDraftDropdown =
+    showEditButton && !!hasUnpublishedDraftChanges && !!onDiscardDraftAndStartEdit && !enterEditModeDisabled;
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
@@ -183,11 +192,19 @@ function SecondaryHeaderActions({
       ) : null}
 
       {showEditButton ? (
-        <EnterEditButton
-          onClick={onEnterEditMode}
-          disabled={!!enterEditModeDisabled}
-          disabledTooltip={enterEditModeDisabledTooltip}
-        />
+        showDraftDropdown ? (
+          <EnterEditDraftDropdown
+            onContinueEditing={onEnterEditMode}
+            onDiscardAndStartEdit={onDiscardDraftAndStartEdit!}
+            updatedAt={unpublishedDraftUpdatedAt}
+          />
+        ) : (
+          <EnterEditButton
+            onClick={onEnterEditMode}
+            disabled={!!enterEditModeDisabled}
+            disabledTooltip={enterEditModeDisabledTooltip}
+          />
+        )
       ) : null}
 
       {mode === "default" && onSave && !saveButtonHidden ? (

--- a/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
+++ b/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
@@ -1,0 +1,55 @@
+import { TimeAgo } from "@/components/TimeAgo";
+import { Button as UIButton } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdownMenu";
+import { Pencil, Trash2 } from "lucide-react";
+
+export function EnterEditDraftDropdown({
+  onContinueEditing,
+  onDiscardAndStartEdit,
+  updatedAt,
+}: {
+  onContinueEditing: () => void;
+  onDiscardAndStartEdit: () => void;
+  updatedAt?: string;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <UIButton type="button" variant="default" size="sm" data-testid="canvas-edit-button">
+          <Pencil className="h-3.5 w-3.5" />
+          Edit
+        </UIButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72 px-2">
+        <div className="px-3 pt-3 pb-2">
+          <div className="text-sm font-medium text-slate-900">You have an unpublished draft</div>
+          {updatedAt ? (
+            <div className="text-xs text-slate-500">
+              Last edited <TimeAgo date={updatedAt} />
+            </div>
+          ) : null}
+        </div>
+        <DropdownMenuSeparator className="my-0" />
+        <div className="py-1">
+          <DropdownMenuItem onClick={onContinueEditing} className="gap-2 px-3 py-2 text-slate-700 cursor-pointer">
+            <Pencil className="h-4 w-4" />
+            <span>Continue editing</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={onDiscardAndStartEdit}
+            className="gap-2 px-3 py-2 text-red-600 focus:text-red-700 cursor-pointer"
+          >
+            <Trash2 className="h-4 w-4" />
+            <span>Discard draft &amp; start fresh</span>
+          </DropdownMenuItem>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -170,6 +170,8 @@ export interface CanvasPageProps {
   runsNotificationCount?: number;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
+  unpublishedDraftUpdatedAt?: string;
+  onDiscardDraftAndStartEdit?: () => void;
   isAutoLayoutOnUpdateEnabled?: boolean;
   onToggleAutoLayoutOnUpdate?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
@@ -1119,6 +1121,8 @@ function CanvasPage(props: CanvasPageProps) {
           runsNotificationCount={props.runsNotificationCount}
           publishVersionLabel={props.publishVersionLabel}
           hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
+          unpublishedDraftUpdatedAt={props.unpublishedDraftUpdatedAt}
+          onDiscardDraftAndStartEdit={props.onDiscardDraftAndStartEdit}
           showCanvasSettingsMenu={props.showCanvasSettingsMenu}
           isVersionControlOpen={props.isVersionControlOpen}
           onOpenVersionControl={props.onOpenVersionControl}
@@ -1630,6 +1634,8 @@ function CanvasContentHeader({
   runsNotificationCount,
   publishVersionLabel,
   hasUnpublishedDraftChanges,
+  unpublishedDraftUpdatedAt,
+  onDiscardDraftAndStartEdit,
   showCanvasSettingsMenu,
   isVersionControlOpen,
   onOpenVersionControl,
@@ -1662,6 +1668,8 @@ function CanvasContentHeader({
   runsNotificationCount?: number;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
+  unpublishedDraftUpdatedAt?: string;
+  onDiscardDraftAndStartEdit?: () => void;
   showCanvasSettingsMenu?: boolean;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
@@ -1704,6 +1712,8 @@ function CanvasContentHeader({
       runsNotificationCount={runsNotificationCount}
       publishVersionLabel={publishVersionLabel}
       hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+      unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
+      onDiscardDraftAndStartEdit={onDiscardDraftAndStartEdit}
       showCanvasSettingsMenu={showCanvasSettingsMenu}
       isVersionControlOpen={isVersionControlOpen}
       onOpenVersionControl={onOpenVersionControl}


### PR DESCRIPTION
## Summary

  When a canvas has an unpublished draft and the user is viewing the live version, clicking **Edit** now opens a small dropdown with two clear choices instead of
  silently dropping them into the existing draft:

  - **Continue editing** — opens the existing draft (previous default behavior).
  - **Discard draft & start fresh** — deletes the draft, then creates a new one from live and enters edit mode.

  The dropdown header shows "You have an unpublished draft" and a live "Last edited X ago" timestamp. When no unpublished draft exists, the Edit button behaves
  exactly as before (single click → edit).

  ## Why

  It's currently invisible that an existing draft is being reused when re-entering edit mode. Users who wanted to start over had to enter edit mode and then Discard
  from the version-edit toolbar, which is two extra steps and creates a moment where the previous draft's changes are loaded onto the canvas. Surfacing the choice at
   the Edit-button click makes the state explicit and gives a one-click "start fresh" path.
