### PR TITLE
chore: update app URL in CLI outputs

### DIFF
--- a/pkg/cli/commands/apps/canvas/get.go
+++ b/pkg/cli/commands/apps/canvas/get.go
@@ -73,8 +73,8 @@ func (c *getCommand) Execute(ctx core.CommandContext) error {
 	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
 		_, _ = fmt.Fprintf(stdout, "ID: %s\n", resource.Metadata.GetId())
 		_, _ = fmt.Fprintf(stdout, "Name: %s\n", resource.Metadata.GetName())
-		if url := common.BuildCanvasURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
-			_, _ = fmt.Fprintf(stdout, "Canvas URL: %s\n", url)
+		if url := common.BuildAppURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
+			_, _ = fmt.Fprintf(stdout, "App URL: %s\n", url)
 		}
 		_, _ = fmt.Fprintf(stdout, "Nodes: %d\n", len(resource.Spec.GetNodes()))
 		_, err := fmt.Fprintf(stdout, "Edges: %d\n", len(resource.Spec.GetEdges()))

--- a/pkg/cli/commands/apps/canvas/get_test.go
+++ b/pkg/cli/commands/apps/canvas/get_test.go
@@ -34,7 +34,7 @@ func TestGetCommandPrintsCanvasOnSuccess(t *testing.T) {
 	require.Contains(t, stdout.String(), "Name: my-canvas")
 	require.Contains(t, stdout.String(), "Nodes: 0")
 	require.Contains(t, stdout.String(), "Edges: 0")
-	require.NotContains(t, stdout.String(), "Canvas URL:")
+	require.NotContains(t, stdout.String(), "App URL:")
 }
 
 func TestGetCommandPrintsURLFromResponseOrgID(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGetCommandPrintsURLFromResponseOrgID(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "ID: "+testGetCanvasID)
 	require.Contains(t, stdout.String(), "Name: my-canvas")
-	require.Contains(t, stdout.String(), "Canvas URL: https://app.superplane.com/org-uuid/canvases/"+testGetCanvasID)
+	require.Contains(t, stdout.String(), "App URL: https://app.superplane.com/org-uuid/apps/"+testGetCanvasID)
 	require.Contains(t, stdout.String(), "Nodes: 0")
 	require.Contains(t, stdout.String(), "Edges: 0")
 }
@@ -69,7 +69,7 @@ func TestGetCommandSkipsURLWhenResponseMissingOrgID(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), "ID: "+testGetCanvasID)
 	require.Contains(t, stdout.String(), "Name: my-canvas")
-	require.NotContains(t, stdout.String(), "Canvas URL:")
+	require.NotContains(t, stdout.String(), "App URL:")
 }
 
 func TestGetUsesActiveAppWhenNoArg(t *testing.T) {

--- a/pkg/cli/commands/apps/common/common.go
+++ b/pkg/cli/commands/apps/common/common.go
@@ -215,14 +215,14 @@ func DescribeAppVersionByID(
 	return *response.Version, nil
 }
 
-// BuildCanvasURL composes the canonical web URL for a canvas. Returns "" when
-// the context, base URL, organization id, or canvas id is missing so callers
+// BuildCanvasURL composes the canonical web URL for an app. Returns "" when
+// the context, base URL, organization id, or app id is missing so callers
 // can omit the URL output without erroring.
 //
 // orgID and canvasID should come from the API response (canvas metadata)
 // rather than the local CLI context, so the URL stays correct even if the
 // active context drifts.
-func BuildCanvasURL(ctx core.CommandContext, orgID, canvasID string) string {
+func BuildAppURL(ctx core.CommandContext, orgID, canvasID string) string {
 	if ctx.Config == nil || orgID == "" || canvasID == "" {
 		return ""
 	}
@@ -232,5 +232,5 @@ func BuildCanvasURL(ctx core.CommandContext, orgID, canvasID string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/%s/canvases/%s", baseURL, orgID, canvasID)
+	return fmt.Sprintf("%s/%s/apps/%s", baseURL, orgID, canvasID)
 }

--- a/pkg/cli/commands/apps/create.go
+++ b/pkg/cli/commands/apps/create.go
@@ -143,7 +143,7 @@ func validateAndPrintCreateResponse(
 		if _, err := fmt.Fprintf(stdout, "App %q created (ID: %s)\n", canvas.Metadata.GetName(), canvas.Metadata.GetId()); err != nil {
 			return err
 		}
-		if url := common.BuildCanvasURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
+		if url := common.BuildAppURL(ctx, canvas.Metadata.GetOrganizationId(), canvas.Metadata.GetId()); url != "" {
 			if _, err := fmt.Fprintf(stdout, "App URL: %s\n", url); err != nil {
 				return err
 			}

--- a/pkg/cli/commands/apps/create_test.go
+++ b/pkg/cli/commands/apps/create_test.go
@@ -43,7 +43,7 @@ func TestCreateCommandPrintsURLFromResponseOrgID(t *testing.T) {
 	err := (&createCommand{}).Execute(ctx)
 	require.NoError(t, err)
 	require.Contains(t, stdout.String(), `App "my-canvas" created (ID: abc-123)`)
-	require.Contains(t, stdout.String(), "App URL: https://app.superplane.com/org-uuid/canvases/abc-123")
+	require.Contains(t, stdout.String(), "App URL: https://app.superplane.com/org-uuid/apps/abc-123")
 }
 
 func TestCreateCommandSkipsURLWhenResponseMissingOrgID(t *testing.T) {

--- a/pkg/cli/commands/apps/root.go
+++ b/pkg/cli/commands/apps/root.go
@@ -17,8 +17,8 @@ func NewCommand(options core.BindOptions) *cobra.Command {
 
 An app is a SuperPlane automation made up of a canvas, console, and files.
 
-App URL pattern: {baseURL}/{organizationId}/canvases/{appId}
-(e.g. https://app.superplane.com/<organization-id>/canvases/<app-id>)`,
+App URL pattern: {baseURL}/{organizationId}/apps/{appId}
+(e.g. https://app.superplane.com/<organization-id>/apps/<app-id>)`,
 		Aliases: []string{"app"},
 	}
 


### PR DESCRIPTION
UI uses /apps route now. See: https://github.com/superplanehq/superplane/pull/5156. Just updating the CLI outputs to reference it