### PR TITLE
fix: teach agent about console updates

### DIFF
--- a/pkg/agents/anthropic/resources.go
+++ b/pkg/agents/anthropic/resources.go
@@ -22,6 +22,7 @@ import (
 var richUIWidgetsContent []byte
 
 const skillsRepoRawBaseURL = "https://raw.githubusercontent.com/superplanehq/skills/main"
+const superplaneRepoRawBaseURL = "https://raw.githubusercontent.com/superplanehq/superplane/main"
 
 var resourceNameCamelBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 
@@ -116,6 +117,17 @@ func defaultResourceSourcesForSkillsBaseURL(skillsBaseURL string) ([]resourceSou
 			),
 		},
 		{
+			MountPath: "ref/skills/superplane-cli/references/console-yaml-spec.md",
+			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-cli", "references", "console-yaml-spec.md")),
+			SourceURL: skillsRawURL(
+				skillsBaseURL,
+				"skills",
+				"superplane-cli",
+				"references",
+				"console-yaml-spec.md",
+			),
+		},
+		{
 			MountPath: "ref/skills/superplane-monitor/SKILL.md",
 			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-monitor", "SKILL.md")),
 			SourceURL: skillsRawURL(
@@ -123,6 +135,16 @@ func defaultResourceSourcesForSkillsBaseURL(skillsBaseURL string) ([]resourceSou
 				"skills",
 				"superplane-monitor",
 				"SKILL.md",
+			),
+		},
+		{
+			MountPath: "ref/docs/prd/console-and-widgets.md",
+			SourceKey: filepath.ToSlash(filepath.Join("docs", "prd", "console-and-widgets.md")),
+			SourceURL: skillsRawURL(
+				superplaneRepoRawBaseURL,
+				"docs",
+				"prd",
+				"console-and-widgets.md",
 			),
 		},
 	}

--- a/pkg/agents/anthropic/resources_test.go
+++ b/pkg/agents/anthropic/resources_test.go
@@ -43,6 +43,21 @@ func TestDefaultResourceSourcesForSkillsBaseURL(t *testing.T) {
 	)
 	assert.Equal(
 		t,
+		"https://example.test/root/skills/superplane-cli/references/console-yaml-spec.md",
+		byMountPath["ref/skills/superplane-cli/references/console-yaml-spec.md"].SourceURL,
+	)
+	assert.Equal(
+		t,
+		"https://raw.githubusercontent.com/superplanehq/superplane/main/docs/prd/console-and-widgets.md",
+		byMountPath["ref/docs/prd/console-and-widgets.md"].SourceURL,
+	)
+	assert.Equal(
+		t,
+		"docs/prd/console-and-widgets.md",
+		byMountPath["ref/docs/prd/console-and-widgets.md"].SourceKey,
+	)
+	assert.Equal(
+		t,
 		"https://example.test/root/skills/superplane-monitor/SKILL.md",
 		byMountPath["ref/skills/superplane-monitor/SKILL.md"].SourceURL,
 	)

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -33,12 +33,15 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"  - canvases:update_version:%s\n" +
 	"\n" +
 	"The canvases:update_version scope is limited to draft canvas version\n" +
-	"editing. It does not grant permission to publish versions, delete\n" +
-	"canvases, or perform live-canvas operational actions.\n" +
+	"editing. Draft version editing includes canvas graph updates and console\n" +
+	"updates through the version-scoped dashboard endpoint. It does not grant\n" +
+	"permission to publish versions, delete canvases, or perform live-canvas\n" +
+	"operational actions.\n" +
 	"\n" +
 	"SuperPlane has no separate `events` permission. The canvases:read\n" +
 	"scope grants every read endpoint scoped to this canvas, including:\n" +
 	"  GET /api/v1/canvases/{canvas_id}                       describe canvas\n" +
+	"  GET /api/v1/canvases/{canvas_id}/dashboard             read console panels/layout\n" +
 	"  GET /api/v1/canvases/{canvas_id}/events                list canvas events\n" +
 	"  GET /api/v1/canvases/{canvas_id}/events/{id}/executions\n" +
 	"  GET /api/v1/canvases/{canvas_id}/runs\n" +
