### PR TITLE
feat: stream agent output

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -295,7 +296,7 @@ func TestStreamEvents_MapsKnownTypes(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	err := p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	err := p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	})
@@ -309,6 +310,123 @@ func TestStreamEvents_MapsKnownTypes(t *testing.T) {
 	assert.Equal(t, "ls -la", received[1].ToolInput, "bash-style tools surface the `command` field as the input")
 	assert.Equal(t, agents.ProviderEventToolUseFinished, received[2].Type)
 	assert.Equal(t, agents.ProviderEventTurnCompleted, received[3].Type)
+}
+
+func TestStreamEvents_RunsAfterOpenBeforeReadingEvents(t *testing.T) {
+	streamOpened := make(chan struct{})
+	releaseEvents := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sessions/sesn_abc/events/stream", r.URL.Path)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		close(streamOpened)
+		<-releaseEvents
+		_, _ = io.WriteString(w, "data: {\"type\":\"session.status_idle\"}\n\n")
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	events := 0
+	err := p.StreamEvents(ctx, "sesn_abc", func(context.Context) error {
+		select {
+		case <-streamOpened:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		close(releaseEvents)
+		return nil
+	}, func(agents.ProviderEvent) error {
+		events++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, events)
+}
+
+func TestStreamEvents_AccumulatesConsecutiveAgentMessages(t *testing.T) {
+	const sse = "data: {\"id\":\"msg-1\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}]}\n\n" +
+		"data: {\"id\":\"msg-2\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\", world\"}]}\n\n" +
+		"data: {\"type\":\"session.status_idle\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 3)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[0].Type)
+	assert.Equal(t, "msg-1", received[0].ProviderEventID)
+	assert.Equal(t, "Hello", received[0].Text)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[1].Type)
+	assert.Equal(t, "msg-1", received[1].ProviderEventID)
+	assert.Equal(t, "Hello, world", received[1].Text)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[2].Type)
+}
+
+func TestStreamEvents_AccumulatesAgentMessageDeltas(t *testing.T) {
+	const sse = "data: {\"id\":\"msg-1\",\"type\":\"agent.message_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n" +
+		"data: {\"id\":\"msg-1\",\"type\":\"agent.message_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\", world\"}}\n\n" +
+		"data: {\"type\":\"session.status_idle\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 3)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[0].Type)
+	assert.Equal(t, "msg-1", received[0].ProviderEventID)
+	assert.Equal(t, "Hello", received[0].Text)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[1].Type)
+	assert.Equal(t, "msg-1", received[1].ProviderEventID)
+	assert.Equal(t, "Hello, world", received[1].Text)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[2].Type)
+}
+
+func TestStreamEvents_AccumulatesContentBlockDeltas(t *testing.T) {
+	const sse = "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg-1\"}}\n\n" +
+		"data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n" +
+		"data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\", world\"}}\n\n" +
+		"data: {\"type\":\"message_stop\"}\n\n" +
+		"data: {\"type\":\"session.status_idle\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 3)
+	assert.Equal(t, "msg-1", received[0].ProviderEventID)
+	assert.Equal(t, "Hello", received[0].Text)
+	assert.Equal(t, "msg-1", received[1].ProviderEventID)
+	assert.Equal(t, "Hello, world", received[1].Text)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[2].Type)
 }
 
 func TestStreamEvents_PairsToolUseAndResultByToolUseID(t *testing.T) {
@@ -326,7 +444,7 @@ func TestStreamEvents_PairsToolUseAndResultByToolUseID(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -346,7 +464,7 @@ func TestStreamEvents_FallsBackToEventIDWhenToolUseIDMissing(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -368,7 +486,7 @@ func TestStreamEvents_RedactsJWTsInToolCommands(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -389,7 +507,7 @@ func TestStreamEvents_RedactsJWTsInAssistantMessages(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -408,7 +526,7 @@ func TestStreamEvents_ToolInputFallsBackToJSON(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -428,7 +546,7 @@ func TestStreamEvents_SessionFailed(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -450,7 +568,7 @@ func TestStreamEvents_SessionErrorDoesNotStopStream(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	var received []agents.ProviderEvent
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		received = append(received, e)
 		return nil
 	}))
@@ -472,7 +590,7 @@ func TestStreamEvents_SkipsMalformed(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	count := 0
-	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		count++
 		return nil
 	}))
@@ -490,7 +608,7 @@ func TestStreamEvents_StopsOnCallbackError(t *testing.T) {
 
 	p := newTestProvider(t, server)
 	count := 0
-	err := p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+	err := p.StreamEvents(context.Background(), "sesn_abc", nil, func(e agents.ProviderEvent) error {
 		count++
 		return io.ErrUnexpectedEOF
 	})
@@ -506,7 +624,7 @@ func TestStreamEvents_PropagatesHTTPError(t *testing.T) {
 	defer server.Close()
 
 	p := newTestProvider(t, server)
-	err := p.StreamEvents(context.Background(), "sesn_abc", func(agents.ProviderEvent) error { return nil })
+	err := p.StreamEvents(context.Background(), "sesn_abc", nil, func(agents.ProviderEvent) error { return nil })
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "503"))
 }

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/agents"
 )
 
@@ -15,6 +16,9 @@ type anthropicEvent struct {
 	ToolUseID string                  `json:"tool_use_id,omitempty"`
 	Input     json.RawMessage         `json:"input,omitempty"`
 	Content   []anthropicContentBlock `json:"content"`
+	Message   *anthropicMessage       `json:"message,omitempty"`
+	Delta     *anthropicDelta         `json:"delta,omitempty"`
+	Text      string                  `json:"text,omitempty"`
 	Error     *struct {
 		Message string `json:"message"`
 	} `json:"error"`
@@ -37,6 +41,15 @@ type anthropicContentBlock struct {
 	Text string `json:"text"`
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+type anthropicMessage struct {
+	ID string `json:"id"`
+}
+
+type anthropicDelta struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
 }
 
 func mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
@@ -74,6 +87,113 @@ func assistantMessageEvent(raw anthropicEvent) agents.ProviderEvent {
 		Type:            agents.ProviderEventAssistantMessage,
 		Text:            redactSensitive(joinText(raw.Content)),
 	}
+}
+
+type streamEventMapper struct {
+	currentAssistantEventID string
+	currentAssistantText    string
+}
+
+func newStreamEventMapper() *streamEventMapper {
+	return &streamEventMapper{}
+}
+
+func (m *streamEventMapper) mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
+	switch raw.Type {
+	case "message_start":
+		m.startAssistantMessage(raw)
+		return agents.ProviderEvent{}, false
+	case "content_block_delta", "agent.message_delta":
+		return m.assistantMessageDeltaEvent(raw)
+	case "message_stop":
+		m.finishAssistantMessage()
+		return agents.ProviderEvent{}, false
+	case "agent.message":
+		return m.assistantMessageEvent(raw)
+	}
+
+	m.finishAssistantMessage()
+	return mapEvent(raw)
+}
+
+func (m *streamEventMapper) startAssistantMessage(raw anthropicEvent) {
+	m.currentAssistantText = ""
+
+	if raw.Message != nil && raw.Message.ID != "" {
+		m.currentAssistantEventID = raw.Message.ID
+		return
+	}
+
+	if raw.ID != "" {
+		m.currentAssistantEventID = raw.ID
+	}
+}
+
+func (m *streamEventMapper) assistantMessageDeltaEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
+	text := textDelta(raw)
+	if text == "" {
+		return agents.ProviderEvent{}, false
+	}
+
+	if m.currentAssistantEventID == "" {
+		m.currentAssistantEventID = assistantEventID(raw)
+	}
+
+	m.currentAssistantText += text
+	return agents.ProviderEvent{
+		ProviderEventID: m.currentAssistantEventID,
+		Type:            agents.ProviderEventAssistantMessage,
+		Text:            redactSensitive(m.currentAssistantText),
+	}, true
+}
+
+func (m *streamEventMapper) assistantMessageEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
+	text := joinText(raw.Content)
+	if text == "" {
+		return agents.ProviderEvent{}, false
+	}
+
+	if m.currentAssistantEventID != "" {
+		m.currentAssistantText += text
+		return agents.ProviderEvent{
+			ProviderEventID: m.currentAssistantEventID,
+			Type:            agents.ProviderEventAssistantMessage,
+			Text:            redactSensitive(m.currentAssistantText),
+		}, true
+	}
+
+	m.currentAssistantEventID = assistantEventID(raw)
+	m.currentAssistantText = text
+	return agents.ProviderEvent{
+		ProviderEventID: m.currentAssistantEventID,
+		Type:            agents.ProviderEventAssistantMessage,
+		Text:            redactSensitive(m.currentAssistantText),
+	}, true
+}
+
+func (m *streamEventMapper) finishAssistantMessage() {
+	m.currentAssistantEventID = ""
+	m.currentAssistantText = ""
+}
+
+func assistantEventID(raw anthropicEvent) string {
+	if raw.ID != "" {
+		return raw.ID
+	}
+	return "assistant-stream-" + uuid.NewString()
+}
+
+func textDelta(raw anthropicEvent) string {
+	if raw.Text != "" {
+		return raw.Text
+	}
+	if raw.Delta == nil || raw.Delta.Text == "" {
+		return ""
+	}
+	if raw.Delta.Type != "" && raw.Delta.Type != "text_delta" {
+		return ""
+	}
+	return raw.Delta.Text
 }
 
 func toolEvent(raw anthropicEvent, eventType agents.ProviderEventType) agents.ProviderEvent {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -147,7 +147,12 @@ func (p *Provider) DefineOutcome(ctx context.Context, providerSessionID string, 
 	return nil
 }
 
-func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, onEvent func(agents.ProviderEvent) error) error {
+func (p *Provider) StreamEvents(
+	ctx context.Context,
+	providerSessionID string,
+	afterOpen func(context.Context) error,
+	onEvent func(agents.ProviderEvent) error,
+) error {
 	if providerSessionID == "" {
 		return fmt.Errorf("anthropic: provider session id is required")
 	}
@@ -157,6 +162,13 @@ func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, o
 		return fmt.Errorf("anthropic: open stream: %w", err)
 	}
 	defer body.Close()
+
+	if afterOpen != nil {
+		if err := afterOpen(ctx); err != nil {
+			return err
+		}
+	}
+
 	return forwardSSE(ctx, body, onEvent)
 }
 
