### PR TITLE
fix: attach version id to workflow runs

### DIFF
--- a/db/migrations/20260520171949_attach-version-id-to-workflow-runs.up.sql
+++ b/db/migrations/20260520171949_attach-version-id-to-workflow-runs.up.sql
@@ -4,20 +4,26 @@ ALTER TABLE public.workflow_runs
   ADD COLUMN version_id uuid;
 
 UPDATE public.workflow_runs AS r
-SET version_id = COALESCE(
-  (
-    SELECT v.id
-    FROM public.workflow_versions AS v
-    WHERE v.workflow_id = r.workflow_id
-      AND v.state = 'published'
-      AND v.published_at <= r.created_at
-    ORDER BY v.published_at DESC, v.created_at DESC
-    LIMIT 1
-  ),
-  w.live_version_id
-)
-FROM public.workflows AS w
-WHERE w.id = r.workflow_id;
+SET version_id = (
+  SELECT v.id
+  FROM public.workflow_versions AS v
+  WHERE v.workflow_id = r.workflow_id
+  ORDER BY
+    CASE
+      WHEN v.state = 'published' AND v.published_at <= r.created_at THEN 0
+      WHEN v.state = 'published' THEN 1
+      ELSE 2
+    END,
+    CASE
+      WHEN v.state = 'published' AND v.published_at <= r.created_at THEN v.published_at
+    END DESC NULLS LAST,
+    CASE
+      WHEN v.state = 'published' THEN v.published_at
+    END ASC NULLS LAST,
+    v.created_at ASC,
+    v.id ASC
+  LIMIT 1
+);
 
 ALTER TABLE public.workflow_runs
   ALTER COLUMN version_id SET NOT NULL;

