### PR TITLE
feat: add support for HEAD HTTP method in Core component

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -489,7 +489,11 @@ The HTTP component allows you to make HTTP requests to external APIs and service
 
 ### Supported Methods
 
-- GET, POST, PUT, DELETE, PATCH
+- GET, POST, PUT, DELETE, PATCH, HEAD
+
+HEAD requests do not send a body and the response body is empty by design.
+Use HEAD for health checks, URL validation, or to inspect response headers
+and status without downloading the full response payload.
 
 ### Request Configuration
 

--- a/pkg/components/http/http.go
+++ b/pkg/components/http/http.go
@@ -143,7 +143,11 @@ func (e *HTTP) Documentation() string {
 
 ## Supported Methods
 
-- GET, POST, PUT, DELETE, PATCH
+- GET, POST, PUT, DELETE, PATCH, HEAD
+
+HEAD requests do not send a body and the response body is empty by design.
+Use HEAD for health checks, URL validation, or to inspect response headers
+and status without downloading the full response payload.
 
 ## Request Configuration
 
@@ -345,6 +349,7 @@ func (e *HTTP) Configuration() []configuration.Field {
 						{Label: "PUT", Value: "PUT"},
 						{Label: "DELETE", Value: "DELETE"},
 						{Label: "PATCH", Value: "PATCH"},
+						{Label: "HEAD", Value: "HEAD"},
 					},
 				},
 			},

--- a/pkg/components/http/http_test.go
+++ b/pkg/components/http/http_test.go
@@ -438,6 +438,46 @@ func TestHTTP__Execute__GET(t *testing.T) {
 	assert.Equal(t, "world", body["hello"])
 }
 
+func TestHTTP__Execute__HEAD(t *testing.T) {
+	h := &HTTP{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "HEAD", r.Method)
+		assert.Equal(t, "/health", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Empty(t, body)
+
+		w.Header().Set("X-Custom", "ok")
+		w.Header().Set("Content-Length", "42")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, stateCtx, _ := createExecutionContext(map[string]any{
+		"method": "HEAD",
+		"url":    server.URL + "/health",
+	})
+
+	err := h.Execute(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, stateCtx.Passed)
+	assert.True(t, stateCtx.Finished)
+	assert.Equal(t, SuccessOutputChannel, stateCtx.Channel)
+	assert.Equal(t, "http.request.finished", stateCtx.Type)
+
+	response := responsePayload(t, stateCtx)
+	assert.Equal(t, http.StatusOK, response["status"])
+	assert.Nil(t, response["body"])
+
+	headers, ok := response["headers"].(http.Header)
+	require.True(t, ok)
+	assert.Equal(t, "ok", headers.Get("X-Custom"))
+	assert.Equal(t, "42", headers.Get("Content-Length"))
+}
+
 func TestHTTP__Execute__SetsAuthorizationFromSecret(t *testing.T) {
 	h := &HTTP{}
 	var gotAuth string


### PR DESCRIPTION
Closes: https://github.com/superplanehq/superplane/issues/4866

This update introduces the HEAD method to the HTTP component, allowing users to make requests that do not return a body. The HEAD method is useful for health checks, URL validation, and inspecting response headers without downloading the full response payload.