### PR TITLE
fix: preserve zoom when switching to runs view

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -106,7 +106,7 @@ import {
 } from "./lib/canvas-versions";
 import { buildChangeRequestVersionRowsForStatus } from "./lib/change-requests";
 import { getNodeIntegrationName, overlayIntegrationWarnings } from "./lib/node-integrations";
-import { getRunsFitAllDecision, prepareRunsViewportOnModeEntry } from "./lib/runs-viewport";
+import { getRunsFitAllDecision, getRunsFitAllRequest, prepareRunsViewportOnModeEntry } from "./lib/runs-viewport";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
 import { getVersionActionAvailability } from "./lib/version-action-state";
 import { getCustomFieldRenderer, getState, getStateMap } from "./mappers";
@@ -134,6 +134,7 @@ import {
   summarizeWorkflowChanges,
 } from "./utils";
 import { actionsFromCapabilities, triggersFromCapabilities } from "@/lib/capabilities";
+
 function getNodeAnalyticsProps(
   node: ComponentsNode,
   availableIntegrations: IntegrationsIntegrationDefinition[],
@@ -2031,9 +2032,9 @@ export function WorkflowPageV2() {
 
     skipNextRunsFitAllRef.current = fitDecision.skipInitialRunsFitAll;
     if (!fitDecision.shouldFitAll) return;
-
     setRunsFitAllNonce((n) => n + 1);
   }, [isRunsMode, runCanvasNodeIdsKey]);
