### PR TITLE
feat: add GCP VM power, machine type, and metrics components

### DIFF
--- a/docs/components/GoogleCloud.mdx
+++ b/docs/components/GoogleCloud.mdx
@@ -30,11 +30,14 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="Cloud Functions • Invoke Function" href="#cloud-functions-•-invoke-function" description="Invoke a Google Cloud Function and return the response" />
   <LinkCard title="Compute • Create Virtual Machine" href="#compute-•-create-virtual-machine" description="Create a Google Compute Engine VM. Configure machine type, zone, provisioning model, and more." />
   <LinkCard title="Compute • Delete VM Instance" href="#compute-•-delete-vm-instance" description="Permanently delete a Google Compute Engine VM instance" />
+  <LinkCard title="Compute • Get VM Metrics" href="#compute-•-get-vm-metrics" description="Fetch CPU and network metrics for a Google Compute Engine VM instance" />
+  <LinkCard title="Compute • Manage VM Power" href="#compute-•-manage-vm-power" description="Perform power operations on a Google Compute Engine VM instance" />
   <LinkCard title="Pub/Sub • Create Subscription" href="#pub/sub-•-create-subscription" description="Create a GCP Pub/Sub subscription" />
   <LinkCard title="Pub/Sub • Create Topic" href="#pub/sub-•-create-topic" description="Create a GCP Pub/Sub topic" />
   <LinkCard title="Pub/Sub • Delete Subscription" href="#pub/sub-•-delete-subscription" description="Delete a GCP Pub/Sub subscription" />
   <LinkCard title="Pub/Sub • Delete Topic" href="#pub/sub-•-delete-topic" description="Delete a GCP Pub/Sub topic" />
   <LinkCard title="Pub/Sub • Publish Message" href="#pub/sub-•-publish-message" description="Publish a message to a GCP Pub/Sub topic" />
+  <LinkCard title="Compute • Update VM Machine Type" href="#compute-•-update-vm-machine-type" description="Change the machine type of a Google Compute Engine VM instance" />
 </CardGrid>
 
 ## Instructions
@@ -59,7 +62,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
 - `roles/logging.configWriter` — create logging sinks for event triggers
 - `roles/pubsub.admin` — manage Pub/Sub topics, subscriptions, and IAM policies for event delivery
-- Additional roles depending on which components you use (e.g. `roles/compute.admin` for VM management)
+- Additional roles depending on which components you use (e.g. `roles/compute.admin` for VM management, `roles/monitoring.viewer` to read VM metrics)
 
 <a id="artifact-registry-•-on-artifact-analysis"></a>
 
@@ -830,6 +833,122 @@ Returns information about the deleted instance:
 }
 ```
 
+<a id="compute-•-get-vm-metrics"></a>
+
+## Compute • Get VM Metrics
+
+**Component key:** `gcp.getVMInstanceMetrics`
+
+The Get VM Metrics component retrieves CPU utilization and network throughput metrics for a Compute Engine VM instance from Cloud Monitoring over a specified lookback window.
+
+### Use Cases
+
+- **Performance monitoring**: Sample current resource utilization before scaling decisions
+- **Incident investigation**: Pull recent metrics when responding to an alert
+- **Capacity planning**: Gather trend data to inform right-sizing of infrastructure
+- **Automated scaling**: Use metric outputs to conditionally trigger resize or power operations
+
+### Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node. The selection encodes both the zone and the instance name.
+- **Lookback Period**: How far back to retrieve metrics — 1h, 6h, 24h, 7d, or 14d (required).
+
+### Output
+
+Returns an averaged metrics payload over the lookback window:
+- **instanceId**: The numeric ID of the queried instance
+- **name**, **zone**: Instance identity
+- **start**, **end**: ISO 8601 timestamps of the metrics window
+- **lookbackPeriod**: The selected lookback period
+- **avgCpuUsagePercent**: Average CPU utilization percentage over the window
+- **avgNetworkInboundBytesPerSec**: Average received network throughput in bytes/sec
+- **avgNetworkOutboundBytesPerSec**: Average sent network throughput in bytes/sec
+
+All metric values are rounded to two decimal places.
+
+### Important Notes
+
+- Requires the `roles/monitoring.viewer` IAM role on the integration's service account.
+- Metrics are read from Cloud Monitoring (`compute.googleapis.com` metrics), which are available for all Compute Engine instances by default.
+- Data point resolution varies by window: shorter windows return finer-grained data.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "avgCpuUsagePercent": 23.47,
+    "avgNetworkInboundBytesPerSec": 10485.76,
+    "avgNetworkOutboundBytesPerSec": 8192.33,
+    "end": "2025-02-14T12:00:00Z",
+    "instanceId": "1234567890123456789",
+    "lookbackPeriod": "1h",
+    "name": "my-vm",
+    "start": "2025-02-14T11:00:00Z",
+    "zone": "us-central1-a"
+  },
+  "timestamp": "2025-02-14T12:00:00Z",
+  "type": "gcp.compute.vmInstance.metrics"
+}
+```
+
+<a id="compute-•-manage-vm-power"></a>
+
+## Compute • Manage VM Power
+
+**Component key:** `gcp.manageVMInstancePower`
+
+The Manage VM Power component performs power management operations on a Compute Engine VM instance.
+
+### Use Cases
+
+- **Automated restarts**: Reset instances on a schedule or in response to alerts
+- **Cost optimization**: Stop instances during non-business hours
+- **Maintenance workflows**: Stop instances before updates, start them after completion
+- **Recovery procedures**: Reset instances experiencing issues
+
+### Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the `selfLink` emitted by `gcp.createVM`). The selection encodes both the zone and the instance name.
+- **Operation**: The power operation to perform (required):
+  - **start**: Start a stopped (TERMINATED) instance
+  - **stop**: Stop a running instance
+  - **reset**: Hard reset a running instance (does not perform a clean shutdown)
+  - **suspend**: Suspend a running instance, preserving memory state
+  - **resume**: Resume a suspended instance
+
+### Output
+
+Returns the instance state after the operation completes:
+- **instanceId**, **name**, **zone**, **status**, **selfLink**, **machineType**, **internalIP**, **externalIP**
+- **operation**: The power operation that was performed
+
+### Important Notes
+
+- **reset** is a forced operation and does not perform a clean OS shutdown
+- The component waits for the underlying zone operation to complete before emitting
+- Operations may take several minutes depending on the instance state
+
+### Example Output
+
+```json
+{
+  "data": {
+    "externalIP": "34.1.2.3",
+    "instanceId": "1234567890123456789",
+    "internalIP": "10.0.0.2",
+    "machineType": "e2-medium",
+    "name": "my-vm",
+    "operation": "power_off",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+    "status": "TERMINATED",
+    "zone": "us-central1-a"
+  },
+  "timestamp": "2025-02-14T12:00:00Z",
+  "type": "gcp.compute.vmInstance.power.power_off"
+}
+```
+
 <a id="pub/sub-•-create-subscription"></a>
 
 ## Pub/Sub • Create Subscription
@@ -964,6 +1083,57 @@ The Publish Message component sends a message to a GCP Pub/Sub topic.
   },
   "timestamp": "2025-01-01T00:00:00Z",
   "type": "gcp.pubsub.message.published"
+}
+```
+
+<a id="compute-•-update-vm-machine-type"></a>
+
+## Compute • Update VM Machine Type
+
+**Component key:** `gcp.updateVMInstanceType`
+
+The Update VM Machine Type component changes the machine type (size) of an existing Compute Engine VM instance.
+
+### Use Cases
+
+- **Vertical scaling**: Resize an instance up or down in response to load
+- **Cost optimization**: Move to a smaller machine type during off-peak hours
+- **Right-sizing**: Adjust machine type based on observed utilization
+
+### Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the `selfLink` emitted by `gcp.createVM`). The selection encodes both the zone and the instance name.
+- **Machine Type**: The new machine type name, e.g. `e2-medium` or `n2-standard-4` (required, supports expressions).
+- **Restart after update**: Whether to start the instance again after the machine type is changed. Enabled by default. Compute Engine requires the instance to be stopped to change its machine type, so a running instance is always stopped first.
+
+### Output
+
+Returns the instance state after the update completes:
+- **instanceId**, **name**, **zone**, **status**, **selfLink**, **machineType**, **internalIP**, **externalIP**
+
+### Important Notes
+
+- Changing the machine type requires the instance to be **stopped (TERMINATED)**. A running instance is stopped automatically before the change.
+- If **Restart after update** is enabled, the instance is started again once the new machine type is applied.
+- The new machine type must be available in the instance's zone.
+- The component waits for each underlying zone operation to complete before proceeding.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "externalIP": "34.1.2.3",
+    "instanceId": "1234567890123456789",
+    "internalIP": "10.0.0.2",
+    "machineType": "n2-standard-4",
+    "name": "my-vm",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+    "status": "RUNNING",
+    "zone": "us-central1-a"
+  },
+  "timestamp": "2025-02-14T12:00:00Z",
+  "type": "gcp.compute.vmInstance.machineTypeUpdated"
 }
 ```
 

--- a/pkg/integrations/gcp/compute/delete_vm_instance.go
+++ b/pkg/integrations/gcp/compute/delete_vm_instance.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	gcpcommon "github.com/superplanehq/superplane/pkg/integrations/gcp/common"
 )
 
 type DeleteVMInstance struct{}
@@ -149,71 +148,9 @@ func (d *DeleteVMInstance) Setup(ctx core.SetupContext) error {
 		return errors.New("instance is required")
 	}
 
