### PR TITLE
feat: run modal tweaks

### DIFF
--- a/test/e2e/parameterized_manual_run_test.go
+++ b/test/e2e/parameterized_manual_run_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/e2e/session"
+	"github.com/superplanehq/superplane/test/e2e/shared"
+)
+
+func TestParameterizedManualRun(t *testing.T) {
+	t.Run("creates and runs a parameterized manual run", func(t *testing.T) {
+		steps := &parameterizedManualRunSteps{t: t}
+		steps.start()
+		steps.givenACanvasWithParameterizedManualTrigger()
+		steps.whenIRunWithParameter("Hello from E2E")
+		steps.thenTheRunCompletedWithMessage("Hello from E2E")
+	})
+}
+
+type parameterizedManualRunSteps struct {
+	t       *testing.T
+	session *session.TestSession
+	canvas  *shared.CanvasSteps
+}
+
+func (s *parameterizedManualRunSteps) start() {
+	s.session = ctx.NewSession(s.t)
+	s.session.Start()
+	s.session.Login()
+}
+
+func (s *parameterizedManualRunSteps) givenACanvasWithParameterizedManualTrigger() {
+	s.canvas = shared.NewCanvasSteps("Parameterized Manual Run", s.t, s.session)
+	s.canvas.CreatePublishedWithParameterizedManualRun()
+}
+
+func (s *parameterizedManualRunSteps) whenIRunWithParameter(message string) {
+	s.canvas.RunParameterizedManualTrigger("Start", map[string]string{
+		"message": message,
+	})
+}
+
+func (s *parameterizedManualRunSteps) thenTheRunCompletedWithMessage(expected string) {
+	s.canvas.WaitForExecution("Output", models.CanvasNodeExecutionStateFinished, 30*time.Second)
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		event := s.findLatestRootEvent()
+		if event != nil {
+			message, ok := rootEventMessage(event)
+			if ok && message == expected {
+				return
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	event := s.findLatestRootEvent()
+	require.NotNil(s.t, event, "no root event found for canvas")
+	message, ok := rootEventMessage(event)
+	require.True(s.t, ok, "expected root event payload to include message")
+	require.Equal(s.t, expected, message)
+}
+
+func (s *parameterizedManualRunSteps) findLatestRootEvent() *models.CanvasEvent {
+	var event models.CanvasEvent
+	err := database.Conn().
+		Where("workflow_id = ?", s.canvas.WorkflowID).
+		Where("execution_id IS NULL").
+		Order("created_at DESC").
+		First(&event).Error
+
+	if err != nil {
+		return nil
+	}
+	return &event
+}
+
+func rootEventMessage(event *models.CanvasEvent) (string, bool) {
+	data, ok := event.Data.Data().(map[string]any)
+	if !ok {
+		return "", false
+	}
+
+	inner, ok := data["data"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+
+	message, ok := inner["message"].(string)
+	return message, ok
+}

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -19,6 +19,7 @@ import (
 	q "github.com/superplanehq/superplane/test/e2e/queries"
 	"github.com/superplanehq/superplane/test/e2e/session"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/datatypes"
 )
 
 type CanvasSteps struct {
@@ -95,6 +96,63 @@ func (s *CanvasSteps) Create() {
 	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
 	require.NoError(s.t, err)
 	canvas, _ := support.CreateCanvas(s.t, s.session.OrgID, user.ID, nil, nil)
+	s.WorkflowID = canvas.ID
+
+	err = database.Conn().
+		Model(&models.Canvas{}).
+		Where("id = ?", s.WorkflowID).
+		Update("name", s.CanvasName).Error
+	require.NoError(s.t, err)
+
+	s.Visit()
+}
+
+func (s *CanvasSteps) CreatePublishedWithParameterizedManualRun() {
+	user, err := models.FindMaybeDeletedUserByEmail(s.session.OrgID.String(), s.session.Account.Email)
+	require.NoError(s.t, err)
+
+	startNodeID := "start-trigger"
+	outputNodeID := "noop-output"
+
+	canvas, _ := support.CreateCanvas(s.t, s.session.OrgID, user.ID, []models.CanvasNode{
+		{
+			NodeID: startNodeID,
+			Name:   "Start",
+			Type:   models.NodeTypeTrigger,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Trigger: &models.TriggerRef{Name: "start"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{
+				"templates": []any{
+					map[string]any{
+						"name": "Hello World",
+						"payload": map[string]any{
+							"message": `{{ parameters["message"] }}`,
+						},
+						"parameters": []any{
+							map[string]any{
+								"name": "message",
+								"type": "string",
+							},
+						},
+					},
+				},
+			}),
+			Position: datatypes.NewJSONType(models.Position{X: 600, Y: 200}),
+		},
+		{
+			NodeID: outputNodeID,
+			Name:   "Output",
+			Type:   models.NodeTypeComponent,
+			Ref: datatypes.NewJSONType(models.NodeRef{
+				Component: &models.ComponentRef{Name: "noop"},
+			}),
+			Configuration: datatypes.NewJSONType(map[string]any{}),
+			Position:      datatypes.NewJSONType(models.Position{X: 1000, Y: 200}),
+		},
+	}, []models.Edge{
+		{SourceID: startNodeID, TargetID: outputNodeID, Channel: "default"},
+	})
 	s.WorkflowID = canvas.ID
 
 	err = database.Conn().
@@ -429,6 +487,17 @@ func (s *CanvasSteps) RunManualTrigger(name string) {
 	// Use the Start node's template Run button (in the default payload template) instead of the removed header Run button
 	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-` + strings.ToLower(name) + `-header"]) [data-testid="start-template-run"]`)
 	s.session.Click(startTemplateRun)
+	s.session.Click(q.TestID("emit-event-submit-button"))
+}
+
+func (s *CanvasSteps) RunParameterizedManualTrigger(name string, parameters map[string]string) {
+	startTemplateRun := q.Locator(`.react-flow__node:has([data-testid="node-` + strings.ToLower(name) + `-header"]) [data-testid="start-template-run"]`)
+	s.session.Click(startTemplateRun)
+
+	for paramName, value := range parameters {
+		s.session.FillIn(q.Locator("#start-run-param-"+paramName), value)
+	}
+
 	s.session.Click(q.TestID("emit-event-submit-button"))
 }
 

--- a/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
+++ b/web_src/src/pages/workflowv2/mappers/editModeActions.spec.tsx
@@ -166,6 +166,8 @@ describe("workflow v2 edit-mode action affordances", () => {
     fireEvent.click(screen.getByTestId("start-template-run"));
 
     expect(openModal).toHaveBeenCalledTimes(1);
+    expect(openModal).toHaveBeenCalledWith(expect.objectContaining({ title: "Start" }));
+    expect(openModal.mock.calls[0][0]).not.toHaveProperty("description");
     expect(invokeNodeTriggerHook).not.toHaveBeenCalled();
 
     const modal = openModal.mock.calls[0][0] as {

--- a/web_src/src/pages/workflowv2/mappers/start/index.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/index.tsx
@@ -14,7 +14,7 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { Play } from "lucide-react";
 import { StartRunModal } from "./runModal";
-import { payloadForTemplateRun, type StartConfiguration } from "./templatePayload";
+import { payloadForTemplateRun, startRunModalTitle, type StartConfiguration } from "./templatePayload";
 
 /**
  * Default renderer for the start trigger
@@ -95,8 +95,7 @@ const startCustomFieldRenderer: CustomFieldRenderer = {
                   e.stopPropagation();
                   if ((template.parameters?.length ?? 0) > 0) {
                     actions.openModal({
-                      title: `Run ${template.name}`,
-                      description: "Provide parameter values for this manual run.",
+                      title: startRunModalTitle(node.name, template.name),
                       content: ({ close }) => (
                         <StartRunModal
                           parameters={template.parameters}

--- a/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/runModal.tsx
@@ -58,7 +58,7 @@ export function StartRunModal({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="mt-1 space-y-4">
       {useParameterForm ? (
         <StartRunParameterFields
           parameters={parameters ?? []}

--- a/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
+++ b/web_src/src/pages/workflowv2/mappers/start/startRunParameterFields.tsx
@@ -7,8 +7,8 @@ import { Checkbox } from "@/ui/checkbox";
 
 import {
   parameterDisplayLabel,
+  parameterInputPlaceholder,
   selectOptionValues,
-  parameterPlaceholder,
   type StartTemplateParameter,
 } from "./templatePayload";
 
@@ -78,7 +78,7 @@ export function StartRunParameterFields({
                 <Input
                   id={id}
                   type={param.type === "number" ? "number" : "text"}
-                  placeholder={parameterPlaceholder(param)}
+                  placeholder={parameterInputPlaceholder(param, label)}
                   value={String(parameterValues[param.name] ?? "")}
                   onChange={(e) =>
                     onParameterValuesChange((prev) => ({

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.spec.ts
@@ -7,8 +7,10 @@ import {
   isValidSelectParameterValue,
   parameterDefaultValue,
   parameterDisplayLabel,
+  parameterInputPlaceholder,
   parseJsonEventPayload,
   parameterPlaceholder,
+  startRunModalTitle,
   payloadForTemplateRun,
   payloadRecordForParameters,
   selectOptionValues,
@@ -51,6 +53,26 @@ describe("parameterDisplayLabel", () => {
     expect(parameterDisplayLabel({ name: "msg", type: "string" })).toBe("msg");
     expect(parameterDisplayLabel({ name: "msg", title: "  ", type: "string" })).toBe("msg");
   });
+
+  it("does not duplicate when title matches name ignoring case", () => {
+    expect(parameterDisplayLabel({ name: "Name", title: "Name", type: "string" })).toBe("Name");
+    expect(parameterDisplayLabel({ name: "name", title: "Name", type: "string" })).toBe("Name");
+  });
+});
+
+describe("startRunModalTitle", () => {
+  it("prefers the node name over the template name", () => {
+    expect(startRunModalTitle("Start OpenClaw server", "run")).toBe("Start OpenClaw server");
+  });
+
+  it("falls back to the template name when the node is unnamed", () => {
+    expect(startRunModalTitle("", "Hello World")).toBe("Hello World");
+    expect(startRunModalTitle(undefined, "Hello World")).toBe("Hello World");
+  });
+
+  it("falls back to Run when both names are empty", () => {
+    expect(startRunModalTitle("", "")).toBe("Run");
+  });
 });
 
 describe("parameterPlaceholder", () => {
@@ -63,6 +85,20 @@ describe("parameterPlaceholder", () => {
   it("returns empty string when placeholder is missing or blank", () => {
     expect(parameterPlaceholder({ name: "agent", type: "string" })).toBe("");
     expect(parameterPlaceholder({ name: "agent", placeholder: "  ", type: "string" })).toBe("");
+  });
+});
+
+describe("parameterInputPlaceholder", () => {
+  it("omits placeholders that repeat the field label", () => {
+    expect(
+      parameterInputPlaceholder({ name: "name", title: "Name", placeholder: "Name", type: "string" }, "Name"),
+    ).toBe(undefined);
+  });
+
+  it("keeps distinct placeholders", () => {
+    expect(
+      parameterInputPlaceholder({ name: "agent", placeholder: "Name of the openclaw agent", type: "string" }, "Agent"),
+    ).toBe("Name of the openclaw agent");
   });
 });
 

--- a/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
+++ b/web_src/src/pages/workflowv2/mappers/start/templatePayload.ts
@@ -18,7 +18,11 @@ export interface StartTemplateParameter {
 
 export function parameterDisplayLabel(param: StartTemplateParameter): string {
   const title = typeof param.title === "string" ? param.title.trim() : "";
-  return title || param.name;
+  const name = param.name.trim();
+  if (title && name && title.toLowerCase() === name.toLowerCase()) {
+    return title;
+  }
+  return title || name;
 }
 
 export function selectOptionValues(param: StartTemplateParameter): string[] {
@@ -39,6 +43,28 @@ export function isValidSelectParameterValue(param: StartTemplateParameter, value
 export function parameterPlaceholder(param: StartTemplateParameter): string {
   const placeholder = typeof param.placeholder === "string" ? param.placeholder.trim() : "";
   return placeholder;
+}
+
+/** Placeholder for run-form inputs; omitted when it would repeat the field label. */
+export function parameterInputPlaceholder(param: StartTemplateParameter, label: string): string | undefined {
+  const placeholder = parameterPlaceholder(param);
+  if (!placeholder || placeholder.toLowerCase() === label.toLowerCase()) {
+    return undefined;
+  }
+  return placeholder;
+}
+
+/** Title for the manual-run modal opened from a Start trigger template. */
+export function startRunModalTitle(nodeName: string | undefined, templateName: string): string {
+  const trimmedNodeName = nodeName?.trim();
+  if (trimmedNodeName) {
+    return trimmedNodeName;
+  }
+  const trimmedTemplateName = templateName.trim();
+  if (trimmedTemplateName) {
+    return trimmedTemplateName;
+  }
+  return "Run";
 }
 
 export interface StartTemplate {


### PR DESCRIPTION
Improves the UX of the Start trigger manual-run modal when a template has parameters, and adds end-to-end coverage for the parameterized manual-run flow.

## Run modal UX

- Modal title now uses the Start node name (e.g. “Start OpenClaw server”) instead of Run `{template name}`, with fallbacks to the template name or "Run".
- Removes the generic description (“Provide parameter values for this manual run.”) so the modal stays focused.
- Parameter input placeholders are hidden when they duplicate the field label (e.g. label and placeholder both “Name”), avoiding redundant UI.
- Field labels no longer show duplicate title/name pairs when they differ only by case.
Minor spacing tweak in the modal content area.

## Testing

- Adds unit tests for startRunModalTitle, parameterInputPlaceholder, and label deduplication.
Updates the edit-mode action spec to assert the new modal title behavior.
- Adds an E2E test that creates a canvas with a parameterized Start trigger, runs it with a message parameter, and verifies the emitted event payload.

## Related Issues

Closes #5039