### PR TITLE
fix: expose canvas version role permissions

### DIFF
--- a/web_src/src/pages/organization/settings/CreateRolePage.tsx
+++ b/web_src/src/pages/organization/settings/CreateRolePage.tsx
@@ -197,6 +197,22 @@ const ORGANIZATION_PERMISSIONS: PermissionCategory[] = [
         action: "update",
       },
       {
+        id: "canvas.update_version",
+        name: "Edit Drafts",
+        description: "Create, update, and discard canvas drafts",
+        category: "Canvases",
+        resource: "canvases",
+        action: "update_version",
+      },
+      {
+        id: "canvas.publish",
+        name: "Publish Drafts",
+        description: "Publish canvas drafts",
+        category: "Canvases",
+        resource: "canvases",
+        action: "publish",
+      },
+      {
         id: "canvas.delete",
         name: "Delete Canvases",
         description: "Delete canvases from the organization",


### PR DESCRIPTION
## Summary
- Add canvas version edit permission to the role create/edit UI
- Add canvas version publish permission to match RBAC policy

## Tests
- make format.js
- make check.lint.ui
- make check.build.ui
- git diff --check