### PR TITLE
feat: memory list values and Console widget improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ junit-report.xml
 pkg/web/assets/dist
 tmp
 build/
+node_modules/
 design/node_modules/
 # macOS Finder metadata
 .DS_Store

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -215,7 +215,7 @@ Send a POST request to the webhook URL with your payload. The workflow will rece
 
 ## Add Memory
 
-The Add Memory component appends a new item to canvas-level memory storage.
+The Add Memory component appends one or more items to canvas-level memory storage.
 
 ### Use Cases
 
@@ -228,6 +228,14 @@ The Add Memory component appends a new item to canvas-level memory storage.
 1. Reads `namespace` and value fields from configuration
 2. Appends a new memory row for the current canvas
 3. Emits `memory.added` with the saved payload
+
+### List Mode
+
+Enable "Input is a list" to add one memory row per element of a list expression.
+Configure `listSource` (the expression that yields the list) and `itemVariable`
+(the name to reference each element in field-value expressions, defaults to `item`).
+
+A single `memory.added` event is emitted with all written rows and the total `count`.
 
 ### Example Output
 
@@ -905,6 +913,13 @@ The Update Memory component updates matching rows in canvas-level memory storage
 - **Found**: At least one matching memory row was updated
 - **Not Found**: No matching memory rows were updated
 
