### PR TITLE
fix: align agent mention cursor padding

### DIFF
--- a/web_src/src/components/AgentSidebar/BackdropContent.spec.tsx
+++ b/web_src/src/components/AgentSidebar/BackdropContent.spec.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BackdropContent } from "./BackdropContent";
+
+describe("BackdropContent", () => {
+  it("renders mention highlights without changing text metrics", () => {
+    render(<BackdropContent text="@Create Release deploy" mentions={[{ label: "Create Release", startIndex: 0 }]} />);
+
+    const mention = screen.getByText("@Create Release");
+    expect(mention).toHaveClass("bg-blue-100", "text-blue-700");
+    expect(mention.className).not.toMatch(/\bp[trblxy]?-/);
+    expect(mention.className).not.toMatch(/\bfont-(?:medium|semibold|bold|extrabold|black)\b/);
+  });
+});

--- a/web_src/src/components/AgentSidebar/BackdropContent.tsx
+++ b/web_src/src/components/AgentSidebar/BackdropContent.tsx
@@ -1,7 +1,5 @@
 /**
- * Renders the text with @mentions styled as inline chips.
- * Non-mention text is rendered transparent (invisible — shows through from textarea caret).
- * Mention spans are styled as visible pills.
+ * Renders the text with @mentions highlighted behind a transparent textarea.
  */
 export function BackdropContent({
   text,
@@ -43,7 +41,7 @@ export function BackdropContent({
     <>
       {segments.map((seg, i) =>
         seg.isMention ? (
-          <span key={i} className="rounded bg-blue-100 px-0.5 text-sm font-medium text-blue-700">
+          <span key={i} className="rounded bg-blue-100 text-blue-700">
             {seg.text}
           </span>
         ) : (

--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
 import type { AgentMode } from "./agentMode";
 import { ComposerToolbar } from "./ComposerToolbar";
 import { useMentions } from "./useMentions";
@@ -89,12 +89,6 @@ export function ChatComposer({
     dismiss();
     textareaRef.current?.focus();
   }, [dismiss]);
-
-  useEffect(() => {
-    if (!showDropdown) {
-      mentionKeyboardRef.current = null;
-    }
-  }, [showDropdown]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { AgentMode } from "./agentMode";
 import { ComposerToolbar } from "./ComposerToolbar";
 import { useMentions } from "./useMentions";
@@ -55,7 +55,7 @@ export function ChatComposer({
     dismiss,
   } = useMentions();
 
-  const candidates = useMentionCandidates(nodes, runs, filter);
+  const candidates = useMentionCandidates(nodes, runs, filter, showDropdown);
   const canSend = !isEmpty && !sendPending;
 
   const handleSend = useCallback(async () => {
@@ -90,6 +90,12 @@ export function ChatComposer({
     textareaRef.current?.focus();
   }, [dismiss]);
 
+  useEffect(() => {
+    if (!showDropdown) {
+      mentionKeyboardRef.current = null;
+    }
+  }, [showDropdown]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (mentionKeyboardRef.current?.(e)) return;
@@ -101,6 +107,10 @@ export function ChatComposer({
     },
     [canSend, handleSend],
   );
+
+  const handleToolbarSend = useStableCallback(() => {
+    void handleSend();
+  });
 
   return (
     <footer className="px-3 pb-3 pt-2">
@@ -127,17 +137,26 @@ export function ChatComposer({
           statusLabel={statusLabel}
           canSend={canSend}
           onStop={onStop}
-          onSend={() => void handleSend()}
+          onSend={handleToolbarSend}
         />
       </div>
-      <MentionDropdown
-        items={candidates}
-        visible={showDropdown}
-        anchorEl={containerRef.current}
-        onSelect={handleMentionSelect}
-        onDismiss={handleDismiss}
-        keyboardRef={mentionKeyboardRef}
-      />
+      {showDropdown ? (
+        <MentionDropdown
+          items={candidates}
+          visible={showDropdown}
+          anchorEl={containerRef.current}
+          onSelect={handleMentionSelect}
+          onDismiss={handleDismiss}
+          keyboardRef={mentionKeyboardRef}
+        />
+      ) : null}
     </footer>
   );
+}
+
+function useStableCallback(callback: () => void): () => void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  return useCallback(() => callbackRef.current(), []);
 }

--- a/web_src/src/components/AgentSidebar/ComposerToolbar.tsx
+++ b/web_src/src/components/AgentSidebar/ComposerToolbar.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { ArrowUp, Loader2, Square } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { AgentMode } from "./agentMode";
@@ -15,7 +16,7 @@ interface ComposerToolbarProps {
   onSend: () => void;
 }
 
-export function ComposerToolbar({
+export const ComposerToolbar = memo(function ComposerToolbar({
   agentMode,
   onModeSwitch,
   modeDisabled,
@@ -65,4 +66,4 @@ export function ComposerToolbar({
       </div>
     </div>
   );
-}
+});

--- a/web_src/src/components/AgentSidebar/MentionDropdown.tsx
+++ b/web_src/src/components/AgentSidebar/MentionDropdown.tsx
@@ -163,7 +163,7 @@ export function MentionDropdown({
       keyboardRef.current = null;
       return;
     }
-    keyboardRef.current = (e: React.KeyboardEvent): boolean => {
+    const handleKeyboard = (e: React.KeyboardEvent): boolean => {
       if (e.key === "ArrowDown") {
         e.preventDefault();
         setHighlightedIndex((i) => (i < items.length - 1 ? i + 1 : 0));
@@ -185,6 +185,13 @@ export function MentionDropdown({
         return true;
       }
       return false;
+    };
+
+    keyboardRef.current = handleKeyboard;
+    return () => {
+      if (keyboardRef.current === handleKeyboard) {
+        keyboardRef.current = null;
+      }
     };
   }, [visible, items, highlightedIndex, onSelect, onDismiss, keyboardRef]);
 

--- a/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
@@ -74,4 +74,17 @@ describe("MentionTextarea", () => {
     expect(textarea.style.overflowY).toBe("auto");
     expect(backdrop.scrollTop).toBe(56);
   });
+
+  it("clamps bottom scroll before syncing the backdrop", () => {
+    const { textarea, backdrop } = renderTextarea("@New Component\none\ntwo\nthree\nfour\nfive\nsix");
+    setReadonlyNumber(textarea, "scrollHeight", 240);
+    setReadonlyNumber(textarea, "clientHeight", 144);
+
+    fireEvent.change(textarea, { target: { value: `${textarea.value}\nseven` } });
+    textarea.scrollTop = 96;
+    fireEvent.scroll(textarea);
+
+    expect(textarea.scrollTop).toBeCloseTo(94.08);
+    expect(backdrop.scrollTop).toBeCloseTo(94.08);
+  });
 });

--- a/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
@@ -84,7 +84,10 @@ describe("MentionTextarea", () => {
     textarea.scrollTop = 96;
     fireEvent.scroll(textarea);
 
-    expect(textarea.scrollTop).toBeCloseTo(94.08);
-    expect(backdrop.scrollTop).toBeCloseTo(94.08);
+    const maxScrollTop = textarea.scrollHeight - textarea.clientHeight;
+    expect(textarea.scrollTop).toBeLessThan(maxScrollTop);
+    expect(textarea.scrollTop).toBeLessThanOrEqual(maxScrollTop * 0.96);
+    expect(textarea.scrollTop).toBeGreaterThan(maxScrollTop * 0.94);
+    expect(backdrop.scrollTop).toBe(textarea.scrollTop);
   });
 });

--- a/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.spec.tsx
@@ -1,0 +1,77 @@
+import { createRef } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MentionTextarea } from "./MentionTextarea";
+import type { InsertedMention } from "./useMentions";
+
+function renderTextarea(value = "") {
+  const textareaRef = createRef<HTMLTextAreaElement>();
+  const backdropRef = createRef<HTMLDivElement>();
+  render(
+    <MentionTextarea
+      value={value}
+      mentions={[]}
+      setValue={vi.fn()}
+      setCursorPos={vi.fn()}
+      onKeyDown={vi.fn()}
+      textareaRef={textareaRef}
+      backdropRef={backdropRef}
+    />,
+  );
+
+  return {
+    textarea: screen.getByTestId("agent-input") as HTMLTextAreaElement,
+    backdrop: backdropRef.current as HTMLDivElement,
+  };
+}
+
+function setReadonlyNumber(element: HTMLElement, property: "clientHeight" | "scrollHeight", value: number) {
+  Object.defineProperty(element, property, { configurable: true, value });
+}
+
+describe("MentionTextarea", () => {
+  it("grows to fit multiline content before internal scrolling", () => {
+    const { textarea } = renderTextarea();
+    setReadonlyNumber(textarea, "scrollHeight", 72);
+
+    fireEvent.change(textarea, { target: { value: "@New Component\nasdasdasdas" } });
+
+    expect(textarea.style.height).toBe("72px");
+    expect(textarea.style.overflowY).toBe("hidden");
+  });
+
+  it("caps height and syncs internal scroll with the backdrop", () => {
+    const mention: InsertedMention = {
+      id: "node-1",
+      type: "node",
+      label: "New Component",
+      displayText: "@New Component",
+      startIndex: 0,
+    };
+    const textareaRef = createRef<HTMLTextAreaElement>();
+    const backdropRef = createRef<HTMLDivElement>();
+    render(
+      <MentionTextarea
+        value="@New Component\none\ntwo\nthree\nfour\nfive\nsix"
+        mentions={[mention]}
+        setValue={vi.fn()}
+        setCursorPos={vi.fn()}
+        onKeyDown={vi.fn()}
+        textareaRef={textareaRef}
+        backdropRef={backdropRef}
+      />,
+    );
+
+    const textarea = screen.getByTestId("agent-input") as HTMLTextAreaElement;
+    const backdrop = backdropRef.current as HTMLDivElement;
+    setReadonlyNumber(textarea, "scrollHeight", 240);
+
+    fireEvent.change(textarea, { target: { value: `${textarea.value}\nseven` } });
+    textarea.scrollTop = 56;
+    fireEvent.scroll(textarea);
+
+    expect(textarea.style.height).toBe("144px");
+    expect(textarea.style.overflowY).toBe("auto");
+    expect(backdrop.scrollTop).toBe(56);
+  });
+});

--- a/web_src/src/components/AgentSidebar/MentionTextarea.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.tsx
@@ -3,6 +3,8 @@ import { cn } from "@/lib/utils";
 import { BackdropContent } from "./BackdropContent";
 import type { InsertedMention } from "./useMentions";
 
+const composerTextMetrics = "px-3 py-2.5 text-sm leading-5 font-normal tracking-normal";
+
 interface MentionTextareaProps {
   value: string;
   mentions: InsertedMention[];
@@ -53,7 +55,7 @@ export function MentionTextarea({
         aria-hidden="true"
         className={cn(
           "pointer-events-none absolute inset-0 whitespace-pre-wrap break-words overflow-hidden",
-          "px-3 py-2.5 text-sm",
+          composerTextMetrics,
         )}
       >
         <BackdropContent text={value} mentions={mentions} />
@@ -70,7 +72,8 @@ export function MentionTextarea({
         placeholder={placeholder}
         data-testid="agent-input"
         className={cn(
-          "relative min-h-9 w-full resize-none border-0 bg-transparent px-3 py-2.5 text-sm shadow-none",
+          "relative min-h-9 w-full resize-none border-0 bg-transparent shadow-none",
+          composerTextMetrics,
           "outline-none ring-0 focus-visible:border-0 focus-visible:ring-0 focus-visible:outline-none",
           "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           "text-transparent caret-slate-900 selection:bg-blue-200/50",

--- a/web_src/src/components/AgentSidebar/MentionTextarea.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.tsx
@@ -5,7 +5,7 @@ import type { InsertedMention } from "./useMentions";
 
 const composerTextMetrics = "px-3 py-2.5 text-sm leading-5 font-normal tracking-normal";
 const maxTextareaHeight = 144;
-const maxScrollRatio = 0.98;
+const maxScrollRatio = 0.96;
 
 interface MentionTextareaProps {
   value: string;

--- a/web_src/src/components/AgentSidebar/MentionTextarea.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.tsx
@@ -5,6 +5,7 @@ import type { InsertedMention } from "./useMentions";
 
 const composerTextMetrics = "px-3 py-2.5 text-sm leading-5 font-normal tracking-normal";
 const maxTextareaHeight = 144;
+const maxScrollRatio = 0.98;
 
 interface MentionTextareaProps {
   value: string;
@@ -33,7 +34,12 @@ export function MentionTextarea({
         return;
       }
 
-      backdropRef.current.scrollTop = textarea.scrollTop;
+      const scrollTop = clampScrollTop(textarea);
+      if (textarea.scrollTop !== scrollTop) {
+        textarea.scrollTop = scrollTop;
+      }
+
+      backdropRef.current.scrollTop = scrollTop;
       backdropRef.current.scrollLeft = textarea.scrollLeft;
     },
     [backdropRef],
@@ -119,4 +125,11 @@ export function MentionTextarea({
       />
     </div>
   );
+}
+
+function clampScrollTop(textarea: HTMLTextAreaElement): number {
+  const maxScrollTop = Math.max(0, textarea.scrollHeight - textarea.clientHeight);
+  const maxAllowedScrollTop = maxScrollTop * maxScrollRatio;
+
+  return Math.min(textarea.scrollTop, maxAllowedScrollTop);
 }

--- a/web_src/src/components/AgentSidebar/MentionTextarea.tsx
+++ b/web_src/src/components/AgentSidebar/MentionTextarea.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useLayoutEffect } from "react";
 import { cn } from "@/lib/utils";
 import { BackdropContent } from "./BackdropContent";
 import type { InsertedMention } from "./useMentions";
 
 const composerTextMetrics = "px-3 py-2.5 text-sm leading-5 font-normal tracking-normal";
+const maxTextareaHeight = 144;
 
 interface MentionTextareaProps {
   value: string;
@@ -26,12 +27,48 @@ export function MentionTextarea({
   textareaRef,
   backdropRef,
 }: MentionTextareaProps) {
+  const syncBackdropScroll = useCallback(
+    (textarea: HTMLTextAreaElement) => {
+      if (!backdropRef.current) {
+        return;
+      }
+
+      backdropRef.current.scrollTop = textarea.scrollTop;
+      backdropRef.current.scrollLeft = textarea.scrollLeft;
+    },
+    [backdropRef],
+  );
+
+  const syncTextareaLayout = useCallback(
+    (textarea: HTMLTextAreaElement) => {
+      textarea.style.height = "auto";
+      const nextHeight = Math.min(textarea.scrollHeight, maxTextareaHeight);
+
+      if (nextHeight > 0) {
+        textarea.style.height = `${nextHeight}px`;
+      }
+
+      textarea.style.overflowY = textarea.scrollHeight > maxTextareaHeight ? "auto" : "hidden";
+      syncBackdropScroll(textarea);
+    },
+    [syncBackdropScroll],
+  );
+
+  useLayoutEffect(() => {
+    if (!textareaRef.current) {
+      return;
+    }
+
+    syncTextareaLayout(textareaRef.current);
+  }, [syncTextareaLayout, textareaRef, value]);
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setValue(e.target.value);
       setCursorPos(e.target.selectionStart ?? e.target.value.length);
+      syncTextareaLayout(e.target);
     },
-    [setValue, setCursorPos],
+    [setValue, setCursorPos, syncTextareaLayout],
   );
 
   const handleSelect = useCallback(
@@ -42,11 +79,10 @@ export function MentionTextarea({
   );
 
   const handleScroll = useCallback(() => {
-    if (textareaRef.current && backdropRef.current) {
-      backdropRef.current.scrollTop = textareaRef.current.scrollTop;
-      backdropRef.current.scrollLeft = textareaRef.current.scrollLeft;
+    if (textareaRef.current) {
+      syncBackdropScroll(textareaRef.current);
     }
-  }, [textareaRef, backdropRef]);
+  }, [textareaRef, syncBackdropScroll]);
 
   return (
     <div className="relative">

--- a/web_src/src/components/AgentSidebar/useMentionCandidates.spec.ts
+++ b/web_src/src/components/AgentSidebar/useMentionCandidates.spec.ts
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CanvasesCanvasRun, SuperplaneComponentsNode } from "@/api-client";
+import { useMentionCandidates } from "./useMentionCandidates";
+
+const nodes = [
+  { id: "node-1", name: "Deploy API", component: "http", type: "TYPE_COMPONENT" },
+  { id: "node-2", name: "Start", component: "webhook", type: "TYPE_TRIGGER" },
+] as SuperplaneComponentsNode[];
+
+const runs = [{ id: "abcdef123", result: "RESULT_PASSED", createdAt: new Date().toISOString() }] as CanvasesCanvasRun[];
+
+describe("useMentionCandidates", () => {
+  it("returns a stable empty list while candidate lookup is disabled", () => {
+    const { result, rerender } = renderHook(({ filter }) => useMentionCandidates(nodes, runs, filter, false), {
+      initialProps: { filter: "" },
+    });
+    const initialCandidates = result.current;
+
+    rerender({ filter: "deploy" });
+
+    expect(result.current).toBe(initialCandidates);
+    expect(result.current).toEqual([]);
+  });
+
+  it("builds filtered candidates when lookup is enabled", () => {
+    const { result } = renderHook(() => useMentionCandidates(nodes, runs, "deploy", true));
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        type: "node",
+        id: "node-1",
+        label: "Deploy API",
+      }),
+    ]);
+  });
+});

--- a/web_src/src/components/AgentSidebar/useMentionCandidates.ts
+++ b/web_src/src/components/AgentSidebar/useMentionCandidates.ts
@@ -3,6 +3,8 @@ import type { MentionCandidate } from "./MentionDropdown";
 import type { SuperplaneComponentsNode } from "@/api-client";
 import type { CanvasesCanvasRun } from "@/api-client";
 
+const emptyMentionCandidates: MentionCandidate[] = [];
+
 function timeAgo(dateStr?: string): string {
   if (!dateStr) return "";
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -45,12 +47,17 @@ export function useMentionCandidates(
   nodes: SuperplaneComponentsNode[] | undefined,
   runs: CanvasesCanvasRun[] | undefined,
   filter: string,
+  enabled = true,
 ): MentionCandidate[] {
   return useMemo(() => {
+    if (!enabled) {
+      return emptyMentionCandidates;
+    }
+
     const filterLower = filter.toLowerCase();
     return [
       ...(nodes ? buildNodeCandidates(nodes, filterLower) : []),
       ...(runs ? buildRunCandidates(runs, filterLower) : []),
     ];
-  }, [nodes, runs, filter]);
+  }, [nodes, runs, filter, enabled]);
 }

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
@@ -1,6 +1,7 @@
 import { createRef } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { createSystemMessage } from "@/components/AgentSidebar/systemMessages";
 import { ConversationTranscript } from "./AgentConversationTranscript";
 import type { MessageGroup } from "./agentMessageGroups";
 
@@ -51,5 +52,59 @@ describe("ConversationTranscript command groups", () => {
 
     expect(screen.getByText("Running command...")).toBeInTheDocument();
     expect(screen.getByText(/SUPERPLANE_URL/)).toBeInTheDocument();
+  });
+});
+
+describe("ConversationTranscript hidden messages", () => {
+  it("does not render an empty turn above the thinking row", () => {
+    render(
+      <ConversationTranscript
+        {...baseProps}
+        messageGroups={[
+          {
+            type: "message",
+            message: {
+              id: "system-notification",
+              role: "user",
+              content: createSystemMessage("Canvas changed"),
+              toolName: "",
+              toolCallId: "",
+              toolStatus: "",
+              createdAt: null,
+            },
+          },
+        ]}
+        showThinking
+      />,
+    );
+
+    const transcriptBody = screen.getByTestId("agent-thinking").parentElement;
+    expect(transcriptBody?.firstElementChild).toBe(screen.getByTestId("agent-thinking"));
+  });
+
+  it("does not render an empty turn above command groups", () => {
+    render(
+      <ConversationTranscript
+        {...baseProps}
+        messageGroups={[
+          {
+            type: "message",
+            message: {
+              id: "system-message",
+              role: "system",
+              content: "Internal event",
+              toolName: "",
+              toolCallId: "",
+              toolStatus: "",
+              createdAt: null,
+            },
+          },
+          ...toolGroup("started"),
+        ]}
+      />,
+    );
+
+    const transcriptBody = screen.getByTestId("agent-tool-group").parentElement;
+    expect(transcriptBody?.firstElementChild).toBe(screen.getByTestId("agent-tool-group"));
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.spec.tsx
@@ -36,6 +36,23 @@ function toolGroup(status: string): MessageGroup[] {
   ];
 }
 
+function userMessage(content: string): MessageGroup[] {
+  return [
+    {
+      type: "message",
+      message: {
+        id: "user-message",
+        role: "user",
+        content,
+        toolName: "",
+        toolCallId: "",
+        toolStatus: "",
+        createdAt: null,
+      },
+    },
+  ];
+}
+
 describe("ConversationTranscript command groups", () => {
   it("collapses completed command groups by default", () => {
     render(<ConversationTranscript {...baseProps} messageGroups={toolGroup("finished")} />);
@@ -52,6 +69,30 @@ describe("ConversationTranscript command groups", () => {
 
     expect(screen.getByText("Running command...")).toBeInTheDocument();
     expect(screen.getByText(/SUPERPLANE_URL/)).toBeInTheDocument();
+  });
+});
+
+describe("ConversationTranscript user messages", () => {
+  it("keeps compact user messages sticky", () => {
+    render(<ConversationTranscript {...baseProps} messageGroups={userMessage("Build a release workflow")} />);
+
+    expect(screen.getByTestId("agent-user-message").parentElement).toHaveClass("sticky");
+  });
+
+  it("does not keep long user messages sticky", () => {
+    const longPrompt = [
+      "My idea is: Create an elixir clusterautoprovisioning app with enough detail to wrap across multiple lines.",
+      "",
+      "- CI/CD deployment on push to main.",
+      "- Metric integration that provisions another node when usage gets high.",
+      "- Backup postgres too.",
+      "",
+      "Also suggest other workflows in the canvas if you find interesting ones for the hackaton.",
+    ].join("\n");
+
+    render(<ConversationTranscript {...baseProps} messageGroups={userMessage(longPrompt)} />);
+
+    expect(screen.getByTestId("agent-user-message").parentElement).not.toHaveClass("sticky");
   });
 });
 

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -34,7 +34,7 @@ export const ConversationTranscript = memo(function ConversationTranscript({
   // next user message). Each turn is its own block so the sticky user bubble inside is bounded by
   // its turn — when the turn scrolls past, the bubble scrolls with it and the next turn's bubble
   // pushes up to take its place. No two stickies ever overlap.
-  const turns = useMemo(() => chunkIntoTurns(messageGroups), [messageGroups]);
+  const turns = useMemo(() => chunkIntoTurns(messageGroups.filter(isRenderableGroup)), [messageGroups]);
 
   return (
     <div ref={scrollRef} className="min-h-0 min-w-0 flex-1 overflow-y-auto px-3" data-testid="agent-chat-messages">
@@ -85,6 +85,14 @@ function chunkIntoTurns(groups: MessageGroup[]): MessageGroup[][] {
 
   if (current.length > 0) turns.push(current);
   return turns;
+}
+
+function isRenderableGroup(group: MessageGroup): boolean {
+  if (group.type !== "message") {
+    return true;
+  }
+
+  return shouldRenderMessage(group.message);
 }
 
 function turnKey(turn: MessageGroup[]): string {
@@ -157,7 +165,7 @@ const MessageRow = memo(function MessageRow({
     return <ToolMessageRow message={message} />;
   }
 
-  if (message.role === "system" || (message.role === "user" && isSystemNotification(message.content))) {
+  if (!shouldRenderMessage(message)) {
     return null;
   }
 
@@ -197,6 +205,10 @@ const MessageRow = memo(function MessageRow({
     </div>
   );
 });
+
+function shouldRenderMessage(message: AgentMessage): boolean {
+  return message.role !== "system" && !(message.role === "user" && isSystemNotification(message.content));
+}
 
 function SubagentCard({ messages }: { messages: AgentMessage[] }) {
   const [expanded, setExpanded] = useState(false);

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -7,6 +7,9 @@ import { cn } from "@/lib/utils";
 import type { AgentMessage } from "./types";
 import type { MessageGroup } from "./agentMessageGroups";
 
+const STICKY_USER_MESSAGE_MAX_CHARS = 240;
+const STICKY_USER_MESSAGE_MAX_LINES = 4;
+
 export const ConversationTranscript = memo(function ConversationTranscript({
   error,
   canvasId,
@@ -170,16 +173,18 @@ const MessageRow = memo(function MessageRow({
   }
 
   const isUser = message.role === "user";
+  const shouldStickUserMessage = isUser && isCompactUserMessage(message.content);
 
   return (
     <div
       className={cn(
         "flex w-full min-w-0 flex-col",
-        // User bubbles stick to the top of the scrollable transcript so the most-recent question
-        // remains visible while a long agent reply scrolls past underneath it. Older user messages
-        // also stick, but the most recent one paints on top via DOM order, so visually it's always
-        // the latest. Background is opaque to mask scrolling content behind.
-        isUser ? "sticky top-0 z-10 items-end bg-white py-1.5" : "items-start",
+        isUser && "items-end py-1.5",
+        !isUser && "items-start",
+        // Compact user bubbles stick to the top of the scrollable transcript so the current prompt
+        // remains visible while a long agent reply scrolls past. Long prompts must scroll normally;
+        // otherwise the sticky bubble can cover the active Thinking or command rows.
+        shouldStickUserMessage && "sticky top-0 z-10 bg-white",
       )}
     >
       <div
@@ -208,6 +213,10 @@ const MessageRow = memo(function MessageRow({
 
 function shouldRenderMessage(message: AgentMessage): boolean {
   return message.role !== "system" && !(message.role === "user" && isSystemNotification(message.content));
+}
+
+function isCompactUserMessage(content: string): boolean {
+  return content.length <= STICKY_USER_MESSAGE_MAX_CHARS && content.split("\n").length <= STICKY_USER_MESSAGE_MAX_LINES;
 }
 
 function SubagentCard({ messages }: { messages: AgentMessage[] }) {


### PR DESCRIPTION
## Summary
- keep the agent mention textarea and backdrop on identical text metrics
- remove mention highlight padding/font weight so highlighted text no longer shifts the caret alignment
- resize the agent input until a max height and sync internal textarea scroll with the mention backdrop
- clamp agent input bottom scrolling to 96% before syncing the mention backdrop, avoiding the full-bottom padding mismatch
- reduce typing work in the agent composer by skipping mention candidate building while the dropdown is closed, unmounting the closed dropdown, and memoizing the composer toolbar path
- keep the agent composer under the UI lint budget by relying on dropdown cleanup instead of a duplicate effect
- filter hidden transcript messages before creating turn wrappers so empty rows do not appear above Thinking or command rows
- let long user prompts scroll normally instead of pinning them above current agent output
- add regression coverage for mention highlighting, input scroll sync, 96% bottom-scroll clamping, mention candidate gating, hidden transcript rows, and long prompt stickiness

Fixes #5207

## Tests
- make format.js
- make check.lint.ui
- npm run test:run -- MentionTextarea.spec.tsx useMentionCandidates.spec.ts BackdropContent.spec.tsx AgentConversationTranscript.spec.tsx
- git diff --check
- make check.build.ui
