### PR TITLE
fix: speed up agent component lookups

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -75,6 +75,8 @@ Initially, you can leave the **"IAM Role ARN"** field empty, as you will be guid
 
 ## CloudWatch • On Alarm
 
+**Trigger key:** `aws.cloudwatch.onAlarm`
+
 The On Alarm trigger starts a workflow execution when a CloudWatch alarm transitions to the ALARM state.
 
 ### Use Cases
@@ -134,6 +136,8 @@ Each alarm event includes:
 
 ## CodeArtifact • On Package Version
 
+**Trigger key:** `aws.codeArtifact.onPackageVersion`
+
 The On Package Version trigger starts a workflow execution when a package version is created, modified, or deleted in AWS CodeArtifact.
 
 ### Use Cases
@@ -188,6 +192,8 @@ The On Package Version trigger starts a workflow execution when a package versio
 <a id="code-pipeline-•-on-pipeline"></a>
 
 ## CodePipeline • On Pipeline
+
+**Trigger key:** `aws.codepipeline.onPipeline`
 
 The On Pipeline trigger starts a workflow execution when AWS CodePipeline emits a pipeline execution state change event.
 
@@ -247,6 +253,8 @@ Each event includes:
 
 ## EC2 • On Image
 
+**Trigger key:** `aws.ec2.onImage`
+
 The On Image trigger starts a workflow execution when an EC2 AMI changes state.
 
 ### Use Cases
@@ -295,6 +303,8 @@ Each AMI state event includes:
 <a id="ecr-•-on-image-push"></a>
 
 ## ECR • On Image Push
+
+**Trigger key:** `aws.ecr.onImagePush`
 
 The On Image Push trigger starts a workflow execution when an image is pushed to an ECR repository.
 
@@ -348,6 +358,8 @@ Each image push event includes:
 <a id="ecr-•-on-image-scan"></a>
 
 ## ECR • On Image Scan
+
+**Trigger key:** `aws.ecr.onImageScan`
 
 The On Image Scan trigger starts a workflow execution when an ECR image scan completes.
 
@@ -409,6 +421,8 @@ Each image scan event includes:
 
 ## SNS • On Topic Message
 
+**Trigger key:** `aws.sns.onTopicMessage`
+
 The On Topic Message trigger starts a workflow execution when a message is published to an AWS SNS topic.
 
 ### Use Cases
@@ -457,6 +471,8 @@ During setup, SuperPlane creates a webhook endpoint for this trigger and subscri
 
 ## CodeArtifact • Copy Package Versions
 
+**Component key:** `aws.codeArtifact.copyPackageVersions`
+
 The Copy Package Versions component copies one or more package versions from a source repository to a destination repository in the same domain.
 
 ### Use Cases
@@ -491,6 +507,8 @@ The Copy Package Versions component copies one or more package versions from a s
 
 ## CodeArtifact • Create Repository
 
+**Component key:** `aws.codeArtifact.createRepository`
+
 The Create Repository component creates a new repository in an AWS CodeArtifact domain.
 
 ### Use Cases
@@ -523,6 +541,8 @@ The Create Repository component creates a new repository in an AWS CodeArtifact 
 
 ## CodeArtifact • Delete Package Versions
 
+**Component key:** `aws.codeArtifact.deletePackageVersions`
+
 The Delete Package Versions component permanently removes package versions and their assets. Deleted versions cannot be restored. To remove from view but keep the option to restore later, use Update Package Versions Status to set status to Archived instead.
 
 ### Use Cases
@@ -552,6 +572,8 @@ The Delete Package Versions component permanently removes package versions and t
 <a id="code-artifact-•-delete-repository"></a>
 
 ## CodeArtifact • Delete Repository
+
+**Component key:** `aws.codeArtifact.deleteRepository`
 
 The Delete Repository component deletes a repository from an AWS CodeArtifact domain.
 
@@ -585,6 +607,8 @@ The Delete Repository component deletes a repository from an AWS CodeArtifact do
 
 ## CodeArtifact • Dispose Package Versions
 
+**Component key:** `aws.codeArtifact.disposePackageVersions`
+
 The Dispose Package Versions component deletes the assets of package versions and sets their status to Disposed. The version record remains so you can still see it in ListPackageVersions with status Disposed; assets cannot be restored.
 
 ### Use Cases
@@ -614,6 +638,8 @@ The Dispose Package Versions component deletes the assets of package versions an
 <a id="code-artifact-•-get-package-version"></a>
 
 ## CodeArtifact • Get Package Version
+
+**Component key:** `aws.codeArtifact.getPackageVersion`
 
 The Get Package Version component retrieves metadata for a specific package version in AWS CodeArtifact.
 
@@ -672,6 +698,8 @@ The Get Package Version component retrieves metadata for a specific package vers
 
 ## CodeArtifact • Update Package Versions Status
 
+**Component key:** `aws.codeArtifact.updatePackageVersionsStatus`
+
 The Update Package Versions Status component sets the status of package versions to Archived, Published, or Unlisted.
 
 ### Use Cases
@@ -705,6 +733,8 @@ The Update Package Versions Status component sets the status of package versions
 <a id="code-pipeline-•-get-pipeline"></a>
 
 ## CodePipeline • Get Pipeline
+
+**Component key:** `aws.codepipeline.getPipeline`
 
 The Get Pipeline component retrieves the full definition of an AWS CodePipeline pipeline.
 
@@ -781,6 +811,8 @@ Emits the full pipeline definition including:
 
 ## CodePipeline • Get Pipeline Execution
 
+**Component key:** `aws.codepipeline.getPipelineExecution`
+
 The Get Pipeline Execution component retrieves the details of a specific AWS CodePipeline execution.
 
 ### Use Cases
@@ -840,6 +872,8 @@ Emits the full pipeline execution details including:
 
 ## CodePipeline • Retry Stage Execution
 
+**Component key:** `aws.codepipeline.retryStageExecution`
+
 The Retry Stage Execution component retries a stage within an existing AWS CodePipeline execution.
 
 ### Use Cases
@@ -885,6 +919,8 @@ Emits retry result metadata including:
 <a id="code-pipeline-•-run-pipeline"></a>
 
 ## CodePipeline • Run Pipeline
+
+**Component key:** `aws.codepipeline.runPipeline`
 
 The Run Pipeline component triggers an AWS CodePipeline execution and waits for it to complete.
 
@@ -946,6 +982,8 @@ The Run Pipeline component triggers an AWS CodePipeline execution and waits for 
 
 ## EC2 • Copy Image
 
+**Component key:** `aws.ec2.copyImage`
+
 The Copy Image component copies an AMI to another AWS region.
 
 ### Use Cases
@@ -998,6 +1036,8 @@ The Copy Image component copies an AMI to another AWS region.
 
 ## EC2 • Create Image
 
+**Component key:** `aws.ec2.createImage`
+
 The Create Image component creates a new Amazon Machine Image (AMI) from an EC2 instance.
 
 ### Use Cases
@@ -1049,6 +1089,8 @@ The Create Image component creates a new Amazon Machine Image (AMI) from an EC2 
 <a id="ec2-•-create-instance"></a>
 
 ## EC2 • Create Instance
+
+**Component key:** `aws.ec2.createInstance`
 
 The Create Instance component launches a new Amazon EC2 instance and waits until it reaches **running** state before emitting.
 
@@ -1110,6 +1152,8 @@ Emits instance details on the default output channel, including:
 
 ## EC2 • Delete Instance
 
+**Component key:** `aws.ec2.deleteInstance`
+
 The Delete Instance component terminates an Amazon EC2 instance and waits until AWS reports it as **terminated**.
 
 ### Use Cases
@@ -1145,6 +1189,8 @@ Emits a deletion payload on the default output channel:
 
 ## EC2 • Deregister Image
 
+**Component key:** `aws.ec2.deregisterImage`
+
 The Deregister Image component removes an AMI from your account in a region.
 
 ### Use Cases
@@ -1178,6 +1224,8 @@ The Deregister Image component removes an AMI from your account in a region.
 
 ## EC2 • Disable Image
 
+**Component key:** `aws.ec2.disableImage`
+
 The Disable Image component disables an AMI so it cannot be launched.
 
 ### Use Cases
@@ -1209,6 +1257,8 @@ The Disable Image component disables an AMI so it cannot be launched.
 <a id="ec2-•-disable-image-deprecation"></a>
 
 ## EC2 • Disable Image Deprecation
+
+**Component key:** `aws.ec2.disableImageDeprecation`
 
 The Disable Image Deprecation component removes the deprecation schedule from an AMI.
 
@@ -1242,6 +1292,8 @@ The Disable Image Deprecation component removes the deprecation schedule from an
 
 ## EC2 • Enable Image
 
+**Component key:** `aws.ec2.enableImage`
+
 The Enable Image component enables a previously disabled AMI.
 
 ### Use Cases
@@ -1273,6 +1325,8 @@ The Enable Image component enables a previously disabled AMI.
 <a id="ec2-•-enable-image-deprecation"></a>
 
 ## EC2 • Enable Image Deprecation
+
+**Component key:** `aws.ec2.enableImageDeprecation`
 
 The Enable Image Deprecation component sets a deprecation time for an AMI.
 
@@ -1307,6 +1361,8 @@ The Enable Image Deprecation component sets a deprecation time for an AMI.
 <a id="ec2-•-get-image"></a>
 
 ## EC2 • Get Image
+
+**Component key:** `aws.ec2.getImage`
 
 The Get Image component retrieves metadata for an EC2 AMI.
 
@@ -1351,6 +1407,8 @@ The Get Image component retrieves metadata for an EC2 AMI.
 
 ## ECR • Get Image
 
+**Component key:** `aws.ecr.getImage`
+
 The Get Image component retrieves image metadata from an ECR repository by digest, tag, or both.
 
 ### Use Cases
@@ -1393,6 +1451,8 @@ At least one of **Image Digest** or **Image Tag** is required. If both are provi
 <a id="ecr-•-get-image-scan-findings"></a>
 
 ## ECR • Get Image Scan Findings
+
+**Component key:** `aws.ecr.getImageScanFindings`
 
 The Get Image Scan Findings component retrieves vulnerability scan results for an ECR image.
 
@@ -1461,6 +1521,8 @@ At least one of **Image Digest** or **Image Tag** is required. If both are provi
 
 ## ECR • Scan Image
 
+**Component key:** `aws.ecr.scanImage`
+
 The Scan Image component scans an ECR image for vulnerabilities.
 
 ### Use Cases
@@ -1528,6 +1590,8 @@ At least one of **Image Digest** or **Image Tag** is required. If both are provi
 
 ## ECS • Create Service
 
+**Component key:** `aws.ecs.createService`
+
 The Create Service component creates a new ECS service in a cluster.
 
 ### Use Cases
@@ -1572,6 +1636,8 @@ The Create Service component creates a new ECS service in a cluster.
 <a id="ecs-•-describe-service"></a>
 
 ## ECS • Describe Service
+
+**Component key:** `aws.ecs.describeService`
 
 The Describe Service component fetches details about a single ECS service.
 
@@ -1655,6 +1721,8 @@ The Describe Service component fetches details about a single ECS service.
 
 ## ECS • Execute Command
 
+**Component key:** `aws.ecs.executeCommand`
+
 The Execute Command component runs ECS Exec against a running task container.
 
 ### Use Cases
@@ -1694,6 +1762,8 @@ The Execute Command component runs ECS Exec against a running task container.
 <a id="ecs-•-run-task"></a>
 
 ## ECS • Run Task
+
+**Component key:** `aws.ecs.runTask`
 
 The Run Task component starts one or more ECS tasks and completes based on task lifecycle events.
 
@@ -1745,6 +1815,8 @@ The Run Task component starts one or more ECS tasks and completes based on task 
 
 ## ECS • Stop Task
 
+**Component key:** `aws.ecs.stopTask`
+
 The Stop Task component requests ECS to stop a running task and waits for the task to reach STOPPED.
 
 ### Use Cases
@@ -1785,6 +1857,8 @@ The Stop Task component requests ECS to stop a running task and waits for the ta
 <a id="ecs-•-update-service"></a>
 
 ## ECS • Update Service
+
+**Component key:** `aws.ecs.updateService`
 
 The Update Service component updates configuration for an existing ECS service.
 
@@ -1831,6 +1905,8 @@ The Update Service component updates configuration for an existing ECS service.
 
 ## Lambda • Run Function
 
+**Component key:** `aws.lambda.runFunction`
+
 The Run Lambda component invokes a Lambda function.
 
 ### Use Cases
@@ -1872,6 +1948,8 @@ The Run Lambda component invokes a Lambda function.
 
 ## Route 53 • Create DNS Record
 
+**Component key:** `aws.route53.createRecord`
+
 The Create DNS Record component creates a new DNS record in an AWS Route 53 hosted zone.
 
 ### Use Cases
@@ -1909,6 +1987,8 @@ The Create DNS Record component creates a new DNS record in an AWS Route 53 host
 <a id="route-53-•-delete-dns-record"></a>
 
 ## Route 53 • Delete DNS Record
+
+**Component key:** `aws.route53.deleteRecord`
 
 The Delete DNS Record component deletes a DNS record from an AWS Route 53 hosted zone.
 
@@ -1949,6 +2029,8 @@ The Delete DNS Record component deletes a DNS record from an AWS Route 53 hosted
 
 ## Route 53 • Upsert DNS Record
 
+**Component key:** `aws.route53.upsertRecord`
+
 The Upsert DNS Record component creates or updates a DNS record in an AWS Route 53 hosted zone.
 
 ### Use Cases
@@ -1987,6 +2069,8 @@ The Upsert DNS Record component creates or updates a DNS record in an AWS Route 
 
 ## SNS • Create Topic
 
+**Component key:** `aws.sns.createTopic`
+
 The Create Topic component creates an AWS SNS topic and returns its metadata.
 
 ### Use Cases
@@ -2021,6 +2105,8 @@ The Create Topic component creates an AWS SNS topic and returns its metadata.
 
 ## SNS • Delete Topic
 
+**Component key:** `aws.sns.deleteTopic`
+
 The Delete Topic component deletes an AWS SNS topic.
 
 ### Use Cases
@@ -2045,6 +2131,8 @@ The Delete Topic component deletes an AWS SNS topic.
 <a id="sns-•-get-subscription"></a>
 
 ## SNS • Get Subscription
+
+**Component key:** `aws.sns.getSubscription`
 
 The Get Subscription component retrieves metadata and attributes for an AWS SNS subscription.
 
@@ -2082,6 +2170,8 @@ The Get Subscription component retrieves metadata and attributes for an AWS SNS 
 
 ## SNS • Get Topic
 
+**Component key:** `aws.sns.getTopic`
+
 The Get Topic component retrieves metadata and attributes for an AWS SNS topic.
 
 ### Use Cases
@@ -2116,6 +2206,8 @@ The Get Topic component retrieves metadata and attributes for an AWS SNS topic.
 
 ## SNS • Publish Message
 
+**Component key:** `aws.sns.publishMessage`
+
 The Publish Message component sends a message to an AWS SNS topic.
 
 ### Use Cases
@@ -2141,6 +2233,8 @@ The Publish Message component sends a message to an AWS SNS topic.
 
 ## SQS • Create Queue
 
+**Component key:** `aws.sqs.createQueue`
+
 The Create Queue component creates a new AWS SQS queue.
 
 ### Configuration
@@ -2165,6 +2259,8 @@ The Create Queue component creates a new AWS SQS queue.
 
 ## SQS • Delete Queue
 
+**Component key:** `aws.sqs.deleteQueue`
+
 The Delete Queue component deletes an AWS SQS queue.
 
 ### Configuration
@@ -2188,6 +2284,8 @@ The Delete Queue component deletes an AWS SQS queue.
 <a id="sqs-•-get-queue"></a>
 
 ## SQS • Get Queue
+
+**Component key:** `aws.sqs.getQueue`
 
 The Get Queue component retrieves metadata and attributes for an AWS SQS queue.
 
@@ -2220,6 +2318,8 @@ The Get Queue component retrieves metadata and attributes for an AWS SQS queue.
 
 ## SQS • Purge Queue
 
+**Component key:** `aws.sqs.purgeQueue`
+
 The Purge Queue component removes all messages from an AWS SQS queue.
 
 ### Configuration
@@ -2243,6 +2343,8 @@ The Purge Queue component removes all messages from an AWS SQS queue.
 <a id="sqs-•-send-message"></a>
 
 ## SQS • Send Message
+
+**Component key:** `aws.sqs.sendMessage`
 
 The Send Message component publishes a message to an AWS SQS queue.
 

--- a/docs/components/Bitbucket.mdx
+++ b/docs/components/Bitbucket.mdx
@@ -31,6 +31,8 @@ To configure Bitbucket with SuperPlane:
 
 ## On Push
 
+**Trigger key:** `bitbucket.onPush`
+
 The On Push trigger starts a workflow execution when code is pushed to a Bitbucket repository.
 
 ### Use Cases

--- a/docs/components/CircleCI.mdx
+++ b/docs/components/CircleCI.mdx
@@ -31,6 +31,8 @@ Create a Personal API Token in CircleCI → User Settings → Personal API Token
 
 ## On Workflow Completed
 
+**Trigger key:** `circleci.onWorkflowCompleted`
+
 Triggers when a CircleCI workflow completes.
 
 ### Use Cases
@@ -92,6 +94,8 @@ This trigger automatically sets up a CircleCI webhook when configured. The webho
 
 ## Get Flaky Tests
 
+**Component key:** `circleci.getFlakyTests`
+
 The Get Flaky Tests component identifies flaky tests in a CircleCI project using the Insights API.
 
 ### Use Cases
@@ -146,6 +150,8 @@ Emits a `circleci.flakyTests` payload with a list of flaky tests and their flaki
 
 ## Get Last Workflow
 
+**Component key:** `circleci.getLastWorkflow`
+
 The Get Last Workflow component retrieves the most recent workflow for a CircleCI project.
 
 ### Use Cases
@@ -190,6 +196,8 @@ Emits a `circleci.workflow` payload with the most recent matching workflow detai
 <a id="get-recent-workflow-runs"></a>
 
 ## Get Recent Workflow Runs
+
+**Component key:** `circleci.getRecentWorkflowRuns`
 
 The Get Recent Workflow Runs component fetches recent individual runs for a named CircleCI workflow via the Insights API.
 
@@ -251,6 +259,8 @@ Emits a `circleci.workflowRuns` payload containing an array of recent workflow r
 <a id="get-test-metrics"></a>
 
 ## Get Test Metrics
