### PR TITLE
feat: add Jira heartbeat management components

### DIFF
--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -36,6 +36,8 @@ To connect Jira to SuperPlane:
 
 ## Create Heartbeat
 
+**Component key:** `jira.createHeartbeat`
+
 The Create Heartbeat component registers a new heartbeat in Jira Service Management Operations.
 
 ### Use Cases
@@ -223,6 +225,8 @@ Returns the created issue including:
 <a id="delete-heartbeat"></a>
 
 ## Delete Heartbeat
+
+**Component key:** `jira.deleteHeartbeat`
 
 The Delete Heartbeat component removes a heartbeat from Jira Service Management Operations.
 
@@ -446,6 +450,8 @@ Returns the Jira issue object including `id`, `key`, `self` and the full `fields
 
 ## Ping Heartbeat
 
+**Component key:** `jira.pingHeartbeat`
+
 The Ping Heartbeat component reports that a monitored system is alive.
 
 ### Use Cases
@@ -483,6 +489,8 @@ Returns the API **message** (for example "PONG - Heartbeat received").
 <a id="update-heartbeat"></a>
 
 ## Update Heartbeat
+
+**Component key:** `jira.updateHeartbeat`
 
 The Update Heartbeat component changes settings on an existing JSM Operations heartbeat.
 

--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -66,19 +66,22 @@ Returns the created heartbeat object from the JSM Operations API, including **na
 
 ```json
 {
-  "alertMessage": "DNS Server Checker is expired",
-  "alertPriority": "P3",
-  "alertTags": [
-    "critical",
-    "dns"
-  ],
-  "description": "Checks whether the DNS server responds",
-  "enabled": true,
-  "interval": 5,
-  "intervalUnit": "minutes",
-  "name": "DNS Server Checker",
-  "ownerTeamId": "4b26961a-a837-49d2-a1fe-0973013e3c3b",
-  "status": "Pending"
+  "data": {
+    "alertMessage": "The alert has been raised",
+    "alertPriority": "P3",
+    "alertTags": [
+      "tag1"
+    ],
+    "description": "my new heartbeat",
+    "enabled": true,
+    "interval": 1,
+    "intervalUnit": "minutes",
+    "name": "DNS checker",
+    "ownerTeamId": "b071f2e7-2159-4110-aa25-7718b2713ed5",
+    "status": "Pending"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.created"
 }
 ```
 
@@ -247,8 +250,12 @@ Confirms deletion with **deleted** set to true and the **name** of the removed h
 
 ```json
 {
-  "deleted": true,
-  "name": "DNS Server Checker"
+  "data": {
+    "deleted": true,
+    "name": "DNS checker"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.deleted"
 }
 ```
 
@@ -465,7 +472,11 @@ Returns the API **message** (for example "PONG - Heartbeat received").
 
 ```json
 {
-  "message": "PONG - Heartbeat received"
+  "data": {
+    "message": "PONG - Heartbeat received"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.pinged"
 }
 ```
 
@@ -500,13 +511,22 @@ Returns the updated heartbeat object from the JSM Operations API.
 
 ```json
 {
-  "alertPriority": "P2",
-  "description": "Checks whether the DNS server responds",
-  "enabled": true,
-  "interval": 10,
-  "intervalUnit": "minutes",
-  "name": "DNS Server Checker",
-  "status": "Responsive"
+  "data": {
+    "alertMessage": "The alert has been raised",
+    "alertPriority": "P3",
+    "alertTags": [
+      "tag1"
+    ],
+    "description": "my new heartbeat",
+    "enabled": true,
+    "interval": 5,
+    "intervalUnit": "minutes",
+    "name": "DNS checker",
+    "ownerTeamId": "b071f2e7-2159-4110-aa25-7718b2713ed5",
+    "status": "Responsive"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.updated"
 }
 ```
 

--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -9,12 +9,16 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 ## Actions
 
 <CardGrid>
+  <LinkCard title="Create Heartbeat" href="#create-heartbeat" description="Create a Jira Service Management Operations heartbeat monitor" />
   <LinkCard title="Create Incident" href="#create-incident" description="Create a Jira Service Management incident via the Incidents API" />
   <LinkCard title="Create Issue" href="#create-issue" description="Create a new issue in Jira" />
+  <LinkCard title="Delete Heartbeat" href="#delete-heartbeat" description="Delete a Jira Service Management Operations heartbeat" />
   <LinkCard title="Delete Incident" href="#delete-incident" description="Delete a Jira Service Management incident by issue id or issue key" />
   <LinkCard title="Delete Issue" href="#delete-issue" description="Delete a Jira issue" />
   <LinkCard title="Get Incident" href="#get-incident" description="Fetch a Jira Service Management incident by issue id or issue key" />
   <LinkCard title="Get Issue" href="#get-issue" description="Retrieve a Jira issue by its key" />
+  <LinkCard title="Ping Heartbeat" href="#ping-heartbeat" description="Send a ping to a Jira Service Management Operations heartbeat" />
+  <LinkCard title="Update Heartbeat" href="#update-heartbeat" description="Update a Jira Service Management Operations heartbeat" />
   <LinkCard title="Update Issue" href="#update-issue" description="Update fields on a Jira issue" />
 </CardGrid>
 
@@ -27,6 +31,56 @@ To connect Jira to SuperPlane:
 3. Paste your **Jira Site URL** into SuperPlane. For Jira Cloud, this usually looks like `https://your-domain.atlassian.net`.
 4. Paste the Atlassian account **Email** that owns the API token.
 5. Paste the generated **API Token**.
+
+<a id="create-heartbeat"></a>
+
+## Create Heartbeat
+
+The Create Heartbeat component registers a new heartbeat in Jira Service Management Operations.
+
+### Use Cases
+
+- **Cron monitoring**: Register an expected ping interval for scheduled jobs or agents
+- **Infrastructure checks**: Create heartbeats when provisioning monitored systems
+- **Automation setup**: Pair with Ping Heartbeat in workflows that report liveness
+
+### Configuration
+
+- **Team**: JSM Operations team that owns the heartbeat
+- **Name** (required): Unique heartbeat name within the team
+- **Interval** (required): How often a ping is expected (minimum 1)
+- **Interval unit**: minutes, hours, or days
+- **Enabled**: Whether monitoring is active (defaults to enabled)
+- **Description**, **alert message**, **alert tags**, **alert priority**: Optional expiration alert settings
+
+### Output
+
+Returns the created heartbeat object from the JSM Operations API, including **name**, **interval**, **intervalUnit**, **enabled**, and **status**.
+
+### Notes
+
+- Requires Jira Service Management Operations (Premium) with heartbeats enabled on your site.
+- Re-sync the Jira integration so SuperPlane has your Atlassian cloud id.
+
+### Example Output
+
+```json
+{
+  "alertMessage": "DNS Server Checker is expired",
+  "alertPriority": "P3",
+  "alertTags": [
+    "critical",
+    "dns"
+  ],
+  "description": "Checks whether the DNS server responds",
+  "enabled": true,
+  "interval": 5,
+  "intervalUnit": "minutes",
+  "name": "DNS Server Checker",
+  "ownerTeamId": "4b26961a-a837-49d2-a1fe-0973013e3c3b",
+  "status": "Pending"
+}
+```
 
 <a id="create-incident"></a>
 
@@ -160,6 +214,41 @@ Returns the created issue including:
   },
   "timestamp": "2026-01-19T12:00:00Z",
   "type": "jira.issue"
+}
+```
+
+<a id="delete-heartbeat"></a>
+
+## Delete Heartbeat
+
+The Delete Heartbeat component removes a heartbeat from Jira Service Management Operations.
+
+### Use Cases
+
+- **Decommissioning**: Remove heartbeats when systems are retired
+- **Test cleanup**: Delete heartbeats created during automation tests
+- **Lifecycle management**: Tear down monitoring when workflows are disabled
+
+### Configuration
+
+- **Team**: Team that owns the heartbeat
+- **Heartbeat**: Name of the heartbeat to delete
+
+### Output
+
+Confirms deletion with **deleted** set to true and the **name** of the removed heartbeat.
+
+### Notes
+
+- Requires Jira Service Management Operations with heartbeats enabled.
+- Deletion is permanent; recreate the heartbeat if needed.
+
+### Example Output
+
+```json
+{
+  "deleted": true,
+  "name": "DNS Server Checker"
 }
 ```
 
@@ -343,6 +432,81 @@ Returns the Jira issue object including `id`, `key`, `self` and the full `fields
   },
   "timestamp": "2026-01-19T12:00:00Z",
   "type": "jira.issue"
+}
+```
+
+<a id="ping-heartbeat"></a>
+
+## Ping Heartbeat
+
+The Ping Heartbeat component reports that a monitored system is alive.
+
+### Use Cases
+
+- **Scheduled jobs**: Ping at the end of a cron workflow so JSM detects missed runs
+- **Deploy pipelines**: Confirm a service is up after deployment
+- **Agent check-ins**: Let automation prove an external process completed
+
+### Configuration
+
+- **Team**: Team that owns the heartbeat
+- **Heartbeat**: Heartbeat name to ping (from the team's heartbeat list)
+
+### Output
+
+Returns the API **message** (for example "PONG - Heartbeat received").
+
+### Notes
+
+- Requires Jira Service Management Operations with heartbeats enabled.
+- The heartbeat must already exist (use Create Heartbeat or configure it in JSM).
+
+### Example Output
+
+```json
+{
+  "message": "PONG - Heartbeat received"
+}
+```
+
+<a id="update-heartbeat"></a>
+
+## Update Heartbeat
+
+The Update Heartbeat component changes settings on an existing JSM Operations heartbeat.
+
+### Use Cases
+
+- **Tune intervals**: Adjust expected ping frequency after operational changes
+- **Enable/disable monitoring**: Turn heartbeats on or off from automation
+- **Alert tuning**: Update expiration alert message, tags, or priority
+
+### Configuration
+
+- **Team** and **Heartbeat** (required): Identify the heartbeat to update
+- **Optional fields** use toggles: only enabled fields are sent to the Jira API
+- Heartbeat **name** cannot be changed (create a new heartbeat instead)
+
+### Output
+
+Returns the updated heartbeat object from the JSM Operations API.
+
+### Notes
+
+- Enable at least one optional field toggle before saving or running the node.
+- Requires Jira Service Management Operations with heartbeats enabled.
+
+### Example Output
+
+```json
+{
+  "alertPriority": "P2",
+  "description": "Checks whether the DNS server responds",
+  "enabled": true,
+  "interval": 10,
+  "intervalUnit": "minutes",
+  "name": "DNS Server Checker",
+  "status": "Responsive"
 }
 ```
 

--- a/pkg/integrations/jira/client.go
+++ b/pkg/integrations/jira/client.go
@@ -1424,6 +1424,205 @@ func (c *Client) DeleteIncident(cloudID, issueID string) error {
 	return err
 }
 
+// OpsTeam is one JSM Operations team from GET /v1/teams.
+type OpsTeam struct {
+	TeamID   string `json:"teamId"`
+	TeamName string `json:"teamName"`
+}
+
+type listOpsTeamsResponse struct {
+	PlatformTeams []OpsTeam `json:"platformTeams"`
+}
+
+// Heartbeat is a JSM Operations heartbeat monitor.
+type Heartbeat struct {
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	Interval      int      `json:"interval"`
+	IntervalUnit  string   `json:"intervalUnit"`
+	Enabled       bool     `json:"enabled"`
+	Status        string   `json:"status,omitempty"`
+	OwnerTeamID   string   `json:"ownerTeamId,omitempty"`
+	AlertMessage  string   `json:"alertMessage,omitempty"`
+	AlertTags     []string `json:"alertTags,omitempty"`
+	AlertPriority string   `json:"alertPriority,omitempty"`
+}
+
+type heartbeatPaginatedResponse struct {
+	Values []Heartbeat `json:"values"`
+}
+
+// CreateHeartbeatRequest is the JSON body for POST .../heartbeats.
+type CreateHeartbeatRequest struct {
+	Name          string   `json:"name"`
+	Description   string   `json:"description,omitempty"`
+	Interval      int      `json:"interval"`
+	IntervalUnit  string   `json:"intervalUnit"`
+	Enabled       *bool    `json:"enabled,omitempty"`
+	AlertMessage  string   `json:"alertMessage,omitempty"`
+	AlertTags     []string `json:"alertTags,omitempty"`
+	AlertPriority string   `json:"alertPriority,omitempty"`
+}
+
+// UpdateHeartbeatRequest is the JSON body for PATCH .../heartbeats?name=...
+type UpdateHeartbeatRequest struct {
+	Description   string   `json:"description,omitempty"`
+	Interval      *int     `json:"interval,omitempty"`
+	IntervalUnit  string   `json:"intervalUnit,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty"`
+	AlertMessage  string   `json:"alertMessage,omitempty"`
+	AlertTags     []string `json:"alertTags,omitempty"`
+	AlertPriority string   `json:"alertPriority,omitempty"`
+}
+
+// PingHeartbeatResponse is returned when a heartbeat ping succeeds.
+type PingHeartbeatResponse struct {
+	Message string `json:"message"`
+}
+
+func (c *Client) opsAPIURL(cloudID, pathSuffix string) string {
+	return fmt.Sprintf("%s/jsm/ops/api/%s/v1%s", atlassianIncidentAPIHost, cloudID, pathSuffix)
+}
+
+// ListOpsTeams returns JSM Operations teams visible to the authenticated user.
+func (c *Client) ListOpsTeams(cloudID string) ([]OpsTeam, error) {
+	u := c.opsAPIURL(cloudID, "/teams")
+	responseBody, err := c.execRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseOpsTeamsResponse(responseBody)
+}
+
+func parseOpsTeamsResponse(responseBody []byte) ([]OpsTeam, error) {
+	body := bytes.TrimSpace(responseBody)
+	if len(body) == 0 || bytes.Equal(body, []byte("null")) {
+		return []OpsTeam{}, nil
+	}
+
+	// Live Jira Cloud often returns a JSON array; OpenAPI also documents { "platformTeams": [...] }.
+	if body[0] == '[' {
+		var teams []OpsTeam
+		if err := json.Unmarshal(body, &teams); err != nil {
+			return nil, fmt.Errorf("parse ops teams array response: %w", err)
+		}
+		return normalizeOpsTeams(teams), nil
+	}
+
+	var wrapped listOpsTeamsResponse
+	if err := json.Unmarshal(body, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse ops teams response: %w", err)
+	}
+	if wrapped.PlatformTeams == nil {
+		return []OpsTeam{}, nil
+	}
+	return normalizeOpsTeams(wrapped.PlatformTeams), nil
+}
+
+func normalizeOpsTeams(teams []OpsTeam) []OpsTeam {
+	out := make([]OpsTeam, 0, len(teams))
+	for _, team := range teams {
+		id := strings.TrimSpace(team.TeamID)
+		name := strings.TrimSpace(team.TeamName)
+		if id == "" && name == "" {
+			continue
+		}
+		if name == "" {
+			name = id
+		}
+		out = append(out, OpsTeam{TeamID: id, TeamName: name})
+	}
+	return out
+}
+
+// ListHeartbeats returns heartbeats for an operations team.
+func (c *Client) ListHeartbeats(cloudID, teamID string) ([]Heartbeat, error) {
+	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats", url.PathEscape(teamID)))
+	responseBody, err := c.execRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var page heartbeatPaginatedResponse
+	if err := json.Unmarshal(responseBody, &page); err != nil {
+		return nil, fmt.Errorf("parse heartbeats response: %w", err)
+	}
+	if page.Values == nil {
+		return []Heartbeat{}, nil
+	}
+	return page.Values, nil
+}
+
+// CreateHeartbeat creates a heartbeat in JSM Operations.
+func (c *Client) CreateHeartbeat(cloudID, teamID string, req *CreateHeartbeatRequest) (*Heartbeat, error) {
+	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats", url.PathEscape(teamID)))
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal create heartbeat body: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var out Heartbeat
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse create heartbeat response: %w", err)
+	}
+	return &out, nil
+}
+
+// PingHeartbeat sends a ping for the named heartbeat.
+func (c *Client) PingHeartbeat(cloudID, teamID, name string) (*PingHeartbeatResponse, error) {
+	q := url.Values{}
+	q.Set("name", name)
+	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats/ping?%s", url.PathEscape(teamID), q.Encode()))
+
+	responseBody, err := c.execRequest(http.MethodPost, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out PingHeartbeatResponse
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse ping heartbeat response: %w", err)
+	}
+	return &out, nil
+}
+
+// UpdateHeartbeat updates a heartbeat identified by name (name cannot be changed).
+func (c *Client) UpdateHeartbeat(cloudID, teamID, name string, req *UpdateHeartbeatRequest) (*Heartbeat, error) {
+	q := url.Values{}
+	q.Set("name", name)
+	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats?%s", url.PathEscape(teamID), q.Encode()))
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update heartbeat body: %w", err)
+	}
+
+	responseBody, err := c.execRequest(http.MethodPatch, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	var out Heartbeat
+	if err := json.Unmarshal(responseBody, &out); err != nil {
+		return nil, fmt.Errorf("parse update heartbeat response: %w", err)
+	}
+	return &out, nil
+}
+
+// DeleteHeartbeat deletes a heartbeat by name.
+func (c *Client) DeleteHeartbeat(cloudID, teamID, name string) error {
+	q := url.Values{}
+	q.Set("name", name)
+	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats?%s", url.PathEscape(teamID), q.Encode()))
+	_, err := c.execRequest(http.MethodDelete, u, nil)
+	return err
+}
+
 // ResolveNumericIssueID returns the numeric issue id for the Incidents API path. If ref is all digits it is
 // returned unchanged; otherwise ref is treated as an issue key and resolved with the Jira platform REST API.
 func (c *Client) ResolveNumericIssueID(ref string) (string, error) {

--- a/pkg/integrations/jira/client.go
+++ b/pkg/integrations/jira/client.go
@@ -1448,8 +1448,13 @@ type Heartbeat struct {
 	AlertPriority string   `json:"alertPriority,omitempty"`
 }
 
+type heartbeatLinks struct {
+	Next string `json:"next,omitempty"`
+}
+
 type heartbeatPaginatedResponse struct {
-	Values []Heartbeat `json:"values"`
+	Values []Heartbeat     `json:"values"`
+	Links  *heartbeatLinks `json:"links,omitempty"`
 }
 
 // CreateHeartbeatRequest is the JSON body for POST .../heartbeats.
@@ -1536,22 +1541,35 @@ func normalizeOpsTeams(teams []OpsTeam) []OpsTeam {
 	return out
 }
 
-// ListHeartbeats returns heartbeats for an operations team.
+// ListHeartbeats returns all heartbeats for an operations team, following links.next pagination.
 func (c *Client) ListHeartbeats(cloudID, teamID string) ([]Heartbeat, error) {
-	u := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats", url.PathEscape(teamID)))
-	responseBody, err := c.execRequest(http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
+	nextURL := c.opsAPIURL(cloudID, fmt.Sprintf("/teams/%s/heartbeats", url.PathEscape(teamID)))
+	var all []Heartbeat
+	const maxPages = 100
+	for range maxPages {
+		responseBody, err := c.execRequest(http.MethodGet, nextURL, nil)
+		if err != nil {
+			return nil, err
+		}
 
-	var page heartbeatPaginatedResponse
-	if err := json.Unmarshal(responseBody, &page); err != nil {
-		return nil, fmt.Errorf("parse heartbeats response: %w", err)
+		var page heartbeatPaginatedResponse
+		if err := json.Unmarshal(responseBody, &page); err != nil {
+			return nil, fmt.Errorf("parse heartbeats response: %w", err)
+		}
+
+		all = append(all, page.Values...)
+
+		if page.Links == nil || page.Links.Next == "" || len(page.Values) == 0 {
+			break
+		}
+
+		if strings.HasPrefix(page.Links.Next, "http") {
+			nextURL = page.Links.Next
+		} else {
+			nextURL = atlassianIncidentAPIHost + page.Links.Next
+		}
 	}
-	if page.Values == nil {
-		return []Heartbeat{}, nil
-	}
-	return page.Values, nil
+	return all, nil
 }
 
 // CreateHeartbeat creates a heartbeat in JSM Operations.

--- a/pkg/integrations/jira/client_test.go
+++ b/pkg/integrations/jira/client_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -774,6 +775,56 @@ func Test__Client__HeartbeatsAPI(t *testing.T) {
 		err = client.DeleteHeartbeat(cloudID, teamID, "DNS Checker")
 		require.NoError(t, err)
 		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+
+	t.Run("list heartbeats follows links.next pagination", func(t *testing.T) {
+		page2URL := fmt.Sprintf("/jsm/ops/api/%s/v1/teams/%s/heartbeats?offset=1&size=1", cloudID, teamID)
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"name":"HB-1"}],"links":{"next":"` + page2URL + `"}}`,
+					)),
+				},
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"name":"HB-2"}]}`,
+					)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		heartbeats, err := client.ListHeartbeats(cloudID, teamID)
+		require.NoError(t, err)
+		require.Len(t, heartbeats, 2)
+		assert.Equal(t, "HB-1", heartbeats[0].Name)
+		assert.Equal(t, "HB-2", heartbeats[1].Name)
+		require.Len(t, httpContext.Requests, 2)
+		assert.Contains(t, httpContext.Requests[1].URL.String(), "offset=1")
+	})
+
+	t.Run("list heartbeats single page", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(
+						`{"values":[{"name":"HB-1"},{"name":"HB-2"}]}`,
+					)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		heartbeats, err := client.ListHeartbeats(cloudID, teamID)
+		require.NoError(t, err)
+		require.Len(t, heartbeats, 2)
+		require.Len(t, httpContext.Requests, 1)
 	})
 }
 

--- a/pkg/integrations/jira/client_test.go
+++ b/pkg/integrations/jira/client_test.go
@@ -643,6 +643,162 @@ func Test__Client__IncidentsAPI(t *testing.T) {
 	})
 }
 
+func Test__Client__HeartbeatsAPI(t *testing.T) {
+	cloudID := "35273b54-3f06-40d2-880f-dd28cf6daafa"
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	appCtx := &contexts.IntegrationContext{
+		Configuration: map[string]any{
+			"siteUrl":  "https://test.atlassian.net",
+			"email":    "test@example.com",
+			"apiToken": "test-token",
+		},
+	}
+
+	t.Run("list ops teams array response", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`[{"teamId":"` + teamID + `","teamName":"On-call"}]`)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		teams, err := client.ListOpsTeams(cloudID)
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		assert.Equal(t, "On-call", teams[0].TeamName)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/jsm/ops/api/"+cloudID+"/v1/teams")
+	})
+
+	t.Run("list ops teams wrapped response", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"platformTeams":[{"teamId":"` + teamID + `","teamName":"On-call"}]}`)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		teams, err := client.ListOpsTeams(cloudID)
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		assert.Equal(t, teamID, teams[0].TeamID)
+	})
+
+	t.Run("create heartbeat", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"name":"DNS Checker","interval":5,"intervalUnit":"minutes","enabled":true}`)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		enabled := true
+		resp, err := client.CreateHeartbeat(cloudID, teamID, &CreateHeartbeatRequest{
+			Name:         "DNS Checker",
+			Interval:     5,
+			IntervalUnit: "minutes",
+			Enabled:      &enabled,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "DNS Checker", resp.Name)
+		assert.Equal(t, http.MethodPost, httpContext.Requests[0].Method)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/teams/"+teamID+"/heartbeats")
+	})
+
+	t.Run("ping heartbeat", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusAccepted,
+					Body:       io.NopCloser(strings.NewReader(`{"message":"PONG - Heartbeat received"}`)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		resp, err := client.PingHeartbeat(cloudID, teamID, "DNS Checker")
+		require.NoError(t, err)
+		assert.Equal(t, "PONG - Heartbeat received", resp.Message)
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "/heartbeats/ping")
+		assert.Contains(t, httpContext.Requests[0].URL.String(), "name=DNS+Checker")
+	})
+
+	t.Run("update heartbeat", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"name":"DNS Checker","interval":10,"intervalUnit":"minutes","enabled":false}`)),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		interval := 10
+		enabled := false
+		resp, err := client.UpdateHeartbeat(cloudID, teamID, "DNS Checker", &UpdateHeartbeatRequest{
+			Interval: &interval,
+			Enabled:  &enabled,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 10, resp.Interval)
+		assert.Equal(t, http.MethodPatch, httpContext.Requests[0].Method)
+	})
+
+	t.Run("delete heartbeat", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+		client, err := NewClient(httpContext, appCtx)
+		require.NoError(t, err)
+
+		err = client.DeleteHeartbeat(cloudID, teamID, "DNS Checker")
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodDelete, httpContext.Requests[0].Method)
+	})
+}
+
+func Test__parseOpsTeamsResponse(t *testing.T) {
+	t.Run("array", func(t *testing.T) {
+		teams, err := parseOpsTeamsResponse([]byte(`[{"teamId":"abc","teamName":"Ops"}]`))
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		assert.Equal(t, "abc", teams[0].TeamID)
+		assert.Equal(t, "Ops", teams[0].TeamName)
+	})
+
+	t.Run("wrapped platformTeams", func(t *testing.T) {
+		teams, err := parseOpsTeamsResponse([]byte(`{"platformTeams":[{"teamId":"abc","teamName":"Ops"}]}`))
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		teams, err := parseOpsTeamsResponse([]byte(`[]`))
+		require.NoError(t, err)
+		assert.Empty(t, teams)
+	})
+}
+
 func Test__Client__ResolveNumericIssueID(t *testing.T) {
 	t.Run("numeric passthrough", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{Responses: []*http.Response{}}

--- a/pkg/integrations/jira/common.go
+++ b/pkg/integrations/jira/common.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/core"
@@ -86,4 +87,33 @@ func resolveCloudID(httpCtx core.HTTPContext, integration core.IntegrationContex
 		return "", fmt.Errorf("resolve cloud id: %w", err)
 	}
 	return cloudID, nil
+}
+
+// heartbeatAlertTagsFromList converts a raw list of any values into a slice of
+// trimmed, non-empty strings suitable for the JSM heartbeat alert tags field.
+func heartbeatAlertTagsFromList(raw []any) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s := strings.TrimSpace(fmt.Sprint(e))
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// heartbeatAlertPriorityForAPI normalises a priority string for the JSM API,
+// returning an empty string when the value is unset or the sentinel "__none__".
+func heartbeatAlertPriorityForAPI(priority string) string {
+	p := strings.TrimSpace(priority)
+	if p == "" || p == "__none__" {
+		return ""
+	}
+	return p
 }

--- a/pkg/integrations/jira/common.go
+++ b/pkg/integrations/jira/common.go
@@ -66,3 +66,24 @@ func cloudIDFromIntegration(integration core.IntegrationContext) (string, error)
 	}
 	return meta.CloudID, nil
 }
