### PR TITLE
fix: align canvas mode overlays with sidebar layout

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import type { CanvasMemoryEntry } from "@/hooks/useCanvasData";
-import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/ui/collapsible";
 import { ChevronDown, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -14,14 +13,8 @@ export type CanvasMemoryViewProps = {
 };
 
 export function CanvasMemoryView(props: CanvasMemoryViewProps) {
-  const leftOffset = useEffectiveLeftSidebarWidth();
-
   return (
-    <div
-      className="absolute bottom-0 top-[5rem] z-10 flex flex-col overflow-hidden bg-slate-50"
-      style={{ left: leftOffset, right: 0 }}
-      data-testid="memory-overlay"
-    >
+    <div className="absolute inset-0 z-10 flex flex-col overflow-hidden bg-slate-50" data-testid="memory-overlay">
       <CanvasMemoryViewBody {...props} />
     </div>
   );

--- a/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useRef } from "react";
 import type { CanvasesDashboardLayoutItem, CanvasesDashboardPanel } from "@/api-client";
-import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
 
 import type { SuperplaneComponentsNode } from "@/api-client";
 import type {
@@ -111,16 +110,11 @@ export function DashboardOverlay({
   }, []);
 
   const contextNodes = canvasNodes ?? [];
-  const leftOffset = useEffectiveLeftSidebarWidth();
   // The YAML modal is opened from the canvas page header (next to "Add panel").
   // The dashboard overlay no longer renders its own toolbar so the white
   // strip is gone and the grid fills the available area.
   const overlayContent = (
-    <div
-      className="absolute bottom-0 top-[5rem] z-10 flex flex-col bg-slate-100"
-      style={{ left: leftOffset, right: 0 }}
-      data-testid="dashboard-overlay"
-    >
+    <div className="absolute inset-0 z-10 flex flex-col bg-slate-100" data-testid="dashboard-overlay">
       <div className="min-h-0 flex-1 overflow-auto">
         <DashboardView
           panels={panels}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5502,35 +5502,6 @@ export function WorkflowPageV2() {
   return (
     <>
       <div className="relative h-full w-full">
-        <WorkflowDashboardOverlay
-          isDashboardMode={isDashboardMode}
-          dashboardsFeatureEnabled={dashboardsFeatureEnabled}
-          canUpdateCanvas={canUpdateCanvas}
-          isTemplate={isTemplate}
-          canvasDeletedRemotely={canvasDeletedRemotely}
-          dashboardQuery={dashboardQuery}
-          updateDashboardMutation={updateDashboardMutation}
-          addPanelDialogOpen={isDashboardAddPanelOpen}
-          onAddPanelDialogOpenChange={handleDashboardAddPanelDialogOpenChange}
-          yamlModalOpen={isDashboardYamlOpen}
-          onYamlModalOpenChange={setIsDashboardYamlOpen}
-          canvasId={canvasId || undefined}
-          canvasName={canvas?.metadata?.name || undefined}
-          organizationId={organizationId || undefined}
-          canvasNodes={canvasNodes}
-          nodeStatuses={dashboardNodeStatuses}
-          onTriggerNode={handleDashboardTriggerNode}
-        />
-        <WorkflowMemoryOverlayLayer
-          isMemoryMode={isMemoryMode}
-          isViewingDraftVersion={isViewingDraftVersion}
-          isViewingLiveVersion={isViewingLiveVersion}
-          canUpdateCanvas={canUpdateCanvas}
-          entries={canvasMemoryEntries}
-          isLoading={canvasMemoryLoading}
-          error={canvasMemoryError}
-          deleteCanvasMemoryEntry={deleteCanvasMemoryEntry}
-        />
         <CanvasPage
           key={canvasRenderKey}
           // Persist right sidebar in query params
@@ -5554,6 +5525,39 @@ export function WorkflowPageV2() {
           showBottomStatusControls={!isTemplate && !isRunsMode && !isMemoryMode}
           hideAddControls={isTemplate || isRunsMode || isMemoryMode}
           hideCanvasToolSidebar={isTemplate}
+          modeOverlay={
+            <>
+              <WorkflowDashboardOverlay
+                isDashboardMode={isDashboardMode}
+                dashboardsFeatureEnabled={dashboardsFeatureEnabled}
+                canUpdateCanvas={canUpdateCanvas}
+                isTemplate={isTemplate}
+                canvasDeletedRemotely={canvasDeletedRemotely}
+                dashboardQuery={dashboardQuery}
+                updateDashboardMutation={updateDashboardMutation}
+                addPanelDialogOpen={isDashboardAddPanelOpen}
+                onAddPanelDialogOpenChange={handleDashboardAddPanelDialogOpenChange}
+                yamlModalOpen={isDashboardYamlOpen}
+                onYamlModalOpenChange={setIsDashboardYamlOpen}
+                canvasId={canvasId || undefined}
+                canvasName={canvas?.metadata?.name || undefined}
+                organizationId={organizationId || undefined}
+                canvasNodes={canvasNodes}
+                nodeStatuses={dashboardNodeStatuses}
+                onTriggerNode={handleDashboardTriggerNode}
+              />
+              <WorkflowMemoryOverlayLayer
+                isMemoryMode={isMemoryMode}
+                isViewingDraftVersion={isViewingDraftVersion}
+                isViewingLiveVersion={isViewingLiveVersion}
+                canUpdateCanvas={canUpdateCanvas}
+                entries={canvasMemoryEntries}
+                isLoading={canvasMemoryLoading}
+                error={canvasMemoryError}
+                deleteCanvasMemoryEntry={deleteCanvasMemoryEntry}
+              />
+            </>
+          }
           onSelectMemory={isTemplate ? undefined : handleSelectMemoryMode}
           onYamlOpen={() => setIsYamlViewModalOpen(true)}
           nodes={nodes}

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -69,7 +69,7 @@ vi.mock("../componentSidebar", () => ({
 }));
 
 vi.mock("@/components/CanvasToolSidebar", () => ({
-  CanvasToolSidebar: () => null,
+  CanvasToolSidebar: () => <aside data-testid="canvas-tool-sidebar" />,
 }));
 
 vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
@@ -195,6 +195,36 @@ describe("CanvasPage connection drop", () => {
       unobserve() {}
       disconnect() {}
     };
+  });
+
+  it("renders mode overlays in the canvas region after the tool sidebar", () => {
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="dashboard"
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={false}
+          activeCanvasVersionId="live-version"
+          onYamlOpen={vi.fn()}
+          modeOverlay={<div data-testid="mode-overlay" />}
+        />
+      </MemoryRouter>,
+    );
+
+    const toolSidebar = screen.getByTestId("canvas-tool-sidebar");
+    const overlay = screen.getByTestId("mode-overlay");
+    const mainContentRow = toolSidebar.parentElement;
+    const canvasRegion = overlay.parentElement;
+
+    expect(mainContentRow).toContainElement(toolSidebar);
+    expect(mainContentRow).toContainElement(overlay);
+    expect(canvasRegion).not.toBe(mainContentRow);
+    expect(Array.from(mainContentRow?.children ?? []).indexOf(toolSidebar)).toBeLessThan(
+      Array.from(mainContentRow?.children ?? []).indexOf(canvasRegion as Element),
+    );
   });
 
   it("does not close the building blocks sidebar from the pane click that follows a connection drop", () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -221,6 +221,8 @@ export interface CanvasPageProps {
   hideAddControls?: boolean;
   /** Hide the Agent / Runs / Versions left panel toggle (templates only); runs view keeps the tool sidebar visible. */
   hideCanvasToolSidebar?: boolean;
+  /** Full-surface overlay for alternate canvas modes such as Console and Memory. */
+  modeOverlay?: React.ReactNode;
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
   canUpdateIntegrations?: boolean;
@@ -1459,6 +1461,7 @@ function CanvasPage(props: CanvasPageProps) {
               canCreateIntegrations={props.canCreateIntegrations}
             />
           </ReactFlowProvider>
+          {props.modeOverlay}
           {props.headerMode === "runs" ? null : (
             <Sidebar
               state={state}


### PR DESCRIPTION
## Summary
- render Console and Memory overlays inside CanvasPage's main canvas region so the left tool sidebar consumes layout width consistently
- adjust overlay positioning to fill that region instead of offsetting from the page header
- add a CanvasPage layout regression test for mode overlays

## Tests
- cd web_src && npm run test -- src/ui/CanvasPage/index.spec.tsx
- make format.js
- make check.build.ui