### PR TITLE
feat: canvas repository APIs

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -200,6 +200,24 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 			DomainType:       models.DomainTypeOrganization,
 			ResourceResolver: defaultResourceResolver,
 		},
+		pbCanvases.Canvases_GetCanvasRepository_FullMethodName: {
+			Resource:         "canvases",
+			Action:           "read",
+			DomainType:       models.DomainTypeOrganization,
+			ResourceResolver: canvasResourceResolver,
+		},
+		pbCanvases.Canvases_ListCanvasRepositoryFiles_FullMethodName: {
+			Resource:         "canvases",
+			Action:           "read",
+			DomainType:       models.DomainTypeOrganization,
+			ResourceResolver: canvasResourceResolver,
+		},
+		pbCanvases.Canvases_CommitCanvasRepositoryFiles_FullMethodName: {
+			Resource:         "canvases",
+			Action:           "update",
+			DomainType:       models.DomainTypeOrganization,
+			ResourceResolver: canvasResourceResolver,
+		},
 		pbCanvases.Canvases_CreateCanvasVersion_FullMethodName: {
 			Resource:         "canvases",
 			Action:           "update_version",

--- a/pkg/git/inmemory/provider.go
+++ b/pkg/git/inmemory/provider.go
@@ -1,9 +1,15 @@
 package inmemory
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
+	"sort"
 
 	"github.com/superplanehq/superplane/pkg/git/provider"
 )