+### List Mode
+
+Enable "Input is a list" to iterate over a list expression and run one update per element.
+The `matchList` is evaluated once (same matches for every iteration), while each
+`valueList` field value is evaluated per element with the iteration variable in scope
+(defaults to `item`). All resulting updates are reported in a single `memory.updated` event.
+
 ### Example Output
 
 ```json
@@ -964,6 +979,17 @@ This lets you store just one field (for example `value`) without extra marker fi
 ### Output
 
 Always emits to the default channel. Check `data.operation` to know whether the component updated existing rows or created a new row.
+
+### List Mode
+
+Enable "Input is a list" to iterate over a list expression and run one upsert per element.
+The `matchList` is evaluated once (same matches for every iteration), while each
+`valueList` field value is evaluated per element with the iteration variable in scope
+(defaults to `item`). All upserts are reported in a single `memory.upserted` event with per-item operation results.
+
+Note: when a non-empty `matchList` is configured in list mode, each iteration attempts to
+update the same matched rows. List mode is most useful for inserting multiple rows
+(empty `matchList`) or when each item's values are meant to overwrite the matched rows.
 
 ### Example Output
 

--- a/pkg/components/addmemory/add_memory.go
+++ b/pkg/components/addmemory/add_memory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/components/memorywrite"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -22,15 +23,23 @@ func init() {
 type AddMemory struct{}
 
 type Spec struct {
-	Namespace string      `json:"namespace"`
-	Values    any         `json:"values,omitempty"`
-	ValueList []ValuePair `json:"valueList,omitempty"`
+	Namespace    string      `json:"namespace"`
+	Values       any         `json:"values,omitempty"`
+	ValueList    []ValuePair `json:"valueList,omitempty"`
+	IterateList  bool        `json:"iterateList,omitempty"`
+	ListSource   string      `json:"listSource,omitempty"`
+	ItemVariable string      `json:"itemVariable,omitempty"`
 }
 
-type ValuePair struct {
-	Name  string `json:"name"`
-	Value any    `json:"value"`
+func (s Spec) listMode() memorywrite.ListMode {
+	return memorywrite.ListMode{
+		IterateList:  s.IterateList,
+		ListSource:   s.ListSource,
+		ItemVariable: s.ItemVariable,
+	}.Normalize()
 }
+
+type ValuePair = memorywrite.NameValuePair
 
 func (c *AddMemory) Name() string {
 	return ComponentName
@@ -45,7 +54,7 @@ func (c *AddMemory) Description() string {
 }
 
 func (c *AddMemory) Documentation() string {
-	return `The Add Memory component appends a new item to canvas-level memory storage.
+	return `The Add Memory component appends one or more items to canvas-level memory storage.
 
 ## Use Cases
 
@@ -57,7 +66,15 @@ func (c *AddMemory) Documentation() string {
 
 1. Reads ` + "`namespace`" + ` and value fields from configuration
 2. Appends a new memory row for the current canvas
-3. Emits ` + "`memory.added`" + ` with the saved payload`
+3. Emits ` + "`memory.added`" + ` with the saved payload
+
+## List Mode
+
+Enable "Input is a list" to add one memory row per element of a list expression.
+Configure ` + "`listSource`" + ` (the expression that yields the list) and ` + "`itemVariable`" + `
+(the name to reference each element in field-value expressions, defaults to ` + "`item`" + `).
+
+A single ` + "`memory.added`" + ` event is emitted with all written rows and the total ` + "`count`" + `.`
 }
 
 func (c *AddMemory) Icon() string {
@@ -82,6 +99,31 @@ func (c *AddMemory) Configuration() []configuration.Field {
 			Required:    true,
 		},
 		{
+			Name:        "iterateList",
+			Label:       "Input is a list",
+			Type:        configuration.FieldTypeBool,
+			Description: "When enabled, iterate over a list expression and add one memory row per element",
+		},
+		{
+			Name:        "listSource",
+			Label:       "List Source",
+			Type:        configuration.FieldTypeExpression,
+			Description: "Expression that evaluates to a list, e.g. $[\"Runner\"].data.result.services",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
+		},
+		{
+			Name:        "itemVariable",
+			Label:       "Item Variable",
+			Type:        configuration.FieldTypeString,
+			Description: "Variable name bound to each list element when evaluating field values (default: item)",
+			Default:     memorywrite.DefaultItemVariable,
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
+		},
+		{
 			Name:        "valueList",
 			Label:       "Values",
 			Type:        configuration.FieldTypeList,
@@ -104,7 +146,7 @@ func (c *AddMemory) Configuration() []configuration.Field {
 								Name:        "value",
 								Label:       "Field Value",
 								Type:        configuration.FieldTypeExpression,
-								Description: "Object field value (can be expression)",
+								Description: "Object field value (can be expression). In list mode, reference each element with the iteration variable, e.g. item.name",
 								Required:    true,
 							},
 						},
@@ -124,6 +166,15 @@ func (c *AddMemory) Execute(ctx core.ExecutionContext) error {
 	spec.Namespace = strings.TrimSpace(spec.Namespace)
 	if spec.Namespace == "" {
 		return fmt.Errorf("namespace is required")
+	}
+
+	mode := spec.listMode()
+	if err := mode.Validate(); err != nil {
+		return err
+	}
+
+	if mode.IterateList {
+		return c.executeListMode(ctx, spec, mode)
 	}
 
 	values := buildValues(spec)
@@ -152,6 +203,69 @@ func (c *AddMemory) Execute(ctx core.ExecutionContext) error {
 			},
 		},
 	)
+}
+
+func (c *AddMemory) executeListMode(ctx core.ExecutionContext, spec Spec, mode memorywrite.ListMode) error {
+	items, err := mode.EvaluateList(ctx.Expressions)
+	if err != nil {
+		return err
+	}
+
+	writtenValues := make([]any, 0, len(items))
+	for i, item := range items {
+		scope := mode.Scope(item)
+		values, resolveErr := memorywrite.ResolvePairs(spec.ValueList, scope, ctx.Expressions)
+		if resolveErr != nil {
+			return fmt.Errorf("failed to resolve values for list item %d: %w", i, resolveErr)
+		}
+		if err := ctx.CanvasMemory.Add(spec.Namespace, values); err != nil {
+			return fmt.Errorf("failed to add canvas memory for list item %d: %w", i, err)
+		}
+		writtenValues = append(writtenValues, values)
+	}
+
+	metadata := map[string]any{
+		"namespace":    spec.Namespace,
+		"fields":       extractFieldNames(spec.ValueList),
+		"iterateList":  true,
+		"itemVariable": mode.ItemVariable,
+		"count":        len(writtenValues),
+	}
+
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return fmt.Errorf("failed to set execution metadata: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		PayloadType,
+		[]any{
+			map[string]any{
+				"data": map[string]any{
+					"namespace": spec.Namespace,
+					"values":    writtenValues,
+					"count":     len(writtenValues),
+				},
+			},
+		},
+	)
+}
+
+func extractFieldNames(pairs []ValuePair) []string {
+	fields := make([]string, 0, len(pairs))
+	seen := map[string]struct{}{}
+	for _, pair := range pairs {
+		name := strings.TrimSpace(pair.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		fields = append(fields, name)
+	}
+	return fields
 }
 
 func buildValues(spec Spec) any {
@@ -207,7 +321,11 @@ func (c *AddMemory) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, 
 }
 
 func (c *AddMemory) Setup(ctx core.SetupContext) error {
-	return nil
+	var spec Spec
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	return spec.listMode().Validate()
 }
 
 func (c *AddMemory) Cancel(ctx core.ExecutionContext) error {

--- a/pkg/components/addmemory/add_memory_test.go
+++ b/pkg/components/addmemory/add_memory_test.go
@@ -1,9 +1,11 @@
 package addmemory
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -12,6 +14,7 @@ type canvasMemoryContext struct {
 	namespace string
 	values    any
 	addCalls  int
+	addArgs   []any
 	err       error
 }
 
@@ -19,6 +22,7 @@ func (c *canvasMemoryContext) Add(namespace string, values any) error {
 	c.addCalls++
 	c.namespace = namespace
 	c.values = values
+	c.addArgs = append(c.addArgs, values)
 	return c.err
 }
 
@@ -86,4 +90,141 @@ func TestAddMemoryExecute(t *testing.T) {
 		)
 	})
 
+	t.Run("list mode adds one row per element", func(t *testing.T) {
+		component := &AddMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{}
+		execMetadata := &contexts.MetadataContext{}
+
+		items := []any{
+			map[string]any{"name": "api", "id": "1"},
+			map[string]any{"name": "worker", "id": "2"},
+		}
+
+		expressions := &contexts.ExpressionContext{
+			Output: items,
+			ScopedOutputFn: func(expression string, scope map[string]any) (any, error) {
+				item, ok := scope["item"].(map[string]any)
+				require.True(t, ok)
+				switch expression {
+				case "item.name":
+					return item["name"], nil
+				case "item.id":
+					return item["id"], nil
+				}
+				return nil, fmt.Errorf("unexpected expression %q", expression)
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":    "services",
+				"iterateList":  true,
+				"listSource":   `$["Runner"].data.services`,
+				"itemVariable": "item",
+				"valueList": []map[string]any{
+					{"name": "name", "value": "item.name"},
+					{"name": "id", "value": "item.id"},
+				},
+			},
+			Metadata:       execMetadata,
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+			Expressions:    expressions,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, memoryCtx.addCalls)
+		assert.Equal(t, "services", memoryCtx.namespace)
+		assert.Equal(t, []any{
+			map[string]any{"name": "api", "id": "1"},
+			map[string]any{"name": "worker", "id": "2"},
+		}, memoryCtx.addArgs)
+
+		metadata, ok := execMetadata.Get().(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "services", metadata["namespace"])
+		assert.Equal(t, []string{"name", "id"}, metadata["fields"])
+		assert.Equal(t, true, metadata["iterateList"])
+		assert.Equal(t, "item", metadata["itemVariable"])
+		assert.Equal(t, 2, metadata["count"])
+
+		require.Len(t, execState.Payloads, 1)
+		payload, ok := execState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		outerData, ok := payload["data"].(map[string]any)
+		require.True(t, ok)
+		innerData, ok := outerData["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "services", innerData["namespace"])
+		assert.Equal(t, 2, innerData["count"])
+		assert.Equal(t, []any{
+			map[string]any{"name": "api", "id": "1"},
+			map[string]any{"name": "worker", "id": "2"},
+		}, innerData["values"])
+	})
+
+	t.Run("list mode rejects non-list source", func(t *testing.T) {
+		component := &AddMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":   "services",
+				"iterateList": true,
+				"listSource":  "x",
+				"valueList": []map[string]any{
+					{"name": "name", "value": "item.name"},
+				},
+			},
+			Metadata:       &contexts.MetadataContext{},
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+			Expressions:    &contexts.ExpressionContext{Output: "not a list"},
+		})
+
+		require.Error(t, err)
+		assert.Equal(t, 0, memoryCtx.addCalls)
+	})
+}
+
+func TestAddMemorySetup(t *testing.T) {
+	t.Run("accepts valid list-mode config", func(t *testing.T) {
+		err := (&AddMemory{}).Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":    "services",
+				"iterateList":  true,
+				"listSource":   `$["Runner"].data.services`,
+				"itemVariable": "service",
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects missing listSource", func(t *testing.T) {
+		err := (&AddMemory{}).Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":   "services",
+				"iterateList": true,
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "listSource")
+	})
+
+	t.Run("rejects reserved item variable", func(t *testing.T) {
+		err := (&AddMemory{}).Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":    "services",
+				"iterateList":  true,
+				"listSource":   "x",
+				"itemVariable": "memory",
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserved")
+	})
 }

--- a/pkg/components/memorywrite/list.go
+++ b/pkg/components/memorywrite/list.go
@@ -1,0 +1,161 @@
+// Package memorywrite holds shared list-mode helpers used by the memory
+// write components (addMemory, updateMemory, upsertMemory).
+//
+// When list mode is enabled, the component evaluates a list expression at
+// execute time and writes one memory row per element, exposing each element
+// as a configurable iteration variable for the per-item value expressions.
+package memorywrite
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const DefaultItemVariable = "item"
+
+var (
+	reservedItemVariables = map[string]struct{}{
+		"$":        {},
+		"memory":   {},
+		"config":   {},
+		"root":     {},
+		"previous": {},
+		"ctx":      {},
+	}
+
+	itemVariablePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+// ListMode captures the optional list-mode configuration shared by every
+// memory write component.
+type ListMode struct {
+	IterateList  bool   `mapstructure:"iterateList" json:"iterateList,omitempty"`
+	ListSource   string `mapstructure:"listSource" json:"listSource,omitempty"`
+	ItemVariable string `mapstructure:"itemVariable" json:"itemVariable,omitempty"`
+}
+
+// Normalize trims whitespace and applies the default iteration variable.
+func (m ListMode) Normalize() ListMode {
+	m.ListSource = strings.TrimSpace(m.ListSource)
+	m.ItemVariable = strings.TrimSpace(m.ItemVariable)
+	if m.IterateList && m.ItemVariable == "" {
+		m.ItemVariable = DefaultItemVariable
+	}
+	return m
+}
+
+// Validate ensures list-mode configuration is internally consistent.
+// It only validates when IterateList is true.
+func (m ListMode) Validate() error {
+	if !m.IterateList {
+		return nil
+	}
+	if m.ListSource == "" {
+		return fmt.Errorf("listSource is required when iterateList is true")
+	}
+	if !itemVariablePattern.MatchString(m.ItemVariable) {
+		return fmt.Errorf("itemVariable %q must match %s", m.ItemVariable, itemVariablePattern.String())
+	}
+	if _, ok := reservedItemVariables[m.ItemVariable]; ok {
+		return fmt.Errorf("itemVariable %q is reserved", m.ItemVariable)
+	}
+	return nil
+}
+
+// EvaluateList resolves the configured list expression to a slice of items.
+// It accepts []any directly or coerces common slice/array shapes.
+func (m ListMode) EvaluateList(expressions core.ExpressionContext) ([]any, error) {
+	if !m.IterateList {
+		return nil, fmt.Errorf("list mode is not enabled")
+	}
+	if expressions == nil {
+		return nil, fmt.Errorf("expression context is not available")
+	}
+
+	value, err := expressions.Run(m.ListSource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate listSource: %w", err)
+	}
+
+	return coerceToList(value)
+}
+
+func coerceToList(value any) ([]any, error) {
+	switch v := value.(type) {
+	case nil:
+		return []any{}, nil
+	case []any:
+		return v, nil
+	case []map[string]any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = item
+		}
+		return out, nil
+	case []string:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = item
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("listSource must evaluate to a list, got %T", value)
+	}
+}
+
+// Scope builds the per-item expression scope (just the iteration variable
+// for now; future enhancements can add index/totalCount).
+func (m ListMode) Scope(item any) map[string]any {
+	return map[string]any{m.ItemVariable: item}
+}
+
+// ResolveValue evaluates a single value field for a per-item iteration.
+//
+// String values are evaluated as bare expr expressions with the iteration
+// scope merged in. Anything else (already resolved at Build time, for
+// example via a {{ }} template) is returned unchanged so that the same
+// resolved value is written for every list element.
+func ResolveValue(value any, scope map[string]any, expressions core.ExpressionContext) (any, error) {
+	raw, ok := value.(string)
+	if !ok {
+		return value, nil
+	}
+
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return raw, nil
+	}
+
+	resolved, err := expressions.RunWithScope(trimmed, scope)
+	if err != nil {
+		return nil, err
+	}
+	return resolved, nil
+}
+
+// NameValuePair is the common shape for configured name/value field lists.
+type NameValuePair struct {
+	Name  string `json:"name"`
+	Value any    `json:"value"`
+}
+
+// ResolvePairs evaluates each pair's value in scope and returns a map keyed by
+// trimmed name. Pairs with empty names are skipped.
+func ResolvePairs(pairs []NameValuePair, scope map[string]any, expressions core.ExpressionContext) (map[string]any, error) {
+	values := make(map[string]any, len(pairs))
+	for _, pair := range pairs {
+		name := strings.TrimSpace(pair.Name)
+		if name == "" {
+			continue
+		}
+		resolved, err := ResolveValue(pair.Value, scope, expressions)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", name, err)
+		}
+		values[name] = resolved
+	}
+	return values, nil
+}

--- a/pkg/components/memorywrite/list_test.go
+++ b/pkg/components/memorywrite/list_test.go
@@ -1,0 +1,155 @@
+package memorywrite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeExpressionContext struct {
+	listOutput any
+	listErr    error
+	runCalls   []string
+	scopeCalls []scopeCall
+	scopeFunc  func(expression string, scope map[string]any) (any, error)
+}
+
+type scopeCall struct {
+	expression string
+	scope      map[string]any
+}
+
+func (f *fakeExpressionContext) Run(expression string) (any, error) {
+	f.runCalls = append(f.runCalls, expression)
+	return f.listOutput, f.listErr
+}
+
+func (f *fakeExpressionContext) RunWithScope(expression string, scope map[string]any) (any, error) {
+	f.scopeCalls = append(f.scopeCalls, scopeCall{expression: expression, scope: scope})
+	if f.scopeFunc != nil {
+		return f.scopeFunc(expression, scope)
+	}
+	return nil, nil
+}
+
+func TestListMode_NormalizeAppliesDefaultItemVariable(t *testing.T) {
+	mode := ListMode{IterateList: true, ListSource: " $x ", ItemVariable: ""}.Normalize()
+	assert.Equal(t, "$x", mode.ListSource)
+	assert.Equal(t, DefaultItemVariable, mode.ItemVariable)
+}
+
+func TestListMode_NormalizeNoOpWhenDisabled(t *testing.T) {
+	mode := ListMode{IterateList: false}.Normalize()
+	assert.Equal(t, "", mode.ItemVariable)
+}
+
+func TestListMode_ValidateRequiresSource(t *testing.T) {
+	err := ListMode{IterateList: true, ItemVariable: "item"}.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listSource")
+}
+
+func TestListMode_ValidateRejectsReservedAndInvalidNames(t *testing.T) {
+	cases := []string{"$", "memory", "1bad", "with space", ""}
+	for _, name := range cases {
+		t.Run(fmt.Sprintf("rejects %q", name), func(t *testing.T) {
+			err := ListMode{IterateList: true, ListSource: "list", ItemVariable: name}.Validate()
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestListMode_EvaluateListCoercesShapes(t *testing.T) {
+	cases := []struct {
+		name     string
+		output   any
+		expected []any
+	}{
+		{"any slice", []any{1, 2}, []any{1, 2}},
+		{"maps slice", []map[string]any{{"a": 1}}, []any{map[string]any{"a": 1}}},
+		{"string slice", []string{"x", "y"}, []any{"x", "y"}},
+		{"nil", nil, []any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expressions := &fakeExpressionContext{listOutput: tc.output}
+			mode := ListMode{IterateList: true, ListSource: "src", ItemVariable: "item"}
+			items, err := mode.EvaluateList(expressions)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, items)
+			assert.Equal(t, []string{"src"}, expressions.runCalls)
+		})
+	}
+}
+
+func TestListMode_EvaluateListRejectsNonList(t *testing.T) {
+	expressions := &fakeExpressionContext{listOutput: "scalar"}
+	mode := ListMode{IterateList: true, ListSource: "src", ItemVariable: "item"}
+	_, err := mode.EvaluateList(expressions)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listSource must evaluate to a list")
+}
+
+func TestResolveValue_StringEvaluatedWithScope(t *testing.T) {
+	expressions := &fakeExpressionContext{
+		scopeFunc: func(expression string, scope map[string]any) (any, error) {
+			assert.Equal(t, "item.service", expression)
+			assert.Equal(t, "api", scope["item"].(map[string]any)["service"])
+			return "api", nil
+		},
+	}
+
+	got, err := ResolveValue("item.service", map[string]any{"item": map[string]any{"service": "api"}}, expressions)
+	require.NoError(t, err)
+	assert.Equal(t, "api", got)
+}
+
+func TestResolveValue_NonStringPassThrough(t *testing.T) {
+	expressions := &fakeExpressionContext{}
+	got, err := ResolveValue(42, map[string]any{"item": "x"}, expressions)
+	require.NoError(t, err)
+	assert.Equal(t, 42, got)
+	assert.Empty(t, expressions.scopeCalls)
+}
+
+func TestResolveValue_EmptyStringIsLiteral(t *testing.T) {
+	expressions := &fakeExpressionContext{}
+	got, err := ResolveValue("   ", map[string]any{}, expressions)
+	require.NoError(t, err)
+	assert.Equal(t, "   ", got)
+	assert.Empty(t, expressions.scopeCalls)
+}
+
+func TestResolvePairs_TrimsNamesAndSkipsEmpty(t *testing.T) {
+	expressions := &fakeExpressionContext{
+		scopeFunc: func(expression string, _ map[string]any) (any, error) {
+			if expression == "expr" {
+				return 42, nil
+			}
+			return nil, fmt.Errorf("unexpected %q", expression)
+		},
+	}
+
+	got, err := ResolvePairs([]NameValuePair{
+		{Name: " kept ", Value: "expr"},
+		{Name: "literal", Value: 7},
+		{Name: "  ", Value: "ignored"},
+	}, map[string]any{"item": "x"}, expressions)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"kept": 42, "literal": 7}, got)
+}
+
+func TestResolvePairs_WrapsResolveErrors(t *testing.T) {
+	expressions := &fakeExpressionContext{
+		scopeFunc: func(string, map[string]any) (any, error) {
+			return nil, fmt.Errorf("boom")
+		},
+	}
+
+	_, err := ResolvePairs([]NameValuePair{{Name: "bad", Value: "x"}}, nil, expressions)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `field "bad"`)
+	assert.Contains(t, err.Error(), "boom")
+}

--- a/pkg/components/updatememory/update_memory.go
+++ b/pkg/components/updatememory/update_memory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/components/memorywrite"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -24,14 +25,22 @@ func init() {
 type UpdateMemory struct{}
 
 type Spec struct {
-	Namespace string      `json:"namespace"`
-	MatchList []FieldPair `json:"matchList"`
-	ValueList []FieldPair `json:"valueList"`
+	Namespace    string      `json:"namespace"`
+	MatchList    []FieldPair `json:"matchList"`
+	ValueList    []FieldPair `json:"valueList"`
+	IterateList  bool        `json:"iterateList,omitempty"`
+	ListSource   string      `json:"listSource,omitempty"`
+	ItemVariable string      `json:"itemVariable,omitempty"`
 }
 
-type FieldPair struct {
-	Name  string `json:"name"`
-	Value any    `json:"value"`
+type FieldPair = memorywrite.NameValuePair
+
+func (s Spec) listMode() memorywrite.ListMode {
+	return memorywrite.ListMode{
+		IterateList:  s.IterateList,
+		ListSource:   s.ListSource,
+		ItemVariable: s.ItemVariable,
+	}.Normalize()
 }
 
 type canvasMemoryUpdateContext interface {
@@ -68,7 +77,14 @@ func (c *UpdateMemory) Documentation() string {
 ## Output Channels
 
 - **Found**: At least one matching memory row was updated
-- **Not Found**: No matching memory rows were updated`
+- **Not Found**: No matching memory rows were updated
+
+## List Mode
+
+Enable "Input is a list" to iterate over a list expression and run one update per element.
+The ` + "`matchList`" + ` is evaluated once (same matches for every iteration), while each
+` + "`valueList`" + ` field value is evaluated per element with the iteration variable in scope
+(defaults to ` + "`item`" + `). All resulting updates are reported in a single ` + "`memory.updated`" + ` event.`
 }
 
 func (c *UpdateMemory) Icon() string {
@@ -98,6 +114,31 @@ func (c *UpdateMemory) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Description: "Memory namespace to update in",
 			Required:    true,
+		},
+		{
+			Name:        "iterateList",
+			Label:       "Input is a list",
+			Type:        configuration.FieldTypeBool,
+			Description: "When enabled, iterate over a list expression and update once per element (matchList stays global)",
+		},
+		{
+			Name:        "listSource",
+			Label:       "List Source",
+			Type:        configuration.FieldTypeExpression,
+			Description: "Expression that evaluates to a list, e.g. $[\"Runner\"].data.result.services",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
+		},
+		{
+			Name:        "itemVariable",
+			Label:       "Item Variable",
+			Type:        configuration.FieldTypeString,
+			Description: "Variable name bound to each list element when evaluating field values (default: item)",
+			Default:     memorywrite.DefaultItemVariable,
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
 		},
 		{
 			Name:        "matchList",
@@ -170,7 +211,10 @@ func (c *UpdateMemory) Setup(ctx core.SetupContext) error {
 		return err
 	}
 	spec = normalizeSpec(spec)
-	return validateSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+	return spec.listMode().Validate()
 }
 
 func (c *UpdateMemory) Execute(ctx core.ExecutionContext) error {
@@ -186,6 +230,15 @@ func (c *UpdateMemory) Execute(ctx core.ExecutionContext) error {
 	updateCtx, ok := ctx.CanvasMemory.(canvasMemoryUpdateContext)
 	if !ok {
 		return fmt.Errorf("canvas memory update operations are not supported")
+	}
+
+	mode := spec.listMode()
+	if err := mode.Validate(); err != nil {
+		return err
+	}
+
+	if mode.IterateList {
+		return executeListMode(ctx, spec, mode, updateCtx)
 	}
 
 	matches := buildPairs(spec.MatchList)
@@ -223,6 +276,66 @@ func (c *UpdateMemory) Execute(ctx core.ExecutionContext) error {
 					"values":    values,
 					"updated":   updatedValues,
 					"count":     len(updatedValues),
+				},
+			},
+		},
+	)
+}
+
+func executeListMode(ctx core.ExecutionContext, spec Spec, mode memorywrite.ListMode, updateCtx canvasMemoryUpdateContext) error {
+	items, err := mode.EvaluateList(ctx.Expressions)
+	if err != nil {
+		return err
+	}
+
+	matches := buildPairs(spec.MatchList)
+	allUpdated := make([]any, 0)
+	perItemValues := make([]any, 0, len(items))
+	for i, item := range items {
+		scope := mode.Scope(item)
+		values, resolveErr := memorywrite.ResolvePairs(spec.ValueList, scope, ctx.Expressions)
+		if resolveErr != nil {
+			return fmt.Errorf("failed to resolve values for list item %d: %w", i, resolveErr)
+		}
+		perItemValues = append(perItemValues, values)
+		updated, updateErr := updateCtx.Update(spec.Namespace, matches, values)
+		if updateErr != nil {
+			return fmt.Errorf("failed to update canvas memory for list item %d: %w", i, updateErr)
+		}
+		allUpdated = append(allUpdated, updated...)
+	}
+
+	metadata := map[string]any{
+		"namespace":    spec.Namespace,
+		"matchFields":  extractFieldNames(spec.MatchList),
+		"valueFields":  extractFieldNames(spec.ValueList),
+		"matches":      matches,
+		"updatedCount": len(allUpdated),
+		"iterateList":  true,
+		"itemVariable": mode.ItemVariable,
+		"count":        len(items),
+	}
+
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return fmt.Errorf("failed to set execution metadata: %w", err)
+	}
+
+	channel := ChannelNameNotFound
+	if len(allUpdated) > 0 {
+		channel = ChannelNameFound
+	}
+
+	return ctx.ExecutionState.Emit(
+		channel,
+		PayloadType,
+		[]any{
+			map[string]any{
+				"data": map[string]any{
+					"namespace": spec.Namespace,
+					"matches":   matches,
+					"values":    perItemValues,
+					"updated":   allUpdated,
+					"count":     len(allUpdated),
 				},
 			},
 		},

--- a/pkg/components/updatememory/update_memory_test.go
+++ b/pkg/components/updatememory/update_memory_test.go
@@ -5,17 +5,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
 type canvasMemoryContext struct {
-	namespace     string
-	matches       map[string]any
-	values        map[string]any
-	updatedValues []any
-	updateCalls   int
-	err           error
+	namespace      string
+	matches        map[string]any
+	values         map[string]any
+	valuesPerCall  []map[string]any
+	matchesPerCall []map[string]any
+	updatedValues  []any
+	updatedPerCall [][]any
+	updateCalls    int
+	err            error
 }
 
 func (c *canvasMemoryContext) Add(namespace string, values any) error {
@@ -35,8 +39,17 @@ func (c *canvasMemoryContext) Update(namespace string, matches map[string]any, v
 	c.namespace = namespace
 	c.matches = matches
 	c.values = values
+	c.valuesPerCall = append(c.valuesPerCall, values)
+	c.matchesPerCall = append(c.matchesPerCall, matches)
 	if c.err != nil {
 		return nil, c.err
+	}
+	if len(c.updatedPerCall) > 0 {
+		idx := c.updateCalls - 1
+		if idx >= len(c.updatedPerCall) {
+			idx = len(c.updatedPerCall) - 1
+		}
+		return c.updatedPerCall[idx], nil
 	}
 	return c.updatedValues, nil
 }
@@ -138,6 +151,109 @@ func TestUpdateMemoryExecute(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to update canvas memory")
 	})
+
+	t.Run("list mode updates once per element with same matches", func(t *testing.T) {
+		component := &UpdateMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{
+			updatedPerCall: [][]any{
+				{map[string]any{"name": "api", "status": "running"}},
+				{map[string]any{"name": "worker", "status": "running"}},
+			},
+		}
+		execMetadata := &contexts.MetadataContext{}
+
+		items := []any{
+			map[string]any{"name": "api"},
+			map[string]any{"name": "worker"},
+		}
+
+		expressions := &contexts.ExpressionContext{
+			Output: items,
+			ScopedOutputFn: func(expression string, scope map[string]any) (any, error) {
+				item := scope["item"].(map[string]any)
+				switch expression {
+				case "item.name":
+					return item["name"], nil
+				}
+				return "running", nil
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":    "services",
+				"iterateList":  true,
+				"listSource":   `$["Runner"].data.services`,
+				"itemVariable": "item",
+				"matchList": []map[string]any{
+					{"name": "env", "value": "prod"},
+				},
+				"valueList": []map[string]any{
+					{"name": "name", "value": "item.name"},
+					{"name": "status", "value": "\"running\""},
+				},
+			},
+			Metadata:       execMetadata,
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+			Expressions:    expressions,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, memoryCtx.updateCalls)
+		assert.Equal(t, ChannelNameFound, execState.Channel)
+		for _, matches := range memoryCtx.matchesPerCall {
+			assert.Equal(t, map[string]any{"env": "prod"}, matches)
+		}
+		assert.Equal(t, "api", memoryCtx.valuesPerCall[0]["name"])
+		assert.Equal(t, "worker", memoryCtx.valuesPerCall[1]["name"])
+
+		metadata, ok := execMetadata.Get().(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, true, metadata["iterateList"])
+		assert.Equal(t, "item", metadata["itemVariable"])
+		assert.Equal(t, 2, metadata["count"])
+		assert.Equal(t, 2, metadata["updatedCount"])
+	})
+
+	t.Run("list mode emits notFound when nothing matches", func(t *testing.T) {
+		component := &UpdateMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{updatedValues: []any{}}
+
+		items := []any{map[string]any{"name": "api"}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":    "services",
+				"iterateList":  true,
+				"listSource":   "list",
+				"itemVariable": "item",
+				"matchList": []map[string]any{
+					{"name": "env", "value": "prod"},
+				},
+				"valueList": []map[string]any{
+					{"name": "name", "value": "item.name"},
+				},
+			},
+			Metadata:       &contexts.MetadataContext{},
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+			Expressions: &contexts.ExpressionContext{
+				Output: items,
+				ScopedOutputFn: func(expression string, scope map[string]any) (any, error) {
+					return scope["item"].(map[string]any)["name"], nil
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, ChannelNameNotFound, execState.Channel)
+		assert.Equal(t, 1, memoryCtx.updateCalls)
+	})
 }
 
 func TestUpdateMemorySetup(t *testing.T) {
@@ -200,5 +316,40 @@ func TestUpdateMemorySetup(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "at least one memory value update is required")
+	})
+
+	t.Run("list mode requires listSource", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":   "machines",
+				"iterateList": true,
+				"matchList": []map[string]any{
+					{"name": "creator", "value": "igor"},
+				},
+				"valueList": []map[string]any{
+					{"name": "status", "value": "running"},
+				},
+			},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "listSource")
+	})
+
+	t.Run("list mode accepts valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":    "machines",
+				"iterateList":  true,
+				"listSource":   "x",
+				"itemVariable": "service",
+				"matchList": []map[string]any{
+					{"name": "creator", "value": "igor"},
+				},
+				"valueList": []map[string]any{
+					{"name": "status", "value": "service.status"},
+				},
+			},
+		})
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/components/upsertmemory/upsert_memory.go
+++ b/pkg/components/upsertmemory/upsert_memory.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/components/memorywrite"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -24,15 +25,23 @@ func init() {
 type UpsertMemory struct{}
 
 type Spec struct {
-	Namespace string      `json:"namespace"`
-	MatchList []FieldPair `json:"matchList"`
-	ValueList []FieldPair `json:"valueList"`
+	Namespace    string      `json:"namespace"`
+	MatchList    []FieldPair `json:"matchList"`
+	ValueList    []FieldPair `json:"valueList"`
+	IterateList  bool        `json:"iterateList,omitempty"`
+	ListSource   string      `json:"listSource,omitempty"`
+	ItemVariable string      `json:"itemVariable,omitempty"`
 }
 
-type FieldPair struct {
-	Name  string `json:"name"`
-	Value any    `json:"value"`
+func (s Spec) listMode() memorywrite.ListMode {
+	return memorywrite.ListMode{
+		IterateList:  s.IterateList,
+		ListSource:   s.ListSource,
+		ItemVariable: s.ItemVariable,
+	}.Normalize()
 }
+
+type FieldPair = memorywrite.NameValuePair
 
 type canvasMemoryUpdateContext interface {
 	Update(namespace string, matches map[string]any, values map[string]any) ([]any, error)
@@ -73,7 +82,18 @@ This lets you store just one field (for example ` + "`value`" + `) without extra
 
 ## Output
 
-Always emits to the default channel. Check ` + "`data.operation`" + ` to know whether the component updated existing rows or created a new row.`
+Always emits to the default channel. Check ` + "`data.operation`" + ` to know whether the component updated existing rows or created a new row.
+
+## List Mode
+
+Enable "Input is a list" to iterate over a list expression and run one upsert per element.
+The ` + "`matchList`" + ` is evaluated once (same matches for every iteration), while each
+` + "`valueList`" + ` field value is evaluated per element with the iteration variable in scope
+(defaults to ` + "`item`" + `). All upserts are reported in a single ` + "`memory.upserted`" + ` event with per-item operation results.
+
+Note: when a non-empty ` + "`matchList`" + ` is configured in list mode, each iteration attempts to
+update the same matched rows. List mode is most useful for inserting multiple rows
+(empty ` + "`matchList`" + `) or when each item's values are meant to overwrite the matched rows.`
 }
 
 func (c *UpsertMemory) Icon() string {
@@ -100,6 +120,31 @@ func (c *UpsertMemory) Configuration() []configuration.Field {
 			Type:        configuration.FieldTypeString,
 			Description: "Memory namespace to upsert in",
 			Required:    true,
+		},
+		{
+			Name:        "iterateList",
+			Label:       "Input is a list",
+			Type:        configuration.FieldTypeBool,
+			Description: "When enabled, iterate over a list expression and upsert once per element (matchList stays global)",
+		},
+		{
+			Name:        "listSource",
+			Label:       "List Source",
+			Type:        configuration.FieldTypeExpression,
+			Description: "Expression that evaluates to a list, e.g. $[\"Runner\"].data.result.services",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
+		},
+		{
+			Name:        "itemVariable",
+			Label:       "Item Variable",
+			Type:        configuration.FieldTypeString,
+			Description: "Variable name bound to each list element when evaluating field values (default: item)",
+			Default:     memorywrite.DefaultItemVariable,
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "iterateList", Values: []string{"true"}},
+			},
 		},
 		{
 			Name:        "valueList",
@@ -173,7 +218,10 @@ func (c *UpsertMemory) Setup(ctx core.SetupContext) error {
 		return err
 	}
 	spec = normalizeSpec(spec)
-	return validateSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+	return spec.listMode().Validate()
 }
 
 func (c *UpsertMemory) Execute(ctx core.ExecutionContext) error {
@@ -189,6 +237,15 @@ func (c *UpsertMemory) Execute(ctx core.ExecutionContext) error {
 	updateCtx, ok := ctx.CanvasMemory.(canvasMemoryUpdateContext)
 	if !ok {
 		return fmt.Errorf("canvas memory update operations are not supported")
+	}
+
+	mode := spec.listMode()
+	if err := mode.Validate(); err != nil {
+		return err
+	}
+
+	if mode.IterateList {
+		return executeListMode(ctx, spec, mode, updateCtx)
 	}
 
 	matches := buildPairs(spec.MatchList)
@@ -234,6 +291,87 @@ func (c *UpsertMemory) Execute(ctx core.ExecutionContext) error {
 					"operation": operation,
 					"records":   affectedValues,
 					"count":     len(affectedValues),
+				},
+			},
+		},
+	)
+}
+
+func executeListMode(ctx core.ExecutionContext, spec Spec, mode memorywrite.ListMode, updateCtx canvasMemoryUpdateContext) error {
+	items, err := mode.EvaluateList(ctx.Expressions)
+	if err != nil {
+		return err
+	}
+
+	matches := buildPairs(spec.MatchList)
+	records := make([]any, 0)
+	perItemValues := make([]any, 0, len(items))
+	itemResults := make([]any, 0, len(items))
+	updatedTotal := 0
+	createdTotal := 0
+
+	for i, item := range items {
+		scope := mode.Scope(item)
+		values, resolveErr := memorywrite.ResolvePairs(spec.ValueList, scope, ctx.Expressions)
+		if resolveErr != nil {
+			return fmt.Errorf("failed to resolve values for list item %d: %w", i, resolveErr)
+		}
+		perItemValues = append(perItemValues, values)
+
+		updatedValues, updateErr := updateCtx.Update(spec.Namespace, matches, values)
+		if updateErr != nil {
+			return fmt.Errorf("failed to upsert canvas memory for list item %d: %w", i, updateErr)
+		}
+
+		operation := OperationUpdated
+		affected := updatedValues
+		if len(updatedValues) == 0 {
+			if err := ctx.CanvasMemory.Add(spec.Namespace, values); err != nil {
+				return fmt.Errorf("failed to upsert canvas memory for list item %d: %w", i, err)
+			}
+			operation = OperationCreated
+			affected = []any{values}
+			createdTotal++
+		} else {
+			updatedTotal += len(updatedValues)
+		}
+
+		records = append(records, affected...)
+		itemResults = append(itemResults, map[string]any{
+			"operation": operation,
+			"values":    values,
+			"records":   affected,
+		})
+	}
+
+	metadata := map[string]any{
+		"namespace":    spec.Namespace,
+		"matchFields":  extractFieldNames(spec.MatchList),
+		"valueFields":  extractFieldNames(spec.ValueList),
+		"matches":      matches,
+		"updatedCount": updatedTotal,
+		"createdCount": createdTotal,
+		"iterateList":  true,
+		"itemVariable": mode.ItemVariable,
+		"count":        len(items),
+	}
+
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return fmt.Errorf("failed to set execution metadata: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		PayloadType,
+		[]any{
+			map[string]any{
+				"data": map[string]any{
+					"namespace": spec.Namespace,
+					"matches":   matches,
+					"values":    perItemValues,
+					"items":     itemResults,
+					"records":   records,
+					"count":     len(records),
 				},
 			},
 		},

--- a/pkg/components/upsertmemory/upsert_memory_test.go
+++ b/pkg/components/upsertmemory/upsert_memory_test.go
@@ -5,19 +5,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
 type canvasMemoryContext struct {
-	namespace     string
-	matches       map[string]any
-	values        map[string]any
-	updatedValues []any
-	updateCalls   int
-	addCalls      int
-	err           error
-	addErr        error
+	namespace      string
+	matches        map[string]any
+	values         map[string]any
+	addedValues    []any
+	updatedValues  []any
+	updatedPerCall [][]any
+	updateCalls    int
+	addCalls       int
+	err            error
+	addErr         error
 }
 
 func (c *canvasMemoryContext) Add(namespace string, values any) error {
@@ -27,6 +30,7 @@ func (c *canvasMemoryContext) Add(namespace string, values any) error {
 	if ok {
 		c.values = valueMap
 	}
+	c.addedValues = append(c.addedValues, values)
 	return c.addErr
 }
 
@@ -45,6 +49,13 @@ func (c *canvasMemoryContext) Update(namespace string, matches map[string]any, v
 	c.values = values
 	if c.err != nil {
 		return nil, c.err
+	}
+	if len(c.updatedPerCall) > 0 {
+		idx := c.updateCalls - 1
+		if idx >= len(c.updatedPerCall) {
+			idx = len(c.updatedPerCall) - 1
+		}
+		return c.updatedPerCall[idx], nil
 	}
 	return c.updatedValues, nil
 }
@@ -222,6 +233,78 @@ func TestUpsertMemoryExecute(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to upsert canvas memory")
 	})
+
+	t.Run("list mode upserts one row per element", func(t *testing.T) {
+		component := &UpsertMemory{}
+		execState := &contexts.ExecutionStateContext{}
+		memoryCtx := &canvasMemoryContext{
+			updatedPerCall: [][]any{
+				{map[string]any{"environment": "production", "name": "api"}},
+				nil,
+			},
+		}
+		execMetadata := &contexts.MetadataContext{}
+
+		items := []any{
+			map[string]any{"name": "api"},
+			map[string]any{"name": "worker"},
+		}
+
+		expressions := &contexts.ExpressionContext{
+			Output: items,
+			ScopedOutputFn: func(expression string, scope map[string]any) (any, error) {
+				return scope["item"].(map[string]any)["name"], nil
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"namespace":    "deployments",
+				"iterateList":  true,
+				"listSource":   "list",
+				"itemVariable": "item",
+				"matchList":    []map[string]any{},
+				"valueList": []map[string]any{
+					{"name": "name", "value": "item.name"},
+				},
+			},
+			Metadata:       execMetadata,
+			NodeMetadata:   &contexts.MetadataContext{},
+			CanvasMemory:   memoryCtx,
+			ExecutionState: execState,
+			Expressions:    expressions,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, memoryCtx.updateCalls)
+		assert.Equal(t, 1, memoryCtx.addCalls)
+
+		metadata, ok := execMetadata.Get().(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, true, metadata["iterateList"])
+		assert.Equal(t, "item", metadata["itemVariable"])
+		assert.Equal(t, 2, metadata["count"])
+		assert.Equal(t, 1, metadata["updatedCount"])
+		assert.Equal(t, 1, metadata["createdCount"])
+
+		require.Len(t, execState.Payloads, 1)
+		payload, ok := execState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		outerData, ok := payload["data"].(map[string]any)
+		require.True(t, ok)
+		innerData, ok := outerData["data"].(map[string]any)
+		require.True(t, ok)
+
+		itemsResults, ok := innerData["items"].([]any)
+		require.True(t, ok)
+		require.Len(t, itemsResults, 2)
+		first, ok := itemsResults[0].(map[string]any)
+		require.True(t, ok)
+		second, ok := itemsResults[1].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, OperationUpdated, first["operation"])
+		assert.Equal(t, OperationCreated, second["operation"])
+	})
 }
 
 func TestUpsertMemorySetup(t *testing.T) {
@@ -279,6 +362,37 @@ func TestUpsertMemorySetup(t *testing.T) {
 				"matchList": []map[string]any{},
 				"valueList": []map[string]any{
 					{"name": "value", "value": "abc123"},
+				},
+			},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("list mode requires listSource", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":   "deployments",
+				"iterateList": true,
+				"matchList":   []map[string]any{},
+				"valueList": []map[string]any{
+					{"name": "value", "value": "abc"},
+				},
+			},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "listSource")
+	})
+
+	t.Run("list mode accepts valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"namespace":    "deployments",
+				"iterateList":  true,
+				"listSource":   "x",
+				"itemVariable": "service",
+				"matchList":    []map[string]any{},
+				"valueList": []map[string]any{
+					{"name": "name", "value": "service.name"},
 				},
 			},
 		})

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -46,6 +46,7 @@ type ExecutionContext struct {
 
 type ExpressionContext interface {
 	Run(expression string) (any, error)
+	RunWithScope(expression string, scope map[string]any) (any, error)
 }
 
 /*

--- a/pkg/integrations/grafana/create_silence_test.go
+++ b/pkg/integrations/grafana/create_silence_test.go
@@ -179,6 +179,10 @@ func (c *sequenceExpressionContext) Run(expression string) (any, error) {
 	return output, nil
 }
 
+func (c *sequenceExpressionContext) RunWithScope(expression string, _ map[string]any) (any, error) {
+	return c.Run(expression)
+}
+
 func Test__CreateSilence__Execute__evaluatesBareExpressions(t *testing.T) {
 	component := CreateSilence{}
 	httpCtx := &contexts.HTTPContext{

--- a/pkg/integrations/grafana/time_inputs_test.go
+++ b/pkg/integrations/grafana/time_inputs_test.go
@@ -15,6 +15,10 @@ func (t testExpressionContext) Run(expression string) (any, error) {
 	return t.run(expression)
 }
 
+func (t testExpressionContext) RunWithScope(expression string, _ map[string]any) (any, error) {
+	return t.run(expression)
+}
+
 func Test__resolveGrafanaTimeInput(t *testing.T) {
 	t.Run("preserves grafana relative values", func(t *testing.T) {
 		value, err := resolveGrafanaTimeInput("now-24h", nil, nil)

--- a/pkg/models/canvas_dashboard_yml.go
+++ b/pkg/models/canvas_dashboard_yml.go
@@ -7,11 +7,15 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 const (
+	// ConsoleKind is the canonical YAML kind for canvas consoles (product name).
+	ConsoleKind = "Console"
+	// DashboardKind is the legacy YAML kind accepted on import for back-compat.
 	DashboardKind       = "Dashboard"
 	DashboardAPIVersion = "v1"
 
@@ -108,7 +112,7 @@ func DashboardToYML(dashboard *CanvasDashboard, canvasName string) ([]byte, erro
 
 	resource := DashboardYAML{
 		APIVersion: DashboardAPIVersion,
-		Kind:       DashboardKind,
+		Kind:       ConsoleKind,
 		Metadata: DashboardYAMLMetadata{
 			CanvasID: dashboard.CanvasID.String(),
 			Name:     canvasName,
@@ -152,11 +156,15 @@ func (d *DashboardYAML) Validate() error {
 	if d.Kind == "" {
 		return errors.New("kind is required")
 	}
-	if d.Kind != DashboardKind {
-		return fmt.Errorf("unsupported kind %q (expected %q)", d.Kind, DashboardKind)
+	if !isValidDashboardYAMLKind(d.Kind) {
+		return fmt.Errorf("unsupported kind %q (expected %q)", d.Kind, ConsoleKind)
 	}
 
 	return ValidateDashboardContent(d.Spec.Panels, d.Spec.Layout)
+}
+
+func isValidDashboardYAMLKind(kind string) bool {
+	return kind == ConsoleKind || kind == DashboardKind
 }
 
 // ValidateDashboardContent enforces the shared validation rules used by both
@@ -376,8 +384,33 @@ func validateChartPanelContent(panel DashboardPanel) error {
 	if xField, ok := render["xField"].(string); !ok || xField == "" {
 		return fmt.Errorf("panel %q render.xField must be a non-empty string", panel.ID)
 	}
-	if series, ok := render["series"].([]any); !ok || len(series) == 0 {
+	series, ok := render["series"].([]any)
+	if !ok || len(series) == 0 {
 		return fmt.Errorf("panel %q render.series must be a non-empty array", panel.ID)
+	}
+	for i, rawSeries := range series {
+		if err := validateChartSeries(panel.ID, i, rawSeries); err != nil {
+			return err
+		}
+	}
+	if legend, ok := render["legend"]; ok && legend != nil {
+		legendStr, isString := legend.(string)
+		if !isString || !slices.Contains([]string{"auto", "show", "hide"}, legendStr) {
+			return fmt.Errorf("panel %q render.legend must be one of auto/show/hide", panel.ID)
+		}
+	}
+	return nil
+}
+
+func validateChartSeries(panelID string, index int, raw any) error {
+	series, ok := raw.(map[string]any)
+	if !ok || series == nil {
+		return fmt.Errorf("panel %q render.series[%d] must be an object", panelID, index)
+	}
+	for _, key := range []string{"field", "label", "color", "format", "prefix", "suffix"} {
+		if err := validateOptionalString(panelID, fmt.Sprintf("render.series[%d].%s", index, key), series[key]); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -478,13 +511,32 @@ func validateNumberPanelContent(panel DashboardPanel) error {
 	if panel.Content == nil {
 		return fmt.Errorf("panel %q content is required", panel.ID)
 	}
-	if err := validateDataSource(panel.ID, panel.Content["dataSource"]); err != nil {
+	if err := validateNumberDataSource(panel.ID, panel.Content["dataSource"]); err != nil {
 		return err
 	}
 	render, err := validateRender(panel.ID, panel.Content["render"], "number")
 	if err != nil {
 		return err
 	}
+	if err := validateOptionalString(panel.ID, "render.prefix", render["prefix"]); err != nil {
+		return err
+	}
+	if err := validateOptionalString(panel.ID, "render.suffix", render["suffix"]); err != nil {
+		return err
+	}
+
+	// Composite memory sources carry per-source aggregation; render-level
+	// aggregation/field must be absent so configuration is unambiguous.
+	if isCompositeMemoryDataSource(panel.Content["dataSource"]) {
+		if _, hasAgg := render["aggregation"]; hasAgg {
+			return fmt.Errorf("panel %q render.aggregation must not be set when dataSource.sources is used (each source defines its own aggregation)", panel.ID)
+		}
+		if _, hasField := render["field"]; hasField {
+			return fmt.Errorf("panel %q render.field must not be set when dataSource.sources is used (each source defines its own field)", panel.ID)
+		}
+		return nil
+	}
+
 	aggregation, _ := render["aggregation"].(string)
 	switch aggregation {
 	case "count", "sum", "avg", "min", "max", "first", "last":
@@ -497,6 +549,78 @@ func validateNumberPanelContent(panel DashboardPanel) error {
 		}
 	}
 	return nil
+}
+
+func isCompositeMemoryDataSource(raw any) bool {
+	ds, ok := raw.(map[string]any)
+	if !ok || ds == nil {
+		return false
+	}
+	if ds["kind"] != "memory" {
+		return false
+	}
+	_, ok = ds["sources"].([]any)
+	return ok
+}
+
+var allowedNumberCombineOps = []string{"sum", "min", "max", "avg"}
+var allowedNumberAggregations = []string{"count", "sum", "avg", "min", "max", "first", "last"}
+
+// validateNumberDataSource accepts the shared data-source shapes plus the
+// composite memory variant where each namespace has its own aggregation and
+// the partials are merged via `combine`.
+func validateNumberDataSource(panelID string, raw any) error {
+	ds, ok := raw.(map[string]any)
+	if !ok || ds == nil {
+		return fmt.Errorf("panel %q dataSource must be an object", panelID)
+	}
+	if ds["kind"] == "memory" {
+		if _, hasSources := ds["sources"]; hasSources {
+			return validateCompositeMemoryDataSource(panelID, ds)
+		}
+	}
+	return validateDataSource(panelID, raw)
+}
+
+func validateCompositeMemoryDataSource(panelID string, ds map[string]any) error {
+	sources, ok := ds["sources"].([]any)
+	if !ok {
+		return fmt.Errorf("panel %q dataSource.sources must be an array", panelID)
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("panel %q dataSource.sources must be a non-empty array", panelID)
+	}
+	for i, raw := range sources {
+		if err := validateMemoryNumberSource(panelID, i, raw); err != nil {
+			return err
+		}
+	}
+	combine, _ := ds["combine"].(string)
+	if !slices.Contains(allowedNumberCombineOps, combine) {
+		return fmt.Errorf("panel %q dataSource.combine must be one of %s", panelID, strings.Join(allowedNumberCombineOps, "/"))
+	}
+	return nil
+}
+
+func validateMemoryNumberSource(panelID string, index int, raw any) error {
+	source, ok := raw.(map[string]any)
+	if !ok || source == nil {
+		return fmt.Errorf("panel %q dataSource.sources[%d] must be an object", panelID, index)
+	}
+	namespace, _ := source["namespace"].(string)
+	if namespace == "" {
+		return fmt.Errorf("panel %q dataSource.sources[%d].namespace must be a non-empty string", panelID, index)
+	}
+	aggregation, _ := source["aggregation"].(string)
+	if !slices.Contains(allowedNumberAggregations, aggregation) {
+		return fmt.Errorf("panel %q dataSource.sources[%d].aggregation must be one of %s", panelID, index, strings.Join(allowedNumberAggregations, "/"))
+	}
+	if aggregation != "count" {
+		if field, ok := source["field"].(string); !ok || field == "" {
+			return fmt.Errorf("panel %q dataSource.sources[%d].field is required when aggregation is %q", panelID, index, aggregation)
+		}
+	}
+	return validateOptionalString(panelID, fmt.Sprintf("dataSource.sources[%d].fieldPath", index), source["fieldPath"])
 }
 
 // normalizeDashboardPanelsForExport ensures stable field order in panel

--- a/pkg/models/canvas_dashboard_yml_test.go
+++ b/pkg/models/canvas_dashboard_yml_test.go
@@ -34,7 +34,7 @@ spec:
 	resource, err := DashboardFromYML([]byte(yaml))
 	require.NoError(t, err)
 	require.Equal(t, "v1", resource.APIVersion)
-	require.Equal(t, "Dashboard", resource.Kind)
+	require.Equal(t, DashboardKind, resource.Kind)
 	require.Equal(t, "My dashboard", resource.Metadata.Name)
 	require.Len(t, resource.Spec.Panels, 1)
 	require.Equal(t, "intro", resource.Spec.Panels[0].ID)
@@ -44,6 +44,32 @@ spec:
 	require.Equal(t, 12, resource.Spec.Layout[0].W)
 	require.NotNil(t, resource.Spec.Layout[0].MinW)
 	assert.Equal(t, 2, *resource.Spec.Layout[0].MinW)
+}
+
+func TestDashboardFromYML_ParsesValidConsoleKind(t *testing.T) {
+	yaml := `apiVersion: v1
+kind: Console
+metadata:
+  name: Ops console
+spec:
+  panels:
+    - id: intro
+      type: markdown
+      content:
+        body: "# Hello"
+  layout:
+    - i: intro
+      x: 0
+      y: 0
+      w: 12
+      h: 6
+`
+
+	resource, err := DashboardFromYML([]byte(yaml))
+	require.NoError(t, err)
+	require.Equal(t, ConsoleKind, resource.Kind)
+	require.Equal(t, "Ops console", resource.Metadata.Name)
+	require.Len(t, resource.Spec.Panels, 1)
 }
 
 func TestDashboardFromYML_RejectsEmptyInput(t *testing.T) {
@@ -195,12 +221,13 @@ func TestDashboardToYML_RoundTripsEmptyDashboard(t *testing.T) {
 	out, err := DashboardToYML(dashboard, "Canvas Name")
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "apiVersion: v1")
-	assert.Contains(t, string(out), "kind: Dashboard")
+	assert.Contains(t, string(out), "kind: Console")
 	assert.Contains(t, string(out), canvasID.String())
 	assert.Contains(t, string(out), "name: Canvas Name")
 
 	parsed, err := DashboardFromYML(out)
 	require.NoError(t, err)
+	require.Equal(t, ConsoleKind, parsed.Kind)
 	assert.Empty(t, parsed.Spec.Panels)
 	assert.Empty(t, parsed.Spec.Layout)
 }
@@ -384,6 +411,141 @@ func TestValidateDashboardContent_RejectsInvalidTypedPanelConfig(t *testing.T) {
 			},
 			contains: "dataSource.limit must be a number",
 		},
+		{
+			name: "number render prefix must be string",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "runs"},
+					"render":     map[string]any{"kind": "number", "aggregation": "count", "prefix": 42},
+				},
+			},
+			contains: "render.prefix must be a string",
+		},
+		{
+			name: "composite number panel rejects render.aggregation",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number", "aggregation": "sum", "field": "cost"},
+				},
+			},
+			contains: "render.aggregation must not be set",
+		},
+		{
+			name: "composite number panel rejects render.field",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number", "field": "cost"},
+				},
+			},
+			contains: "render.field must not be set",
+		},
+		{
+			name: "composite number panel rejects unknown combine",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "median",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.combine must be one of",
+		},
+		{
+			name: "composite number panel requires field for non-count source",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum"},
+						},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.sources[0].field is required",
+		},
+		{
+			name: "composite number panel rejects empty sources",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.sources must be a non-empty array",
+		},
+		{
+			name: "chart series prefix must be a string",
+			panel: DashboardPanel{
+				ID:   "chart",
+				Type: DashboardPanelTypeChart,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "executions"},
+					"render": map[string]any{
+						"kind":   "chart",
+						"type":   "bar",
+						"xField": "service",
+						"series": []any{map[string]any{"field": "cost", "prefix": 42}},
+					},
+				},
+			},
+			contains: "render.series[0].prefix must be a string",
+		},
+		{
+			name: "chart legend mode must be auto/show/hide",
+			panel: DashboardPanel{
+				ID:   "chart",
+				Type: DashboardPanelTypeChart,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "executions"},
+					"render": map[string]any{
+						"kind":   "chart",
+						"type":   "bar",
+						"xField": "service",
+						"series": []any{map[string]any{"field": "cost"}},
+						"legend": "bogus",
+					},
+				},
+			},
+			contains: "render.legend must be one of auto/show/hide",
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,4 +555,51 @@ func TestValidateDashboardContent_RejectsInvalidTypedPanelConfig(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.contains)
 		})
 	}
+}
+
+func TestValidateDashboardContent_AcceptsChartSeriesFormatAndLegend(t *testing.T) {
+	panels := []DashboardPanel{
+		{
+			ID:   "chart",
+			Type: DashboardPanelTypeChart,
+			Content: map[string]any{
+				"dataSource": map[string]any{"kind": "executions"},
+				"render": map[string]any{
+					"kind":   "chart",
+					"type":   "bar",
+					"xField": "service",
+					"series": []any{
+						map[string]any{"field": "cost", "label": "Cost", "format": "number", "prefix": "$", "suffix": " /mo"},
+					},
+					"legend": "show",
+				},
+			},
+		},
+	}
+
+	err := ValidateDashboardContent(panels, nil)
+	require.NoError(t, err)
+}
+
+func TestValidateDashboardContent_AcceptsCompositeNumberPanel(t *testing.T) {
+	panels := []DashboardPanel{
+		{
+			ID:   "score",
+			Type: DashboardPanelTypeNumber,
+			Content: map[string]any{
+				"dataSource": map[string]any{
+					"kind":    "memory",
+					"combine": "sum",
+					"sources": []any{
+						map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						map[string]any{"namespace": "b", "aggregation": "count"},
+					},
+				},
+				"render": map[string]any{"kind": "number", "prefix": "R$"},
+			},
+		},
+	}
+
+	err := ValidateDashboardContent(panels, nil)
+	require.NoError(t, err)
 }

--- a/pkg/workers/contexts/expression_context.go
+++ b/pkg/workers/contexts/expression_context.go
@@ -11,3 +11,7 @@ func NewExpressionContext(configurationBuilder *NodeConfigurationBuilder) *Expre
 func (c *ExpressionContext) Run(expression string) (any, error) {
 	return c.configurationBuilder.ResolveExpression(expression)
 }
+
+func (c *ExpressionContext) RunWithScope(expression string, scope map[string]any) (any, error) {
+	return c.configurationBuilder.ResolveExpressionWithScope(expression, scope)
+}

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -245,6 +245,14 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {
+	return b.ResolveExpressionWithScope(expression, nil)
+}
+
+// ResolveExpressionWithScope evaluates an expression with extra variables
+// merged into the eval environment. Scope keys override no built-ins; we
+// reject any attempt to shadow reserved names so that `$`, `memory`, `config`,
+// `root`, and `previous` stay deterministic.
+func (b *NodeConfigurationBuilder) ResolveExpressionWithScope(expression string, scope map[string]any) (any, error) {
 	referencedNodes, err := expressionvalidation.ParseReferencedNodes(expression)
 	if err != nil {
 		return "", err
@@ -262,6 +270,13 @@ func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, er
 
 	if b.parentBlueprintNode != nil {
 		env["config"] = b.parentBlueprintNode.Configuration.Data()
+	}
+
+	for key, value := range scope {
+		if isReservedExpressionIdentifier(key) {
+			return "", fmt.Errorf("scope variable %q is reserved", key)
+		}
+		env[key] = value
 	}
 
 	exprOptions := []expr.Option{
@@ -626,6 +641,20 @@ func latestEventByExecution(events []models.CanvasEvent, executionIDs []uuid.UUI
 	}
 
 	return latestByExecution
+}
+
+var reservedExpressionIdentifiers = map[string]struct{}{
+	"$":        {},
+	"memory":   {},
+	"config":   {},
+	"root":     {},
+	"previous": {},
+	"ctx":      {},
+}
+
+func isReservedExpressionIdentifier(name string) bool {
+	_, ok := reservedExpressionIdentifiers[name]
+	return ok
 }
 
 func parseDepth(param any) (int, error) {

--- a/pkg/workers/contexts/node_configuration_builder_expr_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_expr_test.go
@@ -16,3 +16,23 @@ func TestNodeConfigurationBuilder_ResolveExpression_DateWithTimezoneOption(t *te
 	require.NoError(t, err)
 	require.Equal(t, "2026-03-17T01:02:03.000000001Z", out)
 }
+
+func TestNodeConfigurationBuilder_ResolveExpressionWithScope_BindsIterationVariable(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).WithInput(map[string]any{})
+
+	out, err := b.ResolveExpressionWithScope(`item.service`, map[string]any{
+		"item": map[string]any{"service": "api"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "api", out)
+}
+
+func TestNodeConfigurationBuilder_ResolveExpressionWithScope_RejectsReservedNames(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).WithInput(map[string]any{})
+
+	_, err := b.ResolveExpressionWithScope(`memory`, map[string]any{
+		"memory": "hijacked",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved")
+}

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -420,11 +420,25 @@ func (c *SecretsContext) GetKey(secretName, keyName string) ([]byte, error) {
 }
 
 type ExpressionContext struct {
-	Output any
-	Error  error
+	Output         any
+	Error          error
+	ScopedOutputs  map[string]any
+	ScopedOutputFn func(expression string, scope map[string]any) (any, error)
 }
 
 func (c *ExpressionContext) Run(expression string) (any, error) {
+	return c.Output, c.Error
+}
+
+func (c *ExpressionContext) RunWithScope(expression string, scope map[string]any) (any, error) {
+	if c.ScopedOutputFn != nil {
+		return c.ScopedOutputFn(expression, scope)
+	}
+	if c.ScopedOutputs != nil {
+		if v, ok := c.ScopedOutputs[expression]; ok {
+			return v, nil
+		}
+	}
 	return c.Output, c.Error
 }
 

--- a/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
@@ -1,22 +1,15 @@
 import { useState } from "react";
-import { AlertTriangle, Trash2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
-import { DataSourceForm } from "./DataSourceForm";
+import { ChartPanelForm } from "./ChartPanelForm";
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
 import type { ChartPanelContent } from "./panelTypes";
 import { useWidgetData } from "./widget/useWidgetData";
 import { WidgetChart } from "./widget/WidgetChart";
-import type { WidgetChartKind, WidgetChartSeries } from "./widget/types";
-
-const CHART_KINDS: WidgetChartKind[] = ["bar", "stacked-bar", "line", "area", "donut"];
 
 interface ChartPanelCardProps {
   panel: DashboardPanel;
@@ -64,108 +57,6 @@ function ChartPanelDataBound({ content, canvasId }: { content: ChartPanelContent
   const { rows, isLoading, error } = useWidgetData(canvasId, content.dataSource);
   if (error) return <PanelError message={error} />;
   return <WidgetChart render={content.render} rows={rows} isLoading={isLoading} />;
-}
-
-function ChartPanelForm({
-  value,
-  onChange,
-}: {
-  value: ChartPanelContent;
-  onChange: (next: ChartPanelContent) => void;
-}) {
-  const updateSeries = (idx: number, patch: Partial<WidgetChartSeries>) => {
-    const series = value.render.series.map((s, i) => (i === idx ? { ...s, ...patch } : s));
-    onChange({ ...value, render: { ...value.render, series } });
-  };
-  const addSeries = () => {
-    onChange({
-      ...value,
-      render: { ...value.render, series: [...value.render.series, { field: "", label: "" }] },
-    });
-  };
-  const removeSeries = (idx: number) => {
-    onChange({ ...value, render: { ...value.render, series: value.render.series.filter((_, i) => i !== idx) } });
-  };
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
-        <Input
-          value={value.title ?? ""}
-          onChange={(e) => onChange({ ...value, title: e.target.value })}
-          placeholder="Defaults to panel id"
-        />
-      </div>
-      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Chart type</Label>
-          <Select
-            value={value.render.type}
-            onValueChange={(v) => onChange({ ...value, render: { ...value.render, type: v as WidgetChartKind } })}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {CHART_KINDS.map((k) => (
-                <SelectItem key={k} value={k}>
-                  {k}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">X-axis field</Label>
-          <Input
-            value={value.render.xField}
-            onChange={(e) => onChange({ ...value, render: { ...value.render, xField: e.target.value } })}
-            placeholder="e.g. status"
-          />
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label className="text-xs font-medium text-slate-600">Series</Label>
-          <Button type="button" size="sm" variant="outline" onClick={addSeries} data-testid="chart-add-series">
-            Add series
-          </Button>
-        </div>
-        <div className="space-y-2">
-          {value.render.series.map((s, idx) => (
-            <div key={idx} className="grid grid-cols-12 items-center gap-2 rounded border border-slate-200 p-2">
-              <Input
-                className="col-span-5 h-8"
-                value={s.field ?? ""}
-                onChange={(e) => updateSeries(idx, { field: e.target.value || undefined })}
-                placeholder="field (blank = count)"
-                aria-label={`Series ${idx + 1} field`}
-              />
-              <Input
-                className="col-span-5 h-8"
-                value={s.label ?? ""}
-                onChange={(e) => updateSeries(idx, { label: e.target.value })}
-                placeholder="label"
-                aria-label={`Series ${idx + 1} label`}
-              />
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="col-span-2 h-8 w-8 text-slate-400 hover:text-red-600"
-                onClick={() => removeSeries(idx)}
-                aria-label={`Remove series ${idx + 1}`}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function PanelError({ message }: { message: string }) {

--- a/web_src/src/pages/workflowv2/dashboard/ChartPanelForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartPanelForm.tsx
@@ -1,0 +1,63 @@
+import { Info } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { ChartSeriesList } from "./ChartSeriesList";
+import { ChartTopControls } from "./ChartTopControls";
+import { DataSourceForm } from "./DataSourceForm";
+import { useDashboardContext } from "./DashboardContext";
+import type { ChartPanelContent } from "./panelTypes";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function ChartPanelForm({
+  value,
+  onChange,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace = value.dataSource.kind === "memory" ? value.dataSource.namespace : undefined;
+  const { fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const fieldListId = memoryNamespace ? `chart-fields-${memoryNamespace}` : undefined;
+  const hasFieldSuggestions = fields.length > 0 && Boolean(fieldListId);
+  const stackedBarNeedsMoreSeries = value.render.type === "stacked-bar" && value.render.series.length < 2;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
+        <Input
+          value={value.title ?? ""}
+          onChange={(e) => onChange({ ...value, title: e.target.value })}
+          placeholder="Defaults to panel id"
+        />
+      </div>
+      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
+      <ChartTopControls value={value} onChange={onChange} fieldListId={hasFieldSuggestions ? fieldListId : undefined} />
+      {stackedBarNeedsMoreSeries ? <StackedBarHint /> : null}
+      {hasFieldSuggestions ? (
+        <datalist id={fieldListId}>
+          {fields.map((f) => (
+            <option key={f.field} value={f.field} />
+          ))}
+        </datalist>
+      ) : null}
+      <ChartSeriesList value={value} onChange={onChange} fieldListId={hasFieldSuggestions ? fieldListId : undefined} />
+    </div>
+  );
+}
+
+function StackedBarHint() {
+  return (
+    <div
+      className="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800"
+      data-testid="chart-stacked-bar-hint"
+    >
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>Stacked bar combines multiple series per category. Add another series, or pick Bar.</span>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartSeriesList.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartSeriesList.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+import { ChartSeriesRow } from "./ChartSeriesRow";
+import type { ChartPanelContent } from "./panelTypes";
+import type { WidgetChartSeries } from "./widget/types";
+
+export function ChartSeriesList({
+  value,
+  onChange,
+  fieldListId,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+  fieldListId: string | undefined;
+}) {
+  const updateSeries = (idx: number, patch: Partial<WidgetChartSeries>) => {
+    const series = value.render.series.map((s, i) => (i === idx ? { ...s, ...patch } : s));
+    onChange({ ...value, render: { ...value.render, series } });
+  };
+  const addSeries = () => {
+    onChange({
+      ...value,
+      render: { ...value.render, series: [...value.render.series, { field: "", label: "" }] },
+    });
+  };
+  const removeSeries = (idx: number) => {
+    onChange({ ...value, render: { ...value.render, series: value.render.series.filter((_, i) => i !== idx) } });
+  };
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs font-medium text-slate-600">Series</Label>
+        <Button type="button" size="sm" variant="outline" onClick={addSeries} data-testid="chart-add-series">
+          Add series
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {value.render.series.map((s, idx) => (
+          <ChartSeriesRow
+            key={idx}
+            index={idx}
+            series={s}
+            fieldListId={fieldListId}
+            onChange={(patch) => updateSeries(idx, patch)}
+            onRemove={() => removeSeries(idx)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartSeriesRow.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartSeriesRow.tsx
@@ -1,0 +1,88 @@
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { CHART_SERIES_FORMATS } from "./chartPanelFormConstants";
+import type { WidgetChartSeries, WidgetColumnFormat } from "./widget/types";
+
+export function ChartSeriesRow({
+  index,
+  series,
+  fieldListId,
+  onChange,
+  onRemove,
+}: {
+  index: number;
+  series: WidgetChartSeries;
+  fieldListId: string | undefined;
+  onChange: (patch: Partial<WidgetChartSeries>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="space-y-2 rounded border border-slate-200 p-2">
+      <div className="grid grid-cols-12 items-center gap-2">
+        <Input
+          list={fieldListId}
+          className="col-span-5 h-8"
+          value={series.field ?? ""}
+          onChange={(e) => onChange({ field: e.target.value || undefined })}
+          placeholder="field (blank = count)"
+          aria-label={`Series ${index + 1} field`}
+        />
+        <Input
+          className="col-span-5 h-8"
+          value={series.label ?? ""}
+          onChange={(e) => onChange({ label: e.target.value || undefined })}
+          placeholder="label"
+          aria-label={`Series ${index + 1} label`}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="col-span-2 h-8 w-8 text-slate-400 hover:text-red-600"
+          onClick={onRemove}
+          aria-label={`Remove series ${index + 1}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="grid grid-cols-12 items-center gap-2">
+        <div className="col-span-4">
+          <Select
+            value={series.format ?? "__none__"}
+            onValueChange={(v) => onChange({ format: v === "__none__" ? undefined : (v as WidgetColumnFormat) })}
+          >
+            <SelectTrigger className="h-8 w-full" aria-label={`Series ${index + 1} format`}>
+              <SelectValue placeholder="Format" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">Default</SelectItem>
+              {CHART_SERIES_FORMATS.map((f) => (
+                <SelectItem key={f} value={f}>
+                  {f}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Input
+          className="col-span-4 h-8"
+          value={series.prefix ?? ""}
+          onChange={(e) => onChange({ prefix: e.target.value || undefined })}
+          placeholder="prefix (e.g. $)"
+          aria-label={`Series ${index + 1} prefix`}
+        />
+        <Input
+          className="col-span-4 h-8"
+          value={series.suffix ?? ""}
+          onChange={(e) => onChange({ suffix: e.target.value || undefined })}
+          placeholder="suffix (e.g. MWh)"
+          aria-label={`Series ${index + 1} suffix`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartTopControls.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartTopControls.tsx
@@ -1,0 +1,68 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { CHART_KIND_LABELS, CHART_KINDS, CHART_LEGEND_MODE_LABELS } from "./chartPanelFormConstants";
+import type { ChartPanelContent } from "./panelTypes";
+import { WIDGET_CHART_LEGEND_MODES, type WidgetChartKind, type WidgetChartLegendMode } from "./widget/types";
+
+export function ChartTopControls({
+  value,
+  onChange,
+  fieldListId,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+  fieldListId: string | undefined;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Chart type</Label>
+        <Select
+          value={value.render.type}
+          onValueChange={(v) => onChange({ ...value, render: { ...value.render, type: v as WidgetChartKind } })}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CHART_KINDS.map((k) => (
+              <SelectItem key={k} value={k}>
+                {CHART_KIND_LABELS[k]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">X-axis field</Label>
+        <Input
+          list={fieldListId}
+          value={value.render.xField}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, xField: e.target.value } })}
+          placeholder="e.g. status"
+          data-testid="chart-x-field"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Legend</Label>
+        <Select
+          value={value.render.legend ?? "auto"}
+          onValueChange={(v) => onChange({ ...value, render: { ...value.render, legend: v as WidgetChartLegendMode } })}
+        >
+          <SelectTrigger className="w-full" data-testid="chart-legend-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {WIDGET_CHART_LEGEND_MODES.map((m) => (
+              <SelectItem key={m} value={m}>
+                {CHART_LEGEND_MODE_LABELS[m]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/DataSourceForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DataSourceForm.tsx
@@ -1,9 +1,10 @@
 import { useDashboardContext } from "./DashboardContext";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 import type { ChartPanelDataSource } from "./panelTypes";
+import { DataSourceExecutionsFields, DataSourceMemoryFields, DataSourceRunsFields } from "./dataSourceFormFields";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
 
 interface DataSourceFormProps {
   value: ChartPanelDataSource;
@@ -20,6 +21,11 @@ interface DataSourceFormProps {
 export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormProps) {
   const ctx = useDashboardContext();
   const nodes = ctx?.nodes ?? [];
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace = value.kind === "memory" ? value.namespace : undefined;
+  const { namespaces, fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const namespaceListId = canvasId ? `data-source-namespaces-${canvasId}` : undefined;
+  const fieldPathListId = memoryNamespace ? `data-source-field-paths-${memoryNamespace}` : undefined;
 
   const setKind = (kind: "memory" | "executions" | "runs") => {
     if (kind === "memory") {
@@ -48,86 +54,18 @@ export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormPro
       </div>
 
       {value.kind === "runs" ? (
-        hideLimit ? null : (
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Limit</Label>
-            <Input
-              type="number"
-              min={1}
-              value={value.limit ?? ""}
-              onChange={(e) =>
-                onChange({
-                  ...value,
-                  limit: e.target.value === "" ? undefined : Number(e.target.value),
-                })
-              }
-              placeholder="100"
-            />
-          </div>
-        )
+        <DataSourceRunsFields value={value} hideLimit={hideLimit} onChange={onChange} />
       ) : value.kind === "executions" ? (
-        <>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Node (optional)</Label>
-            <Select
-              value={value.node ?? "__all__"}
-              onValueChange={(v) =>
-                onChange({
-                  ...value,
-                  node: v === "__all__" ? undefined : v,
-                })
-              }
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="All nodes" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">All nodes</SelectItem>
-                {nodes.map((n) => (
-                  <SelectItem key={n.id} value={n.name || n.id || ""}>
-                    {n.name || n.id}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {hideLimit ? null : (
-            <div className="space-y-1.5">
-              <Label className="text-xs font-medium text-slate-600">Limit</Label>
-              <Input
-                type="number"
-                min={1}
-                value={value.limit ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    ...value,
-                    limit: e.target.value === "" ? undefined : Number(e.target.value),
-                  })
-                }
-                placeholder="50"
-              />
-            </div>
-          )}
-        </>
+        <DataSourceExecutionsFields value={value} hideLimit={hideLimit} nodes={nodes} onChange={onChange} />
       ) : (
-        <>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Namespace</Label>
-            <Input
-              value={value.namespace}
-              onChange={(e) => onChange({ ...value, namespace: e.target.value })}
-              placeholder="e.g. deployments"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Field path (optional)</Label>
-            <Input
-              value={value.fieldPath ?? ""}
-              onChange={(e) => onChange({ ...value, fieldPath: e.target.value || undefined })}
-              placeholder="e.g. items"
-            />
-          </div>
-        </>
+        <DataSourceMemoryFields
+          value={value}
+          namespaces={namespaces}
+          fields={fields}
+          namespaceListId={namespaceListId}
+          fieldPathListId={fieldPathListId}
+          onChange={onChange}
+        />
       )}
     </div>
   );

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
@@ -1,22 +1,21 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
-import { DataSourceForm } from "./DataSourceForm";
+import { useCanvasMemoryEntries } from "@/hooks/useCanvasData";
+
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
-import type { NumberPanelContent } from "./panelTypes";
+import { NumberPanelForm } from "./NumberPanelForm";
+import {
+  isCompositeMemoryDataSource,
+  type CompositeMemoryNumberDataSource,
+  type NumberPanelContent,
+} from "./panelTypes";
 import { useWidgetData } from "./widget/useWidgetData";
 import { WidgetNumber } from "./widget/WidgetNumber";
-import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
-
-const AGGREGATIONS: WidgetNumberAggregation[] = ["count", "sum", "avg", "min", "max", "first", "last"];
-const NUMBER_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];
 
 interface NumberPanelCardProps {
   panel: DashboardPanel;
@@ -57,116 +56,47 @@ export function NumberPanelCard({ panel, readOnly, onDelete, onChange }: NumberP
 function NumberPanelBody({ content }: { content: NumberPanelContent }) {
   const ctx = useDashboardContext();
   if (!ctx?.canvasId) return <PanelError message="Loading canvas…" />;
-  return <NumberPanelDataBound content={content} canvasId={ctx.canvasId} />;
+  const dataSource = content.dataSource;
+  if (isCompositeMemoryDataSource(dataSource)) {
+    return <CompositeNumberPanelDataBound content={content} dataSource={dataSource} canvasId={ctx.canvasId} />;
+  }
+  return <NumberPanelDataBound content={content} dataSource={dataSource} canvasId={ctx.canvasId} />;
 }
 
-function NumberPanelDataBound({ content, canvasId }: { content: NumberPanelContent; canvasId: string }) {
-  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, content.dataSource);
+function NumberPanelDataBound({
+  content,
+  dataSource,
+  canvasId,
+}: {
+  content: NumberPanelContent;
+  dataSource: Exclude<NumberPanelContent["dataSource"], CompositeMemoryNumberDataSource>;
+  canvasId: string;
+}) {
+  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, dataSource);
   if (error) return <PanelError message={error} />;
   return <WidgetNumber render={content.render} rows={rows} isLoading={isLoading} totalCount={totalCount} />;
 }
 
-function NumberPanelForm({
-  value,
-  onChange,
+function CompositeNumberPanelDataBound({
+  content,
+  dataSource,
+  canvasId,
 }: {
-  value: NumberPanelContent;
-  onChange: (next: NumberPanelContent) => void;
+  content: NumberPanelContent;
+  dataSource: CompositeMemoryNumberDataSource;
+  canvasId: string;
 }) {
-  const aggregationNeedsField = value.render.aggregation !== "count";
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
-        <Input
-          value={value.title ?? ""}
-          onChange={(e) => onChange({ ...value, title: e.target.value })}
-          placeholder="Defaults to panel id"
-        />
-      </div>
-      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Aggregation</Label>
-          <Select
-            value={value.render.aggregation}
-            onValueChange={(v) =>
-              onChange({ ...value, render: { ...value.render, aggregation: v as WidgetNumberAggregation } })
-            }
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {AGGREGATIONS.map((a) => (
-                <SelectItem key={a} value={a}>
-                  {a}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        {aggregationNeedsField ? (
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Field</Label>
-            <Input
-              value={value.render.field ?? ""}
-              onChange={(e) => onChange({ ...value, render: { ...value.render, field: e.target.value } })}
-              placeholder="e.g. durationMs"
-            />
-          </div>
-        ) : null}
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Format</Label>
-          <Select
-            value={value.render.format ?? "__none__"}
-            onValueChange={(v) =>
-              onChange({
-                ...value,
-                render: { ...value.render, format: v === "__none__" ? undefined : (v as WidgetColumnFormat) },
-              })
-            }
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Default" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">Default</SelectItem>
-              {NUMBER_FORMATS.map((f) => (
-                <SelectItem key={f} value={f}>
-                  {f}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Label (optional)</Label>
-          <Input
-            value={value.render.label ?? ""}
-            onChange={(e) => onChange({ ...value, render: { ...value.render, label: e.target.value || undefined } })}
-            placeholder="e.g. Total duration"
-          />
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Sparkline field (optional)</Label>
-        <Input
-          value={value.render.sparklineField ?? ""}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              render: { ...value.render, sparklineField: e.target.value || undefined },
-            })
-          }
-          placeholder="e.g. createdAt"
-        />
-      </div>
-    </div>
+  const memoryQuery = useCanvasMemoryEntries(canvasId, true);
+  const composite = useMemo(
+    () => ({
+      entries: memoryQuery.data ?? [],
+      sources: dataSource.sources,
+      combine: dataSource.combine,
+    }),
+    [memoryQuery.data, dataSource.sources, dataSource.combine],
   );
+  if (memoryQuery.error) return <PanelError message={String(memoryQuery.error)} />;
+  return <WidgetNumber render={content.render} rows={[]} isLoading={memoryQuery.isLoading} composite={composite} />;
 }
 
 function PanelError({ message }: { message: string }) {

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelCompositeSourcesEditor.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelCompositeSourcesEditor.tsx
@@ -1,0 +1,198 @@
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { useDashboardContext } from "./DashboardContext";
+import { NUMBER_PANEL_AGGREGATIONS } from "./numberPanelFormConstants";
+import {
+  WIDGET_NUMBER_COMBINE_OPS,
+  type CompositeMemoryNumberDataSource,
+  type MemoryNumberSource,
+  type NumberPanelContent,
+  type WidgetNumberCombine,
+} from "./panelTypes";
+import type { WidgetNumberAggregation } from "./widget/types";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function NumberPanelCompositeSourcesEditor({
+  value,
+  dataSource,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  dataSource: CompositeMemoryNumberDataSource;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const { namespaces } = useMemoryCatalog(canvasId);
+  const namespaceOptions = namespaces.map((n) => n.namespace);
+  const namespaceListId = namespaceOptions.length > 0 ? `number-source-namespaces-${canvasId ?? ""}` : undefined;
+
+  const updateDataSource = (next: CompositeMemoryNumberDataSource) => {
+    onChange({ ...value, dataSource: next });
+  };
+
+  const updateSource = (idx: number, patch: Partial<MemoryNumberSource>) => {
+    const sources = dataSource.sources.map((source, i) => (i === idx ? { ...source, ...patch } : source));
+    updateDataSource({ ...dataSource, sources });
+  };
+
+  const addSource = () => {
+    updateDataSource({
+      ...dataSource,
+      sources: [...dataSource.sources, { namespace: "", aggregation: "count" }],
+    });
+  };
+
+  const removeSource = (idx: number) => {
+    if (dataSource.sources.length <= 1) return;
+    updateDataSource({ ...dataSource, sources: dataSource.sources.filter((_, i) => i !== idx) });
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Combine</Label>
+          <Select
+            value={dataSource.combine}
+            onValueChange={(v) => updateDataSource({ ...dataSource, combine: v as WidgetNumberCombine })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WIDGET_NUMBER_COMBINE_OPS.map((op) => (
+                <SelectItem key={op} value={op}>
+                  {op}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-xs font-medium text-slate-600">Memory sources</Label>
+          <Button type="button" size="sm" variant="outline" onClick={addSource} data-testid="number-add-source">
+            Add source
+          </Button>
+        </div>
+        <p className="text-[11px] text-slate-500">
+          Each source aggregates its own namespace independently; the partials are combined with the operator above.
+        </p>
+        <div className="space-y-2">
+          {dataSource.sources.map((source, idx) => (
+            <MemorySourceRow
+              key={idx}
+              source={source}
+              canvasId={canvasId}
+              sourceRowId={idx}
+              namespaceListId={namespaceListId}
+              onChange={(patch) => updateSource(idx, patch)}
+              onRemove={dataSource.sources.length > 1 ? () => removeSource(idx) : undefined}
+            />
+          ))}
+        </div>
+        {namespaceListId ? (
+          <datalist id={namespaceListId}>
+            {namespaceOptions.map((ns) => (
+              <option key={ns} value={ns} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MemorySourceRow({
+  source,
+  canvasId,
+  sourceRowId,
+  namespaceListId,
+  onChange,
+  onRemove,
+}: {
+  source: MemoryNumberSource;
+  canvasId: string | undefined;
+  sourceRowId: number;
+  namespaceListId: string | undefined;
+  onChange: (patch: Partial<MemoryNumberSource>) => void;
+  onRemove?: () => void;
+}) {
+  const { fields } = useMemoryCatalog(canvasId, source.namespace);
+  const needsField = source.aggregation !== "count";
+  const fieldListId = fields.length > 0 ? `number-source-fields-${canvasId ?? ""}-${sourceRowId}` : undefined;
+
+  return (
+    <div className="space-y-2 rounded-md border border-slate-200 bg-white p-2">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Namespace</Label>
+          <Input
+            list={namespaceListId}
+            value={source.namespace}
+            onChange={(e) => onChange({ namespace: e.target.value })}
+            placeholder="e.g. african-countries"
+            data-testid="number-source-namespace"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Aggregation</Label>
+          <Select
+            value={source.aggregation}
+            onValueChange={(v) =>
+              onChange({
+                aggregation: v as WidgetNumberAggregation,
+                field: v === "count" ? undefined : source.field,
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {NUMBER_PANEL_AGGREGATIONS.map((a) => (
+                <SelectItem key={a} value={a}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      {needsField ? (
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Field</Label>
+          <Input
+            list={fieldListId}
+            value={source.field ?? ""}
+            onChange={(e) => onChange({ field: e.target.value || undefined })}
+            placeholder="e.g. cost"
+            data-testid="number-source-field"
+          />
+          {fieldListId ? (
+            <datalist id={fieldListId}>
+              {fields.map((f) => (
+                <option key={f.field} value={f.field} />
+              ))}
+            </datalist>
+          ) : null}
+        </div>
+      ) : null}
+      {onRemove ? (
+        <div className="flex justify-end">
+          <Button type="button" size="sm" variant="ghost" onClick={onRemove} data-testid="number-source-remove">
+            <Trash2 className="h-3.5 w-3.5" />
+            <span className="sr-only">Remove source</span>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelForm.tsx
@@ -1,0 +1,206 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { DataSourceForm } from "./DataSourceForm";
+import { useDashboardContext } from "./DashboardContext";
+import { NumberPanelCompositeSourcesEditor } from "./NumberPanelCompositeSourcesEditor";
+import { NumberPanelSourceModeToggle } from "./NumberPanelSourceModeToggle";
+import { NUMBER_PANEL_AGGREGATIONS, NUMBER_PANEL_FORMATS } from "./numberPanelFormConstants";
+import { isCompositeMemoryDataSource, type NumberPanelContent } from "./panelTypes";
+import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function NumberPanelForm({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const dataSource = value.dataSource;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
+        <Input
+          value={value.title ?? ""}
+          onChange={(e) => onChange({ ...value, title: e.target.value })}
+          placeholder="Defaults to panel id"
+        />
+      </div>
+      <NumberPanelSourceModeToggle value={value} onChange={onChange} />
+      {isCompositeMemoryDataSource(dataSource) ? (
+        <NumberPanelCompositeSourcesEditor value={value} dataSource={dataSource} onChange={onChange} />
+      ) : (
+        <>
+          <DataSourceForm value={dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
+          <SimpleAggregationFields value={value} onChange={onChange} />
+        </>
+      )}
+      <FormatLabelRow value={value} onChange={onChange} />
+      <PrefixSuffixRow value={value} onChange={onChange} />
+      {isCompositeMemoryDataSource(dataSource) ? null : <SparklineField value={value} onChange={onChange} />}
+    </div>
+  );
+}
+
+function SimpleAggregationFields({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace =
+    value.dataSource.kind === "memory" && "namespace" in value.dataSource ? value.dataSource.namespace : undefined;
+  const { fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const aggregation = value.render.aggregation ?? "count";
+  const aggregationNeedsField = aggregation !== "count";
+  const fieldListId = memoryNamespace ? `number-simple-fields-${memoryNamespace}` : undefined;
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Aggregation</Label>
+        <Select
+          value={aggregation}
+          onValueChange={(v) =>
+            onChange({ ...value, render: { ...value.render, aggregation: v as WidgetNumberAggregation } })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NUMBER_PANEL_AGGREGATIONS.map((a) => (
+              <SelectItem key={a} value={a}>
+                {a}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {aggregationNeedsField ? (
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Field</Label>
+          <Input
+            list={fields.length > 0 && fieldListId ? fieldListId : undefined}
+            value={value.render.field ?? ""}
+            onChange={(e) => onChange({ ...value, render: { ...value.render, field: e.target.value } })}
+            placeholder="e.g. durationMs"
+            data-testid="number-simple-field"
+          />
+          {fields.length > 0 && fieldListId ? (
+            <datalist id={fieldListId}>
+              {fields.map((f) => (
+                <option key={f.field} value={f.field} />
+              ))}
+            </datalist>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FormatLabelRow({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Format</Label>
+        <Select
+          value={value.render.format ?? "__none__"}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              render: { ...value.render, format: v === "__none__" ? undefined : (v as WidgetColumnFormat) },
+            })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Default" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">Default</SelectItem>
+            {NUMBER_PANEL_FORMATS.map((f) => (
+              <SelectItem key={f} value={f}>
+                {f}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Label (optional)</Label>
+        <Input
+          value={value.render.label ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, label: e.target.value || undefined } })}
+          placeholder="e.g. Total duration"
+        />
+      </div>
+    </div>
+  );
+}
+
+function PrefixSuffixRow({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Prefix (optional)</Label>
+        <Input
+          value={value.render.prefix ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, prefix: e.target.value || undefined } })}
+          placeholder="e.g. R$"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Suffix (optional)</Label>
+        <Input
+          value={value.render.suffix ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, suffix: e.target.value || undefined } })}
+          placeholder="e.g. MWh"
+        />
+      </div>
+    </div>
+  );
+}
+
+function SparklineField({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Sparkline field (optional)</Label>
+      <Input
+        value={value.render.sparklineField ?? ""}
+        onChange={(e) =>
+          onChange({
+            ...value,
+            render: { ...value.render, sparklineField: e.target.value || undefined },
+          })
+        }
+        placeholder="e.g. createdAt"
+      />
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelSourceModeToggle.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelSourceModeToggle.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+import { isCompositeMemoryDataSource, type MemoryNumberSource, type NumberPanelContent } from "./panelTypes";
+
+export function NumberPanelSourceModeToggle({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const dataSource = value.dataSource;
+  const composite = isCompositeMemoryDataSource(dataSource);
+
+  const switchToComposite = () => {
+    if (isCompositeMemoryDataSource(dataSource)) return;
+    const seed: MemoryNumberSource =
+      dataSource.kind === "memory"
+        ? {
+            namespace: dataSource.namespace || "",
+            aggregation: value.render.aggregation ?? "count",
+            field: value.render.field,
+            fieldPath: dataSource.fieldPath,
+          }
+        : { namespace: "", aggregation: value.render.aggregation ?? "count", field: value.render.field };
+    onChange({
+      ...value,
+      dataSource: { kind: "memory", sources: [seed], combine: "sum" },
+      render: { ...value.render, aggregation: undefined, field: undefined },
+    });
+  };
+
+  const switchToSimple = () => {
+    if (!isCompositeMemoryDataSource(dataSource)) return;
+    const first = dataSource.sources[0];
+    onChange({
+      ...value,
+      dataSource: { kind: "memory", namespace: first?.namespace ?? "", fieldPath: first?.fieldPath },
+      render: { ...value.render, aggregation: first?.aggregation ?? "count", field: first?.field },
+    });
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Source mode</Label>
+      <div className="flex gap-1">
+        <Button
+          type="button"
+          size="sm"
+          variant={composite ? "outline" : "secondary"}
+          onClick={switchToSimple}
+          data-testid="number-mode-simple"
+        >
+          Single source
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={composite ? "secondary" : "outline"}
+          onClick={switchToComposite}
+          data-testid="number-mode-composite"
+        >
+          Multiple memory sources
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/chartPanelFormConstants.ts
+++ b/web_src/src/pages/workflowv2/dashboard/chartPanelFormConstants.ts
@@ -1,0 +1,19 @@
+import type { WidgetChartKind, WidgetChartLegendMode, WidgetColumnFormat } from "./widget/types";
+
+export const CHART_KINDS: WidgetChartKind[] = ["bar", "stacked-bar", "line", "area", "donut"];
+
+export const CHART_KIND_LABELS: Record<WidgetChartKind, string> = {
+  bar: "Bar",
+  "stacked-bar": "Stacked bar",
+  line: "Line",
+  area: "Area",
+  donut: "Donut",
+};
+
+export const CHART_SERIES_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];
+
+export const CHART_LEGEND_MODE_LABELS: Record<WidgetChartLegendMode, string> = {
+  auto: "Auto",
+  show: "Always show",
+  hide: "Hide",
+};

--- a/web_src/src/pages/workflowv2/dashboard/dashboardYaml.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardYaml.spec.ts
@@ -236,6 +236,160 @@ spec:
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("Unsupported apiVersion");
   });
+
+  it("round-trips a number panel with prefix and suffix symbols", () => {
+    const panels = [
+      {
+        id: "spend",
+        type: "number",
+        content: {
+          dataSource: { kind: "memory", namespace: "expenses" },
+          render: {
+            kind: "number",
+            aggregation: "sum",
+            field: "amount",
+            format: "number",
+            prefix: "R$",
+            suffix: " /mo",
+          },
+        },
+      },
+    ];
+    const layout = [{ i: "spend", x: 0, y: 0, w: 6, h: 3 }];
+    const text = dashboardToYaml({ panels, layout });
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.data.spec.panels).toEqual(panels);
+  });
+
+  it("round-trips a composite memory number panel with heterogeneous sources", () => {
+    const panels = [
+      {
+        id: "score",
+        type: "number",
+        content: {
+          dataSource: {
+            kind: "memory",
+            combine: "sum",
+            sources: [
+              { namespace: "a", aggregation: "sum", field: "cost" },
+              { namespace: "b", aggregation: "count" },
+            ],
+          },
+          render: { kind: "number", format: "number", prefix: "R$" },
+        },
+      },
+    ];
+    const layout = [{ i: "score", x: 0, y: 0, w: 4, h: 3 }];
+    const text = dashboardToYaml({ panels, layout });
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.data.spec.panels).toEqual(panels);
+  });
+
+  it("rejects a composite memory number panel when render.aggregation is set", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+          aggregation: sum
+          field: cost
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/render\.aggregation must not be set/);
+  });
+
+  it("rejects a composite memory number panel when only render.field is set", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+          field: cost
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/render\.field must not be set/);
+  });
+
+  it("rejects a composite memory number panel with an unknown combine operator", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: median
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/dataSource\.combine must be one of/);
+  });
+
+  it("rejects a composite memory source missing a field for non-count aggregation", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+        render:
+          kind: number
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/dataSource\.sources\[0\]\.field is required/);
+  });
 });
 
 describe("validateDashboardContent", () => {
@@ -260,7 +414,7 @@ describe("validateDashboardContent", () => {
     ).toContain("non-negative");
   });
 
-  it("accepts a valid dashboard", () => {
+  it("accepts a valid console", () => {
     expect(
       validateDashboardContent(
         [{ id: "p", type: "markdown", content: { body: "ok" } }],

--- a/web_src/src/pages/workflowv2/dashboard/dataSourceFormFields.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/dataSourceFormFields.tsx
@@ -1,0 +1,149 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { SuperplaneComponentsNode } from "@/api-client";
+
+import type { ChartPanelDataSource } from "./panelTypes";
+
+export function DataSourceRunsFields({
+  value,
+  hideLimit,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "runs" }>;
+  hideLimit?: boolean;
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  if (hideLimit) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Limit</Label>
+      <Input
+        type="number"
+        min={1}
+        value={value.limit ?? ""}
+        onChange={(e) =>
+          onChange({
+            ...value,
+            limit: e.target.value === "" ? undefined : Number(e.target.value),
+          })
+        }
+        placeholder="100"
+      />
+    </div>
+  );
+}
+
+export function DataSourceExecutionsFields({
+  value,
+  hideLimit,
+  nodes,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "executions" }>;
+  hideLimit?: boolean;
+  nodes: SuperplaneComponentsNode[];
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Node (optional)</Label>
+        <Select
+          value={value.node ?? "__all__"}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              node: v === "__all__" ? undefined : v,
+            })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="All nodes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All nodes</SelectItem>
+            {nodes.map((n) => (
+              <SelectItem key={n.id} value={n.name || n.id || ""}>
+                {n.name || n.id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {hideLimit ? null : (
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Limit</Label>
+          <Input
+            type="number"
+            min={1}
+            value={value.limit ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                limit: e.target.value === "" ? undefined : Number(e.target.value),
+              })
+            }
+            placeholder="50"
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export function DataSourceMemoryFields({
+  value,
+  namespaces,
+  fields,
+  namespaceListId,
+  fieldPathListId,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "memory" }>;
+  namespaces: { namespace: string }[];
+  fields: { field: string }[];
+  namespaceListId: string | undefined;
+  fieldPathListId: string | undefined;
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Namespace</Label>
+        <Input
+          list={namespaces.length > 0 && namespaceListId ? namespaceListId : undefined}
+          value={value.namespace}
+          onChange={(e) => onChange({ ...value, namespace: e.target.value })}
+          placeholder="e.g. deployments"
+          data-testid="data-source-namespace"
+        />
+        {namespaces.length > 0 && namespaceListId ? (
+          <datalist id={namespaceListId}>
+            {namespaces.map((n) => (
+              <option key={n.namespace} value={n.namespace} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Field path (optional)</Label>
+        <Input
+          list={fields.length > 0 && fieldPathListId ? fieldPathListId : undefined}
+          value={value.fieldPath ?? ""}
+          onChange={(e) => onChange({ ...value, fieldPath: e.target.value || undefined })}
+          placeholder="e.g. items"
+          data-testid="data-source-field-path"
+        />
+        {fields.length > 0 && fieldPathListId ? (
+          <datalist id={fieldPathListId}>
+            {fields.map((f) => (
+              <option key={f.field} value={f.field} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/numberPanelFormConstants.ts
+++ b/web_src/src/pages/workflowv2/dashboard/numberPanelFormConstants.ts
@@ -1,0 +1,13 @@
+import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
+
+export const NUMBER_PANEL_AGGREGATIONS: WidgetNumberAggregation[] = [
+  "count",
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "first",
+  "last",
+];
+
+export const NUMBER_PANEL_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];

--- a/web_src/src/pages/workflowv2/dashboard/panelTypes.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/panelTypes.spec.ts
@@ -157,4 +157,141 @@ describe("validatePanelContent", () => {
       }),
     ).toBeNull();
   });
+
+  it("accepts number panels with prefix and suffix symbols", () => {
+    expect(
+      validatePanelContent("number", {
+        dataSource: { kind: "runs" },
+        render: { kind: "number", aggregation: "count", prefix: "R$", suffix: " MWh" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects non-string prefix on number panels", () => {
+    const error = validatePanelContent("number", {
+      dataSource: { kind: "runs" },
+      render: { kind: "number", aggregation: "count", prefix: 42 },
+    });
+    expect(error).toMatch(/render\.prefix must be a string/);
+  });
+
+  it("accepts composite memory number panels with heterogeneous sources", () => {
+    expect(
+      validatePanelContent("number", {
+        dataSource: {
+          kind: "memory",
+          combine: "sum",
+          sources: [
+            { namespace: "a", aggregation: "sum", field: "cost" },
+            { namespace: "b", aggregation: "count" },
+          ],
+        },
+        render: { kind: "number" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects composite memory panels that also set render.aggregation", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number", aggregation: "sum" },
+    });
+    expect(error).toMatch(/render\.aggregation must not be set/);
+  });
+
+  it("rejects composite memory panels that also set render.field", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number", field: "cost" },
+    });
+    expect(error).toMatch(/render\.field must not be set/);
+  });
+
+  it("rejects composite memory panels with an unknown combine operator", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "median",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.combine must be one of/);
+  });
+
+  it("rejects composite memory sources missing a field for non-count aggregation", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum" }],
+      },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.sources\[0\]\.field is required/);
+  });
+
+  it("rejects composite memory panels with empty sources", () => {
+    const error = validatePanelContent("number", {
+      dataSource: { kind: "memory", combine: "sum", sources: [] },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.sources must be a non-empty array/);
+  });
+});
+
+describe("validatePanelContent — chart series and legend", () => {
+  it("accepts chart series with format, prefix, and suffix", () => {
+    expect(
+      validatePanelContent("chart", {
+        dataSource: { kind: "executions" },
+        render: {
+          kind: "chart",
+          type: "bar",
+          xField: "service",
+          series: [{ field: "cost", label: "Cost", format: "number", prefix: "$", suffix: " /mo" }],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects chart series with a non-string prefix", () => {
+    const error = validatePanelContent("chart", {
+      dataSource: { kind: "executions" },
+      render: {
+        kind: "chart",
+        type: "bar",
+        xField: "service",
+        series: [{ field: "cost", prefix: 42 }],
+      },
+    });
+    expect(error).toMatch(/render\.series\[0\]\.prefix must be a string/);
+  });
+
+  it("accepts chart legend modes", () => {
+    for (const legend of ["auto", "show", "hide"] as const) {
+      expect(
+        validatePanelContent("chart", {
+          dataSource: { kind: "executions" },
+          render: { kind: "chart", type: "bar", xField: "x", series: [{}], legend },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("rejects unknown legend modes", () => {
+    const error = validatePanelContent("chart", {
+      dataSource: { kind: "executions" },
+      render: { kind: "chart", type: "bar", xField: "x", series: [{}], legend: "bogus" },
+    });
+    expect(error).toMatch(/render\.legend must be one of/);
+  });
 });

--- a/web_src/src/pages/workflowv2/dashboard/panelTypes.ts
+++ b/web_src/src/pages/workflowv2/dashboard/panelTypes.ts
@@ -13,13 +13,15 @@
 
 import type {
   WidgetChartRender,
+  WidgetNumberAggregation,
   WidgetNumberRender,
   WidgetRowAction,
   WidgetTableColumn,
   WidgetTableFilter,
   WidgetTableRender,
 } from "./widget/types";
-import { normalizeRowAction, WIDGET_FILTER_OPS } from "./widget/types";
+import { normalizeRowAction, WIDGET_CHART_LEGEND_MODES, WIDGET_FILTER_OPS } from "./widget/types";
+import type { WidgetChartLegendMode } from "./widget/types";
 
 /** All panel kinds the dashboard currently understands. */
 export const PANEL_TYPES = ["markdown", "node", "table", "chart", "number"] as const;
@@ -109,7 +111,36 @@ export type TablePanelDataSource =
   | { kind: "executions"; node?: string; limit?: number }
   | { kind: "runs"; limit?: number };
 export type ChartPanelDataSource = TablePanelDataSource;
-export type NumberPanelDataSource = TablePanelDataSource;
+
+/** How partial aggregates from a composite memory data source are combined into a single value. */
+export type WidgetNumberCombine = "sum" | "min" | "max" | "avg";
+export const WIDGET_NUMBER_COMBINE_OPS: WidgetNumberCombine[] = ["sum", "min", "max", "avg"];
+
+/** One namespace contribution inside a composite memory data source. */
+export interface MemoryNumberSource {
+  namespace: string;
+  aggregation: WidgetNumberAggregation;
+  field?: string;
+  fieldPath?: string;
+}
+
+export type CompositeMemoryNumberDataSource = {
+  kind: "memory";
+  sources: MemoryNumberSource[];
+  combine: WidgetNumberCombine;
+};
+
+/**
+ * Number panels accept the shared table/chart data sources plus a composite
+ * memory variant where each namespace carries its own aggregation and field.
+ */
+export type NumberPanelDataSource = TablePanelDataSource | CompositeMemoryNumberDataSource;
+
+export function isCompositeMemoryDataSource(value: unknown): value is CompositeMemoryNumberDataSource {
+  const obj = asObject(value);
+  if (!obj) return false;
+  return obj.kind === "memory" && Array.isArray(obj.sources);
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Templates — used to seed new panels
@@ -243,6 +274,58 @@ function validateMemoryDataSource(obj: Record<string, unknown>): string | null {
   }
   if (obj.fieldPath != null && typeof obj.fieldPath !== "string") {
     return "dataSource.fieldPath must be a string.";
+  }
+  return null;
+}
+
+/**
+ * Number panels accept either the shared data-source shapes (memory with a
+ * single namespace, executions, runs) or a composite memory variant where
+ * each namespace declares its own aggregation/field and the partials are
+ * merged with a configured combine operator.
+ */
+function validateNumberDataSource(value: unknown): string | null {
+  const obj = asObject(value);
+  if (!obj) return "dataSource must be an object.";
+  if (obj.kind === "memory" && Array.isArray(obj.sources)) {
+    return validateCompositeMemoryDataSource(obj);
+  }
+  return validateDataSource(value);
+}
+
+const ALLOWED_NUMBER_AGGREGATIONS = ["count", "sum", "avg", "min", "max", "first", "last"];
+
+function validateCompositeMemoryDataSource(obj: Record<string, unknown>): string | null {
+  const sources = obj.sources as unknown[];
+  if (sources.length === 0) {
+    return "dataSource.sources must be a non-empty array.";
+  }
+  for (let i = 0; i < sources.length; i += 1) {
+    const sourceError = validateMemoryNumberSource(sources[i], i);
+    if (sourceError) return sourceError;
+  }
+  if (typeof obj.combine !== "string" || !WIDGET_NUMBER_COMBINE_OPS.includes(obj.combine as WidgetNumberCombine)) {
+    return `dataSource.combine must be one of ${WIDGET_NUMBER_COMBINE_OPS.join(", ")}.`;
+  }
+  return null;
+}
+
+function validateMemoryNumberSource(raw: unknown, index: number): string | null {
+  const source = asObject(raw);
+  if (!source) return `dataSource.sources[${index}] must be an object.`;
+  if (typeof source.namespace !== "string" || source.namespace.trim() === "") {
+    return `dataSource.sources[${index}].namespace must be a non-empty string.`;
+  }
+  if (typeof source.aggregation !== "string" || !ALLOWED_NUMBER_AGGREGATIONS.includes(source.aggregation)) {
+    return `dataSource.sources[${index}].aggregation must be one of ${ALLOWED_NUMBER_AGGREGATIONS.join(", ")}.`;
+  }
+  if (source.aggregation !== "count") {
+    if (typeof source.field !== "string" || source.field.trim() === "") {
+      return `dataSource.sources[${index}].field is required when aggregation is "${source.aggregation}".`;
+    }
+  }
+  if (source.fieldPath != null && typeof source.fieldPath !== "string") {
+    return `dataSource.sources[${index}].fieldPath must be a string.`;
   }
   return null;
 }
@@ -402,6 +485,10 @@ function validateChartContent(content: unknown): string | null {
   if (dsError) return dsError;
   const render = asObject(obj.render);
   if (!render) return "render must be an object.";
+  return validateChartRender(render);
+}
+
+function validateChartRender(render: Record<string, unknown>): string | null {
   if (render.kind !== "chart") return 'render.kind must be "chart".';
   const allowedTypes = ["bar", "stacked-bar", "line", "area", "donut"];
   if (typeof render.type !== "string" || !allowedTypes.includes(render.type)) {
@@ -413,17 +500,51 @@ function validateChartContent(content: unknown): string | null {
   if (!Array.isArray(render.series) || render.series.length === 0) {
     return "render.series must be a non-empty array.";
   }
+  for (let i = 0; i < render.series.length; i += 1) {
+    const seriesError = validateChartSeries(render.series[i], i);
+    if (seriesError) return seriesError;
+  }
+  return validateChartLegend(render.legend);
+}
+
+function validateChartLegend(legend: unknown): string | null {
+  if (legend === undefined) return null;
+  if (typeof legend !== "string" || !WIDGET_CHART_LEGEND_MODES.includes(legend as WidgetChartLegendMode)) {
+    return `render.legend must be one of ${WIDGET_CHART_LEGEND_MODES.join(", ")}.`;
+  }
+  return null;
+}
+
+function validateChartSeries(raw: unknown, index: number): string | null {
+  const series = asObject(raw);
+  if (!series) return `render.series[${index}] must be an object.`;
+  for (const key of ["field", "label", "color", "format", "prefix", "suffix"] as const) {
+    if (series[key] !== undefined && series[key] !== null && typeof series[key] !== "string") {
+      return `render.series[${index}].${key} must be a string.`;
+    }
+  }
   return null;
 }
 
 function validateNumberContent(content: unknown): string | null {
   const obj = asObject(content);
   if (!obj) return "content must be an object.";
-  const dsError = validateDataSource(obj.dataSource);
+  const dsError = validateNumberDataSource(obj.dataSource);
   if (dsError) return dsError;
   const render = asObject(obj.render);
   if (!render) return "render must be an object.";
   if (render.kind !== "number") return 'render.kind must be "number".';
+  const symbolError = validateNumberRenderSymbols(render);
+  if (symbolError) return symbolError;
+  if (isCompositeMemoryDataSource(obj.dataSource)) {
+    if (render.aggregation !== undefined) {
+      return "render.aggregation must not be set when dataSource.sources is used (each source defines its own aggregation).";
+    }
+    if (render.field !== undefined) {
+      return "render.field must not be set when dataSource.sources is used (each source defines its own field).";
+    }
+    return null;
+  }
   const allowedAggregations = ["count", "sum", "avg", "min", "max", "first", "last"];
   if (typeof render.aggregation !== "string" || !allowedAggregations.includes(render.aggregation)) {
     return `render.aggregation must be one of ${allowedAggregations.join(", ")}.`;
@@ -432,6 +553,16 @@ function validateNumberContent(content: unknown): string | null {
     if (typeof render.field !== "string" || render.field.trim() === "") {
       return `render.field is required when aggregation is "${render.aggregation}".`;
     }
+  }
+  return null;
+}
+
+function validateNumberRenderSymbols(render: Record<string, unknown>): string | null {
+  if (render.prefix !== undefined && render.prefix !== null && typeof render.prefix !== "string") {
+    return "render.prefix must be a string.";
+  }
+  if (render.suffix !== undefined && render.suffix !== null && typeof render.suffix !== "string") {
+    return "render.suffix must be a string.";
   }
   return null;
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.spec.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.spec.tsx
@@ -1,0 +1,191 @@
+import type { ReactNode } from "react";
+import type * as Recharts from "recharts";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("recharts", async () => {
+  const actual = (await vi.importActual("recharts")) as typeof Recharts;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div data-testid="responsive-container" style={{ width: 600, height: 400 }}>
+        <actual.ResponsiveContainer width={600} height={400}>
+          {children as never}
+        </actual.ResponsiveContainer>
+      </div>
+    ),
+  };
+});
+
+import { WidgetChart } from "./WidgetChart";
+import type { WidgetChartRender } from "./types";
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+const ROWS = [
+  { service: "ec2", cost: 1200, errors: 4 },
+  { service: "s3", cost: 350, errors: 1 },
+  { service: "rds", cost: 600, errors: 2 },
+];
+
+function renderChart(render_: WidgetChartRender, options: { rows?: unknown[]; isLoading?: boolean } = {}) {
+  return render(<WidgetChart render={render_} rows={options.rows ?? ROWS} isLoading={options.isLoading ?? false} />);
+}
+
+describe("WidgetChart states", () => {
+  it("renders a loading spinner when isLoading", () => {
+    const { container } = renderChart(
+      { kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] },
+      { isLoading: true },
+    );
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(screen.queryByTestId("widget-chart")).toBeNull();
+  });
+
+  it("renders an empty-state message when there are no rows", () => {
+    renderChart(
+      { kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] },
+      { rows: [] },
+    );
+    expect(screen.getByTestId("widget-chart-empty")).toBeInTheDocument();
+  });
+
+  it("renders the chart container when rows are present", () => {
+    renderChart({ kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] });
+    expect(screen.getByTestId("widget-chart")).toBeInTheDocument();
+  });
+
+  it("renders the optional chart title", () => {
+    renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+      title: "AWS spend",
+    });
+    expect(screen.getByText("AWS spend")).toBeInTheDocument();
+  });
+});
+
+describe("WidgetChart bar variants", () => {
+  it("uses a shared stackId when type is stacked-bar", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "stacked-bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    const layers = container.querySelectorAll(".recharts-bar");
+    expect(layers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders multiple bar series side-by-side for grouped bars", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    const layers = container.querySelectorAll(".recharts-bar");
+    expect(layers.length).toBe(2);
+  });
+});
+
+describe("WidgetChart legend visibility", () => {
+  it("hides the legend by default for a single-series cartesian chart", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).toBeNull();
+  });
+
+  it("shows the legend automatically when there are 2+ series", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+
+  it("renders a legend even for a single-series chart when legend is forced to show", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+      legend: "show",
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+
+  it("hides the legend when legend is set to hide", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+      legend: "hide",
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).toBeNull();
+  });
+});
+
+describe("WidgetChart donut", () => {
+  it("renders a pie when type is donut", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "donut",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost", prefix: "$" }],
+    });
+    expect(container.querySelector(".recharts-pie")).not.toBeNull();
+  });
+
+  it("renders an empty-state message when every slice value is zero", () => {
+    renderChart(
+      {
+        kind: "chart",
+        type: "donut",
+        xField: "service",
+        series: [{ field: "cost", label: "Cost" }],
+      },
+      { rows: [{ service: "a", cost: 0 }] },
+    );
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+
+  it("shows a legend by default", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "donut",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.tsx
@@ -1,8 +1,32 @@
-import { useMemo } from "react";
+import { useMemo, type CSSProperties } from "react";
 import { Loader2 } from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 
 import { applyFilters, buildChartData } from "./widgetData";
-import type { WidgetChartRender } from "./types";
+import { formatPercentOfTotal, formatSeriesValue } from "./chartFormat";
+import type { WidgetChartLegendMode, WidgetChartRender, WidgetChartSeries } from "./types";
 
 interface WidgetChartProps {
   render: WidgetChartRender;
@@ -11,32 +35,36 @@ interface WidgetChartProps {
 }
 
 const DEFAULT_PALETTE = ["#0284c7", "#16a34a", "#dc2626", "#a855f7", "#f59e0b", "#0ea5e9"];
+const STACK_ID = "stack";
+
+interface ChartSeries extends WidgetChartSeries {
+  key: string;
+  color: string;
+}
 
 /**
- * Compact SVG-based chart renderer used by Dashboard widget blocks.
- *
- * Kept dependency-free on purpose: the canvas already ships Recharts but that
- * library expects to live inside its own ResponsiveContainer, which makes
- * reliable embedding inside a dashboard cell tricky. The chart shapes covered
- * here (bar, stacked-bar, line, area, donut) all map cleanly onto a small set
- * of SVG primitives so the renderer stays predictable.
+ * Dashboard chart renderer powered by Recharts via the project's shadcn
+ * `ChartContainer`. Supports bar (grouped/stacked), line, area, and donut
+ * charts, with hover tooltips and a configurable legend. Each series can
+ * declare a `format` / `prefix` / `suffix` so currencies, durations, or
+ * percentages render consistently in the tooltip.
  */
 export function WidgetChart({ render, rows, isLoading }: WidgetChartProps) {
   const filtered = useMemo(() => applyFilters(rows, render.filters), [rows, render.filters]);
-  const seriesKeys = useMemo(
+  const series = useMemo<ChartSeries[]>(
     () =>
       render.series.map((s, idx) => ({
+        ...s,
         key: s.label ?? s.field ?? `series-${idx}`,
-        field: s.field,
         color: s.color ?? DEFAULT_PALETTE[idx % DEFAULT_PALETTE.length],
       })),
     [render.series],
   );
   const data = useMemo(() => {
-    const built = buildChartData(filtered, render.xField, seriesKeys);
+    const built = buildChartData(filtered, render.xField, series);
     if (render.limit) return built.slice(0, render.limit);
     return built;
-  }, [filtered, render.xField, render.limit, seriesKeys]);
+  }, [filtered, render.xField, render.limit, series]);
 
   if (isLoading) {
     return (
@@ -54,222 +82,229 @@ export function WidgetChart({ render, rows, isLoading }: WidgetChartProps) {
   }
 
   return (
-    <div className="flex h-full flex-col gap-2 p-3" data-testid="widget-chart">
+    <div className="flex h-full min-h-0 flex-col gap-1 p-3" data-testid="widget-chart">
       {render.title ? <div className="text-xs font-medium text-slate-600">{render.title}</div> : null}
-      <div className="min-h-[120px] flex-1">
+      <div className="min-h-0 flex-1">
         {render.type === "donut" ? (
-          <DonutChart data={data} series={seriesKeys[0]} />
+          <DonutChartView data={data} series={series[0]} legendMode={render.legend ?? "auto"} />
         ) : (
-          <CartesianChart type={render.type} data={data} series={seriesKeys} />
+          <CartesianChartView type={render.type} data={data} series={series} legendMode={render.legend ?? "auto"} />
         )}
       </div>
-      <Legend series={seriesKeys} />
     </div>
   );
 }
 
-interface SeriesKey {
-  key: string;
-  field?: string;
-  color: string;
-}
+const CHART_MARGIN = { top: 8, right: 8, left: 0, bottom: 0 } as const;
+// Recharts wraps the tooltip in an absolutely positioned div with a default
+// `transform 400ms ease` transition. That transition makes the tooltip slide
+// in from the chart origin (top-left) the first time it appears, which feels
+// confusing. We disable the wrapper transition and add a quick fade-in on the
+// content so the tooltip appears in place.
+const TOOLTIP_WRAPPER_STYLE: CSSProperties = { transition: "none" };
+const TOOLTIP_CONTENT_CLASS = "animate-in fade-in duration-150";
 
-function CartesianChart({
+function CartesianChartView({
   type,
   data,
   series,
+  legendMode,
 }: {
-  type: WidgetChartRender["type"];
+  type: Exclude<WidgetChartRender["type"], "donut">;
   data: Array<Record<string, unknown>>;
-  series: SeriesKey[];
+  series: ChartSeries[];
+  legendMode: WidgetChartLegendMode;
 }) {
-  const width = 320;
-  const height = 160;
-  const padding = { top: 8, right: 8, bottom: 24, left: 32 };
-  const innerW = width - padding.left - padding.right;
-  const innerH = height - padding.top - padding.bottom;
-
-  const values = data.flatMap((row) => series.map((s) => toNumber(row[s.key])));
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const config: ChartConfig = {};
+    for (const s of series) {
+      config[s.key] = { label: s.label ?? s.field ?? s.key, color: s.color };
+    }
+    return config;
+  }, [series]);
+  const seriesByKey = useMemo(() => new Map(series.map((s) => [s.key, s])), [series]);
+  const showLegend = legendMode === "show" || (legendMode === "auto" && series.length > 1);
   const stacked = type === "stacked-bar";
-  const stackTotals = stacked
-    ? data.map((row) => series.reduce((acc, s) => acc + Math.max(0, toNumber(row[s.key]) ?? 0), 0))
-    : null;
-  const max = stacked
-    ? Math.max(...(stackTotals ?? [0]), 0)
-    : Math.max(0, ...values.filter((v): v is number => v != null));
-  const safeMax = max === 0 ? 1 : max;
 
-  const slotW = innerW / data.length;
-  const groupGap = 0.2 * slotW;
+  const sharedAxes = <CartesianFrame stacked={stacked || type === "bar"} seriesByKey={seriesByKey} />;
+  const legend = showLegend ? <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" /> : null;
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} className="h-full w-full" role="img" aria-label="chart">
-      <ChartAxes padding={padding} innerW={innerW} innerH={innerH} />
-      {data.map((row, i) => {
-        const x = padding.left + slotW * i + groupGap / 2;
-        const xLabel = padding.left + slotW * (i + 0.5);
-        if (type === "bar" || type === "stacked-bar") {
-          const barAreaW = slotW - groupGap;
-          if (type === "stacked-bar") {
-            let cumulative = 0;
-            return (
-              <g key={i}>
-                {series.map((s) => {
-                  const v = Math.max(0, toNumber(row[s.key]) ?? 0);
-                  const h = (v / safeMax) * innerH;
-                  const y = padding.top + innerH - cumulative - h;
-                  cumulative += h;
-                  return <rect key={s.key} x={x} y={y} width={barAreaW} height={h} fill={s.color} />;
-                })}
-                <text x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-                  {String(row.x ?? "")}
-                </text>
-              </g>
-            );
-          }
-          const perBarW = barAreaW / series.length;
-          return (
-            <g key={i}>
-              {series.map((s, si) => {
-                const v = toNumber(row[s.key]) ?? 0;
-                const h = (Math.max(0, v) / safeMax) * innerH;
-                const y = padding.top + innerH - h;
-                return (
-                  <rect
-                    key={s.key}
-                    x={x + si * perBarW}
-                    y={y}
-                    width={Math.max(0, perBarW - 1)}
-                    height={h}
-                    fill={s.color}
-                  />
-                );
-              })}
-              <text x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-                {String(row.x ?? "")}
-              </text>
-            </g>
-          );
-        }
-        // line/area: handled below as polylines
-        return (
-          <text key={`label-${i}`} x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-            {String(row.x ?? "")}
-          </text>
-        );
-      })}
-      {(type === "line" || type === "area") &&
-        series.map((s) => {
-          const points = data.map((row, i) => {
-            const v = toNumber(row[s.key]) ?? 0;
-            const x = padding.left + slotW * (i + 0.5);
-            const y = padding.top + innerH - (Math.max(0, v) / safeMax) * innerH;
-            return `${x.toFixed(1)},${y.toFixed(1)}`;
-          });
-          const linePath = points.join(" ");
-          if (type === "area") {
-            const baseY = padding.top + innerH;
-            const firstX = padding.left + slotW * 0.5;
-            const lastX = padding.left + slotW * (data.length - 0.5);
-            const areaPath = `${firstX},${baseY} ${linePath} ${lastX},${baseY}`;
-            return (
-              <g key={s.key}>
-                <polygon points={areaPath} fill={s.color} fillOpacity={0.18} />
-                <polyline points={linePath} fill="none" stroke={s.color} strokeWidth={1.5} />
-              </g>
-            );
-          }
-          return <polyline key={s.key} points={linePath} fill="none" stroke={s.color} strokeWidth={1.5} />;
-        })}
-    </svg>
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
+      {type === "area" ? (
+        <AreaChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Area
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={s.color}
+              fill={s.color}
+              fillOpacity={0.2}
+              strokeWidth={2}
+            />
+          ))}
+        </AreaChart>
+      ) : type === "line" ? (
+        <LineChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={s.color}
+              strokeWidth={2}
+              dot={{ r: 2.5, fill: s.color }}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      ) : (
+        <BarChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              fill={s.color}
+              stackId={stacked ? STACK_ID : undefined}
+              radius={stacked ? 0 : [3, 3, 0, 0]}
+            />
+          ))}
+        </BarChart>
+      )}
+    </ChartContainer>
   );
 }
 
