### PR TITLE
fix: prevent undefined organization logo link

### DIFF
--- a/web_src/src/components/OrganizationMenuButton.spec.tsx
+++ b/web_src/src/components/OrganizationMenuButton.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
+
+vi.mock("@/contexts/useAccount", () => ({
+  useAccount: () => ({
+    account: {
+      id: "user-1",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      installation_admin: false,
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useOrganizationData", () => ({
+  useOrganization: () => ({ data: null }),
+  useOrganizationUsage: () => ({ data: null, error: null }),
+}));
+
+vi.mock("@/contexts/usePermissions", () => ({
+  usePermissions: () => ({ canAct: () => true, isLoading: false }),
+}));
+
+vi.mock("@/lib/env", () => ({
+  isUsagePageForced: () => false,
+}));
+
+vi.mock("@/posthog", () => ({
+  posthog: { reset: vi.fn() },
+}));
+
+describe("OrganizationMenuButton", () => {
+  it("links the logo to organization selection when no organization is active", () => {
+    render(
+      <MemoryRouter>
+        <OrganizationMenuButton />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Go to canvases" })).toHaveAttribute("href", "/");
+  });
+
+  it("links the logo to the active organization when one is active", () => {
+    render(
+      <MemoryRouter>
+        <OrganizationMenuButton organizationId="org-123" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Go to canvases" })).toHaveAttribute("href", "/org-123");
+  });
+});

--- a/web_src/src/components/OrganizationMenuButton.tsx
+++ b/web_src/src/components/OrganizationMenuButton.tsx
@@ -75,6 +75,7 @@ export function OrganizationMenuButton({ organizationId, className }: Organizati
 
   const organizationName = organization?.metadata?.name || "Organization";
   const usageEnabled = usageStatus?.enabled === true || !!usageError || isUsagePageForced();
+  const logoHref = organizationId ? `/${organizationId}` : "/";
 
   const sidebarUserLinks = [
     ...(organizationId
@@ -278,7 +279,7 @@ export function OrganizationMenuButton({ organizationId, className }: Organizati
         )}
       </div>
       <Link
-        to={`/${organizationId}`}
+        to={logoHref}
         aria-label="Go to canvases"
         className="flex h-8 cursor-pointer items-center rounded-md px-2 hover:bg-slate-100"
       >


### PR DESCRIPTION
## Summary
- Route the SuperPlane logo to organization selection when no organization is active
- Keep active organization logo navigation unchanged
- Add regression coverage for both logo link states

## Tests
- cd web_src && npm run test:run -- src/components/OrganizationMenuButton.spec.tsx
- make check.lint.ui
- make check.build.ui
- git diff --check