@@ -182,12 +194,13 @@ func withPreamble(message, preamble string) string {
 func forwardSSE(ctx context.Context, body io.Reader, onEvent func(agents.ProviderEvent) error) error {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	mapper := newStreamEventMapper()
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		event, ok := parseSSEData(scanner.Text())
+		event, ok := parseSSEData(scanner.Text(), mapper)
 		if !ok {
 			continue
 		}
@@ -204,7 +217,7 @@ func forwardSSE(ctx context.Context, body io.Reader, onEvent func(agents.Provide
 	return nil
 }
 
-func parseSSEData(line string) (agents.ProviderEvent, bool) {
+func parseSSEData(line string, mapper *streamEventMapper) (agents.ProviderEvent, bool) {
 	if !strings.HasPrefix(line, "data: ") {
 		return agents.ProviderEvent{}, false
 	}
@@ -217,7 +230,7 @@ func parseSSEData(line string) (agents.ProviderEvent, bool) {
 		log.WithError(err).Debug("anthropic: skipping malformed sse event")
 		return agents.ProviderEvent{}, false
 	}
-	return mapEvent(raw)
+	return mapper.mapEvent(raw)
 }
 
 func isTerminalEvent(t agents.ProviderEventType) bool {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -88,9 +88,11 @@ type Provider interface {
 	// DefineOutcome starts a rubric-driven execution loop on the provider side.
 	DefineOutcome(ctx context.Context, providerSessionID string, opts DefineOutcomeOptions) error
 	// StreamEvents blocks until the provider closes the stream, ctx is
-	// cancelled, or onEvent errors. Implementations must not call onEvent
-	// after returning.
-	StreamEvents(ctx context.Context, providerSessionID string, onEvent func(ProviderEvent) error) error
+	// cancelled, afterOpen errors, or onEvent errors. afterOpen runs after the
+	// stream is subscribed and before the first event is read; callers use it
+	// to trigger provider work without missing early events.
+	// Implementations must not call onEvent after returning.
+	StreamEvents(ctx context.Context, providerSessionID string, afterOpen func(context.Context) error, onEvent func(ProviderEvent) error) error
 }
 
 type ProviderSessionCleaner interface {

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -149,7 +149,7 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 	if err := models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusStreaming); err != nil {
 		log.WithError(err).Warn("failed to mark agent session as streaming")
 	}
-	if err := s.enqueueStream(sessionID, organizationID, userID); err != nil {
+	if err := s.enqueueStream(sessionID, organizationID, userID, uuid.Nil, ModeBuilder); err != nil {
 		log.WithError(err).Warn("failed to enqueue stream after define outcome")
 	}
 	return nil
@@ -160,7 +160,7 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		return nil, fmt.Errorf("message content is required")
 	}
 
-	session, err := models.FindAgentSessionForUser(organizationID, userID, sessionID)
+	_, err := models.FindAgentSessionForUser(organizationID, userID, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -168,16 +168,6 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 	agentMode := ModeOperator
 	if len(mode) > 0 {
 		agentMode = NormalizeMode(mode[0])
-	}
-
-	preamble, err := s.buildPreamble(session, organizationID, userID, agentMode)
-	if err != nil {
-		return nil, fmt.Errorf("build preamble: %w", err)
-	}
-
-	if err := s.provider.SendMessage(ctx, session.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
-		_ = models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusFailed)
-		return nil, fmt.Errorf("forward to provider: %w", err)
 	}
 
 	messageRole := models.AgentMessageRoleUser
@@ -197,10 +187,33 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		log.WithError(err).Warn("failed to mark agent session as streaming")
 	}
 
-	if err := s.enqueueStream(sessionID, organizationID, userID); err != nil {
+	if err := s.enqueueStream(sessionID, organizationID, userID, persisted.ID, agentMode); err != nil {
 		return nil, err
 	}
 	return persisted, nil
+}
+
+func (s *Service) SendPersistedMessage(ctx context.Context, session *models.AgentSession, messageID uuid.UUID, mode string) error {
+	message, err := models.FindAgentSessionMessage(session.ID, messageID)
+	if err != nil {
+		return fmt.Errorf("load queued user message: %w", err)
+	}
+
+	if message.Role != models.AgentMessageRoleUser && message.Role != models.AgentMessageRoleSystem {
+		return fmt.Errorf("queued message has unsupported role: %s", message.Role)
+	}
+
+	agentMode := NormalizeMode(mode)
+	preamble, err := s.buildPreamble(session, session.OrganizationID, session.UserID, agentMode)
+	if err != nil {
+		return fmt.Errorf("build preamble: %w", err)
+	}
+
+	if err := s.provider.SendMessage(ctx, session.ProviderSessionID, message.Content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
+		return fmt.Errorf("forward to provider: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Service) buildPreamble(session *models.AgentSession, organizationID, userID uuid.UUID, mode Mode) (string, error) {
@@ -222,12 +235,18 @@ func (s *Service) buildPreamble(session *models.AgentSession, organizationID, us
 	return base + "\n\n" + modeInstructions(mode) + "\n\n" + draftStatus, nil
 }
 
-func (s *Service) enqueueStream(sessionID, organizationID, userID uuid.UUID) error {
-	err := messages.PublishAgentStreamRequested(messages.AgentStreamRequest{
+func (s *Service) enqueueStream(sessionID, organizationID, userID uuid.UUID, userMessageID uuid.UUID, mode Mode) error {
+	req := messages.AgentStreamRequest{
 		SessionID:      sessionID.String(),
 		OrganizationID: organizationID.String(),
 		UserID:         userID.String(),
-	})
+		Mode:           string(mode),
+	}
+	if userMessageID != uuid.Nil {
+		req.UserMessageID = userMessageID.String()
+	}
+
+	err := messages.PublishAgentStreamRequested(req)
 	if err == nil {
 		return nil
 	}

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -41,7 +41,7 @@ func (b *blockingProvider) DefineOutcome(_ context.Context, _ string, _ agents.D
 	return nil
 }
 
-func (b *blockingProvider) StreamEvents(context.Context, string, func(agents.ProviderEvent) error) error {
+func (b *blockingProvider) StreamEvents(context.Context, string, func(context.Context) error, func(agents.ProviderEvent) error) error {
 	return nil
 }
 
@@ -92,7 +92,7 @@ func (f *fakeProvider) DefineOutcome(_ context.Context, _ string, opts agents.De
 	return nil
 }
 
-func (f *fakeProvider) StreamEvents(_ context.Context, _ string, _ func(agents.ProviderEvent) error) error {
+func (f *fakeProvider) StreamEvents(_ context.Context, _ string, _ func(context.Context) error, _ func(agents.ProviderEvent) error) error {
 	return nil
 }
 
@@ -249,9 +249,10 @@ func TestService_SendMessage_ReturnsPersistedUserMessage(t *testing.T) {
 	require.NotNil(t, persisted)
 	require.NotEqual(t, uuid.Nil, persisted.ID)
 	assert.Equal(t, "hello", persisted.Content)
+	assert.Equal(t, 0, provider.sendCalled, "provider send happens after the stream worker subscribes")
 }
 
-func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
+func TestService_SendPersistedMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 
@@ -262,7 +263,9 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
 	require.NoError(t, err)
 
-	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "first")
+	first, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "first")
+	require.NoError(t, err)
+	err = svc.SendPersistedMessage(context.Background(), session, first.ID, string(agents.ModeOperator))
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastPreamble, canvas.ID.String())
 	assert.Contains(t, provider.lastPreamble, "api_token:")
@@ -275,13 +278,15 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())
 
 	provider.lastPreamble = "<sentinel>"
-	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "second")
+	second, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "second")
+	require.NoError(t, err)
+	err = svc.SendPersistedMessage(context.Background(), session, second.ID, string(agents.ModeOperator))
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastPreamble, "api_token:",
 		"a fresh api_token must be re-injected on every turn so the session never expires mid-conversation")
 }
 
-func TestService_SendMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing.T) {
+func TestService_SendPersistedMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 
@@ -292,12 +297,16 @@ func TestService_SendMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing
 	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
 	require.NoError(t, err)
 
-	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "first")
+	first, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "first")
+	require.NoError(t, err)
+	err = svc.SendPersistedMessage(context.Background(), session, first.ID, string(agents.ModeOperator))
 	require.Error(t, err)
 
 	provider.sendErr = nil
 	provider.lastPreamble = "<sentinel>"
-	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "retry")
+	retry, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "retry")
+	require.NoError(t, err)
+	err = svc.SendPersistedMessage(context.Background(), session, retry.ID, string(agents.ModeOperator))
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastPreamble, "api_token:",
 		"preamble must still be injected after the previous attempt failed at the provider")