-function ChartAxes({
-  padding,
-  innerW,
-  innerH,
-}: {
-  padding: { top: number; right: number; bottom: number; left: number };
-  innerW: number;
-  innerH: number;
-}) {
+function CartesianFrame({ stacked, seriesByKey }: { stacked: boolean; seriesByKey: Map<string, ChartSeries> }) {
+  const tooltipFormatter = (value: unknown, name: unknown) => {
+    const key = String(name ?? "");
+    const s = seriesByKey.get(key);
+    const label = s?.label ?? s?.field ?? key;
+    const formatted = formatSeriesValue(value, { format: s?.format, prefix: s?.prefix, suffix: s?.suffix });
+    return (
+      <div className="flex w-full items-center justify-between gap-3">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-mono font-medium text-foreground tabular-nums">{formatted}</span>
+      </div>
+    );
+  };
   return (
     <>
-      <line
-        x1={padding.left}
-        x2={padding.left}
-        y1={padding.top}
-        y2={padding.top + innerH}
-        stroke="#cbd5e1"
-        strokeWidth={1}
+      <CartesianGrid vertical={false} strokeDasharray="3 3" />
+      <XAxis
+        dataKey="x"
+        tickLine={false}
+        axisLine={false}
+        fontSize={11}
+        interval="preserveStartEnd"
+        minTickGap={16}
+        tickFormatter={(v: unknown) => String(v ?? "")}
       />
-      <line
-        x1={padding.left}
-        x2={padding.left + innerW}
-        y1={padding.top + innerH}
-        y2={padding.top + innerH}
-        stroke="#cbd5e1"
-        strokeWidth={1}
+      <YAxis tickLine={false} axisLine={false} fontSize={11} width={36} tickFormatter={yTickFormatter} />
+      <ChartTooltip
+        cursor={stacked ? { fill: "rgba(148, 163, 184, 0.12)" } : true}
+        wrapperStyle={TOOLTIP_WRAPPER_STYLE}
+        content={<ChartTooltipContent formatter={tooltipFormatter} indicator="dot" className={TOOLTIP_CONTENT_CLASS} />}
       />
     </>
   );
 }
 
-function DonutChart({ data, series }: { data: Array<Record<string, unknown>>; series: SeriesKey | undefined }) {
+function yTickFormatter(value: number) {
+  if (!Number.isFinite(value)) return String(value);
+  if (Math.abs(value) >= 1000) return value.toLocaleString();
+  return String(value);
+}
+
+function DonutChartView({
+  data,
+  series,
+  legendMode,
+}: {
+  data: Array<Record<string, unknown>>;
+  series: ChartSeries | undefined;
+  legendMode: WidgetChartLegendMode;
+}) {
+  const seriesKey = series?.key ?? "";
+  const sliceData = useMemo(() => {
+    if (!seriesKey) return [];
+    return data.map((row, idx) => ({
+      x: String(row.x ?? ""),
+      value: Number(row[seriesKey]) || 0,
+      color: DEFAULT_PALETTE[idx % DEFAULT_PALETTE.length],
+    }));
+  }, [data, seriesKey]);
+
+  const total = useMemo(() => sliceData.reduce((acc, slice) => acc + slice.value, 0), [sliceData]);
+
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const config: ChartConfig = {};
+    for (const slice of sliceData) {
+      config[slice.x || "(empty)"] = { label: slice.x || "(empty)", color: slice.color };
+    }
+    return config;
+  }, [sliceData]);
+
   if (!series) return null;
-  const radius = 56;
-  const width = radius * 2 + 24;
-  const height = radius * 2 + 24;
-  const cx = width / 2;
-  const cy = height / 2;
-  const total = data.reduce((acc, row) => acc + (toNumber(row[series.key]) ?? 0), 0);
-  if (total === 0) return <div className="p-4 text-center text-xs text-slate-500">No data</div>;
-  let cumulative = 0;
-  return (
-    <svg viewBox={`0 0 ${width} ${height}`} className="mx-auto h-full" role="img" aria-label="donut">
-      {data.map((row, i) => {
-        const value = toNumber(row[series.key]) ?? 0;
-        if (value === 0) return null;
-        const start = (cumulative / total) * Math.PI * 2;
-        cumulative += value;
-        const end = (cumulative / total) * Math.PI * 2;
-        const largeArc = end - start > Math.PI ? 1 : 0;
-        const x1 = cx + radius * Math.sin(start);
-        const y1 = cy - radius * Math.cos(start);
-        const x2 = cx + radius * Math.sin(end);
-        const y2 = cy - radius * Math.cos(end);
-        const color = DEFAULT_PALETTE[i % DEFAULT_PALETTE.length];
-        return (
-          <path
-            key={i}
-            d={`M ${cx} ${cy} L ${x1.toFixed(1)} ${y1.toFixed(1)} A ${radius} ${radius} 0 ${largeArc} 1 ${x2.toFixed(1)} ${y2.toFixed(1)} Z`}
-            fill={color}
-            stroke="#fff"
-            strokeWidth={1.5}
-          />
-        );
-      })}
-      <circle cx={cx} cy={cy} r={radius * 0.55} fill="#fff" />
-    </svg>
-  );
-}
+  if (total === 0) {
+    return <div className="p-4 text-center text-xs text-slate-500">No data</div>;
+  }
 
