### PR TITLE
feat(cli): new apps memory list command

### DIFF
--- a/pkg/cli/commands/apps/memory/list.go
+++ b/pkg/cli/commands/apps/memory/list.go
@@ -1,0 +1,188 @@
+package memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/superplanehq/superplane/pkg/cli/commands/apps/common"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+	"github.com/superplanehq/superplane/pkg/openapi_client"
+)
+
+type listCommand struct {
+	namespace *string
+}
+
+func (c *listCommand) Execute(ctx core.CommandContext) error {
+	if len(ctx.Args) > 1 {
+		return fmt.Errorf("list accepts at most one positional argument")
+	}
+
+	appArg := ""
+	if len(ctx.Args) == 1 {
+		appArg = strings.TrimSpace(ctx.Args[0])
+	}
+
+	appID, err := common.ResolveAppNameOrIDArg(ctx, appArg)
+	if err != nil {
+		return err
+	}
+
+	response, _, err := ctx.API.CanvasAPI.CanvasesListCanvasMemories(ctx.Context, appID).Execute()
+	if err != nil {
+		return err
+	}
+
+	memories := filterByNamespace(response.GetItems(), c.namespaceValue())
+	if !ctx.Renderer.IsText() {
+		return ctx.Renderer.Render(memories)
+	}
+
+	return ctx.Renderer.RenderText(func(stdout io.Writer) error {
+		return renderMemoryListText(stdout, memories)
+	})
+}
+
+func (c *listCommand) namespaceValue() string {
+	if c.namespace == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*c.namespace)
+}
+
+func filterByNamespace(memories []openapi_client.CanvasesCanvasMemory, namespace string) []openapi_client.CanvasesCanvasMemory {
+	if namespace == "" {
+		return memories
+	}
+
+	filtered := make([]openapi_client.CanvasesCanvasMemory, 0, len(memories))
+	for _, memory := range memories {
+		if memory.GetNamespace() == namespace {
+			filtered = append(filtered, memory)
+		}
+	}
+
+	return filtered
+}
+
+func renderMemoryListText(stdout io.Writer, memories []openapi_client.CanvasesCanvasMemory) error {
+	if len(memories) == 0 {
+		_, err := fmt.Fprintln(stdout, "No memory records found.")
+		return err
+	}
+
+	groups := groupByNamespace(memories)
+	for i, group := range groups {
+		if len(groups) > 1 {
+			if i > 0 {
+				_, _ = fmt.Fprintln(stdout)
+			}
+			_, _ = fmt.Fprintf(stdout, "Namespace: %s\n", group.namespace)
+		}
+
+		if err := renderNamespaceTable(stdout, group.memories); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type namespaceGroup struct {
+	namespace string
+	memories  []openapi_client.CanvasesCanvasMemory
+}
+
+func groupByNamespace(memories []openapi_client.CanvasesCanvasMemory) []namespaceGroup {
+	groupsByNamespace := map[string]int{}
+	groups := make([]namespaceGroup, 0)
+
+	for _, memory := range memories {
+		namespace := memory.GetNamespace()
+		if namespace == "" {
+			namespace = "(no namespace)"
+		}
+
+		index, ok := groupsByNamespace[namespace]
+		if !ok {
+			groupsByNamespace[namespace] = len(groups)
+			groups = append(groups, namespaceGroup{namespace: namespace})
+			index = len(groups) - 1
+		}
+
+		groups[index].memories = append(groups[index].memories, memory)
+	}
+
+	return groups
+}
+
+func renderNamespaceTable(stdout io.Writer, memories []openapi_client.CanvasesCanvasMemory) error {
+	columns := collectValueColumns(memories)
+	if len(columns) == 0 {
+		columns = []string{"VALUE"}
+	}
+
+	writer := tabwriter.NewWriter(stdout, 0, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, strings.Join(columns, "\t"))
+
+	for _, memory := range memories {
+		values := memory.GetValues()
+		row := make([]string, 0, len(columns))
+		for _, column := range columns {
+			value, ok := values[column]
+			if !ok {
+				row = append(row, "")
+				continue
+			}
+
+			formatted, err := formatValue(value)
+			if err != nil {
+				return err
+			}
+
+			row = append(row, formatted)
+		}
+
+		_, _ = fmt.Fprintln(writer, strings.Join(row, "\t"))
+	}
+
+	return writer.Flush()
+}
+
+func collectValueColumns(memories []openapi_client.CanvasesCanvasMemory) []string {
+	columnsByName := map[string]bool{}
+	for _, memory := range memories {
+		for column := range memory.GetValues() {
+			columnsByName[column] = true
+		}
+	}
+
+	columns := make([]string, 0, len(columnsByName))
+	for column := range columnsByName {
+		columns = append(columns, column)
+	}
+	sort.Strings(columns)
+
+	return columns
+}
+
+func formatValue(value any) (string, error) {
+	switch typed := value.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return typed, nil
+	default:
+		payload, err := json.Marshal(typed)
+		if err != nil {
+			return "", fmt.Errorf("failed to format memory value: %w", err)
+		}
+
+		return string(payload), nil
+	}
+}

--- a/pkg/cli/commands/apps/memory/list_test.go
+++ b/pkg/cli/commands/apps/memory/list_test.go
@@ -1,0 +1,146 @@
+package memory
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/test/support/cli"
+)
+
+const memoriesListResponse = `{
+	"items": [
+		{
+			"id": "memory-001",
+			"namespace": "deployments",
+			"values": {
+				"environment": "production",
+				"version": "v1.2.3"
+			},
+			"source": "SOURCE_NODE",
+			"createdAt": "2026-06-08T10:00:00Z",
+			"updatedAt": "2026-06-08T10:15:00Z"
+		},
+		{
+			"id": "memory-002",
+			"namespace": "incidents",
+			"values": {
+				"severity": "critical",
+				"ticket": 42
+			},
+			"source": "SOURCE_MANUAL",
+			"createdAt": "2026-06-08T11:00:00Z",
+			"updatedAt": "2026-06-08T11:15:00Z"
+		}
+	]
+}`
+
+const memoryCanvasID = "11111111-1111-1111-1111-111111111111"
+
+func newMemoryListServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/canvases":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"canvases":[{"metadata":{"id":"` + memoryCanvasID + `","name":"my-app"}}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/canvases/"+memoryCanvasID+"/memory":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(memoriesListResponse))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestListCommandReturnsJSON(t *testing.T) {
+	server := newMemoryListServer(t)
+	ctx, stdout := cli.NewCommandContext(t, server, "json")
+	ctx.Args = []string{"my-app"}
+
+	err := (&listCommand{}).Execute(ctx)
+	require.NoError(t, err)
+
+	var result []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	require.Len(t, result, 2)
+	require.Equal(t, "memory-001", result[0]["id"])
+	require.Equal(t, "deployments", result[0]["namespace"])
+	require.Equal(t, "SOURCE_NODE", result[0]["source"])
+	require.Equal(t, map[string]any{
+		"environment": "production",
+		"version":     "v1.2.3",
+	}, result[0]["values"])
+}
+
+func TestListCommandReturnsTextOutput(t *testing.T) {
+	server := newMemoryListServer(t)
+	ctx, stdout := cli.NewCommandContext(t, server, "text")
+	ctx.Args = []string{"my-app"}
+
+	err := (&listCommand{}).Execute(ctx)
+	require.NoError(t, err)
+
+	raw := stdout.String()
+	require.Contains(t, raw, "Namespace: deployments")
+	require.Contains(t, raw, "Namespace: incidents")
+	require.Contains(t, raw, "environment")
+	require.Contains(t, raw, "version")
+	require.Contains(t, raw, "production")
+	require.Contains(t, raw, "v1.2.3")
+	require.Contains(t, raw, "severity")
+	require.Contains(t, raw, "ticket")
+	require.Contains(t, raw, "critical")
+	require.Contains(t, raw, "42")
+	require.NotContains(t, raw, "memory-001")
+	require.NotContains(t, raw, "SOURCE_NODE")
+	require.NotContains(t, raw, "CREATED_AT")
+}
+
+func TestListCommandFiltersByNamespace(t *testing.T) {
+	server := newMemoryListServer(t)
+	ctx, stdout := cli.NewCommandContext(t, server, "text")
+	ctx.Args = []string{"my-app"}
+	namespace := "deployments"
+
+	err := (&listCommand{namespace: &namespace}).Execute(ctx)
+	require.NoError(t, err)
+
+	raw := stdout.String()
+	require.Contains(t, raw, "environment")
+	require.Contains(t, raw, "version")
+	require.Contains(t, raw, "production")
+	require.NotContains(t, raw, "Namespace:")
+	require.NotContains(t, raw, "severity")
+	require.NotContains(t, raw, "critical")
+}
+
+func TestListCommandUsesActiveAppWhenArgumentIsOmitted(t *testing.T) {
+	server := newMemoryListServer(t)
+	ctx, stdout := cli.NewCommandContextWithConfig(t, server, "text", &cli.FakeConfig{ActiveApp: memoryCanvasID})
+
+	err := (&listCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "production")
+}
+
+func TestListCommandPrintsEmptyTextMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/canvases/"+memoryCanvasID+"/memory", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, stdout := cli.NewCommandContextWithConfig(t, server, "text", &cli.FakeConfig{ActiveApp: memoryCanvasID})
+
+	err := (&listCommand{}).Execute(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "No memory records found.\n", stdout.String())
+}

