### PR TITLE
fix: keep loaded versions visible when selecting versions

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -2,15 +2,16 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { VersionsTabPanel } from "./VersionsTabPanel";
 
-function makeVersion(id: string, number: number) {
+function makePublishedVersion(id: string, number: number) {
   return {
     metadata: {
       id,
       owner: { name: "Alice" },
       createdAt: "2026-05-18T12:00:00Z",
+      state: "STATE_PUBLISHED",
+      publishedAt: "2026-05-18T12:00:00Z",
     },
     version: number,
-    publishedAt: "2026-05-18T12:00:00Z",
   };
 }
 
@@ -36,7 +37,7 @@ describe("VersionsTabPanel", () => {
     render(
       <VersionsTabPanel
         liveCanvasVersionId="version-2"
-        liveVersions={[makeVersion("version-2", 2), makeVersion("version-1", 1)]}
+        liveVersions={[makePublishedVersion("version-2", 2), makePublishedVersion("version-1", 1)]}
         canUpdateCanvas={true}
         isTemplate={false}
         canvasDeletedRemotely={false}
@@ -45,8 +46,53 @@ describe("VersionsTabPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("Preview Draft version"));
+    fireEvent.click(screen.getByLabelText("Preview Published version"));
 
     expect(onUseVersion).toHaveBeenCalledWith("version-2");
+  });
+
+  it("keeps expanded versions visible when selecting a different version", () => {
+    const liveVersions = Array.from({ length: 12 }, (_, index) => {
+      const number = 12 - index;
+      return makePublishedVersion(`version-${number}`, number);
+    });
+
+    const { rerender } = render(
+      <VersionsTabPanel
+        liveCanvasVersionId="version-12"
+        selectedCanvasVersion={null}
+        liveVersions={liveVersions}
+        canUpdateCanvas={true}
+        isTemplate={false}
+        canvasDeletedRemotely={false}
+        onUseVersion={vi.fn()}
+        onVersionNodeDiffContextChange={vi.fn()}
+      />,
+    );
+
+    // Starts collapsed to 5 versions so the first version ("v1") isn't visible.
+    expect(screen.queryByText("v1")).not.toBeInTheDocument();
+
+    // Expand twice (5 -> 10 -> 12) to reveal the first version row.
+    fireEvent.click(screen.getByRole("button", { name: "Load older versions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load older versions" }));
+    expect(screen.getByText("v1")).toBeInTheDocument();
+
+    // After selecting another version, the expanded view should remain.
+    rerender(
+      <VersionsTabPanel
+        liveCanvasVersionId="version-12"
+        selectedCanvasVersion={makePublishedVersion("version-9", 9)}
+        liveVersions={liveVersions}
+        canUpdateCanvas={true}
+        isTemplate={false}
+        canvasDeletedRemotely={false}
+        onUseVersion={vi.fn()}
+        onVersionNodeDiffContextChange={vi.fn()}
+      />,
+    );
+
+    // Version rows beyond the initial 5 should still be visible without clicking again.
+    expect(screen.getByText("v1")).toBeInTheDocument();
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { CanvasesCanvasVersion } from "@/api-client";
 import { describe, expect, it, vi } from "vitest";
 import { VersionsTabPanel } from "./VersionsTabPanel";
 
-function makePublishedVersion(id: string, number: number) {
+function makePublishedVersion(id: string): CanvasesCanvasVersion {
   return {
     metadata: {
       id,
@@ -11,7 +12,6 @@ function makePublishedVersion(id: string, number: number) {
       state: "STATE_PUBLISHED",
       publishedAt: "2026-05-18T12:00:00Z",
     },
-    version: number,
   };
 }
 
@@ -37,7 +37,7 @@ describe("VersionsTabPanel", () => {
     render(
       <VersionsTabPanel
         liveCanvasVersionId="version-2"
-        liveVersions={[makePublishedVersion("version-2", 2), makePublishedVersion("version-1", 1)]}
+        liveVersions={[makePublishedVersion("version-2"), makePublishedVersion("version-1")]}
         canUpdateCanvas={true}
         isTemplate={false}
         canvasDeletedRemotely={false}
@@ -54,7 +54,7 @@ describe("VersionsTabPanel", () => {
   it("keeps expanded versions visible when selecting a different version", () => {
     const liveVersions = Array.from({ length: 12 }, (_, index) => {
       const number = 12 - index;
-      return makePublishedVersion(`version-${number}`, number);
+      return makePublishedVersion(`version-${number}`);
     });
 
     const { rerender } = render(
@@ -82,7 +82,7 @@ describe("VersionsTabPanel", () => {
     rerender(
       <VersionsTabPanel
         liveCanvasVersionId="version-12"
-        selectedCanvasVersion={makePublishedVersion("version-9", 9)}
+        selectedCanvasVersion={makePublishedVersion("version-9")}
         liveVersions={liveVersions}
         canUpdateCanvas={true}
         isTemplate={false}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
Fix requested in PR comment: when using Versions → “Load older versions” then clicking to view a different version, the already-loaded history should stay available (no re-loading / re-clicking required).

## What’s in this PR (WIP)
- Adds a frontend regression test for the Versions sidebar to ensure expanded history remains visible when selecting a different version.

## Next steps in this PR
- Reproduce the issue end-to-end in `workflowv2` and implement the fix so the test represents the real regression (and add/adjust an integration-level test if needed).
- Run `make format.js` and `make check.build.ui`.

## Testing
- Unit test added (not yet validated in CI/local in this PR revision).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29121969-11c9-4d8a-90ca-1a45f53b71ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29121969-11c9-4d8a-90ca-1a45f53b71ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