+
+// resolveCloudID returns the Atlassian cloud id from integration metadata, or fetches it from
+// the site tenant_info endpoint when metadata was not populated (e.g. integrations connected
+// before cloud id was stored during sync).
+func resolveCloudID(httpCtx core.HTTPContext, integration core.IntegrationContext) (string, error) {
+	if cloudID, err := cloudIDFromIntegration(integration); err == nil {
+		return cloudID, nil
+	}
+	if httpCtx == nil {
+		return "", fmt.Errorf("integration is missing cloud id; re-sync the Jira integration")
+	}
+	client, err := NewClient(httpCtx, integration)
+	if err != nil {
+		return "", err
+	}
+	cloudID, err := client.FetchCloudID()
+	if err != nil {
+		return "", fmt.Errorf("resolve cloud id: %w", err)
+	}
+	return cloudID, nil
+}

--- a/pkg/integrations/jira/create_heartbeat.go
+++ b/pkg/integrations/jira/create_heartbeat.go
@@ -21,7 +21,7 @@ type CreateHeartbeatSpec struct {
 	Description   string `json:"description,omitempty" mapstructure:"description"`
 	Interval      int    `json:"interval" mapstructure:"interval"`
 	IntervalUnit  string `json:"intervalUnit" mapstructure:"intervalUnit"`
-	Enabled       bool   `json:"enabled" mapstructure:"enabled"`
+	Enabled       *bool  `json:"enabled,omitempty" mapstructure:"enabled"`
 	AlertMessage  string `json:"alertMessage,omitempty" mapstructure:"alertMessage"`
 	AlertTags     []any  `json:"alertTags,omitempty" mapstructure:"alertTags"`
 	AlertPriority string `json:"alertPriority,omitempty" mapstructure:"alertPriority"`
@@ -258,7 +258,7 @@ func (c *CreateHeartbeat) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("interval must be at least 1")
 	}
 
