### PR TITLE
feat: Global edit mode across canvas views

### DIFF
--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -575,9 +575,9 @@ func (s *CanvasPageSteps) assertNodesAreNotConnectedInDB(sourceName, targetName 
 
 func (s *CanvasPageSteps) openYamlPreviewModal() {
 	// Adding a node opens the component sidebar over the canvas chrome; dismiss it so
-	// the floating YAML control (same corner as the sidebar) is clickable.
+	// the header YAML control is clickable.
 	s.canvas.ClickOnEmptyCanvasArea()
-	s.session.Click(q.TestID("open-yaml-modal-button"))
+	s.session.Click(q.TestID("canvas-yaml-button"))
 }
 
 func (s *CanvasPageSteps) closeYamlPreviewModal() {

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -132,8 +132,9 @@ func (s *CanvasSteps) OpenBuildingBlocksSidebar() {
 		return
 	}
 
-	openButton := q.TestID("open-sidebar-button").Run(s.session)
 	editButton := q.TestID("canvas-edit-button").Run(s.session)
+	addComponentButton := q.TestID("canvas-add-component-button").Run(s.session)
+	openButton := q.TestID("open-sidebar-button").Run(s.session)
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -152,6 +153,12 @@ func (s *CanvasSteps) OpenBuildingBlocksSidebar() {
 
 		if isVisible, _ := editButton.IsVisible(); isVisible {
 			if err := editButton.Click(); err == nil {
+				s.session.Sleep(250)
+			}
+		}
+
+		if isVisible, _ := addComponentButton.IsVisible(); isVisible {
+			if err := addComponentButton.Click(); err == nil {
 				s.session.Sleep(250)
 			}
 		}

--- a/web_src/.eslint-budget-baseline.json
+++ b/web_src/.eslint-budget-baseline.json
@@ -12,8 +12,8 @@
     "no-eslint-disable-next-line": 6
   },
   "maxAllowedMetricMaximumByRule": {
-    "max-lines": 5089,
-    "complexity": 317
+    "max-lines": 5088,
+    "complexity": 303
   },
-  "updatedAt": "2026-05-22T11:35:36.734Z"
+  "updatedAt": "2026-05-25T20:53:31.238Z"
 }

--- a/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
@@ -33,11 +33,13 @@ export function WorkflowMemoryOverlayLayer({
 
   return (
     <CanvasMemoryView
-      entries={isViewingDraftVersion ? [] : entries}
-      isLoading={isViewingDraftVersion ? false : isLoading}
-      errorMessage={isViewingDraftVersion ? undefined : error instanceof Error ? error.message : undefined}
+      entries={entries}
+      isLoading={isLoading}
+      errorMessage={error instanceof Error ? error.message : undefined}
       onDeleteEntry={
-        canUpdateCanvas && isViewingLiveVersion ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined
+        canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion
+          ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId)
+          : undefined
       }
       deletingId={deleteCanvasMemoryEntry.isPending ? deleteCanvasMemoryEntry.variables : undefined}
     />

--- a/web_src/src/pages/workflowv2/dashboard/DashboardView.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DashboardView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import GridLayout, { type Layout, WidthProvider } from "react-grid-layout";
-import { Plus, Loader2, LayoutGrid, FileText, Hash, LineChart, Table2, Workflow } from "lucide-react";
+import { Loader2, LayoutGrid, FileText, Hash, LineChart, Table2, Workflow } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -93,7 +93,7 @@ export function DashboardView({
   if (localPanels.length === 0) {
     return (
       <>
-        <EmptyState readOnly={readOnly} onAdd={() => setAddPanelOpen(true)} />
+        <EmptyState />
         <AddPanelDialog open={addPanelOpen} onConfirm={confirmAddPanel} onCancel={() => setAddPanelOpen(false)} />
       </>
     );
@@ -196,7 +196,7 @@ function toDashboardLayout(next: Layout[]): DashboardLayoutItem[] {
   });
 }
 
-function EmptyState({ readOnly, onAdd }: { readOnly: boolean; onAdd: () => void }) {
+function EmptyState() {
   return (
     <div className="flex flex-1 items-center justify-center p-6 sm:p-8" data-testid="dashboard-empty-state">
       <div className="flex w-full max-w-4xl flex-col items-center rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-10 shadow-sm sm:px-10">
@@ -232,13 +232,6 @@ function EmptyState({ readOnly, onAdd }: { readOnly: boolean; onAdd: () => void 
             </p>
           </div>
         </div>
-
-        {!readOnly ? (
-          <Button variant="default" className="mt-10" onClick={onAdd} data-testid="dashboard-add-first-panel">
-            <Plus className="mr-1.5 h-4 w-4" />
-            Add panel
-          </Button>
-        ) : null}
       </div>
     </div>
   );

--- a/web_src/src/pages/workflowv2/dashboard/dashboardHeaderActions.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardHeaderActions.ts
@@ -1,4 +1,5 @@
 interface DashboardHeaderActionsConfig {
+  isEditing: boolean;
   isDashboardMode: boolean;
   dashboardsFeatureEnabled: boolean;
   isTemplate: boolean;
@@ -9,6 +10,7 @@ interface DashboardHeaderActionsConfig {
 }
 
 export function getDashboardHeaderActions({
+  isEditing,
   isDashboardMode,
   dashboardsFeatureEnabled,
   isTemplate,
@@ -18,11 +20,11 @@ export function getDashboardHeaderActions({
   openYaml,
 }: DashboardHeaderActionsConfig) {
   const dashboardVisible = isDashboardMode && dashboardsFeatureEnabled;
-  const canEditDashboard = dashboardVisible && !isTemplate && canUpdateCanvas && !canvasDeletedRemotely;
+  const canEditDashboard = isEditing && dashboardVisible && !isTemplate && canUpdateCanvas && !canvasDeletedRemotely;
 
   return {
     onDashboardAddPanel: canEditDashboard ? openAddPanel : undefined,
-    onDashboardOpenYaml: dashboardVisible ? openYaml : undefined,
+    onDashboardOpenYaml: isEditing && dashboardVisible ? openYaml : undefined,
     dashboardYamlReadOnly: !canUpdateCanvas || isTemplate || canvasDeletedRemotely,
   };
 }

--- a/web_src/src/pages/workflowv2/dashboard/useDashboardModeActions.ts
+++ b/web_src/src/pages/workflowv2/dashboard/useDashboardModeActions.ts
@@ -3,9 +3,6 @@ import type { SetURLSearchParams } from "react-router-dom";
 
 interface DashboardModeActionsConfig {
   dashboardsFeatureEnabled: boolean;
-  hasEditableVersion: boolean;
-  liveCanvasVersionId: string | undefined;
-  handleUseVersion: (versionId: string) => void;
   setIsDashboardMode: (value: boolean) => void;
   setIsDashboardAddPanelOpen: (value: boolean) => void;
   setIsDashboardYamlOpen: (value: boolean) => void;
@@ -17,9 +14,6 @@ interface DashboardModeActionsConfig {
 
 export function useDashboardModeActions({
   dashboardsFeatureEnabled,
-  hasEditableVersion,
-  liveCanvasVersionId,
-  handleUseVersion,
   setIsDashboardMode,
   setIsDashboardAddPanelOpen,
   setIsDashboardYamlOpen,
@@ -30,24 +24,13 @@ export function useDashboardModeActions({
 }: DashboardModeActionsConfig) {
   const handleSelectDashboardMode = useCallback(() => {
     if (!dashboardsFeatureEnabled) return;
-    if (hasEditableVersion && liveCanvasVersionId) handleUseVersion(liveCanvasVersionId);
 
     setIsDashboardMode(true);
     setIsRunsMode(false);
     setIsMemoryMode(false);
     setSelectedRunId(null);
     setSearchParams(toDashboardSearchParams, { replace: true });
-  }, [
-    dashboardsFeatureEnabled,
-    handleUseVersion,
-    hasEditableVersion,
-    liveCanvasVersionId,
-    setIsDashboardMode,
-    setIsMemoryMode,
-    setIsRunsMode,
-    setSearchParams,
-    setSelectedRunId,
-  ]);
+  }, [dashboardsFeatureEnabled, setIsDashboardMode, setIsMemoryMode, setIsRunsMode, setSearchParams, setSelectedRunId]);
 
   const handleExitDashboardMode = useCallback(() => {
     setIsDashboardMode(false);

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -4858,9 +4858,6 @@ export function WorkflowPageV2() {
 
   const { handleSelectDashboardMode, handleExitDashboardMode } = useDashboardModeActions({
     dashboardsFeatureEnabled,
-    handleUseVersion,
-    hasEditableVersion,
-    liveCanvasVersionId,
     setIsDashboardMode,
     setIsDashboardAddPanelOpen,
     setIsDashboardYamlOpen,
@@ -4871,9 +4868,6 @@ export function WorkflowPageV2() {
   });
 
   const { handleSelectMemoryMode, handleExitMemoryMode } = useMemoryModeActions({
-    handleUseVersion,
-    hasEditableVersion,
-    liveCanvasVersionId,
     setIsMemoryMode,
     setIsDashboardMode,
     setIsDashboardAddPanelOpen,
@@ -4883,13 +4877,22 @@ export function WorkflowPageV2() {
     setSelectedRunId,
   });
 
+  const handleSelectCanvasView = useCallback(() => {
+    if (isDashboardMode) {
+      handleExitDashboardMode();
+      return;
+    }
+    if (isMemoryMode) {
+      handleExitMemoryMode();
+      return;
+    }
+    if (isRunsMode) {
+      handleExitRunsMode();
+    }
+  }, [handleExitDashboardMode, handleExitMemoryMode, handleExitRunsMode, isDashboardMode, isMemoryMode, isRunsMode]);
+
   const { handleEnterEditModeFromHeader, handleExitEditModeFromHeader } = useWorkflowHeaderEditActions({
-    isDashboardMode,
-    isMemoryMode,
     isRunsMode,
-    handleExitDashboardMode,
-    handleExitMemoryMode,
-    handleExitRunsMode,
     handleToggleEditMode,
     setIsRunsMode,
     setSelectedRunId,
@@ -5466,15 +5469,33 @@ export function WorkflowPageV2() {
     dashboardsFeatureEnabled,
     isRunsMode,
     isMemoryMode,
-    canvasMode,
   });
+  const handleDashboardAddPanelRequest = useCallback(async () => {
+    if (!hasEditableVersion) {
+      await handleToggleEditMode();
+    }
+    setIsDashboardAddPanelOpen(true);
+  }, [hasEditableVersion, handleToggleEditMode]);
+  const handleDashboardAddPanelDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        void handleDashboardAddPanelRequest();
+        return;
+      }
+      setIsDashboardAddPanelOpen(false);
+    },
+    [handleDashboardAddPanelRequest],
+  );
   const { onDashboardAddPanel, onDashboardOpenYaml, dashboardYamlReadOnly } = getDashboardHeaderActions({
+    isEditing: hasEditableVersion,
     isDashboardMode,
     dashboardsFeatureEnabled,
     isTemplate,
     canUpdateCanvas,
     canvasDeletedRemotely,
-    openAddPanel: () => setIsDashboardAddPanelOpen(true),
+    openAddPanel: () => {
+      void handleDashboardAddPanelRequest();
+    },
     openYaml: () => setIsDashboardYamlOpen(true),
   });
   const canvasStateMode = getWorkflowCanvasStateMode({
@@ -5512,7 +5533,7 @@ export function WorkflowPageV2() {
           dashboardQuery={dashboardQuery}
           updateDashboardMutation={updateDashboardMutation}
           addPanelDialogOpen={isDashboardAddPanelOpen}
-          onAddPanelDialogOpenChange={setIsDashboardAddPanelOpen}
+          onAddPanelDialogOpenChange={handleDashboardAddPanelDialogOpenChange}
           yamlModalOpen={isDashboardYamlOpen}
           onYamlModalOpenChange={setIsDashboardYamlOpen}
           canvasId={canvasId || undefined}
@@ -5635,6 +5656,7 @@ export function WorkflowPageV2() {
           onDiscardDraftAndStartEdit={handleDiscardDraftAndStartEdit}
           unpublishedDraftUpdatedAt={latestDraftVersion?.metadata?.updatedAt || latestDraftVersion?.metadata?.createdAt}
           headerMode={headerMode}
+          onSelectCanvasView={handleSelectCanvasView}
           onEnterEditMode={handleEnterEditModeFromHeader}
           enterEditModeDisabled={toggleEditModeDisabled}
           enterEditModeDisabledTooltip={toggleEditModeDisabledTooltip}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -4891,6 +4891,23 @@ export function WorkflowPageV2() {
     }
   }, [handleExitDashboardMode, handleExitMemoryMode, handleExitRunsMode, isDashboardMode, isMemoryMode, isRunsMode]);
 
+  const handleDashboardAddPanelRequest = useCallback(async () => {
+    if (!hasEditableVersion) {
+      await handleToggleEditMode();
+    }
+    setIsDashboardAddPanelOpen(true);
+  }, [hasEditableVersion, handleToggleEditMode, setIsDashboardAddPanelOpen]);
+  const handleDashboardAddPanelDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        void handleDashboardAddPanelRequest();
+        return;
+      }
+      setIsDashboardAddPanelOpen(false);
+    },
+    [handleDashboardAddPanelRequest, setIsDashboardAddPanelOpen],
+  );
+
   const { handleEnterEditModeFromHeader, handleExitEditModeFromHeader } = useWorkflowHeaderEditActions({
     isRunsMode,
     handleToggleEditMode,
@@ -5470,22 +5487,6 @@ export function WorkflowPageV2() {
     isRunsMode,
     isMemoryMode,
   });
-  const handleDashboardAddPanelRequest = useCallback(async () => {
-    if (!hasEditableVersion) {
-      await handleToggleEditMode();
-    }
-    setIsDashboardAddPanelOpen(true);
-  }, [hasEditableVersion, handleToggleEditMode, setIsDashboardAddPanelOpen]);
-  const handleDashboardAddPanelDialogOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        void handleDashboardAddPanelRequest();
-        return;
-      }
-      setIsDashboardAddPanelOpen(false);
-    },
-    [handleDashboardAddPanelRequest, setIsDashboardAddPanelOpen],
-  );
   const { onDashboardAddPanel, onDashboardOpenYaml, dashboardYamlReadOnly } = getDashboardHeaderActions({
     isEditing: hasEditableVersion,
     isDashboardMode,

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5475,7 +5475,7 @@ export function WorkflowPageV2() {
       await handleToggleEditMode();
     }
     setIsDashboardAddPanelOpen(true);
-  }, [hasEditableVersion, handleToggleEditMode]);
+  }, [hasEditableVersion, handleToggleEditMode, setIsDashboardAddPanelOpen]);
   const handleDashboardAddPanelDialogOpenChange = useCallback(
     (open: boolean) => {
       if (open) {
@@ -5484,7 +5484,7 @@ export function WorkflowPageV2() {
       }
       setIsDashboardAddPanelOpen(false);
     },
-    [handleDashboardAddPanelRequest],
+    [handleDashboardAddPanelRequest, setIsDashboardAddPanelOpen],
   );
   const { onDashboardAddPanel, onDashboardOpenYaml, dashboardYamlReadOnly } = getDashboardHeaderActions({
     isEditing: hasEditableVersion,

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -80,7 +80,6 @@ import { IntegrationCreateDialog } from "@/ui/IntegrationCreateDialog";
 import { ConfigureIntegrationDialog } from "@/ui/ConfigureIntegrationDialog";
 import { statusFiltersToApiFilters, type RunStatusFilter } from "@/ui/Runs/runPresentation";
 import { RunNodeDetailModal } from "@/ui/Runs/RunNodeDetailModal";
-import { getDashboardHeaderActions } from "./dashboard/dashboardHeaderActions";
 import { deriveDashboardNodeStatuses } from "./dashboard/deriveNodeStatuses";
 import { useDashboardModeActions } from "./dashboard/useDashboardModeActions";
 import { useDashboardTriggerNode } from "./dashboard/useDashboardTriggerNode";
@@ -88,6 +87,7 @@ import { WorkflowDashboardOverlay } from "./dashboard/WorkflowDashboardOverlay";
 import { useWorkflowViewSearchParams } from "./useWorkflowViewSearchParams";
 import { useMemoryModeActions } from "./useMemoryModeActions";
 import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
+import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
 import { CanvasChangeRequestConflictResolver } from "./CanvasChangeRequestConflictResolver";
 import { WorkflowMemoryOverlayLayer } from "./WorkflowMemoryOverlayLayer";
 import { CanvasPageModals } from "./CanvasPageModals";
@@ -123,8 +123,7 @@ import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
 import {
   getExitEditModeDisabledTooltip,
   getRunActionState,
-  getWorkflowCanvasStateMode,
-  getWorkflowHeaderMode,
+  getWorkflowViewPresentation,
   readStoredBoolean,
 } from "./viewState";
 import {
@@ -4877,36 +4876,28 @@ export function WorkflowPageV2() {
     setSelectedRunId,
   });
 
-  const handleSelectCanvasView = useCallback(() => {
-    if (isDashboardMode) {
-      handleExitDashboardMode();
-      return;
-    }
-    if (isMemoryMode) {
-      handleExitMemoryMode();
-      return;
-    }
-    if (isRunsMode) {
-      handleExitRunsMode();
-    }
-  }, [handleExitDashboardMode, handleExitMemoryMode, handleExitRunsMode, isDashboardMode, isMemoryMode, isRunsMode]);
-
-  const handleDashboardAddPanelRequest = useCallback(async () => {
-    if (!hasEditableVersion) {
-      await handleToggleEditMode();
-    }
-    setIsDashboardAddPanelOpen(true);
-  }, [hasEditableVersion, handleToggleEditMode, setIsDashboardAddPanelOpen]);
-  const handleDashboardAddPanelDialogOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        void handleDashboardAddPanelRequest();
-        return;
-      }
-      setIsDashboardAddPanelOpen(false);
-    },
-    [handleDashboardAddPanelRequest, setIsDashboardAddPanelOpen],
-  );
+  const {
+    handleSelectCanvasView,
+    handleDashboardAddPanelDialogOpenChange,
+    onDashboardAddPanel,
+    onDashboardOpenYaml,
+    dashboardYamlReadOnly,
+  } = useWorkflowViewModeActions({
+    isDashboardMode,
+    isMemoryMode,
+    isRunsMode,
+    hasEditableVersion,
+    dashboardsFeatureEnabled,
+    isTemplate,
+    canUpdateCanvas,
+    canvasDeletedRemotely,
+    handleExitDashboardMode,
+    handleExitMemoryMode,
+    handleExitRunsMode,
+    handleToggleEditMode,
+    setIsDashboardAddPanelOpen,
+    setIsDashboardYamlOpen,
+  });
 
   const { handleEnterEditModeFromHeader, handleExitEditModeFromHeader } = useWorkflowHeaderEditActions({
     isRunsMode,
@@ -5481,25 +5472,11 @@ export function WorkflowPageV2() {
     isPreparingVersionAction,
     hasDraftDiffVersusLive: !!latestDraftVersion && hasDraftGraphDiffVersusLive,
   });
-  const headerMode = getWorkflowHeaderMode({
+  const { headerMode, canvasStateMode } = getWorkflowViewPresentation({
     isDashboardMode,
     dashboardsFeatureEnabled,
     isRunsMode,
     isMemoryMode,
-  });
-  const { onDashboardAddPanel, onDashboardOpenYaml, dashboardYamlReadOnly } = getDashboardHeaderActions({
-    isEditing: hasEditableVersion,
-    isDashboardMode,
-    dashboardsFeatureEnabled,
-    isTemplate,
-    canUpdateCanvas,
-    canvasDeletedRemotely,
-    openAddPanel: () => {
-      void handleDashboardAddPanelRequest();
-    },
-    openYaml: () => setIsDashboardYamlOpen(true),
-  });
-  const canvasStateMode = getWorkflowCanvasStateMode({
     hasEditableVersion,
     isViewingPendingApprovalVersion,
     isViewingCurrentLiveVersion,

--- a/web_src/src/pages/workflowv2/useMemoryModeActions.ts
+++ b/web_src/src/pages/workflowv2/useMemoryModeActions.ts
@@ -2,9 +2,6 @@ import { useCallback } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
 interface MemoryModeActionsConfig {
-  hasEditableVersion: boolean;
-  liveCanvasVersionId: string | undefined;
-  handleUseVersion: (versionId: string) => void;
   setIsMemoryMode: (value: boolean) => void;
   setIsDashboardMode: (value: boolean) => void;
   setIsDashboardAddPanelOpen: (value: boolean) => void;
@@ -15,9 +12,6 @@ interface MemoryModeActionsConfig {
 }
 
 export function useMemoryModeActions({
-  hasEditableVersion,
-  liveCanvasVersionId,
-  handleUseVersion,
   setIsMemoryMode,
   setIsDashboardMode,
   setIsDashboardAddPanelOpen,
@@ -27,8 +21,6 @@ export function useMemoryModeActions({
   setSearchParams,
 }: MemoryModeActionsConfig) {
   const handleSelectMemoryMode = useCallback(() => {
-    if (hasEditableVersion && liveCanvasVersionId) handleUseVersion(liveCanvasVersionId);
-
     setIsMemoryMode(true);
     setIsDashboardMode(false);
     setIsDashboardAddPanelOpen(false);
@@ -37,9 +29,6 @@ export function useMemoryModeActions({
     setSelectedRunId(null);
     setSearchParams(toMemorySearchParams, { replace: true });
   }, [
-    handleUseVersion,
-    hasEditableVersion,
-    liveCanvasVersionId,
     setIsDashboardAddPanelOpen,
     setIsDashboardMode,
     setIsDashboardYamlOpen,

--- a/web_src/src/pages/workflowv2/useWorkflowHeaderEditActions.ts
+++ b/web_src/src/pages/workflowv2/useWorkflowHeaderEditActions.ts
@@ -2,12 +2,7 @@ import { useCallback } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
 interface WorkflowHeaderEditActionsConfig {
-  isDashboardMode: boolean;
-  isMemoryMode: boolean;
   isRunsMode: boolean;
-  handleExitDashboardMode: () => void;
-  handleExitMemoryMode: () => void;
-  handleExitRunsMode: () => void;
   handleToggleEditMode: () => Promise<void>;
   setIsRunsMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
@@ -16,12 +11,7 @@ interface WorkflowHeaderEditActionsConfig {
 }
 
 export function useWorkflowHeaderEditActions({
-  isDashboardMode,
-  isMemoryMode,
   isRunsMode,
-  handleExitDashboardMode,
-  handleExitMemoryMode,
-  handleExitRunsMode,
   handleToggleEditMode,
   setIsRunsMode,
   setSelectedRunId,
@@ -29,61 +19,19 @@ export function useWorkflowHeaderEditActions({
   setSearchParams,
 }: WorkflowHeaderEditActionsConfig) {
   const handleEnterEditModeFromHeader = useCallback(async () => {
-    if (isDashboardMode) {
-      handleExitDashboardMode();
-      await handleToggleEditMode();
-      return;
-    }
-    if (isMemoryMode) {
-      handleExitMemoryMode();
-      await handleToggleEditMode();
-      return;
-    }
     if (isRunsMode) {
       setIsRunsMode(false);
       setSelectedRunId(null);
       setRunDetailNodeId(null);
-      await handleToggleEditMode();
       setSearchParams(clearRunsViewSearchParams, { replace: true });
-      return;
     }
+
     await handleToggleEditMode();
-  }, [
-    handleExitDashboardMode,
-    handleExitMemoryMode,
-    handleToggleEditMode,
-    isDashboardMode,
-    isMemoryMode,
-    isRunsMode,
-    setIsRunsMode,
-    setRunDetailNodeId,
-    setSearchParams,
-    setSelectedRunId,
-  ]);
+  }, [handleToggleEditMode, isRunsMode, setIsRunsMode, setRunDetailNodeId, setSearchParams, setSelectedRunId]);
 
   const handleExitEditModeFromHeader = useCallback(async () => {
-    if (isDashboardMode) {
-      handleExitDashboardMode();
-      return;
-    }
-    if (isMemoryMode) {
-      handleExitMemoryMode();
-      return;
-    }
-    if (isRunsMode) {
-      handleExitRunsMode();
-      return;
-    }
     await handleToggleEditMode();
-  }, [
-    handleExitDashboardMode,
-    handleExitMemoryMode,
-    handleExitRunsMode,
-    handleToggleEditMode,
-    isDashboardMode,
-    isMemoryMode,
-    isRunsMode,
-  ]);
+  }, [handleToggleEditMode]);
 
   return { handleEnterEditModeFromHeader, handleExitEditModeFromHeader };
 }

--- a/web_src/src/pages/workflowv2/useWorkflowViewModeActions.ts
+++ b/web_src/src/pages/workflowv2/useWorkflowViewModeActions.ts
@@ -1,0 +1,85 @@
+import { useCallback } from "react";
+
+import { getDashboardHeaderActions } from "./dashboard/dashboardHeaderActions";
+
+interface WorkflowViewModeActionsConfig {
+  isDashboardMode: boolean;
+  isMemoryMode: boolean;
+  isRunsMode: boolean;
+  hasEditableVersion: boolean;
+  dashboardsFeatureEnabled: boolean;
+  isTemplate: boolean;
+  canUpdateCanvas: boolean;
+  canvasDeletedRemotely: boolean;
+  handleExitDashboardMode: () => void;
+  handleExitMemoryMode: () => void;
+  handleExitRunsMode: () => void;
+  handleToggleEditMode: () => Promise<void>;
+  setIsDashboardAddPanelOpen: (value: boolean) => void;
+  setIsDashboardYamlOpen: (value: boolean) => void;
+}
+
+export function useWorkflowViewModeActions({
+  isDashboardMode,
+  isMemoryMode,
+  isRunsMode,
+  hasEditableVersion,
+  dashboardsFeatureEnabled,
+  isTemplate,
+  canUpdateCanvas,
+  canvasDeletedRemotely,
+  handleExitDashboardMode,
+  handleExitMemoryMode,
+  handleExitRunsMode,
+  handleToggleEditMode,
+  setIsDashboardAddPanelOpen,
+  setIsDashboardYamlOpen,
+}: WorkflowViewModeActionsConfig) {
+  const handleSelectCanvasView = useCallback(() => {
+    if (isDashboardMode) {
+      handleExitDashboardMode();
+      return;
+    }
+    if (isMemoryMode) {
+      handleExitMemoryMode();
+      return;
+    }
+    if (isRunsMode) {
+      handleExitRunsMode();
+    }
+  }, [handleExitDashboardMode, handleExitMemoryMode, handleExitRunsMode, isDashboardMode, isMemoryMode, isRunsMode]);
+
+  const handleDashboardAddPanelRequest = useCallback(async () => {
+    if (!hasEditableVersion) {
+      await handleToggleEditMode();
+    }
+    setIsDashboardAddPanelOpen(true);
+  }, [hasEditableVersion, handleToggleEditMode, setIsDashboardAddPanelOpen]);
+
+  const handleDashboardAddPanelDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        void handleDashboardAddPanelRequest();
+        return;
+      }
+      setIsDashboardAddPanelOpen(false);
+    },
+    [handleDashboardAddPanelRequest, setIsDashboardAddPanelOpen],
+  );
+
+  return {
+    handleSelectCanvasView,
+    handleDashboardAddPanelRequest,
+    handleDashboardAddPanelDialogOpenChange,
+    ...getDashboardHeaderActions({
+      isEditing: hasEditableVersion,
+      isDashboardMode,
+      dashboardsFeatureEnabled,
+      isTemplate,
+      canUpdateCanvas,
+      canvasDeletedRemotely,
+      openAddPanel: () => void handleDashboardAddPanelRequest(),
+      openYaml: () => setIsDashboardYamlOpen(true),
+    }),
+  };
+}

--- a/web_src/src/pages/workflowv2/viewState.ts
+++ b/web_src/src/pages/workflowv2/viewState.ts
@@ -23,13 +23,11 @@ export function getWorkflowHeaderMode({
   dashboardsFeatureEnabled,
   isRunsMode,
   isMemoryMode,
-  canvasMode,
 }: {
   isDashboardMode: boolean;
   dashboardsFeatureEnabled: boolean;
   isRunsMode: boolean;
   isMemoryMode: boolean;
-  canvasMode: "edit" | "live";
 }): WorkflowHeaderMode {
   if (isDashboardMode) {
     return dashboardsFeatureEnabled ? "dashboard" : "version-live";
@@ -43,7 +41,7 @@ export function getWorkflowHeaderMode({
     return "runs";
   }
 
-  return canvasMode === "edit" ? "version-edit" : "version-live";
+  return "version-live";
 }
 
 export function getWorkflowCanvasStateMode({

--- a/web_src/src/pages/workflowv2/viewState.ts
+++ b/web_src/src/pages/workflowv2/viewState.ts
@@ -68,6 +68,33 @@ export function getWorkflowCanvasStateMode({
   return "default";
 }
 
+export function getWorkflowViewPresentation({
+  isDashboardMode,
+  dashboardsFeatureEnabled,
+  isRunsMode,
+  isMemoryMode,
+  hasEditableVersion,
+  isViewingPendingApprovalVersion,
+  isViewingCurrentLiveVersion,
+}: {
+  isDashboardMode: boolean;
+  dashboardsFeatureEnabled: boolean;
+  isRunsMode: boolean;
+  isMemoryMode: boolean;
+  hasEditableVersion: boolean;
+  isViewingPendingApprovalVersion: boolean;
+  isViewingCurrentLiveVersion: boolean;
+}) {
+  return {
+    headerMode: getWorkflowHeaderMode({ isDashboardMode, dashboardsFeatureEnabled, isRunsMode, isMemoryMode }),
+    canvasStateMode: getWorkflowCanvasStateMode({
+      hasEditableVersion,
+      isViewingPendingApprovalVersion,
+      isViewingCurrentLiveVersion,
+    }),
+  };
+}
+
 export function getExitEditModeDisabledTooltip({
   canUpdateCanvas,
   canvasDeletedRemotely,

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { CanvasModeToggle } from "./components/CanvasModeToggle";
 import { CanvasProjectSwitcher } from "./components/CanvasProjectSwitcher";
 import { CanvasToolSidebarTrigger } from "./components/CanvasToolSidebarTrigger";
-import { SecondaryHeaderActions } from "./HeaderSecondaryActions";
+import { SecondaryHeaderActions, EditModeTopHeaderActions, LiveModeTopHeaderActions } from "./HeaderSecondaryActions";
 
 export type HeaderMode = "default" | "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
 
@@ -76,6 +76,23 @@ export function Header(props: HeaderProps) {
         organizationId={props.organizationId}
         headerTitle={headerTitle}
         showCanvasSettingsMenu={props.showCanvasSettingsMenu}
+        mode={props.mode}
+        hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
+        onDiscardVersion={props.onDiscardVersion}
+        discardVersionDisabled={props.discardVersionDisabled}
+        discardVersionDisabledTooltip={props.discardVersionDisabledTooltip}
+        onExitEditMode={props.onExitEditMode}
+        exitEditModeDisabled={props.exitEditModeDisabled}
+        exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
+        onPublishVersion={props.onPublishVersion}
+        publishVersionLabel={props.publishVersionLabel}
+        publishVersionDisabled={props.publishVersionDisabled}
+        publishVersionDisabledTooltip={props.publishVersionDisabledTooltip}
+        onEnterEditMode={props.onEnterEditMode}
+        enterEditModeDisabled={props.enterEditModeDisabled}
+        enterEditModeDisabledTooltip={props.enterEditModeDisabledTooltip}
+        onDiscardDraftAndStartEdit={props.onDiscardDraftAndStartEdit}
+        unpublishedDraftUpdatedAt={props.unpublishedDraftUpdatedAt}
       />
 
       <SecondaryHeader {...props} />
@@ -87,10 +104,44 @@ function PageHeader({
   organizationId,
   headerTitle,
   showCanvasSettingsMenu = true,
+  mode,
+  hasUnpublishedDraftChanges,
+  onDiscardVersion,
+  discardVersionDisabled,
+  discardVersionDisabledTooltip,
+  onExitEditMode,
+  exitEditModeDisabled,
+  exitEditModeDisabledTooltip,
+  onPublishVersion,
+  publishVersionLabel,
+  publishVersionDisabled,
+  publishVersionDisabledTooltip,
+  onEnterEditMode,
+  enterEditModeDisabled,
+  enterEditModeDisabledTooltip,
+  onDiscardDraftAndStartEdit,
+  unpublishedDraftUpdatedAt,
 }: {
   organizationId?: string;
   headerTitle: string;
   showCanvasSettingsMenu?: boolean;
+  mode?: HeaderMode;
+  hasUnpublishedDraftChanges?: boolean;
+  onDiscardVersion?: () => void;
+  discardVersionDisabled?: boolean;
+  discardVersionDisabledTooltip?: string;
+  onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
+  onPublishVersion?: () => void;
+  publishVersionLabel?: string;
+  publishVersionDisabled?: boolean;
+  publishVersionDisabledTooltip?: string;
+  onEnterEditMode?: () => void;
+  enterEditModeDisabled?: boolean;
+  enterEditModeDisabledTooltip?: string;
+  onDiscardDraftAndStartEdit?: () => void;
+  unpublishedDraftUpdatedAt?: string;
 }) {
   const navigate = useNavigate();
   const { workflowId, canvasId: canvasIdParam } = useParams<{ workflowId?: string; canvasId?: string }>();
@@ -114,7 +165,32 @@ function PageHeader({
           )}
         </div>
       </div>
-      <div className="relative z-10 ml-auto flex shrink-0 items-center">
+      <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
+        {mode === "version-live" && onEnterEditMode ? (
+          <LiveModeTopHeaderActions
+            onEnterEditMode={onEnterEditMode}
+            enterEditModeDisabled={enterEditModeDisabled}
+            enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
+            hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+            onDiscardDraftAndStartEdit={onDiscardDraftAndStartEdit}
+            unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
+          />
+        ) : null}
+        {mode === "version-edit" ? (
+          <EditModeTopHeaderActions
+            hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+            onDiscardVersion={onDiscardVersion}
+            discardVersionDisabled={discardVersionDisabled}
+            discardVersionDisabledTooltip={discardVersionDisabledTooltip}
+            onExitEditMode={onExitEditMode}
+            exitEditModeDisabled={exitEditModeDisabled}
+            exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
+            onPublishVersion={onPublishVersion}
+            publishVersionLabel={publishVersionLabel}
+            publishVersionDisabled={publishVersionDisabled}
+            publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+          />
+        ) : null}
         {showCanvasSettingsMenu && organizationId && activeCanvasId ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -39,6 +39,10 @@ export interface HeaderProps {
   discardVersionDisabled?: boolean;
   discardVersionDisabledTooltip?: string;
   mode?: HeaderMode;
+  /** When true, the canvas draft is active regardless of the current Console / Canvas / Memory tab. */
+  isEditing?: boolean;
+  /** Switches back to the Canvas tab without changing edit mode. */
+  onSelectCanvasView?: () => void;
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
@@ -48,10 +52,14 @@ export interface HeaderProps {
   onSelectDashboard?: () => void;
   /** Provided when Memory is available as a first-class tab; opens the Memory view. */
   onSelectMemory?: () => void;
-  /** When set with `mode === "dashboard"`, shows Add panel in the secondary header. */
+  /** When set with `mode === "dashboard"` and editing, shows Add panel in the secondary header. */
   onDashboardAddPanel?: () => void;
-  /** When set with `mode === "dashboard"`, shows the YAML button in the secondary header. */
+  /** When set with `mode === "dashboard"` and editing, shows the YAML button in the secondary header. */
   onDashboardOpenYaml?: () => void;
+  /** When set with the Canvas tab active and editing, opens the canvas YAML modal. */
+  onCanvasOpenYaml?: () => void;
+  /** When set with the Canvas tab active and editing, opens the add-component sidebar. */
+  onCanvasAddComponent?: () => void;
   /** When true, the YAML button advertises read-only YAML view. Defaults to editable copy. */
   dashboardYamlReadOnly?: boolean;
   /** Label for the publish/propose-change button in version edit mode. Defaults to "Publish". */
@@ -77,6 +85,7 @@ export function Header(props: HeaderProps) {
         headerTitle={headerTitle}
         showCanvasSettingsMenu={props.showCanvasSettingsMenu}
         mode={props.mode}
+        isEditing={props.isEditing}
         hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
         onDiscardVersion={props.onDiscardVersion}
         discardVersionDisabled={props.discardVersionDisabled}
@@ -105,6 +114,7 @@ function PageHeader({
   headerTitle,
   showCanvasSettingsMenu = true,
   mode,
+  isEditing = false,
   hasUnpublishedDraftChanges,
   onDiscardVersion,
   discardVersionDisabled,
@@ -126,6 +136,7 @@ function PageHeader({
   headerTitle: string;
   showCanvasSettingsMenu?: boolean;
   mode?: HeaderMode;
+  isEditing?: boolean;
   hasUnpublishedDraftChanges?: boolean;
   onDiscardVersion?: () => void;
   discardVersionDisabled?: boolean;
@@ -166,7 +177,7 @@ function PageHeader({
         </div>
       </div>
       <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
-        {mode === "version-live" && onEnterEditMode ? (
+        {mode !== "runs" && !isEditing && onEnterEditMode ? (
           <LiveModeTopHeaderActions
             onEnterEditMode={onEnterEditMode}
             enterEditModeDisabled={enterEditModeDisabled}
@@ -176,7 +187,7 @@ function PageHeader({
             unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
           />
         ) : null}
-        {mode === "version-edit" ? (
+        {isEditing ? (
           <EditModeTopHeaderActions
             hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
             onDiscardVersion={onDiscardVersion}
@@ -220,11 +231,7 @@ function PageHeader({
 function SecondaryHeader(props: HeaderProps) {
   const showCanvasViewModeToggle =
     (!!props.onSelectDashboard || !!props.onSelectMemory) &&
-    (props.mode === "version-live" ||
-      props.mode === "version-edit" ||
-      props.mode === "runs" ||
-      props.mode === "dashboard" ||
-      props.mode === "memory");
+    (props.mode === "version-live" || props.mode === "runs" || props.mode === "dashboard" || props.mode === "memory");
   const canvasViewMode =
     props.mode === "runs"
       ? "runs"
@@ -233,7 +240,7 @@ function SecondaryHeader(props: HeaderProps) {
         : props.mode === "memory"
           ? "memory"
           : "version-live";
-  const editing = props.mode === "version-edit";
+  const editing = props.isEditing ?? props.mode === "version-edit";
 
   return (
     <div className="relative z-10 flex h-10 items-center gap-3 border-b border-slate-950/15 bg-white px-4">
@@ -241,14 +248,13 @@ function SecondaryHeader(props: HeaderProps) {
 
       <div className="pointer-events-none absolute inset-x-0 flex justify-center px-16 sm:px-24">
         <div className="pointer-events-auto">
-          {showCanvasViewModeToggle && props.onExitEditMode ? (
+          {showCanvasViewModeToggle && props.onSelectCanvasView ? (
             <CanvasModeToggle
               mode={canvasViewMode}
-              onSelectLive={props.onExitEditMode}
+              onSelectLive={props.onSelectCanvasView}
               onSelectDashboard={props.onSelectDashboard}
               onSelectMemory={props.onSelectMemory}
               editing={editing}
-              hasDraft={!!props.hasUnpublishedDraftChanges}
             />
           ) : null}
         </div>

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -19,44 +19,15 @@ export function SecondaryHeaderActions({
   visualDiffEnabled,
   draftVisualDiff,
   onToggleVisualDiff,
-  onDiscardVersion,
-  discardVersionDisabled,
-  discardVersionDisabledTooltip,
-  onPublishVersion,
-  publishVersionLabel,
-  publishVersionDisabled,
-  publishVersionDisabledTooltip,
-  onEnterEditMode,
-  enterEditModeDisabled,
-  enterEditModeDisabledTooltip,
-  onExitEditMode,
-  exitEditModeDisabled,
-  exitEditModeDisabledTooltip,
-  unpublishedDraftUpdatedAt,
-  onDiscardDraftAndStartEdit,
   onDashboardAddPanel,
   onDashboardOpenYaml,
   dashboardYamlReadOnly,
 }: HeaderProps) {
-  const showEditButton = mode === "version-live" && !!onEnterEditMode;
-  const showDraftDropdown =
-    showEditButton && !!hasUnpublishedDraftChanges && !!onDiscardDraftAndStartEdit && !enterEditModeDisabled;
   const showDashboardAddPanel = mode === "dashboard" && !!onDashboardAddPanel;
   const showDashboardYaml = mode === "dashboard" && !!onDashboardOpenYaml;
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
-      <LiveModeEditControls
-        showEditButton={showEditButton}
-        showDraftDropdown={showDraftDropdown}
-        onEnterEditMode={onEnterEditMode}
-        enterEditModeDisabled={enterEditModeDisabled}
-        enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
-        hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
-        onDiscardDraftAndStartEdit={onDiscardDraftAndStartEdit}
-        unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
-      />
-
       {mode === "default" && onSave && !saveButtonHidden ? (
         <SaveButton
           onSave={onSave}
@@ -66,23 +37,13 @@ export function SecondaryHeaderActions({
         />
       ) : null}
 
-      {mode === "version-edit" ? (
-        <EditModeVersionActions
-          hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
-          onShowDiff={onShowDiff}
+      {mode === "version-edit" && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
+        <DiffSummaryHoverCard
+          diffCounts={draftVisualDiff.diffCounts}
           visualDiffEnabled={visualDiffEnabled}
-          draftVisualDiff={draftVisualDiff}
           onToggleVisualDiff={onToggleVisualDiff}
-          onDiscardVersion={onDiscardVersion}
-          discardVersionDisabled={discardVersionDisabled}
-          discardVersionDisabledTooltip={discardVersionDisabledTooltip}
-          onExitEditMode={onExitEditMode}
-          exitEditModeDisabled={exitEditModeDisabled}
-          exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
-          onPublishVersion={onPublishVersion}
-          publishVersionLabel={publishVersionLabel}
-          publishVersionDisabled={publishVersionDisabled}
-          publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+          diffToggles={draftVisualDiff.diffToggles}
+          onShowDiff={onShowDiff}
         />
       ) : null}
 
@@ -125,9 +86,7 @@ export function SecondaryHeaderActions({
   );
 }
 
-function LiveModeEditControls({
-  showEditButton,
-  showDraftDropdown,
+export function LiveModeTopHeaderActions({
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
@@ -142,13 +101,12 @@ function LiveModeEditControls({
   | "hasUnpublishedDraftChanges"
   | "onDiscardDraftAndStartEdit"
   | "unpublishedDraftUpdatedAt"
-> & {
-  showEditButton: boolean;
-  showDraftDropdown: boolean;
-}) {
-  if (!showEditButton || !onEnterEditMode) {
+>) {
+  if (!onEnterEditMode) {
     return null;
   }
+
+  const showDraftDropdown = !!hasUnpublishedDraftChanges && !!onDiscardDraftAndStartEdit && !enterEditModeDisabled;
 
   if (showDraftDropdown && onDiscardDraftAndStartEdit) {
     return (
@@ -170,12 +128,8 @@ function LiveModeEditControls({
   );
 }
 
-function EditModeVersionActions({
+export function EditModeTopHeaderActions({
   hasUnpublishedDraftChanges,
-  onShowDiff,
-  visualDiffEnabled,
-  draftVisualDiff,
-  onToggleVisualDiff,
   onDiscardVersion,
   discardVersionDisabled,
   discardVersionDisabledTooltip,
@@ -189,10 +143,6 @@ function EditModeVersionActions({
 }: Pick<
   HeaderProps,
   | "hasUnpublishedDraftChanges"
-  | "onShowDiff"
-  | "visualDiffEnabled"
-  | "draftVisualDiff"
-  | "onToggleVisualDiff"
   | "onDiscardVersion"
   | "discardVersionDisabled"
   | "discardVersionDisabledTooltip"
@@ -207,22 +157,11 @@ function EditModeVersionActions({
   return (
     <div className="flex items-center gap-2">
       {hasUnpublishedDraftChanges ? (
-        <>
-          {draftVisualDiff?.diffCounts && (
-            <DiffSummaryHoverCard
-              diffCounts={draftVisualDiff.diffCounts}
-              visualDiffEnabled={visualDiffEnabled}
-              onToggleVisualDiff={onToggleVisualDiff}
-              diffToggles={draftVisualDiff.diffToggles}
-              onShowDiff={onShowDiff}
-            />
-          )}
-          <DiscardDraftButton
-            onDiscard={() => onDiscardVersion?.()}
-            disabled={discardVersionDisabled || !onDiscardVersion}
-            disabledTooltip={discardVersionDisabledTooltip}
-          />
-        </>
+        <DiscardDraftButton
+          onDiscard={() => onDiscardVersion?.()}
+          disabled={discardVersionDisabled || !onDiscardVersion}
+          disabledTooltip={discardVersionDisabledTooltip}
+        />
       ) : null}
       {onExitEditMode ? (
         <ExitEditButton

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -27,11 +27,6 @@ export function SecondaryHeaderActions({
   onCanvasAddComponent,
 }: HeaderProps) {
   const onCanvasTab = mode === "version-live" || mode === "version-edit";
-  const showCanvasDiff = isEditing && onCanvasTab && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts;
-  const showCanvasYaml = isEditing && onCanvasTab && !!onCanvasOpenYaml;
-  const showCanvasAddComponent = isEditing && onCanvasTab && !!onCanvasAddComponent;
-  const showDashboardAddPanel = isEditing && mode === "dashboard" && !!onDashboardAddPanel;
-  const showDashboardYaml = isEditing && mode === "dashboard" && !!onDashboardOpenYaml;
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
@@ -44,24 +39,67 @@ export function SecondaryHeaderActions({
         />
       ) : null}
 
-      {showCanvasDiff ? (
+      {isEditing && onCanvasTab ? (
+        <EditModeCanvasSecondaryActions
+          hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+          onShowDiff={onShowDiff}
+          visualDiffEnabled={visualDiffEnabled}
+          draftVisualDiff={draftVisualDiff}
+          onToggleVisualDiff={onToggleVisualDiff}
+          onCanvasOpenYaml={onCanvasOpenYaml}
+          onCanvasAddComponent={onCanvasAddComponent}
+        />
+      ) : null}
+
+      {isEditing && mode === "dashboard" ? (
+        <EditModeDashboardSecondaryActions
+          onDashboardAddPanel={onDashboardAddPanel}
+          onDashboardOpenYaml={onDashboardOpenYaml}
+          dashboardYamlReadOnly={dashboardYamlReadOnly}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function EditModeCanvasSecondaryActions({
+  hasUnpublishedDraftChanges,
+  onShowDiff,
+  visualDiffEnabled,
+  draftVisualDiff,
+  onToggleVisualDiff,
+  onCanvasOpenYaml,
+  onCanvasAddComponent,
+}: Pick<
+  HeaderProps,
+  | "hasUnpublishedDraftChanges"
+  | "onShowDiff"
+  | "visualDiffEnabled"
+  | "draftVisualDiff"
+  | "onToggleVisualDiff"
+  | "onCanvasOpenYaml"
+  | "onCanvasAddComponent"
+>) {
+  return (
+    <>
+      {hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
         <DiffSummaryHoverCard
-          diffCounts={draftVisualDiff!.diffCounts}
+          diffCounts={draftVisualDiff.diffCounts}
           visualDiffEnabled={visualDiffEnabled}
           onToggleVisualDiff={onToggleVisualDiff}
-          diffToggles={draftVisualDiff!.diffToggles}
+          diffToggles={draftVisualDiff.diffToggles}
           onShowDiff={onShowDiff}
         />
       ) : null}
 
-      {showCanvasYaml ? (
+      {onCanvasOpenYaml ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <UIButton
               type="button"
               size="sm"
               variant="outline"
-              onClick={() => onCanvasOpenYaml!()}
+              onClick={() => onCanvasOpenYaml()}
               data-testid="canvas-yaml-button"
               aria-label="View / Import YAML"
             >
@@ -73,27 +111,37 @@ export function SecondaryHeaderActions({
         </Tooltip>
       ) : null}
 
-      {showCanvasAddComponent ? (
+      {onCanvasAddComponent ? (
         <UIButton
           type="button"
           size="sm"
           variant="default"
-          onClick={() => onCanvasAddComponent!()}
+          onClick={() => onCanvasAddComponent()}
           data-testid="canvas-add-component-button"
         >
           <Plus className="mr-1 h-3.5 w-3.5" />
           Add component
         </UIButton>
       ) : null}
+    </>
+  );
+}
 
-      {showDashboardYaml ? (
+function EditModeDashboardSecondaryActions({
+  onDashboardAddPanel,
+  onDashboardOpenYaml,
+  dashboardYamlReadOnly,
+}: Pick<HeaderProps, "onDashboardAddPanel" | "onDashboardOpenYaml" | "dashboardYamlReadOnly">) {
+  return (
+    <>
+      {onDashboardOpenYaml ? (
         <Tooltip>
           <TooltipTrigger asChild>
             <UIButton
               type="button"
               size="sm"
               variant="outline"
-              onClick={() => onDashboardOpenYaml!()}
+              onClick={() => onDashboardOpenYaml()}
               data-testid="dashboard-yaml-button"
               aria-label={dashboardYamlReadOnly ? "View YAML" : "View / Import YAML"}
             >
@@ -109,19 +157,19 @@ export function SecondaryHeaderActions({
         </Tooltip>
       ) : null}
 
-      {showDashboardAddPanel ? (
+      {onDashboardAddPanel ? (
         <UIButton
           type="button"
           size="sm"
           variant="default"
-          onClick={() => onDashboardAddPanel!()}
+          onClick={() => onDashboardAddPanel()}
           data-testid="dashboard-add-panel"
         >
           <Plus className="mr-1 h-3.5 w-3.5" />
           Add panel
         </UIButton>
       ) : null}
-    </div>
+    </>
   );
 }
 
@@ -234,7 +282,7 @@ function EnterEditButton({
   const button = (
     <UIButton
       type="button"
-      variant="default"
+      variant="outline"
       size="sm"
       onClick={onClick}
       disabled={disabled}

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -9,6 +9,7 @@ import type { HeaderProps } from "./Header";
 
 export function SecondaryHeaderActions({
   mode,
+  isEditing = false,
   onSave,
   saveButtonHidden,
   saveDisabled,
@@ -22,9 +23,15 @@ export function SecondaryHeaderActions({
   onDashboardAddPanel,
   onDashboardOpenYaml,
   dashboardYamlReadOnly,
+  onCanvasOpenYaml,
+  onCanvasAddComponent,
 }: HeaderProps) {
-  const showDashboardAddPanel = mode === "dashboard" && !!onDashboardAddPanel;
-  const showDashboardYaml = mode === "dashboard" && !!onDashboardOpenYaml;
+  const onCanvasTab = mode === "version-live" || mode === "version-edit";
+  const showCanvasDiff = isEditing && onCanvasTab && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts;
+  const showCanvasYaml = isEditing && onCanvasTab && !!onCanvasOpenYaml;
+  const showCanvasAddComponent = isEditing && onCanvasTab && !!onCanvasAddComponent;
+  const showDashboardAddPanel = isEditing && mode === "dashboard" && !!onDashboardAddPanel;
+  const showDashboardYaml = isEditing && mode === "dashboard" && !!onDashboardOpenYaml;
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
@@ -37,14 +44,46 @@ export function SecondaryHeaderActions({
         />
       ) : null}
 
-      {mode === "version-edit" && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
+      {showCanvasDiff ? (
         <DiffSummaryHoverCard
-          diffCounts={draftVisualDiff.diffCounts}
+          diffCounts={draftVisualDiff!.diffCounts}
           visualDiffEnabled={visualDiffEnabled}
           onToggleVisualDiff={onToggleVisualDiff}
-          diffToggles={draftVisualDiff.diffToggles}
+          diffToggles={draftVisualDiff!.diffToggles}
           onShowDiff={onShowDiff}
         />
+      ) : null}
+
+      {showCanvasYaml ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <UIButton
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onCanvasOpenYaml!()}
+              data-testid="canvas-yaml-button"
+              aria-label="View / Import YAML"
+            >
+              <FileCode className="mr-1 h-3.5 w-3.5" />
+              YAML
+            </UIButton>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">View, copy, download, or import this canvas as YAML</TooltipContent>
+        </Tooltip>
+      ) : null}
+
+      {showCanvasAddComponent ? (
+        <UIButton
+          type="button"
+          size="sm"
+          variant="default"
+          onClick={() => onCanvasAddComponent!()}
+          data-testid="canvas-add-component-button"
+        >
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          Add component
+        </UIButton>
       ) : null}
 
       {showDashboardYaml ? (
@@ -75,7 +114,7 @@ export function SecondaryHeaderActions({
           type="button"
           size="sm"
           variant="default"
-          onClick={() => onDashboardAddPanel()}
+          onClick={() => onDashboardAddPanel!()}
           data-testid="dashboard-add-panel"
         >
           <Plus className="mr-1 h-3.5 w-3.5" />
@@ -195,7 +234,7 @@ function EnterEditButton({
   const button = (
     <UIButton
       type="button"
-      variant="outline"
+      variant="default"
       size="sm"
       onClick={onClick}
       disabled={disabled}

--- a/web_src/src/ui/CanvasPage/RightSideControls.tsx
+++ b/web_src/src/ui/CanvasPage/RightSideControls.tsx
@@ -5,6 +5,8 @@ import { memo, type ReactNode } from "react";
 
 export type RightSideControlsProps = {
   mode: "live" | "edit";
+  /** When true, only the floating Add note control is shown (component/YAML live in the header while editing). */
+  addNoteOnly?: boolean;
 
   onSidebarOpen: () => void;
   onAddNote: () => void | Promise<void>;
@@ -20,7 +22,11 @@ export const RightSideControls = memo(function RightSideControls(props: RightSid
   );
 });
 
-function EditCanvasButtons({ onSidebarOpen, onAddNote, onYamlOpen }: RightSideControlsProps) {
+function EditCanvasButtons({ addNoteOnly, onSidebarOpen, onAddNote, onYamlOpen }: RightSideControlsProps) {
+  if (addNoteOnly) {
+    return <ControlButton tooltip="Add note" onClick={onAddNote} testId="add-note-button" icon={<StickyNote />} />;
+  }
+
   return (
     <>
       <ControlButton tooltip="Add component" onClick={onSidebarOpen} testId="open-sidebar-button" icon={<Plus />} />

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -1,4 +1,5 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import { useEffect, useRef } from "react";
 
 type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard" | "memory";
@@ -9,7 +10,6 @@ interface CanvasModeToggleProps {
   onSelectDashboard?: () => void;
   onSelectMemory?: () => void;
   editing?: boolean;
-  hasDraft?: boolean;
 }
 
 const CANVAS_TAB = "canvas";
@@ -23,7 +23,6 @@ export function CanvasModeToggle({
   onSelectDashboard,
   onSelectMemory,
   editing = false,
-  hasDraft = false,
 }: CanvasModeToggleProps) {
   const showDashboard = Boolean(onSelectDashboard);
   const showMemory = Boolean(onSelectMemory);
@@ -79,7 +78,12 @@ export function CanvasModeToggle({
     >
       <TabsList
         aria-label="Canvas view"
-        className="h-7 min-h-7 bg-slate-100 [&_[data-slot=tabs-trigger][data-state=inactive]]:text-slate-500 [&_[data-slot=tabs-trigger]]:text-[13px]"
+        className={cn(
+          "h-7 min-h-7 p-1 [&_[data-slot=tabs-trigger]]:text-[13px]",
+          editing
+            ? "rounded-full bg-[var(--purple)] text-white [&_[data-slot=tabs-trigger]]:transition-none [&_[data-slot=tabs-trigger][data-state=inactive]]:bg-transparent [&_[data-slot=tabs-trigger][data-state=inactive]]:text-white/90 [&_[data-slot=tabs-trigger][data-state=inactive]]:hover:text-white [&_[data-slot=tabs-trigger][data-state=active]]:rounded-full [&_[data-slot=tabs-trigger][data-state=active]]:bg-white [&_[data-slot=tabs-trigger][data-state=active]]:text-slate-900 [&_[data-slot=tabs-trigger][data-state=active]]:shadow-none"
+            : "bg-slate-100 [&_[data-slot=tabs-trigger][data-state=inactive]]:text-slate-500",
+        )}
       >
         {showDashboard ? (
           <TabsTrigger value={DASHBOARD_TAB} data-testid="canvas-view-mode-dashboard" aria-label="Console">
@@ -89,18 +93,9 @@ export function CanvasModeToggle({
         <TabsTrigger
           value={CANVAS_TAB}
           data-testid="canvas-view-mode-live"
-          aria-label={editing ? "Canvas (editing)" : hasDraft ? "Canvas (unpublished draft)" : "Canvas"}
+          aria-label={editing ? "Canvas (editing)" : "Canvas"}
         >
-          <span className="inline-flex items-center gap-1.5">
-            Canvas
-            {hasDraft ? (
-              <span
-                className="inline-flex size-1.5 shrink-0 rounded-full bg-muted-foreground/70"
-                aria-hidden="true"
-                data-testid="canvas-view-mode-live-draft-dot"
-              />
-            ) : null}
-          </span>
+          Canvas
         </TabsTrigger>
         {showMemory ? (
           <TabsTrigger value={MEMORY_TAB} data-testid="canvas-view-mode-memory" aria-label="Memory">

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -87,13 +87,7 @@ vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
 }));
 
 vi.mock("./Header", () => ({
-  Header: ({
-    isEditing,
-    onCanvasAddComponent,
-  }: {
-    isEditing?: boolean;
-    onCanvasAddComponent?: () => void;
-  }) => (
+  Header: ({ isEditing, onCanvasAddComponent }: { isEditing?: boolean; onCanvasAddComponent?: () => void }) => (
     <header data-testid="canvas-header">
       {isEditing && onCanvasAddComponent ? (
         <button type="button" data-testid="canvas-add-component-button" onClick={() => onCanvasAddComponent()}>

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -87,7 +87,21 @@ vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
 }));
 
 vi.mock("./Header", () => ({
-  Header: () => <header data-testid="canvas-header" />,
+  Header: ({
+    isEditing,
+    onCanvasAddComponent,
+  }: {
+    isEditing?: boolean;
+    onCanvasAddComponent?: () => void;
+  }) => (
+    <header data-testid="canvas-header">
+      {isEditing && onCanvasAddComponent ? (
+        <button type="button" data-testid="canvas-add-component-button" onClick={() => onCanvasAddComponent()}>
+          Add component
+        </button>
+      ) : null}
+    </header>
+  ),
 }));
 
 import { CanvasNodeErrorBoundary, CanvasPage } from "./index";
@@ -297,6 +311,7 @@ describe("CanvasPage connection drop", () => {
       <MemoryRouter>
         <CanvasPage
           title="Canvas"
+          headerMode="version-live"
           nodes={[]}
           edges={[]}
           buildingBlocks={[]}

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -310,7 +310,7 @@ describe("CanvasPage connection drop", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByTestId("open-sidebar-button"));
+      fireEvent.click(screen.getByTestId("canvas-add-component-button"));
     });
 
     expect(onPlaceholderAdd).toHaveBeenCalledTimes(1);

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -183,6 +183,8 @@ export interface CanvasPageProps {
   onExitEditMode?: () => void;
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
+  /** Switches back to the Canvas tab without changing edit mode. */
+  onSelectCanvasView?: () => void;
   onSelectRuns?: () => void;
   onExitRunsMode?: () => void;
   onSelectDashboard?: () => void;
@@ -192,6 +194,10 @@ export interface CanvasPageProps {
   onDashboardAddPanel?: () => void;
   /** Opens the dashboard YAML modal when `headerMode` is `dashboard`. */
   onDashboardOpenYaml?: () => void;
+  /** Opens the canvas YAML modal from the secondary header when editing on the Canvas tab. */
+  onCanvasOpenYaml?: () => void;
+  /** Opens the add-component sidebar from the secondary header when editing on the Canvas tab. */
+  onCanvasAddComponent?: () => void;
   /** Whether the dashboard YAML modal will open in read-only mode (no apply). */
   dashboardYamlReadOnly?: boolean;
   publishVersionLabel?: string;
@@ -278,7 +284,7 @@ export interface CanvasPageProps {
 
   // Building blocks for adding new nodes
   buildingBlocks: BuildingBlockCategory[];
-  /** When true with a non-empty `activeCanvasVersionId`, the agent may run in build mode. */
+  /** When true, the canvas draft is active across Canvas, Console, and Memory tabs. */
   isEditing: boolean;
   /** Active canvas version id (draft when editing); drives agent build mode. */
   activeCanvasVersionId: string;
@@ -1154,7 +1160,7 @@ function CanvasPage(props: CanvasPageProps) {
     disabled:
       readOnly ||
       Boolean(props.hideAddControls) ||
-      props.headerMode === "version-live" ||
+      !props.isEditing ||
       props.headerMode === "dashboard" ||
       props.headerMode === "memory" ||
       props.headerMode === "runs" ||
@@ -1269,6 +1275,8 @@ function CanvasPage(props: CanvasPageProps) {
           discardVersionDisabled={props.discardVersionDisabled}
           discardVersionDisabledTooltip={props.discardVersionDisabledTooltip}
           headerMode={props.headerMode}
+          isEditing={props.isEditing}
+          onSelectCanvasView={props.onSelectCanvasView}
           onEnterEditMode={props.onEnterEditMode}
           enterEditModeDisabled={props.enterEditModeDisabled}
           enterEditModeDisabledTooltip={props.enterEditModeDisabledTooltip}
@@ -1279,6 +1287,8 @@ function CanvasPage(props: CanvasPageProps) {
           onSelectMemory={props.onSelectMemory}
           onDashboardAddPanel={props.onDashboardAddPanel}
           onDashboardOpenYaml={props.onDashboardOpenYaml}
+          onCanvasOpenYaml={props.isEditing ? props.onYamlOpen : undefined}
+          onCanvasAddComponent={props.isEditing ? handleBuildingBlocksShortcutOpen : undefined}
           dashboardYamlReadOnly={props.dashboardYamlReadOnly}
           publishVersionLabel={props.publishVersionLabel}
           hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
@@ -1306,7 +1316,7 @@ function CanvasPage(props: CanvasPageProps) {
           versionsContent={props.toolSidebarVersionsContent}
         />
 
-        {props.headerMode === "runs" || props.headerMode === "memory" ? null : (
+        {props.headerMode === "runs" || props.headerMode === "memory" || props.isEditing ? null : (
           <RightSideControls
             mode={readOnly ? "live" : "edit"}
             onSidebarOpen={handleBuildingBlocksShortcutOpen}
@@ -1318,7 +1328,7 @@ function CanvasPage(props: CanvasPageProps) {
           <BuildingBlocksSidebar
             isOpen={
               isBuildingBlocksSidebarOpen &&
-              props.headerMode !== "version-live" &&
+              !!props.isEditing &&
               props.headerMode !== "dashboard" &&
               props.headerMode !== "memory" &&
               props.headerMode !== "runs"
@@ -1416,6 +1426,7 @@ function CanvasPage(props: CanvasPageProps) {
               setCurrentTab={setCurrentTab}
               showBottomStatusControls={props.showBottomStatusControls}
               headerMode={props.headerMode}
+              isEditing={props.isEditing}
               isAutoLayoutOnUpdateEnabled={props.isAutoLayoutOnUpdateEnabled}
               onToggleAutoLayoutOnUpdate={props.onToggleAutoLayoutOnUpdate}
               autoLayoutOnUpdateDisabled={props.autoLayoutOnUpdateDisabled}
@@ -1465,11 +1476,7 @@ function CanvasPage(props: CanvasPageProps) {
               configurationSaveMode={props.configurationSaveMode}
               currentTab={currentTab}
               onTabChange={setCurrentTab}
-              canvasMode={
-                props.headerMode === "version-live" || props.headerMode === "dashboard" || props.headerMode === "memory"
-                  ? "live"
-                  : "edit"
-              }
+              canvasMode={props.isEditing ? "edit" : "live"}
               organizationId={props.organizationId}
               getCustomField={props.getCustomField}
               integrations={props.integrations}
@@ -1778,6 +1785,8 @@ function CanvasContentHeader({
   discardVersionDisabled,
   discardVersionDisabledTooltip,
   headerMode,
+  isEditing,
+  onSelectCanvasView,
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
@@ -1788,6 +1797,8 @@ function CanvasContentHeader({
   onSelectMemory,
   onDashboardAddPanel,
   onDashboardOpenYaml,
+  onCanvasOpenYaml,
+  onCanvasAddComponent,
   dashboardYamlReadOnly,
   publishVersionLabel,
   hasUnpublishedDraftChanges,
@@ -1823,6 +1834,8 @@ function CanvasContentHeader({
   discardVersionDisabled?: boolean;
   discardVersionDisabledTooltip?: string;
   headerMode?: CanvasPageProps["headerMode"];
+  isEditing?: boolean;
+  onSelectCanvasView?: () => void;
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
@@ -1833,6 +1846,8 @@ function CanvasContentHeader({
   onSelectMemory?: () => void;
   onDashboardAddPanel?: () => void;
   onDashboardOpenYaml?: () => void;
+  onCanvasOpenYaml?: () => void;
+  onCanvasAddComponent?: () => void;
   dashboardYamlReadOnly?: boolean;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
@@ -1870,6 +1885,8 @@ function CanvasContentHeader({
       discardVersionDisabled={discardVersionDisabled}
       discardVersionDisabledTooltip={discardVersionDisabledTooltip}
       mode={headerMode}
+      isEditing={isEditing}
+      onSelectCanvasView={onSelectCanvasView}
       onEnterEditMode={onEnterEditMode}
       enterEditModeDisabled={enterEditModeDisabled}
       enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
@@ -1880,6 +1897,8 @@ function CanvasContentHeader({
       onSelectMemory={onSelectMemory}
       onDashboardAddPanel={onDashboardAddPanel}
       onDashboardOpenYaml={onDashboardOpenYaml}
+      onCanvasOpenYaml={onCanvasOpenYaml}
+      onCanvasAddComponent={onCanvasAddComponent}
       dashboardYamlReadOnly={dashboardYamlReadOnly}
       publishVersionLabel={publishVersionLabel}
       hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
@@ -1955,6 +1974,7 @@ function CanvasContent({
   setCurrentTab,
   showBottomStatusControls = true,
   headerMode,
+  isEditing = false,
   isAutoLayoutOnUpdateEnabled,
   onToggleAutoLayoutOnUpdate,
   autoLayoutOnUpdateDisabled,
@@ -2011,6 +2031,7 @@ function CanvasContent({
   setCurrentTab?: (tab: "latest" | "settings" | "docs") => void;
   showBottomStatusControls?: boolean;
   headerMode?: CanvasPageProps["headerMode"];
+  isEditing?: boolean;
   isAutoLayoutOnUpdateEnabled?: boolean;
   onToggleAutoLayoutOnUpdate?: () => void;
   autoLayoutOnUpdateDisabled?: boolean;
@@ -2092,7 +2113,7 @@ function CanvasContent({
     return saved ? parseInt(saved, 10) : 320;
   });
   const [isSnapToGridEnabled, setIsSnapToGridEnabled] = useState(true);
-  const isEditMode = headerMode === "version-edit";
+  const isEditMode = isEditing;
   const runSelectableSet = useMemo(() => {
     if (headerMode !== "runs" || !runParticipantNodeIds || runParticipantNodeIds.length === 0) {
       return null;

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1316,7 +1316,17 @@ function CanvasPage(props: CanvasPageProps) {
           versionsContent={props.toolSidebarVersionsContent}
         />
 
-        {props.headerMode === "runs" || props.headerMode === "memory" || props.isEditing ? null : (
+        {props.headerMode === "runs" || props.headerMode === "memory" ? null : props.isEditing ? (
+          props.headerMode === "dashboard" ? null : (
+            <RightSideControls
+              mode="edit"
+              addNoteOnly
+              onSidebarOpen={handleBuildingBlocksShortcutOpen}
+              onAddNote={handleAddNote}
+              onYamlOpen={props.onYamlOpen}
+            />
+          )
+        ) : (
           <RightSideControls
             mode={readOnly ? "live" : "edit"}
             onSidebarOpen={handleBuildingBlocksShortcutOpen}


### PR DESCRIPTION
## Summary
- Move Edit/Continue Editing, Discard, Exit edit, and Publish actions to the top header so they stay visible across Canvas, Console, and Memory tabs
- Persist edit mode when switching between Canvas, Console, and Memory (no longer auto-switch to live version)
- Polish edit-mode UX: purple tab switcher, hide floating canvas controls while editing, Console add-panel enters edit first, remove draft dot and empty-state add button

## Test plan
- [ ] Enter edit from Canvas, switch to Console/Memory — edit actions remain in top header
- [ ] Discard / Exit edit / Publish work from any tab while editing
- [ ] Console "+ Add panel" (header) enters edit mode when not already editing, then opens dialog
- [ ] Memory shows entries while editing; delete disabled on draft
- [ ] Live mode: Edit button in top header; secondary header shows tab-specific actions only
- [ ] `make check.build.ui` / eslint budget pass


Made with [Cursor](https://cursor.com)