### PR TITLE
feat: Session browser — view all agent sessions on a canvas

### DIFF
--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -391,15 +391,14 @@ func (s *Service) ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]Canv
 		SessionID    string
 		UserID       string
 		UserName     string
-		UserEmail    string
 		Status       string
 		LastActiveAt *time.Time
 	}
 
 	err := database.Conn().
 		Table("agent_sessions").
-		Select("agent_sessions.id as session_id, agent_sessions.user_id, COALESCE(NULLIF(accounts.name, ''), accounts.email, 'Unknown') as user_name, COALESCE(accounts.email, '') as user_email, agent_sessions.status, agent_sessions.last_active_at").
-		Joins("LEFT JOIN accounts ON accounts.id = agent_sessions.user_id").
+		Select("agent_sessions.id as session_id, agent_sessions.user_id, COALESCE(NULLIF(users.name, ''), 'Unknown') as user_name, agent_sessions.status, agent_sessions.last_active_at").
+		Joins("LEFT JOIN users ON users.id = agent_sessions.user_id").
 		Where("agent_sessions.organization_id = ? AND agent_sessions.canvas_id = ?", organizationID, canvasID).
 		Order("agent_sessions.updated_at DESC").
 		Scan(&results).Error

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -160,7 +160,7 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		return nil, fmt.Errorf("message content is required")
 	}
 
-	session, err := models.FindAgentSessionForUser(organizationID, userID, sessionID)
+	session, err := models.FindAgentSessionInOrg(organizationID, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -218,8 +218,15 @@ func (s *Service) buildPreamble(session *models.AgentSession, organizationID, us
 		session.CanvasID.String(),
 		session.CanvasID.String(),
 	)
+
+	// Inject user identity so the agent knows who is talking
+	userIdentity := fmt.Sprintf("current_user_id: %s", userID.String())
+	if user, err := models.FindUnscopedUserByID(userID.String()); err == nil && user.Name != "" {
+		userIdentity = fmt.Sprintf("current_user_id: %s\ncurrent_user_name: %s", userID.String(), user.Name)
+	}
+
 	draftStatus := getDraftStatus(session.CanvasID)
-	return base + "\n\n" + modeInstructions(mode) + "\n\n" + draftStatus, nil
+	return base + "\n" + userIdentity + "\n\n" + modeInstructions(mode) + "\n\n" + draftStatus, nil
 }
 
 func (s *Service) enqueueStream(sessionID, organizationID, userID uuid.UUID) error {

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -375,3 +375,46 @@ func sessionTitle(organizationID, canvasID uuid.UUID) string {
 	}
 	return org.Name + " - " + canvas.Name
 }
+
+// CanvasSessionInfo holds session + user info for the session browser.
+type CanvasSessionInfo struct {
+	SessionID    string
+	UserID       string
+	UserName     string
+	Status       string
+	LastActiveAt *time.Time
+}
+
+// ListCanvasSessions returns all agent sessions for a canvas with user info.
+func (s *Service) ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]CanvasSessionInfo, error) {
+	var results []struct {
+		SessionID    string
+		UserID       string
+		UserName     string
+		Status       string
+		LastActiveAt *time.Time
+	}
+
+	err := database.Conn().
+		Table("agent_sessions").
+		Select("agent_sessions.id as session_id, agent_sessions.user_id, accounts.name as user_name, agent_sessions.status, agent_sessions.last_active_at").
+		Joins("LEFT JOIN accounts ON accounts.id = agent_sessions.user_id").
+		Where("agent_sessions.organization_id = ? AND agent_sessions.canvas_id = ?", organizationID, canvasID).
+		Order("agent_sessions.updated_at DESC").
+		Scan(&results).Error
+	if err != nil {
+		return nil, fmt.Errorf("list canvas sessions: %w", err)
+	}
+
+	entries := make([]CanvasSessionInfo, len(results))
+	for i, r := range results {
+		entries[i] = CanvasSessionInfo{
+			SessionID:    r.SessionID,
+			UserID:       r.UserID,
+			UserName:     r.UserName,
+			Status:       r.Status,
+			LastActiveAt: r.LastActiveAt,
+		}
+	}
+	return entries, nil
+}

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -391,13 +391,14 @@ func (s *Service) ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]Canv
 		SessionID    string
 		UserID       string
 		UserName     string
