### PR TITLE
feat: register and load console.yaml when installing from GitHub

### DIFF
--- a/docs/prd/console-and-widgets.md
+++ b/docs/prd/console-and-widgets.md
@@ -411,6 +411,17 @@ Rules:
 
 Frontend YAML parsing lives in `dashboardYaml.ts`. Backend YAML parsing and validation lives in `canvas_dashboard_yml.go`. Keep error behavior and accepted shapes aligned.
 
+## Bundling A Console With An Installable App
+
+Apps installed from a public GitHub repository (`POST /apps/install`) can ship an optional `console.yaml` alongside `canvas.yaml`. When present, the install flow loads it from the same ref and writes it as the new canvas's console.
+
+- File path: `console.yaml` at the repo root, same branch (`main` or `master`) that `canvas.yaml` is read from.
+- Schema: same `apiVersion: v1`, `kind: Console` shape documented above; parsed and validated by `models.DashboardFromYML`. A malformed file aborts the install with HTTP 400 before any canvas is created.
+- Optional: a missing file is fine — the new canvas just starts with an empty console.
+- Replace-all on install: `metadata.canvasId` is ignored; the panels and layout become the canvas's full console.
+
+Implementation lives in `pkg/installation/fetch.go` (`FetchConsole`) and `pkg/installation/install.go` (`persistInstalledConsole`).
+
 ## Authorization
 
 | Operation | Expected permission / state |

--- a/pkg/installation/fetch.go
+++ b/pkg/installation/fetch.go
@@ -2,6 +2,7 @@ package installation
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,11 +11,21 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-const canvasFileName = "canvas.yaml"
+const (
+	canvasFileName  = "canvas.yaml"
+	consoleFileName = "console.yaml"
+)
+
+// errFileNotFound is returned (wrapped) by fetchURL when the upstream
+// raw.githubusercontent.com responds with 404. Callers that treat a missing
+// file as a non-error (for example, the optional console.yaml in installable
+// apps) can detect it with errors.Is.
+var errFileNotFound = errors.New("file not found")
 
 var defaultRefs = []string{"main", "master"}
 
