### PR TITLE
feat: add AWS EC2 power management and get instance components

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -42,6 +42,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="EC2 • Enable Image" href="#ec2-•-enable-image" description="Enable an EC2 AMI image" />
   <LinkCard title="EC2 • Enable Image Deprecation" href="#ec2-•-enable-image-deprecation" description="Enable deprecation for an EC2 AMI image" />
   <LinkCard title="EC2 • Get Image" href="#ec2-•-get-image" description="Get an EC2 AMI image by ID" />
+  <LinkCard title="EC2 • Get Instance" href="#ec2-•-get-instance" description="Fetch the current state and details of an EC2 instance" />
+  <LinkCard title="EC2 • Manage Instance Power" href="#ec2-•-manage-instance-power" description="Perform power operations on an EC2 instance" />
   <LinkCard title="ECR • Get Image" href="#ecr-•-get-image" description="Get an ECR image by digest or tag" />
   <LinkCard title="ECR • Get Image Scan Findings" href="#ecr-•-get-image-scan-findings" description="Get ECR image scan findings by digest or tag" />
   <LinkCard title="ECR • Scan Image" href="#ecr-•-scan-image" description="Scan an ECR image for vulnerabilities" />
@@ -1400,6 +1402,112 @@ The Get Image component retrieves metadata for an EC2 AMI.
   },
   "timestamp": "2026-02-18T12:00:00Z",
   "type": "aws.ec2.image"
