### PR TITLE
fix: show runner commands in logs

### DIFF
--- a/pkg/components/runner/commands.go
+++ b/pkg/components/runner/commands.go
@@ -29,6 +29,22 @@ func normalizeCommands(commands string) []string {
 	return out
 }
 
+func commandsWithLogHeaders(commands []string) []string {
+	out := make([]string, 0, len(commands))
+	for _, command := range commands {
+		out = append(out, commandWithLogHeader(command))
+	}
+	return out
+}
+
+func commandWithLogHeader(command string) string {
+	return fmt.Sprintf("printf '%%s\\n' %s >&2\n%s", shellQuote("+ "+command), command)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
 func validateCommands(commands string) error {
 	lines := normalizeCommands(commands)
 	if len(lines) == 0 {

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -282,6 +282,7 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 	}
 
 	cmds := normalizeCommands(spec.Commands)
+	brokerCommands := commandsWithLogHeaders(cmds)
 	broker, err := NewBrokerClient(ctx.HTTP)
 	if err != nil {
 		return fmt.Errorf("new broker client: %w", err)
@@ -289,7 +290,7 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 
 	mode := normalizeExecutionMode(spec.ExecutionMode)
 	params := CreateTaskParams{
-		Commands:       cmds,
+		Commands:       brokerCommands,
 		WebhookURL:     webhookURL,
 		Environment:    environment,
 		ExecutionMode:  mode,

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -31,6 +31,17 @@ func TestNormalizeCommands(t *testing.T) {
 	}
 }
 
+func TestCommandsWithLogHeaders(t *testing.T) {
+	t.Parallel()
+
+	got := commandsWithLogHeaders([]string{"echo hello", "echo 'quoted value'"})
+
+	assert.Equal(t, []string{
+		"printf '%s\\n' '+ echo hello' >&2\necho hello",
+		"printf '%s\\n' '+ echo '\"'\"'quoted value'\"'\"'' >&2\necho 'quoted value'",
+	}, got)
+}
+
 func TestValidateEnvironment(t *testing.T) {
 	t.Parallel()
 
@@ -163,7 +174,7 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &req))
 
 	assert.Equal(t, "fleet-1", req.FleetID)
-	assert.Equal(t, []string{"echo hello"}, req.Commands)
+	assert.Equal(t, []string{"printf '%s\\n' '+ echo hello' >&2\necho hello"}, req.Commands)
 	assert.Equal(t, "host", req.ExecutionMode)
 	assert.Equal(t, []BrokerEnvironmentVariable{
 		{Name: "COMMIT_AUTHOR", Value: "alice@example.com"},


### PR DESCRIPTION
Closes #4804

## Summary
- print each runner command before its output in task logs
- preserve the original command execution while shell-quoting the displayed command header
- cover the broker payload and quoting behavior with runner tests

## Tests
- go test ./pkg/components/runner