### PR TITLE
fix: restore keyboard delete shortcut for canvas components

### DIFF
--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -70,6 +70,7 @@ import { CustomEdge } from "./CustomEdge";
 import { Header } from "./Header";
 import { RightSideControls } from "./RightSideControls";
 import { useBuildingBlocksShortcut } from "./useBuildingBlocksShortcut";
+import { useDeleteShortcut } from "./useDeleteShortcut";
 import type { CanvasPageState } from "./useCanvasState";
 import { useCanvasState } from "./useCanvasState";
 import type { TriggerActionModal } from "@/pages/workflowv2/mappers/types";
@@ -1874,7 +1875,7 @@ function CanvasContent({
   canCreateIntegrations?: boolean;
   onLogView?: () => void;
 }) {
-  const { fitView, screenToFlowPosition, getViewport, getInternalNode, setViewport } = useReactFlow();
+  const { fitView, screenToFlowPosition, getViewport, getInternalNode, getNodes, setViewport } = useReactFlow();
   const { zoom } = useViewport();
   const isReadOnly = readOnly ?? false;
 
@@ -1991,6 +1992,36 @@ function CanvasContent({
     onChange: useCallback(({ nodes }: { nodes: ReactFlowNode[] }) => {
       setMultiSelectedNodes(nodes.length >= 2 ? nodes : []);
     }, []),
+  });
+
+  const handleDeleteShortcut = useCallback(() => {
+    if (!onNodesDelete && !onNodeDelete) return;
+    // Read directly from React Flow's internal store — `stateRef.current.nodes`
+    // lags by one render cycle, so a fast click+Delete would miss the selection.
+    const selectedNodes = getNodes().filter((n) => n.selected);
+    if (selectedNodes.length === 0) return;
+    const message =
+      selectedNodes.length === 1
+        ? "Are you sure you want to delete this component? This action cannot be undone."
+        : `Are you sure you want to delete the ${selectedNodes.length} selected components? This action cannot be undone.`;
+    if (!window.confirm(message)) {
+      return;
+    }
+    const nodeIds = selectedNodes.map((n) => n.id);
+    if (onNodesDelete) {
+      onNodesDelete(nodeIds);
+    } else {
+      for (const id of nodeIds) {
+        onNodeDelete?.(id);
+      }
+    }
+    stateRef.current.setNodes((nodes) => nodes.map((node) => ({ ...node, selected: false })));
+    setMultiSelectedNodes([]);
+  }, [getNodes, onNodesDelete, onNodeDelete]);
+
+  useDeleteShortcut({
+    disabled: isReadOnly || !isEditMode || (!onNodesDelete && !onNodeDelete),
+    onDelete: handleDeleteShortcut,
   });
 
   const multiSelectedNodeIds = useMemo(() => new Set(multiSelectedNodes.map((n) => n.id)), [multiSelectedNodes]);
@@ -2968,7 +2999,7 @@ function CanvasContent({
                                 event.stopPropagation();
                                 if (
                                   !window.confirm(
-                                    "Are you sure you want to delete the selected nodes? This action cannot be undone.",
+                                    `Are you sure you want to delete the ${multiSelectedNodes.length} selected components? This action cannot be undone.`,
                                   )
                                 ) {
                                   return;

--- a/web_src/src/ui/CanvasPage/useDeleteShortcut.spec.tsx
+++ b/web_src/src/ui/CanvasPage/useDeleteShortcut.spec.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDeleteShortcut } from "./useDeleteShortcut";
+
+function Harness({ disabled = false, onDelete }: { disabled?: boolean; onDelete: () => void }) {
+  useDeleteShortcut({ disabled, onDelete });
+  return (
+    <div>
+      <input data-testid="text-input" />
+      <textarea data-testid="textarea" />
+      <select data-testid="select">
+        <option value="a">A</option>
+      </select>
+      <div data-testid="editable" contentEditable="true" />
+      <div data-testid="monaco" className="monaco-editor">
+        <div data-testid="monaco-inner" />
+      </div>
+    </div>
+  );
+}
+
+describe("useDeleteShortcut", () => {
+  it("calls onDelete when Delete is pressed with default body focus", () => {
+    const onDelete = vi.fn();
+    render(<Harness onDelete={onDelete} />);
+
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete when plain Backspace is pressed (Mac 'delete' key)", () => {
+    const onDelete = vi.fn();
+    render(<Harness onDelete={onDelete} />);
+
+    fireEvent.keyDown(window, { key: "Backspace" });
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when any modifier is held — those are OS-level text-editing shortcuts", () => {
+    const onDelete = vi.fn();
+    render(<Harness onDelete={onDelete} />);
+
+    for (const key of ["Delete", "Backspace"]) {
+      fireEvent.keyDown(window, { key, metaKey: true });
+      fireEvent.keyDown(window, { key, ctrlKey: true });
+      fireEvent.keyDown(window, { key, altKey: true });
+      fireEvent.keyDown(window, { key, shiftKey: true });
+    }
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("does not fire while disabled", () => {
+    const onDelete = vi.fn();
+    render(<Harness disabled={true} onDelete={onDelete} />);
+
+    fireEvent.keyDown(window, { key: "Delete" });
+    fireEvent.keyDown(window, { key: "Backspace" });
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys other than Delete or Backspace", () => {
+    const onDelete = vi.fn();
+    render(<Harness onDelete={onDelete} />);
+
+    fireEvent.keyDown(window, { key: "x" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["text-input", "an <input>"],
+    ["textarea", "a <textarea>"],
+    ["select", "a <select>"],
+    ["editable", "a contenteditable element"],
+    ["monaco-inner", "a Monaco editor"],
+  ])("does not fire when focus is in %s (%s) — guards against #1668", (testId) => {
+    const onDelete = vi.fn();
+    const { getByTestId } = render(<Harness onDelete={onDelete} />);
+
+    fireEvent.keyDown(getByTestId(testId), { key: "Delete" });
+    fireEvent.keyDown(getByTestId(testId), { key: "Backspace" });
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount so it cannot leak across canvases", () => {
+    const onDelete = vi.fn();
+    const { unmount } = render(<Harness onDelete={onDelete} />);
+
+    unmount();
+    fireEvent.keyDown(window, { key: "Delete" });
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/ui/CanvasPage/useDeleteShortcut.ts
+++ b/web_src/src/ui/CanvasPage/useDeleteShortcut.ts
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+
+export interface UseDeleteShortcutOptions {
+  /** When true (read-only, live mode, or no delete handler available), the shortcut is inert. */
+  disabled: boolean;
+  /** Invoked when a valid delete keystroke fires. Caller handles confirm + delete. */
+  onDelete: () => void;
+}
+
+/**
+ * Global keyboard shortcut for deleting selected canvas components.
+ *
+ * Fires on plain `Delete` or `Backspace`, no modifiers — between the two,
+ * every platform's natural delete keystroke is covered (Windows Delete key,
+ * Mac fn+delete, and the Mac key labeled "delete" which sends Backspace).
+ *
+ * Suppressed whenever focus is in any editable element — plain inputs,
+ * textareas, contenteditable regions, or a Monaco editor — so users can
+ * still edit text fields without accidentally deleting components (the
+ * regression #1668 was filed to fix, which #1717 worked around by
+ * disabling the shortcut entirely via `deleteKeyCode={null}`).
+ *
+ * Restores the keyboard delete UX requested in #3243 without re-introducing
+ * the #1668 bug.
+ */
+export function useDeleteShortcut({ disabled, onDelete }: UseDeleteShortcutOptions): void {
+  useEffect(() => {
+    if (disabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Accept plain Delete or Backspace, no modifiers.
+      // On macOS the key labeled "delete" sends `Backspace`; the dedicated
+      // forward-Delete (fn+delete) sends `Delete`. Between the two, every
+      // platform's natural keystroke is covered. Modifier combos are reserved
+      // for OS-level text editing shortcuts and not consumed here.
+      const isDeleteKey =
+        (event.key === "Delete" || event.key === "Backspace") &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey;
+      if (!isDeleteKey) {
+        return;
+      }
+
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest('input, textarea, select, [contenteditable="true"], .monaco-editor')
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      onDelete();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [disabled, onDelete]);
+}

--- a/web_src/src/ui/componentSidebar/SettingsTab.tsx
+++ b/web_src/src/ui/componentSidebar/SettingsTab.tsx
@@ -480,7 +480,6 @@ export function SettingsTab({
             value={currentNodeName}
             onChange={(e) => setCurrentNodeName(e.target.value)}
             placeholder="Enter a name for this node"
-            autoFocus
             className="shadow-none"
             disabled={isReadOnly}
           />


### PR DESCRIPTION
Closes #3243

## Summary

Pressing `Delete` or `Backspace` with components selected on the canvas now removes them, restoring the UX requested in #3243.

Re-enables the keyboard shortcut that was disabled in #1717 (via `deleteKeyCode={null}`) to work around #1668, but does so with a focus gate so typing in inputs, textareas, contenteditable fields, or the Monaco expression editor still edits text rather than deleting components — the original #1668 concern remains addressed.

## Changes

- **New hook `useDeleteShortcut`** (`web_src/src/ui/CanvasPage/useDeleteShortcut.ts`) — listens for plain `Delete` or `Backspace` on `window`, skips when focus is inside any editable element (`input`, `textarea`, `select`, `[contenteditable]`, `.monaco-editor`). Follows the same pattern as the existing `useBuildingBlocksShortcut`.
- **Wired up in `CanvasPage`** — fires `onNodesDelete` / `onNodeDelete` for currently-selected nodes, with a confirmation dialog matching the existing multi-select toolbar trash button. Reads selection from `useReactFlow().getNodes()` to avoid the one-render lag that `stateRef.current.nodes` has.
- **Removed `autoFocus` from the Name input** in `componentSidebar/SettingsTab.tsx` — clicking a component should select it without stealing keyboard focus into a text input. Without this, even with the new keyboard handler, Delete would just edit characters in the Name field instead of deleting the node.
- **Context-aware confirmation copy** — *"this component"* vs *"the N selected components"*. Applied to both the new keyboard path and the existing multi-select toolbar trash dialog (was always plural before; now consistent).

## Test plan

- [x] Unit tests cover the fire/skip matrix (11 tests in \`useDeleteShortcut.spec.tsx\`):
  - Plain Delete fires
  - Plain Backspace fires
  - Any modifier (Cmd/Ctrl/Alt/Shift) suppresses
  - Other keys ignored
  - Focus inside input / textarea / select / contenteditable / Monaco suppresses
  - Disabled flag suppresses
  - Listener removed on unmount
- [x] Manual smoke test against latest \`main\`:
  - Click a component → press \`Delete\` → confirms → deletes
  - Click into Name field → press \`Backspace\` → edits text, doesn't delete component
  - Press \`Delete\` inside an expression editor (Monaco) → edits text, doesn't delete component
  - Multi-select Cmd-click + \`Delete\` → confirms with correct count → deletes
  - In read-only / live mode → shortcut inert

## Known limitation (NOT introduced by this PR)

There's a pre-existing bug in \`workflowv2/index.tsx\`'s \`handleNodesDelete\` (plural handler) where the first delete attempt sometimes silently fails and a second press is needed. This affects the existing multi-select toolbar trash button on \`main\` and is inherited by this PR's keyboard shortcut for the same reason. Reproducible on plain upstream/main without any of these changes. Will file a separate issue.