### PR TITLE
feat: add Delete VM Instance component for GCP

### DIFF
--- a/docs/components/GoogleCloud.mdx
+++ b/docs/components/GoogleCloud.mdx
@@ -784,7 +784,7 @@ Returns information about the deleted instance:
 - This operation is **permanent** and cannot be undone
 - All data on the instance will be lost unless boot/data disks have auto-delete disabled
 - The instance will be stopped if running before deletion
-- Deleting an already-deleted instance is treated as success (idempotent)
+- If the instance is not found in the configured zone, the action fails so that misconfigured zone/project values do not silently mask incomplete cleanup
 
 ### Example Output
 

--- a/docs/components/GoogleCloud.mdx
+++ b/docs/components/GoogleCloud.mdx
@@ -29,6 +29,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Cloud DNS • Update Record" href="#cloud-dns-•-update-record" description="Update an existing DNS record in a Google Cloud DNS managed zone" />
   <LinkCard title="Cloud Functions • Invoke Function" href="#cloud-functions-•-invoke-function" description="Invoke a Google Cloud Function and return the response" />
   <LinkCard title="Compute • Create Virtual Machine" href="#compute-•-create-virtual-machine" description="Create a Google Compute Engine VM. Configure machine type, zone, provisioning model, and more." />
+  <LinkCard title="Compute • Delete VM Instance" href="#compute-•-delete-vm-instance" description="Permanently delete a Google Compute Engine VM instance by name and zone" />
   <LinkCard title="Pub/Sub • Create Subscription" href="#pub/sub-•-create-subscription" description="Create a GCP Pub/Sub subscription" />
   <LinkCard title="Pub/Sub • Create Topic" href="#pub/sub-•-create-topic" description="Create a GCP Pub/Sub topic" />
   <LinkCard title="Pub/Sub • Delete Subscription" href="#pub/sub-•-delete-subscription" description="Delete a GCP Pub/Sub subscription" />
@@ -751,6 +752,50 @@ Emits a payload with instance details: instanceId, selfLink, internalIP, externa
   },
   "timestamp": "2025-02-14T12:00:00Z",
   "type": "gcp.createVM.completed"
