### PR TITLE
feat: add runner fleet selection

### DIFF
--- a/pkg/components/runner/broker.go
+++ b/pkg/components/runner/broker.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -30,6 +31,15 @@ type ActiveTask struct {
 	ExecutionTimeoutSeconds *int       `json:"execution_timeout_seconds,omitempty"`
 }
 
+// Fleet is one runner pool registered in the task broker fleet catalog.
+type Fleet struct {
+	ID          string `json:"id"`
+	Provisioner string `json:"provisioner,omitempty"`
+	Arch        string `json:"arch,omitempty"`
+	Size        string `json:"size,omitempty"`
+	CreatedAt   int64  `json:"created_at_unix,omitempty"`
+}
+
 const (
 	brokerHTTPTimeout = 30 * time.Second
 
@@ -46,15 +56,16 @@ type BrokerClient struct {
 }
 
 func NewBrokerClient(httpClient core.HTTPContext) (*BrokerClient, error) {
+	if httpClient == nil || isRegistryHTTPContext(httpClient) {
+		httpClient = &http.Client{Timeout: brokerHTTPTimeout}
+	}
+
 	baseURL := os.Getenv("TASK_BROKER_BASE_URL")
 	if baseURL == "" {
 		return nil, fmt.Errorf("TASK_BROKER_BASE_URL is not set")
 	}
 
 	fleetID := os.Getenv("TASK_BROKER_FLEET_ID")
-	if fleetID == "" {
-		return nil, fmt.Errorf("TASK_BROKER_FLEET_ID is not set")
-	}
 
 	authToken := os.Getenv("TASK_BROKER_AUTH_TOKEN")
 	if authToken == "" {
@@ -67,6 +78,23 @@ func NewBrokerClient(httpClient core.HTTPContext) (*BrokerClient, error) {
 		fleetID:    fleetID,
 		authToken:  authToken,
 	}, nil
+}
+
+// The task broker URL is trusted server configuration, not user input. Avoid
+// routing it through the registry HTTP context, which enforces external-call
+// SSRF policy and blocks local/private broker addresses used in deployments.
+func isRegistryHTTPContext(httpClient core.HTTPContext) bool {
+	t := reflect.TypeOf(httpClient)
+	if t == nil {
+		return false
+	}
+
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	return t.PkgPath() == "github.com/superplanehq/superplane/pkg/registry" &&
+		(t.Name() == "HTTPContext" || t.Name() == "HTTPContextInTransaction")
 }
 
 // Create Task
@@ -108,6 +136,7 @@ type BrokerEnvironmentVariable struct {
 
 // CreateTaskParams is forwarded to the task broker POST /v1/tasks.
 type CreateTaskParams struct {
+	FleetID        string
 	Commands       []string
 	WebhookURL     string
 	Environment    []BrokerEnvironmentVariable
@@ -126,8 +155,16 @@ func (b *BrokerClient) CreateTask(p CreateTaskParams) (string, error) {
 		mode = ExecutionModeHost
 	}
 
+	fleetID := strings.TrimSpace(p.FleetID)
+	if fleetID == "" {
+		fleetID = strings.TrimSpace(b.fleetID)
+	}
+	if fleetID == "" {
+		return "", fmt.Errorf("fleet_id is required")
+	}
+
 	req := brokerCreateTaskRequest{
-		FleetID:       b.fleetID,
+		FleetID:       fleetID,
 		Commands:      p.Commands,
 		Environment:   p.Environment,
 		WebhookURL:    p.WebhookURL,
@@ -180,6 +217,43 @@ func (b *BrokerClient) CreateTask(p CreateTaskParams) (string, error) {
 	}
 
 	return out.ID, nil
+}
+
+func (b *BrokerClient) ListFleets() ([]Fleet, error) {
+	httpCtx, cancel := context.WithTimeout(context.Background(), brokerHTTPTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(httpCtx, http.MethodGet, b.baseURL+"/v1/fleets", nil)
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+b.authToken)
+
+	resp, err := b.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("broker request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("broker rejected list fleets: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var fleets []Fleet
+	if err := json.Unmarshal(body, &fleets); err != nil {
+		return nil, fmt.Errorf("unmarshal list fleets response: %w", err)
+	}
+
+	if fleets == nil {
+		return []Fleet{}, nil
+	}
+
+	return fleets, nil
 }
 
 // Task is the broker task payload (GET /v1/tasks/:id and webhook body).

--- a/pkg/components/runner/run_commands.go
+++ b/pkg/components/runner/run_commands.go
@@ -94,6 +94,13 @@ If the completed broker task includes valid JSON in **result**, SuperPlane inclu
 func (c *Runner) Configuration() []configuration.Field {
 	return []configuration.Field{
 		{
+			Name:        "fleet_id",
+			Label:       "Fleet",
+			Type:        configuration.FieldTypeString,
+			Required:    false, // legacy nodes can still use TASK_BROKER_FLEET_ID on the app server.
+			Description: "Runner fleet to execute this task. Choose a registered fleet from the task broker.",
+		},
+		{
 			Name:        "execution_mode",
 			Label:       "Execution mode",
 			Type:        configuration.FieldTypeSelect,
@@ -290,6 +297,7 @@ func (c *Runner) Execute(ctx core.ExecutionContext) error {
 
 	mode := normalizeExecutionMode(spec.ExecutionMode)
 	params := CreateTaskParams{
+		FleetID:        spec.FleetID,
 		Commands:       cmds,
 		WebhookURL:     webhookURL,
 		Environment:    environment,

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
 
@@ -173,6 +175,39 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 	assert.Equal(t, DefaultExecutionTimeoutSeconds, *req.ExecutionTimeoutSeconds)
 	assert.Equal(t, "task-123", state.KVs["task_id"])
 	assert.Equal(t, hookActionPoll, requests.Action)
+}
+
+func TestRunnerExecuteUsesConfiguredFleetID(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_FLEET_ID", "fleet-env")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(`{"id":"task-123"}`))},
+		},
+	}
+
+	err := (&Runner{}).Execute(core.ExecutionContext{
+		Configuration: map[string]any{
+			"fleet_id": "fleet-config",
+			"commands": "echo hello",
+		},
+		HTTP:           httpContext,
+		Webhook:        &contexts.NodeWebhookContext{},
+		ExecutionState: &contexts.ExecutionStateContext{KVs: map[string]string{}},
+		Requests:       &contexts.RequestContext{},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 1)
+
+	body, err := io.ReadAll(httpContext.Requests[0].Body)
+	require.NoError(t, err)
+
+	var req brokerCreateTaskRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	assert.Equal(t, "fleet-config", req.FleetID)
 }
 
 func TestRunnerExecuteOmitsEmptyEnvironment(t *testing.T) {
@@ -402,4 +437,63 @@ func TestBrokerListActiveTasks(t *testing.T) {
 	assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
 	assert.Equal(t, "/v1/tasks", httpContext.Requests[0].URL.Path)
 	assert.Equal(t, "Bearer token-1", httpContext.Requests[0].Header.Get("Authorization"))
+}
+
+func TestBrokerListFleets(t *testing.T) {
+	t.Setenv("TASK_BROKER_BASE_URL", "https://broker.example")
+	t.Setenv("TASK_BROKER_FLEET_ID", "")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`[
+					{"id":"aws-standard-amd64","provisioner":"aws","arch":"amd64","size":"t3.micro","created_at_unix":1710000000}
+				]`)),
+			},
+		},
+	}
+
+	broker, err := NewBrokerClient(httpContext)
+	require.NoError(t, err)
+
+	fleets, err := broker.ListFleets()
+	require.NoError(t, err)
+	require.Len(t, fleets, 1)
+	assert.Equal(t, "aws-standard-amd64", fleets[0].ID)
+	assert.Equal(t, "aws", fleets[0].Provisioner)
+	assert.Equal(t, "amd64", fleets[0].Arch)
+	assert.Equal(t, "t3.micro", fleets[0].Size)
+	assert.Equal(t, int64(1710000000), fleets[0].CreatedAt)
+	require.Len(t, httpContext.Requests, 1)
+	assert.Equal(t, http.MethodGet, httpContext.Requests[0].Method)
+	assert.Equal(t, "/v1/fleets", httpContext.Requests[0].URL.Path)
+	assert.Equal(t, "Bearer token-1", httpContext.Requests[0].Header.Get("Authorization"))
+}
+
+func TestBrokerClientBypassesRegistryHTTPPolicyForTrustedBrokerURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/fleets", r.URL.Path)
+		assert.Equal(t, "Bearer token-1", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`[{"id":"local-standard-amd64","arch":"amd64","size":"standard"}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("TASK_BROKER_BASE_URL", server.URL)
+	t.Setenv("TASK_BROKER_FLEET_ID", "")
+	t.Setenv("TASK_BROKER_AUTH_TOKEN", "token-1")
+
+	httpContext, err := registry.NewHTTPContext(registry.HTTPOptions{
+		PrivateIPRanges: []string{"127.0.0.0/8", "::1/128"},
+	})
+	require.NoError(t, err)
+
+	broker, err := NewBrokerClient(httpContext)
+	require.NoError(t, err)
+
+	fleets, err := broker.ListFleets()
+	require.NoError(t, err)
+	require.Len(t, fleets, 1)
+	assert.Equal(t, "local-standard-amd64", fleets[0].ID)
 }

--- a/pkg/components/runner/spec.go
+++ b/pkg/components/runner/spec.go
@@ -35,6 +35,7 @@ type EnvironmentVariable struct {
 
 // Spec is persisted Runner node configuration.
 type Spec struct {
+	FleetID                 string                `json:"fleet_id" mapstructure:"fleet_id"`
 	Commands                string                `mapstructure:"commands"`
 	Environment             []EnvironmentVariable `mapstructure:"environment"`
 	ExecutionMode           string                `mapstructure:"execution_mode"`

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -4,6 +4,19 @@
 // graduated to all organizations by setting Released to a pointer to true.
 package features
 
+import (
+	"os"
+	"strings"
+)
+
+const (
+	// FeatureRunner enables the sandboxed Runner component.
+	FeatureRunner = "runner"
+
+	// EnvRunnerEnabled releases the Runner feature for every organization.
+	EnvRunnerEnabled = "RUNNER_ENABLED"
+)
+
 type Feature struct {
 	ID          string
 	Label       string
@@ -21,18 +34,19 @@ func released() *bool {
 }
 
 var registry = []Feature{
-	{ID: "runner", Label: "Runners", Description: "Sandboxed Runners"},
+	{ID: FeatureRunner, Label: "Runners", Description: "Sandboxed Runners"},
 	{ID: FeatureClaudeManagedAgents, Label: "Claude Managed Agents", Description: "Chat with a Claude-powered agent against the canvas", Released: released()},
 }
 
 func All() []Feature {
 	out := make([]Feature, len(registry))
 	copy(out, registry)
+	applyRuntimeOverrides(out)
 	return out
 }
 
 func Get(id string) (Feature, bool) {
-	for _, f := range registry {
+	for _, f := range All() {
 		if f.ID == id {
 			return f, true
 		}
@@ -64,4 +78,25 @@ func WithRegistryForTest(r []Feature) func() {
 	original := registry
 	registry = r
 	return func() { registry = original }
+}
+
+func applyRuntimeOverrides(features []Feature) {
+	if !envTruthy(EnvRunnerEnabled) {
+		return
+	}
+
+	for i := range features {
+		if features[i].ID == FeatureRunner {
+			features[i].Released = released()
+		}
+	}
+}
+
+func envTruthy(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -7,10 +7,12 @@ import (
 )
 
 func Test__Get(t *testing.T) {
+	t.Setenv(EnvRunnerEnabled, "")
+
 	t.Run("known id returns feature and true", func(t *testing.T) {
-		f, ok := Get("runner")
+		f, ok := Get(FeatureRunner)
 		assert.True(t, ok)
-		assert.Equal(t, "runner", f.ID)
+		assert.Equal(t, FeatureRunner, f.ID)
 		assert.Equal(t, "Runners", f.Label)
 		assert.Equal(t, "Sandboxed Runners", f.Description)
 	})
@@ -28,12 +30,14 @@ func Test__Get(t *testing.T) {
 }
 
 func Test__Exists(t *testing.T) {
-	assert.True(t, Exists("runner"))
+	assert.True(t, Exists(FeatureRunner))
 	assert.False(t, Exists("does-not-exist"))
 	assert.False(t, Exists(""))
 }
 
 func Test__All_isCopy(t *testing.T) {
+	t.Setenv(EnvRunnerEnabled, "")
+
 	a := All()
 	require := len(a)
 	a[0] = Feature{ID: "mutated"}
@@ -44,12 +48,14 @@ func Test__All_isCopy(t *testing.T) {
 }
 
 func Test__IsReleased(t *testing.T) {
+	t.Setenv(EnvRunnerEnabled, "")
+
 	t.Run("unknown id is not released", func(t *testing.T) {
 		assert.False(t, IsReleased("does-not-exist"))
 	})
 
 	t.Run("registered id with nil Released is not released", func(t *testing.T) {
-		assert.False(t, IsReleased("runner"))
+		assert.False(t, IsReleased(FeatureRunner))
 	})
 
 	t.Run("registered id with Released=&true is released", func(t *testing.T) {
@@ -69,4 +75,14 @@ func Test__IsReleased(t *testing.T) {
 		registry = []Feature{{ID: "explicit-false", Label: "X", Released: &v}}
 		assert.False(t, IsReleased("explicit-false"))
 	})
+}
+
+func Test__RunnerEnabledEnvReleasesRunner(t *testing.T) {
+	t.Setenv(EnvRunnerEnabled, "yes")
+
+	f, ok := Get(FeatureRunner)
+	assert.True(t, ok)
+	assert.NotNil(t, f.Released)
+	assert.True(t, *f.Released)
+	assert.True(t, IsReleased(FeatureRunner))
 }

--- a/pkg/public/runner_fleets.go
+++ b/pkg/public/runner_fleets.go
@@ -1,0 +1,40 @@
+package public
+
+import (
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/components/runner"
+)
+
+type runnerFleetsResponse struct {
+	Configured bool           `json:"configured"`
+	Fleets     []runner.Fleet `json:"fleets"`
+}
+
+func (s *Server) handleRunnerFleets(w http.ResponseWriter, r *http.Request) {
+	broker, err := runner.NewBrokerClient(s.registry.HTTPContext())
+	if err != nil {
+		respondJSON(w, runnerFleetsResponse{
+			Configured: false,
+			Fleets:     []runner.Fleet{},
+		})
+		return
+	}
+
+	fleets, err := broker.ListFleets()
+	if err != nil {
+		log.Errorf("runner: failed to list fleets: %v", err)
+		http.Error(w, "Failed to list runner fleets", http.StatusBadGateway)
+		return
+	}
+
+	if fleets == nil {
+		fleets = []runner.Fleet{}
+	}
+
+	respondJSON(w, runnerFleetsResponse{
+		Configured: true,
+		Fleets:     fleets,
+	})
+}

--- a/pkg/public/runner_fleets_test.go
+++ b/pkg/public/runner_fleets_test.go
@@ -1,0 +1,78 @@
+package public
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func runnerFleetsGET(
+	t *testing.T,
+	server *Server,
+	signer *jwt.Signer,
+	r *support.ResourceRegistry,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runner/fleets", nil)
+	req.Header.Set("x-organization-id", r.Organization.ID.String())
+	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+
+	rec := httptest.NewRecorder()
+	server.Router.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestRunnerFleets(t *testing.T) {
+	r := support.Setup(t)
+	server, signer := mustRunnerLiveLogServer(t, r)
+
+	t.Run("broker not configured", func(t *testing.T) {
+		t.Setenv("TASK_BROKER_BASE_URL", "")
+		t.Setenv("TASK_BROKER_AUTH_TOKEN", "")
+
+		response := runnerFleetsGET(t, server, signer, r)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body runnerFleetsResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.False(t, body.Configured)
+		assert.Empty(t, body.Fleets)
+	})
+
+	t.Run("returns broker fleets", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v1/fleets", r.URL.Path)
+			assert.Equal(t, "Bearer broker-token", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"aws-standard-amd64","provisioner":"aws","arch":"amd64","size":"t3.micro","created_at_unix":1710000000}]`))
+		}))
+		defer upstream.Close()
+
+		t.Setenv("TASK_BROKER_BASE_URL", upstream.URL)
+		t.Setenv("TASK_BROKER_AUTH_TOKEN", "broker-token")
+
+		response := runnerFleetsGET(t, server, signer, r)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		var body runnerFleetsResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+		assert.True(t, body.Configured)
+		require.Len(t, body.Fleets, 1)
+		assert.Equal(t, "aws-standard-amd64", body.Fleets[0].ID)
+		assert.Equal(t, "aws", body.Fleets[0].Provisioner)
+		assert.Equal(t, "amd64", body.Fleets[0].Arch)
+		assert.Equal(t, "t3.micro", body.Fleets[0].Size)
+		assert.Equal(t, int64(1710000000), body.Fleets[0].CreatedAt)
+	})
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -351,6 +351,11 @@ func (s *Server) RegisterGRPCGateway(grpcServerAddr string) error {
 	// Protect the gRPC gateway routes with organization authentication
 	orgAuthMiddleware := middleware.OrganizationAuthMiddleware(s.jwt)
 
+	s.Router.Handle(
+		"/api/v1/runner/fleets",
+		orgAuthMiddleware(http.HandlerFunc(s.handleRunnerFleets)),
+	).Methods(http.MethodGet)
+
 	//
 	// This is not part of the proto APIs and gRPC gateway route,
 	// because of how we need to handle the file streaming.

--- a/web_src/src/hooks/useRunnerFleets.ts
+++ b/web_src/src/hooks/useRunnerFleets.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+
+export type RunnerFleet = {
+  id: string;
+  provisioner?: string;
+  arch?: string;
+  size?: string;
+  created_at_unix?: number;
+};
+
+export type RunnerFleetsResponse = {
+  configured: boolean;
+  fleets: RunnerFleet[];
+};
+
+export const runnerFleetKeys = {
+  all: ["runner-fleets"] as const,
+  list: (organizationId?: string) => [...runnerFleetKeys.all, organizationId ?? "current"] as const,
+};
+
+export function useRunnerFleets(organizationId?: string) {
+  return useQuery({
+    queryKey: runnerFleetKeys.list(organizationId),
+    queryFn: async (): Promise<RunnerFleetsResponse> => {
+      const response = await fetch(
+        "/api/v1/runner/fleets",
+        withOrganizationHeader({
+          organizationId,
+          credentials: "include",
+        }),
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text.trim() || "Failed to load runner fleets");
+      }
+
+      const data = (await response.json()) as Partial<RunnerFleetsResponse>;
+      return {
+        configured: data.configured ?? false,
+        fleets: data.fleets ?? [],
+      };
+    },
+    staleTime: 60 * 1000,
+  });
+}

