### PR TITLE
fix(ui): clarify GitHub on-push path filter copy

### DIFF
--- a/pkg/integrations/github/components/contents/on_push.go
+++ b/pkg/integrations/github/components/contents/on_push.go
@@ -45,7 +45,7 @@ func (p *OnPush) Documentation() string {
 
 - **Repository**: Select the GitHub repository to monitor
 - **Refs**: Configure which branches/tags to monitor (e.g., ` + "`refs/heads/main`" + `, ` + "`refs/tags/*`" + `)
-- **Paths** *(optional)*: Glob patterns (GitHub Actions–style) for added, modified, and removed files. Use ` + "`!`" + ` prefix to exclude (for example ` + "`billing/**`" + ` with ` + "`!billing/**/*.md`" + `). Patterns starting only with ` + "`!`" + ` assume an include of ` + "`**`" + `. Lists stored as legacy ref-style predicates still honor ` + "`equals`" + ` values as globs; ` + "`matches`" + ` must be replaced with glob patterns. If the webhook has no per-commit file lists (empty ` + "`commits`" + ` or missing ` + "`added`" + `/` + "`modified`" + `/` + "`removed`" + ` arrays), a configured path filter cannot match and the trigger will not fire. Leave empty to fire on all pushes.
+- **Changed path filter** *(optional)*: Glob patterns matched against added, modified, and removed file paths in each push. Use ` + "`!`" + ` prefix to exclude (for example ` + "`billing/**`" + ` with ` + "`!billing/**/*.md`" + `). Patterns starting only with ` + "`!`" + ` assume an include of ` + "`**`" + `. Lists stored as legacy ref-style predicates still honor ` + "`equals`" + ` values as globs; ` + "`matches`" + ` must be replaced with glob patterns. If the webhook has no per-commit file lists (empty ` + "`commits`" + ` or missing ` + "`added`" + `/` + "`modified`" + `/` + "`removed`" + ` arrays), a configured path filter cannot match and the trigger will not fire. Leave empty to run on every push.
 
 ## Event Data
 
@@ -102,14 +102,15 @@ func (p *OnPush) Configuration() []configuration.Field {
 		},
 		{
 			Name:        "paths",
-			Label:       "Paths",
-			Description: "Optional. GitHub Actions–style globs for changed files. Prefix with ! to exclude. Exclude-only lists assume ** (all paths). Leave empty to fire on all pushes.",
+			Label:       "Changed path filter",
+			Placeholder: "e.g. pkg/** or web_src/**/*.tsx",
+			Description: "Optional. Only run when added, modified, or removed paths in the push match these glob patterns. Prefix with ! to exclude. Exclude-only lists assume ** (all paths). Leave empty to run on every push.",
 			Type:        configuration.FieldTypeList,
 			Required:    false,
 			Togglable:   true,
 			TypeOptions: &configuration.TypeOptions{
 				List: &configuration.ListTypeOptions{
-					ItemLabel: "Pattern",
+					ItemLabel: "Path pattern",
 					ItemDefinition: &configuration.ListItemDefinition{
 						Type: configuration.FieldTypeString,
 					},

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -163,6 +163,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
             ) : (
               <Input
                 type={itemDefinition?.type === "number" ? "number" : "text"}
+                placeholder={field.placeholder ?? ""}
                 value={item ?? ""}
                 onChange={(e) => {
                   const val =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes https://github.com/superplanehq/superplane/issues/4860.

## Summary

- **GitHub on-push trigger** (`github.onPush`): Renamed the optional paths section to **Changed path filter**, rewrote the description so it clearly refers to filtering pushes by **added, modified, and removed file paths**, removed **GitHub Actions** wording from the in-app description and trigger documentation, and set an example **placeholder** for each path pattern row.
- **List fields**: `ListFieldRenderer` now passes the field definition `placeholder` through to each primitive list row `Input`, so list-backed settings can show placeholders (not only this trigger).

## Verification

- `go test ./pkg/integrations/github/components/contents/...`
- Full `web_src` production build was not run locally (generated `@/api-client` absent in this environment); CI / `make check.build.ui` after `make dev.setup` should validate the UI bundle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4555a4f5-71ad-45bc-ba20-6fbf3e7ae226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4555a4f5-71ad-45bc-ba20-6fbf3e7ae226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

