### PR TITLE
fix: include example payloads for integration components in index CLI

### DIFF
--- a/pkg/cli/commands/index/actions.go
+++ b/pkg/cli/commands/index/actions.go
@@ -293,6 +293,7 @@ func actionsFromCapabilities(capabilities []openapi_client.IntegrationsCapabilit
 			Description:    capability.Description,
 			Configuration:  capability.Configuration,
 			OutputChannels: capability.OutputChannels,
+			ExampleOutput:  capability.ExampleOutput,
 		})
 	}
 	return actions

--- a/pkg/cli/commands/index/dump_test.go
+++ b/pkg/cli/commands/index/dump_test.go
@@ -95,6 +95,8 @@ func TestDumpIntegrationContainsNestedFields(t *testing.T) {
 	}
 	require.Contains(t, capNames, "slack.post-message")
 	require.Contains(t, capNames, "slack.message-received")
+	require.NotEmpty(t, integration.GetCapabilities()[0].GetExampleOutput())
+	require.NotEmpty(t, integration.GetCapabilities()[1].GetExampleData())
 
 	rawStr := string(raw)
 	require.Contains(t, rawStr, "post-message")

--- a/pkg/cli/commands/index/index_test.go
+++ b/pkg/cli/commands/index/index_test.go
@@ -22,8 +22,16 @@ const integrationsListResponse = `{
 			"description": "Slack integration",
 			"configuration": [{"name": "token", "type": "string", "required": true}],
 			"capabilities": [
-				{"type": "TYPE_ACTION", "name": "slack.post-message"},
-				{"type": "TYPE_TRIGGER", "name": "slack.message-received"}
+				{
+					"type": "TYPE_ACTION",
+					"name": "slack.post-message",
+					"exampleOutput": {"channel": "C123", "ts": "1712345678.000100"}
+				},
+				{
+					"type": "TYPE_TRIGGER",
+					"name": "slack.message-received",
+					"exampleData": {"channel": "C123", "text": "hello"}
+				}
 			]
 		}
 	]
@@ -134,6 +142,25 @@ func TestActionsListReturnsFullJSON(t *testing.T) {
 	require.Contains(t, raw, "http")
 }
 
+func TestActionsDescribeIntegrationActionIncludesExamplePayload(t *testing.T) {
+	server := newMultiRouteIndexServer(t, map[string]string{
+		"/api/v1/integrations": integrationsListResponse,
+	})
+	ctx, stdout := newIndexCommandContext(t, server, "text")
+	name := "slack.post-message"
+	from := ""
+	full := false
+	cmd := &actionsCommand{name: &name, from: &from, full: &full}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	out := stdout.String()
+	require.Contains(t, out, "Name: slack.post-message")
+	require.Contains(t, out, "Example Payload:")
+	require.Contains(t, out, `"channel": "C123"`)
+	require.Contains(t, out, `"ts": "1712345678.000100"`)
+}
+
 func TestRenderConfigurationTextOmitsNestedDetailsInTable(t *testing.T) {
 	var configuration []openapi_client.ConfigurationField
 	err := json.Unmarshal([]byte(`[
@@ -215,6 +242,25 @@ func TestTriggersListReturnsFullJSON(t *testing.T) {
 	require.Contains(t, raw, "cron")
 }
 
+func TestTriggersDescribeIntegrationTriggerIncludesExamplePayload(t *testing.T) {
+	server := newMultiRouteIndexServer(t, map[string]string{
+		"/api/v1/integrations": integrationsListResponse,
+	})
+	ctx, stdout := newIndexCommandContext(t, server, "text")
+	name := "slack.message-received"
+	from := ""
+	full := false
+	cmd := &triggersCommand{name: &name, from: &from, full: &full}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	out := stdout.String()
+	require.Contains(t, out, "Name: slack.message-received")
+	require.Contains(t, out, "Example Payload:")
+	require.Contains(t, out, `"channel": "C123"`)
+	require.Contains(t, out, `"text": "hello"`)
+}
+
 func TestIntegrationsListTextOutput(t *testing.T) {
 	server := newIndexServer(t, "GET", "/api/v1/integrations", integrationsListResponse)
 	ctx, stdout := newIndexCommandContext(t, server, "text")
@@ -277,6 +323,23 @@ func TestActionsListFromIntegrationTextOutput(t *testing.T) {
 	require.Contains(t, out, "slack.post-message")
 }
 
+func TestActionsListFromIntegrationFullJSONIncludesExamplePayload(t *testing.T) {
+	server := newMultiRouteIndexServer(t, map[string]string{
+		"/api/v1/integrations": integrationsListResponse,
+	})
+	ctx, stdout := newIndexCommandContext(t, server, "json")
+	name := ""
+	from := "slack"
+	full := true
+	cmd := &actionsCommand{name: &name, from: &from, full: &full}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	raw := stdout.String()
+	require.Contains(t, raw, `"exampleOutput"`)
+	require.Contains(t, raw, `"ts": "1712345678.000100"`)
+}
+
 func TestActionsDescribeByNameTextOutput(t *testing.T) {
 	const describeHTTP = `{
 		"action": {
@@ -337,6 +400,23 @@ func TestTriggersListFromIntegrationTextOutput(t *testing.T) {
 
 	require.NoError(t, cmd.Execute(ctx))
 	require.Contains(t, stdout.String(), "slack.message-received")
+}
+
+func TestTriggersListFromIntegrationFullJSONIncludesExamplePayload(t *testing.T) {
+	server := newMultiRouteIndexServer(t, map[string]string{
+		"/api/v1/integrations": integrationsListResponse,
+	})
+	ctx, stdout := newIndexCommandContext(t, server, "json")
+	name := ""
+	from := "slack"
+	full := true
+	cmd := &triggersCommand{name: &name, from: &from, full: &full}
+
+	require.NoError(t, cmd.Execute(ctx))
+
+	raw := stdout.String()
+	require.Contains(t, raw, `"exampleData"`)
+	require.Contains(t, raw, `"text": "hello"`)
 }
 
 func TestTriggersDescribeByNameTextOutput(t *testing.T) {

--- a/pkg/cli/commands/index/triggers.go
+++ b/pkg/cli/commands/index/triggers.go
@@ -192,6 +192,7 @@ func triggersFromCapabilities(capabilities []openapi_client.IntegrationsCapabili
 			Label:         capability.Label,
 			Description:   capability.Description,
 			Configuration: capability.Configuration,
+			ExampleData:   capability.ExampleData,
 		})
 	}
 	return triggers

--- a/pkg/core/integration_setup_provider.go
+++ b/pkg/core/integration_setup_provider.go
@@ -237,6 +237,8 @@ type Capability struct {
 	Description    string                    `json:"description"`
 	Configuration  []configuration.Field     `json:"configuration"`
 	OutputChannels []OutputChannel           `json:"outputChannels"`
+	ExampleOutput  map[string]any            `json:"exampleOutput,omitempty"`
+	ExampleData    map[string]any            `json:"exampleData,omitempty"`
 }
 
 /*

--- a/pkg/grpc/actions/integrations/list_integrations.go
+++ b/pkg/grpc/actions/integrations/list_integrations.go
@@ -85,12 +85,8 @@ func serializeCapabilities(registry *registry.Registry, integration core.Integra
 				OutputChannels: []*actionpb.OutputChannel{},
 			}
 
-			if output := capability.ExampleOutput; output != nil {
-				capabilityDef.ExampleOutput, _ = structpb.NewStruct(output)
-			}
-			if data := capability.ExampleData; data != nil {
-				capabilityDef.ExampleData, _ = structpb.NewStruct(data)
-			}
+			capabilityDef.ExampleOutput = toStruct(capability.ExampleOutput)
+			capabilityDef.ExampleData = toStruct(capability.ExampleData)
 
 			for _, field := range capability.Configuration {
 				capabilityDef.Configuration = append(capabilityDef.Configuration, actions.ConfigurationFieldToProto(field))

--- a/pkg/grpc/actions/integrations/list_integrations.go
+++ b/pkg/grpc/actions/integrations/list_integrations.go
@@ -9,6 +9,7 @@ import (
 	configpb "github.com/superplanehq/superplane/pkg/protos/configuration"
 	pb "github.com/superplanehq/superplane/pkg/protos/integrations"
 	"github.com/superplanehq/superplane/pkg/registry"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func ListIntegrations(ctx context.Context, registry *registry.Registry) (*pb.ListIntegrationsResponse, error) {
@@ -84,6 +85,13 @@ func serializeCapabilities(registry *registry.Registry, integration core.Integra
 				OutputChannels: []*actionpb.OutputChannel{},
 			}
 
+			if output := capability.ExampleOutput; output != nil {
+				capabilityDef.ExampleOutput, _ = structpb.NewStruct(output)
+			}
+			if data := capability.ExampleData; data != nil {
+				capabilityDef.ExampleData, _ = structpb.NewStruct(data)
+			}
+
 			for _, field := range capability.Configuration {
 				capabilityDef.Configuration = append(capabilityDef.Configuration, actions.ConfigurationFieldToProto(field))
 			}
@@ -128,6 +136,7 @@ func serializeLegacyCapabilities(integration core.Integration) []*pb.CapabilityD
 			Description:    action.Description(),
 			Configuration:  configuration,
 			OutputChannels: outputChannels,
+			ExampleOutput:  toStruct(action.ExampleOutput()),
 		})
 	}
 
@@ -144,8 +153,18 @@ func serializeLegacyCapabilities(integration core.Integration) []*pb.CapabilityD
 			Description:    trigger.Description(),
 			Configuration:  configuration,
 			OutputChannels: []*actionpb.OutputChannel{},
+			ExampleData:    toStruct(trigger.ExampleData()),
 		})
 	}
 
 	return capabilities
+}
+
+func toStruct(value map[string]any) *structpb.Struct {
+	if value == nil {
+		return nil
+	}
+
+	out, _ := structpb.NewStruct(value)
+	return out
 }

--- a/pkg/grpc/actions/integrations/list_integrations_test.go
+++ b/pkg/grpc/actions/integrations/list_integrations_test.go
@@ -1,0 +1,148 @@
+package integrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+	"github.com/superplanehq/superplane/test/support/impl"
+)
+
+type testAction struct {
+	name    string
+	example map[string]any
+}
+
+func (a *testAction) Name() string                  { return a.name }
+func (a *testAction) Label() string                 { return a.name }
+func (a *testAction) Description() string           { return a.name }
+func (a *testAction) Documentation() string         { return "" }
+func (a *testAction) Icon() string                  { return "" }
+func (a *testAction) Color() string                 { return "" }
+func (a *testAction) ExampleOutput() map[string]any { return a.example }
+func (a *testAction) OutputChannels(any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+func (a *testAction) Configuration() []configuration.Field                          { return nil }
+func (a *testAction) Setup(core.SetupContext) error                                 { return nil }
+func (a *testAction) ProcessQueueItem(core.ProcessQueueContext) (*uuid.UUID, error) { return nil, nil }
+func (a *testAction) Execute(core.ExecutionContext) error                           { return nil }
+func (a *testAction) Hooks() []core.Hook                                            { return nil }
+func (a *testAction) HandleHook(core.ActionHookContext) error                       { return nil }
+func (a *testAction) HandleWebhook(core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+func (a *testAction) Cancel(core.ExecutionContext) error { return nil }
+func (a *testAction) Cleanup(core.SetupContext) error    { return nil }
+
+type testTrigger struct {
+	name    string
+	example map[string]any
+}
+
+func (t *testTrigger) Name() string                         { return t.name }
+func (t *testTrigger) Label() string                        { return t.name }
+func (t *testTrigger) Description() string                  { return t.name }
+func (t *testTrigger) Documentation() string                { return "" }
+func (t *testTrigger) Icon() string                         { return "" }
+func (t *testTrigger) Color() string                        { return "" }
+func (t *testTrigger) ExampleData() map[string]any          { return t.example }
+func (t *testTrigger) Configuration() []configuration.Field { return nil }
+func (t *testTrigger) HandleWebhook(core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+func (t *testTrigger) Setup(core.TriggerContext) error                            { return nil }
+func (t *testTrigger) Hooks() []core.Hook                                         { return nil }
+func (t *testTrigger) HandleHook(core.TriggerHookContext) (map[string]any, error) { return nil, nil }
+func (t *testTrigger) Cleanup(core.TriggerContext) error                          { return nil }
+
+type testSetupProvider struct {
+	groups []core.CapabilityGroup
+}
+
+func (p *testSetupProvider) CapabilityGroups() []core.CapabilityGroup       { return p.groups }
+func (p *testSetupProvider) FirstStep(core.SetupStepContext) core.SetupStep { return core.SetupStep{} }
+func (p *testSetupProvider) OnStepSubmit(core.SetupStepContext) (*core.SetupStep, error) {
+	return nil, nil
+}
+func (p *testSetupProvider) OnStepRevert(core.SetupStepContext) error { return nil }
+func (p *testSetupProvider) OnPropertyUpdate(core.PropertyUpdateContext) (*core.SetupStep, error) {
+	return nil, nil
+}
+func (p *testSetupProvider) OnSecretUpdate(core.SecretUpdateContext) (*core.SetupStep, error) {
+	return nil, nil
+}
+func (p *testSetupProvider) OnCapabilityUpdate(core.CapabilityUpdateContext) (*core.SetupStep, error) {
+	return nil, nil
+}
+
+func TestListIntegrationsIncludesExamplePayloadsForLegacyCapabilities(t *testing.T) {
+	r := &registry.Registry{
+		Integrations: map[string]core.Integration{
+			"dummy": impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+				Actions: []core.Action{
+					&testAction{
+						name:    "dummy.action",
+						example: map[string]any{"id": "123"},
+					},
+				},
+				Triggers: []core.Trigger{
+					&testTrigger{
+						name:    "dummy.trigger",
+						example: map[string]any{"event": "created"},
+					},
+				},
+			}),
+		},
+		SetupProviders: map[string]core.IntegrationSetupProvider{},
+	}
+
+	resp, err := ListIntegrations(context.Background(), r)
+	require.NoError(t, err)
+	require.Len(t, resp.Integrations, 1)
+	require.Len(t, resp.Integrations[0].Capabilities, 2)
+
+	require.Equal(t, "123", resp.Integrations[0].Capabilities[0].GetExampleOutput().GetFields()["id"].GetStringValue())
+	require.Equal(t, "created", resp.Integrations[0].Capabilities[1].GetExampleData().GetFields()["event"].GetStringValue())
+}
+
+func TestListIntegrationsIncludesExamplePayloadsForSetupProviderCapabilities(t *testing.T) {
+	r := &registry.Registry{
+		Integrations: map[string]core.Integration{
+			"dummy": impl.NewDummyIntegration(impl.DummyIntegrationOptions{}),
+		},
+		SetupProviders: map[string]core.IntegrationSetupProvider{
+			"dummy": &testSetupProvider{
+				groups: []core.CapabilityGroup{
+					{
+						Label: "Test",
+						Capabilities: []core.Capability{
+							{
+								Type:          core.IntegrationCapabilityTypeAction,
+								Name:          "dummy.action",
+								ExampleOutput: map[string]any{"status": "ok"},
+							},
+							{
+								Type:        core.IntegrationCapabilityTypeTrigger,
+								Name:        "dummy.trigger",
+								ExampleData: map[string]any{"kind": "push"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := ListIntegrations(context.Background(), r)
+	require.NoError(t, err)
+	require.Len(t, resp.Integrations, 1)
+	require.Len(t, resp.Integrations[0].Capabilities, 2)
+
+	require.Equal(t, "ok", resp.Integrations[0].Capabilities[0].GetExampleOutput().GetFields()["status"].GetStringValue())
+	require.Equal(t, "push", resp.Integrations[0].Capabilities[1].GetExampleData().GetFields()["kind"].GetStringValue())
+}

--- a/pkg/integrations/github/setup_provider.go
+++ b/pkg/integrations/github/setup_provider.go
@@ -181,6 +181,7 @@ func (g *SetupProvider) CapabilityGroups() []core.CapabilityGroup {
 					Description:    c.Action.Description(),
 					Configuration:  c.Action.Configuration(),
 					OutputChannels: c.Action.OutputChannels(nil),
+					ExampleOutput:  c.Action.ExampleOutput(),
 				})
 			}
 
@@ -191,6 +192,7 @@ func (g *SetupProvider) CapabilityGroups() []core.CapabilityGroup {
 					Label:         c.Trigger.Label(),
 					Description:   c.Trigger.Description(),
 					Configuration: c.Trigger.Configuration(),
+					ExampleData:   c.Trigger.ExampleData(),
 				})
 			}
 		}

--- a/pkg/integrations/semaphore/setup_provider.go
+++ b/pkg/integrations/semaphore/setup_provider.go
@@ -48,6 +48,7 @@ func (s *SetupProvider) genCapabilities(actions []core.Action, triggers []core.T
 			Description:    action.Description(),
 			Configuration:  action.Configuration(),
 			OutputChannels: action.OutputChannels(nil),
+			ExampleOutput:  action.ExampleOutput(),
 		})
 	}
 	for _, trigger := range triggers {
@@ -57,6 +58,7 @@ func (s *SetupProvider) genCapabilities(actions []core.Action, triggers []core.T
 			Label:         trigger.Label(),
 			Description:   trigger.Description(),
 			Configuration: trigger.Configuration(),
+			ExampleData:   trigger.ExampleData(),
 		})
 	}
 

--- a/protos/integrations.proto
+++ b/protos/integrations.proto
@@ -5,6 +5,7 @@ package Superplane.Integrations;
 import "actions.proto";
 import "configuration.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/superplanehq/superplane/pkg/protos/integrations";
@@ -75,6 +76,8 @@ message CapabilityDefinition {
   string description = 4;
   repeated Configuration.Field configuration = 5;
   repeated Actions.OutputChannel output_channels = 6;
+  google.protobuf.Struct example_output = 7;
+  google.protobuf.Struct example_data = 8;
 }
 
 message CapabilityGroup {


### PR DESCRIPTION
## Summary
- add example payload fields to integration capability definitions
- serialize example payloads for both legacy and setup-provider integration capabilities
- map those fields back into `superplane index actions|triggers` and cover the regression with tests

## Testing
- make pb.gen openapi.spec.gen openapi.client.gen openapi.web.client.gen
- make test PKG_TEST_PACKAGES="./pkg/cli/commands/index ./pkg/grpc/actions/integrations"
- make lint
- make check.build.app

Closes #4912