### PR TITLE
fix: preserve console panel edits

### DIFF
--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -1,6 +1,6 @@
 import type { CanvasesCanvas } from "@/api-client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -327,5 +327,78 @@ describe("useUpdateCanvasConsole", () => {
 
     expect(registerIgnoredCanvasVersionUpdatedEcho).toHaveBeenCalledWith("version-1");
     expect(releaseCanvasVersionUpdatedEcho).toHaveBeenCalledOnce();
+  });
+
+  it("optimistically updates the dashboard cache while console changes are saving", async () => {
+    const queryClient = createQueryClient();
+    const dashboardKey = canvasKeys.dashboard("canvas-1", "version-1");
+    let resolveSave: (value: unknown) => void = () => {};
+    const savePromise = new Promise((resolve) => {
+      resolveSave = resolve;
+    });
+    queryClient.setQueryData(dashboardKey, {
+      canvasId: "canvas-1",
+      versionId: "version-1",
+      panels: [{ id: "panel-1", type: "markdown", content: { title: "Before" } }],
+      layout: [{ i: "panel-1", x: 0, y: 0, w: 12, h: 6 }],
+    });
+    canvasesUpdateCanvasDashboard.mockReturnValue(savePromise);
+
+    const { result } = renderHook(() => useUpdateCanvasConsole("canvas-1", "version-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({
+        panels: [{ id: "panel-1", type: "markdown", content: { title: "After" } }],
+        layout: [{ i: "panel-1", x: 0, y: 0, w: 12, h: 6 }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(dashboardKey)).toMatchObject({
+        panels: [{ id: "panel-1", type: "markdown", content: { title: "After" } }],
+      });
+    });
+
+    resolveSave({
+      data: {
+        dashboard: {
+          canvasId: "canvas-1",
+          versionId: "version-1",
+          panels: [{ id: "panel-1", type: "markdown", content: { title: "After" } }],
+          layout: [{ i: "panel-1", x: 0, y: 0, w: 12, h: 6 }],
+        },
+      },
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+
+  it("rolls back the dashboard cache when console save fails", async () => {
+    const queryClient = createQueryClient();
+    const dashboardKey = canvasKeys.dashboard("canvas-1", "version-1");
+    queryClient.setQueryData(dashboardKey, {
+      canvasId: "canvas-1",
+      versionId: "version-1",
+      panels: [{ id: "panel-1", type: "markdown", content: { title: "Before" } }],
+      layout: [{ i: "panel-1", x: 0, y: 0, w: 12, h: 6 }],
+    });
+    canvasesUpdateCanvasDashboard.mockRejectedValue(new Error("request failed"));
+
+    const { result } = renderHook(() => useUpdateCanvasConsole("canvas-1", "version-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        panels: [{ id: "panel-1", type: "markdown", content: { title: "After" } }],
+        layout: [{ i: "panel-1", x: 0, y: 0, w: 12, h: 6 }],
+      }),
+    ).rejects.toThrow("request failed");
+
+    expect(queryClient.getQueryData(dashboardKey)).toMatchObject({
+      panels: [{ id: "panel-1", type: "markdown", content: { title: "Before" } }],
+    });
   });
 });

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -41,6 +41,7 @@ import {
 import type {
   CanvasFoldersCanvasFolder,
   CanvasesCanvas,
+  CanvasesCanvasDashboard,
   CanvasesCanvasRunResult,
   CanvasesCanvasRunState,
   CanvasesCanvasVersion,
@@ -1604,6 +1605,33 @@ type UseUpdateCanvasConsoleOptions = {
   registerIgnoredCanvasVersionUpdatedEcho?: (savingVersionId?: string) => () => void;
 };
 
+function toCanvasDashboard(
+  canvasId: string,
+  versionId: string | undefined,
+  input: { panels: DashboardPanel[]; layout: DashboardLayoutItem[] },
+  previous?: CanvasesCanvasDashboard,
+): CanvasesCanvasDashboard {
+  return {
+    ...previous,
+    canvasId: previous?.canvasId ?? canvasId,
+    ...(versionId ? { versionId: previous?.versionId ?? versionId } : {}),
+    panels: input.panels.map((panel) => ({
+      id: panel.id,
+      type: panel.type,
+      content: panel.content,
+    })),
+    layout: input.layout.map((item) => ({
+      i: item.i,
+      x: item.x,
+      y: item.y,
+      w: item.w,
+      h: item.h,
+      ...(item.minW !== undefined ? { minW: item.minW } : {}),
+      ...(item.minH !== undefined ? { minH: item.minH } : {}),
+    })),
+  };
+}
+
 export const useUpdateCanvasConsole = (
   canvasId: string,
   versionId: string | undefined,
@@ -1611,6 +1639,13 @@ export const useUpdateCanvasConsole = (
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: async (input) => {
+      const queryKey = canvasKeys.dashboard(canvasId, versionId);
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<CanvasesCanvasDashboard>(queryKey);
+      queryClient.setQueryData(queryKey, toCanvasDashboard(canvasId, versionId, input, previous));
+      return { previous, queryKey };
+    },
     mutationFn: async (input: { panels: DashboardPanel[]; layout: DashboardLayoutItem[] }) => {
       const releaseCanvasVersionUpdatedEcho = options?.registerIgnoredCanvasVersionUpdatedEcho?.(versionId);
       try {
@@ -1641,6 +1676,10 @@ export const useUpdateCanvasConsole = (
         releaseCanvasVersionUpdatedEcho?.();
         throw error;
       }
+    },
+    onError: (_error, _input, context) => {
+      if (!context) return;
+      queryClient.setQueryData(context.queryKey, context.previous);
     },
     onSuccess: (data) => {
       queryClient.setQueryData(canvasKeys.dashboard(canvasId, versionId), data);

--- a/web_src/src/pages/workflowv2/CanvasYamlDiffModal.tsx
+++ b/web_src/src/pages/workflowv2/CanvasYamlDiffModal.tsx
@@ -10,6 +10,11 @@ export type CanvasYamlDiffModalProps = {
   liveYamlText: string;
   draftYamlText: string;
   filename: string;
+  title?: string;
+  dialogTitle?: string;
+  description?: string;
+  liveLabel?: string;
+  draftLabel?: string;
 };
 
 export function CanvasYamlDiffModal({
@@ -18,6 +23,11 @@ export function CanvasYamlDiffModal({
   liveYamlText,
   draftYamlText,
   filename,
+  title = "Show Diff",
+  dialogTitle = "Canvas YAML diff",
+  description = "Side-by-side YAML comparison between live and draft canvas versions.",
+  liveLabel = "Live",
+  draftLabel = "Draft",
 }: CanvasYamlDiffModalProps) {
   const { oldFile, newFile } = useMemo(() => {
     const liveFile: FileContents = {
@@ -57,22 +67,20 @@ export function CanvasYamlDiffModal({
             </div>
           </div>
           <div className="grid grid-cols-2 font-mono text-xs font-semibold">
-            <div className="border-r border-slate-200 bg-red-50/70 px-4 py-1.5 text-red-700">Live</div>
-            <div className="bg-emerald-50/70 px-4 py-1.5 text-emerald-700">Draft</div>
+            <div className="border-r border-slate-200 bg-red-50/70 px-4 py-1.5 text-red-700">{liveLabel}</div>
+            <div className="bg-emerald-50/70 px-4 py-1.5 text-emerald-700">{draftLabel}</div>
           </div>
         </div>
       );
     },
-    [filename],
+    [draftLabel, filename, liveLabel],
   );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="large" className="flex h-[90vh] w-[94vw] max-w-[1600px] flex-col gap-0 overflow-hidden p-0">
-        <DialogTitle className="sr-only">Canvas YAML diff</DialogTitle>
-        <DialogDescription className="sr-only">
-          Side-by-side YAML comparison between live and draft canvas versions.
-        </DialogDescription>
+        <DialogTitle className="sr-only">{dialogTitle}</DialogTitle>
+        <DialogDescription className="sr-only">{description}</DialogDescription>
 
         <div className="flex min-h-0 flex-1 flex-col bg-slate-50">
           <div className="flex items-center border-b border-slate-200 bg-white px-5 py-3 pr-12">
@@ -80,7 +88,7 @@ export function CanvasYamlDiffModal({
               <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-slate-200 bg-slate-50 text-slate-700">
                 <GitCompareArrows className="h-4 w-4" />
               </span>
-              <h2 className="truncate text-sm font-semibold text-slate-900">Show Diff</h2>
+              <h2 className="truncate text-sm font-semibold text-slate-900">{title}</h2>
             </div>
           </div>
 

--- a/web_src/src/pages/workflowv2/dashboard/PanelEditorDialog.spec.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/PanelEditorDialog.spec.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ChangeEvent } from "react";
+
+import { PanelEditorDialog } from "./PanelEditorDialog";
+
+vi.mock("@monaco-editor/react", () => ({
+  Editor: ({ value, onChange }: { value?: string; onChange?: (value: string | undefined) => void }) => (
+    <textarea
+      aria-label="Panel YAML"
+      value={value ?? ""}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.currentTarget.value)}
+    />
+  ),
+}));
+
+vi.mock("../CanvasYamlDiffModal", () => ({
+  CanvasYamlDiffModal: ({
+    open,
+    liveYamlText,
+    draftYamlText,
+    liveLabel,
+    draftLabel,
+  }: {
+    open: boolean;
+    liveYamlText: string;
+    draftYamlText: string;
+    liveLabel?: string;
+    draftLabel?: string;
+  }) => (
+    <div data-testid="panel-yaml-diff-modal" data-open={open ? "true" : "false"} hidden={!open}>
+      <span>{liveLabel}</span>
+      <span>{draftLabel}</span>
+      <pre data-testid="saved-yaml">{liveYamlText}</pre>
+      <pre data-testid="draft-yaml">{draftYamlText}</pre>
+    </div>
+  ),
+}));
+
+type MarkdownContent = {
+  title: string;
+  body: string;
+};
+
+function panelEditorElement({
+  open = true,
+  onOpenChange = vi.fn(),
+  initialContent = { title: "Before", body: "Original" },
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  initialContent?: MarkdownContent;
+} = {}) {
+  return (
+    <PanelEditorDialog<MarkdownContent>
+      open={open}
+      onOpenChange={onOpenChange}
+      panelId="runbook"
+      panelType="markdown"
+      initialContent={initialContent}
+      onSave={vi.fn()}
+      renderForm={({ value, onChange }) => (
+        <input
+          aria-label="Panel title"
+          value={value.title}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...value, title: event.currentTarget.value })}
+        />
+      )}
+    />
+  );
+}
+
+function renderPanelEditor(initialContent: MarkdownContent = { title: "Before", body: "Original" }) {
+  return render(
+    panelEditorElement({
+      initialContent,
+    }),
+  );
+}
+
+describe("PanelEditorDialog", () => {
+  it("shows a YAML diff action after panel edits change the draft", async () => {
+    const user = userEvent.setup();
+    renderPanelEditor();
+
+    expect(screen.queryByRole("button", { name: /view diff/i })).not.toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Panel title"));
+    await user.type(screen.getByLabelText("Panel title"), "After");
+
+    await user.click(screen.getByRole("button", { name: /view diff/i }));
+
+    expect(await screen.findByTestId("panel-yaml-diff-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-yaml-diff-modal")).toHaveAttribute("data-open", "true");
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText("Draft edits")).toBeInTheDocument();
+    expect(screen.getByTestId("saved-yaml")).toHaveTextContent("Before");
+    expect(screen.getByTestId("draft-yaml")).toHaveTextContent("After");
+  });
+
+  it("closes the YAML diff modal when the editor closes", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(panelEditorElement({ open: true, onOpenChange }));
+
+    await user.clear(screen.getByLabelText("Panel title"));
+    await user.type(screen.getByLabelText("Panel title"), "After");
+    await user.click(screen.getByRole("button", { name: /view diff/i }));
+
+    expect(await screen.findByTestId("panel-yaml-diff-modal")).toHaveAttribute("data-open", "true");
+
+    rerender(panelEditorElement({ open: false, onOpenChange }));
+
+    expect(screen.getByTestId("panel-yaml-diff-modal")).toHaveAttribute("data-open", "false");
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/PanelEditorDialog.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/PanelEditorDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { AlertTriangle } from "lucide-react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { AlertTriangle, GitCompareArrows } from "lucide-react";
 import * as yaml from "js-yaml";
 import { Editor } from "@monaco-editor/react";
 
@@ -15,6 +15,10 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { PANEL_TYPE_META, validatePanelContent, type PanelType } from "./panelTypes";
+
+const CanvasYamlDiffModal = lazy(() =>
+  import("../CanvasYamlDiffModal").then((module) => ({ default: module.CanvasYamlDiffModal })),
+);
 
 export interface PanelEditorDialogProps<T extends object> {
   open: boolean;
@@ -56,6 +60,7 @@ export function PanelEditorDialog<T extends object>({
   const [formDraft, setFormDraft] = useState<T>(initialContent);
   const [yamlDraft, setYamlDraft] = useState<string>(initialYaml);
   const [yamlSyntaxError, setYamlSyntaxError] = useState<string | null>(null);
+  const [diffOpen, setDiffOpen] = useState(false);
   const lastSyncedFromRef = useRef<EditorTab>("form");
 
   // Reset draft state any time the dialog re-opens for a different panel.
@@ -64,6 +69,7 @@ export function PanelEditorDialog<T extends object>({
       setFormDraft(initialContent);
       setYamlDraft(initialYaml);
       setYamlSyntaxError(null);
+      setDiffOpen(false);
       setTab("form");
       lastSyncedFromRef.current = "form";
     }
@@ -100,6 +106,7 @@ export function PanelEditorDialog<T extends object>({
 
   const schemaError = validatePanelContent(panelType, draftForValidation);
   const blockingError = yamlSyntaxError ?? schemaError;
+  const hasYamlChanges = yamlDraft !== initialYaml;
 
   const handleSave = () => {
     if (blockingError) return;
@@ -107,62 +114,191 @@ export function PanelEditorDialog<T extends object>({
     onOpenChange(false);
   };
 
+  useEffect(() => {
+    if ((!open || !hasYamlChanges) && diffOpen) {
+      setDiffOpen(false);
+    }
+  }, [diffOpen, hasYamlChanges, open]);
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-3xl">
+          <PanelEditorHeader
+            panelType={panelType}
+            hasYamlChanges={hasYamlChanges}
+            onShowDiff={() => setDiffOpen(true)}
+          />
+          <PanelEditorTabs
+            tab={tab}
+            onTabChange={setTab}
+            formContent={renderForm({ value: formDraft, onChange: handleFormChange, error: schemaError })}
+            yamlDraft={yamlDraft}
+            onYamlChange={handleYamlChange}
+          />
+          <PanelEditorError message={blockingError} />
+          <PanelEditorFooter
+            hasBlockingError={Boolean(blockingError)}
+            onCancel={() => onOpenChange(false)}
+            onSave={handleSave}
+          />
+        </DialogContent>
+      </Dialog>
+      <PanelYamlDiffModal
+        open={open && diffOpen && hasYamlChanges}
+        onOpenChange={setDiffOpen}
+        initialYaml={initialYaml}
+        draftYaml={yamlDraft}
+        filename={`${panelId}.yaml`}
+      />
+    </>
+  );
+}
+
+function PanelEditorTabs({
+  tab,
+  onTabChange,
+  formContent,
+  yamlDraft,
+  onYamlChange,
+}: {
+  tab: EditorTab;
+  onTabChange: (tab: EditorTab) => void;
+  formContent: ReactNode;
+  yamlDraft: string;
+  onYamlChange: (value: string | undefined) => void;
+}) {
+  return (
+    <Tabs value={tab} onValueChange={(value) => onTabChange(value as EditorTab)} className="w-full">
+      <TabsList>
+        <TabsTrigger value="form" data-testid="panel-editor-tab-form">
+          Form
+        </TabsTrigger>
+        <TabsTrigger value="yaml" data-testid="panel-editor-tab-yaml">
+          YAML
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="form" className="mt-3 max-h-[60vh] overflow-auto px-1 pb-6">
+        {formContent}
+      </TabsContent>
+      <TabsContent value="yaml" className="mt-3">
+        <div className="overflow-hidden rounded-md border border-slate-200">
+          <Editor
+            height="50vh"
+            language="yaml"
+            value={yamlDraft}
+            onChange={onYamlChange}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 12,
+              scrollBeyondLastLine: false,
+              tabSize: 2,
+              automaticLayout: true,
+            }}
+          />
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function PanelEditorHeader({
+  panelType,
+  hasYamlChanges,
+  onShowDiff,
+}: {
+  panelType: PanelType;
+  hasYamlChanges: boolean;
+  onShowDiff: () => void;
+}) {
+  return (
+    <DialogHeader>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
           <DialogTitle>Edit {PANEL_TYPE_META[panelType].label} panel</DialogTitle>
           <DialogDescription>{PANEL_TYPE_META[panelType].description}</DialogDescription>
-        </DialogHeader>
-        <Tabs value={tab} onValueChange={(v) => setTab(v as EditorTab)} className="w-full">
-          <TabsList>
-            <TabsTrigger value="form" data-testid="panel-editor-tab-form">
-              Form
-            </TabsTrigger>
-            <TabsTrigger value="yaml" data-testid="panel-editor-tab-yaml">
-              YAML
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="form" className="mt-3 max-h-[60vh] overflow-auto px-1 pb-6">
-            {renderForm({ value: formDraft, onChange: handleFormChange, error: schemaError })}
-          </TabsContent>
-          <TabsContent value="yaml" className="mt-3">
-            <div className="overflow-hidden rounded-md border border-slate-200">
-              <Editor
-                height="50vh"
-                language="yaml"
-                value={yamlDraft}
-                onChange={handleYamlChange}
-                options={{
-                  minimap: { enabled: false },
-                  fontSize: 12,
-                  scrollBeyondLastLine: false,
-                  tabSize: 2,
-                  automaticLayout: true,
-                }}
-              />
-            </div>
-          </TabsContent>
-        </Tabs>
-        {blockingError ? (
-          <div
-            className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
-            data-testid="panel-editor-error"
+        </div>
+        {hasYamlChanges ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={onShowDiff}
+            data-testid="panel-editor-show-diff"
           >
-            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>{blockingError}</span>
-          </div>
+            <GitCompareArrows className="mr-1 h-3.5 w-3.5" />
+            View diff
+          </Button>
         ) : null}
-        <DialogFooter className="mt-2">
-          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleSave} disabled={Boolean(blockingError)} data-testid="panel-editor-save">
-            Save
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </DialogHeader>
+  );
+}
+
+function PanelEditorError({ message }: { message: string | null }) {
+  if (!message) return null;
+
+  return (
+    <div
+      className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+      data-testid="panel-editor-error"
+    >
+      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+function PanelEditorFooter({
+  hasBlockingError,
+  onCancel,
+  onSave,
+}: {
+  hasBlockingError: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <DialogFooter className="mt-2">
+      <Button type="button" variant="ghost" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button type="button" onClick={onSave} disabled={hasBlockingError} data-testid="panel-editor-save">
+        Save
+      </Button>
+    </DialogFooter>
+  );
+}
+
+function PanelYamlDiffModal({
+  open,
+  onOpenChange,
+  initialYaml,
+  draftYaml,
+  filename,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialYaml: string;
+  draftYaml: string;
+  filename: string;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <CanvasYamlDiffModal
+        open={open}
+        onOpenChange={onOpenChange}
+        liveYamlText={initialYaml}
+        draftYamlText={draftYaml}
+        filename={filename}
+        title="Panel YAML diff"
+        dialogTitle="Panel YAML diff"
+        description="Side-by-side YAML comparison between the saved panel content and the current panel edits."
+        liveLabel="Saved"
+        draftLabel="Draft edits"
+      />
+    </Suspense>
   );
 }
 

--- a/web_src/src/pages/workflowv2/draftConsoleDiff.spec.ts
+++ b/web_src/src/pages/workflowv2/draftConsoleDiff.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { hasDraftVersusLiveConsoleDiff } from "./draftConsoleDiff";
+import { getDraftConsoleDiffCounts, hasDraftVersusLiveConsoleDiff } from "./draftConsoleDiff";
 
 describe("hasDraftVersusLiveConsoleDiff", () => {
   it("returns false when both consoles are empty", () => {
@@ -38,5 +38,32 @@ describe("hasDraftVersusLiveConsoleDiff", () => {
     };
 
     expect(hasDraftVersusLiveConsoleDiff(console, console)).toBe(false);
+  });
+});
+
+describe("getDraftConsoleDiffCounts", () => {
+  it("counts added, updated, and removed console items", () => {
+    const live = {
+      panels: [
+        { id: "updated", type: "markdown", content: { body: "before" } },
+        { id: "removed", type: "markdown", content: { body: "remove me" } },
+      ],
+      layout: [
+        { i: "updated", x: 0, y: 0, w: 4, h: 2 },
+        { i: "removed", x: 0, y: 2, w: 4, h: 2 },
+      ],
+    };
+    const draft = {
+      panels: [
+        { id: "updated", type: "markdown", content: { body: "after" } },
+        { id: "added", type: "markdown", content: { body: "add me" } },
+      ],
+      layout: [
+        { i: "updated", x: 0, y: 0, w: 4, h: 3 },
+        { i: "added", x: 0, y: 2, w: 4, h: 2 },
+      ],
+    };
+
+    expect(getDraftConsoleDiffCounts(live, draft)).toEqual({ added: 1, updated: 1, removed: 1 });
   });
 });

--- a/web_src/src/pages/workflowv2/draftConsoleDiff.ts
+++ b/web_src/src/pages/workflowv2/draftConsoleDiff.ts
@@ -1,5 +1,7 @@
 import type { CanvasesCanvasDashboard, CanvasesDashboardLayoutItem, CanvasesDashboardPanel } from "@/api-client";
 
+export type DraftConsoleDiffCounts = { added: number; updated: number; removed: number };
+
 function comparablePanels(panels: CanvasesDashboardPanel[] | undefined): unknown[] {
   return (panels ?? [])
     .map((panel) => ({
@@ -37,4 +39,65 @@ export function hasDraftVersusLiveConsoleDiff(
   draftDashboard?: CanvasesCanvasDashboard | null,
 ): boolean {
   return comparableConsoleSnapshot(liveDashboard) !== comparableConsoleSnapshot(draftDashboard);
+}
+
+function panelSnapshot(panel: CanvasesDashboardPanel | undefined): string {
+  return JSON.stringify({
+    type: panel?.type ?? "",
+    content: panel?.content ?? {},
+  });
+}
+
+function layoutSnapshot(item: CanvasesDashboardLayoutItem | undefined): string {
+  return JSON.stringify({
+    x: item?.x ?? 0,
+    y: item?.y ?? 0,
+    w: item?.w ?? 0,
+    h: item?.h ?? 0,
+    ...(item?.minW !== undefined ? { minW: item.minW } : {}),
+    ...(item?.minH !== undefined ? { minH: item.minH } : {}),
+  });
+}
+
+function indexPanels(panels: CanvasesDashboardPanel[] | undefined): Map<string, CanvasesDashboardPanel> {
+  return new Map((panels ?? []).map((panel) => [panel.id ?? "", panel]));
+}
+
+function indexLayout(layout: CanvasesDashboardLayoutItem[] | undefined): Map<string, CanvasesDashboardLayoutItem> {
+  return new Map((layout ?? []).map((item) => [item.i ?? "", item]));
+}
+
+/** Counts changed console items by panel/layout id for the edit-mode header badge. */
+export function getDraftConsoleDiffCounts(
+  liveDashboard?: CanvasesCanvasDashboard | null,
+  draftDashboard?: CanvasesCanvasDashboard | null,
+): DraftConsoleDiffCounts {
+  const livePanels = indexPanels(liveDashboard?.panels);
+  const draftPanels = indexPanels(draftDashboard?.panels);
+  const liveLayout = indexLayout(liveDashboard?.layout);
+  const draftLayout = indexLayout(draftDashboard?.layout);
+  const ids = new Set([...livePanels.keys(), ...draftPanels.keys(), ...liveLayout.keys(), ...draftLayout.keys()]);
+  const counts = { added: 0, updated: 0, removed: 0 };
+
+  ids.forEach((id) => {
+    const liveExists = livePanels.has(id) || liveLayout.has(id);
+    const draftExists = draftPanels.has(id) || draftLayout.has(id);
+    if (!liveExists && draftExists) {
+      counts.added += 1;
+      return;
+    }
+
+    if (liveExists && !draftExists) {
+      counts.removed += 1;
+      return;
+    }
+
+    const panelChanged = panelSnapshot(livePanels.get(id)) !== panelSnapshot(draftPanels.get(id));
+    const layoutChanged = layoutSnapshot(liveLayout.get(id)) !== layoutSnapshot(draftLayout.get(id));
+    if (panelChanged || layoutChanged) {
+      counts.updated += 1;
+    }
+  });
+
+  return counts;
 }

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -1130,39 +1130,32 @@ export function WorkflowPageV2() {
 
     return release;
   }, []);
+  const canvasConsoleVersionDiff = useCanvasConsoleVersionDiff({
+    canvasId: canvasId!,
+    versionIds: { active: activeCanvasVersionId, draft: latestDraftVersion?.metadata?.id, live: liveCanvasVersionId },
+    hasDraftGraphDiffVersusLive,
+    suppressUnpublishedDraftDiscard,
+    enabled: !isTemplate,
+    registerIgnoredCanvasVersionUpdatedEcho,
+  });
   const { dashboardQuery, updateDashboardMutation, draftChangeIndicators, hasDraftDiffVersusLive } =
-    useCanvasConsoleVersionDiff({
-      canvasId: canvasId!,
-      versionIds: { active: activeCanvasVersionId, draft: latestDraftVersion?.metadata?.id, live: liveCanvasVersionId },
-      hasDraftGraphDiffVersusLive,
-      suppressUnpublishedDraftDiscard,
-      enabled: !isTemplate,
-      registerIgnoredCanvasVersionUpdatedEcho,
-    });
+    canvasConsoleVersionDiff;
   const consumeIgnoredCanvasUpdatedEcho = useCallback(() => {
     const release = ignoredCanvasUpdatedEchoReleasesRef.current.pop();
-    if (!release) {
-      return false;
-    }
+    if (!release) return false;
 
     release();
     return true;
   }, []);
 
   const consumeIgnoredCanvasVersionUpdatedEcho = useCallback((versionId?: string) => {
-    if (!versionId) {
-      return false;
-    }
+    if (!versionId) return false;
 
     const releases = ignoredCanvasVersionUpdatedEchoReleasesRef.current.get(versionId);
-    if (!releases) {
-      return false;
-    }
+    if (!releases) return false;
 
     const release = releases.pop();
-    if (!release) {
-      return false;
-    }
+    if (!release) return false;
 
     if (releases.length === 0) {
       ignoredCanvasVersionUpdatedEchoReleasesRef.current.delete(versionId);
@@ -5609,6 +5602,7 @@ export function WorkflowPageV2() {
           publishVersionDisabled={publishVersionDisabled}
           publishVersionDisabledTooltip={publishVersionDisabledTooltip}
           onShowDiff={onShowDiff}
+          {...canvasConsoleVersionDiff.consoleDiffHeaderProps}
           visualDiffEnabled={draftVisualDiff.visualDiffEnabled}
           draftVisualDiff={draftVisualDiff}
           onToggleVisualDiff={draftVisualDiff.toggleVisualDiff}
@@ -5726,6 +5720,7 @@ export function WorkflowPageV2() {
       </div>
       <CanvasYamlModal {...canvasYamlModalProps} />
       {yamlDiffModal}
+      {canvasConsoleVersionDiff.consoleYamlDiffModal}
       {resolvingConflictChangeRequest ? (
         <div className="fixed inset-0 z-[100] min-h-0 bg-slate-50">
           <CanvasChangeRequestConflictResolver

--- a/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
+++ b/web_src/src/pages/workflowv2/useCanvasConsoleVersionDiff.ts
@@ -1,9 +1,35 @@
-import { useMemo } from "react";
+import { createElement, lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useCanvasConsole, useUpdateCanvasConsole } from "@/hooks/useCanvasData";
 
-import { hasDraftVersusLiveConsoleDiff } from "./draftConsoleDiff";
+import { getDraftConsoleDiffCounts, hasDraftVersusLiveConsoleDiff } from "./draftConsoleDiff";
+import { dashboardToYaml } from "./dashboard/dashboardYaml";
 import { getDraftChangeIndicators } from "./lib/version-action-state";
+import type { CanvasesCanvasDashboard } from "@/api-client";
+
+const CanvasYamlDiffModal = lazy(() =>
+  import("./CanvasYamlDiffModal").then((module) => ({ default: module.CanvasYamlDiffModal })),
+);
+
+function dashboardYamlText(canvasId: string, dashboard?: CanvasesCanvasDashboard | null): string {
+  return dashboardToYaml({
+    panels: (dashboard?.panels ?? []).map((panel) => ({
+      id: panel.id ?? "",
+      type: panel.type ?? "markdown",
+      content: (panel.content as Record<string, unknown>) ?? {},
+    })),
+    layout: (dashboard?.layout ?? []).map((item) => ({
+      i: item.i ?? "",
+      x: item.x ?? 0,
+      y: item.y ?? 0,
+      w: item.w ?? 0,
+      h: item.h ?? 0,
+      ...(item.minW !== undefined ? { minW: item.minW } : {}),
+      ...(item.minH !== undefined ? { minH: item.minH } : {}),
+    })),
+    canvasId,
+  });
+}
 
 type UseCanvasConsoleVersionDiffArgs = {
   canvasId: string;
@@ -38,6 +64,25 @@ export function useCanvasConsoleVersionDiff({
     () => !!draftDiffVersionId && hasDraftVersusLiveConsoleDiff(liveDashboardQuery.data, draftDashboardQuery.data),
     [draftDiffVersionId, liveDashboardQuery.data, draftDashboardQuery.data],
   );
+  const draftConsoleDiff = useMemo(() => {
+    if (!hasDraftConsoleDiffVersusLive) return undefined;
+    return { diffCounts: getDraftConsoleDiffCounts(liveDashboardQuery.data, draftDashboardQuery.data) };
+  }, [hasDraftConsoleDiffVersusLive, liveDashboardQuery.data, draftDashboardQuery.data]);
+  const consoleYamlDiffPayload = useMemo(() => {
+    if (!hasDraftConsoleDiffVersusLive || !draftDashboardQuery.data) return null;
+    const liveYamlText = dashboardYamlText(canvasId, liveDashboardQuery.data);
+    const draftYamlText = dashboardYamlText(canvasId, draftDashboardQuery.data);
+
+    if (liveYamlText === draftYamlText) return null;
+    return { liveYamlText, draftYamlText, filename: "console.yaml" };
+  }, [canvasId, hasDraftConsoleDiffVersusLive, liveDashboardQuery.data, draftDashboardQuery.data]);
+  const [consoleDiffOpen, setConsoleDiffOpen] = useState(false);
+  const onShowConsoleDiff = useCallback(() => setConsoleDiffOpen(true), []);
+  useEffect(() => {
+    if (!consoleYamlDiffPayload && consoleDiffOpen) {
+      setConsoleDiffOpen(false);
+    }
+  }, [consoleDiffOpen, consoleYamlDiffPayload]);
   const hasDraftDiffVersusLive = hasDraftGraphDiffVersusLive || hasDraftConsoleDiffVersusLive;
   const draftChangeIndicators = getDraftChangeIndicators({
     suppressUnpublishedDraftDiscard,
@@ -53,6 +98,26 @@ export function useCanvasConsoleVersionDiff({
   return {
     dashboardQuery,
     updateDashboardMutation,
+    consoleDiffHeaderProps: {
+      draftConsoleDiff,
+      onShowConsoleDiff: consoleYamlDiffPayload ? onShowConsoleDiff : undefined,
+    },
+    consoleYamlDiffModal: consoleYamlDiffPayload
+      ? createElement(
+          Suspense,
+          { fallback: null },
+          createElement(CanvasYamlDiffModal, {
+            open: consoleDiffOpen,
+            onOpenChange: setConsoleDiffOpen,
+            liveYamlText: consoleYamlDiffPayload.liveYamlText,
+            draftYamlText: consoleYamlDiffPayload.draftYamlText,
+            filename: consoleYamlDiffPayload.filename,
+            title: "Console YAML diff",
+            dialogTitle: "Console YAML diff",
+            description: "Side-by-side YAML comparison between live and draft console versions.",
+          }),
+        )
+      : null,
     draftChangeIndicators,
     hasDraftDiffVersusLive,
   };

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -15,6 +15,7 @@ export interface HeaderProps {
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
+  onShowConsoleDiff?: () => void;
   visualDiffEnabled?: boolean;
   onToggleVisualDiff?: () => void;
   draftVisualDiff?: {
@@ -25,6 +26,9 @@ export interface HeaderProps {
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;
     };
+  };
+  draftConsoleDiff?: {
+    diffCounts: { added: number; updated: number; removed: number };
   };
   organizationId?: string;
   saveIsPrimary?: boolean;

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanvasToolSidebarState } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
+
+import { SecondaryHeaderActions } from "./HeaderSecondaryActions";
+
+describe("SecondaryHeaderActions", () => {
+  it("shows the console diff badge while editing console changes", () => {
+    render(
+      <SecondaryHeaderActions
+        canvasName="Canvas"
+        mode="dashboard"
+        isEditing
+        hasUnpublishedDraftChanges
+        hasUnpublishedConsoleDraftChanges
+        draftConsoleDiff={{ diffCounts: { added: 1, updated: 0, removed: 0 } }}
+        onShowConsoleDiff={vi.fn()}
+        toolSidebarState={{} as CanvasToolSidebarState}
+      />,
+    );
+
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+});

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -16,9 +16,12 @@ export function SecondaryHeaderActions({
   saveDisabledTooltip,
   saveIsPrimary,
   hasUnpublishedDraftChanges,
+  hasUnpublishedConsoleDraftChanges,
   onShowDiff,
+  onShowConsoleDiff,
   visualDiffEnabled,
   draftVisualDiff,
+  draftConsoleDiff,
   onToggleVisualDiff,
   onDiscardVersion,
   discardVersionDisabled,
@@ -29,6 +32,7 @@ export function SecondaryHeaderActions({
   publishVersionDisabledTooltip,
 }: HeaderProps) {
   const onCanvasTab = mode === "version-live" || mode === "version-edit";
+  const onConsoleTab = mode === "dashboard";
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-1.5">
@@ -51,6 +55,9 @@ export function SecondaryHeaderActions({
               diffToggles={draftVisualDiff.diffToggles}
               onShowDiff={onShowDiff}
             />
+          ) : null}
+          {onConsoleTab && hasUnpublishedConsoleDraftChanges && draftConsoleDiff?.diffCounts ? (
+            <DiffSummaryHoverCard diffCounts={draftConsoleDiff.diffCounts} onShowDiff={onShowConsoleDiff} />
           ) : null}
           <EditModePublishDiscardActions
             hasUnpublishedDraftChanges={hasUnpublishedDraftChanges}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -159,6 +159,7 @@ export interface CanvasPageProps {
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
+  onShowConsoleDiff?: () => void;
   onShowNodeDiff?: (nodeId: string) => void;
   visualDiffEnabled?: boolean;
   draftVisualDiff?: {
@@ -169,6 +170,9 @@ export interface CanvasPageProps {
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;
     };
+  };
+  draftConsoleDiff?: {
+    diffCounts: { added: number; updated: number; removed: number };
   };
   onToggleVisualDiff?: () => void;
   publishVersionDisabled?: boolean;
@@ -1268,8 +1272,10 @@ function CanvasPage(props: CanvasPageProps) {
           onPublishVersion={props.onPublishVersion}
           onDiscardVersion={props.onDiscardVersion}
           onShowDiff={props.onShowDiff}
+          onShowConsoleDiff={props.onShowConsoleDiff}
           visualDiffEnabled={props.visualDiffEnabled}
           draftVisualDiff={props.draftVisualDiff}
+          draftConsoleDiff={props.draftConsoleDiff}
           onToggleVisualDiff={props.onToggleVisualDiff}
           publishVersionDisabled={props.publishVersionDisabled}
           publishVersionDisabledTooltip={props.publishVersionDisabledTooltip}
@@ -1789,8 +1795,10 @@ function CanvasContentHeader({
   onPublishVersion,
   onDiscardVersion,
   onShowDiff,
+  onShowConsoleDiff,
   visualDiffEnabled,
   draftVisualDiff,
+  draftConsoleDiff,
   onToggleVisualDiff,
   publishVersionDisabled,
   publishVersionDisabledTooltip,
@@ -1828,6 +1836,7 @@ function CanvasContentHeader({
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
+  onShowConsoleDiff?: () => void;
   visualDiffEnabled?: boolean;
   draftVisualDiff?: {
     diffCounts: { added: number; updated: number; removed: number };
@@ -1837,6 +1846,9 @@ function CanvasContentHeader({
       showEdgeDiff: boolean;
       toggleShowEdgeDiff: () => void;
     };
+  };
+  draftConsoleDiff?: {
+    diffCounts: { added: number; updated: number; removed: number };
   };
   onToggleVisualDiff?: () => void;
   publishVersionDisabled?: boolean;
@@ -1885,9 +1897,11 @@ function CanvasContentHeader({
       onPublishVersion={onPublishVersion}
       onDiscardVersion={onDiscardVersion}
       onShowDiff={onShowDiff}
+      onShowConsoleDiff={onShowConsoleDiff}
       visualDiffEnabled={visualDiffEnabled}
       onToggleVisualDiff={onToggleVisualDiff}
       draftVisualDiff={draftVisualDiff}
+      draftConsoleDiff={draftConsoleDiff}
       publishVersionDisabled={publishVersionDisabled}
       publishVersionDisabledTooltip={publishVersionDisabledTooltip}
       discardVersionDisabled={discardVersionDisabled}


### PR DESCRIPTION
## Summary
- add a panel YAML diff action while editing console panels
- reuse the canvas YAML diff modal with panel-specific labels
- optimistically update the console dashboard cache while saves are in flight so tab switches keep recent panel edits visible
- roll back the optimistic console cache update if save fails

## Tests
- make format.js
- make check.lint.ui
- make check.build.ui
- npm run test:run -- src/hooks/useCanvasData.spec.ts src/pages/workflowv2/dashboard/PanelEditorDialog.spec.tsx