### PR TITLE
feat: consolidate canvas and console edit controls layout

### DIFF
--- a/web_src/src/components/AgentSidebar/ModeToggle.tsx
+++ b/web_src/src/components/AgentSidebar/ModeToggle.tsx
@@ -19,14 +19,14 @@ const modeConfig = {
 } as const;
 
 function indicatorClasses(mode: AgentMode): string {
-  if (mode === "builder") return "bg-orange-100 border-orange-900";
+  if (mode === "builder") return "border-0 bg-[var(--purple)]";
   if (mode === "operator") return "bg-slate-500 border-transparent";
   return "bg-white border-transparent";
 }
 
 function labelColor(key: AgentMode, isActive: boolean): string {
   if (!isActive) return "text-slate-600 hover:text-slate-700";
-  if (key === "builder") return "text-orange-900";
+  if (key === "builder") return "text-white";
   if (key === "operator") return "text-white";
   return "text-slate-900";
 }

--- a/web_src/src/components/zoom-slider.tsx
+++ b/web_src/src/components/zoom-slider.tsx
@@ -132,7 +132,7 @@ export const ZoomSlider = memo(function ZoomSlider({
   }, [zoomIn, zoomOut, zoomTo, fitView, handleScreenshot, screenshotName]);
 
   const baseClassName = cn(
-    "bg-white text-gray-800 outline-1 outline-slate-950/15 flex items-center gap-0.5 rounded-md p-0.5 h-8",
+    "bg-white text-gray-800 outline-1 outline-slate-950/15 flex items-center gap-0.5 rounded-md p-0.5 h-7",
     orientation === "horizontal" ? "flex-row" : "flex-col",
     className,
   );
@@ -142,7 +142,7 @@ export const ZoomSlider = memo(function ZoomSlider({
       <div className={cn("flex items-center gap-1", orientation === "horizontal" ? "flex-row" : "flex-col-reverse")}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className="h-8 w-8" onClick={() => zoomOut({ duration: 300 })}>
+            <Button variant="ghost" size="icon-sm" className="h-7 w-7" onClick={() => zoomOut({ duration: 300 })}>
               <Minus className="h-3 w-3" />
             </Button>
           </TooltipTrigger>
@@ -166,7 +166,7 @@ export const ZoomSlider = memo(function ZoomSlider({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className="h-8 w-8" onClick={() => zoomIn({ duration: 300 })}>
+            <Button variant="ghost" size="icon-sm" className="h-7 w-7" onClick={() => zoomIn({ duration: 300 })}>
               <Plus className="h-3 w-3" />
             </Button>
           </TooltipTrigger>
@@ -178,7 +178,7 @@ export const ZoomSlider = memo(function ZoomSlider({
           <Button
             className={cn(
               "tabular-nums text-xs",
-              orientation === "horizontal" ? "w-[50px] min-w-[50px] h-8" : "h-[40px] w-[40px]",
+              orientation === "horizontal" ? "w-[50px] min-w-[50px] h-7" : "h-[40px] w-[40px]",
             )}
             variant="ghost"
             onClick={() => zoomTo(1, { duration: 300 })}
@@ -190,7 +190,7 @@ export const ZoomSlider = memo(function ZoomSlider({
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon-sm" className="h-8 w-8" onClick={() => fitView({ duration: 300 })}>
+          <Button variant="ghost" size="icon-sm" className="h-7 w-7" onClick={() => fitView({ duration: 300 })}>
             <Eye className="h-3 w-3" />
           </Button>
         </TooltipTrigger>
@@ -200,7 +200,7 @@ export const ZoomSlider = memo(function ZoomSlider({
       {screenshotName && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className="h-8 w-8" onClick={handleScreenshot}>
+            <Button variant="ghost" size="icon-sm" className="h-7 w-7" onClick={handleScreenshot}>
               <Camera className="h-3 w-3" />
             </Button>
           </TooltipTrigger>
@@ -210,7 +210,7 @@ export const ZoomSlider = memo(function ZoomSlider({
       {onSnapToGridToggle && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className="h-8 w-8" onClick={onSnapToGridToggle}>
+            <Button variant="ghost" size="icon-sm" className="h-7 w-7" onClick={onSnapToGridToggle}>
               {isSnapToGridEnabled ? <CircleDot className="h-3 w-3" /> : <CircleDotDashed className="h-3 w-3" />}
             </Button>
           </TooltipTrigger>

--- a/web_src/src/pages/workflowv2/CanvasYamlModal.spec.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlModal.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CanvasYamlModal } from "./CanvasYamlModal";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value }: { value?: string }) => <pre data-testid="monaco-stub">{value}</pre>,
+}));
+
+describe("CanvasYamlModal", () => {
+  it("shows a dismissible dialog even before YAML content is available", () => {
+    render(<CanvasYamlModal open onOpenChange={vi.fn()} onCopy={vi.fn()} onDownload={vi.fn()} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Canvas YAML is not available yet.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Download" })).toBeDisabled();
+  });
+});

--- a/web_src/src/pages/workflowv2/CanvasYamlModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlModal.tsx
@@ -1,0 +1,133 @@
+import { Copy, Download, Upload } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+
+import { Editor } from "@monaco-editor/react";
+import { ImportYamlIntoCanvasDialog } from "./ImportYamlIntoCanvasDialog";
+
+export type CanvasYamlModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+
+  yamlText?: string;
+  filename?: string;
+  onCopy?: () => void;
+  onDownload?: () => void;
+  onImport?: (data: { nodes: unknown[]; edges: unknown[] }) => Promise<void>;
+  isImporting?: boolean;
+};
+
+export function CanvasYamlModal(props: CanvasYamlModalProps) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent size="large" className="flex h-full max-h-[90vh] w-[90vw] flex-col gap-0 overflow-hidden p-0">
+        <DialogTitle className="sr-only">Canvas YAML</DialogTitle>
+
+        <div className="flex h-full flex-col">
+          <div className="flex items-center justify-between border-b border-gray-200 bg-white px-4 py-2">
+            <span className="font-mono text-sm text-gray-600">{props.filename ?? "Canvas YAML"}</span>
+            <div className="mr-8 flex items-center gap-2">
+              <ImportButton {...props} />
+              <CopyButton {...props} />
+              <DownloadButton {...props} />
+            </div>
+          </div>
+
+          <YamlEditor {...props} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function YamlEditor(props: CanvasYamlModalProps) {
+  if (props.yamlText === undefined) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center bg-white p-8 text-sm text-gray-500">
+        Canvas YAML is not available yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="canvas-yaml-monaco h-full min-h-0 min-w-0">
+      <Editor
+        height="100%"
+        language="yaml"
+        value={props.yamlText}
+        theme="vs"
+        options={{
+          readOnly: true,
+          domReadOnly: true,
+          minimap: { enabled: false },
+          fontSize: 13,
+          lineNumbers: "on",
+          wordWrap: "on",
+          folding: true,
+          scrollBeyondLastLine: false,
+          renderWhitespace: "boundary",
+          smoothScrolling: true,
+          tabSize: 2,
+          renderLineHighlight: "line",
+          renderLineHighlightOnlyWhenFocus: false,
+        }}
+      />
+    </div>
+  );
+}
+
+function ImportButton(props: CanvasYamlModalProps) {
+  if (!props.onImport) {
+    return null;
+  }
+
+  return <ImportButtonWithDialog onImport={props.onImport} isImporting={props.isImporting} />;
+}
+
+type ImportButtonWithDialogProps = {
+  onImport: NonNullable<CanvasYamlModalProps["onImport"]>;
+  isImporting?: boolean;
+};
+
+function ImportButtonWithDialog({ onImport, isImporting }: ImportButtonWithDialogProps) {
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setIsImportDialogOpen(true)}>
+        <Upload />
+        Import
+      </Button>
+      <ImportYamlIntoCanvasDialog
+        open={isImportDialogOpen}
+        onOpenChange={setIsImportDialogOpen}
+        onImport={onImport}
+        isImporting={isImporting}
+      />
+    </>
+  );
+}
+
+function CopyButton(props: CanvasYamlModalProps) {
+  if (!props.onCopy) return null;
+
+  return (
+    <Button variant="outline" size="sm" onClick={props.onCopy} disabled={props.yamlText === undefined}>
+      <Copy />
+      Copy
+    </Button>
+  );
+}
+
+function DownloadButton(props: CanvasYamlModalProps) {
+  if (!props.onDownload) return null;
+
+  return (
+    <Button variant="outline" size="sm" onClick={props.onDownload} disabled={props.yamlText === undefined}>
+      <Download />
+      Download
+    </Button>
+  );
+}

--- a/web_src/src/pages/workflowv2/ImportYamlIntoCanvasDialog.spec.tsx
+++ b/web_src/src/pages/workflowv2/ImportYamlIntoCanvasDialog.spec.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { analytics } from "@/lib/analytics";
+import { ImportYamlIntoCanvasDialog } from "./ImportYamlIntoCanvasDialog";
+
+vi.mock("@/lib/analytics", () => ({
+  analytics: {
+    yamlImport: vi.fn(),
+  },
+}));
+
+describe("ImportYamlIntoCanvasDialog", () => {
+  it("keeps the dialog open and skips analytics when import fails", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ImportYamlIntoCanvasDialog
+        open
+        onOpenChange={onOpenChange}
+        onImport={vi.fn().mockRejectedValue(new Error("Save failed"))}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("YAML definition"), {
+      target: {
+        value: "apiVersion: v1\nkind: Canvas\nspec:\n  nodes: []\n  edges: []",
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Import" }));
+
+    expect(await screen.findByText("Save failed")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(analytics.yamlImport).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/workflowv2/ImportYamlIntoCanvasDialog.tsx
+++ b/web_src/src/pages/workflowv2/ImportYamlIntoCanvasDialog.tsx
@@ -1,0 +1,247 @@
+/**
+ * Dialog for importing a YAML definition into an existing canvas.
+ *
+ * Accepts either a file upload (.yaml / .yml) or pasted text, validates the
+ * content against the v1 Canvas schema, and hands the parsed nodes + edges
+ * back to the caller via `onImport`.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { analytics } from "@/lib/analytics";
+import { AlertCircle, FileText, Upload } from "lucide-react";
+import * as yaml from "js-yaml";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ParsedCanvas {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    description?: string;
+  };
+  spec?: {
+    nodes?: unknown[];
+    edges?: unknown[];
+  };
+}
+
+function validateCanvasYaml(parsed: ParsedCanvas): string | null {
+  if (parsed.apiVersion && parsed.apiVersion !== "v1") {
+    return `Unsupported apiVersion "${parsed.apiVersion}". Only "v1" is supported.`;
+  }
+
+  if (parsed.kind && parsed.kind !== "Canvas") {
+    return `Unsupported kind "${parsed.kind}". Only "Canvas" is supported.`;
+  }
+
+  if (!parsed.spec || !Array.isArray(parsed.spec.nodes)) {
+    return "YAML must contain a spec with a nodes array. Is this a valid Canvas definition?";
+  }
+
+  return null;
+}
+
+function parseCanvasYaml(text: string): { data: { nodes: unknown[]; edges: unknown[] } } | { error: string } {
+  const trimmed = text.trim();
+  if (!trimmed) return { error: "Please provide a YAML definition." };
+
+  let parsed: ParsedCanvas;
+  try {
+    parsed = yaml.load(trimmed) as ParsedCanvas;
+  } catch (error) {
+    return { error: `Invalid YAML syntax: ${error instanceof Error ? error.message : "Unknown error"}` };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { error: "YAML content must be a valid object." };
+  }
+
+  const validationError = validateCanvasYaml(parsed);
+  if (validationError) return { error: validationError };
+
+  return {
+    data: {
+      nodes: (parsed.spec?.nodes as unknown[]) || [],
+      edges: (parsed.spec?.edges as unknown[]) || [],
+    },
+  };
+}
+
+export interface ImportYamlDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImport: (data: { nodes: unknown[]; edges: unknown[] }) => Promise<void>;
+  isImporting?: boolean;
+}
+
+function ImportYamlFileUpload({
+  fileName,
+  fileInputRef,
+  onFileSelect,
+}: {
+  fileName: string | null;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
+  return (
+    <div>
+      <Label htmlFor="yaml-import-file-input" className="mb-2">
+        Upload YAML file
+      </Label>
+      <div
+        className="flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-gray-300 p-4 transition-colors hover:border-gray-400"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <Upload className="h-5 w-5 text-gray-400" />
+        <div className="flex-1">
+          {fileName ? (
+            <div className="flex items-center gap-2">
+              <FileText className="h-4 w-4 text-gray-500" />
+              <span className="text-sm text-gray-700">{fileName}</span>
+            </div>
+          ) : (
+            <span className="text-sm text-gray-500">Click to select a .yaml or .yml file</span>
+          )}
+        </div>
+        <input
+          ref={fileInputRef}
+          id="yaml-import-file-input"
+          type="file"
+          accept=".yaml,.yml"
+          className="hidden"
+          onChange={onFileSelect}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ImportYamlIntoCanvasDialog({ open, onOpenChange, onImport, isImporting }: ImportYamlDialogProps) {
+  const [yamlText, setYamlText] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const reset = useCallback(() => {
+    setYamlText("");
+    setParseError(null);
+    setFileName(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        reset();
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, reset],
+  );
+
+  const handleFileSelect = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!file.name.endsWith(".yaml") && !file.name.endsWith(".yml")) {
+      setParseError("Please select a .yaml or .yml file.");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const content = event.target?.result as string;
+      setYamlText(content);
+      setFileName(file.name);
+      setParseError(null);
+    };
+    reader.onerror = () => {
+      setParseError("Failed to read the file.");
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    setParseError(null);
+    const result = parseCanvasYaml(yamlText);
+    if ("error" in result) {
+      setParseError(result.error);
+      return;
+    }
+
+    try {
+      await onImport(result.data);
+      analytics.yamlImport();
+      handleOpenChange(false);
+    } catch (error) {
+      setParseError(error instanceof Error ? error.message : "Import failed. Please try again.");
+    }
+  }, [yamlText, onImport, handleOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Import YAML</DialogTitle>
+          <DialogDescription>Upload a YAML file or paste a Canvas definition to update this canvas.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <ImportYamlFileUpload fileName={fileName} fileInputRef={fileInputRef} onFileSelect={handleFileSelect} />
+
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-xs text-gray-400">or paste YAML below</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+
+          <div>
+            <Label htmlFor="yaml-import-paste-input" className="mb-2">
+              YAML definition
+            </Label>
+            <Textarea
+              id="yaml-import-paste-input"
+              value={yamlText}
+              onChange={(event) => {
+                setYamlText(event.target.value);
+                setParseError(null);
+                setFileName(null);
+              }}
+              placeholder={`apiVersion: v1\nkind: Canvas\nmetadata:\n  name: my-canvas\nspec:\n  nodes: []\n  edges: []`}
+              rows={12}
+              className="max-h-[50vh] overflow-y-auto font-mono text-sm"
+            />
+          </div>
+
+          {parseError ? (
+            <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 p-3">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+              <span className="text-sm text-red-700">{parseError}</span>
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport} disabled={!yamlText.trim() || isImporting}>
+            {isImporting ? "Importing..." : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/DashboardOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import type { CanvasesDashboardLayoutItem, CanvasesDashboardPanel } from "@/api-client";
 import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
+import { RightSideControls } from "@/ui/CanvasPage/RightSideControls";
 
 import type { SuperplaneComponentsNode } from "@/api-client";
 import type {
@@ -55,6 +56,10 @@ export type DashboardOverlayProps = {
   nodeStatuses?: Record<string, DashboardNodeStatus | undefined>;
   /** Callback invoked when a manual-run chip is clicked. */
   onTriggerNode?: DashboardContextValue["onTriggerNode"];
+  showDashboardEditControls?: boolean;
+  onDashboardAddPanel?: () => void;
+  onDashboardOpenYaml?: () => void;
+  dashboardYamlReadOnly?: boolean;
 };
 
 export function DashboardOverlay({
@@ -73,6 +78,10 @@ export function DashboardOverlay({
   canvasNodes,
   nodeStatuses,
   onTriggerNode,
+  showDashboardEditControls = false,
+  onDashboardAddPanel,
+  onDashboardOpenYaml,
+  dashboardYamlReadOnly,
 }: DashboardOverlayProps) {
   const updateDashboardMutationRef = useRef(updateDashboardMutation);
   updateDashboardMutationRef.current = updateDashboardMutation;
@@ -116,22 +125,34 @@ export function DashboardOverlay({
   // The dashboard overlay no longer renders its own toolbar so the white
   // strip is gone and the grid fills the available area.
   const overlayContent = (
-    <div
-      className="absolute bottom-0 top-[5rem] z-10 flex flex-col bg-slate-100"
-      style={{ left: leftOffset, right: 0 }}
-      data-testid="dashboard-overlay"
-    >
-      <div className="min-h-0 flex-1 overflow-auto">
-        <DashboardView
-          panels={panels}
-          layout={layout}
-          isLoading={dashboardQuery.isLoading}
-          errorMessage={dashboardQuery.error ? String(dashboardQuery.error) : undefined}
-          readOnly={readOnly}
-          onChange={handleChange}
-          addPanelDialogOpen={addPanelDialogOpen}
-          onAddPanelDialogOpenChange={onAddPanelDialogOpenChange}
-        />
+    <>
+      <div
+        className="absolute bottom-0 top-[5rem] z-10 flex flex-row bg-slate-100"
+        style={{ left: leftOffset, right: 0 }}
+        data-testid="dashboard-overlay"
+      >
+        <div className="min-h-0 flex-1 overflow-auto">
+          <DashboardView
+            panels={panels}
+            layout={layout}
+            isLoading={dashboardQuery.isLoading}
+            errorMessage={dashboardQuery.error ? String(dashboardQuery.error) : undefined}
+            readOnly={readOnly}
+            onChange={handleChange}
+            addPanelDialogOpen={addPanelDialogOpen}
+            onAddPanelDialogOpenChange={onAddPanelDialogOpenChange}
+          />
+        </div>
+        {showDashboardEditControls ? (
+          <RightSideControls
+            mode="edit"
+            layout="embedded"
+            dashboardEditControls
+            onDashboardAddPanel={onDashboardAddPanel}
+            onDashboardOpenYaml={onDashboardOpenYaml}
+            dashboardYamlReadOnly={dashboardYamlReadOnly}
+          />
+        ) : null}
       </div>
 
       <DashboardYamlModal
@@ -144,7 +165,7 @@ export function DashboardOverlay({
         onImport={canImportYaml ? handleImportYaml : undefined}
         isImporting={updateDashboardMutation.isPending}
       />
-    </div>
+    </>
   );
 
   if (!canvasId || !organizationId) {

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -59,7 +59,6 @@ import { useNodeHistory } from "@/hooks/useNodeHistory";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useQueueHistory } from "@/hooks/useQueueHistory";
 import { analytics } from "@/lib/analytics";
-// getColorClass moved to workflowPageHelpers
 import { filterVisibleConfiguration } from "@/lib/components";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getIntegrationWebhookUrl } from "@/lib/integrationUtils";
@@ -83,6 +82,7 @@ import { useDashboardTriggerNode } from "./dashboard/useDashboardTriggerNode";
 import { WorkflowDashboardOverlay } from "./dashboard/WorkflowDashboardOverlay";
 import { buildWorkflowFiles } from "./lib/canvas-files";
 import { WorkflowFilesOverlayLayer } from "./WorkflowFilesOverlayLayer";
+import { CanvasYamlModal } from "./CanvasYamlModal";
 import { useWorkflowViewSearchParams } from "./useWorkflowViewSearchParams";
 import { useFilesModeActions } from "./useFilesModeActions";
 import { useMemoryModeActions } from "./useMemoryModeActions";
@@ -114,12 +114,14 @@ import { resolveExecutionErrors } from "./mappers/dash0";
 import type { TriggerActionModal } from "./mappers/types";
 import { useCancelExecutionHandler } from "./useCancelExecutionHandler";
 import { useCanvasYamlDiffModal } from "./useCanvasYamlDiffModal";
+import { useCanvasYaml } from "./useCanvasYaml";
 import { useCanvasConsoleVersionDiff, useDraftVisualDiff } from "./useDraftVisualDiff";
 import { useExecutionChainData } from "./useExecutionChainData";
 import { useOnCancelQueueItemHandler } from "./useOnCancelQueueItemHandler";
 import { useRunCanvasData, useRunCanvasPresentation } from "./useRunCanvasData";
 import { useSelectedRunCanvas } from "./useSelectedRunCanvas";
 import {
+  clearComponentSidebarSearchParams,
   getExitEditModeDisabledTooltip,
   getRunActionState,
   getWorkflowViewPresentation,
@@ -149,12 +151,6 @@ const LOCAL_CANVAS_LIFECYCLE_ECHO_TTL_MS = 5000;
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
 const EMPTY_CANVAS_EDGES: ComponentsEdge[] = [];
-
-function clearComponentSidebarSearchParams(params: URLSearchParams): URLSearchParams {
-  params.delete("sidebar");
-  params.delete("node");
-  return params;
-}
 
 type ChangeRequestAction = "ACTION_APPROVE" | "ACTION_UNAPPROVE" | "ACTION_PUBLISH" | "ACTION_REJECT" | "ACTION_REOPEN";
 type CanvasSaveResult = {
@@ -591,6 +587,7 @@ export function WorkflowPageV2() {
   );
   /** After creating a change request, hide draft Discard until the user enters edit mode again. */
   const [suppressUnpublishedDraftDiscard, setSuppressUnpublishedDraftDiscard] = useState(false);
+  const [isYamlViewModalOpen, setIsYamlViewModalOpen] = useState(false);
   const [versionNodeDiffContext, setVersionNodeDiffContext] = useState<CanvasVersionNodeDiffContext | null>(null);
   const versionNodeDiffLiveChangeRequest = useMemo(() => {
     const fallback = versionNodeDiffContext?.changeRequest;
@@ -608,10 +605,6 @@ export function WorkflowPageV2() {
   }, [canvasChangeRequests, resolvingConflictChangeRequestId]);
   const createWorkflowMutation = useCreateCanvas(organizationId!);
 
-  // Warm up org users and roles cache so approval specs can pretty-print
-  // user IDs as emails and role names as display names.
-  // We don't use the values directly here; loading them populates the
-  // react-query cache which prepareApprovalNode reads from.
   useOrganizationRoles(organizationId!);
 
   /**
@@ -5263,7 +5256,20 @@ export function WorkflowPageV2() {
     [canvasNodesById],
   );
 
-  const canvasYamlPayload = useMemo(() => getYamlExportPayload(nodes), [getYamlExportPayload, nodes]);
+  const { yamlPayload: canvasYamlPayload, modalProps: canvasYamlModalProps } = useCanvasYaml({
+    canvasId: canvasId!,
+    organizationId: organizationId!,
+    open: isYamlViewModalOpen,
+    onOpenChange: setIsYamlViewModalOpen,
+    isImporting: hasLocalSaveActivity,
+    nodes,
+    getYamlExportPayload,
+    canvas,
+    isReadOnly,
+    handleSaveWorkflow,
+    onWorkflowImported: applyLocalWorkflowUpdate,
+  });
+
   const workflowFiles = useMemo(
     () =>
       buildWorkflowFiles({
@@ -5485,6 +5491,10 @@ export function WorkflowPageV2() {
           isDashboardMode={isDashboardMode}
           canActOnCanvas={canActOnCanvas}
           editLocked={isReadOnly}
+          showDashboardEditControls={isEditing}
+          onDashboardAddPanel={onDashboardAddPanel}
+          onDashboardOpenYaml={onDashboardOpenYaml}
+          dashboardYamlReadOnly={dashboardYamlReadOnly}
           dashboardQuery={dashboardQuery}
           updateDashboardMutation={updateDashboardMutation}
           addPanelDialogOpen={isDashboardAddPanelOpen}
@@ -5522,9 +5532,9 @@ export function WorkflowPageV2() {
           title={canvas?.metadata?.name || liveCanvas?.metadata?.name || (isTemplate ? "Template" : "Canvas")}
           headerBanner={headerBanner}
           canvasStateMode={canvasStateMode}
+          showCanvasSettingsMenu={canUpdateCanvas}
           onPreviewPreviousVersionViewDetails={handlePreviewPreviousVersionViewDetails}
           awaitingApprovalBanner={awaitingApprovalBanner}
-          showCanvasSettingsMenu={canUpdateCanvas}
           isVersionControlOpen={isVersionControlOpen}
           onOpenVersionControl={handleOpenVersionControl}
           hasAutoOpenedVersionControl={hasAutoOpenedVersionControl}
@@ -5621,9 +5631,7 @@ export function WorkflowPageV2() {
           onExitRunsMode={handleExitRunsMode}
           onSelectDashboard={isTemplate ? undefined : handleSelectDashboardMode}
           onSelectFiles={isTemplate ? undefined : handleSelectFilesMode}
-          onDashboardAddPanel={onDashboardAddPanel}
-          onDashboardOpenYaml={onDashboardOpenYaml}
-          dashboardYamlReadOnly={dashboardYamlReadOnly}
+          onYamlOpen={() => setIsYamlViewModalOpen(true)}
           exitEditModeDisabled={exitEditModeDisabled}
           exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
           hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
@@ -5719,6 +5727,7 @@ export function WorkflowPageV2() {
           />
         ) : null}
       </div>
+      <CanvasYamlModal {...canvasYamlModalProps} />
       {yamlDiffModal}
       {resolvingConflictChangeRequest ? (
         <div className="fixed inset-0 z-[100] min-h-0 bg-slate-50">

--- a/web_src/src/pages/workflowv2/useCanvasYaml.spec.tsx
+++ b/web_src/src/pages/workflowv2/useCanvasYaml.spec.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CanvasesCanvas } from "@/api-client";
+import { useCanvasYaml } from "./useCanvasYaml";
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+  showSuccessToast: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  analytics: {
+    yamlExport: vi.fn(),
+  },
+}));
+
+const baseCanvas = {
+  metadata: { id: "canvas-1", name: "Preview" },
+  spec: {
+    nodes: [{ id: "old-node" }],
+    edges: [],
+  },
+} as unknown as CanvasesCanvas;
+
+function renderUseCanvasYaml(
+  overrides: Partial<Parameters<typeof useCanvasYaml>[0]> = {},
+  handleSaveWorkflow = vi.fn().mockResolvedValue({ status: "saved" }),
+) {
+  const onWorkflowImported = vi.fn();
+
+  const result = renderHook(() =>
+    useCanvasYaml({
+      canvasId: "canvas-1",
+      organizationId: "org-1",
+      open: true,
+      onOpenChange: vi.fn(),
+      isImporting: false,
+      nodes: [],
+      getYamlExportPayload: vi.fn().mockReturnValue({ yamlText: "spec: {}", filename: "canvas.yaml" }),
+      canvas: baseCanvas,
+      isReadOnly: false,
+      handleSaveWorkflow,
+      onWorkflowImported,
+      ...overrides,
+    }),
+  );
+
+  return { ...result, handleSaveWorkflow, onWorkflowImported };
+}
+
+describe("useCanvasYaml", () => {
+  it("syncs the imported workflow after a successful save", async () => {
+    const { result, handleSaveWorkflow, onWorkflowImported } = renderUseCanvasYaml();
+
+    await result.current.modalProps.onImport?.({
+      nodes: [{ id: "new-node" }],
+      edges: [{ source: "new-node", target: "next-node" }],
+    });
+
+    expect(handleSaveWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          nodes: [{ id: "new-node" }],
+          edges: [{ source: "new-node", target: "next-node" }],
+        }),
+      }),
+    );
+    expect(onWorkflowImported).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          nodes: [{ id: "new-node" }],
+          edges: [{ source: "new-node", target: "next-node" }],
+        }),
+      }),
+    );
+  });
+
+  it("rejects failed saves so the import dialog stays open", async () => {
+    const handleSaveWorkflow = vi.fn().mockResolvedValue({ status: "stale" });
+    const { result, onWorkflowImported } = renderUseCanvasYaml({}, handleSaveWorkflow);
+
+    await expect(result.current.modalProps.onImport?.({ nodes: [], edges: [] })).rejects.toThrow(
+      "The canvas changed while importing. Refresh and try again.",
+    );
+    expect(onWorkflowImported).not.toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/workflowv2/useCanvasYaml.spec.tsx
+++ b/web_src/src/pages/workflowv2/useCanvasYaml.spec.tsx
@@ -65,6 +65,7 @@ describe("useCanvasYaml", () => {
           edges: [{ source: "new-node", target: "next-node" }],
         }),
       }),
+      { showToast: false },
     );
     expect(onWorkflowImported).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/web_src/src/pages/workflowv2/useCanvasYaml.ts
+++ b/web_src/src/pages/workflowv2/useCanvasYaml.ts
@@ -1,0 +1,121 @@
+import { useCallback, useMemo } from "react";
+import type {
+  CanvasesCanvas,
+  SuperplaneComponentsEdge as ComponentsEdge,
+  SuperplaneComponentsNode as ComponentsNode,
+} from "@/api-client";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+import { analytics } from "@/lib/analytics";
+import type { CanvasNode } from "@/ui/CanvasPage";
+import type { CanvasYamlModalProps } from "./CanvasYamlModal";
+
+interface UseCanvasYamlParams {
+  canvasId: string;
+  organizationId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isImporting: boolean;
+  nodes: CanvasNode[];
+  getYamlExportPayload: (nodes: CanvasNode[]) => { yamlText: string; filename: string } | null;
+  canvas?: CanvasesCanvas | null;
+  isReadOnly: boolean;
+  handleSaveWorkflow: (
+    workflowToSave?: CanvasesCanvas,
+    options?: { showToast?: boolean },
+  ) => Promise<{ status: "saved" | "replaced" | "stale" } | undefined | void>;
+  onWorkflowImported: (workflow: CanvasesCanvas) => void;
+}
+
+export function useCanvasYaml({
+  canvasId,
+  organizationId,
+  open,
+  onOpenChange,
+  isImporting,
+  nodes,
+  getYamlExportPayload,
+  canvas,
+  isReadOnly,
+  handleSaveWorkflow,
+  onWorkflowImported,
+}: UseCanvasYamlParams) {
+  const yamlPayload = useMemo(() => getYamlExportPayload(nodes), [getYamlExportPayload, nodes]);
+
+  const importYamlGuardError = !canvas || !organizationId || !canvasId ? "Canvas data is not available" : null;
+
+  const handleYamlViewCopy = useCallback(async () => {
+    if (!yamlPayload) return;
+
+    try {
+      await navigator.clipboard.writeText(yamlPayload.yamlText);
+      showSuccessToast("YAML copied to clipboard");
+    } catch {
+      showErrorToast("Failed to copy YAML to clipboard");
+    }
+  }, [yamlPayload]);
+
+  const handleYamlViewDownload = useCallback(() => {
+    if (!yamlPayload) return;
+
+    const blob = new Blob([yamlPayload.yamlText], { type: "text/yaml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = yamlPayload.filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    showSuccessToast("Canvas exported as YAML");
+    analytics.yamlExport(canvasId, organizationId);
+  }, [yamlPayload, canvasId, organizationId]);
+
+  const handleImportYaml = useCallback(
+    async (data: { nodes: unknown[]; edges: unknown[] }) => {
+      if (importYamlGuardError) throw new Error(importYamlGuardError);
+
+      const updatedWorkflow = {
+        ...canvas!,
+        spec: {
+          ...canvas!.spec,
+          nodes: data.nodes as ComponentsNode[],
+          edges: data.edges as ComponentsEdge[],
+        },
+      };
+
+      const result = await handleSaveWorkflow(updatedWorkflow);
+      if (result?.status !== "saved") {
+        throw new Error(getImportFailureMessage(result?.status));
+      }
+
+      onWorkflowImported(updatedWorkflow);
+    },
+    [importYamlGuardError, canvas, handleSaveWorkflow, onWorkflowImported],
+  );
+
+  return {
+    yamlPayload,
+    modalProps: {
+      open,
+      onOpenChange,
+      yamlText: yamlPayload?.yamlText,
+      filename: yamlPayload?.filename,
+      onCopy: handleYamlViewCopy,
+      onDownload: handleYamlViewDownload,
+      onImport: isReadOnly ? undefined : handleImportYaml,
+      isImporting,
+    } satisfies CanvasYamlModalProps,
+  };
+}
+
+function getImportFailureMessage(status?: "replaced" | "stale") {
+  if (status === "stale") {
+    return "The canvas changed while importing. Refresh and try again.";
+  }
+
+  if (status === "replaced") {
+    return "A newer canvas save replaced this import. Try importing again.";
+  }
+
+  return "YAML import could not be saved. Try again.";
+}

--- a/web_src/src/pages/workflowv2/useCanvasYaml.ts
+++ b/web_src/src/pages/workflowv2/useCanvasYaml.ts
@@ -83,7 +83,7 @@ export function useCanvasYaml({
         },
       };
 
-      const result = await handleSaveWorkflow(updatedWorkflow);
+      const result = await handleSaveWorkflow(updatedWorkflow, { showToast: false });
       if (result?.status !== "saved") {
         throw new Error(getImportFailureMessage(result?.status));
       }

--- a/web_src/src/pages/workflowv2/viewState.ts
+++ b/web_src/src/pages/workflowv2/viewState.ts
@@ -18,6 +18,12 @@ export function readStoredBoolean(key: string): boolean {
   }
 }
 
+export function clearComponentSidebarSearchParams(params: URLSearchParams): URLSearchParams {
+  params.delete("sidebar");
+  params.delete("node");
+  return params;
+}
+
 export function getWorkflowHeaderMode({
   isDashboardMode,
   isRunsMode,

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -51,14 +51,6 @@ export interface HeaderProps {
   onSelectMemory?: () => void;
   /** Provided when Files is available as a first-class tab; opens the Files view. */
   onSelectFiles?: () => void;
-  /** When set with `mode === "dashboard"` and editing, shows Add panel in the secondary header. */
-  onDashboardAddPanel?: () => void;
-  /** When set with `mode === "dashboard"` and editing, shows the YAML button in the secondary header. */
-  onDashboardOpenYaml?: () => void;
-  /** When set with the Canvas tab active and editing, opens the add-component sidebar. */
-  onCanvasAddComponent?: () => void;
-  /** When true, the YAML button advertises read-only YAML view. Defaults to editable copy. */
-  dashboardYamlReadOnly?: boolean;
   /** Label for the publish/propose-change button in version edit mode. Defaults to "Publish". */
   publishVersionLabel?: string;
   /** When true, shows the Discard control next to Publish in version edit mode (draft differs from live). */
@@ -80,25 +72,18 @@ export function Header(props: HeaderProps) {
       <PageHeader
         organizationId={props.organizationId}
         headerTitle={headerTitle}
-        showCanvasSettingsMenu={props.showCanvasSettingsMenu}
         mode={props.mode}
         isEditing={props.isEditing}
         hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
-        onDiscardVersion={props.onDiscardVersion}
-        discardVersionDisabled={props.discardVersionDisabled}
-        discardVersionDisabledTooltip={props.discardVersionDisabledTooltip}
         onExitEditMode={props.onExitEditMode}
         exitEditModeDisabled={props.exitEditModeDisabled}
         exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
-        onPublishVersion={props.onPublishVersion}
-        publishVersionLabel={props.publishVersionLabel}
-        publishVersionDisabled={props.publishVersionDisabled}
-        publishVersionDisabledTooltip={props.publishVersionDisabledTooltip}
         onEnterEditMode={props.onEnterEditMode}
         enterEditModeDisabled={props.enterEditModeDisabled}
         enterEditModeDisabledTooltip={props.enterEditModeDisabledTooltip}
         onDiscardDraftAndStartEdit={props.onDiscardDraftAndStartEdit}
         unpublishedDraftUpdatedAt={props.unpublishedDraftUpdatedAt}
+        showCanvasSettingsMenu={props.showCanvasSettingsMenu}
       />
 
       <SecondaryHeader {...props} />
@@ -109,25 +94,18 @@ export function Header(props: HeaderProps) {
 function PageHeader({
   organizationId,
   headerTitle,
-  showCanvasSettingsMenu = true,
   mode,
   isEditing = false,
   hasUnpublishedDraftChanges,
-  onDiscardVersion,
-  discardVersionDisabled,
-  discardVersionDisabledTooltip,
   onExitEditMode,
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
-  onPublishVersion,
-  publishVersionLabel,
-  publishVersionDisabled,
-  publishVersionDisabledTooltip,
   onEnterEditMode,
   enterEditModeDisabled,
   enterEditModeDisabledTooltip,
   onDiscardDraftAndStartEdit,
   unpublishedDraftUpdatedAt,
+  showCanvasSettingsMenu = true,
 }: {
   organizationId?: string;
   headerTitle: string;
@@ -135,16 +113,9 @@ function PageHeader({
   mode?: HeaderMode;
   isEditing?: boolean;
   hasUnpublishedDraftChanges?: boolean;
-  onDiscardVersion?: () => void;
-  discardVersionDisabled?: boolean;
-  discardVersionDisabledTooltip?: string;
   onExitEditMode?: () => void;
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
-  onPublishVersion?: () => void;
-  publishVersionLabel?: string;
-  publishVersionDisabled?: boolean;
-  publishVersionDisabledTooltip?: string;
   onEnterEditMode?: () => void;
   enterEditModeDisabled?: boolean;
   enterEditModeDisabledTooltip?: string;
@@ -155,7 +126,7 @@ function PageHeader({
   const activeCanvasId = canvasIdParam || workflowId;
 
   return (
-    <div className="relative z-20 flex h-10 items-center border-b border-slate-950/15 px-3 sm:px-4">
+    <div className="relative z-20 flex h-10 items-center border-b border-slate-950/15 px-2 sm:px-3">
       <div className="relative z-10 flex min-w-0 shrink-0 items-center">
         <OrganizationMenuButton organizationId={organizationId} />
       </div>
@@ -186,17 +157,9 @@ function PageHeader({
         ) : null}
         {isEditing ? (
           <EditModeTopHeaderActions
-            hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
-            onDiscardVersion={onDiscardVersion}
-            discardVersionDisabled={discardVersionDisabled}
-            discardVersionDisabledTooltip={discardVersionDisabledTooltip}
             onExitEditMode={onExitEditMode}
             exitEditModeDisabled={exitEditModeDisabled}
             exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
-            onPublishVersion={onPublishVersion}
-            publishVersionLabel={publishVersionLabel}
-            publishVersionDisabled={publishVersionDisabled}
-            publishVersionDisabledTooltip={publishVersionDisabledTooltip}
           />
         ) : null}
       </div>
@@ -225,7 +188,7 @@ function SecondaryHeader(props: HeaderProps) {
   const editing = props.isEditing ?? props.mode === "version-edit";
 
   return (
-    <div className="relative z-10 flex h-10 items-center gap-3 border-b border-slate-950/15 bg-white px-4">
+    <div className="relative z-10 flex h-10 items-center gap-3 border-b border-slate-950/15 bg-white px-3">
       <CanvasToolSidebarTrigger toolSidebarState={props.toolSidebarState} />
 
       <div className="pointer-events-none absolute inset-x-0 flex justify-center px-16 sm:px-24">

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -1,6 +1,6 @@
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 import { Button } from "../button";
 import { DiffSummaryHoverCard } from "./components/DiffSummaryHoverCard";
@@ -20,13 +20,18 @@ export function SecondaryHeaderActions({
   visualDiffEnabled,
   draftVisualDiff,
   onToggleVisualDiff,
-  onDashboardAddPanel,
-  onCanvasAddComponent,
+  onDiscardVersion,
+  discardVersionDisabled,
+  discardVersionDisabledTooltip,
+  onPublishVersion,
+  publishVersionLabel,
+  publishVersionDisabled,
+  publishVersionDisabledTooltip,
 }: HeaderProps) {
   const onCanvasTab = mode === "version-live" || mode === "version-edit";
 
   return (
-    <div className="relative z-10 ml-auto flex shrink-0 items-center gap-2">
+    <div className="relative z-10 ml-auto flex shrink-0 items-center gap-1.5">
       {mode === "default" && onSave && !saveButtonHidden ? (
         <SaveButton
           onSave={onSave}
@@ -36,84 +41,70 @@ export function SecondaryHeaderActions({
         />
       ) : null}
 
-      {isEditing && onCanvasTab ? (
-        <EditModeCanvasSecondaryActions
-          hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
-          onShowDiff={onShowDiff}
-          visualDiffEnabled={visualDiffEnabled}
-          draftVisualDiff={draftVisualDiff}
-          onToggleVisualDiff={onToggleVisualDiff}
-          onCanvasAddComponent={onCanvasAddComponent}
-        />
-      ) : null}
-
-      {isEditing && mode === "dashboard" ? (
-        <EditModeDashboardSecondaryActions onDashboardAddPanel={onDashboardAddPanel} />
+      {isEditing ? (
+        <>
+          {onCanvasTab && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
+            <DiffSummaryHoverCard
+              diffCounts={draftVisualDiff.diffCounts}
+              visualDiffEnabled={visualDiffEnabled}
+              onToggleVisualDiff={onToggleVisualDiff}
+              diffToggles={draftVisualDiff.diffToggles}
+              onShowDiff={onShowDiff}
+            />
+          ) : null}
+          <EditModePublishDiscardActions
+            hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+            onDiscardVersion={onDiscardVersion}
+            discardVersionDisabled={discardVersionDisabled}
+            discardVersionDisabledTooltip={discardVersionDisabledTooltip}
+            onPublishVersion={onPublishVersion}
+            publishVersionLabel={publishVersionLabel}
+            publishVersionDisabled={publishVersionDisabled}
+            publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+          />
+        </>
       ) : null}
     </div>
   );
 }
 
-function EditModeCanvasSecondaryActions({
+function EditModePublishDiscardActions({
   hasUnpublishedDraftChanges,
-  onShowDiff,
-  visualDiffEnabled,
-  draftVisualDiff,
-  onToggleVisualDiff,
-  onCanvasAddComponent,
+  onDiscardVersion,
+  discardVersionDisabled,
+  discardVersionDisabledTooltip,
+  onPublishVersion,
+  publishVersionLabel,
+  publishVersionDisabled,
+  publishVersionDisabledTooltip,
 }: Pick<
   HeaderProps,
   | "hasUnpublishedDraftChanges"
-  | "onShowDiff"
-  | "visualDiffEnabled"
-  | "draftVisualDiff"
-  | "onToggleVisualDiff"
-  | "onCanvasAddComponent"
+  | "onDiscardVersion"
+  | "discardVersionDisabled"
+  | "discardVersionDisabledTooltip"
+  | "onPublishVersion"
+  | "publishVersionLabel"
+  | "publishVersionDisabled"
+  | "publishVersionDisabledTooltip"
 >) {
   return (
-    <>
-      {hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
-        <DiffSummaryHoverCard
-          diffCounts={draftVisualDiff.diffCounts}
-          visualDiffEnabled={visualDiffEnabled}
-          onToggleVisualDiff={onToggleVisualDiff}
-          diffToggles={draftVisualDiff.diffToggles}
-          onShowDiff={onShowDiff}
+    <div className="flex items-center gap-1.5">
+      {hasUnpublishedDraftChanges ? (
+        <DiscardDraftButton
+          onDiscard={() => onDiscardVersion?.()}
+          disabled={discardVersionDisabled || !onDiscardVersion}
+          disabledTooltip={discardVersionDisabledTooltip}
         />
       ) : null}
-
-      {onCanvasAddComponent ? (
-        <UIButton
-          type="button"
-          size="sm"
-          variant="default"
-          onClick={() => onCanvasAddComponent()}
-          data-testid="canvas-add-component-button"
-        >
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          Add component
-        </UIButton>
-      ) : null}
-    </>
-  );
-}
-
-function EditModeDashboardSecondaryActions({ onDashboardAddPanel }: Pick<HeaderProps, "onDashboardAddPanel">) {
-  return (
-    <>
-      {onDashboardAddPanel ? (
-        <UIButton
-          type="button"
-          size="sm"
-          variant="default"
-          onClick={() => onDashboardAddPanel()}
-          data-testid="dashboard-add-panel"
-        >
-          <Plus className="mr-1 h-3.5 w-3.5" />
-          Add panel
-        </UIButton>
-      ) : null}
-    </>
+      <PublishVersionButton
+        onPublish={() => onPublishVersion?.()}
+        label={publishVersionLabel || "Publish"}
+        disabled={publishVersionDisabled || !onPublishVersion}
+        publishVersionDisabled={!!publishVersionDisabled}
+        publishVersionDisabledTooltip={publishVersionDisabledTooltip}
+      />
+    </div>
   );
 }
 
@@ -160,55 +151,20 @@ export function LiveModeTopHeaderActions({
 }
 
 export function EditModeTopHeaderActions({
-  hasUnpublishedDraftChanges,
-  onDiscardVersion,
-  discardVersionDisabled,
-  discardVersionDisabledTooltip,
   onExitEditMode,
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
-  onPublishVersion,
-  publishVersionLabel,
-  publishVersionDisabled,
-  publishVersionDisabledTooltip,
-}: Pick<
-  HeaderProps,
-  | "hasUnpublishedDraftChanges"
-  | "onDiscardVersion"
-  | "discardVersionDisabled"
-  | "discardVersionDisabledTooltip"
-  | "onExitEditMode"
-  | "exitEditModeDisabled"
-  | "exitEditModeDisabledTooltip"
-  | "onPublishVersion"
-  | "publishVersionLabel"
-  | "publishVersionDisabled"
-  | "publishVersionDisabledTooltip"
->) {
+}: Pick<HeaderProps, "onExitEditMode" | "exitEditModeDisabled" | "exitEditModeDisabledTooltip">) {
+  if (!onExitEditMode) {
+    return null;
+  }
+
   return (
-    <div className="flex items-center gap-2">
-      {hasUnpublishedDraftChanges ? (
-        <DiscardDraftButton
-          onDiscard={() => onDiscardVersion?.()}
-          disabled={discardVersionDisabled || !onDiscardVersion}
-          disabledTooltip={discardVersionDisabledTooltip}
-        />
-      ) : null}
-      {onExitEditMode ? (
-        <ExitEditButton
-          onClick={() => onExitEditMode()}
-          disabled={!!exitEditModeDisabled}
-          disabledTooltip={exitEditModeDisabledTooltip}
-        />
-      ) : null}
-      <PublishVersionButton
-        onPublish={() => onPublishVersion?.()}
-        label={publishVersionLabel || "Publish"}
-        disabled={publishVersionDisabled || !onPublishVersion}
-        publishVersionDisabled={!!publishVersionDisabled}
-        publishVersionDisabledTooltip={publishVersionDisabledTooltip}
-      />
-    </div>
+    <ExitEditButton
+      onClick={() => onExitEditMode()}
+      disabled={!!exitEditModeDisabled}
+      disabledTooltip={exitEditModeDisabledTooltip}
+    />
   );
 }
 
@@ -267,8 +223,13 @@ function ExitEditButton({
       onClick={onClick}
       disabled={disabled}
       data-testid="canvas-exit-edit-button"
+      className={cn(
+        "rounded-full border-0 bg-[var(--purple)] px-3.5 text-[13px] text-white shadow-none",
+        "hover:bg-[var(--purple)] hover:text-white hover:brightness-95",
+        "focus-visible:border-[var(--purple)] focus-visible:ring-[var(--purple)]/30",
+      )}
     >
-      Exit edit
+      Exit Edit
     </UIButton>
   );
 

--- a/web_src/src/ui/CanvasPage/RightSideControls.tsx
+++ b/web_src/src/ui/CanvasPage/RightSideControls.tsx
@@ -1,35 +1,129 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Plus, StickyNote } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Code2, FileCode, FilePlus, Plus } from "lucide-react";
 import { memo, type ReactNode } from "react";
 
 export type RightSideControlsProps = {
   mode: "live" | "edit";
-  /** When true, only the floating Add note control is shown (component/YAML live in the header while editing). */
-  addNoteOnly?: boolean;
+  /** When true, shows canvas edit controls in the right rail. */
+  canvasEditControls?: boolean;
+  /** When true, shows console edit controls in the right rail. */
+  dashboardEditControls?: boolean;
+  /** Overlay on the canvas area (default) or embedded beside dashboard content. */
+  layout?: "overlay" | "embedded";
 
-  onSidebarOpen: () => void;
-  onAddNote: () => void | Promise<void>;
+  onSidebarOpen?: () => void;
+  onAddNote?: () => void | Promise<void>;
+  onYamlOpen?: () => void;
+  onDashboardAddPanel?: () => void;
+  onDashboardOpenYaml?: () => void;
+  dashboardYamlReadOnly?: boolean;
 };
 
 export const RightSideControls = memo(function RightSideControls(props: RightSideControlsProps) {
   if (props.mode === "live") return null;
+
+  const railClassName =
+    props.layout === "embedded"
+      ? "flex w-9 shrink-0 flex-col items-center gap-1.5 border-l border-slate-950/15 bg-slate-100 py-2"
+      : "absolute inset-y-0 right-0 z-10 flex w-9 flex-col items-center gap-1.5 border-l border-slate-950/15 bg-slate-100 py-2";
+
   return (
-    <div className="absolute top-4 right-4 z-10 flex flex-col gap-2.5">
-      <EditCanvasButtons {...props} />
+    <div className={railClassName}>
+      <EditModeButtons {...props} />
     </div>
   );
 });
 
-function EditCanvasButtons({ addNoteOnly, onSidebarOpen, onAddNote }: RightSideControlsProps) {
-  if (addNoteOnly) {
-    return <ControlButton tooltip="Add note" onClick={onAddNote} testId="add-note-button" icon={<StickyNote />} />;
+function EditModeButtons({
+  canvasEditControls,
+  dashboardEditControls,
+  onSidebarOpen,
+  onAddNote,
+  onYamlOpen,
+  onDashboardAddPanel,
+  onDashboardOpenYaml,
+  dashboardYamlReadOnly,
+}: RightSideControlsProps) {
+  if (dashboardEditControls) {
+    return (
+      <>
+        {onDashboardAddPanel ? (
+          <ControlButton
+            tooltip="Add Panel"
+            onClick={onDashboardAddPanel}
+            testId="dashboard-add-panel"
+            icon={<Plus className="h-3.5 w-3.5" />}
+          />
+        ) : null}
+        {onDashboardOpenYaml ? (
+          <ControlButton
+            tooltip={
+              dashboardYamlReadOnly
+                ? "View the console as YAML"
+                : "View, copy, download, or import this console as YAML"
+            }
+            onClick={onDashboardOpenYaml}
+            testId="dashboard-yaml-button"
+            ariaLabel={dashboardYamlReadOnly ? "View YAML" : "View / Import YAML"}
+            icon={<FileCode className="h-3.5 w-3.5" />}
+          />
+        ) : null}
+      </>
+    );
+  }
+
+  if (canvasEditControls) {
+    return (
+      <>
+        <ControlButton
+          tooltip="New Component"
+          onClick={() => onSidebarOpen?.()}
+          testId="canvas-add-component-button"
+          icon={<Plus className="h-3.5 w-3.5" />}
+        />
+        {onYamlOpen ? (
+          <ControlButton
+            tooltip="View, copy, download, or import this canvas as YAML"
+            onClick={onYamlOpen}
+            testId="canvas-yaml-button"
+            ariaLabel="View / Import YAML"
+            icon={<FileCode className="h-3.5 w-3.5" />}
+          />
+        ) : null}
+        <ControlButton
+          tooltip="Add Note"
+          onClick={() => onAddNote?.()}
+          testId="add-note-button"
+          icon={<FilePlus className="h-3.5 w-3.5" />}
+        />
+      </>
+    );
   }
 
   return (
     <>
-      <ControlButton tooltip="Add component" onClick={onSidebarOpen} testId="open-sidebar-button" icon={<Plus />} />
-      <ControlButton tooltip="Add note" onClick={onAddNote} testId="add-note-button" icon={<StickyNote />} />
+      <ControlButton
+        tooltip="Add component"
+        onClick={() => onSidebarOpen?.()}
+        testId="open-sidebar-button"
+        icon={<Plus className="h-3.5 w-3.5" />}
+      />
+      <ControlButton
+        tooltip="Add Note"
+        onClick={() => onAddNote?.()}
+        testId="add-note-button"
+        icon={<FilePlus className="h-3.5 w-3.5" />}
+      />
+      {onYamlOpen ? (
+        <ControlButton
+          tooltip="YAML"
+          onClick={onYamlOpen}
+          testId="open-yaml-modal-button"
+          icon={<Code2 className="h-3.5 w-3.5" />}
+        />
+      ) : null}
     </>
   );
 }
@@ -39,24 +133,30 @@ interface ControlButtonProps {
   onClick: () => void;
   testId: string;
   icon: ReactNode;
+  ariaLabel?: string;
 }
 
-function ControlButton(props: ControlButtonProps) {
+function ControlButton({ tooltip, onClick, testId, icon, ariaLabel }: ControlButtonProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
           type="button"
-          variant="outline"
-          onClick={props.onClick}
-          aria-label={props.tooltip}
-          data-testid={props.testId}
-          children={props.icon}
-        />
+          variant="ghost"
+          size="icon-sm"
+          onClick={onClick}
+          aria-label={ariaLabel ?? tooltip}
+          data-testid={testId}
+          className={cn(
+            "h-7 w-7 shrink-0 rounded-md border-0 shadow-none text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+          )}
+        >
+          {icon}
+        </Button>
       </TooltipTrigger>
 
-      <TooltipContent side="left" sideOffset={10}>
-        {props.tooltip}
+      <TooltipContent side="left" sideOffset={10} className="max-w-xs">
+        {tooltip}
       </TooltipContent>
     </Tooltip>
   );

--- a/web_src/src/ui/CanvasPage/components/DiffSummaryHoverCard.tsx
+++ b/web_src/src/ui/CanvasPage/components/DiffSummaryHoverCard.tsx
@@ -1,7 +1,6 @@
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Checkbox } from "@/ui/checkbox";
 import { Switch } from "@/ui/switch";
-import { Minus, Pencil, Plus } from "lucide-react";
 
 interface DiffSummaryHoverCardProps {
   diffCounts: { added: number; updated: number; removed: number };
@@ -20,26 +19,9 @@ function DiffBadgeSegments({ diffCounts }: Pick<DiffSummaryHoverCardProps, "diff
   const { added, updated, removed } = diffCounts;
   return (
     <>
-      {added > 0 && (
-        <span className="flex items-center gap-0.5 px-1 text-emerald-600">
-          <Plus className="h-3 w-3" />
-          {added}
-        </span>
-      )}
-      {added > 0 && (updated > 0 || removed > 0) && <span className="text-slate-300">|</span>}
-      {updated > 0 && (
-        <span className="flex items-center gap-0.5 px-1 text-sky-600">
-          <Pencil className="h-3 w-3" />
-          {updated}
-        </span>
-      )}
-      {updated > 0 && removed > 0 && <span className="text-slate-300">|</span>}
-      {removed > 0 && (
-        <span className="flex items-center gap-0.5 px-1 text-red-600">
-          <Minus className="h-3 w-3" />
-          {removed}
-        </span>
-      )}
+      {added > 0 && <span className="tabular-nums text-emerald-600">+{added}</span>}
+      {updated > 0 && <span className="tabular-nums text-sky-600">±{updated}</span>}
+      {removed > 0 && <span className="tabular-nums text-red-600">-{removed}</span>}
     </>
   );
 }
@@ -59,7 +41,7 @@ export function DiffSummaryHoverCard({
       <HoverCardTrigger asChild>
         <button
           type="button"
-          className="flex cursor-default items-center gap-0 rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-xs font-medium transition-colors hover:bg-slate-100"
+          className="flex h-7 cursor-default items-center gap-0.5 rounded-md border border-slate-950/15 bg-white px-1.5 py-1 text-[13px] font-medium transition-colors hover:bg-slate-50"
         >
           <DiffBadgeSegments diffCounts={diffCounts} />
         </button>

--- a/web_src/src/ui/CanvasPage/index.spec.tsx
+++ b/web_src/src/ui/CanvasPage/index.spec.tsx
@@ -87,15 +87,7 @@ vi.mock("@/components/CanvasToolSidebar/useCanvasToolSidebarState", () => ({
 }));
 
 vi.mock("./Header", () => ({
-  Header: ({ isEditing, onCanvasAddComponent }: { isEditing?: boolean; onCanvasAddComponent?: () => void }) => (
-    <header data-testid="canvas-header">
-      {isEditing && onCanvasAddComponent ? (
-        <button type="button" data-testid="canvas-add-component-button" onClick={() => onCanvasAddComponent()}>
-          Add component
-        </button>
-      ) : null}
-    </header>
-  ),
+  Header: () => <header data-testid="canvas-header" />,
 }));
 
 import { CanvasNodeErrorBoundary, CanvasPage } from "./index";
@@ -327,6 +319,34 @@ describe("CanvasPage connection drop", () => {
     });
     expect(payload?.sourceNodeId).toBeUndefined();
     expect(payload?.sourceHandleId).toBeUndefined();
+  });
+
+  it("opens the canvas YAML modal without switching to the Files tab", async () => {
+    const onYamlOpen = vi.fn();
+    const onSelectFiles = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <CanvasPage
+          title="Canvas"
+          headerMode="version-live"
+          nodes={[]}
+          edges={[]}
+          buildingBlocks={[]}
+          isEditing={true}
+          activeCanvasVersionId="draft-version"
+          onYamlOpen={onYamlOpen}
+          onSelectFiles={onSelectFiles}
+        />
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("canvas-yaml-button"));
+    });
+
+    expect(onYamlOpen).toHaveBeenCalledTimes(1);
+    expect(onSelectFiles).not.toHaveBeenCalled();
   });
 
   it("loads node run data only while the component sidebar is open in live mode", async () => {

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -193,14 +193,8 @@ export interface CanvasPageProps {
   onSelectMemory?: () => void;
   /** Switches the canvas surface to the Files tab. Omitted on templates. */
   onSelectFiles?: () => void;
-  /** Opens the canvas dashboard add-panel dialog when `headerMode` is `dashboard`. */
-  onDashboardAddPanel?: () => void;
-  /** Opens the dashboard YAML modal when `headerMode` is `dashboard`. */
-  onDashboardOpenYaml?: () => void;
-  /** Opens the add-component sidebar from the secondary header when editing on the Canvas tab. */
-  onCanvasAddComponent?: () => void;
-  /** Whether the dashboard YAML modal will open in read-only mode (no apply). */
-  dashboardYamlReadOnly?: boolean;
+  /** Opens the canvas YAML modal. */
+  onYamlOpen?: () => void;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
   unpublishedDraftUpdatedAt?: string;
@@ -210,6 +204,7 @@ export interface CanvasPageProps {
   autoLayoutOnUpdateDisabled?: boolean;
   autoLayoutOnUpdateDisabledTooltip?: string;
   canvasStateMode?: "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
+  /** When true, enables inline rename and app settings in the project switcher. */
   showCanvasSettingsMenu?: boolean;
   isVersionControlOpen?: boolean;
   onOpenVersionControl?: () => void;
@@ -1290,10 +1285,6 @@ function CanvasPage(props: CanvasPageProps) {
           onSelectDashboard={props.onSelectDashboard}
           onSelectMemory={props.onSelectMemory}
           onSelectFiles={props.onSelectFiles}
-          onDashboardAddPanel={props.onDashboardAddPanel}
-          onDashboardOpenYaml={props.onDashboardOpenYaml}
-          onCanvasAddComponent={props.isEditing ? handleBuildingBlocksShortcutOpen : undefined}
-          dashboardYamlReadOnly={props.dashboardYamlReadOnly}
           publishVersionLabel={props.publishVersionLabel}
           hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
           unpublishedDraftUpdatedAt={props.unpublishedDraftUpdatedAt}
@@ -1326,9 +1317,10 @@ function CanvasPage(props: CanvasPageProps) {
           props.headerMode === "dashboard" ? null : (
             <RightSideControls
               mode="edit"
-              addNoteOnly
+              canvasEditControls
               onSidebarOpen={handleBuildingBlocksShortcutOpen}
               onAddNote={handleAddNote}
+              onYamlOpen={props.onYamlOpen}
             />
           )
         ) : (
@@ -1336,6 +1328,7 @@ function CanvasPage(props: CanvasPageProps) {
             mode={readOnly ? "live" : "edit"}
             onSidebarOpen={handleBuildingBlocksShortcutOpen}
             onAddNote={handleAddNote}
+            onYamlOpen={props.onYamlOpen}
           />
         )}
         {props.hideAddControls || !isBuildingBlocksSidebarOpen ? null : (
@@ -1811,10 +1804,6 @@ function CanvasContentHeader({
   onSelectDashboard,
   onSelectMemory,
   onSelectFiles,
-  onDashboardAddPanel,
-  onDashboardOpenYaml,
-  onCanvasAddComponent,
-  dashboardYamlReadOnly,
   publishVersionLabel,
   hasUnpublishedDraftChanges,
   unpublishedDraftUpdatedAt,
@@ -1860,10 +1849,6 @@ function CanvasContentHeader({
   onSelectDashboard?: () => void;
   onSelectMemory?: () => void;
   onSelectFiles?: () => void;
-  onDashboardAddPanel?: () => void;
-  onDashboardOpenYaml?: () => void;
-  onCanvasAddComponent?: () => void;
-  dashboardYamlReadOnly?: boolean;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
   unpublishedDraftUpdatedAt?: string;
@@ -1911,10 +1896,6 @@ function CanvasContentHeader({
       onSelectDashboard={onSelectDashboard}
       onSelectMemory={onSelectMemory}
       onSelectFiles={onSelectFiles}
-      onDashboardAddPanel={onDashboardAddPanel}
-      onDashboardOpenYaml={onDashboardOpenYaml}
-      onCanvasAddComponent={onCanvasAddComponent}
-      dashboardYamlReadOnly={dashboardYamlReadOnly}
       publishVersionLabel={publishVersionLabel}
       hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
       unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
@@ -2926,7 +2907,7 @@ function CanvasContent({
             <Button
               variant="ghost"
               size="sm"
-              className="h-8 w-8 px-0 text-slate-600 hover:text-slate-900"
+              className="h-7 w-7 px-0 text-slate-600 hover:text-slate-900"
               onClick={handleToggleAutoLayoutOnUpdate}
               disabled={isAutoLayoutToggleDisabled}
               aria-pressed={isAutoLayoutOnUpdateEnabled}
@@ -2953,7 +2934,13 @@ function CanvasContent({
     () => (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="ghost" size="icon-sm" onClick={handleOpenCommandPalette} aria-label="Search Components">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="h-7 w-7"
+            onClick={handleOpenCommandPalette}
+            aria-label="Search commands and components"
+          >
             <Search className="h-3 w-3" />
           </Button>
         </TooltipTrigger>
@@ -3028,7 +3015,7 @@ function CanvasContent({
             style={reactFlowStyle}
             className="h-full w-full"
           >
-            <Background gap={8} size={2} bgColor="#F1F5F9" color="#d9d9d9ff" />
+            <Background gap={8} size={2} bgColor="#F1F5F9" color="#cbd5e1" />
             <GlobalCommandPaletteCanvasNodeSearch onSearch={handleNodeSearch} onSelectNode={handleNodeSearchSelect} />
             <Panel
               position="bottom-left"
@@ -3044,7 +3031,7 @@ function CanvasContent({
                   />
                 </div>
               )}
-              <div className="flex items-center gap-3">
+              <div className="flex h-7 items-center gap-3">
                 <ZoomSlider
                   orientation="horizontal"
                   className="!static !m-0"
@@ -3054,14 +3041,14 @@ function CanvasContent({
                   {zoomSliderContent}
                 </ZoomSlider>
                 {showBottomStatusControls && !isLogSidebarOpen ? (
-                  <div className="bg-white text-gray-800 outline-1 outline-slate-950/15 flex items-center gap-1 rounded-md p-0.5 h-8">
+                  <div className="bg-white text-gray-800 outline-1 outline-slate-950/15 flex h-7 items-center gap-1 rounded-md p-0.5">
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
                           variant="ghost"
                           size="sm"
                           className={cn(
-                            "h-8 items-center text-xs font-medium",
+                            "h-7 items-center text-xs font-medium",
                             unacknowledgedErrorCount > 0 && "text-red-500",
                           )}
                           onClick={() => handleLogButtonClick("errors")}
@@ -3085,7 +3072,7 @@ function CanvasContent({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-8 items-center text-xs font-medium"
+                          className="h-7 items-center text-xs font-medium"
                           onClick={() => handleLogButtonClick("warnings")}
                         >
                           <TriangleAlert


### PR DESCRIPTION
Move canvas edit actions into a right rail, relocate publish/discard to the secondary header, embed the console rail beside panels, and align edit-mode styling and labels.