### PR TITLE
feat: Visual diff on canvas nodes in edit mode

### DIFF
--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -230,5 +230,11 @@ export function buildDraftDiffMap(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
 
-  return { statusMap, removedNodes };
+  // Compute edge diff: edges from live that connect to removed nodes
+  const liveEdges = (liveVersion?.spec?.edges || []) as Array<Record<string, unknown>>;
+  const removedEdges = liveEdges.filter(
+    (e) => statusMap[String(e.sourceId)] === "removed" || statusMap[String(e.targetId)] === "removed",
+  );
+
+  return { statusMap, removedNodes, removedEdges };
 }

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -221,13 +221,46 @@ export function buildDraftDiffMap(
   statusMap: Record<string, "added" | "updated" | "removed">;
   removedNodes: Array<Record<string, unknown>>;
 } {
-  const { items } = buildDraftNodeDiffSummary(liveVersion, draftVersion);
+  const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
+  const draftNodes = (draftVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
+
+  const byID = (nodes: Array<Record<string, unknown>>) => {
+    const map = new Map<string, Record<string, unknown>>();
+    nodes.forEach((node) => {
+      const id = String(node.id || "");
+      if (id) map.set(id, node);
+    });
+    return map;
+  };
+
+  // Compare without position — layout changes are not functional edits
+  const functionalSnapshot = (node: Record<string, unknown>) =>
+    JSON.stringify({
+      name: node.name || null,
+      type: node.type || null,
+      ref: node.ref || null,
+      configuration: node.configuration || null,
+      isCollapsed: node.isCollapsed || false,
+      integrationId: getComparableIntegrationId(node),
+    });
+
+  const liveByID = byID(liveNodes);
+  const draftByID = byID(draftNodes);
+  const allIDs = new Set([...liveByID.keys(), ...draftByID.keys()]);
+
   const statusMap: Record<string, "added" | "updated" | "removed"> = {};
-  for (const item of items) {
-    statusMap[item.id] = item.changeType;
+  for (const id of allIDs) {
+    const liveNode = liveByID.get(id);
+    const draftNode = draftByID.get(id);
+    if (!liveNode && draftNode) {
+      statusMap[id] = "added";
+    } else if (liveNode && !draftNode) {
+      statusMap[id] = "removed";
+    } else if (liveNode && draftNode && functionalSnapshot(liveNode) !== functionalSnapshot(draftNode)) {
+      statusMap[id] = "updated";
+    }
   }
 
-  const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
 
   return { statusMap, removedNodes };

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -230,11 +230,5 @@ export function buildDraftDiffMap(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
 
-  // Compute edge diff: edges from live that connect to removed nodes
-  const liveEdges = (liveVersion?.spec?.edges || []) as Array<Record<string, unknown>>;
-  const removedEdges = liveEdges.filter(
-    (e) => statusMap[String(e.sourceId)] === "removed" || statusMap[String(e.targetId)] === "removed",
-  );
-
-  return { statusMap, removedNodes, removedEdges };
+  return { statusMap, removedNodes };
 }

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -230,5 +230,30 @@ export function buildDraftDiffMap(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
 
-  return { statusMap, removedNodes };
+  // Compute per-edge diff
+  const edgeKey = (e: { sourceId: string; targetId: string; channel: string }) =>
+    `${e.sourceId}->${e.targetId}::${e.channel}`;
+
+  const liveEdgeList = (Array.isArray(liveVersion?.spec?.edges) ? liveVersion.spec.edges : []) as Array<
+    Record<string, unknown>
+  >;
+  const draftEdgeList = (Array.isArray(draftVersion?.spec?.edges) ? draftVersion.spec.edges : []) as Array<
+    Record<string, unknown>
+  >;
+
+  const normalize = (e: Record<string, unknown>) => ({
+    sourceId: String(e.sourceId ?? ""),
+    targetId: String(e.targetId ?? ""),
+    channel: String(e.channel ?? "default"),
+  });
+
+  const liveEdgeSet = new Set(liveEdgeList.map((e) => edgeKey(normalize(e))));
+  const draftEdgeSet = new Set(draftEdgeList.map((e) => edgeKey(normalize(e))));
+
+  const addedEdges = draftEdgeList.filter((e) => !liveEdgeSet.has(edgeKey(normalize(e))));
+  const removedEdgeKeys = new Set(
+    liveEdgeList.filter((e) => !draftEdgeSet.has(edgeKey(normalize(e)))).map((e) => edgeKey(normalize(e))),
+  );
+
+  return { statusMap, removedNodes, addedEdges, removedEdgeKeys };
 }

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -230,30 +230,5 @@ export function buildDraftDiffMap(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
 
-  // Compute per-edge diff
-  const edgeKey = (e: { sourceId: string; targetId: string; channel: string }) =>
-    `${e.sourceId}->${e.targetId}::${e.channel}`;
-
-  const liveEdgeList = (Array.isArray(liveVersion?.spec?.edges) ? liveVersion.spec.edges : []) as Array<
-    Record<string, unknown>
-  >;
-  const draftEdgeList = (Array.isArray(draftVersion?.spec?.edges) ? draftVersion.spec.edges : []) as Array<
-    Record<string, unknown>
-  >;
-
-  const normalize = (e: Record<string, unknown>) => ({
-    sourceId: String(e.sourceId ?? ""),
-    targetId: String(e.targetId ?? ""),
-    channel: String(e.channel ?? "default"),
-  });
-
-  const liveEdgeSet = new Set(liveEdgeList.map((e) => edgeKey(normalize(e))));
-  const draftEdgeSet = new Set(draftEdgeList.map((e) => edgeKey(normalize(e))));
-
-  const addedEdges = draftEdgeList.filter((e) => !liveEdgeSet.has(edgeKey(normalize(e))));
-  const removedEdgeKeys = new Set(
-    liveEdgeList.filter((e) => !draftEdgeSet.has(edgeKey(normalize(e)))).map((e) => edgeKey(normalize(e))),
-  );
-
-  return { statusMap, removedNodes, addedEdges, removedEdgeKeys };
+  return { statusMap, removedNodes };
 }

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -209,3 +209,26 @@ export function buildDraftNodeDiffSummary(
 
   return { items, addedCount, updatedCount, removedCount };
 }
+
+/**
+ * Returns a map of nodeId -> diff status for canvas node rendering.
+ * Includes positions for removed nodes so they can be rendered as ghost nodes.
+ */
+export function buildDraftDiffMap(
+  liveVersion?: CanvasesCanvasVersion,
+  draftVersion?: CanvasesCanvasVersion,
+): {
+  statusMap: Record<string, "added" | "updated" | "removed">;
+  removedNodes: Array<Record<string, unknown>>;
+} {
+  const { items } = buildDraftNodeDiffSummary(liveVersion, draftVersion);
+  const statusMap: Record<string, "added" | "updated" | "removed"> = {};
+  for (const item of items) {
+    statusMap[item.id] = item.changeType;
+  }
+
+  const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
+  const removedNodes = liveNodes.filter((n) => statusMap[String(n.id)] === "removed");
+
+  return { statusMap, removedNodes };
+}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -421,12 +421,6 @@ export function WorkflowPageV2() {
     !!selectedCanvasVersionID && pendingApprovalVersionIds.has(selectedCanvasVersionID);
   const isViewingDraftVersion =
     !!selectedCanvasVersion && isDraftVersion(selectedCanvasVersion) && !isViewingPendingApprovalVersion;
-  const draftDiffResult = useMemo(() => {
-    if (!isViewingDraftVersion || !canvas) return undefined;
-    // Use the current canvas spec (includes live edits) for accurate diff
-    const currentDraft = { spec: canvas.spec } as CanvasesCanvasVersion;
-    return buildDraftDiffMap(liveCanvasVersion, currentDraft);
-  }, [isViewingDraftVersion, liveCanvasVersion, canvas]);
   const isViewingCurrentLiveVersion =
     !selectedCanvasVersion || selectedCanvasVersion.metadata?.id === liveCanvasVersionId;
   const isViewingLiveVersion = isViewingCurrentLiveVersion;
@@ -511,6 +505,11 @@ export function WorkflowPageV2() {
       spec: versionSpec,
     };
   }, [liveCanvas, selectedCanvasVersion, isViewingDraftVersion, draftSpecToRender]);
+  const draftDiffResult = useMemo(() => {
+    if (!isViewingDraftVersion || !canvas) return undefined;
+    const currentDraft = { spec: canvas.spec } as CanvasesCanvasVersion;
+    return buildDraftDiffMap(liveCanvasVersion, currentDraft);
+  }, [isViewingDraftVersion, liveCanvasVersion, canvas]);
   const isChangeManagementDisabled = !(
     liveCanvas?.spec?.changeManagement?.enabled ??
     liveCanvasVersion?.spec?.changeManagement?.enabled ??

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1901,36 +1901,6 @@ export function WorkflowPageV2() {
     return [...preparedNodes, ...ghostNodes];
   }, [preparedNodes, draftDiffResult, liveCanvasVersion, allTriggers, allComponents, canvasId, queryClient]);
 
-  // Inject ghost edges for deleted connections and style edges based on node diff
-  const edgesWithDiff = useMemo(() => {
-    if (!draftDiffResult) return preparedEdges;
-    const { statusMap, removedEdges } = draftDiffResult;
-
-    // Style existing edges based on connected node status
-    const styledExisting = preparedEdges.map((edge) => {
-      const srcStatus = statusMap[edge.source];
-      const tgtStatus = statusMap[edge.target];
-      if (srcStatus === "added" || tgtStatus === "added") {
-        return { ...edge, data: { ...edge.data, _draftDiffStatus: "added" } };
-      }
-      if (srcStatus === "updated" || tgtStatus === "updated") {
-        return { ...edge, data: { ...edge.data, _draftDiffStatus: "updated" } };
-      }
-      return edge;
-    });
-
-    // Add ghost edges for removed connections
-    const ghostEdges = removedEdges.map((e) => ({
-      id: `ghost-${String(e.sourceId)}->${String(e.targetId)}-${String(e.channel || "default")}`,
-      source: String(e.sourceId),
-      target: String(e.targetId),
-      sourceHandle: String(e.channel || "default"),
-      data: { _draftDiffStatus: "removed" },
-    }));
-
-    return [...styledExisting, ...ghostEdges];
-  }, [preparedEdges, draftDiffResult]);
-
   const nodesWithIntegrationStatus = useMemo(
     () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),
     [nodesWithGhosts, integrations, canvasNodes],
@@ -1962,7 +1932,7 @@ export function WorkflowPageV2() {
     selectedRun,
     runCanvasData,
     liveNodes: nodesWithIntegrationStatus,
-    liveEdges: edgesWithDiff,
+    liveEdges: preparedEdges,
     isSelectedRunVersionLoading,
     isSelectedRunExecutionsLoading: selectedRunExecutionsQuery.isLoading,
   });

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1872,7 +1872,8 @@ export function WorkflowPageV2() {
   // Run them through the real preparation pipeline so they render with full body,
   // then overlay dimBodyBelowHeader for the gray slate look.
   const nodesWithGhosts = useMemo(() => {
-    if (!draftDiffResult?.removedNodes?.length) return preparedNodes;
+    // Ghost nodes for deleted nodes disabled for now
+    if (true || !draftDiffResult?.removedNodes?.length) return preparedNodes;
     const liveNodes = (liveCanvasVersion?.spec?.nodes || []) as ComponentsNode[];
     const ghostNodes = draftDiffResult.removedNodes.map((removedNode) => {
       const node = removedNode as unknown as ComponentsNode;

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1896,11 +1896,6 @@ export function WorkflowPageV2() {
         ...prepared,
         draggable: false,
         selectable: false,
-        data: {
-          ...prepared.data,
-          _draftDiffStatus: "removed" as const,
-          _dimBodyBelowHeader: true,
-        },
       };
     });
     return [...preparedNodes, ...ghostNodes];

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1888,8 +1888,8 @@ export function WorkflowPageV2() {
             iconSlug: "trash-2",
             iconColor: "text-gray-400",
             title: String(removedNode.name || "Deleted node"),
-            collapsed: !!removedNode.isCollapsed,
-            parameters: [],
+            collapsed: false,
+            parameters: [{ label: "This node was removed from the draft", value: "" }],
           },
         },
       };

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -421,10 +421,12 @@ export function WorkflowPageV2() {
     !!selectedCanvasVersionID && pendingApprovalVersionIds.has(selectedCanvasVersionID);
   const isViewingDraftVersion =
     !!selectedCanvasVersion && isDraftVersion(selectedCanvasVersion) && !isViewingPendingApprovalVersion;
-  const draftDiffResult = useMemo(
-    () => (isViewingDraftVersion ? buildDraftDiffMap(liveCanvasVersion, latestDraftVersion) : undefined),
-    [isViewingDraftVersion, liveCanvasVersion, latestDraftVersion],
-  );
+  const draftDiffResult = useMemo(() => {
+    if (!isViewingDraftVersion || !canvas) return undefined;
+    // Use the current canvas spec (includes live edits) for accurate diff
+    const currentDraft = { spec: canvas.spec } as CanvasesCanvasVersion;
+    return buildDraftDiffMap(liveCanvasVersion, currentDraft);
+  }, [isViewingDraftVersion, liveCanvasVersion, canvas]);
   const isViewingCurrentLiveVersion =
     !selectedCanvasVersion || selectedCanvasVersion.metadata?.id === liveCanvasVersionId;
   const isViewingLiveVersion = isViewingCurrentLiveVersion;

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1901,6 +1901,42 @@ export function WorkflowPageV2() {
     return [...preparedNodes, ...ghostNodes];
   }, [preparedNodes, draftDiffResult, liveCanvasVersion, allTriggers, allComponents, canvasId, queryClient]);
 
+  // Style edges based on draft vs live diff
+  const edgesWithDiff = useMemo(() => {
+    if (!draftDiffResult) return preparedEdges;
+    const { addedEdges, removedEdgeKeys } = draftDiffResult;
+    const edgeKey = (source: string, target: string, channel: string) => `${source}->${target}::${channel}`;
+    const addedSet = new Set(
+      (addedEdges || []).map((e: Record<string, unknown>) =>
+        edgeKey(String(e.sourceId ?? ""), String(e.targetId ?? ""), String(e.channel ?? "default")),
+      ),
+    );
+
+    // Mark new edges
+    const styled = preparedEdges.map((edge) => {
+      const key = edgeKey(edge.source, edge.target, edge.sourceHandle || "default");
+      if (addedSet.has(key)) {
+        return { ...edge, data: { ...edge.data, _draftDiffStatus: "added" } };
+      }
+      return edge;
+    });
+
+    // Inject ghost edges for removed connections
+    const ghostEdges = [...(removedEdgeKeys || [])].map((key) => {
+      const [sourcePart, rest] = key.split("::");
+      const [source, target] = sourcePart.split("->");
+      return {
+        id: `ghost-edge-${key}`,
+        source,
+        target,
+        sourceHandle: rest || "default",
+        data: { _draftDiffStatus: "removed" },
+      };
+    });
+
+    return [...styled, ...ghostEdges];
+  }, [preparedEdges, draftDiffResult]);
+
   const nodesWithIntegrationStatus = useMemo(
     () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),
     [nodesWithGhosts, integrations, canvasNodes],
@@ -1932,7 +1968,7 @@ export function WorkflowPageV2() {
     selectedRun,
     runCanvasData,
     liveNodes: nodesWithIntegrationStatus,
-    liveEdges: preparedEdges,
+    liveEdges: edgesWithDiff,
     isSelectedRunVersionLoading,
     isSelectedRunExecutionsLoading: selectedRunExecutionsQuery.isLoading,
   });

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1887,9 +1887,16 @@ export function WorkflowPageV2() {
           component: {
             iconSlug: "trash-2",
             iconColor: "text-gray-400",
+            collapsedBackground: "bg-gray-200",
             title: String(removedNode.name || "Deleted node"),
             collapsed: false,
-            parameters: [{ label: "This node was removed from the draft", value: "" }],
+            includeEmptyState: true,
+            emptyStateProps: {
+              title: "Removed from draft",
+              purpose: "runtime" as const,
+              tone: "neutral" as const,
+            },
+            parameters: [],
           },
         },
       };

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1901,41 +1901,50 @@ export function WorkflowPageV2() {
     return [...preparedNodes, ...ghostNodes];
   }, [preparedNodes, draftDiffResult, liveCanvasVersion, allTriggers, allComponents, canvasId, queryClient]);
 
