### PR TITLE
feat: parameterized manual runs

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -121,20 +121,23 @@ The Manual Run trigger allows you to start workflow executions manually from the
 ### How It Works
 
 1. Add the Manual Run trigger as the starting node of your workflow
-2. Configure one or more templates, each with a name and a default payload
+2. Configure one or more templates, each with a name, default payload, and optional parameters
 3. Click the "Run" button in the workflow UI, or invoke the `run` hook via the API/CLI to start an execution
-4. The workflow begins immediately with either the configured payload or an override supplied at run time
+4. The workflow begins immediately with the configured payload for the selected template
 
 ### Configuration
 
 Each Manual Run trigger exposes a list of templates. A template has:
 
 - `name` (required): a label used as the run target (and the event channel)
-- `payload` (required): a default JSON object emitted when the template is used
+- `parameters` (optional): a list of typed parameters exposed to payload expressions as `parameters["name"]` and used by the run form
+- `payload` (required): a default JSON object emitted when the template is used. Supports expressions such as `{{ now() }}` and `{{ parameters["my parameter"] }}` in JSON values.
+
+Each parameter has a `name` (plain text), required `type` (`string`, `number`, or `boolean`), an optional `title` for the run form label (defaults to `name` when unset), and an optional default (`defaultString`, `defaultNumber`, or `defaultBoolean`) whose editor matches the selected type.
 
 ### Event Data
 
-Manual runs emit an event with type `manual.run`. The data is either the template's saved payload or the override passed in the run request.
+Manual runs emit an event with type `manual.run`. The data is the selected template's payload after expression resolution.
 
 ### Example Data
 

--- a/pkg/configuration/expressionvalidation/canvas.go
+++ b/pkg/configuration/expressionvalidation/canvas.go
@@ -2,6 +2,7 @@ package expressionvalidation
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/superplanehq/superplane/pkg/configuration"
 	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
@@ -111,9 +112,10 @@ func validateString(fieldPath string, field configuration.Field, value string, k
 	}
 
 	var errs []ExpressionError