+		UserEmail    string
 		Status       string
 		LastActiveAt *time.Time
 	}
 
 	err := database.Conn().
 		Table("agent_sessions").
-		Select("agent_sessions.id as session_id, agent_sessions.user_id, accounts.name as user_name, agent_sessions.status, agent_sessions.last_active_at").
+		Select("agent_sessions.id as session_id, agent_sessions.user_id, COALESCE(NULLIF(accounts.name, ''), accounts.email, 'Unknown') as user_name, COALESCE(accounts.email, '') as user_email, agent_sessions.status, agent_sessions.last_active_at").
 		Joins("LEFT JOIN accounts ON accounts.id = agent_sessions.user_id").
 		Where("agent_sessions.organization_id = ? AND agent_sessions.canvas_id = ?", organizationID, canvasID).
 		Order("agent_sessions.updated_at DESC").
@@ -417,4 +418,10 @@ func (s *Service) ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]Canv
 		}
 	}
 	return entries, nil
+}
+
+// GetSessionInOrg finds a session by ID within an organization, regardless of owner.
+// Used for the session browser read-only view.
+func (s *Service) GetSessionInOrg(organizationID, sessionID uuid.UUID) (*models.AgentSession, error) {
+	return models.FindAgentSessionInOrg(organizationID, sessionID)
 }

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -178,6 +178,12 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 			DomainType:                   models.DomainTypeOrganization,
 			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
 		},
+		pbAgents.Agents_ListCanvasSessions_FullMethodName: {
+			Resource:                     "agents",
+			Action:                       "read",
+			DomainType:                   models.DomainTypeOrganization,
+			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+		},
 		pbAgents.Agents_ListAgentChatMessages_FullMethodName: {
 			Resource:                     "agents",
 			Action:                       "read",

--- a/pkg/grpc/actions/agents/common.go
+++ b/pkg/grpc/actions/agents/common.go
@@ -23,6 +23,7 @@ type AgentsService interface {
 	InterruptSession(ctx context.Context, organizationID, userID, sessionID uuid.UUID) error
 	DefineOutcome(ctx context.Context, organizationID, userID, sessionID uuid.UUID, description, rubric string, maxIterations int) error
 	ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]agentservice.CanvasSessionInfo, error)
+	GetSessionInOrg(organizationID, sessionID uuid.UUID) (*models.AgentSession, error)
 }
 
 func agentModeFromProto(mode pb.AgentMode) string {

--- a/pkg/grpc/actions/agents/common.go
+++ b/pkg/grpc/actions/agents/common.go
@@ -22,6 +22,7 @@ type AgentsService interface {
 	SendMessage(ctx context.Context, organizationID, userID, sessionID uuid.UUID, content string, mode ...string) (*models.AgentSessionMessage, error)
 	InterruptSession(ctx context.Context, organizationID, userID, sessionID uuid.UUID) error
 	DefineOutcome(ctx context.Context, organizationID, userID, sessionID uuid.UUID, description, rubric string, maxIterations int) error
+	ListCanvasSessions(organizationID, canvasID uuid.UUID) ([]agentservice.CanvasSessionInfo, error)
 }
 
 func agentModeFromProto(mode pb.AgentMode) string {

--- a/pkg/grpc/actions/agents/list_agent_chat_messages.go
+++ b/pkg/grpc/actions/agents/list_agent_chat_messages.go
@@ -24,12 +24,15 @@ func ListAgentChatMessages(_ context.Context, svc AgentsService, orgID, userID s
 		return nil, status.Error(codes.InvalidArgument, "invalid chat id")
 	}
 
+	// Try user-scoped first, then fall back to org-scoped (for session browser read-only view)
 	if _, err := svc.GetSession(org, user, chatID); err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, status.Error(codes.NotFound, "agent chat not found")
+		if _, orgErr := svc.GetSessionInOrg(org, chatID); orgErr != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, status.Error(codes.NotFound, "agent chat not found")
+			}
+			log.WithError(err).WithField("chat_id", chatID).Error("failed to load agent chat")
+			return nil, status.Error(codes.Internal, "failed to load agent chat")
 		}