-	return d.resolveNodeMetadata(ctx, instanceValue)
-}
-
-func (d *DeleteVMInstance) resolveNodeMetadata(ctx core.SetupContext, instanceValue string) error {
-	// Expressions are resolved at execution time. Store the raw value so the UI
-	// can still display something meaningful in the collapsed node.
-	if strings.Contains(instanceValue, "{{") {
-		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: instanceValue,
-		})
-	}
-
-	_, zone, name, err := parseInstancePath(instanceValue)
-	if err != nil {
-		return err
-	}
-
-	// If metadata is already set for the same instance, skip the API call
-	var existing VMInstanceNodeMetadata
-	if decErr := mapstructure.Decode(ctx.Metadata.Get(), &existing); decErr == nil &&
-		existing.InstanceName == name && existing.Zone == zone {
-		return nil
-	}
-
-	// No integration available (e.g. in tests without credentials) — store what we have
-	if ctx.Integration == nil {
-		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: name,
-			Zone:         zone,
-		})
-	}
-
-	client, err := gcpcommon.NewClient(ctx.HTTP, ctx.Integration)
-	if err != nil {
-		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: name,
-			Zone:         zone,
-		})
-	}
-
-	body, err := GetInstance(context.Background(), client, client.ProjectID(), zone, name)
-	if err != nil {
-		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: name,
-			Zone:         zone,
-		})
-	}
-
-	payload, err := InstancePayloadFromGetResponse(body, zone)
-	if err != nil {
-		return ctx.Metadata.Set(VMInstanceNodeMetadata{
-			InstanceName: name,
-			Zone:         zone,
-		})
-	}
-
-	resolvedName, _ := payload["name"].(string)
-	if resolvedName == "" {
-		resolvedName = name
-	}
-
-	return ctx.Metadata.Set(VMInstanceNodeMetadata{
-		InstanceName: resolvedName,
-		Zone:         zone,
-	})
+	// Reuse the shared instance-metadata resolver (see instance_helpers.go),
+	// which the power/update/metrics components also use.
+	return resolveInstanceNodeMetadata(ctx, instanceValue)
 }
 
 func (d *DeleteVMInstance) Execute(ctx core.ExecutionContext) error {

--- a/pkg/integrations/gcp/compute/example.go
+++ b/pkg/integrations/gcp/compute/example.go
@@ -16,6 +16,15 @@ var exampleOutputDeleteVMInstanceBytes []byte
 //go:embed example_data_on_vm_instance.json
 var exampleDataOnVMInstanceBytes []byte
 
+//go:embed example_output_manage_vm_instance_power.json
+var exampleOutputManageVMInstancePowerBytes []byte
+
+//go:embed example_output_update_vm_instance_type.json
+var exampleOutputUpdateVMInstanceTypeBytes []byte
+
+//go:embed example_output_get_vm_instance_metrics.json
+var exampleOutputGetVMInstanceMetricsBytes []byte
+
 var (
 	exampleOutputCreateVMOnce sync.Once
 	exampleOutputCreateVM     map[string]any
@@ -25,6 +34,15 @@ var (
 
 	exampleDataOnVMInstanceOnce sync.Once
 	exampleDataOnVMInstance     map[string]any
+
+	exampleOutputManageVMInstancePowerOnce sync.Once
+	exampleOutputManageVMInstancePower     map[string]any
+
+	exampleOutputUpdateVMInstanceTypeOnce sync.Once
+	exampleOutputUpdateVMInstanceType     map[string]any
+
+	exampleOutputGetVMInstanceMetricsOnce sync.Once
+	exampleOutputGetVMInstanceMetrics     map[string]any
 )
 
 func (c *CreateVM) ExampleOutput() map[string]any {
@@ -37,4 +55,16 @@ func (d *DeleteVMInstance) ExampleOutput() map[string]any {
 
 func (t *OnVMInstance) ExampleData() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleDataOnVMInstanceOnce, exampleDataOnVMInstanceBytes, &exampleDataOnVMInstance)
+}
+
+func (m *ManageVMInstancePower) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputManageVMInstancePowerOnce, exampleOutputManageVMInstancePowerBytes, &exampleOutputManageVMInstancePower)
+}
+
+func (u *UpdateVMInstanceType) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputUpdateVMInstanceTypeOnce, exampleOutputUpdateVMInstanceTypeBytes, &exampleOutputUpdateVMInstanceType)
+}
+
+func (g *GetVMInstanceMetrics) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetVMInstanceMetricsOnce, exampleOutputGetVMInstanceMetricsBytes, &exampleOutputGetVMInstanceMetrics)
 }

--- a/pkg/integrations/gcp/compute/example_output_get_vm_instance_metrics.json
+++ b/pkg/integrations/gcp/compute/example_output_get_vm_instance_metrics.json
@@ -1,0 +1,15 @@
+{
+  "type": "gcp.compute.vmInstance.metrics",
+  "data": {
+    "instanceId": "1234567890123456789",
+    "name": "my-vm",
+    "zone": "us-central1-a",
+    "start": "2025-02-14T11:00:00Z",
+    "end": "2025-02-14T12:00:00Z",
+    "lookbackPeriod": "1h",
+    "avgCpuUsagePercent": 23.47,
+    "avgNetworkInboundBytesPerSec": 10485.76,
+    "avgNetworkOutboundBytesPerSec": 8192.33
+  },
+  "timestamp": "2025-02-14T12:00:00Z"
+}

--- a/pkg/integrations/gcp/compute/example_output_manage_vm_instance_power.json
+++ b/pkg/integrations/gcp/compute/example_output_manage_vm_instance_power.json
@@ -1,0 +1,15 @@
+{
+  "type": "gcp.compute.vmInstance.power.power_off",
+  "data": {
+    "instanceId": "1234567890123456789",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+    "internalIP": "10.0.0.2",
+    "externalIP": "34.1.2.3",
+    "status": "TERMINATED",
+    "zone": "us-central1-a",
+    "name": "my-vm",
+    "machineType": "e2-medium",
+    "operation": "power_off"
+  },
+  "timestamp": "2025-02-14T12:00:00Z"
+}

--- a/pkg/integrations/gcp/compute/example_output_update_vm_instance_type.json
+++ b/pkg/integrations/gcp/compute/example_output_update_vm_instance_type.json
@@ -1,0 +1,14 @@
+{
+  "type": "gcp.compute.vmInstance.machineTypeUpdated",
+  "data": {
+    "instanceId": "1234567890123456789",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/instances/my-vm",
+    "internalIP": "10.0.0.2",
+    "externalIP": "34.1.2.3",
+    "status": "RUNNING",
+    "zone": "us-central1-a",
+    "name": "my-vm",
+    "machineType": "n2-standard-4"
+  },
+  "timestamp": "2025-02-14T12:00:00Z"
+}

