### PR TITLE
fix: preserve rubric markdown sections

### DIFF
--- a/web_src/src/components/AgentSidebar/widgets/MarkdownCode.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/MarkdownCode.tsx
@@ -1,0 +1,17 @@
+import type { ComponentProps, ReactNode } from "react";
+import { CodeBlockWidget } from "./CodeBlockWidget";
+
+export function MarkdownCode({ className, children, ...props }: ComponentProps<"code"> & { children?: ReactNode }) {
+  const match = /language-(\w+)/.exec(className || "");
+  const code = String(children).replace(/\n$/, "");
+
+  if (match) {
+    return <CodeBlockWidget code={code} language={match[1]} />;
+  }
+
+  return (
+    <code className={className} {...props}>
+      {children}
+    </code>
+  );
+}

--- a/web_src/src/components/AgentSidebar/widgets/RichMessage.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RichMessage.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { RichMessage } from "./RichMessage";
@@ -43,5 +43,36 @@ describe("RichMessage", () => {
 
     // When ids are available, `run:` links should render as RunChip buttons (not external anchors).
     expect(screen.getByRole("button", { name: "run link" })).toBeInTheDocument();
+  });
+
+  it("renders full markdown sections inside rubric modals", () => {
+    render(
+      <MemoryRouter>
+        <RichMessage
+          content={[
+            ":::rubric HTTP Monitor with Retry + GitHub Notify Spec",
+            "## Flow",
+            "1. **Schedule** fires every 15 minutes",
+            "2. **HTTP GET** `https://httpbin.org/get`",
+            "",
+            "## Components",
+            "| Node | Component | Notes |",
+            "|------|-----------|-------|",
+            "| Schedule | `schedule` | minutesInterval: 15 |",
+            "",
+            "```yaml",
+            'successCodes: "200"',
+            "```",
+            ":::",
+          ].join("\n")}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /view full plan/i }));
+
+    expect(screen.getAllByText("Schedule").some((element) => element.tagName === "STRONG")).toBe(true);
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByTestId("monaco-stub")).toHaveTextContent('successCodes: "200"');
   });
 });

--- a/web_src/src/components/AgentSidebar/widgets/RichMessage.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RichMessage.tsx
@@ -5,9 +5,9 @@ import remarkGfm from "remark-gfm";
 import { BannerWidget } from "./BannerWidget";
 import { ButtonsWidget } from "./ButtonsWidget";
 import { ChartWidget } from "./ChartWidget";
-import { CodeBlockWidget } from "./CodeBlockWidget";
 import { CollapseWidget } from "./CollapseWidget";
 import { ConfirmWidget } from "./ConfirmWidget";
+import { MarkdownCode } from "./MarkdownCode";
 import { RubricWidget } from "./RubricWidget";
 import { MermaidWidget } from "./MermaidWidget";
 import { NodeChipFromLink } from "./NodeChip";
@@ -211,21 +211,6 @@ function renderSpecialLink(href: string | undefined, children: ReactNode, canvas
   }
 
   return null;
