### PR TITLE
feat: add jira incident action components

### DIFF
--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -13,6 +13,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Delete Issue" href="#delete-issue" description="Delete a Jira issue" />
   <LinkCard title="Get Issue" href="#get-issue" description="Retrieve a Jira issue by its key" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update fields on a Jira issue" />
+  <LinkCard title="Delete Incident" href="#delete-incident" description="Delete a Jira Service Management incident by issue id or issue key" />
+  <LinkCard title="Get Incident" href="#get-incident" description="Fetch a Jira Service Management incident by issue id or issue key" />
 </CardGrid>
 
 ## Instructions
@@ -24,6 +26,129 @@ To connect Jira to SuperPlane:
 3. Paste your **Jira Site URL** into SuperPlane. For Jira Cloud, this usually looks like `https://your-domain.atlassian.net`.
 4. Paste the Atlassian account **Email** that owns the API token.
 5. Paste the generated **API Token**.
+
+<a id="create-incident"></a>
+
+## Create Incident
+
+The Create Incident component opens a new incident in Jira Service Management using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+### Use Cases
+
+- **Alert-driven incidents**: Create an incident from a monitoring or ticketing workflow
+- **Cross-tool orchestration**: Open a JSM incident when another system reports an outage
+- **Responder assignment**: Pass responders and other fields supported by your service desk
+
+### Configuration
+
+- **Service desk**: Choose a Jira Service Management service desk (from your site via the JSM API)
+- **Request type**: Choose a request type on that service desk (lists after a service desk is selected)
+- **Summary** (required): Short title for the incident; sent as the Jira **summary** field (Jira requires this). You can set this directly, or supply summary only via **Additional fields**.
+- **Description** (optional): Plain text stored as Jira description (Atlassian Document Format).
+- **Due date** (optional): Jira **duedate** (use your site date format, typically YYYY-MM-DD).
+- **Priority** (optional): Jira priority **name** (for example Medium).
+- **Impact** (optional): Impact level from your Jira request type (options load after service desk and request type are selected).
+- **Urgency** (optional): Urgency level from your Jira request type (options load after service desk and request type are selected).
+- **Original estimate** (optional): Jira **timetracking.originalEstimate** (for example 2h, 1d).
+- **Custom fields** (optional): List of Jira field ids with JSON values—for affected services, pending reason, or any customfield_*; the value must be valid JSON (object or string) as Jira expects for that field type.
+- **Additional fields** (optional): JSON object merged into the API **fields** map (same pattern as other integrations such as Honeycomb **Fields JSON**).
+- **Update** (optional): JSON object for the Incidents API **update** property.
+- **Alert IDs** (optional): List of alert id strings to associate with the incident.
+
+### Output
+
+Returns **id** (numeric issue id), **key** (e.g. ITSM-30), and **self** (issue REST URL) from the create response.
+
+### Notes
+
+- Requires a Jira Cloud site with Jira Service Management and a synced SuperPlane Jira integration (cloud id is resolved automatically).
+- **Request types** must belong to Jira's **Incident management** work category; other request types (for example service requests) are hidden from the picker when Jira returns a practice field on request types. If your site uses an unrecognized practice value, contact support with a sample from GET /rest/servicedeskapi/servicedesk/&lbrace;serviceDeskId&rbrace;/requesttype/&lbrace;requestTypeId&rbrace; with expand=practice.
+- Field ids such as responders are site-specific; use **Custom fields** or **Additional fields** with values that match your JSM configuration.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "id": "10050",
+    "key": "ITSM-30",
+    "self": "https://your-domain.atlassian.net/rest/api/3/issue/10050"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.incident.created"
+}
+```
+
+
+<a id="delete-incident"></a>
+
+## Delete Incident
+
+The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+### Use Cases
+
+- **Automated cleanup**: Remove incidents created during tests or erroneous automation
+- **Lifecycle workflows**: Delete when a duplicate or mistaken incident is closed upstream
+
+### Configuration
+
+- **Project** (optional): Narrows the issue picker to one Jira project (up to 500 most recently updated issues in that project).
+- **Issue**: The incident issue to delete (issue key from Jira search).
+
+### Output
+
+Confirms deletion with **deleted** set to true.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "deleted": true
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.incident.deleted"
+}
+```
+
+
+<a id="get-incident"></a>
+
+## Get Incident
+
+The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+### Use Cases
+
+- **Enrichment**: Load incident DTO after an issue webhook or workflow step
+- **Status checks**: Read priority, status, responders, and affected services from JSM
+
+### Configuration
+
+- **Project** (optional): When set, the issue picker lists issues in that project (by project key), paged from Jira search (up to 500, most recently updated first). Leave empty to list issues updated in roughly the last 90 days across projects you can access (same cap and ordering).
+- **Issue**: Choose an issue by key (from Jira search). The stored value is the issue key; numeric ids still work when they are saved as the issue reference.
+
+### Output
+
+Payload type jira.incident.fetched with the incident object returned by Atlassian (summary, reporter, priority, status, responders, etc.).
+
+### Example Output
+
+```json
+{
+  "data": {
+    "priority": {
+      "id": "1",
+      "name": "High"
+    },
+    "summary": "Example incident"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.incident.fetched"
+}
+```
+
 
 <a id="create-issue"></a>
 

--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -9,12 +9,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Actions
 
 <CardGrid>
+  <LinkCard title="Create Incident" href="#create-incident" description="Create a Jira Service Management incident via the Incidents API" />
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in Jira" />
+  <LinkCard title="Delete Incident" href="#delete-incident" description="Delete a Jira Service Management incident by issue id or issue key" />
   <LinkCard title="Delete Issue" href="#delete-issue" description="Delete a Jira issue" />
+  <LinkCard title="Get Incident" href="#get-incident" description="Fetch a Jira Service Management incident by issue id or issue key" />
   <LinkCard title="Get Issue" href="#get-issue" description="Retrieve a Jira issue by its key" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update fields on a Jira issue" />
-  <LinkCard title="Delete Incident" href="#delete-incident" description="Delete a Jira Service Management incident by issue id or issue key" />
-  <LinkCard title="Get Incident" href="#get-incident" description="Fetch a Jira Service Management incident by issue id or issue key" />
 </CardGrid>
 
 ## Instructions
@@ -78,77 +79,6 @@ Returns **id** (numeric issue id), **key** (e.g. ITSM-30), and **self** (issue R
   "type": "jira.incident.created"
 }
 ```
-
-
-<a id="delete-incident"></a>
-
-## Delete Incident
-
-The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
-
-### Use Cases
-
-- **Automated cleanup**: Remove incidents created during tests or erroneous automation
-- **Lifecycle workflows**: Delete when a duplicate or mistaken incident is closed upstream
-
-### Configuration
-
-- **Project** (optional): Narrows the issue picker to one Jira project (up to 500 most recently updated issues in that project).
-- **Issue**: The incident issue to delete (issue key from Jira search).
-
-### Output
-
-Confirms deletion with **deleted** set to true.
-
-### Example Output
-
-```json
-{
-  "data": {
-    "deleted": true
-  },
-  "timestamp": "2026-01-19T12:00:00Z",
-  "type": "jira.incident.deleted"
-}
-```
-
-
-<a id="get-incident"></a>
-
-## Get Incident
-
-The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
-
-### Use Cases
-
-- **Enrichment**: Load incident DTO after an issue webhook or workflow step
-- **Status checks**: Read priority, status, responders, and affected services from JSM
-
-### Configuration
-
-- **Project** (optional): When set, the issue picker lists issues in that project (by project key), paged from Jira search (up to 500, most recently updated first). Leave empty to list issues updated in roughly the last 90 days across projects you can access (same cap and ordering).
-- **Issue**: Choose an issue by key (from Jira search). The stored value is the issue key; numeric ids still work when they are saved as the issue reference.
-
-### Output
-
-Payload type jira.incident.fetched with the incident object returned by Atlassian (summary, reporter, priority, status, responders, etc.).
-
-### Example Output
-
-```json
-{
-  "data": {
-    "priority": {
-      "id": "1",
-      "name": "High"
-    },
-    "summary": "Example incident"
-  },
-  "timestamp": "2026-01-19T12:00:00Z",
-  "type": "jira.incident.fetched"
-}
-```
-
 
 <a id="create-issue"></a>
 
@@ -229,6 +159,38 @@ Returns the created issue including:
 }
 ```
 
+<a id="delete-incident"></a>
+
+## Delete Incident
+
+The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+### Use Cases
+
+- **Automated cleanup**: Remove incidents created during tests or erroneous automation
+- **Lifecycle workflows**: Delete when a duplicate or mistaken incident is closed upstream
+
+### Configuration
+
+- **Project** (optional): Narrows the issue picker to one Jira project (up to 500 most recently updated issues in that project).
+- **Issue**: The incident issue to delete (issue key from Jira search).
+
+### Output
+
+Confirms deletion with **deleted** set to true.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "deleted": true
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.incident.deleted"
+}
+```
+
 <a id="delete-issue"></a>
 
 ## Delete Issue
@@ -261,6 +223,42 @@ Returns the deleted issue's `id` and `key`, plus `deleted: true`.
   },
   "timestamp": "2026-01-19T13:00:00Z",
   "type": "jira.issueDeleted"
+}
+```
+
+<a id="get-incident"></a>
+
+## Get Incident
+
+The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+### Use Cases
+
+- **Enrichment**: Load incident DTO after an issue webhook or workflow step
+- **Status checks**: Read priority, status, responders, and affected services from JSM
+
+### Configuration
+
+- **Project** (optional): When set, the issue picker lists issues in that project (by project key), paged from Jira search (up to 500, most recently updated first). Leave empty to list issues updated in roughly the last 90 days across projects you can access (same cap and ordering).
+- **Issue**: Choose an issue by key (from Jira search). The stored value is the issue key; numeric ids still work when they are saved as the issue reference.
+
+### Output
+
+Payload type jira.incident.fetched with the incident object returned by Atlassian (summary, reporter, priority, status, responders, etc.).
+
+### Example Output
+
+```json
+{
+  "data": {
+    "priority": {
+      "id": "1",
+      "name": "High"
+    },
+    "summary": "Example incident"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.incident.fetched"
 }
 ```
 

--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -32,7 +32,7 @@ To connect Jira to SuperPlane:
 
 ## Create Incident
 
-The Create Incident component opens a new incident in Jira Service Management using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+The Create Incident component opens a new incident in Jira Service Management.
 
 ### Use Cases
 
@@ -163,7 +163,7 @@ Returns the created issue including:
 
 ## Delete Incident
 
-The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+The Delete Incident component removes an incident from Jira Service Management.
 
 ### Use Cases
 
@@ -230,7 +230,7 @@ Returns the deleted issue's `id` and `key`, plus `deleted: true`.
 
 ## Get Incident
 
-The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+The Get Incident component returns incident details from Jira Service Management.
 
 ### Use Cases
 

--- a/pkg/integrations/jira/client.go
+++ b/pkg/integrations/jira/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/superplanehq/superplane/pkg/core"
@@ -465,4 +466,986 @@ func (c *Client) DeleteIssue(issueKey string, opts DeleteIssueOptions) error {
 		return err
 	}
 	return nil