-function Legend({ series }: { series: SeriesKey[] }) {
-  if (series.length <= 1) return null;
-  return (
-    <div className="flex flex-wrap items-center gap-3 text-[11px] text-slate-600">
-      {series.map((s) => (
-        <div key={s.key} className="inline-flex items-center gap-1">
-          <span className="inline-block size-2 rounded-full" style={{ backgroundColor: s.color }} />
-          {s.key}
-        </div>
-      ))}
-    </div>
-  );
-}
+  const showLegend = legendMode !== "hide";
 
-function toNumber(value: unknown): number | null {
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : null;
+  const tooltipFormatter = (value: unknown, _name: unknown, item: { payload?: { x?: string } }) => {
+    const sliceName = item.payload?.x ?? String(_name ?? "");
+    const formatted = formatSeriesValue(value, {
+      format: series.format,
+      prefix: series.prefix,
+      suffix: series.suffix,
+    });
+    const pct = formatPercentOfTotal(value, total);
+    return (
+      <div className="flex w-full items-center justify-between gap-3">
+        <span className="text-muted-foreground">{sliceName}</span>
+        <span className="font-mono font-medium text-foreground tabular-nums">
+          {formatted}
+          {pct}
+        </span>
+      </div>
+    );
+  };
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
+      <PieChart>
+        <ChartTooltip
+          wrapperStyle={TOOLTIP_WRAPPER_STYLE}
+          content={
+            <ChartTooltipContent nameKey="x" hideLabel formatter={tooltipFormatter} className={TOOLTIP_CONTENT_CLASS} />
+          }
+        />
+        {showLegend ? <ChartLegend content={<ChartLegendContent nameKey="x" />} verticalAlign="bottom" /> : null}
+        <Pie
+          data={sliceData}
+          dataKey="value"
+          nameKey="x"
+          cx="50%"
+          cy="50%"
+          innerRadius="55%"
+          outerRadius="85%"
+          paddingAngle={1}
+          stroke="#fff"
+          strokeWidth={1.5}
+        >
+          {sliceData.map((slice) => (
+            <Cell key={slice.x} fill={slice.color} />
+          ))}
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  );
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetNumber.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetNumber.tsx
@@ -1,28 +1,44 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 
-import { applyFilters, aggregateNumber } from "./widgetData";
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { aggregateNumber, aggregateNumberPerSource, applyFilters, combinePartials } from "./widgetData";
 import { formatValue } from "./widgetFormat";
 import { getValueAtPath } from "./fieldPath";
 import type { WidgetNumberRender } from "./types";
