### PR TITLE
fix: preserve zoom when switching to runs view

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -100,6 +100,7 @@ import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 import { prepareAnnotationNode } from "./lib/canvas-annotation-node";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
+import { syncViewportOnModeSwitch } from "./lib/runs-viewport";
 import { prepareComponentNode, prepareTriggerNode } from "./lib/canvas-node-preparation";
 import {
   isDraftVersion,
@@ -730,7 +731,8 @@ export function WorkflowPageV2() {
    */
   const viewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const runsViewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
-  const lastRunsViewportKeyRef = useRef<string | null>(null);
+  const lastRunsViewportKeyRef = useRef<"runs" | null>(null);
+  const skipNextRunsFitAllRef = useRef(false);
 
   // Track unsaved changes on the canvas
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -2017,8 +2019,29 @@ export function WorkflowPageV2() {
   const runsViewportKey = isRunsMode ? "runs" : null;
 
   if (lastRunsViewportKeyRef.current !== runsViewportKey) {
-    runsHasFitToViewRef.current = false;
-    runsViewportRef.current = undefined;
+    const viewportSync = syncViewportOnModeSwitch({
+      previousMode: lastRunsViewportKeyRef.current,
+      nextMode: runsViewportKey,
+      canvasViewport: viewportRef.current,
+      runsViewport: runsViewportRef.current,
+    });
+
+    if (viewportSync) {
+      if (viewportSync.canvasViewport) {
+        viewportRef.current = viewportSync.canvasViewport;
+      }
+      if (viewportSync.canvasHasFitToView !== undefined) {
+        hasFitToViewRef.current = viewportSync.canvasHasFitToView;
+      }
+      if (viewportSync.runsViewport !== undefined || runsViewportKey === "runs") {
+        runsViewportRef.current = viewportSync.runsViewport;
+      }
+      if (viewportSync.runsHasFitToView !== undefined) {
+        runsHasFitToViewRef.current = viewportSync.runsHasFitToView;
+      }
+      skipNextRunsFitAllRef.current = viewportSync.skipNextRunsFitAll;
+    }
+
     lastRunsViewportKeyRef.current = runsViewportKey;
   }
 
@@ -2033,6 +2056,12 @@ export function WorkflowPageV2() {
   useEffect(() => {
     if (!isRunsMode) return;
     if (!runCanvasNodeIdsKey) return;
+
+    if (skipNextRunsFitAllRef.current) {
+      skipNextRunsFitAllRef.current = false;
+      return;
+    }
+
     setRunsFitAllNonce((n) => n + 1);
   }, [isRunsMode, runCanvasNodeIdsKey]);
 

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { syncViewportOnModeSwitch } from "./runs-viewport";
+
+describe("syncViewportOnModeSwitch", () => {
+  it("copies the current canvas viewport into runs mode and skips the initial fit-all", () => {
+    expect(
+      syncViewportOnModeSwitch({
+        previousMode: null,
+        nextMode: "runs",
+        canvasViewport: { x: 120, y: -40, zoom: 0.72 },
+      }),
+    ).toEqual({
+      runsViewport: { x: 120, y: -40, zoom: 0.72 },
+      runsHasFitToView: true,
+      skipNextRunsFitAll: true,
+    });
+  });
+
+  it("falls back to a fresh runs fit when there is no canvas viewport to preserve", () => {
+    expect(
+      syncViewportOnModeSwitch({
+        previousMode: null,
+        nextMode: "runs",
+      }),
+    ).toEqual({
+      runsViewport: undefined,
+      runsHasFitToView: false,
+      skipNextRunsFitAll: false,
+    });
+  });
+
+  it("copies the latest runs viewport back to the canvas when leaving runs mode", () => {
+    expect(
+      syncViewportOnModeSwitch({
+        previousMode: "runs",
+        nextMode: null,
+        runsViewport: { x: -300, y: 90, zoom: 0.55 },
+      }),
+    ).toEqual({
+      canvasViewport: { x: -300, y: 90, zoom: 0.55 },
+      canvasHasFitToView: true,
+      skipNextRunsFitAll: false,
+    });
+  });
+});

--- a/web_src/src/pages/workflowv2/lib/runs-viewport.ts
+++ b/web_src/src/pages/workflowv2/lib/runs-viewport.ts
@@ -1,0 +1,62 @@
+export type CanvasViewport = {
+  x: number;
+  y: number;
+  zoom: number;
+};
+
+type WorkflowViewMode = "runs" | null;
+
+type SyncViewportOnModeSwitchInput = {
+  previousMode: WorkflowViewMode;
+  nextMode: WorkflowViewMode;
+  canvasViewport?: CanvasViewport;
+  runsViewport?: CanvasViewport;
+};
+
+type SyncViewportOnModeSwitchResult = {
+  canvasViewport?: CanvasViewport;
+  runsViewport?: CanvasViewport;
+  canvasHasFitToView?: boolean;
+  runsHasFitToView?: boolean;
+  skipNextRunsFitAll: boolean;
+};
+
+export function syncViewportOnModeSwitch(input: SyncViewportOnModeSwitchInput): SyncViewportOnModeSwitchResult | null {
+  if (input.previousMode === input.nextMode) {
+    return null;
+  }
+
+  if (input.nextMode === "runs") {
+    if (!input.canvasViewport) {
+      return {
+        runsViewport: undefined,
+        runsHasFitToView: false,
+        skipNextRunsFitAll: false,
+      };
+    }
+
+    return {
+      runsViewport: input.canvasViewport,
+      runsHasFitToView: true,
+      skipNextRunsFitAll: true,
+    };
+  }
+
+  if (input.previousMode === "runs") {
+    if (!input.runsViewport) {
+      return {
+        skipNextRunsFitAll: false,
+      };
+    }
+
+    return {
+      canvasViewport: input.runsViewport,
+      canvasHasFitToView: true,
+      skipNextRunsFitAll: false,
+    };
+  }
+
+  return {
+    skipNextRunsFitAll: false,
+  };
+}


### PR DESCRIPTION
## Summary
- preserve the current viewport when switching between canvas and runs view
- skip the initial runs fit-all when reusing the existing viewport
- add unit tests for the viewport sync helper

## Verification
- npm run test:run -- src/pages/workflowv2/lib/runs-viewport.spec.ts

## Notes
- I also attempted a full frontend build, but this fresh clone is missing generated api-client files, so the build fails repo-wide before reaching this change.