### PR TITLE
chore: restore minimal gray styling and simplify mode toggle in agent ui

### DIFF
--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -1,8 +1,8 @@
-import { Loader2, Send } from "lucide-react";
+import { ArrowUp, Loader2, Square } from "lucide-react";
 import { useCallback, useState } from "react";
-// import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import type { AgentMode } from "./agentMode";
 import { ModeToggle } from "./ModeToggle";
 
@@ -11,7 +11,7 @@ export function ChatComposer({
   onStop,
   sending,
   stopping,
-  statusLabel: _statusLabel,
+  statusLabel,
   agentMode,
   onModeSwitch,
   modeDisabled,
@@ -26,6 +26,7 @@ export function ChatComposer({
   modeDisabled?: boolean;
 }) {
   const [draft, setDraft] = useState("");
+  const canSend = Boolean(draft.trim()) && !sending;
 
   const handleSend = useCallback(async () => {
     const content = draft.trim();
@@ -41,49 +42,67 @@ export function ChatComposer({
   }, [draft, onSend]);
 
   return (
-    <footer className="border-t border-border p-3 flex flex-col gap-2">
+    <footer className="border-t border-slate-950/15 px-3 pb-3">
       <Textarea
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
-        rows={3}
+        rows={1}
         placeholder="Ask the agent…"
         data-testid="agent-input"
-        className="resize-none"
+        className={cn(
+          "min-h-9 w-full resize-none border-0 bg-transparent px-0 py-2 text-sm shadow-none",
+          "outline-none ring-0 focus-visible:border-0 focus-visible:ring-0 focus-visible:outline-none",
+          "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "text-[rgba(10,10,10,1)] dark:bg-transparent",
+        )}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            if (draft.trim()) {
-              void handleSend();
-            }
-          }
+          if (e.key !== "Enter") return;
+          const nativeEvent = e.nativeEvent;
+          if ("isComposing" in nativeEvent && nativeEvent.isComposing) return;
+          if (e.shiftKey) return;
+          e.preventDefault();
+          if (!canSend) return;
+          void handleSend();
         }}
       />
-      <div className="flex items-center justify-between">
-        <ModeToggle mode={agentMode} onSwitch={onModeSwitch} disabled={modeDisabled} streaming={sending} />
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{statusLabel}</span>
+        <div className="flex shrink-0 items-center gap-1.5">
           {sending && (
             <Button
               type="button"
-              variant="destructive"
+              variant="outline"
               size="icon"
+              className="size-7 shrink-0 rounded-full border-slate-300 bg-white text-slate-700 hover:bg-slate-100"
               onClick={onStop}
               disabled={stopping}
-              data-testid="agent-stop-button"
+              aria-label={stopping ? "Stopping" : "Stop"}
               title={stopping ? "Stopping..." : "Stop"}
+              data-testid="agent-stop-button"
             >
-              {stopping ? <Loader2 className="size-3 animate-spin" /> : <div className="size-3 rounded-sm bg-white" />}
+              {stopping ? (
+                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              ) : (
+                <Square className="size-3 fill-current" aria-hidden />
+              )}
             </Button>
           )}
           <Button
             type="button"
+            variant="default"
+            size="icon"
+            className="size-7 shrink-0 rounded-full"
             onClick={() => void handleSend()}
-            disabled={!draft.trim()}
+            disabled={!canSend}
+            aria-label="Send message"
             data-testid="agent-send-message-button"
           >
-            <Send className="size-4" />
-            Send
+            <ArrowUp className="size-3.5" aria-hidden />
           </Button>
         </div>
+      </div>
+      <div className="flex items-center pt-1.5">
+        <ModeToggle mode={agentMode} onSwitch={onModeSwitch} disabled={modeDisabled} streaming={sending} />
       </div>
     </footer>
   );

--- a/web_src/src/components/AgentSidebar/ModeToggle.tsx
+++ b/web_src/src/components/AgentSidebar/ModeToggle.tsx
@@ -1,4 +1,5 @@
 import { Compass, Hammer, Monitor } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { AgentMode } from "./agentMode";
 
@@ -6,25 +7,21 @@ const modeConfig = {
   builder: {
     icon: Hammer,
     label: "Build",
-    activeText: "text-orange-700",
-    activeBg: "bg-orange-50 border-orange-300",
-    activeShadow: "shadow-sm shadow-orange-100",
+    description: "Build mode — make changes to the canvas",
   },
   architect: {
     icon: Compass,
     label: "Plan",
-    activeText: "text-blue-700",
-    activeBg: "bg-blue-50 border-blue-300",
-    activeShadow: "shadow-sm shadow-blue-100",
+    description: "Plan mode — design before building",
   },
   operator: {
     icon: Monitor,
     label: "Ask",
-    activeText: "text-emerald-700",
-    activeBg: "bg-emerald-50 border-emerald-300",
-    activeShadow: "shadow-sm shadow-emerald-100",
+    description: "Ask mode — read-only questions and diagnostics",
   },
 } as const;
+
+const VISIBLE_MODES: AgentMode[] = ["builder", "operator"];
 
 export function ModeToggle({
   mode,
@@ -37,34 +34,43 @@ export function ModeToggle({
   disabled?: boolean;
   streaming?: boolean;
 }) {
+  const activeLabel = modeConfig[mode].label;
+
   return (
-    <div className="flex items-center bg-slate-100 rounded-md p-0.5 gap-0.5" data-testid="agent-mode-toggle">
-      {(Object.keys(modeConfig) as AgentMode[]).map((key) => {
-        const config = modeConfig[key];
-        const Icon = config.icon;
-        const isActive = mode === key;
-        return (
-          <button
-            key={key}
-            type="button"
-            onClick={() => onSwitch(key)}
-            disabled={disabled || streaming}
-            className={cn(
-              "flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-all border border-transparent",
-              isActive
-                ? cn(config.activeText, config.activeBg, config.activeShadow)
-                : "text-slate-500 hover:text-slate-700",
-              (disabled || streaming) && !isActive && "opacity-40 cursor-not-allowed",
-              isActive && streaming && "animate-pulse-border",
-            )}
-            aria-label={`${config.label} mode`}
-            data-testid={`agent-mode-${key}`}
-          >
-            <Icon size={12} />
-            {config.label}
-          </button>
-        );
-      })}
+    <div className="flex items-center gap-1.5" data-testid="agent-mode-toggle">
+      <div className="flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5">
+        {VISIBLE_MODES.map((key) => {
+          const config = modeConfig[key];
+          const Icon = config.icon;
+          const isActive = mode === key;
+          return (
+            <Tooltip key={key}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => onSwitch(key)}
+                  disabled={disabled || streaming}
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded transition-colors",
+                    isActive
+                      ? "bg-white text-slate-900 shadow-sm"
+                      : "text-slate-500 hover:text-slate-700",
+                    (disabled || streaming) && !isActive && "cursor-not-allowed opacity-40",
+                    isActive && streaming && "animate-pulse-border",
+                  )}
+                  aria-label={`${config.label} mode`}
+                  aria-pressed={isActive}
+                  data-testid={`agent-mode-${key}`}
+                >
+                  <Icon size={12} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{config.description}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+      <span className="text-xs font-medium text-slate-600">{activeLabel}</span>
     </div>
   );
 }

--- a/web_src/src/components/AgentSidebar/ModeToggle.tsx
+++ b/web_src/src/components/AgentSidebar/ModeToggle.tsx
@@ -1,7 +1,7 @@
 import { Compass, Hammer, Monitor } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { AgentMode } from "./agentMode";
+import { VISIBLE_AGENT_MODES, type AgentMode } from "./agentMode";
 
 const modeConfig = {
   builder: {
@@ -21,8 +21,6 @@ const modeConfig = {
   },
 } as const;
 
-const VISIBLE_MODES: AgentMode[] = ["builder", "operator"];
-
 export function ModeToggle({
   mode,
   onSwitch,
@@ -39,7 +37,7 @@ export function ModeToggle({
   return (
     <div className="flex items-center gap-1.5" data-testid="agent-mode-toggle">
       <div className="flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5">
-        {VISIBLE_MODES.map((key) => {
+        {VISIBLE_AGENT_MODES.map((key) => {
           const config = modeConfig[key];
           const Icon = config.icon;
           const isActive = mode === key;
@@ -52,9 +50,7 @@ export function ModeToggle({
                   disabled={disabled || streaming}
                   className={cn(
                     "flex h-6 w-6 items-center justify-center rounded transition-colors",
-                    isActive
-                      ? "bg-white text-slate-900 shadow-sm"
-                      : "text-slate-500 hover:text-slate-700",
+                    isActive ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700",
                     (disabled || streaming) && !isActive && "cursor-not-allowed opacity-40",
                     isActive && streaming && "animate-pulse-border",
                   )}

--- a/web_src/src/components/AgentSidebar/agentMode.ts
+++ b/web_src/src/components/AgentSidebar/agentMode.ts
@@ -2,14 +2,20 @@ export type AgentMode = "builder" | "operator" | "architect";
 
 const CANVAS_AGENT_MODE_STORAGE_KEY = "canvasAgentMode";
 
+export const VISIBLE_AGENT_MODES: AgentMode[] = ["builder", "operator"];
+const DEFAULT_AGENT_MODE: AgentMode = "operator";
+
+function isVisibleMode(value: unknown): value is AgentMode {
+  return typeof value === "string" && (VISIBLE_AGENT_MODES as string[]).includes(value);
+}
+
 export function readInitialAgentMode(): AgentMode {
-  if (typeof window === "undefined") return "operator";
+  if (typeof window === "undefined") return DEFAULT_AGENT_MODE;
   try {
     const stored = window.localStorage.getItem(CANVAS_AGENT_MODE_STORAGE_KEY);
-    if (stored === "builder" || stored === "architect") return stored;
-    return "operator";
+    return isVisibleMode(stored) ? stored : DEFAULT_AGENT_MODE;
   } catch {
-    return "operator";
+    return DEFAULT_AGENT_MODE;
   }
 }
 

--- a/web_src/src/components/AgentSidebar/widgets/ButtonsWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/ButtonsWidget.tsx
@@ -8,10 +8,10 @@ interface ButtonsWidgetProps {
 
 export function ButtonsWidget({ prompt, items, onAction }: ButtonsWidgetProps) {
   return (
-    <div className="my-4 rounded-lg border border-violet-200 bg-white shadow-sm overflow-hidden">
+    <div className="my-4 rounded-lg border border-slate-200 bg-white shadow-sm overflow-hidden">
       {prompt && (
-        <div className="px-3 py-2 bg-violet-50 border-b border-violet-200">
-          <p className="text-xs font-medium text-violet-900">{prompt}</p>
+        <div className="px-3 py-2 bg-slate-50 border-b border-slate-200">
+          <p className="text-xs font-medium text-slate-900">{prompt}</p>
         </div>
       )}
       <div className="p-2 flex flex-col gap-1.5 overflow-x-auto">
@@ -20,10 +20,10 @@ export function ButtonsWidget({ prompt, items, onAction }: ButtonsWidgetProps) {
             key={item}
             variant="ghost"
             size="sm"
-            className="justify-start text-xs text-slate-700 hover:bg-violet-50 hover:text-violet-900 h-auto py-2 px-3 text-left whitespace-normal"
+            className="justify-start text-xs text-slate-700 hover:bg-slate-50 hover:text-slate-900 h-auto py-2 px-3 text-left whitespace-normal"
             onClick={() => onAction?.(item)}
           >
-            <span className="inline-flex items-center justify-center size-5 rounded bg-violet-100 text-violet-700 text-[10px] font-semibold mr-2 shrink-0">
+            <span className="inline-flex items-center justify-center size-5 rounded bg-slate-100 text-slate-700 text-[10px] font-semibold mr-2 shrink-0">
               {String.fromCharCode(65 + i)}
             </span>
             {item}

--- a/web_src/src/components/AgentSidebar/widgets/ChartWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/ChartWidget.tsx
@@ -60,7 +60,7 @@ function XYChartWidget({ config }: { config: ChartConfig }) {
   const ChartComponent = type === "bar" ? BarChart : type === "area" ? AreaChart : LineChart;
 
   return (
-    <div className="my-4 rounded-lg border border-violet-200 bg-white p-3 shadow-sm">
+    <div className="my-4 rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
       {title && <p className="text-xs font-medium text-slate-700 mb-2">{title}</p>}
       <ChartContainer config={chartConfig} className="h-[200px] w-full">
         <ChartComponent data={data} margin={{ top: 5, right: 5, left: -10, bottom: 5 }}>
@@ -119,7 +119,7 @@ function PieChartWidget({ config }: { config: ChartConfig }) {
   });
 
   return (
-    <div className="my-4 rounded-lg border border-violet-200 bg-white p-3 shadow-sm">
+    <div className="my-4 rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
       {title && <p className="text-xs font-medium text-slate-700 mb-2">{title}</p>}
       <ChartContainer config={chartConfig} className="h-[200px] w-full">
         <PieChart>

--- a/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.tsx
@@ -1,7 +1,6 @@
 import { Eye, Rocket, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 export interface DraftActionsWidgetProps {
   versionId: string;
@@ -85,7 +84,7 @@ export function DraftActionsWidget({
         size="sm"
         onClick={handlePublish}
         disabled={busy !== null}
-        className={cn("text-xs h-7 gap-1 bg-violet-600 hover:bg-violet-700")}
+        className="text-xs h-7 gap-1"
       >
         <Rocket size={12} />
         {busy === "publish" ? "Publishing..." : "Publish"}

--- a/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/MermaidWidget.tsx
@@ -84,7 +84,7 @@ export function MermaidWidget({ content }: MermaidWidgetProps) {
       <div
         ref={containerRef}
         onClick={() => setExpanded(true)}
-        className="my-4 rounded-lg border border-violet-200 bg-white p-3 shadow-sm overflow-x-auto cursor-pointer hover:border-violet-300 transition-colors [&_svg]:max-w-full [&_svg]:h-auto [&_svg]:mx-auto"
+        className="my-4 rounded-lg border border-slate-200 bg-white p-3 shadow-sm overflow-x-auto cursor-pointer hover:border-slate-300 transition-colors [&_svg]:max-w-full [&_svg]:h-auto [&_svg]:mx-auto"
       >
         <div className="pointer-events-none" dangerouslySetInnerHTML={{ __html: svg }} />
       </div>

--- a/web_src/src/components/AgentSidebar/widgets/OutcomeProgressWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/OutcomeProgressWidget.tsx
@@ -152,7 +152,7 @@ function RubricSummary({
       <button
         type="button"
         onClick={onOpenRubric}
-        className="text-[10px] font-medium text-violet-600 hover:text-violet-800"
+        className="text-[10px] font-medium text-slate-600 hover:text-slate-800"
       >
         View rubric
       </button>
@@ -233,7 +233,7 @@ function RubricModal({ open, state, onClose }: { open: boolean; state: OutcomeSt
     <CenteredModal
       title={state.title}
       onClose={onClose}
-      titleIcon={<ClipboardList size={16} className="text-violet-600" />}
+      titleIcon={<ClipboardList size={16} className="text-slate-600" />}
     >
       {state.categories && state.categories.length > 0 ? (
         <CategorizedCriteriaList categories={state.categories} />
@@ -303,11 +303,11 @@ function CategorizedCriteriaList({ categories }: { categories: RubricCategory[] 
     <div className="space-y-3">
       {categories.map((category, categoryIndex) => (
         <div key={categoryIndex}>
-          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-violet-600">{category.heading}</p>
+          <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500">{category.heading}</p>
           {category.criteria.map((criterion, criterionIndex) => (
             <CriteriaRow
               key={criterionIndex}
-              prefix={<span className="mt-0.5 shrink-0 text-xs text-violet-400">✦</span>}
+              prefix={<span className="mt-0.5 shrink-0 text-xs text-slate-400">✦</span>}
             >
               <span className="text-sm text-slate-700">{criterion.text}</span>
             </CriteriaRow>
@@ -325,7 +325,7 @@ function FlatCriteriaList({ criteria }: { criteria: OutcomeState["criteria"] }) 
         <CriteriaRow
           key={index}
           bordered
-          prefix={<span className="mt-0.5 shrink-0 text-sm font-medium text-violet-500">{index + 1}.</span>}
+          prefix={<span className="mt-0.5 shrink-0 text-sm font-medium text-slate-500">{index + 1}.</span>}
         >
           <span className="text-sm text-slate-700">{criterion.text}</span>
         </CriteriaRow>

--- a/web_src/src/components/AgentSidebar/widgets/RichMessage.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RichMessage.tsx
@@ -33,7 +33,7 @@ const MARKDOWN_CLASSES =
   "[&_th]:border-b [&_th]:border-slate-200 " +
   "[&_td]:px-3 [&_td]:py-1.5 [&_td]:text-slate-600 [&_td]:border-b [&_td]:border-slate-100 " +
   "[&_tbody_tr:nth-child(even)]:bg-slate-50/60 " +
-  "[&_tr:last-child_td]:border-b-0 [&_tr:hover]:bg-violet-50/50";
+  "[&_tr:last-child_td]:border-b-0 [&_tr:hover]:bg-slate-50/50";
 
 type StartBuildingRubric = {
   title: string;
@@ -141,7 +141,7 @@ function MarkdownSegment({
           code: MarkdownCode,
           pre: ({ children }) => <>{children}</>,
           table: ({ children, ...props }) => (
-            <div className="my-4 overflow-x-auto rounded-lg border border-violet-200 bg-white shadow-sm">
+            <div className="my-4 overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm">
               <table {...props}>{children}</table>
             </div>
           ),

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
@@ -57,12 +57,12 @@ export function RubricWidget({ title, criteria, categories, onAction, onStartBui
 
   return (
     <>
-      <div className="my-4 rounded-lg border border-violet-200 bg-white shadow-sm overflow-hidden">
+      <div className="my-4 rounded-lg border border-slate-200 bg-white shadow-sm overflow-hidden">
         {/* Header */}
-        <div className="px-3 py-2 bg-violet-50 border-b border-violet-200 flex items-center gap-2">
-          <ClipboardList size={14} className="text-violet-600 shrink-0" />
-          <p className="text-xs font-semibold text-violet-900 flex-1">{rubricTitle}</p>
-          <span className="text-[10px] text-violet-500 font-medium">
+        <div className="px-3 py-2 bg-slate-50 border-b border-slate-200 flex items-center gap-2">
+          <ClipboardList size={14} className="text-slate-600 shrink-0" />
+          <p className="text-xs font-semibold text-slate-900 flex-1">{rubricTitle}</p>
+          <span className="text-[10px] text-slate-500 font-medium">
             {hasCategories ? `${categories.length} sections · ` : ""}
             {totalCriteria} criteria
           </span>
@@ -81,13 +81,13 @@ export function RubricWidget({ title, criteria, categories, onAction, onStartBui
         />
 
         {/* Actions */}
-        <div className="px-3 pb-3 pt-1 flex items-center gap-2 border-t border-violet-100">
+        <div className="px-3 pb-3 pt-1 flex items-center gap-2 border-t border-slate-100">
           <Button variant="ghost" size="sm" className="text-xs text-slate-500 h-7" onClick={openModal}>
             View Full Plan
           </Button>
           <Button
             size="sm"
-            className="text-xs h-7 bg-violet-600 hover:bg-violet-700 text-white ml-auto"
+            className="text-xs h-7 ml-auto"
             onClick={handleStartBuilding}
           >
             Start Building →
@@ -131,7 +131,7 @@ function RubricPreview({
   return (
     <div className="px-3 py-2">
       {hasCategories && !expanded ? (
-        <p className="text-[10px] font-semibold text-violet-600 uppercase tracking-wide mb-1">
+        <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">
           {categories?.[0]?.heading}
         </p>
       ) : null}
@@ -172,7 +172,7 @@ function RubricModal({
       <div className="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[80vh] flex flex-col mx-4">
         <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
           <div className="flex items-center gap-2">
-            <ClipboardList size={16} className="text-violet-600" />
+            <ClipboardList size={16} className="text-slate-600" />
             <h2 className="text-sm font-semibold text-slate-900">{title}</h2>
           </div>
           <button type="button" onClick={onClose} className="text-slate-400 hover:text-slate-600">
@@ -209,7 +209,7 @@ function PreviewToggleButton({
     <button
       type="button"
       onClick={onClick}
-      className="flex items-center gap-1 text-[10px] text-violet-500 hover:text-violet-700 mt-1"
+      className="flex items-center gap-1 text-[10px] text-slate-500 hover:text-slate-700 mt-1"
     >
       {direction === "down" ? <ChevronDown size={10} /> : <ChevronUp size={10} />}
       {children}
@@ -220,7 +220,7 @@ function PreviewToggleButton({
 function FlatCriteriaList({ criteria }: { criteria: RubricCriterion[] }) {
   return criteria.map((criterion, index) => (
     <div key={index} className="flex items-start gap-2 py-0.5">
-      <span className="text-violet-400 text-xs mt-0.5 shrink-0">✦</span>
+      <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
       <span className="text-xs text-slate-700">{criterion.text}</span>
     </div>
   ));
@@ -229,7 +229,7 @@ function FlatCriteriaList({ criteria }: { criteria: RubricCriterion[] }) {
 function NumberedCriteriaList({ criteria }: { criteria: RubricCriterion[] }) {
   return criteria.map((criterion, index) => (
     <div key={index} className="flex items-start gap-2 py-1.5 border-b border-slate-50 last:border-0">
-      <span className="text-violet-500 text-sm mt-0.5 shrink-0 font-medium">{index + 1}.</span>
+      <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{index + 1}.</span>
       <span className="text-sm text-slate-700">{criterion.text}</span>
     </div>
   ));
@@ -241,7 +241,7 @@ function CategorizedList({ categories, showNumbers }: { categories: RubricCatego
     <div className="space-y-3">
       {categories.map((cat, ci) => (
         <div key={ci}>
-          <p className="text-[10px] font-semibold text-violet-600 uppercase tracking-wide mb-1">{cat.heading}</p>
+          <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">{cat.heading}</p>
           {cat.criteria.map((c, i) => {
             globalIndex++;
             return (
@@ -250,9 +250,9 @@ function CategorizedList({ categories, showNumbers }: { categories: RubricCatego
                 className={`flex items-start gap-2 ${showNumbers ? "py-1.5 border-b border-slate-50 last:border-0" : "py-0.5"}`}
               >
                 {showNumbers ? (
-                  <span className="text-violet-500 text-sm mt-0.5 shrink-0 font-medium">{globalIndex}.</span>
+                  <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{globalIndex}.</span>
                 ) : (
-                  <span className="text-violet-400 text-xs mt-0.5 shrink-0">✦</span>
+                  <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
                 )}
                 <span className={`${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>{c.text}</span>
               </div>

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
@@ -85,11 +85,7 @@ export function RubricWidget({ title, criteria, categories, onAction, onStartBui
           <Button variant="ghost" size="sm" className="text-xs text-slate-500 h-7" onClick={openModal}>
             View Full Plan
           </Button>
-          <Button
-            size="sm"
-            className="text-xs h-7 ml-auto"
-            onClick={handleStartBuilding}
-          >
+          <Button size="sm" className="text-xs h-7 ml-auto" onClick={handleStartBuilding}>
             Start Building →
           </Button>
         </div>

--- a/web_src/src/components/AgentSidebar/widgets/StepsWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/StepsWidget.tsx
@@ -10,7 +10,7 @@ export function StepsWidget({ items }: StepsWidgetProps) {
   const firstPending = items.findIndex((i) => !i.done);
 
   return (
-    <div className="my-4 space-y-1 rounded-lg border border-violet-200 bg-white p-3 shadow-sm">
+    <div className="my-4 space-y-1 rounded-lg border border-slate-200 bg-white p-3 shadow-sm">
       {items.map((item, i) => {
         const isActive = i === firstPending;
         return (
@@ -18,7 +18,7 @@ export function StepsWidget({ items }: StepsWidgetProps) {
             {item.done ? (
               <Check className="size-3.5 text-green-600 shrink-0" />
             ) : isActive ? (
-              <Loader2 className="size-3.5 text-violet-600 shrink-0 animate-spin" />
+              <Loader2 className="size-3.5 text-slate-600 shrink-0 animate-spin" />
             ) : (
               <div className="size-3.5 rounded-full border border-slate-300 shrink-0" />
             )}

--- a/web_src/src/components/AgentSidebar/widgets/SurveyWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/SurveyWidget.tsx
@@ -77,11 +77,11 @@ export function SurveyWidget({ questions, onAction }: SurveyWidgetProps) {
   const isLast = currentIndex === questions.length - 1;
 
   return (
-    <div className="my-4 rounded-lg border border-violet-200 bg-white shadow-sm overflow-hidden">
+    <div className="my-4 rounded-lg border border-slate-200 bg-white shadow-sm overflow-hidden">
       {/* Header */}
-      <div className="px-3 py-2 bg-violet-50 border-b border-violet-200 flex items-center justify-between">
-        <p className="text-xs font-medium text-violet-900">{current.prompt}</p>
-        <span className="text-[10px] text-violet-500 font-medium">
+      <div className="px-3 py-2 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
+        <p className="text-xs font-medium text-slate-900">{current.prompt}</p>
+        <span className="text-[10px] text-slate-500 font-medium">
           {currentIndex + 1}/{questions.length}
         </span>
       </div>
@@ -117,8 +117,8 @@ export function SurveyWidget({ questions, onAction }: SurveyWidgetProps) {
               className={cn(
                 "flex-1 text-xs px-3 py-2 rounded border transition-colors outline-none",
                 customInputs[currentIndex] && answers[currentIndex] === customInputs[currentIndex].trim()
-                  ? "border-violet-300 bg-violet-50 ring-1 ring-violet-300"
-                  : "border-slate-200 bg-white focus:border-violet-300",
+                  ? "border-slate-400 bg-slate-50 ring-1 ring-slate-300"
+                  : "border-slate-200 bg-white focus:border-slate-400",
               )}
             />
           </div>
@@ -184,7 +184,7 @@ function SurveyStepDot({
       onClick={handleClick}
       className={cn(
         "size-2 rounded-full transition-colors",
-        isActive ? "bg-violet-600" : isAnswered ? "bg-violet-300" : "bg-slate-200",
+        isActive ? "bg-slate-700" : isAnswered ? "bg-slate-400" : "bg-slate-200",
       )}
       aria-label={`Question ${index + 1}`}
     />
@@ -213,12 +213,12 @@ function SurveyOptionButton({
       className={cn(
         "justify-start text-xs h-auto py-2 px-3 text-left whitespace-normal",
         selected
-          ? "bg-violet-100 text-violet-900 ring-1 ring-violet-300"
-          : "text-slate-700 hover:bg-violet-50 hover:text-violet-900",
+          ? "bg-slate-100 text-slate-900 ring-1 ring-slate-300"
+          : "text-slate-700 hover:bg-slate-50 hover:text-slate-900",
       )}
       onClick={handleClick}
     >
-      <span className="inline-flex items-center justify-center size-5 rounded bg-violet-100 text-violet-700 text-[10px] font-semibold mr-2 shrink-0">
+      <span className="inline-flex items-center justify-center size-5 rounded bg-slate-100 text-slate-700 text-[10px] font-semibold mr-2 shrink-0">
         {String.fromCharCode(65 + index)}
       </span>
       {option}
@@ -247,7 +247,7 @@ function SurveyNavigation({
       </Button>
 
       {isLast ? (
-        <Button size="sm" className="text-xs h-7 bg-violet-600 hover:bg-violet-700 text-white" onClick={onSubmit}>
+        <Button size="sm" className="text-xs h-7" onClick={onSubmit}>
           Continue →
         </Button>
       ) : (

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -135,8 +135,10 @@ const MessageRow = memo(function MessageRow({
     <div className={cn("flex flex-col", isUser ? "items-end" : "items-start")}>
       <div
         className={cn(
-          "max-w-[85%] break-words rounded-lg px-3 py-2 text-sm",
-          isUser ? "bg-violet-600 text-white whitespace-pre-wrap" : "bg-slate-100 text-slate-900",
+          "break-words text-sm",
+          isUser
+            ? "max-w-[85%] rounded-lg bg-slate-100 px-3 py-2 whitespace-pre-wrap text-slate-900"
+            : "max-w-[720px] text-slate-900",
         )}
         data-testid={isUser ? "agent-user-message" : "agent-assistant-message"}
       >

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -333,7 +333,7 @@ function DraftActionsBar({
   if (!latestDraft) return null;
 
   return (
-    <div className="border-t border-violet-200 bg-violet-50/80 px-3 py-2">
+    <div className="border-t border-slate-200 bg-slate-50/80 px-3 py-2">
       <DraftActionsWidget
         versionId={latestDraft.versionId}
         message={latestDraft.message}

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -130,7 +130,7 @@ export function isOutcomeActive(outcomeState: OutcomeState | null): boolean {
 export function statusLabel(status: string): string {
   switch (status) {
     case "streaming":
-      return "Agent is working...";
+      return "Agent is running...";
     case "failed":
       return "Last turn failed";
     case "terminated":

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -222,7 +222,7 @@ describe("CanvasToolSidebar", () => {
 
     const input = await screen.findByTestId("agent-input");
     await user.type(input, "first");
-    await user.click(screen.getByRole("button", { name: "Send" }));
+    await user.click(screen.getByTestId("agent-send-message-button"));
 
     // While the first send is still pending, user can type a new message.
     await user.type(input, "second");


### PR DESCRIPTION
## Summary

  After PR #4823 added agent modes, stop action, and outcome
  widgets, the Agent
  sidebar drifted away from the minimal gray design established in
  PR #4816.
  This PR restores that styling while preserving the new
  functionality.

  ## Changes

  ### Composer
  - Borderless textarea, single thin slate footer border (matches
  #4816)
  - Circular `size-7` send button with `ArrowUp` icon (no "Send"
  label)
  - New stop button with matching shape — outlined circle with a
  filled square
    icon — sits next to the send button only while the agent is
  working
  - Status label (`Ready` / `Agent is working...`) restored on the
  top-left
  - Mode toggle moved to its own row below the status/send row

  ### Mode toggle
  - Reduced to icon-only segmented control with tooltips
  - Only the active mode's label is rendered (to the right of the
  icons)
  - Active state uses neutral `bg-white` / `shadow-sm` instead of
  per-mode
    orange/blue/emerald accents
  - `Plan` mode hidden from the UI (kept in code and backend for
  now); visible
    order is `[Build][Ask]`

  ### Color cleanup
  Replaced `violet-*` with neutral `slate-*` across:
  - `AgentConversationTranscript` — user bubble back to
  `bg-slate-100`,
    assistant message rendered as plain text (no bubble)
  - `AgentTabPanel` draft-actions bar background
  variant now)
    order is `[Build][Ask]`

  ### Color cleanup
  Replaced `violet-*` with neutral `slate-*` across:
  - `AgentConversationTranscript` — user bubble back to `bg-slate-100`,
    assistant message rendered as plain text (no bubble)
  - `AgentTabPanel` draft-actions bar background
  - `DraftActionsWidget` publish button (uses default Button variant now)
  - `RubricWidget`, `SurveyWidget`, `ButtonsWidget`, `StepsWidget`,
    `MermaidWidget`, `ChartWidget`, `OutcomeProgressWidget`, `RichMessage`

  No functional changes
  
  
<img width="1058" height="1478" alt="image" src="https://github.com/user-attachments/assets/7a83b117-4a7b-4c58-a655-87f190d1df42" />
