### PR TITLE
fix: Lock Console and Memory when in Read Mode

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
+++ b/web_src/src/pages/workflowv2/CanvasMemoryView.tsx
@@ -159,6 +159,7 @@ function renderNamespaceTable(
     return <div className="px-3 py-2 text-xs text-gray-500">No items</div>;
   }
 
+  const showActions = !!onDeleteEntry;
   const objectValues = values.map((entry) => entry.values).filter(isRecord) as Record<string, unknown>[];
   if (objectValues.length === values.length) {
     const columns = collectColumns(objectValues);
@@ -172,7 +173,9 @@ function renderNamespaceTable(
                   {column}
                 </th>
               ))}
-              <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
+              {showActions ? (
+                <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
+              ) : null}
             </tr>
           </thead>
           <tbody>
@@ -185,21 +188,23 @@ function renderNamespaceTable(
                       {formatValue(item[column])}
                     </td>
                   ))}
-                  <td className="px-3 py-2 text-right align-middle">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={!onDeleteEntry || !entry.id || deletingId === entry.id}
-                      onClick={() => {
-                        if (entry.id) onDeleteEntry?.(entry.id);
-                      }}
-                      className="text-gray-500 hover:text-red-600"
-                      title="Delete entry"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </td>
+                  {showActions ? (
+                    <td className="px-3 py-2 text-right align-middle">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={!entry.id || deletingId === entry.id}
+                        onClick={() => {
+                          if (entry.id) onDeleteEntry?.(entry.id);
+                        }}
+                        className="text-gray-500 hover:text-red-600"
+                        title="Delete entry"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  ) : null}
                 </tr>
               );
             })}
