### PR TITLE
feat: improve runner live log viewer UX

### DIFF
--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
@@ -5,13 +5,14 @@ import type { CommandSection } from "./types";
 import { useLiveLogStream } from "./useLiveLogStream";
 
 export function LiveLogStreamView({ executionId }: { executionId: string }) {
-  const { sections, orphanLines, error, toggleSection, scrollRef } = useLiveLogStream(executionId);
+  const { sections, orphanLines, error, streamWarning, toggleSection, scrollRef } = useLiveLogStream(executionId);
   const hasAnyLogs = orphanLines.length > 0 || sections.length > 0;
   const lastSectionIndex = sections.length - 1;
 
   return (
     <div ref={scrollRef} className="h-full min-h-0 overflow-y-auto bg-slate-50">
       {error ? <ErrorMessage /> : null}
+      {!error && streamWarning ? <StreamWarningMessage message={streamWarning} /> : null}
       {!error && !hasAnyLogs ? <NoLogsMessage /> : null}
 
       {sections.map((section, index) => (
@@ -36,6 +37,10 @@ function ErrorMessage() {
       Something went wrong while fetching logs. Please try again later.
     </div>
   );
+}
+
+function StreamWarningMessage({ message }: { message: string }) {
+  return <div className="px-4 py-3 text-left text-amber-700">{message}</div>;
 }
 
 function CommandSectionView({

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/LiveLogStreamView.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
 import { cn } from "../../../lib/utils";
 import type { CommandSection } from "./types";
 import { useLiveLogStream } from "./useLiveLogStream";
@@ -6,14 +7,20 @@ import { useLiveLogStream } from "./useLiveLogStream";
 export function LiveLogStreamView({ executionId }: { executionId: string }) {
   const { sections, orphanLines, error, toggleSection, scrollRef } = useLiveLogStream(executionId);
   const hasAnyLogs = orphanLines.length > 0 || sections.length > 0;
+  const lastSectionIndex = sections.length - 1;
 
   return (
     <div ref={scrollRef} className="h-full min-h-0 overflow-y-auto bg-slate-50">
       {error ? <ErrorMessage /> : null}
       {!error && !hasAnyLogs ? <NoLogsMessage /> : null}
 
-      {sections.map((section) => (
-        <CommandSectionView key={`${section.index}-${section.text}`} section={section} onToggle={toggleSection} />
+      {sections.map((section, index) => (
+        <CommandSectionView
+          key={`${section.index}-${section.text}`}
+          section={section}
+          onToggle={toggleSection}
+          isLast={index === lastSectionIndex}
+        />
       ))}
     </div>
   );
@@ -31,16 +38,32 @@ function ErrorMessage() {
   );
 }
 
-function CommandSectionView({ section, onToggle }: { section: CommandSection; onToggle: (index: number) => void }) {
+function CommandSectionView({
+  section,
+  onToggle,
+  isLast,
+}: {
+  section: CommandSection;
+  onToggle: (index: number) => void;
+  isLast: boolean;
+}) {
   return (
     <div className="border-b border-slate-200">
-      <CommandSectionHeader section={section} onToggle={onToggle} />
+      <CommandSectionHeader section={section} onToggle={onToggle} isLast={isLast} />
       <CommandSectionContent section={section} />
     </div>
   );
 }
 
-function CommandSectionHeader({ section, onToggle }: { section: CommandSection; onToggle: (index: number) => void }) {
+function CommandSectionHeader({
+  section,
+  onToggle,
+  isLast,
+}: {
+  section: CommandSection;
+  onToggle: (index: number) => void;
+  isLast: boolean;
+}) {
   const isCollapsed = section.status === "passed" && section.collapsed;
 
   const openChevron = <ChevronRight className="size-4" />;
@@ -49,7 +72,10 @@ function CommandSectionHeader({ section, onToggle }: { section: CommandSection; 
   return (
     <button
       type="button"
-      className="flex w-full cursor-pointer items-center justify-between gap-2 px-4 py-2 font-mono text-left text-xs"
+      className={cn(
+        "flex w-full cursor-pointer items-center justify-between gap-2 px-4 py-2 font-mono text-left text-xs",
+        isLast && "sticky top-0 z-10 border-b border-slate-200 bg-slate-50",
+      )}
       onClick={() => onToggle(section.index)}
     >
       <div className="flex items-center gap-2">
@@ -58,7 +84,7 @@ function CommandSectionHeader({ section, onToggle }: { section: CommandSection; 
       </div>
 
       <div className="flex items-center gap-2">
-        <Duration duration={section.duration_ms ?? 0} />
+        <Duration status={section.status} durationMs={section.duration_ms} startedAt={section.started_at} />
         <StatusBadge status={section.status} />
       </div>
     </button>
@@ -77,7 +103,29 @@ function CommandSectionContent({ section }: { section: CommandSection }) {
   );
 }
 
-function Duration({ duration }: { duration: number }) {
+function Duration({
+  status,
+  durationMs,
+  startedAt,
+}: {
+  status: CommandSection["status"];
+  durationMs: number | null;
+  startedAt: number | null;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (status !== "running" || startedAt === null) {
+      return;
+    }
+
+    setNow(Date.now());
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [status, startedAt]);
+
+  const duration = status === "running" && startedAt !== null ? Math.max(0, now - startedAt) : (durationMs ?? 0);
+
   return <div className="flex items-center gap-1">{formatDuration(duration)}</div>;
 }
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
@@ -6,12 +6,13 @@ type LiveLogRecordEnvelope = {
   index?: number;
   status?: "passed" | "failed";
   duration_ms?: number;
+  started_at?: number;
 };
 
 export type LiveLogStreamHandlers = {
   onLogLine: (text: string) => void;
   onStreamError: (message: string) => void;
-  onCmdStart?: (index: number, text: string) => void;
+  onCmdStart?: (index: number, text: string, startedAtMs: number | null) => void;
   onCmdEnd?: (index: number, status: "passed" | "failed", durationMs: number) => void;
 };
 
@@ -60,7 +61,8 @@ function dispatchLiveLogRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStre
     return;
   }
   if (rec.type === "cmd_start" && typeof rec.index === "number" && typeof rec.text === "string") {
-    handlers.onCmdStart?.(rec.index, rec.text);
+    const startedAtMs = typeof rec.started_at === "number" && rec.started_at >= 0 ? rec.started_at : null;
+    handlers.onCmdStart?.(rec.index, rec.text, startedAtMs);
     return;
   }
   if (

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/liveLogStream.ts
@@ -51,28 +51,58 @@ function tryParseLiveLogRecord(line: string): LiveLogRecordEnvelope | null {
   }
 }
 
-function dispatchLiveLogRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): void {
-  if (rec.type === "line" && typeof rec.text === "string") {
-    handlers.onLogLine(rec.text);
-    return;
+function parseStartedAtMs(value: number | undefined): number | null {
+  return typeof value === "number" && value >= 0 ? value : null;
+}
+
+function dispatchLineRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): boolean {
+  if (rec.type !== "line" || typeof rec.text !== "string") {
+    return false;
   }
-  if (rec.type === "error" && typeof rec.message === "string") {
-    handlers.onStreamError(rec.message);
-    return;
+  handlers.onLogLine(rec.text);
+  return true;
+}
+
+function dispatchErrorRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): boolean {
+  if (rec.type !== "error" || typeof rec.message !== "string") {
+    return false;
   }
-  if (rec.type === "cmd_start" && typeof rec.index === "number" && typeof rec.text === "string") {
-    const startedAtMs = typeof rec.started_at === "number" && rec.started_at >= 0 ? rec.started_at : null;
-    handlers.onCmdStart?.(rec.index, rec.text, startedAtMs);
-    return;
+  handlers.onStreamError(rec.message);
+  return true;
+}
+
+function dispatchCmdStartRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): boolean {
+  if (rec.type !== "cmd_start" || typeof rec.index !== "number" || typeof rec.text !== "string") {
+    return false;
   }
+  handlers.onCmdStart?.(rec.index, rec.text, parseStartedAtMs(rec.started_at));
+  return true;
+}
+
+function dispatchCmdEndRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): boolean {
   if (
-    rec.type === "cmd_end" &&
-    typeof rec.index === "number" &&
-    (rec.status === "passed" || rec.status === "failed") &&
-    typeof rec.duration_ms === "number"
+    rec.type !== "cmd_end" ||
+    typeof rec.index !== "number" ||
+    (rec.status !== "passed" && rec.status !== "failed") ||
+    typeof rec.duration_ms !== "number"
   ) {
-    handlers.onCmdEnd?.(rec.index, rec.status, rec.duration_ms);
+    return false;
   }
+  handlers.onCmdEnd?.(rec.index, rec.status, rec.duration_ms);
+  return true;
+}
+
+function dispatchLiveLogRecord(rec: LiveLogRecordEnvelope, handlers: LiveLogStreamHandlers): void {
+  if (dispatchLineRecord(rec, handlers)) {
+    return;
+  }
+  if (dispatchErrorRecord(rec, handlers)) {
+    return;
+  }
+  if (dispatchCmdStartRecord(rec, handlers)) {
+    return;
+  }
+  dispatchCmdEndRecord(rec, handlers);
 }
 
 /** Consumes complete NDJSON lines from buffer; returns the trailing incomplete fragment. */

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
@@ -26,5 +26,6 @@ export type LogState = {
   sections: CommandSection[];
   orphanLines: string[];
   error: string | null;
+  streamWarning: string | null;
   isStreaming: boolean;
 };

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/types.ts
@@ -9,7 +9,7 @@ export type RunnerLiveLogDialogProps = {
 export type LiveLogRecord =
   | { type: "line"; text: string }
   | { type: "error"; message: string }
-  | { type: "cmd_start"; index: number; text: string }
+  | { type: "cmd_start"; index: number; text: string; started_at?: number }
   | { type: "cmd_end"; index: number; status: "passed" | "failed"; duration_ms: number };
 
 export type CommandSection = {
@@ -18,6 +18,7 @@ export type CommandSection = {
   lines: string[];
   status: "running" | "passed" | "failed";
   duration_ms: number | null;
+  started_at: number | null;
   collapsed: boolean;
 };
 

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -32,13 +32,14 @@ function appendLineToLatestSection(state: LogState, text: string): LogState {
   };
 }
 
-function pushCommandSection(state: LogState, index: number, text: string): LogState {
+function pushCommandSection(state: LogState, index: number, text: string, startedAtMs: number | null): LogState {
   const section: CommandSection = {
     index,
     text,
     lines: [],
     status: "running",
     duration_ms: null,
+    started_at: startedAtMs ?? Date.now(),
     collapsed: false,
   };
 
@@ -113,7 +114,8 @@ export function useLiveLogStream(executionId: string) {
         await stream.pump({
           onLogLine: (t) => setState((prev) => appendLineToLatestSection(prev, t)),
           onStreamError: (m) => setState((prev) => ({ ...prev, error: m })),
-          onCmdStart: (index, text) => setState((prev) => pushCommandSection(prev, index, text)),
+          onCmdStart: (index, text, startedAtMs) =>
+            setState((prev) => pushCommandSection(prev, index, text, startedAtMs)),
           onCmdEnd: (index, status, durationMs) =>
             setState((prev) => completeCommandSection(prev, index, status, durationMs)),
         });

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -1,18 +1,40 @@
 import { useCanvasId } from "@/hooks/useCanvasId";
 import { useOrganizationId } from "@/hooks/useOrganizationId";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { LiveLogStream } from "./liveLogStream";
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
+import { LiveLogStream, type LiveLogStreamHandlers } from "./liveLogStream";
 import type { CommandSection, LogState } from "./types";
 import { useScrollToBottom } from "./useScrollToBottom";
+
+const RECONNECT_DELAY_MS = 2000;
 
 const initialLogState: LogState = {
   sections: [],
   orphanLines: [],
   error: null,
+  streamWarning: null,
   isStreaming: false,
 };
 
-function appendLineToLatestSection(state: LogState, text: string): LogState {
+function hasRunningCommand(state: LogState): boolean {
+  return state.sections.some((section) => section.status === "running");
+}
+
+function applyStreamFailure(state: LogState, message: string): LogState {
+  if (hasRunningCommand(state)) {
+    return {
+      ...state,
+      streamWarning: "Live log stream interrupted. Reconnecting…",
+    };
+  }
+
+  if (state.sections.length === 0 && state.orphanLines.length === 0) {
+    return { ...state, error: message };
+  }
+
+  return state;
+}
+
+function appendLineToLatestSection(state: LogState, text: string, replayLineSkip?: Map<number, number>): LogState {
   if (state.sections.length === 0) {
     return {
       ...state,
@@ -20,19 +42,31 @@ function appendLineToLatestSection(state: LogState, text: string): LogState {
     };
   }
 
+  const lastSectionIndex = state.sections.length - 1;
+  const section = state.sections[lastSectionIndex];
+  const skipLeft = replayLineSkip?.get(section.index) ?? 0;
+  if (skipLeft > 0) {
+    replayLineSkip?.set(section.index, skipLeft - 1);
+    return state;
+  }
+
   const nextSections = [...state.sections];
-  const lastSectionIndex = nextSections.length - 1;
   nextSections[lastSectionIndex] = {
-    ...nextSections[lastSectionIndex],
-    lines: [...nextSections[lastSectionIndex].lines, text],
+    ...section,
+    lines: [...section.lines, text],
   };
   return {
     ...state,
     sections: nextSections,
+    streamWarning: null,
   };
 }
 
 function pushCommandSection(state: LogState, index: number, text: string, startedAtMs: number | null): LogState {
+  if (state.sections.some((section) => section.index === index)) {
+    return state;
+  }
+
   const section: CommandSection = {
     index,
     text,
@@ -46,6 +80,7 @@ function pushCommandSection(state: LogState, index: number, text: string, starte
   return {
     ...state,
     sections: [...state.sections, section],
+    streamWarning: null,
   };
 }
 
@@ -55,6 +90,11 @@ function completeCommandSection(
   status: "passed" | "failed",
   durationMs: number,
 ): LogState {
+  const existing = state.sections.find((section) => section.index === index);
+  if (!existing || existing.status !== "running") {
+    return state;
+  }
+
   const nextSections = state.sections.map((section) => {
     if (section.index !== index) {
       return section;
@@ -70,13 +110,62 @@ function completeCommandSection(
   return {
     ...state,
     sections: nextSections,
+    streamWarning: null,
   };
+}
+
+function createStreamHandlers(
+  reconnecting: boolean,
+  replayLineSkip: Map<number, number>,
+  setState: Dispatch<SetStateAction<LogState>>,
+): LiveLogStreamHandlers {
+  return {
+    onLogLine: (text) => setState((prev) => appendLineToLatestSection(prev, text, replayLineSkip)),
+    onStreamError: (message) => setState((prev) => applyStreamFailure(prev, message)),
+    onCmdStart: (index, text, startedAtMs) => {
+      setState((prev) => {
+        const existing = prev.sections.find((section) => section.index === index);
+        if (existing) {
+          if (reconnecting) {
+            replayLineSkip.set(index, existing.lines.length);
+          }
+          return prev;
+        }
+        return pushCommandSection(prev, index, text, startedAtMs);
+      });
+    },
+    onCmdEnd: (index, status, durationMs) =>
+      setState((prev) => completeCommandSection(prev, index, status, durationMs)),
+  };
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      window.clearTimeout(timeout);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export function useLiveLogStream(executionId: string) {
   const organizationId = useOrganizationId();
   const canvasId = useCanvasId();
   const [state, setState] = useState<LogState>(initialLogState);
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   const scrollTrigger = useMemo(() => {
     const lineCount = state.sections.reduce((count, section) => count + section.lines.length, 0);
@@ -105,31 +194,67 @@ export function useLiveLogStream(executionId: string) {
       return;
     }
 
+    const sessionAbort = new AbortController();
+    let activeStream: LiveLogStream | null = null;
     setState({ ...initialLogState, isStreaming: true });
 
-    const stream = new LiveLogStream(organizationId, canvasId, executionId);
-
     (async () => {
-      try {
-        await stream.pump({
-          onLogLine: (t) => setState((prev) => appendLineToLatestSection(prev, t)),
-          onStreamError: (m) => setState((prev) => ({ ...prev, error: m })),
-          onCmdStart: (index, text, startedAtMs) =>
-            setState((prev) => pushCommandSection(prev, index, text, startedAtMs)),
-          onCmdEnd: (index, status, durationMs) =>
-            setState((prev) => completeCommandSection(prev, index, status, durationMs)),
-        });
-      } catch (e) {
-        if ((e as Error).name === "AbortError") {
+      let reconnecting = false;
+
+      while (!sessionAbort.signal.aborted) {
+        const stream = new LiveLogStream(organizationId, canvasId, executionId);
+        activeStream = stream;
+        const replayLineSkip = new Map<number, number>();
+
+        try {
+          await stream.pump(createStreamHandlers(reconnecting, replayLineSkip, setState));
+        } catch (error) {
+          if ((error as Error).name === "AbortError") {
+            return;
+          }
+          if (!sessionAbort.signal.aborted) {
+            setState((prev) => applyStreamFailure(prev, (error as Error).message));
+          }
+        } finally {
+          stream.stop();
+          if (activeStream === stream) {
+            activeStream = null;
+          }
+        }
+
+        if (sessionAbort.signal.aborted) {
           return;
         }
-        setState((prev) => ({ ...prev, error: (e as Error).message }));
-      } finally {
+
+        if (!hasRunningCommand(stateRef.current)) {
+          break;
+        }
+
+        reconnecting = true;
+        setState((prev) => ({
+          ...prev,
+          isStreaming: false,
+          streamWarning: "Live log stream interrupted. Reconnecting…",
+        }));
+
+        try {
+          await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
+        } catch {
+          return;
+        }
+
+        setState((prev) => ({ ...prev, isStreaming: true }));
+      }
+
+      if (!sessionAbort.signal.aborted) {
         setState((prev) => ({ ...prev, isStreaming: false }));
       }
     })();
 
-    return () => stream.stop();
+    return () => {
+      sessionAbort.abort();
+      activeStream?.stop();
+    };
   }, [organizationId, canvasId, executionId]);
 
   return { ...state, toggleSection, scrollRef };

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useLiveLogStream.ts
@@ -160,6 +160,67 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+type LiveLogSessionParams = {
+  organizationId: string;
+  canvasId: string;
+  executionId: string;
+  sessionAbort: AbortController;
+  stateRef: { current: LogState };
+  setState: Dispatch<SetStateAction<LogState>>;
+  setActiveStream: (stream: LiveLogStream | null) => void;
+};
+
+async function runLiveLogSession({
+  organizationId,
+  canvasId,
+  executionId,
+  sessionAbort,
+  stateRef,
+  setState,
+  setActiveStream,
+}: LiveLogSessionParams): Promise<void> {
+  let reconnecting = false;
+
+  while (!sessionAbort.signal.aborted) {
+    const stream = new LiveLogStream(organizationId, canvasId, executionId);
+    setActiveStream(stream);
+    const replayLineSkip = new Map<number, number>();
+
+    try {
+      await stream.pump(createStreamHandlers(reconnecting, replayLineSkip, setState));
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        return;
+      }
+      if (!sessionAbort.signal.aborted) {
+        setState((prev) => applyStreamFailure(prev, (error as Error).message));
+      }
+    } finally {
+      stream.stop();
+      setActiveStream(null);
+    }
+
+    if (sessionAbort.signal.aborted || !hasRunningCommand(stateRef.current)) {
+      return;
+    }
+
+    reconnecting = true;
+    setState((prev) => ({
+      ...prev,
+      isStreaming: false,
+      streamWarning: "Live log stream interrupted. Reconnecting…",
+    }));
+
+    try {
+      await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
+    } catch {
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isStreaming: true }));
+  }
+}
+
 export function useLiveLogStream(executionId: string) {
   const organizationId = useOrganizationId();
   const canvasId = useCanvasId();
@@ -198,58 +259,21 @@ export function useLiveLogStream(executionId: string) {
     let activeStream: LiveLogStream | null = null;
     setState({ ...initialLogState, isStreaming: true });
 
-    (async () => {
-      let reconnecting = false;
-
-      while (!sessionAbort.signal.aborted) {
-        const stream = new LiveLogStream(organizationId, canvasId, executionId);
+    void runLiveLogSession({
+      organizationId,
+      canvasId,
+      executionId,
+      sessionAbort,
+      stateRef,
+      setState,
+      setActiveStream: (stream) => {
         activeStream = stream;
-        const replayLineSkip = new Map<number, number>();
-
-        try {
-          await stream.pump(createStreamHandlers(reconnecting, replayLineSkip, setState));
-        } catch (error) {
-          if ((error as Error).name === "AbortError") {
-            return;
-          }
-          if (!sessionAbort.signal.aborted) {
-            setState((prev) => applyStreamFailure(prev, (error as Error).message));
-          }
-        } finally {
-          stream.stop();
-          if (activeStream === stream) {
-            activeStream = null;
-          }
-        }
-
-        if (sessionAbort.signal.aborted) {
-          return;
-        }
-
-        if (!hasRunningCommand(stateRef.current)) {
-          break;
-        }
-
-        reconnecting = true;
-        setState((prev) => ({
-          ...prev,
-          isStreaming: false,
-          streamWarning: "Live log stream interrupted. Reconnecting…",
-        }));
-
-        try {
-          await sleep(RECONNECT_DELAY_MS, sessionAbort.signal);
-        } catch {
-          return;
-        }
-
-        setState((prev) => ({ ...prev, isStreaming: true }));
-      }
-
+      },
+    }).finally(() => {
       if (!sessionAbort.signal.aborted) {
         setState((prev) => ({ ...prev, isStreaming: false }));
       }
-    })();
+    });
 
     return () => {
       sessionAbort.abort();

--- a/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useScrollToBottom.ts
+++ b/web_src/src/ui/CanvasPage/RunnerLiveLogDialog/useScrollToBottom.ts
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useRef } from "react";
 
+const BOTTOM_THRESHOLD_PX = 16;
+
+function isScrolledToBottom(el: HTMLDivElement): boolean {
+  const { scrollTop, scrollHeight, clientHeight } = el;
+  return scrollHeight - scrollTop - clientHeight <= BOTTOM_THRESHOLD_PX;
+}
+
 export function useScrollToBottom(trigger: unknown) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
 
   const scrollToBottom = useCallback(() => {
     const el = scrollRef.current;
@@ -11,6 +19,25 @@ export function useScrollToBottom(trigger: unknown) {
   }, []);
 
   useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+
+    const handleScroll = () => {
+      stickToBottomRef.current = isScrolledToBottom(el);
+    };
+
+    el.addEventListener("scroll", handleScroll);
+    handleScroll();
+
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (!stickToBottomRef.current) {
+      return;
+    }
     scrollToBottom();
   }, [trigger, scrollToBottom]);
 


### PR DESCRIPTION
## Summary
- Disable auto-scroll when the user scrolls up; resume when they return to the bottom
- Keep the last command header sticky in list order while scrolling through its output
- Tick the duration timer while a command is running, using runner `started_at` when available
- Reconnect and show a non-fatal warning when the log stream drops while a command is still running

## Test plan
- [ ] Open runner live logs during a multi-command run
- [ ] Scroll up through earlier commands and confirm auto-scroll pauses/resumes
- [ ] Confirm the running command header stays in order and sticks while scrolling its output
- [ ] Confirm the running command timer increments every second
- [ ] Simulate or wait for a stream interruption and confirm reconnect instead of fatal error


Made with [Cursor](https://cursor.com)