### PR TITLE
fix: prevent stale draft diff state

### DIFF
--- a/web_src/src/pages/workflowv2/draftNodeDiff.spec.ts
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.spec.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { buildDraftDiffMap, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 
 describe("hasDraftVersusLiveGraphDiff", () => {
-  const node = (id: string, integrationId?: string | null) => ({
+  const node = (id: string, integrationId?: string | null, configuration: Record<string, unknown> = {}) => ({
     id,
     name: "N",
     type: "TYPE_ACTION",
     ref: "r",
-    configuration: {},
+    configuration,
     position: { x: 0, y: 0 },
     isCollapsed: false,
     integration: integrationId ? { id: integrationId, name: `integration-${integrationId}` } : undefined,
@@ -36,6 +36,39 @@ describe("hasDraftVersusLiveGraphDiff", () => {
     const edges = [{ sourceId: "a", targetId: "b", channel: "default" }];
     const live = { spec: { nodes, edges } };
     const draft = { spec: { nodes, edges } };
+
+    expect(hasDraftVersusLiveGraphDiff(live as never, draft as never)).toBe(false);
+  });
+
+  it("returns false when empty configuration is omitted in one version", () => {
+    const liveNode = {
+      id: "a",
+      name: "N",
+      type: "TYPE_ACTION",
+      ref: "r",
+      position: { x: 0, y: 0 },
+      isCollapsed: false,
+    };
+    const draftNode = { ...liveNode, configuration: {} };
+    const live = { spec: { nodes: [liveNode], edges: [] } };
+    const draft = { spec: { nodes: [draftNode], edges: [] } };
+
+    expect(hasDraftVersusLiveGraphDiff(live as never, draft as never)).toBe(false);
+  });
+
+  it("returns false when configuration keys are ordered differently", () => {
+    const live = {
+      spec: {
+        nodes: [node("a", null, { a: 1, b: { c: 2, d: 3 } })],
+        edges: [] as { sourceId: string; targetId: string; channel: string }[],
+      },
+    };
+    const draft = {
+      spec: {
+        nodes: [node("a", null, { b: { d: 3, c: 2 }, a: 1 })],
+        edges: [] as { sourceId: string; targetId: string; channel: string }[],
+      },
+    };
 
     expect(hasDraftVersusLiveGraphDiff(live as never, draft as never)).toBe(false);
   });
@@ -95,6 +128,30 @@ describe("buildDraftDiffMap", () => {
   it("does not mark position-only changes as visual edits", () => {
     const live = { spec: { nodes: [node("a", { position: { x: 0, y: 0 } })] } };
     const draft = { spec: { nodes: [node("a", { position: { x: 100, y: 200 } })] } };
+
+    expect(buildDraftDiffMap(live as never, draft as never)).toEqual({
+      statusMap: {},
+      removedNodes: [],
+    });
+  });
+
+  it("does not mark empty or reordered configuration as visual edits", () => {
+    const live = {
+      spec: {
+        nodes: [
+          node("empty-live", { configuration: undefined }),
+          node("ordered-live", { configuration: { a: 1, b: { c: 2, d: 3 } } }),
+        ],
+      },
+    };
+    const draft = {
+      spec: {
+        nodes: [
+          node("empty-live", { configuration: {} }),
+          node("ordered-live", { configuration: { b: { d: 3, c: 2 }, a: 1 } }),
+        ],
+      },
+    };
 
     expect(buildDraftDiffMap(live as never, draft as never)).toEqual({
       statusMap: {},

--- a/web_src/src/pages/workflowv2/draftNodeDiff.tsx
+++ b/web_src/src/pages/workflowv2/draftNodeDiff.tsx
@@ -46,6 +46,49 @@ function comparableEdgesSnapshot(edges: unknown): string {
   return JSON.stringify(normalized);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeComparableValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeComparableValue);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const normalized = Object.keys(value)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce<Record<string, unknown>>((acc, key) => {
+      if (value[key] === undefined) {
+        return acc;
+      }
+
+      acc[key] = normalizeComparableValue(value[key]);
+      return acc;
+    }, {});
+
+  return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+function comparableNode(node: Record<string, unknown>) {
+  return {
+    name: node.name || null,
+    type: node.type || null,
+    ref: node.ref || null,
+    configuration: normalizeComparableValue(node.configuration),
+    position: normalizeComparableValue(node.position),
+    isCollapsed: node.isCollapsed || false,
+    integrationId: getComparableIntegrationId(node),
+  };
+}
+
 /** True when draft workflow graph differs from live (nodes and/or edges). */
 export function hasDraftVersusLiveGraphDiff(
   liveVersion?: CanvasesCanvasVersion,
@@ -76,16 +119,6 @@ export function buildDraftNodeDiffSummary(
     });
     return map;
   };
-
-  const comparableNode = (node: Record<string, unknown>) => ({
-    name: node.name || null,
-    type: node.type || null,
-    ref: node.ref || null,
-    configuration: node.configuration || null,
-    position: node.position || null,
-    isCollapsed: node.isCollapsed || false,
-    integrationId: getComparableIntegrationId(node),
-  });
 
   const formatDiffValueLines = (value: unknown): string[] => {
     const normalizedValue = value === undefined ? null : value;
@@ -242,7 +275,7 @@ export function buildDraftDiffMap(
       name: node.name || null,
       type: node.type || null,
       ref: node.ref || null,
-      configuration: node.configuration || null,
+      configuration: normalizeComparableValue(node.configuration),
       isCollapsed: node.isCollapsed || false,
       integrationId: getComparableIntegrationId(node),
     });

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -97,6 +97,7 @@ import { WorkflowTemplateBanner } from "./WorkflowTemplateBanner";
 import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary, hasDraftVersusLiveGraphDiff } from "./draftNodeDiff";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
+import { activateDraftVersion, clearPublishedDraftVersion as clearDraftVersion } from "./lib/draft-spec-cache";
 import {
   isDraftVersion,
   isPublishedVersion,
@@ -1408,7 +1409,7 @@ export function WorkflowPageV2() {
       }
 
       activeCanvasVersionIdRef.current = version.metadata?.id || "";
-      setActiveCanvasVersion(version);
+      activateDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, version);
       setHasUnsavedChanges(false);
       setHasNonPositionalUnsavedChanges(false);
       setLastSavedWorkflowSnapshot(null);
@@ -4266,7 +4267,7 @@ export function WorkflowPageV2() {
 
       await publishCanvasVersionMutation.mutateAsync(versionIdToPublish);
       activeCanvasVersionIdRef.current = "";
-      setActiveCanvasVersion(null);
+      clearDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, versionIdToPublish);
       setSearchParams((current) => {
         const next = new URLSearchParams(current);
         next.delete("version");

--- a/web_src/src/pages/workflowv2/lib/draft-spec-cache.ts
+++ b/web_src/src/pages/workflowv2/lib/draft-spec-cache.ts
@@ -1,0 +1,31 @@
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+type DraftSpecCache = Map<string, DraftSpec>;
+
+export function activateDraftVersion(
+  draftCanvasSpecs: DraftSpecCache,
+  setActiveCanvasVersion: (version: CanvasesCanvasVersion | null) => void,
+  setDraftCanvasSpec: (spec: DraftSpec) => void,
+  version: CanvasesCanvasVersion,
+) {
+  const spec = version.spec ?? null;
+  const versionID = version.metadata?.id;
+  setActiveCanvasVersion(version);
+  setDraftCanvasSpec(spec);
+  if (versionID) {
+    draftCanvasSpecs.set(versionID, spec);
+  }
+}
+
+export function clearPublishedDraftVersion(
+  draftCanvasSpecs: DraftSpecCache,
+  setActiveCanvasVersion: (version: CanvasesCanvasVersion | null) => void,
+  setDraftCanvasSpec: (spec: DraftSpec) => void,
+  versionID: string,
+) {
+  setActiveCanvasVersion(null);
+  setDraftCanvasSpec(null);
+  draftCanvasSpecs.delete(versionID);
+}


### PR DESCRIPTION
## Summary
- Prevent clean drafts from showing nodes as edited due to representation-only YAML differences
- Clear stale draft specs after publishing so deleted node and edge diff visuals do not reuse old draft state

## Tests
- npm run test:run -- src/pages/workflowv2/draftNodeDiff.spec.ts src/pages/workflowv2/index.spec.ts
- make format.js
- make check.lint.ui
- make check.build.ui