### PR TITLE
feat: Extend auth token validity on usage

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -287,21 +287,10 @@ func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, g
 		return
 	}
 
-	token, err := a.jwtSigner.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := IssueAccountSession(w, r, a.jwtSigner, account.ID.String()); err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "account_token",
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(24 * time.Hour.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	redirectURL := getRedirectURL(r)
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
@@ -392,24 +381,11 @@ func (a *Handler) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate JWT token
-	token, err := a.jwtSigner.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := IssueAccountSession(w, r, a.jwtSigner, account.ID.String()); err != nil {
 		log.Errorf("Failed to generate token for password login: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	// Set cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     "account_token",
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(24 * time.Hour.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	// Redirect
 	redirectURL := getRedirectURL(r)
@@ -498,21 +474,10 @@ func (a *Handler) handlePasswordSignup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := a.jwtSigner.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := IssueAccountSession(w, r, a.jwtSigner, account.ID.String()); err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "account_token",
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(24 * time.Hour.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	redirectURL := getRedirectURL(r)
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
@@ -796,22 +761,11 @@ func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	token, err := a.jwtSigner.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := IssueAccountSession(w, r, a.jwtSigner, account.ID.String()); err != nil {
 		log.Errorf("Failed to generate token for magic code login: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "account_token",
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(24 * time.Hour.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	redirectURL := getRedirectURL(r)
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)

--- a/pkg/authentication/session.go
+++ b/pkg/authentication/session.go
@@ -1,24 +1,33 @@
 package authentication
 
 import (
+	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
+	jwtLib "github.com/golang-jwt/jwt/v4"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 )
 
-const defaultAccountSessionTTL = 24 * time.Hour
-
-var (
-	accountSessionTTLOnce sync.Once
-	accountSessionTTL     time.Duration
+const (
+	defaultAccountSessionTTL    = 24 * time.Hour
+	defaultAccountSessionMaxAge = 7 * 24 * time.Hour
+	sessionStartClaim           = "ses"
 )
 
-// AccountSessionTTL returns how long account_token cookies remain valid.
-// Override with ACCOUNT_SESSION_TTL (Go duration syntax, e.g. "24h").
+var (
+	accountSessionTTLOnce    sync.Once
+	accountSessionTTL        time.Duration
+	accountSessionMaxAgeOnce sync.Once
+	accountSessionMaxAge     time.Duration
+)
+
+// AccountSessionTTL returns how long account_token cookies remain valid
+// between activity refreshes. Override with ACCOUNT_SESSION_TTL.
 func AccountSessionTTL() time.Duration {
 	accountSessionTTLOnce.Do(func() {
 		if v := os.Getenv("ACCOUNT_SESSION_TTL"); v != "" {
@@ -32,16 +41,69 @@ func AccountSessionTTL() time.Duration {
 	return accountSessionTTL
 }
 
-// ResetAccountSessionTTLForTests clears the cached session TTL.
+// AccountSessionMaxAge returns the absolute lifetime of a login session,
+// measured from the first sign-in, regardless of sliding refresh.
+// Override with ACCOUNT_SESSION_MAX_AGE.
+func AccountSessionMaxAge() time.Duration {
+	accountSessionMaxAgeOnce.Do(func() {
+		if v := os.Getenv("ACCOUNT_SESSION_MAX_AGE"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				accountSessionMaxAge = d
+				return
+			}
+		}
+		accountSessionMaxAge = defaultAccountSessionMaxAge
+	})
+	return accountSessionMaxAge
+}
+
+// ResetAccountSessionTTLForTests clears cached session duration settings.
 func ResetAccountSessionTTLForTests() {
 	accountSessionTTLOnce = sync.Once{}
 	accountSessionTTL = 0
+	accountSessionMaxAgeOnce = sync.Once{}
+	accountSessionMaxAge = 0
 }
 
-// IssueAccountSession mints a fresh account_token and writes it to the response.
+// SessionStartFromClaims returns when the login session began from the ses
+// claim. Tokens without ses cannot be used for absolute max-age enforcement.
+func SessionStartFromClaims(claims jwtLib.MapClaims) (time.Time, bool) {
+	if ses, ok := claims[sessionStartClaim].(string); ok {
+		if unix, err := strconv.ParseInt(ses, 10, 64); err == nil {
+			return time.Unix(unix, 0), true
+		}
+	}
+
+	return time.Time{}, false
+}
+
+// IsAccountSessionWithinMaxAge reports whether the session is still within
+// its absolute lifetime cap. Tokens without ses are rejected.
+func IsAccountSessionWithinMaxAge(claims jwtLib.MapClaims) bool {
+	start, ok := SessionStartFromClaims(claims)
+	if !ok {
+		return false
+	}
+
+	return time.Since(start) <= AccountSessionMaxAge()
+}
+
+// GenerateAccountToken creates a signed account_token JWT with session tracking.
+func GenerateAccountToken(jwtSigner *jwt.Signer, accountID string, sessionStart time.Time, ttl time.Duration) (string, error) {
+	return jwtSigner.GenerateWithClaims(ttl, map[string]string{
+		"sub":             accountID,
+		sessionStartClaim: fmt.Sprintf("%d", sessionStart.Unix()),
+	})
+}
+
+// IssueAccountSession mints a fresh account_token for a new login session.
 func IssueAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.Signer, accountID string) error {
+	return issueAccountSession(w, r, jwtSigner, accountID, time.Now())
+}
+
+func issueAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.Signer, accountID string, sessionStart time.Time) error {
 	ttl := AccountSessionTTL()
-	token, err := jwtSigner.Generate(accountID, ttl)
+	token, err := GenerateAccountToken(jwtSigner, accountID, sessionStart, ttl)
 	if err != nil {
 		return err
 	}
@@ -52,7 +114,7 @@ func IssueAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.
 
 // MaybeRefreshAccountSession extends active sessions using a sliding window.
 // Any authenticated activity reissues the token for another full TTL, except
-// when the token was just minted (login redirect + first page load).
+// when the token was just minted or the absolute session max age is reached.
 func MaybeRefreshAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.Signer, account *models.Account) {
 	cookie, err := r.Cookie("account_token")
 	if err != nil {
@@ -61,6 +123,10 @@ func MaybeRefreshAccountSession(w http.ResponseWriter, r *http.Request, jwtSigne
 
 	claims, err := jwtSigner.ValidateAndGetClaims(cookie.Value)
 	if err != nil {
+		return
+	}
+
+	if !IsAccountSessionWithinMaxAge(claims) {
 		return
 	}
 
@@ -73,5 +139,10 @@ func MaybeRefreshAccountSession(w http.ResponseWriter, r *http.Request, jwtSigne
 		return
 	}
 
-	_ = IssueAccountSession(w, r, jwtSigner, account.ID.String())
+	sessionStart, ok := SessionStartFromClaims(claims)
+	if !ok {
+		return
+	}
+
+	_ = issueAccountSession(w, r, jwtSigner, account.ID.String(), sessionStart)
 }

--- a/pkg/authentication/session.go
+++ b/pkg/authentication/session.go
@@ -1,0 +1,77 @@
+package authentication
+
+import (
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const defaultAccountSessionTTL = 24 * time.Hour
+
+var (
+	accountSessionTTLOnce sync.Once
+	accountSessionTTL     time.Duration
+)
+
+// AccountSessionTTL returns how long account_token cookies remain valid.
+// Override with ACCOUNT_SESSION_TTL (Go duration syntax, e.g. "24h").
+func AccountSessionTTL() time.Duration {
+	accountSessionTTLOnce.Do(func() {
+		if v := os.Getenv("ACCOUNT_SESSION_TTL"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				accountSessionTTL = d
+				return
+			}
+		}
+		accountSessionTTL = defaultAccountSessionTTL
+	})
+	return accountSessionTTL
+}
+
+// ResetAccountSessionTTLForTests clears the cached session TTL.
+func ResetAccountSessionTTLForTests() {
+	accountSessionTTLOnce = sync.Once{}
+	accountSessionTTL = 0
+}
+
+// IssueAccountSession mints a fresh account_token and writes it to the response.
+func IssueAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.Signer, accountID string) error {
+	ttl := AccountSessionTTL()
+	token, err := jwtSigner.Generate(accountID, ttl)
+	if err != nil {
+		return err
+	}
+
+	SetAccountCookie(w, r, token, ttl)
+	return nil
+}
+
+// MaybeRefreshAccountSession extends active sessions using a sliding window.
+// Any authenticated activity reissues the token for another full TTL, except
+// when the token was just minted (login redirect + first page load).
+func MaybeRefreshAccountSession(w http.ResponseWriter, r *http.Request, jwtSigner *jwt.Signer, account *models.Account) {
+	cookie, err := r.Cookie("account_token")
+	if err != nil {
+		return
+	}
+
+	claims, err := jwtSigner.ValidateAndGetClaims(cookie.Value)
+	if err != nil {
+		return
+	}
+
+	iat, ok := claims["iat"].(float64)
+	if !ok {
+		return
+	}
+
+	if time.Since(time.Unix(int64(iat), 0)) < time.Minute {
+		return
+	}
+
+	_ = IssueAccountSession(w, r, jwtSigner, account.ID.String())
+}

--- a/pkg/authentication/session_test.go
+++ b/pkg/authentication/session_test.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,14 +31,32 @@ func TestAccountSessionTTL(t *testing.T) {
 	})
 }
 
-func mintAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt time.Time, ttl time.Duration) string {
+func TestAccountSessionMaxAge(t *testing.T) {
+	t.Run("defaults to 7 days", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+
+		assert.Equal(t, 7*24*time.Hour, AccountSessionMaxAge())
+	})
+
+	t.Run("reads ACCOUNT_SESSION_MAX_AGE from environment", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+		t.Setenv("ACCOUNT_SESSION_MAX_AGE", "168h")
+
+		assert.Equal(t, 168*time.Hour, AccountSessionMaxAge())
+	})
+}
+
+func mintAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt time.Time, sessionStart time.Time, ttl time.Duration) string {
 	t.Helper()
 
 	token := jwtLib.NewWithClaims(jwtLib.SigningMethodHS256, jwtLib.MapClaims{
-		"sub": accountID,
-		"iat": issuedAt.Unix(),
-		"nbf": issuedAt.Unix(),
-		"exp": issuedAt.Add(ttl).Unix(),
+		"sub":             accountID,
+		"iat":             issuedAt.Unix(),
+		"nbf":             issuedAt.Unix(),
+		"exp":             issuedAt.Add(ttl).Unix(),
+		sessionStartClaim: fmt.Sprintf("%d", sessionStart.Unix()),
 	})
 
 	tokenString, err := token.SignedString([]byte(signer.Secret))
@@ -54,7 +73,8 @@ func TestMaybeRefreshAccountSession(t *testing.T) {
 		ResetAccountSessionTTLForTests()
 		t.Cleanup(ResetAccountSessionTTLForTests)
 
-		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), time.Now().Add(-2*time.Minute), 20*time.Hour)
+		issuedAt := time.Now().Add(-2 * time.Minute)
+		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), issuedAt, issuedAt, 20*time.Hour)
 
 		req := httptest.NewRequest(http.MethodGet, "/account", nil)
 		req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
@@ -66,13 +86,20 @@ func TestMaybeRefreshAccountSession(t *testing.T) {
 		require.Len(t, cookies, 1)
 		assert.NotEqual(t, oldToken, cookies[0].Value)
 		assert.Equal(t, int(24*time.Hour.Seconds()), cookies[0].MaxAge)
+
+		newClaims, err := signer.ValidateAndGetClaims(cookies[0].Value)
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%d", issuedAt.Unix()), newClaims[sessionStartClaim])
 	})
 
 	t.Run("does not refresh a token that was just issued", func(t *testing.T) {
 		ResetAccountSessionTTLForTests()
 		t.Cleanup(ResetAccountSessionTTLForTests)
 
-		token, err := signer.Generate(r.Account.ID.String(), 24*time.Hour)
+		token, err := signer.GenerateWithClaims(24*time.Hour, map[string]string{
+			"sub":             r.Account.ID.String(),
+			sessionStartClaim: fmt.Sprintf("%d", time.Now().Unix()),
+		})
 		require.NoError(t, err)
 
 		req := httptest.NewRequest(http.MethodGet, "/account", nil)
@@ -88,9 +115,9 @@ func TestMaybeRefreshAccountSession(t *testing.T) {
 		ResetAccountSessionTTLForTests()
 		t.Cleanup(ResetAccountSessionTTLForTests)
 
-		// Token from yesterday morning with only a minute of lifetime left.
-		issuedAt := time.Now().Add(-24*time.Hour + time.Minute)
-		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), issuedAt, 24*time.Hour)
+		sessionStart := time.Now().Add(-24*time.Hour + time.Minute)
+		issuedAt := sessionStart
+		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), issuedAt, sessionStart, 24*time.Hour)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/canvases", nil)
 		req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
@@ -108,4 +135,39 @@ func TestMaybeRefreshAccountSession(t *testing.T) {
 		require.True(t, ok)
 		assert.Greater(t, int64(exp)-time.Now().Unix(), int64(23*time.Hour.Seconds()))
 	})
