### PR TITLE
fix: continue Anthropic streams after session errors

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -331,7 +331,7 @@ func TestStreamEvents_ToolInputFallsBackToJSON(t *testing.T) {
 }
 
 func TestStreamEvents_SessionFailed(t *testing.T) {
-	const sse = "data: {\"type\":\"session.error\",\"error\":{\"message\":\"boom\"}}\n\n"
+	const sse = "data: {\"type\":\"session.status_terminated\",\"error\":{\"message\":\"boom\"}}\n\n"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -348,6 +348,30 @@ func TestStreamEvents_SessionFailed(t *testing.T) {
 	require.Len(t, received, 1)
 	assert.Equal(t, agents.ProviderEventSessionFailed, received[0].Type)
 	assert.Equal(t, "boom", received[0].ErrorMessage)
+}
+
+func TestStreamEvents_SessionErrorDoesNotStopStream(t *testing.T) {
+	const sse = "data: {\"type\":\"session.error\",\"error\":{\"message\":\"An internal service error occurred\"}}\n\n" +
+		"data: {\"id\":\"e1\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"Recovered\"}]}\n\n" +
+		"data: {\"type\":\"session.status_idle\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 2)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[0].Type)
+	assert.Equal(t, "Recovered", received[0].Text)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[1].Type)
 }
 
 func TestStreamEvents_SkipsMalformed(t *testing.T) {

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -49,8 +49,12 @@ func mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
 		return toolEvent(raw, agents.ProviderEventToolUseFinished), true
 	case "session.status_idle":
 		return agents.ProviderEvent{Type: agents.ProviderEventTurnCompleted}, true
-	case "session.status_terminated", "session.error":
+	case "session.status_terminated":
 		return sessionFailedEvent(raw), true
+	case "session.error":
+		// Managed Agents can emit recoverable internal errors and keep the
+		// session running; only status_terminated is terminal for us.
+		return agents.ProviderEvent{}, false
 	case "span.outcome_evaluation_start":
 		return outcomeEvaluationStartEvent(raw), true
 	case "agent.thread_message_sent":


### PR DESCRIPTION
## Summary
- Treat Anthropic `session.error` events as non-terminal so recovered managed-agent sessions keep streaming.
- Keep `session.status_terminated` mapped to provider session failure.
- Add regression coverage for a recoverable `session.error` followed by assistant output and idle.

## Tests
- `make format.go`
- `make test PKG_TEST_PACKAGES=./pkg/agents/anthropic`
- `docker compose -f docker-compose.dev.yml exec app go test ./pkg/workers -run "TestAgentStreamWorker" -count=1 -p 1`

Note: `make test PKG_TEST_PACKAGES=./pkg/workers` is currently blocked by unrelated cleanup-worker failures because the test DB is missing the `repositories` table.