### PR TITLE
chore: Add .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+tmp/
+.git/
+**/node_modules/
+agent/node_modules/


### PR DESCRIPTION
Reduces Docker build context from ~1GB to ~148MB by excluding:
- `tmp/` (Go module cache, build artifacts)
- `.git/`
- `**/node_modules/`

Cuts `make dev.up` time from ~3min to ~40s on agent machines.