### PR TITLE
fix: stabilize org settings layout when toggling change management

### DIFF
--- a/web_src/src/pages/organization/settings/General.tsx
+++ b/web_src/src/pages/organization/settings/General.tsx
@@ -32,6 +32,7 @@ export function General({ organization }: GeneralProps) {
   );
 
   const updateOrganizationMutation = useUpdateOrganization(organizationId || "");
+  const updateChangeManagementMutation = useUpdateOrganization(organizationId || "");
   const deleteOrganizationMutation = useDeleteOrganization(organizationId || "");
   const canUpdateOrg = canAct("org", "update");
   const canDeleteOrg = canAct("org", "delete");
@@ -92,11 +93,13 @@ export function General({ organization }: GeneralProps) {
     setChangeManagementMessage(null);
 
     try {
-      await updateOrganizationMutation.mutateAsync({
+      await updateChangeManagementMutation.mutateAsync({
         changeManagementEnabled: enabled,
       });
-      setChangeManagementMessage(`Change management ${enabled ? "enabled" : "disabled"}`);
-      setTimeout(() => setChangeManagementMessage(null), 3000);
+      if (enabled) {
+        setChangeManagementMessage("Change management enabled");
+        setTimeout(() => setChangeManagementMessage(null), 3000);
+      }
     } catch {
       setChangeManagementEnabled(previous);
       setChangeManagementMessage("Failed to update change management");
@@ -180,7 +183,7 @@ export function General({ organization }: GeneralProps) {
                   id="organization-change-management-switch"
                   checked={changeManagementEnabled}
                   onCheckedChange={handleChangeManagementToggle}
-                  disabled={updateOrganizationMutation.isPending || !canUpdateOrg}
+                  disabled={updateChangeManagementMutation.isPending || !canUpdateOrg}
                   aria-label="Toggle change management"
                 />
               </div>

--- a/web_src/src/pages/organization/settings/index.tsx
+++ b/web_src/src/pages/organization/settings/index.tsx
@@ -435,7 +435,7 @@ export function OrganizationSettings() {
         </SidebarBody>
       </Sidebar>
 
-      <div className="flex-1 overflow-auto bg-slate-100 dark:bg-slate-900">
+      <div className="flex-1 overflow-auto bg-slate-100 dark:bg-slate-900 [scrollbar-gutter:stable]">
         <div className={cn("mx-auto w-full px-8 pb-8", isIntegrationSetupRoute ? "max-w-6xl" : "max-w-3xl")}>
           <div className="pt-10 pb-8">
             <h1 className="!text-2xl font-medium text-gray-900 dark:text-white">{activeMeta.title}</h1>


### PR DESCRIPTION
## Summary

Closes #4766
Fixing a few small UX issues on **Organization → Settings → General** when interacting with the Change Management switch:

- **Save Changes button no longer flashes "Saving..." on toggle.** The Organization Name "Save Changes" button and the Change Management toggle were sharing the same `useUpdateOrganization` mutation instance, so flipping the switch flipped the unrelated button's `isPending`. The toggle now uses its own `updateChangeManagementMutation` instance.
- **No more horizontal jitter of the centered column on toggle.** Showing/hiding the confirmation message (and other small height changes) crossed the scroll-overflow threshold and made the vertical scrollbar appear/disappear, which shifted the centered `max-w-3xl` content. Added `[scrollbar-gutter:stable]` to the org settings scroll container so the gutter is always reserved.
- **Confirmation toast only on enable.** Previously turning the switch off briefly hid then re-showed the green message before clearing it. We now only show the green "Change management enabled" message when enabling. Failure toasts still appear in both directions and the switch reverts on error.

Files touched:

- `web_src/src/pages/organization/settings/General.tsx`
- `web_src/src/pages/organization/settings/index.tsx`

## Test plan

- [ ] On `/{org}/settings/general`, toggle Change Management on and off several times; the top "Save Changes" button never enters "Saving..." mode.
- [ ] The centered settings column does not shake left/right while toggling.
- [ ] The green "Change management enabled" message appears only when enabling, and toggling off does not show any confirmation message.
- [ ] Force a failure (eg. block the network) and confirm the red "Failed to update change management" message still appears and the switch reverts to its previous state.
- [ ] `make format.js`, `make check.build.ui`, and `npm run lint:budget` are all clean.