### PR TITLE
feat: Console - Support Node Data in Runs as Source

### DIFF
--- a/docs/prd/console-and-widgets.md
+++ b/docs/prd/console-and-widgets.md
@@ -142,8 +142,8 @@ Table, chart, and number panels share these data sources:
 | Source | Query | Result rows |
 | --- | --- | --- |
 | `memory` | `useCanvasMemoryEntries` | Canvas memory entries filtered by namespace. Optional `fieldPath` flattens a nested value or list. |
-| `executions` | `useInfiniteCanvasEvents` | Flattened `event.executions[]`, optionally filtered to one resolved node. Rows include `status`, `nodeName`, and `durationMs`. |
-| `runs` | `useInfiniteCanvasRuns` | Raw run objects. Number widgets can use API `totalCount` for count KPIs. |
+| `executions` | `useInfiniteCanvasEvents` | Flattened `event.executions[]`, optionally filtered to one resolved node. Rows include `status`, `nodeName`, `durationMs`, and `payload` (the data the node received from its root event). |
+| `runs` | `useInfiniteCanvasRuns` (+ `useEventExecutionsBatch` for `$`) | Raw run objects plus derived `status`, `nodeName` (the node that initiated the run, resolved from `rootEvent.nodeId`), `payload` (alias for `rootEvent.data`, the initial payload that triggered the run), `durationMs` (created-to-finished elapsed time in milliseconds — pair with `format: duration`), and `$` (a map keyed by node display name with each node's full execution including `outputs` — see [Addressing per-node outputs](#addressing-per-node-outputs)). Number widgets can use API `totalCount` for count KPIs. |
 
 Execution widgets eager-load more event pages until they have enough execution rows for the configured `limit`, or until a bounded page cap is reached. This avoids count widgets flashing an intermediate value when the first event page has few executions.
 
@@ -195,10 +195,29 @@ The table editor populates the column dropdown, the filter / sort field datalist
 | Data source | Field catalog |
 | --- | --- |
 | `memory` | Discovered live from canvas memory entries in the chosen namespace. |
-| `executions` | Static catalog mirroring the execution row shape (`status`, `nodeName`, `durationMs`, `state`, `result`, `resultReason`, `resultMessage`, `id`, `nodeId`, `canvasId`, `parentExecutionId`, `previousExecutionId`, `createdAt`, `updatedAt`). |
-| `runs` | Static catalog mirroring `CanvasesCanvasRun` (`state`, `result`, `id`, `canvasId`, `versionId`, `createdAt`, `updatedAt`, `finishedAt`). |
+| `executions` | Static catalog mirroring the execution row shape (`status`, `nodeName`, `durationMs`, `payload`, `state`, `result`, `resultReason`, `resultMessage`, `id`, `nodeId`, `canvasId`, `parentExecutionId`, `previousExecutionId`, `createdAt`, `updatedAt`). |
+| `runs` | Static catalog mirroring `CanvasesCanvasRun` plus the derived fields appended by `collectRunRows` (`state`, `result`, `status`, `nodeName`, `payload`, `durationMs`, `$`, `id`, `canvasId`, `versionId`, `createdAt`, `updatedAt`, `finishedAt`, `rootEvent.nodeId`, `rootEvent.customName`). |
 
-When suggestions are available, the column header bar also exposes an **Add all fields** button and quick-add chips that insert a column for each catalog field with `suggestColumnFormat`-derived formatting (e.g. `status` → `status`, `createdAt` → `relative`). Authors can still type a custom field (or `{{ CEL }}` template) — the dropdown switches to a free-text input via the `Custom…` option.
+When suggestions are available, the column header bar also exposes an **Add all fields** button and quick-add chips that insert a column for each catalog field with `suggestColumnFormat`-derived formatting (e.g. `status` → `status`, `createdAt` → `relative`).
+
+The column, filter, row-style, and sort field inputs are free-text — authors can type any **nested dot path** (e.g. `payload.user_id`, `rootEvent.customName`) or `{{ CEL }}` template. Catalog entries surface as `<datalist>` autocomplete suggestions. When the typed value matches a known catalog field, the column's `label` and `format` are auto-filled (only when the author hasn't already set them) so picking from the dropdown stays one-click.
+
+#### Addressing per-node outputs
+
+Run rows expose a `$` map keyed by **node display name** so authors can address the outputs of any node within that run. The shape mirrors the canvas-side expression syntax (`$['Node Name'].data`):
+
+| Path | Resolves to |
+| --- | --- |
+| `$["deploy-prod"].outputs` | The raw outputs map (`{ <channel>: [<event>, ...] }`) for the `deploy-prod` execution. |
+| `$["deploy-prod"].outputs.default[0]` | The first event emitted on the `default` channel. |
+| `$["deploy-prod"].data` | Convenience shortcut for the **last** event of the `default` channel (or the first available channel) with one `data` envelope unwrapped — matches what canvas-side `$['Node'].data` resolves to. |
+| `$["deploy-prod"].state`, `$["deploy-prod"].result` | Per-node state and result fields, useful for row styling. |
+
+The same syntax works in both literal field paths (e.g. a column `field: $["deploy-prod"].data.url`) and in `{{ }}` CEL templates (e.g. `format: link, label: "{{ $['deploy-prod'].data.url }}"`). Under the hood the CEL compiler rewrites `$` to a safe identifier (cel-js doesn't accept `$` as an identifier), but authors don't need to be aware of the rewrite — string literals are preserved verbatim, so a `$` inside `"..."` or `'...'` is left alone.
+
+**Missing nodes resolve to `undefined`** — when a given node didn't run for that run (e.g. the workflow forked and only one branch executed, or the execution hasn't reached that node yet), `$["other-node"].outputs` returns `undefined` and the widget cell renders as `-`. This is intentional and matches how missing dot paths behave elsewhere.
+
+**Performance:** Run-level outputs are not part of the `ListRuns` payload (executions are returned as lightweight refs). The widget side-loads them via `ListEventExecutions(rootEventId)` for each visible run, capped by the panel's `limit`. React Query caches the response keyed by `(canvasId, rootEventId)`, so opening the run detail modal and the widget share results. Authors with very large `limit` values should expect one extra request per run on first load.
 
 ### Columns
 
@@ -261,6 +280,26 @@ Console widgets support two related expression styles:
 - Legacy expressions such as `status == "running"` are supported in `show` and some filters.
 
 Use CEL templates for new payloads, confirmation text, and rich interpolation. Use structured `where` filters when the condition is simple and should be validated.
+
+### CEL builtins
+
+In addition to the standard CEL functions cel-js ships with, the dashboard exposes these helpers in every expression's environment:
+
+| Builtin | Description |
+| --- | --- |
+| `int(v)`, `float(v)`, `string(v)` | Type coercions, with sensible fallbacks for nullish input. |
+| `contains(s, sub)`, `startsWith(s, p)`, `endsWith(s, p)`, `matches(s, regex)` | String / regex predicates. |
+| `lower(s)`, `upper(s)` | Case conversions. |
+| `duration(seconds)` | Format a number of seconds as `5m 30s` / `1h 5m`. |
+| `timestamp(seconds)` | Format epoch seconds as an ISO-8601 string. |
+| `formatDate(value, pattern)` | Render any date-like value (ISO string, Date, epoch number) with tokens `yyyy yy MM M dd d HH H mm m ss s`. Renders in the viewer's local time. |
+| `epochMs(value)` | Convert any date-like value (ISO-8601 string, Date instance, epoch seconds, epoch ms) to **milliseconds since epoch**. Returns `0` for unparseable input so arithmetic stays defined. Pairs with `duration()` for human-friendly elapsed-time output. |
+
+Note that `field: finishedAt - createdAt` does **not** work directly because both values are ISO-8601 strings and CEL doesn't subtract strings. Use one of:
+
+- `field: durationMs, format: duration` — easiest for the standard "how long did this take" cell on `runs` or `executions` rows (the derived field is already there).
+- `field: '{{ duration((epochMs(finishedAt) - epochMs(createdAt)) / 1000) }}'` — the explicit CEL form, useful when comparing arbitrary timestamp fields or subtracting the trigger time from the finish time.
+- `field: '{{ epochMs(finishedAt) - epochMs(createdAt) }}', format: duration` — gives you a numeric ms value the column formatter can render and downstream filters can compare against.
 
 Loose equality in legacy expressions is implemented explicitly by normalizing scalar strings, numbers, booleans, and `null`; do not add `eslint-disable-next-line` directives for equality checks.
 

--- a/docs/prd/console-and-widgets.md
+++ b/docs/prd/console-and-widgets.md
@@ -496,13 +496,13 @@ Supported authoring features:
 
 ## Node Panels
 
-Node panels resolve the configured `node` by id or name. They display the latest status from `deriveDashboardNodeStatuses` and can optionally show a manual Run button.
+Node panels resolve the configured `node` by id or name. They display the node's name and can optionally show a manual Run button.
 
 `showRun` only exposes the button. The actual click still requires `canRunNodes`, and the backend authorization remains the source of truth.
 
 ## Multi-Node Panels
 
