### PR TITLE
fix: update skills refs

### DIFF
--- a/pkg/agents/anthropic/resources.go
+++ b/pkg/agents/anthropic/resources.go
@@ -75,22 +75,22 @@ func defaultResourceSources() ([]resourceSource, error) {
 func defaultResourceSourcesForSkillsBaseURL(skillsBaseURL string) ([]resourceSource, error) {
 	sources := []resourceSource{
 		{
-			MountPath: "ref/skills/superplane-canvas-builder/SKILL.md",
-			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-canvas-builder", "SKILL.md")),
+			MountPath: "ref/skills/superplane-app-builder/SKILL.md",
+			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-app-builder", "SKILL.md")),
 			SourceURL: skillsRawURL(
 				skillsBaseURL,
 				"skills",
-				"superplane-canvas-builder",
+				"superplane-app-builder",
 				"SKILL.md",
 			),
 		},
 		{
-			MountPath: "ref/skills/superplane-canvas-builder/references/components-and-triggers.md",
-			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-canvas-builder", "references", "components-and-triggers.md")),
+			MountPath: "ref/skills/superplane-app-builder/references/components-and-triggers.md",
+			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-app-builder", "references", "components-and-triggers.md")),
 			SourceURL: skillsRawURL(
 				skillsBaseURL,
 				"skills",
-				"superplane-canvas-builder",
+				"superplane-app-builder",
 				"references",
 				"components-and-triggers.md",
 			),

--- a/pkg/agents/anthropic/resources_test.go
+++ b/pkg/agents/anthropic/resources_test.go
@@ -25,16 +25,16 @@ func TestDefaultResourceSourcesForSkillsBaseURL(t *testing.T) {
 		byMountPath[source.MountPath] = source
 	}
 
-	assert.Contains(t, byMountPath, "ref/skills/superplane-canvas-builder/SKILL.md")
+	assert.Contains(t, byMountPath, "ref/skills/superplane-app-builder/SKILL.md")
 	assert.Equal(
 		t,
-		"https://example.test/root/skills/superplane-canvas-builder/SKILL.md",
-		byMountPath["ref/skills/superplane-canvas-builder/SKILL.md"].SourceURL,
+		"https://example.test/root/skills/superplane-app-builder/SKILL.md",
+		byMountPath["ref/skills/superplane-app-builder/SKILL.md"].SourceURL,
 	)
 	assert.Equal(
 		t,
-		"skills/superplane-canvas-builder/SKILL.md",
-		byMountPath["ref/skills/superplane-canvas-builder/SKILL.md"].SourceKey,
+		"skills/superplane-app-builder/SKILL.md",
+		byMountPath["ref/skills/superplane-app-builder/SKILL.md"].SourceKey,
 	)
 	assert.Equal(
 		t,


### PR DESCRIPTION
The `superplane-canvas-builder` skill was renamed to `superplane-app-builder`.