### PR TITLE
feat: gate Runners behind an experimental flag

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -12,7 +12,7 @@ type Feature struct {
 }
 
 var registry = []Feature{
-	{ID: "runners", Label: "Runners", Description: "Sandboxed Runners"},
+	{ID: "runner", Label: "Runners", Description: "Sandboxed Runners"},
 }
 
 func All() []Feature {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -8,9 +8,9 @@ import (
 
 func Test__Get(t *testing.T) {
 	t.Run("known id returns feature and true", func(t *testing.T) {
-		f, ok := Get("runners")
+		f, ok := Get("runner")
 		assert.True(t, ok)
-		assert.Equal(t, "runners", f.ID)
+		assert.Equal(t, "runner", f.ID)
 		assert.Equal(t, "Runners", f.Label)
 		assert.Equal(t, "Sandboxed Runners", f.Description)
 	})
@@ -28,7 +28,7 @@ func Test__Get(t *testing.T) {
 }
 
 func Test__Exists(t *testing.T) {
-	assert.True(t, Exists("runners"))
+	assert.True(t, Exists("runner"))
 	assert.False(t, Exists("does-not-exist"))
 	assert.False(t, Exists(""))
 }
@@ -49,7 +49,7 @@ func Test__IsReleased(t *testing.T) {
 	})
 
 	t.Run("registered id with nil Released is not released", func(t *testing.T) {
-		assert.False(t, IsReleased("runners"))
+		assert.False(t, IsReleased("runner"))
 	})
 
 	t.Run("registered id with Released=&true is released", func(t *testing.T) {

--- a/pkg/models/organization_experimental_features_test.go
+++ b/pkg/models/organization_experimental_features_test.go
@@ -27,44 +27,44 @@ func Test__ExperimentalFeatures(t *testing.T) {
 		org, err := CreateOrganization("expfeat-enable", "")
 		require.NoError(t, err)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"runners"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{"runner"}, []string(reloaded.EnabledExperimentalFeatures))
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
 
 		reloaded, err = FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"runners"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{"runner"}, []string(reloaded.EnabledExperimentalFeatures))
 	})
 
 	t.Run("Disable removes the feature and is idempotent", func(t *testing.T) {
 		org, err := CreateOrganization("expfeat-disable", "")
 		require.NoError(t, err)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runners"))
-		require.NoError(t, DisableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, DisableExperimentalFeature(org.ID, "runner"))
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
 		assert.Empty(t, []string(reloaded.EnabledExperimentalFeatures))
 
 		// Disabling again is a no-op.
-		require.NoError(t, DisableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, DisableExperimentalFeature(org.ID, "runner"))
 	})
 
 	t.Run("Organization.HasExperimentalFeature respects enabled list", func(t *testing.T) {
 		org, err := CreateOrganization("expfeat-has", "")
 		require.NoError(t, err)
 
-		assert.False(t, org.HasExperimentalFeature("runners"))
+		assert.False(t, org.HasExperimentalFeature("runner"))
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.True(t, reloaded.HasExperimentalFeature("runners"))
+		assert.True(t, reloaded.HasExperimentalFeature("runner"))
 	})
 
 	t.Run("released features short-circuit to true regardless of stored list", func(t *testing.T) {
@@ -85,13 +85,13 @@ func Test__ExperimentalFeatures(t *testing.T) {
 		org, err := CreateOrganization("expfeat-load", "")
 		require.NoError(t, err)
 
-		ok, err := HasExperimentalFeature(org.ID, "runners")
+		ok, err := HasExperimentalFeature(org.ID, "runner")
 		require.NoError(t, err)
 		assert.False(t, ok)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runners"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
 
-		ok, err = HasExperimentalFeature(org.ID, "runners")
+		ok, err = HasExperimentalFeature(org.ID, "runner")
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -796,20 +796,20 @@ func TestAdminEnableOrgExperimentalFeature(t *testing.T) {
 	server, r, token := setupAdminTestServer(t)
 
 	t.Cleanup(func() {
-		_ = models.DisableExperimentalFeature(r.Organization.ID, "runners")
+		_ = models.DisableExperimentalFeature(r.Organization.ID, "runner")
 	})
 
 	t.Run("enables a known feature", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "POST",
-			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runners",
+			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runner",
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusOK, response.Code)
 
 		reloaded, err := models.FindOrganizationByID(r.Organization.ID.String())
 		require.NoError(t, err)
-		assert.Contains(t, []string(reloaded.EnabledExperimentalFeatures), "runners")
+		assert.Contains(t, []string(reloaded.EnabledExperimentalFeatures), "runner")
 	})
 
 	t.Run("rejects unknown feature ids", func(t *testing.T) {
@@ -824,7 +824,7 @@ func TestAdminEnableOrgExperimentalFeature(t *testing.T) {
 	t.Run("returns 404 for non-existent org", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "POST",
-			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runners",
+			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runner",
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusNotFound, response.Code)
@@ -835,18 +835,18 @@ func TestAdminDisableOrgExperimentalFeature(t *testing.T) {
 	server, r, token := setupAdminTestServer(t)
 
 	t.Run("disables a previously enabled feature", func(t *testing.T) {
-		require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, "runners"))
+		require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, "runner"))
 
 		response := execRequest(server, requestParams{
 			method:     "DELETE",
-			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runners",
+			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runner",
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusOK, response.Code)
 
 		reloaded, err := models.FindOrganizationByID(r.Organization.ID.String())
 		require.NoError(t, err)
-		assert.NotContains(t, []string(reloaded.EnabledExperimentalFeatures), "runners")
+		assert.NotContains(t, []string(reloaded.EnabledExperimentalFeatures), "runner")
 	})
 
 	t.Run("is idempotent for ids not currently enabled", func(t *testing.T) {
@@ -861,7 +861,7 @@ func TestAdminDisableOrgExperimentalFeature(t *testing.T) {
 	t.Run("returns 404 for non-existent org", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "DELETE",
-			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runners",
+			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runner",
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusNotFound, response.Code)

--- a/pkg/public/experimental_features_test.go
+++ b/pkg/public/experimental_features_test.go
@@ -33,7 +33,7 @@ func TestListExperimentalFeatures(t *testing.T) {
 			id, _ := f["id"].(string)
 			ids = append(ids, id)
 		}
-		assert.Contains(t, ids, "runners")
+		assert.Contains(t, ids, "runner")
 	})
 
 	t.Run("rejects unauthenticated requests", func(t *testing.T) {

--- a/web_src/src/hooks/useComponentData.ts
+++ b/web_src/src/hooks/useComponentData.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { actionsListActions, actionsDescribeAction } from "../api-client/sdk.gen";
 import { withOrganizationHeader } from "../lib/withOrganizationHeader";
+import { useExperimentalFeature } from "./useExperimentalFeature";
+import { useExperimentalFeaturesRegistry } from "./useExperimentalFeatures";
 
 export const componentKeys = {
   all: ["components"] as const,
@@ -11,11 +13,24 @@ export const componentKeys = {
 };
 
 export const useComponents = (organizationId: string) => {
+  const { enabledExperimentalFeatures } = useExperimentalFeature(organizationId);
+  const { data: expRegistry } = useExperimentalFeaturesRegistry();
+  const experimentalFeatures =
+    expRegistry?.features.filter((feature) => !feature.released).map((feature) => feature.id) || [];
+
   return useQuery({
     queryKey: componentKeys.list(organizationId),
     queryFn: async () => {
       const response = await actionsListActions(withOrganizationHeader({}));
       return response.data?.actions || [];
+    },
+    select: (data) => {
+      return (data || []).filter((action) => {
+        const isExperimental = experimentalFeatures.includes(action.name || "");
+        const isEnabled = enabledExperimentalFeatures.includes(action.name || "");
+
+        return !isExperimental || isEnabled;
+      });
     },
     enabled: !!organizationId,
   });

--- a/web_src/src/hooks/useExperimentalFeature.spec.ts
+++ b/web_src/src/hooks/useExperimentalFeature.spec.ts
@@ -71,6 +71,18 @@ beforeEach(() => {
 });
 
 describe("useExperimentalFeature", () => {
+  it("returns has function and enabledExperimentalFeatures array", () => {
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useExperimentalFeature(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(Object.keys(result.current).sort()).toEqual(["enabledExperimentalFeatures", "has"]);
+    expect(result.current.has).toEqual(expect.any(Function));
+    expect(result.current.enabledExperimentalFeatures).toEqual(expect.any(Array));
+  });
+
   it("returns false when the feature is not in the registry, even if the org has opted in", () => {
     const queryClient = createQueryClient();
     seedQueries(queryClient, {
@@ -80,11 +92,11 @@ describe("useExperimentalFeature", () => {
       registry: { features: [makeFeature({ id: "alpha" })] },
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("ghost"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.has("ghost")).toBe(false);
   });
 
   it("returns true when the feature is marked released, regardless of org opt-in", () => {
@@ -98,11 +110,11 @@ describe("useExperimentalFeature", () => {
       },
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(true);
+    expect(result.current.has("alpha")).toBe(true);
   });
 
   it("returns true when the feature exists and the organization has opted in", () => {
@@ -116,11 +128,11 @@ describe("useExperimentalFeature", () => {
       },
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(true);
+    expect(result.current.has("alpha")).toBe(true);
   });
 
   it("returns false when the feature exists but the organization has not opted in", () => {
@@ -134,11 +146,11 @@ describe("useExperimentalFeature", () => {
       },
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.has("alpha")).toBe(false);
   });
 
   it("returns false when enabledExperimentalFeatures is undefined on the organization", () => {
@@ -150,22 +162,22 @@ describe("useExperimentalFeature", () => {
       },
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.has("alpha")).toBe(false);
   });
 
   it("returns false when no organization id is available", () => {
     useOrganizationIdMock.mockReturnValue(null);
     const queryClient = createQueryClient();
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.has("alpha")).toBe(false);
   });
 
   it("returns false while the registry has not loaded yet", () => {
@@ -176,10 +188,47 @@ describe("useExperimentalFeature", () => {
       } as OrganizationsOrganization,
     });
 
-    const { result } = renderHook(() => useExperimentalFeature("alpha"), {
+    const { result } = renderHook(() => useExperimentalFeature(), {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(result.current).toBe(false);
+    expect(result.current.has("alpha")).toBe(false);
+  });
+
+  it("lists released features and features the organization opted into", () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient, {
+      organization: {
+        spec: { enabledExperimentalFeatures: ["beta"] },
+      } as OrganizationsOrganization,
+      registry: {
+        features: [
+          makeFeature({ id: "alpha", released: true }),
+          makeFeature({ id: "beta" }),
+          makeFeature({ id: "gamma" }),
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useExperimentalFeature(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.enabledExperimentalFeatures).toEqual(["alpha", "beta"]);
+  });
+
+  it("returns an empty list while the registry has not loaded yet", () => {
+    const queryClient = createQueryClient();
+    seedQueries(queryClient, {
+      organization: {
+        spec: { enabledExperimentalFeatures: ["alpha"] },
+      } as OrganizationsOrganization,
+    });
+
+    const { result } = renderHook(() => useExperimentalFeature(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.enabledExperimentalFeatures).toEqual([]);
   });
 });

--- a/web_src/src/hooks/useExperimentalFeature.ts
+++ b/web_src/src/hooks/useExperimentalFeature.ts
@@ -1,19 +1,34 @@
+import { useCallback, useMemo } from "react";
 import { useExperimentalFeaturesRegistry } from "./useExperimentalFeatures";
 import { useOrganization } from "./useOrganizationData";
 import { useOrganizationId } from "./useOrganizationId";
 
-export function useExperimentalFeature(featureId: string): boolean {
-  const organizationId = useOrganizationId();
-  const { data: organization } = useOrganization(organizationId || "");
+export interface ExperimentalFeatureAccess {
+  has: (featureId: string) => boolean;
+  enabledExperimentalFeatures: string[];
+}
+
+export function useExperimentalFeature(organizationId?: string): ExperimentalFeatureAccess {
+  const _organizationId = useOrganizationId();
+  const { data: organization } = useOrganization(organizationId || _organizationId || "");
   const { data: features } = useExperimentalFeaturesRegistry();
 
-  const exists = features?.features.some((f) => f.id === featureId);
-  const released = features?.features.some((f) => f.id === featureId && f.released);
-  if (!exists) {
-    return false;
-  }
-  if (released) {
-    return true;
-  }
-  return organization?.spec?.enabledExperimentalFeatures?.includes(featureId) ?? false;
+  const enabledFeatures = useMemo(
+    () => new Set(organization?.spec?.enabledExperimentalFeatures ?? []),
+    [organization?.spec?.enabledExperimentalFeatures],
+  );
+
+  const availableFeatureIds = useMemo(() => {
+    return (
+      features?.features
+        .filter((feature) => feature.released || enabledFeatures.has(feature.id))
+        .map((feature) => feature.id) ?? []
+    );
+  }, [enabledFeatures, features?.features]);
+
+  const availableFeatures = useMemo(() => new Set(availableFeatureIds), [availableFeatureIds]);
+
+  const has = useCallback((featureId: string) => availableFeatures.has(featureId), [availableFeatures]);
+
+  return { has, enabledExperimentalFeatures: [...availableFeatureIds] };
 }


### PR DESCRIPTION
## Summary
Gated Runners (`runner`) behind the newly introduced _experimental feature flag_.
This is handled at `web_src/src/hooks/useComponentData.ts`. The source of truth remains `pkg/features/features.go`.