### PR TITLE
feat: input placeholder for manual run parameters

### DIFF
--- a/pkg/triggers/start/start.go
+++ b/pkg/triggers/start/start.go
@@ -173,6 +173,20 @@ func (s *Start) Configuration() []configuration.Field {
 														},
 													},
 												},
+												{
+													Name:      "placeholder",
+													Label:     "Input Placeholder",
+													Togglable: true,
+													Type:      configuration.FieldTypeString,
+													VisibilityConditions: []configuration.VisibilityCondition{
+														{Field: "type", Values: []string{configuration.FieldTypeString, configuration.FieldTypeNumber}},
+													},
+													TypeOptions: &configuration.TypeOptions{
+														String: &configuration.StringTypeOptions{
+															AllowExpressions: &disallowExpressions,
+														},
+													},
+												},
 											},
 										},
 									},

--- a/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/ui/checkbox";
 
-import { parameterDisplayLabel, type StartTemplateParameter } from "./templatePayload";
+import { parameterDisplayLabel, parameterPlaceholder, type StartTemplateParameter } from "./templatePayload";
 
 export function StartRunParameterFields({
   parameters,
@@ -45,6 +45,7 @@ export function StartRunParameterFields({
                 <Input
                   id={id}
                   type={param.type === "number" ? "number" : "text"}
+                  placeholder={parameterPlaceholder(param)}
                   value={String(parameterValues[param.name] ?? "")}
                   onChange={(e) =>
                     onParameterValuesChange((prev) => ({

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
@@ -5,6 +5,7 @@ import {
   initialParameterValue,
   parameterDefaultValue,
   parameterDisplayLabel,
+  parameterPlaceholder,
   payloadForTemplateRun,
   payloadRecordForParameters,
 } from "./templatePayload";
@@ -44,6 +45,19 @@ describe("parameterDisplayLabel", () => {
   it("falls back to name when title is missing or blank", () => {
     expect(parameterDisplayLabel({ name: "msg", type: "string" })).toBe("msg");
     expect(parameterDisplayLabel({ name: "msg", title: "  ", type: "string" })).toBe("msg");
+  });
+});
+
+describe("parameterPlaceholder", () => {
+  it("returns trimmed placeholder when set", () => {
+    expect(parameterPlaceholder({ name: "agent", placeholder: "  Name of the openclaw agent  ", type: "string" })).toBe(
+      "Name of the openclaw agent",
+    );
+  });
+
+  it("returns empty string when placeholder is missing or blank", () => {
+    expect(parameterPlaceholder({ name: "agent", type: "string" })).toBe("");
+    expect(parameterPlaceholder({ name: "agent", placeholder: "  ", type: "string" })).toBe("");
   });
 });
 

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -3,6 +3,7 @@ export type StartTemplateParameterType = "string" | "number" | "boolean";
 export interface StartTemplateParameter {
   name: string;
   title?: string;
+  placeholder?: string;
   type: StartTemplateParameterType;
   defaultString?: unknown;
   defaultNumber?: unknown;
@@ -12,6 +13,11 @@ export interface StartTemplateParameter {
 export function parameterDisplayLabel(param: StartTemplateParameter): string {
   const title = typeof param.title === "string" ? param.title.trim() : "";
   return title || param.name;
+}
+
+export function parameterPlaceholder(param: StartTemplateParameter): string {
+  const placeholder = typeof param.placeholder === "string" ? param.placeholder.trim() : "";
+  return placeholder;
 }
 
 export interface StartTemplate {


### PR DESCRIPTION
Adds optional placeholder text for Manual Run (Start trigger) template parameters, so workflow authors can show hint text in the run dialog when a field is empty (e.g. “Name of the openclaw agent”).

Closes #5040.

- Extend the Start trigger parameter schema with an optional, togglable Input Placeholder field (string and number parameters only)
- Show the configured placeholder in the manual run form via the existing shadcn `Input` component
- Add `parameterPlaceholder()` helper and unit tests for trimming / empty handling
No API, proto, or database changes — placeholder is stored in existing node configuration JSON and is display-only at run time.

### Motivation
Authors can already set a Display Title and default value for run parameters, but empty fields gave no guidance about what to enter. Placeholders improve the manual run UX without affecting payload resolution or hook invocation.