@@ -82,9 +85,11 @@ Rules:
   :::
 
 - You can add, remove, or modify nodes and edges.
+- You can update the canvas Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Use 'superplane console get ... -o yaml' and 'superplane console set ... -f console.yaml --draft'.
 - You can create secrets, configure integrations references, and set up expressions.
 - For direct canvas edits, prefer the shortest reliable path: read the draft canvas once, list integrations only if integration IDs are needed, make the draft update, then report the result.
 - When reading a canvas for build work, save it once to a local file such as '/tmp/current-canvas.yaml' and inspect that file locally with 'rg', 'yq', 'sed', or an editor. Do not run repeated 'superplane canvases get ... | grep ...' commands against the same draft. Re-fetch only after you update the draft, or after a publish/discard notification invalidates the local file.
+- When editing the Console, save it once to a local file such as '/tmp/current-console.yaml'. Read ref/skills/superplane-cli/references/console-yaml-spec.md for the stable envelope and ref/docs/prd/console-and-widgets.md before editing widget content. Do not repeatedly run 'superplane console get ... | grep ...' against the same draft.
 - For direct component replacements or component additions, check ref/components/Index.md first for the exact YAML key. If more detail is needed, use the vendor doc in ref/components/. Each component or trigger section includes the exact key as "Component key" or "Trigger key". Use these keys instead of searching source code.
 - Do not spawn a researcher/subagent for straightforward component swaps, renames, integration rebinding, or field updates. Use one only when the request needs broad design work or genuinely unknown information.
 - Avoid repeated grep/find/cat command loops. If the mounted docs do not resolve the exact key or required fields after one targeted lookup, ask a clarifying question or explain what is missing.
@@ -92,6 +97,7 @@ Rules:
 - If the user asks a question that doesn't require changes, answer it briefly, but your primary purpose is building.
 - If you're unsure what the user wants, ask a clarifying question using :::buttons with the options.
 - When you receive a system notification that a draft was published or discarded, re-read the canvas (superplane canvases get) to see the current live state before taking any further action. Acknowledge the change briefly.
+- When you receive a system notification that affects the Console, re-read 'superplane console get ... --draft -o yaml' before making further console edits.
 - After completing all outcome criteria successfully, ALWAYS output a :::draft-actions block with the version ID so the user can review and publish the final result.`
 
 const operatorModeInstructions = `[Agent Mode: ASK]
@@ -111,7 +117,7 @@ You are in Plan mode. Your job is to help the user plan what to build, then exec
 
 Rules:
 - During the PLANNING phase (before the user clicks Start Building), do NOT modify the canvas. You are planning only.
-- Once an outcome is active (after Start Building), you CAN and SHOULD modify the canvas to fulfill the rubric criteria. Use "superplane canvases update --draft" for all changes.
+- Once an outcome is active (after Start Building), you CAN and SHOULD modify the canvas and Console to fulfill the rubric criteria. Use "superplane canvases update --draft" for graph changes and "superplane console set ... --draft" for console changes.
 - Ask clarifying questions to understand what the user wants to achieve.
 - When asking ONE question with options, use :::buttons (buttons are clickable options ONLY — no [input] fields, no free text)
 - When asking MULTIPLE questions at once, use :::survey (user answers all, then submits together):

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -269,6 +269,7 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.Contains(t, provider.lastPreamble, "api_token_expires_at:")
 	assert.Contains(t, provider.lastPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
 	assert.Contains(t, provider.lastPreamble, "  - canvases:update_version:"+canvas.ID.String())
+	assert.Contains(t, provider.lastPreamble, "GET /api/v1/canvases/{canvas_id}/dashboard")
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())
 
@@ -325,6 +326,8 @@ func TestService_DefineOutcome_RefreshesPreambleForBuildLoop(t *testing.T) {
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "[Agent Mode: BUILD]")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "ALWAYS use \"superplane canvases update --draft\"")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "superplane console set ... -f console.yaml --draft")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "ref/docs/prd/console-and-widgets.md")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "api_token:")
 }
 

--- a/pkg/grpc/actions/canvases/update_canvas_dashboard.go
+++ b/pkg/grpc/actions/canvases/update_canvas_dashboard.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/grpc/codes"
@@ -105,6 +106,10 @@ func UpdateCanvasDashboard(
 		}
 		log.WithError(err).Error("failed to update canvas dashboard")
 		return nil, status.Error(codes.Internal, "failed to update canvas dashboard")
