### PR TITLE
fix: UI uses /apps on routes

### DIFF
--- a/test/e2e/canvas_change_management_enforcement_test.go
+++ b/test/e2e/canvas_change_management_enforcement_test.go
@@ -101,7 +101,7 @@ func (s *canvasChangeManagementEnforcementSteps) visitCanvasSettings() {
 
 func (s *canvasChangeManagementEnforcementSteps) saveCanvasSettings() {
 	s.session.Click(q.TestID("canvas-settings-save-changes"))
-	canvasPath := "/" + s.session.OrgID.String() + "/canvases/" + s.canvas.WorkflowID.String()
+	canvasPath := "/" + s.session.OrgID.String() + "/apps/" + s.canvas.WorkflowID.String()
 	s.session.WaitForBrowserPath(canvasPath)
 }
 

--- a/test/e2e/home_page_test.go
+++ b/test/e2e/home_page_test.go
@@ -45,7 +45,7 @@ func (steps *TestHomePageSteps) VisitHomePage() {
 
 func (steps *TestHomePageSteps) AssertNavigatedToCanvas() {
 	url := steps.session.Page().URL()
-	assert.Regexp(steps.t, `/canvases/[0-9a-f-]{36}`, url)
+	assert.Regexp(steps.t, `/apps/[0-9a-f-]{36}`, url)
 }
 
 func (steps *TestHomePageSteps) AssertCanvasSavedInDB(canvasName string) {

--- a/test/e2e/login_page_test.go
+++ b/test/e2e/login_page_test.go
@@ -72,7 +72,7 @@ func (steps *TestLoginPageSteps) VisitLoginPage() {
 }
 
 func (steps *TestLoginPageSteps) VisitProtectedRandomURL() {
-	steps.protectedURLPath = "/" + steps.session.OrgID.String() + "/canvases/redirect-test"
+	steps.protectedURLPath = "/" + steps.session.OrgID.String() + "/apps/redirect-test"
 	steps.session.Visit(steps.protectedURLPath)
 }
 

--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -94,7 +94,7 @@ func (s *runsViewSteps) whenTheManualTriggerRuns() {
 }
 
 func (s *runsViewSteps) whenIVisitRunsView() {
-	s.session.Visit("/" + s.session.OrgID.String() + "/canvases/" + s.canvas.WorkflowID.String() + "?view=runs")
+	s.session.Visit("/" + s.session.OrgID.String() + "/apps/" + s.canvas.WorkflowID.String() + "?view=runs")
 }
 
 func (s *runsViewSteps) givenFinishedRuns(count int) {

--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -385,7 +385,7 @@ func (s *TestSession) AssertURLContains(part string) {
 
 // WaitForBrowserPath polls until the URL path (ignoring query and fragment) equals expectedPath
 // after normalizing trailing slashes. expectedPath is typically an app pathname such as
-// "/<orgID>/canvases/<canvasID>" (not including the origin or query string).
+// "/<orgID>/apps/<appID>" (not including the origin or query string).
 func (s *TestSession) WaitForBrowserPath(expectedPath string) {
 	want := normalizeE2EBrowserPath(expectedPath)
 	deadline := time.Now().Add(time.Duration(s.timeoutMs) * time.Millisecond)

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -165,7 +165,7 @@ func (s *CanvasSteps) CreatePublishedWithParameterizedManualRun() {
 }
 
 func (s *CanvasSteps) Visit() {
-	s.session.Visit("/" + s.session.OrgID.String() + "/canvases/" + s.WorkflowID.String())
+	s.session.Visit("/" + s.session.OrgID.String() + "/apps/" + s.WorkflowID.String())
 }
 
 func (s *CanvasSteps) OpenBuildingBlocksSidebar() {

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -1,7 +1,8 @@
 import { TooltipProvider } from "@/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation } from "react-router-dom";
+import { BrowserRouter, Navigate, Outlet, Route, Routes, useLocation, useParams } from "react-router-dom";
+import { appPath, appSettingsPath } from "./lib/appPaths";
 import { Toaster } from "sonner";
 import "./App.css";
 
@@ -107,12 +108,14 @@ function AppRouter() {
                 <Route index element={withAuthAndPermission(HomePage, "canvases", "read")} />
                 <Route path="apps">
                   <Route path="new" element={withAuthAndPermission(NewAppPage, "canvases", "read")} />
+                  <Route
+                    path=":appId/settings"
+                    element={withAuthAndPermission(CanvasSettingsPage, "canvases", "update")}
+                  />
+                  <Route path=":appId" element={withAuthAndPermission(WorkflowPageV2, "canvases", "read")} />
                 </Route>
-                <Route
-                  path="canvases/:canvasId/settings"
-                  element={withAuthAndPermission(CanvasSettingsPage, "canvases", "update")}
-                />
-                <Route path="canvases/:canvasId" element={withAuthAndPermission(WorkflowPageV2, "canvases", "read")} />
+                <Route path="canvases/:canvasId/settings" element={<LegacyCanvasRedirect settings />} />
+                <Route path="canvases/:canvasId" element={<LegacyCanvasRedirect />} />
                 <Route path="templates" element={withAuthAndPermission(TemplatesPage, "canvases", "read")} />
                 <Route path="templates/:canvasId" element={withAuthAndPermission(WorkflowPageV2, "canvases", "read")} />
                 <Route path="settings/*" element={withAuthOnly(OrganizationSettings)} />
@@ -134,6 +137,18 @@ function OrganizationScope() {
       <Outlet />
     </PermissionsProvider>
   );
+}
+
+function LegacyCanvasRedirect({ settings = false }: { settings?: boolean }) {
+  const { organizationId, canvasId } = useParams<{ organizationId: string; canvasId: string }>();
+  const location = useLocation();
+
+  if (!organizationId || !canvasId) {
+    return <Navigate to="/" replace />;
+  }
+
+  const path = settings ? appSettingsPath(organizationId, canvasId) : appPath(organizationId, canvasId);
+  return <Navigate to={`${path}${location.search}`} replace />;
 }
 
 function SetupGuard({ children }: { children: React.ReactNode }) {

--- a/web_src/src/components/AgentSidebar/widgets/NodeChip.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/NodeChip.tsx
@@ -1,6 +1,7 @@
 import { createElement, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { cn, resolveIcon } from "@/lib/utils";
+import { appPath } from "@/lib/appPaths";
 import { useCanvas } from "@/hooks/useCanvasData";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
@@ -168,7 +169,7 @@ export function NodeChip({ nodeId, label, canvasId, organizationId }: NodeChipPr
   const edges = canvas?.spec?.edges ?? [];
 
   const handleClick = useCallback(() => {
-    navigate(`/${organizationId}/canvases/${canvasId}?sidebar=1&node=${node?.id ?? nodeId}`);
+    navigate(appPath(organizationId, canvasId, `?sidebar=1&node=${node?.id ?? nodeId}`));
     window.dispatchEvent(new CustomEvent("agent:focus-node", { detail: { nodeId: node?.id ?? nodeId } }));
   }, [navigate, organizationId, canvasId, node?.id, nodeId]);
 

--- a/web_src/src/components/AgentSidebar/widgets/RunChip.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/RunChip.tsx
@@ -1,6 +1,7 @@
 import { Rabbit } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
+import { appPath } from "@/lib/appPaths";
 import { RUN_STATUS_META, type RunStatusKey } from "@/ui/Runs/runPresentation";
 
 interface RunChipProps {
@@ -51,7 +52,7 @@ export function RunChip({ runId, label, status, canvasId, organizationId }: RunC
   return (
     <button
       type="button"
-      onClick={() => navigate(`/${organizationId}/canvases/${canvasId}?view=runs&run=${runId}`)}
+      onClick={() => navigate(appPath(organizationId, canvasId, `?view=runs&run=${runId}`))}
       className={cn(
         "inline-flex items-center gap-1 px-2 py-0.5 rounded-full ring-0 text-xs font-medium transition-colors cursor-pointer align-middle",
         meta.badgeClassName,

--- a/web_src/src/components/GlobalCommandPalette/actions.ts
+++ b/web_src/src/components/GlobalCommandPalette/actions.ts
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import type { CanvasToolSidebarTab } from "@/components/CanvasToolSidebar/events";
 import { ADMIN_LINKS, DOCS_URL, ORGANIZATION_SETTINGS_LINKS } from "./constants";
+import { appSettingsPath } from "@/lib/appPaths";
 import type { CommandPage, PaletteAction, PalettePageAction } from "./types";
 
 type RootPageActionParams = {
@@ -219,7 +220,7 @@ export function buildCurrentCanvasActions({
       description: currentCanvasName,
       icon: Settings,
       disabled: !canUpdateCanvas,
-      onSelect: () => goTo(`/${organizationId}/canvases/${canvasId}/settings`),
+      onSelect: () => organizationId && canvasId && goTo(appSettingsPath(organizationId, canvasId)),
       keywords: ["canvas", "settings"],
     },
   ];

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -134,7 +134,7 @@ function openPalette() {
   openGlobalCommandPalette();
 }
 
-function renderPalette(path = "/org-1/canvases/canvas-1") {
+function renderPalette(path = "/org-1/apps/canvas-1") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -196,13 +196,13 @@ describe("GlobalCommandPalette", () => {
   it("opens current canvas tool tabs from commands", async () => {
     const user = userEvent.setup();
     const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
-    renderPalette("/org-1/canvases/canvas-1?view=memory");
+    renderPalette("/org-1/apps/canvas-1?view=memory");
 
     openPalette();
     await user.click(await screen.findByText("Versions"));
 
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith("/org-1/canvases/canvas-1");
+      expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-1");
       expect(dispatchEventSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "canvas-tool-sidebar:select-tab",
@@ -243,7 +243,7 @@ describe("GlobalCommandPalette", () => {
     await user.click(await screen.findByText("Canvas Settings"));
     await user.click(await screen.findByText("Database Backups"));
 
-    expect(navigateMock).toHaveBeenCalledWith("/org-1/canvases/canvas-2/settings");
+    expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-2/settings");
   });
 
   it("disables canvas settings commands without canvas update permission", async () => {
@@ -282,7 +282,7 @@ describe("GlobalCommandPalette", () => {
     await waitFor(() => {
       expect(createCanvasMock).toHaveBeenCalledWith({ name: "generated-canvas", method: "ui" });
     });
-    expect(navigateMock).toHaveBeenCalledWith("/org-1/canvases/canvas-new");
+    expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-new");
   });
 
   it("searches canvas components from the root command palette", async () => {

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -224,6 +224,17 @@ describe("GlobalCommandPalette", () => {
     expect(screen.queryByPlaceholderText("Search components and commands")).not.toBeInTheDocument();
   });
 
+  it("does not treat apps/new as a current canvas route", async () => {
+    renderPalette("/org-1/apps/new");
+
+    openPalette();
+
+    expect(await screen.findByPlaceholderText("What can we help with?")).toBeInTheDocument();
+    expect(screen.queryByText("Console")).not.toBeInTheDocument();
+    expect(screen.queryByText("Versions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+  });
+
   it("opens organization settings as a nested command page", async () => {
     const user = userEvent.setup();
     renderPalette();

--- a/web_src/src/components/GlobalCommandPalette/model.ts
+++ b/web_src/src/components/GlobalCommandPalette/model.ts
@@ -7,6 +7,7 @@ import { useCanvases, useCreateCanvas } from "@/hooks/useCanvasData";
 import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 import { useOrganization, useOrganizationUsage } from "@/hooks/useOrganizationData";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
+import { appPath } from "@/lib/appPaths";
 import { isUsagePageForced } from "@/lib/env";
 import { showErrorToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
@@ -205,7 +206,7 @@ function usePaletteNavigation(
   const goToCurrentCanvasView = useCallback(
     (view?: "dashboard" | "memory" | "runs") => {
       if (!organizationId || !canvasId) return;
-      goTo(`/${organizationId}/canvases/${canvasId}${view ? `?view=${view}` : ""}`);
+      goTo(appPath(organizationId, canvasId, view ? `?view=${view}` : ""));
     },
     [canvasId, goTo, organizationId],
   );
@@ -214,7 +215,7 @@ function usePaletteNavigation(
     (tab: CanvasToolSidebarTab) => {
       if (!organizationId || !canvasId) return;
       closePalette();
-      navigate(`/${organizationId}/canvases/${canvasId}`);
+      navigate(appPath(organizationId, canvasId));
       window.setTimeout(() => openCanvasToolSidebarTab(tab), 0);
     },
     [canvasId, closePalette, navigate, organizationId],
@@ -237,7 +238,7 @@ function useCreateCanvasCommand(
       const nextCanvasId = result?.data?.canvas?.metadata?.id;
       if (!nextCanvasId) return;
       closePalette();
-      navigate(`/${organizationId}/canvases/${nextCanvasId}`);
+      navigate(appPath(organizationId, nextCanvasId));
     } catch (error) {
       showErrorToast(getUsageLimitToastMessage(error, "Failed to create canvas"));
     }

--- a/web_src/src/components/GlobalCommandPalette/pages.tsx
+++ b/web_src/src/components/GlobalCommandPalette/pages.tsx
@@ -1,6 +1,7 @@
 import { CommandGroup, CommandSeparator } from "@/components/ui/command";
 import { Palette, Settings } from "lucide-react";
 import { openPageAction } from "./actions";
+import { appPath, appSettingsPath } from "@/lib/appPaths";
 import { ActionItem, CanvasListItems, NestedPage, PageItem } from "./items";
 import type { CanvasCommandListProps, CommandPage, PaletteAction, PalettePageAction } from "./types";
 
@@ -111,7 +112,7 @@ export function CanvasSettingsPage({
               label: currentCanvasName,
               description: "Open canvas settings",
               icon: Settings,
-              onSelect: () => organizationId && goTo(`/${organizationId}/canvases/${canvasId}/settings`),
+              onSelect: () => organizationId && canvasId && goTo(appSettingsPath(organizationId, canvasId)),
             }}
           />
         ) : null}
@@ -152,7 +153,7 @@ function CanvasSettingsList({ goTo, organizationId, ...props }: CanvasCommandLis
       icon={Settings}
       onSelect={(canvas) => {
         const id = canvas.metadata?.id;
-        if (organizationId && id) goTo(`/${organizationId}/canvases/${id}/settings`);
+        if (organizationId && id) goTo(appSettingsPath(organizationId, id));
       }}
     />
   );
@@ -167,7 +168,7 @@ function OpenCanvasList({ goTo, organizationId, ...props }: CanvasCommandListPro
       icon={Palette}
       onSelect={(canvas) => {
         const id = canvas.metadata?.id;
-        if (organizationId && id) goTo(`/${organizationId}/canvases/${id}`);
+        if (organizationId && id) goTo(appPath(organizationId, id));
       }}
     />
   );

--- a/web_src/src/components/GlobalCommandPalette/route.spec.ts
+++ b/web_src/src/components/GlobalCommandPalette/route.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getRouteContext } from "./route";
+
+describe("getRouteContext", () => {
+  it("parses app routes as canvas context", () => {
+    expect(getRouteContext("/org-1/apps/canvas-1")).toEqual({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      isTemplateRoute: false,
+    });
+  });
+
+  it("does not treat apps/new as a canvas route", () => {
+    expect(getRouteContext("/org-1/apps/new")).toEqual({
+      organizationId: "org-1",
+      canvasId: null,
+      isTemplateRoute: false,
+    });
+  });
+
+  it("does not treat apps/new/settings as a canvas route", () => {
+    expect(getRouteContext("/org-1/apps/new/settings")).toEqual({
+      organizationId: "org-1",
+      canvasId: null,
+      isTemplateRoute: false,
+    });
+  });
+
+  it("still parses legacy canvas routes", () => {
+    expect(getRouteContext("/org-1/canvases/canvas-1")).toEqual({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      isTemplateRoute: false,
+    });
+  });
+
+  it("parses template routes", () => {
+    expect(getRouteContext("/org-1/templates/template-1")).toEqual({
+      organizationId: "org-1",
+      canvasId: "template-1",
+      isTemplateRoute: true,
+    });
+  });
+});

--- a/web_src/src/components/GlobalCommandPalette/route.ts
+++ b/web_src/src/components/GlobalCommandPalette/route.ts
@@ -9,7 +9,9 @@ export function getRouteContext(pathname: string): {
   const segments = pathname.split("/").filter(Boolean);
   const firstSegment = segments[0] || "";
   const organizationId = PUBLIC_TOP_LEVEL_SEGMENTS.has(firstSegment) ? null : firstSegment;
-  const canvasSegmentIndex = segments.findIndex((segment) => segment === "canvases" || segment === "templates");
+  const canvasSegmentIndex = segments.findIndex(
+    (segment) => segment === "apps" || segment === "canvases" || segment === "templates",
+  );
   const canvasId = canvasSegmentIndex >= 0 ? segments[canvasSegmentIndex + 1] || null : null;
   const isTemplateRoute = canvasSegmentIndex >= 0 && segments[canvasSegmentIndex] === "templates";
   return { organizationId, canvasId, isTemplateRoute };

--- a/web_src/src/components/GlobalCommandPalette/route.ts
+++ b/web_src/src/components/GlobalCommandPalette/route.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_TOP_LEVEL_SEGMENTS } from "./constants";
+import { isAppRouteId } from "@/lib/appPaths";
 import type { CommandPage } from "./types";
 
 export function getRouteContext(pathname: string): {
@@ -12,7 +13,9 @@ export function getRouteContext(pathname: string): {
   const canvasSegmentIndex = segments.findIndex(
     (segment) => segment === "apps" || segment === "canvases" || segment === "templates",
   );
-  const canvasId = canvasSegmentIndex >= 0 ? segments[canvasSegmentIndex + 1] || null : null;
+  const parentSegment = canvasSegmentIndex >= 0 ? segments[canvasSegmentIndex] : null;
+  const rawCanvasId = canvasSegmentIndex >= 0 ? segments[canvasSegmentIndex + 1] || null : null;
+  const canvasId = parentSegment === "apps" ? (isAppRouteId(rawCanvasId) ? rawCanvasId : null) : rawCanvasId;
   const isTemplateRoute = canvasSegmentIndex >= 0 && segments[canvasSegmentIndex] === "templates";
   return { organizationId, canvasId, isTemplateRoute };
 }

--- a/web_src/src/hooks/useCanvasId.ts
+++ b/web_src/src/hooks/useCanvasId.ts
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 
 export const useCanvasId = (): string | null => {
-  const { canvasId } = useParams<{ canvasId?: string }>();
-  return canvasId || null;
+  const { appId, canvasId } = useParams<{ appId?: string; canvasId?: string }>();
+  return appId || canvasId || null;
 };

--- a/web_src/src/hooks/useCanvasId.ts
+++ b/web_src/src/hooks/useCanvasId.ts
@@ -1,6 +1,10 @@
 import { useParams } from "react-router-dom";
+import { isAppRouteId } from "@/lib/appPaths";
 
 export const useCanvasId = (): string | null => {
   const { appId, canvasId } = useParams<{ appId?: string; canvasId?: string }>();
-  return appId || canvasId || null;
+  if (appId) {
+    return isAppRouteId(appId) ? appId : null;
+  }
+  return canvasId || null;
 };

--- a/web_src/src/lib/appPaths.ts
+++ b/web_src/src/lib/appPaths.ts
@@ -1,0 +1,7 @@
+export function appPath(organizationId: string, appId: string, search = ""): string {
+  return `/${organizationId}/apps/${appId}${search}`;
+}
+
+export function appSettingsPath(organizationId: string, appId: string): string {
+  return `/${organizationId}/apps/${appId}/settings`;
+}

--- a/web_src/src/lib/appPaths.ts
+++ b/web_src/src/lib/appPaths.ts
@@ -1,3 +1,9 @@
+const RESERVED_APP_PATH_SEGMENTS = new Set(["new"]);
+
+export function isAppRouteId(segment: string | undefined | null): segment is string {
+  return !!segment && !RESERVED_APP_PATH_SEGMENTS.has(segment);
+}
+
 export function appPath(organizationId: string, appId: string, search = ""): string {
   return `/${organizationId}/apps/${appId}${search}`;
 }

--- a/web_src/src/pages/canvas/TemplatesPage.tsx
+++ b/web_src/src/pages/canvas/TemplatesPage.tsx
@@ -8,6 +8,7 @@ import { TemplateCard } from "./TemplateCard";
 import { ImportYamlDialog } from "./ImportYamlDialog";
 import { ALL_TAGS, getTemplateTags } from "./templateMetadata";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { appPath } from "@/lib/appPaths";
 import { useMemo, useState } from "react";
 import { ArrowLeft, LayoutTemplate, Search, Upload } from "lucide-react";
 import { Input } from "@/components/Input/input";
@@ -158,7 +159,7 @@ export function TemplatesPage() {
           open={isImportYamlOpen}
           onOpenChange={setIsImportYamlOpen}
           organizationId={organizationId}
-          onSuccess={(canvasId) => navigate(`/${organizationId}/canvases/${canvasId}`)}
+          onSuccess={(canvasId) => navigate(appPath(organizationId, canvasId))}
         />
       ) : null}
     </div>

--- a/web_src/src/pages/canvas/settings/index.tsx
+++ b/web_src/src/pages/canvas/settings/index.tsx
@@ -6,13 +6,15 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import { Loader2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { appPath } from "@/lib/appPaths";
 import { buildSettingsInitialValues } from "./buildInitialValues";
 import { PageHeader } from "./PageHeader";
 import type { SettingsSavePayload } from "./types";
 import { SettingsView } from "./View";
 
 export function CanvasSettingsPage() {
-  const { organizationId = "", canvasId = "" } = useParams<{ organizationId: string; canvasId: string }>();
+  const { organizationId = "", appId = "" } = useParams<{ organizationId: string; appId: string }>();
+  const canvasId = appId;
 
   const { canAct } = usePermissions();
   const canReadOrg = !!organizationId && canAct("org", "read");
@@ -69,7 +71,7 @@ function NormalView({ canvas, organization }: { canvas: CanvasesCanvas; organiza
   const orgId = organization.metadata!.id!;
   const resolvedCanvasId = canvas.metadata!.id!;
   const canvasName = canvas.metadata?.name || "Canvas";
-  const baseCanvasPath = `/${orgId}/canvases/${resolvedCanvasId}`;
+  const baseCanvasPath = appPath(orgId, resolvedCanvasId);
   const isOrgChangeManagementEnabled = organization?.spec?.changeManagementEnabled ?? false;
 
   usePageTitle([`${canvasName} · Settings`]);
@@ -148,7 +150,7 @@ function useApproverRoles(organizationRoles: RolesRole[]) {
 function useSaveCallback(canvasId: string, organizationId: string): (values: SettingsSavePayload) => Promise<void> {
   const navigate = useNavigate();
   const updateCanvasMutation = useUpdateCanvas(organizationId, canvasId);
-  const baseCanvasPath = `/${organizationId}/canvases/${canvasId}`;
+  const baseCanvasPath = appPath(organizationId, canvasId);
 
   return useCallback(
     async (values: SettingsSavePayload) => {

--- a/web_src/src/pages/home/CanvasCardsGrid.tsx
+++ b/web_src/src/pages/home/CanvasCardsGrid.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@/components/Heading/heading";
 import type { SuperplaneComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
 import { Link } from "react-router-dom";
+import { appPath } from "@/lib/appPaths";
 import { CanvasActionsMenu } from "./CanvasActionsMenu";
 import { CanvasCardDescription } from "./CanvasCardDescription";
 import type { CanvasCardData, CanvasFolderData } from "./types";
@@ -71,7 +72,7 @@ function CanvasCard({
   canDeleteCanvases,
   permissionsLoading,
 }: CanvasCardProps) {
-  const canvasHref = `/${organizationId}/canvases/${canvas.id}`;
+  const canvasHref = appPath(organizationId, canvas.id);
   const previewNodes = canvas.nodes || [];
   const previewEdges = canvas.edges || [];
 

--- a/web_src/src/pages/home/useCreateApp.tsx
+++ b/web_src/src/pages/home/useCreateApp.tsx
@@ -5,6 +5,7 @@ import { useCreateCanvas } from "@/hooks/useCanvasData";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { showErrorToast } from "@/lib/toast";
 import { PLACEHOLDER_NODE_CONTEXT_KEY, setAgentBootContext } from "@/lib/agentBootContext";
+import { appPath } from "@/lib/appPaths";
 
 interface UseCreateAppOptions {
   onCreated?: () => void;
@@ -37,7 +38,7 @@ export function useCreateApp({ onCreated }: UseCreateAppOptions = {}) {
           localStorage.setItem("canvasSidebarOpen", "false");
           setAgentBootContext(canvasId, "blank");
           sessionStorage.setItem(PLACEHOLDER_NODE_CONTEXT_KEY, canvasId);
-          navigate(`/${organizationId}/canvases/${canvasId}?edit=1`);
+          navigate(appPath(organizationId, canvasId, "?edit=1"));
         }
       } catch (error) {
         showErrorToast(getUsageLimitToastMessage(error, "Failed to create app"));

--- a/web_src/src/pages/home/useInstallTemplate.ts
+++ b/web_src/src/pages/home/useInstallTemplate.ts
@@ -7,6 +7,7 @@ import { showErrorToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { setAgentBootContext } from "@/lib/agentBootContext";
+import { appPath } from "@/lib/appPaths";
 
 interface InstallResult {
   canvasId: string;
@@ -53,7 +54,7 @@ export function useInstallTemplate() {
         if (agentContext?.instructions || agentContext?.initialMessage) {
           setAgentBootContext(result.canvasId, agentContext);
         }
-        navigate(`/${result.organizationId}/canvases/${result.canvasId}?edit=1`);
+        navigate(appPath(result.organizationId, result.canvasId, "?edit=1"));
       } catch (error) {
         const message = getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to install template"));
         showErrorToast(message);

--- a/web_src/src/pages/install/useInstallApp.ts
+++ b/web_src/src/pages/install/useInstallApp.ts
@@ -2,6 +2,7 @@ import { canvasKeys } from "@/hooks/useCanvasData";
 import { getApiErrorMessage } from "@/lib/errors";
 import { showErrorToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
+import { appPath } from "@/lib/appPaths";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -83,7 +84,7 @@ export function useInstallApp({
 
         const result = (await response.json()) as InstallResult;
         await queryClient.refetchQueries({ queryKey: canvasKeys.list(result.organizationId) });
-        navigate(`/${result.organizationId}/canvases/${result.canvasId}`);
+        navigate(appPath(result.organizationId, result.canvasId));
       } catch (error) {
         const message = getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to install app"));
         showErrorToast(message);

--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/DisableCapabilitiesInUseDialog.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/DisableCapabilitiesInUseDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Link } from "@/components/Link/link";
+import { appPath } from "@/lib/appPaths";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Fragment } from "react";
 import {
@@ -47,7 +48,7 @@ function CanvasNamesUsedInSummary({
         <Fragment key={canvas.canvasId}>
           {index > 0 ? <span className="text-gray-500 dark:text-gray-400">, </span> : null}
           <Link
-            href={`/${organizationId}/canvases/${canvas.canvasId}`}
+            href={appPath(organizationId, canvas.canvasId)}
             target="_blank"
             rel="noopener noreferrer"
             style={CANVAS_LINK_UNDERLINE_STYLE}

--- a/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/UsageTab.tsx
+++ b/web_src/src/pages/organization/settings/components/CapabilityBasedIntegrationDetails/UsageTab.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from "lucide-react";
 import { Fragment } from "react";
+import { appPath } from "@/lib/appPaths";
 import { INTEGRATION_INLINE_CODE_CLASSES } from "./lib";
 
 export type CapabilityIntegrationUsageGroup = {
@@ -70,11 +71,11 @@ export function UsageTab({ organizationId, workflowGroups }: UsageTabProps) {
                       <tr
                         key={group.canvasId}
                         className="cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50"
-                        onClick={() => window.open(`/${organizationId}/canvases/${group.canvasId}`, "_blank")}
+                        onClick={() => window.open(appPath(organizationId, group.canvasId), "_blank")}
                         onKeyDown={(event) => {
                           if (event.key !== "Enter" && event.key !== " ") return;
                           event.preventDefault();
-                          window.open(`/${organizationId}/canvases/${group.canvasId}`, "_blank");
+                          window.open(appPath(organizationId, group.canvasId), "_blank");
                         }}
                         tabIndex={0}
                         role="link"

--- a/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/LegacyIntegrationDetails.tsx
@@ -11,6 +11,7 @@ import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { ConfigurationFieldRenderer } from "@/ui/configurationFieldRenderer";
 import { IntegrationInstructions } from "@/ui/IntegrationInstructions";
 import { getApiErrorMessage } from "@/lib/errors";
+import { appPath } from "@/lib/appPaths";
 import { getIntegrationTypeDisplayName } from "@/lib/integrationDisplayName";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { usePageTitle } from "@/hooks/usePageTitle";
@@ -356,7 +357,7 @@ export function LegacyIntegrationDetails({ organizationId, integration }: Legacy
                   {workflowGroups.map((group) => (
                     <button
                       key={group.canvasId}
-                      onClick={() => window.open(`/${organizationId}/canvases/${group.canvasId}`, "_blank")}
+                      onClick={() => window.open(appPath(organizationId, group.canvasId), "_blank")}
                       className="w-full flex items-center gap-2 p-3 bg-gray-50 dark:bg-gray-800/50 rounded-md border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-left"
                     >
                       <div className="flex-1">

--- a/web_src/src/pages/workflowv2/index.tsx
+++ b/web_src/src/pages/workflowv2/index.tsx
@@ -61,6 +61,7 @@ import { useNodeHistory } from "@/hooks/useNodeHistory";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useQueueHistory } from "@/hooks/useQueueHistory";
 import { analytics } from "@/lib/analytics";
+import { appPath } from "@/lib/appPaths";
 import { filterVisibleConfiguration } from "@/lib/components";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getIntegrationWebhookUrl } from "@/lib/integrationUtils";
@@ -162,10 +163,16 @@ const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
 const EMPTY_CANVAS_EDGES: ComponentsEdge[] = [];
 
 export function WorkflowPageV2() {
-  const { organizationId, canvasId } = useParams<{
+  const {
+    organizationId,
+    appId,
+    canvasId: templateCanvasId,
+  } = useParams<{
     organizationId: string;
-    canvasId: string;
+    appId?: string;
+    canvasId?: string;
   }>();
+  const canvasId = appId || templateCanvasId || "";
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -5130,7 +5137,7 @@ export function WorkflowPageV2() {
 
       if (result?.data?.canvas?.metadata?.id) {
         setIsUseTemplateOpen(false);
-        navigate(`/${organizationId}/canvases/${result.data.canvas.metadata.id}`);
+        navigate(appPath(organizationId, result.data.canvas.metadata.id));
       }
     },
     [canvas, organizationId, createWorkflowMutation, navigate, queryClient, canvasId],
@@ -5320,11 +5327,11 @@ export function WorkflowPageV2() {
   };
 
   const hasRunBlockingChanges = hasUnsavedChanges && hasNonPositionalUnsavedChanges;
-  const appId = searchParams.get("appId") ?? undefined;
-  const appBanner = appId ? (
+  const backToAppId = searchParams.get("appId") ?? undefined;
+  const appBanner = backToAppId ? (
     <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 flex items-center gap-2">
       <Link
-        to={`/${organizationId}/apps/${appId}`}
+        to={appPath(organizationId!, backToAppId)}
         className="flex items-center gap-1 text-sm text-blue-700 hover:text-blue-900 transition-colors"
       >
         <ArrowLeft size={14} />

--- a/web_src/src/pages/workflowv2/mappers/incident/setSigningSecretSection.tsx
+++ b/web_src/src/pages/workflowv2/mappers/incident/setSigningSecretSection.tsx
@@ -16,6 +16,7 @@ import { Label } from "@/components/ui/label";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { canvasKeys } from "@/hooks/useCanvasData";
+import { useCanvasId } from "@/hooks/useCanvasId";
 
 /** Applies signingSecretConfigured to the given node on a canvas copy. Does not mutate. */
 function applySigningSecretConfigured(
@@ -35,7 +36,8 @@ export function SetSigningSecretSection({ nodeId }: { nodeId: string }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const queryClient = useQueryClient();
-  const { organizationId, canvasId } = useParams<{ organizationId: string; canvasId: string }>();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const canvasId = useCanvasId();
   const [searchParams] = useSearchParams();
   const versionId = searchParams.get("version");
 

--- a/web_src/src/pages/workflowv2/mappers/webhook/fieldComponents.tsx
+++ b/web_src/src/pages/workflowv2/mappers/webhook/fieldComponents.tsx
@@ -4,6 +4,7 @@ import { canvasesInvokeNodeTriggerHook } from "@/api-client";
 import { Icon } from "@/components/Icon";
 import { useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
+import { useCanvasId } from "@/hooks/useCanvasId";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import { showErrorToast } from "@/lib/toast";
@@ -40,7 +41,8 @@ export const ResetAuthButton: React.FC<{
   const [isResetting, setIsResetting] = useState(false);
   const [newSecret, setNewSecret] = useState<string | null>(null);
   const queryClient = useQueryClient();
-  const { organizationId, canvasId } = useParams<{ organizationId: string; canvasId: string }>();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const canvasId = useCanvasId();
 
   const getAuthLabels = () => {
     switch (authMethod) {

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -132,8 +132,16 @@ function PageHeader({
   onDiscardDraftAndStartEdit?: () => void;
   unpublishedDraftUpdatedAt?: string;
 }) {
-  const { workflowId, canvasId: canvasIdParam } = useParams<{ workflowId?: string; canvasId?: string }>();
-  const activeCanvasId = canvasIdParam || workflowId;
+  const {
+    workflowId,
+    canvasId: canvasIdParam,
+    appId,
+  } = useParams<{
+    workflowId?: string;
+    canvasId?: string;
+    appId?: string;
+  }>();
+  const activeCanvasId = appId || canvasIdParam || workflowId;
 
   return (
     <div className="relative z-20 flex h-10 items-center border-b border-slate-950/15 px-2 sm:px-3">

--- a/web_src/src/ui/CanvasPage/components/CanvasProjectSwitcher.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasProjectSwitcher.tsx
@@ -5,6 +5,7 @@ import { useCanvases, useUpdateCanvas } from "@/hooks/useCanvasData";
 import { useRecentCanvasOpens } from "@/hooks/useRecentCanvasOpens";
 import { getApiErrorMessage } from "@/lib/errors";
 import { sortCanvasProjectsByRecentOpen, type CanvasProjectOption } from "@/lib/recentCanvasOpens";
+import { appPath, appSettingsPath } from "@/lib/appPaths";
 import { showErrorToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/dropdownMenu";
@@ -100,7 +101,7 @@ export function CanvasProjectSwitcher({
       return;
     }
 
-    navigate(`/${organizationId}/canvases/${activeCanvasId}/settings`);
+    navigate(appSettingsPath(organizationId, activeCanvasId));
   }, [activeCanvasId, navigate, organizationId]);
 
   const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -122,7 +123,7 @@ export function CanvasProjectSwitcher({
       return;
     }
 
-    navigate(`/${organizationId}/canvases/${canvasId}`);
+    navigate(appPath(organizationId, canvasId));
   };
 
   const switcherSurface = rename.isRenaming ? (


### PR DESCRIPTION
Updates the UI to use /{organizationId}/apps/{appId} instead of /{organizationId}/canvases/{canvasId}. API paths (/api/v1/canvases/...) remain unchanged for now — only client-side routing was updated.

### Route changes

- App page: apps/:appId
- App settings: apps/:appId/settings
- Legacy redirects from /canvases/:canvasId → /apps/:appId (query params preserved), so old bookmarked /canvases/... URLs redirect automatically.