### PR TITLE
fix: isolate edit mode sidebar state

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -149,6 +149,13 @@ const LOCAL_CANVAS_LIFECYCLE_ECHO_TTL_MS = 5000;
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
 const EMPTY_CANVAS_EDGES: ComponentsEdge[] = [];
+
+function clearComponentSidebarSearchParams(params: URLSearchParams): URLSearchParams {
+  params.delete("sidebar");
+  params.delete("node");
+  return params;
+}
+
 type ChangeRequestAction = "ACTION_APPROVE" | "ACTION_UNAPPROVE" | "ACTION_PUBLISH" | "ACTION_REJECT" | "ACTION_REOPEN";
 type CanvasSaveResult = {
   status: "saved" | "replaced" | "stale";
@@ -894,7 +901,7 @@ export function WorkflowPageV2() {
       setSearchParams((current) => {
         const next = new URLSearchParams(current);
         next.delete("version");
-        return next;
+        return clearComponentSidebarSearchParams(next);
       });
       hasSyncedVersionFromURLRef.current = true;
       return;
@@ -1412,7 +1419,7 @@ export function WorkflowPageV2() {
         if (version.metadata?.id) {
           next.set("version", version.metadata.id);
         }
-        return next;
+        return clearComponentSidebarSearchParams(next);
       });
 
       queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
@@ -4183,7 +4190,7 @@ export function WorkflowPageV2() {
         setSearchParams((current) => {
           const next = new URLSearchParams(current);
           next.set("version", editVersionID);
-          return next;
+          return clearComponentSidebarSearchParams(next);
         });
       }
 
@@ -4251,7 +4258,7 @@ export function WorkflowPageV2() {
       setSearchParams((current) => {
         const next = new URLSearchParams(current);
         next.delete("version");
-        return next;
+        return clearComponentSidebarSearchParams(next);
       });
       await refreshLatestLiveCanvasData();
       showSuccessToast("Version published");
@@ -4342,7 +4349,7 @@ export function WorkflowPageV2() {
           setSearchParams((current) => {
             const next = new URLSearchParams(current);
             next.delete("version");
-            return next;
+            return clearComponentSidebarSearchParams(next);
           });
           await refreshLatestLiveCanvasData();
         },
@@ -4498,7 +4505,7 @@ export function WorkflowPageV2() {
           setSearchParams((current) => {
             const next = new URLSearchParams(current);
             next.set("version", resolvedVersionID);
-            return next;
+            return clearComponentSidebarSearchParams(next);
           });
         }
 
@@ -4581,7 +4588,7 @@ export function WorkflowPageV2() {
         } else {
           next.set("version", versionID);
         }
-        return next;
+        return clearComponentSidebarSearchParams(next);
       });
 
       queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
@@ -4994,7 +5001,7 @@ export function WorkflowPageV2() {
       setSearchParams((current) => {
         const next = new URLSearchParams(current);
         next.delete("version");
-        return next;
+        return clearComponentSidebarSearchParams(next);
       });
 
       if (liveCanvasVersion?.spec) {

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement, ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,6 +62,10 @@ vi.mock("@xyflow/react", () => ({
 vi.mock("../BuildingBlocksSidebar", () => ({
   BuildingBlocksSidebar: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <aside data-testid="building-blocks-sidebar" /> : null,
+}));
+
+vi.mock("../componentSidebar", () => ({
+  ComponentSidebar: () => <aside data-testid="component-sidebar" />,
 }));
 
 vi.mock("@/components/CanvasToolSidebar", () => ({
@@ -320,6 +324,84 @@ describe("CanvasPage connection drop", () => {
     });
     expect(payload?.sourceNodeId).toBeUndefined();
     expect(payload?.sourceHandleId).toBeUndefined();
+  });
+
+  it("loads node run data only while the component sidebar is open in live mode", async () => {
+    const loadSidebarData = vi.fn();
+    const getSidebarData = vi.fn(() => ({
+      latestEvents: [],
+      nextInQueueEvents: [],
+      title: "Node",
+      totalInQueueCount: 0,
+      totalInHistoryCount: 0,
+    }));
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-edit"
+          canvasStateMode="editing"
+          nodes={[
+            {
+              id: "node-1",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Node",
+                state: "pending",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          activeCanvasVersionId="draft-version"
+          initialSidebar={{ isOpen: true, nodeId: "node-1" }}
+          getSidebarData={getSidebarData}
+          loadSidebarData={loadSidebarData}
+          workflowNodes={[{ id: "node-1", type: "TYPE_ACTION", name: "Node" }]}
+          onMemoryOpen={vi.fn()}
+          onYamlOpen={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {});
+    expect(loadSidebarData).not.toHaveBeenCalled();
+
+    rerender(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          canvasStateMode="default"
+          nodes={[
+            {
+              id: "node-1",
+              position: { x: 0, y: 0 },
+              data: {
+                label: "Node",
+                state: "pending",
+                type: "component",
+              },
+            },
+          ]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId=""
+          initialSidebar={{ isOpen: true, nodeId: "node-1" }}
+          getSidebarData={getSidebarData}
+          loadSidebarData={loadSidebarData}
+          workflowNodes={[{ id: "node-1", type: "TYPE_ACTION", name: "Node" }]}
+          onMemoryOpen={vi.fn()}
+          onYamlOpen={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(loadSidebarData).toHaveBeenCalledWith("node-1"));
   });
 
   it("does not re-run fit all when only run canvas nodes change", () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1556,10 +1556,10 @@ function Sidebar({
 
   // Trigger data loading when sidebar opens for a node
   useEffect(() => {
-    if (state.componentSidebar.selectedNodeId && loadSidebarData) {
+    if (shouldShowRunsSidebar && state.componentSidebar.selectedNodeId && loadSidebarData) {
       loadSidebarData(state.componentSidebar.selectedNodeId);
     }
-  }, [state.componentSidebar.selectedNodeId, loadSidebarData]);
+  }, [state.componentSidebar.selectedNodeId, loadSidebarData, shouldShowRunsSidebar]);
 
   useEffect(() => {
     if (sidebarData?.latestEvents) {


### PR DESCRIPTION
## Summary
- clear component sidebar URL state when switching canvas versions or entering/leaving edit mode
- prevent node run-history loading from the component sidebar while the canvas is in edit mode
- add a CanvasPage regression test for live-only sidebar event loading

## Validation
- npm run test:run -- src/ui/CanvasPage/index.spec.tsx
- make format.js
- make check.build.ui