@@ -12,17 +18,21 @@ import (
  * In-memory git provider.
  *
  * This provider is used for testing purposes.
- * It does not store any data in a real git repository.
- * It is used to test the git provider interface and implementation.
+ * It does not store data in a real git repository.
  * It is not meant to be used in production.
  */
 type Provider struct {
-	repositories map[string]provider.Repository
+	repositories map[string]*repositoryState
+}
+
+type repositoryState struct {
+	files   map[string][]byte
+	headSHA string
 }
 
 func NewProvider() *Provider {
 	return &Provider{
-		repositories: map[string]provider.Repository{},
+		repositories: map[string]*repositoryState{},
 	}
 }
 
@@ -34,29 +44,103 @@ func (p *Provider) GetRepositoryID(options provider.RepositoryOptions) string {
 	return fmt.Sprintf("orgs/%s/canvases/%s", options.OrganizationID.String(), options.CanvasID.String())
 }
 
-func (p *Provider) CreateRepository(ctx context.Context, repoID string) (*provider.Repository, error) {
-	repo := provider.Repository{ID: repoID}
-	p.repositories[repoID] = repo
-	return &repo, nil
+func (p *Provider) CreateRepository(_ context.Context, repoID string) (*provider.Repository, error) {
+	if _, ok := p.repositories[repoID]; ok {
+		return nil, provider.ErrInvalidRepositoryID
+	}
+
+	p.repositories[repoID] = &repositoryState{
+		files: map[string][]byte{
+			"README.md": {},
+		},
+		headSHA: initialHeadSHA(repoID),
+	}
+
+	return &provider.Repository{ID: repoID}, nil
 }
 
-func (p *Provider) DeleteRepository(ctx context.Context, repoID string) error {
+func (p *Provider) DeleteRepository(_ context.Context, repoID string) error {
 	delete(p.repositories, repoID)
 	return nil
 }
 
-func (p *Provider) ListFiles(ctx context.Context, repoID string) ([]string, error) {
-	return nil, nil
+func (p *Provider) ListFiles(_ context.Context, repoID string) ([]string, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := slices.Collect(maps.Keys(repository.files))
+	sort.Strings(paths)
+	return paths, nil
 }
 
-func (p *Provider) GetFile(ctx context.Context, repoID string, path string) (io.ReadCloser, error) {
-	return nil, nil
+func (p *Provider) GetFile(_ context.Context, repoID string, path string) (io.ReadCloser, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return nil, err
+	}
+
+	content, ok := repository.files[path]
+	if !ok {
+		return nil, provider.ErrInvalidPath
+	}
+
+	return io.NopCloser(bytes.NewReader(content)), nil
 }
 
-func (p *Provider) Commit(ctx context.Context, repoID string, options provider.CommitOptions) (string, error) {
-	return "", nil
+func (p *Provider) Commit(_ context.Context, repoID string, options provider.CommitOptions) (string, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return "", err
+	}
+
+	if options.ExpectedHeadSHA != repository.headSHA {
+		return "", provider.ErrExpectedHeadMismatch
+	}
+
+	for _, operation := range options.Operations {
+		if operation.Delete {
+			delete(repository.files, operation.Path)
+			continue
+		}
+
+		content, err := io.ReadAll(operation.Content)
+		if err != nil {
+			return "", fmt.Errorf("read file content: %w", err)
+		}
+
+		repository.files[operation.Path] = content
+	}
+
+	repository.headSHA = nextHeadSHA(repository.headSHA, options.Message)
+	return repository.headSHA, nil
 }
 
-func (p *Provider) Head(ctx context.Context, repoID string) (string, error) {
-	return "", nil
+func (p *Provider) Head(_ context.Context, repoID string) (string, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return "", err
+	}
+
+	return repository.headSHA, nil
+}
+
+func (p *Provider) repository(repoID string) (*repositoryState, error) {
+	repository, ok := p.repositories[repoID]
+	if !ok {
+		return nil, provider.ErrInvalidRepositoryID
+	}
+
+	return repository, nil
+}
+
+func initialHeadSHA(repoID string) string {
+	sum := sha256.Sum256([]byte("initial:" + repoID))
+	return hex.EncodeToString(sum[:8])
+}
+
+func nextHeadSHA(currentHeadSHA, message string) string {
+	sum := sha256.Sum256([]byte(currentHeadSHA + ":" + message))
+	return hex.EncodeToString(sum[:8])
 }

--- a/pkg/git/inmemory/provider_test.go
+++ b/pkg/git/inmemory/provider_test.go
@@ -1,0 +1,63 @@
+package inmemory
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/git/provider"
+)
+
+func TestProviderRepositoryLifecycle(t *testing.T) {
+	p := NewProvider()
+	ctx := context.Background()
+	repoID := p.GetRepositoryID(provider.RepositoryOptions{
+		OrganizationID: uuid.New(),
+		CanvasID:       uuid.New(),
+	})
+
+	_, err := p.CreateRepository(ctx, repoID)
+	require.NoError(t, err)
+
+	headSHA, err := p.Head(ctx, repoID)
+	require.NoError(t, err)
+
+	commitSHA, err := p.Commit(ctx, repoID, provider.CommitOptions{
+		ExpectedHeadSHA: headSHA,
+		Message:         "add docs",
+		Operations: []provider.FileOperation{
+			{
+				Path:      "docs/guide.md",
+				Content:   bytes.NewReader([]byte("guide")),
+				SizeBytes: 5,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, commitSHA)
+
+	files, err := p.ListFiles(ctx, repoID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"README.md", "docs/guide.md"}, files)
+
+	reader, err := p.GetFile(ctx, repoID, "docs/guide.md")
+	require.NoError(t, err)
+	content, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, "guide", string(content))
+
+	commitSHA, err = p.Commit(ctx, repoID, provider.CommitOptions{
+		ExpectedHeadSHA: headSHA,
+		Message:         "stale head",
+	})
+	require.ErrorIs(t, err, provider.ErrExpectedHeadMismatch)
+
+	require.NoError(t, p.DeleteRepository(ctx, repoID))
+	_, err = p.Head(ctx, repoID)
+	require.ErrorIs(t, err, provider.ErrInvalidRepositoryID)
+}

--- a/pkg/grpc/actions/canvases/commit_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_repository_files.go
@@ -33,9 +33,14 @@ func CommitCanvasRepositoryFiles(
 		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
 	}
 
-	repository, err := models.FindRepository(canvasID)
+	orgID, err := uuid.Parse(organizationID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find repository for canvas %s: %v", canvasID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	repository, err := models.FindRepository(orgID, canvasID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "repository not found: %v", err)
 	}
 
 	user, err := models.FindActiveUserByID(organizationID, userID)
@@ -72,7 +77,7 @@ func CommitCanvasRepositoryFiles(
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "failed to commit repository files: %v", err)
 	}
 
 	return &pb.CommitCanvasRepositoryFilesResponse{

--- a/pkg/grpc/actions/canvases/commit_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_repository_files.go
@@ -1,0 +1,81 @@
+package canvases
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	git "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func CommitCanvasRepositoryFiles(
+	ctx context.Context,
+	gitProvider git.Provider,
+	organizationID string,
+	id string,
+	expectedHeadSha string,
+	message string,
+	operations []*pb.CanvasRepositoryFileOperation,
+) (*pb.CommitCanvasRepositoryFilesResponse, error) {
+	userID, ok := authentication.GetUserIdFromMetadata(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "user not authenticated")
+	}
+
+	canvasID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
+	}
+
+	repository, err := models.FindRepository(canvasID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find repository for canvas %s: %v", canvasID, err)
+	}
+
+	user, err := models.FindActiveUserByID(organizationID, userID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find user: %v", err)
+	}
+
+	gitOperations := make([]git.FileOperation, 0, len(operations))
+	for _, operation := range operations {
+		content := operation.GetContent()
+		var reader io.Reader
+		if !operation.GetDelete() {
+			reader = bytes.NewReader(content)
+		}
+
+		gitOperations = append(gitOperations, git.FileOperation{
+			Path:      operation.GetPath(),
+			Content:   reader,
+			SizeBytes: int64(len(content)),
+			Delete:    operation.GetDelete(),
+		})
+	}
+
+	newCommitSha, err := gitProvider.Commit(ctx, repository.RepoID, git.CommitOptions{
+		Branch:          "main",
+		BaseBranch:      "main",
+		ExpectedHeadSHA: expectedHeadSha,
+		Message:         message,
+		Operations:      gitOperations,
+		Author: git.CommitAuthor{
+			Name:  user.Name,
+			Email: user.GetEmail(),
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.CommitCanvasRepositoryFilesResponse{
+		CommitSha: newCommitSha,
+	}, nil
+}

--- a/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
@@ -1,0 +1,124 @@
+package canvases
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	git "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__CommitCanvasRepositoryFiles(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("unauthenticated -> error", func(t *testing.T) {
+		_, err := CommitCanvasRepositoryFiles(
+			context.Background(),
+			r.GitProvider,
+			r.Organization.ID.String(),
+			uuid.New().String(),
+			"abc123",
+			"commit message",
+			nil,
+		)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, s.Code())
+	})
+
+	t.Run("invalid canvas id -> error", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+
+		_, err := CommitCanvasRepositoryFiles(
+			ctx,
+			r.GitProvider,
+			r.Organization.ID.String(),
+			"invalid-id",
+			"abc123",
+			"commit message",
+			nil,
+		)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+	})
+
+	t.Run("repository missing -> error", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		_, err := CommitCanvasRepositoryFiles(
+			ctx,
+			r.GitProvider,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			"abc123",
+			"commit message",
+			nil,
+		)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+	})
+
+	t.Run("commit fails -> propagates error", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+
+		_, err := CommitCanvasRepositoryFiles(
+			ctx,
+			r.GitProvider,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			"stale-head",
+			"commit message",
+			[]*pb.CanvasRepositoryFileOperation{
+				{Path: "README.md", Content: []byte("hello")},
+			},
+		)
+
+		require.ErrorIs(t, err, git.ErrExpectedHeadMismatch)
+	})
+
+	t.Run("commits files with authenticated user as author", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		headSHA, err := r.GitProvider.Head(ctx, repository.RepoID)
+		require.NoError(t, err)
+
+		response, err := CommitCanvasRepositoryFiles(
+			ctx,
+			r.GitProvider,
+			r.Organization.ID.String(),
+			canvas.ID.String(),
+			headSHA,
+			"add readme",
+			[]*pb.CanvasRepositoryFileOperation{
+				{Path: "README.md", Content: []byte("hello world")},
+				{Path: "old.txt", Delete: true},
+			},
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, response.CommitSha)
+
+		reader, err := r.GitProvider.GetFile(ctx, repository.RepoID, "README.md")
+		require.NoError(t, err)
+		content, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+		assert.Equal(t, "hello world", string(content))
+
+		files, err := r.GitProvider.ListFiles(ctx, repository.RepoID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"README.md"}, files)
+	})
+}

