### PR TITLE
fix: restrict agent canvas permissions

### DIFF
--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -31,7 +31,11 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"  - org:read\n" +
 	"  - integrations:read\n" +
 	"  - canvases:read:%s\n" +
-	"  - canvases:update:%s\n" +
+	"  - canvases:update_version:%s\n" +
+	"\n" +
+	"The canvases:update_version scope is limited to draft canvas version\n" +
+	"editing. It does not grant permission to publish versions, delete\n" +
+	"canvases, or perform live-canvas operational actions.\n" +
 	"\n" +
 	"SuperPlane has no separate `events` permission. The canvases:read\n" +
 	"scope grants every read endpoint scoped to this canvas, including:\n" +
@@ -225,7 +229,7 @@ func (s *Service) mintAgentToken(organizationID, userID, canvasID string) (strin
 			{ResourceType: "org", Action: "read"},
 			{ResourceType: "integrations", Action: "read"},
 			{ResourceType: "canvases", Action: "read", Resources: []string{canvasID}},
-			{ResourceType: "canvases", Action: "update", Resources: []string{canvasID}},
+			{ResourceType: "canvases", Action: "update_version", Resources: []string{canvasID}},
 		}),
 	}
 	token, err := s.jwtSigner.GenerateScopedToken(claims, agentTokenTTL)

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -246,6 +246,9 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.Contains(t, provider.lastPreamble, canvas.ID.String())
 	assert.Contains(t, provider.lastPreamble, "api_token:")
 	assert.Contains(t, provider.lastPreamble, "api_token_expires_at:")
+	assert.Contains(t, provider.lastPreamble, "  - canvases:update_version:"+canvas.ID.String())
+	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())
+	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())
 
 	provider.lastPreamble = "<sentinel>"
 	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "second")

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -173,7 +173,7 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		},
 		pbCanvases.Canvases_CreateCanvasVersion_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "update_version",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
@@ -191,13 +191,13 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		},
 		pbCanvases.Canvases_UpdateCanvasVersion_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "update_version",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
 		pbCanvases.Canvases_ApplyCanvasVersionChangeset_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "update_version",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
@@ -209,13 +209,13 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		},
 		pbCanvases.Canvases_DeleteCanvasVersion_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "update_version",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
 		pbCanvases.Canvases_PublishCanvasVersion_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "publish",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},
@@ -239,7 +239,7 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		},
 		pbCanvases.Canvases_ActOnCanvasChangeRequest_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "publish",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -41,6 +41,33 @@ func TestCanvasResourceResolver(t *testing.T) {
 	})
 }
 