+	}
+
+	if err := messages.NewCanvasVersionUpdatedMessage(canvas.ID.String(), saved.VersionID.String()).PublishVersionUpdated(); err != nil {
+		log.Errorf("failed to publish canvas version update RabbitMQ message: %v", err)
 	}
 
 	serialized, err := serializeCanvasDashboard(saved)

--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -4,9 +4,10 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { canvasFoldersUpdateCanvasFolder, canvasesListRuns } = vi.hoisted(() => ({
+const { canvasFoldersUpdateCanvasFolder, canvasesListRuns, canvasesUpdateCanvasDashboard } = vi.hoisted(() => ({
   canvasFoldersUpdateCanvasFolder: vi.fn(),
   canvasesListRuns: vi.fn(),
+  canvasesUpdateCanvasDashboard: vi.fn(),
 }));
 
 vi.mock("../api-client/sdk.gen", async (importOriginal) => {
@@ -15,10 +16,16 @@ vi.mock("../api-client/sdk.gen", async (importOriginal) => {
     ...(actual as Record<string, unknown>),
     canvasFoldersUpdateCanvasFolder,
     canvasesListRuns,
+    canvasesUpdateCanvasDashboard,
   };
 });
 
-import { canvasKeys, useInfiniteCanvasRuns, useUpdateCanvasFolderMembership } from "@/hooks/useCanvasData";
+import {
+  canvasKeys,
+  useInfiniteCanvasRuns,
+  useUpdateCanvasConsole,
+  useUpdateCanvasFolderMembership,
+} from "@/hooks/useCanvasData";
 
 type TestCanvasFolder = {
   metadata?: { id?: string };
@@ -268,5 +275,57 @@ describe("useUpdateCanvasFolderMembership", () => {
     expect(getCanvasFolderId(queryClient, organizationId, "canvas-1")).toBe("folder-1");
     expect(getFolderCanvasIds(queryClient, organizationId, "folder-1")).toEqual(["canvas-1"]);
     expect(getFolderCanvasIds(queryClient, organizationId, "folder-2")).toEqual([]);
+  });
+});
+
+describe("useUpdateCanvasConsole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers a canvas version websocket echo before saving dashboard changes", async () => {
+    const queryClient = createQueryClient();
+    const registerIgnoredCanvasVersionUpdatedEcho = vi.fn(() => vi.fn());
+    canvasesUpdateCanvasDashboard.mockResolvedValue({
+      data: {
+        dashboard: {
+          panels: [],
+          layout: [],
+        },
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useUpdateCanvasConsole("canvas-1", "version-1", {
+          registerIgnoredCanvasVersionUpdatedEcho,
+        }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await result.current.mutateAsync({ panels: [], layout: [] });
+
+    expect(registerIgnoredCanvasVersionUpdatedEcho).toHaveBeenCalledWith("version-1");
+    expect(canvasesUpdateCanvasDashboard).toHaveBeenCalledOnce();
+  });
+
+  it("releases the ignored canvas version echo when dashboard save fails", async () => {
+    const queryClient = createQueryClient();
+    const releaseCanvasVersionUpdatedEcho = vi.fn();
+    const registerIgnoredCanvasVersionUpdatedEcho = vi.fn(() => releaseCanvasVersionUpdatedEcho);
+    canvasesUpdateCanvasDashboard.mockRejectedValue(new Error("request failed"));
+
+    const { result } = renderHook(
+      () =>
+        useUpdateCanvasConsole("canvas-1", "version-1", {
+          registerIgnoredCanvasVersionUpdatedEcho,
+        }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await expect(result.current.mutateAsync({ panels: [], layout: [] })).rejects.toThrow("request failed");
+
+    expect(registerIgnoredCanvasVersionUpdatedEcho).toHaveBeenCalledWith("version-1");
+    expect(releaseCanvasVersionUpdatedEcho).toHaveBeenCalledOnce();
   });
 });

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -1600,33 +1600,47 @@ export const useCanvasConsole = (canvasId: string, versionId: string | undefined
   });
 };
 
-export const useUpdateCanvasConsole = (canvasId: string, versionId: string | undefined) => {
+type UseUpdateCanvasConsoleOptions = {
+  registerIgnoredCanvasVersionUpdatedEcho?: (savingVersionId?: string) => () => void;
+};
+
+export const useUpdateCanvasConsole = (
+  canvasId: string,
+  versionId: string | undefined,
+  options?: UseUpdateCanvasConsoleOptions,
+) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: { panels: DashboardPanel[]; layout: DashboardLayoutItem[] }) => {
-      const response = await canvasesUpdateCanvasDashboard(
-        withOrganizationHeader({
-          path: { canvasId },
-          body: {
-            versionId,
-            panels: input.panels.map((p) => ({
-              id: p.id,
-              type: p.type,
-              content: p.content,
-            })),
-            layout: input.layout.map((l) => ({
-              i: l.i,
-              x: l.x,
-              y: l.y,
-              w: l.w,
-              h: l.h,
-              ...(l.minW !== undefined ? { minW: l.minW } : {}),
-              ...(l.minH !== undefined ? { minH: l.minH } : {}),
-            })),
-          },
-        }),
-      );
-      return response.data?.dashboard;
+      const releaseCanvasVersionUpdatedEcho = options?.registerIgnoredCanvasVersionUpdatedEcho?.(versionId);
+      try {
+        const response = await canvasesUpdateCanvasDashboard(
+          withOrganizationHeader({
+            path: { canvasId },
+            body: {
+              versionId,
+              panels: input.panels.map((p) => ({
+                id: p.id,
+                type: p.type,
+                content: p.content,
+              })),
+              layout: input.layout.map((l) => ({
+                i: l.i,
+                x: l.x,
+                y: l.y,
+                w: l.w,
+                h: l.h,
+                ...(l.minW !== undefined ? { minW: l.minW } : {}),
+                ...(l.minH !== undefined ? { minH: l.minH } : {}),
+              })),
+            },
+          }),
+        );
+        return response.data?.dashboard;
+      } catch (error) {
+        releaseCanvasVersionUpdatedEcho?.();
+        throw error;
+      }
     },
     onSuccess: (data) => {
       queryClient.setQueryData(canvasKeys.dashboard(canvasId, versionId), data);

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -166,4 +166,24 @@ describe("useCanvasWebsocket", () => {
       });
     });
   });
+
+  it("invalidates version and console queries for canvas version updates", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+    emitWebsocketMessage("canvas_version_updated", {
+      canvasId: testCanvasId,
+      versionId: "version-1",
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: canvasKeys.versionList(testCanvasId),
+      });
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: canvasKeys.dashboardAll(testCanvasId),
+      });
+    });
+  });
 });

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -172,6 +172,7 @@ export function useCanvasWebsocket(
           queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
 
           if (data.event === "canvas_version_updated") {
+            queryClient.invalidateQueries({ queryKey: canvasKeys.dashboardAll(canvasId) });
             break;
           }
 

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -569,13 +569,6 @@ export function WorkflowPageV2() {
   const canUpdateCanvas = canAct("canvases", "update");
   usePageTitle([canvas?.metadata?.name || "Canvas"]);
   const isTemplate = liveCanvas?.metadata?.isTemplate ?? false;
-  const { dashboardQuery, updateDashboardMutation, hasDraftDiffVersusLive } = useCanvasConsoleVersionDiff({
-    canvasId: canvasId!,
-    activeCanvasVersionId,
-    liveCanvasVersionId,
-    hasDraftGraphDiffVersusLive,
-    enabled: !isTemplate,
-  });
   const [canvasDeletedRemotely, setCanvasDeletedRemotely] = useState(false);
   const [remoteCanvasUpdatePending, setRemoteCanvasUpdatePending] = useState(false);
   const canvasAccess = { canUpdateCanvas, isTemplate, canvasDeletedRemotely };
@@ -656,7 +649,6 @@ export function WorkflowPageV2() {
     }
   }
   if (isSidebarOpenRef.current === null && canvas) {
-    // Initialize on first render
     isSidebarOpenRef.current = canvas.spec?.nodes?.length === 0;
   }
 
@@ -781,8 +773,7 @@ export function WorkflowPageV2() {
   }, [canvasError, canvasLoading, navigate, organizationId, canvasDeletedRemotely]);
   useEffect(() => {
     if (hasTrackedCanvasView.current) return;
-    if (!canvas || !canvasId || !organizationId) return;
-    if (canvasLoading) return;
+    if (!canvas || !canvasId || !organizationId || canvasLoading) return;
     hasTrackedCanvasView.current = true;
     analytics.canvasView(canvasId, canvas.spec?.nodes?.length ?? 0, canvas.spec?.edges?.length ?? 0, organizationId);
   }, [canvas, canvasId, organizationId, canvasLoading]);