+}
+
+// IssueSearchHit is one element from GET /rest/api/3/search.
+type IssueSearchHit struct {
+	ID     string         `json:"id"`
+	Key    string         `json:"key"`
+	Fields map[string]any `json:"fields"`
+}
+
+type issueSearchAPIResponse struct {
+	StartAt    int              `json:"startAt"`
+	MaxResults int              `json:"maxResults"`
+	Total      int              `json:"total"`
+	Issues     []IssueSearchHit `json:"issues"`
+}
+
+type jiraSearchPOSTBody struct {
+	JQL        string   `json:"jql"`
+	StartAt    int      `json:"startAt"`
+	MaxResults int      `json:"maxResults"`
+	Fields     []string `json:"fields"`
+}
+
+func (c *Client) searchIssuesPage(jql string, startAt, maxResults int) (issueSearchAPIResponse, error) {
+	var empty issueSearchAPIResponse
+	if maxResults <= 0 {
+		maxResults = 50
+	}
+	if maxResults > 100 {
+		maxResults = 100
+	}
+
+	body := jiraSearchPOSTBody{
+		JQL:        jql,
+		StartAt:    startAt,
+		MaxResults: maxResults,
+		Fields:     []string{"summary"},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return empty, fmt.Errorf("marshal search body: %w", err)
+	}
+
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	u := fmt.Sprintf("%s/rest/api/3/search", base)
+	responseBody, err := c.execRequest(http.MethodPost, u, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return empty, err
+	}
+
+	var resp issueSearchAPIResponse
+	if err := json.Unmarshal(responseBody, &resp); err != nil {
+		return empty, fmt.Errorf("parse search response: %w", err)
+	}
+	if resp.Issues == nil {
+		resp.Issues = []IssueSearchHit{}
+	}
+
+	return resp, nil
+}
+
+// SearchIssues runs a JQL search and returns the first page of issues (maxResults is capped at 100).
+func (c *Client) SearchIssues(jql string, maxResults int) ([]IssueSearchHit, error) {
+	resp, err := c.searchIssuesPage(jql, 0, maxResults)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Issues, nil
+}
+
+// SearchIssuesUpTo pages through POST /rest/api/3/search until maxIssues are collected, a page is
+// short, or Jira reports no further results. Jira caps each request at 100 issues; busy service
+// projects often need more than one page so incident pickers are not dominated by recently
+// updated non-incident work.
+func (c *Client) SearchIssuesUpTo(jql string, maxIssues int) ([]IssueSearchHit, error) {
+	if maxIssues <= 0 {
+		maxIssues = 500
+	}
+	const pageCap = 100
+
+	var out []IssueSearchHit
+	startAt := 0
+	for len(out) < maxIssues {
+		pageMax := pageCap
+		if remain := maxIssues - len(out); remain < pageMax {
+			pageMax = remain
+		}
+		if pageMax <= 0 {
+			break
+		}
+
+		resp, err := c.searchIssuesPage(jql, startAt, pageMax)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, resp.Issues...)
+		if len(resp.Issues) == 0 {
+			break
+		}
+		startAt += len(resp.Issues)
+		if len(resp.Issues) < pageMax {
+			break
+		}
+		if resp.Total > 0 && startAt >= resp.Total {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+// CustomerRequestListed is one row from GET /rest/servicedeskapi/request (Jira Service Management).
+type CustomerRequestListed struct {
+	IssueKey string `json:"issueKey"`
+	Summary  string `json:"summary"`
+}
+
+type pagedCustomerRequests struct {
+	Values     []CustomerRequestListed `json:"values"`
+	IsLastPage bool                    `json:"isLastPage"`
+}
+
+// ListCustomerRequestsByServiceDesk pages through customer requests for a service desk.
+// Agents often see JSM work here even when Jira platform issue search returns no rows for the same project.
+func (c *Client) ListCustomerRequestsByServiceDesk(serviceDeskID string, maxTotal int) ([]CustomerRequestListed, error) {
+	serviceDeskID = strings.TrimSpace(serviceDeskID)
+	if serviceDeskID == "" {
+		return nil, fmt.Errorf("service desk id is required")
+	}
+	if maxTotal <= 0 {
+		maxTotal = 500
+	}
+
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	const limit = 100
+	var out []CustomerRequestListed
+	start := 0
+	for len(out) < maxTotal {
+		q := url.Values{}
+		q.Set("serviceDeskId", serviceDeskID)
+		q.Set("start", strconv.Itoa(start))
+		q.Set("limit", strconv.Itoa(limit))
+
+		u := fmt.Sprintf("%s/rest/servicedeskapi/request?%s", base, q.Encode())
+		responseBody, err := c.execRequest(http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page pagedCustomerRequests
+		if err := json.Unmarshal(responseBody, &page); err != nil {
+			return nil, fmt.Errorf("parse customer requests: %w", err)
+		}
+		if page.Values == nil {
+			page.Values = []CustomerRequestListed{}
+		}
+
+		for _, row := range page.Values {
+			out = append(out, row)
+			if len(out) >= maxTotal {
+				break
+			}
+		}
+		if len(out) >= maxTotal {
+			break
+		}
+		if page.IsLastPage || len(page.Values) == 0 {
+			break
+		}
+		start += len(page.Values)
+	}
+
+	return out, nil
+}
+
+func jqlQuotedProjectKey(projectKey string) string {
+	escaped := strings.ReplaceAll(projectKey, `\`, `\\`)
+	return strings.ReplaceAll(escaped, `"`, `\"`)
+}
+
+const atlassianIncidentAPIHost = "https://api.atlassian.com"
+
+type tenantInfoResponse struct {
+	CloudID string `json:"cloudId"`
+}
+
+// FetchCloudID returns the Atlassian cloud id for the configured Jira site (required for the JSM Incidents API).
+func (c *Client) FetchCloudID() (string, error) {
+	tenantURL := strings.TrimSuffix(c.SiteURL, "/") + "/_edge/tenant_info"
+	responseBody, err := c.execRequest(http.MethodGet, tenantURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetch tenant_info: %w", err)
+	}
+
+	var info tenantInfoResponse
+	if err := json.Unmarshal(responseBody, &info); err != nil {
+		return "", fmt.Errorf("parse tenant_info: %w", err)
+	}
+	if info.CloudID == "" {
+		return "", fmt.Errorf("tenant_info response missing cloudId")
+	}
+	return info.CloudID, nil
+}
+
+// ServiceDesk is returned by GET /rest/servicedeskapi/servicedesk (Jira Service Management).
+type ServiceDesk struct {
+	ID          string `json:"id"`
+	ProjectName string `json:"projectName"`
+	ProjectKey  string `json:"projectKey"`
+}
+
+// RequestType is returned by GET /rest/servicedeskapi/servicedesk/{id}/requesttype (use expand=practice for the practice field).
+type RequestType struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Practice string `json:"practice,omitempty"`
+}
+
+type pagedServiceDesks struct {
+	Values     []ServiceDesk `json:"values"`
+	IsLastPage bool          `json:"isLastPage"`
+}
+
+// ListServiceDesks returns service desks the authenticated user can access.
+func (c *Client) ListServiceDesks() ([]ServiceDesk, error) {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	var out []ServiceDesk
+	start := 0
+	const pageSize = 50
+	for range 20 {
+		u := fmt.Sprintf("%s/rest/servicedeskapi/servicedesk?start=%d&limit=%d", base, start, pageSize)
+		responseBody, err := c.execRequest(http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page pagedServiceDesks
+		if err := json.Unmarshal(responseBody, &page); err != nil {
+			return nil, fmt.Errorf("parse service desks: %w", err)
+		}
+
+		out = append(out, page.Values...)
+		if page.IsLastPage || len(page.Values) == 0 {
+			break
+		}
+		start += len(page.Values)
+	}
+
+	return out, nil
+}
+
+type pagedRequestTypes struct {
+	Values     []RequestType `json:"values"`
+	IsLastPage bool          `json:"isLastPage"`
+}
+
+// ListRequestTypes returns customer request types for a service desk.
+func (c *Client) ListRequestTypes(serviceDeskID string) ([]RequestType, error) {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	var out []RequestType
+	start := 0
+	const pageSize = 50
+	for range 20 {
+		q := url.Values{}
+		q.Set("start", strconv.Itoa(start))
+		q.Set("limit", strconv.Itoa(pageSize))
+		q.Add("expand", "practice")
+		u := fmt.Sprintf(
+			"%s/rest/servicedeskapi/servicedesk/%s/requesttype?%s",
+			base,
+			url.PathEscape(serviceDeskID),
+			q.Encode(),
+		)
+		responseBody, err := c.execRequest(http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var page pagedRequestTypes
+		if err := json.Unmarshal(responseBody, &page); err != nil {
+			return nil, fmt.Errorf("parse request types: %w", err)
+		}
+
+		out = append(out, page.Values...)
+		if page.IsLastPage || len(page.Values) == 0 {
+			break
+		}
+		start += len(page.Values)
+	}
+
+	return filterRequestTypesForIncidentsAPI(out), nil
+}
+
+// IsIncidentManagementRequestPractice reports whether a JSM request type's `practice` field
+// corresponds to the Incident management work category. The JSM Incidents REST API rejects
+// create calls when the request type is not in that category.
+func IsIncidentManagementRequestPractice(practice string) bool {
+	p := strings.TrimSpace(practice)
+	if p == "" {
+		return false
+	}
+
+	low := strings.ToLower(p)
+	if strings.Contains(low, "post-incident") || strings.Contains(low, "post incident") {
+		return false
+	}
+	if strings.Contains(low, "incident management") {
+		return true
+	}
+
+	u := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(p, "-", "_"), " ", "_"), ".", "_"))
+	switch u {
+	case "ITSM_INCIDENT", "INCIDENT_MANAGEMENT", "INCIDENT", "MANAGE_INCIDENTS", "IM":
+		return true
+	}
+	if strings.Contains(u, "INCIDENT_MANAGEMENT") {
+		return true
+	}
+	if u == "INCIDENT" || strings.HasSuffix(u, "_INCIDENT") {
+		return true
+	}
+	if strings.Contains(u, "INCIDENT") && strings.Contains(u, "MANAGEMENT") {
+		return true
+	}
+	return false
+}
+
+func filterRequestTypesForIncidentsAPI(all []RequestType) []RequestType {
+	hasPractice := false
+	for _, rt := range all {
+		if strings.TrimSpace(rt.Practice) != "" {
+			hasPractice = true
+			break
+		}
+	}
+	if !hasPractice {
+		return all
+	}
+
+	out := make([]RequestType, 0, len(all))
+	for _, rt := range all {
+		p := strings.TrimSpace(rt.Practice)
+		if p == "" {
+			continue
+		}
+		if IsIncidentManagementRequestPractice(p) {
+			out = append(out, rt)
+		}
+	}
+	if len(out) == 0 {
+		return all
+	}
+	return out
+}
+
+// RequestTypeField is returned by GET .../requesttype/{id}/field.
+type RequestTypeField struct {
+	FieldID     string                  `json:"fieldId"`
+	Name        string                  `json:"name"`
+	Required    bool                    `json:"required"`
+	ValidValues []RequestTypeFieldValue `json:"validValues"`
+}
+
+// RequestTypeFieldValue is an allowed option on a request type field.
+type RequestTypeFieldValue struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+}
+
+type requestTypeFieldsResponse struct {
+	RequestTypeFields []RequestTypeField `json:"requestTypeFields"`
+}
+
+// ListRequestTypeFields returns fields for a service desk request type (including hidden fields).
+func (c *Client) ListRequestTypeFields(serviceDeskID, requestTypeID string) ([]RequestTypeField, error) {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	u := fmt.Sprintf(
+		"%s/rest/servicedeskapi/servicedesk/%s/requesttype/%s/field",
+		base,
+		url.PathEscape(serviceDeskID),
+		url.PathEscape(requestTypeID),
+	)
+	responseBody, err := c.execRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out requestTypeFieldsResponse
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse request type fields: %w", err)
+	}
+	return out.RequestTypeFields, nil
+}
+
+type customFieldOptionsPage struct {
+	Values     []customFieldOption `json:"values"`
+	IsLast     bool                `json:"isLast"`
+	StartAt    int                 `json:"startAt"`
+	MaxResults int                 `json:"maxResults"`
+}
+
+type customFieldOption struct {
+	ID       string `json:"id"`
+	Value    string `json:"value"`
+	Disabled bool   `json:"disabled,omitempty"`
+}
+
+type JiraFieldInfo struct {
+	ID     string         `json:"id"`
+	Name   string         `json:"name"`
+	Custom bool           `json:"custom"`
+	Schema map[string]any `json:"schema,omitempty"`
+}
+
+type customFieldContext struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	IsGlobalContext bool     `json:"isGlobalContext"`
+	ProjectIDs      []string `json:"projectIds,omitempty"`
+}
+
+type customFieldContextsPage struct {
+	Values     []customFieldContext `json:"values"`
+	IsLast     bool                 `json:"isLast"`
+	StartAt    int                  `json:"startAt"`
+	MaxResults int                  `json:"maxResults"`
+}
+
+type createMetaResponse struct {
+	Projects []createMetaProject `json:"projects"`
+}
+
+type createMetaProject struct {
+	IssueTypes []createMetaIssueType `json:"issuetypes"`
+}
+
+type createMetaIssueType struct {
+	ID     string                     `json:"id"`
+	Name   string                     `json:"name"`
+	Fields map[string]createMetaField `json:"fields"`
+}
+
+type createMetaField struct {
+	Name          string                   `json:"name"`
+	AllowedValues []createMetaAllowedValue `json:"allowedValues"`
+}
+
+type createMetaAllowedValue struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type createMetaIssueTypesOnlyResponse struct {
+	IssueTypes []createMetaIssueTypeRef `json:"issueTypes"`
+}
+
+type createMetaIssueTypeRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type createMetaIssueTypeFieldsResponse struct {
+	Fields map[string]createMetaField `json:"fields"`
+}
+
+// ListCustomFieldOptions returns select options for a Jira field on Cloud using best-effort fallbacks.
+func (c *Client) ListCustomFieldOptions(fieldID, projectKey, fieldLabel string) []RequestTypeFieldValue {
+	fieldID = strings.TrimSpace(fieldID)
+	fieldLabel = strings.TrimSpace(fieldLabel)
+	projectKey = strings.TrimSpace(projectKey)
+
+	if projectKey != "" && fieldLabel != "" {
+		if opts, _ := c.listFieldAllowedValuesFromCreateMeta(projectKey, fieldLabel); len(opts) > 0 {
+			return opts
+		}
+	}
+
+	if fieldID != "" {
+		if opts := c.listCustomFieldOptionsDirect(fieldID); len(opts) > 0 {
+			return opts
+		}
+		if strings.HasPrefix(fieldID, "customfield_") {
+			if opts := c.listCustomFieldOptionsFromContexts(fieldID); len(opts) > 0 {
+				return opts
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) listCustomFieldOptionsDirect(fieldID string) []RequestTypeFieldValue {
+	if !strings.HasPrefix(fieldID, "customfield_") {
+		return nil
+	}
+
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	var out []RequestTypeFieldValue
+	startAt := 0
+	const pageSize = 100
+
+	for range 20 {
+		u := fmt.Sprintf(
+			"%s/rest/api/3/field/%s/option?startAt=%d&maxResults=%d",
+			base,
+			url.PathEscape(fieldID),
+			startAt,
+			pageSize,
+		)
+		body, status, err := c.execRequestWithStatus(http.MethodGet, u, nil)
+		if err != nil || status == http.StatusNotFound {
+			return out
+		}
+		if status < 200 || status >= 300 {
+			return out
+		}
+
+		var page customFieldOptionsPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return out
+		}
+
+		out = append(out, pageValuesToFieldOptions(page.Values)...)
+
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+
+	return out
+}
+
+func (c *Client) listCustomFieldOptionsFromContexts(fieldID string) []RequestTypeFieldValue {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	var contexts []customFieldContext
+	startAt := 0
+	const pageSize = 50
+
+	for range 20 {
+		u := fmt.Sprintf(
+			"%s/rest/api/3/field/%s/context?startAt=%d&maxResults=%d",
+			base,
+			url.PathEscape(fieldID),
+			startAt,
+			pageSize,
+		)
+		body, status, err := c.execRequestWithStatus(http.MethodGet, u, nil)
+		if err != nil || status == http.StatusNotFound {
+			return nil
+		}
+		if status < 200 || status >= 300 {
+			return nil
+		}
+
+		var page customFieldContextsPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil
+		}
+		contexts = append(contexts, page.Values...)
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+
+	ordered := orderFieldContexts(contexts, "")
+	for _, ctx := range ordered {
+		if opts := c.listCustomFieldOptionsForContext(fieldID, ctx.ID); len(opts) > 0 {
+			return opts
+		}
+	}
+	return nil
+}
+
+func orderFieldContexts(contexts []customFieldContext, projectID string) []customFieldContext {
+	if projectID == "" {
+		return contexts
+	}
+	var matched, global, rest []customFieldContext
+	for _, ctx := range contexts {
+		switch {
+		case contextIncludesProject(ctx, projectID):
+			matched = append(matched, ctx)
+		case ctx.IsGlobalContext:
+			global = append(global, ctx)
+		default:
+			rest = append(rest, ctx)
+		}
+	}
+	out := make([]customFieldContext, 0, len(contexts))
+	out = append(out, matched...)
+	out = append(out, global...)
+	out = append(out, rest...)
+	return out
+}
+
+func contextIncludesProject(ctx customFieldContext, projectID string) bool {
+	for _, id := range ctx.ProjectIDs {
+		if id == projectID {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) listCustomFieldOptionsForContext(fieldID, contextID string) []RequestTypeFieldValue {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	var out []RequestTypeFieldValue
+	startAt := 0
+	const pageSize = 100
+
+	for range 20 {
+		u := fmt.Sprintf(
+			"%s/rest/api/3/field/%s/context/%s/option?startAt=%d&maxResults=%d",
+			base,
+			url.PathEscape(fieldID),
+			url.PathEscape(contextID),
+			startAt,
+			pageSize,
+		)
+		body, status, err := c.execRequestWithStatus(http.MethodGet, u, nil)
+		if err != nil || status == http.StatusNotFound {
+			return out
+		}
+		if status < 200 || status >= 300 {
+			return out
+		}
+
+		var page customFieldOptionsPage
+		if err := json.Unmarshal(body, &page); err != nil {
+			return out
+		}
+
+		out = append(out, pageValuesToFieldOptions(page.Values)...)
+
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+
+	return out
+}
+
+func pageValuesToFieldOptions(values []customFieldOption) []RequestTypeFieldValue {
+	out := make([]RequestTypeFieldValue, 0, len(values))
+	for _, opt := range values {
+		if opt.Disabled {
+			continue
+		}
+		id := strings.TrimSpace(opt.ID)
+		label := strings.TrimSpace(opt.Value)
+		if id == "" && label == "" {
+			continue
+		}
+		if id == "" {
+			id = label
+		}
+		if label == "" {
+			label = id
+		}
+		out = append(out, RequestTypeFieldValue{Label: label, Value: id})
+	}
+	return out
+}
+
+// ListFields returns all fields visible to the integration (Jira REST API v3).
+func (c *Client) ListFields() ([]JiraFieldInfo, error) {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	body, err := c.execRequest(http.MethodGet, base+"/rest/api/3/field", nil)
+	if err != nil {
+		return nil, err
+	}
+	var fields []JiraFieldInfo
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, fmt.Errorf("parse fields: %w", err)
+	}
+	return fields, nil
+}
+
+// FindGlobalFieldByLabel finds a field id by display name (e.g. "Urgency").
+func FindGlobalFieldByLabel(fields []JiraFieldInfo, fieldLabel string) *JiraFieldInfo {
+	want := strings.ToLower(strings.TrimSpace(fieldLabel))
+	var contains []JiraFieldInfo
+
+	for i := range fields {
+		f := &fields[i]
+		nameLower := strings.ToLower(strings.TrimSpace(f.Name))
+		if nameLower == want {
+			return f
+		}
+		if strings.Contains(nameLower, want) {
+			contains = append(contains, *f)
+		}
+	}
+
+	if len(contains) == 0 {
+		return nil
+	}
+
+	best := &contains[0]
+	bestScore := globalFieldMatchScore(best.Name, want)
+	for i := 1; i < len(contains); i++ {
+		score := globalFieldMatchScore(contains[i].Name, want)
+		if score > bestScore {
+			bestScore = score
+			best = &contains[i]
+		}
+	}
+	return best
+}
+
+func globalFieldMatchScore(name, want string) int {
+	nameLower := strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case nameLower == want:
+		return 50
+	case strings.HasPrefix(nameLower, want+" "), strings.HasPrefix(nameLower, want+"-"):
+		return 40
+	case strings.HasPrefix(nameLower, want):
+		return 30
+	default:
+		return 10
+	}
+}
+
+func (c *Client) listFieldAllowedValuesFromCreateMeta(projectKey, fieldLabel string) ([]RequestTypeFieldValue, string) {
+	if opts, id := c.listFieldAllowedValuesFromCreateMetaModern(projectKey, fieldLabel); len(opts) > 0 {
+		return opts, id
+	}
+	return c.listFieldAllowedValuesFromCreateMetaLegacy(projectKey, fieldLabel)
+}
+
+func (c *Client) listFieldAllowedValuesFromCreateMetaModern(projectKey, fieldLabel string) ([]RequestTypeFieldValue, string) {
+	projectKey = strings.TrimSpace(projectKey)
+	if projectKey == "" {
+		return nil, ""
+	}
+
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	issueTypesURL := fmt.Sprintf("%s/rest/api/3/issue/createmeta/%s/issuetypes", base, url.PathEscape(projectKey))
+	body, status, err := c.execRequestWithStatus(http.MethodGet, issueTypesURL, nil)
+	if err != nil || status < 200 || status >= 300 {
+		return nil, ""
+	}
+
+	var issueTypesResp createMetaIssueTypesOnlyResponse
+	if err := json.Unmarshal(body, &issueTypesResp); err != nil {
+		return nil, ""
+	}
+
+	for _, issueType := range issueTypesResp.IssueTypes {
+		issueTypeID := strings.TrimSpace(issueType.ID)
+		if issueTypeID == "" {
+			continue
+		}
+		fieldsURL := fmt.Sprintf(
+			"%s/rest/api/3/issue/createmeta/%s/issuetypes/%s",
+			base,
+			url.PathEscape(projectKey),
+			url.PathEscape(issueTypeID),
+		)
+		fieldsBody, fieldsStatus, fieldsErr := c.execRequestWithStatus(http.MethodGet, fieldsURL, nil)
+		if fieldsErr != nil || fieldsStatus < 200 || fieldsStatus >= 300 {
+			continue
+		}
+		var fieldsResp createMetaIssueTypeFieldsResponse
+		if err := json.Unmarshal(fieldsBody, &fieldsResp); err != nil {
+			continue
+		}
+		if opts, fieldID := allowedValuesFromCreateMetaFields(fieldsResp.Fields, fieldLabel); len(opts) > 0 {
+			return opts, fieldID
+		}
+	}
+	return nil, ""
+}
+
+func (c *Client) listFieldAllowedValuesFromCreateMetaLegacy(projectKey, fieldLabel string) ([]RequestTypeFieldValue, string) {
+	projectKey = strings.TrimSpace(projectKey)
+	if projectKey == "" {
+		return nil, ""
+	}
+
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	q := url.Values{}
+	q.Set("projectKeys", projectKey)
+	q.Set("expand", "projects.issuetypes.fields")
+	u := fmt.Sprintf("%s/rest/api/3/issue/createmeta?%s", base, q.Encode())
+
+	body, status, err := c.execRequestWithStatus(http.MethodGet, u, nil)
+	if err != nil || status < 200 || status >= 300 {
+		return nil, ""
+	}
+
+	var meta createMetaResponse
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return nil, ""
+	}
+
+	for _, project := range meta.Projects {
+		for _, issueType := range project.IssueTypes {
+			if opts, fieldID := allowedValuesFromCreateMetaFields(issueType.Fields, fieldLabel); len(opts) > 0 {
+				return opts, fieldID
+			}
+		}
+	}
+	return nil, ""
+}
+
+func allowedValuesFromCreateMetaFields(fields map[string]createMetaField, fieldLabel string) ([]RequestTypeFieldValue, string) {
+	want := strings.ToLower(strings.TrimSpace(fieldLabel))
+	for fieldID, field := range fields {
+		nameLower := strings.ToLower(strings.TrimSpace(field.Name))
+		if fieldLabel != "" && nameLower != want && !strings.Contains(nameLower, want) {
+			continue
+		}
+		if len(field.AllowedValues) == 0 {
+			continue
+		}
+		out := make([]RequestTypeFieldValue, 0, len(field.AllowedValues))
+		for _, av := range field.AllowedValues {
+			id := strings.TrimSpace(av.ID)
+			label := strings.TrimSpace(av.Name)
+			if label == "" {
+				label = strings.TrimSpace(av.Value)
+			}
+			if id == "" && label == "" {
+				continue
+			}
+			if id == "" {
+				id = label
+			}
+			if label == "" {
+				label = id
+			}
+			out = append(out, RequestTypeFieldValue{Label: label, Value: id})
+		}
+		if len(out) > 0 {
+			return out, fieldID
+		}
+	}
+	return nil, ""
+}
+
+func (c *Client) execRequestWithStatus(method, requestURL string, body io.Reader) ([]byte, int, error) {
+	req, err := http.NewRequest(method, requestURL, body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error building request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", c.basicAuthHeader())
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error executing request: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, res.StatusCode, fmt.Errorf("error reading body: %v", err)
+	}
+
+	return responseBody, res.StatusCode, nil
+}
+
+// GetRequestType returns one request type, optionally expanded (always requests expand=practice).
+func (c *Client) GetRequestType(serviceDeskID, requestTypeID string) (*RequestType, error) {
+	base := strings.TrimSuffix(c.SiteURL, "/")
+	q := url.Values{}
+	q.Add("expand", "practice")
+	u := fmt.Sprintf(
+		"%s/rest/servicedeskapi/servicedesk/%s/requesttype/%s?%s",
+		base,
+		url.PathEscape(serviceDeskID),
+		url.PathEscape(requestTypeID),
+		q.Encode(),
+	)
+	responseBody, err := c.execRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	var rt RequestType
+	if err := json.Unmarshal(responseBody, &rt); err != nil {
+		return nil, fmt.Errorf("parse request type: %w", err)
+	}
+	return &rt, nil
+}
+
+// CreateIncidentAPIRequest is the JSON body for JSM Incidents POST /v1/incident.
+type CreateIncidentAPIRequest struct {
+	ServiceDeskID string         `json:"serviceDeskId"`
+	RequestTypeID string         `json:"requestTypeId"`
+	Fields        map[string]any `json:"fields"`
+	Update        map[string]any `json:"update,omitempty"`
+	AlertIDs      []string       `json:"alertIds,omitempty"`
+}
+
+// CreateIncidentAPIResponse is returned when an incident is created successfully.
+type CreateIncidentAPIResponse struct {
+	ID   string `json:"id"`
+	Key  string `json:"key"`
+	Self string `json:"self"`
+}
+
+func (c *Client) incidentAPIURL(cloudID, pathSuffix string) string {
+	return fmt.Sprintf("%s/jsm/incidents/cloudId/%s/v1%s", atlassianIncidentAPIHost, cloudID, pathSuffix)
+}
+
+// CreateIncident creates an incident via the JSM Incidents API.
+func (c *Client) CreateIncident(cloudID string, req *CreateIncidentAPIRequest) (*CreateIncidentAPIResponse, error) {
+	u := c.incidentAPIURL(cloudID, "/incident")
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create incident body: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var out CreateIncidentAPIResponse
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse create incident response: %w", err)
+	}
+
+	return &out, nil
+}
+
+// GetIncident returns the incident from the JSM Incidents API (issueID must be the numeric Jira issue id).
+func (c *Client) GetIncident(cloudID, issueID string) (map[string]any, error) {
+	u := c.incidentAPIURL(cloudID, fmt.Sprintf("/incident/%s", url.PathEscape(issueID)))
+	responseBody, err := c.execRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse get incident response: %w", err)
+	}
+
+	return out, nil
+}
+
+// DeleteIncident deletes an incident via the JSM Incidents API.
+func (c *Client) DeleteIncident(cloudID, issueID string) error {
+	u := c.incidentAPIURL(cloudID, fmt.Sprintf("/incident/%s", url.PathEscape(issueID)))
+	_, err := c.execRequest(http.MethodDelete, u, nil)
+	return err
+}
+
+// ResolveNumericIssueID returns the numeric issue id for the Incidents API path. If ref is all digits it is
+// returned unchanged; otherwise ref is treated as an issue key and resolved with the Jira platform REST API.
+func (c *Client) ResolveNumericIssueID(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("issue reference is required")
+	}
+	if isNumericIssueRef(ref) {
+		return ref, nil
+	}
+
+	issue, err := c.GetIssue(ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve issue key %q: %w", ref, err)
+	}
+	return issue.ID, nil
+}
+
+func isNumericIssueRef(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
 }