+func TestCanvasAuthorizationRulesSeparateDraftAndLiveActions(t *testing.T) {
+	interceptor := NewAuthorizationInterceptor(nil)
+
+	tests := []struct {
+		method string
+		action string
+	}{
+		{pbCanvases.Canvases_CreateCanvasVersion_FullMethodName, "update_version"},
+		{pbCanvases.Canvases_UpdateCanvasVersion_FullMethodName, "update_version"},
+		{pbCanvases.Canvases_ApplyCanvasVersionChangeset_FullMethodName, "update_version"},
+		{pbCanvases.Canvases_DeleteCanvasVersion_FullMethodName, "update_version"},
+		{pbCanvases.Canvases_PublishCanvasVersion_FullMethodName, "publish"},
+		{pbCanvases.Canvases_ActOnCanvasChangeRequest_FullMethodName, "publish"},
+		{pbCanvases.Canvases_UpdateCanvas_FullMethodName, "update"},
+		{pbCanvases.Canvases_DeleteCanvas_FullMethodName, "delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			rule, ok := interceptor.rules[tt.method]
+			require.True(t, ok)
+			assert.Equal(t, "canvases", rule.Resource)
+			assert.Equal(t, tt.action, rule.Action)
+		})
+	}
+}
+
 func TestHasRequiredScopedTokenPermission(t *testing.T) {
 	ruleWithDefaultResolver := AuthorizationRule{
 		Resource:         "canvases",

--- a/pkg/authorization/service_test.go
+++ b/pkg/authorization/service_test.go
@@ -35,11 +35,11 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have all canvas permissions (inherited from admin)
-		actions := []string{"read", "create", "update", "delete"}
+		actions := []string{"read", "create", "update", "update_version", "publish", "delete"}
 		for _, action := range actions {
 			allowed, err := r.AuthService.CheckOrganizationPermission(userID, orgID, canvasPath, action)
 			require.NoError(t, err)
-			assert.True(t, allowed, "Org owner should have %s permission for workflows", action)
+			assert.True(t, allowed, "Org owner should have %s permission for canvases", action)
 		}
 
 		// Should have user management permissions (inherited from admin)
@@ -71,11 +71,11 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should have canvas management permissions
-		actions := []string{"read", "create", "update", "delete"}
+		actions := []string{"read", "create", "update", "update_version", "publish", "delete"}
 		for _, action := range actions {
 			allowed, err := r.AuthService.CheckOrganizationPermission(adminID, orgID, canvasPath, action)
 			require.NoError(t, err)
-			assert.True(t, allowed, "Org admin should have %s permission for workflows", action)
+			assert.True(t, allowed, "Org admin should have %s permission for canvases", action)
 		}
 
 		// Should have user management permissions
@@ -111,12 +111,12 @@ func Test__AuthService_OrganizationPermissions(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, allowed)
 
-		// Should not have canvas create/update/delete permissions
-		actions := []string{"create", "update", "delete"}
+		// Should not have canvas create/update/publish/delete permissions
+		actions := []string{"create", "update", "update_version", "publish", "delete"}
 		for _, action := range actions {
 			allowed, err := r.AuthService.CheckOrganizationPermission(viewerID, orgID, canvasPath, action)
 			require.NoError(t, err)
-			assert.False(t, allowed, "Org viewer should not have %s permission for workflows", action)
+			assert.False(t, allowed, "Org viewer should not have %s permission for canvases", action)
 		}
 
 		// Should not have user management permissions

--- a/pkg/grpc/actions/auth/describe_role_test.go
+++ b/pkg/grpc/actions/auth/describe_role_test.go
@@ -22,7 +22,7 @@ func Test_DescribeRole(t *testing.T) {
 		assert.NotNil(t, resp.Role.Spec.InheritedRole)
 		assert.Equal(t, models.RoleOrgAdmin, resp.Role.Metadata.Name)
 		assert.Equal(t, models.RoleOrgViewer, resp.Role.Spec.InheritedRole.Metadata.Name)
-		assert.Len(t, resp.Role.Spec.Permissions, 36)
+		assert.Len(t, resp.Role.Spec.Permissions, 38)
 		assert.Len(t, resp.Role.Spec.InheritedRole.Spec.Permissions, 8)
 		assert.Equal(t, "Admin", resp.Role.Spec.DisplayName)
 		assert.Equal(t, "Viewer", resp.Role.Spec.InheritedRole.Spec.DisplayName)

--- a/rbac/rbac_org_policy.csv
+++ b/rbac/rbac_org_policy.csv
@@ -10,6 +10,8 @@ p,/roles/org_viewer,/org/*,service_accounts,read
 p,/roles/org_viewer,/org/*,agents,read
 p,/roles/org_admin,/org/*,canvases,create
 p,/roles/org_admin,/org/*,canvases,update
+p,/roles/org_admin,/org/*,canvases,update_version
+p,/roles/org_admin,/org/*,canvases,publish
 p,/roles/org_admin,/org/*,canvases,delete
 p,/roles/org_admin,/org/*,members,create
 p,/roles/org_admin,/org/*,members,update


### PR DESCRIPTION
## Summary
- Split draft canvas version updates from publish permissions
- Limit agent tokens to canvas read and draft version updates
- Keep publish/delete/live canvas actions out of agent scope
