### PR TITLE
fix: allow agent follow-up while running

### DIFF
--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -100,6 +100,28 @@ func TestAgentE2E(t *testing.T) {
 		steps.assertHidden(q.TestID("agent-stop-button"))
 	})
 
+	t.Run("sends a follow-up message while a turn is still running", func(t *testing.T) {
+		steps := newAgentSteps(t)
+		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
+			if isAgentSystemMessage(call.Message) {
+				return []agents.ProviderEvent{agentTurnCompletedEvent()}, nil
+			}
+
+			return nil, nil
+		})
+
+		steps.start()
+		steps.openAgent()
+		steps.sendMessage("Keep running while I add more context")
+		steps.assertVisible(q.TestID("agent-stop-button"))
+		steps.fillMessage("Here is more context")
+		steps.assertSendButtonEnabled()
+		steps.submitMessage()
+		steps.waitForSendCall(func(call support.AgentProviderSendMessageCall) bool {
+			return call.Message == "Here is more context"
+		})
+	})
+
 	t.Run("starts outcome-based building from a rubric response", func(t *testing.T) {
 		steps := newAgentSteps(t)
 		steps.withSendMessageHandler(func(call support.AgentProviderSendMessageCall) ([]agents.ProviderEvent, error) {
@@ -230,8 +252,24 @@ func (s *agentSteps) switchToAskMode() {
 }
 
 func (s *agentSteps) sendMessage(message string) {
+	s.fillMessage(message)
+	s.submitMessage()
+}
+
+func (s *agentSteps) fillMessage(message string) {
 	s.session.FillIn(q.TestID("agent-input"), message)
+}
+
+func (s *agentSteps) submitMessage() {
 	s.session.Click(q.TestID("agent-send-message-button"))
+}
+
+func (s *agentSteps) assertSendButtonEnabled() {
+	button := q.TestID("agent-send-message-button").Run(s.session)
+	require.Eventually(s.t, func() bool {
+		disabled, err := button.IsDisabled()
+		return err == nil && !disabled
+	}, 10*time.Second, 200*time.Millisecond)
 }
 
 func (s *agentSteps) stopAgent() {

--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -10,6 +10,7 @@ export function ChatComposer({
   onSend,
   onStop,
   sending,
+  sendPending,
   stopping,
   statusLabel,
   agentMode,
@@ -19,6 +20,7 @@ export function ChatComposer({
   onSend: (content: string) => Promise<void>;
   onStop: () => void;
   sending: boolean;
+  sendPending: boolean;
   stopping?: boolean;
   statusLabel: string;
   agentMode: AgentMode;
@@ -26,7 +28,7 @@ export function ChatComposer({
   modeDisabled?: boolean;
 }) {
   const [draft, setDraft] = useState("");
-  const canSend = Boolean(draft.trim()) && !sending;
+  const canSend = Boolean(draft.trim()) && !sendPending;
 
   const handleSend = useCallback(async () => {
     const content = draft.trim();

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -213,6 +213,7 @@ function ChatConversation({
         onSend={handlers.handleSend}
         onStop={handlers.handleStop}
         sending={agentBusy}
+        sendPending={sendMutation.isPending}
         stopping={interruptMutation.isPending}
         statusLabel={statusLabel(status)}
         agentMode={agentMode}

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -258,7 +258,8 @@ describe("CanvasToolSidebar", () => {
     expect(input).toHaveValue("second");
   });
 
-  it("shows Send and Stop while an outcome is still active after the chat turn ends", () => {
+  it("allows sending while an outcome is still active after the chat turn ends", async () => {
+    const user = userEvent.setup();
     sessionStorage.setItem(
       "outcome-chat-1",
       JSON.stringify({
@@ -274,6 +275,8 @@ describe("CanvasToolSidebar", () => {
     render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
 
     expect(screen.getByTestId("agent-stop-button")).toBeInTheDocument();
-    expect(screen.getByTestId("agent-send-message-button")).toBeInTheDocument();
+
+    await user.type(screen.getByTestId("agent-input"), "Keep going");
+    expect(screen.getByTestId("agent-send-message-button")).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary
- keep the Agent composer send button enabled while the agent is streaming/running
- only disable Send while the send mutation itself is pending
- add unit and e2e coverage for sending a follow-up message during an active turn

## Validation
- make format.js
- make format.go
- npm run test:run -- src/components/CanvasToolSidebar/index.spec.tsx
- docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile junit-report.xml --packages="./test/e2e" -- -p 1 -timeout 30m -run '^TestAgentE2E$/^sends_a_follow-up_message_while_a_turn_is_still_running$'
- docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile junit-report.xml --packages="./test/e2e" -- -p 1 -timeout 30m -run '^TestAgentE2E$'
- make check.build.ui
- make lint && make check.build.app