### PR TITLE
fix: publish drafts with invalid integration refs

### DIFF
--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -2,6 +2,7 @@ package changesets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -214,6 +215,10 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 	//
 	// TODO: handle blueprint nodes once blueprints are enabled again
 	//
+	appInstallationID, err := p.getNodeIntegrationID(node)
+	if err != nil {
+		return err
+	}
 
 	now := time.Now()
 	newNode := models.CanvasNode{
@@ -226,7 +231,7 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 		Metadata:          datatypes.NewJSONType(node.Metadata),
 		Position:          datatypes.NewJSONType(node.Position),
 		IsCollapsed:       node.IsCollapsed,
-		AppInstallationID: p.getNodeIntegrationID(node),
+		AppInstallationID: appInstallationID,
 		CreatedAt:         &now,
 		UpdatedAt:         &now,
 	}
@@ -248,7 +253,7 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 	// so when we Setup() it, the contexts can create
 	// records pointing to the new workflow_node record.
 	//
-	err := p.tx.Create(&newNode).Error
+	err = p.tx.Create(&newNode).Error
 	if err != nil {
 		return err
 	}
@@ -299,6 +304,10 @@ func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChang
 	//
 	// TODO: handle blueprint nodes once blueprints are enabled again
 	//
+	appInstallationID, err := p.getNodeIntegrationID(updatedNode)
+	if err != nil {
+		return err
+	}
 
 	//
 	// If node update led to an error, set the node to error state.
@@ -322,7 +331,7 @@ func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChang
 	existingNode.Configuration = datatypes.NewJSONType(updatedNode.Configuration)
 	existingNode.Position = datatypes.NewJSONType(updatedNode.Position)
 	existingNode.IsCollapsed = updatedNode.IsCollapsed
-	existingNode.AppInstallationID = p.getNodeIntegrationID(updatedNode)
+	existingNode.AppInstallationID = appInstallationID
 	existingNode.UpdatedAt = &now
 
 	//
@@ -339,7 +348,7 @@ func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChang
 	// we propagate that into the finalNodes that are
 	// going to be saved into workflow_versions.nodes.
 	//