-  // Style edges based on draft vs live diff
+  // Style edges based on draft vs live diff (compare current edges against live version)
   const edgesWithDiff = useMemo(() => {
-    if (!draftDiffResult) return preparedEdges;
-    const { addedEdges, removedEdgeKeys } = draftDiffResult;
+    if (!isViewingDraftVersion || !liveCanvasVersion) return preparedEdges;
     const edgeKey = (source: string, target: string, channel: string) => `${source}->${target}::${channel}`;
-    const addedSet = new Set(
-      (addedEdges || []).map((e: Record<string, unknown>) =>
-        edgeKey(String(e.sourceId ?? ""), String(e.targetId ?? ""), String(e.channel ?? "default")),
-      ),
+
+    // Build set of live edge keys
+    const liveEdges = (liveCanvasVersion.spec?.edges || []) as Array<Record<string, unknown>>;
+    const liveEdgeSet = new Set(
+      liveEdges.map((e) => edgeKey(String(e.sourceId ?? ""), String(e.targetId ?? ""), String(e.channel ?? "default"))),
     );
 
-    // Mark new edges
+    // Build set of current draft edge keys
+    const draftEdgeSet = new Set(preparedEdges.map((e) => edgeKey(e.source, e.target, e.sourceHandle || "default")));
+
+    // Mark new edges (in draft, not in live)
     const styled = preparedEdges.map((edge) => {
       const key = edgeKey(edge.source, edge.target, edge.sourceHandle || "default");
-      if (addedSet.has(key)) {
+      if (!liveEdgeSet.has(key)) {
         return { ...edge, data: { ...edge.data, _draftDiffStatus: "added" } };
       }
       return edge;
     });
 
-    // Inject ghost edges for removed connections
-    const ghostEdges = [...(removedEdgeKeys || [])].map((key) => {
-      const [sourcePart, rest] = key.split("::");
-      const [source, target] = sourcePart.split("->");
-      return {
-        id: `ghost-edge-${key}`,
-        source,
-        target,
-        sourceHandle: rest || "default",
-        data: { _draftDiffStatus: "removed" },
-      };
-    });
+    // Inject ghost edges for removed connections (in live, not in draft)
+    const ghostEdges = liveEdges
+      .filter((e) => {
+        const key = edgeKey(String(e.sourceId ?? ""), String(e.targetId ?? ""), String(e.channel ?? "default"));
+        return !draftEdgeSet.has(key);
+      })
+      .map((e) => {
+        const src = String(e.sourceId ?? "");
+        const tgt = String(e.targetId ?? "");
+        const ch = String(e.channel ?? "default");
+        return {
+          id: `ghost-edge-${src}->${tgt}::${ch}`,
+          source: src,
+          target: tgt,
+          sourceHandle: ch,
+          data: { _draftDiffStatus: "removed" },
+        };
+      });
 
     return [...styled, ...ghostEdges];
-  }, [preparedEdges, draftDiffResult]);
+  }, [preparedEdges, isViewingDraftVersion, liveCanvasVersion]);
 
   const nodesWithIntegrationStatus = useMemo(
     () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1887,15 +1887,8 @@ export function WorkflowPageV2() {
           component: {
             iconSlug: "trash-2",
             iconColor: "text-gray-400",
-            collapsedBackground: "bg-gray-200",
             title: String(removedNode.name || "Deleted node"),
             collapsed: false,
-            includeEmptyState: true,
-            emptyStateProps: {
-              title: "Removed from draft",
-              purpose: "runtime" as const,
-              tone: "neutral" as const,
-            },
             parameters: [],
           },
         },

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -415,15 +415,15 @@ export function WorkflowPageV2() {
     () => hasDraftVersusLiveGraphDiff(liveCanvasVersion, latestDraftVersion),
     [liveCanvasVersion, latestDraftVersion],
   );
-  const draftDiffResult = useMemo(
-    () => (isViewingDraftVersion ? buildDraftDiffMap(liveCanvasVersion, latestDraftVersion) : undefined),
-    [isViewingDraftVersion, liveCanvasVersion, latestDraftVersion],
-  );
   const selectedCanvasVersionID = selectedCanvasVersion?.metadata?.id || "";
   const isViewingPendingApprovalVersion =
     !!selectedCanvasVersionID && pendingApprovalVersionIds.has(selectedCanvasVersionID);
   const isViewingDraftVersion =
     !!selectedCanvasVersion && isDraftVersion(selectedCanvasVersion) && !isViewingPendingApprovalVersion;
+  const draftDiffResult = useMemo(
+    () => (isViewingDraftVersion ? buildDraftDiffMap(liveCanvasVersion, latestDraftVersion) : undefined),
+    [isViewingDraftVersion, liveCanvasVersion, latestDraftVersion],
+  );
   const isViewingCurrentLiveVersion =
     !selectedCanvasVersion || selectedCanvasVersion.metadata?.id === liveCanvasVersionId;
   const isViewingLiveVersion = isViewingCurrentLiveVersion;

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -97,7 +97,7 @@ import { CanvasPageModals } from "./CanvasPageModals";
 import { CanvasVersionNodeDiffDialog, type CanvasVersionNodeDiffContext } from "./CanvasVersionNodeDiffDialog";
 import { CanvasYamlModal } from "./CanvasYamlModal";
 import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
-import { buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
+import { buildDraftDiffMap, buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
 import {
   isDraftVersion,
@@ -414,6 +414,10 @@ export function WorkflowPageV2() {
   const hasDraftGraphDiffVersusLive = useMemo(
     () => hasDraftVersusLiveGraphDiff(liveCanvasVersion, latestDraftVersion),
     [liveCanvasVersion, latestDraftVersion],
+  );
+  const draftDiffResult = useMemo(
+    () => (isViewingDraftVersion ? buildDraftDiffMap(liveCanvasVersion, latestDraftVersion) : undefined),
+    [isViewingDraftVersion, liveCanvasVersion, latestDraftVersion],
   );
   const selectedCanvasVersionID = selectedCanvasVersion?.metadata?.id || "";
   const isViewingPendingApprovalVersion =
@@ -1842,6 +1846,7 @@ export function WorkflowPageV2() {
       me,
       canvasMode,
       openTriggerModal,
+      draftDiffResult?.statusMap,
     );
   }, [
     canvas,
@@ -1859,11 +1864,42 @@ export function WorkflowPageV2() {
     me,
     canvasMode,
     openTriggerModal,
+    draftDiffResult,
   ]);
 
+  // Inject ghost nodes for deleted nodes (exist in live but removed from draft)
+  const nodesWithGhosts = useMemo(() => {
+    if (!draftDiffResult?.removedNodes?.length) return preparedNodes;
+    const ghostNodes: typeof preparedNodes = draftDiffResult.removedNodes.map((removedNode) => {
+      const pos = (removedNode.position as { x?: number; y?: number }) || {};
+      return {
+        id: String(removedNode.id),
+        position: { x: pos.x ?? 0, y: pos.y ?? 0 },
+        draggable: false,
+        selectable: false,
+        data: {
+          type: "component" as const,
+          label: String(removedNode.name || "Deleted node"),
+          state: "pending" as const,
+          outputChannels: ["default"],
+          _draftDiffStatus: "removed" as const,
+          _dimBodyBelowHeader: true,
+          component: {
+            iconSlug: "trash-2",
+            iconColor: "text-gray-400",
+            title: String(removedNode.name || "Deleted node"),
+            collapsed: !!removedNode.isCollapsed,
+            parameters: [],
+          },
+        },
+      };
+    });
+    return [...preparedNodes, ...ghostNodes];
+  }, [preparedNodes, draftDiffResult]);
+
   const nodesWithIntegrationStatus = useMemo(
-    () => overlayIntegrationWarnings(preparedNodes, integrations, canvasNodes),
-    [preparedNodes, integrations, canvasNodes],
+    () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),
+    [nodesWithGhosts, integrations, canvasNodes],
   );
 
   const runCanvasData = useRunCanvasData({

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1901,6 +1901,36 @@ export function WorkflowPageV2() {
     return [...preparedNodes, ...ghostNodes];
   }, [preparedNodes, draftDiffResult, liveCanvasVersion, allTriggers, allComponents, canvasId, queryClient]);
 
+  // Inject ghost edges for deleted connections and style edges based on node diff
+  const edgesWithDiff = useMemo(() => {
+    if (!draftDiffResult) return preparedEdges;
+    const { statusMap, removedEdges } = draftDiffResult;
+
+    // Style existing edges based on connected node status
+    const styledExisting = preparedEdges.map((edge) => {
+      const srcStatus = statusMap[edge.source];
+      const tgtStatus = statusMap[edge.target];
+      if (srcStatus === "added" || tgtStatus === "added") {
+        return { ...edge, data: { ...edge.data, _draftDiffStatus: "added" } };
+      }
+      if (srcStatus === "updated" || tgtStatus === "updated") {
+        return { ...edge, data: { ...edge.data, _draftDiffStatus: "updated" } };
+      }
+      return edge;
+    });
+
+    // Add ghost edges for removed connections
+    const ghostEdges = removedEdges.map((e) => ({
+      id: `ghost-${String(e.sourceId)}->${String(e.targetId)}-${String(e.channel || "default")}`,
+      source: String(e.sourceId),
+      target: String(e.targetId),
+      sourceHandle: String(e.channel || "default"),
+      data: { _draftDiffStatus: "removed" },
+    }));
+
+    return [...styledExisting, ...ghostEdges];
+  }, [preparedEdges, draftDiffResult]);
+
   const nodesWithIntegrationStatus = useMemo(
     () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),
     [nodesWithGhosts, integrations, canvasNodes],
@@ -1932,7 +1962,7 @@ export function WorkflowPageV2() {
     selectedRun,
     runCanvasData,
     liveNodes: nodesWithIntegrationStatus,
-    liveEdges: preparedEdges,
+    liveEdges: edgesWithDiff,
     isSelectedRunVersionLoading,
     isSelectedRunExecutionsLoading: selectedRunExecutionsQuery.isLoading,
   });

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -142,6 +142,7 @@ import {
   getNodeAnalyticsProps,
   isCanvasLoadNotFoundError,
   prepareData,
+  prepareNode,
   prepareSidebarData,
 } from "./workflowPageHelpers";
 /** Backend flag id (`FeatureDashboards`); the registry label is "Console". */
@@ -1868,34 +1869,42 @@ export function WorkflowPageV2() {
   ]);
 
   // Inject ghost nodes for deleted nodes (exist in live but removed from draft)
+  // Run them through the real preparation pipeline so they render with full body,
+  // then overlay dimBodyBelowHeader for the gray slate look.
   const nodesWithGhosts = useMemo(() => {
     if (!draftDiffResult?.removedNodes?.length) return preparedNodes;
-    const ghostNodes: typeof preparedNodes = draftDiffResult.removedNodes.map((removedNode) => {
-      const pos = (removedNode.position as { x?: number; y?: number }) || {};
+    const liveNodes = (liveCanvasVersion?.spec?.nodes || []) as ComponentsNode[];
+    const ghostNodes = draftDiffResult.removedNodes.map((removedNode) => {
+      const node = removedNode as unknown as ComponentsNode;
+      const prepared = prepareNode(
+        liveNodes,
+        node,
+        allTriggers,
+        allComponents,
+        {},
+        {},
+        {},
+        canvasId!,
+        queryClient,
+        undefined,
+        liveCanvasVersion?.spec?.edges as ComponentsEdge[] | undefined,
+        "edit",
+        undefined,
+        "removed",
+      );
       return {
-        id: String(removedNode.id),
-        position: { x: pos.x ?? 0, y: pos.y ?? 0 },
+        ...prepared,
         draggable: false,
         selectable: false,
         data: {
-          type: "component" as const,
-          label: String(removedNode.name || "Deleted node"),
-          state: "pending" as const,
-          outputChannels: ["default"],
+          ...prepared.data,
           _draftDiffStatus: "removed" as const,
           _dimBodyBelowHeader: true,
-          component: {
-            iconSlug: "trash-2",
-            iconColor: "text-gray-400",
-            title: String(removedNode.name || "Deleted node"),
-            collapsed: false,
-            parameters: [],
-          },
         },
       };
     });
     return [...preparedNodes, ...ghostNodes];
-  }, [preparedNodes, draftDiffResult]);
+  }, [preparedNodes, draftDiffResult, liveCanvasVersion, allTriggers, allComponents, canvasId, queryClient]);
 
   const nodesWithIntegrationStatus = useMemo(
     () => overlayIntegrationWarnings(nodesWithGhosts, integrations, canvasNodes),

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -505,11 +505,10 @@ export function WorkflowPageV2() {
       spec: versionSpec,
     };
   }, [liveCanvas, selectedCanvasVersion, isViewingDraftVersion, draftSpecToRender]);
-  const draftDiffResult = useMemo(() => {
-    if (!isViewingDraftVersion || !canvas) return undefined;
-    const currentDraft = { spec: canvas.spec } as CanvasesCanvasVersion;
-    return buildDraftDiffMap(liveCanvasVersion, currentDraft);
-  }, [isViewingDraftVersion, liveCanvasVersion, canvas]);
+  const draftDiffResult = useMemo(
+    () => (isViewingDraftVersion ? buildDraftDiffMap(liveCanvasVersion, latestDraftVersion) : undefined),
+    [isViewingDraftVersion, liveCanvasVersion, latestDraftVersion],
+  );
   const isChangeManagementDisabled = !(
     liveCanvas?.spec?.changeManagement?.enabled ??
     liveCanvasVersion?.spec?.changeManagement?.enabled ??

--- a/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
@@ -184,7 +184,11 @@ export function prepareTriggerNode(
   triggers: TriggersTrigger[],
   nodeEventsMap: Record<string, CanvasesCanvasEvent[]>,
   canvasMode: "live" | "edit" = "live",
-  options: { canvasId: string; openModal?: (modal: TriggerActionModal) => void; draftDiffStatus?: "added" | "updated" | "removed" },
+  options: {
+    canvasId: string;
+    openModal?: (modal: TriggerActionModal) => void;
+    draftDiffStatus?: "added" | "updated" | "removed";
+  },
 ): CanvasNode {
   const triggerMetadata = triggers.find((t) => t.name === node.component);
   const displayLabel = getTriggerDisplayLabel(node, triggerMetadata);

--- a/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-node-preparation.ts
@@ -49,6 +49,7 @@ type PrepareComponentNodeArgs = {
   currentUser?: User;
   edges?: ComponentsEdge[];
   canvasMode?: "live" | "edit";
+  draftDiffStatus?: "added" | "updated" | "removed";
 };
 
 type PrepareComponentBaseNodeArgs = {
@@ -62,6 +63,7 @@ type PrepareComponentBaseNodeArgs = {
   currentUser?: User;
   edges?: ComponentsEdge[];
   canvasMode?: "live" | "edit";
+  draftDiffStatus?: "added" | "updated" | "removed";
 };
 
 type NodePosition = {
@@ -89,6 +91,7 @@ function buildPreparedTriggerCanvasNode(args: {
   canvasMode?: "live" | "edit";
   canvasId: string;
   openModal?: (modal: TriggerActionModal) => void;
+  draftDiffStatus?: "added" | "updated" | "removed";
 }): CanvasNode {
   const {
     node,
@@ -118,6 +121,7 @@ function buildPreparedTriggerCanvasNode(args: {
       label: displayLabel,
       state: "pending" as const,
       outputChannels: ["default"],
+      _draftDiffStatus: args.draftDiffStatus,
       trigger: {
         ...triggerProps,
         collapsed: node.isCollapsed,
@@ -180,7 +184,7 @@ export function prepareTriggerNode(
   triggers: TriggersTrigger[],
   nodeEventsMap: Record<string, CanvasesCanvasEvent[]>,
   canvasMode: "live" | "edit" = "live",
-  options: { canvasId: string; openModal?: (modal: TriggerActionModal) => void },
+  options: { canvasId: string; openModal?: (modal: TriggerActionModal) => void; draftDiffStatus?: "added" | "updated" | "removed" },
 ): CanvasNode {
   const triggerMetadata = triggers.find((t) => t.name === node.component);
   const displayLabel = getTriggerDisplayLabel(node, triggerMetadata);
@@ -196,6 +200,7 @@ export function prepareTriggerNode(
       canvasMode,
       canvasId: options.canvasId,
       openModal: options.openModal,
+      draftDiffStatus: options.draftDiffStatus,
     });
   } catch (error) {
     console.error(`[CanvasPage] Failed to prepare trigger node "${node.id}":`, error);
@@ -223,6 +228,7 @@ export function prepareComponentNode(args: PrepareComponentNodeArgs): CanvasNode
     currentUser,
     edges,
     canvasMode: args.canvasMode,
+    draftDiffStatus: args.draftDiffStatus,
   });
 }
 
@@ -267,6 +273,7 @@ export function prepareComponentBaseNode(args: PrepareComponentBaseNodeArgs): Ca
         label: displayLabel,
         state: "pending" as const,
         outputChannels: metadata?.outputChannels?.map((channel) => channel.name) || ["default"],
+        _draftDiffStatus: args.draftDiffStatus,
         component: {
           ...componentBaseProps,
           emptyStateProps,

--- a/web_src/src/pages/workflowv2/workflowPageHelpers.ts
+++ b/web_src/src/pages/workflowv2/workflowPageHelpers.ts
@@ -79,6 +79,7 @@ export function prepareData(
   user?: SuperplaneMeUser | null,
   canvasMode: "live" | "edit" = "live",
   openModal?: (modal: TriggerActionModal) => void,
+  draftDiffStatusMap?: Record<string, "added" | "updated" | "removed">,
 ): {
   nodes: CanvasNode[];
   edges: CanvasEdge[];
@@ -104,6 +105,7 @@ export function prepareData(
           workflowEdges,
           canvasMode,
           openModal,
+          draftDiffStatusMap?.[node.id!],
         );
       })
       .map((node) => ({
@@ -128,12 +130,14 @@ export function prepareNode(
   edges?: ComponentsEdge[],
   canvasMode: "live" | "edit" = "live",
   openModal?: (modal: TriggerActionModal) => void,
+  draftDiffStatus?: "added" | "updated" | "removed",
 ): CanvasNode {
   switch (node.type) {
     case "TYPE_TRIGGER":
       return prepareTriggerNode(node, triggers, nodeEventsMap, canvasMode, {
         canvasId: workflowId,
         openModal,
+        draftDiffStatus,
       });
     case "TYPE_WIDGET":
       return prepareAnnotationNode(node);
@@ -150,6 +154,7 @@ export function prepareNode(
         currentUser,
         edges,
         canvasMode,
+        draftDiffStatus,
       });
   }
 }

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -29,7 +29,6 @@ export const Block = React.memo(function Block(props: BlockProps) {
         "relative w-fit rounded-md",
         diffRing,
         shouldFade && !shouldBlankBody && "opacity-30",
-        isDeleted && "opacity-50",
       )}
       onClick={(e) => props.onClick?.(e)}
     >

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { Plus, Minus, Diff } from "lucide-react";
 import { BlockContent } from "./content";
 import { LeftHandle, RightHandle } from "./handles";
 import type { BlockProps } from "./types";
@@ -10,8 +10,8 @@ export type { CanvasBlockData } from "./types";
 
 const DIFF_BADGE: Record<string, { label: string; bg: string; Icon: React.FC<{ className?: string }> }> = {
   added: { label: "ADDED", bg: "bg-green-500", Icon: Plus },
-  updated: { label: "EDITED", bg: "bg-blue-500", Icon: Pencil },
-  removed: { label: "DELETED", bg: "bg-red-500", Icon: Trash2 },
+  updated: { label: "EDITED", bg: "bg-blue-500", Icon: Diff },
+  removed: { label: "REMOVED", bg: "bg-red-500", Icon: Minus },
 };
 
 function DraftDiffBadge({ status }: { status: string }) {

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -18,10 +18,10 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const isHighlighted = data._isHighlighted || false;
   const hasHighlightedNodes = data._hasHighlightedNodes || false;
   const shouldFade = hasHighlightedNodes && !isHighlighted;
-  const shouldBlankBody = data._dimBodyBelowHeader || false;
+  const isDeleted = data._draftDiffStatus === "removed";
+  const shouldBlankBody = data._dimBodyBelowHeader || isDeleted;
   const isConnectionInteractive = props.canvasMode !== "live";
   const diffRing = data._draftDiffStatus ? DRAFT_DIFF_RING[data._draftDiffStatus] || "" : "";
-  const isDeleted = data._draftDiffStatus === "removed";
 
   return (
     <div

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Plus, Minus, Diff } from "lucide-react";
+import { Plus, Minus, Diff, Eye } from "lucide-react";
 import { BlockContent } from "./content";
 import { LeftHandle, RightHandle } from "./handles";
 import type { BlockProps } from "./types";
@@ -19,14 +19,26 @@ function DraftDiffBadge({ status }: { status: string }) {
   if (!badge) return null;
   const { Icon } = badge;
   return (
-    <div
-      className={cn(
-        "absolute -bottom-3 right-2 z-10 flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white shadow-sm",
-        badge.bg,
-      )}
-    >
-      <Icon className="h-3 w-3" />
-      <span>{badge.label}</span>
+    <div className="absolute -bottom-3 right-2 z-10 flex items-center gap-1 nodrag">
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:bg-gray-50 border border-gray-200"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <Eye className="h-3 w-3" />
+        <span>See diff</span>
+      </button>
+      <div
+        className={cn(
+          "flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white shadow-sm",
+          badge.bg,
+        )}
+      >
+        <Icon className="h-3 w-3" />
+        <span>{badge.label}</span>
+      </div>
     </div>
   );
 }

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -7,6 +7,12 @@ import type { BlockProps } from "./types";
 export type { BlockData, BlockProps } from "./types";
 export type { CanvasBlockData } from "./types";
 
+const DRAFT_DIFF_RING: Record<string, string> = {
+  added: "ring-2 ring-green-500",
+  updated: "ring-2 ring-orange-400",
+  removed: "ring-2 ring-red-500 pointer-events-none",
+};
+
 export const Block = React.memo(function Block(props: BlockProps) {
   const data = props.data;
   const isHighlighted = data._isHighlighted || false;
@@ -14,10 +20,17 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const shouldFade = hasHighlightedNodes && !isHighlighted;
   const shouldBlankBody = data._dimBodyBelowHeader || false;
   const isConnectionInteractive = props.canvasMode !== "live";
+  const diffRing = data._draftDiffStatus ? DRAFT_DIFF_RING[data._draftDiffStatus] || "" : "";
+  const isDeleted = data._draftDiffStatus === "removed";
 
   return (
     <div
-      className={cn("relative w-fit", shouldFade && !shouldBlankBody && "opacity-30")}
+      className={cn(
+        "relative w-fit rounded-md",
+        diffRing,
+        shouldFade && !shouldBlankBody && "opacity-30",
+        isDeleted && "opacity-50",
+      )}
       onClick={(e) => props.onClick?.(e)}
     >
       <div className="relative z-[1] w-fit">

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
+import { Plus, Pencil, Trash2 } from "lucide-react";
 import { BlockContent } from "./content";
 import { LeftHandle, RightHandle } from "./handles";
 import type { BlockProps } from "./types";
@@ -7,11 +8,28 @@ import type { BlockProps } from "./types";
 export type { BlockData, BlockProps } from "./types";
 export type { CanvasBlockData } from "./types";
 
-const DRAFT_DIFF_RING: Record<string, string> = {
-  added: "ring-2 ring-green-500",
-  updated: "ring-2 ring-orange-400",
-  removed: "ring-2 ring-red-500 pointer-events-none",
+const DIFF_BADGE: Record<string, { label: string; bg: string; Icon: React.FC<{ className?: string }> }> = {
+  added: { label: "ADDED", bg: "bg-green-500", Icon: Plus },
+  updated: { label: "EDITED", bg: "bg-blue-500", Icon: Pencil },
+  removed: { label: "DELETED", bg: "bg-red-500", Icon: Trash2 },
 };
+
+function DraftDiffBadge({ status }: { status: string }) {
+  const badge = DIFF_BADGE[status];
+  if (!badge) return null;
+  const { Icon } = badge;
+  return (
+    <div
+      className={cn(
+        "absolute -bottom-3 right-2 z-10 flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white shadow-sm",
+        badge.bg,
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      <span>{badge.label}</span>
+    </div>
+  );
+}
 
 export const Block = React.memo(function Block(props: BlockProps) {
   const data = props.data;
@@ -21,11 +39,10 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const isDeleted = data._draftDiffStatus === "removed";
   const shouldBlankBody = data._dimBodyBelowHeader || isDeleted;
   const isConnectionInteractive = props.canvasMode !== "live";
-  const diffRing = data._draftDiffStatus ? DRAFT_DIFF_RING[data._draftDiffStatus] || "" : "";
 
   return (
     <div
-      className={cn("relative w-fit rounded-md", diffRing, shouldFade && !shouldBlankBody && "opacity-30")}
+      className={cn("relative w-fit", shouldFade && !shouldBlankBody && "opacity-30")}
       onClick={(e) => props.onClick?.(e)}
     >
       <div className="relative z-[1] w-fit">
@@ -38,6 +55,7 @@ export const Block = React.memo(function Block(props: BlockProps) {
           onAppendFromNode={props.onAppendFromNode}
         />
       </div>
+      {data._draftDiffStatus && <DraftDiffBadge status={data._draftDiffStatus} />}
     </div>
   );
 });

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -52,7 +52,7 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const shouldFade = hasHighlightedNodes && !isHighlighted;
   const isDeleted = data._draftDiffStatus === "removed";
   const shouldBlankBody = data._dimBodyBelowHeader || isDeleted;
-  const isConnectionInteractive = props.canvasMode !== "live";
+  const isConnectionInteractive = props.canvasMode !== "live" && !isDeleted;
 
   return (
     <div

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -22,7 +22,7 @@ function DraftDiffBadge({ status }: { status: string }) {
     <div className="absolute -bottom-3 right-2 z-10 flex items-center gap-1 nodrag">
       <button
         type="button"
-        className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity group-hover:opacity-100 hover:bg-gray-50 border border-gray-200"
+        className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity group-hover/block:opacity-100 hover:bg-gray-50 border border-gray-200"
         onClick={(e) => {
           e.stopPropagation();
         }}
@@ -54,7 +54,7 @@ export const Block = React.memo(function Block(props: BlockProps) {
 
   return (
     <div
-      className={cn("relative w-fit", shouldFade && !shouldBlankBody && "opacity-30")}
+      className={cn("group/block relative w-fit", shouldFade && !shouldBlankBody && "opacity-30")}
       onClick={(e) => props.onClick?.(e)}
     >
       <div className="relative z-[1] w-fit">

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -20,16 +20,18 @@ function DraftDiffBadge({ status }: { status: string }) {
   const { Icon } = badge;
   return (
     <div className="absolute -bottom-3 right-2 z-10 flex items-center gap-1 nodrag">
-      <button
-        type="button"
-        className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity group-hover/block:opacity-100 hover:bg-gray-50 border border-gray-200"
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        <Eye className="h-3 w-3" />
-        <span>See diff</span>
-      </button>
+      {status === "updated" && (
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 opacity-0 shadow-sm transition-opacity group-hover/block:opacity-100 hover:bg-gray-50 border border-gray-200"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <Eye className="h-3 w-3" />
+          <span>See diff</span>
+        </button>
+      )}
       <div
         className={cn(
           "flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide text-white shadow-sm",

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -25,11 +25,7 @@ export const Block = React.memo(function Block(props: BlockProps) {
 
   return (
     <div
-      className={cn(
-        "relative w-fit rounded-md",
-        diffRing,
-        shouldFade && !shouldBlankBody && "opacity-30",
-      )}
+      className={cn("relative w-fit rounded-md", diffRing, shouldFade && !shouldBlankBody && "opacity-30")}
       onClick={(e) => props.onClick?.(e)}
     >
       <div className="relative z-[1] w-fit">

--- a/web_src/src/ui/CanvasPage/Block/types.ts
+++ b/web_src/src/ui/CanvasPage/Block/types.ts
@@ -46,6 +46,7 @@ export interface BlockInternalData {
   _isHighlighted?: boolean;
   _hasHighlightedNodes?: boolean;
   _dimBodyBelowHeader?: boolean;
+  _draftDiffStatus?: "added" | "updated" | "removed";
   isTemplate?: boolean;
   isPendingConnection?: boolean;
 }

--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -100,9 +100,10 @@ export const CustomEdge = React.memo(function CustomEdge({
   }, [id, onDeleteEdge, setEdges]);
 
   // Update style based on selection and hover state
+  const hasDiffColor = style.stroke && style.stroke !== "#C9D5E1";
   const edgeStyle: CSSProperties = {
     ...style,
-    stroke: selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
+    stroke: hasDiffColor ? style.stroke : selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
     strokeWidth: selected ? 3 : style.strokeWidth || 3,
     pointerEvents: "visibleStroke",
     ...(selected || isHovered ? { strokeOpacity: 1 } : {}),

--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -100,10 +100,9 @@ export const CustomEdge = React.memo(function CustomEdge({
   }, [id, onDeleteEdge, setEdges]);
 
   // Update style based on selection and hover state
-  const hasDiffColor = style.stroke && style.stroke !== "#C9D5E1";
   const edgeStyle: CSSProperties = {
     ...style,
-    stroke: hasDiffColor ? style.stroke : selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
+    stroke: selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
     strokeWidth: selected ? 3 : style.strokeWidth || 3,
     pointerEvents: "visibleStroke",
     ...(selected || isHovered ? { strokeOpacity: 1 } : {}),

--- a/web_src/src/ui/CanvasPage/CustomEdge.tsx
+++ b/web_src/src/ui/CanvasPage/CustomEdge.tsx
@@ -100,9 +100,11 @@ export const CustomEdge = React.memo(function CustomEdge({
   }, [id, onDeleteEdge, setEdges]);
 
   // Update style based on selection and hover state
+  // Preserve diff colors (non-default stroke) on hover/select
+  const hasDiffColor = !!style.stroke && style.stroke !== "#C9D5E1";
   const edgeStyle: CSSProperties = {
     ...style,
-    stroke: selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
+    stroke: hasDiffColor ? style.stroke : selected || isHovered ? "#A1AEC0" : style.stroke || "#DEF3FE",
     strokeWidth: selected ? 3 : style.strokeWidth || 3,
     pointerEvents: "visibleStroke",
     ...(selected || isHovered ? { strokeOpacity: 1 } : {}),

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2695,18 +2695,27 @@ function CanvasContent({
     [],
   );
   const styledEdges = useMemo(() => {
-    return state.edges?.map((e) => ({
-      ...e,
-      ...EDGE_STYLE,
-      style: { ...EDGE_STYLE.style },
-      data: {
-        ...e.data,
-        isHovered: e.id === hoveredEdgeId,
-        canDelete: isEditMode && !isReadOnly,
-        onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
-      },
-      zIndex: e.id === hoveredEdgeId ? 1000 : 0,
-    }));
+    return state.edges?.map((e) => {
+      const diffStatus = (e.data as Record<string, unknown> | undefined)?._draftDiffStatus as string | undefined;
+      const diffStyle =
+        diffStatus === "removed"
+          ? { stroke: "#EF4444", strokeDasharray: "8 4" }
+          : diffStatus === "added"
+            ? { stroke: "#22C55E" }
+            : {};
+      return {
+        ...e,
+        ...EDGE_STYLE,
+        style: { ...EDGE_STYLE.style, ...diffStyle },
+        data: {
+          ...e.data,
+          isHovered: e.id === hoveredEdgeId,
+          canDelete: isEditMode && !isReadOnly && diffStatus !== "removed",
+          onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
+        },
+        zIndex: e.id === hoveredEdgeId ? 1000 : 0,
+      };
+    });
   }, [state.edges, hoveredEdgeId, stableEdgeDelete, isEditMode, isReadOnly]);
 
   const isConnectionEditingEnabled = isEditMode && !isReadOnly && !!onEdgeCreate;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2695,18 +2695,29 @@ function CanvasContent({
     [],
   );
   const styledEdges = useMemo(() => {
-    return state.edges?.map((e) => ({
-      ...e,
-      ...EDGE_STYLE,
-      style: { ...EDGE_STYLE.style },
-      data: {
-        ...e.data,
-        isHovered: e.id === hoveredEdgeId,
-        canDelete: isEditMode && !isReadOnly,
-        onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
-      },
-      zIndex: e.id === hoveredEdgeId ? 1000 : 0,
-    }));
+    return state.edges?.map((e) => {
+      const diffStatus = (e.data as Record<string, unknown> | undefined)?._draftDiffStatus as string | undefined;
+      const diffStyle =
+        diffStatus === "removed"
+          ? { stroke: "#EF4444", strokeDasharray: "8 4" }
+          : diffStatus === "added"
+            ? { stroke: "#22C55E" }
+            : diffStatus === "updated"
+              ? { stroke: "#FB923C" }
+              : {};
+      return {
+        ...e,
+        ...EDGE_STYLE,
+        style: { ...EDGE_STYLE.style, ...diffStyle },
+        data: {
+          ...e.data,
+          isHovered: e.id === hoveredEdgeId,
+          canDelete: isEditMode && !isReadOnly && diffStatus !== "removed",
+          onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
+        },
+        zIndex: e.id === hoveredEdgeId ? 1000 : 0,
+      };
+    });
   }, [state.edges, hoveredEdgeId, stableEdgeDelete, isEditMode, isReadOnly]);
 
   const isConnectionEditingEnabled = isEditMode && !isReadOnly && !!onEdgeCreate;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2695,29 +2695,18 @@ function CanvasContent({
     [],
   );
   const styledEdges = useMemo(() => {
-    return state.edges?.map((e) => {
-      const diffStatus = (e.data as Record<string, unknown> | undefined)?._draftDiffStatus as string | undefined;
-      const diffStyle =
-        diffStatus === "removed"
-          ? { stroke: "#EF4444", strokeDasharray: "8 4" }
-          : diffStatus === "added"
-            ? { stroke: "#22C55E" }
-            : diffStatus === "updated"
-              ? { stroke: "#FB923C" }
-              : {};
-      return {
-        ...e,
-        ...EDGE_STYLE,
-        style: { ...EDGE_STYLE.style, ...diffStyle },
-        data: {
-          ...e.data,
-          isHovered: e.id === hoveredEdgeId,
-          canDelete: isEditMode && !isReadOnly && diffStatus !== "removed",
-          onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
-        },
-        zIndex: e.id === hoveredEdgeId ? 1000 : 0,
-      };
-    });
+    return state.edges?.map((e) => ({
+      ...e,
+      ...EDGE_STYLE,
+      style: { ...EDGE_STYLE.style },
+      data: {
+        ...e.data,
+        isHovered: e.id === hoveredEdgeId,
+        canDelete: isEditMode && !isReadOnly,
+        onDelete: isEditMode && !isReadOnly ? stableEdgeDelete : undefined,
+      },
+      zIndex: e.id === hoveredEdgeId ? 1000 : 0,
+    }));
   }, [state.edges, hoveredEdgeId, stableEdgeDelete, isEditMode, isReadOnly]);
 
   const isConnectionEditingEnabled = isEditMode && !isReadOnly && !!onEdgeCreate;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -2699,9 +2699,9 @@ function CanvasContent({
       const diffStatus = (e.data as Record<string, unknown> | undefined)?._draftDiffStatus as string | undefined;
       const diffStyle =
         diffStatus === "removed"
-          ? { stroke: "#EF4444", strokeDasharray: "8 4" }
+          ? { stroke: "#F9A8A8", strokeDasharray: "8 4" }
           : diffStatus === "added"
-            ? { stroke: "#22C55E" }
+            ? { stroke: "#86EFAC" }
             : {};
       return {
         ...e,


### PR DESCRIPTION
## What

Visual diff indicators on canvas nodes when viewing a draft in edit mode.

## How it looks

| Status | Visual |
|--------|--------|
| New node | Green ring (`ring-2 ring-green-500`) |
| Edited node | Orange ring (`ring-2 ring-orange-400`) |
| Deleted node | Red ring + dimmed ghost node (`ring-2 ring-red-500`, 50% opacity) |
| Unchanged | No change |

## Implementation

- **`draftNodeDiff.tsx`**: New `buildDraftDiffMap()` helper returns `statusMap` (nodeId → added/updated/removed) + `removedNodes` array
- **`Block/types.ts`**: Added `_draftDiffStatus` to `BlockInternalData`
- **`Block/index.tsx`**: Ring styling based on diff status. Deleted nodes get `pointer-events-none`
- **`canvas-node-preparation.ts`**: Accepts + passes through `draftDiffStatus`
- **`workflowPageHelpers.ts`**: Passes diff status from map to each node
- **`index.tsx`**: Computes diff map when editing draft, injects ghost nodes for deletions

## Notes

- Reuses existing `buildDraftNodeDiffSummary` (already used in CreateChangeRequestModal)
- Ghost nodes use live version position data, rendered as non-interactive dimmed blocks
- No backend changes
- Design is prototype-quality — details TBD