+}
+```
+
+<a id="ec2-•-get-instance"></a>
+
+## EC2 • Get Instance
+
+The Get Instance component describes an EC2 instance and emits its current details.
+
+### Use Cases
+
+- **State inspection**: Check whether an instance is running or stopped before taking action
+- **IP resolution**: Retrieve the public or private IP address of an instance at runtime
+- **Metadata lookup**: Fetch instance type, AMI, VPC, and tags mid-workflow
+
+### Configuration
+
+- **Region**: AWS region where the instance runs
+- **Instance**: EC2 instance to describe
+
+### Output
+
+Emits the instance details on the default output channel:
+- `instanceId`, `state`, `instanceType`, `imageId`
+- `publicIpAddress`, `privateIpAddress`, `publicDnsName`, `privateDnsName`
+- `subnetId`, `vpcId`, `region`, `name`, `launchTime`
+
+### Example Output
+
+```json
+{
+  "data": {
+    "imageId": "ami-07f0e4f3e9c123abc",
+    "instanceId": "i-0abc1234567890def",
+    "instanceType": "t3.micro",
+    "keyName": "my-key",
+    "launchTime": "2026-05-21T12:00:00.000Z",
+    "name": "my-server",
+    "privateDnsName": "ip-10-0-1-25.ec2.internal",
+    "privateIpAddress": "10.0.1.25",
+    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
+    "publicIpAddress": "54.198.10.42",
+    "region": "us-east-1",
+    "state": "running",
+    "subnetId": "subnet-0abc1234567890def",
+    "vpcId": "vpc-0abc1234567890def"
+  },
+  "timestamp": "2026-05-21T12:01:00Z",
+  "type": "aws.ec2.instance"
+}
+```
+
+<a id="ec2-•-manage-instance-power"></a>
+
+## EC2 • Manage Instance Power
+
+The Manage Instance Power component performs power management operations on an EC2 instance.
+
+### Use Cases
+
+- **Scheduled workloads**: Start or stop instances on demand from a workflow
+- **Cost optimisation**: Stop or hibernate non-production instances outside business hours
+- **Maintenance workflows**: Stop an instance before resizing or patching, start it after
+- **Recovery**: Reboot an instance experiencing issues
+
+### Configuration
+
+- **Region**: AWS region where the instance runs
+- **Instance**: EC2 instance to manage
+- **Operation**: The power operation to perform:
+  - **Start**: Start a stopped instance and wait for it to reach running state
+  - **Stop**: Gracefully stop a running instance and wait for stopped state
+  - **Reboot**: Reboot a running instance (completes once the reboot signal is sent)
+  - **Hibernate**: Stop an instance and save RAM to disk (instance must have hibernation enabled)
+
+### Output
+
+Emits instance details on the default output channel once the operation completes:
+- `instanceId`, `state`, `region`
+- `publicIpAddress`, `privateIpAddress` (start only)
+
+### Important Notes
+
+- **Hibernate** requires the instance to have been launched with hibernation enabled
+- **Reboot** emits immediately after the reboot signal is accepted; it does not wait for the OS to come back online
+
+### Example Output
+
+```json
+{
+  "data": {
+    "imageId": "ami-07f0e4f3e9c123abc",
+    "instanceId": "i-0abc1234567890def",
+    "instanceType": "t3.micro",
+    "name": "my-server",
+    "privateDnsName": "ip-10-0-1-25.ec2.internal",
+    "privateIpAddress": "10.0.1.25",
+    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
+    "publicIpAddress": "54.198.10.42",
+    "region": "us-east-1",
+    "state": "running",
+    "subnetId": "subnet-0abc1234567890def",
+    "vpcId": "vpc-0abc1234567890def"
+  },
+  "timestamp": "2026-05-21T12:11:00Z",
+  "type": "aws.ec2.instance"
 }
 ```
 

--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -1409,6 +1409,8 @@ The Get Image component retrieves metadata for an EC2 AMI.
 
 ## EC2 • Get Instance
 
+**Component key:** `aws.ec2.getInstance`
+
 The Get Instance component describes an EC2 instance and emits its current details.
 
 ### Use Cases
@@ -1458,6 +1460,8 @@ Emits the instance details on the default output channel:
 
 ## EC2 • Manage Instance Power
 
+**Component key:** `aws.ec2.manageInstancePower`
+
 The Manage Instance Power component performs power management operations on an EC2 instance.
 
 ### Use Cases
@@ -1493,21 +1497,22 @@ Emits instance details on the default output channel once the operation complete
 ```json
 {
   "data": {
-    "imageId": "ami-07f0e4f3e9c123abc",
+    "imageId": "ami-0215d085326c25744",
     "instanceId": "i-0abc1234567890def",
     "instanceType": "t3.micro",
-    "name": "my-server",
-    "privateDnsName": "ip-10-0-1-25.ec2.internal",
+    "launchTime": "2026-05-28T09:41:14.000Z",
+    "name": "preview-pr-5",
+    "privateDnsName": "ip-10.0.1.25.eu-north-1.compute.internal",
     "privateIpAddress": "10.0.1.25",
-    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
+    "publicDnsName": "ec2-54-198-10-42.eu-north-1.compute.amazonaws.com",
     "publicIpAddress": "54.198.10.42",
-    "region": "us-east-1",
+    "region": "eu-north-1",
     "state": "running",
-    "subnetId": "subnet-0abc1234567890def",
-    "vpcId": "vpc-0abc1234567890def"
+    "subnetId": "subnet-0e7c8aa9b0a82aec5",
+    "vpcId": "vpc-0049650f5a479c14b"
   },
-  "timestamp": "2026-05-21T12:11:00Z",
-  "type": "aws.ec2.instance"
+  "timestamp": "2026-05-28T09:41:26.29656651Z",
+  "type": "aws.ec2.instance.power.started"
 }
 ```
 

--- a/pkg/integrations/aws/aws.go
+++ b/pkg/integrations/aws/aws.go
@@ -163,6 +163,8 @@ func (a *AWS) Actions() []core.Action {
 		&ec2.EnableImage{},
 		&ec2.EnableImageDeprecation{},
 		&ec2.GetImage{},
+		&ec2.GetInstance{},
+		&ec2.ManageInstancePower{},
 		&sns.GetTopic{},
 		&sns.GetSubscription{},
 		&sns.CreateTopic{},

--- a/pkg/integrations/aws/ec2/client.go
+++ b/pkg/integrations/aws/ec2/client.go
@@ -125,6 +125,18 @@ type TerminateInstancesOutput struct {
 	State      string `json:"state" mapstructure:"state"`
 }
 
+type StopInstancesOutput struct {
+	RequestID  string `json:"requestId" mapstructure:"requestId"`
+	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+	State      string `json:"state" mapstructure:"state"`
+}
+
+type StartInstancesOutput struct {
+	RequestID  string `json:"requestId" mapstructure:"requestId"`
+	InstanceID string `json:"instanceId" mapstructure:"instanceId"`
+	State      string `json:"state" mapstructure:"state"`
+}
+
 type CreateImageInput struct {
 	InstanceID  string
 	Name        string
@@ -516,6 +528,78 @@ func (c *Client) TerminateInstances(instanceIDs ...string) (*TerminateInstancesO
 		RequestID:  response.RequestID,
 		InstanceID: instance.InstanceID,
 		State:      instance.stateName(),
+	}, nil
+}
+
+func (c *Client) StopInstances(instanceID string) (*StopInstancesOutput, error) {
+	return c.stopInstances(instanceID, false)
+}
+
+func (c *Client) HibernateInstances(instanceID string) (*StopInstancesOutput, error) {
+	return c.stopInstances(instanceID, true)
+}
+
+func (c *Client) stopInstances(instanceID string, hibernate bool) (*StopInstancesOutput, error) {
+	params := url.Values{}
+	params.Set("InstanceId.1", strings.TrimSpace(instanceID))
+	if hibernate {
+		params.Set("Hibernate", "true")
+	}
+
+	response := stopInstancesResponse{}
+	if err := c.postForm("StopInstances", params, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Instances) == 0 {
+		return nil, fmt.Errorf("response did not include instance ID")
+	}
+
+	instance := response.Instances[0]
+	return &StopInstancesOutput{
+		RequestID:  response.RequestID,
+		InstanceID: instance.InstanceID,
+		State:      instance.CurrentState.Name,
+	}, nil
+}
+
+func (c *Client) RebootInstances(instanceID string) error {
+	params := url.Values{}
+	params.Set("InstanceId.1", strings.TrimSpace(instanceID))
+
+	response := struct {
+		RequestID string `xml:"requestId"`
+		Return    bool   `xml:"return"`
+	}{}
+	if err := c.postForm("RebootInstances", params, &response); err != nil {
+		return err
+	}
+
+	if !response.Return {
+		return fmt.Errorf("RebootInstances returned false")
+	}
+
+	return nil
+}
+
+func (c *Client) StartInstances(instanceID string) (*StartInstancesOutput, error) {
+	params := url.Values{}
+	params.Set("InstanceId.1", strings.TrimSpace(instanceID))
+
+	response := startInstancesResponse{}
+	if err := c.postForm("StartInstances", params, &response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Instances) == 0 {
+		return nil, fmt.Errorf("response did not include instance ID")
+	}
+
+	instance := response.Instances[0]
+	return &StartInstancesOutput{
+		RequestID:  response.RequestID,
+		InstanceID: instance.InstanceID,
+		State:      instance.CurrentState.Name,
 	}, nil
 }
 
@@ -1422,6 +1506,26 @@ type runInstancesResponse struct {
 type terminateInstancesResponse struct {
 	RequestID string        `xml:"requestId"`
 	Instances []xmlInstance `xml:"instancesSet>item"`
+}
+
+type stopInstancesResponse struct {
+	RequestID string                   `xml:"requestId"`
+	Instances []xmlInstanceStateChange `xml:"instancesSet>item"`
+}
+
+type startInstancesResponse struct {
+	RequestID string                   `xml:"requestId"`
+	Instances []xmlInstanceStateChange `xml:"instancesSet>item"`
+}
+
+type xmlInstanceStateChange struct {
+	InstanceID   string `xml:"instanceId"`
+	CurrentState struct {
+		Name string `xml:"name"`
+	} `xml:"currentState"`
+	PreviousState struct {
+		Name string `xml:"name"`
+	} `xml:"previousState"`
 }
 
 type describeSubnetsResponse struct {

--- a/pkg/integrations/aws/ec2/ec2.go
+++ b/pkg/integrations/aws/ec2/ec2.go
@@ -25,8 +25,10 @@ const (
 )
 
 const (
-	CreateInstancePayloadType = "aws.ec2.instance"
-	DeleteInstancePayloadType = "aws.ec2.instance.deleted"
+	CreateInstancePayloadType      = "aws.ec2.instance"
+	DeleteInstancePayloadType      = "aws.ec2.instance.deleted"
+	GetInstancePayloadType         = "aws.ec2.instance"
+	ManageInstancePowerPayloadType = "aws.ec2.instance"
 
 	instancePollInterval    = 10 * time.Second
 	maxInstancePollErrors   = 10

--- a/pkg/integrations/aws/ec2/ec2.go
+++ b/pkg/integrations/aws/ec2/ec2.go
@@ -25,10 +25,13 @@ const (
 )
 
 const (
-	CreateInstancePayloadType      = "aws.ec2.instance"
-	DeleteInstancePayloadType      = "aws.ec2.instance.deleted"
-	GetInstancePayloadType         = "aws.ec2.instance"
-	ManageInstancePowerPayloadType = "aws.ec2.instance"
+	CreateInstancePayloadType               = "aws.ec2.instance"
+	DeleteInstancePayloadType               = "aws.ec2.instance.deleted"
+	GetInstancePayloadType                  = "aws.ec2.instance"
+	ManageInstancePowerStartPayloadType     = "aws.ec2.instance.power.started"
+	ManageInstancePowerStopPayloadType      = "aws.ec2.instance.power.stopped"
+	ManageInstancePowerRebootPayloadType    = "aws.ec2.instance.power.rebooted"
+	ManageInstancePowerHibernatePayloadType = "aws.ec2.instance.power.hibernated"
 
 	instancePollInterval    = 10 * time.Second
 	maxInstancePollErrors   = 10

--- a/pkg/integrations/aws/ec2/example.go
+++ b/pkg/integrations/aws/ec2/example.go
@@ -40,6 +40,12 @@ var exampleOutputCreateInstanceBytes []byte
 //go:embed example_output_delete_instance.json
 var exampleOutputDeleteInstanceBytes []byte
 
+//go:embed example_output_get_instance.json
+var exampleOutputGetInstanceBytes []byte
+
+//go:embed example_output_manage_instance_power.json
+var exampleOutputManageInstancePowerBytes []byte
+
 var exampleDataOnImageOnce sync.Once
 var exampleDataOnImage map[string]any
 
@@ -72,6 +78,12 @@ var exampleOutputCreateInstance map[string]any
 
 var exampleOutputDeleteInstanceOnce sync.Once
 var exampleOutputDeleteInstance map[string]any
+
+var exampleOutputGetInstanceOnce sync.Once
+var exampleOutputGetInstance map[string]any
+
+var exampleOutputManageInstancePowerOnce sync.Once
+var exampleOutputManageInstancePower map[string]any
 
 func (t *OnImage) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnImageOnce, exampleDataOnImageBytes, &exampleDataOnImage)
@@ -134,5 +146,21 @@ func (c *DeleteInstance) ExampleOutput() map[string]any {
 		&exampleOutputDeleteInstanceOnce,
 		exampleOutputDeleteInstanceBytes,
 		&exampleOutputDeleteInstance,
+	)
+}
+
+func (c *GetInstance) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetInstanceOnce,
+		exampleOutputGetInstanceBytes,
+		&exampleOutputGetInstance,
+	)
+}
+
+func (c *ManageInstancePower) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputManageInstancePowerOnce,
+		exampleOutputManageInstancePowerBytes,
+		&exampleOutputManageInstancePower,
 	)
 }

--- a/pkg/integrations/aws/ec2/example_output_get_instance.json
+++ b/pkg/integrations/aws/ec2/example_output_get_instance.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "instanceId": "i-0abc1234567890def",
+    "instanceType": "t3.micro",
+    "imageId": "ami-07f0e4f3e9c123abc",
+    "state": "running",
+    "name": "my-server",
+    "keyName": "my-key",
+    "launchTime": "2026-05-21T12:00:00.000Z",
+    "privateIpAddress": "10.0.1.25",
+    "publicIpAddress": "54.198.10.42",
+    "privateDnsName": "ip-10-0-1-25.ec2.internal",
+    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
+    "subnetId": "subnet-0abc1234567890def",
+    "vpcId": "vpc-0abc1234567890def",
+    "region": "us-east-1"
+  },
+  "timestamp": "2026-05-21T12:01:00Z",
+  "type": "aws.ec2.instance"
+}

--- a/pkg/integrations/aws/ec2/example_output_manage_instance_power.json
+++ b/pkg/integrations/aws/ec2/example_output_manage_instance_power.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "instanceId": "i-0abc1234567890def",
+    "instanceType": "t3.micro",
+    "imageId": "ami-07f0e4f3e9c123abc",
+    "state": "running",
+    "name": "my-server",
+    "privateIpAddress": "10.0.1.25",
+    "publicIpAddress": "54.198.10.42",
+    "privateDnsName": "ip-10-0-1-25.ec2.internal",
+    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
+    "subnetId": "subnet-0abc1234567890def",
+    "vpcId": "vpc-0abc1234567890def",
+    "region": "us-east-1"
+  },
+  "timestamp": "2026-05-21T12:11:00Z",
+  "type": "aws.ec2.instance"
+}

--- a/pkg/integrations/aws/ec2/example_output_manage_instance_power.json
+++ b/pkg/integrations/aws/ec2/example_output_manage_instance_power.json
@@ -1,18 +1,19 @@
 {
   "data": {
+    "imageId": "ami-0215d085326c25744",
     "instanceId": "i-0abc1234567890def",
     "instanceType": "t3.micro",
-    "imageId": "ami-07f0e4f3e9c123abc",
-    "state": "running",
-    "name": "my-server",
+    "launchTime": "2026-05-28T09:41:14.000Z",
+    "name": "preview-pr-5",
+    "privateDnsName": "ip-10.0.1.25.eu-north-1.compute.internal",
     "privateIpAddress": "10.0.1.25",
+    "publicDnsName": "ec2-54-198-10-42.eu-north-1.compute.amazonaws.com",
     "publicIpAddress": "54.198.10.42",
-    "privateDnsName": "ip-10-0-1-25.ec2.internal",
-    "publicDnsName": "ec2-54-198-10-42.compute-1.amazonaws.com",
-    "subnetId": "subnet-0abc1234567890def",
-    "vpcId": "vpc-0abc1234567890def",
-    "region": "us-east-1"
+    "region": "eu-north-1",
+    "state": "running",
+    "subnetId": "subnet-0e7c8aa9b0a82aec5",
+    "vpcId": "vpc-0049650f5a479c14b"
   },
-  "timestamp": "2026-05-21T12:11:00Z",
-  "type": "aws.ec2.instance"
+  "timestamp": "2026-05-28T09:41:26.29656651Z",
+  "type": "aws.ec2.instance.power.started"
 }

--- a/pkg/integrations/aws/ec2/get_instance.go
+++ b/pkg/integrations/aws/ec2/get_instance.go
@@ -1,0 +1,215 @@
+package ec2
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type GetInstance struct{}
+
+type GetInstanceConfiguration struct {
+	Region     string `json:"region" mapstructure:"region"`
+	InstanceID string `json:"instance" mapstructure:"instance"`
+}
+
+type GetInstanceNodeMetadata struct {
+	Region       string `json:"region" mapstructure:"region"`
+	InstanceID   string `json:"instanceId" mapstructure:"instanceId"`
+	InstanceName string `json:"instanceName" mapstructure:"instanceName"`
+}
+
+func (c *GetInstance) Name() string {
+	return "aws.ec2.getInstance"
+}
+
+func (c *GetInstance) Label() string {
+	return "EC2 • Get Instance"
+}
+
+func (c *GetInstance) Description() string {
+	return "Fetch the current state and details of an EC2 instance"
+}
+
+func (c *GetInstance) Documentation() string {
+	return `The Get Instance component describes an EC2 instance and emits its current details.
+
+## Use Cases
+
+- **State inspection**: Check whether an instance is running or stopped before taking action
+- **IP resolution**: Retrieve the public or private IP address of an instance at runtime
+- **Metadata lookup**: Fetch instance type, AMI, VPC, and tags mid-workflow
+
+## Configuration
+
+- **Region**: AWS region where the instance runs
+- **Instance**: EC2 instance to describe
+
+## Output
+
+Emits the instance details on the default output channel:
+- ` + "`instanceId`" + `, ` + "`state`" + `, ` + "`instanceType`" + `, ` + "`imageId`" + `
+- ` + "`publicIpAddress`" + `, ` + "`privateIpAddress`" + `, ` + "`publicDnsName`" + `, ` + "`privateDnsName`" + `
+- ` + "`subnetId`" + `, ` + "`vpcId`" + `, ` + "`region`" + `, ` + "`name`" + `, ` + "`launchTime`" + `
+`
+}
+
+func (c *GetInstance) Icon() string {
+	return "aws"
+}
+
+func (c *GetInstance) Color() string {
+	return "gray"
+}
+
+func (c *GetInstance) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetInstance) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "region",
+			Label:    "Region",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "us-east-1",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: common.AllRegions,
+				},
+			},
+		},
+		{
+			Name:        "instance",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "EC2 instance to describe",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "region", Values: []string{"*"}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "ec2.instance",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name: "region",
+							ValueFrom: &configuration.ParameterValueFrom{
+								Field: "region",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *GetInstance) Setup(ctx core.SetupContext) error {
+	config := GetInstanceConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+	instanceID, err := requireInstanceID(config.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	return ctx.Metadata.Set(GetInstanceNodeMetadata{
+		Region:       region,
+		InstanceID:   instanceID,
+		InstanceName: resolveInstanceName(ctx, region, instanceID),
+	})
+}
+
+func (c *GetInstance) Execute(ctx core.ExecutionContext) error {
+	config := GetInstanceConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+	instanceID, err := requireInstanceID(config.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, creds, region)
+	instance, err := client.DescribeInstance(instanceID)
+	if err != nil {
+		return fmt.Errorf("failed to describe instance: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		GetInstancePayloadType,
+		[]any{instanceDetailsToMap(instance)},
+	)
+}
+
+func (c *GetInstance) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetInstance) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *GetInstance) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetInstance) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetInstance) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetInstance) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func resolveInstanceName(ctx core.SetupContext, region, instanceID string) string {
+	if strings.TrimSpace(instanceID) == "" || ctx.HTTP == nil || ctx.Integration == nil || strings.TrimSpace(region) == "" {
+		return instanceID
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return instanceID
+	}
+
+	instance, err := NewClient(ctx.HTTP, creds, region).DescribeInstance(instanceID)
+	if err != nil {
+		return instanceID
+	}
+
+	name := strings.TrimSpace(instance.Name)
+	if name != "" {
+		return name
+	}
+
+	return instanceID
+}

--- a/pkg/integrations/aws/ec2/get_instance_test.go
+++ b/pkg/integrations/aws/ec2/get_instance_test.go
@@ -1,0 +1,120 @@
+package ec2
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetInstance__Setup(t *testing.T) {
+	component := &GetInstance{}
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":   " ",
+				"instance": "i-abc123",
+			},
+		})
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing instance -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"instance": " ",
+			},
+		})
+		require.ErrorContains(t, err, "instance ID is required")
+	})
+
+	t.Run("valid configuration -> no error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"instance": "i-abc123",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test__GetInstance__Execute(t *testing.T) {
+	component := &GetInstance{}
+
+	t.Run("describe instance -> emits instance details", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`
+						<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+							<requestId>req-123</requestId>
+							<reservationSet>
+								<item>
+									<instancesSet>
+										<item>
+											<instanceId>i-abc123</instanceId>
+											<instanceType>t3.micro</instanceType>
+											<imageId>ami-xyz</imageId>
+											<instanceState><name>running</name></instanceState>
+											<privateIpAddress>10.0.0.5</privateIpAddress>
+											<ipAddress>52.1.2.3</ipAddress>
+											<dnsName>ec2-52-1-2-3.compute-1.amazonaws.com</dnsName>
+											<privateDnsName>ip-10-0-0-5.ec2.internal</privateDnsName>
+											<subnetId>subnet-abc</subnetId>
+											<vpcId>vpc-abc</vpcId>
+											<tagSet>
+												<item><key>Name</key><value>my-instance</value></item>
+											</tagSet>
+										</item>
+									</instancesSet>
+								</item>
+							</reservationSet>
+						</DescribeInstancesResponse>
+					`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":   "us-east-1",
+				"instance": "i-abc123",
+			},
+			HTTP:           httpContext,
+			ExecutionState: executionState,
+			Integration: &contexts.IntegrationContext{
+				CurrentSecrets: map[string]core.IntegrationSecret{
+					"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+					"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+					"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		assert.Equal(t, GetInstancePayloadType, executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+		wrapped, ok := executionState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		data, ok := wrapped["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "i-abc123", data["instanceId"])
+		assert.Equal(t, "running", data["state"])
+		assert.Equal(t, "t3.micro", data["instanceType"])
+		assert.Equal(t, "my-instance", data["name"])
+		assert.Equal(t, "52.1.2.3", data["publicIpAddress"])
+	})
+}

--- a/pkg/integrations/aws/ec2/manage_instance_power.go
+++ b/pkg/integrations/aws/ec2/manage_instance_power.go
@@ -232,7 +232,7 @@ func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
 		}
 		return ctx.ExecutionState.Emit(
 			core.DefaultOutputChannel.Name,
-			ManageInstancePowerPayloadType,
+			ManageInstancePowerRebootPayloadType,
 			[]any{instanceDetailsToMap(instance)},
 		)
 	default:
@@ -326,7 +326,7 @@ func (c *ManageInstancePower) pollStart(ctx core.ActionHookContext, instance *In
 	case InstanceStateRunning:
 		return ctx.ExecutionState.Emit(
 			core.DefaultOutputChannel.Name,
-			ManageInstancePowerPayloadType,
+			ManageInstancePowerStartPayloadType,
 			[]any{instanceDetailsToMap(instance)},
 		)
 	case InstanceStateTerminated, InstanceStateShuttingDown:
@@ -343,9 +343,13 @@ func (c *ManageInstancePower) pollStart(ctx core.ActionHookContext, instance *In
 func (c *ManageInstancePower) pollStop(ctx core.ActionHookContext, instance *InstanceDetails, metadata ManageInstancePowerExecutionMetadata) error {
 	switch instance.State {
 	case InstanceStateStopped:
+		payloadType := ManageInstancePowerStopPayloadType
+		if metadata.Operation == powerOperationHibernate {
+			payloadType = ManageInstancePowerHibernatePayloadType
+		}
 		return ctx.ExecutionState.Emit(
 			core.DefaultOutputChannel.Name,
-			ManageInstancePowerPayloadType,
+			payloadType,
 			[]any{instanceDetailsToMap(instance)},
 		)
 	case InstanceStateTerminated, InstanceStateShuttingDown:

--- a/pkg/integrations/aws/ec2/manage_instance_power.go
+++ b/pkg/integrations/aws/ec2/manage_instance_power.go
@@ -329,8 +329,8 @@ func (c *ManageInstancePower) pollStart(ctx core.ActionHookContext, instance *In
 			ManageInstancePowerStartPayloadType,
 			[]any{instanceDetailsToMap(instance)},
 		)
-	case InstanceStateTerminated, InstanceStateShuttingDown:
-		return fmt.Errorf("instance %s entered state %q unexpectedly while starting", instance.InstanceID, instance.State)
+	case InstanceStateTerminated, InstanceStateShuttingDown, InstanceStateStopped, InstanceStateStopping:
+		return fmt.Errorf("instance %s entered state %q and will not reach running without intervention", instance.InstanceID, instance.State)
 	}
 
 	if metadata.PollAttempts >= maxInstancePollAttempts {

--- a/pkg/integrations/aws/ec2/manage_instance_power.go
+++ b/pkg/integrations/aws/ec2/manage_instance_power.go
@@ -1,0 +1,376 @@
+package ec2
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+const (
+	powerOperationStart     = "start"
+	powerOperationStop      = "stop"
+	powerOperationReboot    = "reboot"
+	powerOperationHibernate = "hibernate"
+)
+
+var validPowerOperations = []string{
+	powerOperationStart,
+	powerOperationStop,
+	powerOperationReboot,
+	powerOperationHibernate,
+}
+
+type ManageInstancePower struct{}
+
+type ManageInstancePowerConfiguration struct {
+	Region     string `json:"region" mapstructure:"region"`
+	InstanceID string `json:"instance" mapstructure:"instance"`
+	Operation  string `json:"operation" mapstructure:"operation"`
+}
+
+type ManageInstancePowerNodeMetadata struct {
+	Region       string `json:"region" mapstructure:"region"`
+	InstanceName string `json:"instanceName" mapstructure:"instanceName"`
+}
+
+type ManageInstancePowerExecutionMetadata struct {
+	InstanceID   string `json:"instanceId" mapstructure:"instanceId"`
+	Operation    string `json:"operation" mapstructure:"operation"`
+	PollErrors   int    `json:"pollErrors" mapstructure:"pollErrors"`
+	PollAttempts int    `json:"pollAttempts" mapstructure:"pollAttempts"`
+}
+
+func (c *ManageInstancePower) Name() string {
+	return "aws.ec2.manageInstancePower"
+}
+
+func (c *ManageInstancePower) Label() string {
+	return "EC2 • Manage Instance Power"
+}
+
+func (c *ManageInstancePower) Description() string {
+	return "Perform power operations on an EC2 instance"
+}
+
+func (c *ManageInstancePower) Documentation() string {
+	return `The Manage Instance Power component performs power management operations on an EC2 instance.
+
+## Use Cases
+
+- **Scheduled workloads**: Start or stop instances on demand from a workflow
+- **Cost optimisation**: Stop or hibernate non-production instances outside business hours
+- **Maintenance workflows**: Stop an instance before resizing or patching, start it after
+- **Recovery**: Reboot an instance experiencing issues
+
+## Configuration
+
+- **Region**: AWS region where the instance runs
+- **Instance**: EC2 instance to manage
+- **Operation**: The power operation to perform:
+  - **Start**: Start a stopped instance and wait for it to reach running state
+  - **Stop**: Gracefully stop a running instance and wait for stopped state
+  - **Reboot**: Reboot a running instance (completes once the reboot signal is sent)
+  - **Hibernate**: Stop an instance and save RAM to disk (instance must have hibernation enabled)
+
+## Output
+
+Emits instance details on the default output channel once the operation completes:
+- ` + "`instanceId`" + `, ` + "`state`" + `, ` + "`region`" + `
+- ` + "`publicIpAddress`" + `, ` + "`privateIpAddress`" + ` (start only)
+
+## Important Notes
+
+- **Hibernate** requires the instance to have been launched with hibernation enabled
+- **Reboot** emits immediately after the reboot signal is accepted; it does not wait for the OS to come back online
+`
+}
+
+func (c *ManageInstancePower) Icon() string {
+	return "aws"
+}
+
+func (c *ManageInstancePower) Color() string {
+	return "gray"
+}
+
+func (c *ManageInstancePower) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *ManageInstancePower) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "region",
+			Label:    "Region",
+			Type:     configuration.FieldTypeSelect,
+			Required: true,
+			Default:  "us-east-1",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: common.AllRegions,
+				},
+			},
+		},
+		{
+			Name:        "instance",
+			Label:       "Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "EC2 instance to manage",
+			VisibilityConditions: []configuration.VisibilityCondition{
+				{Field: "region", Values: []string{"*"}},
+			},
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: "ec2.instance",
+					Parameters: []configuration.ParameterRef{
+						{
+							Name: "region",
+							ValueFrom: &configuration.ParameterValueFrom{
+								Field: "region",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "operation",
+			Label:       "Operation",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Description: "The power operation to perform",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Start", Value: powerOperationStart},
+						{Label: "Stop", Value: powerOperationStop},
+						{Label: "Reboot", Value: powerOperationReboot},
+						{Label: "Hibernate", Value: powerOperationHibernate},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *ManageInstancePower) Setup(ctx core.SetupContext) error {
+	config := ManageInstancePowerConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+	if _, err := requireInstanceID(config.InstanceID); err != nil {
+		return err
+	}
+	if !slices.Contains(validPowerOperations, strings.TrimSpace(config.Operation)) {
+		return fmt.Errorf("invalid operation %q: must be one of start, stop, reboot, hibernate", config.Operation)
+	}
+
+	return ctx.Metadata.Set(ManageInstancePowerNodeMetadata{
+		Region:       region,
+		InstanceName: resolveInstanceName(ctx, region, strings.TrimSpace(config.InstanceID)),
+	})
+}
+
+func (c *ManageInstancePower) Execute(ctx core.ExecutionContext) error {
+	config := ManageInstancePowerConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+	instanceID, err := requireInstanceID(config.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, creds, region)
+	operation := strings.TrimSpace(config.Operation)
+
+	switch operation {
+	case powerOperationStart:
+		if _, err := client.StartInstances(instanceID); err != nil {
+			return fmt.Errorf("failed to start instance: %w", err)
+		}
+	case powerOperationStop:
+		if _, err := client.StopInstances(instanceID); err != nil {
+			return fmt.Errorf("failed to stop instance: %w", err)
+		}
+	case powerOperationHibernate:
+		if _, err := client.HibernateInstances(instanceID); err != nil {
+			return fmt.Errorf("failed to hibernate instance: %w", err)
+		}
+	case powerOperationReboot:
+		if err := client.RebootInstances(instanceID); err != nil {
+			return fmt.Errorf("failed to reboot instance: %w", err)
+		}
+		// Reboot is fire-and-forget: the instance stays running throughout.
+		// Emit immediately with the current state rather than polling.
+		instance, err := client.DescribeInstance(instanceID)
+		if err != nil {
+			return fmt.Errorf("failed to describe instance after reboot: %w", err)
+		}
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			ManageInstancePowerPayloadType,
+			[]any{instanceDetailsToMap(instance)},
+		)
+	default:
+		return fmt.Errorf("invalid operation %q", operation)
+	}
+
+	if err := ctx.Metadata.Set(ManageInstancePowerExecutionMetadata{
+		InstanceID: instanceID,
+		Operation:  operation,
+	}); err != nil {
+		return err
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, instancePollInterval)
+}
+
+func (c *ManageInstancePower) Hooks() []core.Hook {
+	return []core.Hook{
+		{Name: "poll", Type: core.HookTypeInternal},
+	}
+}
+
+func (c *ManageInstancePower) HandleHook(ctx core.ActionHookContext) error {
+	if ctx.Name != "poll" {
+		return fmt.Errorf("unknown hook: %s", ctx.Name)
+	}
+
+	return c.poll(ctx)
+}
+
+func (c *ManageInstancePower) poll(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var metadata ManageInstancePowerExecutionMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &metadata); err != nil {
+		return fmt.Errorf("failed to decode metadata: %w", err)
+	}
+	if metadata.InstanceID == "" {
+		return fmt.Errorf("poll metadata is missing instanceId: execution state may be corrupted")
+	}
+
+	config := ManageInstancePowerConfiguration{}
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	region, err := requireRegion(config.Region)
+	if err != nil {
+		return err
+	}
+
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS credentials: %w", err)
+	}
+
+	client := NewClient(ctx.HTTP, creds, region)
+	instance, err := client.DescribeInstance(metadata.InstanceID)
+	if err != nil {
+		metadata.PollErrors++
+		ctx.Logger.Warnf("failed to describe instance %s (attempt %d/%d): %v", metadata.InstanceID, metadata.PollErrors, maxInstancePollErrors, err)
+		if metadata.PollErrors >= maxInstancePollErrors {
+			return fmt.Errorf("giving up polling instance %s after %d consecutive errors: %w", metadata.InstanceID, maxInstancePollErrors, err)
+		}
+		if err := ctx.Metadata.Set(metadata); err != nil {
+			return err
+		}
+		return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, instancePollInterval)
+	}
+
+	metadata.PollErrors = 0
+	metadata.PollAttempts++
+	if err := ctx.Metadata.Set(metadata); err != nil {
+		return err
+	}
+
+	switch metadata.Operation {
+	case powerOperationStart:
+		return c.pollStart(ctx, instance, metadata)
+	case powerOperationStop, powerOperationHibernate:
+		return c.pollStop(ctx, instance, metadata)
+	default:
+		return fmt.Errorf("unknown operation in poll metadata: %q", metadata.Operation)
+	}
+}
+
+func (c *ManageInstancePower) pollStart(ctx core.ActionHookContext, instance *InstanceDetails, metadata ManageInstancePowerExecutionMetadata) error {
+	switch instance.State {
+	case InstanceStateRunning:
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			ManageInstancePowerPayloadType,
+			[]any{instanceDetailsToMap(instance)},
+		)
+	case InstanceStateTerminated, InstanceStateShuttingDown:
+		return fmt.Errorf("instance %s entered state %q unexpectedly while starting", instance.InstanceID, instance.State)
+	}
+
+	if metadata.PollAttempts >= maxInstancePollAttempts {
+		return fmt.Errorf("timed out waiting for instance %s to start after %d poll attempts (state: %s)", instance.InstanceID, metadata.PollAttempts, instance.State)
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, instancePollInterval)
+}
+
+func (c *ManageInstancePower) pollStop(ctx core.ActionHookContext, instance *InstanceDetails, metadata ManageInstancePowerExecutionMetadata) error {
+	switch instance.State {
+	case InstanceStateStopped:
+		return ctx.ExecutionState.Emit(
+			core.DefaultOutputChannel.Name,
+			ManageInstancePowerPayloadType,
+			[]any{instanceDetailsToMap(instance)},
+		)
+	case InstanceStateTerminated, InstanceStateShuttingDown:
+		return fmt.Errorf("instance %s entered state %q unexpectedly while stopping", instance.InstanceID, instance.State)
+	}
+
+	if metadata.PollAttempts >= maxInstancePollAttempts {
+		return fmt.Errorf("timed out waiting for instance %s to stop after %d poll attempts (state: %s)", instance.InstanceID, metadata.PollAttempts, instance.State)
+	}
+
+	return ctx.Requests.ScheduleActionCall("poll", map[string]any{}, instancePollInterval)
+}
+
+func (c *ManageInstancePower) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *ManageInstancePower) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *ManageInstancePower) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *ManageInstancePower) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}

--- a/pkg/integrations/aws/ec2/manage_instance_power_test.go
+++ b/pkg/integrations/aws/ec2/manage_instance_power_test.go
@@ -1,0 +1,454 @@
+package ec2
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ManageInstancePower__Setup(t *testing.T) {
+	component := &ManageInstancePower{}
+
+	t.Run("missing region -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    " ",
+				"instance":  "i-abc123",
+				"operation": "start",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "region is required")
+	})
+
+	t.Run("missing instance id -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"instance":  "",
+				"operation": "start",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance ID is required")
+	})
+
+	t.Run("invalid operation -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"instance":  "i-abc123",
+				"operation": "nuke",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "invalid operation")
+	})
+
+	t.Run("stores instance name in node metadata", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				okResponse(`
+					<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+						<reservationSet>
+							<item>
+								<instancesSet>
+									<item>
+										<instanceId>i-abc123</instanceId>
+										<instanceState><name>running</name></instanceState>
+										<tagSet>
+											<item><key>Name</key><value>my-server</value></item>
+										</tagSet>
+									</item>
+								</instancesSet>
+							</item>
+						</reservationSet>
+					</DescribeInstancesResponse>`),
+			},
+		}
+		metadata := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"instance":  "i-abc123",
+				"operation": "stop",
+			},
+			HTTP:        httpContext,
+			Integration: manageInstancePowerIntegration(),
+			Metadata:    metadata,
+		})
+
+		require.NoError(t, err)
+		stored, ok := metadata.Get().(ManageInstancePowerNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "us-east-1", stored.Region)
+		assert.Equal(t, "my-server", stored.InstanceName)
+	})
+}
+
+func Test__ManageInstancePower__Execute_Start(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{okResponse(startInstancesXML("i-abc123"))},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"region":    "us-east-1",
+			"instance":  "i-abc123",
+			"operation": "start",
+		},
+		HTTP:           httpContext,
+		Metadata:       metadata,
+		Requests:       requests,
+		Integration:    manageInstancePowerIntegration(),
+		ExecutionState: &contexts.ExecutionStateContext{},
+	})
+
+	require.NoError(t, err)
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Action=StartInstances")
+	assert.Contains(t, string(body), "InstanceId.1=i-abc123")
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, ManageInstancePowerExecutionMetadata{
+		InstanceID: "i-abc123",
+		Operation:  "start",
+	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__Execute_Stop(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{okResponse(stopInstancesXML("i-abc123"))},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"region":    "us-east-1",
+			"instance":  "i-abc123",
+			"operation": "stop",
+		},
+		HTTP:           httpContext,
+		Metadata:       metadata,
+		Requests:       requests,
+		Integration:    manageInstancePowerIntegration(),
+		ExecutionState: &contexts.ExecutionStateContext{},
+	})
+
+	require.NoError(t, err)
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Action=StopInstances")
+	assert.NotContains(t, string(body), "Hibernate=true")
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, ManageInstancePowerExecutionMetadata{
+		InstanceID: "i-abc123",
+		Operation:  "stop",
+	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__Execute_Hibernate(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{okResponse(stopInstancesXML("i-abc123"))},
+	}
+	metadata := &contexts.MetadataContext{}
+	requests := &contexts.RequestContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"region":    "us-east-1",
+			"instance":  "i-abc123",
+			"operation": "hibernate",
+		},
+		HTTP:           httpContext,
+		Metadata:       metadata,
+		Requests:       requests,
+		Integration:    manageInstancePowerIntegration(),
+		ExecutionState: &contexts.ExecutionStateContext{},
+	})
+
+	require.NoError(t, err)
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Action=StopInstances")
+	assert.Contains(t, string(body), "Hibernate=true")
+	assert.Equal(t, "poll", requests.Action)
+	assert.Equal(t, ManageInstancePowerExecutionMetadata{
+		InstanceID: "i-abc123",
+		Operation:  "hibernate",
+	}, metadata.Metadata)
+}
+
+func Test__ManageInstancePower__Execute_Reboot(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			okResponse(rebootInstancesXML()),
+			okResponse(describeInstanceXML("i-abc123", "running")),
+		},
+	}
+	executionState := &contexts.ExecutionStateContext{}
+
+	err := component.Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"region":    "us-east-1",
+			"instance":  "i-abc123",
+			"operation": "reboot",
+		},
+		HTTP:           httpContext,
+		Metadata:       &contexts.MetadataContext{},
+		Requests:       &contexts.RequestContext{},
+		Integration:    manageInstancePowerIntegration(),
+		ExecutionState: executionState,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 2)
+	rebootBody, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(rebootBody), "Action=RebootInstances")
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ManageInstancePowerRebootPayloadType, executionState.Type)
+}
+
+func Test__ManageInstancePower__PollStart_EmitsWhenRunning(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("start", "running")
+	executionState := ctx.ExecutionState.(*contexts.ExecutionStateContext)
+
+	require.NoError(t, component.HandleHook(ctx))
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ManageInstancePowerStartPayloadType, executionState.Type)
+}
+
+func Test__ManageInstancePower__PollStart_ReschedulesWhenPending(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("start", "pending")
+	requests := ctx.Requests.(*contexts.RequestContext)
+
+	require.NoError(t, component.HandleHook(ctx))
+	assert.Equal(t, "poll", requests.Action)
+}
+
+func Test__ManageInstancePower__PollStart_ErrorsWhenTerminated(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("start", "terminated")
+
+	err := component.HandleHook(ctx)
+	require.ErrorContains(t, err, "unexpectedly")
+}
+
+func Test__ManageInstancePower__PollStart_ErrorsWhenShuttingDown(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("start", "shutting-down")
+
+	err := component.HandleHook(ctx)
+	require.ErrorContains(t, err, "unexpectedly")
+}
+
+func Test__ManageInstancePower__PollStop_EmitsWhenStopped(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("stop", "stopped")
+	executionState := ctx.ExecutionState.(*contexts.ExecutionStateContext)
+
+	require.NoError(t, component.HandleHook(ctx))
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ManageInstancePowerStopPayloadType, executionState.Type)
+}
+
+func Test__ManageInstancePower__PollStop_ReschedulesWhenStopping(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("stop", "stopping")
+	requests := ctx.Requests.(*contexts.RequestContext)
+
+	require.NoError(t, component.HandleHook(ctx))
+	assert.Equal(t, "poll", requests.Action)
+}
+
+func Test__ManageInstancePower__PollStop_ErrorsWhenTerminated(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("stop", "terminated")
+
+	err := component.HandleHook(ctx)
+	require.ErrorContains(t, err, "unexpectedly")
+}
+
+func Test__ManageInstancePower__PollHibernate_EmitsHibernatePayloadWhenStopped(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := managePowerHookCtx("hibernate", "stopped")
+	executionState := ctx.ExecutionState.(*contexts.ExecutionStateContext)
+
+	require.NoError(t, component.HandleHook(ctx))
+	assert.True(t, executionState.Passed)
+	assert.Equal(t, ManageInstancePowerHibernatePayloadType, executionState.Type)
+}
+
+func Test__ManageInstancePower__Poll_NoopWhenAlreadyFinished(t *testing.T) {
+	component := &ManageInstancePower{}
+	httpContext := &contexts.HTTPContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name:          "poll",
+		Configuration: map[string]any{"region": "us-east-1"},
+		HTTP:          httpContext,
+		Integration:   manageInstancePowerIntegration(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerExecutionMetadata{
+				InstanceID: "i-abc123",
+				Operation:  "start",
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{Finished: true},
+		Logger:         logrus.NewEntry(logrus.New()),
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, httpContext.Requests)
+}
+
+func Test__ManageInstancePower__PollStart_TimesOutAfterMaxAttempts(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := core.ActionHookContext{
+		Name:          "poll",
+		Configuration: map[string]any{"region": "us-east-1"},
+		HTTP:          &contexts.HTTPContext{Responses: []*http.Response{okResponse(describeInstanceXML("i-abc123", "pending"))}},
+		Integration:   manageInstancePowerIntegration(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerExecutionMetadata{
+				InstanceID:   "i-abc123",
+				Operation:    "start",
+				PollAttempts: maxInstancePollAttempts,
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := component.HandleHook(ctx)
+	require.ErrorContains(t, err, "timed out")
+}
+
+func Test__ManageInstancePower__PollStop_TimesOutAfterMaxAttempts(t *testing.T) {
+	component := &ManageInstancePower{}
+	ctx := core.ActionHookContext{
+		Name:          "poll",
+		Configuration: map[string]any{"region": "us-east-1"},
+		HTTP:          &contexts.HTTPContext{Responses: []*http.Response{okResponse(describeInstanceXML("i-abc123", "stopping"))}},
+		Integration:   manageInstancePowerIntegration(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerExecutionMetadata{
+				InstanceID:   "i-abc123",
+				Operation:    "stop",
+				PollAttempts: maxInstancePollAttempts,
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+
+	err := component.HandleHook(ctx)
+	require.ErrorContains(t, err, "timed out")
+}
+
+func manageInstancePowerIntegration() *contexts.IntegrationContext {
+	return &contexts.IntegrationContext{
+		CurrentSecrets: map[string]core.IntegrationSecret{
+			"accessKeyId":     {Name: "accessKeyId", Value: []byte("key")},
+			"secretAccessKey": {Name: "secretAccessKey", Value: []byte("secret")},
+			"sessionToken":    {Name: "sessionToken", Value: []byte("token")},
+		},
+	}
+}
+
+func describeInstanceXML(instanceID, state string) string {
+	return `
+		<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+			<reservationSet>
+				<item>
+					<instancesSet>
+						<item>
+							<instanceId>` + instanceID + `</instanceId>
+							<instanceState><name>` + state + `</name></instanceState>
+						</item>
+					</instancesSet>
+				</item>
+			</reservationSet>
+		</DescribeInstancesResponse>`
+}
+
+func startInstancesXML(instanceID string) string {
+	return `
+		<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+			<requestId>req-start</requestId>
+			<instancesSet>
+				<item>
+					<instanceId>` + instanceID + `</instanceId>
+					<currentState><name>pending</name></currentState>
+				</item>
+			</instancesSet>
+		</StartInstancesResponse>`
+}
+
+func stopInstancesXML(instanceID string) string {
+	return `
+		<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+			<requestId>req-stop</requestId>
+			<instancesSet>
+				<item>
+					<instanceId>` + instanceID + `</instanceId>
+					<currentState><name>stopping</name></currentState>
+				</item>
+			</instancesSet>
+		</StopInstancesResponse>`
+}
+
+func rebootInstancesXML() string {
+	return `<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/"><requestId>req-reboot</requestId><return>true</return></RebootInstancesResponse>`
+}
+
+func okResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func managePowerHookCtx(operation, state string, extraResponses ...*http.Response) core.ActionHookContext {
+	responses := extraResponses
+	if len(responses) == 0 {
+		responses = []*http.Response{okResponse(describeInstanceXML("i-abc123", state))}
+	}
+
+	return core.ActionHookContext{
+		Name:          "poll",
+		Configuration: map[string]any{"region": "us-east-1"},
+		HTTP:          &contexts.HTTPContext{Responses: responses},
+		Integration:   manageInstancePowerIntegration(),
+		Metadata: &contexts.MetadataContext{
+			Metadata: ManageInstancePowerExecutionMetadata{
+				InstanceID: "i-abc123",
+				Operation:  operation,
+			},
+		},
+		Requests:       &contexts.RequestContext{},
+		ExecutionState: &contexts.ExecutionStateContext{},
+		Logger:         logrus.NewEntry(logrus.New()),
+	}
+}