+  const runsFitAllRequest = getRunsFitAllRequest({ isRunsMode, runsFitAllNonce });
 
   const getSidebarData = useCallback(
     (nodeId: string): SidebarData | null => {
@@ -5740,7 +5741,7 @@ export function WorkflowPageV2() {
           isSidebarOpenRef={isSidebarOpenRef}
           viewportRef={isRunsMode ? runsViewportRef : viewportRef}
           initialFocusNodeId={initialFocusNodeIdRef.current}
-          fitAllRequest={isRunsMode ? runsFitAllNonce : null}
+          fitAllRequest={runsFitAllRequest}
           runCanvasLoading={isRunsMode && !!selectedRunRootEventId && selectedRunExecutionsQuery.isLoading}
           saveIsPrimary={saveIsPrimary}
           saveButtonHidden={saveButtonHidden}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -106,6 +106,7 @@ import {
 } from "./lib/canvas-versions";
 import { buildChangeRequestVersionRowsForStatus } from "./lib/change-requests";
 import { getNodeIntegrationName, overlayIntegrationWarnings } from "./lib/node-integrations";
+import { getRunsFitAllDecision, prepareRunsViewportOnModeEntry } from "./lib/runs-viewport";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
 import { getVersionActionAvailability } from "./lib/version-action-state";
 import { getCustomFieldRenderer, getState, getStateMap } from "./mappers";
@@ -711,6 +712,7 @@ export function WorkflowPageV2() {
   const viewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const runsViewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const lastRunsViewportKeyRef = useRef<string | null>(null);
+  const skipNextRunsFitAllRef = useRef(false);
 
   // Track unsaved changes on the canvas
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -1997,8 +1999,18 @@ export function WorkflowPageV2() {
   const runsViewportKey = isRunsMode ? "runs" : null;
 
   if (lastRunsViewportKeyRef.current !== runsViewportKey) {
-    runsHasFitToViewRef.current = false;
-    runsViewportRef.current = undefined;
+    if (isRunsMode) {
+      const modeEntryViewport = prepareRunsViewportOnModeEntry({
+        currentCanvasViewport: viewportRef.current,
+        existingRunsViewport: runsViewportRef.current,
+        hasFitToView: runsHasFitToViewRef.current,
+      });
+
+      runsViewportRef.current = modeEntryViewport.runsViewport;
+      runsHasFitToViewRef.current = modeEntryViewport.hasFitToView;
+      skipNextRunsFitAllRef.current = modeEntryViewport.seededFromCanvasViewport;
+    }
+
     lastRunsViewportKeyRef.current = runsViewportKey;
   }
 
@@ -2011,8 +2023,15 @@ export function WorkflowPageV2() {
   }, [isRunsMode, runCanvasData]);
 
   useEffect(() => {
-    if (!isRunsMode) return;
-    if (!runCanvasNodeIdsKey) return;
+    const fitDecision = getRunsFitAllDecision({
+      isRunsMode,
+      runCanvasNodeIdsKey,
+      skipInitialRunsFitAll: skipNextRunsFitAllRef.current,
+    });
+
+    skipNextRunsFitAllRef.current = fitDecision.skipInitialRunsFitAll;
+    if (!fitDecision.shouldFitAll) return;
+
     setRunsFitAllNonce((n) => n + 1);
   }, [isRunsMode, runCanvasNodeIdsKey]);
 

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { getRunsFitAllDecision, prepareRunsViewportOnModeEntry } from "./runs-viewport";
+
+describe("prepareRunsViewportOnModeEntry", () => {
+  it("seeds runs viewport from current canvas viewport when available", () => {
+    const canvasViewport = { x: 120, y: 240, zoom: 0.75 };
+    const existingRunsViewport = { x: 10, y: 20, zoom: 1.3 };
+
+    const result = prepareRunsViewportOnModeEntry({
+      currentCanvasViewport: canvasViewport,
+      existingRunsViewport,
+      hasFitToView: false,
+    });
+
+    expect(result).toEqual({
+      runsViewport: canvasViewport,
+      hasFitToView: true,
+      seededFromCanvasViewport: true,
+    });
+  });
+
+  it("falls back to existing runs viewport when current canvas viewport is unavailable", () => {
+    const existingRunsViewport = { x: 30, y: 40, zoom: 0.9 };
+
+    const result = prepareRunsViewportOnModeEntry({
+      currentCanvasViewport: undefined,
+      existingRunsViewport,
+      hasFitToView: false,
+    });
+
+    expect(result).toEqual({
+      runsViewport: existingRunsViewport,
+      hasFitToView: true,
+      seededFromCanvasViewport: false,
+    });
+  });
+
+  it("preserves fit state when no viewport exists", () => {
+    const result = prepareRunsViewportOnModeEntry({
+      currentCanvasViewport: undefined,
+      existingRunsViewport: undefined,
+      hasFitToView: false,
+    });
+
+    expect(result).toEqual({
+      runsViewport: undefined,
+      hasFitToView: false,
+      seededFromCanvasViewport: false,
+    });
+  });
+});
+
+describe("getRunsFitAllDecision", () => {
+  it("skips fit-all once after entering runs mode from canvas viewport", () => {
+    const result = getRunsFitAllDecision({
+      isRunsMode: true,
+      runCanvasNodeIdsKey: "node-a|node-b",
+      skipInitialRunsFitAll: true,
+    });
+
+    expect(result).toEqual({
+      shouldFitAll: false,
+      skipInitialRunsFitAll: false,
+    });
+  });
+
+  it("fits all when runs mode is active and skip flag is cleared", () => {
+    const result = getRunsFitAllDecision({
+      isRunsMode: true,
+      runCanvasNodeIdsKey: "node-a|node-b",
+      skipInitialRunsFitAll: false,
+    });
+
+    expect(result).toEqual({
+      shouldFitAll: true,
+      skipInitialRunsFitAll: false,
+    });
+  });
+
+  it("does nothing when runs mode is inactive", () => {
+    const result = getRunsFitAllDecision({
+      isRunsMode: false,
+      runCanvasNodeIdsKey: "node-a|node-b",
+      skipInitialRunsFitAll: true,
+    });
+
+    expect(result).toEqual({
+      shouldFitAll: false,
+      skipInitialRunsFitAll: true,
+    });
+  });
+});

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getRunsFitAllDecision, prepareRunsViewportOnModeEntry } from "./runs-viewport";
+import { getRunsFitAllDecision, getRunsFitAllRequest, prepareRunsViewportOnModeEntry } from "./runs-viewport";
 
 describe("prepareRunsViewportOnModeEntry", () => {
   it("seeds runs viewport from current canvas viewport when available", () => {
@@ -88,5 +88,19 @@ describe("getRunsFitAllDecision", () => {
       shouldFitAll: false,
       skipInitialRunsFitAll: true,
     });
+  });
+});
+
+describe("getRunsFitAllRequest", () => {
+  it("returns null when runs mode is inactive", () => {
+    expect(getRunsFitAllRequest({ isRunsMode: false, runsFitAllNonce: 3 })).toBeNull();
+  });
+
+  it("returns null before any fit-all request has been issued", () => {
+    expect(getRunsFitAllRequest({ isRunsMode: true, runsFitAllNonce: 0 })).toBeNull();
+  });
+
+  it("returns nonce after an explicit fit-all request", () => {
+    expect(getRunsFitAllRequest({ isRunsMode: true, runsFitAllNonce: 2 })).toBe(2);
   });
 });

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.ts
@@ -1,0 +1,70 @@
+type ViewportState = { x: number; y: number; zoom: number };
+
+type PrepareRunsViewportOnModeEntryParams = {
+  currentCanvasViewport: ViewportState | undefined;
+  existingRunsViewport: ViewportState | undefined;
+  hasFitToView: boolean;
+};
+
+type PrepareRunsViewportOnModeEntryResult = {
+  runsViewport: ViewportState | undefined;
+  hasFitToView: boolean;
+  seededFromCanvasViewport: boolean;
+};
+
+export function prepareRunsViewportOnModeEntry({
+  currentCanvasViewport,
+  existingRunsViewport,
+  hasFitToView,
+}: PrepareRunsViewportOnModeEntryParams): PrepareRunsViewportOnModeEntryResult {
+  const runsViewport = currentCanvasViewport ?? existingRunsViewport;
+  if (runsViewport) {
+    return {
+      runsViewport,
+      hasFitToView: true,
+      seededFromCanvasViewport: !!currentCanvasViewport,
+    };
+  }
+
+  return {
+    runsViewport: undefined,
+    hasFitToView,
+    seededFromCanvasViewport: false,
+  };
+}
+
+type RunsFitAllDecisionParams = {
+  isRunsMode: boolean;
+  runCanvasNodeIdsKey: string | null;
+  skipInitialRunsFitAll: boolean;
+};
+
+type RunsFitAllDecision = {
+  shouldFitAll: boolean;
+  skipInitialRunsFitAll: boolean;
+};
+
+export function getRunsFitAllDecision({
+  isRunsMode,
+  runCanvasNodeIdsKey,
+  skipInitialRunsFitAll,
+}: RunsFitAllDecisionParams): RunsFitAllDecision {
+  if (!isRunsMode || !runCanvasNodeIdsKey) {
+    return {
+      shouldFitAll: false,
+      skipInitialRunsFitAll,
+    };
+  }
+
+  if (skipInitialRunsFitAll) {
+    return {
+      shouldFitAll: false,
+      skipInitialRunsFitAll: false,
+    };
+  }
+
+  return {
+    shouldFitAll: true,
+    skipInitialRunsFitAll: false,
+  };
+}

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.ts
@@ -68,3 +68,16 @@ export function getRunsFitAllDecision({
     skipInitialRunsFitAll: false,
   };
 }
+
+type RunsFitAllRequestParams = {
+  isRunsMode: boolean;
+  runsFitAllNonce: number;
+};
+
+export function getRunsFitAllRequest({ isRunsMode, runsFitAllNonce }: RunsFitAllRequestParams): number | null {
+  if (!isRunsMode || runsFitAllNonce <= 0) {
+    return null;
+  }
+
+  return runsFitAllNonce;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the current canvas viewport when entering runs mode so Canvas → Runs does not reset zoom
- gate runs-mode fit-all requests so initial entry does not treat nonce `0` as an explicit fit trigger
- add focused unit coverage for viewport seeding, fit-all decision logic, and fit-all request gating

## Testing
- `npm run test:run -- src/pages/workflowv2/lib/runs-viewport.spec.ts`
- `make format.js`
- `make check.build.ui`

## Manual verification
- set workflow canvas zoom to a non-default value
- switched Canvas → Runs and verified the zoom value remained unchanged

[issue_4800_canvas_to_runs_zoom_persists.mp4](https://cursor.com/agents/bc-1b37e7e5-8687-42cd-8353-e3eeb259e341/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_4800_canvas_to_runs_zoom_persists.mp4)
[Canvas zoom before switching to Runs](https://cursor.com/agents/bc-1b37e7e5-8687-42cd-8353-e3eeb259e341/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_4800_canvas_zoom_before_runs.webp)
[Runs view zoom after switching](https://cursor.com/agents/bc-1b37e7e5-8687-42cd-8353-e3eeb259e341/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_4800_runs_zoom_after_switch.webp)
[Canvas zoom after returning](https://cursor.com/agents/bc-1b37e7e5-8687-42cd-8353-e3eeb259e341/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_4800_canvas_zoom_after_return.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b37e7e5-8687-42cd-8353-e3eeb259e341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b37e7e5-8687-42cd-8353-e3eeb259e341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