-	err := p.setupNode(ctx, &existingNode)
+	err = p.setupNode(ctx, &existingNode)
 	if err != nil {
 		errorMsg := err.Error()
 		existingNode.State = models.CanvasNodeStateError
@@ -362,17 +371,30 @@ func (p *CanvasPublisher) deleteNode(change *pb.CanvasChangeset_Change) error {
 	return models.DeleteCanvasNode(p.tx, existingNode)
 }
 
-func (p *CanvasPublisher) getNodeIntegrationID(node models.Node) *uuid.UUID {
+func (p *CanvasPublisher) getNodeIntegrationID(node models.Node) (*uuid.UUID, error) {
 	//
 	// Only integration-based nodes have an integration ID,
 	// so we must return nil for other node types.
 	//
 	if node.IntegrationID == nil || strings.TrimSpace(*node.IntegrationID) == "" {
-		return nil
+		return nil, nil
 	}
 
-	id := uuid.MustParse(*node.IntegrationID)
-	return &id
+	id, err := uuid.Parse(strings.TrimSpace(*node.IntegrationID))
+	if err != nil {
+		return nil, nil
+	}
+
+	_, err = models.FindIntegrationInTransaction(p.tx, p.options.OrgID, id)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &id, nil
 }
 
 func (p *CanvasPublisher) setupNode(ctx context.Context, node *models.CanvasNode) error {

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher_test.go
@@ -438,7 +438,7 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 		require.Equal(t, existingError, *brokenVersionNode.ErrorMessage)
 	})
 
-	t.Run("update node skips setup when node already has error", func(t *testing.T) {
+	t.Run("add node with stale integration id publishes as errored node without foreign key", func(t *testing.T) {
 		r := support.Setup(t)
 
 		canvas, _ := support.CreateCanvas(
@@ -451,23 +451,20 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 			nil,
 		)
 
-		existingError := "node has invalid setup data"
+		staleIntegrationID := uuid.New().String()
+		existingError := "integration not found or does not belong to this organization"
+		draftNode := componentNode("node-broken", "Node Broken", "github.getIssue", map[string]any{})
+		draftNode.IntegrationID = &staleIntegrationID
+		draftNode.ErrorMessage = &existingError
+
 		draft, err := models.CreateDraftBranchFromLiveInTransaction(
 			database.Conn(),
 			canvas.ID,
 			r.User,
 			"",
 			[]models.Node{
-				{
-					ID:            "node-a",
-					Name:          "Node A Updated",
-					Type:          models.NodeTypeComponent,
-					Ref:           models.NodeRef{Component: &models.ComponentRef{Name: "missingcomponent"}},
-					Configuration: map[string]any{"value": "after"},
-					Metadata:      map[string]any{},
-					Position:      models.Position{X: 10, Y: 20},
-					ErrorMessage:  &existingError,
-				},
+				componentNode("node-a", "Node A", "noop", map[string]any{"value": "before"}),
+				draftNode,
 			},
 			nil,
 		)
@@ -483,12 +480,68 @@ func Test__CanvasPublisher_Publish(t *testing.T) {
 
 		activeNodes, err := models.FindCanvasNodes(canvas.ID)
 		require.NoError(t, err)
-		updatedNode := findCanvasNode(t, activeNodes, "node-a")
-		require.Equal(t, "Node A Updated", updatedNode.Name)
-		require.Equal(t, map[string]any{"value": "after"}, updatedNode.Configuration.Data())
-		require.Equal(t, models.CanvasNodeStateError, updatedNode.State)
-		require.NotNil(t, updatedNode.StateReason)
-		require.Equal(t, existingError, *updatedNode.StateReason)
+		brokenNode := findCanvasNode(t, activeNodes, "node-broken")
+		require.Equal(t, models.CanvasNodeStateError, brokenNode.State)
+		require.NotNil(t, brokenNode.StateReason)
+		require.Equal(t, existingError, *brokenNode.StateReason)
+		require.Nil(t, brokenNode.AppInstallationID)
+
+		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
+		require.NoError(t, err)
+		brokenVersionNode := findVersionNode(t, publishedVersion.Nodes, "node-broken")
+		require.Equal(t, &staleIntegrationID, brokenVersionNode.IntegrationID)
+		require.NotNil(t, brokenVersionNode.ErrorMessage)
+		require.Equal(t, existingError, *brokenVersionNode.ErrorMessage)
+	})
+
+	t.Run("update node skips setup when node already has error", func(t *testing.T) {
+		r := support.Setup(t)
+
+		canvas, _ := support.CreateCanvas(
+			t,
+			r.Organization.ID,
+			r.User,
+			[]models.CanvasNode{
+				componentCanvasNode("node-a", "Node A", "noop", map[string]any{"value": "before"}),
+			},
+			nil,
+		)
+
+		existingError := "node has invalid setup data"
+		staleIntegrationID := uuid.New().String()
+		draftNode := componentNode("node-a", "Node A Updated", "missingcomponent", map[string]any{"value": "after"})
+		draftNode.ErrorMessage = &existingError
+		draftNode.IntegrationID = &staleIntegrationID
+
+		draft, err := models.CreateDraftBranchFromLiveInTransaction(
+			database.Conn(),
+			canvas.ID,
+			r.User,
+			"",
+			[]models.Node{
+				draftNode,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		liveVersion, err := models.FindLiveCanvasVersionInTransaction(database.Conn(), canvas.ID)
+		require.NoError(t, err)
+		publisher, err := NewCanvasPublisher(database.Conn(), draft, liveVersion, canvasPublisherOptions(r))
+		require.NoError(t, err)
+
+		err = publisher.Publish(context.Background())
+		require.NoError(t, err)
+
+		activeNodes, err := models.FindCanvasNodes(canvas.ID)
+		require.NoError(t, err)
+		activeNode := findCanvasNode(t, activeNodes, "node-a")
+		require.Equal(t, "Node A Updated", activeNode.Name)
+		require.Equal(t, map[string]any{"value": "after"}, activeNode.Configuration.Data())
+		require.Equal(t, models.CanvasNodeStateError, activeNode.State)
+		require.NotNil(t, activeNode.StateReason)
+		require.Equal(t, existingError, *activeNode.StateReason)
+		require.Nil(t, activeNode.AppInstallationID)
 
 		publishedVersion, err := models.FindCanvasVersionInTransaction(database.Conn(), canvas.ID, draft.ID)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- allow draft publish to continue when a node already has an invalid or stale integration reference
- validate draft node integration IDs before writing `workflow_nodes.app_installation_id`
- persist missing, malformed, or cross-organization integration references as `NULL` database FKs while preserving the node-level error message
- keep affected nodes published in error state instead of failing the whole publish with a foreign key violation
- add regression coverage for added and updated nodes that carry stale integration IDs

Fixes #5212

## Tests
- make format.go
- make test PKG_TEST_PACKAGES=./pkg/grpc/actions/canvases/changesets
- make lint && make check.build.app
- git diff --check
