### PR TITLE
fix: clean up agent sessions on canvas and organization deletion

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -134,6 +134,36 @@ func TestSendMessage_RequiresSessionID(t *testing.T) {
 	require.Error(t, p.SendMessage(context.Background(), "", "hi", agents.SendMessageOptions{}))
 }
 
+func TestDeleteSession_SendsCorrectRequest(t *testing.T) {
+	var capturedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/sessions/sesn_abc", r.URL.Path)
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	require.NoError(t, p.DeleteSession(context.Background(), "sesn_abc"))
+	assert.Equal(t, "test-key", capturedHeaders.Get("x-api-key"))
+	assert.Equal(t, managedAgentsBeta, capturedHeaders.Get("anthropic-beta"))
+}
+
+func TestDeleteSession_PropagatesAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"running"}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.DeleteSession(context.Background(), "sesn_abc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "409")
+}
+
 func TestStreamEvents_MapsKnownTypes(t *testing.T) {
 	const sse = "data: {\"id\":\"e1\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}]}\n\n" +
 		"data: {\"id\":\"e2\",\"type\":\"agent.tool_use\",\"name\":\"bash\",\"input\":{\"command\":\"ls -la\"}}\n\n" +

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -95,6 +96,18 @@ func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, o
 	}
 	defer body.Close()
 	return forwardSSE(ctx, body, onEvent)
