### PR TITLE
feat: add GitHub status trigger

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -17,6 +17,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="On Pull Request" href="#on-pull-request" description="Listen to pull request events" />
   <LinkCard title="On Push" href="#on-push" description="Listen to GitHub push events" />
   <LinkCard title="On Release" href="#on-release" description="Listen to release events" />
+  <LinkCard title="On Status" href="#on-status" description="Listen to GitHub commit status events" />
   <LinkCard title="On Tag Created" href="#on-tag-created" description="Listen to GitHub tag creation events" />
   <LinkCard title="On Workflow Run" href="#on-workflow-run" description="Listen to workflow run events" />
 </CardGrid>
@@ -1379,6 +1380,92 @@ This trigger automatically sets up a GitHub webhook when configured. The webhook
   },
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.release"
+}
+```
+
+<a id="on-status"></a>
+
+## On Status
+
+**Trigger key:** `github.onStatus`
+
+The On Status trigger starts a workflow execution when a GitHub commit status is created or updated.
+
+### Use Cases
+
+- **Merge automation**: Re-evaluate pull request merge criteria when required status checks change
+- **CI/CD orchestration**: React to status updates from external CI systems
+- **Quality gates**: Route workflows based on commit status context and state
+- **Notifications**: Notify teams when important status checks fail or recover
+
+### Configuration
+
+- **Repository**: Select the GitHub repository to monitor
+- **States**: Select which commit status states to listen for (error, failure, pending, success)
+- **Contexts** *(optional)*: Configure which status contexts to listen for using predicates (e.g., equals "ci/build", matches "deploy/.*")
+- **Branches** *(optional)*: Configure which branch names to listen for using predicates. GitHub includes branches that contain the status SHA.
+
+### Event Data
+
+Each status event includes:
+- **state**: The new commit status state (error, failure, pending, success)
+- **context**: The status context, such as "ci/build"
+- **sha**: Commit SHA for the status
+- **description**: Optional status description
+- **target_url**: Optional link added to the status
+- **branches**: Branches containing the status SHA
+- **commit**: Commit information
+- **repository**: Repository information
+- **sender**: User who triggered the event
+
+### Webhook Setup
+
+This trigger automatically sets up a GitHub webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.
+
+### Example Data
+
+```json
+{
+  "data": {
+    "branches": [
+      {
+        "commit": {
+          "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+          "url": "https://api.github.com/repos/acme-labs/snaketoy/commits/d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44"
+        },
+        "name": "main",
+        "protected": true
+      }
+    ],
+    "commit": {
+      "commit": {
+        "message": "Add checkout validation"
+      },
+      "html_url": "https://github.com/acme-labs/snaketoy/commit/d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+      "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44"
+    },
+    "context": "ci/build",
+    "created_at": "2026-01-16T17:56:16Z",
+    "description": "Build completed successfully",
+    "id": 15384176893,
+    "repository": {
+      "full_name": "acme-labs/snaketoy",
+      "html_url": "https://github.com/acme-labs/snaketoy",
+      "id": 101,
+      "name": "snaketoy"
+    },
+    "sender": {
+      "html_url": "https://github.com/octocat",
+      "id": 583231,
+      "login": "octocat"
+    },
+    "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+    "state": "success",
+    "target_url": "https://github.com/acme-labs/snaketoy/actions/runs/123456789",
+    "updated_at": "2026-01-16T17:57:20Z"
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.status"
 }
 ```
 

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -62,6 +62,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 			PermissionCommitStatuses: {
 				PermissionScope: PermissionScopeRepository,
 				Capabilities: []CapabilityDef{
+					{ReadOnly: true, Trigger: &statuses.OnStatus{}},
 					{ReadOnly: false, Action: &statuses.PublishCommitStatus{}},
 				},
 			},

--- a/pkg/integrations/github/capability_mapper_test.go
+++ b/pkg/integrations/github/capability_mapper_test.go
@@ -131,6 +131,14 @@ func Test__CapabilityMapper__NewPermissionSet(t *testing.T) {
 		got := ps.ForAppManifest()
 		assert.Equal(t, "write", got["deployments"])
 	})
+
+	t.Run("status trigger requests statuses read permission", func(t *testing.T) {
+		t.Parallel()
+
+		ps := m.NewPermissionSet([]string{"github.onStatus"})
+		got := ps.ForAppManifest()
+		assert.Equal(t, "read", got["statuses"])
+	})
 }
 
 func Test__PermissionSet__IsEmpty(t *testing.T) {

--- a/pkg/integrations/github/components/statuses/example.go
+++ b/pkg/integrations/github/components/statuses/example.go
@@ -10,13 +10,27 @@ import (
 //go:embed payloads/publish_commit_status.json
 var exampleOutputPublishCommitStatusBytes []byte
 
+//go:embed payloads/on_status.json
+var exampleDataOnStatusBytes []byte
+
 var exampleOutputPublishCommitStatusOnce sync.Once
 var exampleOutputPublishCommitStatus map[string]any
+
+var exampleDataOnStatusOnce sync.Once
+var exampleDataOnStatus map[string]any
 
 func (c *PublishCommitStatus) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(
 		&exampleOutputPublishCommitStatusOnce,
 		exampleOutputPublishCommitStatusBytes,
 		&exampleOutputPublishCommitStatus,
+	)
+}
+
+func (t *OnStatus) ExampleData() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleDataOnStatusOnce,
+		exampleDataOnStatusBytes,
+		&exampleDataOnStatus,
 	)
 }

--- a/pkg/integrations/github/components/statuses/on_status.go
+++ b/pkg/integrations/github/components/statuses/on_status.go
@@ -1,0 +1,316 @@
+package statuses
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type OnStatus struct{}
+
+type OnStatusConfiguration struct {
+	Repository string                    `json:"repository" mapstructure:"repository"`
+	States     []string                  `json:"states" mapstructure:"states"`
+	Contexts   []configuration.Predicate `json:"contexts" mapstructure:"contexts"`
+	Branches   []configuration.Predicate `json:"branches" mapstructure:"branches"`
+}
+
+func (t *OnStatus) Name() string {
+	return "github.onStatus"
+}
+
+func (t *OnStatus) Label() string {
+	return "On Status"
+}
+
+func (t *OnStatus) Description() string {
+	return "Listen to GitHub commit status events"
+}
+
+func (t *OnStatus) Documentation() string {
+	return `The On Status trigger starts a workflow execution when a GitHub commit status is created or updated.
+
+## Use Cases
+
+- **Merge automation**: Re-evaluate pull request merge criteria when required status checks change
+- **CI/CD orchestration**: React to status updates from external CI systems
+- **Quality gates**: Route workflows based on commit status context and state
+- **Notifications**: Notify teams when important status checks fail or recover
+
+## Configuration
+
+- **Repository**: Select the GitHub repository to monitor
+- **States**: Select which commit status states to listen for (error, failure, pending, success)
+- **Contexts** *(optional)*: Configure which status contexts to listen for using predicates (e.g., equals "ci/build", matches "deploy/.*")
+- **Branches** *(optional)*: Configure which branch names to listen for using predicates. GitHub includes branches that contain the status SHA.
+
+## Event Data
+
+Each status event includes:
+- **state**: The new commit status state (error, failure, pending, success)
+- **context**: The status context, such as "ci/build"
+- **sha**: Commit SHA for the status
+- **description**: Optional status description
+- **target_url**: Optional link added to the status
+- **branches**: Branches containing the status SHA
+- **commit**: Commit information
+- **repository**: Repository information
+- **sender**: User who triggered the event
+
+## Webhook Setup
+
+This trigger automatically sets up a GitHub webhook when configured. The webhook is managed by SuperPlane and will be cleaned up when the trigger is removed.`
+}
+
+func (t *OnStatus) Icon() string {
+	return "github"
+}
+
+func (t *OnStatus) Color() string {
+	return "gray"
+}
+
+func (t *OnStatus) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:     "states",
+			Label:    "States",
+			Type:     configuration.FieldTypeMultiSelect,
+			Required: true,
+			Default:  []string{"error", "failure", "pending", "success"},
+			TypeOptions: &configuration.TypeOptions{
+				MultiSelect: &configuration.MultiSelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{Label: "Error", Value: "error"},
+						{Label: "Failure", Value: "failure"},
+						{Label: "Pending", Value: "pending"},
+						{Label: "Success", Value: "success"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "contexts",
+			Label:       "Contexts",
+			Description: "Optional. Filter status contexts, e.g. ci/build or deploy/production.",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Togglable:   true,
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
+		{
+			Name:        "branches",
+			Label:       "Branches",
+			Description: "Optional. Filter branch names that contain the status SHA.",
+			Type:        configuration.FieldTypeAnyPredicateList,
+			Required:    false,
+			Togglable:   true,
+			TypeOptions: &configuration.TypeOptions{
+				AnyPredicateList: &configuration.AnyPredicateListTypeOptions{
+					Operators: configuration.AllPredicateOperators,
+				},
+			},
+		},
+	}
+}
+
+func (t *OnStatus) Setup(ctx core.TriggerContext) error {
+	err := common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	var config OnStatusConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	return ctx.Integration.RequestWebhook(common.WebhookConfiguration{
+		EventType:  "status",
+		Repository: config.Repository,
+	})
+}
+
+func (t *OnStatus) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (t *OnStatus) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (t *OnStatus) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	ctx = common.WithWebhookLogger(ctx, t.Name())
+	ctx.Logger.Infof("Received GitHub webhook")
+
+	config := OnStatusConfiguration{}
+	err := mapstructure.Decode(ctx.Configuration, &config)
+	if err != nil {
+		ctx.Logger.Errorf("Failed to decode configuration: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	eventType := ctx.Headers.Get("X-GitHub-Event")
+	if eventType == "" {
+		ctx.Logger.Errorf("Missing X-GitHub-Event header")
+		return http.StatusBadRequest, nil, fmt.Errorf("missing X-GitHub-Event header")
+	}
+
+	if eventType != "status" {
+		ctx.Logger.Infof("Ignoring event - event type %q is not a status event", eventType)
+		return http.StatusOK, nil, nil
+	}
+
+	code, err := common.VerifySignature(ctx)
+	if err != nil {
+		ctx.Logger.Errorf("Failed to verify signature: %v", err)
+		return code, nil, err
+	}
+
+	payload := map[string]any{}
+	err = json.Unmarshal(ctx.Body, &payload)
+	if err != nil {
+		ctx.Logger.Errorf("Failed to parse request body: %v", err)
+		return http.StatusBadRequest, nil, fmt.Errorf("error parsing request body: %v", err)
+	}
+
+	statusState, ok := extractStatusState(payload)
+	if !ok {
+		ctx.Logger.Errorf("Missing or invalid status state")
+		return http.StatusBadRequest, nil, fmt.Errorf("missing or invalid status state")
+	}
+
+	if !matchesConfiguredStatusState(statusState, config.States) {
+		ctx.Logger.Infof("Ignoring event - state %q did not match configured filters", statusState)
+		return http.StatusOK, nil, nil
+	}
+
+	statusContext, ok := extractStatusContext(payload)
+	if !ok {
+		ctx.Logger.Errorf("Missing or invalid status context")
+		return http.StatusBadRequest, nil, fmt.Errorf("missing or invalid status context")
+	}
+
+	if !matchesStatusContext(statusContext, config.Contexts) {
+		ctx.Logger.Infof("Ignoring event - context %q did not match configured filters", statusContext)
+		return http.StatusOK, nil, nil
+	}
+
+	if !matchesStatusBranches(payload, config.Branches) {
+		ctx.Logger.Infof("Ignoring event - branches did not match configured filters")
+		return http.StatusOK, nil, nil
+	}
+
+	err = ctx.Events.Emit("github.status", payload)
+	if err != nil {
+		ctx.Logger.Errorf("Failed to emit event: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("error emitting event: %v", err)
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+func matchesConfiguredStatusState(statusState string, allowedStates []string) bool {
+	if len(allowedStates) == 0 {
+		return true
+	}
+
+	return slices.Contains(allowedStates, statusState)
+}
+
+func matchesStatusContext(statusContext string, allowedContexts []configuration.Predicate) bool {
+	if len(allowedContexts) == 0 {
+		return true
+	}
+
+	return configuration.MatchesAnyPredicate(allowedContexts, statusContext)
+}
+
+func matchesStatusBranches(payload map[string]any, allowedBranches []configuration.Predicate) bool {
+	if len(allowedBranches) == 0 {
+		return true
+	}
+
+	return configuration.MatchesAnyPredicateInList(allowedBranches, extractStatusBranches(payload))
+}
+
+func extractStatusState(payload map[string]any) (string, bool) {
+	return extractString(payload, "state")
+}
+
+func extractStatusContext(payload map[string]any) (string, bool) {
+	return extractString(payload, "context")
+}
+
+func extractString(payload map[string]any, key string) (string, bool) {
+	value, ok := payload[key]
+	if !ok {
+		return "", false
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+
+	return text, true
+}
+
+func extractStatusBranches(payload map[string]any) []string {
+	branchesRaw, ok := payload["branches"]
+	if !ok {
+		return nil
+	}
+
+	branches, ok := branchesRaw.([]any)
+	if !ok {
+		return nil
+	}
+
+	names := []string{}
+	for _, branchRaw := range branches {
+		branch, ok := branchRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, ok := branch["name"].(string)
+		if ok {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
+func (t *OnStatus) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}

--- a/pkg/integrations/github/components/statuses/on_status_test.go
+++ b/pkg/integrations/github/components/statuses/on_status_test.go
@@ -1,0 +1,271 @@
+package statuses
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__OnStatus__HandleWebhook(t *testing.T) {
+	trigger := &OnStatus{}
+
+	t.Run("no X-Hub-Signature-256 -> 403", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-GitHub-Event", "status")
+
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+		})
+
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("no X-GitHub-Event -> 400", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
+
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+			Events:  &contexts.EventContext{},
+			Webhook: &contexts.NodeWebhookContext{},
+		})
+
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.ErrorContains(t, err, "missing X-GitHub-Event header")
+	})
+
+	t.Run("wrong event type is ignored", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-GitHub-Event", "push")
+
+		eventContext := &contexts.EventContext{}
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+			Events:  eventContext,
+		})
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("invalid signature -> 403", func(t *testing.T) {
+		headers := http.Header{}
+		headers.Set("X-Hub-Signature-256", "sha256=asdasd")
+		headers.Set("X-GitHub-Event", "status")
+
+		code, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
+			Body:    []byte(`{"state":"success","context":"ci/build"}`),
+			Headers: headers,
+			Logger:  logrus.NewEntry(logrus.New()),
+			Configuration: OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+			},
+			Webhook: &contexts.NodeWebhookContext{Secret: "test-secret"},
+			Events:  &contexts.EventContext{},
+		})
+
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.ErrorContains(t, err, "invalid signature")
+	})
+
+	t.Run("state matches filter -> event is emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"success","context":"ci/build","branches":[{"name":"main"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		require.Equal(t, 1, eventContext.Count())
+		assert.Equal(t, "github.status", eventContext.Payloads[0].Type)
+	})
+
+	t.Run("state does not match filter -> event is not emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"failure","context":"ci/build","branches":[{"name":"main"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("context matches filter -> event is emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"pending","context":"deploy/production","branches":[{"name":"main"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"pending"},
+				Contexts: []configuration.Predicate{
+					{Type: configuration.PredicateTypeMatches, Value: "deploy/.*"},
+				},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+
+	t.Run("context does not match filter -> event is not emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"success","context":"ci/lint","branches":[{"name":"main"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+				Contexts: []configuration.Predicate{
+					{Type: configuration.PredicateTypeEquals, Value: "ci/build"},
+				},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("branch matches filter -> event is emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"success","context":"ci/build","branches":[{"name":"release/v1.2.3"},{"name":"main"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+				Branches: []configuration.Predicate{
+					{Type: configuration.PredicateTypeMatches, Value: "release/.*"},
+				},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, eventContext.Count())
+	})
+
+	t.Run("branch does not match filter -> event is not emitted", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"state":"success","context":"ci/build","branches":[{"name":"feature/example"}]}`),
+			OnStatusConfiguration{
+				Repository: "test",
+				States:     []string{"success"},
+				Branches: []configuration.Predicate{
+					{Type: configuration.PredicateTypeEquals, Value: "main"},
+				},
+			},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusOK, code)
+		assert.NoError(t, err)
+		assert.Zero(t, eventContext.Count())
+	})
+
+	t.Run("missing state -> 400", func(t *testing.T) {
+		eventContext := &contexts.EventContext{}
+
+		code, _, err := trigger.HandleWebhook(signedStatusRequest(
+			[]byte(`{"context":"ci/build"}`),
+			OnStatusConfiguration{Repository: "test"},
+			eventContext,
+		))
+
+		assert.Equal(t, http.StatusBadRequest, code)
+		assert.ErrorContains(t, err, "missing or invalid status state")
+		assert.Zero(t, eventContext.Count())
+	})
+}
+
+func Test__OnStatus__Setup(t *testing.T) {
+	trigger := OnStatus{}
+
+	t.Run("webhook is requested", func(t *testing.T) {
+		integrationCtx := mocks.IntegrationContextForNewSetupFlow()
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		nodeMetadataCtx := contexts.MetadataContext{}
+		require.NoError(t, trigger.Setup(core.TriggerContext{
+			Integration:   integrationCtx,
+			HTTP:          httpCtx,
+			Metadata:      &nodeMetadataCtx,
+			Configuration: map[string]any{"repository": "hello"},
+		}))
+
+		require.Len(t, integrationCtx.WebhookRequests, 1)
+		require.Len(t, httpCtx.Requests, 1)
+		webhookRequest := integrationCtx.WebhookRequests[0].(common.WebhookConfiguration)
+		assert.Equal(t, "status", webhookRequest.EventType)
+		assert.Equal(t, "hello", webhookRequest.Repository)
+	})
+}
+
+func signedStatusRequest(body []byte, config OnStatusConfiguration, eventContext *contexts.EventContext) core.WebhookRequestContext {
+	secret := "test-secret"
+	signature := signWebhookBody(secret, body)
+
+	headers := http.Header{}
+	headers.Set("X-Hub-Signature-256", "sha256="+signature)
+	headers.Set("X-GitHub-Event", "status")
+
+	return core.WebhookRequestContext{
+		Body:          body,
+		Headers:       headers,
+		Logger:        logrus.NewEntry(logrus.New()),
+		Configuration: config,
+		Webhook:       &contexts.NodeWebhookContext{Secret: secret},
+		Events:        eventContext,
+	}
+}
+
+func signWebhookBody(secret string, body []byte) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(body)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/pkg/integrations/github/components/statuses/payloads/on_status.json
+++ b/pkg/integrations/github/components/statuses/payloads/on_status.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "id": 15384176893,
+    "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+    "state": "success",
+    "context": "ci/build",
+    "description": "Build completed successfully",
+    "target_url": "https://github.com/acme-labs/snaketoy/actions/runs/123456789",
+    "created_at": "2026-01-16T17:56:16Z",
+    "updated_at": "2026-01-16T17:57:20Z",
+    "branches": [
+      {
+        "name": "main",
+        "commit": {
+          "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+          "url": "https://api.github.com/repos/acme-labs/snaketoy/commits/d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44"
+        },
+        "protected": true
+      }
+    ],
+    "commit": {
+      "sha": "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+      "html_url": "https://github.com/acme-labs/snaketoy/commit/d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+      "commit": {
+        "message": "Add checkout validation"
+      }
+    },
+    "repository": {
+      "id": 101,
+      "name": "snaketoy",
+      "full_name": "acme-labs/snaketoy",
+      "html_url": "https://github.com/acme-labs/snaketoy"
+    },
+    "sender": {
+      "id": 583231,
+      "login": "octocat",
+      "html_url": "https://github.com/octocat"
+    }
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "github.status"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -57,6 +57,7 @@ var defaultGitHubAppEvents = []string{
 	"pull_request_review_comment",
 	"push",
 	"release",
+	"status",
 	"workflow_run",
 }
 
