### PR TITLE
fix: show console draft indicator

### DIFF
--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1130,15 +1130,15 @@ export function WorkflowPageV2() {
 
     return release;
   }, []);
-
-  const { dashboardQuery, updateDashboardMutation, hasDraftDiffVersusLive } = useCanvasConsoleVersionDiff({
-    canvasId: canvasId!,
-    activeCanvasVersionId,
-    liveCanvasVersionId,
-    hasDraftGraphDiffVersusLive,
-    enabled: !isTemplate,
-    registerIgnoredCanvasVersionUpdatedEcho,
-  });
+  const { dashboardQuery, updateDashboardMutation, draftChangeIndicators, hasDraftDiffVersusLive } =
+    useCanvasConsoleVersionDiff({
+      canvasId: canvasId!,
+      versionIds: { active: activeCanvasVersionId, draft: latestDraftVersion?.metadata?.id, live: liveCanvasVersionId },
+      hasDraftGraphDiffVersusLive,
+      suppressUnpublishedDraftDiscard,
+      enabled: !isTemplate,
+      registerIgnoredCanvasVersionUpdatedEcho,
+    });
   const consumeIgnoredCanvasUpdatedEcho = useCallback(() => {
     const release = ignoredCanvasUpdatedEchoReleasesRef.current.pop();
     if (!release) {
@@ -5290,10 +5290,8 @@ export function WorkflowPageV2() {
       dashboardQuery.isLoading,
     ],
   );
-
-  const hasUnpublishedDraftChanges = !suppressUnpublishedDraftDiscard && !!latestDraftVersion && hasDraftDiffVersusLive;
   const { onShowDiff, onShowNodeDiff, yamlDiffModal } = useCanvasYamlDiffModal({
-    hasUnpublishedDraftChanges,
+    hasUnpublishedDraftChanges: draftChangeIndicators.hasUnpublishedDraftChanges,
     liveCanvas,
     liveCanvasVersion,
     draftCanvasVersion: latestDraftVersion,
@@ -5633,7 +5631,7 @@ export function WorkflowPageV2() {
           onYamlOpen={() => setIsYamlViewModalOpen(true)}
           exitEditModeDisabled={exitEditModeDisabled}
           exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
-          hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+          {...draftChangeIndicators}
           autoLayoutOnUpdateDisabled={isReadOnly}
           autoLayoutOnUpdateDisabledTooltip={isReadOnly ? "You don't have permission to edit this canvas." : undefined}
           runDisabled={runDisabled}

--- a/web_src/src/pages/workflowv2/lib/version-action-state.ts
+++ b/web_src/src/pages/workflowv2/lib/version-action-state.ts
@@ -16,6 +16,42 @@ type VersionActionAvailability = {
   publishVersionDisabledTooltip?: string;
 };
 
+type DraftChangeIndicatorsInput = {
+  suppressUnpublishedDraftDiscard: boolean;
+  hasLatestDraftVersion: boolean;
+  hasDraftGraphDiffVersusLive: boolean;
+  hasDraftConsoleDiffVersusLive: boolean;
+  hasDraftDiffVersusLive: boolean;
+};
+
+type DraftChangeIndicators = {
+  hasUnpublishedDraftChanges: boolean;
+  hasUnpublishedCanvasDraftChanges: boolean;
+  hasUnpublishedConsoleDraftChanges: boolean;
+};
+
+export function getDraftChangeIndicators({
+  suppressUnpublishedDraftDiscard,
+  hasLatestDraftVersion,
+  hasDraftGraphDiffVersusLive,
+  hasDraftConsoleDiffVersusLive,
+  hasDraftDiffVersusLive,
+}: DraftChangeIndicatorsInput): DraftChangeIndicators {
+  if (suppressUnpublishedDraftDiscard || !hasLatestDraftVersion) {
+    return {
+      hasUnpublishedDraftChanges: false,
+      hasUnpublishedCanvasDraftChanges: false,
+      hasUnpublishedConsoleDraftChanges: false,
+    };
+  }
+
+  return {
+    hasUnpublishedDraftChanges: hasDraftDiffVersusLive,
+    hasUnpublishedCanvasDraftChanges: hasDraftGraphDiffVersusLive,
+    hasUnpublishedConsoleDraftChanges: hasDraftConsoleDiffVersusLive,
+  };
+}
+
 function getCreateChangeRequestDisabled({
   isChangeManagementDisabled,
   hasEditableVersion,

--- a/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
+++ b/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
@@ -3,42 +3,57 @@ import { useMemo } from "react";
 import { useCanvasConsole, useUpdateCanvasConsole } from "@/hooks/useCanvasData";
 
 import { hasDraftVersusLiveConsoleDiff } from "./draftConsoleDiff";
+import { getDraftChangeIndicators } from "./lib/version-action-state";
 
 type UseCanvasConsoleVersionDiffArgs = {
   canvasId: string;
-  activeCanvasVersionId: string;
-  liveCanvasVersionId: string | undefined;
+  versionIds: {
+    active: string;
+    draft: string | undefined;
+    live: string | undefined;
+  };
   hasDraftGraphDiffVersusLive: boolean;
+  suppressUnpublishedDraftDiscard: boolean;
   enabled: boolean;
   registerIgnoredCanvasVersionUpdatedEcho?: (savingVersionId?: string) => () => void;
 };
 
 export function useCanvasConsoleVersionDiff({
   canvasId,
-  activeCanvasVersionId,
-  liveCanvasVersionId,
+  versionIds,
   hasDraftGraphDiffVersusLive,
+  suppressUnpublishedDraftDiscard,
   enabled,
   registerIgnoredCanvasVersionUpdatedEcho,
 }: UseCanvasConsoleVersionDiffArgs) {
-  const dashboardQuery = useCanvasConsole(canvasId, activeCanvasVersionId || undefined, enabled);
-  const liveDashboardQuery = useCanvasConsole(
+  const dashboardQuery = useCanvasConsole(canvasId, versionIds.active || undefined, enabled);
+  const draftDiffVersionId = versionIds.active || versionIds.draft;
+  const draftDashboardQuery = useCanvasConsole(
     canvasId,
-    liveCanvasVersionId || undefined,
-    enabled && !!liveCanvasVersionId,
+    draftDiffVersionId || undefined,
+    enabled && !!draftDiffVersionId,
   );
+  const liveDashboardQuery = useCanvasConsole(canvasId, versionIds.live || undefined, enabled && !!versionIds.live);
   const hasDraftConsoleDiffVersusLive = useMemo(
-    () => hasDraftVersusLiveConsoleDiff(liveDashboardQuery.data, dashboardQuery.data),
-    [liveDashboardQuery.data, dashboardQuery.data],
+    () => !!draftDiffVersionId && hasDraftVersusLiveConsoleDiff(liveDashboardQuery.data, draftDashboardQuery.data),
+    [draftDiffVersionId, liveDashboardQuery.data, draftDashboardQuery.data],
   );
   const hasDraftDiffVersusLive = hasDraftGraphDiffVersusLive || hasDraftConsoleDiffVersusLive;
-  const updateDashboardMutation = useUpdateCanvasConsole(canvasId, activeCanvasVersionId || undefined, {
+  const draftChangeIndicators = getDraftChangeIndicators({
+    suppressUnpublishedDraftDiscard,
+    hasLatestDraftVersion: !!versionIds.draft,
+    hasDraftGraphDiffVersusLive,
+    hasDraftConsoleDiffVersusLive,
+    hasDraftDiffVersusLive,
+  });
+  const updateDashboardMutation = useUpdateCanvasConsole(canvasId, versionIds.active || undefined, {
     registerIgnoredCanvasVersionUpdatedEcho,
   });
 
   return {
     dashboardQuery,
     updateDashboardMutation,
+    draftChangeIndicators,
     hasDraftDiffVersusLive,
   };
 }

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -1,7 +1,7 @@
 import type { CanvasToolSidebarState } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
 import { useParams } from "react-router-dom";
-import { CanvasModeToggle } from "./components/CanvasModeToggle";
+import { CanvasModeToggle, type CanvasMode } from "./components/CanvasModeToggle";
 import { CanvasProjectSwitcher } from "./components/CanvasProjectSwitcher";
 import { CanvasToolSidebarTrigger } from "./components/CanvasToolSidebarTrigger";
 import { SecondaryHeaderActions, EditModeTopHeaderActions, LiveModeTopHeaderActions } from "./HeaderSecondaryActions";
@@ -55,6 +55,10 @@ export interface HeaderProps {
   publishVersionLabel?: string;
   /** When true, shows the Discard control next to Publish in version edit mode (draft differs from live). */
   hasUnpublishedDraftChanges?: boolean;
+  /** Draft indicator for the Canvas tab when workflow graph changes exist. */
+  hasUnpublishedCanvasDraftChanges?: boolean;
+  /** Draft indicator for the Console tab when console changes exist. */
+  hasUnpublishedConsoleDraftChanges?: boolean;
   /** ISO timestamp of the existing unpublished draft, used to label "Last edited X" in the Edit dropdown. */
   unpublishedDraftUpdatedAt?: string;
   /** Discard the existing draft and start a new edit session from live. Shown in the Edit dropdown when a draft exists. */
@@ -168,23 +172,8 @@ function PageHeader({
 }
 
 function SecondaryHeader(props: HeaderProps) {
-  const showCanvasViewModeToggle =
-    (!!props.onSelectDashboard || !!props.onSelectMemory || !!props.onSelectFiles) &&
-    (props.mode === "version-live" ||
-      props.mode === "runs" ||
-      props.mode === "dashboard" ||
-      props.mode === "memory" ||
-      props.mode === "files");
-  const canvasViewMode =
-    props.mode === "runs"
-      ? "runs"
-      : props.mode === "dashboard"
-        ? "dashboard"
-        : props.mode === "memory"
-          ? "memory"
-          : props.mode === "files"
-            ? "files"
-            : "version-live";
+  const showCanvasViewModeToggle = shouldShowCanvasViewModeToggle(props);
+  const canvasViewMode = getCanvasViewMode(props.mode);
   const editing = props.isEditing ?? props.mode === "version-edit";
 
   return (
@@ -201,7 +190,8 @@ function SecondaryHeader(props: HeaderProps) {
               onSelectMemory={props.onSelectMemory}
               onSelectFiles={props.onSelectFiles}
               editing={editing}
-              hasDraft={!!props.hasUnpublishedDraftChanges}
+              hasDraft={props.hasUnpublishedCanvasDraftChanges ?? !!props.hasUnpublishedDraftChanges}
+              hasDashboardDraft={!!props.hasUnpublishedConsoleDraftChanges}
             />
           ) : null}
         </div>
@@ -210,4 +200,24 @@ function SecondaryHeader(props: HeaderProps) {
       <SecondaryHeaderActions {...props} />
     </div>
   );
+}
+
+function shouldShowCanvasViewModeToggle(props: HeaderProps): boolean {
+  if (!props.onSelectDashboard && !props.onSelectMemory && !props.onSelectFiles) {
+    return false;
+  }
+
+  return isCanvasViewMode(props.mode);
+}
+
+function isCanvasViewMode(mode: HeaderMode | undefined): boolean {
+  return mode === "version-live" || mode === "runs" || mode === "dashboard" || mode === "memory" || mode === "files";
+}
+
+function getCanvasViewMode(mode: HeaderMode | undefined): CanvasMode {
+  if (mode === "runs" || mode === "dashboard" || mode === "memory" || mode === "files") {
+    return mode;
+  }
+
+  return "version-live";
 }

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -51,6 +51,15 @@ describe("CanvasModeToggle", () => {
     expect(screen.queryByRole("tab", { name: "Memory" })).not.toBeInTheDocument();
   });
 
+  it("shows a draft indicator on the Console tab when the console draft is dirty", () => {
+    render(
+      <CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectDashboard={vi.fn()} hasDashboardDraft />,
+    );
+
+    expect(screen.getByTestId("canvas-view-mode-dashboard-draft-dot")).toBeInTheDocument();
+    expect(screen.queryByTestId("canvas-view-mode-live-draft-dot")).not.toBeInTheDocument();
+  });
+
   it("invokes onSelectFiles when clicking the Files tab", async () => {
     const user = userEvent.setup();
     const onSelectFiles = vi.fn();

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -2,7 +2,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { useEffect, useRef } from "react";
 
-type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard" | "memory" | "files";
+export type CanvasMode = "version-live" | "version-edit" | "runs" | "dashboard" | "memory" | "files";
 
 interface CanvasModeToggleProps {
   mode: CanvasMode;
@@ -12,6 +12,7 @@ interface CanvasModeToggleProps {
   onSelectFiles?: () => void;
   editing?: boolean;
   hasDraft?: boolean;
+  hasDashboardDraft?: boolean;
 }
 
 const CANVAS_TAB = "canvas";
@@ -28,6 +29,7 @@ export function CanvasModeToggle({
   onSelectFiles,
   editing = false,
   hasDraft = false,
+  hasDashboardDraft = false,
 }: CanvasModeToggleProps) {
   const showDashboard = Boolean(onSelectDashboard);
   const showMemory = Boolean(onSelectMemory);
@@ -104,7 +106,10 @@ export function CanvasModeToggle({
       >
         {showDashboard ? (
           <TabsTrigger value={DASHBOARD_TAB} data-testid="canvas-view-mode-dashboard" aria-label="Console">
-            Console
+            <span className="inline-flex items-center gap-1.5">
+              Console
+              <DraftDot show={hasDashboardDraft} testId="canvas-view-mode-dashboard-draft-dot" />
+            </span>
           </TabsTrigger>
         ) : null}
         <TabsTrigger
@@ -114,13 +119,7 @@ export function CanvasModeToggle({
         >
           <span className="inline-flex items-center gap-1.5">
             Canvas
-            {hasDraft ? (
-              <span
-                className="inline-flex size-1.5 shrink-0 rounded-full bg-slate-400"
-                aria-hidden="true"
-                data-testid="canvas-view-mode-live-draft-dot"
-              />
-            ) : null}
+            <DraftDot show={hasDraft} testId="canvas-view-mode-live-draft-dot" />
           </span>
         </TabsTrigger>
         {showMemory ? (
@@ -135,5 +134,15 @@ export function CanvasModeToggle({
         ) : null}
       </TabsList>
     </Tabs>
+  );
+}
+
+function DraftDot({ show, testId }: { show: boolean; testId: string }) {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex size-1.5 shrink-0 rounded-full bg-slate-400" aria-hidden="true" data-testid={testId} />
   );
 }

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -197,6 +197,8 @@ export interface CanvasPageProps {
   onYamlOpen?: () => void;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
+  hasUnpublishedCanvasDraftChanges?: boolean;
+  hasUnpublishedConsoleDraftChanges?: boolean;
   unpublishedDraftUpdatedAt?: string;
   onDiscardDraftAndStartEdit?: () => void;
   isAutoLayoutOnUpdateEnabled?: boolean;
@@ -1287,6 +1289,8 @@ function CanvasPage(props: CanvasPageProps) {
           onSelectFiles={props.onSelectFiles}
           publishVersionLabel={props.publishVersionLabel}
           hasUnpublishedDraftChanges={props.hasUnpublishedDraftChanges}
+          hasUnpublishedCanvasDraftChanges={props.hasUnpublishedCanvasDraftChanges}
+          hasUnpublishedConsoleDraftChanges={props.hasUnpublishedConsoleDraftChanges}
           unpublishedDraftUpdatedAt={props.unpublishedDraftUpdatedAt}
           onDiscardDraftAndStartEdit={props.onDiscardDraftAndStartEdit}
           showCanvasSettingsMenu={props.showCanvasSettingsMenu}
@@ -1806,6 +1810,8 @@ function CanvasContentHeader({
   onSelectFiles,
   publishVersionLabel,
   hasUnpublishedDraftChanges,
+  hasUnpublishedCanvasDraftChanges,
+  hasUnpublishedConsoleDraftChanges,
   unpublishedDraftUpdatedAt,
   onDiscardDraftAndStartEdit,
   showCanvasSettingsMenu,
@@ -1851,6 +1857,8 @@ function CanvasContentHeader({
   onSelectFiles?: () => void;
   publishVersionLabel?: string;
   hasUnpublishedDraftChanges?: boolean;
+  hasUnpublishedCanvasDraftChanges?: boolean;
+  hasUnpublishedConsoleDraftChanges?: boolean;
   unpublishedDraftUpdatedAt?: string;
   onDiscardDraftAndStartEdit?: () => void;
   showCanvasSettingsMenu?: boolean;
@@ -1898,6 +1906,8 @@ function CanvasContentHeader({
       onSelectFiles={onSelectFiles}
       publishVersionLabel={publishVersionLabel}
       hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}
+      hasUnpublishedCanvasDraftChanges={hasUnpublishedCanvasDraftChanges}
+      hasUnpublishedConsoleDraftChanges={hasUnpublishedConsoleDraftChanges}
       unpublishedDraftUpdatedAt={unpublishedDraftUpdatedAt}
       onDiscardDraftAndStartEdit={onDiscardDraftAndStartEdit}
       showCanvasSettingsMenu={showCanvasSettingsMenu}


### PR DESCRIPTION
## Summary
- show the draft dirty indicator on the Console tab when console draft content differs from live
- split canvas and console draft change indicators while preserving the shared unpublished draft state
- add toggle coverage for the Console dirty indicator

## Tests
- make format.js
- make check.lint.ui
- make check.build.ui
- npm run test:run -- src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx