### PR TITLE
feat: Console number and chart widget improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ junit-report.xml
 pkg/web/assets/dist
 tmp
 build/
+node_modules/
 design/node_modules/
 # macOS Finder metadata
 .DS_Store

--- a/pkg/models/canvas_dashboard_yml.go
+++ b/pkg/models/canvas_dashboard_yml.go
@@ -7,11 +7,15 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 const (
+	// ConsoleKind is the canonical YAML kind for canvas consoles (product name).
+	ConsoleKind = "Console"
+	// DashboardKind is the legacy YAML kind accepted on import for back-compat.
 	DashboardKind       = "Dashboard"
 	DashboardAPIVersion = "v1"
 
@@ -108,7 +112,7 @@ func DashboardToYML(dashboard *CanvasDashboard, canvasName string) ([]byte, erro
 
 	resource := DashboardYAML{
 		APIVersion: DashboardAPIVersion,
-		Kind:       DashboardKind,
+		Kind:       ConsoleKind,
 		Metadata: DashboardYAMLMetadata{
 			CanvasID: dashboard.CanvasID.String(),
 			Name:     canvasName,
@@ -152,11 +156,15 @@ func (d *DashboardYAML) Validate() error {
 	if d.Kind == "" {
 		return errors.New("kind is required")
 	}
-	if d.Kind != DashboardKind {
-		return fmt.Errorf("unsupported kind %q (expected %q)", d.Kind, DashboardKind)
+	if !isValidDashboardYAMLKind(d.Kind) {
+		return fmt.Errorf("unsupported kind %q (expected %q)", d.Kind, ConsoleKind)
 	}
 
 	return ValidateDashboardContent(d.Spec.Panels, d.Spec.Layout)
+}
+
+func isValidDashboardYAMLKind(kind string) bool {
+	return kind == ConsoleKind || kind == DashboardKind
 }
 
 // ValidateDashboardContent enforces the shared validation rules used by both
@@ -376,8 +384,33 @@ func validateChartPanelContent(panel DashboardPanel) error {
 	if xField, ok := render["xField"].(string); !ok || xField == "" {
 		return fmt.Errorf("panel %q render.xField must be a non-empty string", panel.ID)
 	}
-	if series, ok := render["series"].([]any); !ok || len(series) == 0 {
+	series, ok := render["series"].([]any)
+	if !ok || len(series) == 0 {
 		return fmt.Errorf("panel %q render.series must be a non-empty array", panel.ID)
+	}
+	for i, rawSeries := range series {
+		if err := validateChartSeries(panel.ID, i, rawSeries); err != nil {
+			return err
+		}
+	}
+	if legend, ok := render["legend"]; ok && legend != nil {
+		legendStr, isString := legend.(string)
+		if !isString || !slices.Contains([]string{"auto", "show", "hide"}, legendStr) {
+			return fmt.Errorf("panel %q render.legend must be one of auto/show/hide", panel.ID)
+		}
+	}
+	return nil
+}
+
+func validateChartSeries(panelID string, index int, raw any) error {
+	series, ok := raw.(map[string]any)
+	if !ok || series == nil {
+		return fmt.Errorf("panel %q render.series[%d] must be an object", panelID, index)
+	}
+	for _, key := range []string{"field", "label", "color", "format", "prefix", "suffix"} {
+		if err := validateOptionalString(panelID, fmt.Sprintf("render.series[%d].%s", index, key), series[key]); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -478,13 +511,32 @@ func validateNumberPanelContent(panel DashboardPanel) error {
 	if panel.Content == nil {
 		return fmt.Errorf("panel %q content is required", panel.ID)
 	}
-	if err := validateDataSource(panel.ID, panel.Content["dataSource"]); err != nil {
+	if err := validateNumberDataSource(panel.ID, panel.Content["dataSource"]); err != nil {
 		return err
 	}
 	render, err := validateRender(panel.ID, panel.Content["render"], "number")
 	if err != nil {
 		return err
 	}
+	if err := validateOptionalString(panel.ID, "render.prefix", render["prefix"]); err != nil {
+		return err
+	}
+	if err := validateOptionalString(panel.ID, "render.suffix", render["suffix"]); err != nil {
+		return err
+	}
+
+	// Composite memory sources carry per-source aggregation; render-level
+	// aggregation/field must be absent so configuration is unambiguous.
+	if isCompositeMemoryDataSource(panel.Content["dataSource"]) {
+		if _, hasAgg := render["aggregation"]; hasAgg {
+			return fmt.Errorf("panel %q render.aggregation must not be set when dataSource.sources is used (each source defines its own aggregation)", panel.ID)
+		}
+		if _, hasField := render["field"]; hasField {
+			return fmt.Errorf("panel %q render.field must not be set when dataSource.sources is used (each source defines its own field)", panel.ID)
+		}
+		return nil
+	}
+
 	aggregation, _ := render["aggregation"].(string)
 	switch aggregation {
 	case "count", "sum", "avg", "min", "max", "first", "last":
@@ -497,6 +549,78 @@ func validateNumberPanelContent(panel DashboardPanel) error {
 		}
 	}
 	return nil
+}
+
+func isCompositeMemoryDataSource(raw any) bool {
+	ds, ok := raw.(map[string]any)
+	if !ok || ds == nil {
+		return false
+	}
+	if ds["kind"] != "memory" {
+		return false
+	}
+	_, ok = ds["sources"].([]any)
+	return ok
+}
+
+var allowedNumberCombineOps = []string{"sum", "min", "max", "avg"}
+var allowedNumberAggregations = []string{"count", "sum", "avg", "min", "max", "first", "last"}
+
+// validateNumberDataSource accepts the shared data-source shapes plus the
+// composite memory variant where each namespace has its own aggregation and
+// the partials are merged via `combine`.
+func validateNumberDataSource(panelID string, raw any) error {
+	ds, ok := raw.(map[string]any)
+	if !ok || ds == nil {
+		return fmt.Errorf("panel %q dataSource must be an object", panelID)
+	}
+	if ds["kind"] == "memory" {
+		if _, hasSources := ds["sources"]; hasSources {
+			return validateCompositeMemoryDataSource(panelID, ds)
+		}
+	}
+	return validateDataSource(panelID, raw)
+}
+
+func validateCompositeMemoryDataSource(panelID string, ds map[string]any) error {
+	sources, ok := ds["sources"].([]any)
+	if !ok {
+		return fmt.Errorf("panel %q dataSource.sources must be an array", panelID)
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("panel %q dataSource.sources must be a non-empty array", panelID)
+	}
+	for i, raw := range sources {
+		if err := validateMemoryNumberSource(panelID, i, raw); err != nil {
+			return err
+		}
+	}
+	combine, _ := ds["combine"].(string)
+	if !slices.Contains(allowedNumberCombineOps, combine) {
+		return fmt.Errorf("panel %q dataSource.combine must be one of %s", panelID, strings.Join(allowedNumberCombineOps, "/"))
+	}
+	return nil
+}
+
+func validateMemoryNumberSource(panelID string, index int, raw any) error {
+	source, ok := raw.(map[string]any)
+	if !ok || source == nil {
+		return fmt.Errorf("panel %q dataSource.sources[%d] must be an object", panelID, index)
+	}
+	namespace, _ := source["namespace"].(string)
+	if namespace == "" {
+		return fmt.Errorf("panel %q dataSource.sources[%d].namespace must be a non-empty string", panelID, index)
+	}
+	aggregation, _ := source["aggregation"].(string)
+	if !slices.Contains(allowedNumberAggregations, aggregation) {
+		return fmt.Errorf("panel %q dataSource.sources[%d].aggregation must be one of %s", panelID, index, strings.Join(allowedNumberAggregations, "/"))
+	}
+	if aggregation != "count" {
+		if field, ok := source["field"].(string); !ok || field == "" {
+			return fmt.Errorf("panel %q dataSource.sources[%d].field is required when aggregation is %q", panelID, index, aggregation)
+		}
+	}
+	return validateOptionalString(panelID, fmt.Sprintf("dataSource.sources[%d].fieldPath", index), source["fieldPath"])
 }
 
 // normalizeDashboardPanelsForExport ensures stable field order in panel

--- a/pkg/models/canvas_dashboard_yml_test.go
+++ b/pkg/models/canvas_dashboard_yml_test.go
@@ -34,7 +34,7 @@ spec:
 	resource, err := DashboardFromYML([]byte(yaml))
 	require.NoError(t, err)
 	require.Equal(t, "v1", resource.APIVersion)
-	require.Equal(t, "Dashboard", resource.Kind)
+	require.Equal(t, DashboardKind, resource.Kind)
 	require.Equal(t, "My dashboard", resource.Metadata.Name)
 	require.Len(t, resource.Spec.Panels, 1)
 	require.Equal(t, "intro", resource.Spec.Panels[0].ID)
@@ -44,6 +44,32 @@ spec:
 	require.Equal(t, 12, resource.Spec.Layout[0].W)
 	require.NotNil(t, resource.Spec.Layout[0].MinW)
 	assert.Equal(t, 2, *resource.Spec.Layout[0].MinW)
+}
+
+func TestDashboardFromYML_ParsesValidConsoleKind(t *testing.T) {
+	yaml := `apiVersion: v1
+kind: Console
+metadata:
+  name: Ops console
+spec:
+  panels:
+    - id: intro
+      type: markdown
+      content:
+        body: "# Hello"
+  layout:
+    - i: intro
+      x: 0
+      y: 0
+      w: 12
+      h: 6
+`
+
+	resource, err := DashboardFromYML([]byte(yaml))
+	require.NoError(t, err)
+	require.Equal(t, ConsoleKind, resource.Kind)
+	require.Equal(t, "Ops console", resource.Metadata.Name)
+	require.Len(t, resource.Spec.Panels, 1)
 }
 
 func TestDashboardFromYML_RejectsEmptyInput(t *testing.T) {
@@ -195,12 +221,13 @@ func TestDashboardToYML_RoundTripsEmptyDashboard(t *testing.T) {
 	out, err := DashboardToYML(dashboard, "Canvas Name")
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "apiVersion: v1")
-	assert.Contains(t, string(out), "kind: Dashboard")
+	assert.Contains(t, string(out), "kind: Console")
 	assert.Contains(t, string(out), canvasID.String())
 	assert.Contains(t, string(out), "name: Canvas Name")
 
 	parsed, err := DashboardFromYML(out)
 	require.NoError(t, err)
+	require.Equal(t, ConsoleKind, parsed.Kind)
 	assert.Empty(t, parsed.Spec.Panels)
 	assert.Empty(t, parsed.Spec.Layout)
 }
@@ -384,6 +411,141 @@ func TestValidateDashboardContent_RejectsInvalidTypedPanelConfig(t *testing.T) {
 			},
 			contains: "dataSource.limit must be a number",
 		},
+		{
+			name: "number render prefix must be string",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "runs"},
+					"render":     map[string]any{"kind": "number", "aggregation": "count", "prefix": 42},
+				},
+			},
+			contains: "render.prefix must be a string",
+		},
+		{
+			name: "composite number panel rejects render.aggregation",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number", "aggregation": "sum", "field": "cost"},
+				},
+			},
+			contains: "render.aggregation must not be set",
+		},
+		{
+			name: "composite number panel rejects render.field",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number", "field": "cost"},
+				},
+			},
+			contains: "render.field must not be set",
+		},
+		{
+			name: "composite number panel rejects unknown combine",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "median",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.combine must be one of",
+		},
+		{
+			name: "composite number panel requires field for non-count source",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{
+							map[string]any{"namespace": "a", "aggregation": "sum"},
+						},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.sources[0].field is required",
+		},
+		{
+			name: "composite number panel rejects empty sources",
+			panel: DashboardPanel{
+				ID:   "n",
+				Type: DashboardPanelTypeNumber,
+				Content: map[string]any{
+					"dataSource": map[string]any{
+						"kind":    "memory",
+						"combine": "sum",
+						"sources": []any{},
+					},
+					"render": map[string]any{"kind": "number"},
+				},
+			},
+			contains: "dataSource.sources must be a non-empty array",
+		},
+		{
+			name: "chart series prefix must be a string",
+			panel: DashboardPanel{
+				ID:   "chart",
+				Type: DashboardPanelTypeChart,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "executions"},
+					"render": map[string]any{
+						"kind":   "chart",
+						"type":   "bar",
+						"xField": "service",
+						"series": []any{map[string]any{"field": "cost", "prefix": 42}},
+					},
+				},
+			},
+			contains: "render.series[0].prefix must be a string",
+		},
+		{
+			name: "chart legend mode must be auto/show/hide",
+			panel: DashboardPanel{
+				ID:   "chart",
+				Type: DashboardPanelTypeChart,
+				Content: map[string]any{
+					"dataSource": map[string]any{"kind": "executions"},
+					"render": map[string]any{
+						"kind":   "chart",
+						"type":   "bar",
+						"xField": "service",
+						"series": []any{map[string]any{"field": "cost"}},
+						"legend": "bogus",
+					},
+				},
+			},
+			contains: "render.legend must be one of auto/show/hide",
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,4 +555,51 @@ func TestValidateDashboardContent_RejectsInvalidTypedPanelConfig(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.contains)
 		})
 	}
+}
+
+func TestValidateDashboardContent_AcceptsChartSeriesFormatAndLegend(t *testing.T) {
+	panels := []DashboardPanel{
+		{
+			ID:   "chart",
+			Type: DashboardPanelTypeChart,
+			Content: map[string]any{
+				"dataSource": map[string]any{"kind": "executions"},
+				"render": map[string]any{
+					"kind":   "chart",
+					"type":   "bar",
+					"xField": "service",
+					"series": []any{
+						map[string]any{"field": "cost", "label": "Cost", "format": "number", "prefix": "$", "suffix": " /mo"},
+					},
+					"legend": "show",
+				},
+			},
+		},
+	}
+
+	err := ValidateDashboardContent(panels, nil)
+	require.NoError(t, err)
+}
+
+func TestValidateDashboardContent_AcceptsCompositeNumberPanel(t *testing.T) {
+	panels := []DashboardPanel{
+		{
+			ID:   "score",
+			Type: DashboardPanelTypeNumber,
+			Content: map[string]any{
+				"dataSource": map[string]any{
+					"kind":    "memory",
+					"combine": "sum",
+					"sources": []any{
+						map[string]any{"namespace": "a", "aggregation": "sum", "field": "cost"},
+						map[string]any{"namespace": "b", "aggregation": "count"},
+					},
+				},
+				"render": map[string]any{"kind": "number", "prefix": "R$"},
+			},
+		},
+	}
+
+	err := ValidateDashboardContent(panels, nil)
+	require.NoError(t, err)
 }

--- a/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
@@ -1,22 +1,15 @@
 import { useState } from "react";
-import { AlertTriangle, Trash2 } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
-import { DataSourceForm } from "./DataSourceForm";
+import { ChartPanelForm } from "./ChartPanelForm";
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
 import type { ChartPanelContent } from "./panelTypes";
 import { useWidgetData } from "./widget/useWidgetData";
 import { WidgetChart } from "./widget/WidgetChart";
