### PR TITLE
fix: show agent intro for blank canvases

### DIFF
--- a/web_src/src/lib/agentBootContext.spec.ts
+++ b/web_src/src/lib/agentBootContext.spec.ts
@@ -55,6 +55,15 @@ describe("agent boot context", () => {
     window.removeEventListener(AGENT_BOOT_CONTEXT_READY_EVENT, listener);
   });
 
+  it("stores a local intro for blank canvases", () => {
+    setAgentBootContext("canvas-1", "blank");
+
+    expect(getAgentBootInitialMessage("canvas-1")).toBe(
+      "I can help design and modify this canvas. Describe the workflow you want, and I'll use the draft, console, and run panels to propose changes, apply approved updates, and explain each step.",
+    );
+    expect(getAgentBootMessage("canvas-1")).toContain("The user just created a new blank app");
+  });
+
   it("stores template intro text separately from the constrained agent prompt", () => {
     setAgentBootContext("canvas-1", {
       instructions: "This template deploys preview environments.",

--- a/web_src/src/lib/agentBootContext.ts
+++ b/web_src/src/lib/agentBootContext.ts
@@ -9,6 +9,9 @@ const DEFAULT_BOOT_MESSAGE =
 const BLANK_BOOT_MESSAGE =
   "The user just created a new blank app with a placeholder node on the canvas. Greet them briefly, then tell them to click on the 'New Component' node on the canvas and pick a component from the sidebar to get started. You can also ask what they want to build and help them choose the right component.";
 
+const BLANK_INITIAL_MESSAGE =
+  "I can help design and modify this canvas. Describe the workflow you want, and I'll use the draft, console, and run panels to propose changes, apply approved updates, and explain each step.";
+
 const TEMPLATE_NEXT_STEP_MESSAGE = "Tell me what you would like to do next in the canvas.";
 
 interface TemplateAgentBootContext {
@@ -23,6 +26,10 @@ interface AgentBootContext {
 }
 
 export function setAgentBootContext(canvasId: string, message: string | TemplateAgentBootContext) {
+  if (message === "blank") {
+    setAgentBootInitialMessage(canvasId, BLANK_INITIAL_MESSAGE);
+  }
+
   if (typeof message !== "string" && message.initialMessage) {
     setAgentBootInitialMessage(canvasId, message.initialMessage);
   }


### PR DESCRIPTION
## Summary
- Store a local initial agent message when a blank canvas boot context is created.
- Keep the existing blank-canvas provider prompt behavior unchanged.
- Add coverage for the blank-canvas intro path.

## Tests
- `make format.js`
- `docker compose -f docker-compose.dev.yml exec app bash -c "cd web_src && npm test -- agentBootContext.spec.ts --run"`
- `make check.build.ui`
- `make check.lint.ui`