+
+	t.Run("rejects tokens without ses claim", func(t *testing.T) {
+		token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+		require.NoError(t, err)
+
+		assert.False(t, IsAccountSessionWithinMaxAge(mustClaims(t, signer, token)))
+	})
+
+	t.Run("does not refresh once absolute max age is reached", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+		t.Setenv("ACCOUNT_SESSION_MAX_AGE", "48h")
+
+		sessionStart := time.Now().Add(-49 * time.Hour)
+		issuedAt := time.Now().Add(-2 * time.Minute)
+		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), issuedAt, sessionStart, 24*time.Hour)
+
+		req := httptest.NewRequest(http.MethodGet, "/account", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
+		res := httptest.NewRecorder()
+
+		MaybeRefreshAccountSession(res, req, signer, r.Account)
+
+		assert.Empty(t, res.Result().Cookies())
+		assert.False(t, IsAccountSessionWithinMaxAge(mustClaims(t, signer, oldToken)))
+	})
+}
+
+func mustClaims(t *testing.T, signer *jwt.Signer, token string) jwtLib.MapClaims {
+	t.Helper()
+
+	claims, err := signer.ValidateAndGetClaims(token)
+	require.NoError(t, err)
+
+	return claims
 }

--- a/pkg/authentication/session_test.go
+++ b/pkg/authentication/session_test.go
@@ -1,0 +1,111 @@
+package authentication
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jwtLib "github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestAccountSessionTTL(t *testing.T) {
+	t.Run("defaults to 24 hours", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+
+		assert.Equal(t, 24*time.Hour, AccountSessionTTL())
+	})
+
+	t.Run("reads ACCOUNT_SESSION_TTL from environment", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+		t.Setenv("ACCOUNT_SESSION_TTL", "48h")
+
+		assert.Equal(t, 48*time.Hour, AccountSessionTTL())
+	})
+}
+
+func mintAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt time.Time, ttl time.Duration) string {
+	t.Helper()
+
+	token := jwtLib.NewWithClaims(jwtLib.SigningMethodHS256, jwtLib.MapClaims{
+		"sub": accountID,
+		"iat": issuedAt.Unix(),
+		"nbf": issuedAt.Unix(),
+		"exp": issuedAt.Add(ttl).Unix(),
+	})
+
+	tokenString, err := token.SignedString([]byte(signer.Secret))
+	require.NoError(t, err)
+
+	return tokenString
+}
+
+func TestMaybeRefreshAccountSession(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test-secret")
+
+	t.Run("refreshes on activity when token is older than one minute", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+
+		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), time.Now().Add(-2*time.Minute), 20*time.Hour)
+
+		req := httptest.NewRequest(http.MethodGet, "/account", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
+		res := httptest.NewRecorder()
+
+		MaybeRefreshAccountSession(res, req, signer, r.Account)
+
+		cookies := res.Result().Cookies()
+		require.Len(t, cookies, 1)
+		assert.NotEqual(t, oldToken, cookies[0].Value)
+		assert.Equal(t, int(24*time.Hour.Seconds()), cookies[0].MaxAge)
+	})
+
+	t.Run("does not refresh a token that was just issued", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+
+		token, err := signer.Generate(r.Account.ID.String(), 24*time.Hour)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/account", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
+		res := httptest.NewRecorder()
+
+		MaybeRefreshAccountSession(res, req, signer, r.Account)
+
+		assert.Empty(t, res.Result().Cookies())
+	})
+
+	t.Run("extends session for daily morning usage pattern", func(t *testing.T) {
+		ResetAccountSessionTTLForTests()
+		t.Cleanup(ResetAccountSessionTTLForTests)
+
+		// Token from yesterday morning with only a minute of lifetime left.
+		issuedAt := time.Now().Add(-24*time.Hour + time.Minute)
+		oldToken := mintAccountToken(t, signer, r.Account.ID.String(), issuedAt, 24*time.Hour)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/canvases", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
+		res := httptest.NewRecorder()
+
+		MaybeRefreshAccountSession(res, req, signer, r.Account)
+
+		cookies := res.Result().Cookies()
+		require.Len(t, cookies, 1)
+
+		newClaims, err := signer.ValidateAndGetClaims(cookies[0].Value)
+		require.NoError(t, err)
+
+		exp, ok := newClaims["exp"].(float64)
+		require.True(t, ok)
+		assert.Greater(t, int64(exp)-time.Now().Unix(), int64(23*time.Hour.Seconds()))
+	})
+}

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -36,7 +37,7 @@ func TestAdminListOrganizations(t *testing.T) {
 		account, err := models.CreateAccount("Regular User", "regular@example.com")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test-client-secret")
-		regularToken, err := signer.Generate(account.ID.String(), time.Hour)
+		regularToken, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		response := execRequest(server, requestParams{
@@ -684,7 +685,7 @@ func TestImpersonationSecurityGuardrails(t *testing.T) {
 	signer := jwt.NewSigner("test-client-secret")
 
 	t.Run("non-admin with impersonation cookie is ignored", func(t *testing.T) {
-		regularToken, err := signer.Generate(otherAccount.ID.String(), time.Hour)
+		regularToken, err := authentication.GenerateAccountToken(signer, otherAccount.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		impToken, err := signer.GenerateWithClaims(time.Hour, map[string]string{

--- a/pkg/public/change_password.go
+++ b/pkg/public/change_password.go
@@ -147,14 +147,11 @@ func (s *Server) changePassword(w http.ResponseWriter, r *http.Request) {
 	// here. Its iat is after PasswordChangedAt, so the freshness check
 	// passes for this device only — every other device's cookie is now
 	// stale and will be rejected.
-	token, err := s.jwt.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := authentication.IssueAccountSession(w, r, s.jwt, account.ID.String()); err != nil {
 		log.Errorf("Failed to issue refreshed account_token after password change for %s: %v", account.ID, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-
-	authentication.SetAccountCookie(w, r, token, 24*time.Hour)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/pkg/public/change_password_test.go
+++ b/pkg/public/change_password_test.go
@@ -42,7 +42,7 @@ func setupChangePasswordTestServer(t *testing.T) (*Server, *support.ResourceRegi
 	_, err = models.CreateAccountPasswordAuth(r.Account.ID, hash)
 	require.NoError(t, err)
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	return server, r, token
@@ -58,7 +58,7 @@ func setupChangePasswordTestServerNoPassword(t *testing.T) (*Server, *support.Re
 	require.NoError(t, err)
 	server.RegisterWebRoutes("")
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	return server, r, token
@@ -80,7 +80,7 @@ func setupChangePasswordTestServerLoginDisabled(t *testing.T) (*Server, *support
 	_, err = models.CreateAccountPasswordAuth(r.Account.ID, hash)
 	require.NoError(t, err)
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	return server, r, token
@@ -339,7 +339,7 @@ func TestChangePassword_InvalidatesOldCookie(t *testing.T) {
 
 	// A freshly minted cookie with iat after password_changed_at is accepted.
 	signer := jwt.NewSigner("test-client-secret")
-	freshToken, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	freshToken, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, check(freshToken))
 }

--- a/pkg/public/middleware/admin_auth_test.go
+++ b/pkg/public/middleware/admin_auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -18,7 +19,7 @@ func TestRequireInstallationAdmin(t *testing.T) {
 	r := support.Setup(t)
 	signer := jwt.NewSigner("test-secret")
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	// Chain: AccountAuthMiddleware → RequireInstallationAdmin → final handler

--- a/pkg/public/middleware/auth.go
+++ b/pkg/public/middleware/auth.go
@@ -148,6 +148,8 @@ func AccountAuthMiddleware(jwtSigner *jwt.Signer) mux.MiddlewareFunc {
 				ctx = context.WithValue(ctx, ImpersonationContextKey, info)
 			}
 
+			authentication.MaybeRefreshAccountSession(w, r, jwtSigner, account)
+
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)
 		})
@@ -233,6 +235,11 @@ func OrganizationAuthMiddleware(jwtSigner *jwt.Signer) mux.MiddlewareFunc {
 			if impersonationInfo != nil {
 				ctx = context.WithValue(ctx, ImpersonationContextKey, impersonationInfo)
 			}
+
+			if account, err := getValidatedAccountFromCookie(r, jwtSigner); err == nil {
+				authentication.MaybeRefreshAccountSession(w, r, jwtSigner, account)
+			}
+
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)
 		})

--- a/pkg/public/middleware/auth.go
+++ b/pkg/public/middleware/auth.go
@@ -511,6 +511,10 @@ func getAccountFromCookie(r *http.Request, jwtSigner *jwt.Signer) (string, int64
 		return "", 0, fmt.Errorf("invalid account token: %v", err)
 	}
 
+	if !authentication.IsAccountSessionWithinMaxAge(claims) {
+		return "", 0, fmt.Errorf("session exceeded maximum age")
+	}
+
 	accountClaim, exists := claims["sub"]
 	if !exists {
 		return "", 0, fmt.Errorf("account ID missing from token")

--- a/pkg/public/middleware/auth_test.go
+++ b/pkg/public/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	jwtLib "github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -194,4 +195,46 @@ func TestAccountAuthMiddleware_FreshnessCheck(t *testing.T) {
 
 		assert.Equal(t, http.StatusNoContent, res.Code)
 	})
+}
+
+func TestOrganizationAuthMiddleware_RefreshesSessionOnActivity(t *testing.T) {
+	r := support.Setup(t)
+	signer := jwt.NewSigner("test-secret")
+
+	issuedAt := time.Now().Add(-2 * time.Hour)
+	oldToken := mintTestAccountToken(t, signer, r.Account.ID.String(), issuedAt, 24*time.Hour)
+
+	handler := OrganizationAuthMiddleware(signer)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/canvases", nil)
+	req.AddCookie(&http.Cookie{Name: "account_token", Value: oldToken})
+	req.Header.Set("x-organization-id", r.Organization.ID.String())
+
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	require.Equal(t, http.StatusNoContent, res.Code)
+
+	cookies := res.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "account_token", cookies[0].Name)
+	assert.NotEqual(t, oldToken, cookies[0].Value)
+}
+
+func mintTestAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt time.Time, ttl time.Duration) string {
+	t.Helper()
+
+	token := jwtLib.NewWithClaims(jwtLib.SigningMethodHS256, jwtLib.MapClaims{
+		"sub": accountID,
+		"iat": issuedAt.Unix(),
+		"nbf": issuedAt.Unix(),
+		"exp": issuedAt.Add(ttl).Unix(),
+	})
+
+	tokenString, err := token.SignedString([]byte(signer.Secret))
+	require.NoError(t, err)
+
+	return tokenString
 }

--- a/pkg/public/middleware/auth_test.go
+++ b/pkg/public/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/jwt"
@@ -20,7 +22,7 @@ func TestOrganizationAuthMiddleware_CookieAuthErrors(t *testing.T) {
 	r := support.Setup(t)
 	signer := jwt.NewSigner("test-secret")
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	handler := OrganizationAuthMiddleware(signer)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -163,8 +165,21 @@ func TestAccountAuthMiddleware_FreshnessCheck(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
+	t.Run("token without ses claim is rejected", func(t *testing.T) {
+		legacyToken, err := signer.Generate(r.Account.ID.String(), time.Hour)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodGet, "/account", nil)
+		req.AddCookie(&http.Cookie{Name: "account_token", Value: legacyToken})
+
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusUnauthorized, res.Code)
+	})
+
 	t.Run("cookie issued before password change is rejected", func(t *testing.T) {
-		oldToken, err := signer.Generate(r.Account.ID.String(), time.Hour)
+		oldToken, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		// Bump password_changed_at so the cookie's iat is now stale.
@@ -184,7 +199,7 @@ func TestAccountAuthMiddleware_FreshnessCheck(t *testing.T) {
 		// cookie's iat is newer than it.
 		require.NoError(t, r.Account.MarkPasswordChangedInTransaction(database.Conn(), time.Now().Add(-time.Hour)))
 
-		freshToken, err := signer.Generate(r.Account.ID.String(), time.Hour)
+		freshToken, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		req := httptest.NewRequest(http.MethodGet, "/account", nil)
@@ -202,7 +217,8 @@ func TestOrganizationAuthMiddleware_RefreshesSessionOnActivity(t *testing.T) {
 	signer := jwt.NewSigner("test-secret")
 
 	issuedAt := time.Now().Add(-2 * time.Hour)
-	oldToken := mintTestAccountToken(t, signer, r.Account.ID.String(), issuedAt, 24*time.Hour)
+	sessionStart := issuedAt
+	oldToken := mintTestAccountToken(t, signer, r.Account.ID.String(), issuedAt, sessionStart, 24*time.Hour)
 
 	handler := OrganizationAuthMiddleware(signer)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -223,7 +239,7 @@ func TestOrganizationAuthMiddleware_RefreshesSessionOnActivity(t *testing.T) {
 	assert.NotEqual(t, oldToken, cookies[0].Value)
 }
 
-func mintTestAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt time.Time, ttl time.Duration) string {
+func mintTestAccountToken(t *testing.T, signer *jwt.Signer, accountID string, issuedAt, sessionStart time.Time, ttl time.Duration) string {
 	t.Helper()
 
 	token := jwtLib.NewWithClaims(jwtLib.SigningMethodHS256, jwtLib.MapClaims{
@@ -231,6 +247,7 @@ func mintTestAccountToken(t *testing.T, signer *jwt.Signer, accountID string, is
 		"iat": issuedAt.Unix(),
 		"nbf": issuedAt.Unix(),
 		"exp": issuedAt.Add(ttl).Unix(),
+		"ses": fmt.Sprintf("%d", sessionStart.Unix()),
 	})
 
 	tokenString, err := token.SignedString([]byte(signer.Secret))

--- a/pkg/public/repository_file_download_test.go
+++ b/pkg/public/repository_file_download_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	git "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -37,7 +38,7 @@ func downloadFile(
 	req := httptest.NewRequest(http.MethodGet, url, nil)
 	if accountID != nil {
 		req.Header.Set("x-organization-id", organizationID.String())
-		token, err := signer.Generate(accountID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, accountID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 		req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
 	}

--- a/pkg/public/runner_live_log_session_test.go
+++ b/pkg/public/runner_live_log_session_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	runneraction "github.com/superplanehq/superplane/pkg/components/runner"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/jwt"
@@ -57,7 +58,7 @@ func runnerLiveLogSessionGET(
 		nil,
 	)
 	req.Header.Set("x-organization-id", r.Organization.ID.String())
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 	req.AddCookie(&http.Cookie{Name: "account_token", Value: token})
 	rec := httptest.NewRecorder()

--- a/pkg/public/server_auth_test.go
+++ b/pkg/public/server_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
@@ -28,7 +29,7 @@ func setupTestServer(r *support.ResourceRegistry, t *testing.T) (*Server, *model
 	server, err := NewServer(r.Encryptor, r.Registry, signer, oidcProvider, r.GitProvider, "", "", "", "test", "/app/templates", r.AuthService, nil, false)
 	require.NoError(t, err)
 
-	token, err := signer.Generate(r.Account.ID.String(), time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, r.Account.ID.String(), time.Now(), time.Hour)
 	require.NoError(t, err)
 
 	server.RegisterWebRoutes("")

--- a/pkg/public/server_test.go
+++ b/pkg/public/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
@@ -429,7 +430,7 @@ func Test__CreateOrganization(t *testing.T) {
 		signer := jwt.NewSigner("test")
 		account, err := models.CreateAccount("test@example.com", "Test User")
 		require.NoError(t, err)
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		//
@@ -486,7 +487,7 @@ func Test__CreateOrganization(t *testing.T) {
 		account, err := models.CreateAccount("success@example.com", "Success User")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		//
@@ -546,7 +547,7 @@ func Test__CreateOrganization(t *testing.T) {
 		account, err := models.CreateAccount("duplicate@example.com", "Duplicate User")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		authService, err := authorization.NewAuthService()
@@ -588,7 +589,7 @@ func Test__CreateOrganization(t *testing.T) {
 		account, err := models.CreateAccount("limited@example.com", "Limited User")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		authService, err := authorization.NewAuthService()
@@ -652,7 +653,7 @@ func Test__GetOrganizationCreationStatus(t *testing.T) {
 		account, err := models.CreateAccount("status-ok@example.com", "Status Ok")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		authService, err := authorization.NewAuthService()
@@ -711,7 +712,7 @@ func Test__GetOrganizationCreationStatus(t *testing.T) {
 		account, err := models.CreateAccount("status-blocked@example.com", "Status Blocked")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		authService, err := authorization.NewAuthService()
@@ -776,7 +777,7 @@ func Test__GetOrganizationCreationStatus(t *testing.T) {
 		account, err := models.CreateAccount("status-unavailable@example.com", "Status Unavailable")
 		require.NoError(t, err)
 		signer := jwt.NewSigner("test")
-		token, err := signer.Generate(account.ID.String(), time.Hour)
+		token, err := authentication.GenerateAccountToken(signer, account.ID.String(), time.Now(), time.Hour)
 		require.NoError(t, err)
 
 		authService, err := authorization.NewAuthService()

--- a/pkg/public/setup_owner.go
+++ b/pkg/public/setup_owner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/crypto"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
@@ -185,22 +186,11 @@ func (s *Server) setupOwner(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Failed to publish organization created message for %s: %v", organization.ID, err)
 	}
 
-	token, err := s.jwt.Generate(account.ID.String(), 24*time.Hour)
-	if err != nil {
+	if err := authentication.IssueAccountSession(w, r, s.jwt, account.ID.String()); err != nil {
 		log.Errorf("Failed to generate account token for owner: %v", err)
 		http.Error(w, "Failed to create owner session", http.StatusInternalServerError)
 		return
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     "account_token",
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(24 * time.Hour.Seconds()),
-		HttpOnly: true,
-		Secure:   r.TLS != nil,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(SetupOwnerResponse{

--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	pw "github.com/playwright-community/playwright-go"
+	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
 	spjwt "github.com/superplanehq/superplane/pkg/jwt"
@@ -140,7 +141,7 @@ func (s *TestSession) resetDatabase() {
 func (s *TestSession) Login() {
 	secret := os.Getenv("JWT_SECRET")
 	signer := spjwt.NewSigner(secret)
-	token, err := signer.Generate(s.Account.ID.String(), 24*time.Hour)
+	token, err := authentication.GenerateAccountToken(signer, s.Account.ID.String(), time.Now(), 24*time.Hour)
 	if err != nil {
 		s.t.Fatalf("jwt: %v", err)
 	}


### PR DESCRIPTION
fixes https://github.com/superplanehq/superplane/issues/5129

Users were getting logged out about once a day even with regular use. Account sessions used a fixed 24-hour JWT with no extension on activity, so any session older than 24 hours expired on the next API call.

This adds sliding session refresh: authenticated requests reissue account_token for another full 24 hours (with a 1-minute debounce right after login to avoid redundant refresh on redirect). The TTL stays 24 hours; active users stay signed in, inactive users are logged out after a day without use.

Every token get a `ses` claim that limits absolute validity of a token for 7 days.