### PR TITLE
chore: specify VITE_ASSET_BASE_URL during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,11 +81,15 @@ COPY templates /app/templates
 RUN rm -rf build && go build -o build/superplane cmd/server/main.go
 
 WORKDIR /app/web_src
-RUN npm install
 RUN if [ "$FRONTEND_PREBUILT" = "1" ]; then \
       echo "Using prebuilt frontend assets from build context"; \
     else \
-      VITE_BASE_URL=$BASE_URL VITE_ASSET_BASE_URL=$VITE_ASSET_BASE_URL npm run build; \
+      npm install && \
+      if [ -n "$VITE_ASSET_BASE_URL" ]; then \
+        VITE_BASE_URL=$BASE_URL VITE_ASSET_BASE_URL=$VITE_ASSET_BASE_URL npm run build; \
+      else \
+        VITE_BASE_URL=$BASE_URL npm run build; \
+      fi; \
     fi
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ CMD [ "/bin/bash",  "-c", "sleep infinity" ]
 FROM dev-base AS builder
 
 ARG BASE_URL=https://app.superplane.com
+ARG VITE_ASSET_BASE_URL=
+ARG FRONTEND_PREBUILT=0
 
 WORKDIR /app
 COPY pkg /app/pkg
@@ -80,7 +82,11 @@ RUN rm -rf build && go build -o build/superplane cmd/server/main.go
 
 WORKDIR /app/web_src
 RUN npm install
-RUN VITE_BASE_URL=$BASE_URL npm run build
+RUN if [ "$FRONTEND_PREBUILT" = "1" ]; then \
+      echo "Using prebuilt frontend assets from build context"; \
+    else \
+      VITE_BASE_URL=$BASE_URL VITE_ASSET_BASE_URL=$VITE_ASSET_BASE_URL npm run build; \
+    fi
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Demo runner: single-container image with embedded Postgres and RabbitMQ.

--- a/Makefile
+++ b/Makefile
@@ -327,10 +327,16 @@ cli.build.m1:
 IMAGE?=superplane
 IMAGE_TAG?=$(shell git rev-list -1 HEAD -- .)
 REGISTRY_HOST?=ghcr.io/superplanehq
+VITE_ASSET_BASE_URL?=
+FRONTEND_PREBUILT?=0
 # pb.gen runs in the compose app container; run `make dev.up` first.
 image.build:
 	$(MAKE) pb.gen
-	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f Dockerfile --target runner --build-arg BASE_URL=$(BASE_URL) --progress plain -t $(IMAGE):$(IMAGE_TAG) .
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f Dockerfile --target runner \
+	  --build-arg BASE_URL=$(BASE_URL) \
+	  --build-arg VITE_ASSET_BASE_URL=$(VITE_ASSET_BASE_URL) \
+	  --build-arg FRONTEND_PREBUILT=$(FRONTEND_PREBUILT) \
+	  --progress plain -t $(IMAGE):$(IMAGE_TAG) .
 
 image.auth:
 	@printf "%s" "$(GITHUB_TOKEN)" | docker login ghcr.io -u superplanehq --password-stdin

--- a/web_src/vite.config.ts
+++ b/web_src/vite.config.ts
@@ -28,10 +28,12 @@ export default defineConfig(({ command }: { command: string }) => {
   const isProduction = process.env.APP_ENV === "production";
   const apiPort = process.env.API_PORT || process.env.PUBLIC_API_PORT || "8000";
   const devPort = Number.parseInt(process.env.VITE_DEV_PORT || "5173", 10);
+  const assetBaseUrl = process.env.VITE_ASSET_BASE_URL?.trim();
 
   return {
     plugins: [react(), tailwindcss(), setHmrPortFromPortPlugin],
-    base: process.env.VITE_ASSET_BASE_URL ?? "/",
+    // Empty env vars are common in Docker ARG defaults; ?? alone would yield base: "".
+    base: assetBaseUrl ? assetBaseUrl : "/",
     server: {
       port: devPort,
       strictPort: true,


### PR DESCRIPTION
Specify VITE_ASSET_BASE_URL during image build. Also, FRONTEND_PREBUILT to control if Vite build should run or is already available.