### PR TITLE
fix: Docker image cache should take arch into consideration

### DIFF
--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -17,6 +17,7 @@ VERSION="$1"
 ARCH="$2"
 
 IMAGE_REPO="${STANDARD_IMAGE_REPO:-ghcr.io/superplanehq/superplane}"
+DEV_BASE_IMAGE_REPO="${DEV_BASE_IMAGE_REPO:-ghcr.io/superplanehq/superplane-dev-base}"
 
 if [ ! -f "pkg/protos/me/me.pb.go" ] || [ ! -f "pkg/protos/me/me.pb.gw.go" ]; then
   echo "Generating protobuf files"
@@ -33,7 +34,7 @@ docker buildx build \
   --provenance=false \
   --push \
   --target runner \
-  --cache-from ghcr.io/superplanehq/superplane-dev-base:app-latest \
+  --cache-from "${DEV_BASE_IMAGE_REPO}:app-latest-${ARCH}" \
   -t "${IMAGE_REPO}:${VERSION}-${ARCH}" \
   -f Dockerfile \
   .


### PR DESCRIPTION
Daily build is failing with:

```
 > [dev-base  4/14] RUN apt-get update &&   apt-get install -y --no-install-recommends bash ca-certificates make unzip &&   apt-get clean &&   rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*:
0.238 exec /bin/sh: exec format error
```