### PR TITLE
fix: Use Canvas YAML copy handler

### DIFF
--- a/web_src/src/pages/workflowv2/CanvasYamlModal.spec.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlModal.spec.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CanvasYamlModal } from "./CanvasYamlModal";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value }: { value?: string }) => <pre data-testid="monaco-stub">{value}</pre>,
+}));
+
+describe("CanvasYamlModal", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    yamlText: "name: test-canvas",
+    filename: "test-canvas.yaml",
+  };
+
+  it("uses the provided copy handler for copy feedback and error handling", () => {
+    const onCopy = vi.fn();
+
+    render(<CanvasYamlModal {...defaultProps} onCopy={onCopy} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the copy button when no copy handler is provided", () => {
+    render(<CanvasYamlModal {...defaultProps} />);
+
+    expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/pages/workflowv2/CanvasYamlModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlModal.tsx
@@ -106,7 +106,7 @@ function CopyButton(props: CanvasYamlModalProps) {
   if (!props.onCopy) return null;
 
   return (
-    <Button variant="outline" size="sm" onClick={() => navigator.clipboard.writeText(props.yamlText)}>
+    <Button variant="outline" size="sm" onClick={props.onCopy}>
       <Copy />
       Copy
     </Button>


### PR DESCRIPTION
## Summary

- Route the Canvas YAML modal's Copy button through the parent-provided copy handler.
- Add coverage for using the handler and hiding the button when no handler is provided.

## Why

`CanvasYamlView` already wires `handleYamlViewCopy` into `CanvasYamlModal`, and that handler owns the success/error toast behavior for YAML copying. The modal was bypassing it with a direct `navigator.clipboard.writeText(...)` call, so copy result feedback was not surfaced through the existing path.

## Testing

- `npx eslint src/pages/workflowv2/CanvasYamlModal.tsx src/pages/workflowv2/CanvasYamlModal.spec.tsx`
- `npm run test:run -- CanvasYamlModal.spec.tsx`
- `npx prettier --check src/pages/workflowv2/CanvasYamlModal.tsx src/pages/workflowv2/CanvasYamlModal.spec.tsx`
- `docker compose -f docker-compose.dev.yml exec app bash -lc "cd web_src && npm run build"`