--- a/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
-	git "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
@@ -67,7 +66,7 @@ func Test__CommitCanvasRepositoryFiles(t *testing.T) {
 		)
 		s, ok := status.FromError(err)
 		require.True(t, ok)
-		assert.Equal(t, codes.Internal, s.Code())
+		assert.Equal(t, codes.NotFound, s.Code())
 	})
 
 	t.Run("commit fails -> propagates error", func(t *testing.T) {
@@ -86,7 +85,29 @@ func Test__CommitCanvasRepositoryFiles(t *testing.T) {
 			},
 		)
 
-		require.ErrorIs(t, err, git.ErrExpectedHeadMismatch)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+		assert.Contains(t, s.Message(), "failed to commit repository files")
+	})
+
+	t.Run("canvas from different organization -> not found", func(t *testing.T) {
+		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		otherOrg := support.CreateOrganization(t, r, r.User)
+
+		_, err := CommitCanvasRepositoryFiles(
+			ctx,
+			r.GitProvider,
+			otherOrg.ID.String(),
+			canvas.ID.String(),
+			"abc123",
+			"commit message",
+			nil,
+		)
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, s.Code())
 	})
 
 	t.Run("commits files with authenticated user as author", func(t *testing.T) {

--- a/pkg/grpc/actions/canvases/get_canvas_repository.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository.go
@@ -27,7 +27,12 @@ func GetCanvasRepository(ctx context.Context, gitProvider git.Provider, organiza
 		return nil, status.Errorf(codes.NotFound, "canvas not found: %v", err)
 	}
 
-	repository, err := models.FindRepository(canvas.ID)
+	orgID, err := uuid.Parse(organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	repository, err := models.FindRepository(orgID, canvasID)
 	if err != nil {
 		return handleMissingRepository(gitProvider, canvas, err)
 	}

--- a/pkg/grpc/actions/canvases/get_canvas_repository.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository.go
@@ -1,0 +1,105 @@
+package canvases
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	git "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
+)
+
+func GetCanvasRepository(ctx context.Context, gitProvider git.Provider, organizationID string, id string) (*pb.GetCanvasRepositoryResponse, error) {
+	canvasID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
+	}
+
+	canvas, err := models.FindCanvas(uuid.MustParse(organizationID), canvasID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "canvas not found: %v", err)
+	}
+
+	repository, err := models.FindRepository(canvas.ID)
+	if err != nil {
+		return handleMissingRepository(gitProvider, canvas, err)
+	}
+
+	headSha, err := gitProvider.Head(ctx, repository.RepoID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get repository head sha: %v", err)
+	}
+
+	return &pb.GetCanvasRepositoryResponse{
+		Repository: &pb.CanvasRepository{
+			Metadata: &pb.CanvasRepository_Metadata{
+				CanvasId:  canvas.ID.String(),
+				UpdatedAt: timestamppb.New(repository.UpdatedAt),
+			},
+			Status: &pb.CanvasRepository_Status{
+				State:   repositoryStateToProto(repository.Status),
+				HeadSha: headSha,
+			},
+		},
+	}, nil
+}
+
+func handleMissingRepository(gitProvider git.Provider, canvas *models.Canvas, err error) (*pb.GetCanvasRepositoryResponse, error) {
+	//
+	// If this is not a NotFound error, we return the error as is.
+	//
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		logrus.Errorf("failed to find repository for canvas %s: %v", canvas.ID, err)
+		return nil, status.Errorf(codes.Internal, "failed to find repository for canvas %s", canvas.ID)
+	}
+
+	//
+	// If canvas exists, but repository does not, we create a pending repository,
+	// and let the repository provisioner worker handle the rest.
+	// This is a trick to provision repositories for existing canvases lazily.
+	//
+	err = canvas.CreatePendingRepository(gitProvider.Name(), gitProvider.GetRepositoryID(git.RepositoryOptions{
+		OrganizationID: canvas.OrganizationID,
+		CanvasID:       canvas.ID,
+	}))
+
+	//
+	// If we fail to create it, we return NotFound still, and just log the error.
+	//
+	if err != nil {
+		logrus.Errorf("failed to create pending repository for canvas %s: %v", canvas.ID, err)
+		return nil, status.Errorf(codes.NotFound, "repository not found: %v", err)
+	}
+
+	return &pb.GetCanvasRepositoryResponse{
+		Repository: &pb.CanvasRepository{
+			Metadata: &pb.CanvasRepository_Metadata{
+				CanvasId:  canvas.ID.String(),
+				UpdatedAt: timestamppb.New(time.Now()),
+			},
+			Status: &pb.CanvasRepository_Status{
+				State: pb.CanvasRepository_STATE_PENDING,
+			},
+		},
+	}, nil
+}
+
+func repositoryStateToProto(state string) pb.CanvasRepository_State {
+	switch state {
+	case models.RepositoryStatusPending:
+		return pb.CanvasRepository_STATE_PENDING
+	case models.RepositoryStatusReady:
+		return pb.CanvasRepository_STATE_READY
+	case models.RepositoryStatusError:
+		return pb.CanvasRepository_STATE_ERROR
+	}
+
+	return pb.CanvasRepository_STATE_UNSPECIFIED
+}

