### PR TITLE
fix: hide agent tab when feature is disabled

### DIFF
--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -94,9 +94,9 @@ func (s *runsViewSteps) whenICloseRunNodeDetails() {
 }
 
 func (s *runsViewSteps) whenIEnterEditModeFromRuns() {
-	// The Canvas-only top toggle is hidden in runs view; switch back via the tool sidebar.
+	// The Agent tab is feature-flagged; switch back through another always-visible tool tab.
 	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Agent")`))
+	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
 	s.session.Click(q.TestID("canvas-edit-button"))
 }
 

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasToolSidebar } from ".";
+import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
 
@@ -53,7 +54,7 @@ vi.mock("@/components/AgentSidebar/widgets/RichMessage", () => ({
   },
 }));
 
-function makeToolSidebarState() {
+function makeToolSidebarState(overrides: Partial<CanvasToolSidebarState> = {}) {
   return {
     canvasId: "canvas-1",
     organizationId: "org-1",
@@ -61,11 +62,13 @@ function makeToolSidebarState() {
     readOnly: false,
     isToolSidebarOpen: true,
     showToolSidebarToggle: true,
+    isAgentEnabled: true,
     handleToolSidebarToggle: vi.fn(),
     openToolSidebar: vi.fn(),
     closeToolSidebar: vi.fn(),
     agentMode: "operator" as const,
     switchAgentMode: vi.fn(),
+    ...overrides,
   };
 }
 
@@ -111,6 +114,37 @@ describe("CanvasToolSidebar", () => {
 
     expect(onExitRunsMode).toHaveBeenCalledTimes(1);
     expect(screen.getByPlaceholderText("Ask the agent…")).toBeInTheDocument();
+  });
+
+  it("hides the agent tab when managed agents are disabled", () => {
+    render(
+      <CanvasToolSidebar
+        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
+        runsContent={<div>Runs content</div>}
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Runs" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Versions" })).toBeInTheDocument();
+    expect(screen.getByText("Runs content")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Ask the agent…")).not.toBeInTheDocument();
+  });
+
+  it("does not switch from runs mode to the agent tab when managed agents are disabled", () => {
+    const onExitRunsMode = vi.fn();
+
+    render(
+      <CanvasToolSidebar
+        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
+        mode="runs"
+        onExitRunsMode={onExitRunsMode}
+        runsContent={<div>Runs content</div>}
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
+    expect(screen.getByText("Runs content")).toBeInTheDocument();
   });
 
   it("enters versions from the versions tab", () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -147,6 +147,34 @@ describe("CanvasToolSidebar", () => {
     expect(screen.getByText("Runs content")).toBeInTheDocument();
   });
 
+  it("falls back to runs when version control closes and managed agents are disabled", () => {
+    const toolSidebarState = makeToolSidebarState({ isAgentEnabled: false });
+    const { rerender } = render(
+      <CanvasToolSidebar
+        toolSidebarState={toolSidebarState}
+        isVersionControlOpen={true}
+        runsContent={<div>Runs content</div>}
+        versionsContent={<div>Versions content</div>}
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Versions content")).toBeInTheDocument();
+
+    rerender(
+      <CanvasToolSidebar
+        toolSidebarState={toolSidebarState}
+        isVersionControlOpen={false}
+        runsContent={<div>Runs content</div>}
+        versionsContent={<div>Versions content</div>}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Runs content")).toBeInTheDocument();
+  });
+
   it("enters versions from the versions tab", () => {
     const onToggleVersionControl = vi.fn();
 

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -60,11 +60,8 @@ function OpenCanvasToolSidebar({
   onToggleVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
-  const [activeTab, setActiveTab] = useState(() => {
-    if (mode === "runs") return TAB_RUNS;
-    if (isVersionControlOpen) return TAB_VERSIONS;
-    return TAB_AGENT;
-  });
+  const hasAgentTab = toolSidebarState.isAgentEnabled;
+  const [activeTab, setActiveTab] = useState(() => defaultToolTab(mode, Boolean(isVersionControlOpen), hasAgentTab));
 
   useEffect(() => {
     if (mode === "runs") {
@@ -75,11 +72,15 @@ function OpenCanvasToolSidebar({
       setActiveTab(TAB_VERSIONS);
       return;
     }
-    setActiveTab((currentTab) => (currentTab === TAB_RUNS || currentTab === TAB_VERSIONS ? TAB_AGENT : currentTab));
-  }, [isVersionControlOpen, mode]);
+    setActiveTab((currentTab) => {
+      if (currentTab === TAB_AGENT && !hasAgentTab) return TAB_RUNS;
+      if ((currentTab === TAB_RUNS || currentTab === TAB_VERSIONS) && hasAgentTab) return TAB_AGENT;
+      return currentTab;
+    });
+  }, [hasAgentTab, isVersionControlOpen, mode]);
 
   const tabs = [
-    { value: TAB_AGENT, label: "Agent" },
+    ...(hasAgentTab ? [{ value: TAB_AGENT, label: "Agent" }] : []),
     { value: TAB_RUNS, label: "Runs" },
     { value: TAB_VERSIONS, label: "Versions" },
   ] as const;
@@ -121,7 +122,7 @@ function OpenCanvasToolSidebar({
           onSelectTab={(value) => handleTabSelect(value as typeof TAB_AGENT | typeof TAB_RUNS | typeof TAB_VERSIONS)}
         />
 
-        {activeTab === TAB_AGENT ? (
+        {activeTab === TAB_AGENT && hasAgentTab ? (
           <div className="m-0 flex min-h-0 flex-1 flex-col overflow-hidden" role="tabpanel">
             <AgentTabPanel toolSidebarState={toolSidebarState} />
           </div>
@@ -139,4 +140,11 @@ function OpenCanvasToolSidebar({
       </div>
     </SidebarShell>
   );
+}
+
+function defaultToolTab(mode: CanvasToolSidebarMode, isVersionControlOpen: boolean, hasAgentTab: boolean) {
+  if (mode === "runs") return TAB_RUNS;
+  if (isVersionControlOpen) return TAB_VERSIONS;
+  if (hasAgentTab) return TAB_AGENT;
+  return TAB_RUNS;
 }

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -73,7 +73,7 @@ function OpenCanvasToolSidebar({
       return;
     }
     setActiveTab((currentTab) => {
-      if (currentTab === TAB_AGENT && !hasAgentTab) return TAB_RUNS;
+      if ((currentTab === TAB_AGENT || currentTab === TAB_VERSIONS) && !hasAgentTab) return TAB_RUNS;
       if ((currentTab === TAB_RUNS || currentTab === TAB_VERSIONS) && hasAgentTab) return TAB_AGENT;
       return currentTab;
     });

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
@@ -17,6 +17,7 @@ function Harness({ onBeforeClose }: { onBeforeClose: () => void }) {
   return (
     <div>
       <div data-testid="open-state">{state.isToolSidebarOpen ? "open" : "closed"}</div>
+      <div data-testid="agent-state">{state.isAgentEnabled ? "enabled" : "disabled"}</div>
       <button type="button" onClick={state.handleToolSidebarToggle}>
         toggle
       </button>
@@ -32,6 +33,7 @@ describe("useCanvasToolSidebarState", () => {
     render(<Harness onBeforeClose={onBeforeClose} />);
 
     expect(screen.getByTestId("open-state")).toHaveTextContent("open");
+    expect(screen.getByTestId("agent-state")).toHaveTextContent("disabled");
 
     fireEvent.click(screen.getByRole("button", { name: "toggle" }));
 

--- a/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
+++ b/web_src/src/components/CanvasToolSidebar/useCanvasToolSidebarState.ts
@@ -85,6 +85,7 @@ export function useCanvasToolSidebarState({
     readOnly,
     isToolSidebarOpen,
     showToolSidebarToggle,
+    isAgentEnabled: featureEnabled,
     handleToolSidebarToggle,
     openToolSidebar,
     closeToolSidebar,


### PR DESCRIPTION
## Summary
- expose managed-agent feature availability separately from sidebar availability
- hide the Agent tab when managed agents are disabled, while keeping Runs and Versions available
- default the sidebar to Runs instead of trying to load Agent when stale localStorage opens the sidebar without the feature

## Tests
- cd web_src && npm run test:run -- src/components/CanvasToolSidebar/index.spec.tsx src/components/CanvasToolSidebar/useCanvasToolSidebarState.spec.tsx
- make format.js
- make check.build.ui