@@ -210,33 +215,37 @@ function renderNamespaceTable(
   }
 
   return (
-    <div className="overflow-x-auto bg-red-500">
+    <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-slate-950/15 bg-slate-50">
             <th className="px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase">Value</th>
-            <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
+            {showActions ? (
+              <th className="w-12 px-3 py-2 text-right text-xs font-semibold text-gray-600 uppercase"></th>
+            ) : null}
           </tr>
         </thead>
         <tbody>
           {values.map((entry, index) => (
             <tr key={entry.id || index} className="border-b border-slate-950/15">
               <td className="px-3 py-2 align-middle font-mono text-xs text-gray-700">{formatValue(entry.values)}</td>
-              <td className="px-3 py-2 text-right align-middle">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  disabled={!onDeleteEntry || !entry.id || deletingId === entry.id}
-                  onClick={() => {
-                    if (entry.id) onDeleteEntry?.(entry.id);
-                  }}
-                  className="text-gray-500 hover:text-red-600"
-                  title="Delete entry"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </td>
+              {showActions ? (
+                <td className="px-3 py-2 text-right align-middle">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={!entry.id || deletingId === entry.id}
+                    onClick={() => {
+                      if (entry.id) onDeleteEntry?.(entry.id);
+                    }}
+                    className="text-gray-500 hover:text-red-600"
+                    title="Delete entry"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </td>
+              ) : null}
             </tr>
           ))}
         </tbody>

--- a/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
@@ -10,12 +10,10 @@ interface DeleteCanvasMemoryMutation {
 
 interface WorkflowMemoryOverlayLayerProps {
   isMemoryMode: boolean;
-  isViewingDraftVersion: boolean;
-  isViewingLiveVersion: boolean;
-  canUpdateCanvas: boolean;
-  // Mirrors the workflow page's app-wide read-only state so the trash
-  // affordance disappears entirely when the canvas is not in edit mode.
-  isReadOnly: boolean;
+  // True when the viewer is allowed to delete memory entries. Computed by the
+  // workflow page via `canEditCanvasMemory` so the gating logic stays in one
+  // place.
+  canDelete: boolean;
   entries: CanvasMemoryEntry[];
   isLoading: boolean;
   error: unknown;
@@ -24,10 +22,7 @@ interface WorkflowMemoryOverlayLayerProps {
 
 export function WorkflowMemoryOverlayLayer({
   isMemoryMode,
-  isViewingDraftVersion,
-  isViewingLiveVersion,
-  canUpdateCanvas,
-  isReadOnly,
+  canDelete,
   entries,
   isLoading,
   error,
@@ -35,14 +30,12 @@ export function WorkflowMemoryOverlayLayer({
 }: WorkflowMemoryOverlayLayerProps) {
   if (!isMemoryMode) return null;
 
-  const canDeleteEntry = !isReadOnly && canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion;
-
   return (
     <CanvasMemoryView
       entries={entries}
       isLoading={isLoading}
       errorMessage={error instanceof Error ? error.message : undefined}
-      onDeleteEntry={canDeleteEntry ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined}
+      onDeleteEntry={canDelete ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined}
       deletingId={deleteCanvasMemoryEntry.isPending ? deleteCanvasMemoryEntry.variables : undefined}
     />
   );

--- a/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowMemoryOverlayLayer.tsx
@@ -13,6 +13,9 @@ interface WorkflowMemoryOverlayLayerProps {
   isViewingDraftVersion: boolean;
   isViewingLiveVersion: boolean;
   canUpdateCanvas: boolean;
+  // Mirrors the workflow page's app-wide read-only state so the trash
+  // affordance disappears entirely when the canvas is not in edit mode.
+  isReadOnly: boolean;
   entries: CanvasMemoryEntry[];
   isLoading: boolean;
   error: unknown;
@@ -24,6 +27,7 @@ export function WorkflowMemoryOverlayLayer({
   isViewingDraftVersion,
   isViewingLiveVersion,
   canUpdateCanvas,
+  isReadOnly,
   entries,
   isLoading,
   error,
@@ -31,16 +35,14 @@ export function WorkflowMemoryOverlayLayer({
 }: WorkflowMemoryOverlayLayerProps) {
   if (!isMemoryMode) return null;
 
+  const canDeleteEntry = !isReadOnly && canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion;
+
   return (
     <CanvasMemoryView
       entries={entries}
       isLoading={isLoading}
       errorMessage={error instanceof Error ? error.message : undefined}
-      onDeleteEntry={
-        canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion
-          ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId)
-          : undefined
-      }
+      onDeleteEntry={canDeleteEntry ? (memoryId) => deleteCanvasMemoryEntry.mutate(memoryId) : undefined}
       deletingId={deleteCanvasMemoryEntry.isPending ? deleteCanvasMemoryEntry.variables : undefined}
     />
   );

--- a/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
@@ -6,6 +6,9 @@ type WorkflowDashboardOverlayProps = Omit<DashboardOverlayProps, "readOnly" | "c
   canUpdateCanvas: boolean;
   isTemplate: boolean;
   canvasDeletedRemotely: boolean;
+  // Mirrors the workflow page's app-wide read-only state so hover/edit
+  // affordances stay hidden when the canvas is not in edit mode.
+  isReadOnly: boolean;
 };
 
 export function WorkflowDashboardOverlay({
@@ -14,16 +17,23 @@ export function WorkflowDashboardOverlay({
   canUpdateCanvas,
   isTemplate,
   canvasDeletedRemotely,
+  isReadOnly,
   ...dashboardProps
 }: WorkflowDashboardOverlayProps) {
   if (!isDashboardMode || !dashboardsFeatureEnabled) return null;
 
-  const dashboardLocked = !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
+  // Authoring affordances (panel edit/delete, drag/resize, YAML import) are
+  // hidden whenever the app is in read mode. Runtime triggers (widget row
+  // actions, Node panel Run button) only depend on permission/template state,
+  // not on whether the canvas is in edit mode — the in-flight run lock
+  // disables them when a run is already executing.
+  const dashboardEditLocked = isReadOnly || !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
+  const dashboardRunLocked = !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
   return (
     <DashboardOverlay
-      readOnly={dashboardLocked}
-      canImportYaml={!dashboardLocked}
-      canRunNodes={!dashboardLocked}
+      readOnly={dashboardEditLocked}
+      canImportYaml={!dashboardEditLocked}
+      canRunNodes={!dashboardRunLocked}
       {...dashboardProps}
     />
   );

--- a/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
@@ -6,9 +6,9 @@ type WorkflowDashboardOverlayProps = Omit<DashboardOverlayProps, "readOnly" | "c
   canUpdateCanvas: boolean;
   isTemplate: boolean;
   canvasDeletedRemotely: boolean;
-  // Mirrors the workflow page's app-wide read-only state so hover/edit
-  // affordances stay hidden when the canvas is not in edit mode.
-  isReadOnly: boolean;
+  // Hides authoring affordances (panel edit/delete, drag/resize, YAML import)
+  // when the app is in read mode.
+  editLocked: boolean;
 };
 
 export function WorkflowDashboardOverlay({
@@ -17,24 +17,16 @@ export function WorkflowDashboardOverlay({
   canUpdateCanvas,
   isTemplate,
   canvasDeletedRemotely,
-  isReadOnly,
+  editLocked,
   ...dashboardProps
 }: WorkflowDashboardOverlayProps) {
   if (!isDashboardMode || !dashboardsFeatureEnabled) return null;
 
-  // Authoring affordances (panel edit/delete, drag/resize, YAML import) are
-  // hidden whenever the app is in read mode. Runtime triggers (widget row
-  // actions, Node panel Run button) only depend on permission/template state,
-  // not on whether the canvas is in edit mode — the in-flight run lock
-  // disables them when a run is already executing.
-  const dashboardEditLocked = isReadOnly || !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
-  const dashboardRunLocked = !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
+  // Runtime triggers (widget row actions, Node panel Run button) only depend
+  // on permission/template state — not on edit mode. The in-flight run lock
+  // handles disabling while a run is already executing.
+  const runLocked = !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
   return (
-    <DashboardOverlay
-      readOnly={dashboardEditLocked}
-      canImportYaml={!dashboardEditLocked}
-      canRunNodes={!dashboardRunLocked}
-      {...dashboardProps}
-    />
+    <DashboardOverlay readOnly={editLocked} canImportYaml={!editLocked} canRunNodes={!runLocked} {...dashboardProps} />
   );
 }

--- a/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/WorkflowDashboardOverlay.tsx
@@ -3,9 +3,7 @@ import { DashboardOverlay, type DashboardOverlayProps } from "./DashboardOverlay
 type WorkflowDashboardOverlayProps = Omit<DashboardOverlayProps, "readOnly" | "canImportYaml" | "canRunNodes"> & {
   isDashboardMode: boolean;
   dashboardsFeatureEnabled: boolean;
-  canUpdateCanvas: boolean;
-  isTemplate: boolean;
-  canvasDeletedRemotely: boolean;
+  canActOnCanvas: boolean;
   // Hides authoring affordances (panel edit/delete, drag/resize, YAML import)
   // when the app is in read mode.
   editLocked: boolean;
@@ -14,9 +12,7 @@ type WorkflowDashboardOverlayProps = Omit<DashboardOverlayProps, "readOnly" | "c
 export function WorkflowDashboardOverlay({
   isDashboardMode,
   dashboardsFeatureEnabled,
-  canUpdateCanvas,
-  isTemplate,
-  canvasDeletedRemotely,
+  canActOnCanvas,
   editLocked,
   ...dashboardProps
 }: WorkflowDashboardOverlayProps) {
@@ -25,7 +21,7 @@ export function WorkflowDashboardOverlay({
   // Runtime triggers (widget row actions, Node panel Run button) only depend
   // on permission/template state — not on edit mode. The in-flight run lock
   // handles disabling while a run is already executing.
-  const runLocked = !canUpdateCanvas || isTemplate || canvasDeletedRemotely;
+  const runLocked = !canActOnCanvas;
   return (
     <DashboardOverlay readOnly={editLocked} canImportYaml={!editLocked} canRunNodes={!runLocked} {...dashboardProps} />
   );

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5508,6 +5508,7 @@ export function WorkflowPageV2() {
           canUpdateCanvas={canUpdateCanvas}
           isTemplate={isTemplate}
           canvasDeletedRemotely={canvasDeletedRemotely}
+          isReadOnly={isReadOnly}
           dashboardQuery={dashboardQuery}
           updateDashboardMutation={updateDashboardMutation}
           addPanelDialogOpen={isDashboardAddPanelOpen}
@@ -5526,6 +5527,7 @@ export function WorkflowPageV2() {
           isViewingDraftVersion={isViewingDraftVersion}
           isViewingLiveVersion={isViewingLiveVersion}
           canUpdateCanvas={canUpdateCanvas}
+          isReadOnly={isReadOnly}
           entries={canvasMemoryEntries}
           isLoading={canvasMemoryLoading}
           error={canvasMemoryError}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -582,7 +582,9 @@ export function WorkflowPageV2() {
   const updateDashboardMutation = useUpdateCanvasConsole(canvasId!);
   const [canvasDeletedRemotely, setCanvasDeletedRemotely] = useState(false);
   const [remoteCanvasUpdatePending, setRemoteCanvasUpdatePending] = useState(false);
-  const isReadOnly = isTemplate || !canUpdateCanvas || canvasDeletedRemotely || !hasEditableVersion;
+  const canvasAccess = { canUpdateCanvas, isTemplate, canvasDeletedRemotely };
+  const canActOnCanvas = canUpdateCanvas && !isTemplate && !canvasDeletedRemotely;
+  const isReadOnly = !canActOnCanvas || !hasEditableVersion;
   const [isUseTemplateOpen, setIsUseTemplateOpen] = useState(false);
   const [isYamlViewModalOpen, setIsYamlViewModalOpen] = useState(false);
   const [isVersionControlOpen, setIsVersionControlOpen] = useState(() =>
@@ -4477,7 +4479,7 @@ export function WorkflowPageV2() {
         setIsVersionControlOpen(true);
       },
       onViewNodeDiff: handleOpenAwaitingApprovalNodeDiff,
-      canAct: canUpdateCanvas && !isTemplate && !canvasDeletedRemotely,
+      canAct: canActOnCanvas,
       actionPending: actOnCanvasChangeRequestMutation.isPending,
       reviewUi,
     };
@@ -4490,9 +4492,7 @@ export function WorkflowPageV2() {
     handleRejectChangeRequest,
     handlePublishChangeRequest,
     handleOpenAwaitingApprovalNodeDiff,
-    canUpdateCanvas,
-    isTemplate,
-    canvasDeletedRemotely,
+    canActOnCanvas,
     actOnCanvasChangeRequestMutation.isPending,
   ]);
 
@@ -5491,9 +5491,7 @@ export function WorkflowPageV2() {
   });
   const { disabled: runDisabled, tooltip: runDisabledTooltip } = getRunActionState({
     hasRunBlockingChanges,
-    isTemplate,
-    canUpdateCanvas,
-    canvasDeletedRemotely,
+    ...canvasAccess,
     isViewingDraftVersion,
     isViewingCurrentLiveVersion,
   });
@@ -5506,9 +5504,7 @@ export function WorkflowPageV2() {
         <WorkflowDashboardOverlay
           isDashboardMode={isDashboardMode}
           dashboardsFeatureEnabled={dashboardsFeatureEnabled}
-          canUpdateCanvas={canUpdateCanvas}
-          isTemplate={isTemplate}
-          canvasDeletedRemotely={canvasDeletedRemotely}
+          canActOnCanvas={canActOnCanvas}
           editLocked={isReadOnly}
           dashboardQuery={dashboardQuery}
           updateDashboardMutation={updateDashboardMutation}
@@ -5526,9 +5522,7 @@ export function WorkflowPageV2() {
         <WorkflowMemoryOverlayLayer
           isMemoryMode={isMemoryMode}
           canDelete={canEditCanvasMemory({
-            canUpdateCanvas,
-            isTemplate,
-            canvasDeletedRemotely,
+            ...canvasAccess,
             isViewingLiveVersion,
             isViewingDraftVersion,
           })}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -90,6 +90,7 @@ import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
 import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
 import { CanvasChangeRequestConflictResolver } from "./CanvasChangeRequestConflictResolver";
 import { WorkflowMemoryOverlayLayer } from "./WorkflowMemoryOverlayLayer";
+import { canEditCanvasMemory } from "./lib/canvas-memory-access";
 import { CanvasPageModals } from "./CanvasPageModals";
 import { CanvasVersionNodeDiffDialog, type CanvasVersionNodeDiffContext } from "./CanvasVersionNodeDiffDialog";
 import { CanvasYamlModal } from "./CanvasYamlModal";
@@ -5508,7 +5509,7 @@ export function WorkflowPageV2() {
           canUpdateCanvas={canUpdateCanvas}
           isTemplate={isTemplate}
           canvasDeletedRemotely={canvasDeletedRemotely}
-          isReadOnly={isReadOnly}
+          editLocked={isReadOnly}
           dashboardQuery={dashboardQuery}
           updateDashboardMutation={updateDashboardMutation}
           addPanelDialogOpen={isDashboardAddPanelOpen}
@@ -5524,10 +5525,7 @@ export function WorkflowPageV2() {
         />
         <WorkflowMemoryOverlayLayer
           isMemoryMode={isMemoryMode}
-          isViewingDraftVersion={isViewingDraftVersion}
-          isViewingLiveVersion={isViewingLiveVersion}
-          canUpdateCanvas={canUpdateCanvas}
-          isReadOnly={isReadOnly}
+          canDelete={canEditCanvasMemory({ isReadOnly, canUpdateCanvas, isViewingLiveVersion, isViewingDraftVersion })}
           entries={canvasMemoryEntries}
           isLoading={canvasMemoryLoading}
           error={canvasMemoryError}

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -5525,7 +5525,13 @@ export function WorkflowPageV2() {
         />
         <WorkflowMemoryOverlayLayer
           isMemoryMode={isMemoryMode}
-          canDelete={canEditCanvasMemory({ isReadOnly, canUpdateCanvas, isViewingLiveVersion, isViewingDraftVersion })}
+          canDelete={canEditCanvasMemory({
+            canUpdateCanvas,
+            isTemplate,
+            canvasDeletedRemotely,
+            isViewingLiveVersion,
+            isViewingDraftVersion,
+          })}
           entries={canvasMemoryEntries}
           isLoading={canvasMemoryLoading}
           error={canvasMemoryError}

--- a/web_src/src/pages/workflowv2/lib/canvas-memory-access.spec.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-memory-access.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { canEditCanvasMemory } from "./canvas-memory-access";
+
+describe("canEditCanvasMemory", () => {
+  const defaultState = {
+    canUpdateCanvas: true,
+    isTemplate: false,
+    canvasDeletedRemotely: false,
+    isViewingLiveVersion: true,
+    isViewingDraftVersion: false,
+  };
+
+  it("allows memory edits on the current live non-draft version", () => {
+    expect(canEditCanvasMemory(defaultState)).toBe(true);
+  });
+
+  it.each([
+    { canUpdateCanvas: false },
+    { isTemplate: true },
+    { canvasDeletedRemotely: true },
+    { isViewingLiveVersion: false },
+    { isViewingDraftVersion: true },
+  ])("blocks memory edits when %o", (override) => {
+    expect(canEditCanvasMemory({ ...defaultState, ...override })).toBe(false);
+  });
+});

--- a/web_src/src/pages/workflowv2/lib/canvas-memory-access.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-memory-access.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolves whether the canvas memory delete affordance should be exposed for
+ * the current viewer + version. Centralized so the workflow page and overlay
+ * stay aligned on a single gating rule.
+ */
+export function canEditCanvasMemory({
+  isReadOnly,
+  canUpdateCanvas,
+  isViewingLiveVersion,
+  isViewingDraftVersion,
+}: {
+  isReadOnly: boolean;
+  canUpdateCanvas: boolean;
+  isViewingLiveVersion: boolean;
+  isViewingDraftVersion: boolean;
+}): boolean {
+  return !isReadOnly && canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion;
+}

--- a/web_src/src/pages/workflowv2/lib/canvas-memory-access.ts
+++ b/web_src/src/pages/workflowv2/lib/canvas-memory-access.ts
@@ -1,18 +1,20 @@
 /**
  * Resolves whether the canvas memory delete affordance should be exposed for
- * the current viewer + version. Centralized so the workflow page and overlay
- * stay aligned on a single gating rule.
+ * the current viewer + version. Memory belongs to the live canvas, so this
+ * should not depend on draft edit mode.
  */
 export function canEditCanvasMemory({
-  isReadOnly,
   canUpdateCanvas,
+  isTemplate,
+  canvasDeletedRemotely,
   isViewingLiveVersion,
   isViewingDraftVersion,
 }: {
-  isReadOnly: boolean;
   canUpdateCanvas: boolean;
+  isTemplate: boolean;
+  canvasDeletedRemotely: boolean;
   isViewingLiveVersion: boolean;
   isViewingDraftVersion: boolean;
 }): boolean {
-  return !isReadOnly && canUpdateCanvas && isViewingLiveVersion && !isViewingDraftVersion;
+  return canUpdateCanvas && !isTemplate && !canvasDeletedRemotely && isViewingLiveVersion && !isViewingDraftVersion;
 }


### PR DESCRIPTION
## Summary

Locks the Console and Memory tabs when in read mode. For the Console, there's a special case to allow for action buttons to be interacted, since what blocks them is the canvas running, not the edit mode.

Resolves #5012