### PR TITLE
fix: stop logging gRPC metadata in authorization interceptor

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -408,19 +408,21 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
-			log.Errorf("Metadata not found in context")
+			log.Errorf("Metadata not found in context for method %s", info.FullMethod)
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 
 		userMeta, ok := md["x-user-id"]
 		if !ok || len(userMeta) == 0 {
-			log.Errorf("User not found in metadata, metadata %v", md)
+			// Do not log `md` itself — it carries the Authorization header,
+			// scoped-token scopes, cookies, etc. Log only the method.
+			log.Errorf("x-user-id missing from metadata for method %s", info.FullMethod)
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 
 		orgMeta, ok := md["x-organization-id"]
 		if !ok || len(orgMeta) == 0 {
-			log.Errorf("Organization not found in metadata, metadata %v", md)
+			log.Errorf("x-organization-id missing from metadata for method %s", info.FullMethod)
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 


### PR DESCRIPTION
The unary authorization interceptor logged the full incoming gRPC metadata at ERROR level whenever the required identity headers were missing:

    log.Errorf("User not found in metadata, metadata %v", md)
    log.Errorf("Organization not found in metadata, metadata %v", md)

gRPC metadata.MD carries every header the caller sent, including the Authorization header (Bearer JWT or user API token), x-token-scopes, and any forwarded cookies. Any client that drifts (missing x-user-id / x-organization-id) writes its credentials into the log pipeline, where retention typically outlives the tokens themselves.

Log only the gRPC method name and which required header was missing. No behavior change otherwise; the same codes.NotFound response is returned.