-import type { WidgetChartKind, WidgetChartSeries } from "./widget/types";
-
-const CHART_KINDS: WidgetChartKind[] = ["bar", "stacked-bar", "line", "area", "donut"];
 
 interface ChartPanelCardProps {
   panel: DashboardPanel;
@@ -64,108 +57,6 @@ function ChartPanelDataBound({ content, canvasId }: { content: ChartPanelContent
   const { rows, isLoading, error } = useWidgetData(canvasId, content.dataSource);
   if (error) return <PanelError message={error} />;
   return <WidgetChart render={content.render} rows={rows} isLoading={isLoading} />;
-}
-
-function ChartPanelForm({
-  value,
-  onChange,
-}: {
-  value: ChartPanelContent;
-  onChange: (next: ChartPanelContent) => void;
-}) {
-  const updateSeries = (idx: number, patch: Partial<WidgetChartSeries>) => {
-    const series = value.render.series.map((s, i) => (i === idx ? { ...s, ...patch } : s));
-    onChange({ ...value, render: { ...value.render, series } });
-  };
-  const addSeries = () => {
-    onChange({
-      ...value,
-      render: { ...value.render, series: [...value.render.series, { field: "", label: "" }] },
-    });
-  };
-  const removeSeries = (idx: number) => {
-    onChange({ ...value, render: { ...value.render, series: value.render.series.filter((_, i) => i !== idx) } });
-  };
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
-        <Input
-          value={value.title ?? ""}
-          onChange={(e) => onChange({ ...value, title: e.target.value })}
-          placeholder="Defaults to panel id"
-        />
-      </div>
-      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Chart type</Label>
-          <Select
-            value={value.render.type}
-            onValueChange={(v) => onChange({ ...value, render: { ...value.render, type: v as WidgetChartKind } })}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {CHART_KINDS.map((k) => (
-                <SelectItem key={k} value={k}>
-                  {k}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">X-axis field</Label>
-          <Input
-            value={value.render.xField}
-            onChange={(e) => onChange({ ...value, render: { ...value.render, xField: e.target.value } })}
-            placeholder="e.g. status"
-          />
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <div className="flex items-center justify-between">
-          <Label className="text-xs font-medium text-slate-600">Series</Label>
-          <Button type="button" size="sm" variant="outline" onClick={addSeries} data-testid="chart-add-series">
-            Add series
-          </Button>
-        </div>
-        <div className="space-y-2">
-          {value.render.series.map((s, idx) => (
-            <div key={idx} className="grid grid-cols-12 items-center gap-2 rounded border border-slate-200 p-2">
-              <Input
-                className="col-span-5 h-8"
-                value={s.field ?? ""}
-                onChange={(e) => updateSeries(idx, { field: e.target.value || undefined })}
-                placeholder="field (blank = count)"
-                aria-label={`Series ${idx + 1} field`}
-              />
-              <Input
-                className="col-span-5 h-8"
-                value={s.label ?? ""}
-                onChange={(e) => updateSeries(idx, { label: e.target.value })}
-                placeholder="label"
-                aria-label={`Series ${idx + 1} label`}
-              />
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="col-span-2 h-8 w-8 text-slate-400 hover:text-red-600"
-                onClick={() => removeSeries(idx)}
-                aria-label={`Remove series ${idx + 1}`}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function PanelError({ message }: { message: string }) {

--- a/web_src/src/pages/workflowv2/dashboard/ChartPanelForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartPanelForm.tsx
@@ -1,0 +1,63 @@
+import { Info } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { ChartSeriesList } from "./ChartSeriesList";
+import { ChartTopControls } from "./ChartTopControls";
+import { DataSourceForm } from "./DataSourceForm";
+import { useDashboardContext } from "./DashboardContext";
+import type { ChartPanelContent } from "./panelTypes";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function ChartPanelForm({
+  value,
+  onChange,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace = value.dataSource.kind === "memory" ? value.dataSource.namespace : undefined;
+  const { fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const fieldListId = memoryNamespace ? `chart-fields-${memoryNamespace}` : undefined;
+  const hasFieldSuggestions = fields.length > 0 && Boolean(fieldListId);
+  const stackedBarNeedsMoreSeries = value.render.type === "stacked-bar" && value.render.series.length < 2;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
+        <Input
+          value={value.title ?? ""}
+          onChange={(e) => onChange({ ...value, title: e.target.value })}
+          placeholder="Defaults to panel id"
+        />
+      </div>
+      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
+      <ChartTopControls value={value} onChange={onChange} fieldListId={hasFieldSuggestions ? fieldListId : undefined} />
+      {stackedBarNeedsMoreSeries ? <StackedBarHint /> : null}
+      {hasFieldSuggestions ? (
+        <datalist id={fieldListId}>
+          {fields.map((f) => (
+            <option key={f.field} value={f.field} />
+          ))}
+        </datalist>
+      ) : null}
+      <ChartSeriesList value={value} onChange={onChange} fieldListId={hasFieldSuggestions ? fieldListId : undefined} />
+    </div>
+  );
+}
+
+function StackedBarHint() {
+  return (
+    <div
+      className="flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800"
+      data-testid="chart-stacked-bar-hint"
+    >
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>Stacked bar combines multiple series per category. Add another series, or pick Bar.</span>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartSeriesList.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartSeriesList.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+import { ChartSeriesRow } from "./ChartSeriesRow";
+import type { ChartPanelContent } from "./panelTypes";
+import type { WidgetChartSeries } from "./widget/types";
+
+export function ChartSeriesList({
+  value,
+  onChange,
+  fieldListId,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+  fieldListId: string | undefined;
+}) {
+  const updateSeries = (idx: number, patch: Partial<WidgetChartSeries>) => {
+    const series = value.render.series.map((s, i) => (i === idx ? { ...s, ...patch } : s));
+    onChange({ ...value, render: { ...value.render, series } });
+  };
+  const addSeries = () => {
+    onChange({
+      ...value,
+      render: { ...value.render, series: [...value.render.series, { field: "", label: "" }] },
+    });
+  };
+  const removeSeries = (idx: number) => {
+    onChange({ ...value, render: { ...value.render, series: value.render.series.filter((_, i) => i !== idx) } });
+  };
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs font-medium text-slate-600">Series</Label>
+        <Button type="button" size="sm" variant="outline" onClick={addSeries} data-testid="chart-add-series">
+          Add series
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {value.render.series.map((s, idx) => (
+          <ChartSeriesRow
+            key={idx}
+            index={idx}
+            series={s}
+            fieldListId={fieldListId}
+            onChange={(patch) => updateSeries(idx, patch)}
+            onRemove={() => removeSeries(idx)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartSeriesRow.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartSeriesRow.tsx
@@ -1,0 +1,88 @@
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { CHART_SERIES_FORMATS } from "./chartPanelFormConstants";
+import type { WidgetChartSeries, WidgetColumnFormat } from "./widget/types";
+
+export function ChartSeriesRow({
+  index,
+  series,
+  fieldListId,
+  onChange,
+  onRemove,
+}: {
+  index: number;
+  series: WidgetChartSeries;
+  fieldListId: string | undefined;
+  onChange: (patch: Partial<WidgetChartSeries>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="space-y-2 rounded border border-slate-200 p-2">
+      <div className="grid grid-cols-12 items-center gap-2">
+        <Input
+          list={fieldListId}
+          className="col-span-5 h-8"
+          value={series.field ?? ""}
+          onChange={(e) => onChange({ field: e.target.value || undefined })}
+          placeholder="field (blank = count)"
+          aria-label={`Series ${index + 1} field`}
+        />
+        <Input
+          className="col-span-5 h-8"
+          value={series.label ?? ""}
+          onChange={(e) => onChange({ label: e.target.value || undefined })}
+          placeholder="label"
+          aria-label={`Series ${index + 1} label`}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="col-span-2 h-8 w-8 text-slate-400 hover:text-red-600"
+          onClick={onRemove}
+          aria-label={`Remove series ${index + 1}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="grid grid-cols-12 items-center gap-2">
+        <div className="col-span-4">
+          <Select
+            value={series.format ?? "__none__"}
+            onValueChange={(v) => onChange({ format: v === "__none__" ? undefined : (v as WidgetColumnFormat) })}
+          >
+            <SelectTrigger className="h-8 w-full" aria-label={`Series ${index + 1} format`}>
+              <SelectValue placeholder="Format" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__none__">Default</SelectItem>
+              {CHART_SERIES_FORMATS.map((f) => (
+                <SelectItem key={f} value={f}>
+                  {f}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Input
+          className="col-span-4 h-8"
+          value={series.prefix ?? ""}
+          onChange={(e) => onChange({ prefix: e.target.value || undefined })}
+          placeholder="prefix (e.g. $)"
+          aria-label={`Series ${index + 1} prefix`}
+        />
+        <Input
+          className="col-span-4 h-8"
+          value={series.suffix ?? ""}
+          onChange={(e) => onChange({ suffix: e.target.value || undefined })}
+          placeholder="suffix (e.g. MWh)"
+          aria-label={`Series ${index + 1} suffix`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/ChartTopControls.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartTopControls.tsx
@@ -1,0 +1,68 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { CHART_KIND_LABELS, CHART_KINDS, CHART_LEGEND_MODE_LABELS } from "./chartPanelFormConstants";
+import type { ChartPanelContent } from "./panelTypes";
+import { WIDGET_CHART_LEGEND_MODES, type WidgetChartKind, type WidgetChartLegendMode } from "./widget/types";
+
+export function ChartTopControls({
+  value,
+  onChange,
+  fieldListId,
+}: {
+  value: ChartPanelContent;
+  onChange: (next: ChartPanelContent) => void;
+  fieldListId: string | undefined;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Chart type</Label>
+        <Select
+          value={value.render.type}
+          onValueChange={(v) => onChange({ ...value, render: { ...value.render, type: v as WidgetChartKind } })}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CHART_KINDS.map((k) => (
+              <SelectItem key={k} value={k}>
+                {CHART_KIND_LABELS[k]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">X-axis field</Label>
+        <Input
+          list={fieldListId}
+          value={value.render.xField}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, xField: e.target.value } })}
+          placeholder="e.g. status"
+          data-testid="chart-x-field"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Legend</Label>
+        <Select
+          value={value.render.legend ?? "auto"}
+          onValueChange={(v) => onChange({ ...value, render: { ...value.render, legend: v as WidgetChartLegendMode } })}
+        >
+          <SelectTrigger className="w-full" data-testid="chart-legend-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {WIDGET_CHART_LEGEND_MODES.map((m) => (
+              <SelectItem key={m} value={m}>
+                {CHART_LEGEND_MODE_LABELS[m]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/DataSourceForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DataSourceForm.tsx
@@ -1,9 +1,10 @@
 import { useDashboardContext } from "./DashboardContext";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 import type { ChartPanelDataSource } from "./panelTypes";
+import { DataSourceExecutionsFields, DataSourceMemoryFields, DataSourceRunsFields } from "./dataSourceFormFields";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
 
 interface DataSourceFormProps {
   value: ChartPanelDataSource;
@@ -20,6 +21,11 @@ interface DataSourceFormProps {
 export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormProps) {
   const ctx = useDashboardContext();
   const nodes = ctx?.nodes ?? [];
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace = value.kind === "memory" ? value.namespace : undefined;
+  const { namespaces, fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const namespaceListId = canvasId ? `data-source-namespaces-${canvasId}` : undefined;
+  const fieldPathListId = memoryNamespace ? `data-source-field-paths-${memoryNamespace}` : undefined;
 
   const setKind = (kind: "memory" | "executions" | "runs") => {
     if (kind === "memory") {
@@ -48,86 +54,18 @@ export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormPro
       </div>
 
       {value.kind === "runs" ? (
-        hideLimit ? null : (
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Limit</Label>
-            <Input
-              type="number"
-              min={1}
-              value={value.limit ?? ""}
-              onChange={(e) =>
-                onChange({
-                  ...value,
-                  limit: e.target.value === "" ? undefined : Number(e.target.value),
-                })
-              }
-              placeholder="100"
-            />
-          </div>
-        )
+        <DataSourceRunsFields value={value} hideLimit={hideLimit} onChange={onChange} />
       ) : value.kind === "executions" ? (
-        <>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Node (optional)</Label>
-            <Select
-              value={value.node ?? "__all__"}
-              onValueChange={(v) =>
-                onChange({
-                  ...value,
-                  node: v === "__all__" ? undefined : v,
-                })
-              }
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="All nodes" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">All nodes</SelectItem>
-                {nodes.map((n) => (
-                  <SelectItem key={n.id} value={n.name || n.id || ""}>
-                    {n.name || n.id}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {hideLimit ? null : (
-            <div className="space-y-1.5">
-              <Label className="text-xs font-medium text-slate-600">Limit</Label>
-              <Input
-                type="number"
-                min={1}
-                value={value.limit ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    ...value,
-                    limit: e.target.value === "" ? undefined : Number(e.target.value),
-                  })
-                }
-                placeholder="50"
-              />
-            </div>
-          )}
-        </>
+        <DataSourceExecutionsFields value={value} hideLimit={hideLimit} nodes={nodes} onChange={onChange} />
       ) : (
-        <>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Namespace</Label>
-            <Input
-              value={value.namespace}
-              onChange={(e) => onChange({ ...value, namespace: e.target.value })}
-              placeholder="e.g. deployments"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Field path (optional)</Label>
-            <Input
-              value={value.fieldPath ?? ""}
-              onChange={(e) => onChange({ ...value, fieldPath: e.target.value || undefined })}
-              placeholder="e.g. items"
-            />
-          </div>
-        </>
+        <DataSourceMemoryFields
+          value={value}
+          namespaces={namespaces}
+          fields={fields}
+          namespaceListId={namespaceListId}
+          fieldPathListId={fieldPathListId}
+          onChange={onChange}
+        />
       )}
     </div>
   );

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
@@ -1,22 +1,21 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
-import { DataSourceForm } from "./DataSourceForm";
+import { useCanvasMemoryEntries } from "@/hooks/useCanvasData";
+
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
-import type { NumberPanelContent } from "./panelTypes";
+import { NumberPanelForm } from "./NumberPanelForm";
+import {
+  isCompositeMemoryDataSource,
+  type CompositeMemoryNumberDataSource,
+  type NumberPanelContent,
+} from "./panelTypes";
 import { useWidgetData } from "./widget/useWidgetData";
 import { WidgetNumber } from "./widget/WidgetNumber";
-import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
-
-const AGGREGATIONS: WidgetNumberAggregation[] = ["count", "sum", "avg", "min", "max", "first", "last"];
-const NUMBER_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];
 
 interface NumberPanelCardProps {
   panel: DashboardPanel;
@@ -57,116 +56,47 @@ export function NumberPanelCard({ panel, readOnly, onDelete, onChange }: NumberP
 function NumberPanelBody({ content }: { content: NumberPanelContent }) {
   const ctx = useDashboardContext();
   if (!ctx?.canvasId) return <PanelError message="Loading canvas…" />;
-  return <NumberPanelDataBound content={content} canvasId={ctx.canvasId} />;
+  const dataSource = content.dataSource;
+  if (isCompositeMemoryDataSource(dataSource)) {
+    return <CompositeNumberPanelDataBound content={content} dataSource={dataSource} canvasId={ctx.canvasId} />;
+  }
+  return <NumberPanelDataBound content={content} dataSource={dataSource} canvasId={ctx.canvasId} />;
 }
 
-function NumberPanelDataBound({ content, canvasId }: { content: NumberPanelContent; canvasId: string }) {
-  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, content.dataSource);
+function NumberPanelDataBound({
+  content,
+  dataSource,
+  canvasId,
+}: {
+  content: NumberPanelContent;
+  dataSource: Exclude<NumberPanelContent["dataSource"], CompositeMemoryNumberDataSource>;
+  canvasId: string;
+}) {
+  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, dataSource);
   if (error) return <PanelError message={error} />;
   return <WidgetNumber render={content.render} rows={rows} isLoading={isLoading} totalCount={totalCount} />;
 }
 
-function NumberPanelForm({
-  value,
-  onChange,
+function CompositeNumberPanelDataBound({
+  content,
+  dataSource,
+  canvasId,
 }: {
-  value: NumberPanelContent;
-  onChange: (next: NumberPanelContent) => void;
+  content: NumberPanelContent;
+  dataSource: CompositeMemoryNumberDataSource;
+  canvasId: string;
 }) {
-  const aggregationNeedsField = value.render.aggregation !== "count";
-
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
-        <Input
-          value={value.title ?? ""}
-          onChange={(e) => onChange({ ...value, title: e.target.value })}
-          placeholder="Defaults to panel id"
-        />
-      </div>
-      <DataSourceForm value={value.dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Aggregation</Label>
-          <Select
-            value={value.render.aggregation}
-            onValueChange={(v) =>
-              onChange({ ...value, render: { ...value.render, aggregation: v as WidgetNumberAggregation } })
-            }
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {AGGREGATIONS.map((a) => (
-                <SelectItem key={a} value={a}>
-                  {a}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        {aggregationNeedsField ? (
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-slate-600">Field</Label>
-            <Input
-              value={value.render.field ?? ""}
-              onChange={(e) => onChange({ ...value, render: { ...value.render, field: e.target.value } })}
-              placeholder="e.g. durationMs"
-            />
-          </div>
-        ) : null}
-      </div>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Format</Label>
-          <Select
-            value={value.render.format ?? "__none__"}
-            onValueChange={(v) =>
-              onChange({
-                ...value,
-                render: { ...value.render, format: v === "__none__" ? undefined : (v as WidgetColumnFormat) },
-              })
-            }
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Default" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">Default</SelectItem>
-              {NUMBER_FORMATS.map((f) => (
-                <SelectItem key={f} value={f}>
-                  {f}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Label (optional)</Label>
-          <Input
-            value={value.render.label ?? ""}
-            onChange={(e) => onChange({ ...value, render: { ...value.render, label: e.target.value || undefined } })}
-            placeholder="e.g. Total duration"
-          />
-        </div>
-      </div>
-      <div className="space-y-1.5">
-        <Label className="text-xs font-medium text-slate-600">Sparkline field (optional)</Label>
-        <Input
-          value={value.render.sparklineField ?? ""}
-          onChange={(e) =>
-            onChange({
-              ...value,
-              render: { ...value.render, sparklineField: e.target.value || undefined },
-            })
-          }
-          placeholder="e.g. createdAt"
-        />
-      </div>
-    </div>
+  const memoryQuery = useCanvasMemoryEntries(canvasId, true);
+  const composite = useMemo(
+    () => ({
+      entries: memoryQuery.data ?? [],
+      sources: dataSource.sources,
+      combine: dataSource.combine,
+    }),
+    [memoryQuery.data, dataSource.sources, dataSource.combine],
   );
+  if (memoryQuery.error) return <PanelError message={String(memoryQuery.error)} />;
+  return <WidgetNumber render={content.render} rows={[]} isLoading={memoryQuery.isLoading} composite={composite} />;
 }
 
 function PanelError({ message }: { message: string }) {

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelCompositeSourcesEditor.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelCompositeSourcesEditor.tsx
@@ -1,0 +1,198 @@
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { useDashboardContext } from "./DashboardContext";
+import { NUMBER_PANEL_AGGREGATIONS } from "./numberPanelFormConstants";
+import {
+  WIDGET_NUMBER_COMBINE_OPS,
+  type CompositeMemoryNumberDataSource,
+  type MemoryNumberSource,
+  type NumberPanelContent,
+  type WidgetNumberCombine,
+} from "./panelTypes";
+import type { WidgetNumberAggregation } from "./widget/types";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function NumberPanelCompositeSourcesEditor({
+  value,
+  dataSource,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  dataSource: CompositeMemoryNumberDataSource;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const { namespaces } = useMemoryCatalog(canvasId);
+  const namespaceOptions = namespaces.map((n) => n.namespace);
+  const namespaceListId = namespaceOptions.length > 0 ? `number-source-namespaces-${canvasId ?? ""}` : undefined;
+
+  const updateDataSource = (next: CompositeMemoryNumberDataSource) => {
+    onChange({ ...value, dataSource: next });
+  };
+
+  const updateSource = (idx: number, patch: Partial<MemoryNumberSource>) => {
+    const sources = dataSource.sources.map((source, i) => (i === idx ? { ...source, ...patch } : source));
+    updateDataSource({ ...dataSource, sources });
+  };
+
+  const addSource = () => {
+    updateDataSource({
+      ...dataSource,
+      sources: [...dataSource.sources, { namespace: "", aggregation: "count" }],
+    });
+  };
+
+  const removeSource = (idx: number) => {
+    if (dataSource.sources.length <= 1) return;
+    updateDataSource({ ...dataSource, sources: dataSource.sources.filter((_, i) => i !== idx) });
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-slate-200 bg-slate-50/40 p-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Combine</Label>
+          <Select
+            value={dataSource.combine}
+            onValueChange={(v) => updateDataSource({ ...dataSource, combine: v as WidgetNumberCombine })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WIDGET_NUMBER_COMBINE_OPS.map((op) => (
+                <SelectItem key={op} value={op}>
+                  {op}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label className="text-xs font-medium text-slate-600">Memory sources</Label>
+          <Button type="button" size="sm" variant="outline" onClick={addSource} data-testid="number-add-source">
+            Add source
+          </Button>
+        </div>
+        <p className="text-[11px] text-slate-500">
+          Each source aggregates its own namespace independently; the partials are combined with the operator above.
+        </p>
+        <div className="space-y-2">
+          {dataSource.sources.map((source, idx) => (
+            <MemorySourceRow
+              key={idx}
+              source={source}
+              canvasId={canvasId}
+              sourceRowId={idx}
+              namespaceListId={namespaceListId}
+              onChange={(patch) => updateSource(idx, patch)}
+              onRemove={dataSource.sources.length > 1 ? () => removeSource(idx) : undefined}
+            />
+          ))}
+        </div>
+        {namespaceListId ? (
+          <datalist id={namespaceListId}>
+            {namespaceOptions.map((ns) => (
+              <option key={ns} value={ns} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MemorySourceRow({
+  source,
+  canvasId,
+  sourceRowId,
+  namespaceListId,
+  onChange,
+  onRemove,
+}: {
+  source: MemoryNumberSource;
+  canvasId: string | undefined;
+  sourceRowId: number;
+  namespaceListId: string | undefined;
+  onChange: (patch: Partial<MemoryNumberSource>) => void;
+  onRemove?: () => void;
+}) {
+  const { fields } = useMemoryCatalog(canvasId, source.namespace);
+  const needsField = source.aggregation !== "count";
+  const fieldListId = fields.length > 0 ? `number-source-fields-${canvasId ?? ""}-${sourceRowId}` : undefined;
+
+  return (
+    <div className="space-y-2 rounded-md border border-slate-200 bg-white p-2">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Namespace</Label>
+          <Input
+            list={namespaceListId}
+            value={source.namespace}
+            onChange={(e) => onChange({ namespace: e.target.value })}
+            placeholder="e.g. african-countries"
+            data-testid="number-source-namespace"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Aggregation</Label>
+          <Select
+            value={source.aggregation}
+            onValueChange={(v) =>
+              onChange({
+                aggregation: v as WidgetNumberAggregation,
+                field: v === "count" ? undefined : source.field,
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {NUMBER_PANEL_AGGREGATIONS.map((a) => (
+                <SelectItem key={a} value={a}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      {needsField ? (
+        <div className="space-y-1">
+          <Label className="text-[10px] font-medium uppercase tracking-wide text-slate-500">Field</Label>
+          <Input
+            list={fieldListId}
+            value={source.field ?? ""}
+            onChange={(e) => onChange({ field: e.target.value || undefined })}
+            placeholder="e.g. cost"
+            data-testid="number-source-field"
+          />
+          {fieldListId ? (
+            <datalist id={fieldListId}>
+              {fields.map((f) => (
+                <option key={f.field} value={f.field} />
+              ))}
+            </datalist>
+          ) : null}
+        </div>
+      ) : null}
+      {onRemove ? (
+        <div className="flex justify-end">
+          <Button type="button" size="sm" variant="ghost" onClick={onRemove} data-testid="number-source-remove">
+            <Trash2 className="h-3.5 w-3.5" />
+            <span className="sr-only">Remove source</span>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelForm.tsx
@@ -1,0 +1,206 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { DataSourceForm } from "./DataSourceForm";
+import { useDashboardContext } from "./DashboardContext";
+import { NumberPanelCompositeSourcesEditor } from "./NumberPanelCompositeSourcesEditor";
+import { NumberPanelSourceModeToggle } from "./NumberPanelSourceModeToggle";
+import { NUMBER_PANEL_AGGREGATIONS, NUMBER_PANEL_FORMATS } from "./numberPanelFormConstants";
+import { isCompositeMemoryDataSource, type NumberPanelContent } from "./panelTypes";
+import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
+import { useMemoryCatalog } from "./widget/useMemoryCatalog";
+
+export function NumberPanelForm({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const dataSource = value.dataSource;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Title (optional)</Label>
+        <Input
+          value={value.title ?? ""}
+          onChange={(e) => onChange({ ...value, title: e.target.value })}
+          placeholder="Defaults to panel id"
+        />
+      </div>
+      <NumberPanelSourceModeToggle value={value} onChange={onChange} />
+      {isCompositeMemoryDataSource(dataSource) ? (
+        <NumberPanelCompositeSourcesEditor value={value} dataSource={dataSource} onChange={onChange} />
+      ) : (
+        <>
+          <DataSourceForm value={dataSource} onChange={(ds) => onChange({ ...value, dataSource: ds })} />
+          <SimpleAggregationFields value={value} onChange={onChange} />
+        </>
+      )}
+      <FormatLabelRow value={value} onChange={onChange} />
+      <PrefixSuffixRow value={value} onChange={onChange} />
+      {isCompositeMemoryDataSource(dataSource) ? null : <SparklineField value={value} onChange={onChange} />}
+    </div>
+  );
+}
+
+function SimpleAggregationFields({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const ctx = useDashboardContext();
+  const canvasId = ctx?.canvasId;
+  const memoryNamespace =
+    value.dataSource.kind === "memory" && "namespace" in value.dataSource ? value.dataSource.namespace : undefined;
+  const { fields } = useMemoryCatalog(canvasId, memoryNamespace);
+  const aggregation = value.render.aggregation ?? "count";
+  const aggregationNeedsField = aggregation !== "count";
+  const fieldListId = memoryNamespace ? `number-simple-fields-${memoryNamespace}` : undefined;
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Aggregation</Label>
+        <Select
+          value={aggregation}
+          onValueChange={(v) =>
+            onChange({ ...value, render: { ...value.render, aggregation: v as WidgetNumberAggregation } })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {NUMBER_PANEL_AGGREGATIONS.map((a) => (
+              <SelectItem key={a} value={a}>
+                {a}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {aggregationNeedsField ? (
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Field</Label>
+          <Input
+            list={fields.length > 0 && fieldListId ? fieldListId : undefined}
+            value={value.render.field ?? ""}
+            onChange={(e) => onChange({ ...value, render: { ...value.render, field: e.target.value } })}
+            placeholder="e.g. durationMs"
+            data-testid="number-simple-field"
+          />
+          {fields.length > 0 && fieldListId ? (
+            <datalist id={fieldListId}>
+              {fields.map((f) => (
+                <option key={f.field} value={f.field} />
+              ))}
+            </datalist>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FormatLabelRow({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Format</Label>
+        <Select
+          value={value.render.format ?? "__none__"}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              render: { ...value.render, format: v === "__none__" ? undefined : (v as WidgetColumnFormat) },
+            })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Default" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none__">Default</SelectItem>
+            {NUMBER_PANEL_FORMATS.map((f) => (
+              <SelectItem key={f} value={f}>
+                {f}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Label (optional)</Label>
+        <Input
+          value={value.render.label ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, label: e.target.value || undefined } })}
+          placeholder="e.g. Total duration"
+        />
+      </div>
+    </div>
+  );
+}
+
+function PrefixSuffixRow({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Prefix (optional)</Label>
+        <Input
+          value={value.render.prefix ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, prefix: e.target.value || undefined } })}
+          placeholder="e.g. R$"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Suffix (optional)</Label>
+        <Input
+          value={value.render.suffix ?? ""}
+          onChange={(e) => onChange({ ...value, render: { ...value.render, suffix: e.target.value || undefined } })}
+          placeholder="e.g. MWh"
+        />
+      </div>
+    </div>
+  );
+}
+
+function SparklineField({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Sparkline field (optional)</Label>
+      <Input
+        value={value.render.sparklineField ?? ""}
+        onChange={(e) =>
+          onChange({
+            ...value,
+            render: { ...value.render, sparklineField: e.target.value || undefined },
+          })
+        }
+        placeholder="e.g. createdAt"
+      />
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelSourceModeToggle.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelSourceModeToggle.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+import { isCompositeMemoryDataSource, type MemoryNumberSource, type NumberPanelContent } from "./panelTypes";
+
+export function NumberPanelSourceModeToggle({
+  value,
+  onChange,
+}: {
+  value: NumberPanelContent;
+  onChange: (next: NumberPanelContent) => void;
+}) {
+  const dataSource = value.dataSource;
+  const composite = isCompositeMemoryDataSource(dataSource);
+
+  const switchToComposite = () => {
+    if (isCompositeMemoryDataSource(dataSource)) return;
+    const seed: MemoryNumberSource =
+      dataSource.kind === "memory"
+        ? {
+            namespace: dataSource.namespace || "",
+            aggregation: value.render.aggregation ?? "count",
+            field: value.render.field,
+            fieldPath: dataSource.fieldPath,
+          }
+        : { namespace: "", aggregation: value.render.aggregation ?? "count", field: value.render.field };
+    onChange({
+      ...value,
+      dataSource: { kind: "memory", sources: [seed], combine: "sum" },
+      render: { ...value.render, aggregation: undefined, field: undefined },
+    });
+  };
+
+  const switchToSimple = () => {
+    if (!isCompositeMemoryDataSource(dataSource)) return;
+    const first = dataSource.sources[0];
+    onChange({
+      ...value,
+      dataSource: { kind: "memory", namespace: first?.namespace ?? "", fieldPath: first?.fieldPath },
+      render: { ...value.render, aggregation: first?.aggregation ?? "count", field: first?.field },
+    });
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Source mode</Label>
+      <div className="flex gap-1">
+        <Button
+          type="button"
+          size="sm"
+          variant={composite ? "outline" : "secondary"}
+          onClick={switchToSimple}
+          data-testid="number-mode-simple"
+        >
+          Single source
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={composite ? "secondary" : "outline"}
+          onClick={switchToComposite}
+          data-testid="number-mode-composite"
+        >
+          Multiple memory sources
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/chartPanelFormConstants.ts
+++ b/web_src/src/pages/workflowv2/dashboard/chartPanelFormConstants.ts
@@ -1,0 +1,19 @@
+import type { WidgetChartKind, WidgetChartLegendMode, WidgetColumnFormat } from "./widget/types";
+
+export const CHART_KINDS: WidgetChartKind[] = ["bar", "stacked-bar", "line", "area", "donut"];
+
+export const CHART_KIND_LABELS: Record<WidgetChartKind, string> = {
+  bar: "Bar",
+  "stacked-bar": "Stacked bar",
+  line: "Line",
+  area: "Area",
+  donut: "Donut",
+};
+
+export const CHART_SERIES_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];
+
+export const CHART_LEGEND_MODE_LABELS: Record<WidgetChartLegendMode, string> = {
+  auto: "Auto",
+  show: "Always show",
+  hide: "Hide",
+};

--- a/web_src/src/pages/workflowv2/dashboard/dashboardYaml.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardYaml.spec.ts
@@ -236,6 +236,160 @@ spec:
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("Unsupported apiVersion");
   });
+
+  it("round-trips a number panel with prefix and suffix symbols", () => {
+    const panels = [
+      {
+        id: "spend",
+        type: "number",
+        content: {
+          dataSource: { kind: "memory", namespace: "expenses" },
+          render: {
+            kind: "number",
+            aggregation: "sum",
+            field: "amount",
+            format: "number",
+            prefix: "R$",
+            suffix: " /mo",
+          },
+        },
+      },
+    ];
+    const layout = [{ i: "spend", x: 0, y: 0, w: 6, h: 3 }];
+    const text = dashboardToYaml({ panels, layout });
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.data.spec.panels).toEqual(panels);
+  });
+
+  it("round-trips a composite memory number panel with heterogeneous sources", () => {
+    const panels = [
+      {
+        id: "score",
+        type: "number",
+        content: {
+          dataSource: {
+            kind: "memory",
+            combine: "sum",
+            sources: [
+              { namespace: "a", aggregation: "sum", field: "cost" },
+              { namespace: "b", aggregation: "count" },
+            ],
+          },
+          render: { kind: "number", format: "number", prefix: "R$" },
+        },
+      },
+    ];
+    const layout = [{ i: "score", x: 0, y: 0, w: 4, h: 3 }];
+    const text = dashboardToYaml({ panels, layout });
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.data.spec.panels).toEqual(panels);
+  });
+
+  it("rejects a composite memory number panel when render.aggregation is set", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+          aggregation: sum
+          field: cost
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/render\.aggregation must not be set/);
+  });
+
+  it("rejects a composite memory number panel when only render.field is set", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+          field: cost
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/render\.field must not be set/);
+  });
+
+  it("rejects a composite memory number panel with an unknown combine operator", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: median
+          sources:
+            - namespace: a
+              aggregation: sum
+              field: cost
+        render:
+          kind: number
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/dataSource\.combine must be one of/);
+  });
+
+  it("rejects a composite memory source missing a field for non-count aggregation", () => {
+    const text = `apiVersion: v1
+kind: Console
+metadata: {}
+spec:
+  panels:
+    - id: score
+      type: number
+      content:
+        dataSource:
+          kind: memory
+          combine: sum
+          sources:
+            - namespace: a
+              aggregation: sum
+        render:
+          kind: number
+  layout: []
+`;
+    const result = parseDashboardYaml(text);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/dataSource\.sources\[0\]\.field is required/);
+  });
 });
 
 describe("validateDashboardContent", () => {
@@ -260,7 +414,7 @@ describe("validateDashboardContent", () => {
     ).toContain("non-negative");
   });
 
-  it("accepts a valid dashboard", () => {
+  it("accepts a valid console", () => {
     expect(
       validateDashboardContent(
         [{ id: "p", type: "markdown", content: { body: "ok" } }],

--- a/web_src/src/pages/workflowv2/dashboard/dataSourceFormFields.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/dataSourceFormFields.tsx
@@ -1,0 +1,149 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { SuperplaneComponentsNode } from "@/api-client";
+
+import type { ChartPanelDataSource } from "./panelTypes";
+
+export function DataSourceRunsFields({
+  value,
+  hideLimit,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "runs" }>;
+  hideLimit?: boolean;
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  if (hideLimit) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Limit</Label>
+      <Input
+        type="number"
+        min={1}
+        value={value.limit ?? ""}
+        onChange={(e) =>
+          onChange({
+            ...value,
+            limit: e.target.value === "" ? undefined : Number(e.target.value),
+          })
+        }
+        placeholder="100"
+      />
+    </div>
+  );
+}
+
+export function DataSourceExecutionsFields({
+  value,
+  hideLimit,
+  nodes,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "executions" }>;
+  hideLimit?: boolean;
+  nodes: SuperplaneComponentsNode[];
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Node (optional)</Label>
+        <Select
+          value={value.node ?? "__all__"}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              node: v === "__all__" ? undefined : v,
+            })
+          }
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="All nodes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All nodes</SelectItem>
+            {nodes.map((n) => (
+              <SelectItem key={n.id} value={n.name || n.id || ""}>
+                {n.name || n.id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {hideLimit ? null : (
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-slate-600">Limit</Label>
+          <Input
+            type="number"
+            min={1}
+            value={value.limit ?? ""}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                limit: e.target.value === "" ? undefined : Number(e.target.value),
+              })
+            }
+            placeholder="50"
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export function DataSourceMemoryFields({
+  value,
+  namespaces,
+  fields,
+  namespaceListId,
+  fieldPathListId,
+  onChange,
+}: {
+  value: Extract<ChartPanelDataSource, { kind: "memory" }>;
+  namespaces: { namespace: string }[];
+  fields: { field: string }[];
+  namespaceListId: string | undefined;
+  fieldPathListId: string | undefined;
+  onChange: (next: ChartPanelDataSource) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Namespace</Label>
+        <Input
+          list={namespaces.length > 0 && namespaceListId ? namespaceListId : undefined}
+          value={value.namespace}
+          onChange={(e) => onChange({ ...value, namespace: e.target.value })}
+          placeholder="e.g. deployments"
+          data-testid="data-source-namespace"
+        />
+        {namespaces.length > 0 && namespaceListId ? (
+          <datalist id={namespaceListId}>
+            {namespaces.map((n) => (
+              <option key={n.namespace} value={n.namespace} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium text-slate-600">Field path (optional)</Label>
+        <Input
+          list={fields.length > 0 && fieldPathListId ? fieldPathListId : undefined}
+          value={value.fieldPath ?? ""}
+          onChange={(e) => onChange({ ...value, fieldPath: e.target.value || undefined })}
+          placeholder="e.g. items"
+          data-testid="data-source-field-path"
+        />
+        {fields.length > 0 && fieldPathListId ? (
+          <datalist id={fieldPathListId}>
+            {fields.map((f) => (
+              <option key={f.field} value={f.field} />
+            ))}
+          </datalist>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/numberPanelFormConstants.ts
+++ b/web_src/src/pages/workflowv2/dashboard/numberPanelFormConstants.ts
@@ -1,0 +1,13 @@
+import type { WidgetColumnFormat, WidgetNumberAggregation } from "./widget/types";
+
+export const NUMBER_PANEL_AGGREGATIONS: WidgetNumberAggregation[] = [
+  "count",
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "first",
+  "last",
+];
+
+export const NUMBER_PANEL_FORMATS: WidgetColumnFormat[] = ["text", "number", "percent", "duration"];

--- a/web_src/src/pages/workflowv2/dashboard/panelTypes.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/panelTypes.spec.ts
@@ -157,4 +157,141 @@ describe("validatePanelContent", () => {
       }),
     ).toBeNull();
   });
+
+  it("accepts number panels with prefix and suffix symbols", () => {
+    expect(
+      validatePanelContent("number", {
+        dataSource: { kind: "runs" },
+        render: { kind: "number", aggregation: "count", prefix: "R$", suffix: " MWh" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects non-string prefix on number panels", () => {
+    const error = validatePanelContent("number", {
+      dataSource: { kind: "runs" },
+      render: { kind: "number", aggregation: "count", prefix: 42 },
+    });
+    expect(error).toMatch(/render\.prefix must be a string/);
+  });
+
+  it("accepts composite memory number panels with heterogeneous sources", () => {
+    expect(
+      validatePanelContent("number", {
+        dataSource: {
+          kind: "memory",
+          combine: "sum",
+          sources: [
+            { namespace: "a", aggregation: "sum", field: "cost" },
+            { namespace: "b", aggregation: "count" },
+          ],
+        },
+        render: { kind: "number" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects composite memory panels that also set render.aggregation", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number", aggregation: "sum" },
+    });
+    expect(error).toMatch(/render\.aggregation must not be set/);
+  });
+
+  it("rejects composite memory panels that also set render.field", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number", field: "cost" },
+    });
+    expect(error).toMatch(/render\.field must not be set/);
+  });
+
+  it("rejects composite memory panels with an unknown combine operator", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "median",
+        sources: [{ namespace: "a", aggregation: "sum", field: "cost" }],
+      },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.combine must be one of/);
+  });
+
+  it("rejects composite memory sources missing a field for non-count aggregation", () => {
+    const error = validatePanelContent("number", {
+      dataSource: {
+        kind: "memory",
+        combine: "sum",
+        sources: [{ namespace: "a", aggregation: "sum" }],
+      },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.sources\[0\]\.field is required/);
+  });
+
+  it("rejects composite memory panels with empty sources", () => {
+    const error = validatePanelContent("number", {
+      dataSource: { kind: "memory", combine: "sum", sources: [] },
+      render: { kind: "number" },
+    });
+    expect(error).toMatch(/dataSource\.sources must be a non-empty array/);
+  });
+});
+
+describe("validatePanelContent — chart series and legend", () => {
+  it("accepts chart series with format, prefix, and suffix", () => {
+    expect(
+      validatePanelContent("chart", {
+        dataSource: { kind: "executions" },
+        render: {
+          kind: "chart",
+          type: "bar",
+          xField: "service",
+          series: [{ field: "cost", label: "Cost", format: "number", prefix: "$", suffix: " /mo" }],
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects chart series with a non-string prefix", () => {
+    const error = validatePanelContent("chart", {
+      dataSource: { kind: "executions" },
+      render: {
+        kind: "chart",
+        type: "bar",
+        xField: "service",
+        series: [{ field: "cost", prefix: 42 }],
+      },
+    });
+    expect(error).toMatch(/render\.series\[0\]\.prefix must be a string/);
+  });
+
+  it("accepts chart legend modes", () => {
+    for (const legend of ["auto", "show", "hide"] as const) {
+      expect(
+        validatePanelContent("chart", {
+          dataSource: { kind: "executions" },
+          render: { kind: "chart", type: "bar", xField: "x", series: [{}], legend },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("rejects unknown legend modes", () => {
+    const error = validatePanelContent("chart", {
+      dataSource: { kind: "executions" },
+      render: { kind: "chart", type: "bar", xField: "x", series: [{}], legend: "bogus" },
+    });
+    expect(error).toMatch(/render\.legend must be one of/);
+  });
 });

--- a/web_src/src/pages/workflowv2/dashboard/panelTypes.ts
+++ b/web_src/src/pages/workflowv2/dashboard/panelTypes.ts
@@ -13,13 +13,15 @@
 
 import type {
   WidgetChartRender,
+  WidgetNumberAggregation,
   WidgetNumberRender,
   WidgetRowAction,
   WidgetTableColumn,
   WidgetTableFilter,
   WidgetTableRender,
 } from "./widget/types";
-import { normalizeRowAction, WIDGET_FILTER_OPS } from "./widget/types";
+import { normalizeRowAction, WIDGET_CHART_LEGEND_MODES, WIDGET_FILTER_OPS } from "./widget/types";
+import type { WidgetChartLegendMode } from "./widget/types";
 
 /** All panel kinds the dashboard currently understands. */
 export const PANEL_TYPES = ["markdown", "node", "table", "chart", "number"] as const;
@@ -109,7 +111,36 @@ export type TablePanelDataSource =
   | { kind: "executions"; node?: string; limit?: number }
   | { kind: "runs"; limit?: number };
 export type ChartPanelDataSource = TablePanelDataSource;
-export type NumberPanelDataSource = TablePanelDataSource;
+
+/** How partial aggregates from a composite memory data source are combined into a single value. */
+export type WidgetNumberCombine = "sum" | "min" | "max" | "avg";
+export const WIDGET_NUMBER_COMBINE_OPS: WidgetNumberCombine[] = ["sum", "min", "max", "avg"];
+
+/** One namespace contribution inside a composite memory data source. */
+export interface MemoryNumberSource {
+  namespace: string;
+  aggregation: WidgetNumberAggregation;
+  field?: string;
+  fieldPath?: string;
+}
+
+export type CompositeMemoryNumberDataSource = {
+  kind: "memory";
+  sources: MemoryNumberSource[];
+  combine: WidgetNumberCombine;
+};
+
+/**
+ * Number panels accept the shared table/chart data sources plus a composite
+ * memory variant where each namespace carries its own aggregation and field.
+ */
+export type NumberPanelDataSource = TablePanelDataSource | CompositeMemoryNumberDataSource;
+
+export function isCompositeMemoryDataSource(value: unknown): value is CompositeMemoryNumberDataSource {
+  const obj = asObject(value);
+  if (!obj) return false;
+  return obj.kind === "memory" && Array.isArray(obj.sources);
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Templates — used to seed new panels
@@ -243,6 +274,58 @@ function validateMemoryDataSource(obj: Record<string, unknown>): string | null {
   }
   if (obj.fieldPath != null && typeof obj.fieldPath !== "string") {
     return "dataSource.fieldPath must be a string.";
+  }
+  return null;
+}
+
+/**
+ * Number panels accept either the shared data-source shapes (memory with a
+ * single namespace, executions, runs) or a composite memory variant where
+ * each namespace declares its own aggregation/field and the partials are
+ * merged with a configured combine operator.
+ */
+function validateNumberDataSource(value: unknown): string | null {
+  const obj = asObject(value);
+  if (!obj) return "dataSource must be an object.";
+  if (obj.kind === "memory" && Array.isArray(obj.sources)) {
+    return validateCompositeMemoryDataSource(obj);
+  }
+  return validateDataSource(value);
+}
+
+const ALLOWED_NUMBER_AGGREGATIONS = ["count", "sum", "avg", "min", "max", "first", "last"];
+
+function validateCompositeMemoryDataSource(obj: Record<string, unknown>): string | null {
+  const sources = obj.sources as unknown[];
+  if (sources.length === 0) {
+    return "dataSource.sources must be a non-empty array.";
+  }
+  for (let i = 0; i < sources.length; i += 1) {
+    const sourceError = validateMemoryNumberSource(sources[i], i);
+    if (sourceError) return sourceError;
+  }
+  if (typeof obj.combine !== "string" || !WIDGET_NUMBER_COMBINE_OPS.includes(obj.combine as WidgetNumberCombine)) {
+    return `dataSource.combine must be one of ${WIDGET_NUMBER_COMBINE_OPS.join(", ")}.`;
+  }
+  return null;
+}
+
+function validateMemoryNumberSource(raw: unknown, index: number): string | null {
+  const source = asObject(raw);
+  if (!source) return `dataSource.sources[${index}] must be an object.`;
+  if (typeof source.namespace !== "string" || source.namespace.trim() === "") {
+    return `dataSource.sources[${index}].namespace must be a non-empty string.`;
+  }
+  if (typeof source.aggregation !== "string" || !ALLOWED_NUMBER_AGGREGATIONS.includes(source.aggregation)) {
+    return `dataSource.sources[${index}].aggregation must be one of ${ALLOWED_NUMBER_AGGREGATIONS.join(", ")}.`;
+  }
+  if (source.aggregation !== "count") {
+    if (typeof source.field !== "string" || source.field.trim() === "") {
+      return `dataSource.sources[${index}].field is required when aggregation is "${source.aggregation}".`;
+    }
+  }
+  if (source.fieldPath != null && typeof source.fieldPath !== "string") {
+    return `dataSource.sources[${index}].fieldPath must be a string.`;
   }
   return null;
 }
@@ -402,6 +485,10 @@ function validateChartContent(content: unknown): string | null {
   if (dsError) return dsError;
   const render = asObject(obj.render);
   if (!render) return "render must be an object.";
+  return validateChartRender(render);
+}
+
+function validateChartRender(render: Record<string, unknown>): string | null {
   if (render.kind !== "chart") return 'render.kind must be "chart".';
   const allowedTypes = ["bar", "stacked-bar", "line", "area", "donut"];
   if (typeof render.type !== "string" || !allowedTypes.includes(render.type)) {
@@ -413,17 +500,51 @@ function validateChartContent(content: unknown): string | null {
   if (!Array.isArray(render.series) || render.series.length === 0) {
     return "render.series must be a non-empty array.";
   }
+  for (let i = 0; i < render.series.length; i += 1) {
+    const seriesError = validateChartSeries(render.series[i], i);
+    if (seriesError) return seriesError;
+  }
+  return validateChartLegend(render.legend);
+}
+
+function validateChartLegend(legend: unknown): string | null {
+  if (legend === undefined) return null;
+  if (typeof legend !== "string" || !WIDGET_CHART_LEGEND_MODES.includes(legend as WidgetChartLegendMode)) {
+    return `render.legend must be one of ${WIDGET_CHART_LEGEND_MODES.join(", ")}.`;
+  }
+  return null;
+}
+
+function validateChartSeries(raw: unknown, index: number): string | null {
+  const series = asObject(raw);
+  if (!series) return `render.series[${index}] must be an object.`;
+  for (const key of ["field", "label", "color", "format", "prefix", "suffix"] as const) {
+    if (series[key] !== undefined && series[key] !== null && typeof series[key] !== "string") {
+      return `render.series[${index}].${key} must be a string.`;
+    }
+  }
   return null;
 }
 
 function validateNumberContent(content: unknown): string | null {
   const obj = asObject(content);
   if (!obj) return "content must be an object.";
-  const dsError = validateDataSource(obj.dataSource);
+  const dsError = validateNumberDataSource(obj.dataSource);
   if (dsError) return dsError;
   const render = asObject(obj.render);
   if (!render) return "render must be an object.";
   if (render.kind !== "number") return 'render.kind must be "number".';
+  const symbolError = validateNumberRenderSymbols(render);
+  if (symbolError) return symbolError;
+  if (isCompositeMemoryDataSource(obj.dataSource)) {
+    if (render.aggregation !== undefined) {
+      return "render.aggregation must not be set when dataSource.sources is used (each source defines its own aggregation).";
+    }
+    if (render.field !== undefined) {
+      return "render.field must not be set when dataSource.sources is used (each source defines its own field).";
+    }
+    return null;
+  }
   const allowedAggregations = ["count", "sum", "avg", "min", "max", "first", "last"];
   if (typeof render.aggregation !== "string" || !allowedAggregations.includes(render.aggregation)) {
     return `render.aggregation must be one of ${allowedAggregations.join(", ")}.`;
@@ -432,6 +553,16 @@ function validateNumberContent(content: unknown): string | null {
     if (typeof render.field !== "string" || render.field.trim() === "") {
       return `render.field is required when aggregation is "${render.aggregation}".`;
     }
+  }
+  return null;
+}
+
+function validateNumberRenderSymbols(render: Record<string, unknown>): string | null {
+  if (render.prefix !== undefined && render.prefix !== null && typeof render.prefix !== "string") {
+    return "render.prefix must be a string.";
+  }
+  if (render.suffix !== undefined && render.suffix !== null && typeof render.suffix !== "string") {
+    return "render.suffix must be a string.";
   }
   return null;
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.spec.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.spec.tsx
@@ -1,0 +1,191 @@
+import type { ReactNode } from "react";
+import type * as Recharts from "recharts";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("recharts", async () => {
+  const actual = (await vi.importActual("recharts")) as typeof Recharts;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div data-testid="responsive-container" style={{ width: 600, height: 400 }}>
+        <actual.ResponsiveContainer width={600} height={400}>
+          {children as never}
+        </actual.ResponsiveContainer>
+      </div>
+    ),
+  };
+});
+
+import { WidgetChart } from "./WidgetChart";
+import type { WidgetChartRender } from "./types";
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+const ROWS = [
+  { service: "ec2", cost: 1200, errors: 4 },
+  { service: "s3", cost: 350, errors: 1 },
+  { service: "rds", cost: 600, errors: 2 },
+];
+
+function renderChart(render_: WidgetChartRender, options: { rows?: unknown[]; isLoading?: boolean } = {}) {
+  return render(<WidgetChart render={render_} rows={options.rows ?? ROWS} isLoading={options.isLoading ?? false} />);
+}
+
+describe("WidgetChart states", () => {
+  it("renders a loading spinner when isLoading", () => {
+    const { container } = renderChart(
+      { kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] },
+      { isLoading: true },
+    );
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+    expect(screen.queryByTestId("widget-chart")).toBeNull();
+  });
+
+  it("renders an empty-state message when there are no rows", () => {
+    renderChart(
+      { kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] },
+      { rows: [] },
+    );
+    expect(screen.getByTestId("widget-chart-empty")).toBeInTheDocument();
+  });
+
+  it("renders the chart container when rows are present", () => {
+    renderChart({ kind: "chart", type: "bar", xField: "service", series: [{ field: "cost", label: "Cost" }] });
+    expect(screen.getByTestId("widget-chart")).toBeInTheDocument();
+  });
+
+  it("renders the optional chart title", () => {
+    renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+      title: "AWS spend",
+    });
+    expect(screen.getByText("AWS spend")).toBeInTheDocument();
+  });
+});
+
+describe("WidgetChart bar variants", () => {
+  it("uses a shared stackId when type is stacked-bar", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "stacked-bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    const layers = container.querySelectorAll(".recharts-bar");
+    expect(layers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders multiple bar series side-by-side for grouped bars", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    const layers = container.querySelectorAll(".recharts-bar");
+    expect(layers.length).toBe(2);
+  });
+});
+
+describe("WidgetChart legend visibility", () => {
+  it("hides the legend by default for a single-series cartesian chart", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).toBeNull();
+  });
+
+  it("shows the legend automatically when there are 2+ series", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+
+  it("renders a legend even for a single-series chart when legend is forced to show", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+      legend: "show",
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+
+  it("hides the legend when legend is set to hide", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "bar",
+      xField: "service",
+      series: [
+        { field: "cost", label: "Cost" },
+        { field: "errors", label: "Errors" },
+      ],
+      legend: "hide",
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).toBeNull();
+  });
+});
+
+describe("WidgetChart donut", () => {
+  it("renders a pie when type is donut", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "donut",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost", prefix: "$" }],
+    });
+    expect(container.querySelector(".recharts-pie")).not.toBeNull();
+  });
+
+  it("renders an empty-state message when every slice value is zero", () => {
+    renderChart(
+      {
+        kind: "chart",
+        type: "donut",
+        xField: "service",
+        series: [{ field: "cost", label: "Cost" }],
+      },
+      { rows: [{ service: "a", cost: 0 }] },
+    );
+    expect(screen.getByText("No data")).toBeInTheDocument();
+  });
+
+  it("shows a legend by default", () => {
+    const { container } = renderChart({
+      kind: "chart",
+      type: "donut",
+      xField: "service",
+      series: [{ field: "cost", label: "Cost" }],
+    });
+    expect(container.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetChart.tsx
@@ -1,8 +1,32 @@
-import { useMemo } from "react";
+import { useMemo, type CSSProperties } from "react";
 import { Loader2 } from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 
 import { applyFilters, buildChartData } from "./widgetData";
-import type { WidgetChartRender } from "./types";
+import { formatPercentOfTotal, formatSeriesValue } from "./chartFormat";
+import type { WidgetChartLegendMode, WidgetChartRender, WidgetChartSeries } from "./types";
 
 interface WidgetChartProps {
   render: WidgetChartRender;
@@ -11,32 +35,36 @@ interface WidgetChartProps {
 }
 
 const DEFAULT_PALETTE = ["#0284c7", "#16a34a", "#dc2626", "#a855f7", "#f59e0b", "#0ea5e9"];
+const STACK_ID = "stack";
+
+interface ChartSeries extends WidgetChartSeries {
+  key: string;
+  color: string;
+}
 
 /**
- * Compact SVG-based chart renderer used by Dashboard widget blocks.
- *
- * Kept dependency-free on purpose: the canvas already ships Recharts but that
- * library expects to live inside its own ResponsiveContainer, which makes
- * reliable embedding inside a dashboard cell tricky. The chart shapes covered
- * here (bar, stacked-bar, line, area, donut) all map cleanly onto a small set
- * of SVG primitives so the renderer stays predictable.
+ * Dashboard chart renderer powered by Recharts via the project's shadcn
+ * `ChartContainer`. Supports bar (grouped/stacked), line, area, and donut
+ * charts, with hover tooltips and a configurable legend. Each series can
+ * declare a `format` / `prefix` / `suffix` so currencies, durations, or
+ * percentages render consistently in the tooltip.
  */
 export function WidgetChart({ render, rows, isLoading }: WidgetChartProps) {
   const filtered = useMemo(() => applyFilters(rows, render.filters), [rows, render.filters]);
-  const seriesKeys = useMemo(
+  const series = useMemo<ChartSeries[]>(
     () =>
       render.series.map((s, idx) => ({
+        ...s,
         key: s.label ?? s.field ?? `series-${idx}`,
-        field: s.field,
         color: s.color ?? DEFAULT_PALETTE[idx % DEFAULT_PALETTE.length],
       })),
     [render.series],
   );
   const data = useMemo(() => {
-    const built = buildChartData(filtered, render.xField, seriesKeys);
+    const built = buildChartData(filtered, render.xField, series);
     if (render.limit) return built.slice(0, render.limit);
     return built;
-  }, [filtered, render.xField, render.limit, seriesKeys]);
+  }, [filtered, render.xField, render.limit, series]);
 
   if (isLoading) {
     return (
@@ -54,222 +82,229 @@ export function WidgetChart({ render, rows, isLoading }: WidgetChartProps) {
   }
 
   return (
-    <div className="flex h-full flex-col gap-2 p-3" data-testid="widget-chart">
+    <div className="flex h-full min-h-0 flex-col gap-1 p-3" data-testid="widget-chart">
       {render.title ? <div className="text-xs font-medium text-slate-600">{render.title}</div> : null}
-      <div className="min-h-[120px] flex-1">
+      <div className="min-h-0 flex-1">
         {render.type === "donut" ? (
-          <DonutChart data={data} series={seriesKeys[0]} />
+          <DonutChartView data={data} series={series[0]} legendMode={render.legend ?? "auto"} />
         ) : (
-          <CartesianChart type={render.type} data={data} series={seriesKeys} />
+          <CartesianChartView type={render.type} data={data} series={series} legendMode={render.legend ?? "auto"} />
         )}
       </div>
-      <Legend series={seriesKeys} />
     </div>
   );
 }
 
-interface SeriesKey {
-  key: string;
-  field?: string;
-  color: string;
-}
+const CHART_MARGIN = { top: 8, right: 8, left: 0, bottom: 0 } as const;
+// Recharts wraps the tooltip in an absolutely positioned div with a default
+// `transform 400ms ease` transition. That transition makes the tooltip slide
+// in from the chart origin (top-left) the first time it appears, which feels
+// confusing. We disable the wrapper transition and add a quick fade-in on the
+// content so the tooltip appears in place.
+const TOOLTIP_WRAPPER_STYLE: CSSProperties = { transition: "none" };
+const TOOLTIP_CONTENT_CLASS = "animate-in fade-in duration-150";
 
-function CartesianChart({
+function CartesianChartView({
   type,
   data,
   series,
+  legendMode,
 }: {
-  type: WidgetChartRender["type"];
+  type: Exclude<WidgetChartRender["type"], "donut">;
   data: Array<Record<string, unknown>>;
-  series: SeriesKey[];
+  series: ChartSeries[];
+  legendMode: WidgetChartLegendMode;
 }) {
-  const width = 320;
-  const height = 160;
-  const padding = { top: 8, right: 8, bottom: 24, left: 32 };
-  const innerW = width - padding.left - padding.right;
-  const innerH = height - padding.top - padding.bottom;
-
-  const values = data.flatMap((row) => series.map((s) => toNumber(row[s.key])));
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const config: ChartConfig = {};
+    for (const s of series) {
+      config[s.key] = { label: s.label ?? s.field ?? s.key, color: s.color };
+    }
+    return config;
+  }, [series]);
+  const seriesByKey = useMemo(() => new Map(series.map((s) => [s.key, s])), [series]);
+  const showLegend = legendMode === "show" || (legendMode === "auto" && series.length > 1);
   const stacked = type === "stacked-bar";
-  const stackTotals = stacked
-    ? data.map((row) => series.reduce((acc, s) => acc + Math.max(0, toNumber(row[s.key]) ?? 0), 0))
-    : null;
-  const max = stacked
-    ? Math.max(...(stackTotals ?? [0]), 0)
-    : Math.max(0, ...values.filter((v): v is number => v != null));
-  const safeMax = max === 0 ? 1 : max;
 
-  const slotW = innerW / data.length;
-  const groupGap = 0.2 * slotW;
+  const sharedAxes = <CartesianFrame stacked={stacked || type === "bar"} seriesByKey={seriesByKey} />;
+  const legend = showLegend ? <ChartLegend content={<ChartLegendContent />} verticalAlign="bottom" /> : null;
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} className="h-full w-full" role="img" aria-label="chart">
-      <ChartAxes padding={padding} innerW={innerW} innerH={innerH} />
-      {data.map((row, i) => {
-        const x = padding.left + slotW * i + groupGap / 2;
-        const xLabel = padding.left + slotW * (i + 0.5);
-        if (type === "bar" || type === "stacked-bar") {
-          const barAreaW = slotW - groupGap;
-          if (type === "stacked-bar") {
-            let cumulative = 0;
-            return (
-              <g key={i}>
-                {series.map((s) => {
-                  const v = Math.max(0, toNumber(row[s.key]) ?? 0);
-                  const h = (v / safeMax) * innerH;
-                  const y = padding.top + innerH - cumulative - h;
-                  cumulative += h;
-                  return <rect key={s.key} x={x} y={y} width={barAreaW} height={h} fill={s.color} />;
-                })}
-                <text x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-                  {String(row.x ?? "")}
-                </text>
-              </g>
-            );
-          }
-          const perBarW = barAreaW / series.length;
-          return (
-            <g key={i}>
-              {series.map((s, si) => {
-                const v = toNumber(row[s.key]) ?? 0;
-                const h = (Math.max(0, v) / safeMax) * innerH;
-                const y = padding.top + innerH - h;
-                return (
-                  <rect
-                    key={s.key}
-                    x={x + si * perBarW}
-                    y={y}
-                    width={Math.max(0, perBarW - 1)}
-                    height={h}
-                    fill={s.color}
-                  />
-                );
-              })}
-              <text x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-                {String(row.x ?? "")}
-              </text>
-            </g>
-          );
-        }
-        // line/area: handled below as polylines
-        return (
-          <text key={`label-${i}`} x={xLabel} y={height - 6} textAnchor="middle" fontSize={9} fill="#64748b">
-            {String(row.x ?? "")}
-          </text>
-        );
-      })}
-      {(type === "line" || type === "area") &&
-        series.map((s) => {
-          const points = data.map((row, i) => {
-            const v = toNumber(row[s.key]) ?? 0;
-            const x = padding.left + slotW * (i + 0.5);
-            const y = padding.top + innerH - (Math.max(0, v) / safeMax) * innerH;
-            return `${x.toFixed(1)},${y.toFixed(1)}`;
-          });
-          const linePath = points.join(" ");
-          if (type === "area") {
-            const baseY = padding.top + innerH;
-            const firstX = padding.left + slotW * 0.5;
-            const lastX = padding.left + slotW * (data.length - 0.5);
-            const areaPath = `${firstX},${baseY} ${linePath} ${lastX},${baseY}`;
-            return (
-              <g key={s.key}>
-                <polygon points={areaPath} fill={s.color} fillOpacity={0.18} />
-                <polyline points={linePath} fill="none" stroke={s.color} strokeWidth={1.5} />
-              </g>
-            );
-          }
-          return <polyline key={s.key} points={linePath} fill="none" stroke={s.color} strokeWidth={1.5} />;
-        })}
-    </svg>
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
+      {type === "area" ? (
+        <AreaChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Area
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={s.color}
+              fill={s.color}
+              fillOpacity={0.2}
+              strokeWidth={2}
+            />
+          ))}
+        </AreaChart>
+      ) : type === "line" ? (
+        <LineChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Line
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              stroke={s.color}
+              strokeWidth={2}
+              dot={{ r: 2.5, fill: s.color }}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      ) : (
+        <BarChart data={data} margin={CHART_MARGIN}>
+          {sharedAxes}
+          {legend}
+          {series.map((s) => (
+            <Bar
+              key={s.key}
+              dataKey={s.key}
+              fill={s.color}
+              stackId={stacked ? STACK_ID : undefined}
+              radius={stacked ? 0 : [3, 3, 0, 0]}
+            />
+          ))}
+        </BarChart>
+      )}
+    </ChartContainer>
   );
 }
 
-function ChartAxes({
-  padding,
-  innerW,
-  innerH,
-}: {
-  padding: { top: number; right: number; bottom: number; left: number };
-  innerW: number;
-  innerH: number;
-}) {
+function CartesianFrame({ stacked, seriesByKey }: { stacked: boolean; seriesByKey: Map<string, ChartSeries> }) {
+  const tooltipFormatter = (value: unknown, name: unknown) => {
+    const key = String(name ?? "");
+    const s = seriesByKey.get(key);
+    const label = s?.label ?? s?.field ?? key;
+    const formatted = formatSeriesValue(value, { format: s?.format, prefix: s?.prefix, suffix: s?.suffix });
+    return (
+      <div className="flex w-full items-center justify-between gap-3">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-mono font-medium text-foreground tabular-nums">{formatted}</span>
+      </div>
+    );
+  };
   return (
     <>
-      <line
-        x1={padding.left}
-        x2={padding.left}
-        y1={padding.top}
-        y2={padding.top + innerH}
-        stroke="#cbd5e1"
-        strokeWidth={1}
+      <CartesianGrid vertical={false} strokeDasharray="3 3" />
+      <XAxis
+        dataKey="x"
+        tickLine={false}
+        axisLine={false}
+        fontSize={11}
+        interval="preserveStartEnd"
+        minTickGap={16}
+        tickFormatter={(v: unknown) => String(v ?? "")}
       />
-      <line
-        x1={padding.left}
-        x2={padding.left + innerW}
-        y1={padding.top + innerH}
-        y2={padding.top + innerH}
-        stroke="#cbd5e1"
-        strokeWidth={1}
+      <YAxis tickLine={false} axisLine={false} fontSize={11} width={36} tickFormatter={yTickFormatter} />
+      <ChartTooltip
+        cursor={stacked ? { fill: "rgba(148, 163, 184, 0.12)" } : true}
+        wrapperStyle={TOOLTIP_WRAPPER_STYLE}
+        content={<ChartTooltipContent formatter={tooltipFormatter} indicator="dot" className={TOOLTIP_CONTENT_CLASS} />}
       />
     </>
   );
 }
 
-function DonutChart({ data, series }: { data: Array<Record<string, unknown>>; series: SeriesKey | undefined }) {
+function yTickFormatter(value: number) {
+  if (!Number.isFinite(value)) return String(value);
+  if (Math.abs(value) >= 1000) return value.toLocaleString();
+  return String(value);
+}
+
+function DonutChartView({
+  data,
+  series,
+  legendMode,
+}: {
+  data: Array<Record<string, unknown>>;
+  series: ChartSeries | undefined;
+  legendMode: WidgetChartLegendMode;
+}) {
+  const seriesKey = series?.key ?? "";
+  const sliceData = useMemo(() => {
+    if (!seriesKey) return [];
+    return data.map((row, idx) => ({
+      x: String(row.x ?? ""),
+      value: Number(row[seriesKey]) || 0,
+      color: DEFAULT_PALETTE[idx % DEFAULT_PALETTE.length],
+    }));
+  }, [data, seriesKey]);
+
+  const total = useMemo(() => sliceData.reduce((acc, slice) => acc + slice.value, 0), [sliceData]);
+
+  const chartConfig = useMemo<ChartConfig>(() => {
+    const config: ChartConfig = {};
+    for (const slice of sliceData) {
+      config[slice.x || "(empty)"] = { label: slice.x || "(empty)", color: slice.color };
+    }
+    return config;
+  }, [sliceData]);
+
   if (!series) return null;
-  const radius = 56;
-  const width = radius * 2 + 24;
-  const height = radius * 2 + 24;
-  const cx = width / 2;
-  const cy = height / 2;
-  const total = data.reduce((acc, row) => acc + (toNumber(row[series.key]) ?? 0), 0);
-  if (total === 0) return <div className="p-4 text-center text-xs text-slate-500">No data</div>;
-  let cumulative = 0;
-  return (
-    <svg viewBox={`0 0 ${width} ${height}`} className="mx-auto h-full" role="img" aria-label="donut">
-      {data.map((row, i) => {
-        const value = toNumber(row[series.key]) ?? 0;
-        if (value === 0) return null;
-        const start = (cumulative / total) * Math.PI * 2;
-        cumulative += value;
-        const end = (cumulative / total) * Math.PI * 2;
-        const largeArc = end - start > Math.PI ? 1 : 0;
-        const x1 = cx + radius * Math.sin(start);
-        const y1 = cy - radius * Math.cos(start);
-        const x2 = cx + radius * Math.sin(end);
-        const y2 = cy - radius * Math.cos(end);
-        const color = DEFAULT_PALETTE[i % DEFAULT_PALETTE.length];
-        return (
-          <path
-            key={i}
-            d={`M ${cx} ${cy} L ${x1.toFixed(1)} ${y1.toFixed(1)} A ${radius} ${radius} 0 ${largeArc} 1 ${x2.toFixed(1)} ${y2.toFixed(1)} Z`}
-            fill={color}
-            stroke="#fff"
-            strokeWidth={1.5}
-          />
-        );
-      })}
-      <circle cx={cx} cy={cy} r={radius * 0.55} fill="#fff" />
-    </svg>
-  );
-}
+  if (total === 0) {
+    return <div className="p-4 text-center text-xs text-slate-500">No data</div>;
+  }
 
-function Legend({ series }: { series: SeriesKey[] }) {
-  if (series.length <= 1) return null;
-  return (
-    <div className="flex flex-wrap items-center gap-3 text-[11px] text-slate-600">
-      {series.map((s) => (
-        <div key={s.key} className="inline-flex items-center gap-1">
-          <span className="inline-block size-2 rounded-full" style={{ backgroundColor: s.color }} />
-          {s.key}
-        </div>
-      ))}
-    </div>
-  );
-}
+  const showLegend = legendMode !== "hide";
 
-function toNumber(value: unknown): number | null {
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? n : null;
+  const tooltipFormatter = (value: unknown, _name: unknown, item: { payload?: { x?: string } }) => {
+    const sliceName = item.payload?.x ?? String(_name ?? "");
+    const formatted = formatSeriesValue(value, {
+      format: series.format,
+      prefix: series.prefix,
+      suffix: series.suffix,
+    });
+    const pct = formatPercentOfTotal(value, total);
+    return (
+      <div className="flex w-full items-center justify-between gap-3">
+        <span className="text-muted-foreground">{sliceName}</span>
+        <span className="font-mono font-medium text-foreground tabular-nums">
+          {formatted}
+          {pct}
+        </span>
+      </div>
+    );
+  };
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
+      <PieChart>
+        <ChartTooltip
+          wrapperStyle={TOOLTIP_WRAPPER_STYLE}
+          content={
+            <ChartTooltipContent nameKey="x" hideLabel formatter={tooltipFormatter} className={TOOLTIP_CONTENT_CLASS} />
+          }
+        />
+        {showLegend ? <ChartLegend content={<ChartLegendContent nameKey="x" />} verticalAlign="bottom" /> : null}
+        <Pie
+          data={sliceData}
+          dataKey="value"
+          nameKey="x"
+          cx="50%"
+          cy="50%"
+          innerRadius="55%"
+          outerRadius="85%"
+          paddingAngle={1}
+          stroke="#fff"
+          strokeWidth={1.5}
+        >
+          {sliceData.map((slice) => (
+            <Cell key={slice.x} fill={slice.color} />
+          ))}
+        </Pie>
+      </PieChart>
+    </ChartContainer>
+  );
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetNumber.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetNumber.tsx
@@ -1,28 +1,44 @@
 import { useMemo } from "react";
 import { Loader2 } from "lucide-react";
 
-import { applyFilters, aggregateNumber } from "./widgetData";
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { aggregateNumber, aggregateNumberPerSource, applyFilters, combinePartials } from "./widgetData";
 import { formatValue } from "./widgetFormat";
 import { getValueAtPath } from "./fieldPath";
 import type { WidgetNumberRender } from "./types";
+import type { MemoryNumberSource, WidgetNumberCombine } from "../panelTypes";
 
 interface WidgetNumberProps {
   render: WidgetNumberRender;
   rows: unknown[];
   isLoading: boolean;
   totalCount?: number;
+  /** Composite memory mode: aggregate each source independently and combine the partials. */
+  composite?: {
+    entries: CanvasMemoryEntry[];
+    sources: MemoryNumberSource[];
+    combine: WidgetNumberCombine;
+  };
 }
 
-export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumberProps) {
+export function WidgetNumber({ render, rows, isLoading, totalCount, composite }: WidgetNumberProps) {
   const filtered = useMemo(() => applyFilters(rows, render.filters), [rows, render.filters]);
   const value = useMemo(() => {
+    if (composite) {
+      const partials = composite.sources.map((source) =>
+        aggregateNumberPerSource(composite.entries, source, render.filters),
+      );
+      return combinePartials(partials, composite.combine);
+    }
     if (render.aggregation === "count" && !render.filters?.length && totalCount !== undefined) {
       return totalCount;
     }
+    if (!render.aggregation) return null;
     return aggregateNumber(filtered, render.aggregation, render.field);
-  }, [filtered, render.aggregation, render.field, render.filters, totalCount]);
+  }, [composite, filtered, render.aggregation, render.field, render.filters, totalCount]);
   const sparkline = useMemo(() => {
-    if (!render.sparklineField) return null;
+    if (!render.sparklineField || composite) return null;
     return filtered
       .map((row) => {
         const raw = getValueAtPath(row, render.sparklineField!);
@@ -30,7 +46,7 @@ export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumb
         return Number.isFinite(n) ? n : null;
       })
       .filter((n): n is number => n != null);
-  }, [filtered, render.sparklineField]);
+  }, [composite, filtered, render.sparklineField]);
 
   if (isLoading) {
     return (
@@ -40,7 +56,10 @@ export function WidgetNumber({ render, rows, isLoading, totalCount }: WidgetNumb
     );
   }
 
-  const display = value == null ? "—" : formatValue(value, render.format ?? "number");
+  const display =
+    value == null
+      ? "—"
+      : `${render.prefix ?? ""}${formatValue(value, render.format ?? "number")}${render.suffix ?? ""}`;
   return (
     <div className="flex h-full flex-col items-start justify-center gap-1 p-4" data-testid="widget-number">
       {render.label ? (

--- a/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPercentOfTotal, formatSeriesValue } from "./chartFormat";
+
+describe("formatSeriesValue", () => {
+  it("wraps numeric values with prefix and suffix", () => {
+    expect(formatSeriesValue(1234.5, { format: "number", prefix: "$" })).toBe("$1,234.5");
+    expect(formatSeriesValue(42, { suffix: " MWh" })).toBe("42 MWh");
+  });
+
+  it("formats fractions as percentages when format is percent", () => {
+    expect(formatSeriesValue(0.42, { format: "percent" })).toBe("42%");
+  });
+
+  it("uses default number formatting when no format is provided", () => {
+    expect(formatSeriesValue(2500, {})).toBe("2,500");
+  });
+
+  it("renders an em-dash for null or undefined values", () => {
+    expect(formatSeriesValue(null, { prefix: "$" })).toBe("—");
+    expect(formatSeriesValue(undefined, {})).toBe("—");
+  });
+
+  it("falls through to string conversion for non-numeric values", () => {
+    expect(formatSeriesValue("hello", { format: "text" })).toBe("hello");
+  });
+});
+
+describe("formatPercentOfTotal", () => {
+  it("returns a percent suffix for positive totals", () => {
+    expect(formatPercentOfTotal(25, 100)).toBe(" (25%)");
+    expect(formatPercentOfTotal(1, 8)).toBe(" (12.5%)");
+  });
+
+  it("returns an empty string when total is zero or invalid", () => {
+    expect(formatPercentOfTotal(10, 0)).toBe("");
+    expect(formatPercentOfTotal(10, NaN)).toBe("");
+  });
+
+  it("returns an empty string when the value is not numeric", () => {
+    expect(formatPercentOfTotal("not a number", 100)).toBe("");
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/chartFormat.ts
@@ -1,0 +1,30 @@
+import { formatValue } from "./widgetFormat";
+import type { WidgetColumnFormat } from "./types";
+
+export interface ChartValueFormat {
+  format?: WidgetColumnFormat;
+  prefix?: string;
+  suffix?: string;
+}
+
+/**
+ * Format a numeric chart value with optional prefix/suffix wrapping. Mirrors
+ * the number widget's display rules so chart tooltips can show currency, units,
+ * or percent values exactly the way KPI cards do.
+ */
+export function formatSeriesValue(value: unknown, { format, prefix, suffix }: ChartValueFormat): string {
+  if (value == null) return "—";
+  return `${prefix ?? ""}${formatValue(value, format ?? "number")}${suffix ?? ""}`;
+}
+
+/**
+ * Render a percentage suffix for donut tooltips (e.g. " (32%)"). Returns an
+ * empty string when total is zero or the value can't be expressed as a number.
+ */
+export function formatPercentOfTotal(value: unknown, total: number): string {
+  if (!Number.isFinite(total) || total <= 0) return "";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "";
+  const pct = (n / total) * 100;
+  return ` (${pct.toFixed(pct % 1 === 0 ? 0 : 1)}%)`;
+}

--- a/web_src/src/pages/workflowv2/dashboard/widget/types.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/types.ts
@@ -92,10 +92,19 @@ export interface WidgetTableRender {
 
 export type WidgetChartKind = "bar" | "stacked-bar" | "line" | "area" | "donut";
 
+export type WidgetChartLegendMode = "auto" | "show" | "hide";
+export const WIDGET_CHART_LEGEND_MODES: WidgetChartLegendMode[] = ["auto", "show", "hide"];
+
 export interface WidgetChartSeries {
   field?: string;
   label?: string;
   color?: string;
+  /** Optional value format applied in tooltips (and in donut value rows). */
+  format?: WidgetColumnFormat;
+  /** Optional display string prepended to the formatted value (e.g. "$"). */
+  prefix?: string;
+  /** Optional display string appended to the formatted value (e.g. " MWh"). */
+  suffix?: string;
 }
 
 export interface WidgetChartRender {
@@ -106,18 +115,25 @@ export interface WidgetChartRender {
   title?: string;
   limit?: number;
   filters?: string[];
+  /** Legend visibility. Defaults to "auto" — visible for donut charts or when 2+ series exist. */
+  legend?: WidgetChartLegendMode;
 }
 
 export type WidgetNumberAggregation = "count" | "sum" | "avg" | "min" | "max" | "first" | "last";
 
 export interface WidgetNumberRender {
   kind: "number";
-  aggregation: WidgetNumberAggregation;
+  /** Required for simple data sources. Composite memory sources carry their own per-source aggregation. */
+  aggregation?: WidgetNumberAggregation;
   field?: string;
   filters?: string[];
   format?: WidgetColumnFormat;
   label?: string;
   sparklineField?: string;
+  /** Optional display string rendered before the formatted value (e.g. "R$"). */
+  prefix?: string;
+  /** Optional display string rendered after the formatted value (e.g. " MWh"). */
+  suffix?: string;
 }
 
 export type WidgetRender = WidgetTableRender | WidgetChartRender | WidgetNumberRender;

--- a/web_src/src/pages/workflowv2/dashboard/widget/widgetData.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/widgetData.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
+import { aggregateNumberPerSource, combinePartials } from "./widgetData";
+
+const entries: CanvasMemoryEntry[] = [
+  { id: "1", namespace: "expenses", values: { amount: 10 } },
+  { id: "2", namespace: "expenses", values: { amount: 30 } },
+  { id: "3", namespace: "tests", values: { name: "a" } },
+  { id: "4", namespace: "tests", values: { name: "b" } },
+  { id: "5", namespace: "tests", values: { name: "c" } },
+];
+
+describe("aggregateNumberPerSource", () => {
+  it("sums a numeric field across rows of the same namespace", () => {
+    const value = aggregateNumberPerSource(
+      entries,
+      { namespace: "expenses", aggregation: "sum", field: "amount" },
+      undefined,
+    );
+    expect(value).toBe(40);
+  });
+
+  it("counts rows in a namespace when aggregation is count", () => {
+    expect(aggregateNumberPerSource(entries, { namespace: "tests", aggregation: "count" }, undefined)).toBe(3);
+  });
+
+  it("returns null when no rows match the namespace and aggregation is not count", () => {
+    expect(
+      aggregateNumberPerSource(entries, { namespace: "missing", aggregation: "sum", field: "amount" }, undefined),
+    ).toBe(null);
+  });
+
+  it("returns 0 when no rows match the namespace and aggregation is count", () => {
+    expect(aggregateNumberPerSource(entries, { namespace: "missing", aggregation: "count" }, undefined)).toBe(0);
+  });
+
+  it("applies shared widget filters before aggregating each source", () => {
+    const value = aggregateNumberPerSource(entries, { namespace: "expenses", aggregation: "sum", field: "amount" }, [
+      "row.amount > 10",
+    ]);
+    expect(value).toBe(30);
+  });
+});
+
+describe("combinePartials", () => {
+  it("sums available partials and skips nulls", () => {
+    expect(combinePartials([40, null, 3], "sum")).toBe(43);
+  });
+
+  it("returns null when every partial is null", () => {
+    expect(combinePartials([null, null], "sum")).toBe(null);
+  });
+
+  it("picks the minimum of non-null partials", () => {
+    expect(combinePartials([5, 2, null, 8], "min")).toBe(2);
+  });
+
+  it("picks the maximum of non-null partials", () => {
+    expect(combinePartials([5, 2, null, 8], "max")).toBe(8);
+  });
+
+  it("averages non-null partials (unweighted across sources)", () => {
+    expect(combinePartials([2, 4, null], "avg")).toBe(3);
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/widgetData.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/widgetData.ts
@@ -1,5 +1,9 @@
+import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
+
 import { getValueAtPath } from "./fieldPath";
+import { flattenMemoryEntries } from "./memoryRow";
 import { evaluateShow } from "./showExpression";
+import type { MemoryNumberSource, WidgetNumberCombine } from "../panelTypes";
 import type { WidgetNumberAggregation } from "./types";
 
 /**
@@ -46,6 +50,51 @@ export function aggregateNumber(
       return numeric[0];
     case "last":
       return numeric[numeric.length - 1];
+    default:
+      return null;
+  }
+}
+
+/**
+ * Aggregate a single memory namespace contribution for a composite number
+ * widget. Flattens the relevant entries (optionally walking `fieldPath`),
+ * filters them with the widget's shared `render.filters`, and runs the
+ * source's own aggregation/field configuration. Returns `null` when the
+ * source has no rows or no numeric values to aggregate (except `count`,
+ * which returns `0` for an empty namespace).
+ */
+export function aggregateNumberPerSource(
+  entries: CanvasMemoryEntry[],
+  source: MemoryNumberSource,
+  filters: string[] | undefined,
+): number | null {
+  const rows = flattenMemoryEntries(entries, source.namespace, source.fieldPath);
+  const filtered = applyFilters(rows, filters);
+  return aggregateNumber(filtered, source.aggregation, source.field);
+}
+
+/**
+ * Merge per-source partial aggregates into a single value. Null partials are
+ * skipped (a namespace that produced no numeric value does not poison the
+ * combine); if every partial is `null`, the result is `null` so the widget
+ * renders its em-dash placeholder.
+ *
+ * `avg` is the unweighted mean of the available partials — not a row-weighted
+ * average across namespaces. Document this in the number panel UI so users
+ * can pick `sum` when they want row-level math.
+ */
+export function combinePartials(partials: Array<number | null>, combine: WidgetNumberCombine): number | null {
+  const present = partials.filter((value): value is number => value != null);
+  if (present.length === 0) return null;
+  switch (combine) {
+    case "sum":
+      return present.reduce((a, b) => a + b, 0);
+    case "min":
+      return Math.min(...present);
+    case "max":
+      return Math.max(...present);
+    case "avg":
+      return present.reduce((a, b) => a + b, 0) / present.length;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Two coupled improvements to the Console widgets and the YAML schema that backs them.

- **Number widget overhaul.** Adds prefix/suffix labels, multi-source composite memory data sources (each namespace declares its own aggregation and field, combined via sum/min/max/avg), and a richer field/path picker flow. The data-source form is broken into reusable fields, and the panel card is split into focused subcomponents (`NumberPanelForm`, `NumberPanelCompositeSourcesEditor`, `NumberPanelSourceModeToggle`, `numberPanelFormConstants`).
- **Chart widget rewrite.** Switches to Recharts, adds configurable series, per-series formatting, picker-driven configuration, top controls (legend mode, type), and a `chartFormat` helper. Chart panel configuration is split out of the card into form / series list / series row / top controls files.

The shared YAML schema (`canvas_dashboard_yml.go`, `panelTypes.ts`, `widget/types.ts`) is extended in lockstep so YAML round-trips faithfully across both surfaces.

Stacked on #4960. **Independent of the memory list backend changes** (#4964) and of the Memory tab promotion (previously #4961, now closed).

## Stack

1. #4960 — Console rebrand
2. **#4963 (this PR)** — Console number/chart widget improvements
3. #4964 — List value support for memory components (sibling, also stacks on #4960)

## Test plan

- [ ] `make check.build.ui` and `make format.js`
- [ ] `make test PKG_TEST_PACKAGES=./pkg/models/...`
- [ ] `make lint && make check.build.app`
- [ ] Number widget with prefix/suffix; composite memory source with sum/min/max/avg combine
- [ ] Chart widget with multiple series, configurable type, legend, formatting
- [ ] YAML import/export round-trips number prefix/suffix and composite memory sources
- [ ] Existing single-source number panels keep rendering unchanged