### PR TITLE
feat: Prevent directory traversal in diskFS.Open

### DIFF
--- a/pkg/web/assets/disk_assets.go
+++ b/pkg/web/assets/disk_assets.go
@@ -6,6 +6,9 @@ package assets
 import (
 	"io/fs"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -16,7 +19,18 @@ type diskFS struct {
 
 func (d diskFS) Open(name string) (fs.File, error) {
 	log.Infof("Opening asset %s/%s", d.root, name)
-	return os.Open(d.root + "/" + name)
+
+	clean := path.Clean("/" + name)
+	full := filepath.Join(d.root, clean)
+
+	rel, err := filepath.Rel(d.root, full)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return nil, fs.ErrPermission
+	}
+	return os.Open(full)
 }
 
 var EmbeddedAssets fs.FS = diskFS{root: "pkg/web/assets/dist"}


### PR DESCRIPTION
# fix: prevent directory traversal in diskFS.Open

## What changed

diskFS.Open previously concatenated `d.root + "/" + name` without validating input, allowing directory traversal via `../` sequences. This change adds path normalization and enforces that resolved paths remain within the configured root directory.

## Why

Even though http.FS performs some path cleaning, fs.FS implementations must be safe on their own. diskFS can be used directly or in future non-HTTP contexts, so relying on caller sanitization is unsafe.

## How

- Normalize input with path.Clean
- Force relative paths by stripping leading "/"
- Join paths using filepath.Join
- Validate containment using filepath.Rel
- Reject any path that escapes d.root

## Before

​```go
return os.Open(d.root + "/" + name)
​```

## After

```
func (d diskFS) Open(name string) (fs.File, error) {
	clean := path.Clean("/" + name)
	clean = strings.TrimPrefix(clean, "/")

	full := filepath.Join(d.root, clean)

	rel, err := filepath.Rel(d.root, full)
	if err != nil {
		return nil, err
	}

	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
		return nil, fs.ErrPermission
	}

	return os.Open(full)
}
```

## Notes

This makes diskFS safe as a standalone fs.FS implementation, independent of http.FS behavior.