### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,22 @@ When working with database transactions, follow these rules to ensure data consi
   - The non-transaction variant should call the transaction variant: `return FindUserInTransaction(database.Conn(), ...)`
 
 **Why this matters**: Using `database.Conn()` inside transaction contexts breaks isolation, causes data inconsistency on rollback, and can lead to race conditions.
+
+## Cursor Cloud specific instructions
+
+The entire dev environment runs inside Docker containers. The VM update script installs Docker, configures `fuse-overlayfs` storage (required for nested Docker), switches to `iptables-legacy`, and starts `dockerd`. After the update script runs, all standard `make` targets are available.
+
+### Starting the environment
+
+1. `make dev.up` — builds the `app` image and starts three containers: `app`, `db` (Postgres 17.5), `rabbitmq`.
+2. `make dev.setup` — runs inside the `app` container: npm install, protobuf codegen, Go module download + build, DB create + migrate for both `superplane_dev` and `superplane_test`.
+3. `make dev.server` — starts Air (Go hot-reload) + Vite dev server inside the `app` container; blocks until the `/health` endpoint responds. UI at `http://localhost:8000`.
+
+### Key caveats
+
+- The `app` container's command is `sleep infinity` by default; `make dev.server` exec's the entrypoint script inside it. Re-running `make dev.server` is safe (it kills existing air/vite first).
+- All Go tooling (lint, test, build) runs inside the `app` container via `docker compose exec/run`. Do **not** try to run `go build` or `revive` on the host.
+- Backend tests require `DB_NAME=superplane_test` (the Makefile handles this). Targeted tests: `make test PKG_TEST_PACKAGES=./pkg/<package>`.
+- The first visit to `http://localhost:8000` triggers the owner setup wizard (`OWNER_SETUP_ENABLED=yes`). Create an account to access the dashboard.
+- If `go mod download` fails with missing files under `tmp/go/pkg/mod`, run `make dev.clean.go.cache` then `make dev.setup.go`.
+- Standard commands for lint/test/build/format are documented in the "Build, Test, and Development Commands" section above — refer there instead of duplicating.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with environment setup and development workflow notes for future Cursor Cloud agents.

### Changes

- Documents the Docker-in-Docker setup requirements (fuse-overlayfs, iptables-legacy)
- Documents the three-step startup flow: `make dev.up` → `make dev.setup` → `make dev.server`
- Notes key caveats: all Go tooling runs inside the `app` container, owner setup wizard on first visit, Go cache cleanup procedure

### Evidence

Dev environment fully verified:

- `make lint` — passes
- `make check.build.app` — passes
- `make check.build.ui` — passes
- `make test PKG_TEST_PACKAGES=./pkg/models` — 49 tests pass
- `make check.format.js` — passes
- Owner setup + canvas creation tested via UI

[superplane_hello_world_demo.mp4](https://cursor.com/agents/bc-31761c22-dd32-4453-b7f7-441c4aa9b510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperplane_hello_world_demo.mp4)
[Dashboard after login](https://cursor.com/agents/bc-31761c22-dd32-4453-b7f7-441c4aa9b510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_after_login.webp)
[Canvas editor](https://cursor.com/agents/bc-31761c22-dd32-4453-b7f7-441c4aa9b510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_editor.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31761c22-dd32-4453-b7f7-441c4aa9b510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31761c22-dd32-4453-b7f7-441c4aa9b510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