--- a/pkg/integrations/gcp/compute/get_vm_instance_metrics.go
+++ b/pkg/integrations/gcp/compute/get_vm_instance_metrics.go
@@ -1,0 +1,337 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const monitoringBaseURL = "https://monitoring.googleapis.com/v3"
+
+type GetVMInstanceMetrics struct{}
+
+type GetVMInstanceMetricsSpec struct {
+	Instance       string `mapstructure:"instance"`
+	LookbackPeriod string `mapstructure:"lookbackPeriod"`
+}
+
+var instanceLookbackOptions = []configuration.FieldOption{
+	{Label: "Last 1 hour", Value: "1h"},
+	{Label: "Last 6 hours", Value: "6h"},
+	{Label: "Last 24 hours", Value: "24h"},
+	{Label: "Last 7 days", Value: "7d"},
+	{Label: "Last 14 days", Value: "14d"},
+}
+
+var instanceLookbackDurations = map[string]time.Duration{
+	"1h":  time.Hour,
+	"6h":  6 * time.Hour,
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+	"14d": 14 * 24 * time.Hour,
+}
+
+func (g *GetVMInstanceMetrics) Name() string {
+	return "gcp.getVMInstanceMetrics"
+}
+
+func (g *GetVMInstanceMetrics) Label() string {
+	return "Compute • Get VM Metrics"
+}
+
+func (g *GetVMInstanceMetrics) Description() string {
+	return "Fetch CPU and network metrics for a Google Compute Engine VM instance"
+}
+
+func (g *GetVMInstanceMetrics) Documentation() string {
+	return `The Get VM Metrics component retrieves CPU utilization and network throughput metrics for a Compute Engine VM instance from Cloud Monitoring over a specified lookback window.
+
+## Use Cases
+
+- **Performance monitoring**: Sample current resource utilization before scaling decisions
+- **Incident investigation**: Pull recent metrics when responding to an alert
+- **Capacity planning**: Gather trend data to inform right-sizing of infrastructure
+- **Automated scaling**: Use metric outputs to conditionally trigger resize or power operations
+
+## Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node. The selection encodes both the zone and the instance name.
+- **Lookback Period**: How far back to retrieve metrics — 1h, 6h, 24h, 7d, or 14d (required).
+
+## Output
+
+Returns an averaged metrics payload over the lookback window:
+- **instanceId**: The numeric ID of the queried instance
+- **name**, **zone**: Instance identity
+- **start**, **end**: ISO 8601 timestamps of the metrics window
+- **lookbackPeriod**: The selected lookback period
+- **avgCpuUsagePercent**: Average CPU utilization percentage over the window
+- **avgNetworkInboundBytesPerSec**: Average received network throughput in bytes/sec
+- **avgNetworkOutboundBytesPerSec**: Average sent network throughput in bytes/sec
+
+All metric values are rounded to two decimal places.
+
+## Important Notes
+
+- Requires the ` + "`roles/monitoring.viewer`" + ` IAM role on the integration's service account.
+- Metrics are read from Cloud Monitoring (` + "`compute.googleapis.com`" + ` metrics), which are available for all Compute Engine instances by default.
+- Data point resolution varies by window: shorter windows return finer-grained data.`
+}
+
+func (g *GetVMInstanceMetrics) Icon() string {
+	return "chart-line"
+}
+
+func (g *GetVMInstanceMetrics) Color() string {
+	return "blue"
+}
+
+func (g *GetVMInstanceMetrics) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetVMInstanceMetrics) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instance",
+			Label:       "VM Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The VM instance to fetch metrics for. Lists every VM in your project across all zones.",
+			Placeholder: "Select instance",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "lookbackPeriod",
+			Label:       "Lookback Period",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Description: "How far back to retrieve metrics data",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: instanceLookbackOptions,
+				},
+			},
+		},
+	}
+}
+
+func (g *GetVMInstanceMetrics) Setup(ctx core.SetupContext) error {
+	spec := GetVMInstanceMetricsSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
+	}
+
+	if spec.LookbackPeriod == "" {
+		return errors.New("lookbackPeriod is required")
+	}
+
+	if _, ok := instanceLookbackDurations[spec.LookbackPeriod]; !ok {
+		return fmt.Errorf("invalid lookbackPeriod %q: must be one of 1h, 6h, 24h, 7d, 14d", spec.LookbackPeriod)
+	}
+
+	return resolveInstanceNodeMetadata(ctx, spec.Instance)
+}
+
+func (g *GetVMInstanceMetrics) Execute(ctx core.ExecutionContext) error {
+	spec := GetVMInstanceMetricsSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to decode configuration: %v", err))
+	}
+
+	duration, ok := instanceLookbackDurations[spec.LookbackPeriod]
+	if !ok {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("invalid lookbackPeriod %q", spec.LookbackPeriod))
+	}
+
+	urlProject, zone, instanceName, err := parseInstancePath(spec.Instance)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", err.Error())
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to create GCP client: %v", err))
+	}
+
+	project := client.ProjectID()
+	if urlProject != "" && urlProject != project {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf(
+			"instance belongs to project %q but this GCP integration is bound to project %q; cross-project operations are not supported",
+			urlProject, project,
+		))
+	}
+
+	callCtx := context.Background()
+
+	// Cloud Monitoring filters by the numeric instance_id, so resolve it first.
+	body, err := GetInstance(callCtx, client, project, zone, instanceName)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to read instance: %v", err))
+	}
+	instancePayload, err := InstancePayloadFromGetResponse(body, zone)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to parse instance: %v", err))
+	}
+	instanceID, _ := instancePayload["instanceId"].(string)
+	if instanceID == "" || instanceID == "0" {
+		return ctx.ExecutionState.Fail("error", "could not resolve numeric instance ID for metrics query")
+	}
+
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-duration)
+
+	cpu, err := queryInstanceMetric(callCtx, client, project, instanceID,
+		"compute.googleapis.com/instance/cpu/utilization", "ALIGN_MEAN", startTime, endTime)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to get CPU metrics: %v", err))
+	}
+
+	inbound, err := queryInstanceMetric(callCtx, client, project, instanceID,
+		"compute.googleapis.com/instance/network/received_bytes_count", "ALIGN_RATE", startTime, endTime)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to get inbound network metrics: %v", err))
+	}
+
+	outbound, err := queryInstanceMetric(callCtx, client, project, instanceID,
+		"compute.googleapis.com/instance/network/sent_bytes_count", "ALIGN_RATE", startTime, endTime)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to get outbound network metrics: %v", err))
+	}
+
+	payload := map[string]any{
+		"instanceId":                    instanceID,
+		"name":                          instancePayload["name"],
+		"zone":                          instancePayload["zone"],
+		"start":                         startTime.Format(time.RFC3339),
+		"end":                           endTime.Format(time.RFC3339),
+		"lookbackPeriod":                spec.LookbackPeriod,
+		"avgCpuUsagePercent":            roundTo2(averageTimeSeries(cpu)*100, 2),
+		"avgNetworkInboundBytesPerSec":  roundTo2(averageTimeSeries(inbound), 2),
+		"avgNetworkOutboundBytesPerSec": roundTo2(averageTimeSeries(outbound), 2),
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gcp.compute.vmInstance.metrics",
+		[]any{payload},
+	)
+}
+
+// timeSeriesResponse models the subset of the Cloud Monitoring timeSeries.list
+// response that we read.
+type timeSeriesResponse struct {
+	TimeSeries []struct {
+		Points []struct {
+			Value struct {
+				DoubleValue *float64 `json:"doubleValue"`
+				Int64Value  *string  `json:"int64Value"`
+			} `json:"value"`
+		} `json:"points"`
+	} `json:"timeSeries"`
+}
+
+// queryInstanceMetric calls Cloud Monitoring timeSeries.list for a single metric
+// type, aligned with the given aligner over the window.
+func queryInstanceMetric(ctx context.Context, client Client, project, instanceID, metricType, aligner string, start, end time.Time) (*timeSeriesResponse, error) {
+	filter := fmt.Sprintf(`metric.type="%s" AND resource.labels.instance_id="%s"`, metricType, instanceID)
+
+	q := url.Values{}
+	q.Set("filter", filter)
+	q.Set("interval.startTime", start.Format(time.RFC3339))
+	q.Set("interval.endTime", end.Format(time.RFC3339))
+	q.Set("aggregation.alignmentPeriod", "60s")
+	q.Set("aggregation.perSeriesAligner", aligner)
+	q.Set("view", "FULL")
+
+	fullURL := fmt.Sprintf("%s/projects/%s/timeSeries?%s", monitoringBaseURL, project, q.Encode())
+
+	body, err := client.GetURL(ctx, fullURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp timeSeriesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse timeSeries response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// averageTimeSeries averages every point across all returned series.
+func averageTimeSeries(resp *timeSeriesResponse) float64 {
+	if resp == nil {
+		return 0
+	}
+
+	var sum float64
+	var count int
+	for _, series := range resp.TimeSeries {
+		for _, point := range series.Points {
+			if point.Value.DoubleValue != nil {
+				sum += *point.Value.DoubleValue
+				count++
+			} else if point.Value.Int64Value != nil {
+				var f float64
+				if _, err := fmt.Sscan(*point.Value.Int64Value, &f); err == nil {
+					sum += f
+					count++
+				}
+			}
+		}
+	}
+
+	if count == 0 {
+		return 0
+	}
+	return sum / float64(count)
+}
+
+func roundTo2(val float64, places int) float64 {
+	p := math.Pow(10, float64(places))
+	return math.Round(val*p) / p
+}
+
+func (g *GetVMInstanceMetrics) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetVMInstanceMetrics) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetVMInstanceMetrics) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (g *GetVMInstanceMetrics) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (g *GetVMInstanceMetrics) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *GetVMInstanceMetrics) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gcp/compute/get_vm_instance_metrics.go
+++ b/pkg/integrations/gcp/compute/get_vm_instance_metrics.go
@@ -225,9 +225,9 @@ func (g *GetVMInstanceMetrics) Execute(ctx core.ExecutionContext) error {
 		"start":                         startTime.Format(time.RFC3339),
 		"end":                           endTime.Format(time.RFC3339),
 		"lookbackPeriod":                spec.LookbackPeriod,
-		"avgCpuUsagePercent":            roundTo2(averageTimeSeries(cpu)*100, 2),
-		"avgNetworkInboundBytesPerSec":  roundTo2(averageTimeSeries(inbound), 2),
-		"avgNetworkOutboundBytesPerSec": roundTo2(averageTimeSeries(outbound), 2),
+		"avgCpuUsagePercent":            roundTo(averageTimeSeries(cpu)*100, 2),
+		"avgNetworkInboundBytesPerSec":  roundTo(averageTimeSeries(inbound), 2),
+		"avgNetworkOutboundBytesPerSec": roundTo(averageTimeSeries(outbound), 2),
 	}
 
 	return ctx.ExecutionState.Emit(
@@ -307,7 +307,7 @@ func averageTimeSeries(resp *timeSeriesResponse) float64 {
 	return sum / float64(count)
 }
 
-func roundTo2(val float64, places int) float64 {
+func roundTo(val float64, places int) float64 {
 	p := math.Pow(10, float64(places))
 	return math.Round(val*p) / p
 }

--- a/pkg/integrations/gcp/compute/get_vm_instance_metrics_test.go
+++ b/pkg/integrations/gcp/compute/get_vm_instance_metrics_test.go
@@ -1,0 +1,104 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func timeSeriesJSON(values ...float64) []byte {
+	points := make([]map[string]any, 0, len(values))
+	for _, v := range values {
+		points = append(points, map[string]any{
+			"value": map[string]any{"doubleValue": v},
+		})
+	}
+	b, _ := json.Marshal(map[string]any{
+		"timeSeries": []map[string]any{{"points": points}},
+	})
+	return b
+}
+
+func Test__GetVMInstanceMetrics__Setup(t *testing.T) {
+	component := &GetVMInstanceMetrics{}
+
+	t.Run("missing instance returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"lookbackPeriod": "1h"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("missing lookbackPeriod returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"instance": "zones/us-central1-a/instances/my-vm"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "lookbackPeriod is required")
+	})
+
+	t.Run("invalid lookbackPeriod returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"instance":       "zones/us-central1-a/instances/my-vm",
+				"lookbackPeriod": "99y",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "invalid lookbackPeriod")
+	})
+}
+
+func Test__GetVMInstanceMetrics__Execute(t *testing.T) {
+	component := &GetVMInstanceMetrics{}
+
+	t.Run("aggregates CPU and network metrics", func(t *testing.T) {
+		mc := &mockInstanceClient{
+			projectID: "my-project",
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				return instanceGetJSON("123", "my-vm", "us-central1-a", "RUNNING", "e2-medium"), nil
+			},
+			getURLFunc: func(ctx context.Context, fullURL string) ([]byte, error) {
+				switch {
+				case strings.Contains(fullURL, "utilization"):
+					return timeSeriesJSON(0.2, 0.3), nil // avg 0.25 -> 25%
+				case strings.Contains(fullURL, "received_bytes_count"):
+					return timeSeriesJSON(1000, 2000), nil // avg 1500
+				case strings.Contains(fullURL, "sent_bytes_count"):
+					return timeSeriesJSON(500, 500), nil // avg 500
+				default:
+					return timeSeriesJSON(), nil
+				}
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":       "zones/us-central1-a/instances/my-vm",
+				"lookbackPeriod": "1h",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.Equal(t, "gcp.compute.vmInstance.metrics", state.Type)
+
+		data := state.Payloads[0].(map[string]any)["data"].(map[string]any)
+		assert.Equal(t, "123", data["instanceId"])
+		assert.Equal(t, 25.0, data["avgCpuUsagePercent"])
+		assert.Equal(t, 1500.0, data["avgNetworkInboundBytesPerSec"])
+		assert.Equal(t, 500.0, data["avgNetworkOutboundBytesPerSec"])
+		assert.Equal(t, "1h", data["lookbackPeriod"])
+	})
+}

--- a/pkg/integrations/gcp/compute/instance_helpers.go
+++ b/pkg/integrations/gcp/compute/instance_helpers.go
@@ -1,0 +1,69 @@
+package compute
+
+import (
+	"context"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+	gcpcommon "github.com/superplanehq/superplane/pkg/integrations/gcp/common"
+)
+
+// resolveInstanceNodeMetadata stores the instance name and zone on the node so
+// the collapsed UI can display something meaningful. It best-effort resolves
+// the canonical instance name via the API, falling back to the parsed values
+// when credentials or the API are unavailable. Components that target an
+// existing VM instance (manage power, update machine type, get metrics) share
+// this behaviour.
+func resolveInstanceNodeMetadata(ctx core.SetupContext, instanceValue string) error {
+	// Expressions are resolved at execution time. Store the raw value so the UI
+	// can still display something meaningful in the collapsed node.
+	if strings.Contains(instanceValue, "{{") {
+		return ctx.Metadata.Set(VMInstanceNodeMetadata{
+			InstanceName: instanceValue,
+		})
+	}
+
+	_, zone, name, err := parseInstancePath(instanceValue)
+	if err != nil {
+		return err
+	}
+
+	// If metadata is already set for the same instance, skip the API call.
+	var existing VMInstanceNodeMetadata
+	if decErr := mapstructure.Decode(ctx.Metadata.Get(), &existing); decErr == nil &&
+		existing.InstanceName == name && existing.Zone == zone {
+		return nil
+	}
+
+	fallback := VMInstanceNodeMetadata{InstanceName: name, Zone: zone}
+
+	if ctx.Integration == nil {
+		return ctx.Metadata.Set(fallback)
+	}
+
+	client, err := gcpcommon.NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return ctx.Metadata.Set(fallback)
+	}
+
+	body, err := GetInstance(context.Background(), client, client.ProjectID(), zone, name)
+	if err != nil {
+		return ctx.Metadata.Set(fallback)
+	}
+
+	payload, err := InstancePayloadFromGetResponse(body, zone)
+	if err != nil {
+		return ctx.Metadata.Set(fallback)
+	}
+
+	resolvedName, _ := payload["name"].(string)
+	if resolvedName == "" {
+		resolvedName = name
+	}
+
+	return ctx.Metadata.Set(VMInstanceNodeMetadata{
+		InstanceName: resolvedName,
+		Zone:         zone,
+	})
+}

