### PR TITLE
feat: support CLI auth from environment variables

### DIFF
--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -27,6 +27,10 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"api_token: %s\n" +
 	"api_token_expires_at: %s\n" +
 	"\n" +
+	"When using the SuperPlane CLI, pass these refreshed values through\n" +
+	"environment variables instead of running `superplane connect`:\n" +
+	"  SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...\n" +
+	"\n" +
 	"api_token scopes (exact strings on the JWT):\n" +
 	"  - org:read\n" +
 	"  - integrations:read\n" +

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -246,6 +246,7 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.Contains(t, provider.lastPreamble, canvas.ID.String())
 	assert.Contains(t, provider.lastPreamble, "api_token:")
 	assert.Contains(t, provider.lastPreamble, "api_token_expires_at:")
+	assert.Contains(t, provider.lastPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
 	assert.Contains(t, provider.lastPreamble, "  - canvases:update_version:"+canvas.ID.String())
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -348,11 +348,11 @@ func (c *CurrentContext) GetActiveCanvas() string {
 }
 
 func (c *CurrentContext) SetActiveCanvas(canvasID string) error {
-	c.context.Canvas = &canvasID
 	if c.readOnly {
 		return fmt.Errorf("cannot set active canvas when using %s and %s; pass --canvas-id instead", EnvURL, EnvToken)
 	}
 
+	c.context.Canvas = &canvasID
 	_, err := UpsertContext(c.context)
 	return err
 }

--- a/pkg/cli/configuration.go
+++ b/pkg/cli/configuration.go
@@ -2,11 +2,17 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/spf13/viper"
 	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+const (
+	EnvURL   = "SUPERPLANE_URL"
+	EnvToken = "SUPERPLANE_TOKEN"
 )
 
 type ConfigContext struct {
@@ -69,6 +75,40 @@ func GetContexts() []ConfigContext {
 	}
 
 	return normalized
+}
+
+func GetEnvironmentContext() (ConfigContext, bool) {
+	context, ok, err := environmentContext()
+	if err != nil {
+		return ConfigContext{}, false
+	}
+
+	return context, ok
+}
+
+func ValidateEnvironmentContext() error {
+	_, _, err := environmentContext()
+	return err
+}
+
+func environmentContext() (ConfigContext, bool, error) {
+	rawURL, urlSet := os.LookupEnv(EnvURL)
+	rawToken, tokenSet := os.LookupEnv(EnvToken)
+	if !urlSet && !tokenSet {
+		return ConfigContext{}, false, nil
+	}
+
+	url := normalizeBaseURL(rawURL)
+	token := strings.TrimSpace(rawToken)
+	if url == "" || token == "" {
+		return ConfigContext{}, false, fmt.Errorf("%s and %s must both be set to use environment CLI authentication", EnvURL, EnvToken)
+	}
+
+	return ConfigContext{
+		URL:          url,
+		Organization: "environment",
+		APIToken:     token,
+	}, true, nil
 }
 
 func GetCurrentContext() (ConfigContext, bool) {
@@ -287,11 +327,16 @@ func findMatchingContextIndex(contexts []ConfigContext, context ConfigContext) i
  * which uses the current context as the source for operations..
  */
 type CurrentContext struct {
-	context ConfigContext
+	context  ConfigContext
+	readOnly bool
 }
 
 func NewCurrentContext(context ConfigContext) core.ConfigContext {
 	return &CurrentContext{context: context}
+}
+
+func NewEnvironmentContext(context ConfigContext) core.ConfigContext {
+	return &CurrentContext{context: context, readOnly: true}
 }
 
 func (c *CurrentContext) GetActiveCanvas() string {
@@ -304,6 +349,10 @@ func (c *CurrentContext) GetActiveCanvas() string {
 
 func (c *CurrentContext) SetActiveCanvas(canvasID string) error {
 	c.context.Canvas = &canvasID
+	if c.readOnly {
+		return fmt.Errorf("cannot set active canvas when using %s and %s; pass --canvas-id instead", EnvURL, EnvToken)
+	}
+
 	_, err := UpsertContext(c.context)
 	return err
 }

--- a/pkg/cli/configuration_test.go
+++ b/pkg/cli/configuration_test.go
@@ -310,6 +310,7 @@ func TestEnvironmentContextOverridesConfiguredContext(t *testing.T) {
 	err = config.SetActiveCanvas("canvas-from-env-run")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "pass --canvas-id")
+	require.Empty(t, config.GetActiveCanvas())
 
 	current, ok := GetCurrentContext()
 	require.True(t, ok)

--- a/pkg/cli/configuration_test.go
+++ b/pkg/cli/configuration_test.go
@@ -282,3 +282,48 @@ func TestGetCurrentContextResolvesAfterUpgrade(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, upgraded.OrganizationID, current.OrganizationID)
 }
+
+func TestEnvironmentContextOverridesConfiguredContext(t *testing.T) {
+	setupViper(t)
+
+	_, err := UpsertContext(ConfigContext{
+		URL:            "https://app.superplane.com",
+		Organization:   "Saved",
+		OrganizationID: "aaaaaaaa-0000-0000-0000-000000000001",
+		APIToken:       "saved-token",
+	})
+	require.NoError(t, err)
+
+	t.Setenv(EnvURL, "https://agent.superplane.com/")
+	t.Setenv(EnvToken, "agent-token")
+
+	require.NoError(t, ValidateEnvironmentContext())
+	require.Equal(t, "https://agent.superplane.com", GetAPIURL())
+	require.Equal(t, "agent-token", GetAPIToken())
+
+	context, ok := GetEnvironmentContext()
+	require.True(t, ok)
+	require.Equal(t, "https://agent.superplane.com", context.URL)
+	require.Equal(t, "agent-token", context.APIToken)
+
+	config := NewEnvironmentContext(context)
+	err = config.SetActiveCanvas("canvas-from-env-run")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pass --canvas-id")
+
+	current, ok := GetCurrentContext()
+	require.True(t, ok)
+	require.Nil(t, current.Canvas)
+	require.Equal(t, "saved-token", current.APIToken)
+}
+
+func TestEnvironmentContextRequiresURLAndToken(t *testing.T) {
+	setupViper(t)
+
+	t.Setenv(EnvURL, "https://agent.superplane.com")
+
+	err := ValidateEnvironmentContext()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), EnvURL)
+	require.Contains(t, err.Error(), EnvToken)
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -40,10 +40,11 @@ var RootCmd = &cobra.Command{
 	Use:   "superplane",
 	Short: "SuperPlane command line interface",
 	Long:  "SuperPlane CLI - Command line interface for the SuperPlane API\n\n" + core.AgentSkillsHelp(),
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if !Verbose {
 			log.SetOutput(io.Discard)
 		}
+		return ValidateEnvironmentContext()
 	},
 }
 
@@ -104,6 +105,10 @@ func defaultBindOptions() core.BindOptions {
 		NewAPIClient:        DefaultClient,
 		DefaultOutputFormat: GetOutputFormat,
 		NewConfigContext: func() core.ConfigContext {
+			if context, ok := GetEnvironmentContext(); ok {
+				return NewEnvironmentContext(context)
+			}
+
 			context, ok := GetCurrentContext()
 			if !ok {
 				return nil
@@ -115,6 +120,10 @@ func defaultBindOptions() core.BindOptions {
 }
 
 func GetAPIURL() string {
+	if context, ok := GetEnvironmentContext(); ok {
+		return context.URL
+	}
+
 	if currentContext, ok := GetCurrentContext(); ok {
 		return currentContext.URL
 	}
@@ -123,6 +132,10 @@ func GetAPIURL() string {
 }
 
 func GetAPIToken() string {
+	if context, ok := GetEnvironmentContext(); ok {
+		return context.APIToken
+	}
+
 	if currentContext, ok := GetCurrentContext(); ok {
 		return currentContext.APIToken
 	}


### PR DESCRIPTION
## Summary

- Add `SUPERPLANE_URL` and `SUPERPLANE_TOKEN` support for CLI authentication
- Prefer env-based auth over saved CLI contexts when both variables are set
- Update agent preamble instructions to use env vars instead of `superplane connect`