+}
+
+func (p *Provider) DeleteSession(ctx context.Context, providerSessionID string) error {
+	if providerSessionID == "" {
+		return fmt.Errorf("anthropic: provider session id is required")
+	}
+
+	if _, err := p.client.executeHTTP(ctx, http.MethodDelete, "/sessions/"+url.PathEscape(providerSessionID), nil); err != nil {
+		return fmt.Errorf("anthropic: delete session: %w", err)
+	}
+
+	return nil
 }
 
 func withPreamble(message, preamble string) string {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -55,4 +55,9 @@ type Provider interface {
 	StreamEvents(ctx context.Context, providerSessionID string, onEvent func(ProviderEvent) error) error
 }
 
+type ProviderSessionCleaner interface {
+	Name() string
+	DeleteSession(ctx context.Context, providerSessionID string) error
+}
+
 var ErrSessionAlreadyTerminated = errors.New("agent session already terminated")

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -100,6 +100,21 @@ func UpdateAgentSessionStatus(sessionID uuid.UUID, status string) error {
 	return UpdateAgentSessionStatusInTransaction(database.Conn(), sessionID, status)
 }
 
+func DeleteAgentSessionsForCanvasInTransaction(tx *gorm.DB, organizationID, canvasID uuid.UUID) error {
+	return tx.
+		Where("organization_id = ?", organizationID).
+		Where("canvas_id = ?", canvasID).
+		Delete(&AgentSession{}).
+		Error
+}
+
+func DeleteAgentSessionsForOrganizationInTransaction(tx *gorm.DB, organizationID uuid.UUID) error {
+	return tx.
+		Where("organization_id = ?", organizationID).
+		Delete(&AgentSession{}).
+		Error
+}
+
 // FailStuckStreamingSessions marks any session in "streaming" state whose
 // last update predates cutoff as failed and returns the affected rows so
 // the caller can fan out session_failed events.

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -84,6 +84,25 @@ func FindAgentSessionByCanvasInTransaction(tx *gorm.DB, organizationID, userID, 
 	return &session, nil
 }
 
+func ListAgentSessionsForCanvasInTransaction(tx *gorm.DB, organizationID, canvasID uuid.UUID) ([]AgentSession, error) {
+	var sessions []AgentSession
+	err := tx.
+		Where("organization_id = ?", organizationID).
+		Where("canvas_id = ?", canvasID).
+		Find(&sessions).
+		Error
+	return sessions, err
+}
+
+func ListAgentSessionsForOrganizationInTransaction(tx *gorm.DB, organizationID uuid.UUID) ([]AgentSession, error) {
+	var sessions []AgentSession
+	err := tx.
+		Where("organization_id = ?", organizationID).
+		Find(&sessions).
+		Error
+	return sessions, err
+}
+
 func UpdateAgentSessionStatusInTransaction(tx *gorm.DB, sessionID uuid.UUID, status string) error {
 	now := time.Now()
 	return tx.Model(&AgentSession{}).

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -196,14 +196,14 @@ func startWorkers(encryptor crypto.Encryptor, registry *registry.Registry, oidcP
 	if os.Getenv("START_WORKFLOW_CLEANUP_WORKER") == "yes" || os.Getenv("START_CANVAS_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Canvas Cleanup Worker")
 
-		w := workers.NewCanvasCleanupWorker()
+		w := workers.NewCanvasCleanupWorker(agentProvider)
 		go w.Start(context.Background())
 	}
 
 	if os.Getenv("START_ORGANIZATION_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Organization Cleanup Worker")
 
-		w := workers.NewOrganizationCleanupWorker()
+		w := workers.NewOrganizationCleanupWorker(agentProvider)
 		go w.Start(context.Background())
 	}
 

--- a/pkg/workers/canvas_cleanup_worker.go
+++ b/pkg/workers/canvas_cleanup_worker.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/telemetry"
@@ -19,14 +20,23 @@ type CanvasCleanupWorker struct {
 	semaphore           *semaphore.Weighted
 	logger              *log.Entry
 	maxResourcesPerTick int
+	sessionCleaner      agents.ProviderSessionCleaner
 }
 
-func NewCanvasCleanupWorker() *CanvasCleanupWorker {
-	return &CanvasCleanupWorker{
+func NewCanvasCleanupWorker(providers ...agents.Provider) *CanvasCleanupWorker {
+	w := &CanvasCleanupWorker{
 		semaphore:           semaphore.NewWeighted(25),
 		logger:              log.WithFields(log.Fields{"worker": "CanvasCleanupWorker"}),
 		maxResourcesPerTick: 500,
 	}
+
+	if len(providers) > 0 {
+		if cleaner, ok := providers[0].(agents.ProviderSessionCleaner); ok {
+			w.sessionCleaner = cleaner
+		}
+	}
+
+	return w
 }
 
 func (w *CanvasCleanupWorker) Start(ctx context.Context) {
@@ -76,7 +86,8 @@ func (w *CanvasCleanupWorker) LockAndProcessCanvas(canvas models.Canvas) error {
 		return nil
 	}
 
-	return database.Conn().Transaction(func(tx *gorm.DB) error {
+	var sessionsToClean []models.AgentSession
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		lockedCanvas, err := models.LockCanvas(tx, canvas.ID)
 		if err != nil {
 			w.logger.Infof("Canvas %s already being processed - skipping", canvas.ID)
@@ -84,20 +95,60 @@ func (w *CanvasCleanupWorker) LockAndProcessCanvas(canvas models.Canvas) error {
 		}
 
 		w.logger.Infof("Processing deleted canvas %s", lockedCanvas.ID)
-		return w.processCanvas(tx, *lockedCanvas)
+		sessions, err := w.processCanvas(tx, *lockedCanvas)
+		if err != nil {
+			return err
+		}
+
+		sessionsToClean = sessions
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	w.cleanupProviderSessions(context.Background(), sessionsToClean)
+	return nil
 }
 
-func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) error {
+func (w *CanvasCleanupWorker) cleanupProviderSessions(ctx context.Context, sessions []models.AgentSession) {
+	if w.sessionCleaner == nil || len(sessions) == 0 {
+		return
+	}
+
+	for _, session := range sessions {
+		if session.Provider != w.sessionCleaner.Name() {
+			w.logger.WithFields(log.Fields{
+				"session_id":       session.ID,
+				"session_provider": session.Provider,
+				"cleaner_provider": w.sessionCleaner.Name(),
+			}).Warn("Skipping provider cleanup for agent session with mismatched provider")
+			continue
+		}
+
+		cleanupCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err := w.sessionCleaner.DeleteSession(cleanupCtx, session.ProviderSessionID)
+		cancel()
+		if err != nil {
+			w.logger.WithFields(log.Fields{
+				"session_id":          session.ID,
+				"provider":            session.Provider,
+				"provider_session_id": session.ProviderSessionID,
+			}).WithError(err).Warn("Failed to cleanup provider agent session")
+		}
+	}
+}
+
+func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) ([]models.AgentSession, error) {
 	if !canvas.DeletedAt.Valid {
 		w.logger.Infof("Skipping non-deleted canvas %s", canvas.ID)
-		return nil
+		return nil, nil
 	}
 
 	var nodes []models.CanvasNode
 	err := tx.Unscoped().Where("workflow_id = ?", canvas.ID).Find(&nodes).Error
 	if err != nil {
-		return fmt.Errorf("failed to find workflow nodes: %w", err)
+		return nil, fmt.Errorf("failed to find workflow nodes: %w", err)
 	}
 
 	totalResourcesDeleted := 0
@@ -111,7 +162,7 @@ func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) e
 
 		resourcesDeleted, allResourcesDeleted, err := w.deleteNodeResourcesBatched(tx, canvas.ID, node.NodeID, w.maxResourcesPerTick-totalResourcesDeleted)
 		if err != nil {
-			return fmt.Errorf("failed to delete resources for node %s: %w", node.NodeID, err)
+			return nil, fmt.Errorf("failed to delete resources for node %s: %w", node.NodeID, err)
 		}
 
 		totalResourcesDeleted += resourcesDeleted
@@ -124,7 +175,7 @@ func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) e
 		}
 
 		if err := tx.Unscoped().Where("workflow_id = ? AND node_id = ?", canvas.ID, node.NodeID).Delete(&models.CanvasNode{}).Error; err != nil {
-			return fmt.Errorf("failed to delete canvas node %s: %w", node.NodeID, err)
+			return nil, fmt.Errorf("failed to delete canvas node %s: %w", node.NodeID, err)
 		}
 
 		w.logger.Infof("Deleted node %s from canvas %s (deleted %d resources)", node.NodeID, canvas.ID, resourcesDeleted)
@@ -137,25 +188,30 @@ func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) e
 	var remainingNodesCount int64
 	err = tx.Unscoped().Model(&models.CanvasNode{}).Where("workflow_id = ?", canvas.ID).Count(&remainingNodesCount).Error
 	if err != nil {
-		return fmt.Errorf("failed to check remaining canvas nodes: %w", err)
+		return nil, fmt.Errorf("failed to check remaining canvas nodes: %w", err)
 	}
 
 	if remainingNodesCount > 0 {
 		w.logger.Infof("Processed %d nodes from canvas %s (deleted %d resources, %d nodes remaining)", nodesProcessed, canvas.ID, totalResourcesDeleted, remainingNodesCount)
-		return nil
+		return nil, nil
+	}
+
+	sessions, err := models.ListAgentSessionsForCanvasInTransaction(tx, canvas.OrganizationID, canvas.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list canvas agent sessions: %w", err)
 	}
 
 	w.logger.Infof("Processed %d nodes from canvas %s (deleted %d resources, %d nodes remaining)", nodesProcessed, canvas.ID, totalResourcesDeleted, remainingNodesCount)
 	if err := models.DeleteAgentSessionsForCanvasInTransaction(tx, canvas.OrganizationID, canvas.ID); err != nil {
-		return fmt.Errorf("delete canvas agent sessions: %w", err)
+		return nil, fmt.Errorf("delete canvas agent sessions: %w", err)
 	}
 
 	if err := tx.Unscoped().Delete(&canvas).Error; err != nil {
-		return fmt.Errorf("failed to delete canvas: %w", err)
+		return nil, fmt.Errorf("failed to delete canvas: %w", err)
 	}
 
 	w.logger.Infof("Successfully cleaned up canvas %s (deleted %d resources total)", canvas.ID, totalResourcesDeleted)
-	return nil
+	return sessions, nil
 }
 
 func (w *CanvasCleanupWorker) deleteNodeResourcesBatched(tx *gorm.DB, workflowID uuid.UUID, nodeID string, maxResources int) (resourcesDeleted int, allResourcesDeleted bool, err error) {

--- a/pkg/workers/canvas_cleanup_worker.go
+++ b/pkg/workers/canvas_cleanup_worker.go
@@ -146,6 +146,10 @@ func (w *CanvasCleanupWorker) processCanvas(tx *gorm.DB, canvas models.Canvas) e
 	}
 
 	w.logger.Infof("Processed %d nodes from canvas %s (deleted %d resources, %d nodes remaining)", nodesProcessed, canvas.ID, totalResourcesDeleted, remainingNodesCount)
+	if err := models.DeleteAgentSessionsForCanvasInTransaction(tx, canvas.OrganizationID, canvas.ID); err != nil {
+		return fmt.Errorf("delete canvas agent sessions: %w", err)
+	}
+
 	if err := tx.Unscoped().Delete(&canvas).Error; err != nil {
 		return fmt.Errorf("failed to delete canvas: %w", err)
 	}

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -14,6 +14,49 @@ import (
 	"gorm.io/gorm"
 )
 
+func createAgentSessionWithMessage(t *testing.T, organizationID, userID, canvasID uuid.UUID) *models.AgentSession {
+	t.Helper()
+
+	session := &models.AgentSession{
+		OrganizationID:    organizationID,
+		UserID:            userID,
+		CanvasID:          canvasID,
+		Provider:          "test",
+		ProviderSessionID: "provider-session-" + uuid.NewString(),
+		Status:            models.AgentSessionStatusIdle,
+	}
+
+	require.NoError(t, database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := models.CreateAgentSessionInTransaction(tx, session); err != nil {
+			return err
+		}
+
+		return models.AppendAgentSessionMessageInTransaction(tx, &models.AgentSessionMessage{
+			SessionID: session.ID,
+			Role:      models.AgentMessageRoleUser,
+			Content:   "hello",
+		})
+	}))
+
+	return session
+}
+
+func countAgentSessions(t *testing.T, sessionID uuid.UUID) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, database.Conn().Model(&models.AgentSession{}).Where("id = ?", sessionID).Count(&count).Error)
+	return count
+}
+
+func countAgentSessionMessages(t *testing.T, sessionID uuid.UUID) int64 {
+	t.Helper()
+
+	var count int64
+	require.NoError(t, database.Conn().Model(&models.AgentSessionMessage{}).Where("session_id = ?", sessionID).Count(&count).Error)
+	return count
+}
+
 func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