--- a/pkg/grpc/actions/messages/agent_session.go
+++ b/pkg/grpc/actions/messages/agent_session.go
@@ -12,12 +12,14 @@ const (
 	AgentSessionEventRoutingKey = "agent-session-event"
 )
 
-// AgentStreamRequest carries only the session id; the worker re-reads state
+// AgentStreamRequest carries identifiers only; the worker re-reads state
 // from the DB so we never publish tokens or message content over the queue.
 type AgentStreamRequest struct {
 	SessionID      string `json:"session_id"`
 	OrganizationID string `json:"organization_id"`
 	UserID         string `json:"user_id"`
+	UserMessageID  string `json:"user_message_id,omitempty"`
+	Mode           string `json:"mode,omitempty"`
 }
 
 func PublishAgentStreamRequested(req AgentStreamRequest) error {

--- a/pkg/models/agent_session_message.go
+++ b/pkg/models/agent_session_message.go
@@ -79,6 +79,18 @@ func AppendAgentSessionMessage(msg *AgentSessionMessage) error {
 	return AppendAgentSessionMessageInTransaction(database.Conn(), msg)
 }
 
+func FindAgentSessionMessage(sessionID, messageID uuid.UUID) (*AgentSessionMessage, error) {
+	var message AgentSessionMessage
+	err := database.Conn().
+		Where("session_id = ?", sessionID).
+		Where("id = ?", messageID).
+		First(&message).Error
+	if err != nil {
+		return nil, err
+	}
+	return &message, nil
+}
+
 // ListAgentSessionMessagesPage returns up to `limit` messages strictly older
 // than `before` (or the most recent `limit` when `before` is nil), in
 // chronological order (oldest-first). Used for tail-paginated chat scroll.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,7 @@ func startWorkers(
 	baseURL string,
 	authService authorization.Authorization,
 	agentProvider agents.Provider,
+	agentTurnSender workers.AgentTurnSender,
 ) {
 	log.Println("Starting Workers")
 
@@ -211,7 +212,7 @@ func startWorkers(
 
 	if agentProvider != nil && os.Getenv("START_AGENT_STREAM_WORKER") != "no" {
 		log.Println("Starting Agent Stream Worker")
-		w := workers.NewAgentStreamWorker(agentProvider, rabbitMQURL)
+		w := workers.NewAgentStreamWorker(agentProvider, rabbitMQURL, agentTurnSender)
 		go w.Start(context.Background())
 	}
 
@@ -530,6 +531,7 @@ func Start() {
 	templates.Setup(registry)
 
 	agentProvider, agentService := buildAgentService(authService, jwtSigner, baseURL)
+	agentTurnSender, _ := agentService.(workers.AgentTurnSender)
 
 	if os.Getenv("START_PUBLIC_API") == "yes" {
 		go startPublicAPI(
@@ -567,6 +569,7 @@ func Start() {
 		baseURL,
 		authService,
 		agentProvider,
+		agentTurnSender,
 	)
 
 	log.Println("SuperPlane is UP.")

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -32,13 +32,24 @@ const (
 // AgentStreamWorker is stateless and safe to run as competing consumers.
 type AgentStreamWorker struct {
 	provider    agents.Provider
+	turnSender  AgentTurnSender
 	rabbitMQURL string
 	slots       chan struct{}
 }
 
-func NewAgentStreamWorker(provider agents.Provider, rabbitMQURL string) *AgentStreamWorker {
+type AgentTurnSender interface {
+	SendPersistedMessage(ctx context.Context, session *models.AgentSession, messageID uuid.UUID, mode string) error
+}
+
+func NewAgentStreamWorker(provider agents.Provider, rabbitMQURL string, turnSenders ...AgentTurnSender) *AgentStreamWorker {
+	var turnSender AgentTurnSender
+	if len(turnSenders) > 0 {
+		turnSender = turnSenders[0]
+	}
+
 	return &AgentStreamWorker{
 		provider:    provider,
+		turnSender:  turnSender,
 		rabbitMQURL: rabbitMQURL,
 		slots:       make(chan struct{}, maxConcurrentStreams),
 	}
@@ -192,7 +203,7 @@ func (w *AgentStreamWorker) handle(parentCtx context.Context, body []byte) error
 
 	var streamErr error
 
-	err = w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
+	err = w.provider.StreamEvents(ctx, session.ProviderSessionID, w.afterStreamOpen(session, req), func(evt agents.ProviderEvent) error {
 		return handleProviderEvent(sessionID, evt, publish, &streamErr)
 	})
 
@@ -217,6 +228,25 @@ func (w *AgentStreamWorker) handle(parentCtx context.Context, body []byte) error
 		log.WithError(err).Warn("agent stream: failed to mark session idle")
 	}
 	return nil
+}
+
+func (w *AgentStreamWorker) afterStreamOpen(session *models.AgentSession, req messages.AgentStreamRequest) func(context.Context) error {
+	if req.UserMessageID == "" {
+		return nil
+	}
+
+	return func(ctx context.Context) error {
+		if w.turnSender == nil {
+			return fmt.Errorf("agent stream: queued user turn has no sender")
+		}
+
+		messageID, err := uuid.Parse(req.UserMessageID)
+		if err != nil {
+			return fmt.Errorf("agent stream: invalid user message id: %w", err)
+		}
+
+		return w.turnSender.SendPersistedMessage(ctx, session, messageID, req.Mode)
+	}
 }
 
 func handleProviderEvent(

--- a/pkg/workers/agent_stream_worker_test.go
+++ b/pkg/workers/agent_stream_worker_test.go
@@ -22,9 +22,10 @@ import (
 const testProvider = "test"
 
 type scriptedProvider struct {
-	name   string
-	events []agents.ProviderEvent
-	err    error
+	name          string
+	events        []agents.ProviderEvent
+	err           error
+	afterOpenSeen bool
 }
 
 func (p *scriptedProvider) Name() string { return p.name }
@@ -40,7 +41,13 @@ func (p *scriptedProvider) InterruptSession(context.Context, string) error {
 func (p *scriptedProvider) DefineOutcome(context.Context, string, agents.DefineOutcomeOptions) error {
 	return errors.New("not used")
 }
-func (p *scriptedProvider) StreamEvents(ctx context.Context, _ string, cb func(agents.ProviderEvent) error) error {
+func (p *scriptedProvider) StreamEvents(ctx context.Context, _ string, afterOpen func(context.Context) error, cb func(agents.ProviderEvent) error) error {
+	if afterOpen != nil {
+		if err := afterOpen(ctx); err != nil {
+			return err
+		}
+		p.afterOpenSeen = true
+	}
 	for _, e := range p.events {
 		if err := cb(e); err != nil {
 			return err
@@ -49,6 +56,20 @@ func (p *scriptedProvider) StreamEvents(ctx context.Context, _ string, cb func(a
 	return p.err
 }
 func (p *scriptedProvider) ArchiveSession(context.Context, string) error { return nil }
+
+type recordingTurnSender struct {
+	sessionID uuid.UUID
+	messageID uuid.UUID
+	mode      string
+	err       error
+}
+
+func (s *recordingTurnSender) SendPersistedMessage(_ context.Context, session *models.AgentSession, messageID uuid.UUID, mode string) error {
+	s.sessionID = session.ID
+	s.messageID = messageID
+	s.mode = mode
+	return s.err
+}
 
 func mustCreateSession(t *testing.T, r *support.ResourceRegistry, canvasID uuid.UUID) *models.AgentSession {
 	t.Helper()
@@ -66,7 +87,7 @@ func mustCreateSession(t *testing.T, r *support.ResourceRegistry, canvasID uuid.
 	return session
 }
 
-func TestAgentStreamWorker_PersistsAssistantTurn(t *testing.T) {
+func TestAgentStreamWorker_UpdatesStreamedAssistantMessage(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -77,7 +98,7 @@ func TestAgentStreamWorker_PersistsAssistantTurn(t *testing.T) {
 		name: testProvider,
 		events: []agents.ProviderEvent{
 			{ProviderEventID: "msg-1", Type: agents.ProviderEventAssistantMessage, Text: "Hello"},
-			{ProviderEventID: "msg-2", Type: agents.ProviderEventAssistantMessage, Text: ", world"},
+			{ProviderEventID: "msg-1", Type: agents.ProviderEventAssistantMessage, Text: "Hello, world"},
 			{Type: agents.ProviderEventTurnCompleted},
 		},
 	}
@@ -95,15 +116,106 @@ func TestAgentStreamWorker_PersistsAssistantTurn(t *testing.T) {
 
 	stored, err := models.ListAgentSessionMessagesPage(session.ID, nil, 100)
 	require.NoError(t, err)
-	require.Len(t, stored, 2, "each assistant text block must persist as its own row so chronology lines up with interleaved tool rows")
+	require.Len(t, stored, 1, "streamed assistant text must update one row so the UI can repaint the current response")
 	assert.Equal(t, models.AgentMessageRoleAssistant, stored[0].Role)
-	assert.Equal(t, "Hello", stored[0].Content)
-	assert.Equal(t, models.AgentMessageRoleAssistant, stored[1].Role)
-	assert.Equal(t, ", world", stored[1].Content)
+	assert.Equal(t, "Hello, world", stored[0].Content)
 
 	refreshed, err := models.FindAgentSession(session.ID)
 	require.NoError(t, err)
 	assert.Equal(t, models.AgentSessionStatusIdle, refreshed.Status)
+}
+
+func TestAgentStreamWorker_SendsQueuedUserMessageAfterStreamOpens(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	message := &models.AgentSessionMessage{
+		SessionID: session.ID,
+		Role:      models.AgentMessageRoleUser,
+		Content:   "Build this",
+	}
+	require.NoError(t, models.AppendAgentSessionMessage(message))
+
+	provider := &scriptedProvider{
+		name: testProvider,
+		events: []agents.ProviderEvent{
+			{ProviderEventID: "msg-1", Type: agents.ProviderEventAssistantMessage, Text: "Done"},
+			{Type: agents.ProviderEventTurnCompleted},
+		},
+	}
+	sender := &recordingTurnSender{}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored", sender)
+	body, _ := json.Marshal(messages.AgentStreamRequest{
+		SessionID:      session.ID.String(),
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		UserMessageID:  message.ID.String(),
+		Mode:           string(agents.ModeBuilder),
+	})
+
+	require.NoError(t, w.Handle(context.Background(), body))
+	assert.True(t, provider.afterOpenSeen)
+	assert.Equal(t, session.ID, sender.sessionID)
+	assert.Equal(t, message.ID, sender.messageID)
+	assert.Equal(t, string(agents.ModeBuilder), sender.mode)
+}
+
+func TestAgentStreamWorker_MarksFailedWhenQueuedUserMessageCannotSend(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	message := &models.AgentSessionMessage{
+		SessionID: session.ID,
+		Role:      models.AgentMessageRoleUser,
+		Content:   "Build this",
+	}
+	require.NoError(t, models.AppendAgentSessionMessage(message))
+
+	provider := &scriptedProvider{name: testProvider}
+	sender := &recordingTurnSender{err: errors.New("provider send failed")}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored", sender)
+	body, _ := json.Marshal(messages.AgentStreamRequest{
+		SessionID:     session.ID.String(),
+		UserMessageID: message.ID.String(),
+	})
+
+	require.NoError(t, w.Handle(context.Background(), body))
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusFailed, refreshed.Status)
+}
+
+func TestAgentStreamWorker_PersistsDistinctAssistantMessages(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	session := mustCreateSession(t, r, canvas.ID)
+
+	provider := &scriptedProvider{
+		name: testProvider,
+		events: []agents.ProviderEvent{
+			{ProviderEventID: "msg-1", Type: agents.ProviderEventAssistantMessage, Text: "First"},
+			{ProviderEventID: "msg-2", Type: agents.ProviderEventAssistantMessage, Text: "Second"},
+			{Type: agents.ProviderEventTurnCompleted},
+		},
+	}
+
+	w := workers.NewAgentStreamWorker(provider, "amqp://ignored")
+	body, _ := json.Marshal(messages.AgentStreamRequest{SessionID: session.ID.String()})
+	require.NoError(t, w.Handle(context.Background(), body))
+
+	stored, err := models.ListAgentSessionMessagesPage(session.ID, nil, 100)
+	require.NoError(t, err)
+	require.Len(t, stored, 2)
+	assert.Equal(t, "First", stored[0].Content)
+	assert.Equal(t, "Second", stored[1].Content)
 }
 
 func TestAgentStreamWorker_PersistsToolEvents(t *testing.T) {

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -42,7 +42,7 @@ func (p *cleanupProvider) DefineOutcome(context.Context, string, agents.DefineOu
 	return errors.New("not used")
 }
 
-func (p *cleanupProvider) StreamEvents(context.Context, string, func(agents.ProviderEvent) error) error {
+func (p *cleanupProvider) StreamEvents(context.Context, string, func(context.Context) error, func(agents.ProviderEvent) error) error {
 	return errors.New("not used")
 }
 

--- a/test/support/agent_provider.go
+++ b/test/support/agent_provider.go
@@ -337,6 +337,7 @@ func (p *TestAgentProvider) DefineOutcome(
 func (p *TestAgentProvider) StreamEvents(
 	ctx context.Context,
 	providerSessionID string,
+	afterOpen func(context.Context) error,
 	onEvent func(agents.ProviderEvent) error,
 ) error {
 	p.mu.Lock()
@@ -350,6 +351,12 @@ func (p *TestAgentProvider) StreamEvents(
 
 	if err != nil {
 		return err
+	}
+
+	if afterOpen != nil {
+		if err := afterOpen(ctx); err != nil {
+			return err
+		}
 	}
 
 	for {

--- a/test/support/agent_provider_test.go
+++ b/test/support/agent_provider_test.go
@@ -32,7 +32,7 @@ func TestAgentProviderCreatesSessionAndStreamsQueuedEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	var events []agents.ProviderEvent
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(event agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(event agents.ProviderEvent) error {
 		events = append(events, event)
 		return nil
 	})
@@ -74,7 +74,7 @@ func TestAgentProviderSendMessageRecordsCallAndQueuesConfiguredEvents(t *testing
 	require.NoError(t, err)
 
 	var events []agents.ProviderEvent
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(event agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(event agents.ProviderEvent) error {
 		events = append(events, event)
 		return nil
 	})
@@ -106,7 +106,7 @@ func TestAgentProviderSendMessageHandlerCanBuildDynamicEvents(t *testing.T) {
 	require.NoError(t, provider.SendMessage(context.Background(), result.ProviderSessionID, "echo me", agents.SendMessageOptions{}))
 
 	var events []agents.ProviderEvent
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(event agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(event agents.ProviderEvent) error {
 		events = append(events, event)
 		return nil
 	})
@@ -139,7 +139,7 @@ func TestAgentProviderDefineOutcomeRecordsCallAndQueuesConfiguredEvents(t *testi
 	require.NoError(t, provider.DefineOutcome(context.Background(), result.ProviderSessionID, options))
 
 	var events []agents.ProviderEvent
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(event agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(event agents.ProviderEvent) error {
 		events = append(events, event)
 		return nil
 	})
@@ -168,7 +168,7 @@ func TestAgentProviderStreamReturnsCallbackAndQueuedErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(agents.ProviderEvent) error {
 		return callbackErr
 	})
 	require.ErrorIs(t, err, callbackErr)
@@ -176,10 +176,46 @@ func TestAgentProviderStreamReturnsCallbackAndQueuedErrors(t *testing.T) {
 	queuedErr := errors.New("stream failed")
 	require.NoError(t, provider.QueueError(result.ProviderSessionID, queuedErr))
 
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(agents.ProviderEvent) error {
 		return nil
 	})
 	require.ErrorIs(t, err, queuedErr)
+}
+
+func TestAgentProviderStreamRunsAfterOpenBeforeEvents(t *testing.T) {
+	provider := NewAgentProvider()
+	provider.SetSessionIDProvider(func() string { return "session-1" })
+
+	result, err := provider.CreateSession(context.Background(), agents.CreateSessionOptions{})
+	require.NoError(t, err)
+	require.NoError(t, provider.QueueEvents(
+		result.ProviderSessionID,
+		agents.ProviderEvent{ProviderEventID: "event-1", Type: agents.ProviderEventAssistantMessage, Text: "hello"},
+		agents.ProviderEvent{ProviderEventID: "event-2", Type: agents.ProviderEventTurnCompleted},
+	))
+
+	afterOpenRan := false
+	eventCountWhenAfterOpenRan := 0
+	eventCount := 0
+
+	err = provider.StreamEvents(
+		context.Background(),
+		result.ProviderSessionID,
+		func(context.Context) error {
+			afterOpenRan = true
+			eventCountWhenAfterOpenRan = eventCount
+			return nil
+		},
+		func(agents.ProviderEvent) error {
+			eventCount++
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, afterOpenRan)
+	require.Equal(t, 0, eventCountWhenAfterOpenRan)
+	require.Equal(t, 2, eventCount)
 }
 
 func TestAgentProviderInterruptAndDeleteUpdateSessionState(t *testing.T) {
@@ -199,7 +235,7 @@ func TestAgentProviderInterruptAndDeleteUpdateSessionState(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, session.Deleted)
 
-	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, func(agents.ProviderEvent) error {
+	err = provider.StreamEvents(context.Background(), result.ProviderSessionID, nil, func(agents.ProviderEvent) error {
 		return nil
 	})
 	require.NoError(t, err)

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.spec.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.spec.ts
@@ -35,6 +35,25 @@ describe("useThinkingIndicator", () => {
     ).toBe(true);
   });
 
+  it("hides once assistant output for the current turn is visible", () => {
+    expect(
+      thinking([
+        message({ id: "user-1", role: "user", content: "Run this" }),
+        message({ id: "assistant-1", role: "assistant", content: "Working on it" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("shows for a new turn even when an earlier assistant message exists", () => {
+    expect(
+      thinking([
+        message({ id: "user-1", role: "user", content: "Run this" }),
+        message({ id: "assistant-1", role: "assistant", content: "Done" }),
+        message({ id: "user-2", role: "user", content: "Run another" }),
+      ]),
+    ).toBe(true);
+  });
+
   it("hides while a tool is active", () => {
     expect(
       thinking([

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -29,7 +29,8 @@ export function useConversationMessages(
 
 export function useThinkingIndicator(messages: AgentMessage[], status: string): boolean {
   const hasRunningTool = useMemo(() => hasActiveTool(messages), [messages]);
-  return status === "streaming" && !hasRunningTool;
+  const hasAssistantOutput = useMemo(() => hasAssistantOutputForCurrentTurn(messages), [messages]);
+  return status === "streaming" && !hasRunningTool && !hasAssistantOutput;
 }
 
 function hasActiveTool(messages: AgentMessage[]): boolean {
@@ -52,6 +53,21 @@ function hasActiveTool(messages: AgentMessage[]): boolean {
   }
 
   return activeToolIds.size > 0;
+}
+
+function hasAssistantOutputForCurrentTurn(messages: AgentMessage[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message.role === "assistant" && message.content.trim() !== "") {
+      return true;
+    }
+
+    if (message.role === "user") {
+      return false;
+    }
+  }
+
+  return false;
 }
 
 export function useStoredOutcomeState(


### PR DESCRIPTION
Implements streaming agent output for the canvas agent conversation.

  The main fix is to align our Managed Agents flow with Anthropic’s documented sequence: subscribe to the session event stream first, then send the user message after the stream is open. This avoids missing early provider output and lets the UI render assistant text as it arrives instead of staying on “Thinking…” until the full response is available.

  ## What changed

  - Moved user-message forwarding into the agent stream worker’s stream-open path.
  - Kept RabbitMQ payloads identifier-only; message content and fresh JWT preambles are re-read/generated server-
  side.
  - Added an `afterOpen` hook to the provider stream interface.
  - Added Anthropic stream mapping that accumulates streamed assistant text into one updatable assistant message
  row.
  - Updated worker persistence so repeated streamed assistant chunks update the same row.
  - Updated the frontend thinking indicator to hide once assistant output exists for the current turn.
  - Expanded unit, support-provider, worker, Anthropic provider, and E2E coverage.
 
Resolves #5032.