+
+**Component key:** `circleci.getTestMetrics`
 
 The Get Test Metrics component fetches test performance data from the CircleCI Insights API.
 
@@ -318,6 +328,8 @@ Emits a `circleci.testMetrics` payload with most failed tests, slowest tests, an
 
 ## Get Workflow
 
+**Component key:** `circleci.getWorkflow`
+
 The Get Workflow component fetches details for a CircleCI workflow.
 
 ### Use Cases
@@ -374,6 +386,8 @@ Emits a `circleci.workflow` payload containing workflow fields like `id`, `name`
 <a id="run-pipeline"></a>
 
 ## Run Pipeline
+
+**Component key:** `circleci.runPipeline`
 
 The Run Pipeline component starts a CircleCI pipeline and waits for it to complete.
 

--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -21,6 +21,8 @@ To get new Claude API key, go to [platform.claude.com](https://platform.claude.c
 
 ## Run Claude Agent
 
+**Component key:** `claude.runAgent`
+
 The **Run Claude Agent** component uses [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview) to start a **session** with a configured agent and environment, sends your task as a **user message**, and waits until the **session** reaches a terminal state (idle or terminated) by polling. Log streaming is not used.
 
 ### Prerequisites
@@ -56,6 +58,8 @@ Emits a finished payload with **session** status, **session id**, and the final 
 <a id="text-prompt"></a>
 
 ## Text Prompt
+
+**Component key:** `claude.textPrompt`
 
 The Text Prompt component uses Anthropic's Claude models to generate text responses.
 

--- a/docs/components/Cloudflare.mdx
+++ b/docs/components/Cloudflare.mdx
@@ -82,6 +82,8 @@ To connect Cloudflare to SuperPlane:
 
 ## On Load Balancing Health Alert
 
+**Trigger key:** `cloudflare.onLoadBalancingHealthAlert`
+
 The On Load Balancing Health Alert trigger starts a workflow from Cloudflare Load Balancing health notifications.
 
 ### Use Cases
@@ -136,6 +138,8 @@ The trigger **title** still prefers an origin name, then pool name, then load ba
 
 ## On Tunnel Health
 
+**Trigger key:** `cloudflare.onTunnelHealth`
+
 The On Tunnel Health trigger starts a workflow from Cloudflare `tunnel_health_event` notifications (Cloudflare Tunnel / cloudflared).
 
 ### Use Cases
@@ -187,6 +191,8 @@ The trigger **Payload** tab (and expressions such as `$.trigger.data`) use a mer
 
 ## Create DNS Record
 
+**Component key:** `cloudflare.createDnsRecord`
+
 The Create DNS Record component creates a DNS record in a Cloudflare zone.
 
 ### Use Cases
@@ -230,6 +236,8 @@ Emits the created DNS record on the default channel. If the zone is not found, t
 
 ## Create KV Namespace
 
+**Component key:** `cloudflare.createKVNamespace`
+
 The Create KV Namespace component creates a new Cloudflare Workers KV namespace.
 
 ### Use Cases
@@ -266,6 +274,8 @@ Returns the created namespace with its assigned ID and title.
 <a id="create-load-balancer"></a>
 
 ## Create Load Balancer
+
+**Component key:** `cloudflare.createLoadBalancer`
 
 The Create Load Balancer component creates a new Cloudflare Load Balancer attached to a zone.
 
@@ -330,6 +340,8 @@ Returns the created load balancer with its assigned ID and full configuration.
 
 ## Create Monitor
 
+**Component key:** `cloudflare.createMonitor`
+
 The Create Monitor component creates a Cloudflare Load Balancing health monitor.
 
 ### Use Cases
@@ -384,6 +396,8 @@ Emits the created monitor and, when configured, the attached pool.
 
 ## Create Origin Rule
 
+**Component key:** `cloudflare.createOriginRule`
+
 The Create Origin Rule component creates a Cloudflare origin rule that routes matching requests to a different origin server.
 
 ### Configuration
@@ -430,6 +444,8 @@ Emits the created origin rule on the default channel.
 <a id="create-pool"></a>
 
 ## Create Pool
+
+**Component key:** `cloudflare.createPool`
 
 The Create Pool component creates a new Cloudflare Load Balancer origin pool.
 
@@ -489,6 +505,8 @@ Returns the created origin pool with its assigned ID and full configuration.
 
 ## Create Tunnel
 
+**Component key:** `cloudflare.createTunnel`
+
 The Create Tunnel component provisions a Cloudflare Tunnel under your account.
 
 ### Use Cases
@@ -534,6 +552,8 @@ Returns the tunnel resource from the Cloudflare API, including its ID. When Clou
 
 ## Delete Certificate Pack
 
+**Component key:** `cloudflare.deleteCertificatePack`
+
 The Delete Certificate Pack component removes a custom SSL/TLS certificate pack from a Cloudflare zone.
 
 ### Use Cases
@@ -571,6 +591,8 @@ Emits the deleted pack ID, resolved zone ID, zone name when known from integrati
 <a id="delete-dns-record"></a>
 
 ## Delete DNS Record
+
+**Component key:** `cloudflare.deleteDnsRecord`
 
 The Delete DNS Record component removes a DNS record from a Cloudflare zone.
 
@@ -613,6 +635,8 @@ Emits the deleted DNS record (zoneId, recordId, record) on the default channel. 
 
 ## Delete KV Namespace
 
+**Component key:** `cloudflare.deleteKVNamespace`
+
 The Delete KV Namespace component permanently removes a Cloudflare Workers KV namespace and all of its key-value pairs.
 
 ### Use Cases
@@ -649,6 +673,8 @@ Emits a confirmation with the account ID, namespace ID, and a deleted flag.
 <a id="delete-kv-value"></a>
 
 ## Delete KV Value
+
+**Component key:** `cloudflare.deleteKVValue`
 
 The Delete KV Value component removes a key-value pair from a Cloudflare Workers KV namespace.
 
@@ -688,6 +714,8 @@ Emits a confirmation with the account ID, namespace ID, and key that was deleted
 
 ## Delete Load Balancer
 
+**Component key:** `cloudflare.deleteLoadBalancer`
+
 The Delete Load Balancer component permanently removes a Cloudflare Load Balancer from a zone.
 
 ### Use Cases
@@ -723,6 +751,8 @@ Emits a confirmation with the zone ID and load balancer ID of the deleted load b
 
 ## Delete Monitor
 
+**Component key:** `cloudflare.deleteMonitor`
+
 The Delete Monitor component removes a Cloudflare Load Balancing health monitor.
 
 ### Use Cases
@@ -757,6 +787,8 @@ Emits the deleted monitor ID and any references Cloudflare reported before delet
 <a id="delete-origin-rule"></a>
 
 ## Delete Origin Rule
+
+**Component key:** `cloudflare.deleteOriginRule`
 
 The Delete Origin Rule component removes a Cloudflare origin rule from a zone.
 
@@ -796,6 +828,8 @@ Emits the deleted origin rule on the default channel.
 
 ## Delete Pool
 
+**Component key:** `cloudflare.deletePool`
+
 The Delete Pool component permanently removes a Cloudflare Load Balancer origin pool.
 
 ### Use Cases
@@ -830,6 +864,8 @@ Emits a confirmation with the account ID and pool ID of the deleted pool.
 <a id="delete-tunnel"></a>
 
 ## Delete Tunnel
+
+**Component key:** `cloudflare.deleteTunnel`
 
 The Delete Tunnel component permanently removes a Cloudflare Tunnel.
 
@@ -866,6 +902,8 @@ Emits confirmation with the account ID and tunnel ID.
 
 ## Delete Worker
 
+**Component key:** `cloudflare.deleteWorker`
+
 The Delete Worker component removes a Worker script.
 
 ### Configuration
@@ -896,6 +934,8 @@ Emits the account ID and Worker Script that were deleted.
 <a id="deploy-worker"></a>
 
 ## Deploy Worker
+
+**Component key:** `cloudflare.deployWorker`
 
 The Deploy Worker component uploads a single-module Worker (`worker.js`) to a **Worker script name** in your account. When **Provision Worker if missing** is enabled (default), it first calls Cloudflare's Create Worker API so a **new** name works without a separate step. After upload, SuperPlane always creates a **deployment** so the new version serves 100% of traffic (`cloudflare.worker.deployed`).
 
@@ -947,6 +987,8 @@ Emits the account ID, script name, new version ID, and deployment object.
 
 ## Get KV Value
 
+**Component key:** `cloudflare.getKVValue`
+
 The Get KV Value component reads a value by key from a Cloudflare Workers KV namespace.
 
 ### Use Cases
@@ -982,6 +1024,8 @@ Returns the account ID, namespace ID, key, and the retrieved value string.
 <a id="get-load-balancer"></a>
 
 ## Get Load Balancer
+
+**Component key:** `cloudflare.getLoadBalancer`
 
 The Get Load Balancer component fetches the current state of a Cloudflare Load Balancer.
 
@@ -1029,6 +1073,8 @@ Returns the full load balancer configuration including pools, steering policy, a
 
 ## Get Monitor
 
+**Component key:** `cloudflare.getMonitor`
+
 The Get Monitor component fetches the current configuration of a Cloudflare Load Balancing health monitor.
 
 ### Use Cases
@@ -1075,6 +1121,8 @@ Returns the full monitor configuration including type, path, port, intervals, an
 <a id="get-pool"></a>
 
 ## Get Pool
+
+**Component key:** `cloudflare.getPool`
 
 The Get Pool component fetches the current state of a Cloudflare Load Balancer origin pool.
 
@@ -1127,6 +1175,8 @@ Returns the full pool configuration including its origins, enabled state, and he
 
 ## Get Tunnel
 
+**Component key:** `cloudflare.getTunnel`
+
 The Get Tunnel component fetches the current state of a Cloudflare Tunnel (cloudflared).
 
 ### Use Cases
@@ -1167,6 +1217,8 @@ Returns the tunnel object from the Cloudflare API (ID, name, status, config sour
 <a id="get-worker"></a>
 
 ## Get Worker
+
+**Component key:** `cloudflare.getWorker`
 
 The Get Worker component loads Workers script **settings** (bindings, compatibility, usage model, etc.) and the list of **deployments** (newest first per Cloudflare).
 
@@ -1213,6 +1265,8 @@ Emits `settings` and `deployments` for use in later workflow steps.
 <a id="order-certificate-pack"></a>
 
 ## Order Certificate Pack
+
+**Component key:** `cloudflare.orderCertificatePack`
 
 The Order Certificate Pack component orders an advanced SSL/TLS certificate pack for custom hostnames in a Cloudflare zone.
 
@@ -1263,6 +1317,8 @@ Emits the resolved zone ID, zone name when known from integration metadata, pack
 
 ## Purge Cache
 
+**Component key:** `cloudflare.purgeCache`
+
 The Purge Cache component clears cached content from the Cloudflare CDN.
 
 ### Use Cases
@@ -1308,6 +1364,8 @@ Emits the Cloudflare purge result ID, zone ID, zone name (when known from integr
 
 ## Put KV Value
 
+**Component key:** `cloudflare.putKVValue`
+
 The Put KV Value component writes a key-value pair to a Cloudflare Workers KV namespace.
 
 ### Use Cases
@@ -1345,6 +1403,8 @@ Emits a confirmation with the account ID, namespace ID, and key that was written
 <a id="update-dns-record"></a>
 
 ## Update DNS Record
+
+**Component key:** `cloudflare.updateDNSRecord`
 
 The Update DNS Record component updates an existing DNS record in a Cloudflare zone.
 
@@ -1389,6 +1449,8 @@ Emits the updated DNS record (id, type, name, content, proxied, ttl) on the defa
 <a id="update-load-balancer"></a>
 
 ## Update Load Balancer
+
+**Component key:** `cloudflare.updateLoadBalancer`
 
 The Update Load Balancer component modifies an existing Cloudflare Load Balancer.
 
@@ -1451,6 +1513,8 @@ Returns the updated load balancer configuration.
 
 ## Update Monitor
 
+**Component key:** `cloudflare.updateMonitor`
+
 The Update Monitor component modifies an existing Cloudflare Load Balancing health monitor.
 
 ### Use Cases
@@ -1501,6 +1565,8 @@ Returns the updated monitor configuration after the change is applied.
 
 ## Update Origin Rule
 
+**Component key:** `cloudflare.updateOriginRule`
+
 The Update Origin Rule component updates a Cloudflare origin rule, such as changing the origin host for matching requests.
 
 ### Configuration
@@ -1545,6 +1611,8 @@ Emits the updated origin rule on the default channel.
 <a id="update-pool"></a>
 
 ## Update Pool
+
+**Component key:** `cloudflare.updatePool`
 
 The Update Pool component modifies an existing Cloudflare Load Balancer origin pool.
 
@@ -1606,6 +1674,8 @@ Returns the updated origin pool configuration.
 
 ## Update Redirect Rule
 
+**Component key:** `cloudflare.updateRedirectRule`
+
 The Update Redirect Rule component modifies an existing redirect rule in a Cloudflare zone.
 
 ### Use Cases
@@ -1665,6 +1735,8 @@ Returns the updated redirect rule with all current configuration.
 <a id="update-worker-route"></a>
 
 ## Update Worker Route
+
+**Component key:** `cloudflare.updateWorkerRoute`
 
 The Update Worker Route component manages **zone routes** for Workers.
 

--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -43,6 +43,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Schedule
 
+**Trigger key:** `schedule`
+
 The Schedule trigger starts workflow executions automatically based on a configured schedule.
 
 ### Use Cases
@@ -109,6 +111,8 @@ Each scheduled execution includes calendar information:
 
 ## Manual Run
 
+**Trigger key:** `start`
+
 The Manual Run trigger allows you to start workflow executions manually from the SuperPlane UI or CLI.
 
 ### Use Cases
@@ -151,6 +155,8 @@ Manual runs emit an event with type `manual.run`. The data is either the templat
 <a id="webhook"></a>
 
 ## Webhook
+
+**Trigger key:** `webhook`
 
 The Webhook trigger starts a new workflow execution when an HTTP request is received at the generated webhook URL.
 
@@ -215,6 +221,8 @@ Send a POST request to the webhook URL with your payload. The workflow will rece
 
 ## Add Memory
 
+**Component key:** `addMemory`
+
 The Add Memory component appends one or more items to canvas-level memory storage.
 
 ### Use Cases
@@ -259,6 +267,8 @@ A single `memory.added` event is emitted with all written rows and the total `co
 <a id="approval"></a>
 
 ## Approval
+
+**Component key:** `approval`
 
 The Approval component pauses workflow execution and waits for manual approval from specified users, groups, or roles before continuing.
 
@@ -328,6 +338,8 @@ The Approval component pauses workflow execution and waits for manual approval f
 
 ## Delete Memory
 
+**Component key:** `deleteMemory`
+
 The Delete Memory component removes memory rows from canvas-level memory storage.
 
 ### Use Cases
@@ -376,6 +388,8 @@ The Delete Memory component removes memory rows from canvas-level memory storage
 
 ## Display
 
+**Component key:** `display`
+
 The Display component displays a debug message from the latest execution.
 
 ### Use Cases
@@ -399,6 +413,8 @@ The Display component displays a debug message from the latest execution.
 <a id="filter"></a>
 
 ## Filter
+
+**Component key:** `filter`
 
 The Filter component evaluates a boolean expression against incoming events and only forwards events that match the condition.
 
@@ -441,6 +457,8 @@ The expression has access to:
 <a id="graph-ql-request"></a>
 
 ## GraphQL Request
+
+**Component key:** `graphql`
 
 The GraphQL component runs a GraphQL document against a URL using the standard **GraphQL over HTTP** JSON body shape.
 
@@ -485,6 +503,8 @@ The GraphQL component runs a GraphQL document against a URL using the standard *
 <a id="http-request"></a>
 
 ## HTTP Request
+
+**Component key:** `http`
 
 The HTTP component allows you to make HTTP requests to external APIs and services as part of your workflow.
 
@@ -548,6 +568,8 @@ The component emits the response with:
 
 ## If
 
+**Component key:** `if`
+
 The If component evaluates a boolean expression and routes events to different output channels based on the result.
 
 ### Use Cases
@@ -594,6 +616,8 @@ The expression has access to:
 <a id="merge"></a>
 
 ## Merge
+
+**Component key:** `merge`
 
 The Merge component waits for events from all upstream nodes before forwarding a combined result downstream.
 
@@ -653,6 +677,8 @@ The Merge component waits for events from all upstream nodes before forwarding a
 
 ## No Operation
 
+**Component key:** `noop`
+
 The No Operation component is a pass-through component that forwards events to downstream nodes without any modification or processing.
 
 ### Use Cases
@@ -678,6 +704,8 @@ When executed, the No Operation component immediately emits the incoming event d
 <a id="read-memory"></a>
 
 ## Read Memory
+
+**Component key:** `readMemory`
 
 The Read Memory component looks up values from canvas-level memory storage.
 
@@ -728,6 +756,8 @@ The Read Memory component looks up values from canvas-level memory storage.
 
 ## Runner
 
+**Component key:** `runner`
+
 Runs shell commands on a fleet runner.
 
 ### Execution
@@ -770,6 +800,8 @@ If the completed broker task includes valid JSON in **result**, SuperPlane inclu
 <a id="send-email-notification"></a>
 
 ## Send Email Notification
+
+**Component key:** `sendEmail`
 
 The Send Email Notification component sends emails through the system's configured email provider (Resend or SMTP) without requiring a separate integration setup.
 
@@ -816,6 +848,8 @@ Emits the list of recipients and the subject to the default output channel.
 
 ## SSH Command
 
+**Component key:** `ssh`
+
 Run one or more commands on a remote host via SSH.
 
 ### Authentication
@@ -857,6 +891,8 @@ Choose **SSH key** or **Password**, then select the organization Secret and the 
 
 ## Time Gate
 
+**Component key:** `timeGate`
+
 The Time Gate component delays event processing until the next valid day and time window, with optional excluded dates.
 
 ### Use Cases
@@ -893,6 +929,8 @@ The Time Gate component delays event processing until the next valid day and tim
 <a id="update-memory"></a>
 
 ## Update Memory
+
+**Component key:** `updateMemory`
 
 The Update Memory component updates matching rows in canvas-level memory storage.
 
@@ -955,6 +993,8 @@ The `matchList` is evaluated once (same matches for every iteration), while each
 <a id="upsert-memory"></a>
 
 ## Upsert Memory
+
+**Component key:** `upsertMemory`
 
 The Upsert Memory component updates matching rows in canvas-level memory storage, and creates a new row when no matches are found.
 
@@ -1026,6 +1066,8 @@ update the same matched rows. List mode is most useful for inserting multiple ro
 <a id="wait"></a>
 
 ## Wait
+
+**Component key:** `wait`
 
 The Wait component pauses workflow execution for a specified duration or until a specific time is reached.
 

--- a/docs/components/Cursor.mdx
+++ b/docs/components/Cursor.mdx
@@ -22,6 +22,8 @@ To get your API keys, visit the [Cursor Dashboard](https://cursor.com/dashboard)
 
 ## Get Daily Usage Data
 
+**Component key:** `cursor.getDailyUsageData`
+
 The Get Daily Usage Data component fetches team usage metrics from Cursor's Admin API.
 
 ### Use Cases
@@ -95,6 +97,8 @@ The output includes per-user daily metrics:
 
 ## Get Last Message
 
+**Component key:** `cursor.getLastMessage`
+
 The Get Last Message component retrieves the last message from a Cursor Cloud Agent's conversation history.
 
 ### Use Cases
@@ -148,6 +152,8 @@ The output includes:
 <a id="launch-cloud-agent"></a>
 
 ## Launch Cloud Agent
+
+**Component key:** `cursor.launchAgent`
 
 The Launch Cloud Agent component triggers a Cursor AI coding agent and waits for it to complete.
 

--- a/docs/components/Dash0.mdx
+++ b/docs/components/Dash0.mdx
@@ -33,6 +33,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Alert Notification
 
+**Trigger key:** `dash0.onAlertNotification`
+
 The On Alert Notification trigger starts a workflow execution when Dash0 sends an alert notification webhook.
 
 ### Setup
@@ -106,6 +108,8 @@ The trigger emits the full JSON payload received from Dash0 as `dash0.alertNotif
 <a id="on-synthetic-check-notification"></a>
 
 ## On Synthetic Check Notification
+
+**Trigger key:** `dash0.onSyntheticCheckNotification`
 
 The On Synthetic Check Notification trigger starts a workflow execution when Dash0 sends a synthetic check notification webhook.
 
@@ -217,6 +221,8 @@ The trigger normalizes these labels into a flat `{key: value}` map in the emitte
 
 ## Create Check Rule
 
+**Component key:** `dash0.createCheckRule`
+
 The Create Check Rule component creates a Prometheus-style alert check rule in Dash0 to monitor metrics and trigger alerts based on PromQL expressions.
 
 ### Use Cases
@@ -292,6 +298,8 @@ Returns the created check rule details from the Dash0 API, including the rule ID
 <a id="create-http-synthetic-check"></a>
 
 ## Create HTTP Synthetic Check
+
+**Component key:** `dash0.createHttpSyntheticCheck`
 
 The Create Synthetic Check component creates an HTTP synthetic check in Dash0 to monitor the availability and performance of your endpoints.
 
@@ -433,6 +441,8 @@ Returns the created synthetic check details from the Dash0 API, including the ch
 
 ## Delete Check Rule
 
+**Component key:** `dash0.deleteCheckRule`
+
 The Delete Check Rule component removes a check rule (Prometheus alert rule) from Dash0 by its ID or origin. Use the check rule ID from a Create/Get/Update output or from the Dash0 dashboard.
 
 ### Use Cases
@@ -467,6 +477,8 @@ Returns a confirmation payload indicating successful deletion.
 
 ## Delete HTTP Synthetic Check
 
+**Component key:** `dash0.deleteHttpSyntheticCheck`
+
 The Delete HTTP Synthetic Check component removes a synthetic check from Dash0 by its ID. Use the check ID from a Create/Get/Update output (e.g. metadata.labels["dash0.com/id"]) or from the Dash0 dashboard.
 
 ### Configuration
@@ -494,6 +506,8 @@ Returns a confirmation payload (e.g. deleted id).
 <a id="get-check-rule"></a>
 
 ## Get Check Rule
+
+**Component key:** `dash0.getCheckRule`
 
 The Get Check Rule component retrieves the full configuration of an existing check rule (Prometheus alert rule) from Dash0.
 
@@ -553,6 +567,8 @@ Returns the complete check rule configuration from the Dash0 API, including:
 <a id="get-http-synthetic-check"></a>
 
 ## Get HTTP Synthetic Check
+
+**Component key:** `dash0.getHttpSyntheticCheck`
 
 The Get HTTP Synthetic Check component retrieves the full configuration and operational metrics of an existing HTTP synthetic check from Dash0.
 
@@ -695,6 +711,8 @@ Note: Metrics are fetched on a best-effort basis. If Prometheus metrics are unav
 
 ## List Issues
 
+**Component key:** `dash0.listIssues`
+
 The List Issues component queries Dash0 to retrieve all current issues and routes execution based on issue severity.
 
 ### Use Cases
@@ -761,6 +779,8 @@ Returns a list of issues with:
 <a id="query-prometheus"></a>
 
 ## Query Prometheus
+
+**Component key:** `dash0.queryPrometheus`
 
 The Query Prometheus component executes PromQL queries against the Dash0 Prometheus API.
 
@@ -832,6 +852,8 @@ Returns the Prometheus query response including:
 
 ## Send Log Event
 
+**Component key:** `dash0.sendLogEvent`
+
 The Send Log Event component sends log records from workflows to Dash0 via OTLP HTTP ingestion.
 
 ### Use Cases
@@ -892,6 +914,8 @@ Returns a confirmation that the log was sent along with the log record details:
 
 ## Update Check Rule
 
+**Component key:** `dash0.updateCheckRule`
+
 The Update Check Rule component updates an existing check rule (Prometheus alert rule) in Dash0. Use the check rule ID from a previous Create Check Rule output or from the Dash0 dashboard.
 
 ### Use Cases
@@ -947,6 +971,8 @@ Returns the updated check rule details from the Dash0 API, including the rule ID
 <a id="update-http-synthetic-check"></a>
 
 ## Update HTTP Synthetic Check
+
+**Component key:** `dash0.updateHttpSyntheticCheck`
 
 The Update HTTP Synthetic Check component updates an existing synthetic check in Dash0. Use the check ID from a previous Create HTTP Synthetic Check output (e.g. metadata.labels["dash0.com/id"]) or from the Dash0 dashboard.
 

--- a/docs/components/Datadog.mdx
+++ b/docs/components/Datadog.mdx
@@ -25,6 +25,8 @@ To configure Datadog to work with SuperPlane:
 
 ## Create Event
 
+**Component key:** `datadog.createEvent`
+
 The Create Event component creates a new event in Datadog.
 
 ### Use Cases

--- a/docs/components/Daytona.mdx
+++ b/docs/components/Daytona.mdx
@@ -21,6 +21,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Create Repository Sandbox
 
+**Component key:** `daytona.createRepositorySandbox`
+
 The Create Repository Sandbox component creates a new Daytona sandbox, clones a repository, and runs a bootstrap script.
 
 ### Use Cases
@@ -68,6 +70,8 @@ The Create Repository Sandbox component creates a new Daytona sandbox, clones a 
 <a id="create-sandbox"></a>
 
 ## Create Sandbox
+
+**Component key:** `daytona.createSandbox`
 
 The Create Sandbox component creates an isolated environment for executing code safely.
 
@@ -155,6 +159,8 @@ Returns the sandbox information including:
 
 ## Delete Sandbox
 
+**Component key:** `daytona.deleteSandbox`
+
 The Delete Sandbox component removes an existing Daytona sandbox.
 
 ### Use Cases
@@ -195,6 +201,8 @@ Returns deletion confirmation including:
 <a id="execute-code"></a>
 
 ## Execute Code
+
+**Component key:** `daytona.executeCode`
 
 The Execute Code component runs code in an existing Daytona sandbox.
 
@@ -240,6 +248,8 @@ Returns the execution result including:
 <a id="execute-command"></a>
 
 ## Execute Command
+
+**Component key:** `daytona.executeCommand`
 
 The Execute Command component runs shell commands in an existing Daytona sandbox.
 
@@ -308,6 +318,8 @@ The payload includes:
 <a id="get-preview-url"></a>
 
 ## Get Preview URL
+
+**Component key:** `daytona.getPreviewUrl`
 
 The Get Preview URL component generates a Daytona preview URL for a specific sandbox port.
 

--- a/docs/components/DigitalOcean.mdx
+++ b/docs/components/DigitalOcean.mdx
@@ -79,6 +79,8 @@ Create an [Access Key ID & Secret Access Key](https://cloud.digitalocean.com/spa
 
 ## Add Data Source
 
+**Component key:** `digitalocean.addDataSource`
+
 The Add Data Source component adds a new data source to an existing knowledge base on the DigitalOcean Gradient AI Platform.
 
 ### How it works
@@ -140,6 +142,8 @@ When indexing is enabled, the output also includes:
 
 ## Assign Reserved IP
 
+**Component key:** `digitalocean.assignReservedIP`
+
 The Assign Reserved IP component assigns or unassigns a DigitalOcean Reserved IP to a droplet.
 
 ### Use Cases
@@ -193,6 +197,8 @@ Returns the action result including:
 
 ## Attach Knowledge Base
 
+**Component key:** `digitalocean.attachKnowledgeBase`
+
 The Attach Knowledge Base component connects a knowledge base to an existing Gradient AI agent, enabling the agent to use it for retrieval-augmented generation (RAG).
 
 ### Use Cases
@@ -228,6 +234,8 @@ Returns confirmation of the attachment including:
 <a id="copy-object"></a>
 
 ## Copy Object
+
+**Component key:** `digitalocean.copyObject`
 
 The Copy Object component copies an object from one location to another within DigitalOcean Spaces. When **Delete Source** is enabled, the source object is deleted after a successful copy, effectively moving the object.
 
@@ -288,6 +296,8 @@ Spaces Access Key ID and Secret Access Key must be configured in the DigitalOcea
 <a id="create-alert-policy"></a>
 
 ## Create Alert Policy
+
+**Component key:** `digitalocean.createAlertPolicy`
 
 The Create Alert Policy component creates a monitoring alert policy that triggers notifications when droplet metrics cross defined thresholds.
 
@@ -361,6 +371,8 @@ Returns the created alert policy including:
 <a id="create-app"></a>
 
 ## Create App
+
+**Component key:** `digitalocean.createApp`
 
 The Create App component provisions a new application on DigitalOcean's App Platform from a GitHub, GitLab, or Bitbucket repository.
 The component requires that you have connected your Git provider in your DigitalOcean account and granted access to the repository you want to deploy.
@@ -464,6 +476,8 @@ Returns the created app including:
 
 ## Create DNS Record
 
+**Component key:** `digitalocean.createDNSRecord`
+
 The Create DNS Record component creates a new DNS record for a domain managed by DigitalOcean.
 
 ### Use Cases
@@ -519,6 +533,8 @@ Returns the created DNS record including:
 
 ## Create Database
 
+**Component key:** `digitalocean.createDatabase`
+
 The Create Database component adds a new database to an existing DigitalOcean Managed Database cluster.
 
 ### Use Cases
@@ -561,6 +577,8 @@ Returns the created database including:
 <a id="create-database-cluster"></a>
 
 ## Create Database Cluster
+
+**Component key:** `digitalocean.createDatabaseCluster`
 
 The Create Database Cluster component provisions a new DigitalOcean Managed Database cluster and waits until it is online.
 
@@ -629,6 +647,8 @@ Returns the created database cluster including:
 <a id="create-droplet"></a>
 
 ## Create Droplet
+
+**Component key:** `digitalocean.createDroplet`
 
 The Create Droplet component creates a new droplet in DigitalOcean.
 
@@ -702,6 +722,8 @@ Returns the created droplet object including:
 <a id="create-gpu-droplet"></a>
 
 ## Create GPU Droplet
+
+**Component key:** `digitalocean.createGPUDroplet`
 
 The Create GPU Droplet component creates a new GPU-powered droplet in DigitalOcean.
 
@@ -780,6 +802,8 @@ Returns the created GPU droplet object including:
 
 ## Create Knowledge Base
 
+**Component key:** `digitalocean.createKnowledgeBase`
+
 The Create Knowledge Base component creates a new knowledge base on the DigitalOcean Gradient AI Platform, ready for use with AI agents via retrieval-augmented generation (RAG).
 
 ### How it works
@@ -844,6 +868,8 @@ Returns the created knowledge base including:
 <a id="create-load-balancer"></a>
 
 ## Create Load Balancer
+
+**Component key:** `digitalocean.createLoadBalancer`
 
 The Create Load Balancer component creates a new load balancer in DigitalOcean and waits until it is active.
 
@@ -917,6 +943,8 @@ Returns the created load balancer object including:
 
 ## Create Snapshot
 
+**Component key:** `digitalocean.createSnapshot`
+
 The Create Snapshot component creates a point-in-time snapshot of a DigitalOcean Droplet.
 
 ### Use Cases
@@ -966,6 +994,8 @@ Returns the snapshot details including:
 
 ## Delete Alert Policy
 
+**Component key:** `digitalocean.deleteAlertPolicy`
+
 The Delete Alert Policy component permanently removes a monitoring alert policy from your DigitalOcean account.
 
 ### Use Cases
@@ -1003,6 +1033,8 @@ Returns information about the deleted policy:
 <a id="delete-app"></a>
 
 ## Delete App
+
+**Component key:** `digitalocean.deleteApp`
 
 The Delete App component removes a DigitalOcean App Platform application.
 
@@ -1042,6 +1074,8 @@ Returns confirmation of the deleted app including:
 <a id="delete-dns-record"></a>
 
 ## Delete DNS Record
+
+**Component key:** `digitalocean.deleteDNSRecord`
 
 The Delete DNS Record component permanently removes a DNS record from a DigitalOcean-managed domain.
 
@@ -1086,6 +1120,8 @@ Returns information about the deleted record:
 
 ## Delete Data Source
 
+**Component key:** `digitalocean.deleteDataSource`
+
 The Delete Data Source component removes a data source from an existing knowledge base on the DigitalOcean Gradient AI Platform.
 
 ### How it works
@@ -1124,6 +1160,8 @@ Returns the deleted data source details:
 <a id="delete-database"></a>
 
 ## Delete Database
+
+**Component key:** `digitalocean.deleteDatabase`
 
 The Delete Database component permanently removes a database from a DigitalOcean Managed Database cluster.
 
@@ -1171,6 +1209,8 @@ Returns information about the deleted database:
 
 ## Delete Droplet
 
+**Component key:** `digitalocean.deleteDroplet`
+
 The Delete Droplet component permanently deletes a droplet from your DigitalOcean account.
 
 ### Use Cases
@@ -1212,6 +1252,8 @@ Returns information about the deleted droplet:
 
 ## Delete GPU Droplet
 
+**Component key:** `digitalocean.deleteGPUDroplet`
+
 The Delete GPU Droplet component permanently deletes a GPU droplet from your DigitalOcean account.
 
 ### Use Cases
@@ -1252,6 +1294,8 @@ Returns information about the deleted GPU droplet:
 <a id="delete-knowledge-base"></a>
 
 ## Delete Knowledge Base
+
+**Component key:** `digitalocean.deleteKnowledgeBase`
 
 The Delete Knowledge Base component removes a knowledge base from the DigitalOcean Gradient AI Platform.
 
@@ -1302,6 +1346,8 @@ Returns confirmation of the deletion including:
 
 ## Delete Load Balancer
 
+**Component key:** `digitalocean.deleteLoadBalancer`
+
 The Delete Load Balancer component permanently deletes a load balancer from your DigitalOcean account.
 
 ### Use Cases
@@ -1340,6 +1386,8 @@ Returns information about the deleted load balancer:
 <a id="delete-object"></a>
 
 ## Delete Object
+
+**Component key:** `digitalocean.deleteObject`
 
 The Delete Object component permanently removes an object from a DigitalOcean Spaces bucket.
 
@@ -1387,6 +1435,8 @@ Spaces Access Key ID and Secret Access Key must be configured in the DigitalOcea
 
 ## Delete Snapshot
 
+**Component key:** `digitalocean.deleteSnapshot`
+
 The Delete Snapshot component deletes a DigitalOcean snapshot image.
 
 ### Use Cases
@@ -1421,6 +1471,8 @@ Returns confirmation of the deleted snapshot including:
 <a id="detach-knowledge-base"></a>
 
 ## Detach Knowledge Base
+
+**Component key:** `digitalocean.detachKnowledgeBase`
 
 The Detach Knowledge Base component removes a knowledge base from an existing Gradient AI agent.
 
@@ -1457,6 +1509,8 @@ Returns confirmation of the detachment including:
 <a id="get-alert-policy"></a>
 
 ## Get Alert Policy
+
+**Component key:** `digitalocean.getAlertPolicy`
 
 The Get Alert Policy component retrieves the full details of a monitoring alert policy.
 
@@ -1514,6 +1568,8 @@ Returns the alert policy object including:
 <a id="get-app"></a>
 
 ## Get App
+
+**Component key:** `digitalocean.getApp`
 
 The Get App component retrieves detailed information about a specific DigitalOcean App Platform application.
 
@@ -1709,6 +1765,8 @@ Returns the app object including:
 
 ## Get Cluster Configuration
 
+**Component key:** `digitalocean.getClusterConfiguration`
+
 The Get Cluster Configuration component retrieves the active configuration for a DigitalOcean Managed Database cluster.
 
 ### Use Cases
@@ -1757,6 +1815,8 @@ Returns the cluster configuration including:
 <a id="get-database"></a>
 
 ## Get Database
+
+**Component key:** `digitalocean.getDatabase`
 
 The Get Database component retrieves a managed database from a DigitalOcean cluster and enriches it with cluster context.
 
@@ -1822,6 +1882,8 @@ Returns the requested database enriched with cluster details, including:
 
 ## Get Database Cluster
 
+**Component key:** `digitalocean.getDatabaseCluster`
+
 The Get Database Cluster component retrieves the details of an existing DigitalOcean Managed Database cluster.
 
 ### Use Cases
@@ -1883,6 +1945,8 @@ Returns the database cluster including:
 <a id="get-droplet"></a>
 
 ## Get Droplet
+
+**Component key:** `digitalocean.getDroplet`
 
 The Get Droplet component retrieves detailed information about a specific droplet.
 
@@ -1956,6 +2020,8 @@ Returns the droplet object including:
 
 ## Get Droplet Metrics
 
+**Component key:** `digitalocean.getDropletMetrics`
+
 The Get Droplet Metrics component retrieves CPU usage, memory utilization, and network bandwidth metrics for a droplet over a specified lookback window.
 
 > **Note:** Monitoring is only available for droplets that had monitoring enabled during creation. Droplets created without monitoring will not report metrics.
@@ -2014,6 +2080,8 @@ All metric values are rounded to two decimal places.
 <a id="get-gpu-droplet"></a>
 
 ## Get GPU Droplet
+
+**Component key:** `digitalocean.getGPUDroplet`
 
 The Get GPU Droplet component retrieves detailed information about a specific GPU droplet.
 
@@ -2089,6 +2157,8 @@ Returns the GPU droplet object including:
 <a id="get-knowledge-base"></a>
 
 ## Get Knowledge Base
+
+**Component key:** `digitalocean.getKnowledgeBase`
 
 The Get Knowledge Base component retrieves comprehensive information about an existing knowledge base on the DigitalOcean Gradient AI Platform.
 
@@ -2179,6 +2249,8 @@ Returns the full knowledge base object including:
 
 ## Get Object
 
+**Component key:** `digitalocean.getObject`
+
 The Get Object component retrieves an object and its metadata from a DigitalOcean Spaces bucket.
 
 ### Prerequisites
@@ -2247,6 +2319,8 @@ Spaces Access Key ID and Secret Access Key must be configured in the DigitalOcea
 
 ## Index Knowledge Base
 
+**Component key:** `digitalocean.indexKnowledgeBase`
+
 The Index Knowledge Base component triggers a new indexing job on an existing knowledge base and polls until it completes.
 
 ### How it works
@@ -2298,6 +2372,8 @@ Returns the completed indexing job details:
 <a id="manage-droplet-power"></a>
 
 ## Manage Droplet Power
+
+**Component key:** `digitalocean.manageDropletPower`
 
 The Manage Droplet Power component performs power management operations on a droplet.
 
@@ -2359,6 +2435,8 @@ Returns the action result including:
 
 ## Put Object
 
+**Component key:** `digitalocean.putObject`
+
 The Put Object component uploads a text-based object to a DigitalOcean Spaces bucket.
 
 ### Prerequisites
@@ -2417,6 +2495,8 @@ Spaces Access Key ID and Secret Access Key must be configured in the DigitalOcea
 <a id="run-evaluation"></a>
 
 ## Run Evaluation
+
+**Component key:** `digitalocean.runEvaluation`
 
 The Run Evaluation component triggers a Gradient AI evaluation test case against an agent, waits for it to complete, and reports whether the agent passed or failed.
 
@@ -2543,6 +2623,8 @@ Returns the evaluation results including:
 
 ## Update Alert Policy
 
+**Component key:** `digitalocean.updateAlertPolicy`
+
 The Update Alert Policy component modifies an existing monitoring alert policy with new settings.
 
 > **Note:** Monitoring is only available for droplets that had monitoring enabled during creation. Droplets created without monitoring will not report metrics or trigger alerts.
@@ -2618,6 +2700,8 @@ Returns the updated alert policy including:
 <a id="update-app"></a>
 
 ## Update App
+
+**Component key:** `digitalocean.updateApp`
 
 The Update App component modifies an existing DigitalOcean App Platform application.
 
@@ -2713,6 +2797,8 @@ Returns the updated app including:
 
 ## Update GPU Droplet
 
+**Component key:** `digitalocean.updateGPUDroplet`
+
 The Update GPU Droplet component allows renaming and upsizing an existing GPU droplet.
 
 ### Use Cases
@@ -2791,6 +2877,8 @@ Returns the updated GPU droplet object including:
 <a id="upsert-dns-record"></a>
 
 ## Upsert DNS Record
+
+**Component key:** `digitalocean.upsertDNSRecord`
 
 The Upsert DNS Record component idempotently creates or updates a DNS record for a DigitalOcean-managed domain.
 

--- a/docs/components/Discord.mdx
+++ b/docs/components/Discord.mdx
@@ -33,6 +33,8 @@ To set up Discord integration:
 
 ## Get Last Mention
 
+**Component key:** `discord.getLastMention`
+
 The Get Last Mention component fetches recent messages from a Discord channel and returns the latest one that mentions your bot.
 
 ### Use Cases
@@ -97,6 +99,8 @@ Output channels:
 <a id="send-text-message"></a>
 
 ## Send Text Message
+
+**Component key:** `discord.sendTextMessage`
 
 The Send Text Message component sends a message to a Discord channel.
 

--- a/docs/components/DockerHub.mdx
+++ b/docs/components/DockerHub.mdx
@@ -29,6 +29,8 @@ To generate a DockerHub access token:
 
 ## On Image Push
 
+**Trigger key:** `dockerhub.onImagePush`
+
 The On Image Push trigger starts a workflow execution when an image tag is pushed to DockerHub.
 
 ### Use Cases
@@ -77,6 +79,8 @@ This trigger generates a webhook URL in SuperPlane. Add that URL as a DockerHub 
 <a id="get-image-tag"></a>
 
 ## Get Image Tag
+
+**Component key:** `dockerhub.getImageTag`
 
 The Get Image Tag component retrieves metadata for a DockerHub image tag.
 

--- a/docs/components/Elastic.mdx
+++ b/docs/components/Elastic.mdx
@@ -36,6 +36,8 @@ To connect Elastic to SuperPlane:
 
 ## When Alert Fires
 
+**Trigger key:** `elastic.onAlertFires`
+
 The When Alert Fires trigger starts a workflow execution when a Kibana alert rule fires via a webhook connector.
 
 ### Shared Connector
@@ -111,6 +113,8 @@ Each received alert emits the parsed JSON body sent by Kibana directly as the ev
 
 ## When Case Status Changes
 
+**Trigger key:** `elastic.onCaseStatusChange`
+
 The When Case Status Changes trigger fires a workflow execution when a Kibana Security case changes status.
 
 ### Shared Connector
@@ -169,6 +173,8 @@ The trigger emits the full case details including id, title, status, severity, v
 
 ## On Document Indexed
 
+**Trigger key:** `elastic.onDocumentIndexed`
+
 The On Document Indexed trigger starts a workflow execution when a new document is indexed into an Elasticsearch index.
 
 ### Shared Connector
@@ -225,6 +231,8 @@ The webhook acts as a signal. When it fires, SuperPlane queries Elasticsearch fo
 
 ## Create Case
 
+**Component key:** `elastic.createCase`
+
 The Create Case component opens a new case in Kibana Security.
 
 ### Configuration
@@ -265,6 +273,8 @@ The component emits an event containing:
 <a id="get-case"></a>
 
 ## Get Case
+
+**Component key:** `elastic.getCase`
 
 The Get Case component retrieves an existing case from Kibana Security by its ID.
 
@@ -312,6 +322,8 @@ The component emits an event containing:
 
 ## Get Document
 
+**Component key:** `elastic.getDocument`
+
 The Get Document component retrieves a JSON document from an Elasticsearch index by its ID.
 
 ### Configuration
@@ -348,6 +360,8 @@ The component emits an event containing:
 <a id="index-document"></a>
 
 ## Index Document
+
+**Component key:** `elastic.indexDocument`
 
 The Index Document component writes a JSON document to an Elasticsearch index.
 
@@ -390,6 +404,8 @@ The component emits an event containing:
 
 ## Update Case
 
+**Component key:** `elastic.updateCase`
+
 The Update Case component applies a partial update to an existing Kibana Security case.
 
 ### Configuration
@@ -431,6 +447,8 @@ The component emits an event containing:
 <a id="update-document"></a>
 
 ## Update Document
+
+**Component key:** `elastic.updateDocument`
 
 The Update Document component applies a partial update to an existing document in an Elasticsearch index.
 

--- a/docs/components/FireHydrant.mdx
+++ b/docs/components/FireHydrant.mdx
@@ -30,6 +30,8 @@ To connect FireHydrant, create an API key:
 
 ## On Incident
 
+**Trigger key:** `firehydrant.onIncident`
+
 The On Incident trigger starts a workflow execution when a FireHydrant incident is created or reaches a specific milestone.
 
 ### Use Cases
@@ -189,6 +191,8 @@ This trigger automatically sets up a FireHydrant webhook endpoint when configure
 <a id="create-incident"></a>
 
 ## Create Incident
+
+**Component key:** `firehydrant.createIncident`
 
 The Create Incident component creates a new incident in FireHydrant.
 

--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -51,6 +51,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Branch Created
 
+**Trigger key:** `github.onBranchCreated`
+
 The On Branch Created trigger starts a workflow execution when a new branch is created in a GitHub repository.
 
 ### Use Cases
@@ -106,6 +108,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 <a id="on-issue"></a>
 
 ## On Issue
+
+**Trigger key:** `github.onIssue`
 
 The On Issue trigger starts a workflow execution when issue events occur in a GitHub repository.
 
@@ -169,6 +173,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 
 ## On Issue Comment
 
+**Trigger key:** `github.onIssueComment`
+
 The On Issue Comment trigger starts a workflow execution when comments are added to issues.
 
 ### Use Cases
@@ -230,6 +236,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 <a id="on-pr-comment"></a>
 
 ## On PR Comment
+
+**Trigger key:** `github.onPRComment`
 
 The On PR Comment trigger starts a workflow execution when comments are added on a pull request conversation.
 
@@ -538,6 +546,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 <a id="on-pr-review-comment"></a>
 
 ## On PR Review Comment
+
+**Trigger key:** `github.onPRReviewComment`
 
 The On PR Review Comment trigger starts a workflow execution when review comments are added to pull requests.
 
@@ -990,6 +1000,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 
 ## On Pull Request
 
+**Trigger key:** `github.onPullRequest`
+
 The On Pull Request trigger starts a workflow execution when pull request events occur in a GitHub repository.
 
 ### Use Cases
@@ -1052,6 +1064,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 <a id="on-push"></a>
 
 ## On Push
+
+**Trigger key:** `github.onPush`
 
 The On Push trigger starts a workflow execution when code is pushed to a GitHub repository.
 
@@ -1312,6 +1326,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 
 ## On Release
 
+**Trigger key:** `github.onRelease`
+
 The On Release trigger starts a workflow execution when release events occur in a GitHub repository.
 
 ### Use Cases
@@ -1370,6 +1386,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 
 ## On Tag Created
 
+**Trigger key:** `github.onTagCreated`
+
 The On Tag Created trigger starts a workflow execution when a new tag is created in a GitHub repository.
 
 ### Use Cases
@@ -1425,6 +1443,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 <a id="on-workflow-run"></a>
 
 ## On Workflow Run
+
+**Trigger key:** `github.onWorkflowRun`
 
 The On Workflow Run trigger starts a workflow execution when GitHub Actions workflow runs complete.
 
@@ -1649,6 +1669,8 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
 
 ## Add Issue Assignee
 
+**Component key:** `github.addIssueAssignee`
+
 The Add Issue Assignee component adds one or more assignees to an existing GitHub issue without affecting existing assignees.
 
 ### Use Cases
@@ -1692,6 +1714,8 @@ Returns the updated issue object with all current information.
 <a id="add-issue-label"></a>
 
 ## Add Issue Label
+
+**Component key:** `github.addIssueLabel`
 
 The Add Issue Label component adds one or more labels to an existing GitHub issue without affecting existing labels.
 
@@ -1740,6 +1764,8 @@ Returns the full list of labels currently on the issue after the addition.
 
 ## Add Reaction
 
+**Component key:** `github.addReaction`
+
 The Add Reaction component adds a reaction emoji to a GitHub comment.
 
 ### Use Cases
@@ -1779,6 +1805,8 @@ Returns the created GitHub reaction object, including id, content, user, and tim
 <a id="create-deployment"></a>
 
 ## Create Deployment
+
+**Component key:** `github.createDeployment`
 
 The Create Deployment component registers a deployment with GitHub for a given ref and environment. This drives the **View deployment** button and environment box on pull requests—the same surface area used by Railway, Vercel, and Netlify.
 
@@ -1852,6 +1880,8 @@ Emits github.deployment with the created deployment, including id for **Create D
 
 ## Create Deployment Status
 
+**Component key:** `github.createDeploymentStatus`
+
 The Create Deployment Status component posts a new status for an existing deployment. Use it after provisioning succeeds or fails, or to mark a preview as **inactive** when tearing down.
 
 ### Use Cases
@@ -1922,6 +1952,8 @@ Emits github.deploymentStatus with the created status record.
 
 ## Create Issue
 
+**Component key:** `github.createIssue`
+
 The Create Issue component creates a new issue in a specified GitHub repository.
 
 ### Use Cases
@@ -1971,6 +2003,8 @@ Returns the created issue object with details including:
 
 ## Create Issue Comment
 
+**Component key:** `github.createIssueComment`
+
 The Create Issue Comment component adds a comment to an existing GitHub issue or pull request.
 Issues and pull requests share the same comment API in GitHub.
 
@@ -2017,6 +2051,8 @@ Returns the created comment object including:
 <a id="create-pull-request"></a>
 
 ## Create Pull Request
+
+**Component key:** `github.createPullRequest`
 
 The Create Pull Request component creates a new pull request in a specified GitHub repository.
 
@@ -2086,6 +2122,8 @@ Returns the created pull request object with details including:
 
 ## Create Release
 
+**Component key:** `github.createRelease`
+
 The Create Release component creates a new release in a GitHub repository.
 
 ### Use Cases
@@ -2130,6 +2168,8 @@ Returns the created release object with all release information including tag, a
 <a id="create-review"></a>
 
 ## Create Review
+
+**Component key:** `github.createReview`
 
 The Create Review component submits a pull request review (approve, request changes, or comment) on a GitHub pull request.
 
@@ -2177,6 +2217,8 @@ Emits the submitted review object including:
 
 ## Delete Release
 
+**Component key:** `github.deleteRelease`
+
 The Delete Release component removes a release from a GitHub repository.
 
 ### Use Cases
@@ -2219,6 +2261,8 @@ Returns confirmation of the deletion.
 <a id="get-issue"></a>
 
 ## Get Issue
+
+**Component key:** `github.getIssue`
 
 The Get Issue component retrieves a specific issue from a GitHub repository by its issue number.
 
@@ -2267,6 +2311,8 @@ Returns the complete issue object including:
 <a id="get-release"></a>
 
 ## Get Release
+
+**Component key:** `github.getRelease`
 
 The Get Release component retrieves release information from a GitHub repository.
 
@@ -2335,6 +2381,8 @@ Returns release information including:
 
 ## Get Repository Permission
 
+**Component key:** `github.getRepositoryPermission`
+
 The Get Repository Permission component retrieves a user's effective permission level for a GitHub repository.
 
 ### Use Cases
@@ -2365,6 +2413,8 @@ The Get Repository Permission component retrieves a user's effective permission 
 <a id="get-workflow-usage"></a>
 
 ## Get Workflow Usage
+
+**Component key:** `github.getWorkflowUsage`
 
 The Get Workflow Usage component retrieves billable GitHub Actions usage (minutes) for the installation's organization.
 
@@ -2448,6 +2498,8 @@ The component stores repository information in node metadata:
 
 ## Publish Commit Status
 
+**Component key:** `github.publishCommitStatus`
+
 The Publish Commit Status component creates a status check on a GitHub commit, commonly used for CI/CD integrations.
 
 ### Use Cases
@@ -2491,6 +2543,8 @@ Returns the created status object with all status information.
 
 ## Remove Issue Assignee
 
+**Component key:** `github.removeIssueAssignee`
+
 The Remove Issue Assignee component removes one or more assignees from an existing GitHub issue without affecting other assignees.
 
 ### Use Cases
@@ -2529,6 +2583,8 @@ Returns the updated issue object with all current information.
 <a id="remove-issue-label"></a>
 
 ## Remove Issue Label
+
+**Component key:** `github.removeIssueLabel`
 
 The Remove Issue Label component removes one or more labels from an existing GitHub issue without affecting other labels.
 
@@ -2569,6 +2625,8 @@ Returns the remaining list of labels on the issue after the removal.
 <a id="run-workflow"></a>
 
 ## Run Workflow
+
+**Component key:** `github.runWorkflow`
 
 The Run Workflow component triggers a GitHub Actions workflow and waits for it to complete.
 
@@ -2626,6 +2684,8 @@ The Run Workflow component triggers a GitHub Actions workflow and waits for it t
 
 ## Update Issue
 
+**Component key:** `github.updateIssue`
+
 The Update Issue component modifies an existing GitHub issue with new information.
 
 ### Use Cases
@@ -2669,6 +2729,8 @@ Returns the updated issue object with all current information.
 <a id="update-release"></a>
 
 ## Update Release
+
+**Component key:** `github.updateRelease`
 
 The Update Release component modifies an existing GitHub release.
 

--- a/docs/components/GitLab.mdx
+++ b/docs/components/GitLab.mdx
@@ -42,6 +42,8 @@ When connecting using Personal Access Token:
 
 ## On Issue
 
+**Trigger key:** `gitlab.onIssue`
+
 The On Issue trigger starts a workflow execution when issue events occur in a GitLab project.
 
 ### Use Cases
@@ -140,6 +142,8 @@ This trigger automatically sets up a GitLab webhook when configured. The webhook
 
 ## On Merge Request
 
+**Trigger key:** `gitlab.onMergeRequest`
+
 The On Merge Request trigger starts a workflow execution when merge request events occur in a GitLab project.
 
 ### Configuration
@@ -237,6 +241,8 @@ The On Merge Request trigger starts a workflow execution when merge request even
 
 ## On Milestone
 
+**Trigger key:** `gitlab.onMilestone`
+
 The On Milestone trigger starts a workflow execution when milestone events occur in a GitLab project.
 
 ### Configuration
@@ -297,6 +303,8 @@ The On Milestone trigger starts a workflow execution when milestone events occur
 
 ## On Pipeline
 
+**Trigger key:** `gitlab.onPipeline`
+
 The On Pipeline trigger starts a workflow execution when pipeline events occur in a GitLab project.
 
 ### Configuration
@@ -355,6 +363,8 @@ This trigger automatically sets up a GitLab webhook when configured. The webhook
 <a id="on-release"></a>
 
 ## On Release
+
+**Trigger key:** `gitlab.onRelease`
 
 The On Release trigger starts a workflow execution when release events occur in a GitLab project.
 
@@ -437,6 +447,8 @@ The On Release trigger starts a workflow execution when release events occur in 
 
 ## On Tag
 
+**Trigger key:** `gitlab.onTag`
+
 The On Tag trigger starts a workflow execution when tag push events occur in a GitLab project.
 
 ### Configuration
@@ -500,6 +512,8 @@ The On Tag trigger starts a workflow execution when tag push events occur in a G
 <a id="on-vulnerability"></a>
 
 ## On Vulnerability
+
+**Trigger key:** `gitlab.onVulnerability`
 
 The On Vulnerability trigger starts a workflow execution when vulnerability events occur in a GitLab project.
 
@@ -584,6 +598,8 @@ The On Vulnerability trigger starts a workflow execution when vulnerability even
 <a id="create-issue"></a>
 
 ## Create Issue
+
+**Component key:** `gitlab.createIssue`
 
 The Create Issue component creates a new issue in a specified GitLab project.
 
@@ -701,6 +717,8 @@ The component outputs the created issue object, including:
 
 ## Get Latest Pipeline
 
+**Component key:** `gitlab.getLatestPipeline`
+
 The Get Latest Pipeline component retrieves the newest pipeline for a GitLab project.
 
 ### Configuration
@@ -755,6 +773,8 @@ The Get Latest Pipeline component retrieves the newest pipeline for a GitLab pro
 <a id="get-pipeline"></a>
 
 ## Get Pipeline
+
+**Component key:** `gitlab.getPipeline`
 
 The Get Pipeline component retrieves details for a specific GitLab pipeline.
 
@@ -815,6 +835,8 @@ Returns pipeline data including status, ref, SHA, and pipeline URL.
 
 ## Get Test Report Summary
 
+**Component key:** `gitlab.getTestReportSummary`
+
 The Get Test Report Summary component fetches the test report summary for a GitLab pipeline.
 
 ### Configuration
@@ -873,6 +895,8 @@ The Get Test Report Summary component fetches the test report summary for a GitL
 <a id="run-pipeline"></a>
 
 ## Run Pipeline
+
+**Component key:** `gitlab.runPipeline`
 
 The Run Pipeline component triggers a GitLab pipeline and waits for it to complete.
 

--- a/docs/components/GoogleCloud.mdx
+++ b/docs/components/GoogleCloud.mdx
@@ -65,6 +65,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Artifact Registry • On Artifact Analysis
 
+**Trigger key:** `gcp.artifactregistry.onArtifactAnalysis`
+
 The On Artifact Analysis trigger starts a workflow execution when Google Container Analysis publishes a new occurrence (e.g. vulnerability finding, build provenance, or attestation) for an artifact.
 
 **Trigger behavior:** SuperPlane subscribes to the `container-analysis-occurrences-v1` Pub/Sub topic that Container Analysis automatically publishes to.
@@ -124,6 +126,8 @@ Each event contains the full Container Analysis Occurrence resource, including `
 
 ## Artifact Registry • On Artifact Push
 
+**Trigger key:** `gcp.artifactregistry.onArtifactPush`
+
 The On Artifact Push trigger starts a workflow execution when a Docker image or other container artifact is pushed to Artifact Registry.
 
 **Trigger behavior:** SuperPlane subscribes to the `gcr` Pub/Sub topic that Artifact Registry automatically publishes to for container image push events.
@@ -167,6 +171,8 @@ Each event contains:
 <a id="cloud-build-•-on-build-complete"></a>
 
 ## Cloud Build • On Build Complete
+
+**Trigger key:** `gcp.cloudbuild.onBuildComplete`
 
 The On Build Complete trigger starts a workflow execution when a GCP Cloud Build build finishes.
 
@@ -214,6 +220,8 @@ Each event contains the full Cloud Build resource, including `id`, `status` (SUC
 
 ## Compute • On VM Instance
 
+**Trigger key:** `gcp.compute.onVMInstance`
+
 The On VM Instance trigger starts a workflow execution when a Compute Engine VM instance lifecycle event occurs.
 
 **Trigger behavior:** SuperPlane creates a Cloud Logging sink that captures Compute Engine audit log events and routes them to a shared Pub/Sub topic. Events are pushed to SuperPlane and matched to this trigger automatically.
@@ -260,6 +268,8 @@ Each event includes the audit log entry with resourceName (e.g. projects/my-proj
 <a id="pub/sub-•-on-message"></a>
 
 ## Pub/Sub • On Message
+
+**Trigger key:** `gcp.pubsub.onMessage`
 
 The On Message trigger starts a workflow execution when a message is published to a GCP Pub/Sub topic.
 
@@ -309,6 +319,8 @@ Each event contains the decoded message payload plus Pub/Sub metadata:
 <a id="artifact-registry-•-get-artifact"></a>
 
 ## Artifact Registry • Get Artifact
+
+**Component key:** `gcp.artifactregistry.getArtifact`
 
 Retrieves the details of a specific artifact version from Google Artifact Registry.
 
@@ -362,6 +374,8 @@ Artifact Registry supports all package formats when using **Select from Registry
 
 ## Artifact Registry • Get Artifact Analysis
 
+**Component key:** `gcp.artifactregistry.getArtifactAnalysis`
+
 Retrieves existing Container Analysis occurrences for an artifact from Google Container Analysis.
 
 ### Configuration
@@ -412,6 +426,8 @@ An analysis summary for the artifact, including:
 
 ## Cloud Build • Create Build
 
+**Component key:** `gcp.cloudbuild.createBuild`
+
 Creates and starts a Google Cloud Build build, then waits for the build to reach a terminal status.
 
 ### Configuration
@@ -461,6 +477,8 @@ The terminal Build resource, including `id`, `status`, `logUrl`, `createTime`, `
 
 ## Cloud Build • Get Build
 
+**Component key:** `gcp.cloudbuild.getBuild`
+
 Retrieves the details of a specific Google Cloud Build build.
 
 ### Configuration
@@ -492,6 +510,8 @@ The full Build resource, including `id`, `status` (SUCCESS, FAILURE, WORKING, QU
 <a id="cloud-build-•-run-trigger"></a>
 
 ## Cloud Build • Run Trigger
+
+**Component key:** `gcp.cloudbuild.runTrigger`
 
 Runs an existing Cloud Build trigger and waits for the resulting build to reach a terminal status.
 
@@ -537,6 +557,8 @@ The terminal Build resource, including `id`, `status`, `logUrl`, `createTime`, `
 <a id="cloud-dns-•-create-record"></a>
 
 ## Cloud DNS • Create Record
+
+**Component key:** `gcp.clouddns.createRecord`
 
 The Create Record component creates a new DNS record set in a Google Cloud DNS managed zone.
 
@@ -584,6 +606,8 @@ The service account must have `roles/dns.admin` or `roles/dns.editor` on the pro
 
 ## Cloud DNS • Delete Record
 
+**Component key:** `gcp.clouddns.deleteRecord`
+
 The Delete Record component deletes a DNS record set from a Google Cloud DNS managed zone.
 
 ### Configuration
@@ -627,6 +651,8 @@ The service account must have `roles/dns.admin` or `roles/dns.editor` on the pro
 <a id="cloud-dns-•-update-record"></a>
 
 ## Cloud DNS • Update Record
+
+**Component key:** `gcp.clouddns.updateRecord`
 
 The Update Record component updates an existing DNS record set in a Google Cloud DNS managed zone.
 
@@ -674,6 +700,8 @@ The service account must have `roles/dns.admin` or `roles/dns.editor` on the pro
 
 ## Cloud Functions • Invoke Function
 
+**Component key:** `gcp.cloudfunctions.invokeFunction`
+
 Invokes a Google Cloud Function and waits for the response.
 
 ### Configuration
@@ -720,6 +748,8 @@ The invocation result, including:
 
 ## Compute • Create Virtual Machine
 
+**Component key:** `gcp.createVM`
+
 Creates a new Google Compute Engine VM.
 
 ### Steps
@@ -758,6 +788,8 @@ Emits a payload with instance details: instanceId, selfLink, internalIP, externa
 <a id="compute-•-delete-vm-instance"></a>
 
 ## Compute • Delete VM Instance
+
+**Component key:** `gcp.deleteVMInstance`
 
 The Delete VM Instance component permanently deletes a Compute Engine VM instance.
 
@@ -802,6 +834,8 @@ Returns information about the deleted instance:
 
 ## Pub/Sub • Create Subscription
 
+**Component key:** `gcp.pubsub.createSubscription`
+
 The Create Subscription component creates a new GCP Pub/Sub subscription on a topic.
 
 ### Use Cases
@@ -829,6 +863,8 @@ The Create Subscription component creates a new GCP Pub/Sub subscription on a to
 
 ## Pub/Sub • Create Topic
 
+**Component key:** `gcp.pubsub.createTopic`
+
 The Create Topic component creates a new GCP Pub/Sub topic.
 
 ### Use Cases
@@ -853,6 +889,8 @@ The Create Topic component creates a new GCP Pub/Sub topic.
 <a id="pub/sub-•-delete-subscription"></a>
 
 ## Pub/Sub • Delete Subscription
+
+**Component key:** `gcp.pubsub.deleteSubscription`
 
 The Delete Subscription component deletes a GCP Pub/Sub subscription.
 
@@ -879,6 +917,8 @@ The Delete Subscription component deletes a GCP Pub/Sub subscription.
 
 ## Pub/Sub • Delete Topic
 
+**Component key:** `gcp.pubsub.deleteTopic`
+
 The Delete Topic component deletes a GCP Pub/Sub topic.
 
 ### Use Cases
@@ -903,6 +943,8 @@ The Delete Topic component deletes a GCP Pub/Sub topic.
 <a id="pub/sub-•-publish-message"></a>
 
 ## Pub/Sub • Publish Message
+
+**Component key:** `gcp.pubsub.publishMessage`
 
 The Publish Message component sends a message to a GCP Pub/Sub topic.
 

--- a/docs/components/Grafana.mdx
+++ b/docs/components/Grafana.mdx
@@ -61,6 +61,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Alert Firing
 
+**Trigger key:** `grafana.onAlertFiring`
+
 The On Alert Firing trigger starts a workflow when Grafana Unified Alerting sends a firing alert webhook.
 
 ### Setup
@@ -115,6 +117,8 @@ The trigger emits the full Grafana webhook payload, including:
 
 ## Add Incident Activity
 
+**Component key:** `grafana.addIncidentActivity`
+
 The Add Incident Activity component posts a user note to a Grafana IRM incident timeline.
 
 ### Configuration
@@ -145,6 +149,8 @@ Returns the created activity item.
 <a id="create-alert-rule"></a>
 
 ## Create Alert Rule
+
+**Component key:** `grafana.createAlertRule`
 
 The Create Alert Rule component creates a Grafana-managed alert rule using the Alerting Provisioning HTTP API.
 
@@ -282,6 +288,8 @@ Returns the created Grafana alert rule object, including identifiers and evaluat
 
 ## Create Annotation
 
+**Component key:** `grafana.createAnnotation`
+
 The Create Annotation component writes an annotation into Grafana, marking operational events on dashboard timelines.
 
 ### Use Cases
@@ -320,6 +328,8 @@ Returns the ID of the newly created annotation.
 <a id="create-http-synthetic-check"></a>
 
 ## Create HTTP Synthetic Check
+
+**Component key:** `grafana.createHttpSyntheticCheck`
 
 The Create HTTP Synthetic Check component creates an HTTP synthetic check in Grafana Synthetic Monitoring.
 
@@ -417,6 +427,8 @@ Returns the created Grafana synthetic check, including its ID and HTTP configura
 
 ## Create Silence
 
+**Component key:** `grafana.createSilence`
+
 The Create Silence component creates a new Alertmanager silence in Grafana, suppressing alert notifications that match the configured matchers during the specified time window.
 
 ### Use Cases
@@ -454,6 +466,8 @@ Returns the ID of the newly created silence.
 <a id="declare-drill"></a>
 
 ## Declare Drill
+
+**Component key:** `grafana.declareDrill`
 
 The Declare Drill component creates a new drill incident in Grafana IRM.
 
@@ -507,6 +521,8 @@ Returns the created Grafana IRM incident.
 
 ## Declare Incident
 
+**Component key:** `grafana.declareIncident`
+
 The Declare Incident component creates a new incident in Grafana IRM.
 
 ### Use Cases
@@ -558,6 +574,8 @@ Returns the created Grafana IRM incident.
 
 ## Delete Alert Rule
 
+**Component key:** `grafana.deleteAlertRule`
+
 The Delete Alert Rule component deletes a Grafana-managed alert rule using the Alerting Provisioning HTTP API.
 
 ### Use Cases
@@ -592,6 +610,8 @@ Returns a confirmation object with the deleted alert rule UID, title, and deleti
 
 ## Delete Annotation
 
+**Component key:** `grafana.deleteAnnotation`
+
 The Delete Annotation component removes an annotation from Grafana by ID.
 
 ### Use Cases
@@ -625,6 +645,8 @@ Returns the annotation ID and a confirmation that the annotation was deleted.
 
 ## Delete HTTP Synthetic Check
 
+**Component key:** `grafana.deleteHttpSyntheticCheck`
+
 The Delete HTTP Synthetic Check component deletes an existing Grafana synthetic check.
 
 ### Configuration
@@ -653,6 +675,8 @@ Returns a compact confirmation payload for the deleted check.
 <a id="delete-silence"></a>
 
 ## Delete Silence
+
+**Component key:** `grafana.deleteSilence`
 
 The Delete Silence component expires an existing silence in Grafana Alertmanager.
 
@@ -685,6 +709,8 @@ Returns the silence ID and a confirmation that the silence was deleted.
 <a id="get-alert-rule"></a>
 
 ## Get Alert Rule
+
+**Component key:** `grafana.getAlertRule`
 
 The Get Alert Rule component fetches a Grafana-managed alert rule using the Alerting Provisioning HTTP API.
 
@@ -811,6 +837,8 @@ Returns the full Grafana alert rule object, including title, folder, group, cond
 
 ## Get Dashboard
 
+**Component key:** `grafana.getDashboard`
+
 The Get Dashboard component fetches a Grafana dashboard using the Grafana Dashboards HTTP API.
 
 ### Use Cases
@@ -868,6 +896,8 @@ Returns the Grafana dashboard object, including title, slug, URL, folder, tags, 
 <a id="get-http-synthetic-check"></a>
 
 ## Get HTTP Synthetic Check
+
+**Component key:** `grafana.getHttpSyntheticCheck`
 
 The Get HTTP Synthetic Check component fetches a Grafana synthetic check and enriches it with best-effort operational metrics.
 
@@ -975,6 +1005,8 @@ Returns a combined payload containing:
 
 ## Get Incident
 
+**Component key:** `grafana.getIncident`
+
 The Get Incident component retrieves a single incident from Grafana IRM.
 
 ### Configuration
@@ -1016,6 +1048,8 @@ Returns the full Grafana IRM incident object.
 <a id="get-silence"></a>
 
 ## Get Silence
+
+**Component key:** `grafana.getSilence`
 
 The Get Silence component fetches the details of a single silence from Grafana Alertmanager using its ID.
 
@@ -1063,6 +1097,8 @@ Returns the silence object including ID, state, comment, matchers, start/end tim
 <a id="list-alert-rules"></a>
 
 ## List Alert Rules
+
+**Component key:** `grafana.listAlertRules`
 
 The List Alert Rules component lists Grafana-managed alert rules using the Alerting Provisioning HTTP API.
 
@@ -1113,6 +1149,8 @@ Returns an object containing the list of Grafana alert rule summaries, including
 <a id="list-annotations"></a>
 
 ## List Annotations
+
+**Component key:** `grafana.listAnnotations`
 
 The List Annotations component retrieves annotations from Grafana, optionally filtered by tag, dashboard, or time range.
 
@@ -1180,6 +1218,8 @@ Returns a list of annotation objects including ID, text, tags, time, and dashboa
 
 ## List Silences
 
+**Component key:** `grafana.listSilences`
+
 The List Silences component retrieves silences from Grafana Alertmanager.
 
 ### Use Cases
@@ -1231,6 +1271,8 @@ Returns a list of silence objects, each including ID, state, comment, matchers, 
 <a id="query-data-source"></a>
 
 ## Query Data Source
+
+**Component key:** `grafana.queryDataSource`
 
 The Query Data Source component executes a query against a Grafana data source using the Grafana Query API.
 
@@ -1298,6 +1340,8 @@ Returns the Grafana query API response JSON.
 <a id="query-logs"></a>
 
 ## Query Logs
+
+**Component key:** `grafana.queryLogs`
 
 The Query Logs component executes a LogQL query against a Loki-backed Grafana data source.
 
@@ -1378,6 +1422,8 @@ Returns the Grafana query API response containing matching log frames.
 <a id="query-traces"></a>
 
 ## Query Traces
+
+**Component key:** `grafana.queryTraces`
 
 The Query Traces component executes a TraceQL query against a Tempo-backed Grafana data source.
 
@@ -1463,6 +1509,8 @@ Returns the Grafana query API response containing matching trace frames.
 
 ## Render Panel
 
+**Component key:** `grafana.renderPanel`
+
 The Render Panel component constructs a Grafana image render URL for a dashboard panel using the Grafana Image Renderer.
 
 ### Use Cases
@@ -1501,6 +1549,8 @@ Returns the Grafana render URL along with the dashboard UID and panel.
 <a id="resolve-incident"></a>
 
 ## Resolve Incident
+
+**Component key:** `grafana.resolveIncident`
 
 The Resolve Incident component marks an existing Grafana IRM incident as resolved.
 
@@ -1545,6 +1595,8 @@ Returns the resolved Grafana IRM incident.
 <a id="update-alert-rule"></a>
 
 ## Update Alert Rule
+
+**Component key:** `grafana.updateAlertRule`
 
 The Update Alert Rule component updates a Grafana-managed alert rule using the Alerting Provisioning HTTP API.
 
@@ -1677,6 +1729,8 @@ Returns the updated Grafana alert rule object after the provisioning API applies
 
 ## Update HTTP Synthetic Check
 
+**Component key:** `grafana.updateHttpSyntheticCheck`
+
 The Update HTTP Synthetic Check component updates an existing Grafana Synthetic Monitoring HTTP check.
 
 ### Configuration
@@ -1759,6 +1813,8 @@ Returns the updated Grafana synthetic check.
 <a id="update-incident"></a>
 
 ## Update Incident
+
+**Component key:** `grafana.updateIncident`
 
 The Update Incident component updates supported fields on an existing Grafana IRM incident.
 

--- a/docs/components/Harness.mdx
+++ b/docs/components/Harness.mdx
@@ -30,6 +30,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Pipeline Completed
 
+**Trigger key:** `harness.onPipelineCompleted`
+
 The On Pipeline Completed trigger starts a workflow when a Harness pipeline execution finishes.
 
 ### Use Cases
@@ -77,6 +79,8 @@ If no pipeline is selected, or webhook delivery is unavailable in your Harness a
 <a id="run-pipeline"></a>
 
 ## Run Pipeline
+
+**Component key:** `harness.runPipeline`
 
 The Run Pipeline component starts a Harness pipeline execution and waits for it to finish.
 

--- a/docs/components/HetznerCloud.mdx
+++ b/docs/components/HetznerCloud.mdx
@@ -25,6 +25,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Create Load Balancer
 
+**Component key:** `hetzner.createLoadBalancer`
+
 The Create Load Balancer component creates a load balancer in Hetzner Cloud.
 
 ### How It Works
@@ -56,6 +58,8 @@ The Create Load Balancer component creates a load balancer in Hetzner Cloud.
 <a id="create-server"></a>
 
 ## Create Server
+
+**Component key:** `hetzner.createServer`
 
 The Create Server component creates a new server in Hetzner Cloud and waits for the create action to complete.
 
@@ -95,6 +99,8 @@ The Create Server component creates a new server in Hetzner Cloud and waits for 
 
 ## Create Snapshot
 
+**Component key:** `hetzner.createSnapshot`
+
 The Create Snapshot component creates a snapshot image from an existing Hetzner Cloud server and waits for completion.
 
 ### How It Works
@@ -128,6 +134,8 @@ The Create Snapshot component creates a snapshot image from an existing Hetzner 
 
 ## Delete Load Balancer
 
+**Component key:** `hetzner.deleteLoadBalancer`
+
 The Delete Load Balancer component deletes a load balancer in Hetzner Cloud.
 
 ### How It Works
@@ -150,6 +158,8 @@ The Delete Load Balancer component deletes a load balancer in Hetzner Cloud.
 <a id="delete-server"></a>
 
 ## Delete Server
+
+**Component key:** `hetzner.deleteServer`
 
 The Delete Server component deletes a server in Hetzner Cloud and waits for the delete action to complete.
 
@@ -175,6 +185,8 @@ The Delete Server component deletes a server in Hetzner Cloud and waits for the 
 <a id="delete-snapshot"></a>
 
 ## Delete Snapshot
+
+**Component key:** `hetzner.deleteSnapshot`
 
 The Delete Snapshot component deletes a snapshot image in Hetzner Cloud.
 

--- a/docs/components/Honeycomb.mdx
+++ b/docs/components/Honeycomb.mdx
@@ -34,6 +34,8 @@ SuperPlane will automatically validate your credentials and manage all necessary
 
 ## On Alert Fired
 
+**Trigger key:** `honeycomb.onAlertFired`
+
 Starts a workflow execution when a Honeycomb Trigger fires.
 
 **Configuration:**
@@ -79,6 +81,8 @@ When the trigger fires, SuperPlane receives the webhook and starts a workflow ex
 <a id="create-event"></a>
 
 ## Create Event
+
+**Component key:** `honeycomb.createEvent`
 
 Sends a JSON event to a Honeycomb dataset.
 

--- a/docs/components/Incident.mdx
+++ b/docs/components/Incident.mdx
@@ -33,6 +33,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Incident
 
+**Trigger key:** `incident.onIncident`
+
 The On Incident trigger starts a workflow execution when incident.io sends webhooks for incident created or updated events.
 
 ### Use Cases
@@ -88,6 +90,8 @@ incident.io does not provide an API to register webhook endpoints. After adding 
 <a id="create-incident"></a>
 
 ## Create Incident
+
+**Component key:** `incident.createIncident`
 
 The Create Incident component creates a new incident in incident.io.
 

--- a/docs/components/JFrogArtifactory.mdx
+++ b/docs/components/JFrogArtifactory.mdx
@@ -33,6 +33,8 @@ To set up the JFrog Artifactory integration:
 
 ## On Artifact Uploaded
 
+**Trigger key:** `jfrogArtifactory.onArtifactUploaded`
+
 The On Artifact Uploaded trigger starts a workflow execution when an artifact is deployed to JFrog Artifactory.
 
 ### Configuration
@@ -62,6 +64,8 @@ The On Artifact Uploaded trigger starts a workflow execution when an artifact is
 <a id="delete-artifact"></a>
 
 ## Delete Artifact
+
+**Component key:** `jfrogArtifactory.deleteArtifact`
 
 The Delete Artifact component removes an artifact from a JFrog Artifactory repository.
 
@@ -96,6 +100,8 @@ Returns the repository and path of the deleted artifact.
 <a id="get-artifact-info"></a>
 
 ## Get Artifact Info
+
+**Component key:** `jfrogArtifactory.getArtifactInfo`
 
 The Get Artifact Info component retrieves metadata about an artifact stored in JFrog Artifactory.
 

--- a/docs/components/Jira.mdx
+++ b/docs/components/Jira.mdx
@@ -32,6 +32,8 @@ To connect Jira to SuperPlane:
 
 ## Create Incident
 
+**Component key:** `jira.createIncident`
+
 The Create Incident component opens a new incident in Jira Service Management.
 
 ### Use Cases
@@ -83,6 +85,8 @@ Returns **id** (numeric issue id), **key** (e.g. ITSM-30), and **self** (issue R
 <a id="create-issue"></a>
 
 ## Create Issue
+
+**Component key:** `jira.createIssue`
 
 The Create Issue component creates a new issue in Jira.
 
@@ -163,6 +167,8 @@ Returns the created issue including:
 
 ## Delete Incident
 
+**Component key:** `jira.deleteIncident`
+
 The Delete Incident component removes an incident from Jira Service Management.
 
 ### Use Cases
@@ -194,6 +200,8 @@ Confirms deletion with **deleted** set to true.
 <a id="delete-issue"></a>
 
 ## Delete Issue
+
+**Component key:** `jira.deleteIssue`
 
 The Delete Issue component permanently removes an issue from Jira.
 
@@ -230,6 +238,8 @@ Returns the deleted issue's `id` and `key`, plus `deleted: true`.
 
 ## Get Incident
 
+**Component key:** `jira.getIncident`
+
 The Get Incident component returns incident details from Jira Service Management.
 
 ### Use Cases
@@ -265,6 +275,8 @@ Payload type jira.incident.fetched with the incident object returned by Atlassia
 <a id="get-issue"></a>
 
 ## Get Issue
+
+**Component key:** `jira.getIssue`
 
 The Get Issue component retrieves a Jira issue and its fields for downstream routing and inspection.
 
@@ -337,6 +349,8 @@ Returns the Jira issue object including `id`, `key`, `self` and the full `fields
 <a id="update-issue"></a>
 
 ## Update Issue
+
+**Component key:** `jira.updateIssue`
 
 The Update Issue component updates fields on an existing Jira issue.
 

--- a/docs/components/LaunchDarkly.mdx
+++ b/docs/components/LaunchDarkly.mdx
@@ -32,6 +32,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Feature Flag Change
 
+**Trigger key:** `launchdarkly.onFeatureFlagChange`
+
 The On Feature Flag Change trigger starts a workflow execution when LaunchDarkly sends webhooks for feature flags in a project.
 
 ### Use Cases
@@ -96,6 +98,8 @@ SuperPlane uses the LaunchDarkly API (via your configured API access token) to c
 
 ## Delete Feature Flag
 
+**Component key:** `launchdarkly.deleteFeatureFlag`
+
 The Delete Feature Flag component permanently deletes a feature flag from a LaunchDarkly project.
 
 ### Use Cases
@@ -132,6 +136,8 @@ Returns a confirmation payload with the deleted flag's project and flag keys.
 <a id="get-feature-flag"></a>
 
 ## Get Feature Flag
+
+**Component key:** `launchdarkly.getFeatureFlag`
 
 The Get Feature Flag component retrieves a specific feature flag from a LaunchDarkly project.
 

--- a/docs/components/Logfire.mdx
+++ b/docs/components/Logfire.mdx
@@ -37,6 +37,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Alert Received
 
+**Trigger key:** `logfire.onAlertReceived`
+
 The On Alert Received trigger starts a workflow execution when Logfire sends an alert payload to your SuperPlane webhook URL.
 
 ### Configuration
@@ -66,6 +68,8 @@ After you save this trigger, SuperPlane provides a webhook URL. Add that URL as 
 <a id="query-logfire"></a>
 
 ## Query Logfire
+
+**Component key:** `logfire.queryLogfire`
 
 The Query Logfire component executes a read-only SQL query against Logfire and returns query results for use in downstream steps.
 

--- a/docs/components/MicrosoftAzure.mdx
+++ b/docs/components/MicrosoftAzure.mdx
@@ -58,6 +58,8 @@ SuperPlane will use Workload Identity Federation to authenticate without storing
 
 ## On Blob Created
 
+**Trigger key:** `azure.onBlobCreated`
+
 The On Blob Created trigger starts a workflow execution when a blob is created or replaced in an Azure Storage Account.
 
 ### Use Cases
@@ -123,6 +125,8 @@ Each blob created event includes:
 
 ## On Blob Deleted
 
+**Trigger key:** `azure.onBlobDeleted`
+
 The On Blob Deleted trigger starts a workflow execution when a blob is deleted from an Azure Storage Account.
 
 ### Use Cases
@@ -184,6 +188,8 @@ Each blob deleted event includes:
 <a id="on-image-deleted"></a>
 
 ## On Image Deleted
+
+**Trigger key:** `azure.onContainerImageDeleted`
 
 The On Image Deleted trigger starts a workflow execution when a container image is deleted from an Azure Container Registry.
 
@@ -262,6 +268,8 @@ Each delete event includes:
 <a id="on-image-pushed"></a>
 
 ## On Image Pushed
+
+**Trigger key:** `azure.onContainerImagePushed`
 
 The On Image Pushed trigger starts a workflow execution when a container image is pushed to an Azure Container Registry.
 
@@ -343,6 +351,8 @@ Each push event includes:
 <a id="on-vm-deallocated"></a>
 
 ## On VM Deallocated
+
+**Trigger key:** `azure.onVirtualMachineDeallocated`
 
 The On VM Deallocated trigger starts a workflow execution when an Azure Virtual Machine is deallocated.
 
@@ -436,6 +446,8 @@ No manual setup is required.
 
 ## On VM Deleted
 
+**Trigger key:** `azure.onVirtualMachineDeleted`
+
 The On VM Deleted trigger starts a workflow execution when an Azure Virtual Machine is deleted.
 
 ### Use Cases
@@ -521,6 +533,8 @@ No manual setup is required.
 <a id="on-vm-restarted"></a>
 
 ## On VM Restarted
+
+**Trigger key:** `azure.onVirtualMachineRestarted`
 
 The On VM Restarted trigger starts a workflow execution when an Azure Virtual Machine is restarted.
 
@@ -615,6 +629,8 @@ No manual setup is required.
 
 ## On VM Started
 
+**Trigger key:** `azure.onVirtualMachineStarted`
+
 The On VM Started trigger starts a workflow execution when an Azure Virtual Machine is started.
 
 ### Use Cases
@@ -703,6 +719,8 @@ No manual setup is required.
 <a id="on-vm-stopped"></a>
 
 ## On VM Stopped
+
+**Trigger key:** `azure.onVirtualMachineStopped`
 
 The On VM Stopped trigger starts a workflow execution when an Azure Virtual Machine is powered off.
 
@@ -795,6 +813,8 @@ No manual setup is required.
 
 ## Create Virtual Machine
 
+**Component key:** `azure.createVirtualMachine`
+
 The Create Virtual Machine component creates a new Azure VM with full configuration options.
 
 ### Use Cases
@@ -859,6 +879,8 @@ Returns the created VM information including:
 
 ## Deallocate Virtual Machine
 
+**Component key:** `azure.deallocateVirtualMachine`
+
 The Deallocate Virtual Machine component deallocates an existing Azure VM, stopping it and
 releasing its compute resources.
 
@@ -915,6 +937,8 @@ Returns the deallocated VM information including:
 
 ## Delete Virtual Machine
 
+**Component key:** `azure.deleteVirtualMachine`
+
 The Delete Virtual Machine component deletes an existing Azure VM.
 
 ### Use Cases
@@ -970,6 +994,8 @@ Returns the deleted VM information including:
 
 ## Restart Virtual Machine
 
+**Component key:** `azure.restartVirtualMachine`
+
 The Restart Virtual Machine component restarts an existing Azure VM in place.
 
 ### Use Cases
@@ -1023,6 +1049,8 @@ Returns the restarted VM information including:
 
 ## Start Virtual Machine
 
+**Component key:** `azure.startVirtualMachine`
+
 The Start Virtual Machine component starts a stopped or deallocated Azure VM.
 
 ### Use Cases
@@ -1075,6 +1103,8 @@ Returns the started VM information including:
 <a id="stop-virtual-machine"></a>
 
 ## Stop Virtual Machine
+
+**Component key:** `azure.stopVirtualMachine`
 
 The Stop Virtual Machine component powers off an existing Azure VM without deallocating it.
 

--- a/docs/components/MicrosoftTeams.mdx
+++ b/docs/components/MicrosoftTeams.mdx
@@ -42,6 +42,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Mention
 
+**Trigger key:** `teams.onMention`
+
 The On Mention trigger starts a workflow execution when the Teams bot is @mentioned in a channel message.
 
 ### Use Cases
@@ -120,6 +122,8 @@ This trigger works with the default Bot Framework behavior — the bot receives 
 
 ## On Message
 
+**Trigger key:** `teams.onMessage`
+
 The On Message trigger starts a workflow execution when any message is posted in a Teams channel.
 
 ### Use Cases
@@ -190,6 +194,8 @@ The generated Teams app manifest includes this permission by default. If you cre
 <a id="send-text-message"></a>
 
 ## Send Text Message
+
+**Component key:** `teams.sendTextMessage`
 
 The Send Text Message component sends a text message to a Microsoft Teams channel.
 

--- a/docs/components/NewRelic.mdx
+++ b/docs/components/NewRelic.mdx
@@ -39,6 +39,8 @@ SuperPlane automatically creates a Webhook Notification Channel in your New Reli
 
 ## On Issue
 
+**Trigger key:** `newrelic.onIssue`
+
 The On Issue trigger starts a workflow execution when a New Relic alert issue is received via webhook.
 
 ### What this trigger does
@@ -85,6 +87,8 @@ SuperPlane automatically creates a Webhook Notification Channel in your New Reli
 
 ## Report Metric
 
+**Component key:** `newrelic.reportMetric`
+
 The Report Metric component sends custom metric data to New Relic's Metric API.
 
 ### Use Cases
@@ -127,6 +131,8 @@ The component emits a metric confirmation containing:
 <a id="run-nrql-query"></a>
 
 ## Run NRQL Query
+
+**Component key:** `newrelic.runNRQLQuery`
 
 The Run NRQL Query component executes a NRQL query against New Relic data via the NerdGraph API.
 

--- a/docs/components/OctopusDeploy.mdx
+++ b/docs/components/OctopusDeploy.mdx
@@ -32,6 +32,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Deployment Event
 
+**Trigger key:** `octopus.onDeploymentEvent`
+
 The On Deployment Event trigger emits events when a deployment's status changes in Octopus Deploy.
 
 ### Use Cases
@@ -101,6 +103,8 @@ Each emitted event includes the following fields:
 <a id="deploy-release"></a>
 
 ## Deploy Release
+
+**Component key:** `octopus.deployRelease`
 
 The Deploy Release component deploys a chosen release to a chosen environment in Octopus Deploy and waits for completion.
 

--- a/docs/components/OpenAI.mdx
+++ b/docs/components/OpenAI.mdx
@@ -16,6 +16,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Text Prompt
 
+**Component key:** `openai.textPrompt`
+
 The Text Prompt component generates text responses using OpenAI's language models.
 
 ### Use Cases

--- a/docs/components/OracleCloudInfrastructure.mdx
+++ b/docs/components/OracleCloudInfrastructure.mdx
@@ -94,6 +94,8 @@ Allow service cloudEvents to use ons-topics in tenancy
 
 ## On Compute Instance Created
 
+**Trigger key:** `oci.onComputeInstanceCreated`
+
 The On Compute Instance Created trigger starts a workflow execution whenever an OCI Compute instance launch completes.
 
 ### How It Works
@@ -152,6 +154,8 @@ Each event payload includes:
 <a id="on-instance-state-change"></a>
 
 ## On Instance State Change
+
+**Trigger key:** `oci.onInstanceStateChange`
 
 The On Instance State Change trigger starts a workflow execution whenever an Oracle Cloud Infrastructure Compute instance completes a power or termination operation.
 
@@ -215,6 +219,8 @@ Each event payload includes:
 
 ## Create Application
 
+**Component key:** `oci.createApplication`
+
 The Create Application component creates a new Oracle Cloud Infrastructure Functions application.
 
 ### Use Cases
@@ -256,6 +262,8 @@ Emits the created application details including:
 <a id="create-compute-instance"></a>
 
 ## Create Compute Instance
+
+**Component key:** `oci.createComputeInstance`
 
 The Create Compute Instance component provisions a new Oracle Cloud Infrastructure Compute instance and waits until it reaches **RUNNING** state before emitting.
 
@@ -315,6 +323,8 @@ Emits the created instance details on the default output channel, including:
 
 ## Create Function
 
+**Component key:** `oci.createFunction`
+
 The Create Function component deploys a new serverless function within an existing OCI Functions application.
 
 ### Use Cases
@@ -366,6 +376,8 @@ Emits the created function details including:
 
 ## Create Image
 
+**Component key:** `oci.createImage`
+
 The Create Image component creates an OCI Compute boot disk image.
 
 ### Use Cases
@@ -416,6 +428,8 @@ The component waits for the image to reach `AVAILABLE` before emitting.
 
 ## Delete Application
 
+**Component key:** `oci.deleteApplication`
+
 The Delete Application component removes an Oracle Cloud Infrastructure Functions application.
 
 > **Important:** OCI will reject the deletion with a 409 Conflict if the application still contains functions.
@@ -451,6 +465,8 @@ Emits the deleted application ID on the default output channel:
 
 ## Delete Function
 
+**Component key:** `oci.deleteFunction`
+
 The Delete Function component removes a function from an Oracle Cloud Infrastructure Functions application.
 
 ### Configuration
@@ -482,6 +498,8 @@ Emits the deleted function ID on the default output channel:
 
 ## Delete Image
 
+**Component key:** `oci.deleteImage`
+
 The Delete Image component deletes an OCI Compute custom image. Oracle-provided platform images cannot be deleted.
 
 ### Use Cases
@@ -507,6 +525,8 @@ The Delete Image component deletes an OCI Compute custom image. Oracle-provided 
 <a id="delete-instance"></a>
 
 ## Delete Instance
+
+**Component key:** `oci.deleteInstance`
 
 The Delete Instance component terminates an Oracle Cloud Infrastructure Compute instance and waits until OCI reports it as terminated.
 
@@ -544,6 +564,8 @@ Emits a minimal deletion payload on the default output channel:
 
 ## Get Image
 
+**Component key:** `oci.getImage`
+
 The Get Image component retrieves metadata for an OCI Compute custom image. Oracle-provided platform images are not returned by this component.
 
 ### Use Cases
@@ -579,6 +601,8 @@ The Get Image component retrieves metadata for an OCI Compute custom image. Orac
 <a id="get-instance"></a>
 
 ## Get Instance
+
+**Component key:** `oci.getInstance`
 
 The Get Instance component fetches the latest details for an Oracle Cloud Infrastructure Compute instance.
 
@@ -631,6 +655,8 @@ Emits the instance details on the default output channel, including:
 
 ## Invoke Function
 
+**Component key:** `oci.invokeFunction`
+
 The Invoke Function component executes an Oracle Cloud Infrastructure serverless function and emits its response.
 
 ### Use Cases
@@ -670,6 +696,8 @@ Emits the function response on the default output channel:
 <a id="manage-instance-power"></a>
 
 ## Manage Instance Power
+
+**Component key:** `oci.manageInstancePower`
 
 The Manage Instance Power component performs a power lifecycle action on an Oracle Cloud Infrastructure Compute instance and waits for the target state.
 
@@ -719,6 +747,8 @@ Emits the instance details on the default output channel once the instance reach
 
 ## Update Image
 
+**Component key:** `oci.updateImage`
+
 The Update Image component updates the display name of an OCI Compute custom image. Oracle-provided platform images cannot be updated.
 
 ### Use Cases
@@ -754,6 +784,8 @@ The Update Image component updates the display name of an OCI Compute custom ima
 <a id="update-instance"></a>
 
 ## Update Instance
+
+**Component key:** `oci.updateInstance`
 
 The Update Instance component updates mutable attributes on an Oracle Cloud Infrastructure Compute instance.
 

--- a/docs/components/PagerDuty.mdx
+++ b/docs/components/PagerDuty.mdx
@@ -33,6 +33,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Incident
 
+**Trigger key:** `pagerduty.onIncident`
+
 The On Incident trigger starts a workflow execution when PagerDuty incident events occur.
 
 ### Use Cases
@@ -139,6 +141,8 @@ This trigger automatically sets up a PagerDuty webhook subscription when configu
 
 ## On Incident Annotated
 
+**Trigger key:** `pagerduty.onIncidentAnnotated`
+
 The On Incident Annotated trigger starts a workflow execution when a note is added to a PagerDuty incident.
 
 ### Use Cases
@@ -231,6 +235,8 @@ This trigger automatically sets up a PagerDuty webhook subscription when configu
 
 ## On Incident Status Update
 
+**Trigger key:** `pagerduty.onIncidentStatusUpdate`
+
 The On Incident Status Update trigger starts a workflow execution when PagerDuty incident status changes.
 
 ### Use Cases
@@ -297,6 +303,8 @@ This trigger automatically sets up a PagerDuty webhook subscription when configu
 <a id="acknowledge-incident"></a>
 
 ## Acknowledge Incident
+
+**Component key:** `pagerduty.acknowledgeIncident`
 
 The Acknowledge Incident component acknowledges an existing PagerDuty incident.
 
@@ -406,6 +414,8 @@ Returns the acknowledged incident object with all current information.
 
 ## Annotate Incident
 
+**Component key:** `pagerduty.annotateIncident`
+
 The Annotate Incident component adds a note to an existing PagerDuty incident.
 
 ### Use Cases
@@ -514,6 +524,8 @@ Returns the incident object with all current information.
 <a id="create-incident"></a>
 
 ## Create Incident
+
+**Component key:** `pagerduty.createIncident`
 
 The Create Incident component creates a new incident in PagerDuty.
 
@@ -631,6 +643,8 @@ Returns the created incident object including:
 <a id="escalate-incident"></a>
 
 ## Escalate Incident
+
+**Component key:** `pagerduty.escalateIncident`
 
 The Escalate Incident component escalates an existing PagerDuty incident to a specific escalation level within its current escalation policy.
 
@@ -750,6 +764,8 @@ Returns the escalated incident object with all current information.
 <a id="list-incidents"></a>
 
 ## List Incidents
+
+**Component key:** `pagerduty.listIncidents`
 
 The List Incidents component queries PagerDuty for open incidents and routes execution based on urgency levels.
 
@@ -889,6 +905,8 @@ Returns a list of open incidents with:
 
 ## List Log Entries
 
+**Component key:** `pagerduty.listLogEntries`
+
 The List Log Entries component retrieves all log entries (audit trail) for a PagerDuty incident.
 
 ### Use Cases
@@ -976,6 +994,8 @@ Returns a list of log entries with:
 
 ## List Notes
 
+**Component key:** `pagerduty.listNotes`
+
 The List Notes component retrieves all notes (timeline entries) for a PagerDuty incident.
 
 ### Use Cases
@@ -1057,6 +1077,8 @@ Returns a list of notes with:
 <a id="resolve-incident"></a>
 
 ## Resolve Incident
+
+**Component key:** `pagerduty.resolveIncident`
 
 The Resolve Incident component resolves an existing PagerDuty incident.
 
@@ -1155,6 +1177,8 @@ Returns the resolved incident object with all current information.
 <a id="snooze-incident"></a>
 
 ## Snooze Incident
+
+**Component key:** `pagerduty.snoozeIncident`
 
 The Snooze Incident component temporarily pauses notifications for an acknowledged PagerDuty incident.
 
@@ -1266,6 +1290,8 @@ Returns the snoozed incident object with all current information.
 <a id="update-incident"></a>
 
 ## Update Incident
+
+**Component key:** `pagerduty.updateIncident`
 
 The Update Incident component modifies an existing PagerDuty incident.
 

--- a/docs/components/Perplexity.mdx
+++ b/docs/components/Perplexity.mdx
@@ -16,6 +16,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Run Agent
 
+**Component key:** `perplexity.runAgent`
+
 The Run Agent component uses Perplexity's Agent API to run AI agents that can search the web and fetch URLs.
 
 ### Use Cases

--- a/docs/components/Prometheus.mdx
+++ b/docs/components/Prometheus.mdx
@@ -44,6 +44,8 @@ After editing config, reload Alertmanager (for example `POST /-/reload` when lif
 
 ## On Alert
 
+**Trigger key:** `prometheus.onAlert`
+
 The On Alert trigger starts a workflow execution when Alertmanager sends alerts to SuperPlane.
 
 ### What this trigger does
@@ -108,6 +110,8 @@ After updating Alertmanager config, reload it (for example `POST /-/reload` when
 
 ## Create Silence
 
+**Component key:** `prometheus.createSilence`
+
 The Create Silence component creates a silence in Alertmanager (`POST /api/v2/silences`) to suppress matching alerts.
 
 ### Configuration
@@ -160,6 +164,8 @@ Emits one `prometheus.silence` payload with silence ID, status, matchers, timing
 
 ## Expire Silence
 
+**Component key:** `prometheus.expireSilence`
+
 The Expire Silence component expires an active silence in Alertmanager (`DELETE /api/v2/silence/{silenceID}`).
 
 ### Configuration
@@ -186,6 +192,8 @@ Emits one `prometheus.silence.expired` payload with silence ID and status.
 <a id="get-alert"></a>
 
 ## Get Alert
+
+**Component key:** `prometheus.getAlert`
 
 The Get Alert component fetches active alerts from Prometheus (`/api/v1/alerts`) and returns the first alert that matches.
 
@@ -223,6 +231,8 @@ Emits one `prometheus.alert` payload with labels, annotations, state, and timing
 <a id="get-silence"></a>
 
 ## Get Silence
+
+**Component key:** `prometheus.getSilence`
 
 The Get Silence component retrieves a silence from Alertmanager (`GET /api/v2/silence/{silenceID}`) by its ID.
 
@@ -263,6 +273,8 @@ Emits one `prometheus.silence` payload with silence ID, status, matchers, timing
 
 ## Query
 
+**Component key:** `prometheus.query`
+
 The Query component executes an instant PromQL query against Prometheus (`GET /api/v1/query`).
 
 ### Configuration
@@ -301,6 +313,8 @@ Emits one `prometheus.query` payload with the result type and results.
 <a id="query-range"></a>
 
 ## Query Range
+
+**Component key:** `prometheus.queryRange`
 
 The Query Range component executes a range PromQL query against Prometheus (`GET /api/v1/query_range`).
 

--- a/docs/components/Render.mdx
+++ b/docs/components/Render.mdx
@@ -42,6 +42,8 @@ Note: **Plan requirement:** Render webhooks require a Professional plan or highe
 
 ## On Build
 
+**Trigger key:** `render.onBuild`
+
 The On Build trigger emits build-related Render events for one selected service.
 
 ### Use Cases
@@ -85,6 +87,8 @@ The default output emits payload data fields like `buildId`, `eventId`, `service
 <a id="on-deploy"></a>
 
 ## On Deploy
+
+**Trigger key:** `render.onDeploy`
 
 The On Deploy trigger emits deploy-related Render events for one selected service.
 
@@ -130,6 +134,8 @@ The default output emits payload data fields like `deployId`, `eventId`, `servic
 <a id="cancel-deploy"></a>
 
 ## Cancel Deploy
+
+**Component key:** `render.cancelDeploy`
 
 The Cancel Deploy component cancels an in-progress deploy for a Render service and waits for it to complete.
 
@@ -183,6 +189,8 @@ The Cancel Deploy component cancels an in-progress deploy for a Render service a
 
 ## Deploy
 
+**Component key:** `render.deploy`
+
 The Deploy component starts a new deploy for a Render service and waits for it to complete.
 
 ### Use Cases
@@ -235,6 +243,8 @@ The Deploy component starts a new deploy for a Render service and waits for it t
 
 ## Get Deploy
 
+**Component key:** `render.getDeploy`
+
 The Get Deploy component fetches a deploy for a Render service.
 
 ### Use Cases
@@ -282,6 +292,8 @@ Emits a `render.deploy` payload containing deploy fields like `deployId`, `statu
 
 ## Get Service
 
+**Component key:** `render.getService`
+
 The Get Service component fetches details for a Render service.
 
 ### Use Cases
@@ -327,6 +339,8 @@ Emits a `render.service` payload containing service fields like `serviceId`, `se
 
 ## Purge Cache
 
+**Component key:** `render.purgeCache`
+
 The Purge Cache component requests a build cache purge for a Render service.
 
 ### Use Cases
@@ -358,6 +372,8 @@ Emits a `render.cache.purge.requested` payload with `serviceId` and a `status` f
 <a id="rollback-deploy"></a>
 
 ## Rollback Deploy
+
+**Component key:** `render.rollbackDeploy`
 
 The Rollback Deploy component triggers a rollback deploy for a Render service and waits for it to complete.
 
@@ -412,6 +428,8 @@ The Rollback Deploy component triggers a rollback deploy for a Render service an
 
 ## Add Custom Domain
 
+**Component key:** `render.service.addCustomDomain`
+
 The Add Custom Domain component adds a custom domain to a Render service.
 
 ### Use Cases
@@ -454,6 +472,8 @@ Emits a `render.customDomain.added` payload with `id`, `name`, `serviceId`, and 
 
 ## Remove Custom Domain
 
+**Component key:** `render.service.removeCustomDomain`
+
 The Remove Custom Domain component removes a custom domain from a Render service.
 
 ### Use Cases
@@ -486,6 +506,8 @@ Emits a `render.customDomain.removed` payload with `name` and `serviceId`.
 <a id="update-env-var"></a>
 
 ## Update Env Var
+
+**Component key:** `render.updateEnvVar`
 
 The Update Env Var component updates a Render service environment variable.
 

--- a/docs/components/Rootly.mdx
+++ b/docs/components/Rootly.mdx
@@ -26,6 +26,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Incident
 
+**Trigger key:** `rootly.onIncident`
+
 The On Incident trigger starts a workflow execution when Rootly incident events occur.
 
 ### Use Cases
@@ -75,6 +77,8 @@ This trigger automatically sets up a Rootly webhook endpoint when configured. Th
 <a id="on-incident-timeline-event"></a>
 
 ## On Incident Timeline Event
+
+**Trigger key:** `rootly.onIncidentTimelineEvent`
 
 The On Incident Timeline Event trigger starts a workflow execution when Rootly incident timeline events are created or updated.
 Only events with kind "event" are emitted.
@@ -157,6 +161,8 @@ This trigger automatically sets up a Rootly webhook endpoint when configured. Th
 
 ## Create Event
 
+**Component key:** `rootly.createEvent`
+
 The Create Event component adds a timeline event (note/annotation) to a Rootly incident.
 
 ### Use Cases
@@ -199,6 +205,8 @@ Returns the created incident event with:
 <a id="create-incident"></a>
 
 ## Create Incident
+
+**Component key:** `rootly.createIncident`
 
 The Create Incident component creates a new incident in Rootly.
 
@@ -246,6 +254,8 @@ Returns the created incident object including:
 <a id="get-incident"></a>
 
 ## Get Incident
+
+**Component key:** `rootly.getIncident`
 
 The Get Incident component retrieves a single incident from Rootly by ID, including related resources.
 
@@ -345,6 +355,8 @@ Returns the incident object including:
 <a id="update-incident"></a>
 
 ## Update Incident
+
+**Component key:** `rootly.updateIncident`
 
 The Update Incident component updates an existing incident in Rootly.
 

--- a/docs/components/SMTP.mdx
+++ b/docs/components/SMTP.mdx
@@ -16,6 +16,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## Send Email
 
+**Component key:** `smtp.sendEmail`
+
 The Send Email component sends emails through a configured SMTP server.
 
 ### Use Cases

--- a/docs/components/Semaphore.mdx
+++ b/docs/components/Semaphore.mdx
@@ -23,6 +23,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Pipeline Done
 
+**Trigger key:** `semaphore.onPipelineDone`
+
 The On Pipeline Done trigger starts a workflow execution when a Semaphore pipeline completes.
 
 ### Use Cases
@@ -135,6 +137,8 @@ This trigger automatically sets up a Semaphore webhook when configured. The webh
 
 ## Get Pipeline
 
+**Component key:** `semaphore.getPipeline`
+
 The Get Pipeline component fetches a Semaphore pipeline by its ID and returns its current state, result, and metadata.
 
 ### Use Cases
@@ -188,6 +192,8 @@ Returns the pipeline object including:
 <a id="run-workflow"></a>
 
 ## Run Workflow
+
+**Component key:** `semaphore.runWorkflow`
 
 The Run Workflow component triggers a Semaphore CI/CD workflow and waits for it to complete.
 

--- a/docs/components/SendGrid.mdx
+++ b/docs/components/SendGrid.mdx
@@ -36,6 +36,8 @@ The SendGrid base integration establishes API access. Actions and triggers will 
 
 ## On Email Event
 
+**Trigger key:** `sendgrid.onEmailEvent`
+
 The On Email Event trigger emits events when SendGrid posts delivery or engagement events to your webhook.
 
 ### Use Cases
@@ -84,6 +86,8 @@ Each event includes fields such as `event`, `email`, `timestamp`, `sg_event_id`,
 
 ## Create or Update Contact
 
+**Component key:** `sendgrid.createOrUpdateContact`
+
 Create or update a contact in SendGrid using the Marketing Contacts API.
 
 ### Use Cases
@@ -127,6 +131,8 @@ Create or update a contact in SendGrid using the Marketing Contacts API.
 <a id="send-email"></a>
 
 ## Send Email
+
+**Component key:** `sendgrid.sendEmail`
 
 Send a single email via SendGrid's Mail Send API.
 

--- a/docs/components/Sentry.mdx
+++ b/docs/components/Sentry.mdx
@@ -42,6 +42,8 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 ## On Issue Event
 
+**Trigger key:** `sentry.onIssue`
+
 The On Issue Event trigger starts a workflow execution when Sentry sends issue webhooks for the connected organization.
 
 ### Use Cases
@@ -116,6 +118,8 @@ This trigger uses the webhook URL configured on your Sentry internal integration
 <a id="create-alert"></a>
 
 ## Create Alert
+
+**Component key:** `sentry.createAlert`
 
 The Create Alert component creates a Sentry metric alert rule for a selected project.
 
@@ -202,6 +206,8 @@ Returns the created Sentry metric alert rule, including triggers, actions, and p
 
 ## Create Deploy
 
+**Component key:** `sentry.createDeploy`
+
 The Create Deploy component marks a deploy against an existing Sentry release.
 
 ### Use Cases
@@ -248,6 +254,8 @@ Returns the created deploy record, including environment, timestamps, URL, and r
 <a id="create-release"></a>
 
 ## Create Release
+
+**Component key:** `sentry.createRelease`
 
 The Create Release component registers a new release in Sentry for a selected project.
 
@@ -301,6 +309,8 @@ Returns the created Sentry release object, including version, associated project
 
 ## Delete Alert
 
+**Component key:** `sentry.deleteAlert`
+
 The Delete Alert component deletes an existing Sentry metric alert rule.
 
 ### Use Cases
@@ -335,6 +345,8 @@ Returns the deleted alert ID and name so downstream steps can record the removal
 <a id="get-alert"></a>
 
 ## Get Alert
+
+**Component key:** `sentry.getAlert`
 
 The Get Alert component retrieves a Sentry metric alert rule and returns its full configuration.
 
@@ -403,6 +415,8 @@ Returns the selected metric alert rule, including projects, query, thresholds, t
 <a id="get-issue"></a>
 
 ## Get Issue
+
+**Component key:** `sentry.getIssue`
 
 The Get Issue component retrieves a Sentry issue and enriches it with recent events for downstream routing and escalation.
 
@@ -491,6 +505,8 @@ Returns the Sentry issue object including:
 
 ## List Alerts
 
+**Component key:** `sentry.listAlerts`
+
 The List Alerts component lists Sentry metric alert rules for the connected organization.
 
 ### Use Cases
@@ -557,6 +573,8 @@ Returns an object containing the list of matching metric alert rules and their c
 <a id="update-alert"></a>
 
 ## Update Alert
+
+**Component key:** `sentry.updateAlert`
 
 The Update Alert component updates an existing Sentry metric alert rule.
 
@@ -636,6 +654,8 @@ Returns the updated Sentry metric alert rule after the change is applied.
 <a id="update-issue"></a>
 
 ## Update Issue
+
+**Component key:** `sentry.updateIssue`
 
 The Update Issue component updates an existing issue in Sentry.
 

--- a/docs/components/ServiceNow.mdx
+++ b/docs/components/ServiceNow.mdx
@@ -39,6 +39,8 @@ Then configure OAuth:
 
 ## Create Incident
 
+**Component key:** `servicenow.createIncident`
+
 The Create Incident component creates a new incident in ServiceNow using the Table API.
 
 ### Use Cases
@@ -186,6 +188,8 @@ Returns the created incident object from the ServiceNow Table API, including:
 <a id="get-incident"></a>
 
 ## Get Incident
+
+**Component key:** `servicenow.getIncident`
 
 Fetch a single ServiceNow incident by selecting it from the dropdown
 

--- a/docs/components/Slack.mdx
+++ b/docs/components/Slack.mdx
@@ -28,6 +28,8 @@ After installation, follow the setup prompt to create the Slack app and add thos
 
 ## On App Mention
 
+**Trigger key:** `slack.onAppMention`
+
 The On App Mention trigger starts a workflow execution when the Slack app is mentioned in a message.
 
 ### Use Cases
@@ -86,6 +88,8 @@ This trigger automatically sets up a Slack event subscription when configured. T
 
 ## Send Text Message
 
+**Component key:** `slack.sendTextMessage`
+
 The Send Text Message component sends a text message to a Slack channel.
 
 ### Use Cases
@@ -128,6 +132,8 @@ Returns metadata about the sent message including channel information.
 <a id="wait-for-button-click"></a>
 
 ## Wait for Button Click
+
+**Component key:** `slack.waitForButtonClick`
 
 The Wait for Button Click component sends a message to a Slack channel or DM with interactive buttons and waits for the user to click one of the configured buttons.
 

--- a/docs/components/Statuspage.mdx
+++ b/docs/components/Statuspage.mdx
@@ -22,6 +22,8 @@ To get your API key: Open your Statuspage, click the icon in the top-right corne
 
 ## Create Incident
 
+**Component key:** `statuspage.createIncident`
+
 The Create Incident component creates a new realtime or scheduled incident on your Atlassian Statuspage.
 
 ### Use Cases
@@ -161,6 +163,8 @@ Returns the full Statuspage Incident object from the API. The payload has struct
 
 ## Get Incident
 
+**Component key:** `statuspage.getIncident`
+
 The Get Incident component fetches the full details of an existing incident on your Atlassian Statuspage.
 
 ### Use Cases
@@ -283,6 +287,8 @@ Returns the full Statuspage Incident object from the API. The payload has struct
 <a id="update-incident"></a>
 
 ## Update Incident
+
+**Component key:** `statuspage.updateIncident`
 
 The Update Incident component updates an existing incident on your Atlassian Statuspage.
 

--- a/docs/components/Telegram.mdx
+++ b/docs/components/Telegram.mdx
@@ -33,6 +33,8 @@ Note: if the bot was already in a group before disabling privacy mode, remove an
 
 ## On Mention
 
+**Trigger key:** `telegram.onMention`
+
 The On Mention trigger starts a workflow execution when the Telegram bot is mentioned in a message.
 
 ### Use Cases
@@ -95,6 +97,8 @@ This trigger automatically sets up a webhook subscription when configured. The s
 
 ## Send Message
 
+**Component key:** `telegram.sendMessage`
+
 The Send Message component sends a text message to a Telegram chat.
 
 ### Use Cases
@@ -139,6 +143,8 @@ Returns metadata about the sent message including message ID, chat ID, text, and
 <a id="wait-for-button-click"></a>
 
 ## Wait for Button Click
+
+**Component key:** `telegram.waitForButtonClick`
 
 The Wait for Button Click component sends a message to a Telegram chat with inline keyboard buttons and waits for the user to click one of the configured buttons.
 

--- a/pkg/agents/anthropic/resources.go
+++ b/pkg/agents/anthropic/resources.go
@@ -151,7 +151,18 @@ func componentResourceSources() ([]resourceSource, error) {
 		return nil, err
 	}
 
-	sources := make([]resourceSource, 0, len(files))
+	indexFile, err := docs.GenerateComponentIndexFile()
+	if err != nil {
+		return nil, err
+	}
+
+	sources := make([]resourceSource, 0, len(files)+1)
+	sources = append(sources, resourceSource{
+		MountPath:  filepath.ToSlash(filepath.Join("ref", "components", indexFile.Name)),
+		SourceKey:  filepath.ToSlash(filepath.Join("docs", "components", indexFile.Name)),
+		SourceData: indexFile.Content,
+	})
+
 	for _, file := range files {
 		sources = append(sources, resourceSource{
 			MountPath:  filepath.ToSlash(filepath.Join("ref", "components", file.Name)),

--- a/pkg/agents/anthropic/resources_test.go
+++ b/pkg/agents/anthropic/resources_test.go
@@ -46,6 +46,8 @@ func TestDefaultResourceSourcesForSkillsBaseURL(t *testing.T) {
 		"https://example.test/root/skills/superplane-monitor/SKILL.md",
 		byMountPath["ref/skills/superplane-monitor/SKILL.md"].SourceURL,
 	)
+	assert.Contains(t, byMountPath, "ref/components/Index.md")
+	assert.Contains(t, string(byMountPath["ref/components/Index.md"].SourceData), "aws.ec2.createInstance")
 
 	componentSourceCount := 0
 	for _, source := range sources {

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -83,6 +83,11 @@ Rules:
 
 - You can add, remove, or modify nodes and edges.
 - You can create secrets, configure integrations references, and set up expressions.
+- For direct canvas edits, prefer the shortest reliable path: read the draft canvas once, list integrations only if integration IDs are needed, make the draft update, then report the result.
+- When reading a canvas for build work, save it once to a local file such as '/tmp/current-canvas.yaml' and inspect that file locally with 'rg', 'yq', 'sed', or an editor. Do not run repeated 'superplane canvases get ... | grep ...' commands against the same draft. Re-fetch only after you update the draft, or after a publish/discard notification invalidates the local file.
+- For direct component replacements or component additions, check ref/components/Index.md first for the exact YAML key. If more detail is needed, use the vendor doc in ref/components/. Each component or trigger section includes the exact key as "Component key" or "Trigger key". Use these keys instead of searching source code.
+- Do not spawn a researcher/subagent for straightforward component swaps, renames, integration rebinding, or field updates. Use one only when the request needs broad design work or genuinely unknown information.
+- Avoid repeated grep/find/cat command loops. If the mounted docs do not resolve the exact key or required fields after one targeted lookup, ask a clarifying question or explain what is missing.
 - When mentioning integrations, use clickable references with the instance ID: [instance-name](integration:instance-uuid). Get IDs from 'superplane integrations list'. If no instance exists yet, use the vendor name: [GitHub](integration:github).
 - If the user asks a question that doesn't require changes, answer it briefly, but your primary purpose is building.
 - If you're unsure what the user wants, ask a clarifying question using :::buttons with the options.

--- a/pkg/docs/generator.go
+++ b/pkg/docs/generator.go
@@ -63,6 +63,21 @@ func GenerateFiles() ([]File, error) {
 	return files, nil
 }
 
+func GenerateComponentIndexFile() (File, error) {
+	reg, err := registry.NewRegistry(crypto.NewNoOpEncryptor(), registry.HTTPOptions{})
+	if err != nil {
+		return File{}, err
+	}
+
+	integrations := reg.ListIntegrations()
+	sort.Slice(integrations, func(i, j int) bool {
+		return integrations[i].Label() < integrations[j].Label()
+	})
+
+	content := renderComponentIndex(reg.ListActions(), reg.ListTriggers(), integrations)
+	return File{Name: "Index.md", Content: content}, nil
+}
+
 func WriteFiles(outputDir string) error {
 	if err := os.MkdirAll(outputDir, 0o755); err != nil {
 		return err
@@ -127,6 +142,89 @@ func renderCoreComponentsDoc(actions []core.Action, triggers []core.Trigger) ([]
 	return buf.Bytes(), nil
 }
 
+func renderComponentIndex(actions []core.Action, triggers []core.Trigger, integrations []core.Integration) []byte {
+	sort.Slice(actions, func(i, j int) bool { return actions[i].Name() < actions[j].Name() })
+	sort.Slice(triggers, func(i, j int) bool { return triggers[i].Name() < triggers[j].Name() })
+
+	var buf bytes.Buffer
+	buf.WriteString("# SuperPlane Component Index\n\n")
+	buf.WriteString("Fast lookup for canvas YAML keys. Use this before searching full component docs.\n\n")
+
+	writeIndexEntries(&buf, "Core Triggers", "Trigger", triggerIndexEntries(triggers))
+	writeIndexEntries(&buf, "Core Actions", "Component", actionIndexEntries(actions))
+
+	for _, integration := range integrations {
+		integrationTriggers := integration.Triggers()
+		integrationActions := integration.Actions()
+		sort.Slice(integrationTriggers, func(i, j int) bool { return integrationTriggers[i].Name() < integrationTriggers[j].Name() })
+		sort.Slice(integrationActions, func(i, j int) bool { return integrationActions[i].Name() < integrationActions[j].Name() })
+
+		writeIndexEntries(
+			&buf,
+			fmt.Sprintf("%s Triggers", integration.Label()),
+			"Trigger",
+			triggerIndexEntries(integrationTriggers),
+		)
+		writeIndexEntries(
+			&buf,
+			fmt.Sprintf("%s Actions", integration.Label()),
+			"Component",
+			actionIndexEntries(integrationActions),
+		)
+	}
+
+	return buf.Bytes()
+}
+
+type componentIndexEntry struct {
+	Key         string
+	Label       string
+	Description string
+}
+
+func actionIndexEntries(actions []core.Action) []componentIndexEntry {
+	entries := make([]componentIndexEntry, 0, len(actions))
+	for _, action := range actions {
+		entries = append(entries, componentIndexEntry{
+			Key:         action.Name(),
+			Label:       action.Label(),
+			Description: action.Description(),
+		})
+	}
+	return entries
+}
+
+func triggerIndexEntries(triggers []core.Trigger) []componentIndexEntry {
+	entries := make([]componentIndexEntry, 0, len(triggers))
+	for _, trigger := range triggers {
+		entries = append(entries, componentIndexEntry{
+			Key:         trigger.Name(),
+			Label:       trigger.Label(),
+			Description: trigger.Description(),
+		})
+	}
+	return entries
+}
+
+func writeIndexEntries(buf *bytes.Buffer, title, keyLabel string, entries []componentIndexEntry) {
+	if len(entries) == 0 {
+		return
+	}
+
+	buf.WriteString(fmt.Sprintf("## %s\n\n", title))
+	buf.WriteString(fmt.Sprintf("| Label | %s key | Description |\n", keyLabel))
+	buf.WriteString("| --- | --- | --- |\n")
+	for _, entry := range entries {
+		buf.WriteString(fmt.Sprintf(
+			"| %s | `%s` | %s |\n",
+			escapeTableCell(entry.Label),
+			entry.Key,
+			escapeTableCell(entry.Description),
+		))
+	}
+	buf.WriteString("\n")
+}
+
 func writeFrontMatter(buf *bytes.Buffer, title string, order *int) {
 	buf.WriteString("---\n")
 	buf.WriteString(fmt.Sprintf("title: \"%s\"\n", escapeQuotes(title)))
@@ -145,6 +243,7 @@ func writeActionSection(buf *bytes.Buffer, actions []core.Action) {
 	for _, action := range actions {
 		buf.WriteString(fmt.Sprintf("<a id=\"%s\"></a>\n\n", slugify(action.Label())))
 		buf.WriteString(fmt.Sprintf("## %s\n\n", action.Label()))
+		writeKeyLine(buf, "Component key", action.Name())
 
 		doc := action.Documentation()
 		if doc != "" {
@@ -165,6 +264,7 @@ func writeTriggerSection(buf *bytes.Buffer, triggers []core.Trigger) {
 	for _, trigger := range triggers {
 		buf.WriteString(fmt.Sprintf("<a id=\"%s\"></a>\n\n", slugify(trigger.Label())))
 		buf.WriteString(fmt.Sprintf("## %s\n\n", trigger.Label()))
+		writeKeyLine(buf, "Trigger key", trigger.Name())
 
 		doc := trigger.Documentation()
 		if doc != "" {
@@ -175,6 +275,14 @@ func writeTriggerSection(buf *bytes.Buffer, triggers []core.Trigger) {
 
 		writeExampleSection("Example Data", trigger.ExampleData(), buf)
 	}
+}
+
+func writeKeyLine(buf *bytes.Buffer, label, key string) {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return
+	}
+	buf.WriteString(fmt.Sprintf("**%s:** `%s`\n\n", label, trimmed))
 }
 
 func writeCardGridImport(buf *bytes.Buffer, triggers []core.Trigger, actions []core.Action) {
@@ -332,4 +440,9 @@ func integrationFilename(integration core.Integration) string {
 
 func escapeQuotes(value string) string {
 	return strings.ReplaceAll(value, "\"", "\\\"")
+}
+
+func escapeTableCell(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	return strings.ReplaceAll(value, "|", "\\|")
 }

--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -75,6 +75,7 @@ func TestAgentE2E(t *testing.T) {
 		steps.openAgent()
 		steps.sendMessage("Inspect the canvas")
 		steps.assertVisible(q.TestID("agent-tool-group"))
+		steps.expandToolGroupIfNeeded()
 		steps.assertVisible(q.TestID("agent-tool-message"))
 		steps.assertAssistantMessage("Tool run complete")
 	})
@@ -361,6 +362,17 @@ func (s *agentSteps) assertUserMessage(message string) {
 
 func (s *agentSteps) assertAssistantMessage(message string) {
 	s.assertVisible(q.Locator(fmt.Sprintf(`[data-testid="agent-assistant-message"]:has-text("%s")`, message)))
+}
+
+func (s *agentSteps) expandToolGroupIfNeeded() {
+	toolMessage := s.session.Page().GetByTestId("agent-tool-message").First()
+	visible, err := toolMessage.IsVisible()
+	require.NoError(s.t, err)
+	if visible {
+		return
+	}
+
+	s.session.Click(q.Locator(`[data-testid="agent-tool-group"] button`))
 }
 
 func (s *agentSteps) assertText(text string) {

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
@@ -1,0 +1,55 @@
+import { createRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationTranscript } from "./AgentConversationTranscript";
+import type { MessageGroup } from "./agentMessageGroups";
+
+const baseProps = {
+  error: null,
+  canvasId: "canvas-1",
+  organizationId: "org-1",
+  isLoading: false,
+  isLoadingMore: false,
+  onAction: vi.fn(async () => undefined),
+  onStartBuilding: vi.fn(async () => undefined),
+  scrollRef: createRef<HTMLDivElement>(),
+  showThinking: false,
+};
+
+function toolGroup(status: string): MessageGroup[] {
+  return [
+    {
+      type: "tool-group",
+      messages: [
+        {
+          id: `tool-${status}`,
+          role: "tool",
+          content: "SUPERPLANE_URL=https://app.test superplane canvases get canvas-1 --draft",
+          toolName: "bash",
+          toolCallId: `call-${status}`,
+          toolStatus: status,
+          createdAt: null,
+        },
+      ],
+    },
+  ];
+}
+
+describe("ConversationTranscript command groups", () => {
+  it("collapses completed command groups by default", () => {
+    render(<ConversationTranscript {...baseProps} messageGroups={toolGroup("finished")} />);
+
+    expect(screen.getByText("Ran 1 command")).toBeInTheDocument();
+    expect(screen.queryByText(/SUPERPLANE_URL/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Ran 1 command"));
+    expect(screen.getByText(/SUPERPLANE_URL/)).toBeInTheDocument();
+  });
+
+  it("keeps running command groups expanded", () => {
+    render(<ConversationTranscript {...baseProps} messageGroups={toolGroup("started")} />);
+
+    expect(screen.getByText("Running command...")).toBeInTheDocument();
+    expect(screen.getByText(/SUPERPLANE_URL/)).toBeInTheDocument();
+  });
+});

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -263,12 +263,16 @@ function truncateQuestion(question: string): string {
 }
 
 function ToolGroupRow({ messages }: { messages: AgentMessage[] }) {
-  const [expanded, setExpanded] = useState(true);
   const hasRunning = messages.some((message) => message.toolStatus === "started");
+  const [expanded, setExpanded] = useState(hasRunning);
   const count = messages.length;
   const label = hasRunning
     ? `Running command${count > 1 ? ` (${count})` : ""}...`
     : `Ran ${count} command${count !== 1 ? "s" : ""}`;
+
+  useEffect(() => {
+    setExpanded(hasRunning);
+  }, [hasRunning]);
 
   return (
     <div className={cn("py-1 text-xs", hasRunning && "animate-tool-glow")} data-testid="agent-tool-group">


### PR DESCRIPTION
## Summary
- Add exact component/trigger YAML keys to generated component docs.
- Mount a compact `ref/components/Index.md` in Anthropic managed-agent sessions for fast component key lookup before searching full docs.
- Tighten Build-mode agent instructions so direct edits use the shortest reliable path, avoid subagents/repeated grep loops, and fetch the draft canvas once into a local file before local inspection.
- Collapse completed agent command groups in the frontend transcript while keeping running command groups expanded.
- Update the agent E2E to expand collapsed completed tool groups before asserting individual tool rows.

## Agent scope
- Inspected live Anthropic managed agent `agent_01TKCC39qeWdnjhMGQUBBLXK` and its delegated Component Researcher.
- Found the live prompt encouraged aggressive researcher usage and 3-5 parallel researchers, which matched the observed slow path.
- Updated the live agent prompt to version 64 so direct canvas edits use the component index/vendor docs first, and researcher delegation is reserved for broad or ambiguous work.
- Updated the live agent prompt again to version 65 so repeated `superplane canvases get ... | grep ...` probes are replaced by a single fetch to `/tmp/current-canvas.yaml`, local inspection, and one post-update verification fetch.

## Validation
- `make format.go`
- `make format.js`
- `make test PKG_TEST_PACKAGES='./pkg/docs ./pkg/agents ./pkg/agents/anthropic'`
- `cd web_src && npm test -- --run src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx`
- `make lint`
- `make check.build.app`
- `make check.build.ui`
- Follow-up after canvas fetch discipline change: `make format.go`, `make test PKG_TEST_PACKAGES='./pkg/agents'`
- Follow-up E2E fix: `make format.go`, `docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile junit-report.xml --packages='./test/e2e' -- -run 'TestAgentE2E/renders_tool_activity_from_provider_events' -count=1 -p 1 -timeout 5m`
