### PR TITLE
fix: restore canvas header polish from #4816

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.tsx
+++ b/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.tsx
@@ -1,46 +1,37 @@
-import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function ToolTabsHeader({
   tabs,
   activeTab,
   onSelectTab,
-  onClose,
 }: {
   tabs: ReadonlyArray<{ value: string; label: string }>;
   activeTab: string;
   onSelectTab: (value: string) => void;
-  onClose: () => void;
 }) {
   return (
-    <div className="flex h-10 min-h-10 shrink-0 items-center border-b border-slate-950/15 px-4">
-      <div className="flex min-w-0 flex-1 flex-row items-stretch" role="tablist" aria-label="Canvas tools">
-        {tabs.map(({ value, label }) => (
-          <button
-            key={value}
-            type="button"
-            role="tab"
-            aria-selected={activeTab === value}
-            onClick={() => onSelectTab(value)}
-            className={cn(
-              "mr-4 mb-[-1px] flex items-center border-b text-[13px] font-medium transition-colors",
-              activeTab === value
-                ? "border-gray-700 text-gray-800 dark:border-blue-600 dark:text-blue-400"
-                : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300",
-            )}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close sidebar"
-        className="ml-2 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
-      >
-        <X className="size-4" />
-      </button>
+    <div
+      className="flex h-10 min-h-10 shrink-0 flex-row items-stretch border-b border-slate-950/15 px-4"
+      role="tablist"
+      aria-label="Canvas tools"
+    >
+      {tabs.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          role="tab"
+          aria-selected={activeTab === value}
+          onClick={() => onSelectTab(value)}
+          className={cn(
+            "mr-4 mb-[-1px] flex items-center border-b text-[13px] font-medium transition-colors",
+            activeTab === value
+              ? "border-gray-700 text-gray-800 dark:border-blue-600 dark:text-blue-400"
+              : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300",
+          )}
+        >
+          {label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -153,45 +153,6 @@ describe("CanvasToolSidebar", () => {
     expect(screen.getByPlaceholderText("Ask the agent…")).toBeInTheDocument();
   });
 
-  it("exits runs mode before closing the sidebar from the runs tab", () => {
-    const toolSidebarState = makeToolSidebarState();
-    const onExitRunsMode = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={toolSidebarState}
-        mode="runs"
-        onExitRunsMode={onExitRunsMode}
-        runsContent={<div>Runs content</div>}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Close sidebar" }));
-
-    expect(onExitRunsMode).toHaveBeenCalledTimes(1);
-    expect(toolSidebarState.closeToolSidebar).toHaveBeenCalledTimes(1);
-  });
-
-  it("exits versions before closing the sidebar from the versions tab", () => {
-    const toolSidebarState = makeToolSidebarState();
-    const onToggleVersionControl = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={toolSidebarState}
-        mode="version-live"
-        isVersionControlOpen={true}
-        onToggleVersionControl={onToggleVersionControl}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Close sidebar" }));
-
-    expect(onToggleVersionControl).toHaveBeenCalledTimes(1);
-    expect(toolSidebarState.closeToolSidebar).toHaveBeenCalledTimes(1);
-  });
-
   it("does not re-render agent messages while typing in the composer", async () => {
     const user = userEvent.setup();
 

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -60,43 +60,29 @@ function OpenCanvasToolSidebar({
   onToggleVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
-  const showRunsTab = Boolean(onSelectRuns || mode === "runs" || runsContent);
-  const showVersionsTab = Boolean(onToggleVersionControl || isVersionControlOpen || versionsContent);
   const [activeTab, setActiveTab] = useState(() => {
-    if (mode === "runs" && showRunsTab) return TAB_RUNS;
-    if (isVersionControlOpen && showVersionsTab) return TAB_VERSIONS;
+    if (mode === "runs") return TAB_RUNS;
+    if (isVersionControlOpen) return TAB_VERSIONS;
     return TAB_AGENT;
   });
 
   useEffect(() => {
-    if (mode === "runs" && showRunsTab) {
+    if (mode === "runs") {
       setActiveTab(TAB_RUNS);
       return;
     }
-    if (isVersionControlOpen && showVersionsTab) {
+    if (isVersionControlOpen) {
       setActiveTab(TAB_VERSIONS);
       return;
     }
     setActiveTab((currentTab) => (currentTab === TAB_RUNS || currentTab === TAB_VERSIONS ? TAB_AGENT : currentTab));
-  }, [isVersionControlOpen, mode, showRunsTab, showVersionsTab]);
+  }, [isVersionControlOpen, mode]);
 
   const tabs = [
     { value: TAB_AGENT, label: "Agent" },
-    ...(showRunsTab ? ([{ value: TAB_RUNS, label: "Runs" }] as const) : []),
-    ...(showVersionsTab ? ([{ value: TAB_VERSIONS, label: "Versions" }] as const) : []),
+    { value: TAB_RUNS, label: "Runs" },
+    { value: TAB_VERSIONS, label: "Versions" },
   ] as const;
-
-  const handleClose = useCallback(() => {
-    if (activeTab === TAB_RUNS) {
-      onExitRunsMode?.();
-    }
-
-    if (activeTab === TAB_VERSIONS && isVersionControlOpen) {
-      onToggleVersionControl?.();
-    }
-
-    toolSidebarState.closeToolSidebar();
-  }, [activeTab, isVersionControlOpen, onExitRunsMode, onToggleVersionControl, toolSidebarState]);
 
   const handleTabSelect = useCallback(
     (nextTab: typeof TAB_AGENT | typeof TAB_RUNS | typeof TAB_VERSIONS) => {
@@ -133,7 +119,6 @@ function OpenCanvasToolSidebar({
           tabs={tabs}
           activeTab={activeTab}
           onSelectTab={(value) => handleTabSelect(value as typeof TAB_AGENT | typeof TAB_RUNS | typeof TAB_VERSIONS)}
-          onClose={handleClose}
         />
 
         {activeTab === TAB_AGENT ? (

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCanvasToolSidebarState } from "./useCanvasToolSidebarState";
+
+vi.mock("@/hooks/useExperimentalFeature", () => ({
+  useExperimentalFeature: () => ({ has: () => false, enabledExperimentalFeatures: [] }),
+}));
+
+function Harness({ onBeforeClose }: { onBeforeClose: () => void }) {
+  const state = useCanvasToolSidebarState({
+    isEditing: false,
+    readOnly: false,
+    forceEnable: true,
+    onBeforeClose,
+  });
+
+  return (
+    <div>
+      <div data-testid="open-state">{state.isToolSidebarOpen ? "open" : "closed"}</div>
+      <button type="button" onClick={state.handleToolSidebarToggle}>
+        toggle
+      </button>
+    </div>
+  );
+}
+
+describe("useCanvasToolSidebarState", () => {
+  it("invokes onBeforeClose when toggling from open to closed", () => {
+    window.localStorage.setItem("canvasAgentSidebarOpen", "true");
+    const onBeforeClose = vi.fn();
+
+    render(<Harness onBeforeClose={onBeforeClose} />);
+
+    expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle" }));
+
+    expect(onBeforeClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("open-state")).toHaveTextContent("closed");
+  });
+});

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -25,6 +25,8 @@ export type UseCanvasToolSidebarStateOptions = {
   hideCanvasToolSidebar?: boolean;
   /** Keeps the tool sidebar available even when managed agents are disabled (runs/versions flows). */
   forceEnable?: boolean;
+  /** Called before the user closes the tool sidebar via the header toggle. */
+  onBeforeClose?: () => void;
 };
 
 export function useCanvasToolSidebarState({
@@ -34,6 +36,7 @@ export function useCanvasToolSidebarState({
   organizationId,
   hideCanvasToolSidebar,
   forceEnable = false,
+  onBeforeClose,
 }: UseCanvasToolSidebarStateOptions) {
   const { has: hasFeature } = useExperimentalFeature(organizationId);
   const featureEnabled = hasFeature(FEATURE_CLAUDE_MANAGED_AGENTS);
@@ -57,12 +60,12 @@ export function useCanvasToolSidebarState({
   }, [persistOpen]);
 
   const handleToolSidebarToggle = useCallback(() => {
-    setIsToolSidebarOpen((prev) => {
-      const next = !prev;
-      persistOpen(next);
-      return next;
-    });
-  }, [persistOpen]);
+    if (isToolSidebarOpen) onBeforeClose?.();
+
+    const next = !isToolSidebarOpen;
+    setIsToolSidebarOpen(next);
+    persistOpen(next);
+  }, [isToolSidebarOpen, onBeforeClose, persistOpen]);
 
   const switchAgentMode = useCallback((mode: AgentMode) => {
     setAgentMode(mode);

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -82,7 +82,7 @@ function PageHeader({
   const activeCanvasId = canvasIdParam || workflowId;
 
   return (
-    <div className="relative flex h-11 items-center border-b border-slate-950/15 px-3 sm:px-4">
+    <div className="relative z-20 flex h-10 items-center border-b border-slate-950/15 px-3 sm:px-4">
       <div className="relative z-10 flex min-w-0 shrink-0 items-center">
         <OrganizationMenuButton organizationId={organizationId} />
       </div>
@@ -127,7 +127,7 @@ function SecondaryHeader(props: HeaderProps) {
   const editing = props.mode === "version-edit";
 
   return (
-    <div className="relative flex h-12 items-center gap-3 border-b border-slate-950/15 bg-slate-100 px-4">
+    <div className="relative z-10 flex h-10 items-center gap-3 border-b border-slate-950/15 bg-white px-4">
       <CanvasToolSidebarTrigger toolSidebarState={props.toolSidebarState} />
 
       <div className="pointer-events-none absolute inset-x-0 flex justify-center px-16 sm:px-24">

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -1,6 +1,6 @@
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { FileCode, Pencil, Plus } from "lucide-react";
+import { FileCode, Plus } from "lucide-react";
 
 import { Button } from "../button";
 import { EnterEditDraftDropdown } from "./components/EnterEditDraftDropdown";
@@ -228,7 +228,6 @@ function EnterEditButton({
       disabled={disabled}
       data-testid="canvas-edit-button"
     >
-      <Pencil className="h-3.5 w-3.5" />
       Edit
     </UIButton>
   );

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasModeToggle } from "./CanvasModeToggle";
+
+describe("CanvasModeToggle", () => {
+  it("exits runs mode when clicking the Canvas tab", async () => {
+    const user = userEvent.setup();
+    const onSelectLive = vi.fn();
+
+    render(<CanvasModeToggle mode="runs" onSelectLive={onSelectLive} onSelectDashboard={vi.fn()} />);
+
+    await user.click(screen.getByRole("tab", { name: "Canvas" }));
+
+    expect(onSelectLive).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -14,4 +14,16 @@ describe("CanvasModeToggle", () => {
 
     expect(onSelectLive).toHaveBeenCalledTimes(1);
   });
+
+  it("does not drop subsequent Canvas clicks when mode does not update immediately", async () => {
+    const user = userEvent.setup();
+    const onSelectLive = vi.fn();
+
+    render(<CanvasModeToggle mode="runs" onSelectLive={onSelectLive} onSelectDashboard={vi.fn()} />);
+
+    await user.click(screen.getByRole("tab", { name: "Canvas" }));
+    await user.click(screen.getByRole("tab", { name: "Canvas" }));
+
+    expect(onSelectLive).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -15,4 +15,3 @@ describe("CanvasModeToggle", () => {
     expect(onSelectLive).toHaveBeenCalledTimes(1);
   });
 });
-

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import { cn } from "@/lib/utils";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard";
 
@@ -11,6 +10,9 @@ interface CanvasModeToggleProps {
   hasDraft?: boolean;
 }
 
+const CANVAS_TAB = "canvas";
+const DASHBOARD_TAB = "dashboard";
+
 export function CanvasModeToggle({
   mode,
   onSelectLive,
@@ -18,91 +20,40 @@ export function CanvasModeToggle({
   editing = false,
   hasDraft = false,
 }: CanvasModeToggleProps) {
-  const showDashboard = !!onSelectDashboard;
-  const baseTrigger =
-    "h-full border-none px-3 py-1 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-50";
-  const canvasActiveClassName =
-    editing || hasDraft
-      ? "bg-amber-50 text-amber-800 shadow-none ring-1 ring-inset ring-amber-200"
-      : "bg-sky-50 text-sky-700 shadow-none";
-  const canvasShapeClassName = getCanvasShapeClassName(showDashboard);
+  const showDashboard = Boolean(onSelectDashboard);
+  const selected = mode === DASHBOARD_TAB ? DASHBOARD_TAB : CANVAS_TAB;
 
   return (
-    <div className="inline-flex w-auto" aria-label="Canvas view" role="group">
-      <div className="flex h-8 w-fit gap-0 overflow-hidden rounded-sm border border-slate-300 bg-white/80 p-0">
-        {showDashboard && onSelectDashboard ? (
-          <DashboardModeTab mode={mode} onSelectDashboard={onSelectDashboard} baseTrigger={baseTrigger} />
+    <Tabs
+      value={selected}
+      onValueChange={(next) => {
+        if (next === CANVAS_TAB && selected !== CANVAS_TAB) void onSelectLive();
+        if (next === DASHBOARD_TAB && selected !== DASHBOARD_TAB && onSelectDashboard) void onSelectDashboard();
+      }}
+    >
+      <TabsList aria-label="Canvas view" className="h-8 min-h-8 bg-slate-100 [&_[data-slot=tabs-trigger]]:text-[13px]">
+        {showDashboard ? (
+          <TabsTrigger value={DASHBOARD_TAB} data-testid="canvas-view-mode-dashboard" aria-label="Dashboard">
+            Dashboard
+          </TabsTrigger>
         ) : null}
-        <ModeButton
-          isActive={mode === "version-live" || mode === "version-edit"}
-          activeClassName={canvasActiveClassName}
+        <TabsTrigger
+          value={CANVAS_TAB}
           data-testid="canvas-view-mode-live"
           aria-label={editing ? "Canvas (editing)" : hasDraft ? "Canvas (unpublished draft)" : "Canvas"}
-          onClick={() => {
-            if (mode !== "version-live" && mode !== "version-edit") void onSelectLive();
-          }}
-          className={cn(baseTrigger, canvasShapeClassName)}
         >
           <span className="inline-flex items-center gap-1.5">
             Canvas
             {hasDraft ? (
               <span
-                className="inline-flex h-1.5 w-1.5 rounded-full bg-orange-500"
+                className="inline-flex size-1.5 shrink-0 rounded-full bg-muted-foreground/70"
                 aria-hidden="true"
                 data-testid="canvas-view-mode-live-draft-dot"
               />
             ) : null}
           </span>
-        </ModeButton>
-      </div>
-    </div>
-  );
-}
-
-function getCanvasShapeClassName(showDashboard: boolean) {
-  if (showDashboard) return "rounded-l-none rounded-r-sm";
-  return "rounded-sm";
-}
-
-function DashboardModeTab({
-  mode,
-  onSelectDashboard,
-  baseTrigger,
-}: {
-  mode: CanvasMode;
-  onSelectDashboard: () => void;
-  baseTrigger: string;
-}) {
-  return (
-    <>
-      <ModeButton
-        isActive={mode === "dashboard"}
-        data-testid="canvas-view-mode-dashboard"
-        aria-label="Dashboard"
-        onClick={() => {
-          if (mode !== "dashboard") void onSelectDashboard();
-        }}
-        className={cn(baseTrigger, "rounded-l-sm rounded-r-none")}
-      >
-        Dashboard
-      </ModeButton>
-      <div className="h-full w-px bg-slate-300" />
-    </>
-  );
-}
-
-interface ModeButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  isActive: boolean;
-  activeClassName?: string;
-}
-
-function ModeButton({
-  isActive,
-  activeClassName = "bg-sky-50 text-sky-700 shadow-none",
-  className,
-  ...props
-}: ModeButtonProps) {
-  return (
-    <button type="button" aria-pressed={isActive} className={cn(isActive && activeClassName, className)} {...props} />
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
   );
 }

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,4 +1,5 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useEffect, useRef } from "react";
 
 type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard";
 
@@ -12,6 +13,7 @@ interface CanvasModeToggleProps {
 
 const CANVAS_TAB = "canvas";
 const DASHBOARD_TAB = "dashboard";
+const RUNS_MODE = "runs";
 
 export function CanvasModeToggle({
   mode,
@@ -21,14 +23,25 @@ export function CanvasModeToggle({
   hasDraft = false,
 }: CanvasModeToggleProps) {
   const showDashboard = Boolean(onSelectDashboard);
-  const selected = mode === DASHBOARD_TAB ? DASHBOARD_TAB : CANVAS_TAB;
+  const selected = mode === DASHBOARD_TAB ? DASHBOARD_TAB : mode === RUNS_MODE ? RUNS_MODE : CANVAS_TAB;
+  const valueChangeHandledRef = useRef(false);
+
+  useEffect(() => {
+    valueChangeHandledRef.current = false;
+  }, [mode]);
 
   return (
     <Tabs
       value={selected}
       onValueChange={(next) => {
+        // When the active `value` doesn't change immediately, Radix may emit more than one value change event.
+        // We only want to act once per mode transition.
+        if (valueChangeHandledRef.current) return;
+
         if (next === CANVAS_TAB && selected !== CANVAS_TAB) void onSelectLive();
         if (next === DASHBOARD_TAB && selected !== DASHBOARD_TAB && onSelectDashboard) void onSelectDashboard();
+
+        valueChangeHandledRef.current = true;
       }}
     >
       <TabsList aria-label="Canvas view" className="h-8 min-h-8 bg-slate-100 [&_[data-slot=tabs-trigger]]:text-[13px]">

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -34,14 +34,27 @@ export function CanvasModeToggle({
     <Tabs
       value={selected}
       onValueChange={(next) => {
-        // When the active `value` doesn't change immediately, Radix may emit more than one value change event.
-        // We only want to act once per mode transition.
+        // Radix Tabs may emit more than one `onValueChange` per click when `value` is controlled and the parent
+        // doesn't update it synchronously. We only want to suppress duplicates from the same user interaction,
+        // not block subsequent clicks.
         if (valueChangeHandledRef.current) return;
 
-        if (next === CANVAS_TAB && selected !== CANVAS_TAB) void onSelectLive();
-        if (next === DASHBOARD_TAB && selected !== DASHBOARD_TAB && onSelectDashboard) void onSelectDashboard();
+        if (next === CANVAS_TAB && selected !== CANVAS_TAB) {
+          valueChangeHandledRef.current = true;
+          queueMicrotask(() => {
+            valueChangeHandledRef.current = false;
+          });
+          void onSelectLive();
+          return;
+        }
 
-        valueChangeHandledRef.current = true;
+        if (next === DASHBOARD_TAB && selected !== DASHBOARD_TAB && onSelectDashboard) {
+          valueChangeHandledRef.current = true;
+          queueMicrotask(() => {
+            valueChangeHandledRef.current = false;
+          });
+          void onSelectDashboard();
+        }
       }}
     >
       <TabsList aria-label="Canvas view" className="h-8 min-h-8 bg-slate-100 [&_[data-slot=tabs-trigger]]:text-[13px]">

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -747,6 +747,10 @@ function CanvasPage(props: CanvasPageProps) {
     readOnly,
     canvasId: props.canvasId,
     organizationId: props.organizationId,
+    onBeforeClose: () => {
+      if (props.headerMode === "runs") props.onExitRunsMode?.();
+      if (props.isVersionControlOpen) props.onOpenVersionControl?.();
+    },
   });
   const { isToolSidebarOpen, openToolSidebar } = toolSidebarState;
   const previousHeaderModeRef = useRef<CanvasPageProps["headerMode"] | undefined>(undefined);


### PR DESCRIPTION
## Summary

  - Restore the visual styles from commit 09cbca1c that were dropped during
  the merge of #4816: shorter (h-10) top and secondary headers, white
  secondary background, Tabs-based Canvas/Dashboard toggle, and icon-less Edit
   button.
  - Rewrite CanvasModeToggle to use the shared Tabs primitive (with the muted
  draft dot) while keeping Dashboard tab support added by #4875.
  - Remove the X close button from the tool sidebar's tab header so the
  Agent/Runs/Versions row matches the original design.
  - Always show the Runs and Versions tabs in the tool sidebar — they were
  hidden when editing a version because onToggleVersionControl /
  versionsContent were undefined.