--- a/pkg/integrations/gcp/compute/instance_test_helpers_test.go
+++ b/pkg/integrations/gcp/compute/instance_test_helpers_test.go
@@ -1,0 +1,71 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// mockInstanceClient is a shared Client mock for the instance-targeting
+// components (manage power, update machine type, get metrics).
+type mockInstanceClient struct {
+	projectID  string
+	getFunc    func(ctx context.Context, path string) ([]byte, error)
+	postFunc   func(ctx context.Context, path string, body any) ([]byte, error)
+	getURLFunc func(ctx context.Context, fullURL string) ([]byte, error)
+}
+
+func (m *mockInstanceClient) Get(ctx context.Context, path string) ([]byte, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, path)
+	}
+	return nil, fmt.Errorf("Get not implemented")
+}
+
+func (m *mockInstanceClient) Post(ctx context.Context, path string, body any) ([]byte, error) {
+	if m.postFunc != nil {
+		return m.postFunc(ctx, path, body)
+	}
+	return nil, fmt.Errorf("Post not implemented")
+}
+
+func (m *mockInstanceClient) Delete(ctx context.Context, path string) ([]byte, error) {
+	return nil, fmt.Errorf("Delete not implemented")
+}
+
+func (m *mockInstanceClient) GetURL(ctx context.Context, fullURL string) ([]byte, error) {
+	if m.getURLFunc != nil {
+		return m.getURLFunc(ctx, fullURL)
+	}
+	return nil, fmt.Errorf("GetURL not implemented")
+}
+
+func (m *mockInstanceClient) ProjectID() string {
+	return m.projectID
+}
+
+// instanceGetJSON builds an instances.get response body matching instanceGetResp.
+func instanceGetJSON(id, name, zone, status, machineType string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"id":          id,
+		"name":        name,
+		"selfLink":    fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/zones/%s/instances/%s", zone, name),
+		"status":      status,
+		"zone":        fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/zones/%s", zone),
+		"machineType": fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/zones/%s/machineTypes/%s", zone, machineType),
+		"networkInterfaces": []map[string]any{
+			{
+				"networkIP":     "10.0.0.2",
+				"accessConfigs": []map[string]any{{"natIP": "34.1.2.3"}},
+			},
+		},
+	})
+	return b
+}
+
+// isOperationPath reports whether a Get path targets a zone operation rather
+// than an instance.
+func isOperationPath(path string) bool {
+	return strings.Contains(path, "/operations/")
+}

--- a/pkg/integrations/gcp/compute/list_resource_handler.go
+++ b/pkg/integrations/gcp/compute/list_resource_handler.go
@@ -19,6 +19,10 @@ const (
 	ResourceTypeZone          = "zone"
 	ResourceTypeMachineFamily = "machineFamily"
 	ResourceTypeMachineType   = "machineType"
+	// ResourceTypeInstanceMachineType lists machine types in the zone of a
+	// selected instance (value is the instance path zones/<zone>/instances/<name>),
+	// so the new-type picker can derive the zone without a separate zone field.
+	ResourceTypeInstanceMachineType = "instanceMachineType"
 )
 
 type Region struct {
@@ -478,6 +482,22 @@ func ListMachineTypeResources(ctx context.Context, c Client, zone, machineFamily
 		out = append(out, core.IntegrationResource{Type: ResourceTypeMachineType, Name: name, ID: mt.Name})
 	}
 	return out, nil
+}
+
+// ListMachineTypeResourcesForInstance lists every machine type available in the
+// zone of the given instance. instanceValue is the instance path
+// (zones/<zone>/instances/<name>) or a selfLink, from which the zone is parsed.
+func ListMachineTypeResourcesForInstance(ctx context.Context, c Client, instanceValue string) ([]core.IntegrationResource, error) {
+	if strings.TrimSpace(instanceValue) == "" {
+		return []core.IntegrationResource{}, nil
+	}
+	_, zone, _, err := parseInstancePath(instanceValue)
+	if err != nil {
+		// Before an instance is selected the picker has no zone to work with;
+		// return an empty list rather than an error so the UI stays clean.
+		return []core.IntegrationResource{}, nil
+	}
+	return ListMachineTypeResources(ctx, c, zone, "")
 }
 
 // ubuntuLTSFamilyOrder defines sort order for Ubuntu LTS families (modern first).

