### PR TITLE
fix: format public server listen address with net.JoinHostPort

### DIFF
--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -1004,6 +1005,10 @@ func (s *Server) HealthCheck(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func listenAddr(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 func (s *Server) Serve(host string, port int) error {
 	log.Infof("Starting server at %s:%d", host, port)
 
@@ -1012,7 +1017,7 @@ func (s *Server) Serve(host string, port int) error {
 	s.wsHub.Run()
 
 	s.httpServer = &http.Server{
-		Addr:         fmt.Sprintf("%s:%d", host, port),
+		Addr:         listenAddr(host, port),
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -101,6 +101,16 @@ func Test__HealthCheckEndpoint(t *testing.T) {
 	require.Equal(t, 200, response.Code)
 }
 
+func Test__ListenAddr(t *testing.T) {
+	t.Run("formats IPv4 addresses", func(t *testing.T) {
+		require.Equal(t, "127.0.0.1:3000", listenAddr("127.0.0.1", 3000))
+	})
+
+	t.Run("formats IPv6 addresses with brackets", func(t *testing.T) {
+		require.Equal(t, "[::1]:3000", listenAddr("::1", 3000))
+	})
+}
+
 func Test__OpenAPIEndpoints(t *testing.T) {
 	checkSwaggerFiles(t)
 


### PR DESCRIPTION
## Summary
- uses `net.JoinHostPort` for the public server listen address
- adds coverage for IPv4 and IPv6 listen address formatting

## Validation
- `git diff --check HEAD~1..HEAD`
- Go tests were not run locally because this Windows environment does not have `go`/`gofmt` available. The targeted command to run in a Go environment is `go test ./pkg/public -run Test__ListenAddr -count=1`.