--- a/pkg/grpc/actions/canvases/get_canvas_repository_test.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository_test.go
@@ -1,0 +1,71 @@
+package canvases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__RepositoryStateToProto(t *testing.T) {
+	assert.Equal(t, pb.CanvasRepository_STATE_PENDING, repositoryStateToProto(models.RepositoryStatusPending))
+	assert.Equal(t, pb.CanvasRepository_STATE_READY, repositoryStateToProto(models.RepositoryStatusReady))
+	assert.Equal(t, pb.CanvasRepository_STATE_ERROR, repositoryStateToProto(models.RepositoryStatusError))
+	assert.Equal(t, pb.CanvasRepository_STATE_UNSPECIFIED, repositoryStateToProto("unknown"))
+}
+
+func Test__GetCanvasRepository(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("invalid canvas id -> error", func(t *testing.T) {
+		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), "invalid-id")
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+	})
+
+	t.Run("canvas does not exist -> error", func(t *testing.T) {
+		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), uuid.New().String())
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, s.Code())
+	})
+
+	t.Run("canvas exists, but repository does not -> creates pending repository", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.Repository)
+		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)
+		assert.Equal(t, pb.CanvasRepository_STATE_PENDING, response.Repository.Status.State)
+		assert.NotNil(t, response.Repository.Metadata.UpdatedAt)
+	})
+
+	t.Run("head lookup fails -> error", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, false)
+		_, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+	})
+
+	t.Run("returns repository metadata and status", func(t *testing.T) {
+		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		response, err := GetCanvasRepository(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		require.NoError(t, err)
+		require.NotNil(t, response.Repository)
+		assert.Equal(t, canvas.ID.String(), response.Repository.Metadata.CanvasId)
+		assert.Equal(t, pb.CanvasRepository_STATE_READY, response.Repository.Status.State)
+		assert.NotEmpty(t, response.Repository.Status.HeadSha)
+		assert.NotNil(t, response.Repository.Metadata.UpdatedAt)
+		assert.Equal(t, repository.UpdatedAt.Unix(), response.Repository.Metadata.UpdatedAt.AsTime().Unix())
+	})
+}

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files.go
@@ -17,14 +17,19 @@ func ListCanvasRepositoryFiles(ctx context.Context, gitProvider git.Provider, or
 		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
 	}
 