-The plural `nodes` panel type renders several pinned canvas nodes in a single card, each with their live status and an optional purpose line. Use it for "Key Nodes" style summaries (for example, the entry/exit nodes of a preview-environment workflow) instead of stamping out one `node` panel per row.
+The plural `nodes` panel type renders several pinned canvas nodes in a single card, each with an optional purpose line. Use it for "Key Nodes" style summaries (for example, the entry/exit nodes of a preview-environment workflow) instead of stamping out one `node` panel per row.
 
 ```yaml
 type: nodes

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, useInfiniteQuery, useQueries } from "@tanstack/react-query";
 import {
   canvasesListCanvases,
   canvasesDescribeCanvas,
@@ -1362,6 +1362,36 @@ export const useEventExecutions = (canvasId: string, eventId: string | null) => 
     refetchOnWindowFocus: false,
     enabled: !!canvasId && !!eventId,
   });
+};
+
+/**
+ * Fetch executions for multiple root event ids in parallel. Each query is
+ * keyed by `(canvasId, eventId)`, identical to `useEventExecutions`, so the
+ * results dedupe with any single-event consumer (e.g. `RunNodeDetailModal`)
+ * already in the React Query cache. Returns the per-event results array
+ * along with an aggregate `isLoading` flag that's `true` while any of the
+ * underlying queries hasn't resolved yet.
+ */
+export const useEventExecutionsBatch = (canvasId: string, eventIds: string[]) => {
+  const queries = useQueries({
+    queries: eventIds.map((eventId) => ({
+      queryKey: canvasKeys.eventExecution(canvasId, eventId),
+      queryFn: async () => {
+        const response = await canvasesListEventExecutions(
+          withOrganizationHeader({
+            path: { canvasId, eventId },
+          }),
+        );
+        return response.data;
+      },
+      refetchOnWindowFocus: false,
+      enabled: !!canvasId && !!eventId,
+      staleTime: 30 * 1000,
+      gcTime: 5 * 60 * 1000,
+    })),
+  });
+  const isLoading = queries.some((q) => q.isLoading);
+  return { queries, isLoading };
 };
 
 export const useChildExecutions = (canvasId: string, executionId: string | null) => {

--- a/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/ChartPanelCard.tsx
@@ -8,7 +8,7 @@ import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
 import type { ChartPanelContent } from "./panelTypes";
-import { useWidgetData } from "./widget/useWidgetData";
+import { renderNeedsRunNodeOutputs, useWidgetData } from "./widget/useWidgetData";
 import { WidgetChart } from "./widget/WidgetChart";
 
 interface ChartPanelCardProps {
@@ -53,7 +53,11 @@ function ChartPanelBody({ content }: { content: ChartPanelContent }) {
 }
 
 function ChartPanelDataBound({ content, canvasId }: { content: ChartPanelContent; canvasId: string }) {
-  const { rows, isLoading, error } = useWidgetData(canvasId, content.dataSource);
+  const { rows, isLoading, error } = useWidgetData(
+    canvasId,
+    content.dataSource,
+    renderNeedsRunNodeOutputs(content.render),
+  );
   if (error) return <PanelError message={error} />;
   return <WidgetChart render={content.render} rows={rows} isLoading={isLoading} />;
 }

--- a/web_src/src/pages/workflowv2/dashboard/NodePanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NodePanelCard.tsx
@@ -5,37 +5,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { cn } from "@/lib/utils";
 import { Checkbox } from "@/ui/checkbox";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { WidgetEmptyState } from "./WidgetEmptyState";
-import { useDashboardContext, resolveDashboardNode, type DashboardNodeStatus } from "./DashboardContext";
+import { useDashboardContext, resolveDashboardNode } from "./DashboardContext";
 import { confirmDashboardTriggerNode } from "./confirmDashboardTriggerNode";
 import { NodeRunConfirmDialog } from "./NodeRunConfirmDialog";
 import type { NodePanelContent } from "./panelTypes";
-
-const STATUS_CLASS: Record<DashboardNodeStatus, string> = {
-  passed: "bg-emerald-100 text-emerald-700 ring-emerald-300",
-  failed: "bg-red-100 text-red-700 ring-red-300",
-  cancelled: "bg-slate-200 text-slate-600 ring-slate-300",
-  running: "bg-sky-100 text-sky-700 ring-sky-300",
-  pending: "bg-amber-100 text-amber-700 ring-amber-300",
-  skipped: "bg-slate-100 text-slate-500 ring-slate-300",
-  unknown: "bg-slate-100 text-slate-500 ring-slate-300",
-};
-
-const STATUS_LABEL: Record<DashboardNodeStatus, string> = {
-  passed: "Passed",
-  failed: "Failed",
-  cancelled: "Cancelled",
-  running: "Running",
-  pending: "Pending",
-  skipped: "Skipped",
-  unknown: "Unknown",
-};
 
 interface NodePanelCardProps {
   panel: DashboardPanel;
@@ -45,8 +24,8 @@ interface NodePanelCardProps {
 }
 
 /**
- * Single-node panel: status badge + node name + optional manual-run button.
- * Resolves the node reference (id or name) through {@link DashboardContext}.
+ * Single-node panel: node name + optional manual-run button. Resolves the
+ * node reference (id or name) through {@link DashboardContext}.
  */
 export function NodePanelCard({ panel, readOnly, onDelete, onChange }: NodePanelCardProps) {
   const [editing, setEditing] = useState(false);
@@ -83,25 +62,14 @@ function NodePanelBody({ content }: { content: NodePanelContent }) {
       <WidgetEmptyState
         icon={CircleDot}
         className="min-h-0"
-        message="Pick a node from the editor to display its status here."
+        message="Pick a node from the editor to display it here."
       />
     );
   }
   const resolved = resolveDashboardNode(ctx, content.node);
-  const status: DashboardNodeStatus = resolveStatus(ctx, resolved?.node.id);
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 p-4">
-      <span
-        className={cn(
-          "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-medium ring-1 ring-inset",
-          STATUS_CLASS[status],
-        )}
-        data-testid="node-panel-status"
-      >
-        <CircleDot className="h-3 w-3" aria-hidden />
-        {STATUS_LABEL[status]}
-      </span>
       <div className="text-sm font-semibold text-slate-800" data-testid="node-panel-name">
         {resolved?.label ?? content.node ?? "—"}
       </div>
@@ -156,11 +124,6 @@ function NodePanelRunControl({
       />
     </>
   );
-}
-
-function resolveStatus(ctx: ReturnType<typeof useDashboardContext>, nodeId: string | undefined): DashboardNodeStatus {
-  if (!nodeId) return "unknown";
-  return ctx?.nodeStatuses?.[nodeId] ?? "unknown";
 }
 
 function NodePanelForm({ value, onChange }: { value: NodePanelContent; onChange: (next: NodePanelContent) => void }) {

--- a/web_src/src/pages/workflowv2/dashboard/NodesPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NodesPanelCard.tsx
@@ -1,42 +1,21 @@
 import { useId, useState } from "react";
-import { CircleDot, Network, Play, Plus, Trash2 } from "lucide-react";
+import { Network, Play, Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
 import { Checkbox } from "@/ui/checkbox";
 import type { DashboardPanel } from "@/hooks/useCanvasData";
 
 import { PanelEditorDialog } from "./PanelEditorDialog";
 import { TypedPanelShell } from "./TypedPanelShell";
 import { WidgetEmptyState } from "./WidgetEmptyState";
-import { useDashboardContext, resolveDashboardNode, type DashboardNodeStatus } from "./DashboardContext";
+import { useDashboardContext, resolveDashboardNode } from "./DashboardContext";
 import { confirmDashboardTriggerNode } from "./confirmDashboardTriggerNode";
 import { NodeRunConfirmDialog } from "./NodeRunConfirmDialog";
 import type { NodesPanelContent, NodesPanelNode } from "./nodesPanelContent";
-
-const STATUS_CLASS: Record<DashboardNodeStatus, string> = {
-  passed: "bg-emerald-100 text-emerald-700 ring-emerald-300",
-  failed: "bg-red-100 text-red-700 ring-red-300",
-  cancelled: "bg-slate-200 text-slate-600 ring-slate-300",
-  running: "bg-sky-100 text-sky-700 ring-sky-300",
-  pending: "bg-amber-100 text-amber-700 ring-amber-300",
-  skipped: "bg-slate-100 text-slate-500 ring-slate-300",
-  unknown: "bg-slate-100 text-slate-500 ring-slate-300",
-};
-
-const STATUS_LABEL: Record<DashboardNodeStatus, string> = {
-  passed: "Passed",
-  failed: "Failed",
-  cancelled: "Cancelled",
-  running: "Running",
-  pending: "Pending",
-  skipped: "Skipped",
-  unknown: "Unknown",
-};
 
 interface NodesPanelCardProps {
   panel: DashboardPanel;
@@ -46,10 +25,10 @@ interface NodesPanelCardProps {
 }
 
 /**
- * Multi-node panel: renders a compact list of canvas nodes with their live
- * status and an optional purpose line. Useful for "Key Nodes" style cards
- * that want to surface several pinned nodes in a single console card
- * instead of one panel per node.
+ * Multi-node panel: renders a compact list of canvas nodes with an optional
+ * purpose line. Useful for "Key Nodes" style cards that want to surface
+ * several pinned nodes in a single console card instead of one panel per
+ * node.
  *
  * Resolution and trigger plumbing reuse {@link useDashboardContext} and
  * mirror the single-node panel so authorization and runtime behavior stay
@@ -86,11 +65,7 @@ export function NodesPanelCard({ panel, readOnly, onDelete, onChange }: NodesPan
 function NodesPanelBody({ content }: { content: NodesPanelContent }) {
   if (content.nodes.length === 0) {
     return (
-      <WidgetEmptyState
-        icon={Network}
-        className="min-h-0"
-        message="Add nodes from the editor to surface their live status here."
-      />
+      <WidgetEmptyState icon={Network} className="min-h-0" message="Add nodes from the editor to surface them here." />
     );
   }
   return (
@@ -105,21 +80,10 @@ function NodesPanelBody({ content }: { content: NodesPanelContent }) {
 function NodesPanelRow({ entry }: { entry: NodesPanelNode }) {
   const ctx = useDashboardContext();
   const resolved = resolveDashboardNode(ctx, entry.node);
-  const status: DashboardNodeStatus = resolveStatus(ctx, resolved?.node.id);
   const displayName = entry.label?.trim() || resolved?.label || entry.node;
 
   return (
     <li className="flex items-center gap-3 px-3 py-2" data-testid="nodes-panel-row">
-      <span
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ring-inset",
-          STATUS_CLASS[status],
-        )}
-        data-testid="nodes-panel-row-status"
-      >
-        <CircleDot className="h-2.5 w-2.5" aria-hidden />
-        {STATUS_LABEL[status]}
-      </span>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-slate-800" data-testid="nodes-panel-row-name">
           {displayName}
@@ -187,11 +151,6 @@ function NodesPanelRunControl({
   );
 }
 
-function resolveStatus(ctx: ReturnType<typeof useDashboardContext>, nodeId: string | undefined): DashboardNodeStatus {
-  if (!nodeId) return "unknown";
-  return ctx?.nodeStatuses?.[nodeId] ?? "unknown";
-}
-
 function NodesPanelForm({
   value,
   onChange,
@@ -230,7 +189,7 @@ function NodesPanelForm({
         </div>
         {value.nodes.length === 0 ? (
           <p className="rounded border border-dashed border-slate-200 px-3 py-4 text-center text-xs text-slate-500">
-            No nodes yet. Add one to display its live status in this panel.
+            No nodes yet. Add one to display it in this panel.
           </p>
         ) : (
           <div className="space-y-3">

--- a/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/NumberPanelCard.tsx
@@ -17,7 +17,7 @@ import {
   type NumberPanelContent,
   type TablePanelDataSource,
 } from "./panelTypes";
-import { useWidgetData } from "./widget/useWidgetData";
+import { renderNeedsRunNodeOutputs, useWidgetData } from "./widget/useWidgetData";
 import { WidgetNumber } from "./widget/WidgetNumber";
 
 interface NumberPanelCardProps {
@@ -85,7 +85,7 @@ function NumberPanelDataBound({
   dataSource: Exclude<NumberPanelContent["dataSource"], CompositeMemoryNumberDataSource | undefined>;
   canvasId: string;
 }) {
-  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, dataSource);
+  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, dataSource, renderNeedsRunNodeOutputs(render));
   if (error) return <PanelError message={error} />;
   return <WidgetNumber render={render} rows={rows} isLoading={isLoading} totalCount={totalCount} />;
 }
@@ -107,7 +107,11 @@ function MultiNumberPanelBody({ metrics, canvasId }: { metrics: NumberMetric[]; 
 }
 
 function NumberMetricItem({ metric, canvasId }: { metric: NumberMetric; canvasId: string }) {
-  const { rows, isLoading, error, totalCount } = useWidgetData(canvasId, metric.dataSource as TablePanelDataSource);
+  const { rows, isLoading, error, totalCount } = useWidgetData(
+    canvasId,
+    metric.dataSource as TablePanelDataSource,
+    renderNeedsRunNodeOutputs(metric.render),
+  );
   if (error) {
     return (
       <div className="flex items-center justify-center gap-2 text-xs text-amber-700">

--- a/web_src/src/pages/workflowv2/dashboard/TablePanelCard.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/TablePanelCard.tsx
@@ -9,7 +9,7 @@ import { TypedPanelShell } from "./TypedPanelShell";
 import { useDashboardContext } from "./DashboardContext";
 import type { TablePanelContent } from "./panelTypes";
 import { normalizeTablePanelContent } from "./panelTypes";
-import { useWidgetData } from "./widget/useWidgetData";
+import { renderNeedsRunNodeOutputs, useWidgetData } from "./widget/useWidgetData";
 import { WidgetTable } from "./widget/WidgetTable";
 
 interface TablePanelCardProps {
@@ -56,7 +56,11 @@ function TablePanelBody({ content }: { content: TablePanelContent }) {
 }
 
 function TablePanelDataBound({ content, canvasId }: { content: TablePanelContent; canvasId: string }) {
-  const { rows, isLoading, error } = useWidgetData(canvasId, content.dataSource);
+  const { rows, isLoading, error } = useWidgetData(
+    canvasId,
+    content.dataSource,
+    renderNeedsRunNodeOutputs(content.render),
+  );
   if (error) return <PanelError message={error} />;
   return <WidgetTable render={content.render} rows={rows} isLoading={isLoading} />;
 }

--- a/web_src/src/pages/workflowv2/dashboard/TablePanelForm.fieldCatalog.spec.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/TablePanelForm.fieldCatalog.spec.tsx
@@ -10,6 +10,7 @@ import { DashboardContextProvider } from "./DashboardContextProvider";
 import type { TablePanelContent } from "./panelTypes";
 import { TablePanelForm } from "./TablePanelForm";
 import { EXECUTIONS_FIELDS, RUNS_FIELDS } from "./widget/staticFieldCatalogs";
+import type { WidgetTableColumn } from "./widget/types";
 
 const START_NODE: SuperplaneComponentsNode = {
   id: "start-id",
@@ -123,5 +124,107 @@ describe("TablePanelForm field catalog", () => {
     render(<Harness initial={makeInitial("memory")} />);
     expect(screen.queryByTestId("table-field-quick-add")).toBeNull();
     expect(screen.queryByTestId("table-add-all-columns")).toBeNull();
+  });
+});
+
+describe("TablePanelForm column field input", () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView ??= () => {};
+  });
+
+  function makeWithColumn(kind: TablePanelContent["dataSource"]["kind"], column: WidgetTableColumn): TablePanelContent {
+    const base = makeInitial(kind);
+    return {
+      ...base,
+      render: { ...base.render, columns: [column] },
+    };
+  }
+
+  it("lets authors type nested dot paths like payload.user_id directly", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "" })} />);
+
+    const input = screen.getByTestId("table-column-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "payload.user_id" } });
+
+    const columns = JSON.parse(screen.getByTestId("harness-columns").textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(columns[0]?.field).toBe("payload.user_id");
+    // No catalog match -> no label / format auto-fill.
+    expect(columns[0]?.label).toBeUndefined();
+    expect(columns[0]?.format).toBeUndefined();
+  });
+
+  it("auto-fills label and format when the typed value matches a catalog field", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "" })} />);
+
+    const input = screen.getByTestId("table-column-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "status" } });
+
+    const columns = JSON.parse(screen.getByTestId("harness-columns").textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(columns[0]?.field).toBe("status");
+    expect(columns[0]?.label).toBe("status");
+    // `suggestColumnFormat` maps "status" -> "status".
+    expect(columns[0]?.format).toBe("status");
+  });
+
+  it("does not clobber a pre-existing label when typing a non-catalog value", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "", label: "Author label" })} />);
+
+    const input = screen.getByTestId("table-column-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "payload.user_id" } });
+
+    const columns = JSON.parse(screen.getByTestId("harness-columns").textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(columns[0]?.field).toBe("payload.user_id");
+    expect(columns[0]?.label).toBe("Author label");
+  });
+
+  it("does not clobber a pre-existing label when typing a catalog field", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "", label: "Author label" })} />);
+
+    const input = screen.getByTestId("table-column-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "status" } });
+
+    const columns = JSON.parse(screen.getByTestId("harness-columns").textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(columns[0]?.field).toBe("status");
+    expect(columns[0]?.label).toBe("Author label");
+    expect(columns[0]?.format).toBe("status");
+  });
+
+  it("renders the shared table-field-options datalist when a catalog is available", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "" })} />);
+    const datalist = document.getElementById("table-field-options");
+    expect(datalist).not.toBeNull();
+    const options = Array.from(datalist?.querySelectorAll("option") ?? []).map((opt) => opt.getAttribute("value"));
+    for (const expected of ["status", "payload", "nodeName"]) {
+      expect(options).toContain(expected);
+    }
+  });
+
+  it("includes the `$` namespace hint in the runs datalist", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "" })} />);
+    const datalist = document.getElementById("table-field-options");
+    const options = Array.from(datalist?.querySelectorAll("option") ?? []).map((opt) => opt.getAttribute("value"));
+    expect(options).toContain("$");
+  });
+
+  it("auto-fills format=duration when typing `durationMs`", () => {
+    render(<Harness initial={makeWithColumn("runs", { field: "" })} />);
+
+    const input = screen.getByTestId("table-column-field") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "durationMs" } });
+
+    const columns = JSON.parse(screen.getByTestId("harness-columns").textContent ?? "[]") as Array<
+      Record<string, unknown>
+    >;
+    expect(columns[0]?.field).toBe("durationMs");
+    expect(columns[0]?.label).toBe("durationMs");
+    expect(columns[0]?.format).toBe("duration");
   });
 });

--- a/web_src/src/pages/workflowv2/dashboard/TablePanelForm.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/TablePanelForm.tsx
@@ -49,6 +49,13 @@ export function TablePanelForm({ value, onChange }: TablePanelFormProps) {
         payloadDrafts={payloadDrafts}
         actions={actions}
       />
+      {fieldOptions.length > 0 ? (
+        <datalist id="table-field-options">
+          {fieldOptions.map((f) => (
+            <option key={f} value={f} />
+          ))}
+        </datalist>
+      ) : null}
     </div>
   );
 }

--- a/web_src/src/pages/workflowv2/dashboard/TablePanelFormRows.tsx
+++ b/web_src/src/pages/workflowv2/dashboard/TablePanelFormRows.tsx
@@ -42,8 +42,6 @@ const COLUMN_FORMATS: WidgetColumnFormat[] = [
   "link",
 ];
 
-const CUSTOM_FIELD = "__custom__";
-
 export function ColumnRow({
   col,
   fieldOptions,
@@ -55,37 +53,24 @@ export function ColumnRow({
   onChange: (patch: Partial<WidgetTableColumn>) => void;
   onRemove: () => void;
 }) {
-  const selectValue = fieldOptions.includes(col.field) ? col.field : col.field ? CUSTOM_FIELD : "";
   return (
     <div className="grid grid-cols-12 items-center gap-2 rounded border border-slate-200 p-2">
-      {selectValue === CUSTOM_FIELD || fieldOptions.length === 0 ? (
-        <Input
-          className="col-span-4 h-8"
-          value={col.field}
-          onChange={(e) => onChange({ field: e.target.value })}
-          placeholder="field or {{ expr }}"
-        />
-      ) : (
-        <Select
-          value={selectValue || CUSTOM_FIELD}
-          onValueChange={(v) => {
-            if (v === CUSTOM_FIELD) return;
-            onChange({ field: v, label: col.label || v, format: col.format ?? suggestColumnFormat(v) });
-          }}
-        >
-          <SelectTrigger className="col-span-4 h-8">
-            <SelectValue placeholder="Field" />
-          </SelectTrigger>
-          <SelectContent>
-            {fieldOptions.map((f) => (
-              <SelectItem key={f} value={f}>
-                {f}
-              </SelectItem>
-            ))}
-            <SelectItem value={CUSTOM_FIELD}>Custom…</SelectItem>
-          </SelectContent>
-        </Select>
-      )}
+      <Input
+        className="col-span-4 h-8"
+        value={col.field}
+        onChange={(e) => {
+          const next = e.target.value;
+          const known = fieldOptions.includes(next);
+          onChange({
+            field: next,
+            ...(known && !col.label ? { label: next } : {}),
+            ...(known && col.format == null ? { format: suggestColumnFormat(next) } : {}),
+          });
+        }}
+        placeholder="field (e.g. payload.user_id) or {{ expr }}"
+        list={fieldOptions.length > 0 ? "table-field-options" : undefined}
+        data-testid="table-column-field"
+      />
       <Input
         className="col-span-3 h-8"
         value={col.label ?? ""}
@@ -133,7 +118,7 @@ export function FilterRow({
         className="col-span-4 h-8"
         value={filter.field}
         onChange={(e) => onChange({ field: e.target.value })}
-        placeholder="field"
+        placeholder="field (e.g. payload.user_id)"
         list={fieldOptions.length > 0 ? "table-field-options" : undefined}
       />
       <Select value={filter.op} onValueChange={(v) => onChange({ op: v as WidgetTableFilter["op"] })}>
@@ -183,7 +168,7 @@ export function RowStyleRow({
         className="col-span-3 h-8"
         value={rule.field}
         onChange={(e) => onChange({ field: e.target.value })}
-        placeholder="field"
+        placeholder="field (e.g. payload.user_id)"
         list={fieldOptions.length > 0 ? "table-field-options" : undefined}
         data-testid="table-row-style-field"
       />
@@ -290,13 +275,6 @@ export function ActionRow({
         onQuickInsert={onPayloadEntryQuickInsert}
       />
       <ActionIconSelect action={action} onChange={onChange} />
-      {fieldOptions.length > 0 ? (
-        <datalist id="table-field-options">
-          {fieldOptions.map((f) => (
-            <option key={f} value={f} />
-          ))}
-        </datalist>
-      ) : null}
     </div>
   );
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/celExpr.dollar.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/celExpr.dollar.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildEnv,
+  compileExpr,
+  compileMaybeExpr,
+  compileTemplate,
+  DOLLAR_REWRITE_IDENTIFIER,
+  evalExpr,
+  evalRowField,
+  evalTemplate,
+  rewriteDollarRefs,
+} from "./celExpr";
+import { getValueAtPath } from "./fieldPath";
+
+describe("rewriteDollarRefs", () => {
+  it("rewrites bare `$` to the safe identifier", () => {
+    expect(rewriteDollarRefs('$["x"].y')).toBe(`${DOLLAR_REWRITE_IDENTIFIER}["x"].y`);
+  });
+
+  it("rewrites multiple `$` occurrences in the same expression", () => {
+    const out = rewriteDollarRefs('$["a"].x + $["b"].y');
+    expect(out).toBe(`${DOLLAR_REWRITE_IDENTIFIER}["a"].x + ${DOLLAR_REWRITE_IDENTIFIER}["b"].y`);
+  });
+
+  it("leaves `$` inside double-quoted strings alone", () => {
+    expect(rewriteDollarRefs('"price: $5"')).toBe('"price: $5"');
+  });
+
+  it("leaves `$` inside single-quoted strings alone", () => {
+    expect(rewriteDollarRefs("'price: $5'")).toBe("'price: $5'");
+  });
+
+  it("respects backslash escapes inside string literals", () => {
+    // The escaped quote shouldn't end the string, so the trailing `$` stays inside.
+    expect(rewriteDollarRefs('"foo\\" $bar"')).toBe('"foo\\" $bar"');
+  });
+
+  it("rewrites a `$` that appears between two string literals", () => {
+    const out = rewriteDollarRefs('"a" + $["x"] + "b"');
+    expect(out).toBe(`"a" + ${DOLLAR_REWRITE_IDENTIFIER}["x"] + "b"`);
+  });
+
+  it("is a no-op for expressions without `$`", () => {
+    expect(rewriteDollarRefs("pr_number / 2")).toBe("pr_number / 2");
+  });
+});
+
+describe("CEL with `$` node refs", () => {
+  it("compiles and evaluates `$['name'].outputs.<key>` against the row", () => {
+    const compiled = compileExpr('$["deploy"].outputs.url');
+    expect(compiled.ok).toBe(true);
+    const env = buildEnv();
+    const row = {
+      [DOLLAR_REWRITE_IDENTIFIER]: {
+        deploy: { outputs: { url: "https://example.com" } },
+      },
+    } as Record<string, unknown>;
+    expect(evalExpr(compiled, row, env)).toBe("https://example.com");
+  });
+
+  it("evaluates `$['name'].data.<key>` (the canvas-style shortcut)", () => {
+    const compiled = compileExpr('$["build"].data.commit');
+    const env = buildEnv();
+    const row = {
+      [DOLLAR_REWRITE_IDENTIFIER]: {
+        build: { data: { commit: "abc123" } },
+      },
+    } as Record<string, unknown>;
+    expect(evalExpr(compiled, row, env)).toBe("abc123");
+  });
+
+  it("works inside a `{{ }}` full expression via compileMaybeExpr", () => {
+    const maybe = compileMaybeExpr('{{ $["a"].outputs.score > 50 }}');
+    expect(maybe.kind).toBe("expr");
+    if (maybe.kind !== "expr") return;
+    const env = buildEnv();
+    const row = {
+      [DOLLAR_REWRITE_IDENTIFIER]: { a: { outputs: { score: 80 } } },
+    } as Record<string, unknown>;
+    expect(evalExpr(maybe.expr, row, env)).toBe(true);
+  });
+
+  it("works inside a partial `{{ }}` template", () => {
+    const template = compileTemplate('Deploy URL: {{ $["deploy"].outputs.url }}');
+    const env = buildEnv();
+    const row = {
+      [DOLLAR_REWRITE_IDENTIFIER]: { deploy: { outputs: { url: "https://x.test" } } },
+    } as Record<string, unknown>;
+    expect(evalTemplate(template, row, env, String)).toBe("Deploy URL: https://x.test");
+  });
+
+  it("resolves literal dot paths via the row's `$` key", () => {
+    // Literal mode (no `{{ }}`) goes through getValueAtPath/parsePath, which
+    // already handles `$["name"]` because `$` is a normal identifier char
+    // there. The row carries `$` directly (alongside the rewrite alias).
+    const maybe = compileMaybeExpr('$["deploy"].outputs.url');
+    const env = buildEnv();
+    const row = {
+      $: { deploy: { outputs: { url: "https://literal.test" } } },
+      [DOLLAR_REWRITE_IDENTIFIER]: { deploy: { outputs: { url: "https://literal.test" } } },
+    } as Record<string, unknown>;
+    expect(evalRowField(maybe, row, env, getValueAtPath)).toBe("https://literal.test");
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/celExpr.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/celExpr.spec.ts
@@ -115,6 +115,52 @@ describe("celExpr", () => {
     });
   });
 
+  describe("epochMs builtin", () => {
+    it("converts an ISO-8601 string to ms-since-epoch", () => {
+      const compiled = compileExpr("epochMs(value)");
+      const env = buildEnv();
+      const result = evalExpr(compiled, { value: "2026-01-01T00:00:00Z" }, env) as number;
+      expect(result).toBe(Date.UTC(2026, 0, 1, 0, 0, 0));
+    });
+
+    it("supports timestamp arithmetic across two ISO strings", () => {
+      // Authors hit this when they write `{{ epochMs(finishedAt) - epochMs(createdAt) }}`
+      // on a runs row to compute elapsed time without the durationMs convenience.
+      const compiled = compileExpr("epochMs(finishedAt) - epochMs(createdAt)");
+      const env = buildEnv();
+      const result = evalExpr(compiled, { createdAt: "2026-01-01T12:00:00Z", finishedAt: "2026-01-01T12:05:00Z" }, env);
+      expect(result).toBe(5 * 60 * 1000);
+    });
+
+    it("composes with `duration()` for human-friendly output", () => {
+      const template = compileTemplate("Took {{ duration((epochMs(finishedAt) - epochMs(createdAt)) / 1000) }}");
+      const env = buildEnv();
+      const result = evalTemplate(
+        template,
+        { createdAt: "2026-01-01T12:00:00Z", finishedAt: "2026-01-01T12:05:00Z" },
+        env,
+        String,
+      );
+      expect(result).toBe("Took 5m");
+    });
+
+    it("returns 0 for unparseable inputs so arithmetic stays defined", () => {
+      const compiled = compileExpr("epochMs(value)");
+      const env = buildEnv();
+      expect(evalExpr(compiled, { value: "not a date" }, env)).toBe(0);
+      expect(evalExpr(compiled, { value: null }, env)).toBe(0);
+    });
+
+    it("accepts epoch numbers (seconds and ms) and Date instances", () => {
+      const compiled = compileExpr("epochMs(value)");
+      const env = buildEnv();
+      const ms = Date.UTC(2026, 5, 1, 12, 0);
+      expect(evalExpr(compiled, { value: ms }, env)).toBe(ms);
+      expect(evalExpr(compiled, { value: ms / 1000 }, env)).toBe(ms);
+      expect(evalExpr(compiled, { value: new Date(ms) }, env)).toBe(ms);
+    });
+  });
+
   describe("error reporting", () => {
     it("reports a compile error for invalid CEL", () => {
       const compiled = compileExpr("value /");

--- a/web_src/src/pages/workflowv2/dashboard/widget/celExpr.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/celExpr.ts
@@ -23,8 +23,61 @@ function isFullExpression(raw: string): boolean {
   return FULL_EXPR_RE.test(raw);
 }
 
+/**
+ * Identifier substituted for bare `$` so cel-js (which only accepts
+ * `[a-zA-Z_][a-zA-Z0-9_]*` identifiers) can parse canvas-style node refs
+ * like `$["deploy-prod"].outputs.url`. Rows that need to resolve those
+ * references must carry the same map under this key.
+ */
+export const DOLLAR_REWRITE_IDENTIFIER = "__runNodes__";
+
+/**
+ * Rewrite bare `$` tokens to `DOLLAR_REWRITE_IDENTIFIER` outside of string
+ * literals so cel-js can parse expressions like `$["node name"].outputs.x`.
+ * Single- and double-quoted strings are copied verbatim (with backslash
+ * escapes preserved) so a `$` inside a string literal is left alone.
+ *
+ * The rewrite is purely additive: cel-js's lexer rejects bare `$` today,
+ * so no existing expression depended on the previous behavior.
+ */
+export function rewriteDollarRefs(raw: string): string {
+  let out = "";
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      out += quote;
+      i++;
+      while (i < raw.length && raw[i] !== quote) {
+        if (raw[i] === "\\" && i + 1 < raw.length) {
+          out += raw[i] + raw[i + 1];
+          i += 2;
+          continue;
+        }
+        out += raw[i];
+        i++;
+      }
+      if (i < raw.length) {
+        out += raw[i];
+        i++;
+      }
+      continue;
+    }
+    if (ch === "$") {
+      out += DOLLAR_REWRITE_IDENTIFIER;
+      i++;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
 export function compileExpr(raw: string): CompiledExpr {
-  const result = celParse(raw);
+  const rewritten = rewriteDollarRefs(raw);
+  const result = celParse(rewritten);
   if (!result.isSuccess) {
     const message = result.errors.join("; ");
     return { ok: false, raw, error: message };
@@ -96,6 +149,15 @@ const BUILTIN_FUNCTIONS: Record<string, CallableFunction> = {
   duration: (seconds: unknown) => formatDurationSeconds(Number(seconds)),
   timestamp: (seconds: unknown) => formatTimestampSeconds(Number(seconds)),
   formatDate,
+  // Convert any date-like value (ISO string, Date, epoch number) to
+  // ms-since-epoch. Returns 0 for unparseable input so arithmetic doesn't
+  // blow up — authors checking `epochMs(x) > 0` can still detect missing
+  // values. Pairs with `duration()` for human-friendly output, e.g.
+  // `{{ duration((epochMs(finishedAt) - epochMs(createdAt)) / 1000) }}`.
+  epochMs: (value: unknown): number => {
+    const date = coerceToDate(value);
+    return date ? date.getTime() : 0;
+  },
 };
 
 function toInt(value: unknown): number {

--- a/web_src/src/pages/workflowv2/dashboard/widget/celExpr.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/celExpr.ts
@@ -46,22 +46,9 @@ export function rewriteDollarRefs(raw: string): string {
   while (i < raw.length) {
     const ch = raw[i];
     if (ch === '"' || ch === "'") {
-      const quote = ch;
-      out += quote;
-      i++;
-      while (i < raw.length && raw[i] !== quote) {
-        if (raw[i] === "\\" && i + 1 < raw.length) {
-          out += raw[i] + raw[i + 1];
-          i += 2;
-          continue;
-        }
-        out += raw[i];
-        i++;
-      }
-      if (i < raw.length) {
-        out += raw[i];
-        i++;
-      }
+      const literal = copyStringLiteral(raw, i, ch);
+      out += literal.value;
+      i = literal.next;
       continue;
     }
     if (ch === "$") {
@@ -73,6 +60,30 @@ export function rewriteDollarRefs(raw: string): string {
     i++;
   }
   return out;
+}
+
+/**
+ * Copy a quoted string literal verbatim (preserving backslash escapes),
+ * starting at the opening quote at `start`. Returns the copied text and the
+ * index immediately after the closing quote (or end of input).
+ */
+function copyStringLiteral(raw: string, start: number, quote: string): { value: string; next: number } {
+  let value = quote;
+  let i = start + 1;
+  while (i < raw.length && raw[i] !== quote) {
+    if (raw[i] === "\\" && i + 1 < raw.length) {
+      value += raw[i] + raw[i + 1];
+      i += 2;
+      continue;
+    }
+    value += raw[i];
+    i++;
+  }
+  if (i < raw.length) {
+    value += raw[i];
+    i++;
+  }
+  return { value, next: i };
 }
 
 export function compileExpr(raw: string): CompiledExpr {

--- a/web_src/src/pages/workflowv2/dashboard/widget/staticFieldCatalogs.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/staticFieldCatalogs.ts
@@ -24,10 +24,10 @@ import type { MemoryFieldSummary } from "./useMemoryCatalog";
  * Field catalog for rows produced by the `executions` data source.
  *
  * Keep this in sync with the row shape constructed by `collectExecutionRows`
- * in `widget/useWidgetData.ts` — the raw execution fields plus the three
- * derived convenience fields (`status`, `nodeName`, `durationMs`). Entries
- * are sorted alphabetically by `field` so the dropdown and quick-add chips
- * stay scannable as the catalog grows.
+ * in `widget/useWidgetData.ts` — the raw execution fields plus the derived
+ * convenience fields (`status`, `nodeName`, `durationMs`, `payload`).
+ * Entries are sorted alphabetically by `field` so the dropdown and
+ * quick-add chips stay scannable as the catalog grows.
  */
 export const EXECUTIONS_FIELDS: MemoryFieldSummary[] = sortFields([
   { field: "status", sample: "passed" },
@@ -44,22 +44,39 @@ export const EXECUTIONS_FIELDS: MemoryFieldSummary[] = sortFields([
   { field: "createdAt", sample: "2026-01-01T12:00:00Z" },
   { field: "updatedAt", sample: "2026-01-01T12:05:00Z" },
   { field: "durationMs", sample: "300000" },
+  { field: "payload", sample: "{}" },
 ]);
 
 /**
  * Field catalog for rows produced by the `runs` data source. Mirrors the
- * `CanvasesCanvasRun` shape returned by `useInfiniteCanvasRuns`. Entries
- * are sorted alphabetically by `field` to match the executions catalog.
+ * `CanvasesCanvasRun` shape returned by `useInfiniteCanvasRuns` plus the
+ * derived convenience fields appended by `collectRunRows` (`status`,
+ * `nodeName`, `payload`, `durationMs`, `$`) and the most useful root-event
+ * fields. Entries are sorted alphabetically by `field` to match the
+ * executions catalog.
+ *
+ * The `$` entry is a hint: each run row carries a `$` map keyed by node
+ * display name with that node's full execution (with `outputs` and a
+ * `data` shortcut). Authors drill in with `$["deploy-prod"].outputs.url`
+ * — the per-canvas node names aren't enumerated here because executions
+ * can fork and a given node may be empty for some runs.
  */
 export const RUNS_FIELDS: MemoryFieldSummary[] = sortFields([
   { field: "state", sample: "STATE_STARTED" },
   { field: "result", sample: "RESULT_PASSED" },
+  { field: "status", sample: "passed" },
+  { field: "nodeName", sample: "deploy-prod" },
+  { field: "payload", sample: "{}" },
+  { field: "durationMs", sample: "300000" },
+  { field: "$", sample: '{ "<node name>": { outputs, data, ... } }' },
   { field: "id", sample: "00000000-0000-0000-0000-000000000000" },
   { field: "canvasId", sample: "00000000-0000-0000-0000-000000000000" },
   { field: "versionId", sample: "00000000-0000-0000-0000-000000000000" },
   { field: "createdAt", sample: "2026-01-01T12:00:00Z" },
   { field: "updatedAt", sample: "2026-01-01T12:05:00Z" },
   { field: "finishedAt", sample: "2026-01-01T12:05:00Z" },
+  { field: "rootEvent.nodeId", sample: "00000000-0000-0000-0000-000000000000" },
+  { field: "rootEvent.customName", sample: "" },
 ]);
 
 /**

--- a/web_src/src/pages/workflowv2/dashboard/widget/useMemoryCatalog.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useMemoryCatalog.ts
@@ -67,11 +67,14 @@ export function useMemoryCatalog(canvasId: string | undefined, namespace?: strin
   };
 }
 
-export function suggestColumnFormat(field: string): "status" | "relative" | "datetime" | "link" | "text" {
+export function suggestColumnFormat(field: string): "status" | "relative" | "datetime" | "link" | "duration" | "text" {
   const lower = field.toLowerCase();
   if (lower === "status" || lower === "state" || lower === "health") return "status";
   if (lower.endsWith("_at") || lower.includes("created") || lower.includes("updated")) return "relative";
   if (lower === "url" || lower === "link" || lower === "href") return "link";
+  // `durationMs` (and any `*Ms` numeric field) renders best with the duration
+  // formatter, which turns ms counts into "5m 30s" style strings.
+  if (lower === "durationms" || lower.endsWith("durationms")) return "duration";
   return "text";
 }
 

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.dollarNodes.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.dollarNodes.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+
+import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/api-client";
+
+import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
+import { buildDollarNodes, buildNodeNameMap, collectRunRows, lastOutputData } from "./useWidgetData";
+
+const NODES: SuperplaneComponentsNode[] = [
+  { id: "node-deploy", name: "deploy-prod", type: "TYPE_ACTION" },
+  { id: "node-build", name: "build", type: "TYPE_ACTION" },
+  { id: "node-noname", type: "TYPE_ACTION" }, // no name on purpose
+];
+
+const DEPLOY_EXEC: CanvasesCanvasNodeExecution = {
+  id: "exec-deploy",
+  nodeId: "node-deploy",
+  state: "STATE_FINISHED",
+  result: "RESULT_PASSED",
+  outputs: {
+    default: [{ data: { url: "https://deploy.example.com", revision: "abc" } }],
+  },
+};
+
+const BUILD_EXEC: CanvasesCanvasNodeExecution = {
+  id: "exec-build",
+  nodeId: "node-build",
+  state: "STATE_FINISHED",
+  result: "RESULT_PASSED",
+  outputs: {
+    artifacts: ["sha256:1", "sha256:2"], // raw (non-envelope) value
+  },
+};
+
+const NAMELESS_EXEC: CanvasesCanvasNodeExecution = {
+  id: "exec-nameless",
+  nodeId: "node-noname",
+  state: "STATE_FINISHED",
+  result: "RESULT_PASSED",
+};
+
+describe("lastOutputData", () => {
+  it("returns undefined when outputs is missing or empty", () => {
+    expect(lastOutputData(undefined)).toBeUndefined();
+    expect(lastOutputData({})).toBeUndefined();
+    expect(lastOutputData({ default: [] })).toBeUndefined();
+  });
+
+  it("prefers the `default` channel and unwraps the `data` envelope", () => {
+    const data = lastOutputData({
+      default: [{ data: { url: "https://final" } }, { data: { url: "https://later" } }],
+      other: [{ data: { url: "https://other" } }],
+    });
+    expect(data).toEqual({ url: "https://later" });
+  });
+
+  it("falls back to the first channel when `default` is absent", () => {
+    const data = lastOutputData({
+      ci: [{ data: { passed: true } }],
+    });
+    expect(data).toEqual({ passed: true });
+  });
+
+  it("returns the raw event when it isn't envelope-shaped", () => {
+    expect(lastOutputData({ artifacts: ["sha256:1", "sha256:2"] })).toBe("sha256:2");
+    expect(lastOutputData({ scores: [42] })).toBe(42);
+  });
+
+  it("treats arrays as raw values (does not look for `.data` on arrays)", () => {
+    const arr = [1, 2, 3];
+    expect(lastOutputData({ default: [arr] })).toBe(arr);
+  });
+});
+
+describe("buildDollarNodes", () => {
+  const nameMap = buildNodeNameMap(NODES);
+
+  it("returns an empty object for missing executions", () => {
+    expect(buildDollarNodes(undefined, nameMap)).toEqual({});
+    expect(buildDollarNodes([], nameMap)).toEqual({});
+  });
+
+  it("keys entries by node display name", () => {
+    const out = buildDollarNodes([DEPLOY_EXEC, BUILD_EXEC], nameMap);
+    expect(Object.keys(out).sort()).toEqual(["build", "deploy-prod"]);
+  });
+
+  it("falls back to the nodeId when the canvas node has no name", () => {
+    const out = buildDollarNodes([NAMELESS_EXEC], nameMap);
+    expect(out["node-noname"]).toBeDefined();
+  });
+
+  it("spreads the full execution and adds a `data` shortcut", () => {
+    const out = buildDollarNodes([DEPLOY_EXEC], nameMap) as Record<string, Record<string, unknown>>;
+    const entry = out["deploy-prod"];
+    expect(entry.id).toBe("exec-deploy");
+    expect(entry.outputs).toEqual({ default: [{ data: { url: "https://deploy.example.com", revision: "abc" } }] });
+    expect(entry.data).toEqual({ url: "https://deploy.example.com", revision: "abc" });
+  });
+
+  it("ignores executions without a nodeId", () => {
+    const exec = { id: "exec-orphan", state: "STATE_FINISHED" } as CanvasesCanvasNodeExecution;
+    const out = buildDollarNodes([exec], nameMap);
+    expect(out).toEqual({});
+  });
+});
+
+describe("collectRunRows with dollar nodes", () => {
+  const PAGES = [
+    {
+      runs: [
+        {
+          id: "run-1",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          rootEvent: { id: "event-1", nodeId: "node-deploy", data: { pr: 7 } },
+        },
+        {
+          id: "run-2",
+          state: "STATE_FINISHED",
+          result: "RESULT_PASSED",
+          rootEvent: { id: "event-2", nodeId: "node-deploy", data: {} },
+        },
+        {
+          id: "run-3",
+          state: "STATE_STARTED",
+          result: "RESULT_UNKNOWN",
+          // No rootEvent.id -- can't side-load executions for this row.
+          rootEvent: { nodeId: "node-deploy", data: {} },
+        },
+      ],
+    },
+  ];
+
+  it("attaches `$` and the rewrite alias to every row when no executions are loaded", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as Array<Record<string, unknown>>;
+    for (const row of rows) {
+      expect(row.$).toEqual({});
+      expect(row[DOLLAR_REWRITE_IDENTIFIER]).toEqual({});
+      // Both keys must point at the same map so literal-path and CEL paths
+      // see identical data.
+      expect(row.$).toBe(row[DOLLAR_REWRITE_IDENTIFIER]);
+    }
+  });
+
+  it("populates `$` from the executions map keyed by rootEvent.id", () => {
+    const executionsByRootEventId = new Map<string, CanvasesCanvasNodeExecution[]>([
+      ["event-1", [DEPLOY_EXEC, BUILD_EXEC]],
+    ]);
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10, executionsByRootEventId) as Array<
+      Record<string, unknown>
+    >;
+    const dollarRun1 = rows[0].$ as Record<string, unknown>;
+    expect(Object.keys(dollarRun1).sort()).toEqual(["build", "deploy-prod"]);
+    // Run 2 has its own rootEvent.id but no entry in the map -- empty.
+    expect(rows[1].$).toEqual({});
+    // Run 3 has no rootEvent.id -- empty.
+    expect(rows[2].$).toEqual({});
+  });
+
+  it("renders missing node refs as undefined (which the renderer formats as `-`)", () => {
+    const executionsByRootEventId = new Map<string, CanvasesCanvasNodeExecution[]>([
+      ["event-1", [DEPLOY_EXEC]], // build did not run for this run
+    ]);
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10, executionsByRootEventId) as Array<
+      Record<string, unknown>
+    >;
+    const dollar = rows[0].$ as Record<string, unknown>;
+    expect(dollar["deploy-prod"]).toBeDefined();
+    expect(dollar["build"]).toBeUndefined();
+  });
+
+  it("`$` and the rewrite alias on a single row reference the same map", () => {
+    const executionsByRootEventId = new Map<string, CanvasesCanvasNodeExecution[]>([["event-1", [DEPLOY_EXEC]]]);
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10, executionsByRootEventId) as Array<
+      Record<string, unknown>
+    >;
+    expect(rows[0].$).toBe(rows[0][DOLLAR_REWRITE_IDENTIFIER]);
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.executionRows.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.executionRows.spec.ts
@@ -14,6 +14,7 @@ const PAGES = [
   {
     events: [
       {
+        data: { pr_number: 42, branch: "main" },
         executions: [
           { id: "exec-1", nodeId: "node-a", state: "STATE_FINISHED", result: "RESULT_PASSED" },
           { id: "exec-2", nodeId: "node-b", state: "STATE_STARTED" },
@@ -30,6 +31,7 @@ type ExecutionRow = {
   nodeId: string;
   nodeName: string;
   status: string;
+  payload?: Record<string, unknown>;
 };
 
 describe("buildNodeNameMap", () => {
@@ -80,5 +82,26 @@ describe("collectExecutionRows nodeName resolution", () => {
   it("derives status from state/result", () => {
     const rows = collectExecutionRows(PAGES, undefined, buildNodeNameMap(NODES), 10) as ExecutionRow[];
     expect(rows.map((r) => r.status)).toEqual(["passed", "running", "failed", "pending"]);
+  });
+
+  it("attaches the parent event's data as the row payload", () => {
+    const rows = collectExecutionRows(PAGES, undefined, buildNodeNameMap(NODES), 10) as ExecutionRow[];
+    for (const row of rows) {
+      expect(row.payload).toEqual({ pr_number: 42, branch: "main" });
+    }
+  });
+
+  it("leaves payload undefined when the parent event has no data", () => {
+    const pages = [
+      {
+        events: [
+          {
+            executions: [{ id: "exec-x", nodeId: "node-a", state: "STATE_STARTED" }],
+          },
+        ],
+      },
+    ];
+    const rows = collectExecutionRows(pages, undefined, buildNodeNameMap(NODES), 10) as ExecutionRow[];
+    expect(rows[0]?.payload).toBeUndefined();
   });
 });

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.needsNodeOutputs.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.needsNodeOutputs.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+
+import { renderNeedsRunNodeOutputs } from "./useWidgetData";
+import type { WidgetChartRender, WidgetNumberRender, WidgetTableRender } from "./types";
+
+describe("renderNeedsRunNodeOutputs", () => {
+  it("returns false for an undefined render", () => {
+    expect(renderNeedsRunNodeOutputs(undefined)).toBe(false);
+  });
+
+  it("returns false for a count KPI that only reads totalCount", () => {
+    const render: WidgetNumberRender = { kind: "number", aggregation: "count" };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(false);
+  });
+
+  it("does not treat currency / label literals containing `$` as a node ref", () => {
+    const render: WidgetNumberRender = {
+      kind: "number",
+      aggregation: "sum",
+      field: "amount",
+      prefix: "R$",
+      suffix: " USD",
+      label: "Total $",
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(false);
+  });
+
+  it("detects `$['node']` in a literal table column field", () => {
+    const render: WidgetTableRender = {
+      kind: "table",
+      columns: [{ field: '$["deploy-prod"].outputs.url', format: "link" }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(true);
+  });
+
+  it("detects `$` inside a `{{ }}` CEL template column", () => {
+    const render: WidgetTableRender = {
+      kind: "table",
+      columns: [{ field: "{{ $['deploy-prod'].data.url }}", format: "link" }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(true);
+  });
+
+  it("detects `$` with whitespace before the bracket", () => {
+    const render: WidgetTableRender = {
+      kind: "table",
+      columns: [{ field: "$ ['deploy-prod'].state" }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(true);
+  });
+
+  it("detects `$` in a row-style condition field", () => {
+    const render: WidgetTableRender = {
+      kind: "table",
+      columns: [{ field: "status" }],
+      rowStyles: [{ field: '$["deploy-prod"].result', op: "eq", value: "RESULT_FAILED", tone: "red" }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(true);
+  });
+
+  it("detects `$` in a chart series field", () => {
+    const render: WidgetChartRender = {
+      kind: "chart",
+      type: "bar",
+      xField: "status",
+      series: [{ field: '$["scoring"].outputs.score' }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(true);
+  });
+
+  it("returns false for a chart that only uses derived run fields", () => {
+    const render: WidgetChartRender = {
+      kind: "chart",
+      type: "bar",
+      xField: "status",
+      series: [{ field: "durationMs" }],
+    };
+    expect(renderNeedsRunNodeOutputs(render)).toBe(false);
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.runRows.spec.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.runRows.spec.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+
+import type { SuperplaneComponentsNode } from "@/api-client";
+
+import { buildNodeNameMap, collectRunRows } from "./useWidgetData";
+
+const NODES: SuperplaneComponentsNode[] = [
+  { id: "trigger-a", name: "deploy-prod", type: "TYPE_TRIGGER" },
+  { id: "trigger-b", name: "manual-run", type: "TYPE_TRIGGER" },
+  { id: "trigger-c", type: "TYPE_TRIGGER" }, // no name on purpose
+];
+
+const PAGES = [
+  {
+    runs: [
+      {
+        id: "run-1",
+        state: "STATE_STARTED",
+        result: "RESULT_UNKNOWN",
+        rootEvent: { nodeId: "trigger-a", data: { pr_number: 42 } },
+      },
+      {
+        id: "run-2",
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        rootEvent: { nodeId: "trigger-b", data: { branch: "main" } },
+      },
+      {
+        id: "run-3",
+        state: "STATE_FINISHED",
+        result: "RESULT_FAILED",
+        rootEvent: { nodeId: "trigger-c", data: {} },
+      },
+      {
+        id: "run-4",
+        state: "STATE_FINISHED",
+        result: "RESULT_CANCELLED",
+        rootEvent: { nodeId: "trigger-unknown", data: { reason: "user cancelled" } },
+      },
+    ],
+  },
+];
+
+type RunRow = {
+  id: string;
+  status: string;
+  nodeName?: string;
+  payload?: Record<string, unknown>;
+  rootEvent?: { nodeId?: string; data?: Record<string, unknown> };
+};
+
+describe("collectRunRows status", () => {
+  it("derives status from state/result", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows.map((r) => r.status)).toEqual(["running", "passed", "failed", "cancelled"]);
+  });
+
+  it("maps a finished state with no explicit result to passed", () => {
+    const pages = [{ runs: [{ id: "run-x", state: "STATE_FINISHED", rootEvent: { nodeId: "trigger-a" } }] }];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.status).toBe("passed");
+  });
+
+  it("maps an unknown state with no result to unknown", () => {
+    const pages = [{ runs: [{ id: "run-x", rootEvent: { nodeId: "trigger-a" } }] }];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.status).toBe("unknown");
+  });
+});
+
+describe("collectRunRows nodeName resolution", () => {
+  it("uses the canvas node name for the initiating node, not its id", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.nodeName).toBe("deploy-prod");
+    expect(rows[1]?.nodeName).toBe("manual-run");
+  });
+
+  it("falls back to nodeId when the canvas node has no name", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[2]?.nodeName).toBe("trigger-c");
+  });
+
+  it("falls back to nodeId when the run's initiating node is no longer on the canvas", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[3]?.nodeName).toBe("trigger-unknown");
+  });
+
+  it("leaves nodeName undefined when the run has no rootEvent", () => {
+    const pages = [{ runs: [{ id: "run-x", state: "STATE_STARTED" }] }];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.nodeName).toBeUndefined();
+  });
+});
+
+describe("collectRunRows payload", () => {
+  it("exposes rootEvent.data as the top-level payload alias", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.payload).toEqual({ pr_number: 42 });
+    expect(rows[1]?.payload).toEqual({ branch: "main" });
+  });
+
+  it("preserves the raw rootEvent so nested dot paths still resolve", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as RunRow[];
+    expect(rows[0]?.rootEvent?.data).toEqual({ pr_number: 42 });
+    expect(rows[0]?.rootEvent?.nodeId).toBe("trigger-a");
+  });
+});
+
+describe("collectRunRows limit", () => {
+  it("stops iterating once `limit` rows have been collected", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 2) as RunRow[];
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toEqual(["run-1", "run-2"]);
+  });
+});
+
+describe("collectRunRows `$` map default", () => {
+  it("defaults `$` to an empty object when no executions side-load is provided", () => {
+    const rows = collectRunRows(PAGES, buildNodeNameMap(NODES), 10) as Array<Record<string, unknown>>;
+    for (const row of rows) {
+      expect(row.$).toEqual({});
+    }
+  });
+});
+
+describe("collectRunRows durationMs", () => {
+  it("derives ms-elapsed from createdAt -> finishedAt", () => {
+    const pages = [
+      {
+        runs: [
+          {
+            id: "run-1",
+            state: "STATE_FINISHED",
+            result: "RESULT_PASSED",
+            createdAt: "2026-01-01T12:00:00Z",
+            finishedAt: "2026-01-01T12:05:00Z",
+            rootEvent: { nodeId: "trigger-a", data: {} },
+          },
+        ],
+      },
+    ];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as Array<Record<string, unknown>>;
+    expect(rows[0]?.durationMs).toBe(5 * 60 * 1000);
+  });
+
+  it("leaves durationMs undefined when finishedAt is missing", () => {
+    const pages = [
+      {
+        runs: [
+          {
+            id: "run-x",
+            state: "STATE_STARTED",
+            createdAt: "2026-01-01T12:00:00Z",
+            rootEvent: { nodeId: "trigger-a", data: {} },
+          },
+        ],
+      },
+    ];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as Array<Record<string, unknown>>;
+    expect(rows[0]?.durationMs).toBeUndefined();
+  });
+
+  it("leaves durationMs undefined when createdAt is missing", () => {
+    const pages = [
+      {
+        runs: [
+          {
+            id: "run-y",
+            state: "STATE_FINISHED",
+            result: "RESULT_PASSED",
+            finishedAt: "2026-01-01T12:05:00Z",
+            rootEvent: { nodeId: "trigger-a", data: {} },
+          },
+        ],
+      },
+    ];
+    const rows = collectRunRows(pages, buildNodeNameMap(NODES), 10) as Array<Record<string, unknown>>;
+    expect(rows[0]?.durationMs).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.ts
@@ -1,9 +1,15 @@
 import { useEffect, useMemo } from "react";
 
-import type { SuperplaneComponentsNode } from "@/api-client";
-import { useCanvasMemoryEntries, useInfiniteCanvasEvents, useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
+import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/api-client";
+import {
+  useCanvasMemoryEntries,
+  useEventExecutionsBatch,
+  useInfiniteCanvasEvents,
+  useInfiniteCanvasRuns,
+} from "@/hooks/useCanvasData";
 
 import { resolveDashboardNode, useDashboardContext } from "../DashboardContext";
+import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
 import { flattenMemoryEntries } from "./memoryRow";
 import type { WidgetDataSource } from "./types";
 
@@ -113,17 +119,51 @@ export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): W
     return collectExecutionRows(pages, targetNodeId, nodeNameById, executionLimit);
   }, [dataSource, eventsData, ctx, executionLimit]);
 
-  const runRows = useMemo(() => {
-    if (dataSource.kind !== "runs") return [];
-    const rows: unknown[] = [];
+  // Collect unique root-event ids for the visible run page so we can lazy-
+  // fetch their per-node executions (with `outputs`) via `ListEventExecutions`.
+  // The runs API only returns lightweight execution refs without outputs, so
+  // we have to side-load the full executions to support `$["node"].outputs`.
+  const runRootEventIds = useMemo(() => {
+    if (dataSource.kind !== "runs") return [] as string[];
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    let count = 0;
     for (const page of runsQuery.data?.pages ?? []) {
       for (const run of page?.runs ?? []) {
-        rows.push(run);
-        if (rows.length >= runsLimit) return rows;
+        if (count >= runsLimit) break;
+        count++;
+        const id = run.rootEvent?.id;
+        if (id && !seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+        }
       }
+      if (count >= runsLimit) break;
     }
-    return rows;
+    return ids;
   }, [dataSource, runsQuery.data, runsLimit]);
+
+  const { queries: runExecutionQueries, isLoading: runExecutionsLoading } = useEventExecutionsBatch(
+    canvasId,
+    runRootEventIds,
+  );
+
+  const executionsByRootEventId = useMemo(() => {
+    const map = new Map<string, CanvasesCanvasNodeExecution[]>();
+    runRootEventIds.forEach((eventId, index) => {
+      const data = runExecutionQueries[index]?.data;
+      if (!data?.executions) return;
+      map.set(eventId, data.executions as CanvasesCanvasNodeExecution[]);
+    });
+    return map;
+  }, [runRootEventIds, runExecutionQueries]);
+
+  const runRows = useMemo(() => {
+    if (dataSource.kind !== "runs") return [];
+    const pages = runsQuery.data?.pages ?? [];
+    const nodeNameById = buildNodeNameMap(ctx?.nodes);
+    return collectRunRows(pages, nodeNameById, runsLimit, executionsByRootEventId);
+  }, [dataSource, runsQuery.data, ctx, runsLimit, executionsByRootEventId]);
 
   // Treat ongoing eager pagination as part of the initial load so panels
   // (especially `count` aggregations) don't flash an intermediate value
@@ -145,6 +185,7 @@ export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): W
     memoryQuery,
     runRows,
     runsQuery,
+    runExecutionsLoading,
     executionRows,
     executionsLoading,
     eventsError,
@@ -255,6 +296,7 @@ function resultForDataSource({
   memoryQuery,
   runRows,
   runsQuery,
+  runExecutionsLoading,
   executionRows,
   executionsLoading,
   eventsError,
@@ -264,6 +306,7 @@ function resultForDataSource({
   memoryQuery: { isLoading: boolean; error: unknown };
   runRows: unknown[];
   runsQuery: { isLoading: boolean; error: unknown; data?: { pages?: Array<{ totalCount?: number }> } };
+  runExecutionsLoading: boolean;
   executionRows: unknown[];
   executionsLoading: boolean;
   eventsError: unknown;
@@ -272,9 +315,12 @@ function resultForDataSource({
     return { rows: memoryRows, isLoading: memoryQuery.isLoading, error: errorMessage(memoryQuery.error) };
   }
   if (dataSource.kind === "runs") {
+    // Treat the per-run execution side-loads as part of the initial load so
+    // count/aggregate panels don't flash with empty `$` references before
+    // the executions resolve.
     return {
       rows: runRows,
-      isLoading: runsQuery.isLoading,
+      isLoading: runsQuery.isLoading || runExecutionsLoading,
       error: errorMessage(runsQuery.error),
       totalCount: runsQuery.data?.pages?.[0]?.totalCount,
     };
@@ -289,13 +335,15 @@ function errorMessage(error: unknown): string | undefined {
 /**
  * Walk the loaded event pages and synthesize the row objects the dashboard's
  * table / chart / number renderers consume. Each row carries the raw
- * execution fields plus three derived conveniences:
+ * execution fields plus four derived conveniences:
  *
  * - `status`: lowercase canonical status string (see {@link deriveExecutionStatus}).
  * - `nodeName`: friendly node label resolved per-row via `nodeNameById`,
  *   falling back to the raw `nodeId` when the canvas no longer contains
  *   that node (e.g. it was deleted after the execution ran).
  * - `durationMs`: created-to-updated elapsed time in milliseconds.
+ * - `payload`: the data carried by the parent (root) event — i.e. the
+ *   payload the node received. Shared by every execution under that event.
  *
  * Iteration stops as soon as `rows.length >= limit`.
  */
@@ -303,6 +351,7 @@ export function collectExecutionRows(
   pages: Array<
     | {
         events?: Array<{
+          data?: Record<string, unknown>;
           executions?: Array<
             Record<string, unknown> & {
               nodeId?: string;
@@ -331,12 +380,134 @@ export function collectExecutionRows(
           nodeName: (exec.nodeId && nodeNameById.get(exec.nodeId)) || exec.nodeId,
           durationMs:
             exec.updatedAt && exec.createdAt ? Date.parse(exec.updatedAt) - Date.parse(exec.createdAt) : undefined,
+          payload: event.data,
         });
         if (rows.length >= limit) return rows;
       }
     }
   }
   return rows;
+}
+
+/**
+ * Walk the loaded run pages and synthesize the row objects the dashboard's
+ * widgets consume. Each row carries the raw `CanvasesCanvasRun` fields plus
+ * a few derived conveniences mirroring what `RunsList` shows:
+ *
+ * - `status`: lowercase canonical status string (see {@link deriveRunStatus}).
+ * - `nodeName`: friendly label of the node that initiated the run, resolved
+ *   from `rootEvent.nodeId` via `nodeNameById`. Falls back to the raw
+ *   `nodeId` when the canvas no longer contains that node.
+ * - `payload`: alias for `rootEvent.data` — the initial payload that
+ *   triggered the run. Exposed at the top level so authors don't have to
+ *   type `rootEvent.data.*` for the common case.
+ * - `durationMs`: created-to-finished elapsed time in milliseconds. Mirrors
+ *   the executions row's `durationMs` so authors can write
+ *   `field: durationMs, format: duration` for a friendly run-duration cell
+ *   without having to write CEL date arithmetic.
+ * - `$` / `DOLLAR_REWRITE_IDENTIFIER`: a map keyed by node display name
+ *   pointing at each node's full execution (with `outputs` and a `data`
+ *   shortcut for the latest output event). Lets authors write
+ *   `$["deploy-prod"].outputs.url` in literal field paths and the same
+ *   syntax in `{{ }}` CEL templates (the CEL compiler rewrites `$` to
+ *   `__runNodes__` since cel-js doesn't accept `$` as an identifier).
+ *
+ * The raw `rootEvent`, `executions`, timestamps, etc. remain reachable via
+ * dot paths (`getValueAtPath`) because we spread the full run into the row.
+ *
+ * Iteration stops as soon as `rows.length >= limit`.
+ */
+export function collectRunRows(
+  pages: Array<
+    | {
+        runs?: Array<
+          Record<string, unknown> & {
+            state?: string;
+            result?: string;
+            createdAt?: string;
+            finishedAt?: string;
+            rootEvent?: {
+              id?: string;
+              nodeId?: string;
+              data?: Record<string, unknown>;
+            };
+          }
+        >;
+      }
+    | undefined
+  >,
+  nodeNameById: Map<string, string>,
+  limit: number,
+  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
+): unknown[] {
+  const rows: unknown[] = [];
+  for (const page of pages) {
+    for (const run of page?.runs ?? []) {
+      const rootEvent = run.rootEvent;
+      const nodeId = rootEvent?.nodeId;
+      const executions = (rootEvent?.id && executionsByRootEventId?.get(rootEvent.id)) || undefined;
+      const dollarNodes = buildDollarNodes(executions, nodeNameById);
+      rows.push({
+        ...run,
+        status: deriveRunStatus(run.state, run.result),
+        nodeName: (nodeId && nodeNameById.get(nodeId)) || nodeId,
+        payload: rootEvent?.data,
+        durationMs:
+          run.finishedAt && run.createdAt ? Date.parse(run.finishedAt) - Date.parse(run.createdAt) : undefined,
+        $: dollarNodes,
+        [DOLLAR_REWRITE_IDENTIFIER]: dollarNodes,
+      });
+      if (rows.length >= limit) return rows;
+    }
+  }
+  return rows;
+}
+
+/**
+ * Build the `$` map for a single run row. Keys are node display names so
+ * authors can write `$["deploy-prod"]` in expressions; falls back to the
+ * `nodeId` when the canvas no longer contains that node (e.g. it was
+ * deleted). The value spreads the full execution and adds a `data` shortcut
+ * mirroring the canvas-side `$['Node Name'].data` semantics.
+ */
+export function buildDollarNodes(
+  executions: CanvasesCanvasNodeExecution[] | undefined,
+  nodeNameById: Map<string, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!executions) return out;
+  for (const exec of executions) {
+    if (!exec.nodeId) continue;
+    const name = nodeNameById.get(exec.nodeId) || exec.nodeId;
+    out[name] = {
+      ...exec,
+      data: lastOutputData(exec.outputs),
+    };
+  }
+  return out;
+}
+
+/**
+ * Pick the most useful single payload from an execution's `outputs` map.
+ * Mirrors how the canvas backend resolves `$['Node Name'].data`: prefer the
+ * `default` channel, otherwise the first available channel; take the last
+ * event in that channel (most recent emission). When the event itself is
+ * an envelope-shaped object with a `.data` field, unwrap it; otherwise
+ * return the event verbatim. Returns `undefined` for missing or empty
+ * outputs so widget cells render `-`.
+ */
+export function lastOutputData(outputs: Record<string, unknown> | undefined): unknown {
+  if (!outputs) return undefined;
+  const channels = Object.keys(outputs);
+  if (channels.length === 0) return undefined;
+  const channel = channels.includes("default") ? "default" : channels[0];
+  const events = outputs[channel];
+  if (!Array.isArray(events) || events.length === 0) return undefined;
+  const last = events[events.length - 1];
+  if (last && typeof last === "object" && !Array.isArray(last) && "data" in last) {
+    return (last as { data: unknown }).data;
+  }
+  return last;
 }
 
 /**
@@ -379,5 +550,23 @@ function deriveExecutionStatus(
         return "unknown";
     }
   }
+  return "unknown";
+}
+
+/**
+ * Collapse the run `state` / `result` enum pair into the lowercase status
+ * vocabulary used across the dashboard and RunsList. Mirrors `getRunStatus`
+ * in `ui/Runs/runPresentation.ts`. Runs have a smaller state machine than
+ * executions — no separate `pending` step — so a started run that has not
+ * yet produced a result maps to `running`.
+ */
+function deriveRunStatus(
+  state: string | undefined,
+  result: string | undefined,
+): "passed" | "failed" | "cancelled" | "running" | "unknown" {
+  if (state === "STATE_STARTED") return "running";
+  if (result === "RESULT_FAILED") return "failed";
+  if (result === "RESULT_CANCELLED") return "cancelled";
+  if (result === "RESULT_PASSED" || state === "STATE_FINISHED") return "passed";
   return "unknown";
 }

--- a/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.ts
+++ b/web_src/src/pages/workflowv2/dashboard/widget/useWidgetData.ts
@@ -11,7 +11,7 @@ import {
 import { resolveDashboardNode, useDashboardContext } from "../DashboardContext";
 import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
 import { flattenMemoryEntries } from "./memoryRow";
-import type { WidgetDataSource } from "./types";
+import type { WidgetDataSource, WidgetRender } from "./types";
 
 export interface WidgetDataResult {
   rows: unknown[];
@@ -48,8 +48,22 @@ const EXECUTIONS_MAX_EAGER_PAGES = 20;
  *   the visible row count fluctuates non-monotonically when a manual run
  *   prepends a new (still-empty) event that pushes an older event-with-
  *   executions off the loaded first page.
+ *
+ * `needsNodeOutputs` controls the `runs` per-node side-load. Resolving
+ * `$["node"].outputs` requires a `ListEventExecutions` call per visible run
+ * (the runs API only returns lightweight execution refs). When the render
+ * never references `$`, callers pass `false` so we skip those calls entirely
+ * and, crucially, don't gate the panel's loading state on them — otherwise a
+ * count KPI that only reads the API `totalCount` would spin until every
+ * side-load resolved even though it never reads per-node data. Defaults to
+ * `true` so a caller that forgets to pass it keeps the safe (fully-loaded)
+ * behavior.
  */
-export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): WidgetDataResult {
+export function useWidgetData(
+  canvasId: string,
+  dataSource: WidgetDataSource,
+  needsNodeOutputs: boolean = true,
+): WidgetDataResult {
   const ctx = useDashboardContext();
 
   const memoryEnabled = dataSource.kind === "memory";
@@ -124,7 +138,7 @@ export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): W
   // The runs API only returns lightweight execution refs without outputs, so
   // we have to side-load the full executions to support `$["node"].outputs`.
   const runRootEventIds = useMemo(() => {
-    if (dataSource.kind !== "runs") return [] as string[];
+    if (dataSource.kind !== "runs" || !needsNodeOutputs) return [] as string[];
     const seen = new Set<string>();
     const ids: string[] = [];
     let count = 0;
@@ -141,7 +155,7 @@ export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): W
       if (count >= runsLimit) break;
     }
     return ids;
-  }, [dataSource, runsQuery.data, runsLimit]);
+  }, [dataSource, runsQuery.data, runsLimit, needsNodeOutputs]);
 
   const { queries: runExecutionQueries, isLoading: runExecutionsLoading } = useEventExecutionsBatch(
     canvasId,
@@ -190,6 +204,31 @@ export function useWidgetData(canvasId: string, dataSource: WidgetDataSource): W
     executionsLoading,
     eventsError,
   });
+}
+
+/**
+ * Matches a canvas-style per-node reference (`$["node"]` / `$['node']`,
+ * with optional whitespace before the bracket) inside a render config. We
+ * key off the `$[` shape rather than a bare `$` so currency/label literals
+ * like `prefix: "R$"` or `label: "Total $"` don't force the per-node
+ * side-load.
+ */
+const RUN_NODE_REF_RE = /\$\s*\[/;
+
+/**
+ * Whether a widget render reads per-node run outputs via the `$["node"]`
+ * syntax — in a literal field path or inside a `{{ }}` CEL template. Only the
+ * `runs` data source side-loads per-node executions to populate the row's `$`
+ * map, so when the render never references `$` the caller can pass the result
+ * as `needsNodeOutputs={false}` to skip the `ListEventExecutions` batch and
+ * avoid gating the panel's loading state on it. Scans the whole render via
+ * `JSON.stringify` so every field/expression-bearing string (columns,
+ * filters, sort, series, sparkline, row actions, …) is covered without
+ * enumerating each render shape.
+ */
+export function renderNeedsRunNodeOutputs(render: WidgetRender | undefined): boolean {
+  if (!render) return false;
+  return RUN_NODE_REF_RE.test(JSON.stringify(render));
 }
 
 function useEagerExecutionPagination({


### PR DESCRIPTION
## Summary
Brings the `$["node Name"]...` syntax to the Runs source for the widgets and adds some extras, like the `durationMs`.

Resolves #5155 