### PR TITLE
fix: wait longer for migration locks

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,22 +3,33 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [ -z $DB_PASSWORD ];         then echo "DB username not set" && exit 1; fi
-if [ -z $DB_HOST ];             then echo "DB host not set"     && exit 1; fi
-if [ -z $DB_PORT ];             then echo "DB port not set"     && exit 1; fi
-if [ -z $DB_USERNAME ];         then echo "DB username not set" && exit 1; fi
-if [ -z $DB_NAME ];             then echo "DB name not set"     && exit 1; fi
-if [ -z $APPLICATION_NAME ];    then echo "Application name not set"     && exit 1; fi
+require_env() {
+  local name="$1"
+
+  if [ -z "${!name:-}" ]; then
+    echo "${name} not set"
+    exit 1
+  fi
+}
+
+require_env DB_PASSWORD
+require_env DB_HOST
+require_env DB_PORT
+require_env DB_USERNAME
+require_env DB_NAME
+require_env APPLICATION_NAME
+
+DB_MIGRATION_LOCK_TIMEOUT="${DB_MIGRATION_LOCK_TIMEOUT:-600}"
 
 [ "${POSTGRES_DB_SSL}" = "true" ] && export PGSSLMODE=require || export PGSSLMODE=disable
 
 echo "Creating DB..."
-PGPASSWORD=${DB_PASSWORD} createdb -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USERNAME} ${DB_NAME} || true
+PGPASSWORD="${DB_PASSWORD}" createdb -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USERNAME}" "${DB_NAME}" || true
 
-echo "Migrating DB..."
+echo "Migrating DB with ${DB_MIGRATION_LOCK_TIMEOUT}s lock timeout..."
 DB_URL="postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=${PGSSLMODE}"
-migrate -source file:///app/db/migrations -database ${DB_URL} up
-migrate -source file:///app/db/data_migrations -database ${DB_URL}\&x-migrations-table=data_migrations up
+migrate -lock-timeout "${DB_MIGRATION_LOCK_TIMEOUT}" -source file:///app/db/migrations -database "${DB_URL}" up
+migrate -lock-timeout "${DB_MIGRATION_LOCK_TIMEOUT}" -source file:///app/db/data_migrations -database "${DB_URL}&x-migrations-table=data_migrations" up
 
 echo "Starting server..."
 /app/build/superplane

--- a/scripts/db_migrate.sh
+++ b/scripts/db_migrate.sh
@@ -5,12 +5,13 @@ IFS=$'\n\t'
 
 export DB_NAME=$1
 export PGPASSWORD=the-cake-is-a-lie
+DB_MIGRATION_LOCK_TIMEOUT="${DB_MIGRATION_LOCK_TIMEOUT:-600}"
 
 rm -f db/structure.sql
 
-migrate -source file://db/migrations -database postgres://postgres:$PGPASSWORD@db:5432/$DB_NAME?sslmode=disable up 2>&1 | awk '!/no change/'
-migrate -source file://db/data_migrations -database postgres://postgres:$PGPASSWORD@db:5432/$DB_NAME?sslmode=disable\&x-migrations-table=data_migrations up 2>&1 | awk '!/no change/'
+migrate -lock-timeout "$DB_MIGRATION_LOCK_TIMEOUT" -source file://db/migrations -database "postgres://postgres:$PGPASSWORD@db:5432/$DB_NAME?sslmode=disable" up 2>&1 | awk '!/no change/'
+migrate -lock-timeout "$DB_MIGRATION_LOCK_TIMEOUT" -source file://db/data_migrations -database "postgres://postgres:$PGPASSWORD@db:5432/$DB_NAME?sslmode=disable&x-migrations-table=data_migrations" up 2>&1 | awk '!/no change/'
 
-pg_dump --schema-only --no-privileges --restrict-key abcdef123 --no-owner -h db -p 5432 -U postgres -d $DB_NAME > db/structure.sql
-pg_dump --data-only --restrict-key abcdef123 --table schema_migrations -h db -p 5432 -U postgres -d $DB_NAME >> db/structure.sql
-pg_dump --data-only --restrict-key abcdef123 --table data_migrations -h db -p 5432 -U postgres -d $DB_NAME >> db/structure.sql
+pg_dump --schema-only --no-privileges --restrict-key abcdef123 --no-owner -h db -p 5432 -U postgres -d "$DB_NAME" > db/structure.sql
+pg_dump --data-only --restrict-key abcdef123 --table schema_migrations -h db -p 5432 -U postgres -d "$DB_NAME" >> db/structure.sql
+pg_dump --data-only --restrict-key abcdef123 --table data_migrations -h db -p 5432 -U postgres -d "$DB_NAME" >> db/structure.sql


### PR DESCRIPTION
## Summary
- add DB_MIGRATION_LOCK_TIMEOUT support to the production entrypoint
- pass the lock timeout to both schema and data migrations so concurrent pods wait for the migrate lock instead of failing quickly
- keep the local db migration script consistent with production behavior

## Validation
- bash -n docker-entrypoint.sh scripts/db_migrate.sh