+import type { MemoryNumberSource, WidgetNumberCombine } from "../panelTypes";
 
 interface WidgetNumberProps {
   render: WidgetNumberRender;
   rows: unknown[];
   isLoading: boolean;
   totalCount?: number;
+  /** Composite memory mode: aggregate each source independently and combine the partials. */
+  composite?: {
+    entries: CanvasMemoryEntry[];
+    sources: MemoryNumberSource[];
+    combine: WidgetNumberCombine;
+  };
 }
 
-export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumberProps) {
+export function WidgetNumber({ render, rows, isLoading, totalCount, composite }: WidgetNumberProps) {
   const filtered = useMemo(() => applyFilters(rows, render.filters), [rows, render.filters]);
   const value = useMemo(() => {
+    if (composite) {
+      const partials = composite.sources.map((source) =>
+        aggregateNumberPerSource(composite.entries, source, render.filters),
+      );
+      return combinePartials(partials, composite.combine);
+    }
     if (render.aggregation === "count" && !render.filters?.length && totalCount !== undefined) {
       return totalCount;
     }
+    if (!render.aggregation) return null;
     return aggregateNumber(filtered, render.aggregation, render.field);
-  }, [filtered, render.aggregation, render.field, render.filters, totalCount]);
+  }, [composite, filtered, render.aggregation, render.field, render.filters, totalCount]);
   const sparkline = useMemo(() => {
-    if (!render.sparklineField) return null;
+    if (!render.sparklineField || composite) return null;
     return filtered
       .map((row) => {
         const raw = getValueAtPath(row, render.sparklineField!);
@@ -30,7 +46,7 @@ export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumb
         return Number.isFinite(n) ? n : null;
       })
       .filter((n): n is number => n != null);
-  }, [filtered, render.sparklineField]);
+  }, [composite, filtered, render.sparklineField]);
 
   if (isLoading) {
     return (
@@ -40,7 +56,10 @@ export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumb
     );
   }
 