-		log.WithError(err).WithField("chat_id", chatID).Error("failed to load agent chat")
-		return nil, status.Error(codes.Internal, "failed to load agent chat")
 	}
 
 	var beforeID uuid.UUID

--- a/pkg/grpc/actions/agents/list_canvas_sessions.go
+++ b/pkg/grpc/actions/agents/list_canvas_sessions.go
@@ -1,0 +1,51 @@
+package agents
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	pb "github.com/superplanehq/superplane/pkg/protos/agents"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func ListCanvasSessions(ctx context.Context, svc AgentsService, orgID, userID string, req *pb.ListCanvasSessionsRequest) (*pb.ListCanvasSessionsResponse, error) {
+	org, _, err := parseOrgUser(orgID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	canvasID, err := uuid.Parse(req.CanvasId)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid canvas id")
+	}
+
+	if err := ensureCanvas(org, canvasID); err != nil {
+		return nil, err
+	}
+
+	entries, err := svc.ListCanvasSessions(org, canvasID)
+	if err != nil {
+		log.WithError(err).Error("failed to list canvas sessions")
+		return nil, status.Error(codes.Internal, "failed to list canvas sessions")
+	}
+
+	sessions := make([]*pb.CanvasSessionInfo, len(entries))
+	for i, e := range entries {
+		var lastActivity *timestamppb.Timestamp
+		if e.LastActiveAt != nil {
+			lastActivity = timestamppb.New(*e.LastActiveAt)
+		}
+		sessions[i] = &pb.CanvasSessionInfo{
+			Id:             e.SessionID,
+			UserId:         e.UserID,
+			UserName:       e.UserName,
+			Status:         e.Status,
+			LastActivityAt: lastActivity,
+		}
+	}
+
+	return &pb.ListCanvasSessionsResponse{Sessions: sessions}, nil
+}

--- a/pkg/grpc/agent_service.go
+++ b/pkg/grpc/agent_service.go
@@ -80,3 +80,11 @@ func (s *AgentsService) DefineAgentOutcome(ctx context.Context, req *pb.DefineAg
 	}
 	return agentsActions.DefineAgentOutcome(ctx, s.service, orgID, userID, req)
 }
+
+func (s *AgentsService) ListCanvasSessions(ctx context.Context, req *pb.ListCanvasSessionsRequest) (*pb.ListCanvasSessionsResponse, error) {
+	orgID, userID, err := s.requestContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agentsActions.ListCanvasSessions(ctx, s.service, orgID, userID, req)
+}

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -166,3 +166,15 @@ func FailStuckStreamingSessions(cutoff time.Time) ([]AgentSession, error) {
 	}
 	return stuck, nil
 }
+
+// FindAgentSessionInOrg finds a session by org and session ID without filtering by user.
+func FindAgentSessionInOrg(organizationID, sessionID uuid.UUID) (*AgentSession, error) {
+	var session AgentSession
+	err := database.Conn().
+		Where("organization_id = ? AND id = ?", organizationID, sessionID).
+		First(&session).Error
+	if err != nil {
+		return nil, err
+	}
+	return &session, nil
+}

--- a/protos/agents.proto
+++ b/protos/agents.proto
@@ -81,6 +81,17 @@ service Agents {
       tags: "Agent";
     };
   }