--- a/pkg/integrations/gcp/compute/list_resource_handler_test.go
+++ b/pkg/integrations/gcp/compute/list_resource_handler_test.go
@@ -80,6 +80,40 @@ func (m *mockOSClient) GetURL(ctx context.Context, fullURL string) ([]byte, erro
 func (m *mockOSClient) ProjectID() string {
 	return m.projectID
 }
+func Test_ListMachineTypeResourcesForInstance(t *testing.T) {
+	t.Run("empty instance returns empty without calling API", func(t *testing.T) {
+		mc := &mockOSClient{projectID: "p1", get: func(ctx context.Context, path string) ([]byte, error) {
+			return nil, errors.New("API should not be called")
+		}}
+		out, err := ListMachineTypeResourcesForInstance(context.Background(), mc, "")
+		assert.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("unparseable instance returns empty without calling API", func(t *testing.T) {
+		mc := &mockOSClient{projectID: "p1", get: func(ctx context.Context, path string) ([]byte, error) {
+			return nil, errors.New("API should not be called")
+		}}
+		out, err := ListMachineTypeResourcesForInstance(context.Background(), mc, "just-a-name")
+		assert.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("valid instance path lists machine types in the parsed zone", func(t *testing.T) {
+		var requestedPath string
+		mc := &mockOSClient{projectID: "lmtfi-proj", get: func(ctx context.Context, path string) ([]byte, error) {
+			requestedPath = path
+			return []byte(`{"items":[{"name":"n2-standard-4","guestCpus":4,"memoryMb":16384}]}`), nil
+		}}
+		out, err := ListMachineTypeResourcesForInstance(context.Background(), mc,
+			"zones/lmtfi-zone-a/instances/my-vm")
+		require.NoError(t, err)
+		assert.Contains(t, requestedPath, "projects/lmtfi-proj/zones/lmtfi-zone-a/machineTypes")
+		require.Len(t, out, 1)
+		assert.Equal(t, "n2-standard-4", out[0].ID)
+	})
+}
+
 func Test_isPublicImageProject(t *testing.T) {
 	assert.True(t, isPublicImageProject("debian-cloud"))
 	assert.True(t, isPublicImageProject("ubuntu-os-cloud"))

--- a/pkg/integrations/gcp/compute/manage_vm_instance_power.go
+++ b/pkg/integrations/gcp/compute/manage_vm_instance_power.go
@@ -1,0 +1,245 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type ManageVMInstancePower struct{}
+
+type ManageVMInstancePowerSpec struct {
+	Instance  string `mapstructure:"instance"`
+	Operation string `mapstructure:"operation"`
+}
+
+// powerOperationEndpoints maps the user-facing operation to the Compute Engine
+// instance sub-resource that performs it. Each call returns a zone operation
+// that we wait on before reading back the instance state.
+var powerOperationEndpoints = map[string]string{
+	"power_on":  "start",
+	"power_off": "stop",
+	"reset":     "reset",
+	"suspend":   "suspend",
+	"resume":    "resume",
+}
+
+func (m *ManageVMInstancePower) Name() string {
+	return "gcp.manageVMInstancePower"
+}
+
+func (m *ManageVMInstancePower) Label() string {
+	return "Compute • Manage VM Power"
+}
+
+func (m *ManageVMInstancePower) Description() string {
+	return "Perform power operations on a Google Compute Engine VM instance"
+}
+
+func (m *ManageVMInstancePower) Documentation() string {
+	return `The Manage VM Power component performs power management operations on a Compute Engine VM instance.
+
+## Use Cases
+
+- **Automated restarts**: Reset instances on a schedule or in response to alerts
+- **Cost optimization**: Stop instances during non-business hours
+- **Maintenance workflows**: Stop instances before updates, start them after completion
+- **Recovery procedures**: Reset instances experiencing issues
+
+## Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the ` + "`selfLink`" + ` emitted by ` + "`gcp.createVM`" + `). The selection encodes both the zone and the instance name.
+- **Operation**: The power operation to perform (required):
+  - **start**: Start a stopped (TERMINATED) instance
+  - **stop**: Stop a running instance
+  - **reset**: Hard reset a running instance (does not perform a clean shutdown)
+  - **suspend**: Suspend a running instance, preserving memory state
+  - **resume**: Resume a suspended instance
+
+## Output
+
+Returns the instance state after the operation completes:
+- **instanceId**, **name**, **zone**, **status**, **selfLink**, **machineType**, **internalIP**, **externalIP**
+- **operation**: The power operation that was performed
+
+## Important Notes
+
+- **reset** is a forced operation and does not perform a clean OS shutdown
+- The component waits for the underlying zone operation to complete before emitting
+- Operations may take several minutes depending on the instance state`
+}
+
+func (m *ManageVMInstancePower) Icon() string {
+	return "power"
+}
+
+func (m *ManageVMInstancePower) Color() string {
+	return "orange"
+}
+
+func (m *ManageVMInstancePower) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (m *ManageVMInstancePower) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instance",
+			Label:       "VM Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The VM instance to manage. Lists every VM in your project across all zones.",
+			Placeholder: "Select instance",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "operation",
+			Label:       "Operation",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Description: "The power operation to perform",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Start", Value: "power_on"},
+						{Label: "Stop", Value: "power_off"},
+						{Label: "Reset (Forced)", Value: "reset"},
+						{Label: "Suspend", Value: "suspend"},
+						{Label: "Resume", Value: "resume"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (m *ManageVMInstancePower) Setup(ctx core.SetupContext) error {
+	spec := ManageVMInstancePowerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
+	}
+
+	if spec.Operation == "" {
+		return errors.New("operation is required")
+	}
+
+	if _, ok := powerOperationEndpoints[spec.Operation]; !ok {
+		return fmt.Errorf("invalid operation %q: must be one of power_on, power_off, reset, suspend, resume", spec.Operation)
+	}
+
+	return resolveInstanceNodeMetadata(ctx, spec.Instance)
+}
+
+func (m *ManageVMInstancePower) Execute(ctx core.ExecutionContext) error {
+	spec := ManageVMInstancePowerSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to decode configuration: %v", err))
+	}
+
+	endpoint, ok := powerOperationEndpoints[spec.Operation]
+	if !ok {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("invalid operation %q", spec.Operation))
+	}
+
+	urlProject, zone, instanceName, err := parseInstancePath(spec.Instance)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", err.Error())
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to create GCP client: %v", err))
+	}
+
+	project := client.ProjectID()
+	if urlProject != "" && urlProject != project {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf(
+			"instance belongs to project %q but this GCP integration is bound to project %q; cross-project operations are not supported",
+			urlProject, project,
+		))
+	}
+
+	callCtx := context.Background()
+	if err := runInstancePowerOperation(callCtx, client, project, zone, instanceName, endpoint); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to %s VM instance: %v", endpoint, err))
+	}
+
+	body, err := GetInstance(callCtx, client, project, zone, instanceName)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to read instance after %s: %v", endpoint, err))
+	}
+
+	payload, err := InstancePayloadFromGetResponse(body, zone)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to parse instance: %v", err))
+	}
+	payload["operation"] = spec.Operation
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		fmt.Sprintf("gcp.compute.vmInstance.power.%s", spec.Operation),
+		[]any{payload},
+	)
+}
+
+// runInstancePowerOperation issues the power sub-resource POST and waits for the
+// resulting zone operation to complete.
+func runInstancePowerOperation(ctx context.Context, client Client, project, zone, instanceName, endpoint string) error {
+	path := fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", project, zone, instanceName, endpoint)
+	body, err := client.Post(ctx, path, nil)
+	if err != nil {
+		return err
+	}
+
+	var opResp struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &opResp); err != nil {
+		return fmt.Errorf("parse power operation response: %w", err)
+	}
+	if opResp.Name == "" {
+		return errors.New("power operation response missing operation name")
+	}
+
+	return WaitForZoneOperation(ctx, client, project, zone, lastSegment(opResp.Name))
+}
+
+func (m *ManageVMInstancePower) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (m *ManageVMInstancePower) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (m *ManageVMInstancePower) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (m *ManageVMInstancePower) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (m *ManageVMInstancePower) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (m *ManageVMInstancePower) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gcp/compute/manage_vm_instance_power_test.go
+++ b/pkg/integrations/gcp/compute/manage_vm_instance_power_test.go
@@ -1,0 +1,148 @@
+package compute
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ManageVMInstancePower__Setup(t *testing.T) {
+	component := &ManageVMInstancePower{}
+
+	t.Run("missing instance returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"operation": "power_on"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("missing operation returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"instance": "zones/us-central1-a/instances/my-vm"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "operation is required")
+	})
+
+	t.Run("invalid operation returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"instance":  "zones/us-central1-a/instances/my-vm",
+				"operation": "explode",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "invalid operation")
+	})
+
+	t.Run("valid config stores parsed metadata", func(t *testing.T) {
+		meta := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"instance":  "zones/us-central1-a/instances/my-vm",
+				"operation": "power_off",
+			},
+			Metadata: meta,
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test__ManageVMInstancePower__Execute(t *testing.T) {
+	component := &ManageVMInstancePower{}
+
+	t.Run("power_off -> stops instance and emits power event", func(t *testing.T) {
+		var postedPath string
+		mc := &mockInstanceClient{
+			projectID: "my-project",
+			postFunc: func(ctx context.Context, path string, body any) ([]byte, error) {
+				postedPath = path
+				return opDone("op-1"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				if isOperationPath(path) {
+					return opDone("op-1"), nil
+				}
+				return instanceGetJSON("123", "my-vm", "us-central1-a", "TERMINATED", "e2-medium"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":  "zones/us-central1-a/instances/my-vm",
+				"operation": "power_off",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.True(t, strings.HasSuffix(postedPath, "/zones/us-central1-a/instances/my-vm/stop"))
+		assert.Equal(t, "gcp.compute.vmInstance.power.power_off", state.Type)
+		require.Len(t, state.Payloads, 1)
+		data := state.Payloads[0].(map[string]any)["data"].(map[string]any)
+		assert.Equal(t, "my-vm", data["name"])
+		assert.Equal(t, "power_off", data["operation"])
+		assert.Equal(t, "TERMINATED", data["status"])
+	})
+
+	t.Run("power_on -> uses start endpoint", func(t *testing.T) {
+		var postedPath string
+		mc := &mockInstanceClient{
+			projectID: "my-project",
+			postFunc: func(ctx context.Context, path string, body any) ([]byte, error) {
+				postedPath = path
+				return opDone("op-2"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				if isOperationPath(path) {
+					return opDone("op-2"), nil
+				}
+				return instanceGetJSON("123", "my-vm", "us-central1-a", "RUNNING", "e2-medium"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":  "zones/us-central1-a/instances/my-vm",
+				"operation": "power_on",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.True(t, strings.HasSuffix(postedPath, "/start"))
+		assert.Equal(t, "gcp.compute.vmInstance.power.power_on", state.Type)
+	})
+
+	t.Run("cross-project selfLink -> fails", func(t *testing.T) {
+		mc := &mockInstanceClient{projectID: "my-project"}
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":  "https://www.googleapis.com/compute/v1/projects/other/zones/us-central1-a/instances/my-vm",
+				"operation": "power_off",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.False(t, state.Passed)
+		assert.Contains(t, state.FailureMessage, "cross-project")
+	})
+}

--- a/pkg/integrations/gcp/compute/update_vm_instance_type.go
+++ b/pkg/integrations/gcp/compute/update_vm_instance_type.go
@@ -1,0 +1,256 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type UpdateVMInstanceType struct{}
+
+type UpdateVMInstanceTypeSpec struct {
+	Instance           string `mapstructure:"instance"`
+	MachineType        string `mapstructure:"machineType"`
+	RestartAfterUpdate *bool  `mapstructure:"restartAfterUpdate"`
+}
+
+func (u *UpdateVMInstanceType) Name() string {
+	return "gcp.updateVMInstanceType"
+}
+
+func (u *UpdateVMInstanceType) Label() string {
+	return "Compute • Update VM Machine Type"
+}
+
+func (u *UpdateVMInstanceType) Description() string {
+	return "Change the machine type of a Google Compute Engine VM instance"
+}
+
+func (u *UpdateVMInstanceType) Documentation() string {
+	return `The Update VM Machine Type component changes the machine type (size) of an existing Compute Engine VM instance.
+
+## Use Cases
+
+- **Vertical scaling**: Resize an instance up or down in response to load
+- **Cost optimization**: Move to a smaller machine type during off-peak hours
+- **Right-sizing**: Adjust machine type based on observed utilization
+
+## Configuration
+
+- **VM Instance**: Pick from the list of VMs in your project, or pass an expression chained from an upstream node (e.g. the ` + "`selfLink`" + ` emitted by ` + "`gcp.createVM`" + `). The selection encodes both the zone and the instance name.
+- **Machine Type**: The new machine type name, e.g. ` + "`e2-medium`" + ` or ` + "`n2-standard-4`" + ` (required, supports expressions).
+- **Restart after update**: Whether to start the instance again after the machine type is changed. Enabled by default. Compute Engine requires the instance to be stopped to change its machine type, so a running instance is always stopped first.
+
+## Output
+
+Returns the instance state after the update completes:
+- **instanceId**, **name**, **zone**, **status**, **selfLink**, **machineType**, **internalIP**, **externalIP**
+
+## Important Notes
+
+- Changing the machine type requires the instance to be **stopped (TERMINATED)**. A running instance is stopped automatically before the change.
+- If **Restart after update** is enabled, the instance is started again once the new machine type is applied.
+- The new machine type must be available in the instance's zone.
+- The component waits for each underlying zone operation to complete before proceeding.`
+}
+
+func (u *UpdateVMInstanceType) Icon() string {
+	return "cpu"
+}
+
+func (u *UpdateVMInstanceType) Color() string {
+	return "blue"
+}
+
+func (u *UpdateVMInstanceType) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (u *UpdateVMInstanceType) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "instance",
+			Label:       "VM Instance",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The VM instance to update. Lists every VM in your project across all zones.",
+			Placeholder: "Select instance",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstance,
+				},
+			},
+		},
+		{
+			Name:        "machineType",
+			Label:       "Machine Type",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "The new machine type, e.g. e2-medium or n2-standard-4.",
+			Placeholder: "e2-medium",
+		},
+		{
+			Name:        "restartAfterUpdate",
+			Label:       "Restart after update",
+			Type:        configuration.FieldTypeBool,
+			Required:    false,
+			Default:     true,
+			Description: "Start the instance again after changing the machine type.",
+		},
+	}
+}
+
+func (u *UpdateVMInstanceType) Setup(ctx core.SetupContext) error {
+	spec := UpdateVMInstanceTypeSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if strings.TrimSpace(spec.Instance) == "" {
+		return errors.New("instance is required")
+	}
+
+	if strings.TrimSpace(spec.MachineType) == "" {
+		return errors.New("machineType is required")
+	}
+
+	return resolveInstanceNodeMetadata(ctx, spec.Instance)
+}
+
+func (u *UpdateVMInstanceType) Execute(ctx core.ExecutionContext) error {
+	spec := UpdateVMInstanceTypeSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to decode configuration: %v", err))
+	}
+
+	machineType := strings.TrimSpace(spec.MachineType)
+	if machineType == "" {
+		return ctx.ExecutionState.Fail("error", "machineType is required")
+	}
+
+	urlProject, zone, instanceName, err := parseInstancePath(spec.Instance)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", err.Error())
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to create GCP client: %v", err))
+	}
+
+	project := client.ProjectID()
+	if urlProject != "" && urlProject != project {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf(
+			"instance belongs to project %q but this GCP integration is bound to project %q; cross-project operations are not supported",
+			urlProject, project,
+		))
+	}
+
+	// setMachineType expects a zone-qualified machine type path. Accept either a
+	// bare name (e.g. e2-medium) or a full path, mirroring gcp.createVM.
+	if !strings.Contains(machineType, "/") {
+		machineType = fmt.Sprintf("zones/%s/machineTypes/%s", zone, machineType)
+	}
+
+	callCtx := context.Background()
+
+	body, err := GetInstance(callCtx, client, project, zone, instanceName)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to read instance: %v", err))
+	}
+
+	var current struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &current); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to parse instance: %v", err))
+	}
+
+	// Compute Engine only allows changing the machine type while the instance is
+	// stopped. Stop it first when it is not already TERMINATED.
+	if current.Status != "TERMINATED" {
+		if err := runInstancePowerOperation(callCtx, client, project, zone, instanceName, "stop"); err != nil {
+			return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to stop instance before update: %v", err))
+		}
+	}
+
+	if err := setMachineType(callCtx, client, project, zone, instanceName, machineType); err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to update machine type: %v", err))
+	}
+
+	restart := spec.RestartAfterUpdate == nil || *spec.RestartAfterUpdate
+	if restart {
+		if err := runInstancePowerOperation(callCtx, client, project, zone, instanceName, "start"); err != nil {
+			return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to start instance after update: %v", err))
+		}
+	}
+
+	updated, err := GetInstance(callCtx, client, project, zone, instanceName)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to read instance after update: %v", err))
+	}
+
+	payload, err := InstancePayloadFromGetResponse(updated, zone)
+	if err != nil {
+		return ctx.ExecutionState.Fail("error", fmt.Sprintf("failed to parse updated instance: %v", err))
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"gcp.compute.vmInstance.machineTypeUpdated",
+		[]any{payload},
+	)
+}
+
+// setMachineType issues the setMachineType POST and waits for the zone operation.
+func setMachineType(ctx context.Context, client Client, project, zone, instanceName, machineType string) error {
+	path := fmt.Sprintf("projects/%s/zones/%s/instances/%s/setMachineType", project, zone, instanceName)
+	body, err := client.Post(ctx, path, map[string]any{"machineType": machineType})
+	if err != nil {
+		return err
+	}
+
+	var opResp struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &opResp); err != nil {
+		return fmt.Errorf("parse setMachineType operation response: %w", err)
+	}
+	if opResp.Name == "" {
+		return errors.New("setMachineType operation response missing operation name")
+	}
+
+	return WaitForZoneOperation(ctx, client, project, zone, lastSegment(opResp.Name))
+}
+
+func (u *UpdateVMInstanceType) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (u *UpdateVMInstanceType) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (u *UpdateVMInstanceType) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (u *UpdateVMInstanceType) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (u *UpdateVMInstanceType) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (u *UpdateVMInstanceType) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/gcp/compute/update_vm_instance_type.go
+++ b/pkg/integrations/gcp/compute/update_vm_instance_type.go
@@ -92,10 +92,18 @@ func (u *UpdateVMInstanceType) Configuration() []configuration.Field {
 		{
 			Name:        "machineType",
 			Label:       "Machine Type",
-			Type:        configuration.FieldTypeString,
+			Type:        configuration.FieldTypeIntegrationResource,
 			Required:    true,
-			Description: "The new machine type, e.g. e2-medium or n2-standard-4.",
-			Placeholder: "e2-medium",
+			Description: "The new machine type to resize the instance to. Lists machine types available in the instance's zone.",
+			Placeholder: "Select machine type",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type: ResourceTypeInstanceMachineType,
+					Parameters: []configuration.ParameterRef{
+						{Name: "instance", ValueFrom: &configuration.ParameterValueFrom{Field: "instance"}},
+					},
+				},
+			},
 		},
 		{
 			Name:        "restartAfterUpdate",

--- a/pkg/integrations/gcp/compute/update_vm_instance_type_test.go
+++ b/pkg/integrations/gcp/compute/update_vm_instance_type_test.go
@@ -1,0 +1,123 @@
+package compute
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateVMInstanceType__Setup(t *testing.T) {
+	component := &UpdateVMInstanceType{}
+
+	t.Run("missing instance returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"machineType": "e2-medium"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "instance is required")
+	})
+
+	t.Run("missing machineType returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{"instance": "zones/us-central1-a/instances/my-vm"},
+			Metadata:      &contexts.MetadataContext{},
+		})
+		require.ErrorContains(t, err, "machineType is required")
+	})
+}
+
+func Test__UpdateVMInstanceType__Execute(t *testing.T) {
+	component := &UpdateVMInstanceType{}
+
+	t.Run("running instance -> stops, sets type, restarts, emits", func(t *testing.T) {
+		var postedPaths []string
+		var setMachineTypeBody map[string]any
+		getCalls := 0
+		mc := &mockInstanceClient{
+			projectID: "my-project",
+			postFunc: func(ctx context.Context, path string, body any) ([]byte, error) {
+				postedPaths = append(postedPaths, path)
+				if strings.HasSuffix(path, "/setMachineType") {
+					setMachineTypeBody, _ = body.(map[string]any)
+				}
+				return opDone("op-1"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				if isOperationPath(path) {
+					return opDone("op-1"), nil
+				}
+				getCalls++
+				// First read: RUNNING (forces a stop). Final read: new type.
+				if getCalls == 1 {
+					return instanceGetJSON("123", "my-vm", "us-central1-a", "RUNNING", "e2-medium"), nil
+				}
+				return instanceGetJSON("123", "my-vm", "us-central1-a", "RUNNING", "n2-standard-4"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":    "zones/us-central1-a/instances/my-vm",
+				"machineType": "n2-standard-4",
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		assert.Equal(t, "gcp.compute.vmInstance.machineTypeUpdated", state.Type)
+
+		// stop, setMachineType, start (in order)
+		require.Len(t, postedPaths, 3)
+		assert.True(t, strings.HasSuffix(postedPaths[0], "/stop"))
+		assert.True(t, strings.HasSuffix(postedPaths[1], "/setMachineType"))
+		assert.True(t, strings.HasSuffix(postedPaths[2], "/start"))
+		assert.Equal(t, "zones/us-central1-a/machineTypes/n2-standard-4", setMachineTypeBody["machineType"])
+
+		data := state.Payloads[0].(map[string]any)["data"].(map[string]any)
+		assert.Equal(t, "n2-standard-4", data["machineType"])
+	})
+
+	t.Run("already stopped + no restart -> skips stop and start", func(t *testing.T) {
+		var postedPaths []string
+		restart := false
+		mc := &mockInstanceClient{
+			projectID: "my-project",
+			postFunc: func(ctx context.Context, path string, body any) ([]byte, error) {
+				postedPaths = append(postedPaths, path)
+				return opDone("op-1"), nil
+			},
+			getFunc: func(ctx context.Context, path string) ([]byte, error) {
+				if isOperationPath(path) {
+					return opDone("op-1"), nil
+				}
+				return instanceGetJSON("123", "my-vm", "us-central1-a", "TERMINATED", "n2-standard-4"), nil
+			},
+		}
+
+		SetClientFactory(func(ctx core.ExecutionContext) (Client, error) { return mc, nil })
+
+		state := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"instance":           "zones/us-central1-a/instances/my-vm",
+				"machineType":        "n2-standard-4",
+				"restartAfterUpdate": restart,
+			},
+			ExecutionState: state,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, state.Passed)
+		require.Len(t, postedPaths, 1)
+		assert.True(t, strings.HasSuffix(postedPaths[0], "/setMachineType"))
+	})
+}

--- a/pkg/integrations/gcp/gcp.go
+++ b/pkg/integrations/gcp/gcp.go
@@ -919,6 +919,8 @@ func (g *GCP) ListResources(resourceType string, ctx core.ListResourcesContext) 
 		return compute.ListMachineFamilyResources(reqCtx, client, p["zone"])
 	case compute.ResourceTypeMachineType:
 		return compute.ListMachineTypeResources(reqCtx, client, p["zone"], p["machineFamily"])
+	case compute.ResourceTypeInstanceMachineType:
+		return compute.ListMachineTypeResourcesForInstance(reqCtx, client, p["instance"])
 	case compute.ResourceTypePublicImages:
 		return compute.ListPublicImageResources(reqCtx, client, p["project"])
 	case compute.ResourceTypeCustomImages:

--- a/pkg/integrations/gcp/gcp.go
+++ b/pkg/integrations/gcp/gcp.go
@@ -102,7 +102,7 @@ func (g *GCP) Instructions() string {
 
 - ` + "`roles/logging.configWriter`" + ` — create logging sinks for event triggers
 - ` + "`roles/pubsub.admin`" + ` — manage Pub/Sub topics, subscriptions, and IAM policies for event delivery
-- Additional roles depending on which components you use (e.g. ` + "`roles/compute.admin`" + ` for VM management)`
+- Additional roles depending on which components you use (e.g. ` + "`roles/compute.admin`" + ` for VM management, ` + "`roles/monitoring.viewer`" + ` to read VM metrics)`
 }
 
 func (g *GCP) Configuration() []configuration.Field {
@@ -163,6 +163,9 @@ func (g *GCP) Actions() []core.Action {
 	return []core.Action{
 		&compute.CreateVM{},
 		&compute.DeleteVMInstance{},
+		&compute.ManageVMInstancePower{},
+		&compute.UpdateVMInstanceType{},
+		&compute.GetVMInstanceMetrics{},
 		&cloudbuild.CreateBuild{},
 		&cloudbuild.GetBuild{},
 		&cloudbuild.RunTrigger{},

--- a/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/delete_vm_instance.ts
@@ -1,11 +1,10 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -13,6 +12,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import gcpIcon from "@/assets/icons/integrations/gcp.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./event_helpers";
 
 interface VMInstanceNodeMetadata {
   instanceName?: string;
@@ -100,32 +100,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootEvent = execution.rootEvent;
-  if (!rootEvent?.nodeId) {
-    return [];
-  }
-
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) {
-    return [];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
-  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
-  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
-  const eventSubtitle = subtitle || fallbackSubtitle;
-
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle,
-      eventState: getState(componentName)(execution),
-      eventId: rootEvent.id!,
-    },
-  ];
 }

--- a/web_src/src/pages/workflowv2/mappers/gcp/event_helpers.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/event_helpers.ts
@@ -1,0 +1,40 @@
+import type { EventSection } from "@/ui/componentBase";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { getState, getTriggerRenderer } from "..";
+import type { ExecutionInfo, NodeInfo } from "../types";
+
+// baseEventSections builds the single event section shown on an action node from
+// its most recent execution, deriving the title/subtitle from the root trigger.
+// Pass eventStateOverride when a component resolves a custom event state (e.g.
+// per-operation power states); otherwise the default action state is used.
+export function baseEventSections(
+  nodes: NodeInfo[],
+  execution: ExecutionInfo,
+  componentName: string,
+  eventStateOverride?: string,
+): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.nodeId) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: subtitle || fallbackSubtitle,
+      eventState: eventStateOverride ?? getState(componentName)(execution),
+      eventId: rootEvent.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getVMInstanceMetricsMapper, GET_VM_INSTANCE_METRICS_STATE_REGISTRY } from "./get_vm_instance_metrics";
+import { buildDetailsCtx, buildExecution, buildOutput } from "./vm_mapper_test_helpers";
+
+const metricsData = (overrides?: Record<string, unknown>) => ({
+  instanceId: "123",
+  name: "my-vm",
+  zone: "us-central1-a",
+  lookbackPeriod: "1h",
+  avgCpuUsagePercent: 23.47,
+  avgNetworkInboundBytesPerSec: 10485.76,
+  avgNetworkOutboundBytesPerSec: 8192.33,
+  ...overrides,
+});
+
+describe("getVMInstanceMetricsMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getVMInstanceMetricsMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns only Executed At when output data is missing", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    const details = getVMInstanceMetricsMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Avg CPU"]).toBeUndefined();
+  });
+
+  it("formats the metric values and resolves the lookback label", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput(metricsData())] } } });
+    const details = getVMInstanceMetricsMapper.getExecutionDetails(ctx);
+    expect(details["Instance Name"]).toBe("my-vm");
+    expect(details["Lookback"]).toBe("Last 1 hour");
+    expect(details["Avg CPU"]).toBe("23.47%");
+    expect(details["Avg Inbound"]).toBe("10485.76 B/s");
+    expect(details["Avg Outbound"]).toBe("8192.33 B/s");
+  });
+
+  it("renders zero metric values rather than omitting them", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(metricsData({ avgCpuUsagePercent: 0 }))] } },
+    });
+    const details = getVMInstanceMetricsMapper.getExecutionDetails(ctx);
+    expect(details["Avg CPU"]).toBe("0%");
+  });
+});
+
+describe("GET_VM_INSTANCE_METRICS_STATE_REGISTRY", () => {
+  it("maps a successful execution to the FETCHED state", () => {
+    const execution = buildExecution({ outputs: { default: [buildOutput(metricsData())] } });
+    expect(GET_VM_INSTANCE_METRICS_STATE_REGISTRY.getState(execution)).toBe("fetched");
+  });
+
+  it("labels the fetched state as FETCHED", () => {
+    expect(GET_VM_INSTANCE_METRICS_STATE_REGISTRY.stateMap["fetched"].label).toBe("FETCHED");
+  });
+
+  it("propagates non-success states", () => {
+    const execution = buildExecution({
+      result: "RESULT_FAILED",
+      resultReason: "RESULT_REASON_ERROR",
+      resultMessage: "boom",
+    });
+    expect(GET_VM_INSTANCE_METRICS_STATE_REGISTRY.getState(execution)).not.toBe("fetched");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.ts
@@ -1,9 +1,11 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
 import type React from "react";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
+  EventStateRegistry,
   ExecutionDetailsContext,
   ExecutionInfo,
   NodeInfo,
@@ -13,6 +15,23 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import gcpIcon from "@/assets/icons/integrations/gcp.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./event_helpers";
+import { defaultStateFunction } from "../stateRegistry";
+
+// A successful metrics fetch shows a "FETCHED" badge rather than the generic
+// "COMPLETED" used by mutating actions.
+const FETCHED_STATE = "fetched";
+
+export const GET_VM_INSTANCE_METRICS_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: {
+    ...DEFAULT_EVENT_STATE_MAP,
+    [FETCHED_STATE]: { ...DEFAULT_EVENT_STATE_MAP.success, label: "FETCHED" },
+  },
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    return state === "success" ? FETCHED_STATE : state;
+  },
+};
 
 interface VMInstanceNodeMetadata {
   instanceName?: string;
@@ -109,31 +128,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootEvent = execution.rootEvent;
-  if (!rootEvent?.nodeId) {
-    return [];
-  }
-
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) {
-    return [];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
-  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
-  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
-
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: subtitle || fallbackSubtitle,
-      eventState: getState(componentName)(execution),
-      eventId: rootEvent.id!,
-    },
-  ];
 }