-  const display = value == null ? "—" : formatValue(value, render.format ?? "number");
+  const display =
+    value == null
+      ? "—"
+      : `${render.prefix ?? ""}${formatValue(value, render.format ?? "number")}${render.suffix ?? ""}`;
   return (
     <div className="flex h-full flex-col items-start justify-center gap-1 p-4" data-testid="widget-number">
       {render.label ? (

--- a/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPercentOfTotal, formatSeriesValue } from "./chartFormat";
+
+describe("formatSeriesValue", () => {
+  it("wraps numeric values with prefix and suffix", () => {
+    expect(formatSeriesValue(1234.5, { format: "number", prefix: "$" })).toBe("$1,234.5");
+    expect(formatSeriesValue(42, { suffix: " MWh" })).toBe("42 MWh");
+  });
+
+  it("formats fractions as percentages when format is percent", () => {
+    expect(formatSeriesValue(0.42, { format: "percent" })).toBe("42%");
+  });
+
+  it("uses default number formatting when no format is provided", () => {
+    expect(formatSeriesValue(2500, {})).toBe("2,500");
+  });
+
+  it("renders an em-dash for null or undefined values", () => {
+    expect(formatSeriesValue(null, { prefix: "$" })).toBe("—");
+    expect(formatSeriesValue(undefined, {})).toBe("—");
+  });
+
+  it("falls through to string conversion for non-numeric values", () => {
+    expect(formatSeriesValue("hello", { format: "text" })).toBe("hello");
+  });
+});
+
+describe("formatPercentOfTotal", () => {
+  it("returns a percent suffix for positive totals", () => {
+    expect(formatPercentOfTotal(25, 100)).toBe(" (25%)");
+    expect(formatPercentOfTotal(1, 8)).toBe(" (12.5%)");
+  });
+
+  it("returns an empty string when total is zero or invalid", () => {
+    expect(formatPercentOfTotal(10, 0)).toBe("");
+    expect(formatPercentOfTotal(10, NaN)).toBe("");
+  });
+
+  it("returns an empty string when the value is not numeric", () => {
+    expect(formatPercentOfTotal("not a number", 100)).toBe("");
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.ts
@@ -1,0 +1,30 @@
+import { formatValue } from "./widgetFormat";
+import type { WidgetColumnFormat } from "./types";
+
+export interface ChartValueFormat {
+  format?: WidgetColumnFormat;
+  prefix?: string;
+  suffix?: string;
+}
+
+/**
+ * Format a numeric chart value with optional prefix/suffix wrapping. Mirrors
+ * the number widget's display rules so chart tooltips can show currency, units,
+ * or percent values exactly the way KPI cards do.
+ */
+export function formatSeriesValue(value: unknown, { format, prefix, suffix }: ChartValueFormat): string {
+  if (value == null) return "—";
+  return `${prefix ?? ""}${formatValue(value, format ?? "number")}${suffix ?? ""}`;
+}
+
+/**
+ * Render a percentage suffix for donut tooltips (e.g. " (32%)"). Returns an
+ * empty string when total is zero or the value can't be expressed as a number.
+ */
+export function formatPercentOfTotal(value: unknown, total: number): string {
+  if (!Number.isFinite(total) || total <= 0) return "";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "";
+  const pct = (n / total) * 100;
+  return ` (${pct.toFixed(pct % 1 === 0 ? 0 : 1)}%)`;
+}

--- a/web_src/src/pages/workflowv2/dashboard/widget/types.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/types.ts
@@ -92,10 +92,19 @@ export interface WidgetTableRender {
 
 export type WidgetChartKind = "bar" | "stacked-bar" | "line" | "area" | "donut";
 
+export type WidgetChartLegendMode = "auto" | "show" | "hide";
+export const WIDGET_CHART_LEGEND_MODES: WidgetChartLegendMode[] = ["auto", "show", "hide"];
+
 export interface WidgetChartSeries {
   field?: string;
   label?: string;
   color?: string;
+  /** Optional value format applied in tooltips (and in donut value rows). */
+  format?: WidgetColumnFormat;
+  /** Optional display string prepended to the formatted value (e.g. "$"). */
+  prefix?: string;
+  /** Optional display string appended to the formatted value (e.g. " MWh"). */
+  suffix?: string;
 }
 
 export interface WidgetChartRender {
@@ -106,18 +115,25 @@ export interface WidgetChartRender {
   title?: string;
   limit?: number;
   filters?: string[];
+  /** Legend visibility. Defaults to "auto" — visible for donut charts or when 2+ series exist. */
+  legend?: WidgetChartLegendMode;
 }
 
 export type WidgetNumberAggregation = "count" | "sum" | "avg" | "min" | "max" | "first" | "last";
 
 export interface WidgetNumberRender {
   kind: "number";
-  aggregation: WidgetNumberAggregation;
+  /** Required for simple data sources. Composite memory sources carry their own per-source aggregation. */
+  aggregation?: WidgetNumberAggregation;
   field?: string;
   filters?: string[];
   format?: WidgetColumnFormat;
   label?: string;
   sparklineField?: string;
+  /** Optional display string rendered before the formatted value (e.g. "R$"). */
+  prefix?: string;
+  /** Optional display string rendered after the formatted value (e.g. " MWh"). */
+  suffix?: string;
 }
 
 export type WidgetRender = WidgetTableRender | WidgetChartRender | WidgetNumberRender;

--- a/web_src/src/pages/workflowv2/dashboard/widget/widgetData.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/widgetData.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { aggregateNumberPerSource, combinePartials } from "./widgetData";
+
+const entries: CanvasMemoryEntry[] = [
+  { id: "1", namespace: "expenses", values: { amount: 10 } },
+  { id: "2", namespace: "expenses", values: { amount: 30 } },
+  { id: "3", namespace: "tests", values: { name: "a" } },
+  { id: "4", namespace: "tests", values: { name: "b" } },
+  { id: "5", namespace: "tests", values: { name: "c" } },
+];
+
+describe("aggregateNumberPerSource", () => {
+  it("sums a numeric field across rows of the same namespace", () => {
+    const value = aggregateNumberPerSource(
+      entries,
+      { namespace: "expenses", aggregation: "sum", field: "amount" },
+      undefined,
+    );
+    expect(value).toBe(40);
+  });
+
+  it("counts rows in a namespace when aggregation is count", () => {
+    expect(aggregateNumberPerSource(entries, { namespace: "tests", aggregation: "count" }, undefined)).toBe(3);
+  });
+
+  it("returns null when no rows match the namespace and aggregation is not count", () => {
+    expect(
+      aggregateNumberPerSource(entries, { namespace: "missing", aggregation: "sum", field: "amount" }, undefined),
+    ).toBe(null);
+  });
+
+  it("returns 0 when no rows match the namespace and aggregation is count", () => {
+    expect(aggregateNumberPerSource(entries, { namespace: "missing", aggregation: "count" }, undefined)).toBe(0);
+  });
+
+  it("applies shared widget filters before aggregating each source", () => {
+    const value = aggregateNumberPerSource(entries, { namespace: "expenses", aggregation: "sum", field: "amount" }, [
+      "row.amount > 10",
+    ]);
+    expect(value).toBe(30);
+  });
+});
+
+describe("combinePartials", () => {
+  it("sums available partials and skips nulls", () => {
+    expect(combinePartials([40, null, 3], "sum")).toBe(43);
+  });
+
+  it("returns null when every partial is null", () => {
+    expect(combinePartials([null, null], "sum")).toBe(null);
+  });
+
+  it("picks the minimum of non-null partials", () => {
+    expect(combinePartials([5, 2, null, 8], "min")).toBe(2);
+  });
+
+  it("picks the maximum of non-null partials", () => {
+    expect(combinePartials([5, 2, null, 8], "max")).toBe(8);
+  });
+
+  it("averages non-null partials (unweighted across sources)", () => {
+    expect(combinePartials([2, 4, null], "avg")).toBe(3);
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/widgetData.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/widgetData.ts
@@ -1,5 +1,9 @@
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
 import { getValueAtPath } from "./fieldPath";
+import { flattenMemoryEntries } from "./memoryRow";
 import { evaluateShow } from "./showExpression";
+import type { MemoryNumberSource, WidgetNumberCombine } from "../panelTypes";
 import type { WidgetNumberAggregation } from "./types";
 
 /**
@@ -46,6 +50,51 @@ export function aggregateNumber(
       return numeric[0];
     case "last":
       return numeric[numeric.length - 1];
+    default:
+      return null;
+  }
+}
+
+/**
+ * Aggregate a single memory namespace contribution for a composite number
+ * widget. Flattens the relevant entries (optionally walking `fieldPath`),
+ * filters them with the widget's shared `render.filters`, and runs the
+ * source's own aggregation/field configuration. Returns `null` when the
+ * source has no rows or no numeric values to aggregate (except `count`,
+ * which returns `0` for an empty namespace).
+ */
+export function aggregateNumberPerSource(
+  entries: CanvasMemoryEntry[],
+  source: MemoryNumberSource,
+  filters: string[] | undefined,
+): number | null {
+  const rows = flattenMemoryEntries(entries, source.namespace, source.fieldPath);
+  const filtered = applyFilters(rows, filters);
+  return aggregateNumber(filtered, source.aggregation, source.field);
+}
+
+/**
+ * Merge per-source partial aggregates into a single value. Null partials are
+ * skipped (a namespace that produced no numeric value does not poison the
+ * combine); if every partial is `null`, the result is `null` so the widget
+ * renders its em-dash placeholder.
+ *
+ * `avg` is the unweighted mean of the available partials — not a row-weighted
+ * average across namespaces. Document this in the number panel UI so users
+ * can pick `sum` when they want row-level math.
+ */
+export function combinePartials(partials: Array<number | null>, combine: WidgetNumberCombine): number | null {
+  const present = partials.filter((value): value is number => value != null);
+  if (present.length === 0) return null;
+  switch (combine) {
+    case "sum":
+      return present.reduce((a, b) => a + b, 0);
+    case "min":
+      return Math.min(...present);
+    case "max":
+      return Math.max(...present);
+    case "avg":
+      return present.reduce((a, b) => a + b, 0) / present.length;
     default:
       return null;
   }

--- a/web_src/src/pages/workflowv2/mappers/addMemory.ts
+++ b/web_src/src/pages/workflowv2/mappers/addMemory.ts
@@ -15,11 +15,17 @@ import { defaultStateFunction } from "./stateRegistry";
 type AddMemoryMetadata = {
   namespace?: string;
   fields?: string[];
+  iterateList?: boolean;
+  itemVariable?: string;
+  count?: number;
 };
 
 type AddMemoryConfiguration = {
   namespace?: string;
   valueList?: Array<{ name?: string; value?: unknown }>;
+  iterateList?: boolean;
+  listSource?: string;
+  itemVariable?: string;
 };
 
 export const addMemoryMapper: ComponentBaseMapper = {
@@ -58,6 +64,15 @@ export const addMemoryMapper: ComponentBaseMapper = {
     if (fields.length > 0) {
       details["Fields"] = fields.join(", ");
     }
+    if (metadata.iterateList) {
+      details["List Mode"] = "Enabled";
+      if (metadata.itemVariable) {
+        details["Item Variable"] = metadata.itemVariable;
+      }
+      if (typeof metadata.count === "number") {
+        details["Rows Added"] = String(metadata.count);
+      }
+    }
 
     return details;
   },
@@ -93,6 +108,9 @@ function getAddMemoryMetadataList(node: NodeInfo): Array<{ icon: string; label: 
   }
   if (fields.length > 0) {
     items.push({ icon: "list", label: fields.join(", ") });
+  }
+  if (config.iterateList || metadata.iterateList) {
+    items.push({ icon: "repeat", label: "List mode" });
   }
 
   return items;

--- a/web_src/src/pages/workflowv2/mappers/updateMemory.ts
+++ b/web_src/src/pages/workflowv2/mappers/updateMemory.ts
@@ -20,12 +20,18 @@ type UpdateMemoryMetadata = {
   valueFields?: string[];
   matches?: Record<string, unknown>;
   updatedCount?: number;
+  iterateList?: boolean;
+  itemVariable?: string;
+  count?: number;
 };
 
 type UpdateMemoryConfiguration = {
   namespace?: string;
   matchList?: Array<{ name?: string; value?: unknown }>;
   valueList?: Array<{ name?: string; value?: unknown }>;
+  iterateList?: boolean;
+  listSource?: string;
+  itemVariable?: string;
 };
 
 type UpdateMemoryOutputs = {
@@ -106,6 +112,18 @@ export const updateMemoryMapper: ComponentBaseMapper = {
     if (valueFields.length > 0) {
       details["Updated Fields"] = valueFields.join(", ");
     }
+    if (metadata.iterateList) {
+      details["List Mode"] = "Enabled";
+      if (metadata.itemVariable) {
+        details["Item Variable"] = metadata.itemVariable;
+      }
+      if (typeof metadata.count === "number") {
+        details["Iterations"] = String(metadata.count);
+      }
+      if (typeof metadata.updatedCount === "number") {
+        details["Rows Updated"] = String(metadata.updatedCount);
+      }
+    }
 
     return details;
   },
@@ -145,6 +163,9 @@ function getUpdateMemoryMetadataList(node: NodeInfo): Array<{ icon: string; labe
   }
   if (valueFields.length > 0) {
     items.push({ icon: "list", label: `set: ${valueFields.join(", ")}` });
+  }
+  if (config.iterateList || metadata.iterateList) {
+    items.push({ icon: "repeat", label: "List mode" });
   }
 
   return items;

--- a/web_src/src/pages/workflowv2/mappers/upsertMemory.ts
+++ b/web_src/src/pages/workflowv2/mappers/upsertMemory.ts
@@ -19,12 +19,19 @@ type UpsertMemoryMetadata = {
   matches?: Record<string, unknown>;
   operation?: string;
   updatedCount?: number;
+  createdCount?: number;
+  iterateList?: boolean;
+  itemVariable?: string;
+  count?: number;
 };
 
 type UpsertMemoryConfiguration = {
   namespace?: string;
   matchList?: Array<{ name?: string; value?: unknown }>;
   valueList?: Array<{ name?: string; value?: unknown }>;
+  iterateList?: boolean;
+  listSource?: string;
+  itemVariable?: string;
 };
 
 export const upsertMemoryMapper: ComponentBaseMapper = {
@@ -78,6 +85,21 @@ export const upsertMemoryMapper: ComponentBaseMapper = {
     if ((metadata.operation || "").trim().length > 0) {
       details["Operation"] = metadata.operation || "";
     }
+    if (metadata.iterateList) {
+      details["List Mode"] = "Enabled";
+      if (metadata.itemVariable) {
+        details["Item Variable"] = metadata.itemVariable;
+      }
+      if (typeof metadata.count === "number") {
+        details["Iterations"] = String(metadata.count);
+      }
+      if (typeof metadata.updatedCount === "number") {
+        details["Rows Updated"] = String(metadata.updatedCount);
+      }
+      if (typeof metadata.createdCount === "number") {
+        details["Rows Created"] = String(metadata.createdCount);
+      }
+    }
 
     return details;
   },
@@ -117,6 +139,9 @@ function getUpsertMemoryMetadataList(node: NodeInfo): Array<{ icon: string; labe
   }
   if (valueFields.length > 0) {
     items.push({ icon: "list", label: `set: ${valueFields.join(", ")}` });
+  }
+  if (config.iterateList || metadata.iterateList) {
+    items.push({ icon: "repeat", label: "List mode" });
   }
 
   return items;


### PR DESCRIPTION
## Summary

Three coupled improvements to the memory subsystem and the Console widgets that depend on it:

- **Memory accepts list values.** The add, update, and upsert memory components support a list value type with append/replace semantics, the new `pkg/components/memorywrite/list` shared helper centralises list serialisation, and the worker expression context exposes list helpers so expressions running over memory can iterate or aggregate. Mappers, docs, and grafana fixtures are updated.
- **Number widget overhaul.** Adds prefix/suffix labels, multi-source composite memory data sources (each namespace declares its own aggregation and field, combined via sum/min/max/avg), and a richer field/path picker flow. The data-source form is broken into reusable fields, and the panel card is split into focused subcomponents.
- **Chart widget rewrite.** Switches to Recharts, adds configurable series, per-series formatting, picker-driven configuration, top-controls (legend mode, type), and a `chartFormat` helper. Chart panel configuration is split out of the card into form/series/topControls files.

The shared YAML schema (`canvas_dashboard_yml.go`, `panelTypes.ts`, `widget/types.ts`) is extended in lockstep so YAML round-trips faithfully across both surfaces.

Stacked on #4961. Third and final PR replacing #4941.

## Stack

1. #4960 — Console rebrand
2. #4961 — Promote Memory to a first-class canvas tab
3. **#TBD (this PR)** — Memory list values + Console number/chart widget improvements

## Test plan

- [ ] `make test PKG_TEST_PACKAGES=./pkg/components/memorywrite/... ./pkg/components/addmemory/... ./pkg/components/updatememory/... ./pkg/components/upsertmemory/...`
- [ ] `make test PKG_TEST_PACKAGES=./pkg/models/... ./pkg/workers/contexts/...`
- [ ] `make check.build.ui` and `make format.js`
- [ ] `make lint && make check.build.app`
- [ ] Add memory with list value (append + replace); update/upsert variants
- [ ] Number widget with prefix/suffix; composite memory source with sum/min/max/avg combine
- [ ] Chart widget with multiple series, configurable type, legend, formatting
- [ ] YAML import/export round-trips number prefix/suffix and composite memory sources
- [ ] Existing single-source number panels keep rendering unchanged


Made with [Cursor](https://cursor.com)