@@ -44,6 +87,8 @@ func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 		},
 		[]models.Edge{},
 	)
+
+	session := createAgentSessionWithMessage(t, r.Organization.ID, r.User, canvas.ID)
 
 	// Create associated data
 	event1 := support.EmitCanvasEventForNode(t, canvas.ID, "node-1", "default", nil)
@@ -92,6 +137,8 @@ func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 	// Verify KV and request exist
 	support.VerifyNodeExecutionKVCount(t, canvas.ID, 1)
 	support.VerifyNodeRequestCount(t, canvas.ID, 1)
+	assert.Equal(t, int64(1), countAgentSessions(t, session.ID))
+	assert.Equal(t, int64(1), countAgentSessionMessages(t, session.ID))
 
 	//
 	// Soft delete the canvas using the new soft delete method
@@ -153,6 +200,9 @@ func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 	// KV and request should be deleted
 	support.VerifyNodeExecutionKVCount(t, canvas.ID, 0)
 	support.VerifyNodeRequestCount(t, canvas.ID, 0)
+
+	assert.Equal(t, int64(0), countAgentSessions(t, session.ID))
+	assert.Equal(t, int64(0), countAgentSessionMessages(t, session.ID))
 }
 
 func Test__CanvasCleanupWorker_ProcessesWorkflowFromSoftDeletedOrganization(t *testing.T) {

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -1,18 +1,45 @@
 package workers
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+type cleanupProvider struct {
+	deleted []string
+	err     error
+}
+
+func (p *cleanupProvider) Name() string { return "test" }
+
+func (p *cleanupProvider) CreateSession(context.Context, agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
+	return nil, errors.New("not used")
+}
+
+func (p *cleanupProvider) SendMessage(context.Context, string, string, agents.SendMessageOptions) error {
+	return errors.New("not used")
+}
+
+func (p *cleanupProvider) StreamEvents(context.Context, string, func(agents.ProviderEvent) error) error {
+	return errors.New("not used")
+}
+
+func (p *cleanupProvider) DeleteSession(_ context.Context, providerSessionID string) error {
+	p.deleted = append(p.deleted, providerSessionID)
+	return p.err
+}
 
 func createAgentSessionWithMessage(t *testing.T, organizationID, userID, canvasID uuid.UUID) *models.AgentSession {
 	t.Helper()
@@ -60,7 +87,8 @@ func countAgentSessionMessages(t *testing.T, sessionID uuid.UUID) int64 {
 func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
-	worker := NewCanvasCleanupWorker()
+	cleaner := &cleanupProvider{}
+	worker := NewCanvasCleanupWorker(cleaner)
 
 	//
 	// Create a canvas with nodes, events, executions, and queue items
@@ -203,6 +231,32 @@ func Test__CanvasCleanupWorker_ProcessesDeletedWorkflow(t *testing.T) {
 
 	assert.Equal(t, int64(0), countAgentSessions(t, session.ID))
 	assert.Equal(t, int64(0), countAgentSessionMessages(t, session.ID))
+	assert.Contains(t, cleaner.deleted, session.ProviderSessionID)
+}
+
+func Test__CanvasCleanupWorker_ProviderCleanupFailureDoesNotBlockDatabaseCleanup(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	cleaner := &cleanupProvider{err: errors.New("provider unavailable")}
+	worker := NewCanvasCleanupWorker(cleaner)
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	session := createAgentSessionWithMessage(t, r.Organization.ID, r.User, canvas.ID)
+
+	require.NoError(t, canvas.SoftDelete())
+	deletedAtOutsideGracePeriod := time.Now().AddDate(0, 0, -31)
+	require.NoError(t, database.Conn().Unscoped().Model(&models.Canvas{}).Where("id = ?", canvas.ID).Update("deleted_at", deletedAtOutsideGracePeriod).Error)
+
+	deletedCanvas, err := models.FindUnscopedCanvas(canvas.ID)
+	require.NoError(t, err)
+	require.NoError(t, worker.LockAndProcessCanvas(*deletedCanvas))
+
+	var canvasCount int64
+	require.NoError(t, database.Conn().Unscoped().Model(&models.Canvas{}).Where("id = ?", canvas.ID).Count(&canvasCount).Error)
+	assert.Equal(t, int64(0), canvasCount)
+	assert.Equal(t, int64(0), countAgentSessions(t, session.ID))
+	assert.Equal(t, int64(0), countAgentSessionMessages(t, session.ID))
+	assert.Contains(t, cleaner.deleted, session.ProviderSessionID)
 }
 
 func Test__CanvasCleanupWorker_ProcessesWorkflowFromSoftDeletedOrganization(t *testing.T) {

--- a/pkg/workers/organization_cleanup_worker.go
+++ b/pkg/workers/organization_cleanup_worker.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"gorm.io/gorm"
 
+	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 )
@@ -19,11 +20,11 @@ type OrganizationCleanupWorker struct {
 	canvasWorker *CanvasCleanupWorker
 }
 
-func NewOrganizationCleanupWorker() *OrganizationCleanupWorker {
+func NewOrganizationCleanupWorker(providers ...agents.Provider) *OrganizationCleanupWorker {
 	return &OrganizationCleanupWorker{
 		semaphore:    semaphore.NewWeighted(10),
 		logger:       log.WithFields(log.Fields{"worker": "OrganizationCleanupWorker"}),
-		canvasWorker: NewCanvasCleanupWorker(),
+		canvasWorker: NewCanvasCleanupWorker(providers...),
 	}
 }
 
@@ -69,59 +70,75 @@ func (w *OrganizationCleanupWorker) LockAndProcessOrganization(organization mode
 		return nil
 	}
 
-	return database.Conn().Transaction(func(tx *gorm.DB) error {
+	var sessionsToClean []models.AgentSession
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		lockedOrganization, err := models.LockDeletedOrganization(tx, organization.ID)
 		if err != nil {
 			w.logger.Infof("Organization %s already being processed - skipping", organization.ID)
 			return nil
 		}
 
-		return w.processOrganization(tx, *lockedOrganization)
+		sessions, err := w.processOrganization(tx, *lockedOrganization)
+		if err != nil {
+			return err
+		}
+
+		sessionsToClean = sessions
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	w.canvasWorker.cleanupProviderSessions(context.Background(), sessionsToClean)
+	return nil
 }
 
-func (w *OrganizationCleanupWorker) processOrganization(tx *gorm.DB, organization models.Organization) error {
+func (w *OrganizationCleanupWorker) processOrganization(tx *gorm.DB, organization models.Organization) ([]models.AgentSession, error) {
 	if !organization.DeletedAt.Valid {
-		return nil
+		return nil, nil
 	}
 
 	canvases, err := models.ListMaybeDeletedCanvasesByOrganizationInTransaction(tx, organization.ID)
 	if err != nil {
-		return fmt.Errorf("list organization canvases: %w", err)
+		return nil, fmt.Errorf("list organization canvases: %w", err)
 	}
 
+	var sessionsToClean []models.AgentSession
 	for _, canvas := range canvases {
 		if !canvas.DeletedAt.Valid {
 			if err := canvas.SoftDeleteInTransaction(tx); err != nil {
-				return fmt.Errorf("soft delete canvas %s: %w", canvas.ID, err)
+				return nil, fmt.Errorf("soft delete canvas %s: %w", canvas.ID, err)
 			}
 
 			canvasInDB, err := models.FindUnscopedCanvasInTransaction(tx, canvas.ID)
 			if err != nil {
-				return fmt.Errorf("reload soft-deleted canvas %s: %w", canvas.ID, err)
+				return nil, fmt.Errorf("reload soft-deleted canvas %s: %w", canvas.ID, err)
 			}
 
 			canvas = *canvasInDB
 		}
 
-		if err := w.canvasWorker.processCanvas(tx, canvas); err != nil {
-			return fmt.Errorf("process canvas %s: %w", canvas.ID, err)
+		sessions, err := w.canvasWorker.processCanvas(tx, canvas)
+		if err != nil {
+			return nil, fmt.Errorf("process canvas %s: %w", canvas.ID, err)
 		}
+		sessionsToClean = append(sessionsToClean, sessions...)
 	}
 
 	var remainingCanvases int64
 	err = tx.Unscoped().Model(&models.Canvas{}).Where("organization_id = ?", organization.ID).Count(&remainingCanvases).Error
 	if err != nil {
-		return fmt.Errorf("count remaining canvases: %w", err)
+		return nil, fmt.Errorf("count remaining canvases: %w", err)
 	}
 
 	if remainingCanvases > 0 {
-		return nil
+		return sessionsToClean, nil
 	}
 
 	integrations, err := models.ListMaybeDeletedIntegrationsByOrganizationInTransaction(tx, organization.ID)
 	if err != nil {
-		return fmt.Errorf("list organization integrations: %w", err)
+		return nil, fmt.Errorf("list organization integrations: %w", err)
 	}
 
 	for _, integration := range integrations {
@@ -131,54 +148,60 @@ func (w *OrganizationCleanupWorker) processOrganization(tx *gorm.DB, organizatio
 
 		webhooks, err := models.ListIntegrationWebhooks(tx, integration.ID)
 		if err != nil {
-			return fmt.Errorf("list integration webhooks for %s: %w", integration.ID, err)
+			return nil, fmt.Errorf("list integration webhooks for %s: %w", integration.ID, err)
 		}
 
 		for _, webhook := range webhooks {
 			if err := tx.Delete(&webhook).Error; err != nil {
-				return fmt.Errorf("soft delete webhook %s: %w", webhook.ID, err)
+				return nil, fmt.Errorf("soft delete webhook %s: %w", webhook.ID, err)
 			}
 		}
 
 		if err := integration.SoftDeleteInTransaction(tx); err != nil {
-			return fmt.Errorf("soft delete integration %s: %w", integration.ID, err)
+			return nil, fmt.Errorf("soft delete integration %s: %w", integration.ID, err)
 		}
 	}
 
 	var remainingIntegrations int64
 	err = tx.Unscoped().Model(&models.Integration{}).Where("organization_id = ?", organization.ID).Count(&remainingIntegrations).Error
 	if err != nil {
-		return fmt.Errorf("count remaining integrations: %w", err)
+		return nil, fmt.Errorf("count remaining integrations: %w", err)
 	}
 
 	if remainingIntegrations > 0 {
-		return nil
+		return sessionsToClean, nil
 	}
 
+	organizationSessions, err := models.ListAgentSessionsForOrganizationInTransaction(tx, organization.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list organization agent sessions: %w", err)
+	}
+	sessionsToClean = append(sessionsToClean, organizationSessions...)
+
 	if err := models.DeleteAgentSessionsForOrganizationInTransaction(tx, organization.ID); err != nil {
-		return fmt.Errorf("delete organization agent sessions: %w", err)
+		return nil, fmt.Errorf("delete organization agent sessions: %w", err)
 	}
 
 	if err := models.DeleteMetadataForOrganization(tx, models.DomainTypeOrganization, organization.ID.String()); err != nil {
-		return fmt.Errorf("delete organization role metadata: %w", err)
+		return nil, fmt.Errorf("delete organization role metadata: %w", err)
 	}
 
 	if err := tx.Where("organization_id = ?", organization.ID).Delete(&models.Blueprint{}).Error; err != nil {
-		return fmt.Errorf("delete organization blueprints: %w", err)
+		return nil, fmt.Errorf("delete organization blueprints: %w", err)
 	}
 
 	if err := tx.Where("domain_type = ?", models.DomainTypeOrganization).Where("domain_id = ?", organization.ID).Delete(&models.Secret{}).Error; err != nil {
-		return fmt.Errorf("delete organization secrets: %w", err)
+		return nil, fmt.Errorf("delete organization secrets: %w", err)
 	}
 
 	if err := tx.Unscoped().Where("organization_id = ?", organization.ID).Delete(&models.User{}).Error; err != nil {
-		return fmt.Errorf("delete organization users: %w", err)
+		return nil, fmt.Errorf("delete organization users: %w", err)
 	}
 
 	if err := tx.Unscoped().Delete(&organization).Error; err != nil {
-		return fmt.Errorf("hard delete organization: %w", err)
+		return nil, fmt.Errorf("hard delete organization: %w", err)
 	}
 
 	w.logger.Infof("Successfully cleaned up organization %s", organization.ID)
-	return nil
+	return sessionsToClean, nil
 }

--- a/pkg/workers/organization_cleanup_worker.go
+++ b/pkg/workers/organization_cleanup_worker.go
@@ -155,6 +155,10 @@ func (w *OrganizationCleanupWorker) processOrganization(tx *gorm.DB, organizatio
 		return nil
 	}
 
+	if err := models.DeleteAgentSessionsForOrganizationInTransaction(tx, organization.ID); err != nil {
+		return fmt.Errorf("delete organization agent sessions: %w", err)
+	}
+
 	if err := models.DeleteMetadataForOrganization(tx, models.DomainTypeOrganization, organization.ID.String()); err != nil {
 		return fmt.Errorf("delete organization role metadata: %w", err)
 	}

--- a/pkg/workers/organization_cleanup_worker_test.go
+++ b/pkg/workers/organization_cleanup_worker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
@@ -85,6 +86,7 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 
 		worker := NewOrganizationCleanupWorker()
 		canvas, _ := support.CreateCanvas(t, r2.Organization.ID, r2.User, []models.CanvasNode{}, []models.Edge{})
+		orphanSession := createAgentSessionWithMessage(t, r2.Organization.ID, r2.User, uuid.New())
 
 		require.NoError(t, models.SoftDeleteOrganization(r2.Organization.ID.String()))
 		deletedAtOutsideGracePeriod := time.Now().AddDate(0, 0, -31)
@@ -107,5 +109,8 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 		var userCount int64
 		require.NoError(t, database.Conn().Unscoped().Model(&models.User{}).Where("organization_id = ?", r2.Organization.ID).Count(&userCount).Error)
 		assert.Equal(t, int64(0), userCount)
+
+		assert.Equal(t, int64(0), countAgentSessions(t, orphanSession.ID))
+		assert.Equal(t, int64(0), countAgentSessionMessages(t, orphanSession.ID))
 	})
 }

--- a/pkg/workers/organization_cleanup_worker_test.go
+++ b/pkg/workers/organization_cleanup_worker_test.go
@@ -84,7 +84,8 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 		r2 := support.Setup(t)
 		defer r2.Close()
 
-		worker := NewOrganizationCleanupWorker()
+		cleaner := &cleanupProvider{}
+		worker := NewOrganizationCleanupWorker(cleaner)
 		canvas, _ := support.CreateCanvas(t, r2.Organization.ID, r2.User, []models.CanvasNode{}, []models.Edge{})
 		orphanSession := createAgentSessionWithMessage(t, r2.Organization.ID, r2.User, uuid.New())
 
@@ -112,5 +113,6 @@ func Test__OrganizationCleanupWorker_GracePeriod(t *testing.T) {
 
 		assert.Equal(t, int64(0), countAgentSessions(t, orphanSession.ID))
 		assert.Equal(t, int64(0), countAgentSessionMessages(t, orphanSession.ID))
+		assert.Contains(t, cleaner.deleted, orphanSession.ProviderSessionID)
 	})
 }


### PR DESCRIPTION
## Summary

- Delete agent sessions when the canvas cleanup worker hard-deletes a canvas
- Delete remaining organization agent sessions during organization cleanup
- Rely on existing `agent_session_messages` cascade delete to remove chat messages
- Add worker tests for canvas session cleanup and organization orphan session cleanup