--- a/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/get_vm_instance_metrics.ts
@@ -1,0 +1,139 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import gcpIcon from "@/assets/icons/integrations/gcp.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface VMInstanceNodeMetadata {
+  instanceName?: string;
+  zone?: string;
+}
+
+interface GetVMInstanceMetricsConfiguration {
+  instance?: string;
+  lookbackPeriod?: string;
+}
+
+interface GetVMInstanceMetricsOutputData {
+  name?: string;
+  zone?: string;
+  lookbackPeriod?: string;
+  avgCpuUsagePercent?: number;
+  avgNetworkInboundBytesPerSec?: number;
+  avgNetworkOutboundBytesPerSec?: number;
+}
+
+const lookbackLabels: Record<string, string> = {
+  "1h": "Last 1 hour",
+  "6h": "Last 6 hours",
+  "24h": "Last 24 hours",
+  "7d": "Last 7 days",
+  "14d": "Last 14 days",
+};
+
+export const getVMInstanceMetricsMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "gcp";
+
+    return {
+      iconSrc: gcpIcon,
+      iconSlug: context.componentDefinition?.icon ?? "chart-line",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition?.label || "Get VM Metrics",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as GetVMInstanceMetricsOutputData | undefined;
+    if (!result) return details;
+
+    if (result.name) details["Instance Name"] = result.name;
+    if (result.lookbackPeriod) details["Lookback"] = lookbackLabels[result.lookbackPeriod] || result.lookbackPeriod;
+    if (result.avgCpuUsagePercent !== undefined) details["Avg CPU"] = `${result.avgCpuUsagePercent}%`;
+    if (result.avgNetworkInboundBytesPerSec !== undefined) {
+      details["Avg Inbound"] = `${result.avgNetworkInboundBytesPerSec} B/s`;
+    }
+    if (result.avgNetworkOutboundBytesPerSec !== undefined) {
+      details["Avg Outbound"] = `${result.avgNetworkOutboundBytesPerSec} B/s`;
+    }
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as VMInstanceNodeMetadata | undefined;
+  const configuration = node.configuration as GetVMInstanceMetricsConfiguration | undefined;
+
+  const instanceName = nodeMetadata?.instanceName || configuration?.instance;
+  if (instanceName) {
+    metadata.push({ icon: "server", label: instanceName });
+  }
+  if (nodeMetadata?.zone) {
+    metadata.push({ icon: "map-pin", label: nodeMetadata.zone });
+  }
+  if (configuration?.lookbackPeriod) {
+    metadata.push({
+      icon: "clock",
+      label: lookbackLabels[configuration.lookbackPeriod] || configuration.lookbackPeriod,
+    });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.nodeId) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: subtitle || fallbackSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/gcp/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/index.ts
@@ -22,7 +22,7 @@ import { cloudDNSMapper } from "./clouddns";
 import { deleteVMInstanceMapper } from "./delete_vm_instance";
 import { manageVMInstancePowerMapper, MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY } from "./manage_vm_instance_power";
 import { updateVMInstanceTypeMapper } from "./update_vm_instance_type";
-import { getVMInstanceMetricsMapper } from "./get_vm_instance_metrics";
+import { getVMInstanceMetricsMapper, GET_VM_INSTANCE_METRICS_STATE_REGISTRY } from "./get_vm_instance_metrics";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createVM: baseMapper,
@@ -59,7 +59,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   deleteVMInstance: buildActionStateRegistry("completed"),
   manageVMInstancePower: MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY,
   updateVMInstanceType: buildActionStateRegistry("completed"),
-  getVMInstanceMetrics: buildActionStateRegistry("completed"),
+  getVMInstanceMetrics: GET_VM_INSTANCE_METRICS_STATE_REGISTRY,
   "cloudbuild.createBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.getBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.runTrigger": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,

--- a/web_src/src/pages/workflowv2/mappers/gcp/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/index.ts
@@ -20,10 +20,16 @@ import {
 import { onMessageTriggerRenderer } from "./on_message";
 import { cloudDNSMapper } from "./clouddns";
 import { deleteVMInstanceMapper } from "./delete_vm_instance";
+import { manageVMInstancePowerMapper, MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY } from "./manage_vm_instance_power";
+import { updateVMInstanceTypeMapper } from "./update_vm_instance_type";
+import { getVMInstanceMetricsMapper } from "./get_vm_instance_metrics";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   createVM: baseMapper,
   deleteVMInstance: deleteVMInstanceMapper,
+  manageVMInstancePower: manageVMInstancePowerMapper,
+  updateVMInstanceType: updateVMInstanceTypeMapper,
+  getVMInstanceMetrics: getVMInstanceMetricsMapper,
   "cloudbuild.createBuild": cloudBuildBaseMapper,
   "cloudbuild.getBuild": cloudBuildBaseMapper,
   "cloudbuild.runTrigger": runTriggerMapper,
@@ -51,6 +57,9 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
 export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createVM: buildActionStateRegistry("completed"),
   deleteVMInstance: buildActionStateRegistry("completed"),
+  manageVMInstancePower: MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY,
+  updateVMInstanceType: buildActionStateRegistry("completed"),
+  getVMInstanceMetrics: buildActionStateRegistry("completed"),
   "cloudbuild.createBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.getBuild": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,
   "cloudbuild.runTrigger": CLOUD_BUILD_EXECUTION_STATE_REGISTRY,

--- a/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  manageVMInstancePowerMapper,
+  MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY,
+  powerStateMap,
+} from "./manage_vm_instance_power";
+import { buildDetailsCtx, buildExecution, buildOutput } from "./vm_mapper_test_helpers";
+
+const powerOutput = (operation: string) =>
+  buildOutput(
+    {
+      name: "my-vm",
+      zone: "us-central1-a",
+      status: "TERMINATED",
+      instanceId: "123",
+      operation,
+    },
+    `gcp.compute.vmInstance.power.${operation}`,
+  );
+
+describe("manageVMInstancePowerMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => manageVMInstancePowerMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns Executed At with no instance fields when output data is missing", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    const details = manageVMInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Instance Name"]).toBeUndefined();
+  });
+
+  it("extracts instance fields and maps the operation label", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [powerOutput("power_off")] } } });
+    const details = manageVMInstancePowerMapper.getExecutionDetails(ctx);
+    expect(details["Instance Name"]).toBe("my-vm");
+    expect(details["Zone"]).toBe("us-central1-a");
+    expect(details["Operation"]).toBe("Stop");
+    expect(details["Status"]).toBe("TERMINATED");
+  });
+});
+
+describe("MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY.getState", () => {
+  it("returns the per-operation power state on success", () => {
+    const execution = buildExecution({ outputs: { default: [powerOutput("power_on")] } });
+    expect(MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("gcp.compute.vmInstance.power.power_on");
+  });
+
+  it("falls back to success when there is no power event", () => {
+    const execution = buildExecution({ outputs: { default: [] } });
+    expect(MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).toBe("success");
+  });
+
+  it("propagates non-success states (e.g. failure)", () => {
+    const execution = buildExecution({
+      result: "RESULT_FAILED",
+      resultReason: "RESULT_REASON_ERROR",
+      resultMessage: "boom",
+      outputs: { default: [] },
+    });
+    expect(MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY.getState(execution)).not.toBe(
+      "gcp.compute.vmInstance.power.power_on",
+    );
+  });
+
+  it("defines labelled state-map entries for every operation", () => {
+    expect(powerStateMap["gcp.compute.vmInstance.power.power_on"].label).toBe("STARTED");
+    expect(powerStateMap["gcp.compute.vmInstance.power.power_off"].label).toBe("STOPPED");
+    expect(powerStateMap["gcp.compute.vmInstance.power.reset"].label).toBe("RESET");
+    expect(powerStateMap["gcp.compute.vmInstance.power.suspend"].label).toBe("SUSPENDED");
+    expect(powerStateMap["gcp.compute.vmInstance.power.resume"].label).toBe("RESUMED");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.ts
@@ -1,7 +1,6 @@
 import type { ComponentBaseProps, EventSection, EventStateMap } from "@/ui/componentBase";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
 import type React from "react";
-import { getState, getTriggerRenderer } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
@@ -16,6 +15,7 @@ import type { MetadataItem } from "@/ui/metadataList";
 import gcpIcon from "@/assets/icons/integrations/gcp.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
 import { defaultStateFunction } from "../stateRegistry";
+import { baseEventSections } from "./event_helpers";
 
 interface VMInstanceNodeMetadata {
   instanceName?: string;
@@ -111,7 +111,7 @@ export const manageVMInstancePowerMapper: ComponentBaseMapper = {
       collapsedBackground: "bg-white",
       collapsed: context.node.isCollapsed,
       title: context.node.name || context.componentDefinition?.label || "Manage VM Power",
-      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      eventSections: lastExecution ? powerEventSections(context.nodes, lastExecution, componentName) : undefined,
       metadata: metadataList(context.node),
       includeEmptyState: !lastExecution,
       eventStateMap: powerStateMap,
@@ -163,34 +163,12 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   return metadata;
 }
 
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootEvent = execution.rootEvent;
-  if (!rootEvent?.nodeId) {
-    return [];
-  }
-
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) {
-    return [];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
-  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
-  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
-
+// powerEventSections resolves the per-operation power state (when present) and
+// delegates the rest of the section construction to the shared helper.
+function powerEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
   const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
   const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(POWER_EVENT_PREFIX));
-  const eventState =
-    powerEvent?.type && powerStateMap[powerEvent.type] ? powerEvent.type : getState(componentName)(execution);
+  const override = powerEvent?.type && powerStateMap[powerEvent.type] ? powerEvent.type : undefined;
 
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: subtitle || fallbackSubtitle,
-      eventState,
-      eventId: rootEvent.id!,
-    },
-  ];
+  return baseEventSections(nodes, execution, componentName, override);
 }

--- a/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/manage_vm_instance_power.ts
@@ -1,0 +1,196 @@
+import type { ComponentBaseProps, EventSection, EventStateMap } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  EventStateRegistry,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import gcpIcon from "@/assets/icons/integrations/gcp.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { defaultStateFunction } from "../stateRegistry";
+
+interface VMInstanceNodeMetadata {
+  instanceName?: string;
+  zone?: string;
+}
+
+interface ManageVMInstancePowerConfiguration {
+  instance?: string;
+  operation?: string;
+}
+
+interface ManageVMInstancePowerOutputData {
+  name?: string;
+  zone?: string;
+  status?: string;
+  instanceId?: string;
+  operation?: string;
+}
+
+const POWER_EVENT_PREFIX = "gcp.compute.vmInstance.power.";
+
+export const powerStateMap: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  "gcp.compute.vmInstance.power.power_on": {
+    icon: "power",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "STARTED",
+  },
+  "gcp.compute.vmInstance.power.power_off": {
+    icon: "power-off",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-gray-100",
+    badgeColor: "bg-gray-500",
+    label: "STOPPED",
+  },
+  "gcp.compute.vmInstance.power.reset": {
+    icon: "rotate-cw",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "RESET",
+  },
+  "gcp.compute.vmInstance.power.suspend": {
+    icon: "pause",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-gray-100",
+    badgeColor: "bg-gray-500",
+    label: "SUSPENDED",
+  },
+  "gcp.compute.vmInstance.power.resume": {
+    icon: "play",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "RESUMED",
+  },
+};
+
+const operationLabels: Record<string, string> = {
+  power_on: "Start",
+  power_off: "Stop",
+  reset: "Reset",
+  suspend: "Suspend",
+  resume: "Resume",
+};
+
+export const MANAGE_VM_INSTANCE_POWER_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: powerStateMap,
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    if (state !== "success") return state;
+
+    const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+    const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(POWER_EVENT_PREFIX));
+    if (powerEvent?.type && powerStateMap[powerEvent.type]) {
+      return powerEvent.type;
+    }
+
+    return "success";
+  },
+};
+
+export const manageVMInstancePowerMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "gcp";
+
+    return {
+      iconSrc: gcpIcon,
+      iconSlug: context.componentDefinition?.icon ?? "power",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition?.label || "Manage VM Power",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: powerStateMap,
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as ManageVMInstancePowerOutputData | undefined;
+    if (!result) return details;
+
+    if (result.name) details["Instance Name"] = result.name;
+    if (result.zone) details["Zone"] = result.zone;
+    if (result.operation) details["Operation"] = operationLabels[result.operation] || result.operation;
+    if (result.status) details["Status"] = result.status;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as VMInstanceNodeMetadata | undefined;
+  const configuration = node.configuration as ManageVMInstancePowerConfiguration | undefined;
+
+  const instanceName = nodeMetadata?.instanceName || configuration?.instance;
+  if (instanceName) {
+    metadata.push({ icon: "server", label: instanceName });
+  }
+  if (nodeMetadata?.zone) {
+    metadata.push({ icon: "map-pin", label: nodeMetadata.zone });
+  }
+  if (configuration?.operation) {
+    const label = operationLabels[configuration.operation] || configuration.operation;
+    metadata.push({ icon: "zap", label: `Operation: ${label}` });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.nodeId) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+  const powerEvent = outputs?.default?.find((output) => output.type?.startsWith(POWER_EVENT_PREFIX));
+  const eventState =
+    powerEvent?.type && powerStateMap[powerEvent.type] ? powerEvent.type : getState(componentName)(execution);
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: subtitle || fallbackSubtitle,
+      eventState,
+      eventId: rootEvent.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { updateVMInstanceTypeMapper } from "./update_vm_instance_type";
+import { buildDetailsCtx, buildOutput } from "./vm_mapper_test_helpers";
+
+describe("updateVMInstanceTypeMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => updateVMInstanceTypeMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns only Executed At when output data is missing", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    const details = updateVMInstanceTypeMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Machine Type"]).toBeUndefined();
+  });
+
+  it("extracts the updated instance fields", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [
+            buildOutput({
+              name: "my-vm",
+              zone: "us-central1-a",
+              status: "RUNNING",
+              machineType: "n2-standard-4",
+            }),
+          ],
+        },
+      },
+    });
+    const details = updateVMInstanceTypeMapper.getExecutionDetails(ctx);
+    expect(details["Instance Name"]).toBe("my-vm");
+    expect(details["Zone"]).toBe("us-central1-a");
+    expect(details["Machine Type"]).toBe("n2-standard-4");
+    expect(details["Status"]).toBe("RUNNING");
+  });
+});

