### PR TITLE
fix: make run detail URLs clickable

### DIFF
--- a/web_src/src/ui/Runs/RunNodeDetailModal.spec.tsx
+++ b/web_src/src/ui/Runs/RunNodeDetailModal.spec.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
+import { RunNodeDetailModal } from "./RunNodeDetailModal";
+
+vi.mock("@uiw/react-json-view", () => ({
+  default: () => <div data-testid="json-view" />,
+}));
+
+vi.mock("@/components/TimeAgo", () => ({
+  TimeAgo: () => <span>time ago</span>,
+}));
+
+vi.mock("@/hooks/useCanvasData", () => ({
+  useEventExecutions: () => ({
+    data: {
+      executions: [
+        {
+          nodeId: "node-1",
+          createdAt: "2026-05-18T12:00:00Z",
+          outputs: {},
+          metadata: {},
+          configuration: {},
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@/pages/workflowv2/mappers", () => ({
+  getExecutionDetails: () => ({
+    "Workflow URL": "https://semaphore.example/workflows/123",
+  }),
+  getState: () => () => "success",
+  getStateMap: () => ({
+    success: { badgeColor: "bg-emerald-500", label: "passed" },
+    triggered: { badgeColor: "bg-blue-500", label: "triggered" },
+  }),
+}));
+
+vi.mock("@/pages/workflowv2/utils", () => ({
+  buildExecutionInfo: (execution: unknown) => execution,
+}));
+
+describe("RunNodeDetailModal", () => {
+  it("renders URL details as clickable links", () => {
+    const run = {
+      id: "run-1",
+      rootEvent: {
+        id: "root-event-1",
+        nodeId: "trigger-node",
+      },
+    } as CanvasesCanvasRun;
+
+    const workflowNodes = [
+      {
+        id: "node-1",
+        name: "Semaphore",
+        component: "semaphore.run_workflow",
+        type: "TYPE_ACTION",
+      },
+    ] as SuperplaneComponentsNode[];
+
+    render(
+      <RunNodeDetailModal
+        canvasId="canvas-1"
+        run={run}
+        nodeId="node-1"
+        workflowNodes={workflowNodes}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "https://semaphore.example/workflows/123" });
+    expect(link).toHaveAttribute("href", "https://semaphore.example/workflows/123");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+});

--- a/web_src/src/ui/Runs/RunNodeDetailModal.tsx
+++ b/web_src/src/ui/Runs/RunNodeDetailModal.tsx
@@ -10,7 +10,7 @@ import type {
 import { TimeAgo } from "@/components/TimeAgo";
 import { Button } from "@/components/ui/button";
 import { useEventExecutions } from "@/hooks/useCanvasData";
-import { cn, flattenObject, resolveIcon } from "@/lib/utils";
+import { cn, flattenObject, isUrl, resolveIcon } from "@/lib/utils";
 import { getExecutionDetails, getState, getStateMap } from "@/pages/workflowv2/mappers";
 import { buildExecutionInfo } from "@/pages/workflowv2/utils";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
@@ -426,12 +426,29 @@ function DetailsView({ details }: { details: Record<string, unknown> }) {
             <span className="w-[120px] shrink-0 truncate text-right text-xs text-gray-500" title={key}>
               {key}:
             </span>
-            <span className="min-w-0 break-all text-xs text-gray-800">
-              {typeof value === "object" ? JSON.stringify(value, null, 2) : String(value ?? "")}
-            </span>
+            <DetailValue value={value} />
           </div>
         );
       })}
     </div>
   );
+}
+
+function DetailValue({ value }: { value: unknown }) {
+  const stringValue = typeof value === "object" ? JSON.stringify(value, null, 2) : String(value ?? "");
+
+  if (isUrl(stringValue)) {
+    return (
+      <a
+        href={stringValue}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="min-w-0 break-all text-xs text-blue-600 underline underline-offset-2 hover:text-blue-700"
+      >
+        {stringValue}
+      </a>
+    );
+  }
+
+  return <span className="min-w-0 break-all text-xs text-gray-800">{stringValue}</span>;
 }


### PR DESCRIPTION
## Summary
- render run detail URLs as anchors in the run node popup
- preserve existing plain-text rendering for non-URL values
- add coverage for clickable URL details in the modal spec

Fixes #4858