### PR TITLE
feat: add minimal canvas dashboard screen

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasDashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/CanvasDashboardOverlay.tsx
@@ -1,0 +1,24 @@
+import { LayoutDashboard } from "lucide-react";
+
+interface CanvasDashboardOverlayProps {
+  canvasName: string;
+  description?: string;
+}
+
+export function CanvasDashboardOverlay({ canvasName, description }: CanvasDashboardOverlayProps) {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-6">
+      <div className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-8 text-center shadow-sm">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-slate-100 text-slate-600">
+          <LayoutDashboard className="h-5 w-5" />
+        </div>
+        <h2 className="text-lg font-semibold text-slate-900">Dashboard</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Minimal dashboard mode for <span className="font-medium text-slate-800">{canvasName}</span>.
+        </p>
+        {description ? <p className="mt-1 text-sm text-slate-500">{description}</p> : null}
+        <p className="mt-4 text-xs text-slate-500">More dashboard widgets and layout controls will be added next.</p>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -87,6 +87,7 @@ import { statusFiltersToApiFilters, type RunStatusFilter } from "@/ui/Runs/runPr
 import { RunNodeDetailModal } from "@/ui/Runs/RunNodeDetailModal";
 import { RunsSidebar } from "@/ui/RunsSidebar";
 import { CanvasChangeRequestConflictResolver } from "./CanvasChangeRequestConflictResolver";
+import { CanvasDashboardOverlay } from "./CanvasDashboardOverlay";
 import { CanvasMemoryModal } from "./CanvasMemoryModal";
 import { CanvasPageModals } from "./CanvasPageModals";
 import { CanvasVersionControlSidebar } from "./CanvasVersionControlSidebar";
@@ -547,6 +548,7 @@ export function WorkflowPageV2() {
   const isEditing = !!activeCanvasVersionId && isViewingDraftVersion;
   const hasEditableVersion = !!activeCanvasVersionId && isViewingDraftVersion;
   const [isRunsMode, setIsRunsMode] = useState(() => searchParams.get("view") === "runs");
+  const [isDashboardMode, setIsDashboardMode] = useState(() => searchParams.get("view") === "dashboard");
   const [selectedRunId, setSelectedRunId] = useState<string | null>(() => searchParams.get("run"));
   const [runDetailNodeId, setRunDetailNodeId] = useState<string | null>(null);
   const [runsFitAllNonce, setRunsFitAllNonce] = useState(0);
@@ -4926,6 +4928,7 @@ export function WorkflowPageV2() {
 
   useEffect(() => {
     setIsRunsMode(searchParams.get("view") === "runs");
+    setIsDashboardMode(searchParams.get("view") === "dashboard");
     setSelectedRunId(searchParams.get("run"));
   }, [searchParams]);
 
@@ -4933,6 +4936,7 @@ export function WorkflowPageV2() {
     (runId: string) => {
       setSelectedRunId(runId);
       setIsRunsMode(true);
+      setIsDashboardMode(false);
       setRunDetailNodeId(null);
       setSearchParams(
         (current) => {
@@ -4955,10 +4959,33 @@ export function WorkflowPageV2() {
     }
 
     setIsRunsMode(true);
+    setIsDashboardMode(false);
     setSearchParams(
       (current) => {
         const next = new URLSearchParams(current);
         next.set("view", "runs");
+        next.delete("sidebar");
+        next.delete("node");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [handleUseVersion, hasEditableVersion, liveCanvasVersionId, setSearchParams]);
+
+  const handleSelectDashboardMode = useCallback(() => {
+    if (hasEditableVersion && liveCanvasVersionId) {
+      handleUseVersion(liveCanvasVersionId);
+    }
+
+    setIsRunsMode(false);
+    setIsDashboardMode(true);
+    setSelectedRunId(null);
+    setRunDetailNodeId(null);
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        next.set("view", "dashboard");
+        next.delete("run");
         next.delete("sidebar");
         next.delete("node");
         return next;
@@ -4983,8 +5010,9 @@ export function WorkflowPageV2() {
   }, [setSearchParams]);
 
   const handleEnterEditModeFromHeader = useCallback(async () => {
-    if (isRunsMode) {
+    if (isRunsMode || isDashboardMode) {
       setIsRunsMode(false);
+      setIsDashboardMode(false);
       setSelectedRunId(null);
       setRunDetailNodeId(null);
       await handleToggleEditMode();
@@ -5000,15 +5028,27 @@ export function WorkflowPageV2() {
       return;
     }
     await handleToggleEditMode();
-  }, [handleToggleEditMode, isRunsMode, setSearchParams]);
+  }, [handleToggleEditMode, isDashboardMode, isRunsMode, setSearchParams]);
 
   const handleExitEditModeFromHeader = useCallback(async () => {
     if (isRunsMode) {
       handleExitRunsMode();
       return;
     }
+    if (isDashboardMode) {
+      setIsDashboardMode(false);
+      setSearchParams(
+        (current) => {
+          const next = new URLSearchParams(current);
+          next.delete("view");
+          return next;
+        },
+        { replace: true },
+      );
+      return;
+    }
     await handleToggleEditMode();
-  }, [handleExitRunsMode, handleToggleEditMode, isRunsMode]);
+  }, [handleExitRunsMode, handleToggleEditMode, isDashboardMode, isRunsMode, setSearchParams]);
 
   const handleRunCanvasNodeClick = useCallback(
     (nodeId: string) => {
@@ -5605,7 +5645,13 @@ export function WorkflowPageV2() {
     hasDraftDiffVersusLive: !!latestDraftVersion && hasDraftGraphDiffVersusLive,
   });
   const activeRunsCount = runsData.runs.filter((run) => run.state === "STATE_STARTED").length;
-  const headerMode = isRunsMode ? "runs" : canvasMode === "edit" ? "version-edit" : "version-live";
+  const headerMode = isRunsMode
+    ? "runs"
+    : isDashboardMode
+      ? "dashboard"
+      : canvasMode === "edit"
+        ? "version-edit"
+        : "version-live";
   const hasUnpublishedDraftChanges =
     !suppressUnpublishedDraftDiscard && !!latestDraftVersion && hasDraftGraphDiffVersusLive;
   const canvasStateMode = hasEditableVersion
@@ -5669,8 +5715,8 @@ export function WorkflowPageV2() {
           onOpenVersionControl={!hasEditableVersion ? () => setIsVersionControlOpen((prev) => !prev) : undefined}
           versionControlButtonTooltip={isVersionControlOpen ? "Close versions" : "Open versions"}
           versionControlNotificationCount={pendingApprovalVersions.length}
-          showBottomStatusControls={!isTemplate && !isRunsMode}
-          hideAddControls={isTemplate || isRunsMode}
+          showBottomStatusControls={!isTemplate && !isRunsMode && !isDashboardMode}
+          hideAddControls={isTemplate || isRunsMode || isDashboardMode}
           memoryItemCount={canvasMemoryEntries.length}
           onMemoryOpen={() => setIsMemoryViewModalOpen(true)}
           onYamlOpen={() => setIsYamlViewModalOpen(true)}
@@ -5715,7 +5761,7 @@ export function WorkflowPageV2() {
           canUpdateIntegrations={canUpdateIntegrations}
           missingIntegrations={missingIntegrations}
           onConnectIntegration={!isReadOnly ? handleConnectIntegration : undefined}
-          readOnly={isReadOnly || isRunsMode}
+          readOnly={isReadOnly || isRunsMode || isDashboardMode}
           hasFitToViewRef={isRunsMode ? runsHasFitToViewRef : hasFitToViewRef}
           hasUserToggledSidebarRef={hasUserToggledSidebarRef}
           isSidebarOpenRef={isSidebarOpenRef}
@@ -5742,6 +5788,7 @@ export function WorkflowPageV2() {
           enterEditModeDisabledTooltip={toggleEditModeDisabledTooltip}
           onExitEditMode={handleExitEditModeFromHeader}
           onSelectRuns={isTemplate ? undefined : handleSelectRunsMode}
+          onSelectDashboard={isTemplate ? undefined : handleSelectDashboardMode}
           runsNotificationCount={activeRunsCount}
           exitEditModeDisabled={exitEditModeDisabled}
           exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
@@ -5797,6 +5844,14 @@ export function WorkflowPageV2() {
                 componentIconMap={componentIconMap}
                 totalCount={runsData.totalCount}
                 onStatusFiltersChange={setRunStatusFilters}
+              />
+            ) : null
+          }
+          dashboardOverlay={
+            isDashboardMode ? (
+              <CanvasDashboardOverlay
+                canvasName={canvas?.metadata?.name || liveCanvas?.metadata?.name || "Canvas"}
+                description={canvas?.metadata?.description || liveCanvas?.metadata?.description}
               />
             ) : null
           }

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -10,7 +10,7 @@ import { AgentSidebarTrigger } from "./components/AgentSidebarTrigger";
 import { CanvasModeToggle } from "./components/CanvasModeToggle";
 import { EnterEditDraftDropdown } from "./components/EnterEditDraftDropdown";
 
-type HeaderMode = "default" | "version-live" | "version-edit" | "runs";
+type HeaderMode = "default" | "dashboard" | "version-live" | "version-edit" | "runs";
 
 interface HeaderProps {
   /** Shown centered in the top bar (canvas or template display name). */
@@ -34,6 +34,7 @@ interface HeaderProps {
   onExitEditMode?: () => void;
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
+  onSelectDashboard?: () => void;
   onSelectRuns?: () => void;
   runsNotificationCount?: number;
   /** Label for the publish/propose-change button in version edit mode. Defaults to "Publish". */
@@ -119,8 +120,11 @@ function PageHeader({
 
 function SecondaryHeader(props: HeaderProps) {
   const showCanvasViewModeToggle =
-    props.mode === "version-live" || props.mode === "version-edit" || props.mode === "runs";
-  const canvasViewMode = props.mode === "runs" ? props.mode : "version-live";
+    props.mode === "dashboard" ||
+    props.mode === "version-live" ||
+    props.mode === "version-edit" ||
+    props.mode === "runs";
+  const canvasViewMode = props.mode === "runs" || props.mode === "dashboard" ? props.mode : "version-live";
   const editing = props.mode === "version-edit";
 
   return (
@@ -132,6 +136,7 @@ function SecondaryHeader(props: HeaderProps) {
           {showCanvasViewModeToggle && props.onExitEditMode ? (
             <CanvasModeToggle
               mode={canvasViewMode}
+              onSelectDashboard={props.onSelectDashboard}
               onSelectLive={props.onExitEditMode}
               onSelectRuns={props.onSelectRuns}
               runsNotificationCount={props.runsNotificationCount}

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,10 +1,11 @@
 import type React from "react";
 import { cn } from "@/lib/utils";
 
-type CanvasMode = "version-live" | "version-edit" | "runs";
+type CanvasMode = "dashboard" | "version-live" | "version-edit" | "runs";
 
 interface CanvasModeToggleProps {
   mode: CanvasMode;
+  onSelectDashboard?: () => void;
   onSelectLive: () => void;
   onSelectRuns?: () => void;
   runsNotificationCount?: number;
@@ -14,12 +15,14 @@ interface CanvasModeToggleProps {
 
 export function CanvasModeToggle({
   mode,
+  onSelectDashboard,
   onSelectLive,
   onSelectRuns,
   runsNotificationCount,
   editing = false,
   hasDraft = false,
 }: CanvasModeToggleProps) {
+  const showDashboard = !!onSelectDashboard;
   const showRuns = !!onSelectRuns;
   const baseTrigger =
     "h-full border-none px-3 py-1 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50";
@@ -31,6 +34,22 @@ export function CanvasModeToggle({
   return (
     <div className="inline-flex w-auto" aria-label="Canvas view" role="group">
       <div className="flex h-8 w-fit gap-0 overflow-hidden rounded-sm border border-slate-300 bg-white/80 p-0">
+        {showDashboard ? (
+          <>
+            <ModeButton
+              isActive={mode === "dashboard"}
+              data-testid="canvas-view-mode-dashboard"
+              aria-label="Dashboard"
+              onClick={() => {
+                if (mode !== "dashboard" && onSelectDashboard) void onSelectDashboard();
+              }}
+              className={cn(baseTrigger, "rounded-sm rounded-br-none rounded-tr-none")}
+            >
+              Dashboard
+            </ModeButton>
+            <div className="h-full w-px bg-slate-300"></div>
+          </>
+        ) : null}
         <ModeButton
           isActive={mode === "version-live" || mode === "version-edit"}
           activeClassName={canvasActiveClassName}
@@ -39,7 +58,16 @@ export function CanvasModeToggle({
           onClick={() => {
             if (mode !== "version-live" && mode !== "version-edit") void onSelectLive();
           }}
-          className={cn(baseTrigger, showRuns ? "rounded-none" : "rounded-sm rounded-bl-none rounded-tl-none")}
+          className={cn(
+            baseTrigger,
+            showDashboard
+              ? showRuns
+                ? "rounded-none"
+                : "rounded-sm rounded-bl-none rounded-tl-none"
+              : showRuns
+                ? "rounded-sm rounded-br-none rounded-tr-none"
+                : "rounded-sm",
+          )}
         >
           <span className="inline-flex items-center gap-1.5">
             Canvas

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -157,7 +157,7 @@ export interface CanvasPageProps {
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;
   discardVersionDisabledTooltip?: string;
-  headerMode?: "default" | "version-live" | "version-edit" | "runs";
+  headerMode?: "default" | "dashboard" | "version-live" | "version-edit" | "runs";
   /** Node settings sidebar: canvas uses debounced autosave without closing the panel after each save. */
   configurationSaveMode?: "manual" | "auto";
   onEnterEditMode?: () => void;
@@ -167,6 +167,7 @@ export interface CanvasPageProps {
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectRuns?: () => void;
+  onSelectDashboard?: () => void;
   runsNotificationCount?: number;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
@@ -233,6 +234,7 @@ export interface CanvasPageProps {
   runsComponentIconMap?: Record<string, string>;
   runsNodeQueueItemsMap?: Record<string, CanvasesCanvasNodeQueueItem[]>;
   runsSidebar?: React.ReactNode;
+  dashboardOverlay?: React.ReactNode;
   onRunNodeSelect?: (nodeId: string) => void;
   onRunExecutionSelect?: (options: {
     nodeId: string;
@@ -1005,6 +1007,7 @@ function CanvasPage(props: CanvasPageProps) {
       Boolean(props.hideAddControls) ||
       props.headerMode === "version-live" ||
       props.headerMode === "runs" ||
+      props.headerMode === "dashboard" ||
       state.componentSidebar.isOpen,
     isSidebarOpen: isBuildingBlocksSidebarOpen,
     onOpen: handleBuildingBlocksShortcutOpen,
@@ -1081,14 +1084,18 @@ function CanvasPage(props: CanvasPageProps) {
 
   const canvasStateMode = props.canvasStateMode || "default";
   const showPreviewFloatingBar =
-    canvasStateMode === "previewing-previous-version" && !!props.onPreviewPreviousVersionViewDetails;
-  const showAwaitingFloatingBar = canvasStateMode === "awaiting-approval" && !!props.awaitingApprovalBanner;
+    props.headerMode !== "dashboard" &&
+    canvasStateMode === "previewing-previous-version" &&
+    !!props.onPreviewPreviousVersionViewDetails;
+  const showAwaitingFloatingBar =
+    props.headerMode !== "dashboard" && canvasStateMode === "awaiting-approval" && !!props.awaitingApprovalBanner;
 
   return (
     <div
       ref={canvasWrapperRef}
       className={cn(
         "h-full w-full overflow-hidden sp-canvas relative flex flex-col",
+        props.headerMode === "dashboard" && "sp-canvas-live",
         props.headerMode === "version-live" && "sp-canvas-live",
         props.headerMode === "runs" && "sp-canvas-live",
       )}
@@ -1118,6 +1125,7 @@ function CanvasPage(props: CanvasPageProps) {
           exitEditModeDisabled={props.exitEditModeDisabled}
           exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
           onSelectRuns={props.onSelectRuns}
+          onSelectDashboard={props.onSelectDashboard}
           runsNotificationCount={props.runsNotificationCount}
           publishVersionLabel={props.publishVersionLabel}
           hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
@@ -1135,11 +1143,11 @@ function CanvasPage(props: CanvasPageProps) {
 
       {/* Main content area with sidebar and canvas */}
       <div className="flex-1 flex relative overflow-hidden">
-        {props.headerMode === "runs" ? null : props.versionControlSidebar}
+        {props.headerMode === "runs" || props.headerMode === "dashboard" ? null : props.versionControlSidebar}
 
         <AgentSidebar agentState={agentState} />
 
-        {props.headerMode === "runs" ? null : (
+        {props.headerMode === "runs" || props.headerMode === "dashboard" ? null : (
           <RightSideControls
             mode={readOnly ? "live" : "edit"}
             onSidebarOpen={handleBuildingBlocksShortcutOpen}
@@ -1153,7 +1161,12 @@ function CanvasPage(props: CanvasPageProps) {
 
         {props.hideAddControls || !isBuildingBlocksSidebarOpen ? null : (
           <BuildingBlocksSidebar
-            isOpen={isBuildingBlocksSidebarOpen && props.headerMode !== "version-live" && props.headerMode !== "runs"}
+            isOpen={
+              isBuildingBlocksSidebarOpen &&
+              props.headerMode !== "version-live" &&
+              props.headerMode !== "runs" &&
+              props.headerMode !== "dashboard"
+            }
             onToggle={handleSidebarToggle}
             blocks={props.buildingBlocks || []}
             integrations={props.integrations}
@@ -1166,6 +1179,9 @@ function CanvasPage(props: CanvasPageProps) {
         )}
 
         <div className="flex-1 relative">
+          {props.headerMode === "dashboard" && props.dashboardOverlay ? (
+            <div className="absolute inset-0 z-[20] overflow-hidden bg-slate-50">{props.dashboardOverlay}</div>
+          ) : null}
           {props.runCanvasLoading && props.headerMode === "runs" ? (
             <div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-50">
               <Loader2 className="h-6 w-6 animate-spin text-slate-500" />
@@ -1270,7 +1286,7 @@ function CanvasPage(props: CanvasPageProps) {
               onLogView={props.onLogView}
             />
           </ReactFlowProvider>
-          {props.headerMode === "runs" ? null : (
+          {props.headerMode === "runs" || props.headerMode === "dashboard" ? null : (
             <Sidebar
               state={state}
               getSidebarData={props.getSidebarData}
@@ -1631,6 +1647,7 @@ function CanvasContentHeader({
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
   onSelectRuns,
+  onSelectDashboard,
   runsNotificationCount,
   publishVersionLabel,
   hasUnpublishedDraftChanges,
@@ -1665,6 +1682,7 @@ function CanvasContentHeader({
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectRuns?: () => void;
+  onSelectDashboard?: () => void;
   runsNotificationCount?: number;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
@@ -1709,6 +1727,7 @@ function CanvasContentHeader({
       exitEditModeDisabled={exitEditModeDisabled}
       exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       onSelectRuns={onSelectRuns}
+      onSelectDashboard={onSelectDashboard}
       runsNotificationCount={runsNotificationCount}
       publishVersionLabel={publishVersionLabel}
       hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a minimal "Dashboard" mode to canvas view switching, based on the repo-backed-projects direction
- wire dashboard selection through `WorkflowPageV2` -> `CanvasPage` -> `Header`/`CanvasModeToggle`
- render a lightweight `CanvasDashboardOverlay` placeholder screen in dashboard mode
- keep existing Canvas and Runs behavior intact while hiding edit/version side controls in dashboard mode
- support `?view=dashboard` URL state and transitions back to live canvas mode

## Validation
- `npm run format` (from `web_src`)
- `npm run format:check` (from `web_src`)
- `npm run build` (from `web_src`) **fails in this environment due missing generated API client modules (`@/api-client`) and unrelated pre-existing TypeScript issues**
- `make format.js` **fails before install (`prettier: not found`)**
- `make check.build.ui` **fails in this environment (`docker: not found`)**
- `npx eslint src/ui/CanvasPage/components/CanvasModeToggle.tsx src/ui/CanvasPage/Header.tsx src/ui/CanvasPage/index.tsx src/pages/workflowv2/index.tsx src/pages/workflowv2/CanvasDashboardOverlay.tsx` (shows existing repo baseline warnings/errors in large files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95fd2102-d5fc-44b9-a6b7-8150daa2ef50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95fd2102-d5fc-44b9-a6b7-8150daa2ef50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