@@ -1140,6 +1131,14 @@ export function WorkflowPageV2() {
     return release;
   }, []);
 
+  const { dashboardQuery, updateDashboardMutation, hasDraftDiffVersusLive } = useCanvasConsoleVersionDiff({
+    canvasId: canvasId!,
+    activeCanvasVersionId,
+    liveCanvasVersionId,
+    hasDraftGraphDiffVersusLive,
+    enabled: !isTemplate,
+    registerIgnoredCanvasVersionUpdatedEcho,
+  });
   const consumeIgnoredCanvasUpdatedEcho = useCallback(() => {
     const release = ignoredCanvasUpdatedEchoReleasesRef.current.pop();
     if (!release) {

--- a/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
+++ b/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
@@ -10,6 +10,7 @@ type UseCanvasConsoleVersionDiffArgs = {
   liveCanvasVersionId: string | undefined;
   hasDraftGraphDiffVersusLive: boolean;
   enabled: boolean;
+  registerIgnoredCanvasVersionUpdatedEcho?: (savingVersionId?: string) => () => void;
 };
 
 export function useCanvasConsoleVersionDiff({
@@ -18,6 +19,7 @@ export function useCanvasConsoleVersionDiff({
   liveCanvasVersionId,
   hasDraftGraphDiffVersusLive,
   enabled,
+  registerIgnoredCanvasVersionUpdatedEcho,
 }: UseCanvasConsoleVersionDiffArgs) {
   const dashboardQuery = useCanvasConsole(canvasId, activeCanvasVersionId || undefined, enabled);
   const liveDashboardQuery = useCanvasConsole(
@@ -30,7 +32,9 @@ export function useCanvasConsoleVersionDiff({
     [liveDashboardQuery.data, dashboardQuery.data],
   );
   const hasDraftDiffVersusLive = hasDraftGraphDiffVersusLive || hasDraftConsoleDiffVersusLive;
-  const updateDashboardMutation = useUpdateCanvasConsole(canvasId, activeCanvasVersionId || undefined);
+  const updateDashboardMutation = useUpdateCanvasConsole(canvasId, activeCanvasVersionId || undefined, {
+    registerIgnoredCanvasVersionUpdatedEcho,
+  });
 
   return {
     dashboardQuery,


### PR DESCRIPTION
## Summary
- update agent preamble so draft version scope explicitly includes Console updates and points to console CLI/docs
- mount the Console YAML spec and current console/widgets PRD as Anthropic resources
- keep frontend Console draft data fresh by invalidating dashboard queries on canvas version websocket updates
- publish canvas version update events after dashboard updates so Console changes propagate over websocket

## Hosted agent
- updated Anthropic Managed Agent agent_01TKCC39qeWdnjhMGQUBBLXK from version 65 to 66 with Console fast-path rules and docs references

## Verification
- make format.go
- make format.js
- make lint
- go test ./pkg/agents/anthropic -run TestDefaultResourceSourcesForSkillsBaseURL
- npm run test:run -- src/hooks/useCanvasWebsocket.spec.ts

## Known blockers
- go test ./pkg/agents -run 'TestService_SendMessage_RefreshesPreambleEveryTurn|TestService_DefineOutcome_RefreshesPreambleForBuildLoop' fails locally before assertions because PostgreSQL is not reachable on /private/tmp/.s.PGSQL.5432
- make check.build.app is blocked by generated proto drift: configuration StringTypeOptions/ListTypeOptions are missing allowExpressions/accordion/reorderable generated fields
- make check.build.ui is blocked by the matching generated TS type drift in configuration field renderer types