@@ -143,6 +144,7 @@ func (g *GitHub) Triggers() []core.Trigger {
 		&pulls.OnPullRequest{},
 		&pulls.OnPRComment{},
 		&pulls.OnPRReviewComment{},
+		&statuses.OnStatus{},
 	}
 }
 

--- a/web_src/src/pages/workflowv2/mappers/github/index.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/index.ts
@@ -9,6 +9,7 @@ import { onBranchCreatedTriggerRenderer } from "./on_branch_created";
 import { onPRCommentTriggerRenderer } from "./on_pr_comment";
 import { onPRReviewCommentTriggerRenderer } from "./on_pr_review_comment";
 import { onWorkflowRunTriggerRenderer } from "./on_workflow_run";
+import { onStatusTriggerRenderer } from "./on_status";
 import { baseIssueMapper } from "./base";
 import { RUN_WORKFLOW_STATE_REGISTRY, runWorkflowMapper } from "./run_workflow";
 import { publishCommitStatusMapper } from "./publish_commit_status";
@@ -86,4 +87,5 @@ export const triggerRenderers: Record<string, TriggerRenderer> = {
   onTagCreated: onTagCreatedTriggerRenderer,
   onBranchCreated: onBranchCreatedTriggerRenderer,
   onWorkflowRun: onWorkflowRunTriggerRenderer,
+  onStatus: onStatusTriggerRenderer,
 };