@@ -48,20 +59,50 @@ func FetchCanvas(repo *Repository) (*pb.Canvas, string, error) {
 }
 
 func fetchCanvasAtRef(repo *Repository, ref string) (*pb.Canvas, error) {
-	rawURL := fmt.Sprintf(
-		"https://raw.githubusercontent.com/%s/%s/%s/%s",
-		repo.Owner,
-		repo.Name,
-		ref,
-		canvasFileName,
-	)
-
-	body, err := fetchURL(rawURL)
+	body, err := fetchURL(rawFileURL(repo, ref, canvasFileName))
 	if err != nil {
 		return nil, err
 	}
 
 	return parseCanvasYAML(body)
+}
+
+// FetchConsole loads and parses an optional console.yaml from a public GitHub
+// repository at the given ref. The console is opt-in: a missing file returns
+// (nil, nil) so callers can install the app without one. Parse and validation
+// errors from models.DashboardFromYML are wrapped and surfaced to the caller.
+//
+// Callers must pass a non-empty ref. Resolve it via FetchCanvas first so the
+// canvas and console are read from the same commit.
+func FetchConsole(repo *Repository, ref string) (*models.DashboardYAML, error) {
+	if ref == "" {
+		return nil, fmt.Errorf("console fetch requires a resolved ref")
+	}
+
+	body, err := fetchURL(rawFileURL(repo, ref, consoleFileName))
+	if err != nil {
+		if errors.Is(err, errFileNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	console, err := models.DashboardFromYML(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse console yaml: %w", err)
+	}
+
+	return console, nil
+}
+
+func rawFileURL(repo *Repository, ref, filename string) string {
+	return fmt.Sprintf(
+		"https://raw.githubusercontent.com/%s/%s/%s/%s",
+		repo.Owner,
+		repo.Name,
+		ref,
+		filename,
+	)
 }
 
 func fetchURL(rawURL string) ([]byte, error) {
@@ -82,7 +123,7 @@ func fetchURL(rawURL string) ([]byte, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("%s not found", rawURL)
+		return nil, fmt.Errorf("%s not found: %w", rawURL, errFileNotFound)
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {

--- a/pkg/installation/fetch_test.go
+++ b/pkg/installation/fetch_test.go
@@ -51,3 +51,29 @@ func TestFetchCanvasFromPublicRepo(t *testing.T) {
 	assert.NotEmpty(t, canvas.GetMetadata().GetName())
 	assert.NotEmpty(t, canvas.GetSpec().GetNodes())
 }
+
+func TestFetchConsoleRequiresRef(t *testing.T) {
+	_, err := FetchConsole(&Repository{Owner: "acme", Name: "demo"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolved ref")
+}
+
+func TestFetchConsoleReturnsNilWhenMissing(t *testing.T) {
+	// The reference app repo ships a canvas.yaml but no console.yaml.
+	// FetchConsole must treat the missing file as opt-in (nil, nil) so that
+	// apps without a bundled console still install cleanly.
+	repo, err := ParseRepository("github.com/superplanehq/preview-env-github-digitalocean")
+	require.NoError(t, err)
+
+	console, err := FetchConsole(repo, "main")
+	require.NoError(t, err)
+	assert.Nil(t, console)
+}
+
+func TestRawFileURLBuildsExpectedPath(t *testing.T) {
+	repo := &Repository{Owner: "acme", Name: "demo"}
+	assert.Equal(t,
+		"https://raw.githubusercontent.com/acme/demo/main/console.yaml",
+		rawFileURL(repo, "main", consoleFileName),
+	)
+}

--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -84,6 +84,14 @@ func (s *Service) Install(ctx context.Context, req InstallRequest) (*InstallResu
 		return nil, err
 	}
 
+	// Pre-parse the optional console.yaml from the same ref. Doing this
+	// before CreateCanvas means a malformed console aborts the install
+	// without leaving an orphan canvas behind.
+	console, err := FetchConsole(repo, repo.Ref)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	canvas.Metadata.Name = name
 
 	ctx = authentication.SetUserIdInMetadata(ctx, user.ID.String())
@@ -111,10 +119,42 @@ func (s *Service) Install(ctx context.Context, req InstallRequest) (*InstallResu
 		return nil, fmt.Errorf("failed to install app")
 	}
 
+	if err := persistInstalledConsole(canvasID, console); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to install console: %v", err)
+	}
+
 	return &InstallResult{
 		CanvasID:       canvasID,
 		OrganizationID: req.OrganizationID.String(),
 	}, nil
+}
+
+// persistInstalledConsole writes the optional console for a freshly created
+// canvas. A nil console is a no-op (the repo did not ship a console.yaml).
+//
+// Note: this runs after canvases.CreateCanvas, in its own transaction. If the
+// upsert fails, the canvas already exists; the user can re-import the console
+// from the UI. We accept that trade-off to avoid changing CreateCanvas's
+// signature just for this side-effect.
+func persistInstalledConsole(canvasID string, console *models.DashboardYAML) error {
+	if console == nil {
+		return nil
+	}
+
+	canvasUUID, err := uuid.Parse(canvasID)
+	if err != nil {
+		return fmt.Errorf("invalid canvas id %q: %w", canvasID, err)
+	}
+
+	return database.Conn().Transaction(func(tx *gorm.DB) error {
+		_, err := models.UpsertCanvasDashboardInTransaction(
+			tx,
+			canvasUUID,
+			console.Spec.Panels,
+			console.Spec.Layout,
+		)
+		return err
+	})
 }
 
 func FindActiveUserForAccountInOrganization(accountID, organizationID uuid.UUID) (*models.User, error) {

--- a/pkg/installation/install_test.go
+++ b/pkg/installation/install_test.go
@@ -1,0 +1,155 @@
+package installation
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestPersistInstalledConsoleNoopWhenNil(t *testing.T) {
+	support.Setup(t)
+
+	// A nil console must not require a valid canvas id — it short-circuits
+	// before any DB write.
+	err := persistInstalledConsole("not-a-uuid", nil)
+	require.NoError(t, err)
+}
+
+func TestPersistInstalledConsoleRejectsInvalidCanvasID(t *testing.T) {
+	support.Setup(t)
+
+	console := &models.DashboardYAML{
+		APIVersion: models.DashboardAPIVersion,
+		Kind:       models.ConsoleKind,
+		Spec: models.DashboardYAMLSpec{
+			Panels: []models.DashboardPanel{
+				{ID: "p1", Type: models.DashboardPanelTypeMarkdown, Content: map[string]any{"body": "hi"}},
+			},
+		},
+	}
+
+	err := persistInstalledConsole("not-a-uuid", console)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid canvas id")
+}
+
+func TestPersistInstalledConsoleWritesPanelsAndLayout(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	minW := 2
+	console := &models.DashboardYAML{
+		APIVersion: models.DashboardAPIVersion,
+		Kind:       models.ConsoleKind,
+		Spec: models.DashboardYAMLSpec{
+			Panels: []models.DashboardPanel{
+				{
+					ID:      "notes",
+					Type:    models.DashboardPanelTypeMarkdown,
+					Content: map[string]any{"title": "Notes", "body": "hello from console.yaml"},
+				},
+			},
+			Layout: []models.DashboardLayoutItem{
+				{I: "notes", X: 0, Y: 0, W: 4, H: 2, MinW: &minW},
+			},
+		},
+	}
+
+	require.NoError(t, persistInstalledConsole(canvas.ID.String(), console))
+
+	stored, err := models.FindCanvasDashboard(canvas.ID)
+	require.NoError(t, err)
+	panels := stored.Panels.Data()
+	layout := stored.Layout.Data()
+
+	require.Len(t, panels, 1)
+	assert.Equal(t, "notes", panels[0].ID)
+	assert.Equal(t, models.DashboardPanelTypeMarkdown, panels[0].Type)
+	assert.Equal(t, "hello from console.yaml", panels[0].Content["body"])
+
+	require.Len(t, layout, 1)
+	assert.Equal(t, "notes", layout[0].I)
+	assert.Equal(t, 4, layout[0].W)
+	require.NotNil(t, layout[0].MinW)
+	assert.Equal(t, 2, *layout[0].MinW)
+}
+
+func TestPersistInstalledConsoleIsReplaceAll(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	// Seed the canvas with a different console first.
+	_, err := models.UpsertCanvasDashboard(
+		canvas.ID,
+		[]models.DashboardPanel{
+			{ID: "old", Type: models.DashboardPanelTypeMarkdown, Content: map[string]any{"body": "old"}},
+		},
+		[]models.DashboardLayoutItem{
+			{I: "old", X: 0, Y: 0, W: 4, H: 2},
+		},
+	)
+	require.NoError(t, err)
+
+	console := &models.DashboardYAML{
+		APIVersion: models.DashboardAPIVersion,
+		Kind:       models.ConsoleKind,
+		Spec: models.DashboardYAMLSpec{
+			Panels: []models.DashboardPanel{
+				{ID: "new", Type: models.DashboardPanelTypeMarkdown, Content: map[string]any{"body": "new"}},
+			},
+			Layout: []models.DashboardLayoutItem{
+				{I: "new", X: 0, Y: 0, W: 6, H: 3},
+			},
+		},
+	}
+
+	require.NoError(t, persistInstalledConsole(canvas.ID.String(), console))
+
+	stored, err := models.FindCanvasDashboard(canvas.ID)
+	require.NoError(t, err)
+	panels := stored.Panels.Data()
+	require.Len(t, panels, 1)
+	assert.Equal(t, "new", panels[0].ID)
+
+	// Sanity-check that calling persistInstalledConsole(nil) on the same
+	// canvas does not clobber an already-stored console.
+	require.NoError(t, persistInstalledConsole(canvas.ID.String(), nil))
+
+	stored, err = models.FindCanvasDashboard(canvas.ID)
+	require.NoError(t, err)
+	require.Len(t, stored.Panels.Data(), 1)
+	assert.Equal(t, "new", stored.Panels.Data()[0].ID)
+}
+
+func TestPersistInstalledConsoleUsesUUIDAsPrimaryKey(t *testing.T) {
+	r := support.Setup(t)
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	console := &models.DashboardYAML{
+		APIVersion: models.DashboardAPIVersion,
+		Kind:       models.ConsoleKind,
+		Spec: models.DashboardYAMLSpec{
+			Panels: []models.DashboardPanel{
+				{ID: "p", Type: models.DashboardPanelTypeMarkdown, Content: map[string]any{}},
+			},
+			Layout: []models.DashboardLayoutItem{
+				{I: "p", X: 0, Y: 0, W: 4, H: 2},
+			},
+		},
+	}
+
+	require.NoError(t, persistInstalledConsole(canvas.ID.String(), console))
+
+	// A different (random) canvas id should not see this console.
+	unrelated, err := models.FindCanvasDashboard(uuid.New())
+	require.NoError(t, err)
+	assert.Empty(t, unrelated.Panels.Data())
+	assert.Empty(t, unrelated.Layout.Data())
+}


### PR DESCRIPTION
Resolves: https://github.com/superplanehq/superplane/issues/4979

### Summary

Besides `canvas.yaml`, SuperPlane now sees `console.yaml` file in the root directory of GitHub repos. It uses that file to load the console view, all the panels and the layout.

If the `console.yaml` is missing, the app starts with a blank console.

If the `console.yaml` is present and malformed, the installation is aborted. This behaviour is to be discussed.