-}
-
-function MarkdownCode({ className, children, ...props }: ComponentProps<"code"> & { children?: ReactNode }) {
-  const match = /language-(\w+)/.exec(className || "");
-  const code = String(children).replace(/\n$/, "");
-
-  if (match) {
-    return <CodeBlockWidget code={code} language={match[1]} />;
-  }
-
-  return (
-    <code className={className} {...props}>
-      {children}
-    </code>
-  );
 }
 
 function isAgentLink(url: string): boolean {

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.spec.tsx
@@ -88,6 +88,33 @@ describe("RubricWidget", () => {
     expect(within(modal).getByTestId("monaco-stub")).toHaveTextContent("npm test");
   });
 
+  it("keeps numbering aligned after body-rendered categories", () => {
+    render(
+      <RubricWidget
+        title="Test Plan"
+        criteria={[{ text: "First" }, { text: "Second" }, { text: "Fallback item" }]}
+        categories={[
+          {
+            heading: "Body",
+            criteria: [{ text: "First" }, { text: "Second" }],
+            body: "1. First\n2. Second",
+          },
+          {
+            heading: "Fallback",
+            criteria: [{ text: "Fallback item" }],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /view full plan/i }));
+
+    const fallbackItem = screen.getByText("Fallback item");
+    const fallbackRow = fallbackItem.closest("div.flex") as HTMLElement;
+    expect(fallbackRow).not.toBeNull();
+    expect(within(fallbackRow).getByText("3.")).toBeInTheDocument();
+  });
+
   it("wraps GFM tables in a horizontal overflow container (Full Plan modal)", () => {
     render(
       <RubricWidget

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.spec.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { RubricWidget } from "./RubricWidget";
+
+vi.mock("@monaco-editor/react", () => ({
+  default: ({ value }: { value?: string }) => <pre data-testid="monaco-stub">{value}</pre>,
+}));
 
 describe("RubricWidget", () => {
   it("renders markdown for criteria in the inline preview", () => {
@@ -51,8 +55,7 @@ describe("RubricWidget", () => {
     render(<RubricWidget title="Test Plan" criteria={[{ text: "Run this:\n\n```bash\nnpm test\n```" }]} />);
 
     // No modal opened — this exercises the inline preview only.
-    const codeElement = screen.getByText("npm test", { selector: "code" });
-    expect(codeElement.closest("pre")).not.toBeNull();
+    expect(screen.getByTestId("monaco-stub")).toHaveTextContent("npm test");
   });
 
   it("renders markdown for criteria inside a categorized inline preview", () => {
@@ -82,9 +85,7 @@ describe("RubricWidget", () => {
     const modal = heading.closest("div.fixed") as HTMLElement;
     expect(modal).not.toBeNull();
 
-    // The fenced code block must render as <pre><code>, not as raw backticks.
-    const codeElement = within(modal).getByText("npm test", { selector: "code" });
-    expect(codeElement.closest("pre")).not.toBeNull();
+    expect(within(modal).getByTestId("monaco-stub")).toHaveTextContent("npm test");
   });
 
   it("wraps GFM tables in a horizontal overflow container (Full Plan modal)", () => {

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
@@ -384,39 +384,44 @@ function CategorizedList({
   let globalIndex = 0;
   return (
     <div className="space-y-3">
-      {categories.map((cat, ci) => (
-        <div key={ci}>
-          <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">{cat.heading}</p>
-          {cat.body ? (
-            <div className={`${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
-              <RubricMarkdown canvasId={canvasId} organizationId={organizationId}>
-                {cat.body}
-              </RubricMarkdown>
-            </div>
-          ) : (
-            cat.criteria.map((c, i) => {
-              globalIndex++;
-              return (
-                <div
-                  key={i}
-                  className={`flex items-start gap-2 ${showNumbers ? "py-1.5 border-b border-slate-50 last:border-0" : "py-0.5"}`}
-                >
-                  {showNumbers ? (
-                    <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{globalIndex}.</span>
-                  ) : (
-                    <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
-                  )}
-                  <div className={`min-w-0 flex-1 ${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
-                    <RubricMarkdown compact canvasId={canvasId} organizationId={organizationId}>
-                      {c.text}
-                    </RubricMarkdown>
+      {categories.map((cat, ci) => {
+        const categoryStartIndex = globalIndex;
+        globalIndex += cat.criteria.length;
+
+        return (
+          <div key={ci}>
+            <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">{cat.heading}</p>
+            {cat.body ? (
+              <div className={`${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
+                <RubricMarkdown canvasId={canvasId} organizationId={organizationId}>
+                  {cat.body}
+                </RubricMarkdown>
+              </div>
+            ) : (
+              cat.criteria.map((c, i) => {
+                const criterionIndex = categoryStartIndex + i + 1;
+                return (
+                  <div
+                    key={i}
+                    className={`flex items-start gap-2 ${showNumbers ? "py-1.5 border-b border-slate-50 last:border-0" : "py-0.5"}`}
+                  >
+                    {showNumbers ? (
+                      <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{criterionIndex}.</span>
+                    ) : (
+                      <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
+                    )}
+                    <div className={`min-w-0 flex-1 ${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
+                      <RubricMarkdown compact canvasId={canvasId} organizationId={organizationId}>
+                        {c.text}
+                      </RubricMarkdown>
+                    </div>
                   </div>
-                </div>
-              );
-            })
-          )}
-        </div>
-      ))}
+                );
+              })
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { ClipboardList, ChevronDown, ChevronUp, X } from "lucide-react";
 import type { RubricCategory } from "./parser";
+import { CodeBlockWidget } from "./CodeBlockWidget";
 import { IntegrationButton } from "./IntegrationButton";
 import { NodeChipFromLink } from "./NodeChip";
 import { RunChipFromLink } from "./RunChip";
@@ -24,17 +25,37 @@ const CRITERION_MARKDOWN_CLASSES =
   "[&_tbody_tr:nth-child(even)]:bg-slate-50/60 " +
   "[&_tr:last-child_td]:border-b-0";
 
-function CriterionMarkdown({
+const RUBRIC_BODY_MARKDOWN_CLASSES =
+  "max-w-none " +
+  "[&_h2]:mb-2 [&_h2]:mt-3 [&_h2]:text-sm [&_h2]:font-semibold [&_h2:first-child]:mt-0 " +
+  "[&_h3]:mb-1.5 [&_h3]:mt-2 [&_h3]:text-sm [&_h3]:font-semibold [&_h3:first-child]:mt-0 " +
+  "[&_p]:mb-2 [&_p]:leading-relaxed [&_p:last-child]:mb-0 " +
+  "[&_ul]:mb-2 [&_ul]:ml-5 [&_ul]:list-disc [&_ol]:mb-2 [&_ol]:ml-5 [&_ol]:list-decimal [&_li]:mb-1 " +
+  "[&_strong]:font-semibold [&_em]:italic " +
+  "[&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-slate-300 [&_blockquote]:pl-3 " +
+  "[&_a]:underline [&_a]:underline-offset-2 [&_a]:text-slate-700 " +
+  "[&_code]:rounded [&_code]:bg-slate-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_code]:font-mono " +
+  "[&_pre_code]:bg-transparent [&_pre_code]:p-0 " +
+  "[&_table]:w-full [&_table]:text-[11px] [&_table]:border-collapse " +
+  "[&_thead]:bg-slate-50 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_th]:font-semibold [&_th]:text-slate-700 " +
+  "[&_th]:border-b [&_th]:border-slate-200 " +
+  "[&_td]:px-2 [&_td]:py-1 [&_td]:text-slate-600 [&_td]:border-b [&_td]:border-slate-100 " +
+  "[&_tbody_tr:nth-child(even)]:bg-slate-50/60 " +
+  "[&_tr:last-child_td]:border-b-0";
+
+function RubricMarkdown({
   children,
   canvasId,
   organizationId,
+  compact = false,
 }: {
   children: string;
   canvasId?: string;
   organizationId?: string;
+  compact?: boolean;
 }) {
   return (
-    <div className={`min-w-0 ${CRITERION_MARKDOWN_CLASSES}`}>
+    <div className={`min-w-0 ${compact ? CRITERION_MARKDOWN_CLASSES : RUBRIC_BODY_MARKDOWN_CLASSES}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         urlTransform={(url) => (isAgentLink(url) ? url : defaultUrlTransform(url))}
@@ -44,6 +65,8 @@ function CriterionMarkdown({
               {linkChildren}
             </AgentLink>
           ),
+          code: RubricMarkdownCode,
+          pre: ({ children: preChildren }) => <>{preChildren}</>,
           table: ({ children: tableChildren, ...props }) => (
             <div className="my-4 overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm">
               <table {...props}>{tableChildren}</table>
@@ -54,6 +77,21 @@ function CriterionMarkdown({
         {children}
       </ReactMarkdown>
     </div>
+  );
+}
+
+function RubricMarkdownCode({ className, children, ...props }: ComponentProps<"code"> & { children?: ReactNode }) {
+  const match = /language-(\w+)/.exec(className || "");
+  const code = String(children).replace(/\n$/, "");
+
+  if (match) {
+    return <CodeBlockWidget code={code} language={match[1]} />;
+  }
+
+  return (
+    <code className={className} {...props}>
+      {children}
+    </code>
   );
 }
 
@@ -318,9 +356,9 @@ function FlatCriteriaList({
     <div key={index} className="flex items-start gap-2 py-0.5">
       <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
       <div className="min-w-0 flex-1 text-xs text-slate-700">
-        <CriterionMarkdown canvasId={canvasId} organizationId={organizationId}>
+        <RubricMarkdown compact canvasId={canvasId} organizationId={organizationId}>
           {criterion.text}
-        </CriterionMarkdown>
+        </RubricMarkdown>
       </div>
     </div>
   ));
@@ -339,9 +377,9 @@ function NumberedCriteriaList({
     <div key={index} className="flex items-start gap-2 py-1.5 border-b border-slate-50 last:border-0">
       <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{index + 1}.</span>
       <div className="min-w-0 flex-1 text-sm text-slate-700">
-        <CriterionMarkdown canvasId={canvasId} organizationId={organizationId}>
+        <RubricMarkdown compact canvasId={canvasId} organizationId={organizationId}>
           {criterion.text}
-        </CriterionMarkdown>
+        </RubricMarkdown>
       </div>
     </div>
   ));
@@ -364,26 +402,34 @@ function CategorizedList({
       {categories.map((cat, ci) => (
         <div key={ci}>
           <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wide mb-1">{cat.heading}</p>
-          {cat.criteria.map((c, i) => {
-            globalIndex++;
-            return (
-              <div
-                key={i}
-                className={`flex items-start gap-2 ${showNumbers ? "py-1.5 border-b border-slate-50 last:border-0" : "py-0.5"}`}
-              >
-                {showNumbers ? (
-                  <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{globalIndex}.</span>
-                ) : (
-                  <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
-                )}
-                <div className={`min-w-0 flex-1 ${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
-                  <CriterionMarkdown canvasId={canvasId} organizationId={organizationId}>
-                    {c.text}
-                  </CriterionMarkdown>
+          {cat.body ? (
+            <div className={`${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
+              <RubricMarkdown canvasId={canvasId} organizationId={organizationId}>
+                {cat.body}
+              </RubricMarkdown>
+            </div>
+          ) : (
+            cat.criteria.map((c, i) => {
+              globalIndex++;
+              return (
+                <div
+                  key={i}
+                  className={`flex items-start gap-2 ${showNumbers ? "py-1.5 border-b border-slate-50 last:border-0" : "py-0.5"}`}
+                >
+                  {showNumbers ? (
+                    <span className="text-slate-500 text-sm mt-0.5 shrink-0 font-medium">{globalIndex}.</span>
+                  ) : (
+                    <span className="text-slate-400 text-xs mt-0.5 shrink-0">✦</span>
+                  )}
+                  <div className={`min-w-0 flex-1 ${showNumbers ? "text-sm" : "text-xs"} text-slate-700`}>
+                    <RubricMarkdown compact canvasId={canvasId} organizationId={organizationId}>
+                      {c.text}
+                    </RubricMarkdown>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
+              );
+            })
+          )}
         </div>
       ))}
     </div>

--- a/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RubricWidget.tsx
@@ -5,8 +5,8 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { ClipboardList, ChevronDown, ChevronUp, X } from "lucide-react";
 import type { RubricCategory } from "./parser";
-import { CodeBlockWidget } from "./CodeBlockWidget";
 import { IntegrationButton } from "./IntegrationButton";
+import { MarkdownCode } from "./MarkdownCode";
 import { NodeChipFromLink } from "./NodeChip";
 import { RunChipFromLink } from "./RunChip";
 
@@ -65,7 +65,7 @@ function RubricMarkdown({
               {linkChildren}
             </AgentLink>
           ),
-          code: RubricMarkdownCode,
+          code: MarkdownCode,
           pre: ({ children: preChildren }) => <>{preChildren}</>,
           table: ({ children: tableChildren, ...props }) => (
             <div className="my-4 overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm">
@@ -77,21 +77,6 @@ function RubricMarkdown({
         {children}
       </ReactMarkdown>
     </div>
-  );
-}
-
-function RubricMarkdownCode({ className, children, ...props }: ComponentProps<"code"> & { children?: ReactNode }) {
-  const match = /language-(\w+)/.exec(className || "");
-  const code = String(children).replace(/\n$/, "");
-
-  if (match) {
-    return <CodeBlockWidget code={code} language={match[1]} />;
-  }
-
-  return (
-    <code className={className} {...props}>
-      {children}
-    </code>
   );
 }
 

--- a/web_src/src/components/AgentSidebar/widgets/parser.test.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.test.ts
@@ -138,4 +138,40 @@ Oops!
     expect(segments[0].type).toBe("markdown");
     expect(segments[1].type).toBe("error");
   });
+
+  it("preserves full markdown bodies inside categorized rubric sections", () => {
+    const content = `:::rubric HTTP Monitor Spec
+## Flow
+1. **Schedule** fires every 15 minutes
+2. **HTTP GET** \`https://httpbin.org/get\`
+
+## Components
+| Node | Component |
+|------|-----------|
+| Schedule | \`schedule\` |
+
+\`\`\`yaml
+minutesInterval: 15
+\`\`\`
+:::`;
+
+    const segments = parseAgentContent(content);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      type: "rubric",
+      title: "HTTP Monitor Spec",
+      body: expect.stringContaining("```yaml"),
+      categories: [
+        {
+          heading: "Flow",
+          body: expect.stringContaining("**Schedule**"),
+        },
+        {
+          heading: "Components",
+          body: expect.stringContaining("| Node | Component |"),
+        },
+      ],
+    });
+  });
 });

--- a/web_src/src/components/AgentSidebar/widgets/parser.ts
+++ b/web_src/src/components/AgentSidebar/widgets/parser.ts
@@ -13,12 +13,13 @@ export type SuccessSegment = { type: "success"; content: string };
 export type ErrorSegment = { type: "error"; content: string };
 export type DraftActionsSegment = { type: "draft-actions"; versionId: string; message?: string };
 export type SurveySegment = { type: "survey"; questions: { prompt: string; options: string[]; hasInput?: boolean }[] };
-export type RubricCategory = { heading: string; criteria: { text: string }[] };
+export type RubricCategory = { heading: string; criteria: { text: string }[]; body?: string };
 export type RubricSegment = {
   type: "rubric";
   title: string;
   criteria: { text: string }[];
   categories?: RubricCategory[];
+  body?: string;
 };
 
 export type Segment =
@@ -295,10 +296,11 @@ function parseSurvey(raw: string): SurveySegment {
 }
 
 function parseRubric(meta: string, raw: string): RubricSegment {
-  const lines = raw.split("\n").filter((l) => l.trim());
+  const rawLines = raw.split("\n");
+  const lines = rawLines.filter((l) => l.trim());
   let title = meta.trim();
   if (lines.some((line) => isRubricHeading(line.trim()))) {
-    return parseCategorizedRubric(lines, title);
+    return parseCategorizedRubric(rawLines, title, raw.trim());
   }
 
   const criteria: { text: string }[] = [];
@@ -317,25 +319,45 @@ function parseRubric(meta: string, raw: string): RubricSegment {
     }
   }
 
-  return { type: "rubric", title: title || "Build Plan", criteria };
+  return { type: "rubric", title: title || "Build Plan", criteria, body: raw.trim() };
 }
 
-function parseCategorizedRubric(lines: string[], initialTitle: string): RubricSegment {
+function parseCategorizedRubric(lines: string[], initialTitle: string, body: string): RubricSegment {
   let title = initialTitle;
   const categories: RubricCategory[] = [];
   const uncategorized: { text: string }[] = [];
-  let currentCategory: RubricCategory | null = null;
+  let currentCategory: (RubricCategory & { bodyLines: string[] }) | null = null;
+
+  const flushCategory = () => {
+    if (!currentCategory) {
+      return;
+    }
+
+    const categoryBody = currentCategory.bodyLines.join("\n").trim();
+    categories.push({
+      heading: currentCategory.heading,
+      criteria: currentCategory.criteria,
+      body: categoryBody || undefined,
+    });
+    currentCategory = null;
+  };
 
   for (const line of lines) {
-    const parsedLine = parseRubricLine(line.trim());
-
-    if (parsedLine.type === "heading") {
-      if (currentCategory) {
-        categories.push(currentCategory);
-      }
-      currentCategory = { heading: parsedLine.heading, criteria: [] };
+    const trimmed = line.trim();
+    if (!trimmed) {
+      currentCategory?.bodyLines.push(line);
       continue;
     }
+
+    const parsedLine = parseRubricLine(trimmed);
+
+    if (parsedLine.type === "heading") {
+      flushCategory();
+      currentCategory = { heading: parsedLine.heading, criteria: [], bodyLines: [] };
+      continue;
+    }
+
+    currentCategory?.bodyLines.push(line);
 
     if (parsedLine.type === "criterion") {
       if (currentCategory) {
@@ -351,15 +373,14 @@ function parseCategorizedRubric(lines: string[], initialTitle: string): RubricSe
     }
   }
 
-  if (currentCategory) {
-    categories.push(currentCategory);
-  }
+  flushCategory();
 
   return {
     type: "rubric",
     title: title || "Build Plan",
     criteria: [...uncategorized, ...categories.flatMap((category) => category.criteria)],
     categories,
+    body,
   };
 }
 

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -92,10 +92,10 @@ export function createWebsocketCallbacks(
 export function buildRubricText(rubric: { title: string; criteria: string[]; categories?: RubricCategory[] }): string {
   if (rubric.categories && rubric.categories.length > 0) {
     const sections = rubric.categories
-      .map(
-        (category) =>
-          `## ${category.heading}\n${category.criteria.map((criterion) => `- ${criterion.text}`).join("\n")}`,
-      )
+      .map((category) => {
+        const body = category.body || category.criteria.map((criterion) => `- ${criterion.text}`).join("\n");
+        return `## ${category.heading}\n${body}`;
+      })
       .join("\n\n");
     return `# ${rubric.title}\n\n${sections}`;
   }


### PR DESCRIPTION
## Summary
- Preserve full markdown bodies for categorized rubric sections instead of flattening them to criteria only
- Render rubric body markdown with GFM tables, fenced code blocks, links, blockquotes, and lists
- Keep preserved rubric markdown when starting a build from a rubric widget

## Tests
- make format.js
- docker compose -f docker-compose.dev.yml exec app bash -c "cd web_src && npm test -- --run src/components/AgentSidebar/widgets/parser.test.ts src/components/AgentSidebar/widgets/RubricWidget.spec.tsx src/components/AgentSidebar/widgets/RichMessage.spec.tsx"
- make check.build.ui
- make check.lint.ui