### PR TITLE
feat: add canvas yaml diff view

### DIFF
--- a/web_src/package-lock.json
+++ b/web_src/package-lock.json
@@ -15,6 +15,7 @@
         "@headlessui/react": "^2.2.4",
         "@hey-api/client-fetch": "^0.10.1",
         "@monaco-editor/react": "^4.7.0",
+        "@pierre/diffs": "^1.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -2438,6 +2439,33 @@
         "win32"
       ]
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.2.tgz",
+      "integrity": "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.0.3",
+        "@shikijs/transformers": "^3.0.0",
+        "diff": "8.0.3",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz",
+      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4517,6 +4545,83 @@
       "peerDependencies": {
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
+      "integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -8136,6 +8241,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diff-match-patch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
@@ -9655,6 +9769,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -9738,6 +9875,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -11097,6 +11244,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -12437,6 +12590,23 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -13467,6 +13637,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -13894,6 +14088,22 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {

--- a/web_src/package.json
+++ b/web_src/package.json
@@ -30,6 +30,7 @@
     "@headlessui/react": "^2.2.4",
     "@hey-api/client-fetch": "^0.10.1",
     "@monaco-editor/react": "^4.7.0",
+    "@pierre/diffs": "^1.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ToolTabsHeader } from "./ToolTabsHeader";
+
+describe("ToolTabsHeader", () => {
+  it("selects the first available tab when the active tab is hidden", () => {
+    render(
+      <ToolTabsHeader
+        tabs={[
+          { value: "runs", label: "Runs" },
+          { value: "versions", label: "Versions" },
+        ]}
+        activeTab="agent"
+        onSelectTab={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.tsx
+++ b/web_src/src/components/CanvasToolSidebar/ToolTabsHeader.tsx
@@ -9,6 +9,8 @@ export function ToolTabsHeader({
   activeTab: string;
   onSelectTab: (value: string) => void;
 }) {
+  const selectedTab = tabs.some(({ value }) => value === activeTab) ? activeTab : tabs[0]?.value;
+
   return (
     <div
       className="flex h-10 min-h-10 shrink-0 flex-row items-stretch border-b border-slate-950/15 px-4"
@@ -20,11 +22,11 @@ export function ToolTabsHeader({
           key={value}
           type="button"
           role="tab"
-          aria-selected={activeTab === value}
+          aria-selected={selectedTab === value}
           onClick={() => onSelectTab(value)}
           className={cn(
             "mr-4 mb-[-1px] flex items-center border-b text-[13px] font-medium transition-colors",
-            activeTab === value
+            selectedTab === value
               ? "border-gray-700 text-gray-800 dark:border-blue-600 dark:text-blue-400"
               : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300",
           )}

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -133,18 +133,18 @@ describe("CanvasToolSidebar", () => {
   });
 
   it("opens version control on first open when managed agents are disabled", async () => {
-    const onToggleVersionControl = vi.fn();
+    const onOpenVersionControl = vi.fn();
 
     render(
       <CanvasToolSidebar
         toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
         mode="version-live"
-        onToggleVersionControl={onToggleVersionControl}
+        onOpenVersionControl={onOpenVersionControl}
       />,
     );
 
     expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    await waitFor(() => expect(onToggleVersionControl).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onOpenVersionControl).toHaveBeenCalledTimes(1));
   });
 
   it("does not switch from runs mode to the agent tab when managed agents are disabled", () => {
@@ -192,33 +192,33 @@ describe("CanvasToolSidebar", () => {
   });
 
   it("enters versions from the versions tab", () => {
-    const onToggleVersionControl = vi.fn();
+    const onOpenVersionControl = vi.fn();
 
     render(
       <CanvasToolSidebar
         toolSidebarState={makeToolSidebarState()}
         mode="version-live"
         isVersionControlOpen={false}
-        onToggleVersionControl={onToggleVersionControl}
+        onOpenVersionControl={onOpenVersionControl}
         versionsContent={<div>Versions content</div>}
       />,
     );
 
     fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
 
-    expect(onToggleVersionControl).toHaveBeenCalledTimes(1);
+    expect(onOpenVersionControl).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Versions content")).toBeInTheDocument();
   });
 
   it("exits versions when switching back to the agent tab", () => {
-    const onToggleVersionControl = vi.fn();
+    const onCloseVersionControl = vi.fn();
 
     render(
       <CanvasToolSidebar
         toolSidebarState={makeToolSidebarState()}
         mode="version-live"
         isVersionControlOpen={true}
-        onToggleVersionControl={onToggleVersionControl}
+        onCloseVersionControl={onCloseVersionControl}
         versionsContent={<div>Versions content</div>}
       />,
     );
@@ -227,7 +227,7 @@ describe("CanvasToolSidebar", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Agent" }));
 
-    expect(onToggleVersionControl).toHaveBeenCalledTimes(1);
+    expect(onCloseVersionControl).toHaveBeenCalledTimes(1);
     expect(screen.getByPlaceholderText("Ask the agent…")).toBeInTheDocument();
   });
 

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasToolSidebar } from ".";
@@ -120,15 +120,31 @@ describe("CanvasToolSidebar", () => {
     render(
       <CanvasToolSidebar
         toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
-        runsContent={<div>Runs content</div>}
+        versionsContent={<div>Versions content</div>}
       />,
     );
 
     expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Runs" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Versions" })).toBeInTheDocument();
-    expect(screen.getByText("Runs content")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Versions content")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("Ask the agent…")).not.toBeInTheDocument();
+  });
+
+  it("opens version control on first open when managed agents are disabled", async () => {
+    const onToggleVersionControl = vi.fn();
+
+    render(
+      <CanvasToolSidebar
+        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
+        mode="version-live"
+        onToggleVersionControl={onToggleVersionControl}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(onToggleVersionControl).toHaveBeenCalledTimes(1));
   });
 
   it("does not switch from runs mode to the agent tab when managed agents are disabled", () => {
@@ -147,7 +163,7 @@ describe("CanvasToolSidebar", () => {
     expect(screen.getByText("Runs content")).toBeInTheDocument();
   });
 
-  it("falls back to runs when version control closes and managed agents are disabled", () => {
+  it("keeps versions selected when version control closes and managed agents are disabled", () => {
     const toolSidebarState = makeToolSidebarState({ isAgentEnabled: false });
     const { rerender } = render(
       <CanvasToolSidebar
@@ -171,8 +187,8 @@ describe("CanvasToolSidebar", () => {
       />,
     );
 
-    expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByText("Runs content")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Versions content")).toBeInTheDocument();
   });
 
   it("enters versions from the versions tab", () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -134,17 +134,39 @@ describe("CanvasToolSidebar", () => {
 
   it("opens version control on first open when managed agents are disabled", async () => {
     const onOpenVersionControl = vi.fn();
+    const onVersionControlAutoOpened = vi.fn();
 
     render(
       <CanvasToolSidebar
         toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
         mode="version-live"
         onOpenVersionControl={onOpenVersionControl}
+        onVersionControlAutoOpened={onVersionControlAutoOpened}
       />,
     );
 
     expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
     await waitFor(() => expect(onOpenVersionControl).toHaveBeenCalledTimes(1));
+    expect(onVersionControlAutoOpened).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-open version control after it already auto-opened for the canvas", () => {
+    const onOpenVersionControl = vi.fn();
+    const onVersionControlAutoOpened = vi.fn();
+
+    render(
+      <CanvasToolSidebar
+        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
+        mode="version-live"
+        hasAutoOpenedVersionControl={true}
+        onOpenVersionControl={onOpenVersionControl}
+        onVersionControlAutoOpened={onVersionControlAutoOpened}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
+    expect(onOpenVersionControl).not.toHaveBeenCalled();
+    expect(onVersionControlAutoOpened).not.toHaveBeenCalled();
   });
 
   it("does not switch from runs mode to the agent tab when managed agents are disabled", () => {

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -18,7 +18,8 @@ export interface CanvasToolSidebarProps {
   onExitRunsMode?: () => void;
   runsContent?: ReactNode;
   isVersionControlOpen?: boolean;
-  onToggleVersionControl?: () => void;
+  onOpenVersionControl?: () => void;
+  onCloseVersionControl?: () => void;
   versionsContent?: ReactNode;
 }
 
@@ -29,7 +30,8 @@ export function CanvasToolSidebar({
   onExitRunsMode,
   runsContent,
   isVersionControlOpen,
-  onToggleVersionControl,
+  onOpenVersionControl,
+  onCloseVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
   if (!toolSidebarState.showToolSidebarToggle || !toolSidebarState.isToolSidebarOpen || !toolSidebarState.canvasId) {
@@ -44,7 +46,8 @@ export function CanvasToolSidebar({
       onExitRunsMode={onExitRunsMode}
       runsContent={runsContent}
       isVersionControlOpen={isVersionControlOpen}
-      onToggleVersionControl={onToggleVersionControl}
+      onOpenVersionControl={onOpenVersionControl}
+      onCloseVersionControl={onCloseVersionControl}
       versionsContent={versionsContent}
     />
   );
@@ -57,7 +60,8 @@ function OpenCanvasToolSidebar({
   onExitRunsMode,
   runsContent,
   isVersionControlOpen,
-  onToggleVersionControl,
+  onOpenVersionControl,
+  onCloseVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
   const hasAgentTab = toolSidebarState.isAgentEnabled;
@@ -86,7 +90,7 @@ function OpenCanvasToolSidebar({
       isVersionControlOpen ||
       mode === "runs" ||
       activeTab !== TAB_VERSIONS ||
-      !onToggleVersionControl ||
+      !onOpenVersionControl ||
       hasAutoOpenedVersionControlRef.current
     ) {
       return;
@@ -94,8 +98,8 @@ function OpenCanvasToolSidebar({
 
     hasAutoOpenedVersionControlRef.current = true;
     toolSidebarState.openToolSidebar();
-    onToggleVersionControl();
-  }, [activeTab, hasAgentTab, isVersionControlOpen, mode, onToggleVersionControl, toolSidebarState]);
+    onOpenVersionControl();
+  }, [activeTab, hasAgentTab, isVersionControlOpen, mode, onOpenVersionControl, toolSidebarState]);
 
   const tabs = [
     ...(hasAgentTab ? [{ value: TAB_AGENT, label: "Agent" }] : []),
@@ -108,7 +112,7 @@ function OpenCanvasToolSidebar({
       setActiveTab(nextTab);
 
       if (nextTab === TAB_RUNS) {
-        if (isVersionControlOpen) onToggleVersionControl?.();
+        if (isVersionControlOpen) onCloseVersionControl?.();
         if (mode !== "runs") {
           toolSidebarState.openToolSidebar();
           onSelectRuns?.();
@@ -121,14 +125,22 @@ function OpenCanvasToolSidebar({
       if (nextTab === TAB_VERSIONS) {
         if (!isVersionControlOpen) {
           toolSidebarState.openToolSidebar();
-          onToggleVersionControl?.();
+          onOpenVersionControl?.();
         }
         return;
       }
 
-      if (isVersionControlOpen) onToggleVersionControl?.();
+      if (isVersionControlOpen) onCloseVersionControl?.();
     },
-    [isVersionControlOpen, mode, onExitRunsMode, onSelectRuns, onToggleVersionControl, toolSidebarState],
+    [
+      isVersionControlOpen,
+      mode,
+      onCloseVersionControl,
+      onExitRunsMode,
+      onOpenVersionControl,
+      onSelectRuns,
+      toolSidebarState,
+    ],
   );
 
   return (

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -19,6 +19,8 @@ export interface CanvasToolSidebarProps {
   runsContent?: ReactNode;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
+  hasAutoOpenedVersionControl?: boolean;
+  onVersionControlAutoOpened?: () => void;
   onCloseVersionControl?: () => void;
   versionsContent?: ReactNode;
 }
@@ -31,6 +33,8 @@ export function CanvasToolSidebar({
   runsContent,
   isVersionControlOpen,
   onOpenVersionControl,
+  hasAutoOpenedVersionControl,
+  onVersionControlAutoOpened,
   onCloseVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
@@ -47,6 +51,8 @@ export function CanvasToolSidebar({
       runsContent={runsContent}
       isVersionControlOpen={isVersionControlOpen}
       onOpenVersionControl={onOpenVersionControl}
+      hasAutoOpenedVersionControl={hasAutoOpenedVersionControl}
+      onVersionControlAutoOpened={onVersionControlAutoOpened}
       onCloseVersionControl={onCloseVersionControl}
       versionsContent={versionsContent}
     />
@@ -61,11 +67,13 @@ function OpenCanvasToolSidebar({
   runsContent,
   isVersionControlOpen,
   onOpenVersionControl,
+  hasAutoOpenedVersionControl,
+  onVersionControlAutoOpened,
   onCloseVersionControl,
   versionsContent,
 }: CanvasToolSidebarProps) {
   const hasAgentTab = toolSidebarState.isAgentEnabled;
-  const hasAutoOpenedVersionControlRef = useRef(false);
+  const hasAutoOpenedVersionControlInMountRef = useRef(false);
   const [activeTab, setActiveTab] = useState(() => defaultToolTab(mode, Boolean(isVersionControlOpen), hasAgentTab));
 
   useEffect(() => {
@@ -91,15 +99,26 @@ function OpenCanvasToolSidebar({
       mode === "runs" ||
       activeTab !== TAB_VERSIONS ||
       !onOpenVersionControl ||
-      hasAutoOpenedVersionControlRef.current
+      hasAutoOpenedVersionControl ||
+      hasAutoOpenedVersionControlInMountRef.current
     ) {
       return;
     }
 
-    hasAutoOpenedVersionControlRef.current = true;
+    hasAutoOpenedVersionControlInMountRef.current = true;
+    onVersionControlAutoOpened?.();
     toolSidebarState.openToolSidebar();
     onOpenVersionControl();
-  }, [activeTab, hasAgentTab, isVersionControlOpen, mode, onOpenVersionControl, toolSidebarState]);
+  }, [
+    activeTab,
+    hasAgentTab,
+    hasAutoOpenedVersionControl,
+    isVersionControlOpen,
+    mode,
+    onOpenVersionControl,
+    onVersionControlAutoOpened,
+    toolSidebarState,
+  ]);
 
   const tabs = [
     ...(hasAgentTab ? [{ value: TAB_AGENT, label: "Agent" }] : []),

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { AgentTabPanel } from "./AgentTabPanel";
 import { EmptyToolTab } from "./EmptyToolTab";
 import { SidebarShell } from "./SidebarShell";
@@ -61,6 +61,7 @@ function OpenCanvasToolSidebar({
   versionsContent,
 }: CanvasToolSidebarProps) {
   const hasAgentTab = toolSidebarState.isAgentEnabled;
+  const hasAutoOpenedVersionControlRef = useRef(false);
   const [activeTab, setActiveTab] = useState(() => defaultToolTab(mode, Boolean(isVersionControlOpen), hasAgentTab));
 
   useEffect(() => {
@@ -73,11 +74,28 @@ function OpenCanvasToolSidebar({
       return;
     }
     setActiveTab((currentTab) => {
-      if ((currentTab === TAB_AGENT || currentTab === TAB_VERSIONS) && !hasAgentTab) return TAB_RUNS;
+      if (currentTab === TAB_AGENT && !hasAgentTab) return TAB_VERSIONS;
       if ((currentTab === TAB_RUNS || currentTab === TAB_VERSIONS) && hasAgentTab) return TAB_AGENT;
       return currentTab;
     });
   }, [hasAgentTab, isVersionControlOpen, mode]);
+
+  useEffect(() => {
+    if (
+      hasAgentTab ||
+      isVersionControlOpen ||
+      mode === "runs" ||
+      activeTab !== TAB_VERSIONS ||
+      !onToggleVersionControl ||
+      hasAutoOpenedVersionControlRef.current
+    ) {
+      return;
+    }
+
+    hasAutoOpenedVersionControlRef.current = true;
+    toolSidebarState.openToolSidebar();
+    onToggleVersionControl();
+  }, [activeTab, hasAgentTab, isVersionControlOpen, mode, onToggleVersionControl, toolSidebarState]);
 
   const tabs = [
     ...(hasAgentTab ? [{ value: TAB_AGENT, label: "Agent" }] : []),
@@ -146,5 +164,5 @@ function defaultToolTab(mode: CanvasToolSidebarMode, isVersionControlOpen: boole
   if (mode === "runs") return TAB_RUNS;
   if (isVersionControlOpen) return TAB_VERSIONS;
   if (hasAgentTab) return TAB_AGENT;
-  return TAB_RUNS;
+  return TAB_VERSIONS;
 }

--- a/web_src/src/pages/workflowv2/CanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlDiffModal.tsx
@@ -1,0 +1,130 @@
+import { MultiFileDiff, type FileContents, type FileDiffMetadata } from "@pierre/diffs/react";
+import { GitCompareArrows } from "lucide-react";
+import { useCallback, useMemo } from "react";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+
+export type CanvasYamlDiffModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  liveYamlText: string;
+  draftYamlText: string;
+  filename: string;
+};
+
+export function CanvasYamlDiffModal({
+  open,
+  onOpenChange,
+  liveYamlText,
+  draftYamlText,
+  filename,
+}: CanvasYamlDiffModalProps) {
+  const { oldFile, newFile } = useMemo(() => {
+    const liveFile: FileContents = {
+      name: filename,
+      contents: liveYamlText,
+      lang: "yaml",
+    };
+    const draftFile: FileContents = {
+      name: filename,
+      contents: draftYamlText,
+      lang: "yaml",
+    };
+
+    return { oldFile: liveFile, newFile: draftFile };
+  }, [draftYamlText, filename, liveYamlText]);
+
+  const renderDiffHeader = useCallback(
+    (fileDiff: FileDiffMetadata) => {
+      const { additions, deletions } = fileDiff.hunks.reduce(
+        (totals, hunk) => ({
+          additions: totals.additions + hunk.additionLines,
+          deletions: totals.deletions + hunk.deletionLines,
+        }),
+        { additions: 0, deletions: 0 },
+      );
+
+      return (
+        <div className="w-full">
+          <div className="flex min-h-11 items-center justify-between gap-4 border-b border-slate-200 bg-slate-50 px-4 py-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="h-2 w-2 shrink-0 rounded-full bg-blue-600" />
+              <span className="truncate font-sans text-sm font-medium text-slate-900">{filename}</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2 font-mono text-xs">
+              <span className="text-red-600">-{deletions}</span>
+              <span className="text-emerald-600">+{additions}</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 font-mono text-xs font-semibold">
+            <div className="border-r border-slate-200 bg-red-50/70 px-4 py-1.5 text-red-700">Live</div>
+            <div className="bg-emerald-50/70 px-4 py-1.5 text-emerald-700">Draft</div>
+          </div>
+        </div>
+      );
+    },
+    [filename],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="large" className="flex h-[90vh] w-[94vw] max-w-[1600px] flex-col gap-0 overflow-hidden p-0">
+        <DialogTitle className="sr-only">Canvas YAML diff</DialogTitle>
+        <DialogDescription className="sr-only">
+          Side-by-side YAML comparison between live and draft canvas versions.
+        </DialogDescription>
+
+        <div className="flex min-h-0 flex-1 flex-col bg-slate-50">
+          <div className="flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-700">
+                <GitCompareArrows className="h-4 w-4" />
+              </span>
+              <h2 className="truncate text-sm font-semibold text-slate-900">Show Diff</h2>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto">
+            <div className="min-w-[980px] border border-slate-200 bg-white">
+              <MultiFileDiff
+                oldFile={oldFile}
+                newFile={newFile}
+                disableWorkerPool
+                renderCustomHeader={renderDiffHeader}
+                options={{
+                  theme: "github-light",
+                  diffStyle: "split",
+                  diffIndicators: "classic",
+                  hunkSeparators: "line-info",
+                  lineDiffType: "word",
+                  overflow: "wrap",
+                  stickyHeader: true,
+                  tokenizeMaxLineLength: 1_000,
+                  unsafeCSS: `
+                    :host {
+                      display: block;
+                      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+                      font-size: 12px;
+                      line-height: 18px;
+                    }
+
+                    [data-diffs-header] {
+                      border-bottom: 1px solid rgb(226 232 240);
+                      background: rgb(248 250 252);
+                      z-index: 5;
+                    }
+
+                    [data-diffs-header="custom"] {
+                      display: block;
+                      padding: 0;
+                    }
+                  `,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/workflowv2/WorkflowTemplateBanner.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowTemplateBanner.tsx
@@ -1,0 +1,104 @@
+import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { countNodesByType, extractIntegrations, getTemplateTags } from "@/pages/canvas/templateMetadata";
+import { getIntegrationIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
+import { ArrowLeft } from "lucide-react";
+import { Link } from "react-router-dom";
+
+type WorkflowTemplateBannerProps = {
+  canvasName?: string;
+  canvasDescription?: string;
+  canvasNodes: ComponentsNode[];
+  organizationId?: string;
+  hasUnsavedChanges: boolean;
+  onUseTemplate: () => void;
+};
+
+export function WorkflowTemplateBanner({
+  canvasName,
+  canvasDescription,
+  canvasNodes,
+  organizationId,
+  hasUnsavedChanges,
+  onUseTemplate,
+}: WorkflowTemplateBannerProps) {
+  const templateIntegrations = extractIntegrations(canvasNodes);
+  const templateTags = getTemplateTags(canvasName);
+  const templateNodeCounts = countNodesByType(canvasNodes);
+
+  return (
+    <div className="border-b border-orange-200 bg-orange-50 px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <p className="mb-1 truncate text-sm font-medium text-gray-900">{canvasName || "Template"}</p>
+
+          {canvasDescription ? <p className="mb-2 max-w-2xl text-[13px] text-gray-600">{canvasDescription}</p> : null}
+
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+            {templateTags.length > 0 ? (
+              <div className="flex flex-wrap gap-1">
+                {templateTags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="bg-white px-1.5 py-0 text-[11px] text-gray-600">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium text-gray-500">Requires:</span>
+              {templateIntegrations.length > 0 ? (
+                <div className="flex items-center gap-2.5">
+                  {templateIntegrations.map((name) => (
+                    <TemplateIntegration key={name} name={name} />
+                  ))}
+                </div>
+              ) : (
+                <span className="text-xs text-gray-500">No integrations needed</span>
+              )}
+            </div>
+
+            <span className="text-xs text-gray-500">
+              {formatTemplateNodeCounts(templateNodeCounts.components, templateNodeCounts.triggers)}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-end gap-2 self-start">
+          <Link
+            to={`/${organizationId}/templates`}
+            className="flex items-center gap-1 text-sm text-gray-600 transition-colors hover:text-gray-900"
+          >
+            <ArrowLeft size={14} />
+            <span>Back to templates</span>
+          </Link>
+          <Button size="sm" onClick={onUseTemplate}>
+            {hasUnsavedChanges ? "Save changes to new canvas" : "Use template"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TemplateIntegration({ name }: { name: string }) {
+  const iconSrc = getIntegrationIconSrc(name);
+  if (!iconSrc) return null;
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="inline-block h-4 w-4 shrink-0">
+        <img src={iconSrc} alt={name} className="h-full w-full object-contain" />
+      </span>
+      <span className="text-xs capitalize text-gray-600">{name}</span>
+    </span>
+  );
+}
+
+function formatTemplateNodeCounts(components: number, triggers: number) {
+  const counts = [];
+  if (components > 0) counts.push(`${components} ${components === 1 ? "component" : "components"}`);
+  if (triggers > 0) counts.push(`${triggers} ${triggers === 1 ? "trigger" : "triggers"}`);
+  return counts.join(" · ");
+}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5275,6 +5275,9 @@ export function WorkflowPageV2() {
     liveCanvas,
     liveCanvasVersion,
     draftCanvasVersion: latestDraftVersion,
+    draftCanvas: canvas,
+    draftNodes: nodes,
+    activeCanvasVersionId,
     buildYamlExportPayload,
   });
 

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -4815,8 +4815,21 @@ export function WorkflowPageV2() {
     );
   }, [setIsRunsMode, setSearchParams, setSelectedRunId]);
 
-  const handleToggleVersionControl = useCallback(() => {
-    setIsVersionControlOpen((prev) => !prev);
+  const handleOpenVersionControl = useCallback(() => {
+    if (hasEditableVersion) {
+      if (!liveCanvasVersionId) {
+        showErrorToast("No live version available");
+        return;
+      }
+
+      handleUseVersion(liveCanvasVersionId);
+    }
+
+    setIsVersionControlOpen(true);
+  }, [handleUseVersion, hasEditableVersion, liveCanvasVersionId]);
+
+  const handleCloseVersionControl = useCallback(() => {
+    setIsVersionControlOpen(false);
   }, []);
 
   const { handleSelectDashboardMode, handleExitDashboardMode } = useDashboardModeActions({
@@ -5509,7 +5522,8 @@ export function WorkflowPageV2() {
           awaitingApprovalBanner={awaitingApprovalBanner}
           showCanvasSettingsMenu={canUpdateCanvas}
           isVersionControlOpen={isVersionControlOpen}
-          onOpenVersionControl={!hasEditableVersion ? handleToggleVersionControl : undefined}
+          onOpenVersionControl={handleOpenVersionControl}
+          onCloseVersionControl={handleCloseVersionControl}
           showBottomStatusControls={!isTemplate && !isRunsMode && !isMemoryMode}
           hideAddControls={isTemplate || isRunsMode || isMemoryMode}
           hideCanvasToolSidebar={isTemplate}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1,9 +1,6 @@
-import { Badge } from "@/components/ui/badge";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
-import { countNodesByType, extractIntegrations, getTemplateTags } from "@/pages/canvas/templateMetadata";
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
-import { getIntegrationIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { useQueryClient } from "@tanstack/react-query";
 import * as yaml from "js-yaml";
 import debounce from "lodash.debounce";
@@ -96,6 +93,7 @@ import { WorkflowMemoryOverlayLayer } from "./WorkflowMemoryOverlayLayer";
 import { CanvasPageModals } from "./CanvasPageModals";
 import { CanvasVersionNodeDiffDialog, type CanvasVersionNodeDiffContext } from "./CanvasVersionNodeDiffDialog";
 import { CanvasYamlModal } from "./CanvasYamlModal";
+import { WorkflowTemplateBanner } from "./WorkflowTemplateBanner";
 import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
@@ -114,6 +112,7 @@ import { getCustomFieldRenderer, getState, getStateMap } from "./mappers";
 import { resolveExecutionErrors } from "./mappers/dash0";
 import type { TriggerActionModal } from "./mappers/types";
 import { useCancelExecutionHandler } from "./useCancelExecutionHandler";
+import { useCanvasYamlDiffModal } from "./useCanvasYamlDiffModal";
 import { useCanvasYaml } from "./useCanvasYaml";
 import { useExecutionChainData } from "./useExecutionChainData";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
@@ -5023,15 +5022,15 @@ export function WorkflowPageV2() {
     setLastSavedWorkflowSnapshot,
   ]);
 
-  const getYamlExportPayload = useCallback(
-    (canvasNodes: CanvasNode[]) => {
-      if (!canvas) return null;
+  const buildYamlExportPayload = useCallback(
+    (workflow: CanvasesCanvas | null | undefined, canvasNodes?: CanvasNode[]) => {
+      if (!workflow) return null;
 
       const updatedNodes =
-        canvas.spec?.nodes?.map((node) => {
-          const canvasNode = canvasNodes.find((cn) => cn.id === node.id);
-          const componentType = (canvasNode?.data?.type as string) || "";
+        workflow.spec?.nodes?.map((node) => {
+          const canvasNode = canvasNodes?.find((cn) => cn.id === node.id);
           if (canvasNode) {
+            const componentType = (canvasNode?.data?.type as string) || "";
             return {
               ...node,
               position: {
@@ -5048,14 +5047,14 @@ export function WorkflowPageV2() {
         apiVersion: "v1",
         kind: "Canvas",
         metadata: {
-          id: canvas.metadata?.id || "",
-          name: canvas.metadata?.name || "Canvas",
-          description: canvas.metadata?.description || "",
-          isTemplate: canvas.metadata?.isTemplate ?? false,
+          id: workflow.metadata?.id || "",
+          name: workflow.metadata?.name || "Canvas",
+          description: workflow.metadata?.description || "",
+          isTemplate: workflow.metadata?.isTemplate ?? false,
         },
         spec: {
           nodes: updatedNodes,
-          edges: canvas.spec?.edges || [],
+          edges: workflow.spec?.edges || [],
         },
       };
 
@@ -5065,7 +5064,7 @@ export function WorkflowPageV2() {
         lineWidth: 0,
       });
 
-      const safeName = (canvas.metadata?.name || "canvas")
+      const safeName = (workflow.metadata?.name || "canvas")
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, "-")
         .replace(/(^-|-$)/g, "");
@@ -5073,7 +5072,12 @@ export function WorkflowPageV2() {
 
       return { yamlText, filename };
     },
-    [canvas],
+    [],
+  );
+
+  const getYamlExportPayload = useCallback(
+    (canvasNodes: CanvasNode[]) => buildYamlExportPayload(canvas, canvasNodes),
+    [buildYamlExportPayload, canvas],
   );
 
   const handleUseTemplateSubmit = useCallback(
@@ -5252,6 +5256,17 @@ export function WorkflowPageV2() {
     ],
   );
 
+  const hasUnpublishedDraftChanges =
+    !suppressUnpublishedDraftDiscard && !!latestDraftVersion && hasDraftGraphDiffVersusLive;
+  const { onShowDiff, yamlDiffModal } = useCanvasYamlDiffModal({
+    hasUnpublishedDraftChanges,
+    liveCanvas,
+    liveCanvasVersionSpec: liveCanvasVersion?.spec,
+    draftCanvas: canvas,
+    nodes,
+    buildYamlExportPayload,
+  });
+
   const isInitialCanvasBootstrapLoading =
     !canvas && (canvasLoading || triggersLoading || componentsLoading || widgetsLoading || usersLoading);
   const isDraftCanvasLoading =
@@ -5342,76 +5357,15 @@ export function WorkflowPageV2() {
         </div>
       </div>
     ) : null;
-  const templateIntegrations = isTemplate ? extractIntegrations(canvasNodes) : [];
-  const templateTags = isTemplate ? getTemplateTags(canvas?.metadata?.name) : [];
-  const templateNodeCounts = isTemplate ? countNodesByType(canvasNodes) : { components: 0, triggers: 0 };
   const templateBanner = isTemplate ? (
-    <div className="bg-orange-50 border-b border-orange-200 px-4 py-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-gray-900 mb-1 truncate">{canvas?.metadata?.name || "Template"}</p>
-
-          {canvas?.metadata?.description ? (
-            <p className="text-[13px] text-gray-600 mb-2 max-w-2xl">{canvas.metadata.description}</p>
-          ) : null}
-
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
-            {templateTags.length > 0 ? (
-              <div className="flex flex-wrap gap-1">
-                {templateTags.map((tag) => (
-                  <Badge key={tag} variant="outline" className="text-[11px] px-1.5 py-0 text-gray-600 bg-white">
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
-            ) : null}
-
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-gray-500">Requires:</span>
-              {templateIntegrations.length > 0 ? (
-                <div className="flex items-center gap-2.5">
-                  {templateIntegrations.map((name) => {
-                    const iconSrc = getIntegrationIconSrc(name);
-                    if (!iconSrc) return null;
-                    return (
-                      <span key={name} className="inline-flex items-center gap-1">
-                        <span className="inline-block h-4 w-4 shrink-0">
-                          <img src={iconSrc} alt={name} className="h-full w-full object-contain" />
-                        </span>
-                        <span className="text-xs text-gray-600 capitalize">{name}</span>
-                      </span>
-                    );
-                  })}
-                </div>
-              ) : (
-                <span className="text-xs text-gray-500">No integrations needed</span>
-              )}
-            </div>
-
-            <span className="text-xs text-gray-500">
-              {templateNodeCounts.components > 0 &&
-                `${templateNodeCounts.components} ${templateNodeCounts.components === 1 ? "component" : "components"}`}
-              {templateNodeCounts.components > 0 && templateNodeCounts.triggers > 0 && " · "}
-              {templateNodeCounts.triggers > 0 &&
-                `${templateNodeCounts.triggers} ${templateNodeCounts.triggers === 1 ? "trigger" : "triggers"}`}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex flex-col items-end gap-2 shrink-0 self-start">
-          <Link
-            to={`/${organizationId}/templates`}
-            className="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-          >
-            <ArrowLeft size={14} />
-            <span>Back to templates</span>
-          </Link>
-          <Button size="sm" onClick={() => setIsUseTemplateOpen(true)}>
-            {hasUnsavedChanges ? "Save changes to new canvas" : "Use template"}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <WorkflowTemplateBanner
+      canvasName={canvas?.metadata?.name}
+      canvasDescription={canvas?.metadata?.description}
+      canvasNodes={canvasNodes}
+      organizationId={organizationId}
+      hasUnsavedChanges={hasUnsavedChanges}
+      onUseTemplate={() => setIsUseTemplateOpen(true)}
+    />
   ) : null;
 
   const canvasViewKey = selectedCanvasVersion?.metadata?.id || liveCanvasVersionId || "live";
@@ -5484,8 +5438,6 @@ export function WorkflowPageV2() {
     openAddPanel: () => setIsDashboardAddPanelOpen(true),
     openYaml: () => setIsDashboardYamlOpen(true),
   });
-  const hasUnpublishedDraftChanges =
-    !suppressUnpublishedDraftDiscard && !!latestDraftVersion && hasDraftGraphDiffVersusLive;
   const canvasStateMode = getWorkflowCanvasStateMode({
     hasEditableVersion,
     isViewingPendingApprovalVersion,
@@ -5630,6 +5582,7 @@ export function WorkflowPageV2() {
           publishVersionLabel={isChangeManagementDisabled ? "Publish" : "Propose Change"}
           publishVersionDisabled={publishVersionDisabled}
           publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+          onShowDiff={onShowDiff}
           onDiscardVersion={handleResetDraftChanges}
           discardVersionDisabled={resetDraftDisabled}
           discardVersionDisabledTooltip={resetDraftDisabledTooltip}
@@ -5753,6 +5706,7 @@ export function WorkflowPageV2() {
           isImporting={hasLocalSaveActivity}
         />
       ) : null}
+      {yamlDiffModal}
       {resolvingConflictChangeRequest ? (
         <div className="fixed inset-0 z-[100] min-h-0 bg-slate-50">
           <CanvasChangeRequestConflictResolver

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -618,6 +618,15 @@ export function WorkflowPageV2() {
   const hasFitToViewRef = useRef(false);
   const runsHasFitToViewRef = useRef(false);
   const hasSyncedVersionFromURLRef = useRef(false);
+  const autoOpenedVersionControlCanvasIdsRef = useRef<Set<string>>(new Set());
+  const hasAutoOpenedVersionControl = Boolean(canvasId && autoOpenedVersionControlCanvasIdsRef.current.has(canvasId));
+  const handleVersionControlAutoOpened = useCallback(() => {
+    if (!canvasId) {
+      return;
+    }
+
+    autoOpenedVersionControlCanvasIdsRef.current.add(canvasId);
+  }, [canvasId]);
 
   /**
    * Capture the initial node focus from the URL so we only zoom once.
@@ -5524,6 +5533,8 @@ export function WorkflowPageV2() {
           showCanvasSettingsMenu={canUpdateCanvas}
           isVersionControlOpen={isVersionControlOpen}
           onOpenVersionControl={handleOpenVersionControl}
+          hasAutoOpenedVersionControl={hasAutoOpenedVersionControl}
+          onVersionControlAutoOpened={handleVersionControlAutoOpened}
           onCloseVersionControl={handleCloseVersionControl}
           showBottomStatusControls={!isTemplate && !isRunsMode && !isMemoryMode}
           hideAddControls={isTemplate || isRunsMode || isMemoryMode}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -698,14 +698,6 @@ export function WorkflowPageV2() {
     setCreateChangeRequestDescription("");
   }, [isCreateChangeRequestMode, canvasChangeRequests.length]);
 
-  useEffect(() => {
-    if (!hasEditableVersion || !isVersionControlOpen) {
-      return;
-    }
-
-    setIsVersionControlOpen(false);
-  }, [hasEditableVersion, isVersionControlOpen]);
-
   const lastSavedWorkflowRef = useRef<CanvasesCanvas | null>(null);
   const lastSavedWorkflowSignatureRef = useRef("");
   const lastAppliedVersionSnapshotRef = useRef("");
@@ -4655,6 +4647,22 @@ export function WorkflowPageV2() {
     ],
   );
 
+  const handleUseVersionFromVersionPanel = useCallback(
+    (versionID: string) => {
+      if (hasEditableVersion && hasPendingLocalCanvasState && versionID !== activeCanvasVersionIdRef.current) {
+        const shouldSwitch = window.confirm(
+          "You have unsaved changes in the current draft. Switch versions and discard those unsaved changes?",
+        );
+        if (!shouldSwitch) {
+          return;
+        }
+      }
+
+      handleUseVersion(versionID);
+    },
+    [handleUseVersion, hasEditableVersion, hasPendingLocalCanvasState],
+  );
+
   const handleSubmitCreateChangeRequest = useCallback(
     async ({ title, description }: { title: string; description: string }) => {
       if (!organizationId || !canvasId) {
@@ -4816,17 +4824,8 @@ export function WorkflowPageV2() {
   }, [setIsRunsMode, setSearchParams, setSelectedRunId]);
 
   const handleOpenVersionControl = useCallback(() => {
-    if (hasEditableVersion) {
-      if (!liveCanvasVersionId) {
-        showErrorToast("No live version available");
-        return;
-      }
-
-      handleUseVersion(liveCanvasVersionId);
-    }
-
     setIsVersionControlOpen(true);
-  }, [handleUseVersion, hasEditableVersion, liveCanvasVersionId]);
+  }, []);
 
   const handleCloseVersionControl = useCallback(() => {
     setIsVersionControlOpen(false);
@@ -5274,9 +5273,8 @@ export function WorkflowPageV2() {
   const { onShowDiff, yamlDiffModal } = useCanvasYamlDiffModal({
     hasUnpublishedDraftChanges,
     liveCanvas,
-    liveCanvasVersionSpec: liveCanvasVersion?.spec,
-    draftCanvas: canvas,
-    nodes,
+    liveCanvasVersion,
+    draftCanvasVersion: latestDraftVersion,
     buildYamlExportPayload,
   });
 
@@ -5665,26 +5663,26 @@ export function WorkflowPageV2() {
             ) : null
           }
           toolSidebarVersionsContent={
-            !hasEditableVersion ? (
-              <VersionsTabPanel
-                scrollPersistenceKey={canvasId}
-                liveCanvasVersionId={liveCanvasVersionId}
-                selectedCanvasVersion={selectedCanvasVersion}
-                pendingApprovalVersions={pendingApprovalVersions}
-                liveVersions={liveVersions}
-                liveVersionChangeRequestsByVersionId={liveVersionChangeRequestsByVersionId}
-                canUpdateCanvas={canUpdateCanvas}
-                isTemplate={isTemplate}
-                canvasDeletedRemotely={canvasDeletedRemotely}
-                onUseVersion={handleUseVersion}
-                onVersionNodeDiffContextChange={setVersionNodeDiffContext}
-                onLoadMoreLiveVersions={hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined}
-                loadMoreLiveVersionsDisabled={!hasMoreLiveVersions || isLoadingMoreLiveVersions}
-                loadMoreLiveVersionsPending={isLoadingMoreLiveVersions}
-                changeRequestApprovalConfig={liveCanvas?.spec?.changeManagement}
-                rejectedVersions={rejectedVersions}
-              />
-            ) : null
+            <VersionsTabPanel
+              scrollPersistenceKey={canvasId}
+              liveCanvasVersionId={liveCanvasVersionId}
+              selectedCanvasVersion={selectedCanvasVersion}
+              pendingApprovalVersions={pendingApprovalVersions}
+              liveVersions={liveVersions}
+              liveVersionChangeRequestsByVersionId={liveVersionChangeRequestsByVersionId}
+              canUpdateCanvas={canUpdateCanvas}
+              isTemplate={isTemplate}
+              canvasDeletedRemotely={canvasDeletedRemotely}
+              onUseVersion={handleUseVersionFromVersionPanel}
+              onVersionNodeDiffContextChange={setVersionNodeDiffContext}
+              onLoadMoreLiveVersions={hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined}
+              loadMoreLiveVersionsDisabled={!hasMoreLiveVersions || isLoadingMoreLiveVersions}
+              loadMoreLiveVersionsPending={isLoadingMoreLiveVersions}
+              changeRequestApprovalConfig={
+                liveCanvasVersion?.spec?.changeManagement ?? liveCanvas?.spec?.changeManagement
+              }
+              rejectedVersions={rejectedVersions}
+            />
           }
           focusRequest={focusRequest}
           onExecutionChainHandled={handleExecutionChainHandled}

--- a/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
@@ -16,6 +16,9 @@ type UseCanvasYamlDiffModalParams = {
   liveCanvas?: CanvasesCanvas;
   liveCanvasVersion?: CanvasesCanvasVersion;
   draftCanvasVersion?: CanvasesCanvasVersion;
+  draftCanvas?: CanvasesCanvas | null;
+  draftNodes: CanvasNode[];
+  activeCanvasVersionId: string;
   buildYamlExportPayload: (workflow?: CanvasesCanvas | null, overrideNodes?: CanvasNode[]) => YamlExportPayload | null;
 };
 
@@ -24,6 +27,9 @@ export function useCanvasYamlDiffModal({
   liveCanvas,
   liveCanvasVersion,
   draftCanvasVersion,
+  draftCanvas,
+  draftNodes,
+  activeCanvasVersionId,
   buildYamlExportPayload,
 }: UseCanvasYamlDiffModalParams): {
   onShowDiff: (() => void) | undefined;
@@ -39,10 +45,14 @@ export function useCanvasYamlDiffModal({
       ...liveCanvas,
       spec: liveCanvasVersion.spec,
     });
-    const draftPayload = buildYamlExportPayload({
-      ...liveCanvas,
-      spec: draftCanvasVersion.spec,
-    });
+    const useCurrentDraftCanvas =
+      !!draftCanvas && !!activeCanvasVersionId && draftCanvasVersion.metadata?.id === activeCanvasVersionId;
+    const draftPayload = useCurrentDraftCanvas
+      ? buildYamlExportPayload(draftCanvas, draftNodes)
+      : buildYamlExportPayload({
+          ...liveCanvas,
+          spec: draftCanvasVersion.spec,
+        });
 
     if (!livePayload || !draftPayload || livePayload.yamlText === draftPayload.yamlText) {
       return null;
@@ -54,8 +64,12 @@ export function useCanvasYamlDiffModal({
       filename: draftPayload.filename || livePayload.filename,
     };
   }, [
+    activeCanvasVersionId,
     buildYamlExportPayload,
+    draftCanvas,
+    draftCanvasVersion?.metadata?.id,
     draftCanvasVersion?.spec,
+    draftNodes,
     hasUnpublishedDraftChanges,
     liveCanvas,
     liveCanvasVersion?.spec,

--- a/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
@@ -1,0 +1,73 @@
+import { lazy, Suspense, useCallback, useMemo, useState, type ReactNode } from "react";
+import type { CanvasesCanvas } from "@/api-client";
+import type { CanvasNode } from "@/ui/CanvasPage";
+
+const CanvasYamlDiffModal = lazy(() =>
+  import("./CanvasYamlDiffModal").then((module) => ({ default: module.CanvasYamlDiffModal })),
+);
+
+type YamlExportPayload = {
+  yamlText: string;
+  filename: string;
+};
+
+type UseCanvasYamlDiffModalParams = {
+  hasUnpublishedDraftChanges: boolean;
+  liveCanvas?: CanvasesCanvas;
+  liveCanvasVersionSpec?: CanvasesCanvas["spec"];
+  draftCanvas?: CanvasesCanvas | null;
+  nodes: CanvasNode[];
+  buildYamlExportPayload: (workflow?: CanvasesCanvas | null, overrideNodes?: CanvasNode[]) => YamlExportPayload | null;
+};
+
+export function useCanvasYamlDiffModal({
+  hasUnpublishedDraftChanges,
+  liveCanvas,
+  liveCanvasVersionSpec,
+  draftCanvas,
+  nodes,
+  buildYamlExportPayload,
+}: UseCanvasYamlDiffModalParams): {
+  onShowDiff: (() => void) | undefined;
+  yamlDiffModal: ReactNode;
+} {
+  const [open, setOpen] = useState(false);
+  const payload = useMemo(() => {
+    if (!hasUnpublishedDraftChanges || !liveCanvas) {
+      return null;
+    }
+
+    const livePayload = buildYamlExportPayload({
+      ...liveCanvas,
+      spec: liveCanvasVersionSpec || liveCanvas.spec,
+    });
+    const draftPayload = buildYamlExportPayload(draftCanvas, nodes);
+
+    if (!livePayload || !draftPayload || livePayload.yamlText === draftPayload.yamlText) {
+      return null;
+    }
+
+    return {
+      liveYamlText: livePayload.yamlText,
+      draftYamlText: draftPayload.yamlText,
+      filename: draftPayload.filename || livePayload.filename,
+    };
+  }, [buildYamlExportPayload, draftCanvas, hasUnpublishedDraftChanges, liveCanvas, liveCanvasVersionSpec, nodes]);
+
+  const onShowDiff = useCallback(() => setOpen(true), []);
+
+  return {
+    onShowDiff: payload ? onShowDiff : undefined,
+    yamlDiffModal: payload ? (
+      <Suspense fallback={null}>
+        <CanvasYamlDiffModal
+          open={open}
+          onOpenChange={setOpen}
+          liveYamlText={payload.liveYamlText}
+          draftYamlText={payload.draftYamlText}
+          filename={payload.filename}
+        />
+      </Suspense>
+    ) : null,
+  };
+}

--- a/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/workflowv2/useCanvasYamlDiffModal.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense, useCallback, useMemo, useState, type ReactNode } from "react";
-import type { CanvasesCanvas } from "@/api-client";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import type { CanvasNode } from "@/ui/CanvasPage";
 
 const CanvasYamlDiffModal = lazy(() =>
@@ -14,18 +14,16 @@ type YamlExportPayload = {
 type UseCanvasYamlDiffModalParams = {
   hasUnpublishedDraftChanges: boolean;
   liveCanvas?: CanvasesCanvas;
-  liveCanvasVersionSpec?: CanvasesCanvas["spec"];
-  draftCanvas?: CanvasesCanvas | null;
-  nodes: CanvasNode[];
+  liveCanvasVersion?: CanvasesCanvasVersion;
+  draftCanvasVersion?: CanvasesCanvasVersion;
   buildYamlExportPayload: (workflow?: CanvasesCanvas | null, overrideNodes?: CanvasNode[]) => YamlExportPayload | null;
 };
 
 export function useCanvasYamlDiffModal({
   hasUnpublishedDraftChanges,
   liveCanvas,
-  liveCanvasVersionSpec,
-  draftCanvas,
-  nodes,
+  liveCanvasVersion,
+  draftCanvasVersion,
   buildYamlExportPayload,
 }: UseCanvasYamlDiffModalParams): {
   onShowDiff: (() => void) | undefined;
@@ -33,15 +31,18 @@ export function useCanvasYamlDiffModal({
 } {
   const [open, setOpen] = useState(false);
   const payload = useMemo(() => {
-    if (!hasUnpublishedDraftChanges || !liveCanvas) {
+    if (!hasUnpublishedDraftChanges || !liveCanvas || !liveCanvasVersion?.spec || !draftCanvasVersion?.spec) {
       return null;
     }
 
     const livePayload = buildYamlExportPayload({
       ...liveCanvas,
-      spec: liveCanvasVersionSpec || liveCanvas.spec,
+      spec: liveCanvasVersion.spec,
     });
-    const draftPayload = buildYamlExportPayload(draftCanvas, nodes);
+    const draftPayload = buildYamlExportPayload({
+      ...liveCanvas,
+      spec: draftCanvasVersion.spec,
+    });
 
     if (!livePayload || !draftPayload || livePayload.yamlText === draftPayload.yamlText) {
       return null;
@@ -52,9 +53,21 @@ export function useCanvasYamlDiffModal({
       draftYamlText: draftPayload.yamlText,
       filename: draftPayload.filename || livePayload.filename,
     };
-  }, [buildYamlExportPayload, draftCanvas, hasUnpublishedDraftChanges, liveCanvas, liveCanvasVersionSpec, nodes]);
+  }, [
+    buildYamlExportPayload,
+    draftCanvasVersion?.spec,
+    hasUnpublishedDraftChanges,
+    liveCanvas,
+    liveCanvasVersion?.spec,
+  ]);
 
   const onShowDiff = useCallback(() => setOpen(true), []);
+
+  useEffect(() => {
+    if (!payload && open) {
+      setOpen(false);
+    }
+  }, [open, payload]);
 
   return {
     onShowDiff: payload ? onShowDiff : undefined,

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -16,6 +16,7 @@ export interface HeaderProps {
   onSave?: () => void;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
+  onShowDiff?: () => void;
   organizationId?: string;
   saveIsPrimary?: boolean;
   saveButtonHidden?: boolean;

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -48,6 +48,7 @@ export function SecondaryHeaderActions({
         onEnterEditMode={onEnterEditMode}
         enterEditModeDisabled={enterEditModeDisabled}
         enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
+        hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
         onDiscardDraftAndStartEdit={onDiscardDraftAndStartEdit}
         unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
       />
@@ -123,6 +124,7 @@ function LiveModeEditControls({
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
+  hasUnpublishedDraftChanges,
   onDiscardDraftAndStartEdit,
   unpublishedDraftUpdatedAt,
 }: Pick<
@@ -130,6 +132,7 @@ function LiveModeEditControls({
   | "onEnterEditMode"
   | "enterEditModeDisabled"
   | "enterEditModeDisabledTooltip"
+  | "hasUnpublishedDraftChanges"
   | "onDiscardDraftAndStartEdit"
   | "unpublishedDraftUpdatedAt"
 > & {
@@ -153,6 +156,7 @@ function LiveModeEditControls({
   return (
     <EnterEditButton
       onClick={onEnterEditMode}
+      label={hasUnpublishedDraftChanges ? "Continue Editing" : "Edit"}
       disabled={!!enterEditModeDisabled}
       disabledTooltip={enterEditModeDisabledTooltip}
     />
@@ -228,10 +232,12 @@ function HeaderActionSeparator() {
 
 function EnterEditButton({
   onClick,
+  label,
   disabled,
   disabledTooltip,
 }: {
   onClick: () => void;
+  label: string;
   disabled: boolean;
   disabledTooltip?: string;
 }) {
@@ -244,7 +250,7 @@ function EnterEditButton({
       disabled={disabled}
       data-testid="canvas-edit-button"
     >
-      Edit
+      {label}
     </UIButton>
   );
 

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -1,6 +1,6 @@
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { FileCode, Plus } from "lucide-react";
+import { FileCode, GitCompareArrows, Plus } from "lucide-react";
 
 import { Button } from "../button";
 import { EnterEditDraftDropdown } from "./components/EnterEditDraftDropdown";
@@ -14,6 +14,7 @@ export function SecondaryHeaderActions({
   saveDisabledTooltip,
   saveIsPrimary,
   hasUnpublishedDraftChanges,
+  onShowDiff,
   onDiscardVersion,
   discardVersionDisabled,
   discardVersionDisabledTooltip,
@@ -63,6 +64,7 @@ export function SecondaryHeaderActions({
       {mode === "version-edit" ? (
         <EditModeVersionActions
           hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+          onShowDiff={onShowDiff}
           onDiscardVersion={onDiscardVersion}
           discardVersionDisabled={discardVersionDisabled}
           discardVersionDisabledTooltip={discardVersionDisabledTooltip}
@@ -159,6 +161,7 @@ function LiveModeEditControls({
 
 function EditModeVersionActions({
   hasUnpublishedDraftChanges,
+  onShowDiff,
   onDiscardVersion,
   discardVersionDisabled,
   discardVersionDisabledTooltip,
@@ -172,6 +175,7 @@ function EditModeVersionActions({
 }: Pick<
   HeaderProps,
   | "hasUnpublishedDraftChanges"
+  | "onShowDiff"
   | "onDiscardVersion"
   | "discardVersionDisabled"
   | "discardVersionDisabledTooltip"
@@ -186,11 +190,19 @@ function EditModeVersionActions({
   return (
     <div className="flex items-center gap-2">
       {hasUnpublishedDraftChanges ? (
-        <DiscardDraftButton
-          onDiscard={() => onDiscardVersion?.()}
-          disabled={discardVersionDisabled || !onDiscardVersion}
-          disabledTooltip={discardVersionDisabledTooltip}
-        />
+        <>
+          {onShowDiff ? (
+            <>
+              <ShowDiffButton onShowDiff={onShowDiff} />
+              <HeaderActionSeparator />
+            </>
+          ) : null}
+          <DiscardDraftButton
+            onDiscard={() => onDiscardVersion?.()}
+            disabled={discardVersionDisabled || !onDiscardVersion}
+            disabledTooltip={discardVersionDisabledTooltip}
+          />
+        </>
       ) : null}
       {onExitEditMode ? (
         <ExitEditButton
@@ -208,6 +220,10 @@ function EditModeVersionActions({
       />
     </div>
   );
+}
+
+function HeaderActionSeparator() {
+  return <span aria-hidden="true" className="mx-1 h-5 w-px shrink-0 bg-slate-200" />;
 }
 
 function EnterEditButton({
@@ -324,6 +340,15 @@ function SaveButton({
     >
       Save
     </Button>
+  );
+}
+
+function ShowDiffButton({ onShowDiff }: { onShowDiff: () => void }) {
+  return (
+    <UIButton type="button" variant="outline" size="sm" onClick={onShowDiff} data-testid="canvas-show-diff-button">
+      <GitCompareArrows className="mr-1 h-3.5 w-3.5" />
+      Show Diff
+    </UIButton>
   );
 }
 

--- a/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
+++ b/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
@@ -22,7 +22,7 @@ export function EnterEditDraftDropdown({
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <UIButton type="button" variant="default" size="sm" data-testid="canvas-edit-button">
-          Edit
+          Continue Editing
         </UIButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-72 px-2">

--- a/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
+++ b/web_src/src/ui/CanvasPage/components/EnterEditDraftDropdown.tsx
@@ -38,7 +38,7 @@ export function EnterEditDraftDropdown({
         <div className="py-1">
           <DropdownMenuItem onClick={onContinueEditing} className="gap-2 px-3 py-2 text-slate-700 cursor-pointer">
             <Pencil className="h-4 w-4" />
-            <span>Continue editing</span>
+            <span>Continue Editing</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={onDiscardAndStartEdit}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -194,6 +194,8 @@ export interface CanvasPageProps {
   onYamlOpen: () => void;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
+  hasAutoOpenedVersionControl?: boolean;
+  onVersionControlAutoOpened?: () => void;
   onCloseVersionControl?: () => void;
   showBottomStatusControls?: boolean;
   readOnly?: boolean;
@@ -1257,6 +1259,8 @@ function CanvasPage(props: CanvasPageProps) {
           runsContent={props.toolSidebarRunsContent}
           isVersionControlOpen={props.isVersionControlOpen}
           onOpenVersionControl={props.onOpenVersionControl}
+          hasAutoOpenedVersionControl={props.hasAutoOpenedVersionControl}
+          onVersionControlAutoOpened={props.onVersionControlAutoOpened}
           onCloseVersionControl={props.onCloseVersionControl}
           versionsContent={props.toolSidebarVersionsContent}
         />

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -194,6 +194,7 @@ export interface CanvasPageProps {
   onYamlOpen: () => void;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
+  onCloseVersionControl?: () => void;
   showBottomStatusControls?: boolean;
   readOnly?: boolean;
   hideAddControls?: boolean;
@@ -751,7 +752,7 @@ function CanvasPage(props: CanvasPageProps) {
     organizationId: props.organizationId,
     onBeforeClose: () => {
       if (props.headerMode === "runs") props.onExitRunsMode?.();
-      if (props.isVersionControlOpen) props.onOpenVersionControl?.();
+      if (props.isVersionControlOpen) props.onCloseVersionControl?.();
     },
   });
   const { isToolSidebarOpen, openToolSidebar } = toolSidebarState;
@@ -1255,7 +1256,8 @@ function CanvasPage(props: CanvasPageProps) {
           onExitRunsMode={props.onExitRunsMode}
           runsContent={props.toolSidebarRunsContent}
           isVersionControlOpen={props.isVersionControlOpen}
-          onToggleVersionControl={props.onOpenVersionControl}
+          onOpenVersionControl={props.onOpenVersionControl}
+          onCloseVersionControl={props.onCloseVersionControl}
           versionsContent={props.toolSidebarVersionsContent}
         />
 

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -156,6 +156,7 @@ export interface CanvasPageProps {
   saveDisabledTooltip?: string;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
+  onShowDiff?: () => void;
   publishVersionDisabled?: boolean;
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;
@@ -1218,6 +1219,7 @@ function CanvasPage(props: CanvasPageProps) {
           saveDisabledTooltip={props.saveDisabledTooltip}
           onPublishVersion={props.onPublishVersion}
           onDiscardVersion={props.onDiscardVersion}
+          onShowDiff={props.onShowDiff}
           publishVersionDisabled={props.publishVersionDisabled}
           publishVersionDisabledTooltip={props.publishVersionDisabledTooltip}
           discardVersionDisabled={props.discardVersionDisabled}
@@ -1734,6 +1736,7 @@ function CanvasContentHeader({
   saveDisabledTooltip,
   onPublishVersion,
   onDiscardVersion,
+  onShowDiff,
   publishVersionDisabled,
   publishVersionDisabledTooltip,
   discardVersionDisabled,
@@ -1767,6 +1770,7 @@ function CanvasContentHeader({
   saveDisabledTooltip?: string;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
+  onShowDiff?: () => void;
   publishVersionDisabled?: boolean;
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;
@@ -1810,6 +1814,7 @@ function CanvasContentHeader({
       saveDisabledTooltip={saveDisabledTooltip}
       onPublishVersion={onPublishVersion}
       onDiscardVersion={onDiscardVersion}
+      onShowDiff={onShowDiff}
       publishVersionDisabled={publishVersionDisabled}
       publishVersionDisabledTooltip={publishVersionDisabledTooltip}
       discardVersionDisabled={discardVersionDisabled}


### PR DESCRIPTION
## Summary
- Add a Show Diff action for canvases with draft changes.
- Render a split live-vs-draft YAML comparison modal using @pierre/diffs.
- Add sticky diff headers and styled labels for easier review while scrolling.

## Verification
- make format.js
- make check.lint.ui
- make check.build.ui