--- a/pkg/integrations/jira/client.go
+++ b/pkg/integrations/jira/client.go
@@ -769,15 +769,16 @@ func IsIncidentManagementRequestPractice(practice string) bool {
 		return false
 	}
 
-	low := strings.ToLower(p)
-	if strings.Contains(low, "post-incident") || strings.Contains(low, "post incident") {
+	u := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(p, "-", "_"), " ", "_"), ".", "_"))
+	if strings.Contains(u, "POST_INCIDENT") {
 		return false
 	}
+
+	low := strings.ToLower(p)
 	if strings.Contains(low, "incident management") {
 		return true
 	}
 
-	u := strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(p, "-", "_"), " ", "_"), ".", "_"))
 	switch u {
 	case "ITSM_INCIDENT", "INCIDENT_MANAGEMENT", "INCIDENT", "MANAGE_INCIDENTS", "IM":
 		return true

--- a/pkg/integrations/jira/client_test.go
+++ b/pkg/integrations/jira/client_test.go
@@ -538,6 +538,19 @@ func Test__jqlQuotedProjectKey(t *testing.T) {
 	assert.Equal(t, `a\\b\"c`, jqlQuotedProjectKey(`a\b"c`))
 }
 
+func Test__IsIncidentManagementRequestPractice(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsIncidentManagementRequestPractice("ITSM_INCIDENT"))
+	assert.True(t, IsIncidentManagementRequestPractice("INCIDENT_MANAGEMENT"))
+	assert.True(t, IsIncidentManagementRequestPractice("Incident management"))
+	assert.True(t, IsIncidentManagementRequestPractice("  incident_management  "))
+	assert.False(t, IsIncidentManagementRequestPractice(""))
+	assert.False(t, IsIncidentManagementRequestPractice("SERVICE_REQUEST"))
+	assert.False(t, IsIncidentManagementRequestPractice("POST_INCIDENT_REVIEW"))
+	assert.False(t, IsIncidentManagementRequestPractice("Post-incident review"))
+	assert.False(t, IsIncidentManagementRequestPractice("ITSM_POST_INCIDENT"))
+}
+
 func Test__Client__IncidentsAPI(t *testing.T) {
 	cloudID := "35273b54-3f06-40d2-880f-dd28cf6daafa"
 

--- a/pkg/integrations/jira/client_test.go
+++ b/pkg/integrations/jira/client_test.go
@@ -424,3 +424,246 @@ func Test__WrapInADF(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func Test__Client__FetchCloudID(t *testing.T) {
+	t.Run("successful tenant_info", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"cloudId":"abc-123"}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl":  "https://test.atlassian.net",
+				"email":    "test@example.com",
+				"apiToken": "test-token",
+			},
+		}
+
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		id, err := client.FetchCloudID()
+		require.NoError(t, err)
+		assert.Equal(t, "abc-123", id)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/_edge/tenant_info")
+	})
+}
+
+func Test__Client__ListServiceDesksAndRequestTypes(t *testing.T) {
+	t.Run("list service desks", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"1","projectName":"SD","projectKey":"SD"}],"isLastPage":true}`)),
+				},
+			},
+		}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "t",
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+		desks, err := client.ListServiceDesks()
+		require.NoError(t, err)
+		require.Len(t, desks, 1)
+		assert.Equal(t, "1", desks[0].ID)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/rest/servicedeskapi/servicedesk?")
+	})
+
+	t.Run("list request types for desk", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"10","name":"Incident","practice":"ITSM_INCIDENT"}],"isLastPage":true}`)),
+				},
+			},
+		}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "t",
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+		rts, err := client.ListRequestTypes("1")
+		require.NoError(t, err)
+		require.Len(t, rts, 1)
+		assert.Equal(t, "10", rts[0].ID)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/rest/servicedeskapi/servicedesk/1/requesttype")
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "expand=practice")
+	})
+
+	t.Run("list service desks paginates by returned count", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"1","projectName":"A","projectKey":"A"}],"isLastPage":false}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"2","projectName":"B","projectKey":"B"}],"isLastPage":true}`)),
+				},
+			},
+		}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "t",
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+		desks, err := client.ListServiceDesks()
+		require.NoError(t, err)
+		require.Len(t, desks, 2)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "start=1")
+	})
+}
+
+func Test__jqlQuotedProjectKey(t *testing.T) {
+	assert.Equal(t, `IT`, jqlQuotedProjectKey("IT"))
+	assert.Equal(t, `IT\"X`, jqlQuotedProjectKey(`IT"X`))
+	assert.Equal(t, `IT\\`, jqlQuotedProjectKey(`IT\`))
+	assert.Equal(t, `a\\b\"c`, jqlQuotedProjectKey(`a\b"c`))
+}
+
+func Test__Client__IncidentsAPI(t *testing.T) {
+	cloudID := "35273b54-3f06-40d2-880f-dd28cf6daafa"
+
+	t.Run("create incident", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"10050","key":"ITSM-30","self":"https://test.atlassian.net/rest/api/3/issue/10050"}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl":  "https://test.atlassian.net",
+				"email":    "test@example.com",
+				"apiToken": "test-token",
+			},
+		}
+
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		resp, err := client.CreateIncident(cloudID, &CreateIncidentAPIRequest{
+			ServiceDeskID: "6",
+			RequestTypeID: "75",
+			Fields:        map[string]any{"summary": "Outage"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "ITSM-30", resp.Key)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "api.atlassian.com/jsm/incidents/cloudId/"+cloudID+"/v1/incident")
+	})
+
+	t.Run("get incident", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"summary":"Sev1","priority":{"name":"High","id":"1"}}`)),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl":  "https://test.atlassian.net",
+				"email":    "test@example.com",
+				"apiToken": "test-token",
+			},
+		}
+
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		dto, err := client.GetIncident(cloudID, "10050")
+		require.NoError(t, err)
+		assert.Equal(t, "Sev1", dto["summary"])
+		require.Len(t, httpContext.Requests, 1)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/v1/incident/10050")
+	})
+
+	t.Run("delete incident", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl":  "https://test.atlassian.net",
+				"email":    "test@example.com",
+				"apiToken": "test-token",
+			},
+		}
+
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		err = client.DeleteIncident(cloudID, "10050")
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+}
+
+func Test__Client__ResolveNumericIssueID(t *testing.T) {
+	t.Run("numeric passthrough", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{Responses: []*http.Response{}}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "t",
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+		id, err := client.ResolveNumericIssueID(" 10050 ")
+		require.NoError(t, err)
+		assert.Equal(t, "10050", id)
+		assert.Len(t, httpContext.Requests, 0)
+	})
+
+	t.Run("resolve by key", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"999","key":"ITSM-1","self":"x","fields":{}}`)),
+				},
+			},
+		}
+		appCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "t",
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+		id, err := client.ResolveNumericIssueID("ITSM-1")
+		require.NoError(t, err)
+		assert.Equal(t, "999", id)
+	})
+}

--- a/pkg/integrations/jira/common.go
+++ b/pkg/integrations/jira/common.go
@@ -47,3 +47,22 @@ func findProject(projects []Project, projectKey string) (*Project, error) {
 
 	return nil, fmt.Errorf("project %s not found", projectKey)
 }
+
+// CreateIncidentNodeMetadata is stored on create-incident nodes at setup for canvas labels and field mapping.
+type CreateIncidentNodeMetadata struct {
+	ServiceDeskName string `json:"serviceDeskName,omitempty"`
+	RequestTypeName string `json:"requestTypeName,omitempty"`
+	ImpactFieldID   string `json:"impactFieldId,omitempty"`
+	UrgencyFieldID  string `json:"urgencyFieldId,omitempty"`
+}
+
+func cloudIDFromIntegration(integration core.IntegrationContext) (string, error) {
+	meta := Metadata{}
+	if err := mapstructure.Decode(integration.GetMetadata(), &meta); err != nil {
+		return "", fmt.Errorf("decode integration metadata: %w", err)
+	}
+	if meta.CloudID == "" {
+		return "", fmt.Errorf("integration is missing cloud id; re-sync the Jira integration after upgrading SuperPlane")
+	}
+	return meta.CloudID, nil
+}

--- a/pkg/integrations/jira/create_incident.go
+++ b/pkg/integrations/jira/create_incident.go
@@ -56,7 +56,7 @@ func (c *CreateIncident) Description() string {
 }
 
 func (c *CreateIncident) Documentation() string {
-	return `The Create Incident component opens a new incident in Jira Service Management using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+	return `The Create Incident component opens a new incident in Jira Service Management.
 
 ## Use Cases
 

--- a/pkg/integrations/jira/create_incident.go
+++ b/pkg/integrations/jira/create_incident.go
@@ -1,0 +1,618 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const CreateJiraIncidentPayloadType = "jira.incident.created"
+
+type CreateIncident struct{}
+
+// CreateIncidentSpec configures JSM Incidents API create (see Atlassian JSM Incidents REST reference).
+type CreateIncidentSpec struct {
+	ServiceDesk            string `json:"serviceDesk" mapstructure:"serviceDesk"`
+	ServiceDeskRequestType string `json:"serviceDeskRequestType" mapstructure:"serviceDeskRequestType"`
+	Summary                string `json:"summary" mapstructure:"summary"`
+
+	Description      string `json:"description,omitempty" mapstructure:"description"`
+	DueDate          string `json:"dueDate,omitempty" mapstructure:"dueDate"`
+	Priority         string `json:"priority,omitempty" mapstructure:"priority"`
+	Impact           string `json:"impact,omitempty" mapstructure:"impact"`
+	Urgency          string `json:"urgency,omitempty" mapstructure:"urgency"`
+	OriginalEstimate string `json:"originalEstimate,omitempty" mapstructure:"originalEstimate"`
+
+	AdditionalFields map[string]any `json:"additionalFields,omitempty" mapstructure:"additionalFields"`
+	Update           map[string]any `json:"update,omitempty" mapstructure:"update"`
+	AlertIDs         []any          `json:"alertIds,omitempty" mapstructure:"alertIds"`
+
+	CustomFieldValues []IncidentCustomFieldRow `json:"customFieldValues,omitempty" mapstructure:"customFieldValues"`
+}
+
+// IncidentCustomFieldRow maps one Jira field id to a JSON value (object or string) as expected by the Jira API.
+type IncidentCustomFieldRow struct {
+	FieldID   string `json:"fieldId" mapstructure:"fieldId"`
+	ValueJSON string `json:"valueJson" mapstructure:"valueJson"`
+}
+
+func (c *CreateIncident) Name() string {
+	return "jira.createIncident"
+}
+
+func (c *CreateIncident) Label() string {
+	return "Create Incident"
+}
+
+func (c *CreateIncident) Description() string {
+	return "Create a Jira Service Management incident via the Incidents API"
+}
+
+func (c *CreateIncident) Documentation() string {
+	return `The Create Incident component opens a new incident in Jira Service Management using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+## Use Cases
+
+- **Alert-driven incidents**: Create an incident from a monitoring or ticketing workflow
+- **Cross-tool orchestration**: Open a JSM incident when another system reports an outage
+- **Responder assignment**: Pass responders and other fields supported by your service desk
+
+## Configuration
+
+- **Service desk**: Choose a Jira Service Management service desk (from your site via the JSM API)
+- **Request type**: Choose a request type on that service desk (lists after a service desk is selected)
+- **Summary** (required): Short title for the incident; sent as the Jira **summary** field (Jira requires this). You can set this directly, or supply summary only via **Additional fields**.
+- **Description** (optional): Plain text stored as Jira description (Atlassian Document Format).
+- **Due date** (optional): Jira **duedate** (use your site date format, typically YYYY-MM-DD).
+- **Priority** (optional): Jira priority **name** (for example Medium).
+- **Impact** (optional): Impact level from your Jira request type (options load after service desk and request type are selected).
+- **Urgency** (optional): Urgency level from your Jira request type (options load after service desk and request type are selected).
+- **Original estimate** (optional): Jira **timetracking.originalEstimate** (for example 2h, 1d).
+- **Custom fields** (optional): List of Jira field ids with JSON values—for affected services, pending reason, or any customfield_*; the value must be valid JSON (object or string) as Jira expects for that field type.
+- **Additional fields** (optional): JSON object merged into the API **fields** map (same pattern as other integrations such as Honeycomb **Fields JSON**).
+- **Update** (optional): JSON object for the Incidents API **update** property.
+- **Alert IDs** (optional): List of alert id strings to associate with the incident.
+
+## Output
+
+Returns **id** (numeric issue id), **key** (e.g. ITSM-30), and **self** (issue REST URL) from the create response.
+
+## Notes
+
+- Requires a Jira Cloud site with Jira Service Management and a synced SuperPlane Jira integration (cloud id is resolved automatically).
+- **Request types** must belong to Jira's **Incident management** work category; other request types (for example service requests) are hidden from the picker when Jira returns a practice field on request types. If your site uses an unrecognized practice value, contact support with a sample from GET /rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttype/{requestTypeId} with expand=practice.
+- Field ids such as responders are site-specific; use **Custom fields** or **Additional fields** with values that match your JSM configuration.`
+}
+
+func (c *CreateIncident) Icon() string {
+	return "jira"
+}
+
+func (c *CreateIncident) Color() string {
+	return "orange"
+}
+
+func (c *CreateIncident) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateIncident) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "serviceDesk",
+			Label:       "Service Desk",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Jira Service Management service desk for the new incident",
+			Placeholder: "Select a service desk",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "serviceDesk",
+				},
+			},
+		},
+		{
+			Name:        "serviceDeskRequestType",
+			Label:       "Service Desk Request Type",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Incident request type on the selected service desk",
+			Placeholder: "Select a request type",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "serviceDeskRequestType",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "serviceDesk",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "serviceDesk"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "summary",
+			Label:       "Summary",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Incident title (Jira summary). Required unless additional fields include summary.",
+			Placeholder: "Brief description of the incident",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "Optional plain-text description (sent as Jira description)",
+			Placeholder: "What happened, scope, links…",
+		},
+		{
+			Name:        "dueDate",
+			Label:       "Due date",
+			Type:        configuration.FieldTypeDate,
+			Required:    false,
+			Description: "Optional Jira due date (YYYY-MM-DD for Cloud)",
+		},
+		{
+			Name:        "priority",
+			Label:       "Priority",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Default:     "__none__",
+			Description: "Optional Jira priority name",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Don't set", Value: "__none__"},
+						{Label: "Highest", Value: "Highest"},
+						{Label: "High", Value: "High"},
+						{Label: "Medium", Value: "Medium"},
+						{Label: "Low", Value: "Low"},
+						{Label: "Lowest", Value: "Lowest"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "impact",
+			Label:       "Impact",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional incident impact (options from the selected request type)",
+			Placeholder: "Select impact",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "impact",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "serviceDesk",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "serviceDesk"},
+						},
+						{
+							Name:      "serviceDeskRequestType",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "serviceDeskRequestType"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "urgency",
+			Label:       "Urgency",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional incident urgency (options from the selected request type)",
+			Placeholder: "Select urgency",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "urgency",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "serviceDesk",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "serviceDesk"},
+						},
+						{
+							Name:      "serviceDeskRequestType",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "serviceDeskRequestType"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "originalEstimate",
+			Label:       "Original estimate",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Optional Jira timetracking original estimate (e.g. 2h, 1d, 30m)",
+			Placeholder: "e.g. 2h",
+		},
+		{
+			Name:        "alertIds",
+			Label:       "Alert IDs",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Optional alert ids to associate with the incident",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Alert ID",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "customFieldValues",
+			Label:       "Custom fields",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Per-field JSON values for affected services, pending reason, or any customfield_* id",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Field",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:        "fieldId",
+								Label:       "Field ID",
+								Type:        configuration.FieldTypeString,
+								Required:    false,
+								Placeholder: "customfield_10001",
+							},
+							{
+								Name:        "valueJson",
+								Label:       "Value (JSON)",
+								Type:        configuration.FieldTypeText,
+								Required:    false,
+								Description: "JSON value Jira expects for that field",
+								Placeholder: `{"name":"High"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "additionalFields",
+			Label:       "Additional fields",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Description: "Optional JSON object merged into Jira fields. Use Custom fields above for known customfield ids with structured rows.",
+			Default:     "{}",
+		},
+		{
+			Name:        "update",
+			Label:       "Update",
+			Type:        configuration.FieldTypeObject,
+			Required:    false,
+			Description: "Optional JSON object for the Incidents API update property",
+			Default:     "{}",
+		},
+	}
+}
+
+func (c *CreateIncident) Setup(ctx core.SetupContext) error {
+	spec := CreateIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := cloudIDFromIntegration(ctx.Integration); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(spec.ServiceDesk) == "" {
+		return fmt.Errorf("serviceDesk is required")
+	}
+	if strings.TrimSpace(spec.ServiceDeskRequestType) == "" {
+		return fmt.Errorf("serviceDeskRequestType is required")
+	}
+
+	nodeMeta := CreateIncidentNodeMetadata{}
+	fieldsPreview, err := incidentCreateFieldsFromSpec(spec, nodeMeta)
+	if err != nil {
+		return err
+	}
+	if err := validateIncidentSummaryPresent(spec.Summary, fieldsPreview); err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	svcID := strings.TrimSpace(spec.ServiceDesk)
+	desks, err := client.ListServiceDesks()
+	if err != nil {
+		return fmt.Errorf("list service desks (JSM): %w", err)
+	}
+
+	var deskName string
+	var projectKey string
+	if !slices.ContainsFunc(desks, func(d ServiceDesk) bool {
+		if d.ID == svcID {
+			deskName = serviceDeskDisplayName(d)
+			projectKey = strings.TrimSpace(d.ProjectKey)
+			return true
+		}
+		return false
+	}) {
+		return fmt.Errorf("service desk %q not found or not accessible with these credentials", svcID)
+	}
+
+	requestTypes, err := client.ListRequestTypes(svcID)
+	if err != nil {
+		return fmt.Errorf("list request types: %w", err)
+	}
+
+	reqID := strings.TrimSpace(spec.ServiceDeskRequestType)
+	if !slices.ContainsFunc(requestTypes, func(rt RequestType) bool { return rt.ID == reqID }) {
+		return fmt.Errorf("request type %q not found on service desk %s", reqID, svcID)
+	}
+
+	rtDetail, err := client.GetRequestType(svcID, reqID)
+	if err != nil {
+		return fmt.Errorf("load request type: %w", err)
+	}
+	practice := strings.TrimSpace(rtDetail.Practice)
+	if practice != "" && !IsIncidentManagementRequestPractice(practice) {
+		return fmt.Errorf(
+			`request type %q (id %s) has practice %q, which is not in Jira's "Incident management" work category; the Incidents API only accepts incident request types — assign it under Space settings > Request management, or choose another type (see https://support.atlassian.com/jira-service-management-cloud/docs/assign-request-types-to-an-it-service-management-category/)`,
+			rtDetail.Name,
+			reqID,
+			practice,
+		)
+	}
+
+	rtFields, err := client.ListRequestTypeFields(svcID, reqID)
+	if err != nil {
+		return fmt.Errorf("list request type fields: %w", err)
+	}
+
+	nodeMeta = CreateIncidentNodeMetadata{
+		ServiceDeskName: deskName,
+		RequestTypeName: strings.TrimSpace(rtDetail.Name),
+		ImpactFieldID:   resolveIncidentFieldID(client, rtFields, projectKey, "impact"),
+		UrgencyFieldID:  resolveIncidentFieldID(client, rtFields, projectKey, "urgency"),
+	}
+
+	return ctx.Metadata.Set(nodeMeta)
+}
+
+func serviceDeskDisplayName(d ServiceDesk) string {
+	if d.ProjectKey != "" {
+		return fmt.Sprintf("%s (%s)", d.ProjectName, d.ProjectKey)
+	}
+	return d.ProjectName
+}
+
+func (c *CreateIncident) Execute(ctx core.ExecutionContext) error {
+	spec := CreateIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := cloudIDFromIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	nodeMeta := CreateIncidentNodeMetadata{}
+	if ctx.NodeMetadata != nil {
+		_ = mapstructure.Decode(ctx.NodeMetadata.Get(), &nodeMeta)
+	}
+
+	fields, err := incidentCreateFieldsFromSpec(spec, nodeMeta)
+	if err != nil {
+		return err
+	}
+	summary, err := resolveIncidentSummary(spec.Summary, fields)
+	if err != nil {
+		return err
+	}
+	fields["summary"] = summary
+
+	update := incidentUpdateFromSpec(spec)
+	alertIDs := incidentAlertIDsFromSpec(spec)
+
+	apiReq := &CreateIncidentAPIRequest{
+		ServiceDeskID: strings.TrimSpace(spec.ServiceDesk),
+		RequestTypeID: strings.TrimSpace(spec.ServiceDeskRequestType),
+		Fields:        fields,
+	}
+	if len(update) > 0 {
+		apiReq.Update = update
+	}
+	if len(alertIDs) > 0 {
+		apiReq.AlertIDs = alertIDs
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.CreateIncident(cloudID, apiReq)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "Incident management work category") {
+			return fmt.Errorf(
+				`failed to create incident: %w — choose a request type assigned to "Incident management" in Jira (see https://support.atlassian.com/jira-service-management-cloud/docs/assign-request-types-to-an-it-service-management-category/)`,
+				err,
+			)
+		}
+		if strings.Contains(msg, "summary") && strings.Contains(strings.ToLower(msg), "must specify") {
+			return fmt.Errorf("failed to create incident: %w — set the Summary field (it is sent as fields.summary to Jira)", err)
+		}
+		return fmt.Errorf("failed to create incident: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		CreateJiraIncidentPayloadType,
+		[]any{resp},
+	)
+}
+
+func (c *CreateIncident) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateIncident) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateIncident) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateIncident) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateIncident) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func summaryFromFieldsMap(fields map[string]any) string {
+	raw, ok := fields["summary"]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch s := raw.(type) {
+	case string:
+		return strings.TrimSpace(s)
+	default:
+		return strings.TrimSpace(fmt.Sprint(s))
+	}
+}
+
+func validateIncidentSummaryPresent(summaryField string, fields map[string]any) error {
+	if strings.TrimSpace(summaryField) != "" {
+		return nil
+	}
+	if summaryFromFieldsMap(fields) != "" {
+		return nil
+	}
+	return fmt.Errorf("summary is required; set the Summary field or include summary in Additional fields")
+}
+
+func resolveIncidentSummary(summaryField string, fields map[string]any) (string, error) {
+	s := strings.TrimSpace(summaryField)
+	if s != "" {
+		return s, nil
+	}
+	if v := summaryFromFieldsMap(fields); v != "" {
+		return v, nil
+	}
+	return "", fmt.Errorf("summary is required; set the Summary field or include summary in Additional fields")
+}
+
+func mergeStringMaps(dst, src map[string]any) {
+	for k, v := range src {
+		if k == "" {
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+func incidentCreateFieldsFromSpec(spec CreateIncidentSpec, meta CreateIncidentNodeMetadata) (map[string]any, error) {
+	fields := map[string]any{}
+
+	if len(spec.AdditionalFields) > 0 {
+		mergeStringMaps(fields, spec.AdditionalFields)
+	}
+
+	if s := strings.TrimSpace(spec.Description); s != "" {
+		fields["description"] = WrapInADF(s)
+	}
+	if s := strings.TrimSpace(spec.DueDate); s != "" {
+		fields["duedate"] = s
+	}
+	if s := strings.TrimSpace(spec.Priority); s != "" && s != "__none__" {
+		fields["priority"] = map[string]any{"name": s}
+	}
+	if s := strings.TrimSpace(spec.OriginalEstimate); s != "" {
+		fields["timetracking"] = map[string]any{"originalEstimate": s}
+	}
+
+	if fid := strings.TrimSpace(meta.ImpactFieldID); fid != "" {
+		if v := jiraOptionFieldValueByID(spec.Impact); v != nil {
+			fields[fid] = v
+		}
+	}
+	if fid := strings.TrimSpace(meta.UrgencyFieldID); fid != "" {
+		if v := jiraOptionFieldValueByID(spec.Urgency); v != nil {
+			fields[fid] = v
+		}
+	}
+
+	for i, row := range spec.CustomFieldValues {
+		fid := strings.TrimSpace(row.FieldID)
+		if fid == "" {
+			continue
+		}
+		raw := strings.TrimSpace(row.ValueJSON)
+		if raw == "" {
+			continue
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			return nil, fmt.Errorf("customFieldValues[%d].valueJson for %q: %w", i, fid, err)
+		}
+		fields[fid] = parsed
+	}
+
+	return fields, nil
+}
+
+func jiraOptionFieldValueByID(raw string) map[string]any {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	return map[string]any{"id": s}
+}
+
+func incidentUpdateFromSpec(spec CreateIncidentSpec) map[string]any {
+	if len(spec.Update) == 0 {
+		return nil
+	}
+	return spec.Update
+}
+
+func incidentAlertIDsFromSpec(spec CreateIncidentSpec) []string {
+	return alertIDsFromSlice(spec.AlertIDs)
+}
+
+func alertIDsFromSlice(raw []any) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s := strings.TrimSpace(fmt.Sprint(e))
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/pkg/integrations/jira/create_incident.go
+++ b/pkg/integrations/jira/create_incident.go
@@ -158,7 +158,7 @@ func (c *CreateIncident) Configuration() []configuration.Field {
 			Label:       "Due date",
 			Type:        configuration.FieldTypeDate,
 			Required:    false,
-			Description: "Optional Jira due date (YYYY-MM-DD for Cloud)",
+			Description: "Optional Jira due date",
 		},
 		{
 			Name:        "priority",

--- a/pkg/integrations/jira/create_incident_test.go
+++ b/pkg/integrations/jira/create_incident_test.go
@@ -1,0 +1,255 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func jiraTestIntegration() *contexts.IntegrationContext {
+	return &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "test@example.com",
+			"apiToken": "test-token",
+		},
+		Metadata: Metadata{
+			CloudID:  "35273b54-3f06-40d2-880f-dd28cf6daafa",
+			Projects: []Project{{ID: "1", Key: "IT", Name: "IT"}},
+		},
+	}
+}
+
+func Test__CreateIncident__Setup(t *testing.T) {
+	component := CreateIncident{}
+	baseCtx := core.SetupContext{Integration: jiraTestIntegration()}
+
+	t.Run("missing serviceDesk", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: baseCtx.Integration,
+			Configuration: map[string]any{
+				"serviceDeskRequestType": "75",
+				"summary":                "Outage",
+			},
+		})
+		require.ErrorContains(t, err, "serviceDesk is required")
+	})
+
+	t.Run("missing summary", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: baseCtx.Integration,
+			Configuration: map[string]any{
+				"serviceDesk":            "6",
+				"serviceDeskRequestType": "75",
+			},
+		})
+		require.ErrorContains(t, err, "summary is required")
+	})
+
+	t.Run("valid setup", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"6","projectName":"IT","projectKey":"IT"}],"isLastPage":true}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"75","name":"Incident","practice":"ITSM_INCIDENT"}],"isLastPage":true}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"75","name":"Incident","practice":"ITSM_INCIDENT"}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{"requestTypeFields":[
+						{"fieldId":"summary","name":"Summary"},
+						{"fieldId":"customfield_10020","name":"Impact"},
+						{"fieldId":"customfield_10021","name":"Urgency"}
+					]}`)),
+				},
+			},
+		}
+		metadataCtx := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			HTTP:        httpContext,
+			Integration: baseCtx.Integration,
+			Metadata:    metadataCtx,
+			Configuration: map[string]any{
+				"serviceDesk":            "6",
+				"serviceDeskRequestType": "75",
+				"summary":                "Database outage",
+				"alertIds":               []any{"a1"},
+			},
+		})
+		require.NoError(t, err)
+
+		var meta CreateIncidentNodeMetadata
+		require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &meta))
+		assert.Equal(t, "IT (IT)", meta.ServiceDeskName)
+		assert.Equal(t, "Incident", meta.RequestTypeName)
+		assert.Equal(t, "customfield_10020", meta.ImpactFieldID)
+		assert.Equal(t, "customfield_10021", meta.UrgencyFieldID)
+	})
+
+	t.Run("valid setup summary in additional fields only", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"6","projectName":"IT","projectKey":"IT"}],"isLastPage":true}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"75","name":"Incident","practice":"ITSM_INCIDENT"}],"isLastPage":true}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"75","name":"Incident","practice":"ITSM_INCIDENT"}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"requestTypeFields":[{"fieldId":"summary","name":"Summary"}]}`)),
+				},
+			},
+		}
+		err := component.Setup(core.SetupContext{
+			HTTP:        httpContext,
+			Integration: baseCtx.Integration,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: map[string]any{
+				"serviceDesk":            "6",
+				"serviceDeskRequestType": "75",
+				"additionalFields":       map[string]any{"summary": "From additional fields"},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test__CreateIncident__Execute(t *testing.T) {
+	component := CreateIncident{}
+
+	t.Run("successful create", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"10050","key":"ITSM-30","self":"https://test.atlassian.net/rest/api/3/issue/10050"}`)),
+				},
+			},
+		}
+		execCtx := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"serviceDesk":            "6",
+				"serviceDeskRequestType": "75",
+				"summary":                "Outage",
+			},
+			HTTP:           httpContext,
+			Integration:    jiraTestIntegration(),
+			ExecutionState: execCtx,
+			NodeMetadata: &contexts.MetadataContext{
+				Metadata: CreateIncidentNodeMetadata{
+					ImpactFieldID:  "customfield_10020",
+					UrgencyFieldID: "customfield_10021",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, execCtx.Finished)
+		assert.Equal(t, CreateJiraIncidentPayloadType, execCtx.Type)
+	})
+}
+
+func Test__incidentCreateFieldsFromSpec__mergesAndScalars(t *testing.T) {
+	spec := CreateIncidentSpec{
+		AdditionalFields: map[string]any{"customfield_1": "x"},
+		Description:      "Hello",
+		DueDate:          "2026-05-20",
+		Priority:         "High",
+		Impact:           "1",
+		Urgency:          "2",
+		OriginalEstimate: "2h",
+		CustomFieldValues: []IncidentCustomFieldRow{
+			{FieldID: "customfield_2", ValueJSON: `{"value":"Urgent"}`},
+		},
+	}
+	meta := CreateIncidentNodeMetadata{
+		ImpactFieldID:  "customfield_impact",
+		UrgencyFieldID: "customfield_urgency",
+	}
+	fields, err := incidentCreateFieldsFromSpec(spec, meta)
+	require.NoError(t, err)
+	assert.Equal(t, "x", fields["customfield_1"])
+	desc := fields["description"]
+	require.NotNil(t, desc)
+	assert.Equal(t, "2026-05-20", fields["duedate"])
+	prio := fields["priority"].(map[string]any)
+	assert.Equal(t, "High", prio["name"])
+	impact := fields["customfield_impact"].(map[string]any)
+	assert.Equal(t, "1", impact["id"])
+	urgency := fields["customfield_urgency"].(map[string]any)
+	assert.Equal(t, "2", urgency["id"])
+	tt := fields["timetracking"].(map[string]any)
+	assert.Equal(t, "2h", tt["originalEstimate"])
+	assert.Equal(t, map[string]any{"value": "Urgent"}, fields["customfield_2"])
+}
+
+func Test__incidentCreateFieldsFromSpec__priorityNoneSentinel(t *testing.T) {
+	for _, prio := range []string{"", "  ", "__none__"} {
+		fields, err := incidentCreateFieldsFromSpec(CreateIncidentSpec{
+			Priority: prio,
+		}, CreateIncidentNodeMetadata{})
+		require.NoError(t, err)
+		_, has := fields["priority"]
+		assert.False(t, has, "priority=%q", prio)
+	}
+}
+
+func Test__incidentCreateFieldsFromSpec__impactUrgencySkippedWithoutFieldIDs(t *testing.T) {
+	fields, err := incidentCreateFieldsFromSpec(CreateIncidentSpec{
+		Impact:  "3",
+		Urgency: "4",
+	}, CreateIncidentNodeMetadata{})
+	require.NoError(t, err)
+	_, hasImpact := fields["impact"]
+	_, hasUrgency := fields["urgency"]
+	assert.False(t, hasImpact)
+	assert.False(t, hasUrgency)
+}
+
+func Test__incidentCreateFieldsFromSpec__invalidCustomValue(t *testing.T) {
+	_, err := incidentCreateFieldsFromSpec(CreateIncidentSpec{
+		CustomFieldValues: []IncidentCustomFieldRow{{FieldID: "cf", ValueJSON: `[`}},
+	}, CreateIncidentNodeMetadata{})
+	require.Error(t, err)
+}
+
+func Test__incidentAlertIDsFromSpec__list(t *testing.T) {
+	ids := incidentAlertIDsFromSpec(CreateIncidentSpec{
+		AlertIDs: []any{"  a ", "b"},
+	})
+	assert.Equal(t, []string{"a", "b"}, ids)
+}
+
+func Test__incidentAlertIDsFromSpec__empty(t *testing.T) {
+	assert.Nil(t, incidentAlertIDsFromSpec(CreateIncidentSpec{}))
+}
+
+func Test__cloudIDFromIntegration__errors(t *testing.T) {
+	app := &contexts.IntegrationContext{
+		Configuration: map[string]any{"siteUrl": "https://x.net", "email": "a@b.com", "apiToken": "t"},
+		Metadata:      Metadata{Projects: []Project{}},
+	}
+	_, err := cloudIDFromIntegration(app)
+	require.Error(t, err)
+}

--- a/pkg/integrations/jira/delete_incident.go
+++ b/pkg/integrations/jira/delete_incident.go
@@ -1,0 +1,176 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const DeleteJiraIncidentPayloadType = "jira.incident.deleted"
+
+type DeleteIncident struct{}
+
+type DeleteIncidentSpec struct {
+	Project string `json:"project,omitempty"`
+	Issue   string `json:"issue"`
+}
+
+func (c *DeleteIncident) Name() string {
+	return "jira.deleteIncident"
+}
+
+func (c *DeleteIncident) Label() string {
+	return "Delete Incident"
+}
+
+func (c *DeleteIncident) Description() string {
+	return "Delete a Jira Service Management incident by issue id or issue key"
+}
+
+func (c *DeleteIncident) Documentation() string {
+	return `The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+## Use Cases
+
+- **Automated cleanup**: Remove incidents created during tests or erroneous automation
+- **Lifecycle workflows**: Delete when a duplicate or mistaken incident is closed upstream
+
+## Configuration
+
+- **Project** (optional): Narrows the issue picker to one Jira project (up to 500 most recently updated issues in that project).
+- **Issue**: The incident issue to delete (issue key from Jira search).
+
+## Output
+
+Confirms deletion with **deleted** set to true.`
+}
+
+func (c *DeleteIncident) Icon() string {
+	return "jira"
+}
+
+func (c *DeleteIncident) Color() string {
+	return "red"
+}
+
+func (c *DeleteIncident) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteIncident) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "project",
+			Label:       "Project",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional: limit the issue list to this Jira project",
+			Placeholder: "Any project",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "project",
+				},
+			},
+		},
+		{
+			Name:        "issue",
+			Label:       "Issue",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Issue key (or id) of the incident to delete",
+			Placeholder: "Select an issue",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "issue",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *DeleteIncident) Setup(ctx core.SetupContext) error {
+	spec := DeleteIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := cloudIDFromIntegration(ctx.Integration); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(spec.Issue) == "" {
+		return fmt.Errorf("issue is required")
+	}
+
+	return nil
+}
+
+func (c *DeleteIncident) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := cloudIDFromIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	issueID, err := client.ResolveNumericIssueID(spec.Issue)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteIncident(cloudID, issueID); err != nil {
+		return fmt.Errorf("failed to delete incident: %w", err)
+	}
+
+	payload := map[string]any{
+		"deleted": true,
+	}
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		DeleteJiraIncidentPayloadType,
+		[]any{payload},
+	)
+}
+
+func (c *DeleteIncident) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteIncident) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteIncident) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteIncident) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteIncident) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/jira/delete_incident.go
+++ b/pkg/integrations/jira/delete_incident.go
@@ -33,7 +33,7 @@ func (c *DeleteIncident) Description() string {
 }
 
 func (c *DeleteIncident) Documentation() string {
-	return `The Delete Incident component removes an incident using the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+	return `The Delete Incident component removes an incident from Jira Service Management.
 
 ## Use Cases
 

--- a/pkg/integrations/jira/delete_incident_test.go
+++ b/pkg/integrations/jira/delete_incident_test.go
@@ -1,0 +1,35 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteIncident__Execute(t *testing.T) {
+	component := DeleteIncident{}
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusNoContent,
+				Body:       io.NopCloser(strings.NewReader("")),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration:  map[string]any{"issue": "10050"},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, DeleteJiraIncidentPayloadType, execCtx.Type)
+}

--- a/pkg/integrations/jira/example.go
+++ b/pkg/integrations/jira/example.go
@@ -13,6 +13,24 @@ var exampleOutputCreateIssueBytes []byte
 var exampleOutputCreateIssueOnce sync.Once
 var exampleOutputCreateIssue map[string]any
 
+//go:embed example_output_create_incident.json
+var exampleOutputCreateIncidentBytes []byte
+
+var exampleOutputCreateIncidentOnce sync.Once
+var exampleOutputCreateIncident map[string]any
+
+//go:embed example_output_get_incident.json
+var exampleOutputGetIncidentBytes []byte
+
+var exampleOutputGetIncidentOnce sync.Once
+var exampleOutputGetIncident map[string]any
+
+//go:embed example_output_delete_incident.json
+var exampleOutputDeleteIncidentBytes []byte
+
+var exampleOutputDeleteIncidentOnce sync.Once
+var exampleOutputDeleteIncident map[string]any
+
 func (c *CreateIssue) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIssueOnce, exampleOutputCreateIssueBytes, &exampleOutputCreateIssue)
 }
@@ -45,4 +63,16 @@ var exampleOutputDeleteIssue map[string]any
 
 func (c *DeleteIssue) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteIssueOnce, exampleOutputDeleteIssueBytes, &exampleOutputDeleteIssue)
+}
+
+func (c *CreateIncident) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateIncidentOnce, exampleOutputCreateIncidentBytes, &exampleOutputCreateIncident)
+}
+
+func (c *GetIncident) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetIncidentOnce, exampleOutputGetIncidentBytes, &exampleOutputGetIncident)
+}
+
+func (c *DeleteIncident) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteIncidentOnce, exampleOutputDeleteIncidentBytes, &exampleOutputDeleteIncident)
 }

--- a/pkg/integrations/jira/example_output_create_incident.json
+++ b/pkg/integrations/jira/example_output_create_incident.json
@@ -1,0 +1,9 @@
+{
+    "type": "jira.incident.created",
+    "data": {
+        "id": "10050",
+        "key": "ITSM-30",
+        "self": "https://your-domain.atlassian.net/rest/api/3/issue/10050"
+    },
+    "timestamp": "2026-01-19T12:00:00Z"
+}

--- a/pkg/integrations/jira/example_output_delete_incident.json
+++ b/pkg/integrations/jira/example_output_delete_incident.json
@@ -1,0 +1,7 @@
+{
+    "type": "jira.incident.deleted",
+    "data": {
+        "deleted": true
+    },
+    "timestamp": "2026-01-19T12:00:00Z"
+}

--- a/pkg/integrations/jira/example_output_get_incident.json
+++ b/pkg/integrations/jira/example_output_get_incident.json
@@ -1,0 +1,11 @@
+{
+    "type": "jira.incident.fetched",
+    "data": {
+        "summary": "Example incident",
+        "priority": {
+            "name": "High",
+            "id": "1"
+        }
+    },
+    "timestamp": "2026-01-19T12:00:00Z"
+}

--- a/pkg/integrations/jira/get_incident.go
+++ b/pkg/integrations/jira/get_incident.go
@@ -33,7 +33,7 @@ func (c *GetIncident) Description() string {
 }
 
 func (c *GetIncident) Documentation() string {
-	return `The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+	return `The Get Incident component returns incident details from Jira Service Management.
 
 ## Use Cases
 

--- a/pkg/integrations/jira/get_incident.go
+++ b/pkg/integrations/jira/get_incident.go
@@ -1,0 +1,174 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const GetJiraIncidentPayloadType = "jira.incident.fetched"
+
+type GetIncident struct{}
+
+type GetIncidentSpec struct {
+	Project string `json:"project,omitempty"`
+	Issue   string `json:"issue"`
+}
+
+func (c *GetIncident) Name() string {
+	return "jira.getIncident"
+}
+
+func (c *GetIncident) Label() string {
+	return "Get Incident"
+}
+
+func (c *GetIncident) Description() string {
+	return "Fetch a Jira Service Management incident by issue id or issue key"
+}
+
+func (c *GetIncident) Documentation() string {
+	return `The Get Incident component returns incident details from the [JSM Incidents REST API](https://developer.atlassian.com/cloud/incidents/rest/api-group-incident/).
+
+## Use Cases
+
+- **Enrichment**: Load incident DTO after an issue webhook or workflow step
+- **Status checks**: Read priority, status, responders, and affected services from JSM
+
+## Configuration
+
+- **Project** (optional): When set, the issue picker lists issues in that project (by project key), paged from Jira search (up to 500, most recently updated first). Leave empty to list issues updated in roughly the last 90 days across projects you can access (same cap and ordering).
+- **Issue**: Choose an issue by key (from Jira search). The stored value is the issue key; numeric ids still work when they are saved as the issue reference.
+
+## Output
+
+Payload type jira.incident.fetched with the incident object returned by Atlassian (summary, reporter, priority, status, responders, etc.).`
+}
+
+func (c *GetIncident) Icon() string {
+	return "jira"
+}
+
+func (c *GetIncident) Color() string {
+	return "blue"
+}
+
+func (c *GetIncident) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetIncident) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "project",
+			Label:       "Project",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    false,
+			Description: "Optional: limit the issue list to this Jira project",
+			Placeholder: "Any project",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "project",
+				},
+			},
+		},
+		{
+			Name:        "issue",
+			Label:       "Issue",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Issue key (or id) of the incident; keys are resolved via the Jira REST API",
+			Placeholder: "Select an issue",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "issue",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "project",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "project"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *GetIncident) Setup(ctx core.SetupContext) error {
+	spec := GetIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := cloudIDFromIntegration(ctx.Integration); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(spec.Issue) == "" {
+		return fmt.Errorf("issue is required")
+	}
+
+	return nil
+}
+
+func (c *GetIncident) Execute(ctx core.ExecutionContext) error {
+	spec := GetIncidentSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := cloudIDFromIntegration(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	issueID, err := client.ResolveNumericIssueID(spec.Issue)
+	if err != nil {
+		return err
+	}
+
+	incident, err := client.GetIncident(cloudID, issueID)
+	if err != nil {
+		return fmt.Errorf("failed to get incident: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetJiraIncidentPayloadType,
+		[]any{incident},
+	)
+}
+
+func (c *GetIncident) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetIncident) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetIncident) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetIncident) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetIncident) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetIncident) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/jira/get_incident_test.go
+++ b/pkg/integrations/jira/get_incident_test.go
@@ -1,0 +1,61 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetIncident__Execute(t *testing.T) {
+	component := GetIncident{}
+
+	t.Run("by numeric id", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"summary":"Sev1"}`)),
+				},
+			},
+		}
+		execCtx := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  map[string]any{"issue": "10050"},
+			HTTP:           httpContext,
+			Integration:    jiraTestIntegration(),
+			ExecutionState: execCtx,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, GetJiraIncidentPayloadType, execCtx.Type)
+	})
+
+	t.Run("by issue key resolves then gets incident", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"id":"10050","key":"ITSM-30","self":"x","fields":{}}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"summary":"via key"}`)),
+				},
+			},
+		}
+		execCtx := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration:  map[string]any{"issue": "ITSM-30"},
+			HTTP:           httpContext,
+			Integration:    jiraTestIntegration(),
+			ExecutionState: execCtx,
+		})
+		require.NoError(t, err)
+		require.Len(t, httpContext.Requests, 2)
+	})
+}

--- a/pkg/integrations/jira/jira.go
+++ b/pkg/integrations/jira/jira.go
@@ -17,6 +17,7 @@ type Jira struct{}
 type Metadata struct {
 	User     *User     `json:"user,omitempty" mapstructure:"user,omitempty"`
 	Projects []Project `json:"projects" mapstructure:"projects"`
+	CloudID  string    `json:"cloudId,omitempty" mapstructure:"cloudId,omitempty"`
 }
 
 const installationInstructions = `
