### PR TITLE
fix: gate managed agent APIs by experimental feature

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	pbActions "github.com/superplanehq/superplane/pkg/protos/actions"
@@ -41,10 +42,11 @@ const DomainIdContextKey contextKey = "domainId"
 type ResourceResolver func(req any) []string
 
 type AuthorizationRule struct {
-	Resource         string
-	Action           string
-	DomainType       string
-	ResourceResolver ResourceResolver
+	Resource                     string
+	Action                       string
+	DomainType                   string
+	ResourceResolver             ResourceResolver
+	RequiredExperimentalFeatures []string
 }
 
 type AuthorizationInterceptor struct {
@@ -152,9 +154,24 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		pbIntegrations.Integrations_ListIntegrations_FullMethodName: {Resource: "org", Action: "read", DomainType: models.DomainTypeOrganization},
 
 		// Agent rules
-		pbAgents.Agents_GetCanvasAgentChat_FullMethodName:    {Resource: "agents", Action: "create", DomainType: models.DomainTypeOrganization},
-		pbAgents.Agents_SendAgentChatMessage_FullMethodName:  {Resource: "agents", Action: "create", DomainType: models.DomainTypeOrganization},
-		pbAgents.Agents_ListAgentChatMessages_FullMethodName: {Resource: "agents", Action: "read", DomainType: models.DomainTypeOrganization},
+		pbAgents.Agents_GetCanvasAgentChat_FullMethodName: {
+			Resource:                     "agents",
+			Action:                       "create",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+		},
+		pbAgents.Agents_SendAgentChatMessage_FullMethodName: {
+			Resource:                     "agents",
+			Action:                       "create",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+		},
+		pbAgents.Agents_ListAgentChatMessages_FullMethodName: {
+			Resource:                     "agents",
+			Action:                       "read",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+		},
 
 		// Canvases rules
 		pbCanvases.Canvases_ListCanvases_FullMethodName: {Resource: "canvases", Action: "read", DomainType: models.DomainTypeOrganization},
@@ -451,11 +468,31 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 
+		if err := checkRequiredExperimentalFeatures(org, rule); err != nil {
+			log.Warnf(
+				"User %s tried to access %s:%s in organization %s without required experimental feature",
+				userID,
+				rule.Resource,
+				rule.Action,
+				org.ID.String(),
+			)
+			return nil, err
+		}
+
 		newContext := context.WithValue(ctx, OrganizationContextKey, organizationID)
 		newContext = context.WithValue(newContext, DomainTypeContextKey, models.DomainTypeOrganization)
 		newContext = context.WithValue(newContext, DomainIdContextKey, organizationID)
 		return handler(newContext, req)
 	}
+}
+
+func checkRequiredExperimentalFeatures(org *models.Organization, rule AuthorizationRule) error {
+	for _, featureID := range rule.RequiredExperimentalFeatures {
+		if !org.HasExperimentalFeature(featureID) {
+			return status.Error(codes.PermissionDenied, "required experimental feature is not enabled")
+		}
+	}
+	return nil
 }
 
 func hasRequiredScopedTokenPermission(ctx context.Context, req any, rule AuthorizationRule) bool {

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -7,9 +7,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/models"
+	pbAgents "github.com/superplanehq/superplane/pkg/protos/agents"
 	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"gorm.io/datatypes"
 )
 
 func TestDefaultResourceResolver(t *testing.T) {
@@ -195,6 +200,36 @@ func TestMetadataScopedTokenPermissions(t *testing.T) {
 		assert.Equal(t, "read", permissions[0].Action)
 		assert.Equal(t, []string{"canvas-123"}, permissions[0].Resources)
 	})
+}
+
+func TestAgentRoutesRequireManagedAgentsFeature(t *testing.T) {
+	interceptor := NewAuthorizationInterceptor(nil)
+	routes := []string{
+		pbAgents.Agents_GetCanvasAgentChat_FullMethodName,
+		pbAgents.Agents_SendAgentChatMessage_FullMethodName,
+		pbAgents.Agents_ListAgentChatMessages_FullMethodName,
+	}
+
+	for _, route := range routes {
+		rule, ok := interceptor.rules[route]
+		require.True(t, ok)
+		assert.Equal(t, []string{features.FeatureClaudeManagedAgents}, rule.RequiredExperimentalFeatures)
+	}
+}
+
+func TestCheckRequiredExperimentalFeatures(t *testing.T) {
+	rule := AuthorizationRule{
+		RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+	}
+
+	err := checkRequiredExperimentalFeatures(&models.Organization{}, rule)
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	err = checkRequiredExperimentalFeatures(&models.Organization{
+		EnabledExperimentalFeatures: datatypes.JSONSlice[string]{features.FeatureClaudeManagedAgents},
+	}, rule)
+	require.NoError(t, err)
 }
 
 func marshalScopes(t *testing.T, scopes []string) string {

--- a/pkg/public/agent_session_ws.go
+++ b/pkg/public/agent_session_ws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/public/middleware"
 	"github.com/superplanehq/superplane/pkg/workers/eventdistributer"
@@ -24,6 +25,16 @@ func (s *Server) handleAgentSessionWebSocket(w http.ResponseWriter, r *http.Requ
 	sessionID, err := uuid.Parse(mux.Vars(r)["sessionId"])
 	if err != nil {
 		http.Error(w, "invalid session id", http.StatusBadRequest)
+		return
+	}
+
+	enabled, err := models.HasExperimentalFeature(user.OrganizationID, features.FeatureClaudeManagedAgents)
+	if err != nil {
+		http.Error(w, "failed to load organization", http.StatusInternalServerError)
+		return
+	}
+	if !enabled {
+		http.Error(w, "agent chat is not enabled", http.StatusForbidden)
 		return
 	}
 

--- a/pkg/public/agent_session_ws_test.go
+++ b/pkg/public/agent_session_ws_test.go
@@ -1,0 +1,36 @@
+package public
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestAgentSessionWebSocketRequiresManagedAgentsFeature(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	server, _, token := setupTestServer(r, t)
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := &models.AgentSession{
+		OrganizationID:    r.Organization.ID,
+		UserID:            r.User,
+		CanvasID:          canvas.ID,
+		Provider:          "anthropic",
+		ProviderSessionID: "provider-session",
+		Status:            models.AgentSessionStatusIdle,
+	}
+	require.NoError(t, models.CreateAgentSessionInTransaction(database.Conn(), session))
+
+	response := execRequest(server, requestParams{
+		method:     http.MethodGet,
+		path:       "/ws/agents/sessions/" + session.ID.String() + "?organization_id=" + r.Organization.ID.String(),
+		authCookie: token,
+	})
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+}


### PR DESCRIPTION
Description:

Adds `RequiredExperimentalFeatures` to authorization route rules and uses it to require `claude_managed_agents` for managed agent APIs. Also blocks the agent session websocket when the org does not have the feature enabled.