### PR TITLE
feat: add Docker support UI for runners

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -29,7 +29,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Merge" href="#merge" description="Merge multiple upstream inputs and forward" />
   <LinkCard title="No Operation" href="#no-operation" description="Just pass events through without any additional processing" />
   <LinkCard title="Read Memory" href="#read-memory" description="Find values from canvas memory by namespace and field matches" />
-  <LinkCard title="Runner" href="#runner" description="Runs bash commands on a dedicated machine" />
+  <LinkCard title="Runner" href="#runner" description="Runs shell commands on a fleet runner (host or Docker container)" />
   <LinkCard title="Send Email Notification" href="#send-email-notification" description="Send an email notification using the system email provider" />
   <LinkCard title="SSH Command" href="#ssh-command" description="Run one or more commands on a remote host via SSH. Authenticate using an organization Secret (SSH key or password)." />
   <LinkCard title="Time Gate" href="#time-gate" description="Route events based on active days and time windows, with optional excluded dates" />
@@ -691,9 +691,17 @@ The Read Memory component looks up values from canvas-level memory storage.
 
 ## Runner
 
-Runs bash commands on a dedicated machine.
+Runs shell commands on a fleet runner.
+
+### Execution
+- **Host**: Commands run directly on the runner machine (Bash with a PTY).
+- **Docker**: Commands run inside a container started from **Docker image**. The runner pulls the image, starts a long-lived container, and executes your script via `docker exec`. The image must include a usable `sleep` (common base images do).
 
 ### Configuration
+- **Execution mode**: Host (default) or Docker.
+- **Container base image**: Choose a common public image, or **Other (custom image)** to enter any OCI reference.
+- **Custom container image**: Shown only for **Other**; use a normal reference (`my.registry.example.com/org/repo:1.2.3` or `debian:bookworm-slim@sha256:…`). Private registries require the runner to be configured with registry credentials.
+- **Execution timeout**: Optional wall-clock limit in seconds (1–86400). Leave at **0** to use the broker default.
 - **Commands**: One or more shell commands, one per line.
 - **Environment variables**: Optional key/value pairs available during command execution. Values can be literal strings (with expression support) or organization secret keys.
 
@@ -702,7 +710,7 @@ Runs bash commands on a dedicated machine.
 - **Failed**: The commands finished with non-zero exit code.
 
 ### Structured result
-When the remote task writes valid JSON to **SUPERPLANE_RESULT_FILE** before exit, that object is returned as **result** on the finished event payload (alongside **status** and **exit_code**).
+If the completed broker task includes valid JSON in **result**, SuperPlane includes it on the `runner.finished` event payload next to **status** and **exit_code** (the exact shape depends on your runner / task implementation).
 
 ### Example Output
 

