### PR TITLE
chore: block complexity rule disable-next-line directives

### DIFF
--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,16 +1,17 @@
 {
-  "maxAllowedTotalIssues": 710,
+  "maxAllowedTotalIssues": 715,
   "maxAllowedByRule": {
     "complexity": 233,
     "@typescript-eslint/no-explicit-any": 160,
     "@typescript-eslint/no-non-null-asserted-optional-chain": 80,
     "max-lines-per-function": 77,
-    "max-statements": 75,
+    "max-statements": 74,
     "react-hooks/exhaustive-deps": 33,
     "react-refresh/only-export-components": 23,
     "max-lines": 17,
     "max-params": 6,
-    "max-depth": 6
+    "max-depth": 6,
+    "no-eslint-disable-next-line": 6
   },
-  "updatedAt": "2026-05-13T14:19:18.922Z"
+  "updatedAt": "2026-05-15T09:07:27.755Z"
 }

--- a/web_src/scripts/check-eslint-budget.mjs
+++ b/web_src/scripts/check-eslint-budget.mjs
@@ -12,7 +12,7 @@ const isUpdateBaseline = process.argv.includes("--update-baseline");
 const ignoredPrefixes = ["src/api-client/", "storybook-static/", "dist/", "dist-ssr/", "node_modules/"];
 const redStart = process.env.NO_COLOR ? "" : "\x1b[31m";
 const colorEnd = process.env.NO_COLOR ? "" : "\x1b[0m";
-const disallowedComplexityDirectivePattern = /(?:\/\/|\/\*)\s*eslint-disable-next-line[^\n]*\bcomplexity\b/;
+const disallowedDisableNextLinePattern = /(?:\/\/|\/\*)\s*eslint-disable-next-line\b/;
 
 function normalizeRuleId(message) {
   if (message.ruleId) {
@@ -78,7 +78,7 @@ function extractDisallowedDirectiveIssues(results) {
 
     const lines = source.split(/\r?\n/u);
     for (const [index, line] of lines.entries()) {
-      const matchIndex = line.search(disallowedComplexityDirectivePattern);
+      const matchIndex = line.search(disallowedDisableNextLinePattern);
       if (matchIndex === -1) {
         continue;
       }
@@ -88,8 +88,8 @@ function extractDisallowedDirectiveIssues(results) {
         line: index + 1,
         column: matchIndex + 1,
         severity: "error",
-        ruleId: "no-eslint-disable-next-line-complexity",
-        message: "Disabling the complexity rule with eslint-disable-next-line is not allowed.",
+        ruleId: "no-eslint-disable-next-line",
+        message: "Using eslint-disable-next-line is not allowed.",
       });
     }
   }

--- a/web_src/scripts/check-eslint-budget.mjs
+++ b/web_src/scripts/check-eslint-budget.mjs
@@ -12,6 +12,7 @@ const isUpdateBaseline = process.argv.includes("--update-baseline");
 const ignoredPrefixes = ["src/api-client/", "storybook-static/", "dist/", "dist-ssr/", "node_modules/"];
 const redStart = process.env.NO_COLOR ? "" : "\x1b[31m";
 const colorEnd = process.env.NO_COLOR ? "" : "\x1b[0m";
+const disallowedComplexityDirectivePattern = /(?:\/\/|\/\*)\s*eslint-disable-next-line[^\n]*\bcomplexity\b/;
 
 function normalizeRuleId(message) {
   if (message.ruleId) {
@@ -49,6 +50,46 @@ function extractIssues(results) {
         severity: message.severity === 2 ? "error" : "warning",
         ruleId: normalizeRuleId(message),
         message: message.message,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function extractDisallowedDirectiveIssues(results) {
+  const issues = [];
+
+  for (const result of results) {
+    const filePath = toRelativeFilePath(result.filePath);
+    const isIgnoredPath = ignoredPrefixes.some((prefix) => filePath.startsWith(prefix));
+    const isStorybookStoryFile = filePath.endsWith(".stories.tsx");
+    const isStorybookSupportFile = filePath.includes("/storybooks/");
+    if (isIgnoredPath || isStorybookStoryFile || isStorybookSupportFile) {
+      continue;
+    }
+
+    let source;
+    try {
+      source = fs.readFileSync(result.filePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const lines = source.split(/\r?\n/u);
+    for (const [index, line] of lines.entries()) {
+      const matchIndex = line.search(disallowedComplexityDirectivePattern);
+      if (matchIndex === -1) {
+        continue;
+      }
+
+      issues.push({
+        filePath,
+        line: index + 1,
+        column: matchIndex + 1,
+        severity: "error",
+        ruleId: "no-eslint-disable-next-line-complexity",
+        message: "Disabling the complexity rule with eslint-disable-next-line is not allowed.",
       });
     }
   }
@@ -139,7 +180,7 @@ function findRegressions(currentByRule, baselineByRule) {
 async function main() {
   const eslint = new ESLint({ cwd: webRoot });
   const results = await eslint.lintFiles(["."]);
-  const issues = extractIssues(results);
+  const issues = [...extractIssues(results), ...extractDisallowedDirectiveIssues(results)];
   const countsByRule = summarizeByRule(issues);
 
   if (isUpdateBaseline) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend `web_src/scripts/check-eslint-budget.mjs` to flag **any** `eslint-disable-next-line` directive as a lint-budget rule (`no-eslint-disable-next-line`)
- keep file/line/column reporting so CI output points directly to the forbidden directive
- update `web_src/.eslint-budget-baseline.json` to snapshot the current 6 existing directives, so CI now blocks additional occurrences (regressions) without requiring immediate broad refactors

## Validation
- `npm run lint:budget` fails before baseline update with `no-eslint-disable-next-line: 6 (allowed 0)`
- `npm run lint:baseline:update`
- `npm run lint:budget` passes at `no-eslint-disable-next-line: 6/6`
- `make format.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9a363b-b6f7-4bcf-93e0-d37bf05b4d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9a363b-b6f7-4bcf-93e0-d37bf05b4d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