--- a/pkg/integrations/aws/ec2/manage_instance_power_test.go
+++ b/pkg/integrations/aws/ec2/manage_instance_power_test.go
@@ -244,20 +244,16 @@ func Test__ManageInstancePower__PollStart_ReschedulesWhenPending(t *testing.T) {
 	assert.Equal(t, "poll", requests.Action)
 }
 
-func Test__ManageInstancePower__PollStart_ErrorsWhenTerminated(t *testing.T) {
-	component := &ManageInstancePower{}
-	ctx := managePowerHookCtx("start", "terminated")
+func Test__ManageInstancePower__PollStart_FailsImmediatelyOnNonRecoverableState(t *testing.T) {
+	for _, state := range []string{"terminated", "shutting-down", "stopped", "stopping"} {
+		t.Run(state, func(t *testing.T) {
+			component := &ManageInstancePower{}
+			ctx := managePowerHookCtx("start", state)
 
-	err := component.HandleHook(ctx)
-	require.ErrorContains(t, err, "unexpectedly")
-}
-
-func Test__ManageInstancePower__PollStart_ErrorsWhenShuttingDown(t *testing.T) {
-	component := &ManageInstancePower{}
-	ctx := managePowerHookCtx("start", "shutting-down")
-
-	err := component.HandleHook(ctx)
-	require.ErrorContains(t, err, "unexpectedly")
+			err := component.HandleHook(ctx)
+			require.ErrorContains(t, err, "will not reach running without intervention")
+		})
+	}
 }
 
 func Test__ManageInstancePower__PollStop_EmitsWhenStopped(t *testing.T) {

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.spec.ts
@@ -83,21 +83,23 @@ describe("getInstanceMapper.props", () => {
     );
   });
 
-  it("shows the raw instance ID as label when no name was resolved", () => {
+  it("shows only the instance ID when no distinct name was resolved (name === id)", () => {
+    // resolveInstanceName falls back to the raw instance ID, never an empty string,
+    // so the realistic "no name" case is instanceName === instanceId.
     const props = getInstanceMapper.props(
       buildComponentCtx({
         configuration: { region: "eu-west-1", instance: "i-xyz999" },
         metadata: {
           region: "eu-west-1",
           instanceId: "i-xyz999",
-          instanceName: "",
+          instanceName: "i-xyz999",
         },
       }),
     );
 
     const serverItem = props.metadata?.find((m) => m.icon === "server");
     expect(serverItem?.label).toBe("i-xyz999");
-    // hash row must not appear when there is no resolved name
+    // hash row must not appear when name and id are the same value
     const hashItem = props.metadata?.find((m) => m.icon === "hash");
     expect(hashItem).toBeUndefined();
   });

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import { getInstanceMapper } from "./get_instance";
+import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../../types";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Get Instance",
+    componentName: "ec2.getInstance",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date("2026-05-21T12:00:00Z").toISOString(),
+    updatedAt: new Date("2026-05-21T12:01:00Z").toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildOutput(data: Record<string, unknown>) {
+  return { type: "json", timestamp: new Date().toISOString(), data };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+function buildComponentCtx(nodeOverrides?: Partial<NodeInfo>): ComponentBaseContext {
+  const node = buildNode(nodeOverrides);
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: {
+      name: "ec2.getInstance",
+      label: "EC2 • Get Instance",
+      description: "",
+      icon: "server",
+      color: "gray",
+    },
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+  };
+}
+
+describe("getInstanceMapper.props", () => {
+  it("shows instance name and region from node metadata", () => {
+    const props = getInstanceMapper.props(
+      buildComponentCtx({
+        configuration: { region: "us-east-1", instance: "i-abc123" },
+        metadata: {
+          region: "us-east-1",
+          instanceId: "i-abc123",
+          instanceName: "my-server",
+        },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "server", label: "my-server" }),
+        expect.objectContaining({ icon: "hash", label: "i-abc123" }),
+        expect.objectContaining({ icon: "globe", label: "us-east-1" }),
+      ]),
+    );
+  });
+
+  it("shows the raw instance ID as label when no name was resolved", () => {
+    const props = getInstanceMapper.props(
+      buildComponentCtx({
+        configuration: { region: "eu-west-1", instance: "i-xyz999" },
+        metadata: {
+          region: "eu-west-1",
+          instanceId: "i-xyz999",
+          instanceName: "",
+        },
+      }),
+    );
+
+    const serverItem = props.metadata?.find((m) => m.icon === "server");
+    expect(serverItem?.label).toBe("i-xyz999");
+    // hash row must not appear when there is no resolved name
+    const hashItem = props.metadata?.find((m) => m.icon === "hash");
+    expect(hashItem).toBeUndefined();
+  });
+
+  it("falls back to configuration when node metadata is absent", () => {
+    const props = getInstanceMapper.props(
+      buildComponentCtx({
+        configuration: { region: "ap-southeast-1", instance: "i-fallback" },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "server", label: "i-fallback" }),
+        expect.objectContaining({ icon: "globe", label: "ap-southeast-1" }),
+      ]),
+    );
+  });
+});
+
+describe("getInstanceMapper.getExecutionDetails", () => {
+  it("shows placeholder fields while output is not yet available", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: {
+          region: "us-east-1",
+          instance: "i-abc123",
+        },
+      },
+      execution: { outputs: undefined },
+    });
+
+    const details = getInstanceMapper.getExecutionDetails(ctx);
+    expect(details["Retrieved At"]).toBeTruthy();
+    expect(details["Region"]).toBe("us-east-1");
+    expect(details["State"]).toBe("-");
+    expect(details["Instance Type"]).toBe("-");
+    expect(details["Public IP"]).toBe("-");
+  });
+
+  it("maps output fields when instance details are present", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-east-1" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "running",
+              instanceType: "t3.micro",
+              publicIpAddress: "54.1.2.3",
+              region: "us-east-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = getInstanceMapper.getExecutionDetails(ctx);
+    expect(Object.keys(details)).toEqual(["Retrieved At", "Region", "State", "Instance Type", "Public IP"]);
+    expect(details["State"]).toBe("running");
+    expect(details["Instance Type"]).toBe("t3.micro");
+    expect(details["Public IP"]).toBe("54.1.2.3");
+  });
+
+  it("prefers region from output over configuration", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-east-1" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "running",
+              instanceType: "t3.micro",
+              publicIpAddress: "",
+              region: "eu-central-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = getInstanceMapper.getExecutionDetails(ctx);
+    expect(details["Region"]).toBe("eu-central-1");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.ts
@@ -1,0 +1,129 @@
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../../types";
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import type { MetadataItem } from "@/ui/metadataList";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "../..";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { stringOrDash } from "../../utils";
+import awsEc2Icon from "@/assets/icons/integrations/aws.ec2.svg";
+import type { Ec2Instance } from "./types";
+
+interface Configuration {
+  region?: string;
+  instance?: string;
+}
+
+interface GetInstanceNodeMetadata {
+  region?: string;
+  instanceId?: string;
+  instanceName?: string;
+}
+
+type Output = Ec2Instance;
+
+export const getInstanceMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      iconSrc: awsEc2Icon,
+      iconColor: getColorClass(context.componentDefinition.color),
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      eventSections: lastExecution ? getInstanceEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      metadata: getInstanceMetadata(context.node),
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const configuration = context.node.configuration as Configuration | undefined;
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const output = outputs?.default?.[0]?.data as Output | undefined;
+    const retrievedAt = context.execution.updatedAt
+      ? new Date(context.execution.updatedAt).toLocaleString()
+      : context.execution.createdAt
+        ? new Date(context.execution.createdAt).toLocaleString()
+        : undefined;
+
+    if (!output) {
+      return {
+        "Retrieved At": stringOrDash(retrievedAt),
+        Region: stringOrDash(configuration?.region),
+        State: "-",
+        "Instance Type": "-",
+        "Public IP": "-",
+      };
+    }
+
+    return {
+      "Retrieved At": stringOrDash(retrievedAt),
+      Region: stringOrDash(output.region ?? configuration?.region),
+      State: stringOrDash(output.state),
+      "Instance Type": stringOrDash(output.instanceType),
+      "Public IP": stringOrDash(output.publicIpAddress),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) {
+      return "";
+    }
+
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function getInstanceMetadata(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as Configuration | undefined;
+  const nodeMetadata = node.metadata as GetInstanceNodeMetadata | undefined;
+
+  const metaInstanceId = nodeMetadata?.instanceId;
+  const metaInstanceName = nodeMetadata?.instanceName;
+  const region = configuration?.region ?? nodeMetadata?.region;
+
+  const metadata: MetadataItem[] = [];
+
+  const instanceLabel = metaInstanceName || metaInstanceId || configuration?.instance;
+  if (instanceLabel) {
+    metadata.push({ icon: "server", label: instanceLabel });
+  }
+
+  if (metaInstanceId && metaInstanceName) {
+    metadata.push({ icon: "hash", label: metaInstanceId });
+  }
+
+  if (region) {
+    metadata.push({ icon: "globe", label: region });
+  }
+
+  return metadata;
+}
+
+function getInstanceEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootTriggerNode = nodes.find((node) => node.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent?.id || "",
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.ts
@@ -101,7 +101,7 @@ function getInstanceMetadata(node: NodeInfo): MetadataItem[] {
     metadata.push({ icon: "server", label: instanceLabel });
   }
 
-  if (metaInstanceId && metaInstanceName) {
+  if (metaInstanceId && metaInstanceName && metaInstanceName !== metaInstanceId) {
     metadata.push({ icon: "hash", label: metaInstanceId });
   }
 

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.spec.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import { manageInstancePowerMapper } from "./manage_instance_power";
+import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../../types";
+
+function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Manage Instance Power",
+    componentName: "ec2.manageInstancePower",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date("2026-05-21T12:00:00Z").toISOString(),
+    updatedAt: new Date("2026-05-21T12:01:00Z").toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+function buildOutput(data: Record<string, unknown>) {
+  return { type: "json", timestamp: new Date().toISOString(), data };
+}
+
+function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+function buildComponentCtx(nodeOverrides?: Partial<NodeInfo>): ComponentBaseContext {
+  const node = buildNode(nodeOverrides);
+  return {
+    nodes: [node],
+    node,
+    componentDefinition: {
+      name: "ec2.manageInstancePower",
+      label: "EC2 • Manage Instance Power",
+      description: "",
+      icon: "server",
+      color: "gray",
+    },
+    lastExecutions: [],
+    currentUser: undefined,
+    actions: { invokeNodeExecutionHook: async () => {} },
+  };
+}
+
+describe("manageInstancePowerMapper.props", () => {
+  it("shows instance name, operation label, and region in metadata", () => {
+    const props = manageInstancePowerMapper.props(
+      buildComponentCtx({
+        configuration: { region: "us-east-1", instance: "i-abc123", operation: "start" },
+        metadata: { region: "us-east-1", instanceName: "my-server" },
+      }),
+    );
+
+    expect(props.metadata).toEqual([
+      { icon: "server", label: "my-server" },
+      { icon: "power", label: "Start" },
+      { icon: "globe", label: "us-east-1" },
+    ]);
+  });
+
+  it("falls back to raw instance ID when node metadata has no name", () => {
+    const props = manageInstancePowerMapper.props(
+      buildComponentCtx({
+        configuration: { region: "us-east-1", instance: "i-abc123", operation: "stop" },
+      }),
+    );
+
+    const serverItem = props.metadata?.find((m) => m.icon === "server");
+    expect(serverItem?.label).toBe("i-abc123");
+  });
+
+  it("renders correct label for each operation", () => {
+    const operations: Record<string, string> = {
+      start: "Start",
+      stop: "Stop",
+      reboot: "Reboot",
+      hibernate: "Hibernate",
+    };
+
+    for (const [value, label] of Object.entries(operations)) {
+      const props = manageInstancePowerMapper.props(
+        buildComponentCtx({
+          configuration: { region: "us-east-1", instance: "i-abc123", operation: value },
+          metadata: { instanceName: "my-server" },
+        }),
+      );
+
+      const powerItem = props.metadata?.find((m) => m.icon === "power");
+      expect(powerItem?.label).toBe(label);
+    }
+  });
+});
+
+describe("manageInstancePowerMapper.getExecutionDetails", () => {
+  it("shows placeholder state while output is not yet available", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-east-1", instance: "i-abc123", operation: "stop" },
+      },
+      execution: { outputs: undefined },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Completed At"]).toBeTruthy();
+    expect(details["Operation"]).toBe("Stop");
+    expect(details["Region"]).toBe("us-east-1");
+    expect(details["State"]).toBe("-");
+  });
+
+  it("maps output fields when instance details are present", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-east-1", operation: "start" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "running",
+              instanceType: "t3.micro",
+              publicIpAddress: "54.1.2.3",
+              region: "us-east-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(Object.keys(details)).toEqual(["Completed At", "Operation", "Region", "State", "Public IP"]);
+    expect(details["Operation"]).toBe("Start");
+    expect(details["State"]).toBe("running");
+    expect(details["Public IP"]).toBe("54.1.2.3");
+  });
+
+  it("shows stopped state for stop operation", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "eu-west-1", operation: "stop" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "stopped",
+              region: "eu-west-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Operation"]).toBe("Stop");
+    expect(details["State"]).toBe("stopped");
+  });
+
+  it("shows stopped state for hibernate operation", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-west-2", operation: "hibernate" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "stopped",
+              region: "us-west-2",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Operation"]).toBe("Hibernate");
+    expect(details["State"]).toBe("stopped");
+  });
+
+  it("shows running state for reboot operation", () => {
+    const ctx = buildDetailsCtx({
+      node: {
+        configuration: { region: "us-east-1", operation: "reboot" },
+      },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "running",
+              region: "us-east-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Operation"]).toBe("Reboot");
+    expect(details["State"]).toBe("running");
+  });
+
+  it("prefers region from output over configuration", () => {
+    const ctx = buildDetailsCtx({
+      node: { configuration: { region: "us-east-1", operation: "start" } },
+      execution: {
+        outputs: {
+          default: [buildOutput({ instanceId: "i-1", state: "running", region: "ap-southeast-1" })],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Region"]).toBe("ap-southeast-1");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { manageInstancePowerMapper } from "./manage_instance_power";
+import { manageInstancePowerMapper, MANAGE_INSTANCE_POWER_STATE_REGISTRY } from "./manage_instance_power";
 import type { ComponentBaseContext, ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../../types";
 
 function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
@@ -153,6 +153,27 @@ describe("manageInstancePowerMapper.getExecutionDetails", () => {
     expect(details["Public IP"]).toBe("54.1.2.3");
   });
 
+  it("omits Public IP when the instance has no public address", () => {
+    const ctx = buildDetailsCtx({
+      node: { configuration: { region: "us-east-1", operation: "stop" } },
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              instanceId: "i-abc123",
+              state: "stopped",
+              publicIpAddress: "",
+              region: "us-east-1",
+            }),
+          ],
+        },
+      },
+    });
+
+    const details = manageInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Public IP"]).toBeUndefined();
+  });
+
   it("shows stopped state for stop operation", () => {
     const ctx = buildDetailsCtx({
       node: {
@@ -234,5 +255,70 @@ describe("manageInstancePowerMapper.getExecutionDetails", () => {
 
     const details = manageInstancePowerMapper.getExecutionDetails(ctx);
     expect(details["Region"]).toBe("ap-southeast-1");
+  });
+});
+
+describe("MANAGE_INSTANCE_POWER_STATE_REGISTRY", () => {
+  const successExecution = buildExecution({
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+  });
+
+  it("returns the payload type as state when a power event is present", () => {
+    const execution = {
+      ...successExecution,
+      outputs: {
+        default: [{ type: "aws.ec2.instance.power.started", timestamp: "", data: {} }],
+      },
+    };
+
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("aws.ec2.instance.power.started");
+  });
+
+  it("returns 'stopped' badge state for stop output", () => {
+    const execution = {
+      ...successExecution,
+      outputs: {
+        default: [{ type: "aws.ec2.instance.power.stopped", timestamp: "", data: {} }],
+      },
+    };
+
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("aws.ec2.instance.power.stopped");
+  });
+
+  it("returns 'rebooted' badge state for reboot output", () => {
+    const execution = {
+      ...successExecution,
+      outputs: {
+        default: [{ type: "aws.ec2.instance.power.rebooted", timestamp: "", data: {} }],
+      },
+    };
+
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("aws.ec2.instance.power.rebooted");
+  });
+
+  it("returns 'hibernated' badge state for hibernate output", () => {
+    const execution = {
+      ...successExecution,
+      outputs: {
+        default: [{ type: "aws.ec2.instance.power.hibernated", timestamp: "", data: {} }],
+      },
+    };
+
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("aws.ec2.instance.power.hibernated");
+  });
+
+  it("falls back to 'success' when no recognised power event is present", () => {
+    const execution = {
+      ...successExecution,
+      outputs: { default: [{ type: "aws.ec2.instance", timestamp: "", data: {} }] },
+    };
+
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("success");
+  });
+
+  it("passes non-success states through unchanged", () => {
+    const failed = buildExecution({ state: "STATE_FINISHED", result: "RESULT_FAILED", resultMessage: "error" });
+    expect(MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(failed)).toBe("error");
   });
 });

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
@@ -1,20 +1,23 @@
+import type { ComponentBaseProps, EventSection, EventStateMap } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type React from "react";
+import type { MetadataItem } from "@/ui/metadataList";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import { getTriggerRenderer } from "../..";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { stringOrDash } from "../../utils";
+import awsEc2Icon from "@/assets/icons/integrations/aws.ec2.svg";
+import { defaultStateFunction } from "../../stateRegistry";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
+  EventStateRegistry,
   ExecutionDetailsContext,
   ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
 } from "../../types";
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
-import type React from "react";
-import type { MetadataItem } from "@/ui/metadataList";
-import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
-import { getState, getStateMap, getTriggerRenderer } from "../..";
-import { renderTimeAgo } from "@/components/TimeAgo";
-import { stringOrDash } from "../../utils";
-import awsEc2Icon from "@/assets/icons/integrations/aws.ec2.svg";
 import type { Ec2Instance } from "./types";
 
 interface Configuration {
@@ -40,10 +43,59 @@ const operationLabels: Record<string, string> = {
   hibernate: "Hibernate",
 };
 
+export const instancePowerStateMap: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  "aws.ec2.instance.power.started": {
+    icon: "play",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "STARTED",
+  },
+  "aws.ec2.instance.power.stopped": {
+    icon: "square",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-gray-100",
+    badgeColor: "bg-gray-500",
+    label: "STOPPED",
+  },
+  "aws.ec2.instance.power.rebooted": {
+    icon: "refresh-cw",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "REBOOTED",
+  },
+  "aws.ec2.instance.power.hibernated": {
+    icon: "moon",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-blue-100",
+    badgeColor: "bg-blue-500",
+    label: "HIBERNATED",
+  },
+};
+
+const powerPayloadPrefix = "aws.ec2.instance.power.";
+
+export const MANAGE_INSTANCE_POWER_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: instancePowerStateMap,
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    if (state !== "success") return state;
+
+    const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+    const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(powerPayloadPrefix));
+    if (powerEvent?.type && instancePowerStateMap[powerEvent.type]) {
+      return powerEvent.type;
+    }
+
+    return "success";
+  },
+};
+
 export const manageInstancePowerMapper: ComponentBaseMapper = {
   props(context: ComponentBaseContext): ComponentBaseProps {
     const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
-    const componentName = context.componentDefinition.name || "unknown";
 
     return {
       title: context.node.name || context.componentDefinition.label || "Unnamed component",
@@ -51,12 +103,10 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
       iconColor: getColorClass(context.componentDefinition.color),
       collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
       collapsed: context.node.isCollapsed,
-      eventSections: lastExecution
-        ? manageInstancePowerEventSections(context.nodes, lastExecution, componentName)
-        : undefined,
+      eventSections: lastExecution ? manageInstancePowerEventSections(context.nodes, lastExecution) : undefined,
       includeEmptyState: !lastExecution,
       metadata: manageInstancePowerMetadata(context.node),
-      eventStateMap: getStateMap(componentName),
+      eventStateMap: instancePowerStateMap,
     };
   },
 
@@ -64,12 +114,13 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
     const configuration = context.node.configuration as Configuration | undefined;
     const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
     const output = outputs?.default?.[0]?.data as Output | undefined;
+    const operation = configuration?.operation;
     const completedAt = context.execution.updatedAt
       ? new Date(context.execution.updatedAt).toLocaleString()
       : context.execution.createdAt
         ? new Date(context.execution.createdAt).toLocaleString()
         : undefined;
-    const operationLabel = operationLabels[configuration?.operation ?? ""] ?? configuration?.operation ?? "-";
+    const operationLabel = (operation && operationLabels[operation]) ?? operation ?? "-";
 
     if (!output) {
       return {
@@ -80,13 +131,18 @@ export const manageInstancePowerMapper: ComponentBaseMapper = {
       };
     }
 
-    return {
+    const details: Record<string, string> = {
       "Completed At": stringOrDash(completedAt),
       Operation: operationLabel,
       Region: stringOrDash(output.region ?? configuration?.region),
       State: stringOrDash(output.state),
-      "Public IP": stringOrDash(output.publicIpAddress),
     };
+
+    if (output.publicIpAddress) {
+      details["Public IP"] = output.publicIpAddress;
+    }
+
+    return details;
   },
 
   subtitle(context: SubtitleContext): string | React.ReactNode {
@@ -123,21 +179,22 @@ function manageInstancePowerMetadata(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function manageInstancePowerEventSections(
-  nodes: NodeInfo[],
-  execution: ExecutionInfo,
-  componentName: string,
-): EventSection[] {
+function manageInstancePowerEventSections(nodes: NodeInfo[], execution: ExecutionInfo): EventSection[] {
   const rootTriggerNode = nodes.find((node) => node.id === execution.rootEvent?.nodeId);
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+  const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(powerPayloadPrefix));
+  const eventState =
+    powerEvent?.type && instancePowerStateMap[powerEvent.type] ? powerEvent.type : defaultStateFunction(execution);
 
   return [
     {
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
       eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState: getState(componentName)(execution),
+      eventState,
       eventId: execution.rootEvent?.id || "",
     },
   ];

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
@@ -1,0 +1,144 @@
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../../types";
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import type { MetadataItem } from "@/ui/metadataList";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "../..";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { stringOrDash } from "../../utils";
+import awsEc2Icon from "@/assets/icons/integrations/aws.ec2.svg";
+import type { Ec2Instance } from "./types";
+
+interface Configuration {
+  region?: string;
+  instance?: string;
+  operation?: string;
+}
+
+interface ManageInstancePowerNodeMetadata {
+  region?: string;
+  instanceName?: string;
+}
+
+type Output = Pick<
+  Ec2Instance,
+  "instanceId" | "state" | "instanceType" | "publicIpAddress" | "privateIpAddress" | "region"
+>;
+
+const operationLabels: Record<string, string> = {
+  start: "Start",
+  stop: "Stop",
+  reboot: "Reboot",
+  hibernate: "Hibernate",
+};
+
+export const manageInstancePowerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name || "unknown";
+
+    return {
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      iconSrc: awsEc2Icon,
+      iconColor: getColorClass(context.componentDefinition.color),
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      eventSections: lastExecution
+        ? manageInstancePowerEventSections(context.nodes, lastExecution, componentName)
+        : undefined,
+      includeEmptyState: !lastExecution,
+      metadata: manageInstancePowerMetadata(context.node),
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const configuration = context.node.configuration as Configuration | undefined;
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const output = outputs?.default?.[0]?.data as Output | undefined;
+    const completedAt = context.execution.updatedAt
+      ? new Date(context.execution.updatedAt).toLocaleString()
+      : context.execution.createdAt
+        ? new Date(context.execution.createdAt).toLocaleString()
+        : undefined;
+    const operationLabel = operationLabels[configuration?.operation ?? ""] ?? configuration?.operation ?? "-";
+
+    if (!output) {
+      return {
+        "Completed At": stringOrDash(completedAt),
+        Operation: operationLabel,
+        Region: stringOrDash(configuration?.region),
+        State: "-",
+      };
+    }
+
+    return {
+      "Completed At": stringOrDash(completedAt),
+      Operation: operationLabel,
+      Region: stringOrDash(output.region ?? configuration?.region),
+      State: stringOrDash(output.state),
+      "Public IP": stringOrDash(output.publicIpAddress),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) {
+      return "";
+    }
+
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function manageInstancePowerMetadata(node: NodeInfo): MetadataItem[] {
+  const configuration = node.configuration as Configuration | undefined;
+  const nodeMetadata = node.metadata as ManageInstancePowerNodeMetadata | undefined;
+
+  const operation = configuration?.operation;
+  const region = configuration?.region ?? nodeMetadata?.region;
+  const instanceName = nodeMetadata?.instanceName ?? configuration?.instance;
+
+  const metadata: MetadataItem[] = [];
+
+  if (instanceName) {
+    metadata.push({ icon: "server", label: instanceName });
+  }
+
+  if (operation) {
+    metadata.push({ icon: "power", label: operationLabels[operation] ?? operation });
+  }
+
+  if (region) {
+    metadata.push({ icon: "globe", label: region });
+  }
+
+  return metadata;
+}
+
+function manageInstancePowerEventSections(
+  nodes: NodeInfo[],
+  execution: ExecutionInfo,
+  componentName: string,
+): EventSection[] {
+  const rootTriggerNode = nodes.find((node) => node.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent?.id || "",
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts
@@ -184,17 +184,12 @@ function manageInstancePowerEventSections(nodes: NodeInfo[], execution: Executio
   const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName || "");
   const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
 
-  const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
-  const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(powerPayloadPrefix));
-  const eventState =
-    powerEvent?.type && instancePowerStateMap[powerEvent.type] ? powerEvent.type : defaultStateFunction(execution);
-
   return [
     {
       receivedAt: new Date(execution.createdAt!),
       eventTitle: title,
       eventSubtitle: renderTimeAgo(new Date(execution.createdAt!)),
-      eventState,
+      eventState: MANAGE_INSTANCE_POWER_STATE_REGISTRY.getState(execution),
       eventId: execution.rootEvent?.id || "",
     },
   ];

--- a/web_src/src/pages/workflowv2/mappers/aws/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/index.ts
@@ -42,7 +42,7 @@ import { createInstanceMapper } from "./ec2/create_instance";
 import { deleteInstanceMapper } from "./ec2/delete_instance";
 import { getImageMapper as getEc2ImageMapper } from "./ec2/get_image";
 import { getInstanceMapper } from "./ec2/get_instance";
-import { manageInstancePowerMapper } from "./ec2/manage_instance_power";
+import { manageInstancePowerMapper, MANAGE_INSTANCE_POWER_STATE_REGISTRY } from "./ec2/manage_instance_power";
 import { copyImageMapper } from "./ec2/copy_image";
 import { deregisterImageMapper } from "./ec2/deregister_image";
 import { enableImageMapper } from "./ec2/enable_image";
@@ -154,5 +154,5 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   "ec2.enableImageDeprecation": buildActionStateRegistry("enabled"),
   "ec2.getImage": buildActionStateRegistry("retrieved"),
   "ec2.getInstance": buildActionStateRegistry("retrieved"),
-  "ec2.manageInstancePower": buildActionStateRegistry("applied"),
+  "ec2.manageInstancePower": MANAGE_INSTANCE_POWER_STATE_REGISTRY,
 };

--- a/web_src/src/pages/workflowv2/mappers/aws/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/aws/index.ts
@@ -41,6 +41,8 @@ import { createImageMapper } from "./ec2/create_image";
 import { createInstanceMapper } from "./ec2/create_instance";
 import { deleteInstanceMapper } from "./ec2/delete_instance";
 import { getImageMapper as getEc2ImageMapper } from "./ec2/get_image";
+import { getInstanceMapper } from "./ec2/get_instance";
+import { manageInstancePowerMapper } from "./ec2/manage_instance_power";
 import { copyImageMapper } from "./ec2/copy_image";
 import { deregisterImageMapper } from "./ec2/deregister_image";
 import { enableImageMapper } from "./ec2/enable_image";
@@ -93,6 +95,8 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   "ec2.enableImage": enableImageMapper,
   "ec2.enableImageDeprecation": enableImageDeprecationMapper,
   "ec2.getImage": getEc2ImageMapper,
+  "ec2.getInstance": getInstanceMapper,
+  "ec2.manageInstancePower": manageInstancePowerMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -149,4 +153,6 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   "ec2.enableImage": buildActionStateRegistry("enabled"),
   "ec2.enableImageDeprecation": buildActionStateRegistry("enabled"),
   "ec2.getImage": buildActionStateRegistry("retrieved"),
+  "ec2.getInstance": buildActionStateRegistry("retrieved"),
+  "ec2.manageInstancePower": buildActionStateRegistry("applied"),
 };


### PR DESCRIPTION
Resolves: #5006

## What changed

Adds two AWS EC2 workflow components:

**Get Instance** — describe an EC2 instance and emit its current state, IP addresses, and metadata
**Manage Instance Power** — perform a power operation on an EC2 instance (start, stop, reboot, or hibernate) and wait for the expected terminal state

## Why

SuperPlane already had EC2 AMI actions (create/get/copy image, etc.) and instance provisioning (create/delete), but no way to inspect a running instance mid-workflow or change its power state

## How

### Backend

Added GetInstance in pkg/integrations/aws/ec2/get_instance.go. Setup resolves the instance name via DescribeInstance and stores it alongside the instance ID in node metadata so the UI card shows both.
Added ManageInstancePower in pkg/integrations/aws/ec2/manage_instance_power.go with four operations: start (polls until running), stop (polls until stopped), hibernate (sends StopInstances?Hibernate=true, polls until stopped), and reboot (fire-and-forget, emits immediately since the instance stays running throughout).
Added RebootInstances and HibernateInstances (via a stopInstances helper with a Hibernate flag) to the EC2 client in pkg/integrations/aws/ec2/client.go.
Registered both components in pkg/integrations/aws/aws.go.
Added example outputs, tests, and updated ec2.go / example.go.

## Frontend

Added workflow v2 mappers:
web_src/src/pages/workflowv2/mappers/aws/ec2/get_instance.ts — metadata card shows resolved instance name, raw instance ID (when a name was found), and region
web_src/src/pages/workflowv2/mappers/aws/ec2/manage_instance_power.ts — metadata card shows instance name, operation label (Start / Stop / Reboot / Hibernate), and region; execution details include the operation and final state
Registered mappers and event state registries in web_src/src/pages/workflowv2/mappers/aws/index.ts
Added mapper specs for both components (get_instance.spec.ts, manage_instance_power.spec.ts)

## Demo

[Screencast From 2026-05-28 14-17-12.webm](https://github.com/user-attachments/assets/e3fe0589-7122-4a7c-b26a-8d97a95edf94)

