### PR TITLE
feat: new CLI commands for managing files

### DIFF
--- a/pkg/cli/commands/canvases/files/root.go
+++ b/pkg/cli/commands/canvases/files/root.go
@@ -1,0 +1,43 @@
+package files
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+func NewRootCommand(options core.BindOptions) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "files",
+		Short: "Read canvas repository files",
+		Long:  "List and read files stored in the git repository attached to a canvas.",
+	}
+
+	treeCmd := &cobra.Command{
+		Use:   "tree [canvas-name-or-id]",
+		Short: "List canvas repository files as a tree",
+		Long: `List files in the canvas git repository as a directory tree.
+
+The canvas argument is optional. When omitted, the active canvas
+configured with "superplane canvases active" is used.`,
+		Args: cobra.MaximumNArgs(1),
+	}
+
+	core.Bind(treeCmd, &TreeCommand{}, options)
+
+	showCmd := &cobra.Command{
+		Use:   "show <path> [canvas-name-or-id]",
+		Short: "Show a canvas repository file",
+		Long: `Print the contents of a file from the canvas git repository.
+
+The canvas argument is optional. When omitted, the active canvas
+configured with "superplane canvases active" is used.`,
+		Args: cobra.RangeArgs(1, 2),
+	}
+
+	core.Bind(showCmd, &ShowCommand{}, options)
+
+	root.AddCommand(treeCmd)
+	root.AddCommand(showCmd)
+
+	return root
+}

--- a/pkg/cli/commands/canvases/files/show.go
+++ b/pkg/cli/commands/canvases/files/show.go
@@ -1,0 +1,129 @@
+package files
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	resolve "github.com/superplanehq/superplane/pkg/cli/canvasresolve"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type ShowCommand struct{}
+
+func (c *ShowCommand) Execute(ctx core.CommandContext) error {
+	path, canvasTarget, err := c.parseArgs(ctx.Args)
+	if err != nil {
+		return err
+	}
+
+	canvasID, err := resolve.ResolveCanvasNameOrIDArg(ctx, canvasTarget)
+	if err != nil {
+		return err
+	}
+
+	content, err := c.fetchFile(ctx, canvasID, path)
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(map[string]any{
+			"canvasId": canvasID,
+			"path":     path,
+			"content":  string(content),
+		})
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		_, err := stdout.Write(content)
+		return err
+	})
+}
+
+func (c *ShowCommand) parseArgs(args []string) (path string, canvasTarget string, err error) {
+	if len(args) == 0 {
+		return "", "", fmt.Errorf("path is required")
+	}
+	if len(args) > 2 {
+		return "", "", fmt.Errorf("show accepts at most two positional arguments")
+	}
+
+	path = c.normalizePath(args[0])
+	if path == "" {
+		return "", "", fmt.Errorf("path is required")
+	}
+
+	if len(args) == 2 {
+		canvasTarget = strings.TrimSpace(args[1])
+	}
+
+	return path, canvasTarget, nil
+}
+
+func (c *ShowCommand) normalizePath(path string) string {
+	return strings.TrimLeft(strings.TrimSpace(strings.ReplaceAll(path, "\\", "/")), "/")
+}
+
+func (c *ShowCommand) fetchFile(ctx core.CommandContext, canvasID string, path string) ([]byte, error) {
+	config := ctx.API.GetConfig()
+	if config == nil {
+		return nil, fmt.Errorf("api client config is required")
+	}
+
+	baseURL, err := config.ServerURLWithContext(ctx.Context, "CanvasRepositoryAPIService.CanvasesListCanvasRepositoryFiles")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, fmt.Errorf("api_url is required")
+	}
+
+	values := url.Values{}
+	values.Set("path", path)
+
+	endpoint := fmt.Sprintf(
+		"%s/api/v1/canvases/%s/repository/file?%s",
+		strings.TrimRight(baseURL, "/"),
+		url.PathEscape(canvasID),
+		values.Encode(),
+	)
+
+	request, err := http.NewRequestWithContext(ctx.Context, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if authorization := strings.TrimSpace(config.DefaultHeader["Authorization"]); authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode >= http.StatusMultipleChoices {
+		message := strings.TrimSpace(string(body))
+		if message != "" {
+			return nil, fmt.Errorf("%s", message)
+		}
+		return nil, fmt.Errorf("failed to read repository file: %s", response.Status)
+	}
+
+	return body, nil
+}

