### PR TITLE
fix: autoload canvas sidebar history

### DIFF
--- a/pkg/grpc/actions/canvases/list_canvas_versions.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions.go
@@ -15,6 +15,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const MaxCanvasVersionLimit = 50
+
 func ListCanvasVersions(ctx context.Context, organizationID string, canvasID string) (*pb.ListCanvasVersionsResponse, error) {
 	return ListCanvasVersionsPaginated(ctx, organizationID, canvasID, 0, nil)
 }
@@ -42,7 +44,7 @@ func ListCanvasVersionsPaginated(
 		return nil, status.Errorf(codes.NotFound, "canvas not found: %v", err)
 	}
 
-	limit = getLimit(limit)
+	limit = getCanvasVersionLimit(limit)
 	beforeTime := getBefore(before)
 
 	var publishedVersions []models.CanvasVersion
@@ -95,6 +97,18 @@ func ListCanvasVersionsPaginated(
 		HasNextPage:   hasNextPage(len(publishedVersions), int(limit), publishedCount),
 		LastTimestamp: getLastCanvasVersionTimestamp(publishedVersions),
 	}, nil
+}
+
+func getCanvasVersionLimit(limit uint32) uint32 {
+	if limit <= 0 {
+		return DefaultLimit
+	}
+
+	if limit > MaxCanvasVersionLimit {
+		return MaxCanvasVersionLimit
+	}
+
+	return limit
 }
 
 func getLastCanvasVersionTimestamp(versions []models.CanvasVersion) *timestamppb.Timestamp {

--- a/pkg/grpc/actions/canvases/list_canvas_versions_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_versions_test.go
@@ -1,0 +1,13 @@
+package canvases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCanvasVersionLimit(t *testing.T) {
+	require.Equal(t, uint32(DefaultLimit), getCanvasVersionLimit(0))
+	require.Equal(t, uint32(20), getCanvasVersionLimit(20))
+	require.Equal(t, uint32(MaxCanvasVersionLimit), getCanvasVersionLimit(MaxCanvasVersionLimit+1))
+}

--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -2,16 +2,20 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	pw "github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/e2e/shared"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -28,6 +32,33 @@ func TestRunsView(t *testing.T) {
 		steps.whenICloseRunNodeDetails()
 		steps.whenIEnterEditModeFromRuns()
 		steps.thenEditModeIsVisible()
+	})
+
+	t.Run("autoloads more runs from the sidebar history", func(t *testing.T) {
+		steps := &runsViewSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithManualTriggerAndNoop()
+		steps.givenFinishedRuns(31)
+		steps.whenIVisitRunsView()
+		steps.thenRunsLoadMoreButtonIsHidden()
+		steps.thenRunsSidebarRowCountIsAtLeast(25)
+		steps.whenIScrollRunsSidebarToTheEnd()
+		steps.thenRunsSidebarRowCountIsAtLeast(31)
+	})
+
+	t.Run("autoloads more versions and keeps them visible after selection", func(t *testing.T) {
+		steps := &runsViewSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithManualTriggerAndNoop()
+		steps.givenOlderPublishedVersions(55)
+		steps.whenIVisitRunsView()
+		steps.whenIOpenVersionsSidebar()
+		steps.thenVersionsLoadMoreButtonIsHidden()
+		steps.thenVersionsSidebarRowCountIsAtLeast(50)
+		steps.whenIScrollVersionsSidebarToTheEnd()
+		steps.thenVersionsSidebarRowCountIsAtLeast(56)
+		steps.whenISelectTheLastLoadedVersion()
+		steps.thenVersionsSidebarRowCountIsAtLeast(56)
 	})
 }
 
@@ -65,6 +96,68 @@ func (s *runsViewSteps) whenIVisitRunsView() {
 	s.session.Visit("/" + s.session.OrgID.String() + "/canvases/" + s.canvas.WorkflowID.String() + "?view=runs")
 }
 
