### PR TITLE
fix: keep agent stop action available while outcome building is active

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -134,6 +134,32 @@ func TestSendMessage_RequiresSessionID(t *testing.T) {
 	require.Error(t, p.SendMessage(context.Background(), "", "hi", agents.SendMessageOptions{}))
 }
 
+func TestDefineOutcome_PrependsPreambleToDescription(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sessions/sesn_abc/events", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.DefineOutcome(context.Background(), "sesn_abc", agents.DefineOutcomeOptions{
+		Description:     "Build the workflow",
+		Rubric:          "- Done",
+		MaxIterations:   3,
+		ContextPreamble: "[ctx]",
+	})
+	require.NoError(t, err)
+
+	events := capturedBody["events"].([]any)
+	require.Len(t, events, 1)
+	event := events[0].(map[string]any)
+	assert.Equal(t, "[ctx]\n\nBuild the workflow", event["description"])
+}
+
 func TestDeleteSession_SendsCorrectRequest(t *testing.T) {
 	var capturedHeaders http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -110,7 +110,7 @@ func (p *Provider) DefineOutcome(ctx context.Context, providerSessionID string, 
 
 	event := map[string]any{
 		"type":        "user.define_outcome",
-		"description": opts.Description,
+		"description": withPreamble(opts.Description, opts.ContextPreamble),
 		"rubric":      map[string]string{"type": "text", "content": opts.Rubric},
 	}
 	if opts.MaxIterations > 0 {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -57,6 +57,9 @@ type DefineOutcomeOptions struct {
 	Rubric string
 	// MaxIterations caps the provider's autonomous build/evaluate loop.
 	MaxIterations int
+	// ContextPreamble is prepended to the description so provider-managed
+	// autonomous loops get the same refreshed session context as normal turns.
+	ContextPreamble string
 }
 
 type CreateSessionResult struct {

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -130,10 +130,17 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 	if err != nil {
 		return fmt.Errorf("get session: %w", err)
 	}
+
+	preamble, err := s.buildPreamble(session, organizationID, userID, ModeBuilder)
+	if err != nil {
+		return fmt.Errorf("build preamble: %w", err)
+	}
+
 	if err := s.provider.DefineOutcome(ctx, session.ProviderSessionID, DefineOutcomeOptions{
-		Description:   description,
-		Rubric:        rubric,
-		MaxIterations: maxIterations,
+		Description:     description,
+		Rubric:          rubric,
+		MaxIterations:   maxIterations,
+		ContextPreamble: preamble,
 	}); err != nil {
 		return fmt.Errorf("define outcome: %w", err)
 	}

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -52,8 +52,10 @@ type fakeProvider struct {
 	createCalled     int
 	sendCalled       int
 	lastPreamble     string
+	lastOutcomeOpts  agents.DefineOutcomeOptions
 	createSessionErr error
 	sendErr          error
+	defineOutcomeErr error
 }
 
 func (f *fakeProvider) Name() string { return testProviderName }
@@ -80,7 +82,13 @@ func (f *fakeProvider) InterruptSession(_ context.Context, _ string) error {
 	return nil
 }
 
-func (f *fakeProvider) DefineOutcome(_ context.Context, _ string, _ agents.DefineOutcomeOptions) error {
+func (f *fakeProvider) DefineOutcome(_ context.Context, _ string, opts agents.DefineOutcomeOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.defineOutcomeErr != nil {
+		return f.defineOutcomeErr
+	}
+	f.lastOutcomeOpts = opts
 	return nil
 }
 
@@ -291,6 +299,33 @@ func TestService_SendMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastPreamble, "api_token:",
 		"preamble must still be injected after the previous attempt failed at the provider")
+}
+
+func TestService_DefineOutcome_RefreshesPreambleForBuildLoop(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	err = svc.DefineOutcome(
+		context.Background(),
+		r.Organization.ID,
+		r.User,
+		session.ID,
+		"Build the requested workflow",
+		"- Draft version created",
+		3,
+	)
+	require.NoError(t, err)
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "[Agent Mode: BUILD]")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "ALWAYS use \"superplane canvases update --draft\"")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "api_token:")
 }
 
 func TestService_SendMessage_PrivateToUser(t *testing.T) {

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -1,7 +1,7 @@
 {
-  "maxAllowedTotalIssues": 657,
+  "maxAllowedTotalIssues": 654,
   "maxAllowedByRule": {
-    "complexity": 232,
+    "complexity": 229,
     "@typescript-eslint/no-explicit-any": 160,
     "@typescript-eslint/no-non-null-asserted-optional-chain": 80,
     "max-lines-per-function": 76,
@@ -12,8 +12,8 @@
     "no-eslint-disable-next-line": 6
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 5412,
-    "complexity": 342
+    "max-lines": 5141,
+    "complexity": 327
   },
-  "updatedAt": "2026-05-18T23:57:00.000Z"
+  "updatedAt": "2026-05-19T03:15:24.576Z"
 }

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -20,6 +20,7 @@ import {
   buildRubricText,
   createInitialOutcomeState,
   createWebsocketCallbacks,
+  isOutcomeActive,
   statusLabel,
   useConversationMessages,
   useStoredOutcomeState,
@@ -115,9 +116,9 @@ function ChatConversation({
 
   const scrollRef = useChatScroll(messagesQuery, chatId, messages.length, showThinking);
   const messageGroups = useMemo(() => groupMessages(messages), [messages]);
-  const modeDisabled =
-    status === "streaming" ||
-    (outcomeState != null && outcomeState.phase !== "passed" && outcomeState.phase !== "exhausted");
+  const outcomeActive = isOutcomeActive(outcomeState);
+  const agentBusy = status === "streaming" || outcomeMutation.isPending || outcomeActive;
+  const modeDisabled = agentBusy;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -155,7 +156,7 @@ function ChatConversation({
       <ChatComposer
         onSend={handlers.handleSend}
         onStop={handlers.handleStop}
-        sending={status === "streaming"}
+        sending={agentBusy}
         stopping={interruptMutation.isPending}
         statusLabel={statusLabel(status)}
         agentMode={agentMode}

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -119,6 +119,14 @@ export function createInitialOutcomeState(rubric: {
   };
 }
 
+export function isOutcomeActive(outcomeState: OutcomeState | null): boolean {
+  if (!outcomeState) {
+    return false;
+  }
+
+  return outcomeState.phase !== "passed" && outcomeState.phase !== "exhausted" && outcomeState.phase !== "failed";
+}
+
 export function statusLabel(status: string): string {
   switch (status) {
     case "streaming":

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -72,6 +72,7 @@ function makeToolSidebarState() {
 describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
+    sessionStorage.clear();
   });
 
   it("enters runs mode from the runs tab", () => {
@@ -230,5 +231,24 @@ describe("CanvasToolSidebar", () => {
       resolveSend?.();
     });
     expect(input).toHaveValue("second");
+  });
+
+  it("shows Stop while an outcome is still active after the chat turn ends", () => {
+    sessionStorage.setItem(
+      "outcome-chat-1",
+      JSON.stringify({
+        title: "Build plan",
+        criteria: [],
+        iteration: 1,
+        maxIterations: 3,
+        phase: "building",
+        log: [{ phase: "building" }],
+      }),
+    );
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    expect(screen.getByTestId("agent-stop-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("agent-send-message-button")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This fixes a frontend state bug in the agent sidebar.

When a chat turn finished but the outcome build/evaluation loop was still running in the background, the composer could switch back to `Send` instead of `Stop`. That made it impossible to interrupt the active run.

## Changes

- treat active outcome phases as a busy/stoppable agent state
- keep the composer in `Stop` mode while outcome building/grading is still running
- add a Vitest regression test covering the case where an active stored outcome is present after the visible turn ends