--- a/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.ts
@@ -1,0 +1,121 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import gcpIcon from "@/assets/icons/integrations/gcp.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+
+interface VMInstanceNodeMetadata {
+  instanceName?: string;
+  zone?: string;
+}
+
+interface UpdateVMInstanceTypeConfiguration {
+  instance?: string;
+  machineType?: string;
+}
+
+interface UpdateVMInstanceTypeOutputData {
+  name?: string;
+  zone?: string;
+  status?: string;
+  machineType?: string;
+}
+
+export const updateVMInstanceTypeMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "gcp";
+
+    return {
+      iconSrc: gcpIcon,
+      iconSlug: context.componentDefinition?.icon ?? "cpu",
+      collapsedBackground: "bg-white",
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition?.label || "Update VM Machine Type",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as UpdateVMInstanceTypeOutputData | undefined;
+    if (!result) return details;
+
+    if (result.name) details["Instance Name"] = result.name;
+    if (result.zone) details["Zone"] = result.zone;
+    if (result.machineType) details["Machine Type"] = result.machineType;
+    if (result.status) details["Status"] = result.status;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    const timestamp = context.execution.updatedAt || context.execution.createdAt;
+    return timestamp ? renderTimeAgo(new Date(timestamp)) : "";
+  },
+};
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as VMInstanceNodeMetadata | undefined;
+  const configuration = node.configuration as UpdateVMInstanceTypeConfiguration | undefined;
+
+  const instanceName = nodeMetadata?.instanceName || configuration?.instance;
+  if (instanceName) {
+    metadata.push({ icon: "server", label: instanceName });
+  }
+  if (nodeMetadata?.zone) {
+    metadata.push({ icon: "map-pin", label: nodeMetadata.zone });
+  }
+  if (configuration?.machineType) {
+    metadata.push({ icon: "cpu", label: configuration.machineType });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.nodeId) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
+  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt!),
+      eventTitle: title,
+      eventSubtitle: subtitle || fallbackSubtitle,
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id!,
+    },
+  ];
+}