--- a/pkg/cli/commands/canvases/files/tree.go
+++ b/pkg/cli/commands/canvases/files/tree.go
@@ -1,0 +1,224 @@
+package files
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	resolve "github.com/superplanehq/superplane/pkg/cli/canvasresolve"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+type TreeCommand struct{}
+
+func NewTreeCommand() *TreeCommand {
+	return &TreeCommand{}
+}
+
+func (c *TreeCommand) Execute(ctx core.CommandContext) error {
+	if len(ctx.Args) > 1 {
+		return fmt.Errorf("tree accepts at most one positional argument")
+	}
+
+	canvasTarget := ""
+	if len(ctx.Args) == 1 {
+		canvasTarget = strings.TrimSpace(ctx.Args[0])
+	}
+
+	canvasID, err := resolve.ResolveCanvasNameOrIDArg(ctx, canvasTarget)
+	if err != nil {
+		return err
+	}
+
+	paths, err := c.listFiles(ctx, canvasID)
+	if err != nil {
+		return err
+	}
+
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(map[string]any{
+			"canvasId": canvasID,
+			"paths":    paths,
+		})
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		if len(paths) == 0 {
+			_, err := fmt.Fprintln(stdout, "No files found.")
+			return err
+		}
+
+		return NewFileTree(paths).Write(stdout)
+	})
+}
+
+func (c *TreeCommand) listFiles(ctx core.CommandContext, canvasID string) ([]string, error) {
+	response, _, err := ctx.API.CanvasRepositoryAPI.
+		CanvasesListCanvasRepositoryFiles(ctx.Context, canvasID).
+		Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make([]string, 0, len(response.GetFiles()))
+	for _, file := range response.GetFiles() {
+		normalized := file.GetPath()
+		if normalized == "" {
+			continue
+		}
+		paths = append(paths, normalized)
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+type FileTree struct {
+	directories map[string]*FileTree
+	files       []string
+}
+
+func NewFileTree(paths []string) *FileTree {
+	root := &FileTree{
+		directories: map[string]*FileTree{},
+	}
+
+	for _, path := range paths {
+		segments := strings.Split(path, "/")
+		node := root
+		for index, segment := range segments {
+			if segment == "" {
+				continue
+			}
+
+			isFile := index == len(segments)-1
+			if isFile {
+				node.files = append(node.files, segment)
+				continue
+			}
+
+			if node.directories == nil {
+				node.directories = map[string]*FileTree{}
+			}
+
+			child, ok := node.directories[segment]
+			if !ok {
+				child = &FileTree{
+					directories: map[string]*FileTree{},
+				}
+				node.directories[segment] = child
+			}
+			node = child
+		}
+	}
+
+	root.Sort()
+	return root
+}
+
+func (t *FileTree) Sort() {
+	sort.Strings(t.files)
+	if len(t.directories) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(t.directories))
+	for name := range t.directories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	sortedDirectories := make(map[string]*FileTree, len(names))
+	for _, name := range names {
+		child := t.directories[name]
+		child.Sort()
+		sortedDirectories[name] = child
+	}
+	t.directories = sortedDirectories
+}
+
+type FileTreeEntry struct {
+	name  string
+	child *FileTree
+}
+
+func (t *FileTree) Entries() []FileTreeEntry {
+	entries := make([]FileTreeEntry, 0, len(t.directories)+len(t.files))
+
+	for name, child := range t.directories {
+		entries = append(entries, FileTreeEntry{
+			name:  name + "/",
+			child: child,
+		})
+	}
+
+	for _, name := range t.files {
+		entries = append(entries, FileTreeEntry{name: name})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].name < entries[j].name
+	})
+
+	return entries
+}
+
+func (t *FileTree) Write(stdout io.Writer) error {
+	entries := t.Entries()
+	if len(entries) == 0 {
+		return nil
+	}
+
+	for index, entry := range entries {
+		prefix := "├── "
+		if index == len(entries)-1 {
+			prefix = "└── "
+		}
+
+		if _, err := fmt.Fprintf(stdout, "%s%s\n", prefix, entry.name); err != nil {
+			return err
+		}
+
+		if entry.child == nil {
+			continue
+		}
+
+		childPrefix := "│   "
+		if index == len(entries)-1 {
+			childPrefix = "    "
+		}
+
+		if err := entry.child.WriteWithPrefix(stdout, childPrefix); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *FileTree) WriteWithPrefix(stdout io.Writer, prefix string) error {
+	entries := t.Entries()
+	for index, entry := range entries {
+		branch := "├── "
+		nextPrefix := prefix + "│   "
+		if index == len(entries)-1 {
+			branch = "└── "
+			nextPrefix = prefix + "    "
+		}
+
+		if _, err := fmt.Fprintf(stdout, "%s%s%s\n", prefix, branch, entry.name); err != nil {
+			return err
+		}
+
+		if entry.child == nil {
+			continue
+		}
+
+		if err := entry.child.WriteWithPrefix(stdout, nextPrefix); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/commands/canvases/files/tree_test.go
+++ b/pkg/cli/commands/canvases/files/tree_test.go
@@ -1,0 +1,25 @@
+package files
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test__FileTree__WriteNestedPaths(t *testing.T) {
+	tree := NewFileTree([]string{
+		"docs/guide.md",
+		"README.md",
+		"docs/setup/install.md",
+	})
+
+	var output bytes.Buffer
+	require.NoError(t, tree.Write(&output))
+	require.Equal(t, `├── README.md
+└── docs/
+    ├── guide.md
+    └── setup/
+        └── install.md
+`, output.String())
+}

--- a/pkg/cli/commands/canvases/root.go
+++ b/pkg/cli/commands/canvases/root.go
@@ -2,6 +2,7 @@ package canvases
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/commands/canvases/files"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 	"github.com/superplanehq/superplane/pkg/openapi_client"
 )
@@ -245,6 +246,7 @@ AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
 		Short: "Delete a canvas",
 		Args:  cobra.ExactArgs(1),
 	}
+
 	core.Bind(deleteCmd, &deleteCommand{}, options)
 
 	root.AddCommand(listCmd)
@@ -255,6 +257,7 @@ AI agents: for canonical canvas YAML shapes and wiring rules, install skills:
 	root.AddCommand(updateCmd)
 	root.AddCommand(deleteCmd)
 	root.AddCommand(changeRequestsCmd)
+	root.AddCommand(files.NewRootCommand(options))
 
 	return root
 }


### PR DESCRIPTION
Two new commands:
- **superplane canvas files tree** - shows the files in a tree-like structure
- **superplane canvas files show <path>** - shows a single file
