### PR TITLE
fix(ui): no overlapping between sidebar and files tab

### DIFF
--- a/web_src/src/pages/workflowv2/WorkflowFilesOverlayLayer.spec.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowFilesOverlayLayer.spec.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSidebarLayoutStore } from "@/stores/sidebarLayoutStore";
 
 import { WorkflowFilesOverlayLayer } from "./WorkflowFilesOverlayLayer";
 
@@ -21,6 +23,11 @@ vi.mock("@pierre/trees/react", () => ({
 }));
 
 describe("WorkflowFilesOverlayLayer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSidebarLayoutStore.getState().hydrateFromStorage();
+  });
+
   it("keeps all editor tabs closed after closing the last tab", async () => {
     const user = userEvent.setup();
 
@@ -48,5 +55,25 @@ describe("WorkflowFilesOverlayLayer", () => {
 
     expect(screen.queryByRole("button", { name: "Close canvas.yaml" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("monaco-stub")).not.toBeInTheDocument();
+  });
+
+  it("offsets the overlay when the left tool sidebar is open", () => {
+    useSidebarLayoutStore.setState({ leftWidth: 420, leftMountCount: 1 });
+
+    render(
+      <WorkflowFilesOverlayLayer
+        isFilesMode
+        files={[
+          {
+            path: "canvas.yaml",
+            content: "canvas: true",
+            language: "yaml",
+          },
+        ]}
+      />,
+    );
+
+    const overlay = screen.getByTestId("workflow-files-overlay");
+    expect(overlay).toHaveStyle({ left: "420px", right: "0px" });
   });
 });

--- a/web_src/src/pages/workflowv2/WorkflowFilesOverlayLayer.tsx
+++ b/web_src/src/pages/workflowv2/WorkflowFilesOverlayLayer.tsx
@@ -1,5 +1,6 @@
 import { Editor } from "@monaco-editor/react";
 import { FileTree as TreesFileTree, useFileTree } from "@pierre/trees/react";
+import { useEffectiveLeftSidebarWidth } from "@/stores/sidebarLayoutStore";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 
@@ -59,6 +60,7 @@ export function WorkflowFilesOverlayLayer({ isFilesMode, files }: WorkflowFilesO
 }
 
 function CanvasYamlFilesView({ files }: { files: WorkflowFile[] }) {
+  const leftOffset = useEffectiveLeftSidebarWidth();
   const filePaths = useMemo(() => files.map((file) => file.path), [files]);
   const [selectedPath, setSelectedPath] = useState<string | null>(() => filePaths[0] ?? null);
   const [openTabs, setOpenTabs] = useState<string[]>(() => (filePaths[0] ? [filePaths[0]] : []));
@@ -92,7 +94,8 @@ function CanvasYamlFilesView({ files }: { files: WorkflowFile[] }) {
 
   return (
     <div
-      className="absolute inset-x-0 bottom-0 top-[5rem] z-10 grid min-h-0 grid-cols-[minmax(180px,260px)_minmax(0,1fr)] overflow-hidden bg-slate-50"
+      className="absolute bottom-0 top-[5rem] z-10 grid min-h-0 grid-cols-[minmax(180px,260px)_minmax(0,1fr)] overflow-hidden bg-slate-50"
+      style={{ left: leftOffset, right: 0 }}
       data-testid="workflow-files-overlay"
     >
       <aside className="flex min-h-0 flex-col border-r border-slate-950/15 bg-white">


### PR DESCRIPTION
Fixes a small issue in the new files tab, where an open left sidebar overlaps with it. Just updates the files tab to use the same approach as the other tabs to not allow them to overlap.