--- a/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/update_vm_instance_type.ts
@@ -1,11 +1,10 @@
-import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type { ComponentBaseProps } from "@/ui/componentBase";
 import type React from "react";
-import { getState, getStateMap, getTriggerRenderer } from "..";
+import { getStateMap } from "..";
 import type {
   ComponentBaseContext,
   ComponentBaseMapper,
   ExecutionDetailsContext,
-  ExecutionInfo,
   NodeInfo,
   OutputPayload,
   SubtitleContext,
@@ -13,6 +12,7 @@ import type {
 import type { MetadataItem } from "@/ui/metadataList";
 import gcpIcon from "@/assets/icons/integrations/gcp.svg";
 import { renderTimeAgo } from "@/components/TimeAgo";
+import { baseEventSections } from "./event_helpers";
 
 interface VMInstanceNodeMetadata {
   instanceName?: string;
@@ -91,31 +91,4 @@ function metadataList(node: NodeInfo): MetadataItem[] {
   }
 
   return metadata;
-}
-
-function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
-  const rootEvent = execution.rootEvent;
-  if (!rootEvent?.nodeId) {
-    return [];
-  }
-
-  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
-  if (!rootTriggerNode?.componentName) {
-    return [];
-  }
-
-  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
-  const { title, subtitle } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
-  const subtitleTimestamp = execution.updatedAt || execution.createdAt;
-  const fallbackSubtitle = subtitleTimestamp ? renderTimeAgo(new Date(subtitleTimestamp)) : "";
-
-  return [
-    {
-      receivedAt: new Date(execution.createdAt!),
-      eventTitle: title,
-      eventSubtitle: subtitle || fallbackSubtitle,
-      eventState: getState(componentName)(execution),
-      eventId: rootEvent.id!,
-    },
-  ];
 }

--- a/web_src/src/pages/workflowv2/mappers/gcp/vm_mapper_test_helpers.ts
+++ b/web_src/src/pages/workflowv2/mappers/gcp/vm_mapper_test_helpers.ts
@@ -1,0 +1,45 @@
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo, OutputPayload } from "../types";
+
+export function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Test VM Node",
+    componentName: "gcp.manageVMInstancePower",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+export function buildOutput(data: unknown, type = "gcp.result"): OutputPayload {
+  return {
+    type,
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+export function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+export function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}


### PR DESCRIPTION
### Summary

This adds gcp instance management components:

- gcp.manageVMInstancePower
- gcp.updateVMInstanceType
- gcp.getVMInstanceMetrics

### Demo

[Screencast from 2026-05-29 13-48-12.webm](https://github.com/user-attachments/assets/f7fd015c-98be-4950-8c3d-e61ee6fcf25b)
