### PR TITLE
fix: update agent cli preamble and dashboard (console) scope

### DIFF
--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -25,6 +25,9 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"When using the SuperPlane CLI, pass these refreshed values through\n" +
 	"environment variables instead of running `superplane connect`:\n" +
 	"  SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...\n" +
+	"Before the first CLI command in a turn, run `superplane version`.\n" +
+	"If it prints an update notice or is missing expected commands, run\n" +
+	"`superplane upgrade`, then continue with the same environment variables.\n" +
 	"\n" +
 	"api_token scopes (exact strings on the JWT):\n" +
 	"  - org:read\n" +

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -268,6 +268,7 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.Contains(t, provider.lastPreamble, "api_token:")
 	assert.Contains(t, provider.lastPreamble, "api_token_expires_at:")
 	assert.Contains(t, provider.lastPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
+	assert.Contains(t, provider.lastPreamble, "Before the first CLI command in a turn, run `superplane version`.")
 	assert.Contains(t, provider.lastPreamble, "  - canvases:update_version:"+canvas.ID.String())
 	assert.Contains(t, provider.lastPreamble, "GET /api/v1/canvases/{canvas_id}/dashboard")
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -413,7 +413,7 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		},
 		pbCanvases.Canvases_UpdateCanvasDashboard_FullMethodName: {
 			Resource:         "canvases",
-			Action:           "update",
+			Action:           "update_version",
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: canvasResourceResolver,
 		},

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -57,6 +57,7 @@ func TestCanvasAuthorizationRulesSeparateDraftAndLiveActions(t *testing.T) {
 		{pbCanvases.Canvases_UpdateCanvasVersion_FullMethodName, "update_version"},
 		{pbCanvases.Canvases_ApplyCanvasVersionChangeset_FullMethodName, "update_version"},
 		{pbCanvases.Canvases_DeleteCanvasVersion_FullMethodName, "update_version"},
+		{pbCanvases.Canvases_UpdateCanvasDashboard_FullMethodName, "update_version"},
 		{pbCanvases.Canvases_PublishCanvasVersion_FullMethodName, "publish"},
 		{pbCanvases.Canvases_ActOnCanvasChangeRequest_FullMethodName, "publish"},
 		{pbCanvases.Canvases_UpdateCanvas_FullMethodName, "update"},


### PR DESCRIPTION
## Summary
- add CLI version verification guidance to the agent preamble before first CLI command
- authorize canvas dashboard updates with canvases:update_version instead of canvases:update
- cover the preamble and authorization rule changes in tests

## Tests
- make format.go
- docker compose -f docker-compose.dev.yml exec -e DB_NAME=superplane_test app bash -lc "go test -p 1 ./pkg/agents ./pkg/authorization ./pkg/grpc/actions/canvases"
- make lint && make check.build.app