--- a/pkg/components/runner/broker.go
+++ b/pkg/components/runner/broker.go
@@ -59,7 +59,9 @@ func NewBrokerClient(httpClient core.HTTPContext) (*BrokerClient, error) {
 //   "commands": ["echo \"Hello, World!\""],
 //   "environment": [{"name": "APP_ENV", "value": "production"}],
 //   "webhook_url": "https://example.com/webhook",
-//   "execution_mode": "host"
+//   "execution_mode": "host",
+//   "docker_image": "debian:bookworm-slim",
+//   "execution_timeout_seconds": 600
 // }
 //
 // Example response:
@@ -70,28 +72,51 @@ func NewBrokerClient(httpClient core.HTTPContext) (*BrokerClient, error) {
 type brokerCreateTaskRequest struct {
 	FleetID string `json:"fleet_id"`
 
-	Commands      []string                    `json:"commands"`
-	Environment   []BrokerEnvironmentVariable `json:"environment,omitempty"`
-	WebhookURL    string                      `json:"webhook_url"`
-	ExecutionMode string                      `json:"execution_mode,omitempty"`
+	Commands                []string                    `json:"commands"`
+	Environment             []BrokerEnvironmentVariable `json:"environment,omitempty"`
+	WebhookURL              string                      `json:"webhook_url"`
+	ExecutionMode           string                      `json:"execution_mode,omitempty"`
+	DockerImage             string                      `json:"docker_image,omitempty"`
+	ExecutionTimeoutSeconds *int                        `json:"execution_timeout_seconds,omitempty"`
 }
 
+// BrokerEnvironmentVariable is forwarded to the task broker as JSON.
 type BrokerEnvironmentVariable struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
+}
+
+// CreateTaskParams is forwarded to the task broker POST /v1/tasks.
+type CreateTaskParams struct {
+	Commands       []string
+	WebhookURL     string
+	Environment    []BrokerEnvironmentVariable
+	ExecutionMode  string
+	DockerImage    string
+	TimeoutSeconds int // 0 = omit (broker / fleet default)
 }
 
 type brokerCreateTaskResponse struct {
 	ID string `json:"id"`
 }
 
-func (b *BrokerClient) CreateTask(commands []string, webhookURL string, environment []BrokerEnvironmentVariable) (string, error) {
+func (b *BrokerClient) CreateTask(p CreateTaskParams) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(p.ExecutionMode))
+	if mode == "" {
+		mode = ExecutionModeHost
+	}
+
 	req := brokerCreateTaskRequest{
 		FleetID:       b.fleetID,
-		Commands:      commands,
-		Environment:   environment,
-		WebhookURL:    webhookURL,
-		ExecutionMode: "host",
+		Commands:      p.Commands,
+		Environment:   p.Environment,
+		WebhookURL:    p.WebhookURL,
+		ExecutionMode: mode,
+		DockerImage:   strings.TrimSpace(p.DockerImage),
+	}
+	if p.TimeoutSeconds > 0 {
+		t := p.TimeoutSeconds
+		req.ExecutionTimeoutSeconds = &t
 	}
 
 	bodyBytes, err := json.Marshal(req)

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -30,16 +29,13 @@ func init() {
 
 type Runner struct{}
 
-type EnvironmentVariable struct {
-	Name        string                     `json:"name" mapstructure:"name"`
-	ValueSource string                     `json:"valueSource" mapstructure:"valueSource"`
-	Value       *string                    `json:"value,omitempty" mapstructure:"value"`
-	Secret      configuration.SecretKeyRef `json:"secret,omitempty" mapstructure:"secret"`
+var dockerExecutionOnly = []configuration.VisibilityCondition{
+	{Field: "execution_mode", Values: []string{ExecutionModeDocker}},
 }
 
-type Spec struct {
-	Commands    string                `json:"commands" mapstructure:"commands"`
-	Environment []EnvironmentVariable `json:"environment,omitempty" mapstructure:"environment"`
+var dockerImageCustomOnly = []configuration.VisibilityCondition{
+	{Field: "execution_mode", Values: []string{ExecutionModeDocker}},
+	{Field: "docker_image_preset", Values: []string{DockerImagePresetCustom}},
 }
 
 func (c *Runner) Name() string  { return "runner" }
@@ -67,13 +63,21 @@ func (c *Runner) OutputChannels(configuration any) []core.OutputChannel {
 }
 
 func (c *Runner) Description() string {
-	return "Runs bash commands on a dedicated machine"
+	return "Runs shell commands on a fleet runner (host or Docker container)"
 }
 
 func (c *Runner) Documentation() string {
-	return `Runs bash commands on a dedicated machine.
+	return `Runs shell commands on a fleet runner.
+
+## Execution
+- **Host**: Commands run directly on the runner machine (Bash with a PTY).
+- **Docker**: Commands run inside a container started from **Docker image**. The runner pulls the image, starts a long-lived container, and executes your script via ` + "`docker exec`" + `. The image must include a usable ` + "`sleep`" + ` (common base images do).
 
 ## Configuration
+- **Execution mode**: Host (default) or Docker.
+- **Container base image**: Choose a common public image, or **Other (custom image)** to enter any OCI reference.
+- **Custom container image**: Shown only for **Other**; use a normal reference (` + "`my.registry.example.com/org/repo:1.2.3`" + ` or ` + "`debian:bookworm-slim@sha256:…`" + `). Private registries require the runner to be configured with registry credentials.
+- **Execution timeout**: Optional wall-clock limit in seconds (1–86400). Leave at **0** to use the broker default.
 - **Commands**: One or more shell commands, one per line.
 - **Environment variables**: Optional key/value pairs available during command execution. Values can be literal strings (with expression support) or organization secret keys.
 
@@ -82,26 +86,88 @@ func (c *Runner) Documentation() string {
 - **Failed**: The commands finished with non-zero exit code.
 
 ## Structured result
-When the remote task writes valid JSON to **SUPERPLANE_RESULT_FILE** before exit, that object is returned as **result** on the finished event payload (alongside **status** and **exit_code**).
+If the completed broker task includes valid JSON in **result**, SuperPlane includes it on the ` + "`runner.finished`" + ` event payload next to **status** and **exit_code** (the exact shape depends on your runner / task implementation).
 `
 }
 
 func (c *Runner) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
+			Name:        "execution_mode",
+			Label:       "Execution mode",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     ExecutionModeHost,
+			Description: "Where the shell commands run: on the runner machine, or inside a container.",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{
+							Label:       "Host",
+							Value:       ExecutionModeHost,
+							Description: "Runs in a Bash session on the runner (PTY). Best when the workflow should use tools already installed on the runner.",
+						},
+						{
+							Label:       "Docker",
+							Value:       ExecutionModeDocker,
+							Description: "Runs in an isolated container started from the image below. The runner must have Docker and (for private registries) pull credentials.",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:                 "docker_image_preset",
+			Label:                "Container base image",
+			Type:                 configuration.FieldTypeSelect,
+			Required:             false,
+			Default:              "debian:bookworm-slim",
+			Description:          "Pick a common image, or choose Other to type your own registry reference.",
+			VisibilityConditions: dockerExecutionOnly,
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Debian Bookworm (slim)", Value: "debian:bookworm-slim"},
+						{Label: "Ubuntu 24.04", Value: "ubuntu:24.04"},
+						{Label: "Alpine 3.20", Value: "alpine:3.20"},
+						{Label: "Node.js 22 (Bookworm)", Value: "node:22-bookworm"},
+						{Label: "Python 3.12 (slim)", Value: "python:3.12-slim"},
+						{Label: "Other (custom image)", Value: DockerImagePresetCustom},
+					},
+				},
+			},
+		},
+		{
+			Name:                 "docker_image",
+			Label:                "Custom container image",
+			Type:                 configuration.FieldTypeString,
+			Required:             false,
+			Placeholder:          "e.g. debian:bookworm-slim",
+			Description:          "Full OCI image reference when you chose Other above. Pin with a tag or digest for reproducible runs.",
+			VisibilityConditions: dockerImageCustomOnly,
+			RequiredConditions: []configuration.RequiredCondition{
+				{Field: "docker_image_preset", Values: []string{DockerImagePresetCustom}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				String: &configuration.StringTypeOptions{
+					MaxLength: intPtr(maxDockerImageReferenceChars),
+				},
+			},
+		},
+		{
 			Name:        "commands",
 			Label:       "Commands",
 			Type:        configuration.FieldTypeText,
 			Required:    true,
 			Placeholder: "echo \"Hello, World!\"",
-			Description: "One or more shell commands, one per line",
+			Description: "One or more shell commands, one per line. In Docker mode these run inside the container (after image entrypoint behavior; use an image that stays alive long enough for your script).",
 		},
 		{
 			Name:        "environment",
 			Label:       "Environment variables",
 			Type:        configuration.FieldTypeList,
 			Required:    false,
-			Description: "Optional key/value pairs available to the commands",
+			Description: "Optional key/value pairs passed into the command environment",
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
 					ItemLabel: "Variable",
@@ -156,24 +222,38 @@ func (c *Runner) Configuration() []configuration.Field {
 				},
 			},
 		},
+		{
+			Name:        "execution_timeout_seconds",
+			Label:       "Execution timeout (seconds)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    true,
+			Default:     0,
+			Description: "Hard time limit for the whole task, including image pull and command run. Use 0 for the broker default.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: intPtr(0),
+					Max: intPtr(maxExecutionTimeoutSecondsRequest),
+				},
+			},
+		},
 	}
 }
 
+func intPtr(v int) *int {
+	return &v
+}
+
 func (c *Runner) Setup(ctx core.SetupContext) error {
-	spec := Spec{}
-	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
-		return fmt.Errorf("decode configuration: %w", err)
-	}
-
-	if err := validateCommands(spec.Commands); err != nil {
+	spec, err := decodeRunnerSpec(ctx.Configuration)
+	if err != nil {
 		return err
 	}
 
-	if err := validateEnvironment(spec.Environment); err != nil {
+	if err := validateRunnerSpec(spec); err != nil {
 		return err
 	}
 
-	_, err := ctx.Webhook.Setup()
+	_, err = ctx.Webhook.Setup()
 	return err
 }
 
@@ -182,16 +262,12 @@ func (c *Runner) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, err
 }
 
 func (c *Runner) Execute(ctx core.ExecutionContext) error {
-	spec := Spec{}
-	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
-		return fmt.Errorf("decode configuration: %w", err)
-	}
-
-	if err := validateCommands(spec.Commands); err != nil {
+	spec, err := decodeRunnerSpec(ctx.Configuration)
+	if err != nil {
 		return err
 	}
 
-	if err := validateEnvironment(spec.Environment); err != nil {
+	if err := validateRunnerSpec(spec); err != nil {
 		return err
 	}
 
@@ -211,12 +287,22 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("new broker client: %w", err)
 	}
 
-	taskID, err := broker.CreateTask(cmds, webhookURL, environment)
+	mode := normalizeExecutionMode(spec.ExecutionMode)
+	params := CreateTaskParams{
+		Commands:       cmds,
+		WebhookURL:     webhookURL,
+		Environment:    environment,
+		ExecutionMode:  mode,
+		DockerImage:    resolvedDockerImageRef(spec),
+		TimeoutSeconds: spec.ExecutionTimeoutSeconds,
+	}
+
+	taskID, err := broker.CreateTask(params)
 	if err != nil {
 		return fmt.Errorf("create task: %w", err)
 	}
 
-	params := map[string]any{"task_id": taskID}
+	hookParams := map[string]any{"task_id": taskID}
 
 	err = ctx.ExecutionState.SetKV("task_id", taskID)
 	if err != nil {
@@ -227,7 +313,7 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("runner execution metadata: %w", err)
 	}
 
-	return ctx.Requests.ScheduleActionCall(hookActionPoll, params, pollInterval)
+	return ctx.Requests.ScheduleActionCall(hookActionPoll, hookParams, pollInterval)
 }
 
 func (c *Runner) Hooks() []core.Hook {

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -96,7 +96,7 @@ func (c *Runner) Configuration() []configuration.Field {
 			Name:        "execution_mode",
 			Label:       "Execution mode",
 			Type:        configuration.FieldTypeSelect,
-			Required:    true,
+			Required:    false, // legacy nodes omit this; defaults applied in decodeRunnerSpec / normalizeExecutionMode
 			Default:     ExecutionModeHost,
 			Description: "Where the shell commands run: on the runner machine, or inside a container.",
 			TypeOptions: &configuration.TypeOptions{
@@ -226,7 +226,7 @@ func (c *Runner) Configuration() []configuration.Field {
 			Name:        "execution_timeout_seconds",
 			Label:       "Execution timeout (seconds)",
 			Type:        configuration.FieldTypeNumber,
-			Required:    true,
+			Required:    false, // legacy nodes omit this; 0 means broker default
 			Default:     0,
 			Description: "Hard time limit for the whole task, including image pull and command run. Use 0 for the broker default.",
 			TypeOptions: &configuration.TypeOptions{

--- a/pkg/components/runner/spec.go
+++ b/pkg/components/runner/spec.go
@@ -52,7 +52,16 @@ func decodeRunnerSpec(raw any) (Spec, error) {
 	if err := dec.Decode(raw); err != nil {
 		return Spec{}, fmt.Errorf("decode runner configuration: %w", err)
 	}
+	applyRunnerSpecDefaults(&spec)
 	return spec, nil
+}
+
+// applyRunnerSpecDefaults fills in values for nodes created before newer Runner fields existed.
+// configuration.ValidateConfiguration does not apply Field.Default, so those fields stay optional at the schema level.
+func applyRunnerSpecDefaults(spec *Spec) {
+	if strings.TrimSpace(spec.ExecutionMode) == "" {
+		spec.ExecutionMode = ExecutionModeHost
+	}
 }
 
 func normalizeExecutionMode(mode string) string {

--- a/pkg/components/runner/spec.go
+++ b/pkg/components/runner/spec.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+// Execution modes accepted by the task broker / fleet manager (lowercase JSON).
+const (
+	ExecutionModeHost   = "host"
+	ExecutionModeDocker = "docker"
+
+	// DockerImagePresetCustom selects the free-text docker_image field instead of a quick-pick ref.
+	DockerImagePresetCustom = "custom"
+
+	maxExecutionTimeoutSecondsRequest = 86400
+	// maxDockerImageReferenceChars caps OCI image references (name:tag, registry/repo@digest, etc.).
+	maxDockerImageReferenceChars = 2048
+)
+
+// EnvironmentVariable is one row in the Runner "Environment variables" list.
+type EnvironmentVariable struct {
+	Name        string                     `json:"name" mapstructure:"name"`
+	ValueSource string                     `json:"valueSource" mapstructure:"valueSource"`
+	Value       *string                    `json:"value,omitempty" mapstructure:"value"`
+	Secret      configuration.SecretKeyRef `json:"secret,omitempty" mapstructure:"secret"`
+}
+
+// Spec is persisted Runner node configuration.
+type Spec struct {
+	Commands                string                `mapstructure:"commands"`
+	Environment             []EnvironmentVariable `mapstructure:"environment"`
+	ExecutionMode           string                `mapstructure:"execution_mode"`
+	DockerImagePreset       string                `mapstructure:"docker_image_preset"`
+	DockerImage             string                `mapstructure:"docker_image"`
+	ExecutionTimeoutSeconds int                   `mapstructure:"execution_timeout_seconds"` // 0 = omit (broker default)
+}
+
+func decodeRunnerSpec(raw any) (Spec, error) {
+	var spec Spec
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &spec,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return Spec{}, fmt.Errorf("runner spec decoder: %w", err)
+	}
+	if err := dec.Decode(raw); err != nil {
+		return Spec{}, fmt.Errorf("decode runner configuration: %w", err)
+	}
+	return spec, nil
+}
+
+func normalizeExecutionMode(mode string) string {
+	m := strings.ToLower(strings.TrimSpace(mode))
+	switch m {
+	case ExecutionModeDocker:
+		return ExecutionModeDocker
+	default:
+		return ExecutionModeHost
+	}
+}
+
+// resolvedDockerImageRef returns the OCI reference sent to the broker in Docker mode.
+// Legacy configs omit docker_image_preset and only set docker_image.
+func resolvedDockerImageRef(spec Spec) string {
+	if normalizeExecutionMode(spec.ExecutionMode) != ExecutionModeDocker {
+		return ""
+	}
+	preset := strings.TrimSpace(spec.DockerImagePreset)
+	custom := strings.TrimSpace(spec.DockerImage)
+	if preset == "" {
+		return custom
+	}
+	if preset == DockerImagePresetCustom {
+		return custom
+	}
+	return preset
+}
+
+func validateRunnerSpec(spec Spec) error {
+	if err := validateCommands(spec.Commands); err != nil {
+		return err
+	}
+
+	if err := validateEnvironment(spec.Environment); err != nil {
+		return err
+	}
+
+	ref := strings.TrimSpace(resolvedDockerImageRef(spec))
+	mode := normalizeExecutionMode(spec.ExecutionMode)
+
+	if ref != "" && len(ref) > maxDockerImageReferenceChars {
+		return fmt.Errorf("container image reference must be at most %d characters", maxDockerImageReferenceChars)
+	}
+	if mode == ExecutionModeDocker && ref == "" {
+		return fmt.Errorf("container image is required when execution mode is Docker")
+	}
+
+	if spec.ExecutionTimeoutSeconds != 0 {
+		if spec.ExecutionTimeoutSeconds < 1 || spec.ExecutionTimeoutSeconds > maxExecutionTimeoutSecondsRequest {
+			return fmt.Errorf("execution timeout must be between 1 and %d seconds, or 0 to use the broker default", maxExecutionTimeoutSecondsRequest)
+		}
+	}
+
+	return nil
+}

--- a/pkg/components/runner/spec_test.go
+++ b/pkg/components/runner/spec_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+)
+
+func TestNormalizeExecutionMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ExecutionModeHost},
+		{"host", ExecutionModeHost},
+		{"HOST", ExecutionModeHost},
+		{"docker", ExecutionModeDocker},
+		{" Docker ", ExecutionModeDocker},
+		{"vm", ExecutionModeHost},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeExecutionMode(tc.in); got != tc.want {
+				t.Fatalf("normalizeExecutionMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateRunnerSpec(t *testing.T) {
+	t.Parallel()
+	if err := validateRunnerSpec(Spec{Commands: "echo hi", ExecutionMode: ExecutionModeHost}); err != nil {
+		t.Fatalf("valid host spec: %v", err)
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:          "echo hi",
+		ExecutionMode:     ExecutionModeDocker,
+		DockerImagePreset: "debian:bookworm-slim",
+	}); err != nil {
+		t.Fatalf("valid docker quick pick: %v", err)
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:          "echo hi",
+		ExecutionMode:     ExecutionModeDocker,
+		DockerImagePreset: DockerImagePresetCustom,
+		DockerImage:       "my.registry.example.com/app:1.0.0",
+	}); err != nil {
+		t.Fatalf("valid docker custom: %v", err)
+	}
+	// Legacy: no preset, only docker_image
+	if err := validateRunnerSpec(Spec{
+		Commands:      "echo hi",
+		ExecutionMode: ExecutionModeDocker,
+		DockerImage:   "debian:bookworm-slim",
+	}); err != nil {
+		t.Fatalf("valid docker legacy: %v", err)
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:                "echo hi",
+		ExecutionMode:           ExecutionModeHost,
+		ExecutionTimeoutSeconds: 120,
+	}); err != nil {
+		t.Fatalf("valid timeout: %v", err)
+	}
+
+	if err := validateRunnerSpec(Spec{Commands: "", ExecutionMode: ExecutionModeHost}); err == nil {
+		t.Fatal("expected error for empty commands")
+	}
+	if err := validateRunnerSpec(Spec{Commands: "echo hi", ExecutionMode: ExecutionModeDocker}); err == nil {
+		t.Fatal("expected error for docker without image")
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:          "echo hi",
+		ExecutionMode:     ExecutionModeDocker,
+		DockerImagePreset: DockerImagePresetCustom,
+		DockerImage:       "",
+	}); err == nil {
+		t.Fatal("expected error for docker custom without image")
+	}
+	longImage := strings.Repeat("a", maxDockerImageReferenceChars+1)
+	if err := validateRunnerSpec(Spec{
+		Commands:          "echo hi",
+		ExecutionMode:     ExecutionModeDocker,
+		DockerImagePreset: DockerImagePresetCustom,
+		DockerImage:       longImage,
+	}); err == nil {
+		t.Fatal("expected error for docker image reference that is too long")
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:                "echo hi",
+		ExecutionMode:           ExecutionModeHost,
+		ExecutionTimeoutSeconds: -1,
+	}); err == nil {
+		t.Fatal("expected error for negative timeout")
+	}
+	if err := validateRunnerSpec(Spec{
+		Commands:                "echo hi",
+		ExecutionMode:           ExecutionModeHost,
+		ExecutionTimeoutSeconds: maxExecutionTimeoutSecondsRequest + 1,
+	}); err == nil {
+		t.Fatal("expected error for timeout above max")
+	}
+}
+
+func TestDecodeRunnerSpec_WeakTypes(t *testing.T) {
+	t.Parallel()
+	raw := map[string]any{
+		"commands":                  "echo x",
+		"execution_mode":            "docker",
+		"docker_image_preset":       "debian:bookworm-slim",
+		"docker_image":              " alpine:latest ",
+		"execution_timeout_seconds": float64(90),
+	}
+	spec, err := decodeRunnerSpec(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if spec.Commands != "echo x" || spec.ExecutionMode != "docker" || spec.DockerImagePreset != "debian:bookworm-slim" || spec.DockerImage != " alpine:latest " {
+		t.Fatalf("unexpected spec: %#v", spec)
+	}
+	if spec.ExecutionTimeoutSeconds != 90 {
+		t.Fatalf("timeout: got %d want 90", spec.ExecutionTimeoutSeconds)
+	}
+	if err := validateRunnerSpec(spec); err != nil {
+		t.Fatalf("validate after decode: %v", err)
+	}
+}
+
+func TestValidateConfigurationRunnerLegacyDockerImageOnly(t *testing.T) {
+	t.Parallel()
+	r := &Runner{}
+	err := configuration.ValidateConfiguration(r.Configuration(), map[string]any{
+		"execution_mode":            ExecutionModeDocker,
+		"commands":                  "echo hi",
+		"execution_timeout_seconds": 0,
+		"docker_image":              "debian:bookworm-slim",
+	})
+	if err != nil {
+		t.Fatalf("legacy docker_image without preset: %v", err)
+	}
+}

--- a/pkg/components/runner/spec_test.go
+++ b/pkg/components/runner/spec_test.go
@@ -35,6 +35,10 @@ func TestValidateRunnerSpec(t *testing.T) {
 	if err := validateRunnerSpec(Spec{Commands: "echo hi", ExecutionMode: ExecutionModeHost}); err != nil {
 		t.Fatalf("valid host spec: %v", err)
 	}
+	// Legacy persisted config: commands only (no execution_mode / execution_timeout_seconds keys).
+	if err := validateRunnerSpec(Spec{Commands: "echo hi"}); err != nil {
+		t.Fatalf("valid legacy host spec (empty execution_mode): %v", err)
+	}
 	if err := validateRunnerSpec(Spec{
 		Commands:          "echo hi",
 		ExecutionMode:     ExecutionModeDocker,
@@ -126,6 +130,30 @@ func TestDecodeRunnerSpec_WeakTypes(t *testing.T) {
 	}
 	if err := validateRunnerSpec(spec); err != nil {
 		t.Fatalf("validate after decode: %v", err)
+	}
+}
+
+func TestValidateConfigurationRunnerLegacyPreExecutionFields(t *testing.T) {
+	t.Parallel()
+	r := &Runner{}
+	legacy := map[string]any{
+		"commands": "echo hi",
+	}
+	if err := configuration.ValidateConfiguration(r.Configuration(), legacy); err != nil {
+		t.Fatalf("ValidateConfiguration legacy runner: %v", err)
+	}
+	spec, err := decodeRunnerSpec(legacy)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if spec.ExecutionMode != ExecutionModeHost {
+		t.Fatalf("execution_mode default: got %q want %q", spec.ExecutionMode, ExecutionModeHost)
+	}
+	if spec.ExecutionTimeoutSeconds != 0 {
+		t.Fatalf("timeout default: got %d want 0", spec.ExecutionTimeoutSeconds)
+	}
+	if err := validateRunnerSpec(spec); err != nil {
+		t.Fatalf("validateRunnerSpec legacy: %v", err)
 	}
 }
 

--- a/web_src/src/pages/workflowv2/mappers/runner.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/runner.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import { runnerConfigurationDetails, runnerMapper } from "./runner";
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo, OutputPayload } from "./types";
+
+function buildRunnerNode(configuration: Record<string, unknown>): NodeInfo {
+  return {
+    id: "node-runner-1",
+    name: "Runner",
+    componentName: "runner",
+    isCollapsed: false,
+    configuration,
+    metadata: {},
+  };
+}
+
+function buildExecution(overrides: {
+  outputs?: { passed?: OutputPayload[]; failed?: OutputPayload[] };
+  state?: ExecutionInfo["state"];
+  result?: ExecutionInfo["result"];
+  createdAt?: string;
+}): ExecutionInfo {
+  const now = overrides.createdAt ?? new Date().toISOString();
+  return {
+    id: "exec-1",
+    createdAt: now,
+    state: overrides.state ?? "STATE_FINISHED",
+    result: overrides.result ?? "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    outputs: overrides.outputs,
+  } as ExecutionInfo;
+}
+
+describe("runnerConfigurationDetails", () => {
+  it.each([
+    [
+      "host — minimal",
+      { execution_mode: "host", commands: "echo hi", execution_timeout_seconds: 0 },
+      {
+        "Execution mode": "Host",
+        "Timeout (seconds)": "Broker default (0)",
+      },
+    ],
+    [
+      "host — ignores stray docker_image (no Container image row)",
+      {
+        execution_mode: "host",
+        commands: "echo hi",
+        docker_image: "should-not-show:tag",
+        docker_image_preset: "debian:bookworm-slim",
+        execution_timeout_seconds: 0,
+      },
+      {
+        "Execution mode": "Host",
+        "Timeout (seconds)": "Broker default (0)",
+      },
+    ],
+    [
+      "docker — quick pick",
+      {
+        execution_mode: "docker",
+        commands: "uname -a",
+        docker_image_preset: "debian:bookworm-slim",
+        execution_timeout_seconds: 0,
+      },
+      {
+        "Execution mode": "Docker",
+        "Container image": "debian:bookworm-slim",
+        "Timeout (seconds)": "Broker default (0)",
+      },
+    ],
+    [
+      "docker — custom image",
+      {
+        execution_mode: "docker",
+        commands: "date",
+        docker_image_preset: "custom",
+        docker_image: "registry.example.com/app:1.2.3",
+        execution_timeout_seconds: 90,
+      },
+      {
+        "Execution mode": "Docker",
+        "Container image": "registry.example.com/app:1.2.3",
+        "Timeout (seconds)": "90",
+      },
+    ],
+    [
+      "docker — legacy (no preset, only docker_image)",
+      {
+        execution_mode: "docker",
+        commands: "true",
+        docker_image: "alpine:3.20",
+        execution_timeout_seconds: 0,
+      },
+      {
+        "Execution mode": "Docker",
+        "Container image": "alpine:3.20",
+        "Timeout (seconds)": "Broker default (0)",
+      },
+    ],
+    [
+      "timeout as string zero",
+      { execution_mode: "host", commands: "x", execution_timeout_seconds: "0" },
+      {
+        "Execution mode": "Host",
+        "Timeout (seconds)": "Broker default (0)",
+      },
+    ],
+    [
+      "timeout as string non-zero",
+      { execution_mode: "host", commands: "x", execution_timeout_seconds: "  45  " },
+      {
+        "Execution mode": "Host",
+        "Timeout (seconds)": "45",
+      },
+    ],
+    [
+      "non-object configuration",
+      null,
+      {},
+    ],
+  ] as const)("case: %s", (_label, configuration, expected) => {
+    expect(runnerConfigurationDetails(configuration)).toEqual(expected);
+  });
+
+  it("omits Timeout when execution_timeout_seconds is absent", () => {
+    expect(
+      runnerConfigurationDetails({
+        execution_mode: "host",
+        commands: "echo",
+      }),
+    ).toEqual({
+      "Execution mode": "Host",
+    });
+  });
+});
+
+describe("runnerMapper.getExecutionDetails", () => {
+  it("merges configuration details with finished payload fields", () => {
+    const node = buildRunnerNode({
+      execution_mode: "docker",
+      docker_image_preset: "python:3.12-slim",
+      commands: "python -V",
+      execution_timeout_seconds: 0,
+    });
+    const execution = buildExecution({
+      outputs: {
+        passed: [
+          {
+            type: "runner.finished",
+            timestamp: new Date().toISOString(),
+            data: { status: "succeeded", exit_code: 0 },
+          },
+        ],
+      },
+    });
+    const ctx: ExecutionDetailsContext = { nodes: [node], node, execution };
+
+    expect(runnerMapper.getExecutionDetails(ctx)).toEqual({
+      "Execution mode": "Docker",
+      "Container image": "python:3.12-slim",
+      "Timeout (seconds)": "Broker default (0)",
+      Status: "succeeded",
+      "Exit code": "0",
+    });
+  });
+
+  it("returns configuration-only details when there is no output payload", () => {
+    const node = buildRunnerNode({ execution_mode: "host", commands: "id", execution_timeout_seconds: 0 });
+    const execution = buildExecution({ outputs: undefined });
+    const ctx: ExecutionDetailsContext = { nodes: [node], node, execution };
+
+    expect(runnerMapper.getExecutionDetails(ctx)).toEqual({
+      "Execution mode": "Host",
+      "Timeout (seconds)": "Broker default (0)",
+    });
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/runner.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/runner.spec.ts
@@ -118,11 +118,7 @@ describe("runnerConfigurationDetails", () => {
         "Timeout (seconds)": "45",
       },
     ],
-    [
-      "non-object configuration",
-      null,
-      {},
-    ],
+    ["non-object configuration", null, {}],
   ] as const)("case: %s", (_label, configuration, expected) => {
     expect(runnerConfigurationDetails(configuration)).toEqual(expected);
   });

--- a/web_src/src/pages/workflowv2/mappers/runner.tsx
+++ b/web_src/src/pages/workflowv2/mappers/runner.tsx
@@ -19,18 +19,59 @@ import type {
 
 import { stringOrDash } from "./utils";
 
-function formatRunnerExecutionResult(value: unknown): string {
-  if (value === undefined || value === null) {
-    return "-";
+const EXECUTION_MODE_DOCKER = "docker";
+const DOCKER_IMAGE_PRESET_CUSTOM = "custom";
+
+/** Mirrors `resolvedDockerImageRef` in pkg/components/runner/spec.go for execution summaries. */
+function resolvedContainerImageRef(c: Record<string, unknown>): string {
+  const rawMode = typeof c.execution_mode === "string" ? c.execution_mode.trim().toLowerCase() : "";
+  if (rawMode !== EXECUTION_MODE_DOCKER) {
+    return "";
   }
-  if (typeof value === "string") {
-    return value;
+  const preset = typeof c.docker_image_preset === "string" ? c.docker_image_preset.trim() : "";
+  const custom = typeof c.docker_image === "string" ? c.docker_image.trim() : "";
+  if (!preset) {
+    return custom;
   }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
+  if (preset === DOCKER_IMAGE_PRESET_CUSTOM) {
+    return custom;
   }
+  return preset;
+}
+
+/** Exported for tests; mirrors runner node configuration shown in execution details. */
+export function runnerConfigurationDetails(configuration: unknown): Record<string, string> {
+  const details: Record<string, string> = {};
+  if (!configuration || typeof configuration !== "object") {
+    return details;
+  }
+  const c = configuration as Record<string, unknown>;
+  const rawMode = typeof c.execution_mode === "string" ? c.execution_mode.trim().toLowerCase() : "";
+  if (rawMode === EXECUTION_MODE_DOCKER) {
+    details["Execution mode"] = "Docker";
+  } else {
+    details["Execution mode"] = "Host";
+  }
+  const image = resolvedContainerImageRef(c);
+  if (image) {
+    details["Container image"] = image;
+  }
+  const timeoutRaw = c.execution_timeout_seconds;
+  if (typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw)) {
+    if (timeoutRaw > 0) {
+      details["Timeout (seconds)"] = String(Math.trunc(timeoutRaw));
+    } else if (timeoutRaw === 0) {
+      details["Timeout (seconds)"] = "Broker default (0)";
+    }
+  } else if (typeof timeoutRaw === "string") {
+    const t = timeoutRaw.trim();
+    if (t === "0") {
+      details["Timeout (seconds)"] = "Broker default (0)";
+    } else if (t !== "") {
+      details["Timeout (seconds)"] = t;
+    }
+  }
+  return details;
 }
 
 const RUNNER_STATE_MAP: EventStateMap = {
@@ -128,13 +169,16 @@ export const runnerMapper: ComponentBaseMapper = {
     return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
   },
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
-    const details: Record<string, string> = {};
+    const details: Record<string, string> = {
+      ...runnerConfigurationDetails(context.node.configuration),
+    };
     const payload = firstRunnerPayload(context.execution);
-    if (!payload) return details;
+    if (!payload) {
+      return details;
+    }
 
-    details["status"] = stringOrDash(payload.status);
-    details["exit_code"] = stringOrDash(payload.exit_code);
-    details["result"] = formatRunnerExecutionResult(payload.result);
+    details["Status"] = stringOrDash(payload.status);
+    details["Exit code"] = stringOrDash(payload.exit_code);
     return details;
   },
 };

--- a/web_src/src/ui/configurationFieldRenderer/SelectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/SelectFieldRenderer.tsx
@@ -29,7 +29,7 @@ export const SelectFieldRenderer: React.FC<FieldRendererProps> = ({ field, value
       </SelectTrigger>
       <SelectContent className="max-h-60">
         {selectOptions.map((opt) => (
-          <SelectItem key={opt.value} value={opt.value ?? ""}>
+          <SelectItem key={opt.value} value={opt.value ?? ""} title={opt.description || undefined}>
             {opt.label}
           </SelectItem>
         ))}


### PR DESCRIPTION
## Summary

- Adds a **Container base image** select for Docker mode with common public image quick picks plus **Other (custom image)**, matching existing workflow patterns (conditional fields after a select, same as components like Wait and Send Email).
- Resolves the **effective OCI image reference** on the server for the task broker (`resolvedDockerImageRef`), including **legacy** nodes that only set `docker_image` with no `docker_image_preset`.
- Refreshes **generated** Runner documentation in `docs/components/Core.mdx` via `make gen.components.docs`.
- Improves **execution detail** copy in the workflow UI: human-readable keys, explicit **broker default** when timeout is `0`, and no **Container image** row in Host mode even if a stray `docker_image` is stored.
- Adds **Vitest** coverage for `runnerConfigurationDetails` and `runnerMapper.getExecutionDetails`, and **Go** tests for spec validation and configuration validation where applicable.
- Select options with optional descriptions now expose a **`title` tooltip** on items (avoids bloating the closed trigger).

## Test plan

- [x] Local stack: SuperPlane app, task broker, and runner as you normally use for Runner development.
- [x] Enable the **Runners** experimental feature for the organization (Admin → organization → experimental features).
- [x] **Host mode:** run a trivial command (`echo` / `uname`) and confirm **Passed** and sensible execution details.
- [x] **Docker mode — quick pick:** choose a preset (e.g. Debian slim), run a command that proves the image (e.g. `/etc/os-release` or `node -v` for the Node preset), confirm **Passed**.
- [x] **Docker mode — Other:** choose **Other (custom image)**, enter a private or non-listed ref your runner can pull, confirm **Passed** or a clear broker/pull error.
- [x] **Execution details:** confirm **Execution mode**, **Container image** (Docker only, matches preset or custom), **Timeout (seconds)** shows **Broker default (0)** when timeout is zero, and **Status** / **Exit code** appear on finished runs.


https://github.com/user-attachments/assets/0fa86c9e-bbef-48ec-8b48-8899e2fb6bfb

Closes #4688 