-	repository, err := models.FindRepository(canvasID)
+	orgID, err := uuid.Parse(organizationID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find repository for canvas %s: %v", canvasID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid organization id: %v", err)
+	}
+
+	repository, err := models.FindRepository(orgID, canvasID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "repository not found: %v", err)
 	}
 
 	files, err := gitProvider.ListFiles(ctx, repository.RepoID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get repository head sha: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to list repository files: %v", err)
 	}
 
 	paths := make([]*pb.CanvasRepositoryFile, 0, len(files))

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files.go
@@ -1,0 +1,40 @@
+package canvases
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	git "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func ListCanvasRepositoryFiles(ctx context.Context, gitProvider git.Provider, organizationID string, id string) (*pb.ListCanvasRepositoryFilesResponse, error) {
+	canvasID, err := uuid.Parse(id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid canvas id: %v", err)
+	}
+
+	repository, err := models.FindRepository(canvasID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find repository for canvas %s: %v", canvasID, err)
+	}
+
+	files, err := gitProvider.ListFiles(ctx, repository.RepoID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get repository head sha: %v", err)
+	}
+
+	paths := make([]*pb.CanvasRepositoryFile, 0, len(files))
+	for _, path := range files {
+		paths = append(paths, &pb.CanvasRepositoryFile{
+			Path: path,
+		})
+	}
+
+	return &pb.ListCanvasRepositoryFilesResponse{
+		Files: paths,
+	}, nil
+}

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
@@ -1,0 +1,51 @@
+package canvases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test__ListCanvasRepositoryFiles(t *testing.T) {
+	r := support.Setup(t)
+
+	t.Run("invalid canvas id -> error", func(t *testing.T) {
+		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), "invalid-id")
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, s.Code())
+	})
+
+	t.Run("repository missing -> error", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+	})
+
+	t.Run("list files fails -> error", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, false)
+
+		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, s.Code())
+	})
+
+	t.Run("returns repository files", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+
+		response, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
+		require.NoError(t, err)
+		require.Len(t, response.Files, 1)
+		assert.Equal(t, "README.md", response.Files[0].Path)
+	})
+}

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files_test.go
@@ -28,7 +28,7 @@ func Test__ListCanvasRepositoryFiles(t *testing.T) {
 		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, r.Organization.ID.String(), canvas.ID.String())
 		s, ok := status.FromError(err)
 		require.True(t, ok)
-		assert.Equal(t, codes.Internal, s.Code())
+		assert.Equal(t, codes.NotFound, s.Code())
 	})
 
 	t.Run("list files fails -> error", func(t *testing.T) {
@@ -47,5 +47,15 @@ func Test__ListCanvasRepositoryFiles(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, response.Files, 1)
 		assert.Equal(t, "README.md", response.Files[0].Path)
+	})
+
+	t.Run("canvas from different organization -> not found", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		otherOrg := support.CreateOrganization(t, r, r.User)
+
+		_, err := ListCanvasRepositoryFiles(context.Background(), r.GitProvider, otherOrg.ID.String(), canvas.ID.String())
+		s, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, s.Code())
 	})
 }

--- a/pkg/grpc/canvas_service.go
+++ b/pkg/grpc/canvas_service.go
@@ -446,3 +446,18 @@ func (s *CanvasService) ResolveExecutionErrors(ctx context.Context, req *pb.Reso
 
 	return canvases.ResolveExecutionErrors(ctx, canvasID, executionIDs)
 }
+
+func (s *CanvasService) GetCanvasRepository(ctx context.Context, req *pb.GetCanvasRepositoryRequest) (*pb.GetCanvasRepositoryResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvases.GetCanvasRepository(ctx, s.gitProvider, organizationID, req.CanvasId)
+}
+
+func (s *CanvasService) ListCanvasRepositoryFiles(ctx context.Context, req *pb.ListCanvasRepositoryFilesRequest) (*pb.ListCanvasRepositoryFilesResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvases.ListCanvasRepositoryFiles(ctx, s.gitProvider, organizationID, req.CanvasId)
+}
+
+func (s *CanvasService) CommitCanvasRepositoryFiles(ctx context.Context, req *pb.CommitCanvasRepositoryFilesRequest) (*pb.CommitCanvasRepositoryFilesResponse, error) {
+	organizationID := ctx.Value(authorization.OrganizationContextKey).(string)
+	return canvases.CommitCanvasRepositoryFiles(ctx, s.gitProvider, organizationID, req.CanvasId, req.ExpectedHeadSha, req.Message, req.Operations)
+}

--- a/pkg/models/repository.go
+++ b/pkg/models/repository.go
@@ -26,7 +26,21 @@ type Repository struct {
 	UpdatedAt      time.Time
 }
 