--- a/db/migrations/20260520171949_attach-version-id-to-workflow-runs.up.sql
+++ b/db/migrations/20260520171949_attach-version-id-to-workflow-runs.up.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+ALTER TABLE public.workflow_runs
+  ADD COLUMN version_id uuid;
+
+UPDATE public.workflow_runs AS r
+SET version_id = COALESCE(
+  (
+    SELECT v.id
+    FROM public.workflow_versions AS v
+    WHERE v.workflow_id = r.workflow_id
+      AND v.state = 'published'
+      AND v.published_at <= r.created_at
+    ORDER BY v.published_at DESC, v.created_at DESC
+    LIMIT 1
+  ),
+  w.live_version_id
+)
+FROM public.workflows AS w
+WHERE w.id = r.workflow_id;
+
+ALTER TABLE public.workflow_runs
+  ALTER COLUMN version_id SET NOT NULL;
+
+ALTER TABLE public.workflow_runs
+  ADD CONSTRAINT workflow_runs_version_id_fkey
+  FOREIGN KEY (version_id) REFERENCES public.workflow_versions(id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_workflow_runs_version_id ON public.workflow_runs(version_id);
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,7 +5,7 @@
 \restrict abcdef123
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
--- Dumped by pg_dump version 17.10 (Ubuntu 17.10-1.pgdg22.04+1)
+-- Dumped by pg_dump version 17.9 (Ubuntu 17.9-1.pgdg22.04+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -666,7 +666,8 @@ CREATE TABLE public.workflow_runs (
     result character varying(32),
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    finished_at timestamp without time zone
+    finished_at timestamp without time zone,
+    version_id uuid NOT NULL
 );
 
 
@@ -1569,6 +1570,13 @@ CREATE INDEX idx_workflow_nodes_state ON public.workflow_nodes USING btree (stat
 
 
 --
+-- Name: idx_workflow_runs_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_workflow_runs_version_id ON public.workflow_runs USING btree (version_id);
+
+
+--
 -- Name: idx_workflow_runs_workflow_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2077,6 +2085,14 @@ ALTER TABLE ONLY public.workflow_nodes
 
 
 --
+-- Name: workflow_runs workflow_runs_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_runs
+    ADD CONSTRAINT workflow_runs_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.workflow_versions(id) ON DELETE RESTRICT;
+
+
+--
 -- Name: workflow_runs workflow_runs_workflow_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2129,7 +2145,7 @@ ALTER TABLE ONLY public.workflows
 \restrict abcdef123
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
--- Dumped by pg_dump version 17.10 (Ubuntu 17.10-1.pgdg22.04+1)
+-- Dumped by pg_dump version 17.9 (Ubuntu 17.9-1.pgdg22.04+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -2148,7 +2164,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260515120000	f
+20260520171949	f
 \.
 
 
@@ -2165,7 +2181,7 @@ COPY public.schema_migrations (version, dirty) FROM stdin;
 \restrict abcdef123
 
 -- Dumped from database version 17.5 (Debian 17.5-1.pgdg130+1)
--- Dumped by pg_dump version 17.10 (Ubuntu 17.10-1.pgdg22.04+1)
+-- Dumped by pg_dump version 17.9 (Ubuntu 17.9-1.pgdg22.04+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/pkg/grpc/actions/canvases/list_runs.go
+++ b/pkg/grpc/actions/canvases/list_runs.go
@@ -149,6 +149,7 @@ func SerializeCanvasRun(run models.CanvasRun, rootEvent models.CanvasEvent, exec
 	serialized := &pb.CanvasRun{
 		Id:         run.ID.String(),
 		CanvasId:   run.WorkflowID.String(),
+		VersionId:  run.VersionID.String(),
 		RootEvent:  serializedRootEvent,
 		State:      RunStateToProto(run.State),
 		Result:     RunResultToProto(run.Result),

--- a/pkg/grpc/actions/canvases/list_runs_test.go
+++ b/pkg/grpc/actions/canvases/list_runs_test.go
@@ -40,6 +40,7 @@ func Test__ListRuns__ReturnsRunsWithRootEventsAndExecutionRefs(t *testing.T) {
 
 	serializedRun := response.Runs[0]
 	assert.Equal(t, run.ID.String(), serializedRun.Id)
+	assert.Equal(t, run.VersionID.String(), serializedRun.VersionId)
 	assert.Equal(t, pb.CanvasRun_STATE_FINISHED, serializedRun.State)
 	assert.Equal(t, pb.CanvasRun_RESULT_PASSED, serializedRun.Result)
 	require.NotNil(t, serializedRun.RootEvent)

--- a/pkg/models/canvas_run.go
+++ b/pkg/models/canvas_run.go
@@ -22,6 +22,7 @@ const (
 type CanvasRun struct {
 	ID         uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
 	WorkflowID uuid.UUID
+	VersionID  uuid.UUID
 	State      string
 	Result     string
 	CreatedAt  *time.Time
@@ -89,9 +90,15 @@ func FindOrCreateCanvasRunForRootEventInTransaction(tx *gorm.DB, rootEvent *Canv
 }
 
 func CreateCanvasRunInTransaction(tx *gorm.DB, workflowID uuid.UUID) (*CanvasRun, error) {
+	liveVersion, err := FindLiveCanvasVersionInTransaction(tx, workflowID)
+	if err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
 	run := &CanvasRun{
 		WorkflowID: workflowID,
+		VersionID:  liveVersion.ID,
 		State:      CanvasRunStateStarted,
 		CreatedAt:  &now,
 		UpdatedAt:  &now,

--- a/pkg/models/canvas_run_test.go
+++ b/pkg/models/canvas_run_test.go
@@ -140,9 +140,13 @@ func Test__ListCanvasRuns__StatesAndResultsAreOredWithinWorkflow(t *testing.T) {
 
 func createRunWithState(t *testing.T, workflowID uuid.UUID, state, result string) *models.CanvasRun {
 	now := time.Now()
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), workflowID)
+	require.NoError(t, err)
+
 	run := models.CanvasRun{
 		ID:         uuid.New(),
 		WorkflowID: workflowID,
+		VersionID:  liveVersion.ID,
 		State:      state,
 		Result:     result,
 		CreatedAt:  &now,

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -1040,6 +1040,7 @@ message CanvasRun {
   google.protobuf.Timestamp created_at = 7;
   google.protobuf.Timestamp updated_at = 8;
   google.protobuf.Timestamp finished_at = 9;
+  string version_id = 10;
 }
 
 message ListEventExecutionsRequest {

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -115,7 +115,7 @@ import { useCancelExecutionHandler } from "./useCancelExecutionHandler";
 import { useCanvasYaml } from "./useCanvasYaml";
 import { useExecutionChainData } from "./useExecutionChainData";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
-import { useRunCanvasData } from "./useRunCanvasData";
+import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
 import {
   getExitEditModeDisabledTooltip,
@@ -1879,8 +1879,19 @@ export function WorkflowPageV2() {
     selectedRunFullExecutions,
   });
 
-  const nodes = runCanvasData ? runCanvasData.nodes : nodesWithIntegrationStatus;
-  const renderedEdges = runCanvasData ? runCanvasData.edges : preparedEdges;
+  const {
+    nodes,
+    edges: renderedEdges,
+    runCanvasLoading,
+  } = useRunCanvasPresentation({
+    isRunsMode,
+    selectedRun,
+    runCanvasData,
+    liveNodes: nodesWithIntegrationStatus,
+    liveEdges: preparedEdges,
+    isSelectedRunVersionLoading,
+    isSelectedRunExecutionsLoading: selectedRunExecutionsQuery.isLoading,
+  });
   const runsViewportKey = isRunsMode ? "runs" : null;
   if (lastRunsViewportKeyRef.current !== runsViewportKey) {
     runsHasFitToViewRef.current = false;
@@ -5612,7 +5623,7 @@ export function WorkflowPageV2() {
               ? runCanvasData.participantNodeIds
               : undefined
           }
-          runCanvasLoading={isRunsMode && !!selectedRun?.rootEvent?.id && selectedRunExecutionsQuery.isLoading}
+          runCanvasLoading={runCanvasLoading}
           saveIsPrimary={saveIsPrimary}
           saveButtonHidden={saveButtonHidden}
           saveDisabled={saveDisabled}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -74,7 +74,7 @@ import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { getActiveNoteId, restoreActiveNoteFocus } from "@/ui/annotationComponent/noteFocus";
 import { buildBuildingBlockCategories } from "@/ui/buildingBlocks";
 import type { LogEntry } from "@/ui/CanvasLogSidebar";
-import type { CanvasEdge, CanvasNode, NewNodeData, NodeEditData, SidebarData } from "@/ui/CanvasPage";
+import type { CanvasNode, NewNodeData, NodeEditData, SidebarData } from "@/ui/CanvasPage";
 import { CANVAS_SIDEBAR_STORAGE_KEY, CanvasPage, type MissingIntegration } from "@/ui/CanvasPage";
 import type { EventState, EventStateMap } from "@/ui/componentBase";
 import type { TabData } from "@/ui/componentSidebar/SidebarEventItem/SidebarEventItem";
@@ -105,11 +105,7 @@ import {
   versionSortValue,
 } from "./lib/canvas-versions";
 import { buildChangeRequestVersionRowsForStatus } from "./lib/change-requests";
-import {
-  getNodeIntegrationName,
-  overlayIntegrationWarnings,
-  stripCanvasNodeSetupWarningsForRunsView,
-} from "./lib/node-integrations";
+import { getNodeIntegrationName, overlayIntegrationWarnings } from "./lib/node-integrations";
 import { renderCanvasNodeCustomField } from "./lib/render-canvas-node-custom-field";
 import { getVersionActionAvailability } from "./lib/version-action-state";
 import { getCustomFieldRenderer, getState, getStateMap } from "./mappers";
@@ -119,6 +115,8 @@ import { useCancelExecutionHandler } from "./useCancelExecutionHandler";
 import { useCanvasYaml } from "./useCanvasYaml";
 import { useExecutionChainData } from "./useExecutionChainData";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
+import { useRunCanvasData } from "./useRunCanvasData";
+import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
 import {
   getExitEditModeDisabledTooltip,
   getRunActionState,
@@ -140,7 +138,6 @@ import { actionsFromCapabilities, triggersFromCapabilities } from "@/lib/capabil
 import {
   getCanvasLogNodesSignature,
   getNodeAnalyticsProps,
-  hydrateRunExecution,
   prepareData,
   prepareSidebarData,
 } from "./workflowPageHelpers";
@@ -538,13 +535,17 @@ export function WorkflowPageV2() {
     () => runsData.runs.find((run) => run.id === selectedRunId) || null,
     [runsData.runs, selectedRunId],
   );
-  // Prefetch full executions (with metadata/outputs) for the selected run as soon
-  // as the user picks it in the sidebar. Mappers like wait/timegate compute states
-  // such as "pushed through" from execution.outputs, which selectedRun.executions
-  // (lightweight refs) don't carry. The same query backs RunNodeDetailModal, so the
-  // payload tab also opens without a follow-up fetch.
   const selectedRunExecutionsQuery = useEventExecutions(canvasId!, selectedRun?.rootEvent?.id ?? null);
   const selectedRunFullExecutions = selectedRunExecutionsQuery.data?.executions;
+  const { selectedRunCanvas, isSelectedRunVersionLoading } = useSelectedRunCanvas({
+    organizationId: organizationId!,
+    canvasId: canvasId!,
+    selectedRun,
+    isRunsMode,
+    liveCanvasVersionId,
+    canvas,
+    liveCanvas,
+  });
   const componentIconMap = useMemo(() => {
     const map: Record<string, string> = {};
     for (const c of components) {
@@ -563,7 +564,6 @@ export function WorkflowPageV2() {
   const deleteCanvasMemoryEntry = useDeleteCanvasMemoryEntry(canvasId!);
   const canUpdateCanvas = canAct("canvases", "update");
   usePageTitle([canvas?.metadata?.name || "Canvas"]);
-
   const isTemplate = liveCanvas?.metadata?.isTemplate ?? false;
   const dashboardQuery = useCanvasDashboard(canvasId!, !isTemplate && dashboardsFeatureEnabled);
   const updateDashboardMutation = useUpdateCanvasDashboard(canvasId!);
@@ -1862,69 +1862,14 @@ export function WorkflowPageV2() {
     [preparedNodes, integrations, canvasNodes],
   );
 
-  const runCanvasData = useMemo<{
-    nodes: CanvasNode[];
-    edges: CanvasEdge[];
-    participantNodeIds: string[];
-  } | null>(() => {
-    if (!isRunsMode || !canvas || canvasLoading || triggersLoading || componentsLoading) {
-      return null;
-    }
-
-    if (!selectedRun) {
-      return { nodes: [], edges: [], participantNodeIds: [] };
-    }
-
-    const runNodeIds = new Set<string>();
-    const nodeEventsMap: Record<string, CanvasesCanvasEvent[]> = {};
-    const nodeExecutionsMap: Record<string, CanvasesCanvasNodeExecution[]> = {};
-
-    if (selectedRun.rootEvent?.nodeId) {
-      runNodeIds.add(selectedRun.rootEvent.nodeId);
-      nodeEventsMap[selectedRun.rootEvent.nodeId] = [selectedRun.rootEvent as CanvasesCanvasEvent];
-    }
-
-    for (const execution of selectedRun.executions || []) {
-      if (!execution.nodeId) continue;
-      runNodeIds.add(execution.nodeId);
-      if (!nodeExecutionsMap[execution.nodeId]) {
-        nodeExecutionsMap[execution.nodeId] = [];
-      }
-
-      nodeExecutionsMap[execution.nodeId].push(
-        hydrateRunExecution(
-          execution,
-          selectedRunFullExecutions,
-          visibleNodeExecutionsMap[execution.nodeId],
-          selectedRun.rootEvent,
-        ),
-      );
-    }
-
-    const prepared = prepareData(
-      canvas,
-      allTriggers,
-      allComponents,
-      nodeEventsMap,
-      nodeExecutionsMap,
-      {},
-      canvasId!,
-      queryClient,
-      me,
-      "live",
-    );
-
-    const nodes = stripCanvasNodeSetupWarningsForRunsView(prepared.nodes);
-    const participantNodeIds = Array.from(runNodeIds);
-
-    return { nodes, edges: prepared.edges, participantNodeIds };
-  }, [
+  const runCanvasData = useRunCanvasData({
     isRunsMode,
     selectedRun,
-    canvas,
+    selectedRunCanvas,
     canvasLoading,
     triggersLoading,
     componentsLoading,
+    isSelectedRunVersionLoading,
     allTriggers,
     allComponents,
     canvasId,
@@ -1932,12 +1877,11 @@ export function WorkflowPageV2() {
     me,
     visibleNodeExecutionsMap,
     selectedRunFullExecutions,
-  ]);
+  });
 
   const nodes = runCanvasData ? runCanvasData.nodes : nodesWithIntegrationStatus;
   const renderedEdges = runCanvasData ? runCanvasData.edges : preparedEdges;
   const runsViewportKey = isRunsMode ? "runs" : null;
-
   if (lastRunsViewportKeyRef.current !== runsViewportKey) {
     runsHasFitToViewRef.current = false;
     runsViewportRef.current = undefined;

--- a/web_src/src/pages/workflowv2/useRunCanvasData.ts
+++ b/web_src/src/pages/workflowv2/useRunCanvasData.ts
@@ -30,6 +30,22 @@ type UseRunCanvasDataParams = {
   selectedRunFullExecutions: CanvasesCanvasNodeExecution[] | undefined;
 };
 
+type UseRunCanvasPresentationParams = {
+  isRunsMode: boolean;
+  selectedRun: CanvasesCanvasRun | null;
+  runCanvasData: RunCanvasData | null;
+  liveNodes: CanvasNode[];
+  liveEdges: CanvasEdge[];
+  isSelectedRunVersionLoading: boolean;
+  isSelectedRunExecutionsLoading: boolean;
+};
+
+type RunCanvasData = {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+  participantNodeIds: string[];
+};
+
 export function useRunCanvasData({
   isRunsMode,
   selectedRun,
@@ -45,11 +61,7 @@ export function useRunCanvasData({
   me,
   visibleNodeExecutionsMap,
   selectedRunFullExecutions,
-}: UseRunCanvasDataParams): {
-  nodes: CanvasNode[];
-  edges: CanvasEdge[];
-  participantNodeIds: string[];
-} | null {
+}: UseRunCanvasDataParams): RunCanvasData | null {
   return useMemo(() => {
     if (
       !isRunsMode ||
@@ -120,4 +132,28 @@ export function useRunCanvasData({
     visibleNodeExecutionsMap,
     selectedRunFullExecutions,
   ]);
+}
+
+export function useRunCanvasPresentation({
+  isRunsMode,
+  selectedRun,
+  runCanvasData,
+  liveNodes,
+  liveEdges,
+  isSelectedRunVersionLoading,
+  isSelectedRunExecutionsLoading,
+}: UseRunCanvasPresentationParams) {
+  if (!isRunsMode) {
+    return {
+      nodes: liveNodes,
+      edges: liveEdges,
+      runCanvasLoading: false,
+    };
+  }
+
+  return {
+    nodes: runCanvasData?.nodes ?? [],
+    edges: runCanvasData?.edges ?? [],
+    runCanvasLoading: !!selectedRun && (isSelectedRunVersionLoading || isSelectedRunExecutionsLoading),
+  };
 }

--- a/web_src/src/pages/workflowv2/useRunCanvasData.ts
+++ b/web_src/src/pages/workflowv2/useRunCanvasData.ts
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import type {
+  CanvasesCanvas,
+  CanvasesCanvasEvent,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasRun,
+  SuperplaneActionsAction,
+  SuperplaneMeUser,
+  TriggersTrigger,
+} from "@/api-client";
+import type { CanvasEdge, CanvasNode } from "@/ui/CanvasPage";
+import { hydrateRunExecution, prepareData } from "./workflowPageHelpers";
+import { stripCanvasNodeSetupWarningsForRunsView } from "./lib/node-integrations";
+
+type UseRunCanvasDataParams = {
+  isRunsMode: boolean;
+  selectedRun: CanvasesCanvasRun | null;
+  selectedRunCanvas?: CanvasesCanvas | null;
+  canvasLoading: boolean;
+  triggersLoading: boolean;
+  componentsLoading: boolean;
+  isSelectedRunVersionLoading: boolean;
+  allTriggers: TriggersTrigger[];
+  allComponents: SuperplaneActionsAction[];
+  canvasId?: string;
+  queryClient: QueryClient;
+  me?: SuperplaneMeUser | null;
+  visibleNodeExecutionsMap: Record<string, CanvasesCanvasNodeExecution[]>;
+  selectedRunFullExecutions: CanvasesCanvasNodeExecution[] | undefined;
+};
+
+export function useRunCanvasData({
+  isRunsMode,
+  selectedRun,
+  selectedRunCanvas,
+  canvasLoading,
+  triggersLoading,
+  componentsLoading,
+  isSelectedRunVersionLoading,
+  allTriggers,
+  allComponents,
+  canvasId,
+  queryClient,
+  me,
+  visibleNodeExecutionsMap,
+  selectedRunFullExecutions,
+}: UseRunCanvasDataParams): {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+  participantNodeIds: string[];
+} | null {
+  return useMemo(() => {
+    if (
+      !isRunsMode ||
+      !selectedRunCanvas ||
+      canvasLoading ||
+      triggersLoading ||
+      componentsLoading ||
+      isSelectedRunVersionLoading
+    ) {
+      return null;
+    }
+    if (!selectedRun) {
+      return { nodes: [], edges: [], participantNodeIds: [] };
+    }
+    const runNodeIds = new Set<string>();
+    const nodeEventsMap: Record<string, CanvasesCanvasEvent[]> = {};
+    const nodeExecutionsMap: Record<string, CanvasesCanvasNodeExecution[]> = {};
+    if (selectedRun.rootEvent?.nodeId) {
+      runNodeIds.add(selectedRun.rootEvent.nodeId);
+      nodeEventsMap[selectedRun.rootEvent.nodeId] = [selectedRun.rootEvent as CanvasesCanvasEvent];
+    }
+    for (const execution of selectedRun.executions || []) {
+      if (!execution.nodeId) continue;
+      runNodeIds.add(execution.nodeId);
+      if (!nodeExecutionsMap[execution.nodeId]) {
+        nodeExecutionsMap[execution.nodeId] = [];
+      }
+
+      nodeExecutionsMap[execution.nodeId].push(
+        hydrateRunExecution(
+          execution,
+          selectedRunFullExecutions,
+          visibleNodeExecutionsMap[execution.nodeId],
+          selectedRun.rootEvent,
+        ),
+      );
+    }
+    const prepared = prepareData(
+      selectedRunCanvas,
+      allTriggers,
+      allComponents,
+      nodeEventsMap,
+      nodeExecutionsMap,
+      {},
+      canvasId!,
+      queryClient,
+      me,
+      "live",
+    );
+    return {
+      nodes: stripCanvasNodeSetupWarningsForRunsView(prepared.nodes),
+      edges: prepared.edges,
+      participantNodeIds: Array.from(runNodeIds),
+    };
+  }, [
+    isRunsMode,
+    selectedRun,
+    selectedRunCanvas,
+    canvasLoading,
+    triggersLoading,
+    componentsLoading,
+    isSelectedRunVersionLoading,
+    allTriggers,
+    allComponents,
+    canvasId,
+    queryClient,
+    me,
+    visibleNodeExecutionsMap,
+    selectedRunFullExecutions,
+  ]);
+}

--- a/web_src/src/pages/workflowv2/useSelectedRunCanvas.ts
+++ b/web_src/src/pages/workflowv2/useSelectedRunCanvas.ts
@@ -40,7 +40,7 @@ export function useSelectedRunCanvas({
     }
 
     if (!liveCanvas || !selectedRunVersion?.spec) {
-      return canvas;
+      return null;
     }
 
     return {

--- a/web_src/src/pages/workflowv2/useSelectedRunCanvas.ts
+++ b/web_src/src/pages/workflowv2/useSelectedRunCanvas.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import type { CanvasesCanvas, CanvasesCanvasRun } from "@/api-client";
+import { useCanvasVersion } from "@/hooks/useCanvasData";
+
+type UseSelectedRunCanvasParams = {
+  organizationId: string;
+  canvasId: string;
+  selectedRun: CanvasesCanvasRun | null;
+  isRunsMode: boolean;
+  liveCanvasVersionId?: string;
+  canvas?: CanvasesCanvas | null;
+  liveCanvas?: CanvasesCanvas | null;
+};
+
+export function useSelectedRunCanvas({
+  organizationId,
+  canvasId,
+  selectedRun,
+  isRunsMode,
+  liveCanvasVersionId,
+  canvas,
+  liveCanvas,
+}: UseSelectedRunCanvasParams) {
+  const selectedRunVersionId = selectedRun?.versionId || "";
+  const selectedRunVersionQuery = useCanvasVersion(
+    organizationId,
+    canvasId,
+    selectedRunVersionId,
+    isRunsMode && !!selectedRunVersionId && selectedRunVersionId !== liveCanvasVersionId,
+  );
+  const selectedRunVersion = selectedRunVersionQuery.data;
+
+  const selectedRunCanvas = useMemo(() => {
+    if (!selectedRunVersionId) {
+      return canvas;
+    }
+
+    if (selectedRunVersionId === liveCanvasVersionId) {
+      return liveCanvas || canvas;
+    }
+
+    if (!liveCanvas || !selectedRunVersion?.spec) {
+      return canvas;
+    }
+
+    return {
+      ...liveCanvas,
+      spec: selectedRunVersion.spec,
+    };
+  }, [canvas, liveCanvas, liveCanvasVersionId, selectedRunVersion?.spec, selectedRunVersionId]);
+
+  return {
+    selectedRunCanvas,
+    isSelectedRunVersionLoading:
+      isRunsMode &&
+      !!selectedRunVersionId &&
+      selectedRunVersionId !== liveCanvasVersionId &&
+      !selectedRunVersion?.spec &&
+      !selectedRunVersionQuery.isError &&
+      (selectedRunVersionQuery.isLoading || selectedRunVersionQuery.isFetching),
+  };
+}


### PR DESCRIPTION
Fixes #4920.

## Summary
- add version_id to workflow_runs and backfill existing runs from the published version active at run creation
- attach the live canvas version when creating new workflow runs and expose it through the CanvasRun API
- load the run's recorded canvas version in runs view so historical/deleted nodes render correctly

## Validation
- make test PKG_TEST_PACKAGES='./pkg/models ./pkg/grpc/actions/canvases'
- make lint
- make check.build.app
- make format.js
- make check.lint.ui
- make check.build.ui
- make check.db.migrations