@@ -84,6 +85,9 @@ func (j *Jira) Actions() []core.Action {
 		&GetIssue{},
 		&UpdateIssue{},
 		&DeleteIssue{},
+		&CreateIncident{},
+		&GetIncident{},
+		&DeleteIncident{},
 	}
 }
 
@@ -106,12 +110,17 @@ func (j *Jira) Sync(ctx core.SyncContext) error {
 		return fmt.Errorf("error verifying Jira credentials: %v", err)
 	}
 
+	cloudID, err := client.FetchCloudID()
+	if err != nil {
+		return fmt.Errorf("error resolving cloud id: %v", err)
+	}
+
 	projects, err := client.ListProjects()
 	if err != nil {
 		return fmt.Errorf("error listing projects: %v", err)
 	}
 
-	ctx.Integration.SetMetadata(Metadata{User: user, Projects: projects})
+	ctx.Integration.SetMetadata(Metadata{User: user, Projects: projects, CloudID: cloudID})
 	ctx.Integration.Ready()
 	return nil
 }

--- a/pkg/integrations/jira/jira_test.go
+++ b/pkg/integrations/jira/jira_test.go
@@ -33,6 +33,10 @@ func Test__Jira__Sync(t *testing.T) {
 				},
 				{
 					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"cloudId":"35273b54-3f06-40d2-880f-dd28cf6daafa"}`)),
+				},
+				{
+					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(`[{"id":"10000","key":"TEST","name":"Test Project"}]`)),
 				},
 			},
@@ -46,11 +50,14 @@ func Test__Jira__Sync(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "ready", appCtx.State)
-		md := appCtx.Metadata.(Metadata)
-		require.NotNil(t, md.User)
-		assert.Equal(t, "acct-1", md.User.AccountID)
-		require.Len(t, md.Projects, 1)
-		assert.Equal(t, "TEST", md.Projects[0].Key)
+
+		meta, ok := appCtx.Metadata.(Metadata)
+		require.True(t, ok)
+		require.NotNil(t, meta.User)
+		assert.Equal(t, "acct-1", meta.User.AccountID)
+		assert.Equal(t, "35273b54-3f06-40d2-880f-dd28cf6daafa", meta.CloudID)
+		require.Len(t, meta.Projects, 1)
+		assert.Equal(t, "TEST", meta.Projects[0].Key)
 	})
 
 	t.Run("invalid credentials -> error", func(t *testing.T) {

--- a/pkg/integrations/jira/list_resources.go
+++ b/pkg/integrations/jira/list_resources.go
@@ -20,6 +20,135 @@ func (j *Jira) ListResources(resourceType string, ctx core.ListResourcesContext)
 		return listAssignees(ctx)
 	case "priority":
 		return listPriorities(ctx)
+	case "serviceDesk":
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		desks, err := client.ListServiceDesks()
+		if err != nil {
+			return nil, fmt.Errorf("list service desks: %w", err)
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(desks))
+		for _, desk := range desks {
+			name := desk.ProjectName
+			if desk.ProjectKey != "" {
+				name = fmt.Sprintf("%s (%s)", desk.ProjectName, desk.ProjectKey)
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   desk.ID,
+			})
+		}
+		return resources, nil
+
+	case "serviceDeskRequestType":
+		deskID := strings.TrimSpace(ctx.Parameters["serviceDesk"])
+		if deskID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		requestTypes, err := client.ListRequestTypes(deskID)
+		if err != nil {
+			return nil, fmt.Errorf("list request types: %w", err)
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(requestTypes))
+		for _, rt := range requestTypes {
+			name := rt.Name
+			if rt.ID != "" {
+				name = fmt.Sprintf("%s (%s)", rt.Name, rt.ID)
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   rt.ID,
+			})
+		}
+		return resources, nil
+
+	case "impact":
+		return j.listRequestTypeFieldResources(resourceType, "impact", ctx)
+
+	case "urgency":
+		return j.listRequestTypeFieldResources(resourceType, "urgency", ctx)
+
+	case "issue":
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+
+		projectKey := strings.TrimSpace(ctx.Parameters["project"])
+
+		if projectKey != "" {
+			desks, derr := client.ListServiceDesks()
+			if derr == nil {
+				for _, desk := range desks {
+					if strings.EqualFold(strings.TrimSpace(desk.ProjectKey), projectKey) {
+						rows, rerr := client.ListCustomerRequestsByServiceDesk(desk.ID, 500)
+						if rerr == nil && len(rows) > 0 {
+							resources := make([]core.IntegrationResource, 0, len(rows))
+							for _, row := range rows {
+								if strings.TrimSpace(row.IssueKey) == "" {
+									continue
+								}
+								name := row.IssueKey
+								if s := strings.TrimSpace(row.Summary); s != "" {
+									name = fmt.Sprintf("%s (%s)", s, row.IssueKey)
+								}
+								resources = append(resources, core.IntegrationResource{
+									Type: resourceType,
+									Name: name,
+									ID:   row.IssueKey,
+								})
+							}
+							return resources, nil
+						}
+						break
+					}
+				}
+			}
+		}
+
+		var jql string
+		if projectKey != "" {
+			jql = fmt.Sprintf(`project = "%s" ORDER BY updated DESC`, jqlQuotedProjectKey(projectKey))
+		} else {
+			jql = "updated >= -90d ORDER BY updated DESC"
+		}
+
+		hits, err := client.SearchIssuesUpTo(jql, 500)
+		if err != nil {
+			return nil, fmt.Errorf("search issues: %w", err)
+		}
+
+		resources := make([]core.IntegrationResource, 0, len(hits))
+		for _, hit := range hits {
+			if strings.TrimSpace(hit.Key) == "" {
+				continue
+			}
+			name := hit.Key
+			if hit.Fields != nil {
+				if s, ok := hit.Fields["summary"].(string); ok && strings.TrimSpace(s) != "" {
+					name = fmt.Sprintf("%s (%s)", strings.TrimSpace(s), hit.Key)
+				}
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   hit.Key,
+			})
+		}
+		return resources, nil
 	default:
 		return []core.IntegrationResource{}, nil
 	}
@@ -178,3 +307,198 @@ func listPriorities(ctx core.ListResourcesContext) ([]core.IntegrationResource, 
 	}
 	return resources, nil
 }
+
+func (j *Jira) listRequestTypeFieldResources(resourceType, fieldLabel string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	deskID := strings.TrimSpace(ctx.Parameters["serviceDesk"])
+	reqID := strings.TrimSpace(ctx.Parameters["serviceDeskRequestType"])
+	if deskID == "" || reqID == "" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	projectKey := resolveServiceDeskProjectKey(client, deskID)
+
+	rtFields, err := client.ListRequestTypeFields(deskID, reqID)
+	if err != nil {
+		return nil, fmt.Errorf("list request type fields: %w", err)
+	}
+
+	field := findRequestTypeField(rtFields, fieldLabel)
+	if field == nil {
+		if allFields, listErr := client.ListFields(); listErr == nil {
+			if gf := FindGlobalFieldByLabel(allFields, fieldLabel); gf != nil {
+				field = &RequestTypeField{FieldID: gf.ID, Name: gf.Name}
+			}
+		}
+	}
+
+	return requestTypeFieldResources(client, field, resourceType, projectKey, fieldLabel)
+}
+
+func findRequestTypeFieldID(fields []RequestTypeField, fieldLabel string) string {
+	if f := findRequestTypeField(fields, fieldLabel); f != nil {
+		return strings.TrimSpace(f.FieldID)
+	}
+	return ""
+}
+
+func findRequestTypeField(fields []RequestTypeField, fieldLabel string) *RequestTypeField {
+	want := strings.ToLower(strings.TrimSpace(fieldLabel))
+
+	var exactNoValues *RequestTypeField
+	var contains []RequestTypeField
+
+	for i := range fields {
+		f := fields[i]
+		nameLower := strings.ToLower(strings.TrimSpace(f.Name))
+		if nameLower == want {
+			if len(f.ValidValues) > 0 {
+				return &fields[i]
+			}
+			if exactNoValues == nil {
+				exactNoValues = &fields[i]
+			}
+			continue
+		}
+		if strings.Contains(nameLower, want) {
+			contains = append(contains, f)
+		}
+	}
+
+	if exactNoValues != nil {
+		return exactNoValues
+	}
+
+	return bestRequestTypeFieldMatch(contains, want)
+}
+
+func bestRequestTypeFieldMatch(candidates []RequestTypeField, want string) *RequestTypeField {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	var best *RequestTypeField
+	bestScore := -1
+	for i := range candidates {
+		f := &candidates[i]
+		score := requestTypeFieldMatchScore(f, want)
+		if len(f.ValidValues) > 0 {
+			score += 100
+		}
+		if score > bestScore {
+			bestScore = score
+			best = f
+		}
+	}
+	return best
+}
+
+func requestTypeFieldMatchScore(f *RequestTypeField, want string) int {
+	nameLower := strings.ToLower(strings.TrimSpace(f.Name))
+	switch {
+	case nameLower == want:
+		return 50
+	case strings.HasPrefix(nameLower, want+" "), strings.HasPrefix(nameLower, want+"-"):
+		return 40
+	case strings.HasPrefix(nameLower, want):
+		return 30
+	case strings.Contains(nameLower, want):
+		return 10
+	default:
+		return 0
+	}
+}
+
+func requestTypeFieldResources(
+	client *Client,
+	field *RequestTypeField,
+	resourceType, projectKey, fieldLabel string,
+) ([]core.IntegrationResource, error) {
+	options := loadRequestTypeFieldOptions(client, field, projectKey, fieldLabel)
+	return fieldOptionsToResources(options, resourceType), nil
+}
+
+func loadRequestTypeFieldOptions(
+	client *Client,
+	field *RequestTypeField,
+	projectKey, fieldLabel string,
+) []RequestTypeFieldValue {
+	if field == nil {
+		if client == nil || projectKey == "" || fieldLabel == "" {
+			return nil
+		}
+		opts, _ := client.listFieldAllowedValuesFromCreateMeta(projectKey, fieldLabel)
+		return opts
+	}
+
+	options := field.ValidValues
+	if len(options) == 0 && client != nil {
+		options = client.ListCustomFieldOptions(field.FieldID, projectKey, fieldLabel)
+	}
+	return options
+}
+
+func resolveIncidentFieldID(client *Client, rtFields []RequestTypeField, projectKey, fieldLabel string) string {
+	if id := findRequestTypeFieldID(rtFields, fieldLabel); id != "" {
+		return id
+	}
+	if client == nil {
+		return ""
+	}
+	allFields, err := client.ListFields()
+	if err == nil {
+		if gf := FindGlobalFieldByLabel(allFields, fieldLabel); gf != nil {
+			return strings.TrimSpace(gf.ID)
+		}
+	}
+	if projectKey != "" {
+		if _, fieldID := client.listFieldAllowedValuesFromCreateMeta(projectKey, fieldLabel); fieldID != "" {
+			return fieldID
+		}
+	}
+	return ""
+}
+
+func fieldOptionsToResources(options []RequestTypeFieldValue, resourceType string) []core.IntegrationResource {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make([]core.IntegrationResource, 0, len(options))
+	for _, opt := range options {
+		id := strings.TrimSpace(opt.Value)
+		label := strings.TrimSpace(opt.Label)
+		if id == "" && label == "" {
+			continue
+		}
+		if id == "" {
+			id = label
+		}
+		if label == "" {
+			label = id
+		}
+		out = append(out, core.IntegrationResource{
+			Type: resourceType,
+			Name: label,
+			ID:   id,
+		})
+	}
+	return out
+}
+
+func resolveServiceDeskProjectKey(client *Client, serviceDeskID string) string {
+	desks, err := client.ListServiceDesks()
+	if err != nil {
+		return ""
+	}
+	for _, desk := range desks {
+		if desk.ID == serviceDeskID {
+			return strings.TrimSpace(desk.ProjectKey)
+		}
+	}
+	return ""
+}
+

--- a/pkg/integrations/jira/list_resources.go
+++ b/pkg/integrations/jira/list_resources.go
@@ -501,4 +501,3 @@ func resolveServiceDeskProjectKey(client *Client, serviceDeskID string) string {
 	}
 	return ""
 }
-

--- a/pkg/integrations/jira/list_resources_test.go
+++ b/pkg/integrations/jira/list_resources_test.go
@@ -566,4 +566,3 @@ func Test__requestTypeFieldResources__createmetaFallback(t *testing.T) {
 	require.Len(t, resources, 1)
 	assert.Equal(t, "5", resources[0].ID)
 }
-

--- a/pkg/integrations/jira/list_resources_test.go
+++ b/pkg/integrations/jira/list_resources_test.go
@@ -212,3 +212,358 @@ func Test__ListResources__Unknown(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resources)
 }
+
+func Test__Jira__ListResources__serviceDesk(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"1","projectName":"Help","projectKey":"HEL"}],"isLastPage":true}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "a@b.com",
+			"apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("serviceDesk", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "serviceDesk"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "1", resources[0].ID)
+	assert.Contains(t, resources[0].Name, "Help")
+}
+
+func Test__Jira__ListResources__serviceDeskRequestType(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"99","name":"Get help","practice":"ITSM_INCIDENT"}],"isLastPage":true}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "a@b.com",
+			"apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("serviceDeskRequestType", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "serviceDeskRequestType", "serviceDesk": "1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "99", resources[0].ID)
+}
+
+func Test__Jira__ListResources__serviceDeskRequestType_emptyDesk(t *testing.T) {
+	j := &Jira{}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "token",
+		},
+	}
+	resources, err := j.ListResources("serviceDeskRequestType", core.ListResourcesContext{
+		HTTP:        &contexts.HTTPContext{},
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "serviceDeskRequestType"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resources, 0)
+}
+
+func Test__Jira__ListResources__impact(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"6","projectName":"IT","projectKey":"IT"}],"isLastPage":true}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{"requestTypeFields":[
+					{"fieldId":"customfield_10020","name":"Impact","validValues":[
+						{"label":"High","value":"10001"},
+						{"label":"Low","value":"10002"}
+					]}
+				]}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("impact", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters: map[string]string{
+			"type":                   "impact",
+			"serviceDesk":            "6",
+			"serviceDeskRequestType": "75",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, "10001", resources[0].ID)
+	assert.Equal(t, "High", resources[0].Name)
+}
+
+func Test__Jira__ListResources__urgency__fieldOptionsFallback(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"6","projectName":"IT","projectKey":"IT"}],"isLastPage":true}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{"requestTypeFields":[
+					{"fieldId":"customfield_10021","name":"Urgency","validValues":[]}
+				]}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"issueTypes":[{"id":"10001","name":"Incident"}]}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"fields":{"customfield_10021":{"name":"Urgency","allowedValues":[{"id":"2","name":"High"}]}}
+				}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("urgency", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters: map[string]string{
+			"type":                   "urgency",
+			"serviceDesk":            "6",
+			"serviceDeskRequestType": "75",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "2", resources[0].ID)
+	assert.Equal(t, "High", resources[0].Name)
+}
+
+func Test__Jira__ListResources__impact_missingParams(t *testing.T) {
+	j := &Jira{}
+	resources, err := j.ListResources("impact", core.ListResourcesContext{
+		HTTP:        &contexts.HTTPContext{},
+		Integration: &contexts.IntegrationContext{Configuration: map[string]any{"siteUrl": "https://x.net", "email": "a@b.com", "apiToken": "t"}},
+		Parameters:  map[string]string{"type": "impact"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resources, 0)
+}
+
+func Test__Jira__ListResources__issue(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"1","projectName":"Help","projectKey":"HEL"}],"isLastPage":true}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{"values":[
+					{"issueKey":"HEL-1","summary":"Ticket one"},
+					{"issueKey":"HEL-2","summary":""}
+				],"isLastPage":true}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "a@b.com",
+			"apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("issue", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "issue", "project": "HEL"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, "HEL-1", resources[0].ID)
+	assert.Contains(t, resources[0].Name, "HEL-1")
+	assert.Contains(t, resources[0].Name, "Ticket one")
+	assert.Equal(t, "HEL-2", resources[1].ID)
+	require.Len(t, httpContext.Requests, 2)
+	assert.Contains(t, httpContext.Requests[0].URL.String(), "/rest/servicedeskapi/servicedesk")
+	assert.Contains(t, httpContext.Requests[1].URL.String(), "/rest/servicedeskapi/request")
+}
+
+func Test__Jira__ListResources__issue_deskEmptyFallsBackToSearch(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"id":"1","projectName":"Help","projectKey":"HEL"}],"isLastPage":true}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[],"isLastPage":true}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"issues":[{"id":"100","key":"HEL-9","fields":{"summary":"From JQL"}}],"total":1}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "a@b.com",
+			"apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("issue", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "issue", "project": "HEL"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "HEL-9", resources[0].ID)
+	require.Len(t, httpContext.Requests, 3)
+	assert.Equal(t, http.MethodPost, httpContext.Requests[2].Method)
+	assert.True(t, strings.HasSuffix(httpContext.Requests[2].URL.Path, "/rest/api/3/search"))
+}
+
+func Test__Jira__ListResources__issue_noProject(t *testing.T) {
+	j := &Jira{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"issues":[{"id":"1","key":"X-1","fields":{"summary":"S"}}]}`)),
+			},
+		},
+	}
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "a@b.com",
+			"apiToken": "token",
+		},
+	}
+
+	resources, err := j.ListResources("issue", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: appCtx,
+		Parameters:  map[string]string{"type": "issue"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "X-1", resources[0].ID)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+	assert.True(t, strings.HasSuffix(httpContext.Requests[0].URL.Path, "/rest/api/3/search"))
+}
+
+func Test__findRequestTypeFieldID(t *testing.T) {
+	fields := []RequestTypeField{
+		{FieldID: "summary", Name: "Summary"},
+		{FieldID: "customfield_10020", Name: "Impact"},
+		{FieldID: "customfield_10021", Name: "Urgency"},
+	}
+
+	assert.Equal(t, "customfield_10020", findRequestTypeFieldID(fields, "impact"))
+	assert.Equal(t, "customfield_10021", findRequestTypeFieldID(fields, "urgency"))
+	assert.Equal(t, "", findRequestTypeFieldID(fields, "priority"))
+}
+
+func Test__findRequestTypeField__prefersExactWithOptions(t *testing.T) {
+	fields := []RequestTypeField{
+		{FieldID: "customfield_1", Name: "Business urgency rating", ValidValues: nil},
+		{FieldID: "customfield_2", Name: "Urgency", ValidValues: []RequestTypeFieldValue{{Label: "High", Value: "1"}}},
+	}
+	f := findRequestTypeField(fields, "urgency")
+	require.NotNil(t, f)
+	assert.Equal(t, "customfield_2", f.FieldID)
+}
+
+func Test__requestTypeFieldResources__fromValidValues(t *testing.T) {
+	field := &RequestTypeField{
+		FieldID: "customfield_10020",
+		Name:    "Impact",
+		ValidValues: []RequestTypeFieldValue{
+			{Label: "High", Value: "10001"},
+			{Label: "Low", Value: "10002"},
+		},
+	}
+	resources, err := requestTypeFieldResources(nil, field, "impact", "", "impact")
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, "10001", resources[0].ID)
+}
+
+func Test__requestTypeFieldResources__createmetaFallback(t *testing.T) {
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"issueTypes":[{"id":"10001","name":"Incident"}]
+				}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"fields":{
+						"customfield_10021":{
+							"name":"Urgency",
+							"allowedValues":[{"id":"5","name":"High"}]
+						}
+					}
+				}`)),
+			},
+		},
+	}
+	client, err := NewClient(httpContext, &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl": "https://test.atlassian.net", "email": "a@b.com", "apiToken": "token",
+		},
+	})
+	require.NoError(t, err)
+
+	resources, err := requestTypeFieldResources(client, nil, "urgency", "IT", "urgency")
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "5", resources[0].ID)
+}
+

--- a/web_src/src/pages/workflowv2/mappers/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/index.ts
@@ -129,6 +129,7 @@ import {
   triggerRenderers as jfrogArtifactoryTriggerRenderers,
   eventStateRegistry as jfrogArtifactoryEventStateRegistry,
 } from "./jfrogArtifactory/index";
+import { componentMappers as jiraComponentMappers, eventStateRegistry as jiraEventStateRegistry } from "./jira/index";
 import {
   componentMappers as azureComponentMappers,
   triggerRenderers as azureTriggerRenderers,
@@ -328,6 +329,7 @@ const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
   cursor: cursorComponentMappers,
   hetzner: hetznerComponentMappers,
   jfrogArtifactory: jfrogArtifactoryComponentMappers,
+  jira: jiraComponentMappers,
   statuspage: statuspageComponentMappers,
   dockerhub: dockerhubComponentMappers,
   honeycomb: honeycombComponentMappers,
@@ -422,6 +424,7 @@ const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>
   gitlab: gitlabEventStateRegistry,
   jira: jiraEventStateRegistry,
   jfrogArtifactory: jfrogArtifactoryEventStateRegistry,
+  jira: jiraEventStateRegistry,
   dockerhub: dockerhubEventStateRegistry,
   honeycomb: honeycombEventStateRegistry,
   harness: harnessEventStateRegistry,

--- a/web_src/src/pages/workflowv2/mappers/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/index.ts
@@ -129,7 +129,6 @@ import {
   triggerRenderers as jfrogArtifactoryTriggerRenderers,
   eventStateRegistry as jfrogArtifactoryEventStateRegistry,
 } from "./jfrogArtifactory/index";
-import { componentMappers as jiraComponentMappers, eventStateRegistry as jiraEventStateRegistry } from "./jira/index";
 import {
   componentMappers as azureComponentMappers,
   triggerRenderers as azureTriggerRenderers,
@@ -329,7 +328,6 @@ const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
   cursor: cursorComponentMappers,
   hetzner: hetznerComponentMappers,
   jfrogArtifactory: jfrogArtifactoryComponentMappers,
-  jira: jiraComponentMappers,
   statuspage: statuspageComponentMappers,
   dockerhub: dockerhubComponentMappers,
   honeycomb: honeycombComponentMappers,
@@ -424,7 +422,6 @@ const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>
   gitlab: gitlabEventStateRegistry,
   jira: jiraEventStateRegistry,
   jfrogArtifactory: jfrogArtifactoryEventStateRegistry,
-  jira: jiraEventStateRegistry,
   dockerhub: dockerhubEventStateRegistry,
   honeycomb: honeycombEventStateRegistry,
   harness: harnessEventStateRegistry,

--- a/web_src/src/pages/workflowv2/mappers/jira/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/base.ts
@@ -22,25 +22,48 @@ export function jiraComponentBaseProps(context: ComponentBaseContext, metadata: 
   };
 }
 
-export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+function buildJiraEventSections(
+  nodes: NodeInfo[],
+  execution: ExecutionInfo,
+  componentName: string,
+  fallbackWhenIncomplete: boolean,
+): EventSection[] {
   const rootEvent = execution.rootEvent;
-  if (!rootEvent?.id || !execution.createdAt) return [];
+  const eventState = getState(componentName)(execution);
 
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) return [];
+  if (!fallbackWhenIncomplete) {
+    if (!rootEvent?.id || !execution.createdAt) return [];
 
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+    const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+    if (!rootTriggerNode?.componentName) return [];
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
-      eventState: getState(componentName)(execution),
-      eventId: rootEvent.id,
-    },
-  ];
+    const { title } = getTriggerRenderer(rootTriggerNode.componentName).getTitleAndSubtitle({ event: rootEvent });
+    return [
+      {
+        receivedAt: new Date(execution.createdAt),
+        eventTitle: title,
+        eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+        eventState,
+        eventId: rootEvent.id,
+      },
+    ];
+  }
+
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const subtitleDate = execution.updatedAt ?? execution.createdAt;
+  const eventSubtitle = subtitleDate ? renderTimeAgo(new Date(subtitleDate)) : "";
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent?.nodeId);
+  if (!rootTriggerNode || !rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
+
+  const { title } = getTriggerRenderer(rootTriggerNode.componentName).getTitleAndSubtitle({ event: rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: rootEvent.id }];
+}
+
+export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  return buildJiraEventSections(nodes, execution, componentName, false);
 }
 
 export function jiraBaseEventSections(
@@ -48,21 +71,5 @@ export function jiraBaseEventSections(
   execution: ExecutionInfo,
   componentName: string,
 ): EventSection[] {
-  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
-  const subtitleDate = execution.updatedAt ?? execution.createdAt;
-  const eventSubtitle = subtitleDate ? renderTimeAgo(new Date(subtitleDate)) : "";
-  const eventState = getState(componentName)(execution);
-
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  if (!rootTriggerNode || !execution.rootEvent?.id) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  if (!rootTriggerRenderer) {
-    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
-  }
-
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
-  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  return buildJiraEventSections(nodes, execution, componentName, true);
 }

--- a/web_src/src/pages/workflowv2/mappers/jira/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/base.ts
@@ -23,7 +23,24 @@ export function jiraComponentBaseProps(context: ComponentBaseContext, metadata: 
 }
 
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  return jiraBaseEventSections(nodes, execution, componentName);
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.id || !execution.createdAt) return [];
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) return [];
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id,
+    },
+  ];
 }
 
 export function jiraBaseEventSections(

--- a/web_src/src/pages/workflowv2/mappers/jira/base.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/base.ts
@@ -23,22 +23,29 @@ export function jiraComponentBaseProps(context: ComponentBaseContext, metadata: 
 }
 
 export function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootEvent = execution.rootEvent;
-  if (!rootEvent?.id || !execution.createdAt) return [];
+  return jiraBaseEventSections(nodes, execution, componentName);
+}
 
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) return [];
+export function jiraBaseEventSections(
+  nodes: NodeInfo[],
+  execution: ExecutionInfo,
+  componentName: string,
+): EventSection[] {
+  const receivedAt = execution.createdAt ? new Date(execution.createdAt) : new Date();
+  const subtitleDate = execution.updatedAt ?? execution.createdAt;
+  const eventSubtitle = subtitleDate ? renderTimeAgo(new Date(subtitleDate)) : "";
+  const eventState = getState(componentName)(execution);
+
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  if (!rootTriggerNode || !execution.rootEvent?.id) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.id ?? "" }];
+  }
 
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  if (!rootTriggerRenderer) {
+    return [{ receivedAt, eventTitle: "Execution", eventSubtitle, eventState, eventId: execution.rootEvent.id }];
+  }
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt),
-      eventTitle: title,
-      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
-      eventState: getState(componentName)(execution),
-      eventId: rootEvent.id,
-    },
-  ];
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  return [{ receivedAt, eventTitle: title, eventSubtitle, eventState, eventId: execution.rootEvent.id }];
 }

--- a/web_src/src/pages/workflowv2/mappers/jira/create_incident.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/create_incident.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  ComponentBaseContext,
+  ComponentDefinition,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+} from "../types";
+import { createIncidentMapper } from "./create_incident";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "JSM",
+    componentName: "jira.createIncident",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "jira.createIncident",
+  label: "Create Incident",
+  description: "",
+  icon: "jira",
+  color: "orange",
+};
+
+function buildPropsContext(overrides?: Partial<ComponentBaseContext>): ComponentBaseContext {
+  return {
+    nodes: [],
+    node: buildNode({
+      configuration: { summary: "Outage", serviceDesk: "6", serviceDeskRequestType: "75" },
+      metadata: { serviceDeskName: "IT (IT)", requestTypeName: "Incident" },
+    }),
+    componentDefinition: defaultDefinition,
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+    ...overrides,
+  };
+}
+
+describe("createIncidentMapper", () => {
+  it("getExecutionDetails includes issue key and url", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            {
+              type: "jira.incident.created",
+              timestamp: new Date().toISOString(),
+              data: {
+                id: "1",
+                key: "IT-2",
+                self: "https://test.atlassian.net/rest/api/3/issue/1",
+              },
+            },
+          ],
+        },
+      },
+    });
+    const details = createIncidentMapper.getExecutionDetails(ctx);
+    expect(details["Issue key"]).toBe("IT-2");
+    expect(details["url"]).toBe("https://test.atlassian.net/rest/api/3/issue/1");
+    expect(details["Issue id"]).toBeUndefined();
+  });
+
+  it("props metadata shows at most service desk, request type, and summary", () => {
+    const props = createIncidentMapper.props(
+      buildPropsContext({
+        node: buildNode({
+          configuration: {
+            summary: "Outage",
+            serviceDesk: "6",
+            serviceDeskRequestType: "75",
+            priority: "High",
+            dueDate: "2026-05-14",
+          },
+          metadata: { serviceDeskName: "IT (IT)", requestTypeName: "Incident" },
+        }),
+      }),
+    );
+    expect(props.metadata).toHaveLength(3);
+    expect(props.metadata?.map((m) => m.label)).toEqual(["IT (IT)", "Incident", "Outage"]);
+  });
+
+  it("event state registry maps success to created", () => {
+    const exec = buildExecution({ result: "RESULT_PASSED" });
+    expect(eventStateRegistry.createIncident.getState(exec)).toBe("created");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/create_incident.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/create_incident.ts
@@ -1,0 +1,91 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface CreateIncidentConfiguration {
+  serviceDesk?: string;
+  serviceDeskRequestType?: string;
+  summary?: string;
+}
+
+interface CreateIncidentNodeMetadata {
+  serviceDeskName?: string;
+  requestTypeName?: string;
+}
+
+export const createIncidentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.createIncident";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!data) {
+      return details;
+    }
+    if (data.key != null) {
+      details["Issue key"] = String(data.key);
+    }
+    if (data.self != null) {
+      details["url"] = String(data.self);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as CreateIncidentConfiguration;
+  const nodeMetadata = node.metadata as CreateIncidentNodeMetadata | undefined;
+
+  const items: MetadataItem[] = [];
+
+  const deskLabel = nodeMetadata?.serviceDeskName || configuration?.serviceDesk;
+  if (deskLabel) {
+    items.push({ icon: "layers", label: deskLabel });
+  }
+
+  const typeLabel = nodeMetadata?.requestTypeName || configuration?.serviceDeskRequestType;
+  if (typeLabel) {
+    items.push({ icon: "tag", label: typeLabel });
+  }
+
+  if (configuration?.summary) {
+    items.push({ icon: "file-text", label: configuration.summary });
+  }
+
+  return items.slice(0, 3);
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/delete_incident.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/delete_incident.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { deleteIncidentMapper } from "./delete_incident";
+import { eventStateRegistry } from "./index";
+
+function buildNode(): NodeInfo {
+  return {
+    id: "n1",
+    name: "Del",
+    componentName: "jira.deleteIncident",
+    isCollapsed: false,
+    configuration: { issue: "IT-9" },
+    metadata: {},
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "e1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("deleteIncidentMapper", () => {
+  it("getExecutionDetails shows Deleted true from payload", () => {
+    const ctx: ExecutionDetailsContext = {
+      nodes: [],
+      node: buildNode(),
+      execution: buildExecution({
+        outputs: {
+          default: [
+            {
+              type: "jira.incident.deleted",
+              timestamp: new Date().toISOString(),
+              data: { deleted: true },
+            },
+          ],
+        },
+      }),
+    };
+    expect(deleteIncidentMapper.getExecutionDetails(ctx)["Deleted"]).toBe("true");
+    expect(deleteIncidentMapper.getExecutionDetails(ctx)["Issue id"]).toBeUndefined();
+  });
+
+  it("event state registry maps success to deleted", () => {
+    const exec = buildExecution({ result: "RESULT_PASSED" });
+    expect(eventStateRegistry.deleteIncident.getState(exec)).toBe("deleted");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/delete_incident.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/delete_incident.ts
@@ -1,0 +1,68 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface DeleteIncidentConfiguration {
+  issue?: string;
+  project?: string;
+}
+
+export const deleteIncidentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.deleteIncident";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (data?.deleted === true) {
+      details["Deleted"] = "true";
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as DeleteIncidentConfiguration;
+  if (configuration?.issue) {
+    metadata.push({ icon: "hash", label: configuration.issue });
+  }
+  if (configuration?.project) {
+    metadata.push({ icon: "folder", label: configuration.project });
+  }
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/get_incident.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/get_incident.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { getIncidentMapper } from "./get_incident";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "n1",
+    name: "Get",
+    componentName: "jira.getIncident",
+    isCollapsed: false,
+    configuration: { issue: "IT-1", project: "IT" },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "e1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("getIncidentMapper", () => {
+  it("getExecutionDetails reads summary and status", () => {
+    const ctx: ExecutionDetailsContext = {
+      nodes: [],
+      node: buildNode(),
+      execution: buildExecution({
+        outputs: {
+          default: [
+            {
+              type: "jira.incident.fetched",
+              timestamp: new Date().toISOString(),
+              data: { summary: "Sev1", status: { name: "Open" } },
+            },
+          ],
+        },
+      }),
+    };
+    const d = getIncidentMapper.getExecutionDetails(ctx);
+    expect(d.Summary).toBe("Sev1");
+    expect(d.Status).toBe("Open");
+  });
+
+  it("event state registry maps success to fetched", () => {
+    const exec = buildExecution({ result: "RESULT_PASSED" });
+    expect(eventStateRegistry.getIncident.getState(exec)).toBe("fetched");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/get_incident.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/get_incident.ts
@@ -1,0 +1,81 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface GetIncidentConfiguration {
+  issue?: string;
+  project?: string;
+}
+
+export const getIncidentMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.getIncident";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!data) {
+      return details;
+    }
+    const summary = data.summary;
+    if (summary != null && typeof summary === "object" && summary !== null && "value" in (summary as object)) {
+      const v = (summary as { value?: unknown }).value;
+      if (v != null) {
+        details["Summary"] = String(v);
+      }
+    } else if (summary != null) {
+      details["Summary"] = String(summary);
+    }
+    const status = data.status as Record<string, unknown> | undefined;
+    if (status?.name != null) {
+      details["Status"] = String(status.name);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const configuration = node.configuration as GetIncidentConfiguration;
+  if (configuration?.issue) {
+    metadata.push({ icon: "hash", label: configuration.issue });
+  }
+  if (configuration?.project) {
+    metadata.push({ icon: "folder", label: configuration.project });
+  }
+  return metadata;
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/index.ts
@@ -4,12 +4,18 @@ import { createIssueMapper } from "./create_issue";
 import { deleteIssueMapper } from "./delete_issue";
 import { getIssueMapper } from "./get_issue";
 import { updateIssueMapper } from "./update_issue";
+import { createIncidentMapper } from "./create_incident";
+import { getIncidentMapper } from "./get_incident";
+import { deleteIncidentMapper } from "./delete_incident";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIssue: createIssueMapper,
   getIssue: getIssueMapper,
   updateIssue: updateIssueMapper,
   deleteIssue: deleteIssueMapper,
+  createIncident: createIncidentMapper,
+  getIncident: getIncidentMapper,
+  deleteIncident: deleteIncidentMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -19,4 +25,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   getIssue: buildActionStateRegistry("retrieved"),
   updateIssue: buildActionStateRegistry("updated"),
   deleteIssue: buildActionStateRegistry("deleted"),
+  createIncident: buildActionStateRegistry("created"),
+  getIncident: buildActionStateRegistry("fetched"),
+  deleteIncident: buildActionStateRegistry("deleted"),
 };


### PR DESCRIPTION
Resolves: #4797 

## What changed

Adds three Jira Service Management (JSM) workflow components :
- **Create Incident** 
- **Get Incident**
- **Delete Incident** 


## Why

SuperPlane already supports Jira issue creation, but not JSM **incidents** via the dedicated Incidents API. 

## How:
### Backend:
Implemented new client methods in pkg/integrations/jira/client.go for incident endpoints.
Registered actions in pkg/integrations/jira/jira.go and updated token permission guidance.
Added tests

### Frontend:
Added Jira workflow v2 mappers
Registered mappers and event states in web_src/src/pages/workflowv2/mappers/jira/index.ts
Added mapper specs