-func FindRepository(canvasID uuid.UUID) (*Repository, error) {
+func FindRepository(organizationID, canvasID uuid.UUID) (*Repository, error) {
+	var repository Repository
+	err := database.Conn().
+		Where("canvas_id = ?", canvasID).
+		Where("organization_id = ?", organizationID).
+		First(&repository).
+		Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &repository, nil
+}
+
+func FindRepositoryUnscoped(canvasID uuid.UUID) (*Repository, error) {
 	return FindRepositoryInTransaction(database.Conn(), canvasID)
 }
 

--- a/pkg/public/repository_file_download.go
+++ b/pkg/public/repository_file_download.go
@@ -64,7 +64,7 @@ func (s *Server) handleRepositoryFileDownload(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	repository, err := models.FindRepository(canvas.ID)
+	repository, err := models.FindRepository(user.OrganizationID, canvas.ID)
 	if err != nil {
 		http.Error(w, "Repository not found", http.StatusNotFound)
 		return

--- a/pkg/public/repository_file_download.go
+++ b/pkg/public/repository_file_download.go
@@ -1,0 +1,94 @@
+package public
+
+import (
+	"io"
+	"mime"
+	"net/http"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/public/middleware"
+)
+
+func (s *Server) handleRepositoryFileDownload(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["canvas_id"]
+	path := r.URL.Query().Get("path")
+
+	if id == "" {
+		http.Error(w, "canvas_id is required", http.StatusBadRequest)
+		return
+	}
+
+	canvasID, err := uuid.Parse(id)
+	if err != nil {
+		http.Error(w, "Invalid canvas_id", http.StatusBadRequest)
+		return
+	}
+
+	if path == "" {
+		http.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+
+	user, ok := middleware.GetUserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "Unauthenticated", http.StatusUnauthorized)
+		return
+	}
+
+	allowed, err := s.authService.CheckOrganizationPermission(
+		user.ID.String(),
+		user.OrganizationID.String(),
+		"canvases",
+		"read",
+	)
+
+	if err != nil {
+		log.Errorf("Failed to check permission: %v", err)
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return
+	}
+
+	if !allowed {
+		log.Warnf("User %s is not authorized to read file %s in canvas %s", user.ID.String(), path, canvasID.String())
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return
+	}
+
+	canvas, err := models.FindCanvas(user.OrganizationID, canvasID)
+	if err != nil {
+		http.Error(w, "Canvas not found", http.StatusNotFound)
+		return
+	}
+
+	repository, err := models.FindRepository(canvas.ID)
+	if err != nil {
+		http.Error(w, "Repository not found", http.StatusNotFound)
+		return
+	}
+
+	reader, err := s.gitProvider.GetFile(r.Context(), repository.RepoID, path)
+	if err != nil {
+		log.Errorf("Failed to get file %s in canvas %s: %v", path, canvasID.String(), err)
+		http.Error(w, "Failed to get file", http.StatusInternalServerError)
+		return
+	}
+
+	defer reader.Close()
+
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{
+		"filename": filepath.Base(path),
+	}))
+
+	_, err = io.Copy(w, reader)
+	if err != nil {
+		log.Errorf("Failed to copy file %s in canvas %s: %v", path, canvasID.String(), err)
+		http.Error(w, "Failed to copy file", http.StatusInternalServerError)
+		return
+	}
+}