--- a/web_src/src/pages/workflowv2/mappers/github/on_status.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/on_status.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { EventInfo, TriggerEventContext, TriggerRendererContext } from "../types";
+import { onStatusTriggerRenderer } from "./on_status";
+
+const definition = {
+  name: "github.onStatus",
+  label: "On Status",
+  description: "",
+  icon: "github",
+  color: "gray",
+};
+
+describe("onStatusTriggerRenderer", () => {
+  it("builds title from status context and SHA", () => {
+    const event = statusEvent({
+      state: "success",
+      context: "ci/build",
+      sha: "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+    });
+
+    const context: TriggerEventContext = { event };
+
+    expect(onStatusTriggerRenderer.getTitleAndSubtitle(context).title).toBe("ci/build - d6f3c8a");
+  });
+
+  it("returns status details for the sidebar", () => {
+    const event = statusEvent({
+      state: "failure",
+      context: "deploy/production",
+      sha: "d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44",
+      description: "Deployment failed",
+      target_url: "https://example.com/build/1",
+      branches: [{ name: "main" }, { name: "release/v1" }],
+      repository: { full_name: "acme/snaketoy" },
+      sender: { login: "octocat" },
+      commit: { html_url: "https://github.com/acme/snaketoy/commit/d6f3c8a" },
+    });
+
+    const values = onStatusTriggerRenderer.getRootEventValues({ event });
+
+    expect(values.State).toBe("failure");
+    expect(values.Context).toBe("deploy/production");
+    expect(values.Branches).toBe("main, release/v1");
+    expect(values.Repository).toBe("acme/snaketoy");
+    expect(values.Sender).toBe("octocat");
+  });
+
+  it("renders repository and filters as node metadata", () => {
+    const context: TriggerRendererContext = {
+      node: {
+        id: "node-1",
+        name: "Status trigger",
+        componentName: "github.onStatus",
+        isCollapsed: false,
+        metadata: {
+          repository: {
+            id: "repo-1",
+            name: "acme/snaketoy",
+            url: "https://github.com/acme/snaketoy",
+          },
+        },
+        configuration: {
+          states: ["success", "failure"],
+          contexts: [{ type: "matches", value: "ci/.*" }],
+          branches: [{ type: "equals", value: "main" }],
+        },
+      },
+      definition,
+      lastEvent: undefined,
+    };
+
+    const props = onStatusTriggerRenderer.getTriggerProps(context);
+
+    expect(props.metadata?.map((item) => item.label)).toEqual([
+      "acme/snaketoy",
+      "success, failure",
+      "context ~ci/.*",
+      "branch =main",
+    ]);
+  });
+});
+
+function statusEvent(data: Record<string, unknown>): EventInfo {
+  return {
+    id: "evt-1",
+    createdAt: new Date().toISOString(),
+    nodeId: "node-1",
+    type: "github.status",
+    data,
+  };
+}

--- a/web_src/src/pages/workflowv2/mappers/github/on_status.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/on_status.ts
@@ -1,0 +1,186 @@
+import { getColorClass, getBackgroundColorClass } from "@/lib/colors";
+import type { MetadataItem } from "@/ui/metadataList";
+import type { TriggerEventContext, TriggerRenderer, TriggerRendererContext } from "../types";
+import type { Predicate } from "../utils";
+import { formatPredicate, stringOrDash } from "../utils";
+import githubIcon from "@/assets/icons/integrations/github.svg";
+import type { TriggerProps } from "@/ui/trigger";
+import type { BaseNodeMetadata } from "./types";
+import { buildGithubSubtitle } from "./utils";
+
+interface OnStatusConfiguration {
+  states?: string[];
+  contexts?: Predicate[];
+  branches?: Predicate[];
+}
+
+interface StatusBranch {
+  name?: string;
+}
+
+interface StatusCommit {
+  sha?: string;
+  html_url?: string;
+  commit?: {
+    message?: string;
+  };
+}
+
+interface OnStatusEventData {
+  sha?: string;
+  state?: string;
+  context?: string;
+  description?: string;
+  target_url?: string;
+  branches?: StatusBranch[];
+  commit?: StatusCommit;
+  repository?: {
+    full_name?: string;
+    html_url?: string;
+  };
+  sender?: {
+    login?: string;
+  };
+}
+
+export const onStatusTriggerRenderer: TriggerRenderer = {
+  getTitleAndSubtitle: (context: TriggerEventContext) => {
+    const eventData = context.event?.data as OnStatusEventData;
+
+    return {
+      title: statusTitle(eventData),
+      subtitle: buildGithubSubtitle(eventData?.state || "", context.event?.createdAt),
+    };
+  },
+
+  getRootEventValues: (context: TriggerEventContext): Record<string, string> => {
+    const eventData = context.event?.data as OnStatusEventData;
+
+    return {
+      State: stringOrDash(statusState(eventData)),
+      Context: stringOrDash(statusContext(eventData)),
+      SHA: stringOrDash(statusSha(eventData)),
+      Description: stringOrDash(statusDescription(eventData)),
+      "Target URL": stringOrDash(statusTargetUrl(eventData)),
+      Branches: stringOrDash(statusBranchNames(eventData).join(", ")),
+      Repository: stringOrDash(statusRepositoryName(eventData)),
+      Sender: stringOrDash(statusSenderLogin(eventData)),
+      "Commit URL": stringOrDash(statusCommitUrl(eventData)),
+    };
+  },
+
+  getTriggerProps: (context: TriggerRendererContext) => {
+    const { node, definition, lastEvent } = context;
+    const metadata = node.metadata as unknown as BaseNodeMetadata;
+    const configuration = node.configuration as unknown as OnStatusConfiguration;
+
+    const props: TriggerProps = {
+      title: node.name || definition.label || "Unnamed trigger",
+      iconSrc: githubIcon,
+      iconColor: getColorClass(definition.color),
+      collapsedBackground: getBackgroundColorClass(definition.color),
+      metadata: statusMetadataItems(metadata?.repository?.name, configuration),
+    };
+
+    if (lastEvent) {
+      const eventData = lastEvent.data as OnStatusEventData;
+      props.lastEventData = {
+        title: statusTitle(eventData),
+        subtitle: buildGithubSubtitle(eventData?.state || "", lastEvent.createdAt),
+        receivedAt: new Date(lastEvent.createdAt),
+        state: "triggered",
+        eventId: lastEvent.id,
+      };
+    }
+
+    return props;
+  },
+};
+
+function statusMetadataItems(
+  repositoryName: string | undefined,
+  configuration?: OnStatusConfiguration,
+): MetadataItem[] {
+  const metadataItems: MetadataItem[] = [];
+
+  if (repositoryName) {
+    metadataItems.push({
+      icon: "book",
+      label: repositoryName,
+    });
+  }
+
+  if (configuration?.states && configuration.states.length > 0) {
+    metadataItems.push({
+      icon: "circle-check",
+      label: configuration.states.join(", "),
+    });
+  }
+
+  if (configuration?.contexts && configuration.contexts.length > 0) {
+    metadataItems.push({
+      icon: "funnel",
+      label: `context ${configuration.contexts.map(formatPredicate).join(", ")}`,
+    });
+  }
+
+  if (configuration?.branches && configuration.branches.length > 0) {
+    metadataItems.push({
+      icon: "git-branch",
+      label: `branch ${configuration.branches.map(formatPredicate).join(", ")}`,
+    });
+  }
+
+  return metadataItems;
+}
+
+function statusTitle(eventData: OnStatusEventData | undefined): string {
+  const context = statusContext(eventData) || "Commit status";
+  const sha = shortSha(statusSha(eventData));
+
+  if (sha) {
+    return `${context} - ${sha}`;
+  }
+
+  return context;
+}
+
+function shortSha(sha: string | undefined): string {
+  return sha ? sha.slice(0, 7) : "";
+}
+
+function statusState(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.state;
+}
+
+function statusContext(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.context;
+}
+
+function statusSha(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.sha || eventData?.commit?.sha;
+}
+
+function statusDescription(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.description;
+}
+
+function statusTargetUrl(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.target_url;
+}
+
+function statusRepositoryName(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.repository?.full_name;
+}
+
+function statusSenderLogin(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.sender?.login;
+}
+
+function statusCommitUrl(eventData: OnStatusEventData | undefined): string | undefined {
+  return eventData?.commit?.html_url;
+}
+
+function statusBranchNames(eventData: OnStatusEventData | undefined): string[] {
+  return (eventData?.branches || []).map((branch) => branch.name).filter((name): name is string => Boolean(name));
+}


### PR DESCRIPTION
 - Add `github.onStatus`, a GitHub commit status webhook trigger.
  - Support filtering by status `state`, status `context`, and branch names containing the status SHA.
  - Wire the trigger into GitHub app default events, capability permissions, generated docs, and Workflow v2
  rendering.

implements #5033.