--- a/web_src/src/pages/admin/RunnerTasks.tsx
+++ b/web_src/src/pages/admin/RunnerTasks.tsx
@@ -183,8 +183,7 @@ const RunnerTasks: React.FC = () => {
           <Terminal size={24} className="mx-auto text-gray-400" />
           <Text className="mt-3 text-sm text-gray-600">
             Runner task broker is not configured. Set{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_BASE_URL</code>,{" "}
-            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_FLEET_ID</code>, and{" "}
+            <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_BASE_URL</code>, and{" "}
             <code className="rounded bg-slate-100 px-1 py-0.5 font-mono text-xs">TASK_BROKER_AUTH_TOKEN</code> on the
             app server.
           </Text>

--- a/web_src/src/pages/workflowv2/mappers/runner.spec.ts
+++ b/web_src/src/pages/workflowv2/mappers/runner.spec.ts
@@ -49,6 +49,15 @@ describe("runnerConfigurationDetails", () => {
       },
     ],
     [
+      "host — selected fleet",
+      { fleet_id: "aws-standard-amd64", execution_mode: "host", commands: "echo hi", execution_timeout_seconds: 0 },
+      {
+        Fleet: "aws-standard-amd64",
+        "Execution mode": "Host",
+        "Timeout (seconds)": String(DEFAULT_EXECUTION_TIMEOUT_SECONDS),
+      },
+    ],
+    [
       "host — ignores stray docker_image (no Container image row)",
       {
         execution_mode: "host",

--- a/web_src/src/pages/workflowv2/mappers/runner.tsx
+++ b/web_src/src/pages/workflowv2/mappers/runner.tsx
@@ -49,6 +49,9 @@ export function runnerConfigurationDetails(configuration: unknown): Record<strin
     return details;
   }
   const c = configuration as Record<string, unknown>;
+  if (typeof c.fleet_id === "string" && c.fleet_id.trim() !== "") {
+    details["Fleet"] = c.fleet_id.trim();
+  }
   const rawMode = typeof c.execution_mode === "string" ? c.execution_mode.trim().toLowerCase() : "";
   if (rawMode === EXECUTION_MODE_DOCKER) {
     details["Execution mode"] = "Docker";

--- a/web_src/src/ui/configurationFieldRenderer/RunnerFleetFieldRenderer.spec.ts
+++ b/web_src/src/ui/configurationFieldRenderer/RunnerFleetFieldRenderer.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatRunnerFleetLabel } from "./RunnerFleetFieldRenderer";
+
+describe("formatRunnerFleetLabel", () => {
+  it("shows product runner classes instead of provider instance sizes", () => {
+    expect(
+      formatRunnerFleetLabel({
+        id: "aws-standard-amd64",
+        provisioner: "aws",
+        arch: "amd64",
+        size: "t3.micro",
+      }),
+    ).toBe("Standard runner · amd64");
+  });
+
+  it("uses regulated size names from fleet identifiers", () => {
+    expect(formatRunnerFleetLabel({ id: "aws-small-amd64", arch: "amd64" })).toBe("Small runner · amd64");
+    expect(formatRunnerFleetLabel({ id: "aws-large-arm64", arch: "arm64" })).toBe("Large runner · arm64");
+    expect(formatRunnerFleetLabel({ id: "aws-xlarge-amd64", arch: "amd64" })).toBe("Extra large runner · amd64");
+  });
+
+  it("defaults to standard without exposing unknown provider metadata", () => {
+    expect(formatRunnerFleetLabel({ id: "local", size: "t3.micro" })).toBe("Standard runner");
+  });
+});

--- a/web_src/src/ui/configurationFieldRenderer/RunnerFleetFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/RunnerFleetFieldRenderer.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useRunnerFleets, type RunnerFleet } from "@/hooks/useRunnerFleets";
+import type { FieldRendererProps } from "./types";
+import { toTestId } from "@/lib/testID";
+
+const UNAVAILABLE_PREFIX = "__unavailable__:";
+
+const RUNNER_TYPE_LABELS: Record<string, string> = {
+  small: "Small",
+  medium: "Standard",
+  standard: "Standard",
+  large: "Large",
+  xlarge: "Extra large",
+  "2xlarge": "2xlarge",
+};
+
+const RUNNER_TYPE_ORDER: Record<string, number> = {
+  Small: 1,
+  Standard: 2,
+  Large: 3,
+  "Extra large": 4,
+  "2xlarge": 5,
+};
+
+export function formatRunnerFleetLabel(fleet: RunnerFleet): string {
+  const runnerType = runnerTypeFromFleet(fleet);
+  const metadata = [`${runnerType} runner`, fleet.arch].filter(
+    (part): part is string => typeof part === "string" && part.trim() !== "",
+  );
+
+  return metadata.join(" · ");
+}
+
+function runnerTypeFromFleet(fleet: RunnerFleet): string {
+  const tokens = `${fleet.id} ${fleet.size ?? ""}`
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+  const orderedTokens = ["2xlarge", "xlarge", "large", "standard", "medium", "small"];
+  const match = orderedTokens.find((token) => tokens.includes(token));
+  if (match) {
+    return RUNNER_TYPE_LABELS[match];
+  }
+
+  return "Standard";
+}
+
+export const RunnerFleetFieldRenderer: React.FC<FieldRendererProps> = ({ field, value, onChange, organizationId }) => {
+  const selectedFleetID = typeof value === "string" ? value : "";
+  const { data, isLoading, error } = useRunnerFleets(organizationId);
+  const fleets = data?.fleets ?? [];
+  const selectedFleet = fleets.find((fleet) => fleet.id === selectedFleetID);
+  const selectedFleetUnavailable = selectedFleetID !== "" && !selectedFleet;
+  const disabled = isLoading || !!error || data?.configured === false || fleets.length === 0;
+  const architectures = React.useMemo(() => architectureOptions(fleets), [fleets]);
+  const [selectedArch, setSelectedArch] = React.useState<string>("");
+
+  React.useEffect(() => {
+    if (selectedFleet?.arch) {
+      setSelectedArch(selectedFleet.arch);
+    }
+  }, [selectedFleet?.arch]);
+
+  const fleetsForSelectedArch = React.useMemo(
+    () => fleets.filter((fleet) => normalizeArch(fleet.arch) === normalizeArch(selectedArch)).sort(compareRunnerFleets),
+    [fleets, selectedArch],
+  );
+
+  if (error) {
+    return (
+      <div className="text-sm text-red-500 dark:text-red-400">
+        {error instanceof Error ? error.message : "Failed to load runner fleets"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={selectedArch}
+        onValueChange={(nextArch) => {
+          setSelectedArch(nextArch);
+          if (selectedFleetID) {
+            onChange(undefined);
+          }
+        }}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          className="w-full"
+          data-testid={field.name ? toTestId(`field-${field.name}-architecture-select`) : undefined}
+        >
+          <SelectValue placeholder={runnerArchitecturePlaceholder(isLoading, data)} />
+        </SelectTrigger>
+        <SelectContent className="max-h-60">
+          {architectures.map((arch) => (
+            <SelectItem key={arch} value={arch}>
+              {formatArchitectureLabel(arch)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={selectedFleetUnavailable ? `${UNAVAILABLE_PREFIX}${selectedFleetID}` : selectedFleetID}
+        onValueChange={(nextValue) => {
+          if (nextValue.startsWith(UNAVAILABLE_PREFIX)) {
+            return;
+          }
+          onChange(nextValue || undefined);
+        }}
+        disabled={disabled || !selectedArch || fleetsForSelectedArch.length === 0}
+      >
+        <SelectTrigger
+          className="w-full"
+          data-testid={field.name ? toTestId(`field-${field.name}-size-select`) : undefined}
+        >
+          <SelectValue placeholder={runnerSizePlaceholder(selectedArch, fleetsForSelectedArch)} />
+        </SelectTrigger>
+        <SelectContent className="max-h-60">
+          {selectedFleetUnavailable ? (
+            <SelectItem value={`${UNAVAILABLE_PREFIX}${selectedFleetID}`} disabled>
+              Unavailable runner
+            </SelectItem>
+          ) : null}
+          {fleetsForSelectedArch.map((fleet) => (
+            <SelectItem key={fleet.id} value={fleet.id} title={fleet.id}>
+              {runnerTypeFromFleet(fleet)} runner
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {selectedFleetUnavailable ? (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          Selected fleet is no longer registered in the task broker.
+        </p>
+      ) : null}
+      {data?.configured === false ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">Runner task broker is not configured.</p>
+      ) : null}
+      {data?.configured === true && fleets.length === 0 ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">No runner fleets are registered yet.</p>
+      ) : null}
+    </div>
+  );
+};
+
+function architectureOptions(fleets: RunnerFleet[]): string[] {
+  return Array.from(new Set(fleets.map((fleet) => fleet.arch).filter((arch): arch is string => !!arch))).sort(
+    compareArchitectures,
+  );
+}
+
+function compareArchitectures(a: string, b: string): number {
+  const order = ["amd64", "arm64"];
+  const aIndex = order.indexOf(normalizeArch(a));
+  const bIndex = order.indexOf(normalizeArch(b));
+  if (aIndex !== -1 || bIndex !== -1) {
+    return (aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex) - (bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex);
+  }
+
+  return a.localeCompare(b);
+}
+
+function compareRunnerFleets(a: RunnerFleet, b: RunnerFleet): number {
+  const aType = runnerTypeFromFleet(a);
+  const bType = runnerTypeFromFleet(b);
+  const byType =
+    (RUNNER_TYPE_ORDER[aType] ?? Number.MAX_SAFE_INTEGER) - (RUNNER_TYPE_ORDER[bType] ?? Number.MAX_SAFE_INTEGER);
+  if (byType !== 0) {
+    return byType;
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+function formatArchitectureLabel(arch: string): string {
+  switch (normalizeArch(arch)) {
+    case "amd64":
+      return "AMD64";
+    case "arm64":
+      return "ARM64";
+    default:
+      return arch;
+  }
+}
+
+function normalizeArch(arch: string | undefined): string {
+  return arch?.trim().toLowerCase() ?? "";
+}
+
+function runnerArchitecturePlaceholder(isLoading: boolean, data: ReturnType<typeof useRunnerFleets>["data"]): string {
+  if (isLoading) {
+    return "Loading fleets...";
+  }
+  if (data?.configured === false) {
+    return "Runner broker not configured";
+  }
+  if (data?.configured === true && data.fleets.length === 0) {
+    return "No fleets registered";
+  }
+  return "Select architecture";
+}
+
+function runnerSizePlaceholder(selectedArch: string, fleets: RunnerFleet[]): string {
+  if (!selectedArch) {
+    return "Select architecture first";
+  }
+  if (fleets.length === 0) {
+    return "No sizes for this architecture";
+  }
+  return "Select runner size";
+}

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -28,6 +28,7 @@ import { SecretKeyFieldRenderer, type SecretKeyRefValue } from "./SecretKeyField
 import { AnyPredicateListFieldRenderer } from "./AnyPredicateListFieldRenderer";
 import { DaysOfWeekFieldRenderer } from "./DaysOfWeekFieldRenderer";
 import { TimeRangeFieldRenderer } from "./TimeRangeFieldRenderer";
+import { RunnerFleetFieldRenderer } from "./RunnerFleetFieldRenderer";
 import { isFieldVisible, isFieldRequired, parseDefaultValues, validateFieldForSubmission } from "../../lib/components";
 import type { AuthorizationDomainType } from "@/api-client";
 import { buildTemplateParametersAutocompleteObject } from "./templateParametersAutocomplete";
@@ -299,6 +300,10 @@ export const ConfigurationFieldRenderer = ({
   };
 
   const renderField = () => {
+    if (field.name === "fleet_id") {
+      return <RunnerFleetFieldRenderer {...commonProps} />;
+    }
+
     switch (field.type) {
       case "string":
         return <StringFieldRenderer {...commonProps} />;


### PR DESCRIPTION
## Summary
- Add Runner fleet discovery through SuperPlane so the UI can load fleets from the task-broker.
- Persist the selected `fleet_id` in Runner configuration and send it when creating broker tasks.
- Add a two-step Runner picker for architecture and runner size, with product labels instead of raw instance types.
- Gate Runner availability with `RUNNER_ENABLED` while preserving per-org experimental feature behavior.

## Test plan
- `go test ./pkg/components/runner`
- `go test ./pkg/features`
- `make lint && make check.build.app`
- `cd web_src && npx vitest run src/ui/configurationFieldRenderer/RunnerFleetFieldRenderer.spec.ts`
- Local smoke: real task-broker + runner completed a task successfully, and `/api/v1/runner/fleets` returned registered fleets.