### PR TITLE
fix: preserve version sidebar scroll

### DIFF
--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -57,8 +57,10 @@ func TestRunsView(t *testing.T) {
 		steps.thenVersionsSidebarRowCountIsAtLeast(50)
 		steps.whenIScrollVersionsSidebarToTheEnd()
 		steps.thenVersionsSidebarRowCountIsAtLeast(56)
+		steps.thenVersionsSidebarIsScrolledFromTop()
 		steps.whenISelectTheLastLoadedVersion()
 		steps.thenVersionsSidebarRowCountIsAtLeast(56)
+		steps.thenVersionsSidebarIsScrolledFromTop()
 	})
 }
 
@@ -215,6 +217,22 @@ func (s *runsViewSteps) thenVersionsSidebarRowCountIsAtLeast(expected int) {
 	s.waitForSidebarRowCountAtLeast(s.session.Page().GetByTestId("canvas-live-version-row"), expected)
 }
 
+func (s *runsViewSteps) thenVersionsSidebarIsScrolledFromTop() {
+	deadline := time.Now().Add(10 * time.Second)
+	scrollTop := 0.0
+
+	for time.Now().Before(deadline) {
+		scrollTop = s.sidebarScrollTop("versions-sidebar-scroll")
+		if scrollTop > 0 {
+			return
+		}
+
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	require.Greater(s.t, scrollTop, 0.0)
+}
+
 func (s *runsViewSteps) whenIScrollRunsSidebarToTheEnd() {
 	s.scrollSidebarToTheEnd("runs-sidebar-scroll")
 }
@@ -238,6 +256,21 @@ func (s *runsViewSteps) scrollSidebarToTheEnd(testID string) {
 	require.NoError(s.t, scroller.Hover(pw.LocatorHoverOptions{Timeout: pw.Float(15000)}))
 	require.NoError(s.t, s.session.Page().Mouse().Wheel(0, 5000))
 	s.session.Sleep(500)
+}
+
+func (s *runsViewSteps) sidebarScrollTop(testID string) float64 {
+	value, err := s.session.Page().GetByTestId(testID).Evaluate(`element => element.scrollTop`, nil)
+	require.NoError(s.t, err)
+
+	switch scrollTop := value.(type) {
+	case float64:
+		return scrollTop
+	case int:
+		return float64(scrollTop)
+	default:
+		s.t.Fatalf("unexpected scrollTop value %T", value)
+		return 0
+	}
 }
 
 func (s *runsViewSteps) waitForSidebarRowCountAtLeast(locator pw.Locator, expected int) int {

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -89,6 +89,34 @@ describe("VersionsTabPanel", () => {
     expect(screen.getByText("v1")).toBeInTheDocument();
   });
 
+  it("restores the sidebar scroll position after remounting for the same canvas", () => {
+    const liveVersions = Array.from({ length: 12 }, (_, index) => {
+      const number = 12 - index;
+      return makePublishedVersion(`version-${number}`);
+    });
+    const props = {
+      scrollPersistenceKey: "canvas-1",
+      liveCanvasVersionId: "version-12",
+      liveVersions,
+      canUpdateCanvas: true,
+      isTemplate: false,
+      canvasDeletedRemotely: false,
+      onUseVersion: vi.fn(),
+      onVersionNodeDiffContextChange: vi.fn(),
+    };
+
+    const { unmount } = render(<VersionsTabPanel {...props} />);
+    const scroller = screen.getByTestId("versions-sidebar-scroll");
+
+    scroller.scrollTop = 420;
+    fireEvent.scroll(scroller);
+    unmount();
+
+    render(<VersionsTabPanel {...props} selectedCanvasVersion={makePublishedVersion("version-9")} />);
+
+    expect(screen.getByTestId("versions-sidebar-scroll").scrollTop).toBe(420);
+  });
+
   it("loads older versions when the sidebar scroll reaches the end", () => {
     const onLoadMoreLiveVersions = vi.fn();
     const liveVersions = [makePublishedVersion("version-3"), makePublishedVersion("version-2")];

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
@@ -1,11 +1,14 @@
 import type { CanvasChangeManagement, CanvasesCanvasChangeRequest, CanvasesCanvasVersion } from "@/api-client";
 import { ChevronDown, ChevronRight, GitBranch } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, type UIEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type UIEvent } from "react";
 import type { CanvasVersionNodeDiffContext } from "@/pages/workflowv2/CanvasVersionNodeDiffDialog";
 import { useAutoLoadMoreOnScroll } from "./useAutoLoadMoreOnScroll";
 import { VersionRow } from "./VersionsTabPanelRow";
 
+const persistedScrollPositions = new Map<string, number>();
+
 export interface VersionsTabPanelProps {
+  scrollPersistenceKey?: string;
   liveCanvasVersionId?: string;
   selectedCanvasVersion?: CanvasesCanvasVersion | null;
   pendingApprovalVersions?: Array<{
@@ -42,6 +45,7 @@ type VersionRowItem = {
 };
 
 export function VersionsTabPanel({
+  scrollPersistenceKey,
   liveCanvasVersionId,
   selectedCanvasVersion,
   pendingApprovalVersions,
@@ -86,10 +90,34 @@ export function VersionsTabPanel({
   });
   const handleScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
+      if (scrollPersistenceKey) {
+        persistedScrollPositions.set(scrollPersistenceKey, event.currentTarget.scrollTop);
+      }
+
       loadMoreIfNeeded(event.currentTarget);
     },
-    [loadMoreIfNeeded],
+    [loadMoreIfNeeded, scrollPersistenceKey],
   );
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!element || !scrollPersistenceKey) return;
+
+    const scrollTop = persistedScrollPositions.get(scrollPersistenceKey);
+    if (scrollTop == null) return;
+
+    element.scrollTop = scrollTop;
+  }, [scrollPersistenceKey]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+
+    return () => {
+      if (!element || !scrollPersistenceKey) return;
+
+      persistedScrollPositions.set(scrollPersistenceKey, element.scrollTop);
+    };
+  }, [scrollPersistenceKey]);
 
   useEffect(() => {
     loadMoreIfNeeded(scrollRef.current);

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5709,6 +5709,7 @@ export function WorkflowPageV2() {
           toolSidebarVersionsContent={
             !hasEditableVersion ? (
               <VersionsTabPanel
+                scrollPersistenceKey={canvasId}
                 liveCanvasVersionId={liveCanvasVersionId}
                 selectedCanvasVersion={selectedCanvasVersion}
                 pendingApprovalVersions={pendingApprovalVersions}


### PR DESCRIPTION
## Summary
- preserve the Versions sidebar scroll position per canvas when version selection remounts/rerenders the sidebar
- pass the canvas ID as the persistence key from the workflow page
- add unit coverage for remount restoration and E2E coverage that selecting a loaded older version does not jump back to the top

## Validation
- make format.js
- make format.go
- cd web_src && npm run test:run -- src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
- make check.build.ui
- make check.lint.ui
- docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile junit-report.xml --packages=./test/e2e -- -run 'TestRunsView/autoloads_more_versions_and_keeps_them_visible_after_selection' -p 1 -timeout 30m