### PR TITLE
fix: gate eslint budget by metric maximums

### DIFF
--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -13,5 +13,9 @@
     "max-depth": 6,
     "no-eslint-disable-next-line": 6
   },
-  "updatedAt": "2026-05-15T09:07:27.755Z"
+  "maxAllowedMetricTotalByRule": {
+    "max-lines": 20410,
+    "complexity": 6153
+  },
+  "updatedAt": "2026-05-15T10:07:08.343Z"
 }

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -13,9 +13,9 @@
     "max-depth": 6,
     "no-eslint-disable-next-line": 6
   },
-  "maxAllowedMetricTotalByRule": {
-    "max-lines": 20410,
-    "complexity": 6153
+  "maxAllowedMetricMaximumByRule": {
+    "max-lines": 5389,
+    "complexity": 332
   },
-  "updatedAt": "2026-05-15T10:07:08.343Z"
+  "updatedAt": "2026-05-15T10:48:16.505Z"
 }

--- a/web_src/scripts/check-eslint-budget.mjs
+++ b/web_src/scripts/check-eslint-budget.mjs
@@ -120,8 +120,8 @@ function extractRuleMetricValue(issue) {
   return null;
 }
 
-function summarizeMetricTotalsByRule(issues) {
-  const totals = {};
+function summarizeMetricMaximumsByRule(issues) {
+  const maximums = {};
 
   for (const issue of issues) {
     const metricValue = extractRuleMetricValue(issue);
@@ -129,10 +129,10 @@ function summarizeMetricTotalsByRule(issues) {
       continue;
     }
 
-    totals[issue.ruleId] = (totals[issue.ruleId] ?? 0) + metricValue;
+    maximums[issue.ruleId] = Math.max(maximums[issue.ruleId] ?? 0, metricValue);
   }
 
-  return Object.fromEntries(Object.entries(totals).sort((a, b) => b[1] - a[1]));
+  return Object.fromEntries(Object.entries(maximums).sort((a, b) => b[1] - a[1]));
 }
 
 function printRuleCountsVsBudget(currentByRule, maxAllowedByRule) {
@@ -166,7 +166,7 @@ function printRuleCountsVsBudget(currentByRule, maxAllowedByRule) {
   }
 }
 
-function printMetricTotalsVsBudget(currentByRule, maxAllowedByRule) {
+function printMetricMaximumsVsBudget(currentByRule, maxAllowedByRule) {
   const allRuleIds = new Set([
     ...Object.keys(currentByRule),
     ...Object.keys(maxAllowedByRule),
@@ -183,7 +183,7 @@ function printMetricTotalsVsBudget(currentByRule, maxAllowedByRule) {
   });
 
   if (sortedRuleIds.length === 0) {
-    console.log("- No metric totals found.");
+    console.log("- No metric maximums found.");
     return;
   }
 
@@ -214,12 +214,12 @@ function readBaseline() {
 }
 
 function writeBaseline(issues, countsByRule) {
-  const metricTotalsByRule = summarizeMetricTotalsByRule(issues);
+  const metricMaximumByRule = summarizeMetricMaximumsByRule(issues);
 
   const baseline = {
     maxAllowedTotalIssues: issues.length,
     maxAllowedByRule: countsByRule,
-    maxAllowedMetricTotalByRule: metricTotalsByRule,
+    maxAllowedMetricMaximumByRule: metricMaximumByRule,
     updatedAt: new Date().toISOString(),
   };
 
@@ -245,7 +245,7 @@ async function main() {
   const results = await eslint.lintFiles(["."]);
   const issues = [...extractIssues(results), ...extractDisallowedDirectiveIssues(results)];
   const countsByRule = summarizeByRule(issues);
-  const metricTotalsByRule = summarizeMetricTotalsByRule(issues);
+  const metricMaximumByRule = summarizeMetricMaximumsByRule(issues);
 
   if (isUpdateBaseline) {
     writeBaseline(issues, countsByRule);
@@ -260,8 +260,8 @@ async function main() {
     console.log("");
     console.log("");
     console.log("");
-    console.log("Rule metric totals vs budget:");
-    printMetricTotalsVsBudget(metricTotalsByRule, metricTotalsByRule);
+    console.log("Rule metric maximums vs budget:");
+    printMetricMaximumsVsBudget(metricMaximumByRule, metricMaximumByRule);
     console.log("");
     console.log("");
     console.log("");
@@ -272,11 +272,12 @@ async function main() {
   const baseline = readBaseline();
   const maxAllowedTotal = baseline.maxAllowedTotalIssues;
   const maxAllowedByRule = baseline.maxAllowedByRule ?? {};
-  const maxAllowedMetricTotalByRule = baseline.maxAllowedMetricTotalByRule ?? {};
+  const maxAllowedMetricMaximumByRule =
+    baseline.maxAllowedMetricMaximumByRule ?? baseline.maxAllowedMetricTotalByRule ?? {};
 
   const totalRegression = issues.length - maxAllowedTotal;
   const byRuleRegressions = findRegressions(countsByRule, maxAllowedByRule);
-  const metricRegressions = findRegressions(metricTotalsByRule, maxAllowedMetricTotalByRule);
+  const metricRegressions = findRegressions(metricMaximumByRule, maxAllowedMetricMaximumByRule);
 
   if (totalRegression > 0 || byRuleRegressions.length > 0 || metricRegressions.length > 0) {
     console.error("ESLint budget exceeded.");
@@ -294,7 +295,7 @@ async function main() {
     }
 
     if (metricRegressions.length > 0) {
-      console.error("- Rule metric total regressions:");
+      console.error("- Rule metric maximum regressions:");
       for (const regression of metricRegressions.slice(0, 20)) {
         console.error(`  - ${regression.ruleId}: ${regression.currentValue} (allowed ${regression.allowedValue})`);
       }
@@ -314,8 +315,8 @@ async function main() {
     console.error("");
     console.error("");
     console.error("");
-    console.error("Rule metric totals vs budget:");
-    printMetricTotalsVsBudget(metricTotalsByRule, maxAllowedMetricTotalByRule);
+    console.error("Rule metric maximums vs budget:");
+    printMetricMaximumsVsBudget(metricMaximumByRule, maxAllowedMetricMaximumByRule);
     console.error("");
     console.error("");
     console.error("");
@@ -333,8 +334,8 @@ async function main() {
   console.log("");
   console.log("");
   console.log("");
-  console.log("Rule metric totals vs budget:");
-  printMetricTotalsVsBudget(metricTotalsByRule, maxAllowedMetricTotalByRule);
+  console.log("Rule metric maximums vs budget:");
+  printMetricMaximumsVsBudget(metricMaximumByRule, maxAllowedMetricMaximumByRule);
   console.log("");
   console.log("");
   console.log("");

--- a/web_src/scripts/check-eslint-budget.mjs
+++ b/web_src/scripts/check-eslint-budget.mjs
@@ -106,6 +106,35 @@ function summarizeByRule(issues) {
   return Object.fromEntries(Object.entries(counts).sort((a, b) => b[1] - a[1]));
 }
 
+function extractRuleMetricValue(issue) {
+  if (issue.ruleId === "max-lines") {
+    const match = issue.message.match(/too many lines \((\d+)\)/iu);
+    return match ? Number(match[1]) : null;
+  }
+
+  if (issue.ruleId === "complexity") {
+    const match = issue.message.match(/complexity of (\d+)/iu);
+    return match ? Number(match[1]) : null;
+  }
+
+  return null;
+}
+
+function summarizeMetricTotalsByRule(issues) {
+  const totals = {};
+
+  for (const issue of issues) {
+    const metricValue = extractRuleMetricValue(issue);
+    if (metricValue === null) {
+      continue;
+    }
+
+    totals[issue.ruleId] = (totals[issue.ruleId] ?? 0) + metricValue;
+  }
+
+  return Object.fromEntries(Object.entries(totals).sort((a, b) => b[1] - a[1]));
+}
+
 function printRuleCountsVsBudget(currentByRule, maxAllowedByRule) {
   const allRuleIds = new Set([
     ...Object.keys(currentByRule),
@@ -137,6 +166,37 @@ function printRuleCountsVsBudget(currentByRule, maxAllowedByRule) {
   }
 }
 
+function printMetricTotalsVsBudget(currentByRule, maxAllowedByRule) {
+  const allRuleIds = new Set([
+    ...Object.keys(currentByRule),
+    ...Object.keys(maxAllowedByRule),
+  ]);
+
+  const sortedRuleIds = [...allRuleIds].sort((a, b) => {
+    const currentA = currentByRule[a] ?? 0;
+    const currentB = currentByRule[b] ?? 0;
+    if (currentA !== currentB) {
+      return currentB - currentA;
+    }
+
+    return a.localeCompare(b);
+  });
+
+  if (sortedRuleIds.length === 0) {
+    console.log("- No metric totals found.");
+    return;
+  }
+
+  for (const ruleId of sortedRuleIds) {
+    const current = currentByRule[ruleId] ?? 0;
+    const allowed = maxAllowedByRule[ruleId] ?? 0;
+    const overBudget = current > allowed;
+    const status = overBudget ? " !!! OVER BUDGET" : "";
+    const line = `- ${ruleId}: ${current}/${allowed}${status}`;
+    console.log(overBudget ? `${redStart}${line}${colorEnd}` : line);
+  }
+}
+
 function printIssues(issues) {
   if (issues.length === 0) {
     console.log("- No ESLint issues found.");
@@ -154,9 +214,12 @@ function readBaseline() {
 }
 
 function writeBaseline(issues, countsByRule) {
+  const metricTotalsByRule = summarizeMetricTotalsByRule(issues);
+
   const baseline = {
     maxAllowedTotalIssues: issues.length,
     maxAllowedByRule: countsByRule,
+    maxAllowedMetricTotalByRule: metricTotalsByRule,
     updatedAt: new Date().toISOString(),
   };
 
@@ -170,11 +233,11 @@ function findRegressions(currentByRule, baselineByRule) {
   for (const [ruleId, currentCount] of currentEntries) {
     const allowedCount = baselineByRule[ruleId] ?? 0;
     if (currentCount > allowedCount) {
-      regressions.push({ ruleId, currentCount, allowedCount });
+      regressions.push({ ruleId, currentValue: currentCount, allowedValue: allowedCount });
     }
   }
 
-  return regressions.sort((a, b) => b.currentCount - a.currentCount);
+  return regressions.sort((a, b) => b.currentValue - a.currentValue);
 }
 
 async function main() {
@@ -182,6 +245,7 @@ async function main() {
   const results = await eslint.lintFiles(["."]);
   const issues = [...extractIssues(results), ...extractDisallowedDirectiveIssues(results)];
   const countsByRule = summarizeByRule(issues);
+  const metricTotalsByRule = summarizeMetricTotalsByRule(issues);
 
   if (isUpdateBaseline) {
     writeBaseline(issues, countsByRule);
@@ -196,6 +260,11 @@ async function main() {
     console.log("");
     console.log("");
     console.log("");
+    console.log("Rule metric totals vs budget:");
+    printMetricTotalsVsBudget(metricTotalsByRule, metricTotalsByRule);
+    console.log("");
+    console.log("");
+    console.log("");
     console.log(`WITHIN BUDGET ${issues.length}/${issues.length}`);
     return;
   }
@@ -203,22 +272,35 @@ async function main() {
   const baseline = readBaseline();
   const maxAllowedTotal = baseline.maxAllowedTotalIssues;
   const maxAllowedByRule = baseline.maxAllowedByRule ?? {};
+  const maxAllowedMetricTotalByRule = baseline.maxAllowedMetricTotalByRule ?? {};
 
   const totalRegression = issues.length - maxAllowedTotal;
   const byRuleRegressions = findRegressions(countsByRule, maxAllowedByRule);
+  const metricRegressions = findRegressions(metricTotalsByRule, maxAllowedMetricTotalByRule);
 
-  if (totalRegression > 0 || byRuleRegressions.length > 0) {
+  if (totalRegression > 0 || byRuleRegressions.length > 0 || metricRegressions.length > 0) {
     console.error("ESLint budget exceeded.");
     console.error(`- Total issues: ${issues.length} (allowed ${maxAllowedTotal})`);
 
     if (byRuleRegressions.length > 0) {
       console.error("- Rule regressions:");
       for (const regression of byRuleRegressions.slice(0, 20)) {
-        console.error(`  - ${regression.ruleId}: ${regression.currentCount} (allowed ${regression.allowedCount})`);
+        console.error(`  - ${regression.ruleId}: ${regression.currentValue} (allowed ${regression.allowedValue})`);
       }
 
       if (byRuleRegressions.length > 20) {
         console.error(`  ... and ${byRuleRegressions.length - 20} more`);
+      }
+    }
+
+    if (metricRegressions.length > 0) {
+      console.error("- Rule metric total regressions:");
+      for (const regression of metricRegressions.slice(0, 20)) {
+        console.error(`  - ${regression.ruleId}: ${regression.currentValue} (allowed ${regression.allowedValue})`);
+      }
+
+      if (metricRegressions.length > 20) {
+        console.error(`  ... and ${metricRegressions.length - 20} more`);
       }
     }
 
@@ -229,6 +311,11 @@ async function main() {
     console.error("");
     console.error("Rule counts vs budget:");
     printRuleCountsVsBudget(countsByRule, maxAllowedByRule);
+    console.error("");
+    console.error("");
+    console.error("");
+    console.error("Rule metric totals vs budget:");
+    printMetricTotalsVsBudget(metricTotalsByRule, maxAllowedMetricTotalByRule);
     console.error("");
     console.error("");
     console.error("");
@@ -243,6 +330,11 @@ async function main() {
   console.log("");
   console.log("Rule counts vs budget:");
   printRuleCountsVsBudget(countsByRule, maxAllowedByRule);
+  console.log("");
+  console.log("");
+  console.log("");
+  console.log("Rule metric totals vs budget:");
+  printMetricTotalsVsBudget(metricTotalsByRule, maxAllowedMetricTotalByRule);
   console.log("");
   console.log("");
   console.log("");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change the ESLint budget checker to gate on per-rule metric maximums for `max-lines` and `complexity` (hard caps), instead of summed metric totals
- keep compatibility with older baselines by falling back to `maxAllowedMetricTotalByRule` when `maxAllowedMetricMaximumByRule` is absent
- regenerate `.eslint-budget-baseline.json` with the new maximum-based budget values (`max-lines: 5389`, `complexity: 332`)

## Testing
- `npm run lint:baseline:update`
- `npm run lint:budget`
- forced failure test by temporarily lowering `maxAllowedMetricMaximumByRule.max-lines` to `5388` and confirming budget failure
- `make format.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea7e1c72-43cc-4b50-93f1-26717dcf9a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea7e1c72-43cc-4b50-93f1-26717dcf9a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