+func (s *runsViewSteps) givenFinishedRuns(count int) {
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), s.canvas.WorkflowID)
+	require.NoError(s.t, err)
+	triggerID := liveVersionNodeID(s.t, liveVersion, "Start")
+	now := time.Now()
+
+	for i := 0; i < count; i++ {
+		createdAt := now.Add(-time.Duration(i) * time.Minute)
+		run := models.CanvasRun{
+			ID:         uuid.New(),
+			WorkflowID: s.canvas.WorkflowID,
+			VersionID:  liveVersion.ID,
+			State:      models.CanvasRunStateFinished,
+			Result:     models.CanvasRunResultPassed,
+			CreatedAt:  &createdAt,
+			UpdatedAt:  &createdAt,
+			FinishedAt: &createdAt,
+		}
+		require.NoError(s.t, database.Conn().Create(&run).Error)
+
+		customName := fmt.Sprintf("Seeded run %02d", i+1)
+		event := models.CanvasEvent{
+			ID:         uuid.New(),
+			WorkflowID: s.canvas.WorkflowID,
+			NodeID:     triggerID,
+			Channel:    "default",
+			CustomName: &customName,
+			Data:       datatypes.NewJSONType[any](map[string]any{}),
+			RunID:      run.ID,
+			State:      models.CanvasEventStateRouted,
+			CreatedAt:  &createdAt,
+		}
+		require.NoError(s.t, database.Conn().Create(&event).Error)
+	}
+}
+
+func (s *runsViewSteps) givenOlderPublishedVersions(count int) {
+	liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), s.canvas.WorkflowID)
+	require.NoError(s.t, err)
+	now := time.Now().Add(-time.Hour)
+
+	for i := 0; i < count; i++ {
+		publishedAt := now.Add(-time.Duration(i) * time.Minute)
+		version := models.CanvasVersion{
+			ID:                      uuid.New(),
+			WorkflowID:              s.canvas.WorkflowID,
+			OwnerID:                 liveVersion.OwnerID,
+			State:                   models.CanvasVersionStatePublished,
+			Name:                    fmt.Sprintf("Seeded version %02d", i+1),
+			Description:             liveVersion.Description,
+			ChangeManagementEnabled: liveVersion.ChangeManagementEnabled,
+			ChangeRequestApprovers:  liveVersion.ChangeRequestApprovers,
+			PublishedAt:             &publishedAt,
+			Nodes:                   liveVersion.Nodes,
+			Edges:                   liveVersion.Edges,
+			CreatedAt:               &publishedAt,
+			UpdatedAt:               &publishedAt,
+		}
+		require.NoError(s.t, database.Conn().Create(&version).Error)
+	}
+}
+
 func (s *runsViewSteps) thenTheFinishedRunIsVisible() {
 	require.NotNil(s.t, s.run, "expected run to be created")
 	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
@@ -98,6 +191,72 @@ func (s *runsViewSteps) whenIEnterEditModeFromRuns() {
 	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
 	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
 	s.session.Click(q.TestID("canvas-edit-button"))
+}
+
+func (s *runsViewSteps) whenIOpenVersionsSidebar() {
+	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
+	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
+	s.session.AssertVisible(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"][aria-selected="true"]:has-text("Versions")`))
+}
+
+func (s *runsViewSteps) thenRunsLoadMoreButtonIsHidden() {
+	s.session.AssertHidden(q.Locator(`[data-testid="canvas-tool-sidebar"] button:has-text("Load more")`))
+}
+
+func (s *runsViewSteps) thenVersionsLoadMoreButtonIsHidden() {
+	s.session.AssertHidden(q.Locator(`[data-testid="canvas-tool-sidebar"] button:has-text("Load older versions")`))
+}
+
+func (s *runsViewSteps) thenRunsSidebarRowCountIsAtLeast(expected int) {
+	s.waitForSidebarRowCountAtLeast(s.session.Page().GetByTestId("runs-sidebar-row"), expected)
+}
+
+func (s *runsViewSteps) thenVersionsSidebarRowCountIsAtLeast(expected int) {
+	s.waitForSidebarRowCountAtLeast(s.session.Page().GetByTestId("canvas-live-version-row"), expected)
+}
+
+func (s *runsViewSteps) whenIScrollRunsSidebarToTheEnd() {
+	s.scrollSidebarToTheEnd("runs-sidebar-scroll")
+}
+
+func (s *runsViewSteps) whenIScrollVersionsSidebarToTheEnd() {
+	s.scrollSidebarToTheEnd("versions-sidebar-scroll")
+}
+
+func (s *runsViewSteps) whenISelectTheLastLoadedVersion() {
+	rows := s.session.Page().GetByTestId("canvas-live-version-row")
+	count := s.waitForSidebarRowCountAtLeast(rows, 56)
+	require.NoError(s.t, rows.Nth(count-1).Click(pw.LocatorClickOptions{Timeout: pw.Float(15000)}))
+}
+
+func (s *runsViewSteps) scrollSidebarToTheEnd(testID string) {
+	scroller := s.session.Page().GetByTestId(testID)
+	require.NoError(s.t, scroller.WaitFor(pw.LocatorWaitForOptions{
+		State:   pw.WaitForSelectorStateVisible,
+		Timeout: pw.Float(15000),
+	}))
+	require.NoError(s.t, scroller.Hover(pw.LocatorHoverOptions{Timeout: pw.Float(15000)}))
+	require.NoError(s.t, s.session.Page().Mouse().Wheel(0, 5000))
+	s.session.Sleep(500)
+}
+
+func (s *runsViewSteps) waitForSidebarRowCountAtLeast(locator pw.Locator, expected int) int {
+	deadline := time.Now().Add(20 * time.Second)
+	lastCount := 0
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		lastCount, lastErr = locator.Count()
+		if lastErr == nil && lastCount >= expected {
+			return lastCount
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	require.NoError(s.t, lastErr)
+	require.GreaterOrEqual(s.t, lastCount, expected)
+	return lastCount
 }
 
 func (s *runsViewSteps) thenEditModeIsVisible() {
@@ -148,4 +307,17 @@ func (s *runsViewSteps) waitForFinishedRun() *models.CanvasRun {
 	require.NoError(s.t, err)
 	require.Equal(s.t, models.CanvasRunStateFinished, run.State)
 	return &run
+}
+
+func liveVersionNodeID(t *testing.T, version *models.CanvasVersion, nodeName string) string {
+	t.Helper()
+
+	for _, node := range version.Nodes {
+		if node.Name == nodeName {
+			return node.ID
+		}
+	}
+
+	t.Fatalf("node %q not found in live canvas version", nodeName)
+	return ""
 }

--- a/web_src/src/components/CanvasToolSidebar/RunsList.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsList.tsx
@@ -1,5 +1,4 @@
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
-import { Button } from "@/components/ui/button";
 import type { RunStatusKey } from "@/ui/Runs/runPresentation";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { RunRow } from "./RunRow";
@@ -22,9 +21,6 @@ interface RunsListProps {
   isLoading?: boolean;
   isError?: boolean;
   onRetry?: () => void;
-  hasNextPage?: boolean;
-  isFetchingNextPage?: boolean;
-  onLoadMore?: () => void;
   onClearFilters: () => void;
 }
 
@@ -38,9 +34,6 @@ export function RunsList({
   isLoading,
   isError,
   onRetry,
-  hasNextPage,
-  isFetchingNextPage,
-  onLoadMore,
   onClearFilters,
 }: RunsListProps) {
   if (isError && runs.length === 0) {
@@ -101,21 +94,6 @@ export function RunsList({
         <div className="h-px bg-slate-300" aria-hidden />
       ) : null}
       {orderedRuns.rest.map(renderRow)}
-      {hasNextPage && onLoadMore ? (
-        <div className="px-3 py-2">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="w-full text-xs"
-            onClick={onLoadMore}
-            disabled={isFetchingNextPage}
-          >
-            {isFetchingNextPage ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : null}
-            Load more
-          </Button>
-        </div>
-      ) : null}
       {isError ? (
         <div role="alert" className="flex items-center justify-between gap-2 px-3 py-2 text-[11px] text-red-600">
           <span className="inline-flex items-center gap-1">

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
 import { RunsTabPanel } from "./RunsTabPanel";
 
@@ -101,5 +101,46 @@ describe("RunsTabPanel", () => {
 
     expect(screen.getByText("Broken deploy")).toBeInTheDocument();
     expect(screen.queryByText("Healthy deploy")).not.toBeInTheDocument();
+  });
+
+  it("loads more runs when the sidebar scroll reaches the end", () => {
+    const onLoadMore = vi.fn();
+    const runs = Array.from({ length: 25 }, (_, index) =>
+      makeRun({
+        id: `run-${index}`,
+        rootEvent: { ...makeRun().rootEvent, customName: `Deploy ${index}` },
+      }),
+    );
+
+    const { rerender } = render(
+      <RunsTabPanel runs={runs} selectedRunId={null} onSelectRun={() => {}} workflowNodes={nodes} />,
+    );
+    const scroller = screen.getByTestId("runs-sidebar-scroll");
+
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 300 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    });
+
+    rerender(
+      <RunsTabPanel
+        runs={runs}
+        selectedRunId={null}
+        onSelectRun={() => {}}
+        workflowNodes={nodes}
+        hasNextPage={true}
+        isFetchingNextPage={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+    expect(onLoadMore).not.toHaveBeenCalled();
+
+    scroller.scrollTop = 860;
+    fireEvent.scroll(scroller);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunsTabPanel.tsx
@@ -1,7 +1,9 @@
 import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import { useCallback, useEffect, useRef, type UIEvent } from "react";
 import type { RunStatusFilter } from "@/ui/Runs/runPresentation";
 import { RunsList } from "./RunsList";
 import { RunsToolbar } from "./RunsToolbar";
+import { useAutoLoadMoreOnScroll } from "./useAutoLoadMoreOnScroll";
 import { useRunFilters } from "./useRunFilters";
 
 export interface RunsTabPanelProps {
@@ -50,6 +52,22 @@ export function RunsTabPanel({
     clearStatuses,
     clearTriggers,
   } = useRunFilters({ runs, workflowNodes, componentIconMap, onStatusFiltersChange });
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const loadMoreIfNeeded = useAutoLoadMoreOnScroll({
+    hasMore: hasNextPage,
+    isLoading: isFetchingNextPage,
+    onLoadMore,
+  });
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      loadMoreIfNeeded(event.currentTarget);
+    },
+    [loadMoreIfNeeded],
+  );
+
+  useEffect(() => {
+    loadMoreIfNeeded(scrollRef.current);
+  }, [filteredRuns.length, loadMoreIfNeeded]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -72,7 +90,12 @@ export function RunsTabPanel({
         onClearTriggers={clearTriggers}
       />
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto"
+        data-testid="runs-sidebar-scroll"
+        onScroll={handleScroll}
+      >
         <RunsList
           runs={runs}
           filteredRuns={filteredRuns}
@@ -83,9 +106,6 @@ export function RunsTabPanel({
           isLoading={isLoading}
           isError={isError}
           onRetry={onRetry}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          onLoadMore={onLoadMore}
           onClearFilters={clearFilters}
         />
       </div>

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -51,7 +51,7 @@ describe("VersionsTabPanel", () => {
     expect(onUseVersion).toHaveBeenCalledWith("version-2");
   });
 
-  it("keeps expanded versions visible when selecting a different version", () => {
+  it("keeps loaded versions visible when selecting a different version", () => {
     const liveVersions = Array.from({ length: 12 }, (_, index) => {
       const number = 12 - index;
       return makePublishedVersion(`version-${number}`);
@@ -70,15 +70,9 @@ describe("VersionsTabPanel", () => {
       />,
     );
 
-    // Starts collapsed to 5 versions so the first version ("v1") isn't visible.
-    expect(screen.queryByText("v1")).not.toBeInTheDocument();
-
-    // Expand twice (5 -> 10 -> 12) to reveal the first version row.
-    fireEvent.click(screen.getByRole("button", { name: "Load older versions" }));
-    fireEvent.click(screen.getByRole("button", { name: "Load older versions" }));
     expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load older versions" })).not.toBeInTheDocument();
 
-    // After selecting another version, the expanded view should remain.
     rerender(
       <VersionsTabPanel
         liveCanvasVersionId="version-12"
@@ -92,7 +86,46 @@ describe("VersionsTabPanel", () => {
       />,
     );
 
-    // Version rows beyond the initial 5 should still be visible without clicking again.
     expect(screen.getByText("v1")).toBeInTheDocument();
+  });
+
+  it("loads older versions when the sidebar scroll reaches the end", () => {
+    const onLoadMoreLiveVersions = vi.fn();
+    const liveVersions = [makePublishedVersion("version-3"), makePublishedVersion("version-2")];
+    const props = {
+      liveCanvasVersionId: "version-3",
+      selectedCanvasVersion: null,
+      liveVersions,
+      canUpdateCanvas: true,
+      isTemplate: false,
+      canvasDeletedRemotely: false,
+      onUseVersion: vi.fn(),
+      onVersionNodeDiffContextChange: vi.fn(),
+    };
+
+    const { rerender } = render(<VersionsTabPanel {...props} />);
+    const scroller = screen.getByTestId("versions-sidebar-scroll");
+
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 1000 },
+      clientHeight: { configurable: true, value: 300 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    });
+
+    rerender(
+      <VersionsTabPanel
+        {...props}
+        onLoadMoreLiveVersions={onLoadMoreLiveVersions}
+        loadMoreLiveVersionsDisabled={false}
+        loadMoreLiveVersionsPending={false}
+      />,
+    );
+
+    expect(onLoadMoreLiveVersions).not.toHaveBeenCalled();
+
+    scroller.scrollTop = 860;
+    fireEvent.scroll(scroller);
+
+    expect(onLoadMoreLiveVersions).toHaveBeenCalledTimes(1);
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
@@ -1,12 +1,9 @@
 import type { CanvasChangeManagement, CanvasesCanvasChangeRequest, CanvasesCanvasVersion } from "@/api-client";
-import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight, GitBranch } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type UIEvent } from "react";
 import type { CanvasVersionNodeDiffContext } from "@/pages/workflowv2/CanvasVersionNodeDiffDialog";
+import { useAutoLoadMoreOnScroll } from "./useAutoLoadMoreOnScroll";
 import { VersionRow } from "./VersionsTabPanelRow";
-
-const INITIAL_VISIBLE_LIVE_VERSIONS = 5;
-const LOAD_OLDER_LIVE_VERSIONS_STEP = 5;
 
 export interface VersionsTabPanelProps {
   liveCanvasVersionId?: string;
@@ -63,17 +60,13 @@ export function VersionsTabPanel({
 }: VersionsTabPanelProps) {
   const {
     hasNoVersions,
-    handleLoadOlderVersions,
     handleViewDiff,
     liveItems,
-    loadOlderVersionsDisabled,
-    loadOlderVersionsPending,
     pendingItems,
     rejectedItems,
     rejectedList,
     rejectedVersionsExpanded,
     setRejectedVersionsExpanded,
-    showLoadOlderVersions,
   } = useVersionsPanelData({
     liveCanvasVersionId,
     selectedCanvasVersion,
@@ -82,10 +75,25 @@ export function VersionsTabPanel({
     liveVersions,
     liveVersionChangeRequestsByVersionId,
     loadMoreLiveVersionsDisabled,
-    loadMoreLiveVersionsPending,
     onLoadMoreLiveVersions,
     onVersionNodeDiffContextChange,
   });
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const loadMoreIfNeeded = useAutoLoadMoreOnScroll({
+    hasMore: Boolean(onLoadMoreLiveVersions) && !loadMoreLiveVersionsDisabled,
+    isLoading: loadMoreLiveVersionsPending,
+    onLoadMore: onLoadMoreLiveVersions,
+  });
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      loadMoreIfNeeded(event.currentTarget);
+    },
+    [loadMoreIfNeeded],
+  );
+
+  useEffect(() => {
+    loadMoreIfNeeded(scrollRef.current);
+  }, [liveItems.length, pendingItems.length, rejectedItems.length, loadMoreIfNeeded]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -96,7 +104,12 @@ export function VersionsTabPanel({
         </span>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto p-3">
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-auto p-3"
+        data-testid="versions-sidebar-scroll"
+        onScroll={handleScroll}
+      >
         <VersionsNotices
           canUpdateCanvas={canUpdateCanvas}
           canvasDeletedRemotely={canvasDeletedRemotely}
@@ -110,10 +123,6 @@ export function VersionsTabPanel({
             <VersionHistorySection
               items={[...pendingItems, ...liveItems]}
               changeRequestApprovalConfig={changeRequestApprovalConfig}
-              showLoadOlderVersions={showLoadOlderVersions}
-              loadOlderVersionsPending={loadOlderVersionsPending}
-              loadOlderVersionsDisabled={loadOlderVersionsDisabled}
-              onLoadOlderVersions={handleLoadOlderVersions}
               onUseVersion={onUseVersion}
               onViewDiff={handleViewDiff}
             />
@@ -141,7 +150,6 @@ function useVersionsPanelData({
   liveVersions,
   liveVersionChangeRequestsByVersionId,
   loadMoreLiveVersionsDisabled,
-  loadMoreLiveVersionsPending,
   onLoadMoreLiveVersions,
   onVersionNodeDiffContextChange,
 }: Pick<
@@ -153,25 +161,12 @@ function useVersionsPanelData({
   | "liveVersions"
   | "liveVersionChangeRequestsByVersionId"
   | "loadMoreLiveVersionsDisabled"
-  | "loadMoreLiveVersionsPending"
   | "onLoadMoreLiveVersions"
   | "onVersionNodeDiffContextChange"
 >) {
   const rejectedList = rejectedVersions ?? [];
   const selectedVersionId = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "";
   const [rejectedVersionsExpanded, setRejectedVersionsExpanded] = useState(false);
-  const {
-    displayedLiveVersions,
-    handleLoadOlderVersions,
-    loadOlderVersionsDisabled,
-    loadOlderVersionsPending,
-    showLoadOlderVersions,
-  } = useVisibleLiveVersions({
-    liveVersions,
-    loadMoreLiveVersionsDisabled,
-    loadMoreLiveVersionsPending,
-    onLoadMoreLiveVersions,
-  });
   const handleViewDiff = useCallback(
     (
       version: CanvasesCanvasVersion,
@@ -184,7 +179,6 @@ function useVersionsPanelData({
   );
   const pendingItems = buildPendingItems(pendingApprovalVersions ?? [], selectedVersionId, liveVersions[0]);
   const liveItems = buildLiveItems({
-    displayedLiveVersions,
     liveCanvasVersionId,
     liveVersions,
     loadMoreLiveVersionsDisabled,
@@ -197,54 +191,13 @@ function useVersionsPanelData({
 
   return {
     hasNoVersions,
-    handleLoadOlderVersions,
     handleViewDiff,
     liveItems,
-    loadOlderVersionsDisabled,
-    loadOlderVersionsPending,
     pendingItems,
     rejectedItems,
     rejectedList,
     rejectedVersionsExpanded,
     setRejectedVersionsExpanded,
-    showLoadOlderVersions,
-  };
-}
-
-function useVisibleLiveVersions({
-  liveVersions,
-  loadMoreLiveVersionsDisabled,
-  loadMoreLiveVersionsPending,
-  onLoadMoreLiveVersions,
-}: Pick<
-  VersionsTabPanelProps,
-  "liveVersions" | "loadMoreLiveVersionsDisabled" | "loadMoreLiveVersionsPending" | "onLoadMoreLiveVersions"
->) {
-  const [visibleLiveVersionCount, setVisibleLiveVersionCount] = useState(INITIAL_VISIBLE_LIVE_VERSIONS);
-  const headLiveVersionId = liveVersions[0]?.metadata?.id ?? "";
-
-  useEffect(() => {
-    setVisibleLiveVersionCount(INITIAL_VISIBLE_LIVE_VERSIONS);
-  }, [headLiveVersionId]);
-
-  const displayedLiveVersions = liveVersions.slice(0, visibleLiveVersionCount);
-  const canExpandLocal = visibleLiveVersionCount < liveVersions.length;
-  const showLoadOlderVersions = canExpandLocal || !!onLoadMoreLiveVersions;
-
-  const handleLoadOlderVersions = useCallback(() => {
-    if (canExpandLocal) {
-      setVisibleLiveVersionCount((prev) => Math.min(prev + LOAD_OLDER_LIVE_VERSIONS_STEP, liveVersions.length));
-      return;
-    }
-    onLoadMoreLiveVersions?.();
-  }, [canExpandLocal, liveVersions.length, onLoadMoreLiveVersions]);
-
-  return {
-    displayedLiveVersions,
-    handleLoadOlderVersions,
-    loadOlderVersionsDisabled: !canExpandLocal && (loadMoreLiveVersionsDisabled ?? !onLoadMoreLiveVersions),
-    loadOlderVersionsPending: !canExpandLocal && !!loadMoreLiveVersionsPending,
-    showLoadOlderVersions,
   };
 }
 
@@ -273,19 +226,11 @@ function VersionsNotices({
 function VersionHistorySection({
   items,
   changeRequestApprovalConfig,
-  showLoadOlderVersions,
-  loadOlderVersionsPending,
-  loadOlderVersionsDisabled,
-  onLoadOlderVersions,
   onUseVersion,
   onViewDiff,
 }: {
   items: VersionRowItem[];
   changeRequestApprovalConfig?: CanvasChangeManagement;
-  showLoadOlderVersions: boolean;
-  loadOlderVersionsPending: boolean;
-  loadOlderVersionsDisabled: boolean;
-  onLoadOlderVersions: () => void;
   onUseVersion: (versionID: string) => void;
   onViewDiff: (
     version: CanvasesCanvasVersion,
@@ -303,12 +248,6 @@ function VersionHistorySection({
           onViewDiff={onViewDiff}
         />
       </div>
-      <LoadOlderVersionsButton
-        show={showLoadOlderVersions}
-        pending={loadOlderVersionsPending}
-        disabled={loadOlderVersionsDisabled}
-        onClick={onLoadOlderVersions}
-      />
     </>
   );
 }
@@ -344,26 +283,6 @@ function VersionRowList({
       onViewDiff={onViewDiff}
     />
   ));
-}
-
-function LoadOlderVersionsButton({
-  show,
-  pending,
-  disabled,
-  onClick,
-}: {
-  show: boolean;
-  pending: boolean;
-  disabled: boolean;
-  onClick: () => void;
-}) {
-  if (!show) return null;
-
-  return (
-    <Button variant="outline" size="sm" className="mt-2 w-fit self-start" onClick={onClick} disabled={disabled}>
-      {pending ? "Loading..." : "Load older versions"}
-    </Button>
-  );
 }
 
 function RejectedVersionsSection({
@@ -438,7 +357,6 @@ function buildPendingItems(
 }
 
 function buildLiveItems({
-  displayedLiveVersions,
   liveCanvasVersionId,
   liveVersions,
   loadMoreLiveVersionsDisabled,
@@ -446,7 +364,6 @@ function buildLiveItems({
   onLoadMoreLiveVersions,
   selectedVersionId,
 }: {
-  displayedLiveVersions: CanvasesCanvasVersion[];
   liveCanvasVersionId?: string;
   liveVersions: CanvasesCanvasVersion[];
   loadMoreLiveVersionsDisabled?: boolean;
@@ -454,12 +371,13 @@ function buildLiveItems({
   onLoadMoreLiveVersions?: () => void;
   selectedVersionId: string;
 }): VersionRowItem[] {
-  return displayedLiveVersions.map((version, index) => {
+  return liveVersions.map((version, index) => {
     const versionID = version.metadata?.id || "";
     const isFirstCanvasVersion =
       index === liveVersions.length - 1 && (onLoadMoreLiveVersions ? !!loadMoreLiveVersionsDisabled : true);
     return {
       key: versionID,
+      rowTestId: "canvas-live-version-row",
       version,
       changeRequest: versionID ? liveVersionChangeRequestsByVersionId?.get(versionID) : undefined,
       isActive: versionID === selectedVersionId,

--- a/web_src/src/components/CanvasToolSidebar/useAutoLoadMoreOnScroll.ts
+++ b/web_src/src/components/CanvasToolSidebar/useAutoLoadMoreOnScroll.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const AUTO_LOAD_SCROLL_THRESHOLD_PX = 160;
+
+export function useAutoLoadMoreOnScroll({
+  hasMore,
+  isLoading,
+  onLoadMore,
+}: {
+  hasMore?: boolean;
+  isLoading?: boolean;
+  onLoadMore?: () => void;
+}) {
+  const requestedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isLoading) {
+      requestedRef.current = false;
+    }
+  }, [isLoading]);
+
+  return useCallback(
+    (element: HTMLElement | null) => {
+      if (!element || !hasMore || isLoading || !onLoadMore || requestedRef.current) return;
+
+      const remainingScroll = element.scrollHeight - element.scrollTop - element.clientHeight;
+      if (remainingScroll > AUTO_LOAD_SCROLL_THRESHOLD_PX) return;
+
+      requestedRef.current = true;
+      onLoadMore();
+    },
+    [hasMore, isLoading, onLoadMore],
+  );
+}

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -268,7 +268,7 @@ export const useInfiniteCanvasLiveVersions = (
   organizationId: string,
   canvasId: string,
   enabled: boolean = true,
-  limit: number = 20,
+  limit: number = 50,
 ) => {
   return useInfiniteQuery({
     queryKey: canvasKeys.versionHistory(canvasId),

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -241,7 +241,7 @@ export function WorkflowPageV2() {
   });
   const { data: organizationUsers = [], isLoading: usersLoading } = useOrganizationUsers(organizationId!);
   const { data: canvasVersions = [] } = useCanvasVersions(organizationId!, canvasId!);
-  const canvasLiveVersionsQuery = useInfiniteCanvasLiveVersions(organizationId!, canvasId!, true, 10);
+  const canvasLiveVersionsQuery = useInfiniteCanvasLiveVersions(organizationId!, canvasId!, true);
   const { data: canvasChangeRequests = [] } = useCanvasChangeRequests(organizationId!, canvasId!);
   const paginatedVersions = useMemo(
     () => (canvasLiveVersionsQuery.data?.pages || []).flatMap((page) => page?.versions || []),


### PR DESCRIPTION
## Summary
- remove manual Load more controls from Runs and Versions sidebars
- autoload additional Runs and Versions pages when scrolling near the sidebar end
- raise the Versions API/page limit to 50 and keep loaded versions rendered after selecting one
- add unit and E2E coverage for sidebar pagination regressions

## Validation
- make format.js
- make format.go
- cd web_src && npm run test:run -- src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx src/components/CanvasToolSidebar/RunsTabPanel.spec.tsx
- make check.build.ui
- make check.lint.ui
- make test PKG_TEST_PACKAGES=./pkg/grpc/actions/canvases
- docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile junit-report.xml --packages=./test/e2e -- -run 'TestRunsView/(autoloads_more_runs_from_the_sidebar_history|autoloads_more_versions_and_keeps_them_visible_after_selection)' -p 1 -timeout 30m
- make lint
- make check.build.app

Fixes #4870