+}
+```
+
+<a id="compute-•-delete-vm-instance"></a>
+
+## Compute • Delete VM Instance
+
+The Delete VM Instance component permanently deletes a Compute Engine VM instance.
+
+### Use Cases
+
+- **Cleanup**: Remove temporary or test VMs after use
+- **Cost optimization**: Automatically tear down unused infrastructure
+- **Automated workflows**: Delete VMs as part of deployment rollback or cleanup processes
+- **Environment management**: Remove ephemeral environments after testing
+
+### Configuration
+
+- **Zone**: The GCP zone where the instance lives (required)
+- **Instance**: The VM instance name to delete (required, supports expressions)
+
+### Output
+
+Returns information about the deleted instance:
+- **instanceName**: The name of the instance that was deleted
+- **zone**: The zone the instance was in
+
+### Important Notes
+
+- This operation is **permanent** and cannot be undone
+- All data on the instance will be lost unless boot/data disks have auto-delete disabled
+- The instance will be stopped if running before deletion
+- Deleting an already-deleted instance is treated as success (idempotent)
+
+### Example Output
+
+```json
+{
+  "data": {
+    "instanceName": "my-vm",
+    "zone": "us-central1-a"
+  },
+  "timestamp": "2025-02-14T12:00:00Z",
+  "type": "gcp.compute.vmInstance.deleted"
 }
 ```
 

--- a/docs/components/GoogleCloud.mdx
+++ b/docs/components/GoogleCloud.mdx
@@ -29,7 +29,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Cloud DNS • Update Record" href="#cloud-dns-•-update-record" description="Update an existing DNS record in a Google Cloud DNS managed zone" />
   <LinkCard title="Cloud Functions • Invoke Function" href="#cloud-functions-•-invoke-function" description="Invoke a Google Cloud Function and return the response" />
   <LinkCard title="Compute • Create Virtual Machine" href="#compute-•-create-virtual-machine" description="Create a Google Compute Engine VM. Configure machine type, zone, provisioning model, and more." />
-  <LinkCard title="Compute • Delete VM Instance" href="#compute-•-delete-vm-instance" description="Permanently delete a Google Compute Engine VM instance by name and zone" />
+  <LinkCard title="Compute • Delete VM Instance" href="#compute-•-delete-vm-instance" description="Permanently delete a Google Compute Engine VM instance" />
   <LinkCard title="Pub/Sub • Create Subscription" href="#pub/sub-•-create-subscription" description="Create a GCP Pub/Sub subscription" />
   <LinkCard title="Pub/Sub • Create Topic" href="#pub/sub-•-create-topic" description="Create a GCP Pub/Sub topic" />
   <LinkCard title="Pub/Sub • Delete Subscription" href="#pub/sub-•-delete-subscription" description="Delete a GCP Pub/Sub subscription" />
@@ -770,8 +770,7 @@ The Delete VM Instance component permanently deletes a Compute Engine VM instanc
 
 ### Configuration
 
-- **Zone**: The GCP zone where the instance lives (required)
-- **Instance**: The VM instance name to delete (required, supports expressions)
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the `selfLink` emitted by `gcp.createVM`). The selection encodes both the zone and the instance name.
 
 ### Output
 
@@ -784,7 +783,7 @@ Returns information about the deleted instance:
 - This operation is **permanent** and cannot be undone
 - All data on the instance will be lost unless boot/data disks have auto-delete disabled
 - The instance will be stopped if running before deletion
-- If the instance is not found in the configured zone, the action fails so that misconfigured zone/project values do not silently mask incomplete cleanup
+- If the instance is not found at the resolved zone/name, the action fails so that misconfigured or stale expressions do not silently mask incomplete cleanup
 
 ### Example Output
 

--- a/pkg/integrations/gcp/common/client.go
+++ b/pkg/integrations/gcp/common/client.go
@@ -134,3 +134,9 @@ func (c *Client) PostURL(ctx context.Context, fullURL string, body any) ([]byte,
 	}
 	return c.ExecRequest(ctx, http.MethodPost, fullURL, bodyReader)
 }
+
+func (c *Client) Delete(ctx context.Context, path string) ([]byte, error) {
+	path = strings.TrimPrefix(path, "/")
+	url := strings.TrimSuffix(c.baseURL, "/") + "/" + path
+	return c.ExecRequest(ctx, http.MethodDelete, url, nil)
+}

--- a/pkg/integrations/gcp/compute/create_vm.go
+++ b/pkg/integrations/gcp/compute/create_vm.go
@@ -20,6 +20,7 @@ import (
 type Client interface {
 	Get(ctx context.Context, path string) ([]byte, error)
 	Post(ctx context.Context, path string, body any) ([]byte, error)
+	Delete(ctx context.Context, path string) ([]byte, error)
 	GetURL(ctx context.Context, fullURL string) ([]byte, error)
 	ProjectID() string
 }

--- a/pkg/integrations/gcp/compute/delete_vm_instance.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance.go
@@ -96,38 +96,46 @@ func (d *DeleteVMInstance) Configuration() []configuration.Field {
 	}
 }
 
-// parseInstancePath extracts (zone, name) from a value of the form
+// parseInstancePath extracts (project, zone, name) from a value of the form
 // `zones/<zone>/instances/<name>` (relative path) or a full GCE selfLink URL
-// containing the same substring. This lets the same field accept both the
-// dropdown value and an expression chaining `selfLink` from an upstream node.
-func parseInstancePath(value string) (string, string, error) {
+// containing `projects/<project>/zones/<zone>/instances/<name>`. The project
+// segment is optional — relative paths from the dropdown have no project, but
+// chained selfLinks do, and the caller must verify it matches the integration's
+// bound project before issuing the delete.
+func parseInstancePath(value string) (project, zone, name string, err error) {
 	s := strings.TrimSpace(value)
 	if s == "" {
-		return "", "", errors.New("instance is required")
+		return "", "", "", errors.New("instance is required")
+	}
+	if idx := strings.Index(s, "projects/"); idx >= 0 {
+		rest := s[idx+len("projects/"):]
+		if slash := strings.Index(rest, "/"); slash > 0 {
+			project = rest[:slash]
+		}
 	}
 	idx := strings.Index(s, "zones/")
 	if idx < 0 {
-		return "", "", fmt.Errorf("instance %q must be a path like zones/<zone>/instances/<name> or a GCE selfLink URL", value)
+		return "", "", "", fmt.Errorf("instance %q must be a path like zones/<zone>/instances/<name> or a GCE selfLink URL", value)
 	}
 	rest := s[idx+len("zones/"):]
 	slash := strings.Index(rest, "/")
 	if slash <= 0 {
-		return "", "", fmt.Errorf("instance %q is missing a zone segment", value)
+		return "", "", "", fmt.Errorf("instance %q is missing a zone segment", value)
 	}
-	zone := rest[:slash]
+	zone = rest[:slash]
 	after := rest[slash+1:]
 	const prefix = "instances/"
 	if !strings.HasPrefix(after, prefix) {
-		return "", "", fmt.Errorf("instance %q is missing an instances/ segment", value)
+		return "", "", "", fmt.Errorf("instance %q is missing an instances/ segment", value)
 	}
-	name := after[len(prefix):]
+	name = after[len(prefix):]
 	if q := strings.IndexAny(name, "/?#"); q >= 0 {
 		name = name[:q]
 	}
 	if zone == "" || name == "" {
-		return "", "", fmt.Errorf("instance %q is missing a zone or name", value)
+		return "", "", "", fmt.Errorf("instance %q is missing a zone or name", value)
 	}
-	return zone, name, nil
+	return project, zone, name, nil
 }
 
 func (d *DeleteVMInstance) Setup(ctx core.SetupContext) error {
@@ -153,7 +161,7 @@ func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, instanceVa
 		})
 	}
 
-	zone, name, err := parseInstancePath(instanceValue)
+	_, zone, name, err := parseInstancePath(instanceValue)
 	if err != nil {
 		return err
 	}
@@ -211,46 +219,54 @@ func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, instanceVa
 func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {
 	spec := DeleteVMInstanceSpec{}
 	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
-		return fmt.Errorf("error decoding configuration: %v", err)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to decode configuration: %v", err))
 	}
 
-	zone, instanceName, err := parseInstancePath(spec.Instance)
+	urlProject, zone, instanceName, err := parseInstancePath(spec.Instance)
 	if err != nil {
-		return err
+		return ctx.ExecutionState.Fail("error", err.Error())
 	}
 
 	client, err := getClient(ctx)
 	if err != nil {
-		return fmt.Errorf("error creating client: %v", err)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to create GCP client: %v", err))
 	}
 
 	project := client.ProjectID()
-	callCtx := context.Background()
+	// If the value carried an explicit project (selfLink form), it must match
+	// the integration's bound project. Silently rewriting to the integration
+	// project could delete a same-named VM in the wrong place.
+	if urlProject != "" && urlProject != project {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf(
+			"instance belongs to project %q but this GCP integration is bound to project %q; cross-project deletes are not supported",
+			urlProject, project,
+		))
+	}
 
+	callCtx := context.Background()
 	path := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instanceName)
 	body, err := client.Delete(callCtx, path)
 	if err != nil {
 		// Surface the underlying API error (including 404s). A 404 may indicate
 		// the instance is genuinely already gone, but it can also be caused by a
 		// stale expression or a renamed resource — in which case the VM may
-		// still exist. Returning the error lets the workflow author decide how
-		// to handle it explicitly rather than silently claiming the cleanup
-		// succeeded.
-		return fmt.Errorf("failed to delete VM instance: %w", err)
+		// still exist. Failing loudly lets the workflow author decide how to
+		// handle it explicitly rather than silently claiming success.
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to delete VM instance: %v", err))
 	}
 
 	var opResp struct {
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(body, &opResp); err != nil {
-		return fmt.Errorf("parse delete operation response: %w", err)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("parse delete operation response: %v", err))
 	}
 	if opResp.Name == "" {
-		return errors.New("delete operation response missing operation name; cannot confirm deletion")
+		return ctx.ExecutionState.Fail("error", "delete operation response missing operation name; cannot confirm deletion")
 	}
 
 	if err := WaitForZoneOperation(callCtx, client, project, zone, lastSegment(opResp.Name)); err != nil {
-		return fmt.Errorf("error waiting for delete operation: %w", err)
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("error waiting for delete operation: %v", err))
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/gcp/compute/delete_vm_instance.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance.go
@@ -1,0 +1,272 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	gcpcommon "github.com/superplanehq/superplane/pkg/integrations/gcp/common"
+)
+
+type DeleteVMInstance struct{}
+
+type DeleteVMInstanceSpec struct {
+	Zone     string `mapstructure:"zone"`
+	Instance string `mapstructure:"instance"`
+}
+
+type VMInstanceNodeMetadata struct {
+	InstanceName string `json:"instanceName" mapstructure:"instanceName"`
+	Zone         string `json:"zone" mapstructure:"zone"`
+}
+
+func (d *DeleteVMInstance) Name() string {
+	return "gcp.deleteVMInstance"
+}
+
+func (d *DeleteVMInstance) Label() string {
+	return "Compute • Delete VM Instance"
+}
+
+func (d *DeleteVMInstance) Description() string {
+	return "Permanently delete a Google Compute Engine VM instance by name and zone"
+}
+
+func (d *DeleteVMInstance) Documentation() string {
+	return `The Delete VM Instance component permanently deletes a Compute Engine VM instance.
+
+## Use Cases
+
+- **Cleanup**: Remove temporary or test VMs after use
+- **Cost optimization**: Automatically tear down unused infrastructure
+- **Automated workflows**: Delete VMs as part of deployment rollback or cleanup processes
+- **Environment management**: Remove ephemeral environments after testing
+
+## Configuration
+
+- **Zone**: The GCP zone where the instance lives (required)
+- **Instance**: The VM instance name to delete (required, supports expressions)
+
+## Output
+
+Returns information about the deleted instance:
+- **instanceName**: The name of the instance that was deleted
+- **zone**: The zone the instance was in
+
+## Important Notes
+
+- This operation is **permanent** and cannot be undone
+- All data on the instance will be lost unless boot/data disks have auto-delete disabled
+- The instance will be stopped if running before deletion
+- Deleting an already-deleted instance is treated as success (idempotent)`
+}
+
+func (d *DeleteVMInstance) Icon() string {
+	return "trash-2"
+}
+
+func (d *DeleteVMInstance) Color() string {
+	return "red"
+}
+
+func (d *DeleteVMInstance) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (d *DeleteVMInstance) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "zone",
+			Label:       "Zone",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The GCP zone where the VM instance is located (e.g. us-central1-a).",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeZone,
+				},
+			},
+		},
+		{
+			Name:        "instance",
+			Label:       "VM Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The VM instance to delete.",
+			Placeholder: "Select instance",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+					Parameters: []configuration.ParameterRef{
+						{Name: "zone", ValueFrom: &configuration.ParameterValueFrom{Field: "zone"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *DeleteVMInstance) Setup(ctx core.SetupContext) error {
+	spec := DeleteVMInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if strings.TrimSpace(spec.Zone) == "" {
+		return errors.New("zone is required")
+	}
+
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
+	}
+
+	return d.resolveNodeMetadata(ctx, spec)
+}
+
+func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, spec DeleteVMInstanceSpec) error {
+	zone := lastSegment(strings.TrimSpace(spec.Zone))
+	instanceName := strings.TrimSpace(spec.Instance)
+
+	// If the instance is an expression, skip the API call and store what we have
+	if strings.Contains(instanceName, "{{") {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceName,
+			Zone:         zone,
+		})
+	}
+
+	// If metadata is already set for the same instance, skip the API call
+	var existing VMInstanceNodeMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &existing); err == nil &&
+		existing.InstanceName == instanceName && existing.Zone == zone {
+		return nil
+	}
+
+	// No integration available (e.g. in tests without credentials) — store what we have
+	if ctx.Integration == nil {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceName,
+			Zone:         zone,
+		})
+	}
+
+	client, err := gcpcommon.NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceName,
+			Zone:         zone,
+		})
+	}
+
+	body, err := GetInstance(context.Background(), client, client.ProjectID(), zone, instanceName)
+	if err != nil {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceName,
+			Zone:         zone,
+		})
+	}
+
+	payload, err := InstancePayloadFromGetResponse(body, zone)
+	if err != nil {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceName,
+			Zone:         zone,
+		})
+	}
+
+	resolvedName, _ := payload["name"].(string)
+	if resolvedName == "" {
+		resolvedName = instanceName
+	}
+
+	return ctx.Metadata.Set(VMInstanceNodeMetadata{
+		InstanceName: resolvedName,
+		Zone:         zone,
+	})
+}
+
+func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {
+	spec := DeleteVMInstanceSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	zone := lastSegment(strings.TrimSpace(spec.Zone))
+	instanceName := strings.TrimSpace(spec.Instance)
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	project := client.ProjectID()
+	callCtx := context.Background()
+
+	path := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instanceName)
+	body, err := client.Delete(callCtx, path)
+	if err != nil {
+		var apiErr *gcpcommon.GCPAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			// Already deleted — emit success (idempotent)
+			return ctx.ExecutionState.Emit(
+				core.DefaultOutputChannel.Name,
+				"gcp.compute.vmInstance.deleted",
+				[]any{map[string]any{"instanceName": instanceName, "zone": zone}},
+			)
+		}
+		return fmt.Errorf("failed to delete VM instance: %v", err)
+	}
+
+	var opResp struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &opResp); err != nil || opResp.Name == "" {
+		// If we can't parse the operation, the delete may have already completed
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			"gcp.compute.vmInstance.deleted",
+			[]any{map[string]any{"instanceName": instanceName, "zone": zone}},
+		)
+	}
+
+	if err := WaitForZoneOperation(callCtx, client, project, zone, lastSegment(opResp.Name)); err != nil {
+		return fmt.Errorf("error waiting for delete operation: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gcp.compute.vmInstance.deleted",
+		[]any{map[string]any{"instanceName": instanceName, "zone": zone}},
+	)
+}
+
+func (d *DeleteVMInstance) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (d *DeleteVMInstance) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (d *DeleteVMInstance) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (d *DeleteVMInstance) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (d *DeleteVMInstance) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (d *DeleteVMInstance) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gcp/compute/delete_vm_instance.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance.go
@@ -65,7 +65,7 @@ Returns information about the deleted instance:
 - This operation is **permanent** and cannot be undone
 - All data on the instance will be lost unless boot/data disks have auto-delete disabled
 - The instance will be stopped if running before deletion
-- Deleting an already-deleted instance is treated as success (idempotent)`
+- If the instance is not found in the configured zone, the action fails so that misconfigured zone/project values do not silently mask incomplete cleanup`
 }
 
 func (d *DeleteVMInstance) Icon() string {
@@ -212,32 +212,27 @@ func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {
 	path := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instanceName)
 	body, err := client.Delete(callCtx, path)
 	if err != nil {
-		var apiErr *gcpcommon.GCPAPIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
-			// Already deleted — emit success (idempotent)
-			return ctx.ExecutionState.Emit(
-				core.DefaultOutputChannel.Name,
-				"gcp.compute.vmInstance.deleted",
-				[]any{map[string]any{"instanceName": instanceName, "zone": zone}},
-			)
-		}
-		return fmt.Errorf("failed to delete VM instance: %v", err)
+		// Surface the underlying API error (including 404s). A 404 may indicate
+		// the instance is genuinely already gone, but it can also be caused by a
+		// misconfigured zone/project pointing at a non-existent resource path —
+		// in which case the VM may still exist elsewhere. Returning the error
+		// lets the workflow author decide how to handle it explicitly rather
+		// than silently claiming the cleanup succeeded.
+		return fmt.Errorf("failed to delete VM instance: %w", err)
 	}
 
 	var opResp struct {
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(body, &opResp); err != nil || opResp.Name == "" {
-		// If we can't parse the operation, the delete may have already completed
-		return ctx.ExecutionState.Emit(
-			core.DefaultOutputChannel.Name,
-			"gcp.compute.vmInstance.deleted",
-			[]any{map[string]any{"instanceName": instanceName, "zone": zone}},
-		)
+	if err := json.Unmarshal(body, &opResp); err != nil {
+		return fmt.Errorf("parse delete operation response: %w", err)
+	}
+	if opResp.Name == "" {
+		return errors.New("delete operation response missing operation name; cannot confirm deletion")
 	}
 
 	if err := WaitForZoneOperation(callCtx, client, project, zone, lastSegment(opResp.Name)); err != nil {
-		return fmt.Errorf("error waiting for delete operation: %v", err)
+		return fmt.Errorf("error waiting for delete operation: %w", err)
 	}
 
 	return ctx.ExecutionState.Emit(

--- a/pkg/integrations/gcp/compute/delete_vm_instance.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance.go
@@ -18,7 +18,6 @@ import (
 type DeleteVMInstance struct{}
 
 type DeleteVMInstanceSpec struct {
-	Zone     string `mapstructure:"zone"`
 	Instance string `mapstructure:"instance"`
 }
 
@@ -36,7 +35,7 @@ func (d *DeleteVMInstance) Label() string {
 }
 
 func (d *DeleteVMInstance) Description() string {
-	return "Permanently delete a Google Compute Engine VM instance by name and zone"
+	return "Permanently delete a Google Compute Engine VM instance"
 }
 
 func (d *DeleteVMInstance) Documentation() string {
@@ -51,8 +50,7 @@ func (d *DeleteVMInstance) Documentation() string {
 
 ## Configuration
 
-- **Zone**: The GCP zone where the instance lives (required)
-- **Instance**: The VM instance name to delete (required, supports expressions)
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the ` + "`selfLink`" + ` emitted by ` + "`gcp.createVM`" + `). The selection encodes both the zone and the instance name.
 
 ## Output
 
@@ -65,7 +63,7 @@ Returns information about the deleted instance:
 - This operation is **permanent** and cannot be undone
 - All data on the instance will be lost unless boot/data disks have auto-delete disabled
 - The instance will be stopped if running before deletion
-- If the instance is not found in the configured zone, the action fails so that misconfigured zone/project values do not silently mask incomplete cleanup`
+- If the instance is not found at the resolved zone/name, the action fails so that misconfigured or stale expressions do not silently mask incomplete cleanup`
 }
 
 func (d *DeleteVMInstance) Icon() string {
@@ -83,34 +81,53 @@ func (d *DeleteVMInstance) OutputChannels(configuration any) []core.OutputChanne
 func (d *DeleteVMInstance) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
-			Name:        "zone",
-			Label:       "Zone",
-			Type:        configuration.FieldTypeIntegrationResource,
-			Required:    true,
-			Description: "The GCP zone where the VM instance is located (e.g. us-central1-a).",
-			TypeOptions: &configuration.TypeOptions{
-				Resource: &configuration.ResourceTypeOptions{
-					Type: ResourceTypeZone,
-				},
-			},
-		},
-		{
 			Name:        "instance",
 			Label:       "VM Instance",
 			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The VM instance to delete.",
+			Description: "The VM instance to delete. Lists every VM in your project across all zones.",
 			Placeholder: "Select instance",
 			TypeOptions: &configuration.TypeOptions{
 				Resource: &configuration.ResourceTypeOptions{
 					Type: ResourceTypeInstance,
-					Parameters: []configuration.ParameterRef{
-						{Name: "zone", ValueFrom: &configuration.ParameterValueFrom{Field: "zone"}},
-					},
 				},
 			},
 		},
 	}
+}
+
+// parseInstancePath extracts (zone, name) from a value of the form
+// `zones/<zone>/instances/<name>` (relative path) or a full GCE selfLink URL
+// containing the same substring. This lets the same field accept both the
+// dropdown value and an expression chaining `selfLink` from an upstream node.
+func parseInstancePath(value string) (string, string, error) {
+	s := strings.TrimSpace(value)
+	if s == "" {
+		return "", "", errors.New("instance is required")
+	}
+	idx := strings.Index(s, "zones/")
+	if idx < 0 {
+		return "", "", fmt.Errorf("instance %q must be a path like zones/<zone>/instances/<name> or a GCE selfLink URL", value)
+	}
+	rest := s[idx+len("zones/"):]
+	slash := strings.Index(rest, "/")
+	if slash <= 0 {
+		return "", "", fmt.Errorf("instance %q is missing a zone segment", value)
+	}
+	zone := rest[:slash]
+	after := rest[slash+1:]
+	const prefix = "instances/"
+	if !strings.HasPrefix(after, prefix) {
+		return "", "", fmt.Errorf("instance %q is missing an instances/ segment", value)
+	}
+	name := after[len(prefix):]
+	if q := strings.IndexAny(name, "/?#"); q >= 0 {
+		name = name[:q]
+	}
+	if zone == "" || name == "" {
+		return "", "", fmt.Errorf("instance %q is missing a zone or name", value)
+	}
+	return zone, name, nil
 }
 
 func (d *DeleteVMInstance) Setup(ctx core.SetupContext) error {
@@ -119,40 +136,39 @@ func (d *DeleteVMInstance) Setup(ctx core.SetupContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	if strings.TrimSpace(spec.Zone) == "" {
-		return errors.New("zone is required")
-	}
-
-	if strings.TrimSpace(spec.Instance) == "" {
+	instanceValue := strings.TrimSpace(spec.Instance)
+	if instanceValue == "" {
 		return errors.New("instance is required")
 	}
 
-	return d.resolveNodeMetadata(ctx, spec)
+	return d.resolveNodeMetadata(ctx, instanceValue)
 }
 
-func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, spec DeleteVMInstanceSpec) error {
-	zone := lastSegment(strings.TrimSpace(spec.Zone))
-	instanceName := strings.TrimSpace(spec.Instance)
-
-	// If the instance is an expression, skip the API call and store what we have
-	if strings.Contains(instanceName, "{{") {
+func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, instanceValue string) error {
+	// Expressions are resolved at execution time. Store the raw value so the UI
+	// can still display something meaningful in the collapsed node.
+	if strings.Contains(instanceValue, "{{") {
 		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceName,
-			Zone:         zone,
+			InstanceName: instanceValue,
 		})
+	}
+
+	zone, name, err := parseInstancePath(instanceValue)
+	if err != nil {
+		return err
 	}
 
 	// If metadata is already set for the same instance, skip the API call
 	var existing VMInstanceNodeMetadata
-	if err := mapstructure.Decode(ctx.Metadata.Get(), &existing); err == nil &&
-		existing.InstanceName == instanceName && existing.Zone == zone {
+	if decErr := mapstructure.Decode(ctx.Metadata.Get(), &existing); decErr == nil &&
+		existing.InstanceName == name && existing.Zone == zone {
 		return nil
 	}
 
 	// No integration available (e.g. in tests without credentials) — store what we have
 	if ctx.Integration == nil {
 		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceName,
+			InstanceName: name,
 			Zone:         zone,
 		})
 	}
@@ -160,15 +176,15 @@ func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, spec Delet
 	client, err := gcpcommon.NewClient(ctx.HTTP, ctx.Integration)
 	if err != nil {
 		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceName,
+			InstanceName: name,
 			Zone:         zone,
 		})
 	}
 
-	body, err := GetInstance(context.Background(), client, client.ProjectID(), zone, instanceName)
+	body, err := GetInstance(context.Background(), client, client.ProjectID(), zone, name)
 	if err != nil {
 		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceName,
+			InstanceName: name,
 			Zone:         zone,
 		})
 	}
@@ -176,14 +192,14 @@ func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, spec Delet
 	payload, err := InstancePayloadFromGetResponse(body, zone)
 	if err != nil {
 		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceName,
+			InstanceName: name,
 			Zone:         zone,
 		})
 	}
 
 	resolvedName, _ := payload["name"].(string)
 	if resolvedName == "" {
-		resolvedName = instanceName
+		resolvedName = name
 	}
 
 	return ctx.Metadata.Set(VMInstanceNodeMetadata{
@@ -198,8 +214,10 @@ func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("error decoding configuration: %v", err)
 	}
 
-	zone := lastSegment(strings.TrimSpace(spec.Zone))
-	instanceName := strings.TrimSpace(spec.Instance)
+	zone, instanceName, err := parseInstancePath(spec.Instance)
+	if err != nil {
+		return err
+	}
 
 	client, err := getClient(ctx)
 	if err != nil {
@@ -214,10 +232,10 @@ func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {
 	if err != nil {
 		// Surface the underlying API error (including 404s). A 404 may indicate
 		// the instance is genuinely already gone, but it can also be caused by a
-		// misconfigured zone/project pointing at a non-existent resource path —
-		// in which case the VM may still exist elsewhere. Returning the error
-		// lets the workflow author decide how to handle it explicitly rather
-		// than silently claiming the cleanup succeeded.
+		// stale expression or a renamed resource — in which case the VM may
+		// still exist. Returning the error lets the workflow author decide how
+		// to handle it explicitly rather than silently claiming the cleanup
+		// succeeded.
 		return fmt.Errorf("failed to delete VM instance: %w", err)
 	}
 

--- a/pkg/integrations/gcp/compute/delete_vm_instance_test.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance_test.go
@@ -172,7 +172,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		assert.Equal(t, "us-central1-a", data["zone"])
 	})
 
-	t.Run("instance not found (404) -> emits success (idempotent)", func(t *testing.T) {
+	t.Run("instance not found (404) -> returns error (no silent success)", func(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
@@ -193,9 +193,62 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.NoError(t, err)
-		assert.True(t, state.Passed)
-		assert.Equal(t, "gcp.compute.vmInstance.deleted", state.Type)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete VM instance")
+		assert.False(t, state.Passed)
+	})
+
+	t.Run("unparseable delete response -> returns error", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return []byte("not-json"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse delete operation response")
+		assert.False(t, state.Passed)
+	})
+
+	t.Run("delete response missing operation name -> returns error", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				body, _ := json.Marshal(map[string]any{"status": "PENDING"})
+				return body, nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing operation name")
+		assert.False(t, state.Passed)
 	})
 
 	t.Run("API error (not 404) -> returns error", func(t *testing.T) {

--- a/pkg/integrations/gcp/compute/delete_vm_instance_test.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance_test.go
@@ -56,46 +56,50 @@ func opDone(name string) []byte {
 
 func Test__ParseInstancePath(t *testing.T) {
 	t.Run("relative path", func(t *testing.T) {
-		zone, name, err := parseInstancePath("zones/us-central1-a/instances/my-vm")
+		project, zone, name, err := parseInstancePath("zones/us-central1-a/instances/my-vm")
 		require.NoError(t, err)
+		assert.Equal(t, "", project)
 		assert.Equal(t, "us-central1-a", zone)
 		assert.Equal(t, "my-vm", name)
 	})
 
 	t.Run("full selfLink URL", func(t *testing.T) {
 		selfLink := "https://www.googleapis.com/compute/v1/projects/elffie/zones/europe-west1-b/instances/web-server-01"
-		zone, name, err := parseInstancePath(selfLink)
+		project, zone, name, err := parseInstancePath(selfLink)
 		require.NoError(t, err)
+		assert.Equal(t, "elffie", project)
 		assert.Equal(t, "europe-west1-b", zone)
 		assert.Equal(t, "web-server-01", name)
 	})
 
 	t.Run("project-qualified relative path", func(t *testing.T) {
-		zone, name, err := parseInstancePath("projects/elffie/zones/us-east1-c/instances/db-1")
+		project, zone, name, err := parseInstancePath("projects/elffie/zones/us-east1-c/instances/db-1")
 		require.NoError(t, err)
+		assert.Equal(t, "elffie", project)
 		assert.Equal(t, "us-east1-c", zone)
 		assert.Equal(t, "db-1", name)
 	})
 
 	t.Run("trims surrounding whitespace", func(t *testing.T) {
-		zone, name, err := parseInstancePath("  zones/us-central1-a/instances/my-vm  ")
+		project, zone, name, err := parseInstancePath("  zones/us-central1-a/instances/my-vm  ")
 		require.NoError(t, err)
+		assert.Equal(t, "", project)
 		assert.Equal(t, "us-central1-a", zone)
 		assert.Equal(t, "my-vm", name)
 	})
 
 	t.Run("plain name is rejected", func(t *testing.T) {
-		_, _, err := parseInstancePath("just-a-name")
+		_, _, _, err := parseInstancePath("just-a-name")
 		require.Error(t, err)
 	})
 
 	t.Run("empty value is rejected", func(t *testing.T) {
-		_, _, err := parseInstancePath("")
+		_, _, _, err := parseInstancePath("")
 		require.Error(t, err)
 	})
 
 	t.Run("missing instances segment is rejected", func(t *testing.T) {
-		_, _, err := parseInstancePath("zones/us-central1-a/foo/my-vm")
+		_, _, _, err := parseInstancePath("zones/us-central1-a/foo/my-vm")
 		require.Error(t, err)
 	})
 }
@@ -240,7 +244,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		assert.True(t, strings.Contains(capturedPath, "zones/us-central1-a/instances/my-vm"))
 	})
 
-	t.Run("instance not found (404) -> returns error (no silent success)", func(t *testing.T) {
+	t.Run("instance not found (404) -> fails execution (no silent success)", func(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
@@ -260,12 +264,13 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to delete VM instance")
+		require.NoError(t, err)
 		assert.False(t, state.Passed)
+		assert.True(t, state.Finished)
+		assert.Contains(t, state.FailureMessage, "failed to delete VM instance")
 	})
 
-	t.Run("unparseable delete response -> returns error", func(t *testing.T) {
+	t.Run("unparseable delete response -> fails execution", func(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
@@ -285,12 +290,12 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "parse delete operation response")
+		require.NoError(t, err)
 		assert.False(t, state.Passed)
+		assert.Contains(t, state.FailureMessage, "parse delete operation response")
 	})
 
-	t.Run("delete response missing operation name -> returns error", func(t *testing.T) {
+	t.Run("delete response missing operation name -> fails execution", func(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
@@ -311,12 +316,12 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "missing operation name")
+		require.NoError(t, err)
 		assert.False(t, state.Passed)
+		assert.Contains(t, state.FailureMessage, "missing operation name")
 	})
 
-	t.Run("API error (not 404) -> returns error", func(t *testing.T) {
+	t.Run("API error (not 404) -> fails execution", func(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
@@ -336,12 +341,12 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to delete VM instance")
+		require.NoError(t, err)
 		assert.False(t, state.Passed)
+		assert.Contains(t, state.FailureMessage, "failed to delete VM instance")
 	})
 
-	t.Run("invalid instance value -> returns error before any API call", func(t *testing.T) {
+	t.Run("invalid instance value -> fails execution before any API call", func(t *testing.T) {
 		var called bool
 		mc := &mockDeleteClient{
 			projectID: "my-project",
@@ -363,7 +368,66 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 			ExecutionState: state,
 		})
 
-		require.Error(t, err)
+		require.NoError(t, err)
+		assert.False(t, state.Passed)
 		assert.False(t, called, "Delete API must not be called for an invalid instance value")
+	})
+
+	t.Run("cross-project selfLink -> fails execution before any API call", func(t *testing.T) {
+		var called bool
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				called = true
+				return opDone("op-x"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				// selfLink points at "other-project", but integration is bound to "my-project"
+				"instance": "https://www.googleapis.com/compute/v1/projects/other-project/zones/us-central1-a/instances/my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.False(t, state.Passed)
+		assert.False(t, called, "Delete API must not be called when the URL project mismatches the integration")
+		assert.Contains(t, state.FailureMessage, "other-project")
+		assert.Contains(t, state.FailureMessage, "my-project")
+		assert.Contains(t, state.FailureMessage, "cross-project")
+	})
+
+	t.Run("selfLink with matching project -> succeeds", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return opDone("op-ok"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return opDone("op-ok"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
 	})
 }

--- a/pkg/integrations/gcp/compute/delete_vm_instance_test.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance_test.go
@@ -1,0 +1,257 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	gcpcommon "github.com/superplanehq/superplane/pkg/integrations/gcp/common"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+type mockDeleteClient struct {
+	projectID  string
+	getFunc    func(ctx context.Context, path string) ([]byte, error)
+	deleteFunc func(ctx context.Context, path string) ([]byte, error)
+}
+
+func (m *mockDeleteClient) Get(ctx context.Context, path string) ([]byte, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, path)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockDeleteClient) Post(ctx context.Context, path string, body any) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockDeleteClient) Delete(ctx context.Context, path string) ([]byte, error) {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, path)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockDeleteClient) GetURL(ctx context.Context, fullURL string) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockDeleteClient) ProjectID() string {
+	return m.projectID
+}
+
+// opDone returns a serialized DONE zone operation response
+func opDone(name string) []byte {
+	b, _ := json.Marshal(map[string]any{"name": name, "status": "DONE"})
+	return b
+}
+
+func Test__DeleteVMInstance__Setup(t *testing.T) {
+	component := &DeleteVMInstance{}
+
+	t.Run("missing zone returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"instance": "my-vm",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "zone is required")
+	})
+
+	t.Run("missing instance returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"zone": "us-central1-a",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("empty zone returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"zone":     "",
+				"instance": "my-vm",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "zone is required")
+	})
+
+	t.Run("empty instance returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("expression instance is accepted without API call", func(t *testing.T) {
+		meta := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "{{ $.trigger.data.instanceName }}",
+			},
+			Metadata: meta,
+		})
+		require.NoError(t, err)
+		var stored VMInstanceNodeMetadata
+		require.NoError(t, mapstructure.Decode(meta.Get(), &stored))
+		assert.Equal(t, "{{ $.trigger.data.instanceName }}", stored.InstanceName)
+		assert.Equal(t, "us-central1-a", stored.Zone)
+	})
+
+	t.Run("valid config without integration stores metadata", func(t *testing.T) {
+		meta := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			Metadata: meta,
+		})
+		require.NoError(t, err)
+		var stored VMInstanceNodeMetadata
+		require.NoError(t, mapstructure.Decode(meta.Get(), &stored))
+		assert.Equal(t, "my-vm", stored.InstanceName)
+		assert.Equal(t, "us-central1-a", stored.Zone)
+	})
+}
+
+func Test__DeleteVMInstance__Execute(t *testing.T) {
+	component := &DeleteVMInstance{}
+
+	t.Run("successful deletion -> emits deleted event", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				assert.True(t, strings.HasSuffix(path, "/instances/my-vm"))
+				return opDone("operation-123"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				// Poll for operation status
+				return opDone("operation-123"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.Equal(t, "default", state.Channel)
+		assert.Equal(t, "gcp.compute.vmInstance.deleted", state.Type)
+		require.Len(t, state.Payloads, 1)
+		wrapped := state.Payloads[0].(map[string]any)
+		data := wrapped["data"].(map[string]any)
+		assert.Equal(t, "my-vm", data["instanceName"])
+		assert.Equal(t, "us-central1-a", data["zone"])
+	})
+
+	t.Run("instance not found (404) -> emits success (idempotent)", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return nil, &gcpcommon.GCPAPIError{StatusCode: http.StatusNotFound, Message: "Instance not found"}
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.Equal(t, "gcp.compute.vmInstance.deleted", state.Type)
+	})
+
+	t.Run("API error (not 404) -> returns error", func(t *testing.T) {
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return nil, &gcpcommon.GCPAPIError{StatusCode: http.StatusInternalServerError, Message: "internal error"}
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"zone":     "us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete VM instance")
+		assert.False(t, state.Passed)
+	})
+
+	t.Run("zone last-segment is extracted correctly", func(t *testing.T) {
+		var capturedPath string
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				capturedPath = path
+				return opDone("operation-abc"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return opDone("operation-abc"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				// zone as full resource URL
+				"zone":     "projects/my-project/zones/us-central1-a",
+				"instance": "my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, strings.Contains(capturedPath, "zones/us-central1-a/instances/my-vm"))
+	})
+}

--- a/pkg/integrations/gcp/compute/delete_vm_instance_test.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance_test.go
@@ -54,73 +54,99 @@ func opDone(name string) []byte {
 	return b
 }
 
+func Test__ParseInstancePath(t *testing.T) {
+	t.Run("relative path", func(t *testing.T) {
+		zone, name, err := parseInstancePath("zones/us-central1-a/instances/my-vm")
+		require.NoError(t, err)
+		assert.Equal(t, "us-central1-a", zone)
+		assert.Equal(t, "my-vm", name)
+	})
+
+	t.Run("full selfLink URL", func(t *testing.T) {
+		selfLink := "https://www.googleapis.com/compute/v1/projects/elffie/zones/europe-west1-b/instances/web-server-01"
+		zone, name, err := parseInstancePath(selfLink)
+		require.NoError(t, err)
+		assert.Equal(t, "europe-west1-b", zone)
+		assert.Equal(t, "web-server-01", name)
+	})
+
+	t.Run("project-qualified relative path", func(t *testing.T) {
+		zone, name, err := parseInstancePath("projects/elffie/zones/us-east1-c/instances/db-1")
+		require.NoError(t, err)
+		assert.Equal(t, "us-east1-c", zone)
+		assert.Equal(t, "db-1", name)
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		zone, name, err := parseInstancePath("  zones/us-central1-a/instances/my-vm  ")
+		require.NoError(t, err)
+		assert.Equal(t, "us-central1-a", zone)
+		assert.Equal(t, "my-vm", name)
+	})
+
+	t.Run("plain name is rejected", func(t *testing.T) {
+		_, _, err := parseInstancePath("just-a-name")
+		require.Error(t, err)
+	})
+
+	t.Run("empty value is rejected", func(t *testing.T) {
+		_, _, err := parseInstancePath("")
+		require.Error(t, err)
+	})
+
+	t.Run("missing instances segment is rejected", func(t *testing.T) {
+		_, _, err := parseInstancePath("zones/us-central1-a/foo/my-vm")
+		require.Error(t, err)
+	})
+}
+
 func Test__DeleteVMInstance__Setup(t *testing.T) {
 	component := &DeleteVMInstance{}
 
-	t.Run("missing zone returns error", func(t *testing.T) {
-		err := component.Setup(core.SetupContext{
-			Configuration: map[string]any{
-				"instance": "my-vm",
-			},
-			Metadata: &contexts.MetadataContext{},
-		})
-		require.ErrorContains(t, err, "zone is required")
-	})
-
 	t.Run("missing instance returns error", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
-			Configuration: map[string]any{
-				"zone": "us-central1-a",
-			},
-			Metadata: &contexts.MetadataContext{},
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
 		})
 		require.ErrorContains(t, err, "instance is required")
-	})
-
-	t.Run("empty zone returns error", func(t *testing.T) {
-		err := component.Setup(core.SetupContext{
-			Configuration: map[string]any{
-				"zone":     "",
-				"instance": "my-vm",
-			},
-			Metadata: &contexts.MetadataContext{},
-		})
-		require.ErrorContains(t, err, "zone is required")
 	})
 
 	t.Run("empty instance returns error", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
-			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "",
-			},
-			Metadata: &contexts.MetadataContext{},
+			Configuration: map[string]any{"instance": ""},
+			Metadata:      &contexts.MetadataContext{},
 		})
 		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("plain instance name is rejected (missing zone segment)", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"instance": "my-vm"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "zones/")
 	})
 
 	t.Run("expression instance is accepted without API call", func(t *testing.T) {
 		meta := &contexts.MetadataContext{}
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "{{ $.trigger.data.instanceName }}",
+				"instance": "{{ $.nodes.create.outputs.default[0].data.selfLink }}",
 			},
 			Metadata: meta,
 		})
 		require.NoError(t, err)
 		var stored VMInstanceNodeMetadata
 		require.NoError(t, mapstructure.Decode(meta.Get(), &stored))
-		assert.Equal(t, "{{ $.trigger.data.instanceName }}", stored.InstanceName)
-		assert.Equal(t, "us-central1-a", stored.Zone)
+		assert.Equal(t, "{{ $.nodes.create.outputs.default[0].data.selfLink }}", stored.InstanceName)
 	})
 
-	t.Run("valid config without integration stores metadata", func(t *testing.T) {
+	t.Run("relative path without integration stores parsed metadata", func(t *testing.T) {
 		meta := &contexts.MetadataContext{}
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			Metadata: meta,
 		})
@@ -129,6 +155,21 @@ func Test__DeleteVMInstance__Setup(t *testing.T) {
 		require.NoError(t, mapstructure.Decode(meta.Get(), &stored))
 		assert.Equal(t, "my-vm", stored.InstanceName)
 		assert.Equal(t, "us-central1-a", stored.Zone)
+	})
+
+	t.Run("selfLink URL without integration stores parsed metadata", func(t *testing.T) {
+		meta := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"instance": "https://www.googleapis.com/compute/v1/projects/elffie/zones/europe-west1-b/instances/db-1",
+			},
+			Metadata: meta,
+		})
+		require.NoError(t, err)
+		var stored VMInstanceNodeMetadata
+		require.NoError(t, mapstructure.Decode(meta.Get(), &stored))
+		assert.Equal(t, "db-1", stored.InstanceName)
+		assert.Equal(t, "europe-west1-b", stored.Zone)
 	})
 }
 
@@ -139,11 +180,10 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
-				assert.True(t, strings.HasSuffix(path, "/instances/my-vm"))
+				assert.True(t, strings.HasSuffix(path, "/zones/us-central1-a/instances/my-vm"))
 				return opDone("operation-123"), nil
 			},
 			getFunc: func(ctx context.Context, path string) ([]byte, error) {
-				// Poll for operation status
 				return opDone("operation-123"), nil
 			},
 		}
@@ -155,8 +195,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			ExecutionState: state,
 		})
@@ -170,6 +209,35 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		data := wrapped["data"].(map[string]any)
 		assert.Equal(t, "my-vm", data["instanceName"])
 		assert.Equal(t, "us-central1-a", data["zone"])
+	})
+
+	t.Run("selfLink form -> extracts zone and name", func(t *testing.T) {
+		var capturedPath string
+		mc := &mockDeleteClient{
+			projectID: "my-project",
+			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
+				capturedPath = path
+				return opDone("operation-abc"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return opDone("operation-abc"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) {
+			return mc, nil
+		})
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, strings.Contains(capturedPath, "zones/us-central1-a/instances/my-vm"))
 	})
 
 	t.Run("instance not found (404) -> returns error (no silent success)", func(t *testing.T) {
@@ -187,8 +255,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			ExecutionState: state,
 		})
@@ -213,8 +280,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			ExecutionState: state,
 		})
@@ -240,8 +306,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			ExecutionState: state,
 		})
@@ -266,8 +331,7 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				"zone":     "us-central1-a",
-				"instance": "my-vm",
+				"instance": "zones/us-central1-a/instances/my-vm",
 			},
 			ExecutionState: state,
 		})
@@ -277,16 +341,13 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		assert.False(t, state.Passed)
 	})
 
-	t.Run("zone last-segment is extracted correctly", func(t *testing.T) {
-		var capturedPath string
+	t.Run("invalid instance value -> returns error before any API call", func(t *testing.T) {
+		var called bool
 		mc := &mockDeleteClient{
 			projectID: "my-project",
 			deleteFunc: func(ctx context.Context, path string) ([]byte, error) {
-				capturedPath = path
-				return opDone("operation-abc"), nil
-			},
-			getFunc: func(ctx context.Context, path string) ([]byte, error) {
-				return opDone("operation-abc"), nil
+				called = true
+				return opDone("op-x"), nil
 			},
 		}
 
@@ -297,14 +358,12 @@ func Test__DeleteVMInstance__Execute(t *testing.T) {
 		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 		err := component.Execute(core.ExecutionContext{
 			Configuration: map[string]any{
-				// zone as full resource URL
-				"zone":     "projects/my-project/zones/us-central1-a",
-				"instance": "my-vm",
+				"instance": "just-a-name",
 			},
 			ExecutionState: state,
 		})
 
-		require.NoError(t, err)
-		assert.True(t, strings.Contains(capturedPath, "zones/us-central1-a/instances/my-vm"))
+		require.Error(t, err)
+		assert.False(t, called, "Delete API must not be called for an invalid instance value")
 	})
 }

--- a/pkg/integrations/gcp/compute/example.go
+++ b/pkg/integrations/gcp/compute/example.go
@@ -10,6 +10,9 @@ import (
 //go:embed example_output_create_vm.json
 var exampleOutputCreateVMBytes []byte
 
+//go:embed example_output_delete_vm_instance.json
+var exampleOutputDeleteVMInstanceBytes []byte
+
 //go:embed example_data_on_vm_instance.json
 var exampleDataOnVMInstanceBytes []byte
 
@@ -17,12 +20,19 @@ var (
 	exampleOutputCreateVMOnce sync.Once
 	exampleOutputCreateVM     map[string]any
 
+	exampleOutputDeleteVMInstanceOnce sync.Once
+	exampleOutputDeleteVMInstance     map[string]any
+
 	exampleDataOnVMInstanceOnce sync.Once
 	exampleDataOnVMInstance     map[string]any
 )
 
 func (c *CreateVM) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputCreateVMOnce, exampleOutputCreateVMBytes, &exampleOutputCreateVM)
+}
+
+func (d *DeleteVMInstance) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeleteVMInstanceOnce, exampleOutputDeleteVMInstanceBytes, &exampleOutputDeleteVMInstance)
 }
 
 func (t *OnVMInstance) ExampleData() map[string]any {

--- a/pkg/integrations/gcp/compute/example_output_delete_vm_instance.json
+++ b/pkg/integrations/gcp/compute/example_output_delete_vm_instance.json
@@ -1,0 +1,8 @@
+{
+  "type": "gcp.compute.vmInstance.deleted",
+  "data": {
+    "instanceName": "my-vm",
+    "zone": "us-central1-a"
+  },
+  "timestamp": "2025-02-14T12:00:00Z"
+}

--- a/pkg/integrations/gcp/compute/list_resource_handler.go
+++ b/pkg/integrations/gcp/compute/list_resource_handler.go
@@ -1327,32 +1327,37 @@ func ListFirewallResources(ctx context.Context, c Client, project string) ([]cor
 const ResourceTypeInstance = "instance"
 
 type Instance struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Zone   string `json:"zone"`
-}
-
-type instancesListResp struct {
-	Items         []*instanceListItem `json:"items"`
-	NextPageToken string              `json:"nextPageToken"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Zone     string `json:"zone"`
+	SelfLink string `json:"selfLink"`
 }
 
 type instanceListItem struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Zone   string `json:"zone"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	Zone     string `json:"zone"`
+	SelfLink string `json:"selfLink"`
 }
 
-func ListInstances(ctx context.Context, c Client, project, zone string) ([]Instance, error) {
+type instancesScopedList struct {
+	Instances []*instanceListItem `json:"instances"`
+}
+
+type instancesAggregatedListResp struct {
+	Items         map[string]*instancesScopedList `json:"items"`
+	NextPageToken string                          `json:"nextPageToken"`
+}
+
+// ListInstances returns every VM instance in the project across all zones using
+// the aggregatedList endpoint, so callers don't need to know which zone the
+// instance lives in.
+func ListInstances(ctx context.Context, c Client, project string) ([]Instance, error) {
 	project = strings.TrimSpace(project)
-	zone = strings.TrimSpace(zone)
 	if project == "" {
 		project = c.ProjectID()
 	}
-	if zone == "" {
-		return nil, fmt.Errorf("zone is required")
-	}
-	path := fmt.Sprintf("projects/%s/zones/%s/instances", project, zone)
+	path := fmt.Sprintf("projects/%s/aggregated/instances", project)
 	var all []Instance
 	var pageToken string
 	for {
@@ -1360,15 +1365,25 @@ func ListInstances(ctx context.Context, c Client, project, zone string) ([]Insta
 		if err != nil {
 			return nil, err
 		}
-		var resp instancesListResp
+		var resp instancesAggregatedListResp
 		if err := json.Unmarshal(body, &resp); err != nil {
-			return nil, fmt.Errorf("parse instances response: %w", err)
+			return nil, fmt.Errorf("parse instances aggregated response: %w", err)
 		}
-		for _, it := range resp.Items {
-			if it == nil {
+		for _, scoped := range resp.Items {
+			if scoped == nil {
 				continue
 			}
-			all = append(all, Instance{Name: it.Name, Status: it.Status, Zone: lastSegment(it.Zone)})
+			for _, it := range scoped.Instances {
+				if it == nil {
+					continue
+				}
+				all = append(all, Instance{
+					Name:     it.Name,
+					Status:   it.Status,
+					Zone:     lastSegment(it.Zone),
+					SelfLink: it.SelfLink,
+				})
+			}
 		}
 		pageToken = resp.NextPageToken
 		if pageToken == "" {
@@ -1378,21 +1393,24 @@ func ListInstances(ctx context.Context, c Client, project, zone string) ([]Insta
 	return all, nil
 }
 
-func ListInstanceResources(ctx context.Context, c Client, project, zone string) ([]core.IntegrationResource, error) {
-	if strings.TrimSpace(zone) == "" {
-		return []core.IntegrationResource{}, nil
-	}
-	list, err := ListInstances(ctx, c, project, zone)
+func ListInstanceResources(ctx context.Context, c Client, project string) ([]core.IntegrationResource, error) {
+	list, err := ListInstances(ctx, c, project)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]core.IntegrationResource, 0, len(list))
 	for _, inst := range list {
 		label := inst.Name
-		if inst.Status != "" {
+		switch {
+		case inst.Zone != "" && inst.Status != "":
+			label = fmt.Sprintf("%s (%s, %s)", inst.Name, inst.Zone, inst.Status)
+		case inst.Zone != "":
+			label = fmt.Sprintf("%s (%s)", inst.Name, inst.Zone)
+		case inst.Status != "":
 			label = fmt.Sprintf("%s (%s)", inst.Name, inst.Status)
 		}
-		out = append(out, core.IntegrationResource{Type: ResourceTypeInstance, Name: label, ID: inst.Name})
+		id := fmt.Sprintf("zones/%s/instances/%s", inst.Zone, inst.Name)
+		out = append(out, core.IntegrationResource{Type: ResourceTypeInstance, Name: label, ID: id})
 	}
 	return out, nil
 }

--- a/pkg/integrations/gcp/compute/list_resource_handler.go
+++ b/pkg/integrations/gcp/compute/list_resource_handler.go
@@ -1323,3 +1323,76 @@ func ListFirewallResources(ctx context.Context, c Client, project string) ([]cor
 	}
 	return out, nil
 }
+
+const ResourceTypeInstance = "instance"
+
+type Instance struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Zone   string `json:"zone"`
+}
+
+type instancesListResp struct {
+	Items         []*instanceListItem `json:"items"`
+	NextPageToken string              `json:"nextPageToken"`
+}
+
+type instanceListItem struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Zone   string `json:"zone"`
+}
+
+func ListInstances(ctx context.Context, c Client, project, zone string) ([]Instance, error) {
+	project = strings.TrimSpace(project)
+	zone = strings.TrimSpace(zone)
+	if project == "" {
+		project = c.ProjectID()
+	}
+	if zone == "" {
+		return nil, fmt.Errorf("zone is required")
+	}
+	path := fmt.Sprintf("projects/%s/zones/%s/instances", project, zone)
+	var all []Instance
+	var pageToken string
+	for {
+		body, err := c.Get(ctx, withPageToken(path, pageToken))
+		if err != nil {
+			return nil, err
+		}
+		var resp instancesListResp
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("parse instances response: %w", err)
+		}
+		for _, it := range resp.Items {
+			if it == nil {
+				continue
+			}
+			all = append(all, Instance{Name: it.Name, Status: it.Status, Zone: lastSegment(it.Zone)})
+		}
+		pageToken = resp.NextPageToken
+		if pageToken == "" {
+			break
+		}
+	}
+	return all, nil
+}
+
+func ListInstanceResources(ctx context.Context, c Client, project, zone string) ([]core.IntegrationResource, error) {
+	if strings.TrimSpace(zone) == "" {
+		return []core.IntegrationResource{}, nil
+	}
+	list, err := ListInstances(ctx, c, project, zone)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.IntegrationResource, 0, len(list))
+	for _, inst := range list {
+		label := inst.Name
+		if inst.Status != "" {
+			label = fmt.Sprintf("%s (%s)", inst.Name, inst.Status)
+		}
+		out = append(out, core.IntegrationResource{Type: ResourceTypeInstance, Name: label, ID: inst.Name})
+	}
+	return out, nil
+}

--- a/pkg/integrations/gcp/compute/list_resource_handler_test.go
+++ b/pkg/integrations/gcp/compute/list_resource_handler_test.go
@@ -69,6 +69,10 @@ func (m *mockOSClient) Post(ctx context.Context, path string, body any) ([]byte,
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockOSClient) Delete(ctx context.Context, path string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *mockOSClient) GetURL(ctx context.Context, fullURL string) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/integrations/gcp/gcp.go
+++ b/pkg/integrations/gcp/gcp.go
@@ -937,7 +937,7 @@ func (g *GCP) ListResources(resourceType string, ctx core.ListResourcesContext) 
 	case compute.ResourceTypeFirewall:
 		return compute.ListFirewallResources(reqCtx, client, p["project"])
 	case compute.ResourceTypeInstance:
-		return compute.ListInstanceResources(reqCtx, client, p["project"], p["zone"])
+		return compute.ListInstanceResources(reqCtx, client, p["project"])
 	case clouddns.ResourceTypeManagedZone:
 		return clouddns.ListManagedZoneResources(reqCtx, client, p["projectId"])
 	case cloudbuild.ResourceTypeTrigger:

--- a/pkg/integrations/gcp/gcp.go
+++ b/pkg/integrations/gcp/gcp.go
@@ -162,6 +162,7 @@ func (g *GCP) Configuration() []configuration.Field {
 func (g *GCP) Actions() []core.Action {
 	return []core.Action{
 		&compute.CreateVM{},
+		&compute.DeleteVMInstance{},
 		&cloudbuild.CreateBuild{},
 		&cloudbuild.GetBuild{},
 		&cloudbuild.RunTrigger{},
@@ -935,6 +936,8 @@ func (g *GCP) ListResources(resourceType string, ctx core.ListResourcesContext) 
 		return compute.ListAddressResources(reqCtx, client, p["project"], p["region"])
 	case compute.ResourceTypeFirewall:
 		return compute.ListFirewallResources(reqCtx, client, p["project"])
+	case compute.ResourceTypeInstance:
+		return compute.ListInstanceResources(reqCtx, client, p["project"], p["zone"])
 	case clouddns.ResourceTypeManagedZone:
 		return clouddns.ListManagedZoneResources(reqCtx, client, p["projectId"])
 	case cloudbuild.ResourceTypeTrigger:

--- a/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
@@ -1,0 +1,108 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import gcpIcon from "@/assets/icons/integrations/gcp.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface VMInstanceNodeMetadata {
+  instanceName?: string;
+  zone?: string;
+}
+
+interface DeleteVMInstanceConfiguration {
+  zone?: string;
+  instance?: string;
+}
+
+export const deleteVMInstanceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "gcp";
+
+    return {
+      iconSrc: gcpIcon,
+      iconSlug: context.componentDefinition?.icon ?? "trash-2",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition?.label || "Delete VM Instance",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    if (!result) return details;
+
+    if (result.instanceName) {
+      details["Instance Name"] = result.instanceName;
+    }
+    if (result.zone) {
+      details["Zone"] = result.zone;
+    }
+    details["Status"] = "Deleted";
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as VMInstanceNodeMetadata | undefined;
+  const configuration = node.configuration as DeleteVMInstanceConfiguration | undefined;
+
+  const instanceName = nodeMetadata?.instanceName || configuration?.instance;
+  const zone = nodeMetadata?.zone || configuration?.zone;
+
+  if (instanceName) {
+    metadata.push({ icon: "trash-2", label: instanceName });
+  }
+  if (zone) {
+    metadata.push({ icon: "map-pin", label: zone });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+  const eventSubtitle = subtitle || fallbackSubtitle;
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent!.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
@@ -20,8 +20,21 @@ interface VMInstanceNodeMetadata {
 }
 
 interface DeleteVMInstanceConfiguration {
-  zone?: string;
   instance?: string;
+}
+
+interface DeleteVMInstanceOutputData {
+  instanceName?: string;
+  zone?: string;
+}
+
+function parseInstancePath(value: string | undefined): { zone: string; name: string } | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes("{{")) return null;
+  const match = trimmed.match(/zones\/([^/]+)\/instances\/([^/?#]+)/);
+  if (!match) return null;
+  return { zone: match[1], name: match[2] };
 }
 
 export const deleteVMInstanceMapper: ComponentBaseMapper = {
@@ -42,7 +55,7 @@ export const deleteVMInstanceMapper: ComponentBaseMapper = {
     };
   },
 
-  getExecutionDetails(context: ExecutionDetailsContext): Record<string, any> {
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
     const details: Record<string, string> = {};
 
     if (context.execution.createdAt) {
@@ -50,7 +63,7 @@ export const deleteVMInstanceMapper: ComponentBaseMapper = {
     }
 
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
-    const result = outputs?.default?.[0]?.data as Record<string, any> | undefined;
+    const result = outputs?.default?.[0]?.data as DeleteVMInstanceOutputData | undefined;
     if (!result) return details;
 
     if (result.instanceName) {
@@ -75,8 +88,9 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   const nodeMetadata = node.metadata as VMInstanceNodeMetadata | undefined;
   const configuration = node.configuration as DeleteVMInstanceConfiguration | undefined;
 
-  const instanceName = nodeMetadata?.instanceName || configuration?.instance;
-  const zone = nodeMetadata?.zone || configuration?.zone;
+  const parsed = parseInstancePath(configuration?.instance);
+  const instanceName = nodeMetadata?.instanceName || parsed?.name || configuration?.instance;
+  const zone = nodeMetadata?.zone || parsed?.zone;
 
   if (instanceName) {
     metadata.push({ icon: "trash-2", label: instanceName });
@@ -89,9 +103,18 @@ function metadataList(node: NodeInfo): MetadataItem[] {
 }
 
 function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName!);
-  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.nodeId) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
   const subtitleTimestamp = execution.updatedAt || execution.createdAt;
   const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
   const eventSubtitle = subtitle || fallbackSubtitle;
@@ -102,7 +125,7 @@ function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componen
       eventTitle: title,
       eventSubtitle,
       eventState: getState(componentName)(execution),
-      eventId: execution.rootEvent!.id!,
+      eventId: rootEvent.id!,
     },
   ];
 }

--- a/web_src/src/pages/workflowv2/mappers/gcp/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/index.ts
@@ -19,9 +19,11 @@ import {
 } from "./pubsub_mapper";
 import { onMessageTriggerRenderer } from "./on_message";
 import { cloudDNSMapper } from "./clouddns";
+import { deleteVMInstanceMapper } from "./delete_vm_instance";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createVM: baseMapper,
+  deleteVMInstance: deleteVMInstanceMapper,
   "cloudbuild.createBuild": cloudBuildBaseMapper,
   "cloudbuild.getBuild": cloudBuildBaseMapper,
   "cloudbuild.runTrigger": runTriggerMapper,
@@ -48,6 +50,7 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createVM: buildActionStateRegistry("completed"),
+  deleteVMInstance: buildActionStateRegistry("completed"),
   "cloudbuild.createBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.getBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.runTrigger": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,


### PR DESCRIPTION
## Summary

- Introduced a new component to permanently delete a Google Compute Engine VM instance

## Demo

[Screencast from 2026-05-22 09-56-43.webm](https://github.com/user-attachments/assets/6c2aecb3-9b90-47a6-bfd4-806c082982dd)
