### PR TITLE
feat!: added edit button beside the add button in manual run component

### DIFF
--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -320,11 +320,9 @@ func (s *CanvasPageSteps) givenACanvasWithManualTriggerAndWaitNodeAndQueuedItems
 	s.canvas.Publish()
 
 	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-start-header"]) [data-testid="start-template-run"]`)
-	emitEvent := q.TestID("emit-event-submit-button")
 
 	for i := 0; i < itemsAmount; i++ {
 		s.session.Click(startTemplateRun)
-		s.session.Click(emitEvent)
 		s.session.Sleep(100)
 	}
 

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -385,7 +385,6 @@ func (s *CanvasSteps) RunManualTrigger(name string) {
 	// Use the Start node's template Run button (in the default payload template) instead of the removed header Run button
 	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-` + strings.ToLower(name) + `-header"]) [data-testid="start-template-run"]`)
 	s.session.Click(startTemplateRun)
-	s.session.Click(q.TestID("emit-event-submit-button"))
 }
 
 func (s *CanvasSteps) RenameNode(name string, newName string) {

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -100,7 +100,7 @@ function makeTriggerContext(overrides?: Partial<TriggerRendererContext>): Trigge
 }
 
 describe("workflow v2 edit-mode action affordances", () => {
-  it("hides start trigger run buttons in edit mode", () => {
+  it("hides start trigger run and edit buttons in edit mode", () => {
     const props = startTriggerRenderer.getTriggerProps({
       ...makeTriggerContext(),
       canvasMode: "edit",
@@ -109,10 +109,11 @@ describe("workflow v2 edit-mode action affordances", () => {
     render(<Trigger {...props} canvasMode="edit" />);
 
     expect(screen.queryByTestId("start-template-run")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("start-template-edit")).not.toBeInTheDocument();
     expect(screen.getByText("Example")).toBeInTheDocument();
   });
 
-  it("keeps start trigger run buttons in live mode", () => {
+  it("keeps start trigger run and edit buttons in live mode", () => {
     const props = startTriggerRenderer.getTriggerProps({
       ...makeTriggerContext(),
       canvasMode: "live",
@@ -122,9 +123,10 @@ describe("workflow v2 edit-mode action affordances", () => {
     render(<Trigger {...props} canvasMode="live" />);
 
     expect(screen.getByTestId("start-template-run")).toBeInTheDocument();
+    expect(screen.getByTestId("start-template-edit")).toBeInTheDocument();
   });
 
-  it("hides start trigger run buttons in live mode when actions are unavailable", () => {
+  it("hides start trigger run and edit buttons in live mode when actions are unavailable", () => {
     const props = startTriggerRenderer.getTriggerProps({
       ...makeTriggerContext(),
       canvasMode: "live",
@@ -134,6 +136,7 @@ describe("workflow v2 edit-mode action affordances", () => {
     render(<Trigger {...props} canvasMode="live" />);
 
     expect(screen.queryByTestId("start-template-run")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("start-template-edit")).not.toBeInTheDocument();
     expect(screen.getByText("Example")).toBeInTheDocument();
   });
 

--- a/web_src/src/pages/workflowv2/mappers/start/index.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.spec.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Trigger } from "@/ui/trigger";
+import { startTriggerRenderer } from "./index";
+import type { TriggerRendererContext } from "../types";
+
+function makeTriggerContext(overrides?: Partial<TriggerRendererContext>): TriggerRendererContext {
+  return {
+    node: {
+      id: "trigger-1",
+      name: "Start",
+      componentName: "start",
+      isCollapsed: false,
+      configuration: {
+        templates: [{ name: "Example", payload: { ok: true } }],
+      },
+      metadata: {},
+    },
+    definition: {
+      name: "start",
+      label: "Start",
+      description: "",
+      icon: "play",
+      color: "purple",
+    },
+    lastEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("start trigger mapper", () => {
+  it("runs with template default payload without opening a modal", async () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const user = userEvent.setup();
+
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    await user.click(screen.getByTestId("start-template-run"));
+
+    expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
+      template: "Example",
+      payload: { ok: true },
+    });
+    expect(openModal).not.toHaveBeenCalled();
+  });
+
+  it("opens the run modal when Edit is clicked", async () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const user = userEvent.setup();
+
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    await user.click(screen.getByTestId("start-template-edit"));
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    expect(invokeNodeTriggerHook).not.toHaveBeenCalled();
+  });
+
+  it("uses empty payload when template payload is invalid", async () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const user = userEvent.setup();
+
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext({
+        node: {
+          id: "trigger-1",
+          name: "Start",
+          componentName: "start",
+          isCollapsed: false,
+          configuration: {
+            templates: [{ name: "Example", payload: [] as unknown as Record<string, unknown> }],
+          },
+          metadata: {},
+        },
+      }),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    await user.click(screen.getByTestId("start-template-run"));
+
+    expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
+      template: "Example",
+      payload: {},
+    });
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/start/index.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.tsx
@@ -77,7 +77,7 @@ export const startTriggerRenderer: TriggerRenderer = {
 };
 
 /**
- * Custom field renderer for the start trigger that displays templates with Run buttons
+ * Custom field renderer for the start trigger that displays templates with Run and Edit buttons
  * This is only used internally by startTriggerRenderer, not registered in the global registry
  */
 const startCustomFieldRenderer: CustomFieldRenderer = {
@@ -93,6 +93,46 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
     const actions = context?.actions;
     const showTemplateRun = mode === "live" && !!actions;
 
+    const onRunTemplateClick = async (e: React.MouseEvent<HTMLButtonElement>, template: StartTemplate) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if(!actions) return;
+      await actions.invokeNodeTriggerHook("run", {
+        template: template.name,
+        payload: payloadForTemplateRun(template),
+      });
+    }
+
+    const onEditTemplateClick = (e: React.MouseEvent<HTMLButtonElement>, template: StartTemplate) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if(!actions) return;
+      actions.openModal({
+        title: "Run trigger",
+        description: (
+          <>
+            Run template <strong>{template.name}</strong> on node{" "}
+            <strong>{node.name || "Unnamed trigger"}</strong>. Edit the payload below to override the
+            template default.
+          </>
+        ),
+        content: ({ close }) => (
+          <StartRunModal
+            initialPayload={payloadForTemplateRun(template)}
+            onClose={close}
+            onRun={async (payload) => {
+              await actions.invokeNodeTriggerHook("run", {
+                template: template.name,
+                payload,
+              });
+            }}
+          />
+        ),
+      });
+      }
+
+
+
     return (
       <div className="px-2 py-1.5 flex flex-col gap-1.5">
         {templates.map((template, index) => (
@@ -104,39 +144,25 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
               <span className="text-[13px] font-medium font-inter text-gray-500 truncate">{template.name}</span>
             </div>
             {showTemplateRun && actions && (
-              <Button
-                size="sm"
-                data-testid="start-template-run"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  actions.openModal({
-                    title: "Run trigger",
-                    description: (
-                      <>
-                        Run template <strong>{template.name}</strong> on node{" "}
-                        <strong>{node.name || "Unnamed trigger"}</strong>. Edit the payload below to override the
-                        template default.
-                      </>
-                    ),
-                    content: ({ close }) => (
-                      <StartRunModal
-                        initialPayload={payloadForTemplateRun(template)}
-                        onClose={close}
-                        onRun={async (payload) => {
-                          await actions.invokeNodeTriggerHook("run", {
-                            template: template.name,
-                            payload,
-                          });
-                        }}
-                      />
-                    ),
-                  });
-                }}
-                className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
-              >
-                Run
-              </Button>
+              <div className="flex items-center gap-1 flex-shrink-0">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  data-testid="start-template-edit"
+                  onClick={(e) => onEditTemplateClick(e, template)}
+                  className="h-7 py-1 px-2"
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  data-testid="start-template-run"
+                  onClick={(e) => onRunTemplateClick(e, template)}
+                  className="h-7 py-1 px-2 bg-black text-white hover:bg-black/80"
+                >
+                  Run
+                </Button>
+              </div>
             )}
           </div>
         ))}


### PR DESCRIPTION
## 📝 Summary
Split the Start trigger’s per-template **Run** action into a one-click run (default payload) and an optional **Edit** flow (payload modal). Added unit and E2E test coverage for the new behavior.

---

## ✨ What Changed

### 🎨 Start Trigger UI
`web_src/src/pages/workflowv2/mappers/start/index.tsx`
Each template row now features distinct **Edit** and **Run** buttons:
* **Run** — Immediately invokes `invokeNodeTriggerHook("run", …)` with the template’s default payload, bypassing the modal entirely.
* **Edit** — Opens the existing `StartRunModal` so users can override the JSON payload before executing.

### 🧪 Tests
* **New:** `web_src/src/pages/workflowv2/mappers/start/index.spec.tsx` — Verifies **Run** invokes the hook without opening the modal, **Edit** opens the modal without premature invocation, and invalid payloads safely fall back to `{}`.
* **Updated:** `web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx` — Confirms both buttons are hidden in edit mode (or when actions are unavailable) and visible in live mode.
* **E2E:** `RunManualTrigger` and canvas queue setup no longer look for the modal submit button after clicking **Run**; a single click is now sufficient for the default payload flow.

---

## 💡 Why
This PR addresses issue: https://github.com/superplanehq/superplane/issues/1881. 

Running a Start template with its default payload previously required two steps (**Run** $\rightarrow$ confirm in modal), adding unnecessary friction for the most common use case. This introduces a fast path while preserving the ability to input custom payloads via the **Edit** path.

---

## 🛠️ How
* Reused `payloadForTemplateRun()` for the immediate **Run** path.
* Moved the legacy behavior (modal + `StartRunModal`) behind the new **Edit** button.
* Kept the same underlying hook API contract: `invokeNodeTriggerHook("run", { template, payload })`.
* Updated E2E helpers to align with the one-click **Run** mechanics.

---

## 🔗 Related Issues
None.

---

## ⚠️ Breaking Changes
* **Backend/API:** None.
* **UX change (intentional):** Clicking **Run** on a Start template no longer opens the payload editor. To edit the payload first, users must click **Edit**.
* **E2E only:** Flows that previously clicked `start-template-run` and then `emit-event-submit-button` must now use **Run** alone for default payloads, or click **Edit** followed by submit for custom payloads.

---

## 🧪 Test Plan
- [ ] **Live Canvas Test:** With a Start node and at least one template, click **Run** $\rightarrow$ verify the workflow runs immediately with the default payload and no modal appears.
- [ ] **Payload Edit Test:** Click **Edit** $\rightarrow$ verify the modal opens with editable JSON and submitting executes the workflow with the modified payload.
- [ ] **Edit Mode Check:** Enter edit mode and confirm neither **Run** nor **Edit** are visible on template rows.
- [ ] **Automated Tests:** Run and pass the unit suite:
  ```bash
  npm run test -- src/pages/workflowv2/mappers/start/index.spec.tsx src/pages/workflowv2/mappers/editModeActions.spec.tsx
  
  ---
  
## Screenshot
<img width="648" height="343" alt="Screenshot 2026-05-19 at 12 36 01 AM" src="https://github.com/user-attachments/assets/19bc3caa-7222-40dc-b42e-40a2249406c9" />

  
  