-	enabled := spec.Enabled
+	enabled := createHeartbeatEnabledFromSpec(spec)
 	req := &CreateHeartbeatRequest{
 		Name:         name,
 		Description:  strings.TrimSpace(spec.Description),
@@ -311,6 +311,13 @@ func (c *CreateHeartbeat) Hooks() []core.Hook {
 
 func (c *CreateHeartbeat) HandleHook(ctx core.ActionHookContext) error {
 	return nil
+}
+
+func createHeartbeatEnabledFromSpec(spec CreateHeartbeatSpec) bool {
+	if spec.Enabled == nil {
+		return true
+	}
+	return *spec.Enabled
 }
 
 func createHeartbeatAlertTagsFromList(raw []any) []string {

--- a/pkg/integrations/jira/create_heartbeat.go
+++ b/pkg/integrations/jira/create_heartbeat.go
@@ -1,0 +1,339 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const CreateJiraHeartbeatPayloadType = "jira.heartbeat.created"
+
+type CreateHeartbeat struct{}
+
+type CreateHeartbeatSpec struct {
+	Team          string `json:"team" mapstructure:"team"`
+	Name          string `json:"name" mapstructure:"name"`
+	Description   string `json:"description,omitempty" mapstructure:"description"`
+	Interval      int    `json:"interval" mapstructure:"interval"`
+	IntervalUnit  string `json:"intervalUnit" mapstructure:"intervalUnit"`
+	Enabled       bool   `json:"enabled" mapstructure:"enabled"`
+	AlertMessage  string `json:"alertMessage,omitempty" mapstructure:"alertMessage"`
+	AlertTags     []any  `json:"alertTags,omitempty" mapstructure:"alertTags"`
+	AlertPriority string `json:"alertPriority,omitempty" mapstructure:"alertPriority"`
+}
+
+type CreateHeartbeatNodeMetadata struct {
+	TeamName string `json:"teamName,omitempty"`
+}
+
+func (c *CreateHeartbeat) Name() string {
+	return "jira.createHeartbeat"
+}
+
+func (c *CreateHeartbeat) Label() string {
+	return "Create Heartbeat"
+}
+
+func (c *CreateHeartbeat) Description() string {
+	return "Create a Jira Service Management Operations heartbeat monitor"
+}
+
+func (c *CreateHeartbeat) Documentation() string {
+	return `The Create Heartbeat component registers a new heartbeat in Jira Service Management Operations.
+
+## Use Cases
+
+- **Cron monitoring**: Register an expected ping interval for scheduled jobs or agents
+- **Infrastructure checks**: Create heartbeats when provisioning monitored systems
+- **Automation setup**: Pair with Ping Heartbeat in workflows that report liveness
+
+## Configuration
+
+- **Team**: JSM Operations team that owns the heartbeat
+- **Name** (required): Unique heartbeat name within the team
+- **Interval** (required): How often a ping is expected (minimum 1)
+- **Interval unit**: minutes, hours, or days
+- **Enabled**: Whether monitoring is active (defaults to enabled)
+- **Description**, **alert message**, **alert tags**, **alert priority**: Optional expiration alert settings
+
+## Output
+
+Returns the created heartbeat object from the JSM Operations API, including **name**, **interval**, **intervalUnit**, **enabled**, and **status**.
+
+## Notes
+
+- Requires Jira Service Management Operations (Premium) with heartbeats enabled on your site.
+- Re-sync the Jira integration so SuperPlane has your Atlassian cloud id.`
+}
+
+func (c *CreateHeartbeat) Icon() string {
+	return "jira"
+}
+
+func (c *CreateHeartbeat) Color() string {
+	return "orange"
+}
+
+func (c *CreateHeartbeat) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateHeartbeat) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "team",
+			Label:       "Team",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "JSM Operations team that owns the heartbeat",
+			Placeholder: "Select a team",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "team",
+				},
+			},
+		},
+		{
+			Name:        "name",
+			Label:       "Name",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Unique heartbeat name within the team",
+			Placeholder: "DNS Server Checker",
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Description: "Optional description of what this heartbeat monitors",
+		},
+		{
+			Name:        "interval",
+			Label:       "Interval",
+			Type:        configuration.FieldTypeNumber,
+			Required:    true,
+			Description: "How often a ping is expected (minimum 1)",
+			Default:     5,
+		},
+		{
+			Name:        "intervalUnit",
+			Label:       "Interval unit",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     "minutes",
+			Description: "Unit for the expected ping interval",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Minutes", Value: "minutes"},
+						{Label: "Hours", Value: "hours"},
+						{Label: "Days", Value: "days"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "enabled",
+			Label:       "Enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Description: "Enable heartbeat monitoring",
+			Default:     true,
+		},
+		{
+			Name:        "alertMessage",
+			Label:       "Alert message",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Description: "Message used when the heartbeat expires",
+		},
+		{
+			Name:        "alertTags",
+			Label:       "Alert tags",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Tags applied to the expiration alert",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Tag",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "alertPriority",
+			Label:       "Alert priority",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Default:     "__none__",
+			Description: "Priority for the expiration alert (defaults to P3 when not set)",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Default (P3)", Value: "__none__"},
+						{Label: "P1", Value: "P1"},
+						{Label: "P2", Value: "P2"},
+						{Label: "P3", Value: "P3"},
+						{Label: "P4", Value: "P4"},
+						{Label: "P5", Value: "P5"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *CreateHeartbeat) Setup(ctx core.SetupContext) error {
+	spec := CreateHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(spec.Team) == "" {
+		return fmt.Errorf("team is required")
+	}
+	if strings.TrimSpace(spec.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+	if spec.Interval < 1 {
+		return fmt.Errorf("interval must be at least 1")
+	}
+	if strings.TrimSpace(spec.IntervalUnit) == "" {
+		return fmt.Errorf("intervalUnit is required")
+	}
+
+	nodeMeta := CreateHeartbeatNodeMetadata{}
+	if ctx.HTTP != nil {
+		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+		if err == nil {
+			client, err := NewClient(ctx.HTTP, ctx.Integration)
+			if err == nil {
+				if teams, err := client.ListOpsTeams(cloudID); err == nil {
+					for _, t := range teams {
+						if t.TeamID == strings.TrimSpace(spec.Team) {
+							nodeMeta.TeamName = strings.TrimSpace(t.TeamName)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return ctx.Metadata.Set(nodeMeta)
+}
+
+func (c *CreateHeartbeat) Execute(ctx core.ExecutionContext) error {
+	spec := CreateHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	teamID := strings.TrimSpace(spec.Team)
+	name := strings.TrimSpace(spec.Name)
+	if teamID == "" {
+		return fmt.Errorf("team is required")
+	}
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if spec.Interval < 1 {
+		return fmt.Errorf("interval must be at least 1")
+	}
+
+	enabled := spec.Enabled
+	req := &CreateHeartbeatRequest{
+		Name:         name,
+		Description:  strings.TrimSpace(spec.Description),
+		Interval:     spec.Interval,
+		IntervalUnit: strings.TrimSpace(spec.IntervalUnit),
+		Enabled:      &enabled,
+		AlertMessage: strings.TrimSpace(spec.AlertMessage),
+		AlertTags:    createHeartbeatAlertTagsFromList(spec.AlertTags),
+	}
+	if p := createHeartbeatAlertPriorityForAPI(spec.AlertPriority); p != "" {
+		req.AlertPriority = p
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.CreateHeartbeat(cloudID, teamID, req)
+	if err != nil {
+		return fmt.Errorf("failed to create heartbeat: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		CreateJiraHeartbeatPayloadType,
+		[]any{resp},
+	)
+}
+
+func (c *CreateHeartbeat) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateHeartbeat) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateHeartbeat) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateHeartbeat) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateHeartbeat) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateHeartbeat) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func createHeartbeatAlertTagsFromList(raw []any) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s := strings.TrimSpace(fmt.Sprint(e))
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func createHeartbeatAlertPriorityForAPI(priority string) string {
+	p := strings.TrimSpace(priority)
+	if p == "" || p == "__none__" {
+		return ""
+	}
+	return p
+}

--- a/pkg/integrations/jira/create_heartbeat.go
+++ b/pkg/integrations/jira/create_heartbeat.go
@@ -214,25 +214,7 @@ func (c *CreateHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("intervalUnit is required")
 	}
 
-	nodeMeta := CreateHeartbeatNodeMetadata{}
-	if ctx.HTTP != nil {
-		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
-		if err == nil {
-			client, err := NewClient(ctx.HTTP, ctx.Integration)
-			if err == nil {
-				if teams, err := client.ListOpsTeams(cloudID); err == nil {
-					for _, t := range teams {
-						if t.TeamID == strings.TrimSpace(spec.Team) {
-							nodeMeta.TeamName = strings.TrimSpace(t.TeamName)
-							break
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return ctx.Metadata.Set(nodeMeta)
+	return ctx.Metadata.Set(CreateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
 }
 
 func (c *CreateHeartbeat) Execute(ctx core.ExecutionContext) error {
@@ -266,9 +248,9 @@ func (c *CreateHeartbeat) Execute(ctx core.ExecutionContext) error {
 		IntervalUnit: strings.TrimSpace(spec.IntervalUnit),
 		Enabled:      &enabled,
 		AlertMessage: strings.TrimSpace(spec.AlertMessage),
-		AlertTags:    createHeartbeatAlertTagsFromList(spec.AlertTags),
+		AlertTags:    heartbeatAlertTagsFromList(spec.AlertTags),
 	}
-	if p := createHeartbeatAlertPriorityForAPI(spec.AlertPriority); p != "" {
+	if p := heartbeatAlertPriorityForAPI(spec.AlertPriority); p != "" {
 		req.AlertPriority = p
 	}
 
@@ -318,29 +300,4 @@ func createHeartbeatEnabledFromSpec(spec CreateHeartbeatSpec) bool {
 		return true
 	}
 	return *spec.Enabled
-}
-
-func createHeartbeatAlertTagsFromList(raw []any) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(raw))
-	for _, e := range raw {
-		s := strings.TrimSpace(fmt.Sprint(e))
-		if s != "" {
-			out = append(out, s)
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func createHeartbeatAlertPriorityForAPI(priority string) string {
-	p := strings.TrimSpace(priority)
-	if p == "" || p == "__none__" {
-		return ""
-	}
-	return p
 }

--- a/pkg/integrations/jira/create_heartbeat.go
+++ b/pkg/integrations/jira/create_heartbeat.go
@@ -197,7 +197,8 @@ func (c *CreateHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
 		return err
 	}
 
@@ -214,7 +215,7 @@ func (c *CreateHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("intervalUnit is required")
 	}
 
-	return ctx.Metadata.Set(CreateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+	return ctx.Metadata.Set(CreateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, cloudID, spec.Team)})
 }
 
 func (c *CreateHeartbeat) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/jira/create_heartbeat_test.go
+++ b/pkg/integrations/jira/create_heartbeat_test.go
@@ -1,0 +1,86 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateHeartbeat__Setup(t *testing.T) {
+	component := CreateHeartbeat{}
+
+	t.Run("missing team", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   jiraTestIntegration(),
+			Configuration: map[string]any{"name": "Checker", "interval": 5, "intervalUnit": "minutes"},
+		})
+		require.ErrorContains(t, err, "team is required")
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   jiraTestIntegration(),
+			Configuration: map[string]any{"team": "team-1", "interval": 5, "intervalUnit": "minutes"},
+		})
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("valid setup", func(t *testing.T) {
+		teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"platformTeams":[{"teamId":"` + teamID + `","teamName":"Ops"}]}`)),
+				},
+			},
+		}
+		metadataCtx := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			HTTP:          httpContext,
+			Integration:   jiraTestIntegration(),
+			Metadata:      metadataCtx,
+			Configuration: map[string]any{"team": teamID, "name": "Checker", "interval": 5, "intervalUnit": "minutes"},
+		})
+		require.NoError(t, err)
+		var meta CreateHeartbeatNodeMetadata
+		require.NoError(t, mapstructure.Decode(metadataCtx.Get(), &meta))
+		assert.Equal(t, "Ops", meta.TeamName)
+	})
+}
+
+func Test__CreateHeartbeat__Execute(t *testing.T) {
+	component := CreateHeartbeat{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(`{"name":"Checker","interval":5,"intervalUnit":"minutes","enabled":true}`)),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":         teamID,
+			"name":         "Checker",
+			"interval":     5,
+			"intervalUnit": "minutes",
+			"enabled":      true,
+		},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, CreateJiraHeartbeatPayloadType, execCtx.Type)
+}

--- a/pkg/integrations/jira/create_heartbeat_test.go
+++ b/pkg/integrations/jira/create_heartbeat_test.go
@@ -84,3 +84,39 @@ func Test__CreateHeartbeat__Execute(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, CreateJiraHeartbeatPayloadType, execCtx.Type)
 }
+
+func Test__CreateHeartbeat__Execute_defaults_enabled_true(t *testing.T) {
+	component := CreateHeartbeat{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(`{"name":"Checker","interval":5,"intervalUnit":"minutes","enabled":true}`)),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":         teamID,
+			"name":         "Checker",
+			"interval":     5,
+			"intervalUnit": "minutes",
+		},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, CreateJiraHeartbeatPayloadType, execCtx.Type)
+}
+
+func Test__createHeartbeatEnabledFromSpec(t *testing.T) {
+	assert.True(t, createHeartbeatEnabledFromSpec(CreateHeartbeatSpec{}))
+	disabled := false
+	assert.False(t, createHeartbeatEnabledFromSpec(CreateHeartbeatSpec{Enabled: &disabled}))
+	enabled := true
+	assert.True(t, createHeartbeatEnabledFromSpec(CreateHeartbeatSpec{Enabled: &enabled}))
+}

--- a/pkg/integrations/jira/delete_heartbeat.go
+++ b/pkg/integrations/jira/delete_heartbeat.go
@@ -115,7 +115,8 @@ func (c *DeleteHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(spec.Team) == "" {
@@ -125,7 +126,7 @@ func (c *DeleteHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("heartbeat is required")
 	}
 
-	return ctx.Metadata.Set(DeleteHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+	return ctx.Metadata.Set(DeleteHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, cloudID, spec.Team)})
 }
 
 func (c *DeleteHeartbeat) Execute(ctx core.ExecutionContext) error {
@@ -192,13 +193,9 @@ func (c *DeleteHeartbeat) HandleHook(ctx core.ActionHookContext) error {
 	return nil
 }
 
-func resolveOpsTeamName(ctx core.SetupContext, teamID string) string {
+func resolveOpsTeamName(ctx core.SetupContext, cloudID, teamID string) string {
 	teamID = strings.TrimSpace(teamID)
-	if teamID == "" || ctx.HTTP == nil {
-		return ""
-	}
-	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
-	if err != nil {
+	if teamID == "" || ctx.HTTP == nil || cloudID == "" {
 		return ""
 	}
 	client, err := NewClient(ctx.HTTP, ctx.Integration)

--- a/pkg/integrations/jira/delete_heartbeat.go
+++ b/pkg/integrations/jira/delete_heartbeat.go
@@ -1,0 +1,218 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const DeleteJiraHeartbeatPayloadType = "jira.heartbeat.deleted"
+
+type DeleteHeartbeat struct{}
+
+type DeleteHeartbeatSpec struct {
+	Team      string `json:"team" mapstructure:"team"`
+	Heartbeat string `json:"heartbeat" mapstructure:"heartbeat"`
+}
+
+type DeleteHeartbeatNodeMetadata struct {
+	TeamName string `json:"teamName,omitempty"`
+}
+
+func (c *DeleteHeartbeat) Name() string {
+	return "jira.deleteHeartbeat"
+}
+
+func (c *DeleteHeartbeat) Label() string {
+	return "Delete Heartbeat"
+}
+
+func (c *DeleteHeartbeat) Description() string {
+	return "Delete a Jira Service Management Operations heartbeat"
+}
+
+func (c *DeleteHeartbeat) Documentation() string {
+	return `The Delete Heartbeat component removes a heartbeat from Jira Service Management Operations.
+
+## Use Cases
+
+- **Decommissioning**: Remove heartbeats when systems are retired
+- **Test cleanup**: Delete heartbeats created during automation tests
+- **Lifecycle management**: Tear down monitoring when workflows are disabled
+
+## Configuration
+
+- **Team**: Team that owns the heartbeat
+- **Heartbeat**: Name of the heartbeat to delete
+
+## Output
+
+Confirms deletion with **deleted** set to true and the **name** of the removed heartbeat.
+
+## Notes
+
+- Requires Jira Service Management Operations with heartbeats enabled.
+- Deletion is permanent; recreate the heartbeat if needed.`
+}
+
+func (c *DeleteHeartbeat) Icon() string {
+	return "jira"
+}
+
+func (c *DeleteHeartbeat) Color() string {
+	return "red"
+}
+
+func (c *DeleteHeartbeat) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteHeartbeat) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "team",
+			Label:       "Team",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "JSM Operations team that owns the heartbeat",
+			Placeholder: "Select a team",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "team",
+				},
+			},
+		},
+		{
+			Name:        "heartbeat",
+			Label:       "Heartbeat",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Heartbeat to delete (listed from the selected team)",
+			Placeholder: "Select a heartbeat",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "heartbeat",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "team",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "team"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *DeleteHeartbeat) Setup(ctx core.SetupContext) error {
+	spec := DeleteHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+		return err
+	}
+	if strings.TrimSpace(spec.Team) == "" {
+		return fmt.Errorf("team is required")
+	}
+	if strings.TrimSpace(spec.Heartbeat) == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+
+	return ctx.Metadata.Set(DeleteHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+}
+
+func (c *DeleteHeartbeat) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	teamID := strings.TrimSpace(spec.Team)
+	name := strings.TrimSpace(spec.Heartbeat)
+	if teamID == "" {
+		return fmt.Errorf("team is required")
+	}
+	if name == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	if err := client.DeleteHeartbeat(cloudID, teamID, name); err != nil {
+		return fmt.Errorf("failed to delete heartbeat: %w", err)
+	}
+
+	payload := map[string]any{
+		"deleted": true,
+		"name":    name,
+	}
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		DeleteJiraHeartbeatPayloadType,
+		[]any{payload},
+	)
+}
+
+func (c *DeleteHeartbeat) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteHeartbeat) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteHeartbeat) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteHeartbeat) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteHeartbeat) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteHeartbeat) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func resolveOpsTeamName(ctx core.SetupContext, teamID string) string {
+	teamID = strings.TrimSpace(teamID)
+	if teamID == "" || ctx.HTTP == nil {
+		return ""
+	}
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return ""
+	}
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return ""
+	}
+	teams, err := client.ListOpsTeams(cloudID)
+	if err != nil {
+		return ""
+	}
+	for _, t := range teams {
+		if t.TeamID == teamID {
+			return strings.TrimSpace(t.TeamName)
+		}
+	}
+	return ""
+}

--- a/pkg/integrations/jira/delete_heartbeat_test.go
+++ b/pkg/integrations/jira/delete_heartbeat_test.go
@@ -1,0 +1,39 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteHeartbeat__Execute(t *testing.T) {
+	component := DeleteHeartbeat{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusNoContent,
+				Body:       io.NopCloser(strings.NewReader("")),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":      teamID,
+			"heartbeat": "DNS Checker",
+		},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, DeleteJiraHeartbeatPayloadType, execCtx.Type)
+}

--- a/pkg/integrations/jira/example.go
+++ b/pkg/integrations/jira/example.go
@@ -76,3 +76,43 @@ func (c *GetIncident) ExampleOutput() map[string]any {
 func (c *DeleteIncident) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteIncidentOnce, exampleOutputDeleteIncidentBytes, &exampleOutputDeleteIncident)
 }
+
+//go:embed example_output_create_heartbeat.json
+var exampleOutputCreateHeartbeatBytes []byte
+
+var exampleOutputCreateHeartbeatOnce sync.Once
+var exampleOutputCreateHeartbeat map[string]any
+
+//go:embed example_output_ping_heartbeat.json
+var exampleOutputPingHeartbeatBytes []byte
+
+var exampleOutputPingHeartbeatOnce sync.Once
+var exampleOutputPingHeartbeat map[string]any
+
+//go:embed example_output_update_heartbeat.json
+var exampleOutputUpdateHeartbeatBytes []byte
+
+var exampleOutputUpdateHeartbeatOnce sync.Once
+var exampleOutputUpdateHeartbeat map[string]any
+
+//go:embed example_output_delete_heartbeat.json
+var exampleOutputDeleteHeartbeatBytes []byte
+
+var exampleOutputDeleteHeartbeatOnce sync.Once
+var exampleOutputDeleteHeartbeat map[string]any
+
+func (c *CreateHeartbeat) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateHeartbeatOnce, exampleOutputCreateHeartbeatBytes, &exampleOutputCreateHeartbeat)
+}
+
+func (c *PingHeartbeat) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputPingHeartbeatOnce, exampleOutputPingHeartbeatBytes, &exampleOutputPingHeartbeat)
+}
+
+func (c *UpdateHeartbeat) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateHeartbeatOnce, exampleOutputUpdateHeartbeatBytes, &exampleOutputUpdateHeartbeat)
+}
+
+func (c *DeleteHeartbeat) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteHeartbeatOnce, exampleOutputDeleteHeartbeatBytes, &exampleOutputDeleteHeartbeat)
+}

--- a/pkg/integrations/jira/example_output_create_heartbeat.json
+++ b/pkg/integrations/jira/example_output_create_heartbeat.json
@@ -1,0 +1,12 @@
+{
+  "name": "DNS Server Checker",
+  "description": "Checks whether the DNS server responds",
+  "interval": 5,
+  "intervalUnit": "minutes",
+  "enabled": true,
+  "status": "Pending",
+  "ownerTeamId": "4b26961a-a837-49d2-a1fe-0973013e3c3b",
+  "alertMessage": "DNS Server Checker is expired",
+  "alertTags": ["critical", "dns"],
+  "alertPriority": "P3"
+}

--- a/pkg/integrations/jira/example_output_create_heartbeat.json
+++ b/pkg/integrations/jira/example_output_create_heartbeat.json
@@ -1,12 +1,16 @@
 {
-  "name": "DNS Server Checker",
-  "description": "Checks whether the DNS server responds",
-  "interval": 5,
-  "intervalUnit": "minutes",
-  "enabled": true,
-  "status": "Pending",
-  "ownerTeamId": "4b26961a-a837-49d2-a1fe-0973013e3c3b",
-  "alertMessage": "DNS Server Checker is expired",
-  "alertTags": ["critical", "dns"],
-  "alertPriority": "P3"
+  "data": {
+    "alertMessage": "The alert has been raised",
+    "alertPriority": "P3",
+    "alertTags": ["tag1"],
+    "description": "my new heartbeat",
+    "enabled": true,
+    "interval": 1,
+    "intervalUnit": "minutes",
+    "name": "DNS checker",
+    "ownerTeamId": "b071f2e7-2159-4110-aa25-7718b2713ed5",
+    "status": "Pending"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.created"
 }

--- a/pkg/integrations/jira/example_output_delete_heartbeat.json
+++ b/pkg/integrations/jira/example_output_delete_heartbeat.json
@@ -1,0 +1,4 @@
+{
+  "deleted": true,
+  "name": "DNS Server Checker"
+}

--- a/pkg/integrations/jira/example_output_delete_heartbeat.json
+++ b/pkg/integrations/jira/example_output_delete_heartbeat.json
@@ -1,4 +1,8 @@
 {
-  "deleted": true,
-  "name": "DNS Server Checker"
+  "data": {
+    "deleted": true,
+    "name": "DNS checker"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.deleted"
 }

--- a/pkg/integrations/jira/example_output_ping_heartbeat.json
+++ b/pkg/integrations/jira/example_output_ping_heartbeat.json
@@ -1,0 +1,3 @@
+{
+  "message": "PONG - Heartbeat received"
+}

--- a/pkg/integrations/jira/example_output_ping_heartbeat.json
+++ b/pkg/integrations/jira/example_output_ping_heartbeat.json
@@ -1,3 +1,7 @@
 {
-  "message": "PONG - Heartbeat received"
+  "data": {
+    "message": "PONG - Heartbeat received"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.pinged"
 }

--- a/pkg/integrations/jira/example_output_update_heartbeat.json
+++ b/pkg/integrations/jira/example_output_update_heartbeat.json
@@ -1,9 +1,16 @@
 {
-  "name": "DNS Server Checker",
-  "description": "Checks whether the DNS server responds",
-  "interval": 10,
-  "intervalUnit": "minutes",
-  "enabled": true,
-  "status": "Responsive",
-  "alertPriority": "P2"
+  "data": {
+    "alertMessage": "The alert has been raised",
+    "alertPriority": "P3",
+    "alertTags": ["tag1"],
+    "description": "my new heartbeat",
+    "enabled": true,
+    "interval": 5,
+    "intervalUnit": "minutes",
+    "name": "DNS checker",
+    "ownerTeamId": "b071f2e7-2159-4110-aa25-7718b2713ed5",
+    "status": "Responsive"
+  },
+  "timestamp": "2026-01-19T12:00:00Z",
+  "type": "jira.heartbeat.updated"
 }

--- a/pkg/integrations/jira/example_output_update_heartbeat.json
+++ b/pkg/integrations/jira/example_output_update_heartbeat.json
@@ -1,0 +1,9 @@
+{
+  "name": "DNS Server Checker",
+  "description": "Checks whether the DNS server responds",
+  "interval": 10,
+  "intervalUnit": "minutes",
+  "enabled": true,
+  "status": "Responsive",
+  "alertPriority": "P2"
+}

--- a/pkg/integrations/jira/jira.go
+++ b/pkg/integrations/jira/jira.go
@@ -88,6 +88,10 @@ func (j *Jira) Actions() []core.Action {
 		&CreateIncident{},
 		&GetIncident{},
 		&DeleteIncident{},
+		&CreateHeartbeat{},
+		&PingHeartbeat{},
+		&UpdateHeartbeat{},
+		&DeleteHeartbeat{},
 	}
 }
 

--- a/pkg/integrations/jira/list_resources.go
+++ b/pkg/integrations/jira/list_resources.go
@@ -21,201 +21,232 @@ func (j *Jira) ListResources(resourceType string, ctx core.ListResourcesContext)
 	case "priority":
 		return listPriorities(ctx)
 	case "serviceDesk":
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-
-		desks, err := client.ListServiceDesks()
-		if err != nil {
-			return nil, fmt.Errorf("list service desks: %w", err)
-		}
-
-		resources := make([]core.IntegrationResource, 0, len(desks))
-		for _, desk := range desks {
-			name := desk.ProjectName
-			if desk.ProjectKey != "" {
-				name = fmt.Sprintf("%s (%s)", desk.ProjectName, desk.ProjectKey)
-			}
-			resources = append(resources, core.IntegrationResource{
-				Type: resourceType,
-				Name: name,
-				ID:   desk.ID,
-			})
-		}
-		return resources, nil
-
+		return listServiceDesks(ctx)
 	case "serviceDeskRequestType":
-		deskID := strings.TrimSpace(ctx.Parameters["serviceDesk"])
-		if deskID == "" {
-			return []core.IntegrationResource{}, nil
-		}
-
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-
-		requestTypes, err := client.ListRequestTypes(deskID)
-		if err != nil {
-			return nil, fmt.Errorf("list request types: %w", err)
-		}
-
-		resources := make([]core.IntegrationResource, 0, len(requestTypes))
-		for _, rt := range requestTypes {
-			name := rt.Name
-			if rt.ID != "" {
-				name = fmt.Sprintf("%s (%s)", rt.Name, rt.ID)
-			}
-			resources = append(resources, core.IntegrationResource{
-				Type: resourceType,
-				Name: name,
-				ID:   rt.ID,
-			})
-		}
-		return resources, nil
-
+		return listServiceDeskRequestTypes(ctx)
 	case "impact":
-		return j.listRequestTypeFieldResources(resourceType, "impact", ctx)
-
+		return listRequestTypeFieldResources(resourceType, "impact", ctx)
 	case "urgency":
-		return j.listRequestTypeFieldResources(resourceType, "urgency", ctx)
-
+		return listRequestTypeFieldResources(resourceType, "urgency", ctx)
 	case "team":
-		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, err
-		}
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-		teams, err := client.ListOpsTeams(cloudID)
-		if err != nil {
-			return nil, fmt.Errorf("list operations teams: %w", err)
-		}
-		resources := make([]core.IntegrationResource, 0, len(teams))
-		for _, team := range teams {
-			if strings.TrimSpace(team.TeamID) == "" {
-				continue
-			}
-			name := strings.TrimSpace(team.TeamName)
-			if name == "" {
-				name = team.TeamID
-			}
-			resources = append(resources, core.IntegrationResource{
-				Type: resourceType,
-				Name: name,
-				ID:   team.TeamID,
-			})
-		}
-		return resources, nil
-
+		return listTeams(ctx)
 	case "heartbeat":
-		teamID := strings.TrimSpace(ctx.Parameters["team"])
-		if teamID == "" {
-			return []core.IntegrationResource{}, nil
-		}
-		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, err
-		}
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-		heartbeats, err := client.ListHeartbeats(cloudID, teamID)
-		if err != nil {
-			return nil, fmt.Errorf("list heartbeats: %w", err)
-		}
-		resources := make([]core.IntegrationResource, 0, len(heartbeats))
-		for _, hb := range heartbeats {
-			if strings.TrimSpace(hb.Name) == "" {
-				continue
-			}
-			name := hb.Name
-			if hb.Status != "" {
-				name = fmt.Sprintf("%s (%s)", hb.Name, hb.Status)
-			}
-			resources = append(resources, core.IntegrationResource{
-				Type: resourceType,
-				Name: name,
-				ID:   hb.Name,
-			})
-		}
-		return resources, nil
-
+		return listHeartbeats(ctx)
 	case "issue":
-		client, err := NewClient(ctx.HTTP, ctx.Integration)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client: %w", err)
-		}
-
-		projectKey := strings.TrimSpace(ctx.Parameters["project"])
-
-		if projectKey != "" {
-			desks, derr := client.ListServiceDesks()
-			if derr == nil {
-				for _, desk := range desks {
-					if strings.EqualFold(strings.TrimSpace(desk.ProjectKey), projectKey) {
-						rows, rerr := client.ListCustomerRequestsByServiceDesk(desk.ID, 500)
-						if rerr == nil && len(rows) > 0 {
-							resources := make([]core.IntegrationResource, 0, len(rows))
-							for _, row := range rows {
-								if strings.TrimSpace(row.IssueKey) == "" {
-									continue
-								}
-								name := row.IssueKey
-								if s := strings.TrimSpace(row.Summary); s != "" {
-									name = fmt.Sprintf("%s (%s)", s, row.IssueKey)
-								}
-								resources = append(resources, core.IntegrationResource{
-									Type: resourceType,
-									Name: name,
-									ID:   row.IssueKey,
-								})
-							}
-							return resources, nil
-						}
-						break
-					}
-				}
-			}
-		}
-
-		var jql string
-		if projectKey != "" {
-			jql = fmt.Sprintf(`project = "%s" ORDER BY updated DESC`, jqlQuotedProjectKey(projectKey))
-		} else {
-			jql = "updated >= -90d ORDER BY updated DESC"
-		}
-
-		hits, err := client.SearchIssuesUpTo(jql, 500)
-		if err != nil {
-			return nil, fmt.Errorf("search issues: %w", err)
-		}
-
-		resources := make([]core.IntegrationResource, 0, len(hits))
-		for _, hit := range hits {
-			if strings.TrimSpace(hit.Key) == "" {
-				continue
-			}
-			name := hit.Key
-			if hit.Fields != nil {
-				if s, ok := hit.Fields["summary"].(string); ok && strings.TrimSpace(s) != "" {
-					name = fmt.Sprintf("%s (%s)", strings.TrimSpace(s), hit.Key)
-				}
-			}
-			resources = append(resources, core.IntegrationResource{
-				Type: resourceType,
-				Name: name,
-				ID:   hit.Key,
-			})
-		}
-		return resources, nil
+		return listIssues(ctx)
 	default:
 		return []core.IntegrationResource{}, nil
 	}
+}
+
+func listServiceDesks(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	desks, err := client.ListServiceDesks()
+	if err != nil {
+		return nil, fmt.Errorf("list service desks: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(desks))
+	for _, desk := range desks {
+		name := desk.ProjectName
+		if desk.ProjectKey != "" {
+			name = fmt.Sprintf("%s (%s)", desk.ProjectName, desk.ProjectKey)
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: "serviceDesk",
+			Name: name,
+			ID:   desk.ID,
+		})
+	}
+	return resources, nil
+}
+
+func listServiceDeskRequestTypes(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	deskID := strings.TrimSpace(ctx.Parameters["serviceDesk"])
+	if deskID == "" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	requestTypes, err := client.ListRequestTypes(deskID)
+	if err != nil {
+		return nil, fmt.Errorf("list request types: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(requestTypes))
+	for _, rt := range requestTypes {
+		name := rt.Name
+		if rt.ID != "" {
+			name = fmt.Sprintf("%s (%s)", rt.Name, rt.ID)
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: "serviceDeskRequestType",
+			Name: name,
+			ID:   rt.ID,
+		})
+	}
+	return resources, nil
+}
+
+func listTeams(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	teams, err := client.ListOpsTeams(cloudID)
+	if err != nil {
+		return nil, fmt.Errorf("list operations teams: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(teams))
+	for _, team := range teams {
+		if strings.TrimSpace(team.TeamID) == "" {
+			continue
+		}
+		name := strings.TrimSpace(team.TeamName)
+		if name == "" {
+			name = team.TeamID
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: "team",
+			Name: name,
+			ID:   team.TeamID,
+		})
+	}
+	return resources, nil
+}
+
+func listHeartbeats(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	teamID := strings.TrimSpace(ctx.Parameters["team"])
+	if teamID == "" {
+		return []core.IntegrationResource{}, nil
+	}
+
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	heartbeats, err := client.ListHeartbeats(cloudID, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("list heartbeats: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(heartbeats))
+	for _, hb := range heartbeats {
+		if strings.TrimSpace(hb.Name) == "" {
+			continue
+		}
+		name := hb.Name
+		if hb.Status != "" {
+			name = fmt.Sprintf("%s (%s)", hb.Name, hb.Status)
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: "heartbeat",
+			Name: name,
+			ID:   hb.Name,
+		})
+	}
+	return resources, nil
+}
+
+func listIssues(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	projectKey := strings.TrimSpace(ctx.Parameters["project"])
+
+	if projectKey != "" {
+		if resources, ok := listIssuesFromServiceDesk(client, projectKey); ok {
+			return resources, nil
+		}
+	}
+
+	var jql string
+	if projectKey != "" {
+		jql = fmt.Sprintf(`project = "%s" ORDER BY updated DESC`, jqlQuotedProjectKey(projectKey))
+	} else {
+		jql = "updated >= -90d ORDER BY updated DESC"
+	}
+
+	hits, err := client.SearchIssuesUpTo(jql, 500)
+	if err != nil {
+		return nil, fmt.Errorf("search issues: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(hits))
+	for _, hit := range hits {
+		if strings.TrimSpace(hit.Key) == "" {
+			continue
+		}
+		name := hit.Key
+		if hit.Fields != nil {
+			if s, ok := hit.Fields["summary"].(string); ok && strings.TrimSpace(s) != "" {
+				name = fmt.Sprintf("%s (%s)", strings.TrimSpace(s), hit.Key)
+			}
+		}
+		resources = append(resources, core.IntegrationResource{
+			Type: "issue",
+			Name: name,
+			ID:   hit.Key,
+		})
+	}
+	return resources, nil
+}
+
+func listIssuesFromServiceDesk(client *Client, projectKey string) ([]core.IntegrationResource, bool) {
+	desks, err := client.ListServiceDesks()
+	if err != nil {
+		return nil, false
+	}
+
+	for _, desk := range desks {
+		if !strings.EqualFold(strings.TrimSpace(desk.ProjectKey), projectKey) {
+			continue
+		}
+		rows, err := client.ListCustomerRequestsByServiceDesk(desk.ID, 500)
+		if err != nil || len(rows) == 0 {
+			break
+		}
+		resources := make([]core.IntegrationResource, 0, len(rows))
+		for _, row := range rows {
+			if strings.TrimSpace(row.IssueKey) == "" {
+				continue
+			}
+			name := row.IssueKey
+			if s := strings.TrimSpace(row.Summary); s != "" {
+				name = fmt.Sprintf("%s (%s)", s, row.IssueKey)
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: "issue",
+				Name: name,
+				ID:   row.IssueKey,
+			})
+		}
+		return resources, true
+	}
+	return nil, false
 }
 
 func listProjects(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
@@ -372,7 +403,7 @@ func listPriorities(ctx core.ListResourcesContext) ([]core.IntegrationResource, 
 	return resources, nil
 }
 
-func (j *Jira) listRequestTypeFieldResources(resourceType, fieldLabel string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+func listRequestTypeFieldResources(resourceType, fieldLabel string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
 	deskID := strings.TrimSpace(ctx.Parameters["serviceDesk"])
 	reqID := strings.TrimSpace(ctx.Parameters["serviceDeskRequestType"])
 	if deskID == "" || reqID == "" {

--- a/pkg/integrations/jira/list_resources.go
+++ b/pkg/integrations/jira/list_resources.go
@@ -81,6 +81,70 @@ func (j *Jira) ListResources(resourceType string, ctx core.ListResourcesContext)
 	case "urgency":
 		return j.listRequestTypeFieldResources(resourceType, "urgency", ctx)
 
+	case "team":
+		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, err
+		}
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+		teams, err := client.ListOpsTeams(cloudID)
+		if err != nil {
+			return nil, fmt.Errorf("list operations teams: %w", err)
+		}
+		resources := make([]core.IntegrationResource, 0, len(teams))
+		for _, team := range teams {
+			if strings.TrimSpace(team.TeamID) == "" {
+				continue
+			}
+			name := strings.TrimSpace(team.TeamName)
+			if name == "" {
+				name = team.TeamID
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   team.TeamID,
+			})
+		}
+		return resources, nil
+
+	case "heartbeat":
+		teamID := strings.TrimSpace(ctx.Parameters["team"])
+		if teamID == "" {
+			return []core.IntegrationResource{}, nil
+		}
+		cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, err
+		}
+		client, err := NewClient(ctx.HTTP, ctx.Integration)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client: %w", err)
+		}
+		heartbeats, err := client.ListHeartbeats(cloudID, teamID)
+		if err != nil {
+			return nil, fmt.Errorf("list heartbeats: %w", err)
+		}
+		resources := make([]core.IntegrationResource, 0, len(heartbeats))
+		for _, hb := range heartbeats {
+			if strings.TrimSpace(hb.Name) == "" {
+				continue
+			}
+			name := hb.Name
+			if hb.Status != "" {
+				name = fmt.Sprintf("%s (%s)", hb.Name, hb.Status)
+			}
+			resources = append(resources, core.IntegrationResource{
+				Type: resourceType,
+				Name: name,
+				ID:   hb.Name,
+			})
+		}
+		return resources, nil
+
 	case "issue":
 		client, err := NewClient(ctx.HTTP, ctx.Integration)
 		if err != nil {

--- a/pkg/integrations/jira/list_resources_test.go
+++ b/pkg/integrations/jira/list_resources_test.go
@@ -566,3 +566,49 @@ func Test__requestTypeFieldResources__createmetaFallback(t *testing.T) {
 	require.Len(t, resources, 1)
 	assert.Equal(t, "5", resources[0].ID)
 }
+
+func Test__ListResources__Team(t *testing.T) {
+	j := &Jira{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"platformTeams":[{"teamId":"` + teamID + `","teamName":"On-call"}]}`)),
+			},
+		},
+	}
+
+	resources, err := j.ListResources("team", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: jiraTestIntegration(),
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "team", resources[0].Type)
+	assert.Equal(t, teamID, resources[0].ID)
+	assert.Equal(t, "On-call", resources[0].Name)
+}
+
+func Test__ListResources__Heartbeat(t *testing.T) {
+	j := &Jira{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"values":[{"name":"DNS Checker","status":"Responsive"}]}`)),
+			},
+		},
+	}
+
+	resources, err := j.ListResources("heartbeat", core.ListResourcesContext{
+		HTTP:        httpContext,
+		Integration: jiraTestIntegration(),
+		Parameters:  map[string]string{"team": teamID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "DNS Checker", resources[0].ID)
+	assert.Contains(t, resources[0].Name, "DNS Checker")
+}

--- a/pkg/integrations/jira/ping_heartbeat.go
+++ b/pkg/integrations/jira/ping_heartbeat.go
@@ -115,7 +115,8 @@ func (c *PingHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(spec.Team) == "" {
@@ -125,7 +126,7 @@ func (c *PingHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("heartbeat is required")
 	}
 
-	return ctx.Metadata.Set(PingHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+	return ctx.Metadata.Set(PingHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, cloudID, spec.Team)})
 }
 
 func (c *PingHeartbeat) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/jira/ping_heartbeat.go
+++ b/pkg/integrations/jira/ping_heartbeat.go
@@ -1,0 +1,190 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const PingJiraHeartbeatPayloadType = "jira.heartbeat.pinged"
+
+type PingHeartbeat struct{}
+
+type PingHeartbeatSpec struct {
+	Team      string `json:"team" mapstructure:"team"`
+	Heartbeat string `json:"heartbeat" mapstructure:"heartbeat"`
+}
+
+type PingHeartbeatNodeMetadata struct {
+	TeamName string `json:"teamName,omitempty"`
+}
+
+func (c *PingHeartbeat) Name() string {
+	return "jira.pingHeartbeat"
+}
+
+func (c *PingHeartbeat) Label() string {
+	return "Ping Heartbeat"
+}
+
+func (c *PingHeartbeat) Description() string {
+	return "Send a ping to a Jira Service Management Operations heartbeat"
+}
+
+func (c *PingHeartbeat) Documentation() string {
+	return `The Ping Heartbeat component reports that a monitored system is alive.
+
+## Use Cases
+
+- **Scheduled jobs**: Ping at the end of a cron workflow so JSM detects missed runs
+- **Deploy pipelines**: Confirm a service is up after deployment
+- **Agent check-ins**: Let automation prove an external process completed
+
+## Configuration
+
+- **Team**: Team that owns the heartbeat
+- **Heartbeat**: Heartbeat name to ping (from the team's heartbeat list)
+
+## Output
+
+Returns the API **message** (for example "PONG - Heartbeat received").
+
+## Notes
+
+- Requires Jira Service Management Operations with heartbeats enabled.
+- The heartbeat must already exist (use Create Heartbeat or configure it in JSM).`
+}
+
+func (c *PingHeartbeat) Icon() string {
+	return "jira"
+}
+
+func (c *PingHeartbeat) Color() string {
+	return "green"
+}
+
+func (c *PingHeartbeat) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *PingHeartbeat) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "team",
+			Label:       "Team",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "JSM Operations team that owns the heartbeat",
+			Placeholder: "Select a team",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "team",
+				},
+			},
+		},
+		{
+			Name:        "heartbeat",
+			Label:       "Heartbeat",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Heartbeat to ping (listed from the selected team)",
+			Placeholder: "Select a heartbeat",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "heartbeat",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "team",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "team"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *PingHeartbeat) Setup(ctx core.SetupContext) error {
+	spec := PingHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+		return err
+	}
+	if strings.TrimSpace(spec.Team) == "" {
+		return fmt.Errorf("team is required")
+	}
+	if strings.TrimSpace(spec.Heartbeat) == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+
+	return ctx.Metadata.Set(PingHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+}
+
+func (c *PingHeartbeat) Execute(ctx core.ExecutionContext) error {
+	spec := PingHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	teamID := strings.TrimSpace(spec.Team)
+	name := strings.TrimSpace(spec.Heartbeat)
+	if teamID == "" {
+		return fmt.Errorf("team is required")
+	}
+	if name == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.PingHeartbeat(cloudID, teamID, name)
+	if err != nil {
+		return fmt.Errorf("failed to ping heartbeat: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		PingJiraHeartbeatPayloadType,
+		[]any{resp},
+	)
+}
+
+func (c *PingHeartbeat) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *PingHeartbeat) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *PingHeartbeat) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *PingHeartbeat) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *PingHeartbeat) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *PingHeartbeat) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/jira/ping_heartbeat_test.go
+++ b/pkg/integrations/jira/ping_heartbeat_test.go
@@ -1,0 +1,39 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__PingHeartbeat__Execute(t *testing.T) {
+	component := PingHeartbeat{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(strings.NewReader(`{"message":"PONG - Heartbeat received"}`)),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":      teamID,
+			"heartbeat": "DNS Checker",
+		},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, PingJiraHeartbeatPayloadType, execCtx.Type)
+}

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -220,11 +220,11 @@ func (c *UpdateHeartbeat) Setup(ctx core.SetupContext) error {
 	if strings.TrimSpace(spec.Heartbeat) == "" {
 		return fmt.Errorf("heartbeat is required")
 	}
-	if !hasAnyHeartbeatUpdate(spec) {
-		return fmt.Errorf("at least one update field must be enabled")
-	}
 	if spec.Interval != nil && *spec.Interval < 1 {
 		return fmt.Errorf("interval must be at least 1")
+	}
+	if !hasEffectiveHeartbeatUpdate(spec) {
+		return fmt.Errorf("at least one update field must be enabled")
 	}
 
 	return ctx.Metadata.Set(UpdateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
@@ -251,7 +251,7 @@ func (c *UpdateHeartbeat) Execute(ctx core.ExecutionContext) error {
 	}
 
 	req := updateHeartbeatRequestFromSpec(spec)
-	if updateHeartbeatRequestEmpty(req) {
+	if !hasEffectiveHeartbeatUpdate(spec) {
 		return fmt.Errorf("at least one update field must be enabled")
 	}
 
@@ -272,14 +272,8 @@ func (c *UpdateHeartbeat) Execute(ctx core.ExecutionContext) error {
 	)
 }
 
-func hasAnyHeartbeatUpdate(spec UpdateHeartbeatSpec) bool {
-	return spec.Description != nil ||
-		spec.Interval != nil ||
-		spec.IntervalUnit != nil ||
-		spec.Enabled != nil ||
-		spec.AlertMessage != nil ||
-		spec.AlertTags != nil ||
-		spec.AlertPriority != nil
+func hasEffectiveHeartbeatUpdate(spec UpdateHeartbeatSpec) bool {
+	return !updateHeartbeatRequestEmpty(updateHeartbeatRequestFromSpec(spec))
 }
 
 func updateHeartbeatRequestFromSpec(spec UpdateHeartbeatSpec) *UpdateHeartbeatRequest {

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -213,7 +213,8 @@ func (c *UpdateHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("failed to decode configuration: %w", err)
 	}
 
-	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
 		return err
 	}
 	if strings.TrimSpace(spec.Team) == "" {
@@ -229,7 +230,7 @@ func (c *UpdateHeartbeat) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("at least one update field must be enabled")
 	}
 
-	return ctx.Metadata.Set(UpdateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+	return ctx.Metadata.Set(UpdateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, cloudID, spec.Team)})
 }
 
 func (c *UpdateHeartbeat) Execute(ctx core.ExecutionContext) error {
@@ -294,7 +295,8 @@ func updateHeartbeatRequestFromSpec(spec UpdateHeartbeatSpec) *UpdateHeartbeatRe
 		}
 	}
 	if spec.Enabled != nil {
-		req.Enabled = spec.Enabled
+		enabled := *spec.Enabled
+		req.Enabled = &enabled
 	}
 	if spec.AlertMessage != nil {
 		req.AlertMessage = strings.TrimSpace(*spec.AlertMessage)

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -1,0 +1,393 @@
+package jira
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const UpdateJiraHeartbeatPayloadType = "jira.heartbeat.updated"
+
+type UpdateHeartbeat struct{}
+
+type UpdateHeartbeatSpec struct {
+	Team          string  `json:"team" mapstructure:"team"`
+	Heartbeat     string  `json:"heartbeat" mapstructure:"heartbeat"`
+	Description   *string `json:"description,omitempty" mapstructure:"description"`
+	Interval      *int    `json:"interval,omitempty" mapstructure:"interval"`
+	IntervalUnit  *string `json:"intervalUnit,omitempty" mapstructure:"intervalUnit"`
+	Enabled       *bool   `json:"enabled,omitempty" mapstructure:"enabled"`
+	AlertMessage  *string `json:"alertMessage,omitempty" mapstructure:"alertMessage"`
+	AlertTags     []any   `json:"alertTags,omitempty" mapstructure:"alertTags"`
+	AlertPriority *string `json:"alertPriority,omitempty" mapstructure:"alertPriority"`
+}
+
+type UpdateHeartbeatNodeMetadata struct {
+	TeamName string `json:"teamName,omitempty"`
+}
+
+func (c *UpdateHeartbeat) Name() string {
+	return "jira.updateHeartbeat"
+}
+
+func (c *UpdateHeartbeat) Label() string {
+	return "Update Heartbeat"
+}
+
+func (c *UpdateHeartbeat) Description() string {
+	return "Update a Jira Service Management Operations heartbeat"
+}
+
+func (c *UpdateHeartbeat) Documentation() string {
+	return `The Update Heartbeat component changes settings on an existing JSM Operations heartbeat.
+
+## Use Cases
+
+- **Tune intervals**: Adjust expected ping frequency after operational changes
+- **Enable/disable monitoring**: Turn heartbeats on or off from automation
+- **Alert tuning**: Update expiration alert message, tags, or priority
+
+## Configuration
+
+- **Team** and **Heartbeat** (required): Identify the heartbeat to update
+- **Optional fields** use toggles: only enabled fields are sent to the Jira API
+- Heartbeat **name** cannot be changed (create a new heartbeat instead)
+
+## Output
+
+Returns the updated heartbeat object from the JSM Operations API.
+
+## Notes
+
+- Enable at least one optional field toggle before saving or running the node.
+- Requires Jira Service Management Operations with heartbeats enabled.`
+}
+
+func (c *UpdateHeartbeat) Icon() string {
+	return "jira"
+}
+
+func (c *UpdateHeartbeat) Color() string {
+	return "blue"
+}
+
+func (c *UpdateHeartbeat) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateHeartbeat) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "team",
+			Label:       "Team",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "JSM Operations team that owns the heartbeat",
+			Placeholder: "Select a team",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "team",
+				},
+			},
+		},
+		{
+			Name:        "heartbeat",
+			Label:       "Heartbeat",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "Heartbeat to update (listed from the selected team)",
+			Placeholder: "Select a heartbeat",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "heartbeat",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "team",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "team"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "description",
+			Label:       "Description",
+			Type:        configuration.FieldTypeText,
+			Required:    false,
+			Togglable:   true,
+			Description: "New description for the heartbeat",
+		},
+		{
+			Name:        "interval",
+			Label:       "Interval",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Togglable:   true,
+			Default:     5,
+			Description: "New expected ping interval (minimum 1)",
+		},
+		{
+			Name:        "intervalUnit",
+			Label:       "Interval unit",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Togglable:   true,
+			Default:     "minutes",
+			Description: "Unit for the expected ping interval",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Minutes", Value: "minutes"},
+						{Label: "Hours", Value: "hours"},
+						{Label: "Days", Value: "days"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "enabled",
+			Label:       "Enabled",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Togglable:   true,
+			Default:     true,
+			Description: "Enable or disable heartbeat monitoring",
+		},
+		{
+			Name:        "alertMessage",
+			Label:       "Alert message",
+			Type:        configuration.FieldTypeString,
+			Required:    false,
+			Togglable:   true,
+			Description: "New expiration alert message",
+		},
+		{
+			Name:        "alertTags",
+			Label:       "Alert tags",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Togglable:   true,
+			Description: "Replacement tags for the expiration alert",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Tag",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "alertPriority",
+			Label:       "Alert priority",
+			Type:        configuration.FieldTypeSelect,
+			Required:    false,
+			Togglable:   true,
+			Default:     "P3",
+			Description: "Priority for the expiration alert",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "P1", Value: "P1"},
+						{Label: "P2", Value: "P2"},
+						{Label: "P3", Value: "P3"},
+						{Label: "P4", Value: "P4"},
+						{Label: "P5", Value: "P5"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *UpdateHeartbeat) Setup(ctx core.SetupContext) error {
+	spec := UpdateHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if _, err := resolveCloudID(ctx.HTTP, ctx.Integration); err != nil {
+		return err
+	}
+	if strings.TrimSpace(spec.Team) == "" {
+		return fmt.Errorf("team is required")
+	}
+	if strings.TrimSpace(spec.Heartbeat) == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+	if !hasAnyHeartbeatUpdate(spec) {
+		return fmt.Errorf("at least one update field must be enabled")
+	}
+	if spec.Interval != nil && *spec.Interval < 1 {
+		return fmt.Errorf("interval must be at least 1")
+	}
+
+	return ctx.Metadata.Set(UpdateHeartbeatNodeMetadata{TeamName: resolveOpsTeamName(ctx, spec.Team)})
+}
+
+func (c *UpdateHeartbeat) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateHeartbeatSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	cloudID, err := resolveCloudID(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	teamID := strings.TrimSpace(spec.Team)
+	name := strings.TrimSpace(spec.Heartbeat)
+	if teamID == "" {
+		return fmt.Errorf("team is required")
+	}
+	if name == "" {
+		return fmt.Errorf("heartbeat is required")
+	}
+
+	req := updateHeartbeatRequestFromSpec(spec)
+	if updateHeartbeatRequestEmpty(req) {
+		return fmt.Errorf("at least one update field must be enabled")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	resp, err := client.UpdateHeartbeat(cloudID, teamID, name, req)
+	if err != nil {
+		return fmt.Errorf("failed to update heartbeat: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		UpdateJiraHeartbeatPayloadType,
+		[]any{resp},
+	)
+}
+
+func hasAnyHeartbeatUpdate(spec UpdateHeartbeatSpec) bool {
+	return spec.Description != nil ||
+		spec.Interval != nil ||
+		spec.IntervalUnit != nil ||
+		spec.Enabled != nil ||
+		spec.AlertMessage != nil ||
+		spec.AlertTags != nil ||
+		spec.AlertPriority != nil
+}
+
+func updateHeartbeatRequestFromSpec(spec UpdateHeartbeatSpec) *UpdateHeartbeatRequest {
+	req := &UpdateHeartbeatRequest{}
+
+	if spec.Description != nil {
+		req.Description = strings.TrimSpace(*spec.Description)
+	}
+	if spec.Interval != nil && *spec.Interval >= 1 {
+		interval := *spec.Interval
+		req.Interval = &interval
+	}
+	if spec.IntervalUnit != nil {
+		if unit := strings.TrimSpace(*spec.IntervalUnit); unit != "" {
+			req.IntervalUnit = unit
+		}
+	}
+	if spec.Enabled != nil {
+		req.Enabled = spec.Enabled
+	}
+	if spec.AlertMessage != nil {
+		req.AlertMessage = strings.TrimSpace(*spec.AlertMessage)
+	}
+	if spec.AlertTags != nil {
+		req.AlertTags = updateHeartbeatAlertTagsFromList(spec.AlertTags)
+	}
+	if spec.AlertPriority != nil {
+		if p := updateHeartbeatAlertPriorityForAPI(*spec.AlertPriority); p != "" {
+			req.AlertPriority = p
+		}
+	}
+
+	return req
+}
+
+func updateHeartbeatRequestEmpty(req *UpdateHeartbeatRequest) bool {
+	if req == nil {
+		return true
+	}
+	if req.Description != "" {
+		return false
+	}
+	if req.Interval != nil {
+		return false
+	}
+	if strings.TrimSpace(req.IntervalUnit) != "" {
+		return false
+	}
+	if req.Enabled != nil {
+		return false
+	}
+	if req.AlertMessage != "" {
+		return false
+	}
+	if len(req.AlertTags) > 0 {
+		return false
+	}
+	if strings.TrimSpace(req.AlertPriority) != "" {
+		return false
+	}
+	return true
+}
+
+func (c *UpdateHeartbeat) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateHeartbeat) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateHeartbeat) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *UpdateHeartbeat) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *UpdateHeartbeat) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdateHeartbeat) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func updateHeartbeatAlertTagsFromList(raw []any) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s := strings.TrimSpace(fmt.Sprint(e))
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func updateHeartbeatAlertPriorityForAPI(priority string) string {
+	p := strings.TrimSpace(priority)
+	if p == "" || p == "__none__" {
+		return ""
+	}
+	return p
+}

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -287,10 +287,10 @@ func updateHeartbeatRequestFromSpec(spec UpdateHeartbeatSpec) *UpdateHeartbeatRe
 	if spec.Interval != nil && *spec.Interval >= 1 {
 		interval := *spec.Interval
 		req.Interval = &interval
-	}
-	if spec.IntervalUnit != nil {
-		if unit := strings.TrimSpace(*spec.IntervalUnit); unit != "" {
-			req.IntervalUnit = unit
+		if spec.IntervalUnit != nil {
+			if unit := strings.TrimSpace(*spec.IntervalUnit); unit != "" {
+				req.IntervalUnit = unit
+			}
 		}
 	}
 	if spec.Enabled != nil {
@@ -319,9 +319,6 @@ func updateHeartbeatRequestEmpty(req *UpdateHeartbeatRequest) bool {
 		return false
 	}
 	if req.Interval != nil {
-		return false
-	}
-	if strings.TrimSpace(req.IntervalUnit) != "" {
 		return false
 	}
 	if req.Enabled != nil {

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -136,9 +136,11 @@ func (c *UpdateHeartbeat) Configuration() []configuration.Field {
 			Label:       "Interval unit",
 			Type:        configuration.FieldTypeSelect,
 			Required:    false,
-			Togglable:   true,
 			Default:     "minutes",
 			Description: "Unit for the expected ping interval",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "interval", Values: []string{"*"}},
+			},
 			TypeOptions: &configuration.TypeOptions{
 				Select: &configuration.SelectTypeOptions{
 					Options: []configuration.FieldOption{

--- a/pkg/integrations/jira/update_heartbeat.go
+++ b/pkg/integrations/jira/update_heartbeat.go
@@ -253,7 +253,7 @@ func (c *UpdateHeartbeat) Execute(ctx core.ExecutionContext) error {
 	}
 
 	req := updateHeartbeatRequestFromSpec(spec)
-	if !hasEffectiveHeartbeatUpdate(spec) {
+	if updateHeartbeatRequestEmpty(req) {
 		return fmt.Errorf("at least one update field must be enabled")
 	}
 
@@ -300,10 +300,10 @@ func updateHeartbeatRequestFromSpec(spec UpdateHeartbeatSpec) *UpdateHeartbeatRe
 		req.AlertMessage = strings.TrimSpace(*spec.AlertMessage)
 	}
 	if spec.AlertTags != nil {
-		req.AlertTags = updateHeartbeatAlertTagsFromList(spec.AlertTags)
+		req.AlertTags = heartbeatAlertTagsFromList(spec.AlertTags)
 	}
 	if spec.AlertPriority != nil {
-		if p := updateHeartbeatAlertPriorityForAPI(*spec.AlertPriority); p != "" {
+		if p := heartbeatAlertPriorityForAPI(*spec.AlertPriority); p != "" {
 			req.AlertPriority = p
 		}
 	}
@@ -358,29 +358,4 @@ func (c *UpdateHeartbeat) Hooks() []core.Hook {
 
 func (c *UpdateHeartbeat) HandleHook(ctx core.ActionHookContext) error {
 	return nil
-}
-
-func updateHeartbeatAlertTagsFromList(raw []any) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(raw))
-	for _, e := range raw {
-		s := strings.TrimSpace(fmt.Sprint(e))
-		if s != "" {
-			out = append(out, s)
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func updateHeartbeatAlertPriorityForAPI(priority string) string {
-	p := strings.TrimSpace(priority)
-	if p == "" || p == "__none__" {
-		return ""
-	}
-	return p
 }

--- a/pkg/integrations/jira/update_heartbeat_test.go
+++ b/pkg/integrations/jira/update_heartbeat_test.go
@@ -65,8 +65,26 @@ func Test__UpdateHeartbeat__Setup_requires_toggled_field(t *testing.T) {
 	require.ErrorContains(t, err, "at least one update field must be enabled")
 }
 
-func Test__hasAnyHeartbeatUpdate(t *testing.T) {
-	assert.False(t, hasAnyHeartbeatUpdate(UpdateHeartbeatSpec{}))
+func Test__UpdateHeartbeat__Setup_rejects_empty_toggled_field(t *testing.T) {
+	component := UpdateHeartbeat{}
+	empty := ""
+	err := component.Setup(core.SetupContext{
+		Integration: jiraTestIntegration(),
+		Configuration: map[string]any{
+			"team":        "team-1",
+			"heartbeat":   "DNS Checker",
+			"description": empty,
+		},
+	})
+	require.ErrorContains(t, err, "at least one update field must be enabled")
+}
+
+func Test__hasEffectiveHeartbeatUpdate(t *testing.T) {
+	assert.False(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{}))
+	empty := ""
+	assert.False(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{Description: &empty}))
 	desc := "x"
-	assert.True(t, hasAnyHeartbeatUpdate(UpdateHeartbeatSpec{Description: &desc}))
+	assert.True(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{Description: &desc}))
+	interval := 5
+	assert.True(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{Interval: &interval}))
 }

--- a/pkg/integrations/jira/update_heartbeat_test.go
+++ b/pkg/integrations/jira/update_heartbeat_test.go
@@ -87,4 +87,31 @@ func Test__hasEffectiveHeartbeatUpdate(t *testing.T) {
 	assert.True(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{Description: &desc}))
 	interval := 5
 	assert.True(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{Interval: &interval}))
+
+	// intervalUnit alone (interval toggle off) must not be treated as a valid update.
+	unit := "minutes"
+	assert.False(t, hasEffectiveHeartbeatUpdate(UpdateHeartbeatSpec{IntervalUnit: &unit}))
+}
+
+func Test__updateHeartbeatRequestFromSpec_intervalUnit(t *testing.T) {
+	unit := "hours"
+	interval := 2
+
+	t.Run("intervalUnit is omitted when interval is absent", func(t *testing.T) {
+		req := updateHeartbeatRequestFromSpec(UpdateHeartbeatSpec{IntervalUnit: &unit})
+		assert.Nil(t, req.Interval)
+		assert.Empty(t, req.IntervalUnit)
+	})
+
+	t.Run("intervalUnit is included when interval is present", func(t *testing.T) {
+		req := updateHeartbeatRequestFromSpec(UpdateHeartbeatSpec{Interval: &interval, IntervalUnit: &unit})
+		assert.Equal(t, &interval, req.Interval)
+		assert.Equal(t, "hours", req.IntervalUnit)
+	})
+
+	t.Run("interval without intervalUnit is still valid", func(t *testing.T) {
+		req := updateHeartbeatRequestFromSpec(UpdateHeartbeatSpec{Interval: &interval})
+		assert.Equal(t, &interval, req.Interval)
+		assert.Empty(t, req.IntervalUnit)
+	})
 }

--- a/pkg/integrations/jira/update_heartbeat_test.go
+++ b/pkg/integrations/jira/update_heartbeat_test.go
@@ -1,0 +1,72 @@
+package jira
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateHeartbeat__Execute(t *testing.T) {
+	component := UpdateHeartbeat{}
+	teamID := "4b26961a-a837-49d2-a1fe-0973013e3c3b"
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(`{"name":"DNS Checker","interval":10,"intervalUnit":"minutes","enabled":true}`)),
+			},
+		},
+	}
+	execCtx := &contexts.ExecutionStateContext{}
+	interval := 10
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":      teamID,
+			"heartbeat": "DNS Checker",
+			"interval":  interval,
+		},
+		HTTP:           httpContext,
+		Integration:    jiraTestIntegration(),
+		ExecutionState: execCtx,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, UpdateJiraHeartbeatPayloadType, execCtx.Type)
+}
+
+func Test__UpdateHeartbeat__Execute_requires_field(t *testing.T) {
+	component := UpdateHeartbeat{}
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"team":      "team-1",
+			"heartbeat": "DNS Checker",
+		},
+		Integration:    jiraTestIntegration(),
+		ExecutionState: &contexts.ExecutionStateContext{},
+	})
+	require.ErrorContains(t, err, "at least one update field must be enabled")
+}
+
+func Test__UpdateHeartbeat__Setup_requires_toggled_field(t *testing.T) {
+	component := UpdateHeartbeat{}
+	err := component.Setup(core.SetupContext{
+		Integration: jiraTestIntegration(),
+		Configuration: map[string]any{
+			"team":      "team-1",
+			"heartbeat": "DNS Checker",
+		},
+	})
+	require.ErrorContains(t, err, "at least one update field must be enabled")
+}
+
+func Test__hasAnyHeartbeatUpdate(t *testing.T) {
+	assert.False(t, hasAnyHeartbeatUpdate(UpdateHeartbeatSpec{}))
+	desc := "x"
+	assert.True(t, hasAnyHeartbeatUpdate(UpdateHeartbeatSpec{Description: &desc}))
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentDefinition, ExecutionInfo, NodeInfo } from "../types";
+import { createHeartbeatMapper } from "./create_heartbeat";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Heartbeat",
+    componentName: "jira.createHeartbeat",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+const defaultDefinition: ComponentDefinition = {
+  name: "jira.createHeartbeat",
+  label: "Create Heartbeat",
+  description: "",
+  icon: "jira",
+  color: "orange",
+};
+
+describe("createHeartbeatMapper", () => {
+  it("props metadata shows team, name, and interval", () => {
+    const props = createHeartbeatMapper.props!({
+      nodes: [],
+      node: buildNode({
+        configuration: { team: "team-1", name: "DNS Checker", interval: 5, intervalUnit: "minutes" },
+        metadata: { teamName: "On-call" },
+      }),
+      componentDefinition: defaultDefinition,
+      lastExecutions: [],
+      currentUser: undefined,
+      actions: { invokeNodeExecutionHook: async () => {} },
+    });
+    expect(props.metadata?.map((m) => m.label)).toEqual(["On-call", "DNS Checker", "5 minutes"]);
+  });
+
+  it("getExecutionDetails includes name and status", () => {
+    const details = createHeartbeatMapper.getExecutionDetails!({
+      nodes: [buildNode()],
+      node: buildNode(),
+      execution: buildExecution({
+        outputs: {
+          default: [
+            {
+              type: "jira.heartbeat.created",
+              timestamp: new Date().toISOString(),
+              data: { name: "DNS Checker", status: "Pending" },
+            },
+          ],
+        },
+      }),
+    });
+    expect(details["Name"]).toBe("DNS Checker");
+    expect(details["Status"]).toBe("Pending");
+  });
+
+  it("event state registry maps success to created", () => {
+    expect(eventStateRegistry.createHeartbeat.getState(buildExecution({ result: "RESULT_PASSED" }))).toBe("created");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.ts
@@ -1,0 +1,87 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface CreateHeartbeatConfiguration {
+  team?: string;
+  name?: string;
+  interval?: number;
+  intervalUnit?: string;
+}
+
+interface CreateHeartbeatNodeMetadata {
+  teamName?: string;
+}
+
+export const createHeartbeatMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.createHeartbeat";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!data) {
+      return details;
+    }
+    if (data.name != null) {
+      details["Name"] = String(data.name);
+    }
+    if (data.status != null) {
+      details["Status"] = String(data.status);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as CreateHeartbeatConfiguration;
+  const nodeMetadata = node.metadata as CreateHeartbeatNodeMetadata | undefined;
+  const items: MetadataItem[] = [];
+
+  const teamLabel = nodeMetadata?.teamName || configuration?.team;
+  if (teamLabel) {
+    items.push({ icon: "users", label: teamLabel });
+  }
+  if (configuration?.name) {
+    items.push({ icon: "activity", label: configuration.name });
+  }
+  if (configuration?.interval != null && configuration?.intervalUnit) {
+    items.push({ icon: "clock", label: `${configuration.interval} ${configuration.intervalUnit}` });
+  }
+
+  return items.slice(0, 3);
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/create_heartbeat.ts
@@ -55,6 +55,13 @@ export const createHeartbeatMapper: ComponentBaseMapper = {
     if (data.name != null) {
       details["Name"] = String(data.name);
     }
+    if (data.description != null) {
+      details["Description"] = String(data.description);
+    }
+    if (data.interval != null) {
+      const unit = data.intervalUnit != null ? ` ${data.intervalUnit}` : "";
+      details["Interval"] = `${data.interval}${unit}`;
+    }
     if (data.status != null) {
       details["Status"] = String(data.status);
     }

--- a/web_src/src/pages/workflowv2/mappers/jira/delete_heartbeat.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/delete_heartbeat.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { deleteHeartbeatMapper } from "./delete_heartbeat";
+import { eventStateRegistry } from "./index";
+
+function buildNode(): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Delete",
+    componentName: "jira.deleteHeartbeat",
+    isCollapsed: false,
+    configuration: { team: "team-1", heartbeat: "DNS Checker" },
+    metadata: {},
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("deleteHeartbeatMapper", () => {
+  it("getExecutionDetails includes deleted and name", () => {
+    const ctx: ExecutionDetailsContext = {
+      nodes: [buildNode()],
+      node: buildNode(),
+      execution: buildExecution({
+        outputs: {
+          default: [
+            {
+              type: "jira.heartbeat.deleted",
+              timestamp: new Date().toISOString(),
+              data: { deleted: true, name: "DNS Checker" },
+            },
+          ],
+        },
+      }),
+    };
+    const details = deleteHeartbeatMapper.getExecutionDetails!(ctx);
+    expect(details["Deleted"]).toBe("true");
+    expect(details["Name"]).toBe("DNS Checker");
+  });
+
+  it("event state registry maps success to deleted", () => {
+    expect(eventStateRegistry.deleteHeartbeat.getState(buildExecution({ result: "RESULT_PASSED" }))).toBe("deleted");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/delete_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/delete_heartbeat.ts
@@ -1,0 +1,79 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface DeleteHeartbeatConfiguration {
+  team?: string;
+  heartbeat?: string;
+}
+
+interface DeleteHeartbeatNodeMetadata {
+  teamName?: string;
+}
+
+export const deleteHeartbeatMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.deleteHeartbeat";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (data?.deleted === true) {
+      details["Deleted"] = "true";
+    }
+    if (data?.name != null) {
+      details["Name"] = String(data.name);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as DeleteHeartbeatConfiguration;
+  const nodeMetadata = node.metadata as DeleteHeartbeatNodeMetadata | undefined;
+  const items: MetadataItem[] = [];
+
+  const teamLabel = nodeMetadata?.teamName || configuration?.team;
+  if (teamLabel) {
+    items.push({ icon: "users", label: teamLabel });
+  }
+  if (configuration?.heartbeat) {
+    items.push({ icon: "activity", label: configuration.heartbeat });
+  }
+
+  return items;
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/index.ts
@@ -7,6 +7,10 @@ import { updateIssueMapper } from "./update_issue";
 import { createIncidentMapper } from "./create_incident";
 import { getIncidentMapper } from "./get_incident";
 import { deleteIncidentMapper } from "./delete_incident";
+import { createHeartbeatMapper } from "./create_heartbeat";
+import { pingHeartbeatMapper } from "./ping_heartbeat";
+import { updateHeartbeatMapper } from "./update_heartbeat";
+import { deleteHeartbeatMapper } from "./delete_heartbeat";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIssue: createIssueMapper,
@@ -16,6 +20,10 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createIncident: createIncidentMapper,
   getIncident: getIncidentMapper,
   deleteIncident: deleteIncidentMapper,
+  createHeartbeat: createHeartbeatMapper,
+  pingHeartbeat: pingHeartbeatMapper,
+  updateHeartbeat: updateHeartbeatMapper,
+  deleteHeartbeat: deleteHeartbeatMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {};
@@ -28,4 +36,8 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createIncident: buildActionStateRegistry("created"),
   getIncident: buildActionStateRegistry("fetched"),
   deleteIncident: buildActionStateRegistry("deleted"),
+  createHeartbeat: buildActionStateRegistry("created"),
+  pingHeartbeat: buildActionStateRegistry("pinged"),
+  updateHeartbeat: buildActionStateRegistry("updated"),
+  deleteHeartbeat: buildActionStateRegistry("deleted"),
 };

--- a/web_src/src/pages/workflowv2/mappers/jira/ping_heartbeat.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/ping_heartbeat.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { pingHeartbeatMapper } from "./ping_heartbeat";
+import { eventStateRegistry } from "./index";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Ping",
+    componentName: "jira.pingHeartbeat",
+    isCollapsed: false,
+    configuration: { team: "team-1", heartbeat: "DNS Checker" },
+    metadata: { teamName: "On-call" },
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("pingHeartbeatMapper", () => {
+  it("getExecutionDetails includes message", () => {
+    const ctx: ExecutionDetailsContext = {
+      nodes: [buildNode()],
+      node: buildNode(),
+      execution: buildExecution({
+        outputs: {
+          default: [
+            {
+              type: "jira.heartbeat.pinged",
+              timestamp: new Date().toISOString(),
+              data: { message: "PONG - Heartbeat received" },
+            },
+          ],
+        },
+      }),
+    };
+    expect(pingHeartbeatMapper.getExecutionDetails!(ctx)["Message"]).toBe("PONG - Heartbeat received");
+  });
+
+  it("event state registry maps success to pinged", () => {
+    expect(eventStateRegistry.pingHeartbeat.getState(buildExecution({ result: "RESULT_PASSED" }))).toBe("pinged");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/ping_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/ping_heartbeat.ts
@@ -1,0 +1,76 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface PingHeartbeatConfiguration {
+  team?: string;
+  heartbeat?: string;
+}
+
+interface PingHeartbeatNodeMetadata {
+  teamName?: string;
+}
+
+export const pingHeartbeatMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.pingHeartbeat";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (data?.message != null) {
+      details["Message"] = String(data.message);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as PingHeartbeatConfiguration;
+  const nodeMetadata = node.metadata as PingHeartbeatNodeMetadata | undefined;
+  const items: MetadataItem[] = [];
+
+  const teamLabel = nodeMetadata?.teamName || configuration?.team;
+  if (teamLabel) {
+    items.push({ icon: "users", label: teamLabel });
+  }
+  if (configuration?.heartbeat) {
+    items.push({ icon: "activity", label: configuration.heartbeat });
+  }
+
+  return items;
+}

--- a/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionInfo } from "../types";
+import { eventStateRegistry } from "./index";
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+describe("updateHeartbeatMapper registry", () => {
+  it("maps success to updated", () => {
+    expect(eventStateRegistry.updateHeartbeat.getState(buildExecution({ result: "RESULT_PASSED" }))).toBe("updated");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.ts
@@ -17,7 +17,23 @@ import { jiraBaseEventSections } from "./base";
 interface UpdateHeartbeatConfiguration {
   team?: string;
   heartbeat?: string;
+  description?: string | null;
+  interval?: number | null;
+  intervalUnit?: string | null;
+  enabled?: boolean | null;
+  alertMessage?: string | null;
+  alertTags?: unknown[] | null;
+  alertPriority?: string | null;
 }
+
+const FIELD_LABELS: Record<string, string> = {
+  description: "Description",
+  interval: "Interval",
+  enabled: "Enabled",
+  alertMessage: "Alert Message",
+  alertTags: "Alert Tags",
+  alertPriority: "Alert Priority",
+};
 
 interface UpdateHeartbeatNodeMetadata {
   teamName?: string;
@@ -53,6 +69,13 @@ export const updateHeartbeatMapper: ComponentBaseMapper = {
     if (data.name != null) {
       details["Name"] = String(data.name);
     }
+    if (data.description != null) {
+      details["Description"] = String(data.description);
+    }
+    if (data.interval != null) {
+      const unit = data.intervalUnit != null ? ` ${data.intervalUnit}` : "";
+      details["Interval"] = `${data.interval}${unit}`;
+    }
     if (data.status != null) {
       details["Status"] = String(data.status);
     }
@@ -78,5 +101,25 @@ function metadataList(node: NodeInfo): MetadataItem[] {
     items.push({ icon: "activity", label: configuration.heartbeat });
   }
 
+  const updated = listUpdatedFields(configuration);
+  if (updated.length > 0) {
+    items.push({ icon: "edit", label: `Updates: ${updated.join(", ")}` });
+  }
+
   return items;
+}
+
+function listUpdatedFields(configuration: UpdateHeartbeatConfiguration | undefined): string[] {
+  if (!configuration) return [];
+  const skip = new Set(["team", "heartbeat", "intervalUnit"]);
+  const updated: string[] = [];
+  (Object.keys(configuration) as (keyof UpdateHeartbeatConfiguration)[]).forEach((key) => {
+    if (skip.has(key)) return;
+    const value = configuration[key];
+    if (value === undefined || value === null) return;
+    if (typeof value === "string" && value.trim() === "") return;
+    if (Array.isArray(value) && value.length === 0) return;
+    updated.push(FIELD_LABELS[key] ?? key);
+  });
+  return updated;
 }

--- a/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.ts
+++ b/web_src/src/pages/workflowv2/mappers/jira/update_heartbeat.ts
@@ -1,0 +1,82 @@
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getStateMap } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import jiraIcon from "@/assets/icons/integrations/jira.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { jiraBaseEventSections } from "./base";
+
+interface UpdateHeartbeatConfiguration {
+  team?: string;
+  heartbeat?: string;
+}
+
+interface UpdateHeartbeatNodeMetadata {
+  teamName?: string;
+}
+
+export const updateHeartbeatMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "jira.updateHeartbeat";
+
+    return {
+      iconSrc: jiraIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? jiraBaseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+    const outputs = context.execution.outputs as { default?: Array<{ data?: unknown }> } | undefined;
+    const data = outputs?.default?.[0]?.data as Record<string, unknown> | undefined;
+    if (!data) {
+      return details;
+    }
+    if (data.name != null) {
+      details["Name"] = String(data.name);
+    }
+    if (data.status != null) {
+      details["Status"] = String(data.status);
+    }
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as UpdateHeartbeatConfiguration;
+  const nodeMetadata = node.metadata as UpdateHeartbeatNodeMetadata | undefined;
+  const items: MetadataItem[] = [];
+
+  const teamLabel = nodeMetadata?.teamName || configuration?.team;
+  if (teamLabel) {
+    items.push({ icon: "users", label: teamLabel });
+  }
+  if (configuration?.heartbeat) {
+    items.push({ icon: "activity", label: configuration.heartbeat });
+  }
+
+  return items;
+}


### PR DESCRIPTION
Resolves #4893

## What changed
Adds four Jira Service Management (JSM) Operations workflow components:

- **Create Heartbeat** — register a new heartbeat monitor (interval, alerts, etc.)
- **Ping Heartbeat** — report liveness for an existing heartbeat
- **Update Heartbeat** — change heartbeat settings (optional fields via toggles)
- **Delete Heartbeat** — remove a heartbeat from a team


## Why
Enable Superplane workflow to manage Jira Heartbeats that detects when scheduled jobs, cron tasks, or automated systems stop reporting in. If a heartbeat is not pinged within its expected interval, Jira Service Management raises an alert.

## How
### Backend:
Implemented new client methods in pkg/integrations/jira/client.go for heartbeat endpoints.
Registered actions in pkg/integrations/jira/jira.go and updated token permission guidance.
Added tests

### Frontend:
Added Jira workflow v2 mappers
Registered mappers and event states in web_src/src/pages/workflowv2/mappers/jira/index.ts
Added mapper specs

## Demo
[Screencast From 2026-05-20 03-40-16.webm](https://github.com/user-attachments/assets/e955a25b-4c87-416a-a554-040d9a5c140c)
