### PR TITLE
fix: preserve runs view zoom

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -99,6 +99,7 @@ import { CanvasYamlModal } from "./CanvasYamlModal";
 import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 import { prepareAnnotationNode } from "./lib/canvas-annotation-node";
+import { shouldRefitRunsViewport } from "./lib/canvas-runs";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
 import { prepareComponentNode, prepareTriggerNode } from "./lib/canvas-node-preparation";
 import {
@@ -730,7 +731,8 @@ export function WorkflowPageV2() {
    */
   const viewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const runsViewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
-  const lastRunsViewportKeyRef = useRef<string | null>(null);
+  const lastRunCanvasNodeIdsKeyRef = useRef<string | null>(null);
+  const skipNextRunsViewportRefitRef = useRef(false);
 
   // Track unsaved changes on the canvas
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -2014,13 +2016,6 @@ export function WorkflowPageV2() {
 
   const nodes = runCanvasData ? runCanvasData.nodes : nodesWithIntegrationStatus;
   const renderedEdges = runCanvasData ? runCanvasData.edges : preparedEdges;
-  const runsViewportKey = isRunsMode ? "runs" : null;
-
-  if (lastRunsViewportKeyRef.current !== runsViewportKey) {
-    runsHasFitToViewRef.current = false;
-    runsViewportRef.current = undefined;
-    lastRunsViewportKeyRef.current = runsViewportKey;
-  }
 
   const runCanvasNodeIdsKey = useMemo(() => {
     if (!isRunsMode || !runCanvasData) return null;
@@ -2031,8 +2026,22 @@ export function WorkflowPageV2() {
   }, [isRunsMode, runCanvasData]);
 
   useEffect(() => {
-    if (!isRunsMode) return;
-    if (!runCanvasNodeIdsKey) return;
+    if (
+      !shouldRefitRunsViewport({
+        isRunsMode,
+        runCanvasNodeIdsKey,
+        previousRunCanvasNodeIdsKey: lastRunCanvasNodeIdsKeyRef.current,
+      })
+    ) {
+      return;
+    }
+
+    lastRunCanvasNodeIdsKeyRef.current = runCanvasNodeIdsKey;
+    if (skipNextRunsViewportRefitRef.current) {
+      skipNextRunsViewportRefitRef.current = false;
+      return;
+    }
+
     setRunsFitAllNonce((n) => n + 1);
   }, [isRunsMode, runCanvasNodeIdsKey]);
 
@@ -4967,6 +4976,12 @@ export function WorkflowPageV2() {
   const handleSelectRunsMode = useCallback(() => {
     if (hasEditableVersion && liveCanvasVersionId) {
       handleUseVersion(liveCanvasVersionId);
+    }
+
+    if (!runsViewportRef.current && viewportRef.current) {
+      runsViewportRef.current = { ...viewportRef.current };
+      runsHasFitToViewRef.current = true;
+      skipNextRunsViewportRefitRef.current = true;
     }
 
     setIsRunsMode(true);

--- a/web_src/src/pages/workflowv2/lib/canvas-runs.spec.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-runs.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { CanvasesCanvasEventWithExecutions, CanvasesCanvasNodeExecutionRef } from "@/api-client";
 import { makeComponentsNode } from "@/test/factories";
-import { filterRunEvents, getAggregateStatus } from "./canvas-runs";
+import { filterRunEvents, getAggregateStatus, shouldRefitRunsViewport } from "./canvas-runs";
 
 function makeExecutionRef(overrides: Partial<CanvasesCanvasNodeExecutionRef> = {}): CanvasesCanvasNodeExecutionRef {
   return {
@@ -201,5 +201,51 @@ describe("filterRunEvents", () => {
     });
 
     expect(filterRunEvents([failedEvent, completedEvent], nodes, "errors", "run checks")).toEqual([failedEvent]);
+  });
+});
+
+describe("shouldRefitRunsViewport", () => {
+  it("does not refit outside runs mode or before a run has nodes", () => {
+    expect(
+      shouldRefitRunsViewport({
+        isRunsMode: false,
+        runCanvasNodeIdsKey: "node-1",
+        previousRunCanvasNodeIdsKey: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefitRunsViewport({
+        isRunsMode: true,
+        runCanvasNodeIdsKey: "",
+        previousRunCanvasNodeIdsKey: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("refits the first run and runs with a different node set", () => {
+    expect(
+      shouldRefitRunsViewport({
+        isRunsMode: true,
+        runCanvasNodeIdsKey: "node-1|node-2",
+        previousRunCanvasNodeIdsKey: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefitRunsViewport({
+        isRunsMode: true,
+        runCanvasNodeIdsKey: "node-2|node-3",
+        previousRunCanvasNodeIdsKey: "node-1|node-2",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the current viewport when re-entering the same run node set", () => {
+    expect(
+      shouldRefitRunsViewport({
+        isRunsMode: true,
+        runCanvasNodeIdsKey: "node-1|node-2",
+        previousRunCanvasNodeIdsKey: "node-1|node-2",
+      }),
+    ).toBe(false);
   });
 });

--- a/web_src/src/pages/workflowv2/lib/canvas-runs.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-runs.ts
@@ -183,6 +183,22 @@ export function findNode(nodes: ComponentsNode[], nodeId: string | undefined): C
   return nodes.find((n) => n.id === nodeId) || nodes.find((n) => n.id === baseNodeId);
 }
 
+export function shouldRefitRunsViewport({
+  isRunsMode,
+  runCanvasNodeIdsKey,
+  previousRunCanvasNodeIdsKey,
+}: {
+  isRunsMode: boolean;
+  runCanvasNodeIdsKey: string | null;
+  previousRunCanvasNodeIdsKey: string | null;
+}) {
+  if (!isRunsMode || !runCanvasNodeIdsKey) {
+    return false;
+  }
+
+  return runCanvasNodeIdsKey !== previousRunCanvasNodeIdsKey;
+}
+
 export function mergeQueueItemsWithEvents(
   events: CanvasesCanvasEventWithExecutions[],
   nodeQueueItemsMap: Record<string, CanvasesCanvasNodeQueueItem[]>,


### PR DESCRIPTION
Fixes #4800.

## Summary
- Preserve the current canvas viewport when entering runs mode so zoom does not reset.
- Keep the runs viewport across mode toggles, and only refit when the selected run's node set changes.
- Add unit coverage for the runs viewport refit decision.

## Tests
- `git diff --check`
- Not run: `make format.js`, `make check.build.ui` (Docker engine and local npm/make are unavailable in this environment).