--- a/pkg/cli/commands/apps/memory/root.go
+++ b/pkg/cli/commands/apps/memory/root.go
@@ -1,0 +1,32 @@
+package memory
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superplanehq/superplane/pkg/cli/core"
+)
+
+func NewCommand(options core.BindOptions) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "memory",
+		Short: "Manage app memory",
+		Long:  "List memory records stored by an app.",
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [app-name-or-id]",
+		Short: "List app memory records",
+		Long: `List memory records stored by an app.
+
+Use --namespace to show records from one namespace.
+The app argument is optional. When omitted, the active app
+configured with "superplane apps active" is used.`,
+		Args: cobra.MaximumNArgs(1),
+	}
+	var listNamespace string
+	listCmd.Flags().StringVar(&listNamespace, "namespace", "", "filter memory records by namespace")
+	core.Bind(listCmd, &listCommand{namespace: &listNamespace}, options)
+
+	root.AddCommand(listCmd)
+
+	return root
+}

--- a/pkg/cli/commands/apps/root.go
+++ b/pkg/cli/commands/apps/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/cli/commands/apps/changes"
 	"github.com/superplanehq/superplane/pkg/cli/commands/apps/console"
 	"github.com/superplanehq/superplane/pkg/cli/commands/apps/files"
+	"github.com/superplanehq/superplane/pkg/cli/commands/apps/memory"
 	"github.com/superplanehq/superplane/pkg/cli/core"
 )
 
@@ -47,6 +48,7 @@ App URL pattern: {baseURL}/{organizationId}/apps/{appId}
 	root.AddCommand(canvas.NewCommand(options))
 	root.AddCommand(console.NewCommand(options))
 	root.AddCommand(files.NewRootCommand(options))
+	root.AddCommand(memory.NewCommand(options))
 
 	return root
 }


### PR DESCRIPTION
Closes https://github.com/superplanehq/superplane/issues/5248

Right now, we don't have a way to inspect the app memory through the CLI. This makes it hard for agents to iterate on the app when using memory components. In this pull request, we introduce a new CLI command - `superplane apps memory list` - to help with that.