### PR TITLE
fix: fixed navbar logo redirection from change organisation page 

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -1,7 +1,8 @@
 import { TooltipProvider } from "@/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import React from "react";
-import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
+import React, { useEffect } from "react";
+import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router-dom";
+import { setCurrentOrgIdToSessionStorage } from "@/lib/currentOrgIdFromSessionStorage";
 import { Toaster } from "sonner";
 import "./App.css";
 
@@ -119,6 +120,14 @@ function AppRouter() {
 }
 
 function OrganizationScope() {
+  const { organizationId } = useParams<{ organizationId: string }>();
+
+  useEffect(() => {
+    if (organizationId) {
+      setCurrentOrgIdToSessionStorage(organizationId);
+    }
+  }, [organizationId]);
+
   return (
     <PermissionsProvider>
       <Outlet />

--- a/web_src/src/components/OrganizationMenuButton.tsx
+++ b/web_src/src/components/OrganizationMenuButton.tsx
@@ -1,5 +1,9 @@
 import SuperplaneLogo from "@/assets/superplane.svg";
 import { useAccount } from "@/contexts/AccountContext";
+import {
+  clearCurrentOrgIdFromSessionStorage,
+  getCurrentOrgIdFromSessionStorage,
+} from "@/lib/currentOrgIdFromSessionStorage";
 import { useOrganization, useOrganizationUsage } from "@/hooks/useOrganizationData";
 import { isUsagePageForced } from "@/lib/env";
 import { cn } from "@/lib/utils";
@@ -30,6 +34,7 @@ interface OrganizationMenuButtonProps {
 }
 
 export function OrganizationMenuButton({ organizationId, className }: OrganizationMenuButtonProps) {
+  const logoOrganizationId = organizationId || getCurrentOrgIdFromSessionStorage() || undefined;
   const { account } = useAccount();
   const { data: organization } = useOrganization(organizationId || "");
   const { canAct, isLoading: permissionsLoading } = usePermissions();
@@ -152,6 +157,7 @@ export function OrganizationMenuButton({ organizationId, className }: Organizati
 
   const handleSignOut = () => {
     setIsMenuOpen(false);
+    clearCurrentOrgIdFromSessionStorage();
     posthog.reset();
     window.location.href = "/logout";
   };
@@ -278,7 +284,7 @@ export function OrganizationMenuButton({ organizationId, className }: Organizati
         )}
       </div>
       <Link
-        to={`/${organizationId}`}
+        to={logoOrganizationId ? `/${logoOrganizationId}` : "/"}
         aria-label="Go to canvases"
         className="flex h-8 cursor-pointer items-center rounded-md px-2 hover:bg-slate-100"
       >

--- a/web_src/src/lib/currentOrgIdFromSessionStorage.ts
+++ b/web_src/src/lib/currentOrgIdFromSessionStorage.ts
@@ -1,0 +1,36 @@
+
+const CURRENT_ORGANIZATION_ID_KEY = "superplane:currentOrganizationId";
+
+export function getCurrentOrgIdFromSessionStorage(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const value = window.sessionStorage.getItem(CURRENT_ORGANIZATION_ID_KEY);
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setCurrentOrgIdToSessionStorage(organizationId: string): void {
+  if (typeof window === "undefined" || !organizationId) {
+    return;
+  }
+  try {
+    window.sessionStorage.setItem(CURRENT_ORGANIZATION_ID_KEY, organizationId);
+  } catch {
+    // Ignore quota / private mode
+  }
+}
+
+export function clearCurrentOrgIdFromSessionStorage(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.sessionStorage.removeItem(CURRENT_ORGANIZATION_ID_KEY);
+  } catch {
+    // Ignore quota / private mode
+  }
+}

--- a/web_src/src/pages/auth/OrganizationSelect.tsx
+++ b/web_src/src/pages/auth/OrganizationSelect.tsx
@@ -1,5 +1,6 @@
 import { Heading } from "@/components/Heading/heading";
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
+import { setCurrentOrgIdToSessionStorage } from "@/lib/currentOrgIdFromSessionStorage";
 import { Palette, Plus, User } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -196,6 +197,7 @@ const OrganizationSelect: React.FC = () => {
               <li key={org.id}>
                 <Link
                   to={`/${org.id}`}
+                  onClick={() => setCurrentOrgIdToSessionStorage(org.id)}
                   className={cn(
                     "flex items-center justify-between gap-4 rounded-md bg-white dark:bg-gray-900 px-4 py-3 shadow-sm outline outline-slate-950/10 hover:outline-slate-950/20 hover:shadow-md transition-colors cursor-pointer",
                     listRowMinHeight,

--- a/web_src/src/pages/organization/settings/index.tsx
+++ b/web_src/src/pages/organization/settings/index.tsx
@@ -18,6 +18,7 @@ import { ServiceAccounts } from "./ServiceAccounts";
 import { ServiceAccountDetail } from "./ServiceAccountDetail";
 import { Usage } from "./Usage";
 import SuperplaneLogo from "@/assets/superplane.svg";
+import { clearCurrentOrgIdFromSessionStorage } from "@/lib/currentOrgIdFromSessionStorage";
 import { isUsagePageForced } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import {
@@ -203,7 +204,15 @@ export function OrganizationSettings() {
 
   const userLinks: NavLink[] = [
     { id: "profile", label: "Profile", href: `/${organizationId}/settings/profile`, Icon: CircleUser },
-    { id: "sign-out", label: "Sign Out", action: () => (window.location.href = "/logout"), Icon: LogOut },
+    {
+      id: "sign-out",
+      label: "Sign Out",
+      action: () => {
+        clearCurrentOrgIdFromSessionStorage();
+        window.location.href = "/logout";
+      },
+      Icon: LogOut,
+    },
   ];
 
   const isLinkActive = (link: NavLink) => {


### PR DESCRIPTION
Issue: https://github.com/superplanehq/superplane/issues/4771

**What changed:** 
Persist the active organization id in sessionStorage, use it for the header logo when the route has no org (e.g. when user is on Change Organisation page), and clear it on sign out.

**Why:** 
After clicking on “Change organization” from the settings menu, users land on "/" route without organizationId in the URL, so the logo targeted "/undefined". We also need a “back to last org” behavior which this PR implements

**How:** 
OrganizationScope (and org list clicks) call setCurrentOrgIdToSessionStorage; 
OrganizationMenuButton resolves the logo with organizationId || getCurrentOrgIdFromSessionStorage(); 
sign out calls clearCurrentOrgIdFromSessionStorage() before /logout.

**Related issues:** 
None

**Breaking changes:** 
None.