### PR TITLE
chore: use VITE_ASSET_BASE_URL for vite build

### DIFF
--- a/web_src/package.json
+++ b/web_src/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build --base=/",
+    "build": "tsc -b && vite build",
     "clean": "rm -rf ../pkg/web/assets/dist",
     "lint": "eslint .",
     "lint:knip": "knip --config knip.json --include files,unlisted,binaries --no-progress",

--- a/web_src/vite.config.ts
+++ b/web_src/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig(({ command }: { command: string }) => {
 
   return {
     plugins: [react(), tailwindcss(), setHmrPortFromPortPlugin],
-    base: "/",
+    base: process.env.VITE_ASSET_BASE_URL ?? "/",
     server: {
       port: devPort,
       strictPort: true,


### PR DESCRIPTION
Preparation for moving asset loading to assets.superplane.com