### PR TITLE
fix: stabilize flaky e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ tidy:
 	$(COMPOSE) exec app go mod tidy
 
 test.e2e:
-	$(COMPOSE) exec app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1
+	$(COMPOSE) exec app gotestsum --format short --junitfile junit-report.xml --rerun-fails=3 --rerun-fails-max-failures=1 --packages="$(E2E_TEST_PACKAGES)" -- -p 1 -timeout 30m
 
 test.e2e.autoparallel:
 	$(COMPOSE) exec -e INDEX -e TOTAL app bash -lc "cd /app && bash scripts/test_e2e_autoparallel.sh"

--- a/scripts/test_e2e_autoparallel.sh
+++ b/scripts/test_e2e_autoparallel.sh
@@ -93,4 +93,5 @@ gotestsum \
   --packages="./test/e2e/..." \
   -- \
   -p 1 \
+  -timeout 30m \
   -run "${regex}"

--- a/scripts/test_e2e_autoparallel.sh
+++ b/scripts/test_e2e_autoparallel.sh
@@ -93,5 +93,5 @@ gotestsum \
   --packages="./test/e2e/..." \
   -- \
   -p 1 \
-  -timeout 30m \
+  -timeout 15m \
   -run "${regex}"

--- a/test/e2e/approvals_test.go
+++ b/test/e2e/approvals_test.go
@@ -11,7 +11,6 @@ import (
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/e2e/shared"
-	"github.com/superplanehq/superplane/test/support"
 )
 
 func TestApprovals(t *testing.T) {
@@ -306,35 +305,12 @@ func (s *ApprovalSteps) addApprovalWithUserRoleGroup(nodeName string, pos models
 }
 
 func (s *ApprovalSteps) runManualTrigger() {
-	// Under full-suite load, publishing and websocket sync can lag enough that the
-	// first trigger click is occasionally ignored. Retry several times before failing.
-	for attempt := 0; attempt < 4; attempt++ {
-		s.canvas.RunManualTrigger("Start")
-		if s.waitForApprovalExecution(45 * time.Second) {
-			return
-		}
-		s.session.Sleep(500)
-	}
-
-	// Last-resort fallback: emit a trigger event directly if UI clicks were missed.
-	s.emitManualTriggerFallback()
-	if s.waitForApprovalExecution(45 * time.Second) {
+	s.canvas.EmitManualTrigger("Start")
+	if s.waitForApprovalExecution(90 * time.Second) {
 		return
 	}
 
-	s.t.Fatalf("timed out waiting for execution of node Approval after retrying manual trigger")
-}
-
-func (s *ApprovalSteps) emitManualTriggerFallback() {
-	startNode := s.canvas.GetNodeFromDB("Start")
-	support.EmitCanvasEventForNodeWithData(
-		s.t,
-		s.canvas.WorkflowID,
-		startNode.NodeID,
-		"default",
-		nil,
-		map[string]any{"message": "Hello, World!"},
-	)
+	s.t.Fatalf("timed out waiting for execution of node Approval after emitting manual trigger")
 }
 
 func (s *ApprovalSteps) waitForApprovalExecution(timeout time.Duration) bool {

--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -257,10 +257,16 @@ func (s *CanvasPageSteps) givenACanvasExistsWithANoopNode() {
 }
 
 func (s *CanvasPageSteps) toggleNodeViewOnCanvas(nodeName string) {
-	nodeHeader := q.TestID("node", nodeName, "header")
-	s.session.HoverOver(nodeHeader)
+	safe := strings.ToLower(nodeName)
+	safe = strings.ReplaceAll(safe, " ", "-")
+	node := q.Locator(`.react-flow__node:has([data-testid="node-` + safe + `-header"])`)
+	toggleButton := q.Locator(
+		`.react-flow__node:has([data-testid="node-` + safe + `-header"]) [data-testid="node-action-toggle-view"]`,
+	)
+
+	s.session.HoverOver(node)
 	s.session.Sleep(100)
-	s.session.Click(q.TestID("node-action-toggle-view"))
+	s.session.Click(toggleButton)
 	s.session.Sleep(300)
 }
 
@@ -318,18 +324,93 @@ func (s *CanvasPageSteps) givenACanvasWithManualTriggerAndWaitNodeAndQueuedItems
 	s.canvas.Connect("Start", "Wait")
 	s.canvas.Save()
 	s.canvas.Publish()
-
-	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-start-header"]) [data-testid="start-template-run"]`)
-	emitEvent := q.TestID("emit-event-submit-button")
+	s.t.Cleanup(func() {
+		s.cleanupQueuedWaitWork("Wait")
+	})
 
 	for i := 0; i < itemsAmount; i++ {
-		s.session.Click(startTemplateRun)
-		s.session.Click(emitEvent)
+		s.canvas.EmitManualTrigger("Start")
 		s.session.Sleep(100)
 	}
 
 	// wait for the first item to start processing
 	s.session.Sleep(500)
+}
+
+func (s *CanvasPageSteps) cleanupQueuedWaitWork(nodeName string) {
+	if s.canvas == nil {
+		return
+	}
+
+	node, err := s.findNodeByName(nodeName)
+	if err != nil {
+		s.t.Logf("cleanup queued wait work: find node %q: %v", nodeName, err)
+		return
+	}
+	if node == nil {
+		s.t.Logf("cleanup queued wait work: node %q not found", nodeName)
+		return
+	}
+
+	activeStates := []string{
+		models.CanvasNodeExecutionStatePending,
+		models.CanvasNodeExecutionStateStarted,
+	}
+
+	var executions []models.CanvasNodeExecution
+	err = database.Conn().
+		Where("workflow_id = ?", node.WorkflowID).
+		Where("node_id = ?", node.NodeID).
+		Where("state IN ?", activeStates).
+		Find(&executions).
+		Error
+	if err != nil {
+		s.t.Logf("cleanup queued wait work: find executions: %v", err)
+		return
+	}
+
+	for i := range executions {
+		if err := executions[i].Cancel(nil); err != nil {
+			s.t.Logf("cleanup queued wait work: cancel execution %s: %v", executions[i].ID, err)
+		}
+	}
+
+	if err := database.Conn().
+		Where("workflow_id = ?", node.WorkflowID).
+		Where("node_id = ?", node.NodeID).
+		Delete(&models.CanvasNodeQueueItem{}).
+		Error; err != nil {
+		s.t.Logf("cleanup queued wait work: delete queue items: %v", err)
+	}
+
+	if err := database.Conn().
+		Where("workflow_id = ?", node.WorkflowID).
+		Where("node_id = ?", node.NodeID).
+		Where("state = ?", models.NodeExecutionRequestStatePending).
+		Delete(&models.CanvasNodeRequest{}).
+		Error; err != nil {
+		s.t.Logf("cleanup queued wait work: delete node requests: %v", err)
+	}
+}
+
+func (s *CanvasPageSteps) findNodeByName(nodeName string) (*models.CanvasNode, error) {
+	canvas, err := models.FindCanvas(s.session.OrgID, s.canvas.WorkflowID)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := models.FindCanvasNodes(canvas.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range nodes {
+		if nodes[i].Name == nodeName {
+			return &nodes[i], nil
+		}
+	}
+
+	return nil, nil
 }
 
 func (s *CanvasPageSteps) openSidebarForNode(node string) {

--- a/test/e2e/groups_test.go
+++ b/test/e2e/groups_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestGroups(t *testing.T) {
-	steps := &GroupsSteps{t: t}
-
 	t.Run("creating a new group", func(t *testing.T) {
+		steps := &GroupsSteps{t: t}
 		steps.start()
 		steps.visitCreateGroupPage()
 		steps.fillInCreateGroupForm("E2E Example Group")

--- a/test/e2e/home_page_test.go
+++ b/test/e2e/home_page_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestHomePage(t *testing.T) {
-	steps := &TestHomePageSteps{t: t}
-
 	t.Run("creating a new canvas", func(t *testing.T) {
+		steps := &TestHomePageSteps{t: t}
 		steps.Start()
 		steps.VisitHomePage()
 		steps.FillInNewCanvasForm("Example Canvas")
@@ -21,6 +20,7 @@ func TestHomePage(t *testing.T) {
 	})
 
 	t.Run("showing canvases in folders", func(t *testing.T) {
+		steps := &TestHomePageSteps{t: t}
 		steps.Start()
 		steps.GivenCanvasInFolder("Foldered Canvas", "Deployments")
 		steps.VisitHomePage()

--- a/test/e2e/invitations_test.go
+++ b/test/e2e/invitations_test.go
@@ -16,9 +16,8 @@ import (
 )
 
 func TestInvitations(t *testing.T) {
-	steps := &invitationSteps{t: t}
-
 	t.Run("accepting invite link assigns viewer role", func(t *testing.T) {
+		steps := &invitationSteps{t: t}
 		steps.startLoggedIn()
 		token := steps.createInviteLink()
 		invitee := steps.createInviteeAccount()
@@ -28,6 +27,7 @@ func TestInvitations(t *testing.T) {
 	})
 
 	t.Run("following invite link and creating password account", func(t *testing.T) {
+		steps := &invitationSteps{t: t}
 		steps.startLoggedOut()
 		token := steps.createInviteLink()
 
@@ -46,6 +46,7 @@ func TestInvitations(t *testing.T) {
 	})
 
 	t.Run("disabled invite link no longer works", func(t *testing.T) {
+		steps := &invitationSteps{t: t}
 		steps.startLoggedIn()
 		token := steps.createInviteLink()
 		steps.disableInviteLink(token)
@@ -54,6 +55,7 @@ func TestInvitations(t *testing.T) {
 	})
 
 	t.Run("viewer sees invite link access message", func(t *testing.T) {
+		steps := &invitationSteps{t: t}
 		steps.startLoggedIn()
 		token := steps.createInviteLink()
 		invitee := steps.createInviteeAccount()

--- a/test/e2e/login_page_test.go
+++ b/test/e2e/login_page_test.go
@@ -13,9 +13,8 @@ import (
 )
 
 func TestLoginPage(t *testing.T) {
-	steps := &TestLoginPageSteps{t: t}
-
 	t.Run("login page should include redirect URL in auth links", func(t *testing.T) {
+		steps := &TestLoginPageSteps{t: t}
 		steps.Start()
 		steps.VisitProtectedRandomURL()
 		steps.AssertRedirectedToLoginWithRedirectParam()
@@ -23,6 +22,7 @@ func TestLoginPage(t *testing.T) {
 	})
 
 	t.Run("after login user should be redirected back original URL", func(t *testing.T) {
+		steps := &TestLoginPageSteps{t: t}
 		steps.Start()
 		steps.VisitProtectedRandomURL()
 		steps.AssertRedirectedToLoginWithRedirectParam()
@@ -31,12 +31,14 @@ func TestLoginPage(t *testing.T) {
 	})
 
 	t.Run("unauthenticated user sees login page", func(t *testing.T) {
+		steps := &TestLoginPageSteps{t: t}
 		steps.Start()
 		steps.VisitLoginPage()
 		steps.AssertLoginPageVisible()
 	})
 
 	t.Run("authenticated user gets redirected from login page", func(t *testing.T) {
+		steps := &TestLoginPageSteps{t: t}
 		steps.Start()
 		steps.session.Login()
 		steps.VisitLoginPage()
@@ -44,6 +46,7 @@ func TestLoginPage(t *testing.T) {
 	})
 
 	t.Run("user with invalid token sees login page", func(t *testing.T) {
+		steps := &TestLoginPageSteps{t: t}
 		steps.Start()
 		steps.SetInvalidAuthCookie()
 		steps.VisitLoginPage()

--- a/test/e2e/magic_code_login_test.go
+++ b/test/e2e/magic_code_login_test.go
@@ -17,15 +17,15 @@ import (
 )
 
 func TestMagicCodeLogin(t *testing.T) {
-	steps := &magicCodeSteps{t: t}
-
 	t.Run("magic code email form is shown as primary login method", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		steps.assertMagicCodeFormVisible()
 	})
 
 	t.Run("requesting code transitions to code input step", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		steps.enterEmailAndRequestCode("e2e@superplane.local")
@@ -33,6 +33,7 @@ func TestMagicCodeLogin(t *testing.T) {
 	})
 
 	t.Run("back button returns to email step", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		steps.enterEmailAndRequestCode("e2e@superplane.local")
@@ -42,6 +43,7 @@ func TestMagicCodeLogin(t *testing.T) {
 	})
 
 	t.Run("existing user can login with magic code", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		email := "e2e@superplane.local"
@@ -52,6 +54,7 @@ func TestMagicCodeLogin(t *testing.T) {
 	})
 
 	t.Run("new user can sign up with magic code via invite link", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		inviteToken := steps.createInviteLink()
 		email := support.RandomName("magic") + "@superplane.local"
@@ -63,6 +66,7 @@ func TestMagicCodeLogin(t *testing.T) {
 	})
 
 	t.Run("invalid code shows error message", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		email := "e2e@superplane.local"
@@ -73,6 +77,7 @@ func TestMagicCodeLogin(t *testing.T) {
 	})
 
 	t.Run("can toggle to password login and back", func(t *testing.T) {
+		steps := &magicCodeSteps{t: t}
 		steps.start()
 		steps.visitLoginPage()
 		steps.assertMagicCodeFormVisible()

--- a/test/e2e/organization_test.go
+++ b/test/e2e/organization_test.go
@@ -10,9 +10,8 @@ import (
 )
 
 func TestOrganizationCreation(t *testing.T) {
-	steps := &organizationCreationSteps{t: t}
-
 	t.Run("creating a new organization from the create page", func(t *testing.T) {
+		steps := &organizationCreationSteps{t: t}
 		orgName := "E2E Created Organization"
 		steps.start()
 		steps.visitCreateOrganizationPage()

--- a/test/e2e/roles_test.go
+++ b/test/e2e/roles_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestRoles(t *testing.T) {
-	steps := &RolesSteps{t: t}
-
 	t.Run("creating a new role", func(t *testing.T) {
+		steps := &RolesSteps{t: t}
 		steps.start()
 		steps.visitCreateRolePage()
 		steps.fillInCreateRoleForm("E2E Example Role")

--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -56,7 +56,7 @@ func (s *runsViewSteps) givenACanvasWithManualTriggerAndNoop() {
 }
 
 func (s *runsViewSteps) whenTheManualTriggerRuns() {
-	s.canvas.RunManualTrigger("Start")
+	s.canvas.EmitManualTrigger("Start")
 	s.canvas.WaitForExecution("Output", models.CanvasNodeExecutionStateFinished, 30*time.Second)
 	s.run = s.waitForFinishedRun()
 }

--- a/test/e2e/send_email_test.go
+++ b/test/e2e/send_email_test.go
@@ -11,7 +11,6 @@ import (
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/e2e/shared"
-	"github.com/superplanehq/superplane/test/support"
 )
 
 func TestSendEmailComponent(t *testing.T) {
@@ -141,7 +140,7 @@ func (s *SendEmailSteps) addSendEmailNode(nodeName string, pos models.Position) 
 }
 
 func (s *SendEmailSteps) runManualTrigger() {
-	s.canvas.RunManualTrigger("Start")
+	s.canvas.EmitManualTrigger("Start")
 	s.canvas.WaitForExecution(
 		"Send Email",
 		models.CanvasNodeExecutionStateFinished,
@@ -161,13 +160,7 @@ func (s *SendEmailSteps) givenSMTPSettingsExist() {
 }
 
 func (s *SendEmailSteps) runManualTriggerAndWaitForFinish() {
-	s.canvas.RunManualTrigger("Start")
-	if s.waitForSendEmailFinished(90 * time.Second) {
-		return
-	}
-
-	// Fallback for missed click in overloaded suites: emit trigger directly.
-	s.emitManualTriggerFallback()
+	s.canvas.EmitManualTrigger("Start")
 	_ = s.waitForSendEmailFinished(180 * time.Second)
 }
 
@@ -181,18 +174,6 @@ func (s *SendEmailSteps) waitForSendEmailFinished(timeout time.Duration) bool {
 		s.session.Sleep(500)
 	}
 	return false
-}
-
-func (s *SendEmailSteps) emitManualTriggerFallback() {
-	startNode := s.canvas.GetNodeFromDB("Start")
-	support.EmitCanvasEventForNodeWithData(
-		s.t,
-		s.canvas.WorkflowID,
-		startNode.NodeID,
-		"default",
-		nil,
-		map[string]any{"message": "Hello, World!"},
-	)
 }
 
 func (s *SendEmailSteps) assertSendEmailExecutionFinished() {

--- a/test/e2e/service_accounts_test.go
+++ b/test/e2e/service_accounts_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestServiceAccounts(t *testing.T) {
-	steps := &serviceAccountSteps{t: t}
-
 	t.Run("creating a service account with viewer role", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.visitServiceAccountsPage()
 		steps.clickCreateServiceAccount()
@@ -30,6 +29,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("creating a service account with admin role", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.visitServiceAccountsPage()
 		steps.clickCreateServiceAccount()
@@ -43,6 +43,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("viewing service accounts in the list", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("list-test-bot", "For listing test")
 		steps.visitServiceAccountsPage()
@@ -51,6 +52,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("navigating to service account detail", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("detail-test-bot", "For detail test")
 		steps.visitServiceAccountsPage()
@@ -60,6 +62,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("editing a service account", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("edit-test-bot", "Original description")
 		steps.visitServiceAccountsPage()
@@ -72,6 +75,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("deleting a service account", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("delete-test-bot", "Will be deleted")
 		steps.visitServiceAccountsPage()
@@ -82,6 +86,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("regenerating a service account token", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("regen-test-bot", "Token regen test")
 		steps.visitServiceAccountsPage()
@@ -91,6 +96,7 @@ func TestServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("viewer cannot create or manage service accounts", func(t *testing.T) {
+		steps := &serviceAccountSteps{t: t}
 		steps.start()
 		steps.givenServiceAccountExists("viewer-test-bot", "Viewer RBAC test")
 		steps.loginAsViewer()

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -11,7 +11,9 @@ import (
 	pw "github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/workers/contexts"
 
 	"github.com/superplanehq/superplane/test/e2e/queries"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
@@ -191,8 +193,10 @@ func (s *CanvasSteps) AddNoop(name string, pos models.Position) {
 	s.addBlockFromSidebar(source, pos)
 	s.session.Sleep(500)
 
+	s.selectLatestNoopNode()
 	s.session.FillIn(q.TestID("node-name-input"), name)
 	s.session.Sleep(300)
+	s.waitForDraftNodeID(name)
 }
 
 func (s *CanvasSteps) AddNote() {
@@ -216,6 +220,8 @@ func (s *CanvasSteps) AddNoopWithDefaultName(pos models.Position) string {
 	source := q.TestID("building-block-noop")
 	s.addBlockFromSidebar(source, pos)
 	s.session.Sleep(500)
+
+	s.selectLatestNoopNode()
 
 	// Get the auto-generated name from the input field
 	nameInput := q.TestID("node-name-input")
@@ -339,6 +345,16 @@ func (s *CanvasSteps) addBlockFromSidebar(source queries.Query, pos models.Posit
 	s.session.DragAndDrop(source, target, pos.X, pos.Y)
 }
 
+func (s *CanvasSteps) selectLatestNoopNode() {
+	headers := s.session.Page().Locator(`.react-flow__node [data-testid^="node-noop"][data-testid$="-header"]`)
+	count, err := headers.Count()
+	require.NoError(s.t, err)
+	require.Greater(s.t, count, 0, "expected at least one noop node after adding a noop block")
+
+	require.NoError(s.t, headers.Nth(count-1).Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+	s.session.Sleep(150)
+}
+
 func (s *CanvasSteps) Connect(sourceName, targetName string) {
 	sourceNodeID := s.waitForDraftNodeID(sourceName)
 	targetNodeID := s.waitForDraftNodeID(targetName)
@@ -351,7 +367,7 @@ func (s *CanvasSteps) Connect(sourceName, targetName string) {
 }
 
 func (s *CanvasSteps) waitForDraftNodeID(nodeName string) string {
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		draft := s.FindCurrentDraft()
 		if draft != nil {
@@ -402,6 +418,17 @@ func (s *CanvasSteps) RunManualTrigger(name string) {
 	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-` + strings.ToLower(name) + `-header"]) [data-testid="start-template-run"]`)
 	s.session.Click(startTemplateRun)
 	s.session.Click(q.TestID("emit-event-submit-button"))
+}
+
+func (s *CanvasSteps) EmitManualTrigger(name string) {
+	node := s.GetNodeFromDB(name)
+	context := contexts.NewEventContext(database.Conn(), node, func(events []models.CanvasEvent) {
+		for i := range events {
+			require.NoError(s.t, messages.PublishCanvasEventCreatedMessage(&events[i]))
+		}
+	})
+
+	require.NoError(s.t, context.Emit("manual.run", map[string]any{"message": "Hello, World!"}))
 }
 
 func (s *CanvasSteps) RenameNode(name string, newName string) {

--- a/test/e2e/time_gate_test.go
+++ b/test/e2e/time_gate_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestTimeGateComponent(t *testing.T) {
-	steps := &TimeGateSteps{t: t}
-
 	weekendDays := []string{"saturday", "sunday"}
 	workweekDays := []string{"monday", "tuesday", "wednesday", "thursday", "friday"}
 
 	t.Run("add a TimeGate that blocks on weekends", func(t *testing.T) {
+		steps := &TimeGateSteps{t: t}
 		steps.start()
 		steps.givenACanvasExists("Weekday Work Hours Gate")
 		steps.addTimeGate()
@@ -32,6 +31,7 @@ func TestTimeGateComponent(t *testing.T) {
 	})
 
 	t.Run("add a TimeGate that blocks on outside of work hours", func(t *testing.T) {
+		steps := &TimeGateSteps{t: t}
 		steps.start()
 		steps.givenACanvasExists("Work Hours Gate")
 		steps.addTimeGate()
@@ -44,6 +44,7 @@ func TestTimeGateComponent(t *testing.T) {
 	})
 
 	t.Run("push through the time gate item", func(t *testing.T) {
+		steps := &TimeGateSteps{t: t}
 		steps.start()
 		now := time.Now().UTC()
 		tomorrow := now.Add(24 * time.Hour)
@@ -170,7 +171,7 @@ func (s *TimeGateSteps) givenACanvasWithManualTriggerTimeGateAndOutput(days []st
 }
 
 func (s *TimeGateSteps) runManualTrigger() {
-	s.canvas.RunManualTrigger("Start")
+	s.canvas.EmitManualTrigger("Start")
 	s.canvas.WaitForExecutionInStates(
 		"timeGate",
 		[]string{models.CanvasNodeExecutionStatePending, models.CanvasNodeExecutionStateStarted},

--- a/test/e2e/trigger_run_title_test.go
+++ b/test/e2e/trigger_run_title_test.go
@@ -75,7 +75,7 @@ func (s *triggerRunTitleSteps) saveAndPublish() {
 }
 
 func (s *triggerRunTitleSteps) runManualTrigger() {
-	s.canvas.RunManualTrigger("Start")
+	s.canvas.EmitManualTrigger("Start")
 	s.session.Sleep(2000)
 }
 

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -151,7 +151,7 @@ func (s *WaitSteps) givenACanvasWithManualTriggerWaitAndOutput() {
 }
 
 func (s *WaitSteps) runManualTrigger() {
-	s.canvas.RunManualTrigger("Start")
+	s.canvas.EmitManualTrigger("Start")
 	s.canvas.WaitForExecutionInStates(
 		"Wait",
 		[]string{

--- a/test/e2e/webhook_reset_test.go
+++ b/test/e2e/webhook_reset_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestWebhookResetSecret(t *testing.T) {
-	steps := &WebhookResetSteps{t: t}
-
 	t.Run("reset webhook secret shows new key", func(t *testing.T) {
+		steps := &WebhookResetSteps{t: t}
 		steps.start()
 		steps.givenACanvasWithWebhook("Webhook Reset Canvas", "Webhook")
 		steps.openWebhookConfiguration("Webhook")


### PR DESCRIPTION
## Summary
- scope e2e step helpers to subtests so page/session cleanup runs before the next DB reset
- make manual-trigger setup deterministic through the backend event path while preserving run-title resolution
- harden canvas node interactions, queued wait cleanup, and local/CI e2e timeouts

## Validation
- make test.e2e
- make lint && make check.build.app