### PR TITLE
feat: promote Memory to a first-class canvas tab

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -9,7 +9,7 @@ const TAB_AGENT = "agent",
   TAB_RUNS = "runs",
   TAB_VERSIONS = "versions";
 
-type CanvasToolSidebarMode = "default" | "version-live" | "version-edit" | "runs" | "dashboard";
+type CanvasToolSidebarMode = "default" | "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
 
 export interface CanvasToolSidebarProps {
   toolSidebarState: CanvasToolSidebarState;

--- a/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
@@ -1,11 +1,10 @@
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
-import { Trash2 } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/ui/collapsible";
+import { ChevronDown, Trash2 } from "lucide-react";
+import { useState } from "react";
 
-export type CanvasMemoryModalProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+export type CanvasMemoryViewProps = {
   entries: CanvasMemoryEntry[];
   isLoading?: boolean;
   errorMessage?: string;
@@ -13,39 +12,13 @@ export type CanvasMemoryModalProps = {
   deletingId?: string;
 };
 
-export function CanvasMemoryModal(props: CanvasMemoryModalProps) {
-  return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent size="large" className="flex max-h-[90vh] w-[90vw] h-full flex-col gap-0 overflow-hidden p-0">
-        <div className="flex h-full min-h-0 flex-col">
-          <div className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
-            <span className="font-mono text-sm text-gray-600">Canvas Memory</span>
-          </div>
-
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-50">
-            <CanvasMemoryModalBody
-              entries={props.entries}
-              isLoading={props.isLoading}
-              errorMessage={props.errorMessage}
-              onDeleteEntry={props.onDeleteEntry}
-              deletingId={props.deletingId}
-            />
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-type CanvasMemoryBodyProps = {
-  entries: CanvasMemoryEntry[];
-  isLoading?: boolean;
-  errorMessage?: string;
-  onDeleteEntry?: (memoryId: string) => void;
-  deletingId?: string;
-};
-
-function CanvasMemoryModalBody({ entries, isLoading, errorMessage, onDeleteEntry, deletingId }: CanvasMemoryBodyProps) {
+export function CanvasMemoryView({
+  entries,
+  isLoading,
+  errorMessage,
+  onDeleteEntry,
+  deletingId,
+}: CanvasMemoryViewProps) {
   const groupedEntries = entries.reduce<Record<string, CanvasMemoryEntry[]>>((acc, entry) => {
     const namespace = entry.namespace || "(no namespace)";
     if (!acc[namespace]) {
@@ -79,15 +52,51 @@ function CanvasMemoryModalBody({ entries, isLoading, errorMessage, onDeleteEntry
   return (
     <div className="min-h-0 w-full min-w-0 flex-1 overflow-auto">
       {Object.entries(groupedEntries).map(([namespace, values]) => (
-        <div key={namespace} className="m-4 border border-slate-300 rounded-md bg-white">
-          <div className="px-3 py-2 font-mono text-sm text-gray-600 border-b border-slate-300">
-            Namespace: {namespace}
-          </div>
-
-          {renderNamespaceTable(values, onDeleteEntry, deletingId)}
-        </div>
+        <NamespaceSection
+          key={namespace}
+          namespace={namespace}
+          values={values}
+          onDeleteEntry={onDeleteEntry}
+          deletingId={deletingId}
+        />
       ))}
     </div>
+  );
+}
+
+type NamespaceSectionProps = {
+  namespace: string;
+  values: CanvasMemoryEntry[];
+  onDeleteEntry?: (memoryId: string) => void;
+  deletingId?: string;
+};
+
+function NamespaceSection({ namespace, values, onDeleteEntry, deletingId }: NamespaceSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="m-4 border border-slate-300 rounded-md bg-white"
+      data-testid={`memory-namespace-section-${namespace}`}
+    >
+      <CollapsibleTrigger
+        className="group flex w-full items-center gap-2 px-3 py-2 text-left font-mono text-sm text-gray-600 border-b border-slate-300 data-[state=closed]:border-b-0 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        data-testid={`memory-namespace-toggle-${namespace}`}
+        aria-label={`Toggle ${namespace} namespace`}
+      >
+        <ChevronDown
+          aria-hidden="true"
+          className="size-4 shrink-0 text-gray-500 transition-transform duration-150 group-data-[state=closed]:-rotate-90"
+        />
+        <span className="flex-1 truncate">Namespace: {namespace}</span>
+        <span className="shrink-0 text-xs font-normal text-gray-500">
+          {values.length} {values.length === 1 ? "item" : "items"}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>{renderNamespaceTable(values, onDeleteEntry, deletingId)}</CollapsibleContent>
+    </Collapsible>
   );
 }
 

--- a/web_src/src/pages/workflowv2/MemoryOverlay.tsx
+++ b/web_src/src/pages/workflowv2/MemoryOverlay.tsx
@@ -1,0 +1,19 @@
+import { CanvasMemoryView, type CanvasMemoryViewProps } from "./CanvasMemoryView";
+
+export type MemoryOverlayProps = CanvasMemoryViewProps;
+
+export function MemoryOverlay(props: MemoryOverlayProps) {
+  return (
+    <div
+      className="absolute inset-x-0 bottom-0 z-10 flex flex-col bg-slate-100 top-[5rem]"
+      data-testid="memory-overlay"
+    >
+      <div className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
+        <span className="font-mono text-sm text-gray-600">Canvas Memory</span>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-slate-50">
+        <CanvasMemoryView {...props} />
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
@@ -1,0 +1,45 @@
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { MemoryOverlay } from "./MemoryOverlay";
+
+interface DeleteCanvasMemoryMutation {
+  mutate: (memoryId: string) => void;
+  isPending: boolean;
+  variables: string | undefined;
+}
+
+interface WorkflowMemoryOverlayLayerProps {
+  isMemoryMode: boolean;
+  isViewingDraftVersion: boolean;
+  isViewingLiveVersion: boolean;
+  canUpdateCanvas: boolean;
+  entries: CanvasMemoryEntry[];
+  isLoading: boolean;
+  error: unknown;
+  deleteCanvasMemoryEntry: DeleteCanvasMemoryMutation;
+}
+
+export function WorkflowMemoryOverlayLayer({
+  isMemoryMode,
+  isViewingDraftVersion,
+  isViewingLiveVersion,
+  canUpdateCanvas,
+  entries,
+  isLoading,
+  error,
+  deleteCanvasMemoryEntry,
+}: WorkflowMemoryOverlayLayerProps) {
+  if (!isMemoryMode) return null;
+
+  return (
+    <MemoryOverlay
+      entries={isViewingDraftVersion ? [] : entries}
+      isLoading={isViewingDraftVersion ? false : isLoading}
+      errorMessage={isViewingDraftVersion ? undefined : error instanceof Error ? error.message : undefined}
+      onDeleteEntry={
+        canUpdateCanvas && isViewingLiveVersion ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined
+      }
+      deletingId={deleteCanvasMemoryEntry.isPending ? deleteCanvasMemoryEntry.variables : undefined}
+    />
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
@@ -115,7 +115,7 @@ export function DashboardOverlay({
   // strip is gone and the grid fills the available area.
   const overlayContent = (
     <div
-      className="absolute inset-x-0 bottom-0 z-10 flex flex-col bg-slate-100 top-[calc(2.75rem+3rem)]"
+      className="absolute inset-x-0 bottom-0 z-10 flex flex-col bg-slate-100 top-[5rem]"
       data-testid="dashboard-overlay"
     >
       <div className="min-h-0 flex-1 overflow-auto">

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -89,8 +89,11 @@ import { useDashboardModeActions } from "./dashboard/useDashboardModeActions";
 import { useDashboardTriggerNode } from "./dashboard/useDashboardTriggerNode";
 import { WorkflowDashboardOverlay } from "./dashboard/WorkflowDashboardOverlay";
 import { useWorkflowViewSearchParams } from "./useWorkflowViewSearchParams";
+import { useMemoryModeActions } from "./useMemoryModeActions";
+import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
 import { CanvasChangeRequestConflictResolver } from "./CanvasChangeRequestConflictResolver";
-import { CanvasMemoryModal } from "./CanvasMemoryModal";
+import { WorkflowMemoryOverlayLayer } from "./WorkflowMemoryOverlayLayer";
+import { countMemoryNamespaces } from "./memoryNamespaces";
 import { CanvasPageModals } from "./CanvasPageModals";
 import { CanvasVersionNodeDiffDialog, type CanvasVersionNodeDiffContext } from "./CanvasVersionNodeDiffDialog";
 import { CanvasYamlModal } from "./CanvasYamlModal";
@@ -138,6 +141,7 @@ import { actionsFromCapabilities, triggersFromCapabilities } from "@/lib/capabil
 import {
   getCanvasLogNodesSignature,
   getNodeAnalyticsProps,
+  isCanvasLoadNotFoundError,
   prepareData,
   prepareSidebarData,
 } from "./workflowPageHelpers";
@@ -192,6 +196,8 @@ export function WorkflowPageV2() {
     setIsRunsMode,
     isDashboardMode,
     setIsDashboardMode,
+    isMemoryMode,
+    setIsMemoryMode,
     isDashboardAddPanelOpen,
     setIsDashboardAddPanelOpen,
     isDashboardYamlOpen,
@@ -569,6 +575,10 @@ export function WorkflowPageV2() {
     error: canvasMemoryError,
   } = useCanvasMemoryEntries(canvasId!, isViewingLiveVersion);
   const deleteCanvasMemoryEntry = useDeleteCanvasMemoryEntry(canvasId!);
+  const memoryNamespaceCount = useMemo(
+    () => (isViewingDraftVersion ? 0 : countMemoryNamespaces(canvasMemoryEntries)),
+    [canvasMemoryEntries, isViewingDraftVersion],
+  );
   const canUpdateCanvas = canAct("canvases", "update");
   usePageTitle([canvas?.metadata?.name || "Canvas"]);
   const isTemplate = liveCanvas?.metadata?.isTemplate ?? false;
@@ -579,7 +589,6 @@ export function WorkflowPageV2() {
   const isReadOnly = isTemplate || !canUpdateCanvas || canvasDeletedRemotely || !hasEditableVersion;
   const [isUseTemplateOpen, setIsUseTemplateOpen] = useState(false);
   const [isYamlViewModalOpen, setIsYamlViewModalOpen] = useState(false);
-  const [isMemoryViewModalOpen, setIsMemoryViewModalOpen] = useState(false);
   const [isVersionControlOpen, setIsVersionControlOpen] = useState(() =>
     readStoredBoolean(CANVAS_VERSION_CONTROL_STORAGE_KEY),
   );
@@ -772,18 +781,11 @@ export function WorkflowPageV2() {
   // Redirect to home page if workflow is not found (404)
   // Use replace to avoid back button issues and prevent 404 flash
   useEffect(() => {
-    if (canvasError && !canvasLoading) {
-      // Check if it's a 404 error
-      const is404 =
-        (canvasError as any)?.status === 404 ||
-        (canvasError as any)?.response?.status === 404 ||
-        (canvasError as any)?.code === "NOT_FOUND" ||
-        (canvasError as any)?.message?.includes("not found") ||
-        (canvasError as any)?.message?.includes("404");
-
-      if (is404 && organizationId && !canvasDeletedRemotely) {
-        navigate(`/${organizationId}`, { replace: true });
-      }
+    if (!canvasError || canvasLoading) {
+      return;
+    }
+    if (isCanvasLoadNotFoundError(canvasError) && organizationId && !canvasDeletedRemotely) {
+      navigate(`/${organizationId}`, { replace: true });
     }
   }, [canvasError, canvasLoading, navigate, organizationId, canvasDeletedRemotely]);
   useEffect(() => {
@@ -4791,6 +4793,7 @@ export function WorkflowPageV2() {
     }
 
     setIsRunsMode(true);
+    setIsMemoryMode(false);
     setSearchParams(
       (current) => {
         const next = new URLSearchParams(current);
@@ -4801,7 +4804,7 @@ export function WorkflowPageV2() {
       },
       { replace: true },
     );
-  }, [handleUseVersion, hasEditableVersion, liveCanvasVersionId, setIsRunsMode, setSearchParams]);
+  }, [handleUseVersion, hasEditableVersion, liveCanvasVersionId, setIsMemoryMode, setIsRunsMode, setSearchParams]);
 
   const handleExitRunsMode = useCallback(() => {
     setIsRunsMode(false);
@@ -4831,54 +4834,37 @@ export function WorkflowPageV2() {
     setIsDashboardAddPanelOpen,
     setIsDashboardYamlOpen,
     setIsRunsMode,
+    setIsMemoryMode,
     setSearchParams,
     setSelectedRunId,
   });
 
-  const handleEnterEditModeFromHeader = useCallback(async () => {
-    if (isDashboardMode) {
-      handleExitDashboardMode();
-      await handleToggleEditMode();
-      return;
-    }
-    if (isRunsMode) {
-      setIsRunsMode(false);
-      setSelectedRunId(null);
-      setRunDetailNodeId(null);
-      await handleToggleEditMode();
-      setSearchParams(
-        (current) => {
-          const next = new URLSearchParams(current);
-          next.delete("view");
-          next.delete("run");
-          return next;
-        },
-        { replace: true },
-      );
-      return;
-    }
-    await handleToggleEditMode();
-  }, [
-    handleExitDashboardMode,
-    handleToggleEditMode,
-    isDashboardMode,
-    isRunsMode,
+  const { handleSelectMemoryMode, handleExitMemoryMode } = useMemoryModeActions({
+    handleUseVersion,
+    hasEditableVersion,
+    liveCanvasVersionId,
+    setIsMemoryMode,
+    setIsDashboardMode,
+    setIsDashboardAddPanelOpen,
+    setIsDashboardYamlOpen,
     setIsRunsMode,
     setSearchParams,
     setSelectedRunId,
-  ]);
+  });
 
-  const handleExitEditModeFromHeader = useCallback(async () => {
-    if (isDashboardMode) {
-      handleExitDashboardMode();
-      return;
-    }
-    if (isRunsMode) {
-      handleExitRunsMode();
-      return;
-    }
-    await handleToggleEditMode();
-  }, [handleExitDashboardMode, handleExitRunsMode, handleToggleEditMode, isDashboardMode, isRunsMode]);
+  const { handleEnterEditModeFromHeader, handleExitEditModeFromHeader } = useWorkflowHeaderEditActions({
+    isDashboardMode,
+    isMemoryMode,
+    isRunsMode,
+    handleExitDashboardMode,
+    handleExitMemoryMode,
+    handleExitRunsMode,
+    handleToggleEditMode,
+    setIsRunsMode,
+    setSelectedRunId,
+    setRunDetailNodeId,
+    setSearchParams,
+  });
 
   const handleRunCanvasNodeClick = useCallback(
     (nodeId: string) => {
@@ -5491,6 +5477,7 @@ export function WorkflowPageV2() {
     isDashboardMode,
     dashboardsFeatureEnabled,
     isRunsMode,
+    isMemoryMode,
     canvasMode,
   });
   const { onDashboardAddPanel, onDashboardOpenYaml, dashboardYamlReadOnly } = getDashboardHeaderActions({
@@ -5549,6 +5536,16 @@ export function WorkflowPageV2() {
           nodeStatuses={dashboardNodeStatuses}
           onTriggerNode={handleDashboardTriggerNode}
         />
+        <WorkflowMemoryOverlayLayer
+          isMemoryMode={isMemoryMode}
+          isViewingDraftVersion={isViewingDraftVersion}
+          isViewingLiveVersion={isViewingLiveVersion}
+          canUpdateCanvas={canUpdateCanvas}
+          entries={canvasMemoryEntries}
+          isLoading={canvasMemoryLoading}
+          error={canvasMemoryError}
+          deleteCanvasMemoryEntry={deleteCanvasMemoryEntry}
+        />
         <CanvasPage
           key={canvasRenderKey}
           // Persist right sidebar in query params
@@ -5566,11 +5563,11 @@ export function WorkflowPageV2() {
           showCanvasSettingsMenu={canUpdateCanvas}
           isVersionControlOpen={isVersionControlOpen}
           onOpenVersionControl={!hasEditableVersion ? handleToggleVersionControl : undefined}
-          showBottomStatusControls={!isTemplate && !isRunsMode}
-          hideAddControls={isTemplate || isRunsMode}
+          showBottomStatusControls={!isTemplate && !isRunsMode && !isMemoryMode}
+          hideAddControls={isTemplate || isRunsMode || isMemoryMode}
           hideCanvasToolSidebar={isTemplate}
-          memoryItemCount={canvasMemoryEntries.length}
-          onMemoryOpen={() => setIsMemoryViewModalOpen(true)}
+          memoryNamespaceCount={memoryNamespaceCount}
+          onSelectMemory={isTemplate ? undefined : handleSelectMemoryMode}
           onYamlOpen={() => setIsYamlViewModalOpen(true)}
           nodes={nodes}
           edges={renderedEdges}
@@ -5761,19 +5758,6 @@ export function WorkflowPageV2() {
           isImporting={hasLocalSaveActivity}
         />
       ) : null}
-      <CanvasMemoryModal
-        open={isMemoryViewModalOpen}
-        onOpenChange={setIsMemoryViewModalOpen}
-        entries={isViewingDraftVersion ? [] : canvasMemoryEntries}
-        isLoading={isViewingDraftVersion ? false : canvasMemoryLoading}
-        errorMessage={
-          isViewingDraftVersion ? undefined : canvasMemoryError instanceof Error ? canvasMemoryError.message : undefined
-        }
-        onDeleteEntry={
-          canUpdateCanvas && isViewingLiveVersion ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined
-        }
-        deletingId={deleteCanvasMemoryEntry.isPending ? deleteCanvasMemoryEntry.variables : undefined}
-      />
       {resolvingConflictChangeRequest ? (
         <div className="fixed inset-0 z-[100] min-h-0 bg-slate-50">
           <CanvasChangeRequestConflictResolver

--- a/web_src/src/pages/workflowv2/memoryNamespaces.spec.ts
+++ b/web_src/src/pages/workflowv2/memoryNamespaces.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { countMemoryNamespaces } from "./memoryNamespaces";
+
+function entry(namespace: string): CanvasMemoryEntry {
+  return { id: `${namespace}-${Math.random()}`, namespace, values: {} };
+}
+
+describe("countMemoryNamespaces", () => {
+  it("returns 0 for an empty entry list", () => {
+    expect(countMemoryNamespaces([])).toBe(0);
+  });
+
+  it("counts a single namespace once regardless of entry count", () => {
+    expect(countMemoryNamespaces([entry("envs"), entry("envs"), entry("envs")])).toBe(1);
+  });
+
+  it("counts distinct namespaces", () => {
+    expect(countMemoryNamespaces([entry("envs"), entry("machines"), entry("envs")])).toBe(2);
+  });
+
+  it("collapses empty and whitespace namespaces into a single bucket", () => {
+    expect(countMemoryNamespaces([entry(""), entry("   "), entry("envs")])).toBe(2);
+  });
+});

--- a/web_src/src/pages/workflowv2/memoryNamespaces.ts
+++ b/web_src/src/pages/workflowv2/memoryNamespaces.ts
@@ -1,0 +1,15 @@
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+/**
+ * Counts distinct namespace buckets in a canvas-memory entry list, matching the
+ * grouping used by the Memory view (entries with an empty/whitespace namespace
+ * collapse into a single "(no namespace)" bucket).
+ */
+export function countMemoryNamespaces(entries: CanvasMemoryEntry[]): number {
+  const namespaces = new Set<string>();
+  for (const entry of entries) {
+    const ns = entry.namespace?.trim() ? entry.namespace.trim() : "(no namespace)";
+    namespaces.add(ns);
+  }
+  return namespaces.size;
+}

--- a/web_src/src/pages/workflowv2/useMemoryModeActions.ts
+++ b/web_src/src/pages/workflowv2/useMemoryModeActions.ts
@@ -1,76 +1,72 @@
 import { useCallback } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
-interface DashboardModeActionsConfig {
-  dashboardsFeatureEnabled: boolean;
+interface MemoryModeActionsConfig {
   hasEditableVersion: boolean;
   liveCanvasVersionId: string | undefined;
   handleUseVersion: (versionId: string) => void;
+  setIsMemoryMode: (value: boolean) => void;
   setIsDashboardMode: (value: boolean) => void;
   setIsDashboardAddPanelOpen: (value: boolean) => void;
   setIsDashboardYamlOpen: (value: boolean) => void;
   setIsRunsMode: (value: boolean) => void;
-  setIsMemoryMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
   setSearchParams: SetURLSearchParams;
 }
 
-export function useDashboardModeActions({
-  dashboardsFeatureEnabled,
+export function useMemoryModeActions({
   hasEditableVersion,
   liveCanvasVersionId,
   handleUseVersion,
+  setIsMemoryMode,
   setIsDashboardMode,
   setIsDashboardAddPanelOpen,
   setIsDashboardYamlOpen,
   setIsRunsMode,
-  setIsMemoryMode,
   setSelectedRunId,
   setSearchParams,
-}: DashboardModeActionsConfig) {
-  const handleSelectDashboardMode = useCallback(() => {
-    if (!dashboardsFeatureEnabled) return;
+}: MemoryModeActionsConfig) {
+  const handleSelectMemoryMode = useCallback(() => {
     if (hasEditableVersion && liveCanvasVersionId) handleUseVersion(liveCanvasVersionId);
 
-    setIsDashboardMode(true);
+    setIsMemoryMode(true);
+    setIsDashboardMode(false);
+    setIsDashboardAddPanelOpen(false);
+    setIsDashboardYamlOpen(false);
     setIsRunsMode(false);
-    setIsMemoryMode(false);
     setSelectedRunId(null);
-    setSearchParams(toDashboardSearchParams, { replace: true });
+    setSearchParams(toMemorySearchParams, { replace: true });
   }, [
-    dashboardsFeatureEnabled,
     handleUseVersion,
     hasEditableVersion,
     liveCanvasVersionId,
+    setIsDashboardAddPanelOpen,
     setIsDashboardMode,
+    setIsDashboardYamlOpen,
     setIsMemoryMode,
     setIsRunsMode,
     setSearchParams,
     setSelectedRunId,
   ]);
 
-  const handleExitDashboardMode = useCallback(() => {
-    setIsDashboardMode(false);
-    setIsDashboardAddPanelOpen(false);
-    setIsDashboardYamlOpen(false);
-    setSearchParams(removeDashboardSearchParam, { replace: true });
-  }, [setIsDashboardAddPanelOpen, setIsDashboardYamlOpen, setIsDashboardMode, setSearchParams]);
+  const handleExitMemoryMode = useCallback(() => {
+    setIsMemoryMode(false);
+    setSearchParams(removeMemorySearchParam, { replace: true });
+  }, [setIsMemoryMode, setSearchParams]);
 
-  return { handleSelectDashboardMode, handleExitDashboardMode };
+  return { handleSelectMemoryMode, handleExitMemoryMode };
 }
 
-function toDashboardSearchParams(current: URLSearchParams): URLSearchParams {
+function toMemorySearchParams(current: URLSearchParams): URLSearchParams {
   const next = new URLSearchParams(current);
-  // Public URL param uses the product name (Console); internal hook/state
-  // identifiers still reference "dashboard".
-  next.set("view", "console");
+  next.set("view", "memory");
   next.delete("run");
   next.delete("sidebar");
   next.delete("node");
   return next;
 }
 
-function removeDashboardSearchParam(current: URLSearchParams): URLSearchParams {
+function removeMemorySearchParam(current: URLSearchParams): URLSearchParams {
   const next = new URLSearchParams(current);
   next.delete("view");
   return next;

--- a/web_src/src/pages/workflowv2/useWorkflowHeaderEditActions.ts
+++ b/web_src/src/pages/workflowv2/useWorkflowHeaderEditActions.ts
@@ -1,0 +1,96 @@
+import { useCallback } from "react";
+import type { SetURLSearchParams } from "react-router-dom";
+
+interface WorkflowHeaderEditActionsConfig {
+  isDashboardMode: boolean;
+  isMemoryMode: boolean;
+  isRunsMode: boolean;
+  handleExitDashboardMode: () => void;
+  handleExitMemoryMode: () => void;
+  handleExitRunsMode: () => void;
+  handleToggleEditMode: () => Promise<void>;
+  setIsRunsMode: (value: boolean) => void;
+  setSelectedRunId: (value: string | null) => void;
+  setRunDetailNodeId: (value: string | null) => void;
+  setSearchParams: SetURLSearchParams;
+}
+
+export function useWorkflowHeaderEditActions({
+  isDashboardMode,
+  isMemoryMode,
+  isRunsMode,
+  handleExitDashboardMode,
+  handleExitMemoryMode,
+  handleExitRunsMode,
+  handleToggleEditMode,
+  setIsRunsMode,
+  setSelectedRunId,
+  setRunDetailNodeId,
+  setSearchParams,
+}: WorkflowHeaderEditActionsConfig) {
+  const handleEnterEditModeFromHeader = useCallback(async () => {
+    if (isDashboardMode) {
+      handleExitDashboardMode();
+      await handleToggleEditMode();
+      return;
+    }
+    if (isMemoryMode) {
+      handleExitMemoryMode();
+      await handleToggleEditMode();
+      return;
+    }
+    if (isRunsMode) {
+      setIsRunsMode(false);
+      setSelectedRunId(null);
+      setRunDetailNodeId(null);
+      await handleToggleEditMode();
+      setSearchParams(clearRunsViewSearchParams, { replace: true });
+      return;
+    }
+    await handleToggleEditMode();
+  }, [
+    handleExitDashboardMode,
+    handleExitMemoryMode,
+    handleToggleEditMode,
+    isDashboardMode,
+    isMemoryMode,
+    isRunsMode,
+    setIsRunsMode,
+    setRunDetailNodeId,
+    setSearchParams,
+    setSelectedRunId,
+  ]);
+
+  const handleExitEditModeFromHeader = useCallback(async () => {
+    if (isDashboardMode) {
+      handleExitDashboardMode();
+      return;
+    }
+    if (isMemoryMode) {
+      handleExitMemoryMode();
+      return;
+    }
+    if (isRunsMode) {
+      handleExitRunsMode();
+      return;
+    }
+    await handleToggleEditMode();
+  }, [
+    handleExitDashboardMode,
+    handleExitMemoryMode,
+    handleExitRunsMode,
+    handleToggleEditMode,
+    isDashboardMode,
+    isMemoryMode,
+    isRunsMode,
+  ]);
+
+  return { handleEnterEditModeFromHeader, handleExitEditModeFromHeader };
+}
+
+function clearRunsViewSearchParams(current: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(current);
+  next.delete("view");
+  next.delete("run");
+  return next;
+}

--- a/web_src/src/pages/workflowv2/useWorkflowViewSearchParams.ts
+++ b/web_src/src/pages/workflowv2/useWorkflowViewSearchParams.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
 /**
- * Keeps runs/dashboard view mode and selected run in sync with `view` and `run` search params.
+ * Keeps runs/console view mode and selected run in sync with `view` and `run` search params.
+ *
+ * Public URL value is `view=console` for the Console tab. Internal state flags
+ * (`isDashboardMode`, etc.) still use the legacy "dashboard" name.
  */
 export function useWorkflowViewSearchParams(
   searchParams: URLSearchParams,
@@ -10,7 +13,8 @@ export function useWorkflowViewSearchParams(
   dashboardsFeatureEnabled: boolean,
 ) {
   const [isRunsMode, setIsRunsMode] = useState(() => searchParams.get("view") === "runs");
-  const [isDashboardMode, setIsDashboardMode] = useState(() => searchParams.get("view") === "dashboard");
+  const [isDashboardMode, setIsDashboardMode] = useState(() => searchParams.get("view") === "console");
+  const [isMemoryMode, setIsMemoryMode] = useState(() => searchParams.get("view") === "memory");
   const [isDashboardAddPanelOpen, setIsDashboardAddPanelOpen] = useState(false);
   const [isDashboardYamlOpen, setIsDashboardYamlOpen] = useState(false);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(() => searchParams.get("run"));
@@ -23,7 +27,8 @@ export function useWorkflowViewSearchParams(
 
   useEffect(() => {
     setIsRunsMode(viewParam === "runs");
-    if (viewParam === "dashboard") {
+    setIsMemoryMode(viewParam === "memory");
+    if (viewParam === "console") {
       if (dashboardsFeatureEnabled) {
         setIsDashboardMode(true);
       } else {
@@ -33,7 +38,7 @@ export function useWorkflowViewSearchParams(
         setSearchParamsRef.current(
           (current) => {
             const next = new URLSearchParams(current);
-            if (next.get("view") !== "dashboard") {
+            if (next.get("view") !== "console") {
               return current;
             }
             next.delete("view");
@@ -46,7 +51,7 @@ export function useWorkflowViewSearchParams(
       setIsDashboardMode(false);
     }
     setSelectedRunId(runParam || null);
-    if (viewParam !== "dashboard") {
+    if (viewParam !== "console") {
       setIsDashboardAddPanelOpen(false);
       setIsDashboardYamlOpen(false);
     }
@@ -57,6 +62,8 @@ export function useWorkflowViewSearchParams(
     setIsRunsMode,
     isDashboardMode,
     setIsDashboardMode,
+    isMemoryMode,
+    setIsMemoryMode,
     isDashboardAddPanelOpen,
     setIsDashboardAddPanelOpen,
     isDashboardYamlOpen,

--- a/web_src/src/pages/workflowv2/viewState.ts
+++ b/web_src/src/pages/workflowv2/viewState.ts
@@ -1,4 +1,6 @@
-export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "dashboard";
+// The "dashboard" header mode is the internal id for the user-facing Console
+// tab. String value kept stable to avoid touching every consumer.
+export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
 export type WorkflowCanvasStateMode = "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
 
 export function readStoredBoolean(key: string): boolean {
@@ -22,15 +24,21 @@ export function getWorkflowHeaderMode({
   isDashboardMode,
   dashboardsFeatureEnabled,
   isRunsMode,
+  isMemoryMode,
   canvasMode,
 }: {
   isDashboardMode: boolean;
   dashboardsFeatureEnabled: boolean;
   isRunsMode: boolean;
+  isMemoryMode: boolean;
   canvasMode: "edit" | "live";
 }): WorkflowHeaderMode {
   if (isDashboardMode) {
     return dashboardsFeatureEnabled ? "dashboard" : "version-live";
+  }
+
+  if (isMemoryMode) {
+    return "memory";
   }
 
   if (isRunsMode) {

--- a/web_src/src/pages/workflowv2/workflowPageHelpers.ts
+++ b/web_src/src/pages/workflowv2/workflowPageHelpers.ts
@@ -217,3 +217,33 @@ export function prepareSidebarData(
     isComposite: false,
   };
 }
+
+function readErrorField(error: unknown, key: string): unknown {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  return (error as Record<string, unknown>)[key];
+}
+
+/** True when a canvas fetch failed because the canvas does not exist. */
+export function isCanvasLoadNotFoundError(error: unknown): boolean {
+  if (readErrorField(error, "status") === 404) {
+    return true;
+  }
+
+  const response = readErrorField(error, "response");
+  if (typeof response === "object" && response !== null && readErrorField(response, "status") === 404) {
+    return true;
+  }
+
+  if (readErrorField(error, "code") === "NOT_FOUND") {
+    return true;
+  }
+
+  const message = readErrorField(error, "message");
+  if (typeof message !== "string") {
+    return false;
+  }
+
+  return message.includes("not found") || message.includes("404");
+}

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -8,7 +8,7 @@ import { CanvasModeToggle } from "./components/CanvasModeToggle";
 import { CanvasToolSidebarTrigger } from "./components/CanvasToolSidebarTrigger";
 import { SecondaryHeaderActions } from "./HeaderSecondaryActions";
 
-export type HeaderMode = "default" | "version-live" | "version-edit" | "runs" | "dashboard";
+export type HeaderMode = "default" | "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
 
 export interface HeaderProps {
   /** Shown centered in the top bar (canvas or template display name). */
@@ -33,6 +33,10 @@ export interface HeaderProps {
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectDashboard?: () => void;
+  /** Provided when Memory is available as a first-class tab; opens the Memory view. */
+  onSelectMemory?: () => void;
+  /** Distinct namespace count for the Memory tab badge. No badge when 0. */
+  memoryNamespaceCount?: number;
   /** When set with `mode === "dashboard"`, shows Add panel in the secondary header. */
   onDashboardAddPanel?: () => void;
   /** When set with `mode === "dashboard"`, shows the YAML button in the secondary header. */
@@ -118,12 +122,20 @@ function PageHeader({
 
 function SecondaryHeader(props: HeaderProps) {
   const showCanvasViewModeToggle =
-    !!props.onSelectDashboard &&
+    (!!props.onSelectDashboard || !!props.onSelectMemory) &&
     (props.mode === "version-live" ||
       props.mode === "version-edit" ||
       props.mode === "runs" ||
-      props.mode === "dashboard");
-  const canvasViewMode = props.mode === "runs" ? "runs" : props.mode === "dashboard" ? "dashboard" : "version-live";
+      props.mode === "dashboard" ||
+      props.mode === "memory");
+  const canvasViewMode =
+    props.mode === "runs"
+      ? "runs"
+      : props.mode === "dashboard"
+        ? "dashboard"
+        : props.mode === "memory"
+          ? "memory"
+          : "version-live";
   const editing = props.mode === "version-edit";
 
   return (
@@ -137,6 +149,8 @@ function SecondaryHeader(props: HeaderProps) {
               mode={canvasViewMode}
               onSelectLive={props.onExitEditMode}
               onSelectDashboard={props.onSelectDashboard}
+              onSelectMemory={props.onSelectMemory}
+              memoryNamespaceCount={props.memoryNamespaceCount}
               editing={editing}
               hasDraft={!!props.hasUnpublishedDraftChanges}
             />

--- a/web_src/src/ui/CanvasPage/RightSideControls.tsx
+++ b/web_src/src/ui/CanvasPage/RightSideControls.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Code2, Database, Plus, StickyNote } from "lucide-react";
+import { Code2, Plus, StickyNote } from "lucide-react";
 import { memo, type ReactNode } from "react";
 
 export type RightSideControlsProps = {
@@ -9,25 +9,16 @@ export type RightSideControlsProps = {
   onSidebarOpen: () => void;
   onAddNote: () => void | Promise<void>;
   onYamlOpen: () => void;
-  onMemoryOpen: () => void;
-  memoryItemCount?: number;
-  /** When false, the canvas memory control is hidden (e.g. dashboard or runs surface). */
-  showMemoryButton?: boolean;
 };
 
 export const RightSideControls = memo(function RightSideControls(props: RightSideControlsProps) {
+  if (props.mode === "live") return null;
   return (
     <div className="absolute top-4 right-4 z-10 flex flex-col gap-2.5">
-      {props.mode === "live" ? <LiveCanvasButtons {...props} /> : <EditCanvasButtons {...props} />}
+      <EditCanvasButtons {...props} />
     </div>
   );
 });
-
-function LiveCanvasButtons({ onMemoryOpen, showMemoryButton = true }: RightSideControlsProps) {
-  return showMemoryButton ? (
-    <ControlButton tooltip="Canvas memory" onClick={onMemoryOpen} testId="open-memory-button" icon={<Database />} />
-  ) : null;
-}
 
 function EditCanvasButtons({ onSidebarOpen, onAddNote, onYamlOpen }: RightSideControlsProps) {
   return (

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -26,4 +26,44 @@ describe("CanvasModeToggle", () => {
 
     expect(onSelectLive).toHaveBeenCalledTimes(2);
   });
+
+  it("invokes onSelectMemory when clicking the Memory tab", async () => {
+    const user = userEvent.setup();
+    const onSelectMemory = vi.fn();
+
+    render(
+      <CanvasModeToggle
+        mode="version-live"
+        onSelectLive={vi.fn()}
+        onSelectDashboard={vi.fn()}
+        onSelectMemory={onSelectMemory}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Memory" }));
+
+    expect(onSelectMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render the namespace count badge while MEMORY_TAB_NAMESPACE_BADGE_ENABLED is false", () => {
+    render(
+      <CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectMemory={vi.fn()} memoryNamespaceCount={3} />,
+    );
+
+    expect(screen.queryByTestId("canvas-view-mode-memory-badge")).not.toBeInTheDocument();
+  });
+
+  it("hides the badge when memoryNamespaceCount is 0", () => {
+    render(
+      <CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectMemory={vi.fn()} memoryNamespaceCount={0} />,
+    );
+
+    expect(screen.queryByTestId("canvas-view-mode-memory-badge")).not.toBeInTheDocument();
+  });
+
+  it("hides the Memory tab when onSelectMemory is not provided", () => {
+    render(<CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectDashboard={vi.fn()} />);
+
+    expect(screen.queryByRole("tab", { name: "Memory" })).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,32 +1,50 @@
+import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useEffect, useRef } from "react";
 
 // The "dashboard" mode/tab value is the internal id for what the product
 // surfaces to users as "Console". The string literal is kept to avoid
 // renaming the canvas mode union and downstream call sites.
-type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard";
+type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
 
 interface CanvasModeToggleProps {
   mode: CanvasMode;
   onSelectLive: () => void;
   onSelectDashboard?: () => void;
+  onSelectMemory?: () => void;
+  /** Distinct namespace count shown as a badge next to the Memory tab. No badge when 0. */
+  memoryNamespaceCount?: number;
   editing?: boolean;
   hasDraft?: boolean;
 }
 
 const CANVAS_TAB = "canvas";
 const DASHBOARD_TAB = "dashboard";
+const MEMORY_TAB = "memory";
 const RUNS_MODE = "runs";
+
+/** Re-enable when the Memory tab namespace count badge should be visible again. */
+const MEMORY_TAB_NAMESPACE_BADGE_ENABLED = false;
 
 export function CanvasModeToggle({
   mode,
   onSelectLive,
   onSelectDashboard,
+  onSelectMemory,
+  memoryNamespaceCount = 0,
   editing = false,
   hasDraft = false,
 }: CanvasModeToggleProps) {
   const showDashboard = Boolean(onSelectDashboard);
-  const selected = mode === DASHBOARD_TAB ? DASHBOARD_TAB : mode === RUNS_MODE ? RUNS_MODE : CANVAS_TAB;
+  const showMemory = Boolean(onSelectMemory);
+  const selected =
+    mode === DASHBOARD_TAB
+      ? DASHBOARD_TAB
+      : mode === MEMORY_TAB
+        ? MEMORY_TAB
+        : mode === RUNS_MODE
+          ? RUNS_MODE
+          : CANVAS_TAB;
   const valueChangeHandledRef = useRef(false);
 
   useEffect(() => {
@@ -57,6 +75,15 @@ export function CanvasModeToggle({
             valueChangeHandledRef.current = false;
           });
           void onSelectDashboard();
+          return;
+        }
+
+        if (next === MEMORY_TAB && selected !== MEMORY_TAB && onSelectMemory) {
+          valueChangeHandledRef.current = true;
+          queueMicrotask(() => {
+            valueChangeHandledRef.current = false;
+          });
+          void onSelectMemory();
         }
       }}
     >
@@ -82,6 +109,22 @@ export function CanvasModeToggle({
             ) : null}
           </span>
         </TabsTrigger>
+        {showMemory ? (
+          <TabsTrigger value={MEMORY_TAB} data-testid="canvas-view-mode-memory" aria-label="Memory">
+            <span className="inline-flex items-center gap-1.5">
+              Memory
+              {MEMORY_TAB_NAMESPACE_BADGE_ENABLED && memoryNamespaceCount > 0 ? (
+                <Badge
+                  variant="secondary"
+                  className="h-4 px-1.5 py-0 text-[10px] leading-none"
+                  data-testid="canvas-view-mode-memory-badge"
+                >
+                  {memoryNamespaceCount}
+                </Badge>
+              ) : null}
+            </span>
+          </TabsTrigger>
+        ) : null}
       </TabsList>
     </Tabs>
   );

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -202,7 +202,6 @@ describe("CanvasPage connection drop", () => {
           buildingBlocks={[]}
           isEditing={true}
           activeCanvasVersionId="draft-version"
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
           onEdgeCreate={vi.fn()}
           onPlaceholderAdd={onPlaceholderAdd}
@@ -260,7 +259,6 @@ describe("CanvasPage connection drop", () => {
           buildingBlocks={[]}
           isEditing={true}
           activeCanvasVersionId="draft-version"
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
           onEdgeCreate={vi.fn()}
           onPlaceholderAdd={onPlaceholderAdd}
@@ -304,7 +302,6 @@ describe("CanvasPage connection drop", () => {
           buildingBlocks={[]}
           isEditing={true}
           activeCanvasVersionId="draft-version"
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
           onEdgeCreate={vi.fn()}
           onPlaceholderAdd={onPlaceholderAdd}
@@ -361,7 +358,6 @@ describe("CanvasPage connection drop", () => {
           getSidebarData={getSidebarData}
           loadSidebarData={loadSidebarData}
           workflowNodes={[{ id: "node-1", type: "TYPE_ACTION", name: "Node" }]}
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
         />
       </MemoryRouter>,
@@ -395,7 +391,6 @@ describe("CanvasPage connection drop", () => {
           getSidebarData={getSidebarData}
           loadSidebarData={loadSidebarData}
           workflowNodes={[{ id: "node-1", type: "TYPE_ACTION", name: "Node" }]}
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
         />
       </MemoryRouter>,
@@ -436,7 +431,6 @@ describe("CanvasPage connection drop", () => {
           activeCanvasVersionId="live-version"
           hasFitToViewRef={hasFitToViewRef}
           fitAllRequest={0}
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
         />
       </MemoryRouter>,
@@ -477,7 +471,6 @@ describe("CanvasPage connection drop", () => {
           activeCanvasVersionId="live-version"
           hasFitToViewRef={hasFitToViewRef}
           fitAllRequest={0}
-          onMemoryOpen={vi.fn()}
           onYamlOpen={vi.fn()}
         />
       </MemoryRouter>,

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -160,7 +160,7 @@ export interface CanvasPageProps {
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;
   discardVersionDisabledTooltip?: string;
-  headerMode?: "default" | "version-live" | "version-edit" | "runs" | "dashboard";
+  headerMode?: "default" | "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
   /** Node settings sidebar: canvas uses debounced autosave without closing the panel after each save. */
   configurationSaveMode?: "manual" | "auto";
   onEnterEditMode?: () => void;
@@ -172,6 +172,8 @@ export interface CanvasPageProps {
   onSelectRuns?: () => void;
   onExitRunsMode?: () => void;
   onSelectDashboard?: () => void;
+  /** Switches the canvas surface to the Memory tab. Omitted on templates. */
+  onSelectMemory?: () => void;
   /** Opens the canvas dashboard add-panel dialog when `headerMode` is `dashboard`. */
   onDashboardAddPanel?: () => void;
   /** Opens the dashboard YAML modal when `headerMode` is `dashboard`. */
@@ -187,10 +189,10 @@ export interface CanvasPageProps {
   autoLayoutOnUpdateDisabled?: boolean;
   autoLayoutOnUpdateDisabledTooltip?: string;
   canvasStateMode?: "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
-  memoryItemCount?: number;
+  /** Distinct namespace count for the Memory tab badge. No badge when 0. */
+  memoryNamespaceCount?: number;
   showCanvasSettingsMenu?: boolean;
   onYamlOpen: () => void;
-  onMemoryOpen: () => void;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
   showBottomStatusControls?: boolean;
@@ -1114,6 +1116,7 @@ function CanvasPage(props: CanvasPageProps) {
       Boolean(props.hideAddControls) ||
       props.headerMode === "version-live" ||
       props.headerMode === "dashboard" ||
+      props.headerMode === "memory" ||
       props.headerMode === "runs" ||
       state.componentSidebar.isOpen,
     isSidebarOpen: isBuildingBlocksSidebarOpen,
@@ -1199,7 +1202,8 @@ function CanvasPage(props: CanvasPageProps) {
       ref={canvasWrapperRef}
       className={cn(
         "h-full w-full overflow-hidden sp-canvas relative flex flex-col",
-        (props.headerMode === "version-live" || props.headerMode === "dashboard") && "sp-canvas-live",
+        (props.headerMode === "version-live" || props.headerMode === "dashboard" || props.headerMode === "memory") &&
+          "sp-canvas-live",
         props.headerMode === "runs" && "sp-canvas-live",
       )}
     >
@@ -1228,6 +1232,8 @@ function CanvasPage(props: CanvasPageProps) {
           exitEditModeDisabled={props.exitEditModeDisabled}
           exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
           onSelectDashboard={props.onSelectDashboard}
+          onSelectMemory={props.onSelectMemory}
+          memoryNamespaceCount={props.memoryNamespaceCount}
           onDashboardAddPanel={props.onDashboardAddPanel}
           onDashboardOpenYaml={props.onDashboardOpenYaml}
           dashboardYamlReadOnly={props.dashboardYamlReadOnly}
@@ -1254,14 +1260,12 @@ function CanvasPage(props: CanvasPageProps) {
           versionsContent={props.toolSidebarVersionsContent}
         />
 
-        {props.headerMode === "runs" ? null : (
+        {props.headerMode === "runs" || props.headerMode === "memory" ? null : (
           <RightSideControls
             mode={readOnly ? "live" : "edit"}
             onSidebarOpen={handleBuildingBlocksShortcutOpen}
             onAddNote={handleAddNote}
-            onMemoryOpen={props.onMemoryOpen}
             onYamlOpen={props.onYamlOpen}
-            showMemoryButton={props.headerMode !== "dashboard"}
           />
         )}
         {props.hideAddControls || !isBuildingBlocksSidebarOpen ? null : (
@@ -1270,6 +1274,7 @@ function CanvasPage(props: CanvasPageProps) {
               isBuildingBlocksSidebarOpen &&
               props.headerMode !== "version-live" &&
               props.headerMode !== "dashboard" &&
+              props.headerMode !== "memory" &&
               props.headerMode !== "runs"
             }
             onToggle={handleSidebarToggle}
@@ -1413,7 +1418,11 @@ function CanvasPage(props: CanvasPageProps) {
               configurationSaveMode={props.configurationSaveMode}
               currentTab={currentTab}
               onTabChange={setCurrentTab}
-              canvasMode={props.headerMode === "version-live" || props.headerMode === "dashboard" ? "live" : "edit"}
+              canvasMode={
+                props.headerMode === "version-live" || props.headerMode === "dashboard" || props.headerMode === "memory"
+                  ? "live"
+                  : "edit"
+              }
               organizationId={props.organizationId}
               getCustomField={props.getCustomField}
               integrations={props.integrations}
@@ -1740,6 +1749,8 @@ function CanvasContentHeader({
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
   onSelectDashboard,
+  onSelectMemory,
+  memoryNamespaceCount,
   onDashboardAddPanel,
   onDashboardOpenYaml,
   dashboardYamlReadOnly,
@@ -1772,6 +1783,8 @@ function CanvasContentHeader({
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectDashboard?: () => void;
+  onSelectMemory?: () => void;
+  memoryNamespaceCount?: number;
   onDashboardAddPanel?: () => void;
   onDashboardOpenYaml?: () => void;
   dashboardYamlReadOnly?: boolean;
@@ -1814,6 +1827,8 @@ function CanvasContentHeader({
       exitEditModeDisabled={exitEditModeDisabled}
       exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       onSelectDashboard={onSelectDashboard}
+      onSelectMemory={onSelectMemory}
+      memoryNamespaceCount={memoryNamespaceCount}
       onDashboardAddPanel={onDashboardAddPanel}
       onDashboardOpenYaml={onDashboardOpenYaml}
       dashboardYamlReadOnly={dashboardYamlReadOnly}


### PR DESCRIPTION
## Summary

Replaces the fly-out/modal memory view with a real **Memory** tab in the canvas header. Memory now sits alongside Canvas, Console, and Runs as an overlay layer with mutual exclusion across tabs and a URL-driven `?view=memory` state. Renames `?view=dashboard` to `?view=console` so both tabs share the same view-search-params hook.

The namespace count badge on the tab is implemented but disabled (`MEMORY_TAB_NAMESPACE_BADGE_ENABLED = false`) until the design is finalised. The console overlay top offset is bumped to `top-[5rem]` to match the taller header. Header edit-mode logic is extracted into `useWorkflowHeaderEditActions` to keep `WorkflowPageV2` manageable.

Stacked on #4960. Second of four PRs replacing #4941.

## Stack

1. #4960 — Console rebrand
2. **#4961 (this PR)** — Promote Memory to a first-class canvas tab
3. #4963 — Console number/chart widget improvements (stacks on this)
4. #4964 — List value support for memory components (stacks on this, parallel to PR3)

## Test plan

- [ ] `make check.build.ui`
- [ ] `make format.js`
- [ ] Memory tab is reachable from header; switching tabs cancels the others
- [ ] `?view=memory` round-trips through reload; back/forward works
- [ ] Existing memory entries / delete actions still work
- [ ] Console overlay top offset has no visual regression on the canvas page
- [ ] Memory tab is hidden on templates / when `onSelectMemory` is undefined
- [ ] Namespace badge stays hidden (flag disabled)