+	extraEnv := expressionValidationExtraEnv(fieldPath)
 	for _, match := range matches {
 		body := match[2 : len(match)-2]
-		if err := ValidateExpression(body, knownNodeNames); err != nil {
+		if err := ValidateExpressionWithExtraEnv(body, knownNodeNames, extraEnv); err != nil {
 			errs = append(errs, ExpressionError{
 				FieldPath:  fieldPath,
 				Expression: match,
@@ -122,4 +124,13 @@ func validateString(fieldPath string, field configuration.Field, value string, k
 		}
 	}
 	return errs
+}
+
+var startTemplatePayloadFieldPattern = regexp.MustCompile(`^templates\[\d+\]\.payload(\.|$)`)
+
+func expressionValidationExtraEnv(fieldPath string) map[string]any {
+	if startTemplatePayloadFieldPattern.MatchString(fieldPath) {
+		return map[string]any{"parameters": map[string]any{}}
+	}
+	return nil
 }

--- a/pkg/configuration/expressionvalidation/canvas.go
+++ b/pkg/configuration/expressionvalidation/canvas.go
@@ -67,8 +67,8 @@ func schemaForNode(reg *registry.Registry, node *componentpb.Node) []configurati
 
 func validateNodeExpressions(nodeID, nodeName string, config map[string]any, fields []configuration.Field, knownNodeNames map[string]struct{}) []ExpressionError {
 	var errs []ExpressionError
-	walkConfiguration(config, fields, func(fieldPath, fieldType, value string) {
-		for _, e := range validateString(fieldPath, fieldType, value, knownNodeNames) {
+	walkConfiguration(config, fields, func(fieldPath string, field configuration.Field, value string) {
+		for _, e := range validateString(fieldPath, field, value, knownNodeNames) {
 			e.NodeID = nodeID
 			e.NodeName = nodeName
 			errs = append(errs, e)
@@ -77,7 +77,23 @@ func validateNodeExpressions(nodeID, nodeName string, config map[string]any, fie
 	return errs
 }
 
-func validateString(fieldPath, fieldType, value string, knownNodeNames map[string]struct{}) []ExpressionError {
+func validateString(fieldPath string, field configuration.Field, value string, knownNodeNames map[string]struct{}) []ExpressionError {
+	if field.Type == configuration.FieldTypeString &&
+		field.TypeOptions != nil &&
+		field.TypeOptions.String != nil &&
+		field.TypeOptions.String.AllowExpressions != nil &&
+		!*field.TypeOptions.String.AllowExpressions {
+		if configuration.ExpressionPlaceholderRegex.MatchString(value) {
+			return []ExpressionError{{
+				FieldPath:  fieldPath,
+				Expression: value,
+				Err:        fmt.Errorf("expressions are not supported for this field"),
+			}}
+		}
+		return nil
+	}
+
+	fieldType := field.Type
 	matches := configuration.ExpressionPlaceholderRegex.FindAllString(value, -1)
 
 	// FieldTypeExpression values without {{ }} framing flow through

--- a/pkg/configuration/expressionvalidation/canvas_test.go
+++ b/pkg/configuration/expressionvalidation/canvas_test.go
@@ -274,4 +274,38 @@ func TestValidateNodeExpressions_Edge(t *testing.T) {
 			t.Fatalf("expected no errors, got %+v", errs)
 		}
 	})
+
+	t.Run("start template payload accepts parameters variable", func(t *testing.T) {
+		fields := []configuration.Field{
+			{
+				Name: "templates",
+				Type: configuration.FieldTypeList,
+				TypeOptions: &configuration.TypeOptions{
+					List: &configuration.ListTypeOptions{
+						ItemDefinition: &configuration.ListItemDefinition{
+							Type: configuration.FieldTypeObject,
+							Schema: []configuration.Field{
+								{
+									Name: "payload",
+									Type: configuration.FieldTypeObject,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		errs := validateNodeExpressions("n1", "Start", map[string]any{
+			"templates": []any{
+				map[string]any{
+					"payload": map[string]any{
+						"message": `{{ parameters["message"] }}`,
+					},
+				},
+			},
+		}, fields, knownSet())
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %+v", errs)
+		}
+	})
 }

--- a/pkg/configuration/expressionvalidation/validator.go
+++ b/pkg/configuration/expressionvalidation/validator.go
@@ -15,11 +15,17 @@ import (
 // unknown node references, function arity mistakes, and unresolved identifiers.
 // Returns nil for a valid expression.
 func ValidateExpression(raw string, knownNodeNames map[string]struct{}) error {
+	return ValidateExpressionWithExtraEnv(raw, knownNodeNames, nil)
+}
+
+// ValidateExpressionWithExtraEnv validates an expression body using the default
+// stub environment plus additional top-level variables provided in extraEnv.
+func ValidateExpressionWithExtraEnv(raw string, knownNodeNames map[string]struct{}, extraEnv map[string]any) error {
 	if err := validateExpressionAST(raw, knownNodeNames); err != nil {
 		return err
 	}
 
-	return compileWithStubEnv(strings.TrimSpace(raw), knownNodeNames)
+	return compileWithStubEnv(strings.TrimSpace(raw), knownNodeNames, extraEnv)
 }
 
 // ValidateBareExpression checks the same expression body but skips the strict
@@ -144,7 +150,7 @@ func checkMemoryCall(method string, args []ast.Node) error {
 	return nil
 }
 
-func compileWithStubEnv(body string, knownNodeNames map[string]struct{}) error {
+func compileWithStubEnv(body string, knownNodeNames map[string]struct{}, extraEnv map[string]any) error {
 	dollar := make(map[string]any, len(knownNodeNames))
 	for name := range knownNodeNames {
 		dollar[name] = map[string]any{}
@@ -155,6 +161,9 @@ func compileWithStubEnv(body string, knownNodeNames map[string]struct{}) error {
 		"$":      dollar,
 		"memory": map[string]any{"find": memoryStub, "findFirst": memoryStub},
 		"config": map[string]any{},
+	}
+	for key, value := range extraEnv {
+		env[key] = value
 	}
 
 	opts := []expr.Option{

--- a/pkg/configuration/expressionvalidation/walker.go
+++ b/pkg/configuration/expressionvalidation/walker.go
@@ -9,7 +9,7 @@ import (
 // stringVisitor receives every string leaf reachable from a configuration map,
 // along with the field type derived from the schema (or empty when the value
 // lies outside the schema).
-type stringVisitor func(fieldPath, fieldType, value string)
+type stringVisitor func(fieldPath string, field configuration.Field, value string)
 
 // walkConfiguration traverses a configuration map and calls visit for each
 // string leaf. Schema-aware where possible: keys present in fields recurse
@@ -35,8 +35,8 @@ func walkFieldValue(path string, field configuration.Field, value any, visit str
 	case configuration.FieldTypeObject:
 		if field.TypeOptions != nil && field.TypeOptions.Object != nil && len(field.TypeOptions.Object.Schema) > 0 {
 			if obj, ok := asAnyMap(value); ok {
-				walkConfiguration(obj, field.TypeOptions.Object.Schema, func(p, t, v string) {
-					visit(path+"."+p, t, v)
+				walkConfiguration(obj, field.TypeOptions.Object.Schema, func(p string, f configuration.Field, v string) {
+					visit(path+"."+p, f, v)
 				})
 				return
 			}
@@ -56,7 +56,7 @@ func walkFieldValue(path string, field configuration.Field, value any, visit str
 
 	default:
 		if str, ok := value.(string); ok {
-			visit(path, field.Type, str)
+			visit(path, field, str)
 			return
 		}
 		walkUntypedValue(path, value, visit)
@@ -68,15 +68,15 @@ func walkList(path string, list []any, itemDef *configuration.ListItemDefinition
 		itemPath := fmt.Sprintf("%s[%d]", path, i)
 		if itemDef != nil && itemDef.Type == configuration.FieldTypeObject && len(itemDef.Schema) > 0 {
 			if obj, ok := asAnyMap(item); ok {
-				walkConfiguration(obj, itemDef.Schema, func(p, t, v string) {
-					visit(itemPath+"."+p, t, v)
+				walkConfiguration(obj, itemDef.Schema, func(p string, f configuration.Field, v string) {
+					visit(itemPath+"."+p, f, v)
 				})
 				continue
 			}
 		}
 		if itemDef != nil && itemDef.Type != "" && itemDef.Type != configuration.FieldTypeObject {
 			if str, ok := item.(string); ok {
-				visit(itemPath, itemDef.Type, str)
+				visit(itemPath, configuration.Field{Type: itemDef.Type}, str)
 				continue
 			}
 		}
@@ -87,14 +87,14 @@ func walkList(path string, list []any, itemDef *configuration.ListItemDefinition
 func walkUntypedValue(path string, value any, visit stringVisitor) {
 	switch v := value.(type) {
 	case string:
-		visit(path, "", v)
+		visit(path, configuration.Field{}, v)
 	case map[string]any:
 		for key, child := range v {
 			walkUntypedValue(path+"."+key, child, visit)
 		}
 	case map[string]string:
 		for key, child := range v {
-			visit(path+"."+key, "", child)
+			visit(path+"."+key, configuration.Field{}, child)
 		}
 	case []any:
 		for i, child := range v {

--- a/pkg/configuration/field.go
+++ b/pkg/configuration/field.go
@@ -207,6 +207,9 @@ type ListTypeOptions struct {
 
 	// When true, list items render in a single-expand accordion instead of stacked cards.
 	Accordion bool `json:"accordion,omitempty"`
+
+	// When true, list items can be reordered with move up/down controls.
+	Reorderable bool `json:"reorderable,omitempty"`
 }
 
 /*

--- a/pkg/configuration/field.go
+++ b/pkg/configuration/field.go
@@ -146,6 +146,9 @@ type NumberTypeOptions struct {
 type StringTypeOptions struct {
 	MinLength *int `json:"minLength,omitempty"`
 	MaxLength *int `json:"maxLength,omitempty"`
+
+	// When false, the field is edited as a plain string without expression placeholders.
+	AllowExpressions *bool `json:"allowExpressions,omitempty"`
 }
 
 type ExpressionTypeOptions struct {

--- a/pkg/configuration/field.go
+++ b/pkg/configuration/field.go
@@ -204,6 +204,9 @@ type ListTypeOptions struct {
 	ItemDefinition *ListItemDefinition `json:"itemDefinition"`
 	ItemLabel      string              `json:"itemLabel,omitempty"`
 	MaxItems       *int                `json:"maxItems,omitempty"`
+
+	// When true, list items render in a single-expand accordion instead of stacked cards.
+	Accordion bool `json:"accordion,omitempty"`
 }
 
 /*

--- a/pkg/configuration/validation.go
+++ b/pkg/configuration/validation.go
@@ -84,6 +84,10 @@ func validateString(field Field, value any) error {
 	}
 
 	options := field.TypeOptions.String
+	if options.AllowExpressions != nil && !*options.AllowExpressions && ExpressionPlaceholderRegex.MatchString(text) {
+		return fmt.Errorf("expressions are not supported for this field")
+	}
+
 	textLength := len(text)
 
 	if options.MinLength != nil && textLength < *options.MinLength {

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -80,8 +80,13 @@ func InvokeNodeTriggerHook(
 		newEvents = append(newEvents, events...)
 	}
 
+	expressionParameters := buildHookExpressionParameters(node.Ref.Data().Trigger.Name, hookName, node.Configuration.Data(), parameters)
+
 	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
 		WithNodeID(node.NodeID).
+		WithExpressionVariables(map[string]any{
+			"parameters": expressionParameters,
+		}).
 		WithConfigurationFields(hookProvider.Configuration()).
 		Build(node.Configuration.Data())
 	if err != nil {
@@ -139,4 +144,86 @@ func InvokeNodeTriggerHook(
 	return &pb.InvokeNodeTriggerHookResponse{
 		Result: resultStruct,
 	}, nil
+}
+
+func buildHookExpressionParameters(triggerName string, hookName string, configuration map[string]any, hookParameters map[string]any) map[string]any {
+	parameters := map[string]any{}
+
+	if triggerName == "start" && hookName == "run" {
+		for key, value := range startTemplateDefaultParameters(configuration, hookParameters) {
+			parameters[key] = value
+		}
+	}
+
+	for key, value := range hookParameters {
+		parameters[key] = value
+	}
+
+	return parameters
+}
+
+func startTemplateDefaultParameters(configuration map[string]any, hookParameters map[string]any) map[string]any {
+	templateName, _ := hookParameters["template"].(string)
+	if templateName == "" {
+		return nil
+	}
+
+	rawTemplates, _ := configuration["templates"].([]any)
+	for _, rawTemplate := range rawTemplates {
+		template, ok := rawTemplate.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := template["name"].(string)
+		if name != templateName {
+			continue
+		}
+		return defaultsFromTemplateParameters(template)
+	}
+
+	return nil
+}
+
+func defaultsFromTemplateParameters(template map[string]any) map[string]any {
+	rawParameters, _ := template["parameters"].([]any)
+	if len(rawParameters) == 0 {
+		return nil
+	}
+
+	parameters := map[string]any{}
+	for _, rawParameter := range rawParameters {
+		parameter, ok := rawParameter.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := parameter["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		switch parameterType, _ := parameter["type"].(string); parameterType {
+		case configuration.FieldTypeNumber:
+			if value, exists := parameter["defaultNumber"]; exists && value != nil {
+				parameters[name] = value
+			}
+		case configuration.FieldTypeBool:
+			if value, exists := parameter["defaultBoolean"]; exists && value != nil {
+				parameters[name] = value
+			}
+		default:
+			if value, exists := parameter["defaultString"]; exists && value != nil {
+				if textValue, isString := value.(string); isString && textValue == "" {
+					continue
+				}
+				parameters[name] = value
+			}
+		}
+	}
+
+	if len(parameters) == 0 {
+		return nil
+	}
+
+	return parameters
 }

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook.go
@@ -80,10 +80,18 @@ func InvokeNodeTriggerHook(
 		newEvents = append(newEvents, events...)
 	}
 
+	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
+		WithNodeID(node.NodeID).
+		WithConfigurationFields(hookProvider.Configuration()).
+		Build(node.Configuration.Data())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to resolve trigger configuration: %v", err)
+	}
+
 	hookCtx := core.TriggerHookContext{
 		Name:          hookName,
 		Parameters:    parameters,
-		Configuration: node.Configuration.Data(),
+		Configuration: resolvedConfiguration,
 		HTTP:          registry.HTTPContext(),
 		Metadata:      contexts.NewNodeMetadataContext(tx, node),
 		Requests:      contexts.NewNodeRequestContext(tx, node),

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
@@ -296,6 +296,122 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, generatedAt)
 	})
 
+	t.Run("run resolves template payload expressions using hook parameters", func(t *testing.T) {
+		expressionNodeID := "start-node-expression-parameters"
+		expressionCanvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{
+					NodeID: expressionNodeID,
+					Name:   expressionNodeID,
+					Type:   models.NodeTypeTrigger,
+					Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+					Configuration: datatypes.NewJSONType(map[string]any{
+						"templates": []any{
+							map[string]any{
+								"name": "Parameterized",
+								"payload": map[string]any{
+									"message": `{{ parameters["message"] }}`,
+								},
+							},
+						},
+					}),
+				},
+			},
+			nil,
+		)
+
+		_, err := InvokeNodeTriggerHook(
+			authedCtx,
+			r.AuthService,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID,
+			expressionCanvas.ID,
+			expressionNodeID,
+			"run",
+			map[string]any{
+				"template": "Parameterized",
+				"message":  "Hello from hook parameter",
+			},
+			"http://localhost",
+		)
+		require.NoError(t, err)
+
+		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		data, ok := events[0].Data.Data().(map[string]any)
+		require.True(t, ok)
+		inner, ok := data["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Hello from hook parameter", inner["message"])
+	})
+
+	t.Run("run resolves template payload expressions using configured template parameter defaults", func(t *testing.T) {
+		expressionNodeID := "start-node-expression-parameter-default"
+		expressionCanvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{
+					NodeID: expressionNodeID,
+					Name:   expressionNodeID,
+					Type:   models.NodeTypeTrigger,
+					Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+					Configuration: datatypes.NewJSONType(map[string]any{
+						"templates": []any{
+							map[string]any{
+								"name": "Parameterized",
+								"payload": map[string]any{
+									"message": `{{ parameters["message"] }}`,
+								},
+								"parameters": []any{
+									map[string]any{
+										"name":          "message",
+										"type":          "string",
+										"defaultString": "Hello from configured defaults",
+									},
+								},
+							},
+						},
+					}),
+				},
+			},
+			nil,
+		)
+
+		_, err := InvokeNodeTriggerHook(
+			authedCtx,
+			r.AuthService,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID,
+			expressionCanvas.ID,
+			expressionNodeID,
+			"run",
+			map[string]any{
+				"template": "Parameterized",
+			},
+			"http://localhost",
+		)
+		require.NoError(t, err)
+
+		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		data, ok := events[0].Data.Data().(map[string]any)
+		require.True(t, ok)
+		inner, ok := data["data"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Hello from configured defaults", inner["message"])
+	})
+
 	t.Run("non-trigger node -> error", func(t *testing.T) {
 		componentNodeID := "component-node"
 		canvasWithComponent, _ := support.CreateCanvas(

--- a/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
+++ b/pkg/grpc/actions/canvases/invoke_node_trigger_hook_test.go
@@ -129,37 +129,171 @@ func Test__InvokeNodeTriggerHook__StartRun(t *testing.T) {
 		assert.Equal(t, "Hello, World!", inner["message"])
 	})
 
-	t.Run("payload override replaces configured payload", func(t *testing.T) {
+	t.Run("run resolves template payload expressions", func(t *testing.T) {
+		expressionNodeID := "start-node-expression"
+		expressionCanvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{
+					NodeID: expressionNodeID,
+					Name:   expressionNodeID,
+					Type:   models.NodeTypeTrigger,
+					Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+					Configuration: datatypes.NewJSONType(map[string]any{
+						"templates": []any{
+							map[string]any{
+								"name": "Timed",
+								"payload": map[string]any{
+									"generatedAt": `{{ now().Format("2006-01-02") }}`,
+								},
+							},
+						},
+					}),
+				},
+			},
+			nil,
+		)
+
 		resp, err := InvokeNodeTriggerHook(
 			authedCtx,
 			r.AuthService,
 			r.Encryptor,
 			r.Registry,
 			r.Organization.ID,
-			canvas.ID,
-			triggerNodeID,
+			expressionCanvas.ID,
+			expressionNodeID,
 			"run",
-			map[string]any{
-				"template": "Hello World",
-				"payload":  map[string]any{"message": "Override"},
-			},
+			map[string]any{"template": "Timed"},
 			"http://localhost",
 		)
 		require.NoError(t, err)
 
-		events, err := models.ListCanvasEvents(canvas.ID, triggerNodeID, 1, nil)
+		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 
 		result := resp.Result.AsMap()
-		assert.Equal(t, "Hello World", result["template"])
+		assert.Equal(t, "Timed", result["template"])
 
 		data, ok := events[0].Data.Data().(map[string]any)
 		require.True(t, ok)
 
 		inner, ok := data["data"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "Override", inner["message"])
+		generatedAt, ok := inner["generatedAt"].(string)
+		require.True(t, ok)
+		assert.NotContains(t, generatedAt, "{{")
+		assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, generatedAt)
+	})
+
+	t.Run("run resolves plain now() expression", func(t *testing.T) {
+		expressionNodeID := "start-node-expression-now"
+		expressionCanvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{
+					NodeID: expressionNodeID,
+					Name:   expressionNodeID,
+					Type:   models.NodeTypeTrigger,
+					Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+					Configuration: datatypes.NewJSONType(map[string]any{
+						"templates": []any{
+							map[string]any{
+								"name": "Timed",
+								"payload": map[string]any{
+									"message": "{{ now() }}",
+								},
+							},
+						},
+					}),
+				},
+			},
+			nil,
+		)
+
+		_, err := InvokeNodeTriggerHook(
+			authedCtx,
+			r.AuthService,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID,
+			expressionCanvas.ID,
+			expressionNodeID,
+			"run",
+			map[string]any{"template": "Timed"},
+			"http://localhost",
+		)
+		require.NoError(t, err)
+
+		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		data, ok := events[0].Data.Data().(map[string]any)
+		require.True(t, ok)
+		inner, ok := data["data"].(map[string]any)
+		require.True(t, ok)
+		message, ok := inner["message"].(string)
+		require.True(t, ok)
+		assert.NotContains(t, message, "{{")
+	})
+
+	t.Run("run resolves template payload expressions from JSON string payload", func(t *testing.T) {
+		expressionNodeID := "start-node-expression-json"
+		expressionCanvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				{
+					NodeID: expressionNodeID,
+					Name:   expressionNodeID,
+					Type:   models.NodeTypeTrigger,
+					Ref:    datatypes.NewJSONType(models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}),
+					Configuration: datatypes.NewJSONType(map[string]any{
+						"templates": []any{
+							map[string]any{
+								"name":    "Timed",
+								"payload": "{\n  \"generatedAt\": \"{{ now().Format(\"2006-01-02\") }}\"\n}",
+							},
+						},
+					}),
+				},
+			},
+			nil,
+		)
+
+		_, err := InvokeNodeTriggerHook(
+			authedCtx,
+			r.AuthService,
+			r.Encryptor,
+			r.Registry,
+			r.Organization.ID,
+			expressionCanvas.ID,
+			expressionNodeID,
+			"run",
+			map[string]any{"template": "Timed"},
+			"http://localhost",
+		)
+		require.NoError(t, err)
+
+		events, err := models.ListCanvasEvents(expressionCanvas.ID, expressionNodeID, 1, nil)
+		require.NoError(t, err)
+		require.Len(t, events, 1)
+
+		data, ok := events[0].Data.Data().(map[string]any)
+		require.True(t, ok)
+
+		inner, ok := data["data"].(map[string]any)
+		require.True(t, ok)
+		generatedAt, ok := inner["generatedAt"].(string)
+		require.True(t, ok)
+		assert.NotContains(t, generatedAt, "{{")
+		assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, generatedAt)
 	})
 
 	t.Run("non-trigger node -> error", func(t *testing.T) {

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -188,6 +188,11 @@ func listTypeOptionsToProto(opts *configuration.ListTypeOptions) *configpb.ListT
 		pbOpts.Accordion = &accordion
 	}
 
+	if opts.Reorderable {
+		reorderable := true
+		pbOpts.Reorderable = &reorderable
+	}
+
 	if opts.MaxItems != nil {
 		maxItems := int32(*opts.MaxItems)
 		pbOpts.MaxItems = &maxItems
@@ -517,8 +522,9 @@ func protoToListTypeOptions(pbOpts *configpb.ListTypeOptions) *configuration.Lis
 	}
 
 	opts := &configuration.ListTypeOptions{
-		ItemLabel: pbOpts.GetItemLabel(),
-		Accordion: pbOpts.GetAccordion(),
+		ItemLabel:   pbOpts.GetItemLabel(),
+		Accordion:   pbOpts.GetAccordion(),
+		Reorderable: pbOpts.GetReorderable(),
 		ItemDefinition: &configuration.ListItemDefinition{
 			Type: pbOpts.ItemDefinition.Type,
 		},

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -183,6 +183,11 @@ func listTypeOptionsToProto(opts *configuration.ListTypeOptions) *configpb.ListT
 		},
 	}
 
+	if opts.Accordion {
+		accordion := true
+		pbOpts.Accordion = &accordion
+	}
+
 	if opts.MaxItems != nil {
 		maxItems := int32(*opts.MaxItems)
 		pbOpts.MaxItems = &maxItems
@@ -512,7 +517,8 @@ func protoToListTypeOptions(pbOpts *configpb.ListTypeOptions) *configuration.Lis
 	}
 
 	opts := &configuration.ListTypeOptions{
-		ItemLabel: pbOpts.ItemLabel,
+		ItemLabel: pbOpts.GetItemLabel(),
+		Accordion: pbOpts.GetAccordion(),
 		ItemDefinition: &configuration.ListItemDefinition{
 			Type: pbOpts.ItemDefinition.Type,
 		},

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -78,6 +78,10 @@ func stringTypeOptionsToProto(opts *configuration.StringTypeOptions) *configpb.S
 		pbOpts.MaxLength = &maxLength
 	}
 
+	if opts.AllowExpressions != nil {
+		pbOpts.AllowExpressions = opts.AllowExpressions
+	}
+
 	return pbOpts
 }
 
@@ -358,6 +362,10 @@ func protoToStringTypeOptions(pbOpts *configpb.StringTypeOptions) *configuration
 	if pbOpts.MaxLength != nil {
 		maxLength := int(*pbOpts.MaxLength)
 		opts.MaxLength = &maxLength
+	}
+
+	if pbOpts.AllowExpressions != nil {
+		opts.AllowExpressions = pbOpts.AllowExpressions
 	}
 
 	return opts

--- a/pkg/grpc/actions/common_test.go
+++ b/pkg/grpc/actions/common_test.go
@@ -66,6 +66,38 @@ func TestConfigurationFieldToProto(t *testing.T) {
 		}
 	})
 
+	t.Run("roundtrip list type options with Accordion and Reorderable preserves fields", func(t *testing.T) {
+		field := configuration.Field{
+			Name:  "parameters",
+			Label: "Parameters",
+			Type:  configuration.FieldTypeList,
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel:   "Parameter",
+					Accordion:   true,
+					Reorderable: true,
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+					},
+				},
+			},
+		}
+
+		pbField := ConfigurationFieldToProto(field)
+		require.NotNil(t, pbField.TypeOptions)
+		require.NotNil(t, pbField.TypeOptions.List)
+		require.NotNil(t, pbField.TypeOptions.List.Accordion)
+		require.True(t, *pbField.TypeOptions.List.Accordion)
+		require.NotNil(t, pbField.TypeOptions.List.Reorderable)
+		require.True(t, *pbField.TypeOptions.List.Reorderable)
+
+		field2 := ProtoToConfigurationField(pbField)
+		require.NotNil(t, field2.TypeOptions)
+		require.NotNil(t, field2.TypeOptions.List)
+		assert.True(t, field2.TypeOptions.List.Accordion)
+		assert.True(t, field2.TypeOptions.List.Reorderable)
+	})
+
 	t.Run("roundtrip list type options with MaxItems preserves field", func(t *testing.T) {
 		maxItems := 4
 

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -53,8 +53,8 @@ func (s *Start) Documentation() string {
 Each Manual Run trigger exposes a list of templates. A template has:
 
 - ` + "`name`" + ` (required): a label used as the run target (and the event channel)
-- ` + "`payload`" + ` (required): a default JSON object emitted when the template is used. Supports expressions such as ` + "`{{ now() }}`" + ` in JSON values.
-- ` + "`parameters`" + ` (optional): a list of typed parameters for UI display
+- ` + "`parameters`" + ` (optional): a list of typed parameters exposed to payload expressions as ` + "`parameters[\"name\"]`" + ` and used by the run form
+- ` + "`payload`" + ` (required): a default JSON object emitted when the template is used. Supports expressions such as ` + "`{{ now() }}`" + ` and ` + "`{{ parameters[\"my parameter\"] }}`" + ` in JSON values.
 
 Each parameter has a ` + "`name`" + ` (plain text), required ` + "`type`" + ` (` + "`string`" + `, ` + "`number`" + `, or ` + "`boolean`" + `), and an optional default (` + "`defaultString`" + `, ` + "`defaultNumber`" + `, or ` + "`defaultBoolean`" + `) whose editor matches the selected type.
 
@@ -171,7 +171,7 @@ func (s *Start) Configuration() []configuration.Field {
 								Label:       "Payload",
 								Type:        configuration.FieldTypeObject,
 								Required:    true,
-								Description: "JSON object emitted when the template runs. Supports expressions such as {{ now() }} in field values.",
+								Description: "JSON object emitted when the template runs. Supports expressions such as {{ now() }} and {{ parameters[\"my parameter\"] }} in field values.",
 								Placeholder: `{
   "message": "Hello, World!"
 }`,

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -56,7 +56,7 @@ Each Manual Run trigger exposes a list of templates. A template has:
 - ` + "`parameters`" + ` (optional): a list of typed parameters exposed to payload expressions as ` + "`parameters[\"name\"]`" + ` and used by the run form
 - ` + "`payload`" + ` (required): a default JSON object emitted when the template is used. Supports expressions such as ` + "`{{ now() }}`" + ` and ` + "`{{ parameters[\"my parameter\"] }}`" + ` in JSON values.
 
-Each parameter has a ` + "`name`" + ` (plain text), required ` + "`type`" + ` (` + "`string`" + `, ` + "`number`" + `, or ` + "`boolean`" + `), and an optional default (` + "`defaultString`" + `, ` + "`defaultNumber`" + `, or ` + "`defaultBoolean`" + `) whose editor matches the selected type.
+Each parameter has a ` + "`name`" + ` (plain text), required ` + "`type`" + ` (` + "`string`" + `, ` + "`number`" + `, or ` + "`boolean`" + `), an optional ` + "`title`" + ` for the run form label (defaults to ` + "`name`" + ` when unset), and an optional default (` + "`defaultString`" + `, ` + "`defaultNumber`" + `, or ` + "`defaultBoolean`" + `) whose editor matches the selected type.
 
 ## Event Data
 
@@ -160,6 +160,17 @@ func (s *Start) Configuration() []configuration.Field {
 													Togglable: true,
 													VisibilityConditions: []configuration.VisibilityCondition{
 														{Field: "type", Values: []string{configuration.FieldTypeBool}},
+													},
+												},
+												{
+													Name:      "title",
+													Label:     "Display Title",
+													Togglable: true,
+													Type:      configuration.FieldTypeString,
+													TypeOptions: &configuration.TypeOptions{
+														String: &configuration.StringTypeOptions{
+															AllowExpressions: &disallowExpressions,
+														},
 													},
 												},
 											},

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -1,6 +1,7 @@
 package manual
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -45,21 +46,21 @@ func (s *Start) Documentation() string {
 1. Add the Manual Run trigger as the starting node of your workflow
 2. Configure one or more templates, each with a name, default payload, and optional parameters
 3. Click the "Run" button in the workflow UI, or invoke the ` + "`run`" + ` hook via the API/CLI to start an execution
-4. The workflow begins immediately with either the configured payload or an override supplied at run time
+4. The workflow begins immediately with the configured payload for the selected template
 
 ## Configuration
 
 Each Manual Run trigger exposes a list of templates. A template has:
 
 - ` + "`name`" + ` (required): a label used as the run target (and the event channel)
-- ` + "`payload`" + ` (required): a default JSON object emitted when the template is used
-- ` + "`parameters`" + ` (optional): a list of typed parameters shown when running the template manually
+- ` + "`payload`" + ` (required): a default JSON object emitted when the template is used. Supports expressions such as ` + "`{{ now() }}`" + ` in JSON values.
+- ` + "`parameters`" + ` (optional): a list of typed parameters for UI display
 
 Each parameter has a ` + "`name`" + ` (plain text), required ` + "`type`" + ` (` + "`string`" + `, ` + "`number`" + `, or ` + "`boolean`" + `), and an optional default (` + "`defaultString`" + `, ` + "`defaultNumber`" + `, or ` + "`defaultBoolean`" + `) whose editor matches the selected type.
 
 ## Event Data
 
-Manual runs emit an event with type ` + "`manual.run`" + `. The data is either the template's saved payload or the override passed in the run request.`
+Manual runs emit an event with type ` + "`manual.run`" + `. The data is the selected template's payload after expression resolution.`
 }
 
 func (s *Start) Icon() string {
@@ -166,10 +167,14 @@ func (s *Start) Configuration() []configuration.Field {
 								},
 							},
 							{
-								Name:     "payload",
-								Label:    "Payload",
-								Type:     configuration.FieldTypeObject,
-								Required: true,
+								Name:        "payload",
+								Label:       "Payload",
+								Type:        configuration.FieldTypeObject,
+								Required:    true,
+								Description: "JSON object emitted when the template runs. Supports expressions such as {{ now() }} in field values.",
+								Placeholder: `{
+  "message": "Hello, World!"
+}`,
 							},
 						},
 					},
@@ -208,11 +213,6 @@ func (s *Start) Hooks() []core.Hook {
 					Type:     configuration.FieldTypeString,
 					Required: true,
 				},
-				{
-					Name:  "payload",
-					Label: "Payload Override",
-					Type:  configuration.FieldTypeObject,
-				},
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func (s *Start) run(ctx core.TriggerHookContext) (map[string]any, error) {
 	}
 
 	var names []string
-	var payload map[string]any
+	var payload any
 	found := false
 
 	for _, raw := range rawTemplates {
@@ -260,15 +260,16 @@ func (s *Start) run(ctx core.TriggerHookContext) (map[string]any, error) {
 		return nil, fmt.Errorf("template %q not found; available: %s", templateName, strings.Join(names, ", "))
 	}
 
-	if override, ok := ctx.Parameters["payload"].(map[string]any); ok {
-		payload = override
-	}
-
 	if payload == nil {
-		return nil, fmt.Errorf("template %q has no payload and no override was provided", templateName)
+		return nil, fmt.Errorf("template %q has no payload", templateName)
 	}
 
-	if err := ctx.Events.Emit("manual.run", payload); err != nil {
+	resolvedPayload, err := payloadObject(payload)
+	if err != nil {
+		return nil, fmt.Errorf("template %q payload must be a JSON object: %w", templateName, err)
+	}
+
+	if err := ctx.Events.Emit("manual.run", resolvedPayload); err != nil {
 		return nil, fmt.Errorf("failed to emit event: %w", err)
 	}
 
@@ -279,7 +280,24 @@ func (s *Start) Cleanup(ctx core.TriggerContext) error {
 	return nil
 }
 
-func templatePayload(tmpl map[string]any) map[string]any {
-	payload, _ := tmpl["payload"].(map[string]any)
-	return payload
+func templatePayload(tmpl map[string]any) any {
+	return tmpl["payload"]
+}
+
+func payloadObject(value any) (map[string]any, error) {
+	switch payload := value.(type) {
+	case map[string]any:
+		return payload, nil
+	case string:
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			return nil, err
+		}
+		if parsed == nil {
+			return nil, fmt.Errorf("empty payload")
+		}
+		return parsed, nil
+	default:
+		return nil, fmt.Errorf("unsupported payload type")
+	}
 }

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -43,7 +43,7 @@ func (s *Start) Documentation() string {
 ## How It Works
 
 1. Add the Manual Run trigger as the starting node of your workflow
-2. Configure one or more templates, each with a name and a default payload
+2. Configure one or more templates, each with a name, default payload, and optional parameters
 3. Click the "Run" button in the workflow UI, or invoke the ` + "`run`" + ` hook via the API/CLI to start an execution
 4. The workflow begins immediately with either the configured payload or an override supplied at run time
 
@@ -53,6 +53,9 @@ Each Manual Run trigger exposes a list of templates. A template has:
 
 - ` + "`name`" + ` (required): a label used as the run target (and the event channel)
 - ` + "`payload`" + ` (required): a default JSON object emitted when the template is used
+- ` + "`parameters`" + ` (optional): a list of typed parameters shown when running the template manually
+
+Each parameter has a ` + "`name`" + ` (plain text), required ` + "`type`" + ` (` + "`string`" + `, ` + "`number`" + `, or ` + "`boolean`" + `), and an optional default (` + "`defaultString`" + `, ` + "`defaultNumber`" + `, or ` + "`defaultBoolean`" + `) whose editor matches the selected type.
 
 ## Event Data
 
@@ -68,6 +71,8 @@ func (s *Start) Color() string {
 }
 
 func (s *Start) Configuration() []configuration.Field {
+	disallowExpressions := false
+
 	return []configuration.Field{
 		{
 			Name:  "templates",
@@ -86,6 +91,80 @@ func (s *Start) Configuration() []configuration.Field {
 								Required: true,
 							},
 							{
+								Name:  "parameters",
+								Label: "Parameters",
+								Type:  configuration.FieldTypeList,
+								TypeOptions: &configuration.TypeOptions{
+									List: &configuration.ListTypeOptions{
+										ItemLabel: "Parameter",
+										ItemDefinition: &configuration.ListItemDefinition{
+											Type: configuration.FieldTypeObject,
+											Schema: []configuration.Field{
+												{
+													Name:     "name",
+													Label:    "Name",
+													Type:     configuration.FieldTypeString,
+													Required: true,
+													TypeOptions: &configuration.TypeOptions{
+														String: &configuration.StringTypeOptions{
+															AllowExpressions: &disallowExpressions,
+														},
+													},
+												},
+												{
+													Name:     "type",
+													Label:    "Type",
+													Type:     configuration.FieldTypeSelect,
+													Required: true,
+													Default:  configuration.FieldTypeString,
+													TypeOptions: &configuration.TypeOptions{
+														Select: &configuration.SelectTypeOptions{
+															Options: []configuration.FieldOption{
+																{Label: "String", Value: configuration.FieldTypeString},
+																{Label: "Number", Value: configuration.FieldTypeNumber},
+																{Label: "Boolean", Value: configuration.FieldTypeBool},
+															},
+														},
+													},
+												},
+												{
+													Name:      "defaultString",
+													Label:     "Default Value",
+													Type:      configuration.FieldTypeString,
+													Togglable: true,
+													VisibilityConditions: []configuration.VisibilityCondition{
+														{Field: "type", Values: []string{configuration.FieldTypeString}},
+													},
+													TypeOptions: &configuration.TypeOptions{
+														String: &configuration.StringTypeOptions{
+															AllowExpressions: &disallowExpressions,
+														},
+													},
+												},
+												{
+													Name:      "defaultNumber",
+													Label:     "Default Value",
+													Type:      configuration.FieldTypeNumber,
+													Togglable: true,
+													VisibilityConditions: []configuration.VisibilityCondition{
+														{Field: "type", Values: []string{configuration.FieldTypeNumber}},
+													},
+												},
+												{
+													Name:      "defaultBoolean",
+													Label:     "Default Value",
+													Type:      configuration.FieldTypeBool,
+													Togglable: true,
+													VisibilityConditions: []configuration.VisibilityCondition{
+														{Field: "type", Values: []string{configuration.FieldTypeBool}},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
 								Name:     "payload",
 								Label:    "Payload",
 								Type:     configuration.FieldTypeObject,
@@ -99,6 +178,9 @@ func (s *Start) Configuration() []configuration.Field {
 				{
 					"name":    "Hello World",
 					"payload": map[string]any{"message": "Hello, World!"},
+					"parameters": []map[string]any{
+						{"name": "message", "type": configuration.FieldTypeString, "defaultString": "Hello, World!"},
+					},
 				},
 			},
 		},
@@ -168,7 +250,7 @@ func (s *Start) run(ctx core.TriggerHookContext) (map[string]any, error) {
 		name, _ := tmpl["name"].(string)
 		names = append(names, name)
 		if name == templateName {
-			payload, _ = tmpl["payload"].(map[string]any)
+			payload = templatePayload(tmpl)
 			found = true
 		}
 	}
@@ -194,4 +276,9 @@ func (s *Start) run(ctx core.TriggerHookContext) (map[string]any, error) {
 
 func (s *Start) Cleanup(ctx core.TriggerContext) error {
 	return nil
+}
+
+func templatePayload(tmpl map[string]any) map[string]any {
+	payload, _ := tmpl["payload"].(map[string]any)
+	return payload
 }

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -182,11 +182,9 @@ func (s *Start) Configuration() []configuration.Field {
 			},
 			Default: []map[string]any{
 				{
-					"name":    "Hello World",
-					"payload": map[string]any{"message": "Hello, World!"},
-					"parameters": []map[string]any{
-						{"name": "message", "type": configuration.FieldTypeString, "defaultString": "Hello, World!"},
-					},
+					"name":       "Hello World",
+					"payload":    map[string]any{"message": "Hello, World!"},
+					"parameters": []map[string]any{},
 				},
 			},
 		},

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -97,8 +97,9 @@ func (s *Start) Configuration() []configuration.Field {
 								Type:  configuration.FieldTypeList,
 								TypeOptions: &configuration.TypeOptions{
 									List: &configuration.ListTypeOptions{
-										ItemLabel: "Parameter",
-										Accordion: true,
+										ItemLabel:   "Parameter",
+										Accordion:   true,
+										Reorderable: true,
 										ItemDefinition: &configuration.ListItemDefinition{
 											Type: configuration.FieldTypeObject,
 											Schema: []configuration.Field{

--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -97,6 +97,7 @@ func (s *Start) Configuration() []configuration.Field {
 								TypeOptions: &configuration.TypeOptions{
 									List: &configuration.ListTypeOptions{
 										ItemLabel: "Parameter",
+										Accordion: true,
 										ItemDefinition: &configuration.ListItemDefinition{
 											Type: configuration.FieldTypeObject,
 											Schema: []configuration.Field{

--- a/pkg/triggers/start/start_test.go
+++ b/pkg/triggers/start/start_test.go
@@ -142,6 +142,66 @@ func TestStart_HandleHook_RejectsNoTemplatesConfigured(t *testing.T) {
 	assert.Contains(t, err.Error(), "no templates configured")
 }
 
+func TestStart_HandleHook_EmitsWithConfiguredParameters(t *testing.T) {
+	s := &Start{}
+	events := &contexts.EventContext{}
+
+	config := map[string]any{
+		"templates": []any{
+			map[string]any{
+				"name":    "Hello",
+				"payload": map[string]any{"message": "Hello, World!"},
+				"parameters": []any{
+					map[string]any{"name": "message", "type": "string", "defaultString": "Hello, World!"},
+				},
+			},
+		},
+	}
+
+	result, err := s.HandleHook(core.TriggerHookContext{
+		Name:          HookRun,
+		Parameters:    map[string]any{"template": "Hello"},
+		Configuration: config,
+		Events:        events,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", result["template"])
+
+	require.Len(t, events.Payloads, 1)
+	payload, ok := events.Payloads[0].Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Hello, World!", payload["message"])
+}
+
+func TestStart_HandleHook_PrefersPayloadOverParameters(t *testing.T) {
+	s := &Start{}
+	events := &contexts.EventContext{}
+
+	config := map[string]any{
+		"templates": []any{
+			map[string]any{
+				"name":    "Hello",
+				"payload": map[string]any{"message": "from payload"},
+				"parameters": []any{
+					map[string]any{"name": "message", "type": "string", "defaultString": "from parameters"},
+				},
+			},
+		},
+	}
+
+	_, err := s.HandleHook(core.TriggerHookContext{
+		Name:          HookRun,
+		Parameters:    map[string]any{"template": "Hello"},
+		Configuration: config,
+		Events:        events,
+	})
+
+	require.NoError(t, err)
+	payload := events.Payloads[0].Data.(map[string]any)
+	assert.Equal(t, "from payload", payload["message"])
+}
+
 func TestStart_HandleHook_RejectsNilPayloadWithoutOverride(t *testing.T) {
 	s := &Start{}
 	events := &contexts.EventContext{}

--- a/pkg/triggers/start/start_test.go
+++ b/pkg/triggers/start/start_test.go
@@ -20,20 +20,15 @@ func TestStart_Hooks_DeclaresUserAccessibleRun(t *testing.T) {
 
 	var paramNames []string
 	var templateRequired bool
-	var payloadRequired bool
 	for _, param := range hook.Parameters {
 		paramNames = append(paramNames, param.Name)
 		if param.Name == "template" {
 			templateRequired = param.Required
 		}
-		if param.Name == "payload" {
-			payloadRequired = param.Required
-		}
 	}
 
-	assert.ElementsMatch(t, []string{"template", "payload"}, paramNames)
+	assert.ElementsMatch(t, []string{"template"}, paramNames)
 	assert.True(t, templateRequired, "template parameter must be required")
-	assert.False(t, payloadRequired, "payload parameter must be optional")
 }
 
 func TestStart_HandleHook_EmitsWithConfiguredPayload(t *testing.T) {
@@ -62,32 +57,6 @@ func TestStart_HandleHook_EmitsWithConfiguredPayload(t *testing.T) {
 	payload, ok := events.Payloads[0].Data.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "Hello, World!", payload["message"])
-}
-
-func TestStart_HandleHook_PayloadOverride(t *testing.T) {
-	s := &Start{}
-	events := &contexts.EventContext{}
-
-	config := map[string]any{
-		"templates": []any{
-			map[string]any{"name": "Hello", "payload": map[string]any{"message": "Hello, World!"}},
-		},
-	}
-
-	_, err := s.HandleHook(core.TriggerHookContext{
-		Name: HookRun,
-		Parameters: map[string]any{
-			"template": "Hello",
-			"payload":  map[string]any{"message": "Override"},
-		},
-		Configuration: config,
-		Events:        events,
-	})
-
-	require.NoError(t, err)
-	require.Len(t, events.Payloads, 1)
-	payload := events.Payloads[0].Data.(map[string]any)
-	assert.Equal(t, "Override", payload["message"])
 }
 
 func TestStart_HandleHook_UnknownTemplateListsAvailable(t *testing.T) {
@@ -202,7 +171,7 @@ func TestStart_HandleHook_PrefersPayloadOverParameters(t *testing.T) {
 	assert.Equal(t, "from payload", payload["message"])
 }
 
-func TestStart_HandleHook_RejectsNilPayloadWithoutOverride(t *testing.T) {
+func TestStart_HandleHook_RejectsNilPayload(t *testing.T) {
 	s := &Start{}
 	events := &contexts.EventContext{}
 

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -26,6 +26,7 @@ type NodeConfigurationBuilder struct {
 	rootEventID         *uuid.UUID
 	rootPayload         any
 	input               any
+	expressionVariables map[string]any
 	parentBlueprintNode *models.CanvasNode
 	configurationFields []configuration.Field
 }
@@ -64,6 +65,11 @@ func (b *NodeConfigurationBuilder) WithPreviousExecution(previousExecutionID *uu
 
 func (b *NodeConfigurationBuilder) WithInput(input any) *NodeConfigurationBuilder {
 	b.input = input
+	return b
+}
+
+func (b *NodeConfigurationBuilder) WithExpressionVariables(variables map[string]any) *NodeConfigurationBuilder {
+	b.expressionVariables = variables
 	return b
 }
 
@@ -245,7 +251,7 @@ func (b *NodeConfigurationBuilder) ResolveTemplateExpressions(expression string)
 }
 
 func (b *NodeConfigurationBuilder) ResolveExpression(expression string) (any, error) {
-	return b.ResolveExpressionWithExtraVariables(expression, nil)
+	return b.ResolveExpressionWithExtraVariables(expression, b.expressionVariables)
 }
 
 // ResolveExpressionWithExtraVariables evaluates an expression with extra

--- a/pkg/workers/contexts/node_configuration_builder_expr_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_expr_test.go
@@ -36,3 +36,17 @@ func TestNodeConfigurationBuilder_ResolveExpressionWithExtraVariables_RejectsRes
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "reserved")
 }
+
+func TestNodeConfigurationBuilder_ResolveExpression_UsesConfiguredExpressionVariables(t *testing.T) {
+	b := NewNodeConfigurationBuilder(nil, uuid.Nil).
+		WithInput(map[string]any{}).
+		WithExpressionVariables(map[string]any{
+			"parameters": map[string]any{
+				"message": "hello",
+			},
+		})
+
+	out, err := b.ResolveExpression(`parameters["message"]`)
+	require.NoError(t, err)
+	require.Equal(t, "hello", out)
+}

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -163,6 +163,9 @@ func (w *NodeRequestWorker) invokeTriggerHook(tx *gorm.DB, request *models.Canva
 
 	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
 		WithNodeID(node.NodeID).
+		WithExpressionVariables(map[string]any{
+			"parameters": spec.InvokeAction.Parameters,
+		}).
 		WithConfigurationFields(hookProvider.Configuration()).
 		Build(node.Configuration.Data())
 	if err != nil {

--- a/pkg/workers/node_request_worker.go
+++ b/pkg/workers/node_request_worker.go
@@ -161,10 +161,18 @@ func (w *NodeRequestWorker) invokeTriggerHook(tx *gorm.DB, request *models.Canva
 		return fmt.Errorf("failed to find hook: %v", err)
 	}
 
+	resolvedConfiguration, err := contexts.NewNodeConfigurationBuilder(tx, node.WorkflowID).
+		WithNodeID(node.NodeID).
+		WithConfigurationFields(hookProvider.Configuration()).
+		Build(node.Configuration.Data())
+	if err != nil {
+		return fmt.Errorf("failed to resolve trigger configuration: %w", err)
+	}
+
 	hookCtx := core.TriggerHookContext{
 		Name:          spec.InvokeAction.ActionName,
 		Parameters:    spec.InvokeAction.Parameters,
-		Configuration: node.Configuration.Data(),
+		Configuration: resolvedConfiguration,
 		Logger:        logging.ForNode(*node),
 		HTTP:          w.registry.HTTPContextInTransaction(tx),
 		Metadata:      contexts.NewNodeMetadataContext(tx, node),

--- a/protos/configuration.proto
+++ b/protos/configuration.proto
@@ -43,6 +43,7 @@ message NumberTypeOptions {
 message StringTypeOptions {
   optional int32 min_length = 1;
   optional int32 max_length = 2;
+  optional bool allow_expressions = 3;
 }
 
 message ExpressionTypeOptions {

--- a/protos/configuration.proto
+++ b/protos/configuration.proto
@@ -99,6 +99,7 @@ message ListTypeOptions {
   string item_label = 2;
   optional int32 max_items = 3;
   optional bool accordion = 4;
+  optional bool reorderable = 5;
 }
 
 message ObjectTypeOptions {

--- a/protos/configuration.proto
+++ b/protos/configuration.proto
@@ -98,6 +98,7 @@ message ListTypeOptions {
   ListItemDefinition item_definition = 1;
   string item_label = 2;
   optional int32 max_items = 3;
+  optional bool accordion = 4;
 }
 
 message ObjectTypeOptions {

--- a/web_src/src/components/AutoCompleteInput/core.spec.ts
+++ b/web_src/src/components/AutoCompleteInput/core.spec.ts
@@ -146,3 +146,19 @@ describe("getSuggestions config fields", () => {
     expect(labels).toContain("config");
   });
 });
+
+describe("getSuggestions top-level globals", () => {
+  it("suggests top-level globals by name when enabled", () => {
+    const suggestions = getSuggestions(
+      "par",
+      "par".length,
+      { parameters: { message: "hello" } },
+      {
+        includeTopLevelGlobals: true,
+      },
+    );
+    const parametersSuggestion = suggestions.find((item) => item.label === "parameters");
+    expect(parametersSuggestion).toBeDefined();
+    expect(parametersSuggestion?.insertText).toBe("parameters.");
+  });
+});

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -529,6 +529,32 @@ export const EXPR_FUNCTIONS: readonly ExprFunction[] = [
   },
 ] as const;
 
+function suggestTopLevelGlobals<TGlobals extends Record<string, unknown>>(
+  globals: TGlobals,
+  prefix: string,
+): Suggestion[] {
+  const out: Suggestion[] = [];
+  const globalKeys = listGlobalKeys(globals);
+  for (const key of globalKeys) {
+    if (key === "$" || key.startsWith("__") || needsQuotingAsIdentifier(key)) {
+      continue;
+    }
+    if (prefix && !key.toLowerCase().startsWith(prefix)) {
+      continue;
+    }
+
+    const value = (globals as Record<string, unknown>)[key];
+    const tailDot = isExpandableValue(value) ? "." : "";
+    out.push({
+      label: key,
+      kind: "variable",
+      insertText: `${key}${tailDot}`,
+      detail: getValueTypeLabel(value),
+    });
+  }
+  return out;
+}
+
 export function getSuggestions<TGlobals extends Record<string, unknown>>(
   text: string,
   cursor: number,
@@ -670,24 +696,7 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
     }
 
     if (includeTopLevelGlobals) {
-      const globalKeys = listGlobalKeys(globals);
-      for (const key of globalKeys) {
-        if (key === "$" || key.startsWith("__") || needsQuotingAsIdentifier(key)) {
-          continue;
-        }
-        if (prefix && !key.toLowerCase().startsWith(prefix)) {
-          continue;
-        }
-
-        const value = (globals as Record<string, unknown>)[key];
-        const tailDot = isExpandableValue(value) ? "." : "";
-        out.push({
-          label: key,
-          kind: "variable",
-          insertText: `${key}${tailDot}`,
-          detail: getValueTypeLabel(value),
-        });
-      }
+      out.push(...suggestTopLevelGlobals(globals, prefix));
     }
   }
 

--- a/web_src/src/components/AutoCompleteInput/core.ts
+++ b/web_src/src/components/AutoCompleteInput/core.ts
@@ -48,6 +48,7 @@ export interface Suggestion {
 export interface GetSuggestionsOptions {
   includeFunctions?: boolean;
   includeGlobals?: boolean;
+  includeTopLevelGlobals?: boolean;
   limit?: number;
   allowInStrings?: boolean;
 }
@@ -534,7 +535,13 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
   globals: TGlobals,
   options: GetSuggestionsOptions = {},
 ): Suggestion[] {
-  const { includeFunctions = true, includeGlobals = true, limit = 30, allowInStrings = false } = options;
+  const {
+    includeFunctions = true,
+    includeGlobals = true,
+    includeTopLevelGlobals = false,
+    limit = 30,
+    allowInStrings = false,
+  } = options;
   const left = text.slice(0, cursor);
   // 0) Env key trigger: after "$" or "$[" suggest keys immediately
   const envTrigger = detectEnvKeyTrigger(left);
@@ -660,6 +667,27 @@ export function getSuggestions<TGlobals extends Record<string, unknown>>(
         description: "Root selector for accessing payload data from all connected components.",
         nodeCount,
       });
+    }
+
+    if (includeTopLevelGlobals) {
+      const globalKeys = listGlobalKeys(globals);
+      for (const key of globalKeys) {
+        if (key === "$" || key.startsWith("__") || needsQuotingAsIdentifier(key)) {
+          continue;
+        }
+        if (prefix && !key.toLowerCase().startsWith(prefix)) {
+          continue;
+        }
+
+        const value = (globals as Record<string, unknown>)[key];
+        const tailDot = isExpandableValue(value) ? "." : "";
+        out.push({
+          label: key,
+          kind: "variable",
+          insertText: `${key}${tailDot}`,
+          detail: getValueTypeLabel(value),
+        });
+      }
     }
   }
 

--- a/web_src/src/lib/reorderListItems.spec.ts
+++ b/web_src/src/lib/reorderListItems.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { reorderListItems } from "./reorderListItems";
+
+describe("reorderListItems", () => {
+  it("moves an item to a new index", () => {
+    expect(reorderListItems(["a", "b", "c"], 0, 2)).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns the same array when indices are equal or out of range", () => {
+    const items = ["a", "b"];
+    expect(reorderListItems(items, 0, 0)).toBe(items);
+    expect(reorderListItems(items, -1, 1)).toBe(items);
+    expect(reorderListItems(items, 0, 5)).toBe(items);
+  });
+});

--- a/web_src/src/lib/reorderListItems.ts
+++ b/web_src/src/lib/reorderListItems.ts
@@ -1,0 +1,10 @@
+export function reorderListItems<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= items.length || toIndex >= items.length) {
+    return items;
+  }
+
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}

--- a/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.spec.ts
@@ -32,7 +32,7 @@ describe("buildDashboardTriggerParameters", () => {
       component: "github",
       configuration: { templates: [{ name: "default" }] } as ComponentsNode["configuration"],
     } as ComponentsNode;
-    expect(buildDashboardTriggerParameters(node, "run")).toEqual({ template: "default", payload: {} });
+    expect(buildDashboardTriggerParameters(node, "run")).toEqual({ template: "default" });
   });
 
   it("returns empty parameters when the start node has no templates", () => {
@@ -41,7 +41,7 @@ describe("buildDashboardTriggerParameters", () => {
     expect(buildDashboardTriggerParameters(makeStartNode(undefined), "run")).toEqual({});
   });
 
-  it("returns the first template's name with its payload when present", () => {
+  it("returns the first template's name when present", () => {
     const node = makeStartNode({
       templates: [
         { name: "deploy", payload: { branch: "main", env: "prod" } },
@@ -50,7 +50,6 @@ describe("buildDashboardTriggerParameters", () => {
     });
     expect(buildDashboardTriggerParameters(node, "run")).toEqual({
       template: "deploy",
-      payload: { branch: "main", env: "prod" },
     });
   });
 
@@ -63,21 +62,19 @@ describe("buildDashboardTriggerParameters", () => {
     });
     expect(buildDashboardTriggerParameters(node, "run", "rollback")).toEqual({
       template: "rollback",
-      payload: { branch: "main" },
     });
   });
 
-  it("defaults payload to an empty object when the template payload is missing or invalid", () => {
+  it("does not depend on template payload shape", () => {
     expect(buildDashboardTriggerParameters(makeStartNode({ templates: [{ name: "deploy" }] }), "run")).toEqual({
       template: "deploy",
-      payload: {},
     });
     expect(
       buildDashboardTriggerParameters(makeStartNode({ templates: [{ name: "deploy", payload: null }] }), "run"),
-    ).toEqual({ template: "deploy", payload: {} });
+    ).toEqual({ template: "deploy" });
     expect(
       buildDashboardTriggerParameters(makeStartNode({ templates: [{ name: "deploy", payload: [1, 2] }] }), "run"),
-    ).toEqual({ template: "deploy", payload: {} });
+    ).toEqual({ template: "deploy" });
   });
 
   it("returns empty parameters when the first template has no name", () => {

--- a/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.ts
@@ -1,4 +1,5 @@
 import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client/types.gen";
+import { payloadForTemplateRun, type StartTemplate } from "@/pages/workflowv2/mappers/start/templatePayload";
 
 /** A Start trigger template as exposed by `node.configuration.templates`. */
 export interface DashboardTriggerTemplate {
@@ -15,17 +16,13 @@ export interface DashboardTriggerTemplate {
  */
 export function getTriggerTemplates(node: ComponentsNode | undefined): DashboardTriggerTemplate[] {
   if (!node) return [];
-  const config = node.configuration as { templates?: Array<{ name?: string; payload?: unknown }> } | undefined;
+  const config = node.configuration as { templates?: StartTemplate[] } | undefined;
   const templates = config?.templates;
   if (!templates || templates.length === 0) return [];
   const out: DashboardTriggerTemplate[] = [];
   for (const tpl of templates) {
     if (!tpl?.name) continue;
-    const payload =
-      tpl.payload && typeof tpl.payload === "object" && !Array.isArray(tpl.payload)
-        ? (tpl.payload as Record<string, unknown>)
-        : {};
-    out.push({ name: tpl.name, payload });
+    out.push({ name: tpl.name, payload: payloadForTemplateRun(tpl) });
   }
   return out;
 }

--- a/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.ts
+++ b/web_src/src/pages/workflowv2/dashboard/dashboardTriggerParameters.ts
@@ -1,10 +1,9 @@
 import type { SuperplaneComponentsNode as ComponentsNode } from "@/api-client/types.gen";
-import { payloadForTemplateRun, type StartTemplate } from "@/pages/workflowv2/mappers/start/templatePayload";
+import type { StartTemplate } from "@/pages/workflowv2/mappers/start/templatePayload";
 
 /** A Start trigger template as exposed by `node.configuration.templates`. */
 export interface DashboardTriggerTemplate {
   name: string;
-  payload: Record<string, unknown>;
 }
 
 /**
@@ -22,7 +21,7 @@ export function getTriggerTemplates(node: ComponentsNode | undefined): Dashboard
   const out: DashboardTriggerTemplate[] = [];
   for (const tpl of templates) {
     if (!tpl?.name) continue;
-    out.push({ name: tpl.name, payload: payloadForTemplateRun(tpl) });
+    out.push({ name: tpl.name });
   }
   return out;
 }
@@ -32,14 +31,10 @@ export function getTriggerTemplates(node: ComponentsNode | undefined): Dashboard
  * expects when the dashboard fires a quick Run on a referenced node.
  *
  * Trigger hooks are typed per-component. For the standard Start trigger
- * the `run` hook requires `{ template, payload }` — passing an empty
- * object causes the backend validator to reject with `field 'template'
- * is required`. To keep the dashboard's Run button frictionless, we
- * mirror the canvas view: pick the first template defined on the node
- * and seed `payload` with that template's default payload. Authors who
- * need to invoke a different template or override the payload can run
- * the trigger from the canvas card instead, which opens the full
- * payload editor.
+ * the `run` hook requires `{ template }` — passing an empty object causes
+ * the backend validator to reject with `field 'template' is required`.
+ * To keep the dashboard's Run button frictionless, we pick the first
+ * template defined on the node by default.
  *
  * When the referenced node does not expose templates, we fall back to an
  * empty parameters object so the API can surface its own validation error
@@ -57,5 +52,5 @@ export function buildDashboardTriggerParameters(
   const templates = getTriggerTemplates(node);
   if (templates.length === 0) return {};
   const template = (templateName ? templates.find((t) => t.name === templateName) : undefined) ?? templates[0];
-  return { template: template.name, payload: template.payload };
+  return { template: template.name };
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/WidgetTable.spec.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/widget/WidgetTable.spec.tsx
@@ -138,7 +138,7 @@ describe("WidgetTable row actions — permission gating", () => {
 });
 
 describe("WidgetTable row actions — confirm dialog preview", () => {
-  it("shows resolved trigger node, template, and merged parameters", () => {
+  it("shows resolved trigger node, template, and run hook parameters", () => {
     const onTrigger = vi.fn().mockResolvedValue(undefined);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const renderWithConfirm = (canvasRender: WidgetTableRender) =>
@@ -187,10 +187,10 @@ describe("WidgetTable row actions — confirm dialog preview", () => {
     expect(preview.textContent).toMatch(/run/);
     expect(preview.textContent).toMatch(/default/);
 
-    // Parameters JSON includes the row-derived issue.number.
+    // Manual run hooks pass template selection only; row payload templates are not merged.
     const params = screen.getByTestId("widget-row-action-start-parameters");
     expect(params.textContent).toContain('"template": "default"');
-    expect(params.textContent).toContain('"number": "42"');
+    expect(params.textContent).not.toContain('"number"');
   });
 });
 

--- a/web_src/src/pages/workflowv2/dashboard/widget/mergeTriggerPayload.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/mergeTriggerPayload.spec.ts
@@ -14,14 +14,13 @@ const START_NODE: SuperplaneComponentsNode = {
 };
 
 describe("mergeTriggerPayload", () => {
-  it("merges row payload into template defaults", () => {
+  it("uses template selection only for run hooks", () => {
     const row = { pr_number: "99" };
     const params = mergeTriggerParameters(START_NODE, "run", "deploy", row, {
       "issue.number": "{{ pr_number }}",
     });
     expect(params).toEqual({
       template: "deploy",
-      payload: { issue: { number: "99" } },
     });
   });
 

--- a/web_src/src/pages/workflowv2/dashboard/widget/mergeTriggerPayload.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/mergeTriggerPayload.ts
@@ -33,16 +33,9 @@ export function mergeTriggerParameters(
   payloadTemplates?: Record<string, string>,
 ): Record<string, unknown> {
   const base = buildDashboardTriggerParameters(node, hookName, templateName);
-  const rowPayload = buildRowPayloadFromTemplates(payloadTemplates, row);
-  if (hookName !== "run") {
-    return deepMergeObjects(base, rowPayload);
+  if (hookName === "run") {
+    return base;
   }
-  const basePayload =
-    base.payload && typeof base.payload === "object" && !Array.isArray(base.payload)
-      ? (base.payload as Record<string, unknown>)
-      : {};
-  return {
-    ...base,
-    payload: deepMergeObjects(basePayload, rowPayload),
-  };
+  const rowPayload = buildRowPayloadFromTemplates(payloadTemplates, row);
+  return deepMergeObjects(base, rowPayload);
 }

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ComponentBase } from "@/ui/componentBase";
@@ -135,6 +135,105 @@ describe("workflow v2 edit-mode action affordances", () => {
 
     expect(screen.queryByTestId("start-template-run")).not.toBeInTheDocument();
     expect(screen.getByText("Example")).toBeInTheDocument();
+  });
+
+  it("opens a parameter modal for manual run templates with parameters", async () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext({
+        node: {
+          id: "trigger-1",
+          name: "Start",
+          componentName: "start",
+          isCollapsed: false,
+          configuration: {
+            templates: [
+              {
+                name: "Example",
+                payload: { message: "default" },
+                parameters: [{ name: "message", type: "string", defaultString: "default" }],
+              },
+            ],
+          },
+        },
+      }),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    fireEvent.click(screen.getByTestId("start-template-run"));
+
+    expect(openModal).toHaveBeenCalledTimes(1);
+    expect(invokeNodeTriggerHook).not.toHaveBeenCalled();
+
+    const modal = openModal.mock.calls[0][0] as {
+      content: (ctx: { close: () => void }) => React.ReactNode;
+    };
+    render(<>{modal.content({ close: vi.fn() })}</>);
+
+    fireEvent.change(screen.getByLabelText("message"), { target: { value: "from form" } });
+    fireEvent.click(screen.getByTestId("emit-event-submit-button"));
+
+    await waitFor(() =>
+      expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
+        template: "Example",
+        message: "from form",
+      }),
+    );
+  });
+
+  it("invokes manual run directly when templates have no parameters", () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext(),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    fireEvent.click(screen.getByTestId("start-template-run"));
+
+    expect(openModal).not.toHaveBeenCalled();
+    expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
+      template: "Example",
+    });
+  });
+
+  it("invokes manual run directly when template parameters array is empty", () => {
+    const invokeNodeTriggerHook = vi.fn().mockResolvedValue(undefined);
+    const openModal = vi.fn();
+    const props = startTriggerRenderer.getTriggerProps({
+      ...makeTriggerContext({
+        node: {
+          id: "trigger-1",
+          name: "Start",
+          componentName: "start",
+          isCollapsed: false,
+          configuration: {
+            templates: [
+              {
+                name: "Example",
+                payload: { ok: true },
+                parameters: [],
+              },
+            ],
+          },
+        },
+      }),
+      canvasMode: "live",
+      actions: { invokeNodeTriggerHook, openModal },
+    });
+
+    render(<Trigger {...props} canvasMode="live" />);
+    fireEvent.click(screen.getByTestId("start-template-run"));
+
+    expect(openModal).not.toHaveBeenCalled();
+    expect(invokeNodeTriggerHook).toHaveBeenCalledWith("run", {
+      template: "Example",
+    });
   });
 
   it("disables approval actions in edit mode", () => {

--- a/web_src/src/pages/workflowv2/mappers/start/index.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.tsx
@@ -13,9 +13,7 @@ import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
-
-import { StartRunModal } from "./runModal";
-import { payloadForTemplateRun, type StartConfiguration } from "./templatePayload";
+import type { StartConfiguration } from "./templatePayload";
 
 /**
  * Default renderer for the start trigger
@@ -94,28 +92,8 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  actions.openModal({
-                    title: "Run trigger",
-                    description: (
-                      <>
-                        Run template <strong>{template.name}</strong> on node{" "}
-                        <strong>{node.name || "Unnamed trigger"}</strong>. Edit the values below to override the
-                        template defaults.
-                      </>
-                    ),
-                    content: ({ close }) => (
-                      <StartRunModal
-                        parameters={template.parameters}
-                        initialPayload={payloadForTemplateRun(template)}
-                        onClose={close}
-                        onRun={async (payload) => {
-                          await actions.invokeNodeTriggerHook("run", {
-                            template: template.name,
-                            payload,
-                          });
-                        }}
-                      />
-                    ),
+                  void actions.invokeNodeTriggerHook("run", {
+                    template: template.name,
                   });
                 }}
                 className="flex-shrink-0 h-7 py-1 px-2 bg-black text-white hover:bg-black/80"

--- a/web_src/src/pages/workflowv2/mappers/start/index.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.tsx
@@ -15,23 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
 
 import { StartRunModal } from "./runModal";
-
-interface StartTemplate {
-  name: string;
-  payload: Record<string, unknown>;
-}
-
-interface StartConfiguration {
-  templates?: StartTemplate[];
-}
-
-function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> {
-  const p = template.payload;
-  if (p && typeof p === "object" && !Array.isArray(p)) {
-    return p as Record<string, unknown>;
-  }
-  return {};
-}
+import { payloadForTemplateRun, type StartConfiguration } from "./templatePayload";
 
 /**
  * Default renderer for the start trigger
@@ -115,12 +99,13 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
                     description: (
                       <>
                         Run template <strong>{template.name}</strong> on node{" "}
-                        <strong>{node.name || "Unnamed trigger"}</strong>. Edit the payload below to override the
-                        template default.
+                        <strong>{node.name || "Unnamed trigger"}</strong>. Edit the values below to override the
+                        template defaults.
                       </>
                     ),
                     content: ({ close }) => (
                       <StartRunModal
+                        parameters={template.parameters}
                         initialPayload={payloadForTemplateRun(template)}
                         onClose={close}
                         onRun={async (payload) => {

--- a/web_src/src/pages/workflowv2/mappers/start/index.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.tsx
@@ -13,7 +13,8 @@ import { renderTimeAgo } from "@/components/TimeAgo";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
-import type { StartConfiguration } from "./templatePayload";
+import { StartRunModal } from "./runModal";
+import { payloadForTemplateRun, type StartConfiguration } from "./templatePayload";
 
 /**
  * Default renderer for the start trigger
@@ -92,6 +93,26 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
+                  if ((template.parameters?.length ?? 0) > 0) {
+                    actions.openModal({
+                      title: `Run ${template.name}`,
+                      description: "Provide parameter values for this manual run.",
+                      content: ({ close }) => (
+                        <StartRunModal
+                          parameters={template.parameters}
+                          initialPayload={payloadForTemplateRun(template)}
+                          onClose={close}
+                          onRun={async (payload) =>
+                            actions.invokeNodeTriggerHook("run", {
+                              template: template.name,
+                              ...payload,
+                            })
+                          }
+                        />
+                      ),
+                    });
+                    return;
+                  }
                   void actions.invokeNodeTriggerHook("run", {
                     template: template.name,
                   });

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -10,7 +10,7 @@ import { Checkbox } from "@/ui/checkbox";
 import {
   coerceParameterValue,
   initialParameterValue,
-  payloadRecordForParameters,
+  parameterDisplayLabel,
   type StartTemplateParameter,
 } from "./templatePayload";
 
@@ -26,12 +26,11 @@ export function StartRunModal({
   onClose: () => void;
 }) {
   const useParameterForm = Boolean(parameters?.length);
-  const parameterPayload = React.useMemo(() => payloadRecordForParameters(initialPayload), [initialPayload]);
   const [parameterValues, setParameterValues] = React.useState<Record<string, string | number | boolean>>(() => {
     const values: Record<string, string | number | boolean> = {};
     for (const param of parameters ?? []) {
       if (!param.name || !param.type) continue;
-      values[param.name] = initialParameterValue(param, parameterPayload);
+      values[param.name] = initialParameterValue(param);
     }
     return values;
   });
@@ -53,7 +52,7 @@ export function StartRunModal({
           typeof parsedData[param.name] === "number" &&
           Number.isNaN(parsedData[param.name])
         ) {
-          showErrorToast(`"${param.name}" must be a valid number`);
+          showErrorToast(`"${parameterDisplayLabel(param)}" must be a valid number`);
           return;
         }
       }
@@ -89,6 +88,7 @@ export function StartRunModal({
           {(parameters ?? []).map((param) => {
             if (!param.name || !param.type) return null;
             const id = `start-run-param-${param.name}`;
+            const label = parameterDisplayLabel(param);
             return (
               <div key={param.name} className="space-y-1.5">
                 {param.type === "boolean" ? (
@@ -104,12 +104,12 @@ export function StartRunModal({
                       }
                     />
                     <Label htmlFor={id} className="cursor-pointer">
-                      {param.name}
+                      {label}
                     </Label>
                   </div>
                 ) : (
                   <>
-                    <Label htmlFor={id}>{param.name}</Label>
+                    <Label htmlFor={id}>{label}</Label>
                     <Input
                       id={id}
                       type={param.type === "number" ? "number" : "text"}

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -7,7 +7,12 @@ import { LoadingButton } from "@/components/ui/loading-button";
 import { showErrorToast } from "@/lib/toast";
 import { Checkbox } from "@/ui/checkbox";
 
-import { coerceParameterValue, initialParameterValue, type StartTemplateParameter } from "./templatePayload";
+import {
+  coerceParameterValue,
+  initialParameterValue,
+  payloadRecordForParameters,
+  type StartTemplateParameter,
+} from "./templatePayload";
 
 export function StartRunModal({
   parameters,
@@ -16,20 +21,23 @@ export function StartRunModal({
   onClose,
 }: {
   parameters?: StartTemplateParameter[];
-  initialPayload: Record<string, unknown>;
+  initialPayload: Record<string, unknown> | string;
   onRun: (payload: Record<string, unknown>) => Promise<void>;
   onClose: () => void;
 }) {
   const useParameterForm = Boolean(parameters?.length);
+  const parameterPayload = React.useMemo(() => payloadRecordForParameters(initialPayload), [initialPayload]);
   const [parameterValues, setParameterValues] = React.useState<Record<string, string | number | boolean>>(() => {
     const values: Record<string, string | number | boolean> = {};
     for (const param of parameters ?? []) {
       if (!param.name || !param.type) continue;
-      values[param.name] = initialParameterValue(param, initialPayload);
+      values[param.name] = initialParameterValue(param, parameterPayload);
     }
     return values;
   });
-  const [eventData, setEventData] = React.useState<string>(() => JSON.stringify(initialPayload, null, 2));
+  const [eventData, setEventData] = React.useState<string>(() =>
+    typeof initialPayload === "string" ? initialPayload : JSON.stringify(initialPayload, null, 2),
+  );
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const handleSubmit = async () => {

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -1,33 +1,66 @@
 import React from "react";
 import Editor from "@monaco-editor/react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { showErrorToast } from "@/lib/toast";
+import { Checkbox } from "@/ui/checkbox";
+
+import { coerceParameterValue, initialParameterValue, type StartTemplateParameter } from "./templatePayload";
 
 export function StartRunModal({
+  parameters,
   initialPayload,
   onRun,
   onClose,
 }: {
+  parameters?: StartTemplateParameter[];
   initialPayload: Record<string, unknown>;
   onRun: (payload: Record<string, unknown>) => Promise<void>;
   onClose: () => void;
 }) {
+  const useParameterForm = Boolean(parameters?.length);
+  const [parameterValues, setParameterValues] = React.useState<Record<string, string | number | boolean>>(() => {
+    const values: Record<string, string | number | boolean> = {};
+    for (const param of parameters ?? []) {
+      if (!param.name || !param.type) continue;
+      values[param.name] = initialParameterValue(param, initialPayload);
+    }
+    return values;
+  });
   const [eventData, setEventData] = React.useState<string>(() => JSON.stringify(initialPayload, null, 2));
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const handleSubmit = async () => {
     let parsedData: Record<string, unknown>;
-    try {
-      const candidate = JSON.parse(eventData) as unknown;
-      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
-        showErrorToast("Payload must be a JSON object");
+    if (useParameterForm) {
+      parsedData = {};
+      for (const param of parameters ?? []) {
+        if (!param.name || !param.type) continue;
+        const raw = parameterValues[param.name];
+        parsedData[param.name] = coerceParameterValue(param, raw);
+        if (
+          param.type === "number" &&
+          typeof parsedData[param.name] === "number" &&
+          Number.isNaN(parsedData[param.name])
+        ) {
+          showErrorToast(`"${param.name}" must be a valid number`);
+          return;
+        }
+      }
+    } else {
+      try {
+        const candidate = JSON.parse(eventData) as unknown;
+        if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+          showErrorToast("Payload must be a JSON object");
+          return;
+        }
+        parsedData = candidate as Record<string, unknown>;
+      } catch {
+        showErrorToast("Invalid JSON format");
         return;
       }
-      parsedData = candidate as Record<string, unknown>;
-    } catch {
-      showErrorToast("Invalid JSON format");
-      return;
     }
 
     setIsSubmitting(true);
@@ -43,21 +76,59 @@ export function StartRunModal({
 
   return (
     <div className="space-y-4">
-      <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
-        <Editor
-          height="300px"
-          defaultLanguage="json"
-          value={eventData}
-          onChange={(value) => setEventData(value || "{}")}
-          options={{
-            minimap: { enabled: false },
-            fontSize: 13,
-            lineNumbers: "on",
-            scrollBeyondLastLine: false,
-            automaticLayout: true,
-          }}
-        />
-      </div>
+      {useParameterForm ? (
+        <div className="space-y-3">
+          {(parameters ?? []).map((param) => {
+            if (!param.name || !param.type) return null;
+            const id = `start-run-param-${param.name}`;
+            return (
+              <div key={param.name} className="space-y-1.5">
+                <Label htmlFor={id}>{param.name}</Label>
+                {param.type === "boolean" ? (
+                  <Checkbox
+                    id={id}
+                    checked={Boolean(parameterValues[param.name])}
+                    onCheckedChange={(checked) =>
+                      setParameterValues((prev) => ({
+                        ...prev,
+                        [param.name]: checked === true,
+                      }))
+                    }
+                  />
+                ) : (
+                  <Input
+                    id={id}
+                    type={param.type === "number" ? "number" : "text"}
+                    value={String(parameterValues[param.name] ?? "")}
+                    onChange={(e) =>
+                      setParameterValues((prev) => ({
+                        ...prev,
+                        [param.name]: e.target.value,
+                      }))
+                    }
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
+          <Editor
+            height="300px"
+            defaultLanguage="json"
+            value={eventData}
+            onChange={(value) => setEventData(value || "{}")}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: "on",
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+            }}
+          />
+        </div>
+      )}
       <div className="flex items-center justify-end gap-2">
         <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
           Cancel

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -91,30 +91,37 @@ export function StartRunModal({
             const id = `start-run-param-${param.name}`;
             return (
               <div key={param.name} className="space-y-1.5">
-                <Label htmlFor={id}>{param.name}</Label>
                 {param.type === "boolean" ? (
-                  <Checkbox
-                    id={id}
-                    checked={Boolean(parameterValues[param.name])}
-                    onCheckedChange={(checked) =>
-                      setParameterValues((prev) => ({
-                        ...prev,
-                        [param.name]: checked === true,
-                      }))
-                    }
-                  />
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id={id}
+                      checked={Boolean(parameterValues[param.name])}
+                      onCheckedChange={(checked) =>
+                        setParameterValues((prev) => ({
+                          ...prev,
+                          [param.name]: checked === true,
+                        }))
+                      }
+                    />
+                    <Label htmlFor={id} className="cursor-pointer">
+                      {param.name}
+                    </Label>
+                  </div>
                 ) : (
-                  <Input
-                    id={id}
-                    type={param.type === "number" ? "number" : "text"}
-                    value={String(parameterValues[param.name] ?? "")}
-                    onChange={(e) =>
-                      setParameterValues((prev) => ({
-                        ...prev,
-                        [param.name]: e.target.value,
-                      }))
-                    }
-                  />
+                  <>
+                    <Label htmlFor={id}>{param.name}</Label>
+                    <Input
+                      id={id}
+                      type={param.type === "number" ? "number" : "text"}
+                      value={String(parameterValues[param.name] ?? "")}
+                      onChange={(e) =>
+                        setParameterValues((prev) => ({
+                          ...prev,
+                          [param.name]: e.target.value,
+                        }))
+                      }
+                    />
+                  </>
                 )}
               </div>
             );

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import Editor from "@monaco-editor/react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { showErrorToast } from "@/lib/toast";
-import { Checkbox } from "@/ui/checkbox";
 
+import { StartRunParameterFields } from "./startRunParameterFields";
 import {
   coerceParameterValue,
   initialParameterValue,
@@ -84,49 +82,11 @@ export function StartRunModal({
   return (
     <div className="space-y-4">
       {useParameterForm ? (
-        <div className="space-y-3">
-          {(parameters ?? []).map((param) => {
-            if (!param.name || !param.type) return null;
-            const id = `start-run-param-${param.name}`;
-            const label = parameterDisplayLabel(param);
-            return (
-              <div key={param.name} className="space-y-1.5">
-                {param.type === "boolean" ? (
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id={id}
-                      checked={Boolean(parameterValues[param.name])}
-                      onCheckedChange={(checked) =>
-                        setParameterValues((prev) => ({
-                          ...prev,
-                          [param.name]: checked === true,
-                        }))
-                      }
-                    />
-                    <Label htmlFor={id} className="cursor-pointer">
-                      {label}
-                    </Label>
-                  </div>
-                ) : (
-                  <>
-                    <Label htmlFor={id}>{label}</Label>
-                    <Input
-                      id={id}
-                      type={param.type === "number" ? "number" : "text"}
-                      value={String(parameterValues[param.name] ?? "")}
-                      onChange={(e) =>
-                        setParameterValues((prev) => ({
-                          ...prev,
-                          [param.name]: e.target.value,
-                        }))
-                      }
-                    />
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <StartRunParameterFields
+          parameters={parameters ?? []}
+          parameterValues={parameterValues}
+          onParameterValuesChange={setParameterValues}
+        />
       ) : (
         <div className="border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden">
           <Editor

--- a/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/ui/checkbox";
+
+import { parameterDisplayLabel, type StartTemplateParameter } from "./templatePayload";
+
+export function StartRunParameterFields({
+  parameters,
+  parameterValues,
+  onParameterValuesChange,
+}: {
+  parameters: StartTemplateParameter[];
+  parameterValues: Record<string, string | number | boolean>;
+  onParameterValuesChange: React.Dispatch<React.SetStateAction<Record<string, string | number | boolean>>>;
+}) {
+  return (
+    <div className="space-y-3">
+      {parameters.map((param) => {
+        if (!param.name || !param.type) return null;
+        const id = `start-run-param-${param.name}`;
+        const label = parameterDisplayLabel(param);
+        return (
+          <div key={param.name} className="space-y-1.5">
+            {param.type === "boolean" ? (
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id={id}
+                  checked={Boolean(parameterValues[param.name])}
+                  onCheckedChange={(checked) =>
+                    onParameterValuesChange((prev) => ({
+                      ...prev,
+                      [param.name]: checked === true,
+                    }))
+                  }
+                />
+                <Label htmlFor={id} className="cursor-pointer">
+                  {label}
+                </Label>
+              </div>
+            ) : (
+              <>
+                <Label htmlFor={id}>{label}</Label>
+                <Input
+                  id={id}
+                  type={param.type === "number" ? "number" : "text"}
+                  value={String(parameterValues[param.name] ?? "")}
+                  onChange={(e) =>
+                    onParameterValuesChange((prev) => ({
+                      ...prev,
+                      [param.name]: e.target.value,
+                    }))
+                  }
+                />
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
@@ -4,7 +4,9 @@ import {
   coerceParameterValue,
   initialParameterValue,
   parameterDefaultValue,
+  parameterDisplayLabel,
   payloadForTemplateRun,
+  payloadRecordForParameters,
 } from "./templatePayload";
 
 describe("payloadForTemplateRun", () => {
@@ -20,6 +22,28 @@ describe("payloadForTemplateRun", () => {
 
   it("returns empty object when payload is missing or invalid", () => {
     expect(payloadForTemplateRun({ name: "t", payload: undefined as unknown as Record<string, unknown> })).toEqual({});
+  });
+});
+
+describe("payloadRecordForParameters", () => {
+  it("returns objects as-is", () => {
+    expect(payloadRecordForParameters({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("parses JSON strings and returns empty object on failure", () => {
+    expect(payloadRecordForParameters('{"a":1}')).toEqual({ a: 1 });
+    expect(payloadRecordForParameters("not json")).toEqual({});
+  });
+});
+
+describe("parameterDisplayLabel", () => {
+  it("uses title when set", () => {
+    expect(parameterDisplayLabel({ name: "msg", title: "Message", type: "string" })).toBe("Message");
+  });
+
+  it("falls back to name when title is missing or blank", () => {
+    expect(parameterDisplayLabel({ name: "msg", type: "string" })).toBe("msg");
+    expect(parameterDisplayLabel({ name: "msg", title: "  ", type: "string" })).toBe("msg");
   });
 });
 
@@ -40,11 +64,12 @@ describe("parameterDefaultValue", () => {
 });
 
 describe("initialParameterValue", () => {
-  it("prefers payload values over parameter defaults", () => {
-    expect(initialParameterValue({ name: "count", type: "number", defaultNumber: 1 }, { count: 5 })).toBe(5);
+  it("uses configured parameter defaults", () => {
+    expect(initialParameterValue({ name: "count", type: "number", defaultNumber: 1 })).toBe(1);
+    expect(initialParameterValue({ name: "redundancy", type: "string", defaultString: "dual" })).toBe("dual");
   });
 
   it("uses false when a boolean default is explicitly set to false", () => {
-    expect(initialParameterValue({ name: "flag", type: "boolean", defaultBoolean: false }, {})).toBe(false);
+    expect(initialParameterValue({ name: "flag", type: "boolean", defaultBoolean: false })).toBe(false);
   });
 });

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coerceParameterValue,
+  initialParameterValue,
+  parameterDefaultValue,
+  payloadForTemplateRun,
+} from "./templatePayload";
+
+describe("payloadForTemplateRun", () => {
+  it("uses the template payload", () => {
+    expect(
+      payloadForTemplateRun({
+        name: "t",
+        payload: { a: 1 },
+        parameters: [{ name: "a", type: "string", defaultString: "2" }],
+      }),
+    ).toEqual({ a: 1 });
+  });
+
+  it("returns empty object when payload is missing or invalid", () => {
+    expect(payloadForTemplateRun({ name: "t", payload: undefined as unknown as Record<string, unknown> })).toEqual({});
+  });
+});
+
+describe("coerceParameterValue", () => {
+  it("coerces by parameter type", () => {
+    expect(coerceParameterValue({ name: "n", type: "number" }, "42")).toBe(42);
+    expect(coerceParameterValue({ name: "b", type: "boolean" }, "true")).toBe(true);
+    expect(coerceParameterValue({ name: "s", type: "string" }, 1)).toBe("1");
+  });
+});
+
+describe("parameterDefaultValue", () => {
+  it("treats null and empty string as unset", () => {
+    expect(parameterDefaultValue({ name: "a", type: "string", defaultString: null })).toBeUndefined();
+    expect(parameterDefaultValue({ name: "a", type: "string", defaultString: "" })).toBeUndefined();
+    expect(parameterDefaultValue({ name: "b", type: "boolean", defaultBoolean: null })).toBeUndefined();
+  });
+});
+
+describe("initialParameterValue", () => {
+  it("prefers payload values over parameter defaults", () => {
+    expect(initialParameterValue({ name: "count", type: "number", defaultNumber: 1 }, { count: 5 })).toBe(5);
+  });
+
+  it("uses false when a boolean default is explicitly set to false", () => {
+    expect(initialParameterValue({ name: "flag", type: "boolean", defaultBoolean: false }, {})).toBe(false);
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -1,0 +1,75 @@
+export type StartTemplateParameterType = "string" | "number" | "boolean";
+
+export interface StartTemplateParameter {
+  name: string;
+  type: StartTemplateParameterType;
+  defaultString?: unknown;
+  defaultNumber?: unknown;
+  defaultBoolean?: unknown;
+}
+
+export interface StartTemplate {
+  name: string;
+  payload: Record<string, unknown>;
+  parameters?: StartTemplateParameter[];
+}
+
+export interface StartConfiguration {
+  templates?: StartTemplate[];
+}
+
+export function parameterDefaultValue(param: StartTemplateParameter): unknown | undefined {
+  switch (param.type) {
+    case "number": {
+      const value = param.defaultNumber;
+      return value === null || value === undefined ? undefined : value;
+    }
+    case "boolean": {
+      const value = param.defaultBoolean;
+      return value === null || value === undefined ? undefined : value;
+    }
+    default: {
+      const value = param.defaultString;
+      if (value === null || value === undefined) return undefined;
+      if (typeof value === "string" && value === "") return undefined;
+      return value;
+    }
+  }
+}
+
+export function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> {
+  const payload = template.payload;
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    return payload;
+  }
+  return {};
+}
+
+export function coerceParameterValue(param: StartTemplateParameter, raw: unknown): unknown {
+  switch (param.type) {
+    case "number":
+      if (typeof raw === "number") return raw;
+      if (raw === "" || raw == null) return 0;
+      return Number(raw);
+    case "boolean":
+      if (typeof raw === "boolean") return raw;
+      return raw === true || raw === "true" || raw === "1";
+    default:
+      return raw == null ? "" : String(raw);
+  }
+}
+
+export function initialParameterValue(
+  param: StartTemplateParameter,
+  payload: Record<string, unknown>,
+): string | number | boolean {
+  const fromPayload = payload[param.name];
+  if (fromPayload !== undefined) {
+    return coerceParameterValue(param, fromPayload) as string | number | boolean;
+  }
+  const configuredDefault = parameterDefaultValue(param);
+  if (configuredDefault !== undefined) {
+    return coerceParameterValue(param, configuredDefault) as string | number | boolean;
+  }
+  return param.type === "boolean" ? false : param.type === "number" ? 0 : "";
+}

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -2,10 +2,16 @@ export type StartTemplateParameterType = "string" | "number" | "boolean";
 
 export interface StartTemplateParameter {
   name: string;
+  title?: string;
   type: StartTemplateParameterType;
   defaultString?: unknown;
   defaultNumber?: unknown;
   defaultBoolean?: unknown;
+}
+
+export function parameterDisplayLabel(param: StartTemplateParameter): string {
+  const title = typeof param.title === "string" ? param.title.trim() : "";
+  return title || param.name;
 }
 
 export interface StartTemplate {
@@ -45,6 +51,21 @@ export function payloadForTemplateRun(template: StartTemplate): Record<string, u
   return {};
 }
 
+export function payloadRecordForParameters(payload: Record<string, unknown> | string): Record<string, unknown> {
+  if (typeof payload !== "string") {
+    return payload;
+  }
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Expression placeholders make the payload invalid JSON until run time.
+  }
+  return {};
+}
+
 export function coerceParameterValue(param: StartTemplateParameter, raw: unknown): unknown {
   switch (param.type) {
     case "number":
@@ -59,14 +80,7 @@ export function coerceParameterValue(param: StartTemplateParameter, raw: unknown
   }
 }
 
-export function initialParameterValue(
-  param: StartTemplateParameter,
-  payload: Record<string, unknown>,
-): string | number | boolean {
-  const fromPayload = payload[param.name];
-  if (fromPayload !== undefined) {
-    return coerceParameterValue(param, fromPayload) as string | number | boolean;
-  }
+export function initialParameterValue(param: StartTemplateParameter): string | number | boolean {
   const configuredDefault = parameterDefaultValue(param);
   if (configuredDefault !== undefined) {
     return coerceParameterValue(param, configuredDefault) as string | number | boolean;

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -10,7 +10,7 @@ export interface StartTemplateParameter {
 
 export interface StartTemplate {
   name: string;
-  payload: Record<string, unknown> | string;
+  payload: Record<string, unknown>;
   parameters?: StartTemplateParameter[];
 }
 
@@ -37,28 +37,10 @@ export function parameterDefaultValue(param: StartTemplateParameter): unknown | 
   }
 }
 
-export function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> | string {
+export function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> {
   const payload = template.payload;
-  if (typeof payload === "string") {
-    return payload;
-  }
   if (payload && typeof payload === "object" && !Array.isArray(payload)) {
     return payload;
-  }
-  return {};
-}
-
-export function payloadRecordForParameters(payload: Record<string, unknown> | string): Record<string, unknown> {
-  if (typeof payload !== "string") {
-    return payload;
-  }
-  try {
-    const parsed = JSON.parse(payload) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    // Expression placeholders make the payload invalid JSON until run time.
   }
   return {};
 }

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -10,7 +10,7 @@ export interface StartTemplateParameter {
 
 export interface StartTemplate {
   name: string;
-  payload: Record<string, unknown>;
+  payload: Record<string, unknown> | string;
   parameters?: StartTemplateParameter[];
 }
 
@@ -37,10 +37,28 @@ export function parameterDefaultValue(param: StartTemplateParameter): unknown | 
   }
 }
 
-export function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> {
+export function payloadForTemplateRun(template: StartTemplate): Record<string, unknown> | string {
   const payload = template.payload;
+  if (typeof payload === "string") {
+    return payload;
+  }
   if (payload && typeof payload === "object" && !Array.isArray(payload)) {
     return payload;
+  }
+  return {};
+}
+
+export function payloadRecordForParameters(payload: Record<string, unknown> | string): Record<string, unknown> {
+  if (typeof payload !== "string") {
+    return payload;
+  }
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Expression placeholders make the payload invalid JSON until run time.
   }
   return {};
 }

--- a/web_src/src/ui/configurationFieldRenderer/BooleanFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/BooleanFieldRenderer.tsx
@@ -1,14 +1,34 @@
+import { Checkbox } from "@/ui/checkbox";
 import { Switch } from "@/ui/switch";
 import React from "react";
 import type { FieldRendererProps } from "./types";
 
-export const BooleanFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange }) => {
+export const BooleanFieldRenderer: React.FC<FieldRendererProps & { labeled?: boolean }> = ({
+  field,
+  value,
+  onChange,
+  labeled = false,
+}) => {
   const fieldName = field?.name || "";
+  const inputId = React.useId();
 
   const checked = React.useMemo(
     () => coerceFieldValuesIntoBoolean(fieldName, value, field?.defaultValue),
     [fieldName, value, field?.defaultValue],
   );
+
+  if (labeled) {
+    const valueLabel = checked ? "True" : "False";
+
+    return (
+      <label htmlFor={inputId} className="contents cursor-pointer">
+        <div className="flex w-9 shrink-0 items-center justify-end">
+          <Checkbox id={inputId} checked={checked} onCheckedChange={(next) => onChange(next === true)} />
+        </div>
+        <span className="text-sm text-gray-600">{valueLabel}</span>
+      </label>
+    );
+  }
 
   return <Switch checked={checked} onCheckedChange={onChange} className="" />;
 };

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.spec.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.spec.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfigurationField } from "@/api-client";
+
+import { ListFieldRenderer } from "./ListFieldRenderer";
+
+function parameterListField(): ConfigurationField {
+  return {
+    name: "parameters",
+    label: "Parameters",
+    type: "list",
+    typeOptions: {
+      list: {
+        itemLabel: "Parameter",
+        accordion: true,
+        reorderable: true,
+        itemDefinition: {
+          type: "object",
+          schema: [
+            { name: "name", label: "Name", type: "string", required: true },
+            { name: "type", label: "Type", type: "select", required: true },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function stubRowRects() {
+  const rows = screen.getAllByTestId("list-item-row");
+  rows.forEach((row, index) => {
+    row.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          top: index * 50,
+          bottom: index * 50 + 50,
+          left: 0,
+          right: 200,
+          height: 50,
+          width: 200,
+          x: 0,
+          y: index * 50,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    );
+  });
+  return rows;
+}
+
+describe("ListFieldRenderer", () => {
+  it("reorders items immediately as the cursor crosses rows and commits on mouseup", () => {
+    const onChange = vi.fn();
+    const value = [
+      { name: "first", type: "string" },
+      { name: "second", type: "string" },
+    ];
+
+    render(<ListFieldRenderer field={parameterListField()} value={value} onChange={onChange} />);
+
+    stubRowRects();
+
+    const handle = screen.getByLabelText("Drag to reorder first");
+    fireEvent.mouseDown(handle, { button: 0 });
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mousemove", { clientY: 75 }));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    const rowsDuringDrag = screen.getAllByTestId("list-item-row");
+    expect(rowsDuringDrag[0]).toHaveTextContent("second");
+    expect(rowsDuringDrag[1]).toHaveTextContent("first");
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([
+      { name: "second", type: "string" },
+      { name: "first", type: "string" },
+    ]);
+  });
+
+  it("does not show drag handles when reorderable is false", () => {
+    const field = parameterListField();
+    field.typeOptions!.list!.reorderable = false;
+
+    render(
+      <ListFieldRenderer
+        field={field}
+        value={[
+          { name: "first", type: "string" },
+          { name: "second", type: "string" },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/Drag to reorder/)).not.toBeInTheDocument();
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -108,7 +108,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
           <div className="flex-1">
             {itemDefinition?.type === "object" && itemDefinition.schema ? (
               <div className="border border-gray-300 dark:border-gray-700 rounded-md p-4 space-y-4">
-                {itemDefinition.schema.map((schemaField) => {
+                {itemDefinition.schema.map((schemaField, schemaIndex) => {
                   const nestedFieldPath = `${fieldPath}[${index}].${schemaField.name}`;
                   const hasNestedError = (() => {
                     if (!validationErrors) return false;
@@ -136,7 +136,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
                   return (
                     <ConfigurationFieldRenderer
                       allowExpressions={allowExpressions}
-                      key={schemaField.name}
+                      key={schemaField.name ?? `field-${schemaIndex}`}
                       field={schemaField}
                       value={itemValues[schemaField.name!]}
                       onChange={(val) => {

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { Plus, Trash2 } from "lucide-react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown, Plus, Trash2 } from "lucide-react";
 import { Button } from "../button";
 import { Input } from "@/components/ui/input";
+import { Accordion, AccordionContent, AccordionItem } from "@/ui/accordion";
 import { DayInYearFieldRenderer } from "./DayInYearFieldRenderer";
 import type { FieldRendererProps, ValidationError } from "./types";
 import { ConfigurationFieldRenderer } from "./index";
+import { listFieldItemTitle } from "./listFieldItemTitle";
+import { cn } from "@/lib/utils";
 import { showErrorToast } from "@/lib/toast";
 
 interface ExtendedFieldRendererProps extends FieldRendererProps {
@@ -29,6 +33,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
   const listOptions = field.typeOptions?.list;
   const itemDefinition = listOptions?.itemDefinition;
   const maxItems = listOptions?.maxItems;
+  const useAccordion = listOptions?.accordion === true;
   const items = Array.isArray(value)
     ? itemDefinition?.type === "day-in-year"
       ? value.filter((item) => typeof item === "string" && item.trim().length > 0)
@@ -43,6 +48,22 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     Array.isArray(itemDefinition.schema) &&
     itemDefinition.schema.some((schemaField) => schemaField.name === "type") &&
     itemDefinition.schema.some((schemaField) => ["user", "role", "group"].includes(schemaField.name || ""));
+
+  const [openItem, setOpenItem] = React.useState<string | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (items.length === 0) {
+      setOpenItem(undefined);
+      return;
+    }
+    if (openItem === undefined) {
+      return;
+    }
+    if (Number(openItem) < items.length) {
+      return;
+    }
+    setOpenItem(undefined);
+  }, [items.length, openItem]);
 
   const getApproverKey = (item: Record<string, unknown>) => {
     const type = typeof item.type === "string" ? item.type : "";
@@ -72,12 +93,24 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     const newItems = [...itemsRef.current, newItem];
     itemsRef.current = newItems;
     onChange(newItems);
+    if (useAccordion) {
+      setOpenItem(String(newItems.length - 1));
+    }
   };
 
   const removeItem = (index: number) => {
     const newItems = itemsRef.current.filter((_, i) => i !== index);
     itemsRef.current = newItems;
     onChange(newItems.length > 0 ? newItems : undefined);
+    if (!useAccordion) return;
+
+    setOpenItem((current) => {
+      if (newItems.length === 0 || current === undefined) return undefined;
+      const openIndex = Number(current);
+      if (openIndex === index) return undefined;
+      if (openIndex > index) return String(openIndex - 1);
+      return current;
+    });
   };
 
   const updateItem = (index: number, newValue: unknown) => {
@@ -101,6 +134,153 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     onChange(newItems);
   };
 
+  const renderObjectItemFields = (item: unknown, index: number) => {
+    if (!itemDefinition?.schema) return null;
+
+    const itemValues =
+      item && typeof item === "object" ? (item as Record<string, unknown>) : ({} as Record<string, unknown>);
+    const nestedValues = isApprovalItemsList
+      ? {
+          ...itemValues,
+          __listItems: items,
+          __itemIndex: index,
+          __isApprovalList: true,
+        }
+      : itemValues;
+
+    return itemDefinition.schema.map((schemaField, schemaIndex) => {
+      const nestedFieldPath = `${fieldPath}[${index}].${schemaField.name}`;
+      const hasNestedError = (() => {
+        if (!validationErrors) return false;
+
+        if (validationErrors instanceof Set) {
+          return validationErrors.has(nestedFieldPath);
+        }
+        return validationErrors.some((error) => error.field === nestedFieldPath);
+      })();
+
+      return (
+        <ConfigurationFieldRenderer
+          allowExpressions={allowExpressions}
+          key={schemaField.name ?? `field-${schemaIndex}`}
+          field={schemaField}
+          value={itemValues[schemaField.name!]}
+          onChange={(val) => {
+            const newItem = { ...itemValues, [schemaField.name!]: val };
+            updateItem(index, newItem);
+          }}
+          allValues={nestedValues}
+          domainId={domainId}
+          domainType={domainType}
+          integrationId={integrationId}
+          organizationId={organizationId}
+          hasError={hasNestedError}
+          autocompleteExampleObj={autocompleteExampleObj}
+        />
+      );
+    });
+  };
+
+  const renderListItemBody = (item: unknown, index: number) => {
+    if (itemDefinition?.type === "object" && itemDefinition.schema) {
+      return <div className="space-y-4">{renderObjectItemFields(item, index)}</div>;
+    }
+
+    if (itemDefinition?.type === "day-in-year") {
+      return (
+        <DayInYearFieldRenderer
+          field={{ name: `${field.name || "item"}-${index}`, label: itemLabel, type: "day-in-year" }}
+          value={item}
+          onChange={(val) => updateItem(index, val)}
+        />
+      );
+    }
+
+    return (
+      <Input
+        type={itemDefinition?.type === "number" ? "number" : "text"}
+        value={(item as string | number) ?? ""}
+        onChange={(e) => {
+          const val =
+            itemDefinition?.type === "number"
+              ? e.target.value === ""
+                ? undefined
+                : Number(e.target.value)
+              : e.target.value;
+          updateItem(index, val);
+        }}
+      />
+    );
+  };
+
+  const renderRemoveButton = (index: number, className?: string) => (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={(event) => {
+        event.stopPropagation();
+        removeItem(index);
+      }}
+      className={className}
+      aria-label={`Remove ${listFieldItemTitle(items[index], index, itemLabel)}`}
+    >
+      <Trash2 className="h-4 w-4 text-red-500" />
+    </Button>
+  );
+
+  if (useAccordion && itemDefinition?.type === "object" && itemDefinition.schema) {
+    return (
+      <div className="space-y-3">
+        <Accordion type="single" collapsible value={openItem} onValueChange={setOpenItem} className="space-y-2">
+          {items.map((item, index) => {
+            const isItemOpen = openItem === String(index);
+            return (
+              <AccordionItem key={index} value={String(index)} className="border-0">
+                <div className="flex items-start gap-2">
+                  <div className="relative min-w-0 flex-1 rounded-md border border-gray-300 dark:border-gray-700">
+                    <AccordionPrimitive.Header
+                      className={cn(
+                        "relative z-10 flex h-11 shrink-0",
+                        isItemOpen && "pointer-events-none absolute inset-x-0 top-0",
+                      )}
+                    >
+                      <AccordionPrimitive.Trigger
+                        className={cn(
+                          "group relative flex h-11 w-full items-center pl-4 text-left text-sm font-medium hover:no-underline focus-visible:outline-none focus-visible:ring-0",
+                          isItemOpen && "pointer-events-auto",
+                        )}
+                      >
+                        <span
+                          className={cn(
+                            "min-w-0 flex-1 truncate pr-2 font-medium text-gray-800",
+                            isItemOpen && "sr-only",
+                          )}
+                        >
+                          {listFieldItemTitle(item, index, itemLabel)}
+                        </span>
+                        <span className="absolute top-1/2 right-2 flex size-8 -translate-y-1/2 items-center justify-center rounded-sm group-focus-visible:ring-2 group-focus-visible:ring-ring/50">
+                          <ChevronDown className={cn("size-4 text-gray-500", isItemOpen && "rotate-180")} />
+                        </span>
+                      </AccordionPrimitive.Trigger>
+                    </AccordionPrimitive.Header>
+                    <AccordionContent className={cn("px-4 pb-4 pr-12", isItemOpen ? "pt-4" : "pt-0")}>
+                      {renderListItemBody(item, index)}
+                    </AccordionContent>
+                  </div>
+                  {renderRemoveButton(index, "mt-1 shrink-0")}
+                </div>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+        <Button variant="outline" onClick={addItem} className="w-full mt-3" disabled={!canAddMore}>
+          <Plus className="h-4 w-4 mr-2" />
+          Add {itemLabel}
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
       {items.map((item, index) => (
@@ -108,77 +288,13 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
           <div className="flex-1">
             {itemDefinition?.type === "object" && itemDefinition.schema ? (
               <div className="border border-gray-300 dark:border-gray-700 rounded-md p-4 space-y-4">
-                {itemDefinition.schema.map((schemaField, schemaIndex) => {
-                  const nestedFieldPath = `${fieldPath}[${index}].${schemaField.name}`;
-                  const hasNestedError = (() => {
-                    if (!validationErrors) return false;
-
-                    if (validationErrors instanceof Set) {
-                      return validationErrors.has(nestedFieldPath);
-                    } else {
-                      return validationErrors.some((error) => error.field === nestedFieldPath);
-                    }
-                  })();
-
-                  const itemValues =
-                    item && typeof item === "object"
-                      ? (item as Record<string, unknown>)
-                      : ({} as Record<string, unknown>);
-                  const nestedValues = isApprovalItemsList
-                    ? {
-                        ...itemValues,
-                        __listItems: items,
-                        __itemIndex: index,
-                        __isApprovalList: true,
-                      }
-                    : itemValues;
-
-                  return (
-                    <ConfigurationFieldRenderer
-                      allowExpressions={allowExpressions}
-                      key={schemaField.name ?? `field-${schemaIndex}`}
-                      field={schemaField}
-                      value={itemValues[schemaField.name!]}
-                      onChange={(val) => {
-                        const newItem = { ...itemValues, [schemaField.name!]: val };
-                        updateItem(index, newItem);
-                      }}
-                      allValues={nestedValues}
-                      domainId={domainId}
-                      domainType={domainType}
-                      integrationId={integrationId}
-                      organizationId={organizationId}
-                      hasError={hasNestedError}
-                      autocompleteExampleObj={autocompleteExampleObj}
-                    />
-                  );
-                })}
+                {renderObjectItemFields(item, index)}
               </div>
-            ) : itemDefinition?.type === "day-in-year" ? (
-              <DayInYearFieldRenderer
-                field={{ name: `${field.name || "item"}-${index}`, label: itemLabel, type: "day-in-year" }}
-                value={item}
-                onChange={(val) => updateItem(index, val)}
-              />
             ) : (
-              <Input
-                type={itemDefinition?.type === "number" ? "number" : "text"}
-                value={item ?? ""}
-                onChange={(e) => {
-                  const val =
-                    itemDefinition?.type === "number"
-                      ? e.target.value === ""
-                        ? undefined
-                        : Number(e.target.value)
-                      : e.target.value;
-                  updateItem(index, val);
-                }}
-              />
+              renderListItemBody(item, index)
             )}
           </div>
-          <Button variant="ghost" size="icon" onClick={() => removeItem(index)} className="mt-1">
-            <Trash2 className="h-4 w-4 text-red-500" />
-          </Button>
+          {renderRemoveButton(index, "mt-1")}
         </div>
       ))}
       <Button variant="outline" onClick={addItem} className="w-full mt-3" disabled={!canAddMore}>

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -8,13 +8,29 @@ import { DayInYearFieldRenderer } from "./DayInYearFieldRenderer";
 import type { FieldRendererProps, ValidationError } from "./types";
 import { ConfigurationFieldRenderer } from "./index";
 import { listFieldItemTitle } from "./listFieldItemTitle";
-import { reorderListItems } from "@/lib/reorderListItems";
+import { useListFieldDragReorder } from "./useListFieldDragReorder";
 import { cn } from "@/lib/utils";
 import { showErrorToast } from "@/lib/toast";
 
 interface ExtendedFieldRendererProps extends FieldRendererProps {
   validationErrors?: ValidationError[] | Set<string>;
   fieldPath?: string;
+}
+
+function getApproverKey(item: Record<string, unknown>) {
+  const type = typeof item.type === "string" ? item.type : "";
+  if (!type) return undefined;
+
+  if (type === "user" && typeof item.user === "string" && item.user.trim()) {
+    return `user:${item.user}`;
+  }
+  if (type === "role" && typeof item.role === "string" && item.role.trim()) {
+    return `role:${item.role}`;
+  }
+  if (type === "group" && typeof item.group === "string" && item.group.trim()) {
+    return `group:${item.group}`;
+  }
+  return undefined;
 }
 
 export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
@@ -52,100 +68,27 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     itemDefinition.schema.some((schemaField) => ["user", "role", "group"].includes(schemaField.name || ""));
 
   const [openItem, setOpenItem] = React.useState<string | undefined>(undefined);
-
-  type DragState = {
-    items: unknown[];
-    activeIndex: number;
-    openAtStart: boolean;
-  };
-  const [dragState, setDragState] = React.useState<DragState | null>(null);
-  const dragStateRef = React.useRef<DragState | null>(null);
-  dragStateRef.current = dragState;
-
   const rowRefs = React.useRef<Array<HTMLDivElement | null>>([]);
-
-  const renderedItems = dragState ? dragState.items : items;
+  const {
+    dragState,
+    renderedItems,
+    startDrag: beginDrag,
+  } = useListFieldDragReorder({
+    items,
+    allowReorder,
+    useAccordion,
+    onChange,
+    setOpenItem,
+    rowRefs,
+  });
 
   React.useEffect(() => {
     if (items.length === 0) {
       setOpenItem(undefined);
-      return;
+    } else if (openItem !== undefined && Number(openItem) >= items.length) {
+      setOpenItem(undefined);
     }
-    if (openItem === undefined) {
-      return;
-    }
-    if (Number(openItem) < items.length) {
-      return;
-    }
-    setOpenItem(undefined);
   }, [items.length, openItem]);
-
-  React.useEffect(() => {
-    if (!dragState) {
-      return;
-    }
-
-    const handleMove = (event: MouseEvent) => {
-      setDragState((current) => {
-        if (!current) return current;
-        for (let i = 0; i < rowRefs.current.length; i++) {
-          const el = rowRefs.current[i];
-          if (!el) continue;
-          const rect = el.getBoundingClientRect();
-          if (event.clientY >= rect.top && event.clientY <= rect.bottom) {
-            if (i === current.activeIndex) {
-              return current;
-            }
-            const nextItems = reorderListItems(current.items, current.activeIndex, i);
-            return { ...current, items: nextItems, activeIndex: i };
-          }
-        }
-        return current;
-      });
-    };
-
-    const handleUp = () => {
-      const current = dragStateRef.current;
-      if (!current) return;
-      itemsRef.current = current.items;
-      onChange(current.items);
-      if (useAccordion && current.openAtStart) {
-        setOpenItem(String(current.activeIndex));
-      }
-      setDragState(null);
-    };
-
-    const previousCursor = document.body.style.cursor;
-    const previousUserSelect = document.body.style.userSelect;
-    document.body.style.cursor = "grabbing";
-    document.body.style.userSelect = "none";
-
-    window.addEventListener("mousemove", handleMove);
-    window.addEventListener("mouseup", handleUp);
-
-    return () => {
-      window.removeEventListener("mousemove", handleMove);
-      window.removeEventListener("mouseup", handleUp);
-      document.body.style.cursor = previousCursor;
-      document.body.style.userSelect = previousUserSelect;
-    };
-  }, [dragState !== null, onChange, useAccordion]);
-
-  const getApproverKey = (item: Record<string, unknown>) => {
-    const type = typeof item.type === "string" ? item.type : "";
-    if (!type) return undefined;
-
-    if (type === "user" && typeof item.user === "string" && item.user.trim()) {
-      return `user:${item.user}`;
-    }
-    if (type === "role" && typeof item.role === "string" && item.role.trim()) {
-      return `role:${item.role}`;
-    }
-    if (type === "group" && typeof item.group === "string" && item.group.trim()) {
-      return `group:${item.group}`;
-    }
-    return undefined;
-  };
 
   const addItem = () => {
     const newItem =
@@ -162,24 +105,6 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     if (useAccordion) {
       setOpenItem(String(newItems.length - 1));
     }
-  };
-
-  const startDrag = (event: React.MouseEvent, index: number) => {
-    if (!allowReorder || items.length < 2) return;
-    if (event.button !== 0) return;
-    event.preventDefault();
-    event.stopPropagation();
-
-    const wasOpen = openItem === String(index);
-    if (wasOpen) {
-      setOpenItem(undefined);
-    }
-
-    setDragState({
-      items: [...items],
-      activeIndex: index,
-      openAtStart: wasOpen,
-    });
   };
 
   const removeItem = (index: number) => {
@@ -315,7 +240,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
           className,
         )}
         onClick={(event) => event.stopPropagation()}
-        onMouseDown={(event) => startDrag(event, index)}
+        onMouseDown={(event) => beginDrag(event, index, openItem)}
       >
         <GripVertical className={cn("h-4 w-4", isActive && "text-gray-900 dark:text-gray-100")} aria-hidden />
       </button>

--- a/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ListFieldRenderer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDown, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, GripVertical, Plus, Trash2 } from "lucide-react";
 import { Button } from "../button";
 import { Input } from "@/components/ui/input";
 import { Accordion, AccordionContent, AccordionItem } from "@/ui/accordion";
@@ -8,6 +8,7 @@ import { DayInYearFieldRenderer } from "./DayInYearFieldRenderer";
 import type { FieldRendererProps, ValidationError } from "./types";
 import { ConfigurationFieldRenderer } from "./index";
 import { listFieldItemTitle } from "./listFieldItemTitle";
+import { reorderListItems } from "@/lib/reorderListItems";
 import { cn } from "@/lib/utils";
 import { showErrorToast } from "@/lib/toast";
 
@@ -34,6 +35,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
   const itemDefinition = listOptions?.itemDefinition;
   const maxItems = listOptions?.maxItems;
   const useAccordion = listOptions?.accordion === true;
+  const allowReorder = listOptions?.reorderable === true;
   const items = Array.isArray(value)
     ? itemDefinition?.type === "day-in-year"
       ? value.filter((item) => typeof item === "string" && item.trim().length > 0)
@@ -51,6 +53,19 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
 
   const [openItem, setOpenItem] = React.useState<string | undefined>(undefined);
 
+  type DragState = {
+    items: unknown[];
+    activeIndex: number;
+    openAtStart: boolean;
+  };
+  const [dragState, setDragState] = React.useState<DragState | null>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  dragStateRef.current = dragState;
+
+  const rowRefs = React.useRef<Array<HTMLDivElement | null>>([]);
+
+  const renderedItems = dragState ? dragState.items : items;
+
   React.useEffect(() => {
     if (items.length === 0) {
       setOpenItem(undefined);
@@ -64,6 +79,57 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     }
     setOpenItem(undefined);
   }, [items.length, openItem]);
+
+  React.useEffect(() => {
+    if (!dragState) {
+      return;
+    }
+
+    const handleMove = (event: MouseEvent) => {
+      setDragState((current) => {
+        if (!current) return current;
+        for (let i = 0; i < rowRefs.current.length; i++) {
+          const el = rowRefs.current[i];
+          if (!el) continue;
+          const rect = el.getBoundingClientRect();
+          if (event.clientY >= rect.top && event.clientY <= rect.bottom) {
+            if (i === current.activeIndex) {
+              return current;
+            }
+            const nextItems = reorderListItems(current.items, current.activeIndex, i);
+            return { ...current, items: nextItems, activeIndex: i };
+          }
+        }
+        return current;
+      });
+    };
+
+    const handleUp = () => {
+      const current = dragStateRef.current;
+      if (!current) return;
+      itemsRef.current = current.items;
+      onChange(current.items);
+      if (useAccordion && current.openAtStart) {
+        setOpenItem(String(current.activeIndex));
+      }
+      setDragState(null);
+    };
+
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("mouseup", handleUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("mouseup", handleUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [dragState !== null, onChange, useAccordion]);
 
   const getApproverKey = (item: Record<string, unknown>) => {
     const type = typeof item.type === "string" ? item.type : "";
@@ -96,6 +162,24 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     if (useAccordion) {
       setOpenItem(String(newItems.length - 1));
     }
+  };
+
+  const startDrag = (event: React.MouseEvent, index: number) => {
+    if (!allowReorder || items.length < 2) return;
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const wasOpen = openItem === String(index);
+    if (wasOpen) {
+      setOpenItem(undefined);
+    }
+
+    setDragState({
+      items: [...items],
+      activeIndex: index,
+      openAtStart: wasOpen,
+    });
   };
 
   const removeItem = (index: number) => {
@@ -213,6 +297,31 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     );
   };
 
+  const renderDragHandle = (index: number, className?: string) => {
+    if (!allowReorder || items.length < 2) {
+      return null;
+    }
+
+    const title = listFieldItemTitle(renderedItems[index], index, itemLabel);
+    const isActive = dragState?.activeIndex === index;
+
+    return (
+      <button
+        type="button"
+        aria-label={`Drag to reorder ${title}`}
+        className={cn(
+          "mt-1 flex h-9 w-8 shrink-0 items-center justify-center rounded-sm text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800",
+          dragState ? "cursor-grabbing" : "cursor-grab",
+          className,
+        )}
+        onClick={(event) => event.stopPropagation()}
+        onMouseDown={(event) => startDrag(event, index)}
+      >
+        <GripVertical className={cn("h-4 w-4", isActive && "text-gray-900 dark:text-gray-100")} aria-hidden />
+      </button>
+    );
+  };
+
   const renderRemoveButton = (index: number, className?: string) => (
     <Button
       variant="ghost"
@@ -222,7 +331,7 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
         removeItem(index);
       }}
       className={className}
-      aria-label={`Remove ${listFieldItemTitle(items[index], index, itemLabel)}`}
+      aria-label={`Remove ${listFieldItemTitle(renderedItems[index], index, itemLabel)}`}
     >
       <Trash2 className="h-4 w-4 text-red-500" />
     </Button>
@@ -232,11 +341,18 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
     return (
       <div className="space-y-3">
         <Accordion type="single" collapsible value={openItem} onValueChange={setOpenItem} className="space-y-2">
-          {items.map((item, index) => {
+          {renderedItems.map((item, index) => {
             const isItemOpen = openItem === String(index);
             return (
               <AccordionItem key={index} value={String(index)} className="border-0">
-                <div className="flex items-start gap-2">
+                <div
+                  ref={(el) => {
+                    rowRefs.current[index] = el;
+                  }}
+                  data-testid="list-item-row"
+                  className="flex items-start gap-2"
+                >
+                  {renderDragHandle(index)}
                   <div className="relative min-w-0 flex-1 rounded-md border border-gray-300 dark:border-gray-700">
                     <AccordionPrimitive.Header
                       className={cn(
@@ -283,20 +399,30 @@ export const ListFieldRenderer: React.FC<ExtendedFieldRendererProps> = ({
 
   return (
     <div className="space-y-3">
-      {items.map((item, index) => (
-        <div key={index} className="flex gap-2 items-center">
-          <div className="flex-1">
-            {itemDefinition?.type === "object" && itemDefinition.schema ? (
-              <div className="border border-gray-300 dark:border-gray-700 rounded-md p-4 space-y-4">
-                {renderObjectItemFields(item, index)}
-              </div>
-            ) : (
-              renderListItemBody(item, index)
-            )}
+      {renderedItems.map((item, index) => {
+        return (
+          <div
+            key={index}
+            ref={(el) => {
+              rowRefs.current[index] = el;
+            }}
+            data-testid="list-item-row"
+            className="flex items-center gap-2"
+          >
+            {renderDragHandle(index)}
+            <div className="flex-1">
+              {itemDefinition?.type === "object" && itemDefinition.schema ? (
+                <div className="border border-gray-300 dark:border-gray-700 rounded-md p-4 space-y-4">
+                  {renderObjectItemFields(item, index)}
+                </div>
+              ) : (
+                renderListItemBody(item, index)
+              )}
+            </div>
+            {renderRemoveButton(index, "mt-1")}
           </div>
-          {renderRemoveButton(index, "mt-1")}
-        </div>
-      ))}
+        );
+      })}
       <Button variant="outline" onClick={addItem} className="w-full mt-3" disabled={!canAddMore}>
         <Plus className="h-4 w-4 mr-2" />
         Add {itemLabel}

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -263,10 +263,10 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
 
   return (
     <div className="border border-gray-300 dark:border-gray-700 rounded-md p-4 space-y-4">
-      {schema.map((schemaField) => (
+      {schema.map((schemaField, schemaIndex) => (
         <ConfigurationFieldRenderer
           allowExpressions={allowExpressions}
-          key={schemaField.name}
+          key={schemaField.name ?? `field-${schemaIndex}`}
           field={schemaField}
           value={objValue[schemaField.name!]}
           onChange={(val) => {

--- a/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/ObjectFieldRenderer.tsx
@@ -47,6 +47,7 @@ export const ObjectFieldRenderer: React.FC<FieldRendererProps> = ({
   const { handleEditorMount } = useMonacoExpressionAutocomplete({
     autocompleteExampleObj,
     languageId: "json",
+    includeTopLevelGlobals: field.name === "payload",
   });
 
   const objectOptions = field.typeOptions?.object;

--- a/web_src/src/ui/configurationFieldRenderer/index.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/index.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildTemplateParametersAutocompleteObject } from "./index";
+
+describe("buildTemplateParametersAutocompleteObject", () => {
+  it("returns null when parameters are missing", () => {
+    expect(buildTemplateParametersAutocompleteObject({})).toBeNull();
+  });
+
+  it("builds defaults and typed fallbacks for template parameters", () => {
+    const out = buildTemplateParametersAutocompleteObject({
+      parameters: [
+        { name: "message", type: "string", defaultString: "Hello" },
+        { name: "count", type: "number" },
+        { name: "enabled", type: "boolean" },
+      ],
+    });
+
+    expect(out).toEqual({
+      message: "Hello",
+      count: 0,
+      enabled: false,
+    });
+  });
+
+  it("ignores invalid items and keeps empty string defaults", () => {
+    const out = buildTemplateParametersAutocompleteObject({
+      parameters: [
+        { name: "message", type: "string", defaultString: "" },
+        { name: "", type: "number", defaultNumber: 1 },
+        { bad: "item" },
+      ],
+    });
+
+    expect(out).toEqual({
+      message: "",
+    });
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/index.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildTemplateParametersAutocompleteObject } from "./index";
+import { buildTemplateParametersAutocompleteObject } from "./templateParametersAutocomplete";
 
 describe("buildTemplateParametersAutocompleteObject", () => {
   it("returns null when parameters are missing", () => {

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -50,6 +50,54 @@ type ConfigurationField = FieldRendererProps["field"];
 /** Stable reference for trigger run-title fields — hides node/previous sources that don't apply. */
 const RUN_TITLE_EXCLUDED_SUGGESTIONS = ["$", "previous"];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function templateParameterValue(parameter: Record<string, unknown>): unknown {
+  const parameterType = parameter.type;
+  if (parameterType === "number") {
+    const value = parameter.defaultNumber;
+    return value === null || value === undefined ? 0 : value;
+  }
+  if (parameterType === "boolean") {
+    const value = parameter.defaultBoolean;
+    return value === null || value === undefined ? false : value;
+  }
+  const value = parameter.defaultString;
+  if (value === null || value === undefined) return "";
+  return value;
+}
+
+export function buildTemplateParametersAutocompleteObject(
+  allValues: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const rawParameters = allValues.parameters;
+  if (!Array.isArray(rawParameters) || rawParameters.length === 0) {
+    return null;
+  }
+
+  const parameters: Record<string, unknown> = {};
+  for (const rawParameter of rawParameters) {
+    if (!isRecord(rawParameter)) {
+      continue;
+    }
+
+    const name = rawParameter.name;
+    if (typeof name !== "string" || name.trim() === "") {
+      continue;
+    }
+
+    parameters[name] = templateParameterValue(rawParameter);
+  }
+
+  if (Object.keys(parameters).length === 0) {
+    return null;
+  }
+
+  return parameters;
+}
+
 function getInitialSelectValue(field: ConfigurationField, parsedDefaultValue: unknown): unknown {
   const selectOptions = field.typeOptions?.select?.options;
   if (!selectOptions) {
@@ -267,13 +315,29 @@ export const ConfigurationFieldRenderer = ({
   const fieldAllowsExpressions =
     allowExpressions && !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false);
 
+  const resolvedAutocompleteExampleObj = React.useMemo(() => {
+    if (field.name !== "payload") {
+      return autocompleteExampleObj;
+    }
+
+    const parameters = buildTemplateParametersAutocompleteObject(allValues);
+    if (!parameters) {
+      return autocompleteExampleObj;
+    }
+
+    return {
+      ...(autocompleteExampleObj ?? {}),
+      parameters,
+    };
+  }, [field.name, allValues, autocompleteExampleObj]);
+
   const commonProps = {
     field,
     value,
     onChange,
     allValues,
     hasError: hasFieldError,
-    autocompleteExampleObj,
+    autocompleteExampleObj: resolvedAutocompleteExampleObj,
     integrationId,
     organizationId,
     allowExpressions: fieldAllowsExpressions,

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -281,7 +281,6 @@ export const ConfigurationFieldRenderer = ({
   };
 
   const renderField = () => {
-
     switch (field.type) {
       case "string":
         return <StringFieldRenderer {...commonProps} />;

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -30,6 +30,7 @@ import { DaysOfWeekFieldRenderer } from "./DaysOfWeekFieldRenderer";
 import { TimeRangeFieldRenderer } from "./TimeRangeFieldRenderer";
 import { isFieldVisible, isFieldRequired, parseDefaultValues, validateFieldForSubmission } from "../../lib/components";
 import type { AuthorizationDomainType } from "@/api-client";
+import { buildTemplateParametersAutocompleteObject } from "./templateParametersAutocomplete";
 
 interface ConfigurationFieldRendererProps extends FieldRendererProps {
   allowExpressions?: boolean;
@@ -49,54 +50,6 @@ type ConfigurationField = FieldRendererProps["field"];
 
 /** Stable reference for trigger run-title fields — hides node/previous sources that don't apply. */
 const RUN_TITLE_EXCLUDED_SUGGESTIONS = ["$", "previous"];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function templateParameterValue(parameter: Record<string, unknown>): unknown {
-  const parameterType = parameter.type;
-  if (parameterType === "number") {
-    const value = parameter.defaultNumber;
-    return value === null || value === undefined ? 0 : value;
-  }
-  if (parameterType === "boolean") {
-    const value = parameter.defaultBoolean;
-    return value === null || value === undefined ? false : value;
-  }
-  const value = parameter.defaultString;
-  if (value === null || value === undefined) return "";
-  return value;
-}
-
-export function buildTemplateParametersAutocompleteObject(
-  allValues: Record<string, unknown>,
-): Record<string, unknown> | null {
-  const rawParameters = allValues.parameters;
-  if (!Array.isArray(rawParameters) || rawParameters.length === 0) {
-    return null;
-  }
-
-  const parameters: Record<string, unknown> = {};
-  for (const rawParameter of rawParameters) {
-    if (!isRecord(rawParameter)) {
-      continue;
-    }
-
-    const name = rawParameter.name;
-    if (typeof name !== "string" || name.trim() === "") {
-      continue;
-    }
-
-    parameters[name] = templateParameterValue(rawParameter);
-  }
-
-  if (Object.keys(parameters).length === 0) {
-    return null;
-  }
-
-  return parameters;
-}
 
 function getInitialSelectValue(field: ConfigurationField, parsedDefaultValue: unknown): unknown {
   const selectOptions = field.typeOptions?.select?.options;

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -309,12 +309,6 @@ export const ConfigurationFieldRenderer = ({
     return hasError;
   }, [allFieldErrors, isRequired, value, validationErrors, enableRealtimeValidation, hasError]);
 
-  if (!isVisible) {
-    return null;
-  }
-  const fieldAllowsExpressions =
-    allowExpressions && !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false);
-
   const resolvedAutocompleteExampleObj = React.useMemo(() => {
     if (field.name !== "payload") {
       return autocompleteExampleObj;
@@ -330,6 +324,13 @@ export const ConfigurationFieldRenderer = ({
       parameters,
     };
   }, [field.name, allValues, autocompleteExampleObj]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const fieldAllowsExpressions =
+    allowExpressions && !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false);
 
   const commonProps = {
     field,

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -264,19 +264,23 @@ export const ConfigurationFieldRenderer = ({
   if (!isVisible) {
     return null;
   }
+  const fieldAllowsExpressions =
+    allowExpressions && !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false);
+
+  const commonProps = {
+    field,
+    value,
+    onChange,
+    allValues,
+    hasError: hasFieldError,
+    autocompleteExampleObj,
+    integrationId,
+    organizationId,
+    allowExpressions: fieldAllowsExpressions,
+    excludedSuggestions: field.name === "customName" ? RUN_TITLE_EXCLUDED_SUGGESTIONS : undefined,
+  };
+
   const renderField = () => {
-    const commonProps = {
-      field,
-      value,
-      onChange,
-      allValues,
-      hasError: hasFieldError,
-      autocompleteExampleObj,
-      integrationId,
-      organizationId,
-      allowExpressions,
-      excludedSuggestions: field.name === "customName" ? RUN_TITLE_EXCLUDED_SUGGESTIONS : undefined,
-    };
 
     switch (field.type) {
       case "string":
@@ -433,13 +437,57 @@ export const ConfigurationFieldRenderer = ({
     }
   };
 
-  // For boolean fields, render label inline with switch
+  // Togglable booleans use the standard label row plus an optional labeled value switch.
+  if (field.type === "boolean" && isTogglable) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          <Switch checked={isEnabled} onCheckedChange={handleToggleChange} />
+          <Label className="block text-left flex-1 min-w-0">
+            {field.label || field.name}
+            {isRequired && <span className="text-gray-800 ml-1">*</span>}
+            {hasFieldError &&
+              ((enableRealtimeValidation && isRequired && (value === undefined || value === null || value === "")) ||
+                (!enableRealtimeValidation &&
+                  validationErrors &&
+                  isRequired &&
+                  (value === undefined || value === null || value === ""))) && (
+                <span className="text-red-500 text-xs ml-2 leading-0">Required</span>
+              )}
+          </Label>
+        </div>
+        {isEnabled && (
+          <div className="flex items-center gap-3">
+            <BooleanFieldRenderer {...commonProps} labeled />
+          </div>
+        )}
+
+        {allFieldErrors.filter((error) => error.message && !error.message.toLowerCase().includes("required")).length >
+          0 && (
+          <div className="space-y-1">
+            {allFieldErrors
+              .filter((error) => error.message && !error.message.toLowerCase().includes("required"))
+              .map((error, index) => (
+                <p key={index} className="text-xs text-red-500 dark:text-red-400 text-left">
+                  {error.message}
+                </p>
+              ))}
+          </div>
+        )}
+
+        {field.description && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-left leading-normal">{field.description}</p>
+        )}
+      </div>
+    );
+  }
+
+  // Non-togglable booleans render the switch inline with the label.
   if (field.type === "boolean") {
     return (
       <div className="space-y-2">
         <div className="flex items-center gap-3">
-          {isTogglable && <Switch checked={isEnabled} onCheckedChange={handleToggleChange} />}
-          {isEnabled && renderField()}
+          {renderField()}
           <Label className="text-left cursor-pointer">
             {field.label || field.name}
             {isRequired && <span className="text-gray-800 ml-1">*</span>}
@@ -454,7 +502,6 @@ export const ConfigurationFieldRenderer = ({
           </Label>
         </div>
 
-        {/* Display validation errors */}
         {allFieldErrors.filter((error) => error.message && !error.message.toLowerCase().includes("required")).length >
           0 && (
           <div className="space-y-1">
@@ -468,7 +515,6 @@ export const ConfigurationFieldRenderer = ({
           </div>
         )}
 
-        {/* Display field description */}
         {field.description && (
           <p className="text-xs text-gray-500 dark:text-gray-400 text-left leading-normal">{field.description}</p>
         )}

--- a/web_src/src/ui/configurationFieldRenderer/listFieldItemTitle.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/listFieldItemTitle.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { listFieldItemTitle } from "./listFieldItemTitle";
+
+describe("listFieldItemTitle", () => {
+  it("uses the item name when present", () => {
+    expect(listFieldItemTitle({ name: "deploy", type: "string" }, 0, "Parameter")).toBe("deploy");
+  });
+
+  it("falls back to type and item label", () => {
+    expect(listFieldItemTitle({ type: "boolean" }, 1, "Parameter")).toBe("Parameter (Boolean)");
+  });
+
+  it("falls back to numbered item label", () => {
+    expect(listFieldItemTitle({}, 2, "Parameter")).toBe("Parameter 3");
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/listFieldItemTitle.ts
+++ b/web_src/src/ui/configurationFieldRenderer/listFieldItemTitle.ts
@@ -1,0 +1,15 @@
+export function listFieldItemTitle(item: unknown, index: number, itemLabel: string): string {
+  if (item && typeof item === "object" && !Array.isArray(item)) {
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    if (name) return name;
+
+    const type = typeof record.type === "string" ? record.type.trim() : "";
+    if (type) {
+      const typeLabel = type.charAt(0).toUpperCase() + type.slice(1);
+      return `${itemLabel} (${typeLabel})`;
+    }
+  }
+
+  return `${itemLabel} ${index + 1}`;
+}

--- a/web_src/src/ui/configurationFieldRenderer/templateParametersAutocomplete.ts
+++ b/web_src/src/ui/configurationFieldRenderer/templateParametersAutocomplete.ts
@@ -1,0 +1,47 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function templateParameterValue(parameter: Record<string, unknown>): unknown {
+  const parameterType = parameter.type;
+  if (parameterType === "number") {
+    const value = parameter.defaultNumber;
+    return value === null || value === undefined ? 0 : value;
+  }
+  if (parameterType === "boolean") {
+    const value = parameter.defaultBoolean;
+    return value === null || value === undefined ? false : value;
+  }
+  const value = parameter.defaultString;
+  if (value === null || value === undefined) return "";
+  return value;
+}
+
+export function buildTemplateParametersAutocompleteObject(
+  allValues: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const rawParameters = allValues.parameters;
+  if (!Array.isArray(rawParameters) || rawParameters.length === 0) {
+    return null;
+  }
+
+  const parameters: Record<string, unknown> = {};
+  for (const rawParameter of rawParameters) {
+    if (!isRecord(rawParameter)) {
+      continue;
+    }
+
+    const name = rawParameter.name;
+    if (typeof name !== "string" || name.trim() === "") {
+      continue;
+    }
+
+    parameters[name] = templateParameterValue(rawParameter);
+  }
+
+  if (Object.keys(parameters).length === 0) {
+    return null;
+  }
+
+  return parameters;
+}

--- a/web_src/src/ui/configurationFieldRenderer/useListFieldDragReorder.ts
+++ b/web_src/src/ui/configurationFieldRenderer/useListFieldDragReorder.ts
@@ -1,0 +1,106 @@
+import React from "react";
+
+import { reorderListItems } from "@/lib/reorderListItems";
+
+type DragState = {
+  items: unknown[];
+  activeIndex: number;
+  openAtStart: boolean;
+};
+
+export function useListFieldDragReorder({
+  items,
+  allowReorder,
+  useAccordion,
+  onChange,
+  setOpenItem,
+  rowRefs,
+}: {
+  items: unknown[];
+  allowReorder: boolean;
+  useAccordion: boolean;
+  onChange: (value: unknown) => void;
+  setOpenItem: React.Dispatch<React.SetStateAction<string | undefined>>;
+  rowRefs: React.MutableRefObject<Array<HTMLDivElement | null>>;
+}) {
+  const itemsRef = React.useRef(items);
+  itemsRef.current = items;
+
+  const [dragState, setDragState] = React.useState<DragState | null>(null);
+  const dragStateRef = React.useRef<DragState | null>(null);
+  dragStateRef.current = dragState;
+
+  const isDragging = dragState !== null;
+  const renderedItems = dragState ? dragState.items : items;
+
+  React.useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    const handleMove = (event: MouseEvent) => {
+      setDragState((current) => {
+        if (!current) return current;
+        for (let i = 0; i < rowRefs.current.length; i++) {
+          const el = rowRefs.current[i];
+          if (!el) continue;
+          const rect = el.getBoundingClientRect();
+          if (event.clientY >= rect.top && event.clientY <= rect.bottom) {
+            if (i === current.activeIndex) {
+              return current;
+            }
+            const nextItems = reorderListItems(current.items, current.activeIndex, i);
+            return { ...current, items: nextItems, activeIndex: i };
+          }
+        }
+        return current;
+      });
+    };
+
+    const handleUp = () => {
+      const current = dragStateRef.current;
+      if (!current) return;
+      itemsRef.current = current.items;
+      onChange(current.items);
+      if (useAccordion && current.openAtStart) {
+        setOpenItem(String(current.activeIndex));
+      }
+      setDragState(null);
+    };
+
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("mouseup", handleUp);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("mouseup", handleUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+  }, [isDragging, onChange, setOpenItem, useAccordion, rowRefs]);
+
+  const startDrag = (event: React.MouseEvent, index: number, openItem: string | undefined) => {
+    if (!allowReorder || items.length < 2) return;
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const wasOpen = openItem === String(index);
+    if (wasOpen) {
+      setOpenItem(undefined);
+    }
+
+    setDragState({
+      items: [...items],
+      activeIndex: index,
+      openAtStart: wasOpen,
+    });
+  };
+
+  return { dragState, renderedItems, startDrag };
+}

--- a/web_src/src/ui/configurationFieldRenderer/useMonacoExpressionAutocomplete.ts
+++ b/web_src/src/ui/configurationFieldRenderer/useMonacoExpressionAutocomplete.ts
@@ -17,6 +17,7 @@ type UseMonacoExpressionAutocompleteProps = {
   prefix?: string;
   suffix?: string;
   allowOutsideExpression?: boolean;
+  includeTopLevelGlobals?: boolean;
 };
 
 type MonacoKeyEvent = {
@@ -181,6 +182,7 @@ export const useMonacoExpressionAutocomplete = ({
   prefix = "{{ ",
   suffix = " }}",
   allowOutsideExpression = false,
+  includeTopLevelGlobals = false,
 }: UseMonacoExpressionAutocompleteProps) => {
   const modelsRef = useRef<Set<MonacoEditor.ITextModel>>(new Set());
   const previousValueRef = useRef<WeakMap<MonacoEditor.ITextModel, string>>(new WeakMap());
@@ -244,7 +246,7 @@ export const useMonacoExpressionAutocomplete = ({
               expressionContext.expressionText,
               expressionContext.expressionCursor,
               context.exampleObj ?? {},
-              { allowInStrings: allowOutsideExpression, limit: 100 },
+              { allowInStrings: allowOutsideExpression, limit: 100, includeTopLevelGlobals },
             ).sort((a, b) => {
               const aPriority = suggestionSortPriority[a.label as keyof typeof suggestionSortPriority];
               const bPriority = suggestionSortPriority[b.label as keyof typeof suggestionSortPriority];
@@ -437,7 +439,7 @@ export const useMonacoExpressionAutocomplete = ({
         modelsRef.current.delete(model);
       });
     },
-    [allowOutsideExpression, autocompleteExampleObj, languageId, prefix, startWord, suffix],
+    [allowOutsideExpression, autocompleteExampleObj, includeTopLevelGlobals, languageId, prefix, startWord, suffix],
   );
 
   return { handleEditorMount };


### PR DESCRIPTION
## What Changed

- `configuration/field` model used to define template parameters.
- Configurable parameter type (for now only string, number, bool).
- Configurable default values and display names for template parameters.
- Template parameter values accessible config via `{{ parameter. }}` expresion (with autocomplete).
- Collapsible sub-forms for template parameters to reduce noise, with drag-and-drop reordering.
- Clicking `[Run]` on a Manual Run with template parameters shows a form with template parameters.
- Clicking `[Run]` on a Manual Run without template parameters calls the hook immediately.

## Related Issues

#4914