+
+  rpc ListCanvasSessions(ListCanvasSessionsRequest) returns (ListCanvasSessionsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/agents/canvases/{canvas_id}/sessions"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List all agent sessions for a canvas";
+      description: "Returns all user sessions for the given canvas, including user info and last activity.";
+      tags: "Agent";
+    };
+  }
 }
 
 enum AgentMode {
@@ -134,6 +145,23 @@ message DefineAgentOutcomeRequest {
 }
 
 message DefineAgentOutcomeResponse {}
+
+message ListCanvasSessionsRequest {
+  string canvas_id = 1;
+}
+
+message ListCanvasSessionsResponse {
+  repeated CanvasSessionInfo sessions = 1;
+}
+
+message CanvasSessionInfo {
+  string id = 1;
+  string user_id = 2;
+  string user_name = 3;
+  string user_avatar_url = 4;
+  string status = 5;
+  google.protobuf.Timestamp last_activity_at = 6;
+}
 
 message AgentChatInfo {
   string id = 1;

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -1,5 +1,6 @@
 import { Bot, ChevronRight, Loader2, SquareTerminal } from "lucide-react";
-import { memo, useCallback, useEffect, useState, type RefObject } from "react";
+import { memo, useCallback, useContext, useEffect, useRef, useState, type RefObject } from "react";
+import { AccountContext } from "@/contexts/accountContextState";
 import { formatSystemNotification, isSystemNotification } from "@/components/AgentSidebar/systemMessages";
 import type { RubricCategory } from "@/components/AgentSidebar/widgets/parser";
 import { RichMessage } from "@/components/AgentSidebar/widgets/RichMessage";
@@ -134,6 +135,7 @@ const MessageRow = memo(function MessageRow({
   }
 
   const isUser = message.role === "user";
+  const { account } = useContext(AccountContext);
 
   return (
     <div className={cn("flex w-full min-w-0 flex-col", isUser ? "items-end" : "items-start")}>
@@ -159,7 +161,23 @@ const MessageRow = memo(function MessageRow({
         )}
       </div>
       {message.createdAt ? (
-        <span className="mt-0.5 px-1 text-[10px] text-slate-400">{formatTime(message.createdAt)}</span>
+        <div className="mt-0.5 flex items-center gap-1.5 px-1">
+          {isUser && account ? (
+            <>
+              <span className="text-[10px] text-slate-400">{formatTime(message.createdAt)}</span>
+              {account.avatar_url ? (
+                <img src={account.avatar_url} alt="" className="size-3.5 rounded-full" />
+              ) : (
+                <div className="flex size-3.5 items-center justify-center rounded-full bg-slate-300 text-[8px] font-medium text-white">
+                  {(account.name?.[0] ?? "?").toUpperCase()}
+                </div>
+              )}
+              <span className="text-[10px] text-slate-400">{account.name?.split(" ")[0]}</span>
+            </>
+          ) : (
+            <span className="text-[10px] text-slate-400">{formatTime(message.createdAt)}</span>
+          )}
+        </div>
       ) : null}
     </div>
   );
@@ -226,8 +244,17 @@ function truncateQuestion(question: string): string {
 }
 
 function ToolGroupRow({ messages }: { messages: AgentMessage[] }) {
-  const [expanded, setExpanded] = useState(true);
   const hasRunning = messages.some((message) => message.toolStatus === "started");
+  const [expanded, setExpanded] = useState(hasRunning);
+  const prevRunning = useRef(hasRunning);
+
+  useEffect(() => {
+    if (prevRunning.current && !hasRunning) {
+      setExpanded(false);
+    }
+    prevRunning.current = hasRunning;
+  }, [hasRunning]);
+
   const count = messages.length;
   const label = hasRunning
     ? `Running command${count > 1 ? ` (${count})` : ""}...`

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -172,8 +172,9 @@ function ChatConversation({
   const { account } = useContext(AccountContext);
   const greetingFirstName = account?.name?.split(" ")[0] ?? "there";
 
-  // Prepend a synthetic greeting as the first message so it never disappears
+  // Prepend a synthetic greeting as the first message (only for own session)
   const messages = useMemo(() => {
+    if (readOnly) return rawMessages;
     const greeting: AgentMessage = {
       id: "__greeting__",
       role: "assistant",
@@ -184,13 +185,14 @@ function ChatConversation({
       toolStatus: "",
     };
     return [greeting, ...rawMessages];
-  }, [rawMessages, greetingFirstName]);
+  }, [rawMessages, greetingFirstName, readOnly]);
 
   const showThinking = useThinkingIndicator(rawMessages, status);
 
   // Auto-kickoff: send a boot message when session is new (no messages yet)
   const bootState = useRef<"idle" | "sending" | "sent">("idle");
   useEffect(() => {
+    if (readOnly) return;
     if (bootState.current !== "idle") return;
     if (!messagesQuery.data || messagesQuery.isLoading) return;
 

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -122,7 +122,6 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
           agentMode={toolSidebarState.agentMode}
           onModeSwitch={toolSidebarState.switchAgentMode}
           isEditing={toolSidebarState.isEditing}
-          readOnly
         />
       </div>
     );

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -2,6 +2,8 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentMode } from "@/components/AgentSidebar/agentMode";
 import { AccountContext } from "@/contexts/accountContextState";
+import { SessionListView } from "./SessionListView";
+import { Users } from "lucide-react";
 import { createSystemMessage } from "@/components/AgentSidebar/systemMessages";
 import { ChatComposer } from "@/components/AgentSidebar/ChatComposer";
 import { useChatScroll } from "@/components/AgentSidebar/useChatScroll";
@@ -12,6 +14,7 @@ import type { RubricCategory } from "@/components/AgentSidebar/widgets/parser";
 import {
   useAgentChatMessages,
   useCanvasAgentChat,
+  useCanvasSessions,
   useDefineAgentOutcome,
   useInterruptAgentChat,
   useSendAgentChatMessage,
@@ -39,6 +42,7 @@ type ChatConversationProps = {
   agentMode: AgentMode;
   onModeSwitch: (mode: AgentMode) => void;
   isEditing: boolean;
+  readOnly?: boolean;
 };
 
 type DraftActionsBarProps = {
@@ -67,6 +71,9 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
   const chatId = chatQuery.data?.id ?? null;
   const { account } = useContext(AccountContext);
   const firstName = account?.name?.split(" ")[0] ?? "there";
+  const [viewMode, setViewMode] = useState<"my-session" | "session-list" | "viewing-session">("my-session");
+  const [viewingSessionId, setViewingSessionId] = useState<string | null>(null);
+  const sessionsQuery = useCanvasSessions(canvasId, organizationId, viewMode === "session-list");
 
   if (chatQuery.isLoading || !chatId) {
     return (
@@ -85,15 +92,63 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
     );
   }
 
+  if (viewMode === "session-list") {
+    return (
+      <SessionListView
+        sessions={sessionsQuery.data ?? []}
+        currentUserId={account?.id ?? ""}
+        onSelectSession={(sessionId) => {
+          setViewingSessionId(sessionId);
+          setViewMode("viewing-session");
+        }}
+        onBack={() => setViewMode("my-session")}
+      />
+    );
+  }
+
+  if (viewMode === "viewing-session" && viewingSessionId) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <button type="button" onClick={() => setViewMode("session-list")} className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-700">
+            <Users className="size-3" />
+            All sessions
+          </button>
+        </div>
+        <ChatConversation
+          chatId={viewingSessionId}
+          canvasId={canvasId}
+          organizationId={organizationId}
+          agentMode={toolSidebarState.agentMode}
+          onModeSwitch={toolSidebarState.switchAgentMode}
+          isEditing={toolSidebarState.isEditing}
+          readOnly
+        />
+      </div>
+    );
+  }
+
   return (
-    <ChatConversation
-      chatId={chatId}
-      canvasId={canvasId}
-      organizationId={organizationId}
-      agentMode={toolSidebarState.agentMode}
-      onModeSwitch={toolSidebarState.switchAgentMode}
-      isEditing={toolSidebarState.isEditing}
-    />
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-end border-b border-border px-3 py-1">
+        <button
+          type="button"
+          onClick={() => setViewMode("session-list")}
+          className="flex items-center gap-1 text-[11px] text-slate-400 hover:text-slate-600"
+        >
+          <Users className="size-3" />
+          All sessions
+        </button>
+      </div>
+      <ChatConversation
+        chatId={chatId}
+        canvasId={canvasId}
+        organizationId={organizationId}
+        agentMode={toolSidebarState.agentMode}
+        onModeSwitch={toolSidebarState.switchAgentMode}
+        isEditing={toolSidebarState.isEditing}
+      />
+    </div>
   );
 }
 
@@ -104,6 +159,7 @@ function ChatConversation({
   agentMode,
   onModeSwitch,
   isEditing,
+  readOnly,
 }: ChatConversationProps) {
   const messagesQuery = useAgentChatMessages(chatId, organizationId, true);
   const sendMutation = useSendAgentChatMessage(organizationId, canvasId);
@@ -209,6 +265,7 @@ function ChatConversation({
         onVersionPublished={() => setOutcomeState(null)}
       />
 
+      {!readOnly && (
       <ChatComposer
         onSend={handlers.handleSend}
         onStop={handlers.handleStop}
@@ -220,6 +277,7 @@ function ChatConversation({
         onModeSwitch={onModeSwitch}
         modeDisabled={modeDisabled}
       />
+      )}
     </div>
   );
 }

--- a/web_src/src/components/CanvasToolSidebar/SessionListView.tsx
+++ b/web_src/src/components/CanvasToolSidebar/SessionListView.tsx
@@ -1,0 +1,77 @@
+import { ArrowLeft, Circle } from "lucide-react";
+import type { CanvasSession } from "@/hooks/useAgentChats";
+
+interface SessionListViewProps {
+  sessions: CanvasSession[];
+  currentUserId: string;
+  onSelectSession: (sessionId: string) => void;
+  onBack: () => void;
+}
+
+export function SessionListView({ sessions, currentUserId, onSelectSession, onBack }: SessionListViewProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <button type="button" onClick={onBack} className="flex items-center gap-1 text-xs text-slate-500 hover:text-slate-700">
+          <ArrowLeft className="size-3" />
+          Back to my session
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-3 py-2">
+          <p className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">Sessions on this canvas</p>
+          {sessions.length === 0 ? (
+            <p className="text-sm text-slate-400">No sessions yet.</p>
+          ) : (
+            <div className="space-y-1">
+              {sessions.map((session) => (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => onSelectSession(session.id)}
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-slate-50 transition-colors"
+                >
+                  {session.userAvatarUrl ? (
+                    <img src={session.userAvatarUrl} alt="" className="size-7 rounded-full" />
+                  ) : (
+                    <div className="flex size-7 items-center justify-center rounded-full bg-slate-200 text-xs font-medium text-slate-600">
+                      {(session.userName?.[0] ?? "?").toUpperCase()}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-slate-800 truncate">
+                        {session.userName || "Unknown"}
+                      </span>
+                      {session.userId === currentUserId && (
+                        <span className="text-[10px] text-slate-400">(you)</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 text-[10px] text-slate-400">
+                      <Circle
+                        className={`size-1.5 fill-current ${session.status === "streaming" ? "text-green-500" : "text-slate-300"}`}
+                      />
+                      <span>{session.status === "streaming" ? "Active" : formatTimeAgo(session.lastActivityAt)}</span>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTimeAgo(timestamp: string | null): string {
+  if (!timestamp) return "No activity";
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -148,3 +148,35 @@ export function useDefineAgentOutcome(organizationId: string | undefined) {
     },
   });
 }
+
+export type CanvasSession = {
+  id: string;
+  userId: string;
+  userName: string;
+  userAvatarUrl: string;
+  status: string;
+  lastActivityAt: string | null;
+};
+
+export function useCanvasSessions(canvasId: string | undefined, organizationId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: [...agentChatKeys.all, "sessions", canvasId],
+    enabled: enabled && Boolean(canvasId),
+    queryFn: async (): Promise<CanvasSession[]> => {
+      const res = await fetch(`/api/v1/agents/canvases/${canvasId}/sessions`, {
+        headers: { "x-organization-id": organizationId ?? "" },
+        credentials: "include",
+      });
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.sessions ?? []).map((s: Record<string, string>) => ({
+        id: s.id ?? "",
+        userId: s.userId ?? "",
+        userName: s.userName ?? "",
+        userAvatarUrl: s.userAvatarUrl ?? "",
+        status: s.status ?? "idle",
+        lastActivityAt: s.lastActivityAt ?? null,
+      }));
+    },
+  });
+}


### PR DESCRIPTION
Adds the ability to browse all agent sessions on a canvas, including sessions from other users.

**Backend:**
- New endpoint: `GET /api/v1/agents/canvases/{canvas_id}/sessions`
- Returns session ID, user name, status, last activity time
- Joins with accounts table for user info

**Frontend:**
- "All sessions" button at the top of the agent chat sidebar
- Session list view showing avatar/initial, name, status, time ago
- Read-only view when viewing another user's session (composer hidden)
- Back navigation between views

Any org member can view any session on a canvas they have access to. Only the session owner can send messages.