--- a/pkg/public/repository_file_download_test.go
+++ b/pkg/public/repository_file_download_test.go
@@ -1,0 +1,153 @@
+package public
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	git "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func downloadFile(
+	t *testing.T,
+	server *Server,
+	signer *jwt.Signer,
+	organizationID uuid.UUID,
+	accountID *uuid.UUID,
+	canvasID string,
+	path string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	url := fmt.Sprintf("/api/v1/canvases/%s/repository/file", canvasID)
+	if path != "" {
+		url += "?path=" + path
+	}
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	if accountID != nil {
+		req.Header.Set("x-organization-id", organizationID.String())
+		token, err := signer.Generate(accountID.String(), time.Hour)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+	}
+
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, req)
+	return rec
+}
+
+func Test__RepositoryFileDownload(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test")
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		signer,
+		support.NewOIDCProvider(),
+		r.GitProvider,
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+
+	require.NoError(t, err)
+	require.NoError(t, server.RegisterGRPCGateway("localhost:50051"))
+
+	authenticated := &r.Account.ID
+
+	t.Run("missing path -> bad request", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, canvas.ID.String(), "")
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+		assert.Contains(t, response.Body.String(), "path is required")
+	})
+
+	t.Run("invalid canvas id -> bad request", func(t *testing.T) {
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, "invalid-id", "README.md")
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+		assert.Contains(t, response.Body.String(), "Invalid canvas_id")
+	})
+
+	t.Run("unauthenticated -> unauthorized", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		response := downloadFile(t, server, signer, r.Organization.ID, nil, canvas.ID.String(), "README.md")
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+
+	t.Run("user without canvas access -> forbidden", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+
+		restrictedAccount, err := models.CreateAccount("restricted@example.com", "Restricted User")
+		require.NoError(t, err)
+		_, err = models.CreateUser(r.Organization.ID, restrictedAccount.ID, restrictedAccount.Email, restrictedAccount.Name)
+		require.NoError(t, err)
+
+		response := downloadFile(t, server, signer, r.Organization.ID, &restrictedAccount.ID, canvas.ID.String(), "README.md")
+		assert.Equal(t, http.StatusForbidden, response.Code)
+		assert.Contains(t, response.Body.String(), "Unauthorized")
+	})
+
+	t.Run("canvas not found -> not found", func(t *testing.T) {
+		invalidID := uuid.NewString()
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, invalidID, "README.md")
+		assert.Equal(t, http.StatusNotFound, response.Code)
+		assert.Contains(t, response.Body.String(), "Canvas not found")
+	})
+
+	t.Run("repository not found -> not found", func(t *testing.T) {
+		canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, canvas.ID.String(), "README.md")
+		assert.Equal(t, http.StatusNotFound, response.Code)
+		assert.Contains(t, response.Body.String(), "Repository not found")
+	})
+
+	t.Run("git provider error -> internal server error", func(t *testing.T) {
+		canvas, _ := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, canvas.ID.String(), "missing.txt")
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		assert.Contains(t, response.Body.String(), "Failed to get file")
+	})
+
+	t.Run("returns file contents", func(t *testing.T) {
+		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
+		headSHA, err := r.GitProvider.Head(context.Background(), repository.RepoID)
+		require.NoError(t, err)
+
+		_, err = r.GitProvider.Commit(context.Background(), repository.RepoID, git.CommitOptions{
+			ExpectedHeadSHA: headSHA,
+			Message:         "seed readme",
+			Operations: []git.FileOperation{
+				{
+					Path:      "README.md",
+					Content:   bytes.NewReader([]byte("updated readme")),
+					SizeBytes: 14,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		response := downloadFile(t, server, signer, r.Organization.ID, authenticated, canvas.ID.String(), "README.md")
+		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, "updated readme", response.Body.String())
+		assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
+		assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
+		assert.Contains(t, response.Header().Get("Content-Disposition"), "README.md")
+	})
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -350,6 +350,18 @@ func (s *Server) RegisterGRPCGateway(grpcServerAddr string) error {
 
 	// Protect the gRPC gateway routes with organization authentication
 	orgAuthMiddleware := middleware.OrganizationAuthMiddleware(s.jwt)
+
+	//
+	// This is not part of the proto APIs and gRPC gateway route,
+	// because of how we need to handle the file streaming.
+	// There is no good way to handle that through the gRPC gateway,
+	// so we need to lift that endpoint here instead.
+	//
+	s.Router.Handle(
+		"/api/v1/canvases/{canvas_id}/repository/file",
+		orgAuthMiddleware(http.HandlerFunc(s.handleRepositoryFileDownload)),
+	).Methods(http.MethodGet)
+
 	protectedGRPCHandler := orgAuthMiddleware(s.grpcGatewayHandler(grpcGatewayMux))
 
 	accountAuthMiddleware := middleware.AccountAuthMiddleware(s.jwt)

--- a/pkg/workers/repository_provisioner.go
+++ b/pkg/workers/repository_provisioner.go
@@ -152,7 +152,7 @@ func (w *RepositoryProvisionerWorker) ConsumeCanvasCreated(delivery tackle.Deliv
 		return nil
 	}
 
-	repository, err := models.FindRepository(canvasID)
+	repository, err := models.FindRepositoryUnscoped(canvasID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -73,6 +73,40 @@ service Canvases {
     };
   }
 
+   rpc GetCanvasRepository(GetCanvasRepositoryRequest) returns (GetCanvasRepositoryResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/canvases/{canvas_id}/repository"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get canvas repository";
+      description: "Returns information about the canvas git repository";
+      tags: "CanvasRepository";
+    };
+  }
+
+  rpc ListCanvasRepositoryFiles(ListCanvasRepositoryFilesRequest) returns (ListCanvasRepositoryFilesResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/canvases/{canvas_id}/repository/files"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List canvas repository files";
+      description: "Lists files in the git repository attached to a canvas";
+      tags: "CanvasRepository";
+    };
+  }
+
+  rpc CommitCanvasRepositoryFiles(CommitCanvasRepositoryFilesRequest) returns (CommitCanvasRepositoryFilesResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/canvases/{canvas_id}/repository/commits"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Commit canvas repository files";
+      description: "Commits file additions, updates, and deletions to the git repository attached to a canvas";
+      tags: "CanvasRepository";
+    };
+  }
+
   rpc CreateCanvasVersion(CreateCanvasVersionRequest) returns (CreateCanvasVersionResponse) {
     option (google.api.http) = {
       post: "/api/v1/canvases/{canvas_id}/versions"
@@ -497,6 +531,66 @@ message CanvasAutoLayout {
   Algorithm algorithm = 1;
   repeated string node_ids = 2;
   Scope scope = 3;
+}
+
+message CanvasRepository {
+  message Metadata {
+    string canvas_id = 1;
+    google.protobuf.Timestamp updated_at = 7;
+  }
+
+  enum State {
+    STATE_UNSPECIFIED = 0;
+    STATE_PENDING = 1;
+    STATE_READY = 2;
+    STATE_ERROR = 3;
+  }
+
+  message Status {
+    State state = 1;
+    string head_sha = 2;
+    optional string error = 3;
+  }
+
+  Metadata metadata = 1;
+  Status status = 2;
+}
+
+message GetCanvasRepositoryRequest {
+  string canvas_id = 1;
+}
+
+message GetCanvasRepositoryResponse {
+  CanvasRepository repository = 1;
+}
+
+message ListCanvasRepositoryFilesRequest {
+  string canvas_id = 1;
+}
+
+message CanvasRepositoryFile {
+  string path = 1;
+}
+
+message ListCanvasRepositoryFilesResponse {
+  repeated CanvasRepositoryFile files = 1;
+}
+
+message CanvasRepositoryFileOperation {
+  string path = 1;
+  bytes content = 2;
+  bool delete = 3;
+}
+
+message CommitCanvasRepositoryFilesRequest {
+  string canvas_id = 1;
+  string expected_head_sha = 2;
+  string message = 3;
+  repeated CanvasRepositoryFileOperation operations = 4;
+}
+
+message CommitCanvasRepositoryFilesResponse {
+  string commit_sha = 1;
 }
 
 message CreateCanvasVersionRequest {

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -574,7 +574,7 @@ func CreateCanvasWithRepository(t *testing.T, r *ResourceRegistry, status string
 		require.NoError(t, err)
 	}
 
-	repository, err := models.FindRepository(canvas.ID)
+	repository, err := models.FindRepository(r.Organization.ID, canvas.ID)
 	require.NoError(t, err)
 
 	switch status {
@@ -584,7 +584,7 @@ func CreateCanvasWithRepository(t *testing.T, r *ResourceRegistry, status string
 		require.NoError(t, repository.MarkError(database.Conn()))
 	}
 
-	repository, err = models.FindRepository(canvas.ID)
+	repository, err = models.FindRepository(r.Organization.ID, canvas.ID)
 	require.NoError(t, err)
 
 	return canvas, repository

--- a/test/support/support.go
+++ b/test/support/support.go
@@ -558,6 +558,38 @@ func VerifyNodeRequestCount(t require.TestingT, workflowID uuid.UUID, expected i
 	require.Equal(t, expected, int(actual))
 }
 
+func CreateCanvasWithRepository(t *testing.T, r *ResourceRegistry, status string, register bool) (*models.Canvas, *models.Repository) {
+	t.Helper()
+
+	canvas, _ := CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	repoID := r.GitProvider.GetRepositoryID(git.RepositoryOptions{
+		OrganizationID: canvas.OrganizationID,
+		CanvasID:       canvas.ID,
+	})
+
+	require.NoError(t, canvas.CreatePendingRepository(r.GitProvider.Name(), repoID))
+
+	if register {
+		_, err := r.GitProvider.CreateRepository(t.Context(), repoID)
+		require.NoError(t, err)
+	}
+
+	repository, err := models.FindRepository(canvas.ID)
+	require.NoError(t, err)
+
+	switch status {
+	case models.RepositoryStatusReady:
+		require.NoError(t, repository.MarkReady(database.Conn()))
+	case models.RepositoryStatusError:
+		require.NoError(t, repository.MarkError(database.Conn()))
+	}
+
+	repository, err = models.FindRepository(canvas.ID)
+	require.NoError(t, err)
+
+	return canvas, repository
+}
+
 func ensureCanvasNodeExists(t require.TestingT, workflowID uuid.UUID, nodeID string) {
 	var existingNode models.CanvasNode
 	err := database.Conn().


### PR DESCRIPTION
Introduce the new canvas repository APIs so the UI and CLI can manage files.

### New endpoints

- GET /api/v1/canvases/{canvas_id}/repository
- GET /api/v1/canvases/{canvas_id}/repository/files
- POST /api/v1/canvases/{canvas_id}/repository/commits
- GET /api/v1/canvases/{canvas_id}/repository/file?path=

### Downloading single file

For downloading a single file, we do not use the proto + gRPC gateway approach. There is no way to use that and not download the file into memory instead of streaming it. For that endpoint specifically, we register a route directly in the HTTP server handlers.

### Lazily provisioning repositories

When GetCanvasRepository is called for an existing canvas that does not yet have a repository provisioned, we create a pending repository for it. This lazily provisions repositories for all existing canvases that are still in use.