### PR TITLE
fix: show commit message in status details

### DIFF
--- a/web_src/src/pages/workflowv2/mappers/github/on_commit_status.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/on_commit_status.spec.ts
@@ -36,6 +36,9 @@ describe("onCommitStatusTriggerRenderer", () => {
       sender: { login: "octocat" },
       commit: {
         author: { login: "monalisa" },
+        commit: {
+          message: "Deploy checkout validation\n\nSigned-off-by: Mona Lisa <mona@example.com>",
+        },
         html_url: "https://github.com/acme/snaketoy/commit/d6f3c8a",
       },
     });
@@ -46,21 +49,24 @@ describe("onCommitStatusTriggerRenderer", () => {
       "State",
       "Context",
       "Description",
-      "Branches",
       "SHA",
-      "Status creator",
+      "Commit message",
       "Commit author",
+      "Branches",
+      "Repository",
+      "Status creator",
       "Commit URL",
       "Target URL",
-      "Repository",
     ]);
     expect(values.State).toBe("failure");
     expect(values.Context).toBe("deploy/production");
     expect(values.Description).toBe("Deployment failed");
-    expect(values.Branches).toBe("main, release/v1");
     expect(values.SHA).toBe("d6f3c8a2e8b7f0a9c0a1f67f0c5d7b2a1d9e3f44");
-    expect(values["Status creator"]).toBe("octocat");
+    expect(values["Commit message"]).toBe("Deploy checkout validation");
     expect(values["Commit author"]).toBe("monalisa");
+    expect(values.Branches).toBe("main, release/v1");
+    expect(values.Repository).toBe("acme/snaketoy");
+    expect(values["Status creator"]).toBe("octocat");
   });
 
   it("renders repository and filters as node metadata", () => {

--- a/web_src/src/pages/workflowv2/mappers/github/on_commit_status.ts
+++ b/web_src/src/pages/workflowv2/mappers/github/on_commit_status.ts
@@ -66,13 +66,14 @@ export const onCommitStatusTriggerRenderer: TriggerRenderer = {
       State: stringOrDash(statusState(eventData)),
       Context: stringOrDash(statusContext(eventData)),
       Description: stringOrDash(statusDescription(eventData)),
-      Branches: stringOrDash(statusBranchNames(eventData).join(", ")),
       SHA: stringOrDash(statusSha(eventData)),
-      "Status creator": stringOrDash(statusCreatorLogin(eventData)),
+      "Commit message": stringOrDash(statusCommitMessage(eventData)),
       "Commit author": stringOrDash(statusCommitAuthor(eventData)),
+      Branches: stringOrDash(statusBranchNames(eventData).join(", ")),
+      Repository: stringOrDash(statusRepositoryName(eventData)),
+      "Status creator": stringOrDash(statusCreatorLogin(eventData)),
       "Commit URL": stringOrDash(statusCommitUrl(eventData)),
       "Target URL": stringOrDash(statusTargetUrl(eventData)),
-      Repository: stringOrDash(statusRepositoryName(eventData)),
     };
   },
 
@@ -203,6 +204,11 @@ function statusCreatorLogin(eventData: OnCommitStatusEventData | undefined): str
 
 function statusCommitAuthor(eventData: OnCommitStatusEventData | undefined): string | undefined {
   return eventData?.commit?.author?.login || eventData?.commit?.commit?.author?.name;
+}
+
+function statusCommitMessage(eventData: OnCommitStatusEventData | undefined): string | undefined {
+  const message = eventData?.commit?.commit?.message;
+  return message?.split("\n")[0];
 }
 
 function statusCommitUrl(eventData: OnCommitStatusEventData | undefined): string | undefined {


### PR DESCRIPTION
Minor update. Changed `github.onCommitStatus` details to include "Commit message" and reordered the fields to read more logically.