### PR TITLE
feat: add SuperPlane managed-agent custom tools

### DIFF
--- a/pkg/agents/anthropic/agent_prompt.go
+++ b/pkg/agents/anthropic/agent_prompt.go
@@ -83,15 +83,16 @@ func toolsEqual(current json.RawMessage, expected []map[string]any) bool {
 	if len(currentByKey) != len(expectedByKey) {
 		return false
 	}
-	for key, currentTool := range currentByKey {
-		if expectedByKey[key] != currentTool {
+	for key, expectedTool := range expectedByKey {
+		currentTool, ok := currentByKey[key]
+		if !ok || !toolContainsExpectedFields(currentTool, expectedTool) {
 			return false
 		}
 	}
 	return true
 }
 
-func toolsByKey(data json.RawMessage) (map[string]string, error) {
+func toolsByKey(data json.RawMessage) (map[string]map[string]any, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("tools missing")
 	}
@@ -101,22 +102,52 @@ func toolsByKey(data json.RawMessage) (map[string]string, error) {
 		return nil, err
 	}
 
-	byKey := map[string]string{}
+	byKey := map[string]map[string]any{}
 	for _, tool := range tools {
 		key := toolIdentity(tool)
 		if key == "" {
 			return nil, fmt.Errorf("tool identity missing")
 		}
-		value, err := json.Marshal(tool)
-		if err != nil {
-			return nil, err
-		}
 		if _, exists := byKey[key]; exists {
 			return nil, fmt.Errorf("duplicate tool identity")
 		}
-		byKey[key] = string(value)
+		byKey[key] = tool
 	}
 	return byKey, nil
+}
+
+func toolContainsExpectedFields(current, expected map[string]any) bool {
+	for key, expectedValue := range expected {
+		currentValue, ok := current[key]
+		if !ok || !valueMatchesExpected(currentValue, expectedValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func valueMatchesExpected(current, expected any) bool {
+	expectedMap, expectedIsMap := expected.(map[string]any)
+	if expectedIsMap {
+		currentMap, ok := current.(map[string]any)
+		return ok && toolContainsExpectedFields(currentMap, expectedMap)
+	}
+
+	expectedSlice, expectedIsSlice := expected.([]any)
+	if expectedIsSlice {
+		currentSlice, ok := current.([]any)
+		if !ok || len(currentSlice) != len(expectedSlice) {
+			return false
+		}
+		for i := range expectedSlice {
+			if !valueMatchesExpected(currentSlice[i], expectedSlice[i]) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return fmt.Sprint(current) == fmt.Sprint(expected)
 }
 
 func toolIdentity(tool map[string]any) string {

--- a/pkg/agents/anthropic/agent_prompt.go
+++ b/pkg/agents/anthropic/agent_prompt.go
@@ -3,7 +3,9 @@ package anthropic
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -35,11 +37,12 @@ func SyncAgentPrompt(ctx context.Context, cfg Config, prompt string) error {
 }
 
 func syncAgentPrompt(ctx context.Context, client *Client, agentID, prompt string) error {
+	expectedTools := defaultAgentTools()
 	current, err := client.getAgent(ctx, agentID)
 	if err != nil {
 		return fmt.Errorf("get agent: %w", err)
 	}
-	if promptsEqual(current.System, prompt) {
+	if promptsEqual(current.System, prompt) && toolsEqual(current.Tools, expectedTools) {
 		return nil
 	}
 
@@ -50,10 +53,174 @@ func syncAgentPrompt(ctx context.Context, client *Client, agentID, prompt string
 	if !promptsEqual(updated.System, prompt) {
 		return fmt.Errorf("update agent prompt: provider returned a different prompt")
 	}
+	if !toolsEqual(updated.Tools, expectedTools) {
+		return fmt.Errorf("update agent prompt: provider returned different tools")
+	}
 
 	return nil
 }
 
 func promptsEqual(a, b string) bool {
 	return strings.TrimRight(a, "\r\n") == strings.TrimRight(b, "\r\n")
+}
+
+func toolsEqual(current json.RawMessage, expected []map[string]any) bool {
+	currentByKey, err := toolsByKey(current)
+	if err != nil {
+		return false
+	}
+
+	expectedBytes, err := json.Marshal(expected)
+	if err != nil {
+		return false
+	}
+
+	expectedByKey, err := toolsByKey(expectedBytes)
+	if err != nil {
+		return false
+	}
+
+	if len(currentByKey) != len(expectedByKey) {
+		return false
+	}
+	for key, currentTool := range currentByKey {
+		if expectedByKey[key] != currentTool {
+			return false
+		}
+	}
+	return true
+}
+
+func toolsByKey(data json.RawMessage) (map[string]string, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("tools missing")
+	}
+
+	var tools []map[string]any
+	if err := json.Unmarshal(data, &tools); err != nil {
+		return nil, err
+	}
+
+	byKey := map[string]string{}
+	for _, tool := range tools {
+		key := toolIdentity(tool)
+		if key == "" {
+			return nil, fmt.Errorf("tool identity missing")
+		}
+		value, err := json.Marshal(tool)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := byKey[key]; exists {
+			return nil, fmt.Errorf("duplicate tool identity")
+		}
+		byKey[key] = string(value)
+	}
+	return byKey, nil
+}
+
+func toolIdentity(tool map[string]any) string {
+	parts := []string{}
+	if value, ok := tool["type"].(string); ok && value != "" {
+		parts = append(parts, "type="+value)
+	}
+	if value, ok := tool["name"].(string); ok && value != "" {
+		parts = append(parts, "name="+value)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+func defaultAgentTools() []map[string]any {
+	return []map[string]any{
+		{
+			"type": "agent_toolset_20260401",
+		},
+		{
+			"type":        "custom",
+			"name":        "superplane_canvas",
+			"description": "Read and update the current SuperPlane app canvas without invoking the SuperPlane CLI. Use this tool before shell commands when you need the canvas YAML, console YAML, connected integration IDs, or when you need to save draft graph or console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues.",
+			"input_schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"action": map[string]any{
+						"type":        "string",
+						"enum":        []string{"read", "update_draft", "list_integrations"},
+						"description": "Operation to run. Use read for current YAML, update_draft to save canvas_yaml and/or console_yaml to a draft, and list_integrations for connected integration IDs.",
+					},
+					"canvas_id": map[string]any{
+						"type":        "string",
+						"description": "Optional safety check. If provided, it must match the current session canvas_id from the preamble.",
+					},
+					"use_draft": map[string]any{
+						"type":        "boolean",
+						"description": "For read. Defaults to true: return the current user's draft when one exists, otherwise live.",
+					},
+					"include_console": map[string]any{
+						"type":        "boolean",
+						"description": "For read. Include console.yaml in the response.",
+					},
+					"include_integrations": map[string]any{
+						"type":        "boolean",
+						"description": "For read. Include connected integration IDs, names, vendors, and state.",
+					},
+					"canvas_yaml": map[string]any{
+						"type":        "string",
+						"description": "For update_draft. Complete canonical canvas.yaml content to save.",
+					},
+					"console_yaml": map[string]any{
+						"type":        "string",
+						"description": "For update_draft. Complete canonical console.yaml content to save.",
+					},
+					"auto_layout": map[string]any{
+						"type":        "object",
+						"description": "Optional auto-layout settings for canvas_yaml updates. If omitted for a canvas_yaml update, the backend applies horizontal full-canvas auto-layout by default. Omit this for console-only updates.",
+						"properties": map[string]any{
+							"scope": map[string]any{
+								"type": "string",
+								"enum": []string{"full_canvas", "connected_component"},
+							},
+							"node_ids": map[string]any{
+								"type":  "array",
+								"items": map[string]any{"type": "string"},
+							},
+						},
+					},
+				},
+				"required": []string{"action"},
+			},
+		},
+		{
+			"type":        "custom",
+			"name":        "superplane_component_schema",
+			"description": "Lookup exact SuperPlane component, trigger, and widget schemas from the backend registry without reading mounted reference files. Use this before read/grep commands or researcher delegation when you need YAML component keys, configuration fields, output channel names, integration requirements, or compact examples. Prefer this tool for repeated schema lookups; mounted docs are fallback only.",
+			"input_schema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"component_keys": map[string]any{
+						"type":        "array",
+						"description": "Exact component, trigger, or widget keys to look up, for example schedule, http, wait, slack.waitForButtonClick.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"vendors": map[string]any{
+						"type":        "array",
+						"description": "Vendor names to list schemas for, for example slack, github, grafana.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"query": map[string]any{
+						"type":        "string",
+						"description": "Search term used against component keys, labels, descriptions, kind, and required integration vendor.",
+					},
+					"include_examples": map[string]any{
+						"type":        "boolean",
+						"description": "Include compact example input/output payloads when available. Honored only for exact component_keys lookups; broad vendor and query lookups stay compact.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum schemas to return. Defaults to 40 and is capped at 40.",
+					},
+				},
+			},
+		},
+	}
 }

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -263,6 +263,30 @@ func TestSyncAgentPrompt_ErrorsWhenUpdatedToolsDiffer(t *testing.T) {
 	assert.Contains(t, err.Error(), "provider returned different tools")
 }
 
+func TestSyncAgentPrompt_ErrorsWhenUpdatedToolsAreOmitted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"old prompt","version":9}`))
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"new prompt","version":10}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	err := SyncAgentPrompt(context.Background(), Config{
+		APIKey:  "test-key",
+		AgentID: "agent-123",
+		BaseURL: server.URL,
+	}, "new prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider returned different tools")
+}
+
 func TestSendMessage_PrependsPreamble(t *testing.T) {
 	var capturedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -590,14 +614,12 @@ func TestStreamEvents_MapsCustomToolUseAndRequiresAction(t *testing.T) {
 		return nil
 	}))
 
-	require.Len(t, received, 3)
+	require.Len(t, received, 2)
 	assert.Equal(t, agents.ProviderEventCustomToolUseStarted, received[0].Type)
 	require.NotNil(t, received[0].CustomToolUse)
 	assert.Equal(t, "evt_custom", received[0].CustomToolUse.ID)
 	assert.Equal(t, agents.ProviderEventCustomToolResultsRequired, received[1].Type)
 	assert.Equal(t, []string{"evt_custom"}, received[1].CustomToolEventIDs)
-	assert.Equal(t, agents.ProviderEventAssistantMessage, received[2].Type)
-	assert.Equal(t, "after pause", received[2].Text)
 }
 
 func TestStreamEvents_EndTurnStopReasonCompletesTurn(t *testing.T) {

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -88,15 +88,23 @@ func TestDefaultAgentPrompt_IsEmbedded(t *testing.T) {
 	assert.Contains(t, prompt, "## App Update Rules")
 }
 
+func defaultAgentToolsJSON(t *testing.T) string {
+	t.Helper()
+	tools, err := json.Marshal(defaultAgentTools())
+	require.NoError(t, err)
+	return string(tools)
+}
+
 func TestSyncAgentPrompt_SkipsUpdateWhenCurrent(t *testing.T) {
 	postCount := 0
+	tools := defaultAgentToolsJSON(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/agents/agent-123", r.URL.Path)
 		assert.Equal(t, "test-key", r.Header.Get("x-api-key"))
 
 		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte("{\"system\":\"current prompt\\n\\n\",\"version\":7}"))
+			_, _ = w.Write([]byte(`{"system":"current prompt\n\n","version":7,"tools":` + tools + `}`))
 			return
 		}
 
@@ -114,8 +122,68 @@ func TestSyncAgentPrompt_SkipsUpdateWhenCurrent(t *testing.T) {
 	assert.Equal(t, 0, postCount)
 }
 
+func TestSyncAgentPrompt_UpdatesWhenCurrentAndToolsOmittedOnRead(t *testing.T) {
+	postCount := 0
+	tools := defaultAgentToolsJSON(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/agent-123", r.URL.Path)
+
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"current prompt\n","version":7}`))
+			return
+		}
+
+		postCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"system":"current prompt\n","version":8,"tools":` + tools + `}`))
+	}))
+	defer server.Close()
+
+	err := SyncAgentPrompt(context.Background(), Config{
+		APIKey:  "test-key",
+		AgentID: "agent-123",
+		BaseURL: server.URL,
+	}, "current prompt\n")
+	require.NoError(t, err)
+	assert.Equal(t, 1, postCount)
+}
+
+func TestSyncAgentPrompt_SkipsUpdateWhenCurrentToolsHaveDifferentOrder(t *testing.T) {
+	postCount := 0
+	reversedTools, err := json.Marshal([]map[string]any{
+		defaultAgentTools()[2],
+		defaultAgentTools()[1],
+		defaultAgentTools()[0],
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/agent-123", r.URL.Path)
+
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"current prompt\n","version":7,"tools":` + string(reversedTools) + `}`))
+			return
+		}
+
+		postCount++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	err = SyncAgentPrompt(context.Background(), Config{
+		APIKey:  "test-key",
+		AgentID: "agent-123",
+		BaseURL: server.URL,
+	}, "current prompt\n")
+	require.NoError(t, err)
+	assert.Equal(t, 0, postCount)
+}
+
 func TestSyncAgentPrompt_UpdatesWhenDifferent(t *testing.T) {
 	var capturedBody map[string]any
+	tools := defaultAgentToolsJSON(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/agents/agent-123", r.URL.Path)
 
@@ -129,7 +197,7 @@ func TestSyncAgentPrompt_UpdatesWhenDifferent(t *testing.T) {
 			_ = json.Unmarshal(body, &capturedBody)
 
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"system":"new prompt","version":10}`))
+			_, _ = w.Write([]byte(`{"system":"new prompt","version":10,"tools":` + tools + `}`))
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -144,9 +212,11 @@ func TestSyncAgentPrompt_UpdatesWhenDifferent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new prompt", capturedBody["system"])
 	assert.Equal(t, float64(9), capturedBody["version"])
+	require.NotEmpty(t, capturedBody["tools"])
 }
 
 func TestSyncAgentPrompt_AcceptsUpdatedPromptWithNormalizedTrailingNewlines(t *testing.T) {
+	tools := defaultAgentToolsJSON(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
@@ -154,7 +224,7 @@ func TestSyncAgentPrompt_AcceptsUpdatedPromptWithNormalizedTrailingNewlines(t *t
 			_, _ = w.Write([]byte(`{"system":"old prompt","version":9}`))
 		case http.MethodPost:
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"system":"new prompt","version":10}`))
+			_, _ = w.Write([]byte(`{"system":"new prompt","version":10,"tools":` + tools + `}`))
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
@@ -167,6 +237,30 @@ func TestSyncAgentPrompt_AcceptsUpdatedPromptWithNormalizedTrailingNewlines(t *t
 		BaseURL: server.URL,
 	}, "new prompt\n\n")
 	require.NoError(t, err)
+}
+
+func TestSyncAgentPrompt_ErrorsWhenUpdatedToolsDiffer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"old prompt","version":9}`))
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"system":"new prompt","version":10,"tools":[{"type":"agent_toolset_20260401"}]}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	err := SyncAgentPrompt(context.Background(), Config{
+		APIKey:  "test-key",
+		AgentID: "agent-123",
+		BaseURL: server.URL,
+	}, "new prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider returned different tools")
 }
 
 func TestSendMessage_PrependsPreamble(t *testing.T) {
@@ -245,6 +339,32 @@ func TestDefineOutcome_PrependsPreambleToDescription(t *testing.T) {
 	require.Len(t, events, 1)
 	event := events[0].(map[string]any)
 	assert.Equal(t, "[ctx]\n\nBuild the workflow", event["description"])
+}
+
+func TestSendCustomToolResults_SendsUserCustomToolResultEvents(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sessions/sesn_abc/events", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendCustomToolResults(context.Background(), "sesn_abc", []agents.CustomToolResult{
+		{CustomToolUseID: "evt_1", Content: `{"ok":true}`},
+	})
+	require.NoError(t, err)
+
+	events := capturedBody["events"].([]any)
+	require.Len(t, events, 1)
+	event := events[0].(map[string]any)
+	assert.Equal(t, "user.custom_tool_result", event["type"])
+	assert.Equal(t, "evt_1", event["custom_tool_use_id"])
+	content := event["content"].([]any)
+	assert.Equal(t, `{"ok":true}`, content[0].(map[string]any)["text"])
 }
 
 func TestDeleteSession_SendsCorrectRequest(t *testing.T) {
@@ -431,6 +551,72 @@ func TestStreamEvents_KeysCustomToolUseByEventID(t *testing.T) {
 	require.NotNil(t, received[0].CustomToolUse)
 	assert.Equal(t, "evt_custom", received[0].CustomToolUse.ID)
 	assert.Equal(t, []string{"evt_custom"}, received[1].CustomToolEventIDs)
+}
+
+func TestStreamEvents_MapsAlternateToolNameField(t *testing.T) {
+	const sse = "data: {\"id\":\"evt_A\",\"type\":\"agent.tool_use\",\"tool_use_id\":\"toolu_1\",\"tool_name\":\"read\",\"input\":{\"file_path\":\"/tmp/spec.md\"}}\n\n" +
+		"data: {\"type\":\"session.status_idle\"}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+	require.Len(t, received, 2)
+	assert.Equal(t, "read", received[0].ToolName)
+	assert.Contains(t, received[0].ToolInput, "/tmp/spec.md")
+}
+
+func TestStreamEvents_MapsCustomToolUseAndRequiresAction(t *testing.T) {
+	const sse = "data: {\"id\":\"evt_custom\",\"type\":\"agent.custom_tool_use\",\"name\":\"superplane_canvas\",\"input\":{\"action\":\"read\"}}\n\n" +
+		"data: {\"type\":\"session.status_idle\",\"stop_reason\":{\"type\":\"requires_action\",\"event_ids\":[\"evt_custom\"]}}\n\n" +
+		"data: {\"id\":\"message_after_pause\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"after pause\"}]}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 3)
+	assert.Equal(t, agents.ProviderEventCustomToolUseStarted, received[0].Type)
+	require.NotNil(t, received[0].CustomToolUse)
+	assert.Equal(t, "evt_custom", received[0].CustomToolUse.ID)
+	assert.Equal(t, agents.ProviderEventCustomToolResultsRequired, received[1].Type)
+	assert.Equal(t, []string{"evt_custom"}, received[1].CustomToolEventIDs)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[2].Type)
+	assert.Equal(t, "after pause", received[2].Text)
+}
+
+func TestStreamEvents_EndTurnStopReasonCompletesTurn(t *testing.T) {
+	const sse = "data: {\"type\":\"session.status_idle\",\"stop_reason\":{\"type\":\"end_turn\"}}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 1)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[0].Type)
 }
 
 func TestStreamEvents_FallsBackToEventIDWhenToolUseIDMissing(t *testing.T) {

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -181,6 +181,28 @@ func TestSyncAgentPrompt_SkipsUpdateWhenCurrentToolsHaveDifferentOrder(t *testin
 	assert.Equal(t, 0, postCount)
 }
 
+func TestToolsEqual_IgnoresProviderMetadata(t *testing.T) {
+	currentTools := defaultAgentTools()
+	currentTools[1]["provider_created_at"] = "2026-06-10T00:00:00Z"
+	currentTools[1]["cache_control"] = nil
+	currentTools[1]["input_schema"].(map[string]any)["provider_schema_id"] = "schema_123"
+
+	current, err := json.Marshal(currentTools)
+	require.NoError(t, err)
+
+	assert.True(t, toolsEqual(current, defaultAgentTools()))
+}
+
+func TestToolsEqual_FailsWhenExpectedToolFieldsDiffer(t *testing.T) {
+	currentTools := defaultAgentTools()
+	currentTools[1]["description"] = "different"
+
+	current, err := json.Marshal(currentTools)
+	require.NoError(t, err)
+
+	assert.False(t, toolsEqual(current, defaultAgentTools()))
+}
+
 func TestSyncAgentPrompt_UpdatesWhenDifferent(t *testing.T) {
 	var capturedBody map[string]any
 	tools := defaultAgentToolsJSON(t)

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -614,12 +614,14 @@ func TestStreamEvents_MapsCustomToolUseAndRequiresAction(t *testing.T) {
 		return nil
 	}))
 
-	require.Len(t, received, 2)
+	require.Len(t, received, 3)
 	assert.Equal(t, agents.ProviderEventCustomToolUseStarted, received[0].Type)
 	require.NotNil(t, received[0].CustomToolUse)
 	assert.Equal(t, "evt_custom", received[0].CustomToolUse.ID)
 	assert.Equal(t, agents.ProviderEventCustomToolResultsRequired, received[1].Type)
 	assert.Equal(t, []string{"evt_custom"}, received[1].CustomToolEventIDs)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[2].Type)
+	assert.Equal(t, "after pause", received[2].Text)
 }
 
 func TestStreamEvents_EndTurnStopReasonCompletesTurn(t *testing.T) {

--- a/pkg/agents/anthropic/client.go
+++ b/pkg/agents/anthropic/client.go
@@ -131,8 +131,9 @@ type apiError struct {
 }
 
 type agentMetadata struct {
-	System  string `json:"system"`
-	Version int    `json:"version"`
+	System  string          `json:"system"`
+	Version int             `json:"version"`
+	Tools   json.RawMessage `json:"tools,omitempty"`
 }
 
 func (e *apiError) Error() string {
@@ -157,6 +158,7 @@ func (c *Client) updateAgentSystemPrompt(ctx context.Context, agentID string, ve
 	body := map[string]any{
 		"system":  prompt,
 		"version": version,
+		"tools":   defaultAgentTools(),
 	}
 	data, err := c.executeHTTP(ctx, http.MethodPost, "/agents/"+url.PathEscape(agentID), body)
 	if err != nil {

--- a/pkg/agents/custom_tool_router.go
+++ b/pkg/agents/custom_tool_router.go
@@ -1,0 +1,45 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// CustomToolRouter dispatches Managed Agent custom tool calls by name. It keeps
+// the stream worker independent from individual tool implementations.
+type CustomToolRouter struct {
+	executors map[string]CustomToolExecutor
+}
+
+func NewCustomToolRouter(executors ...CustomToolExecutor) *CustomToolRouter {
+	router := &CustomToolRouter{executors: map[string]CustomToolExecutor{}}
+	for _, executor := range executors {
+		if named, ok := executor.(interface{ CustomToolName() string }); ok {
+			router.executors[named.CustomToolName()] = executor
+		}
+	}
+	return router
+}
+
+func (r *CustomToolRouter) ExecuteCustomTool(ctx context.Context, session AgentSessionContext, toolUse CustomToolUse) CustomToolResult {
+	if r == nil {
+		return customToolError(toolUse.ID, "custom tool router is not configured")
+	}
+
+	executor, ok := r.executors[toolUse.Name]
+	if !ok {
+		return customToolError(toolUse.ID, fmt.Sprintf("unsupported custom tool %q", toolUse.Name))
+	}
+
+	return executor.ExecuteCustomTool(ctx, session, toolUse)
+}
+
+func customToolError(toolUseID, message string) CustomToolResult {
+	content, _ := json.Marshal(map[string]string{"error": message})
+	return CustomToolResult{
+		CustomToolUseID: toolUseID,
+		Content:         string(content),
+		IsError:         true,
+	}
+}

--- a/pkg/agents/tools/superplane_canvas_tool.go
+++ b/pkg/agents/tools/superplane_canvas_tool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
+	"github.com/superplanehq/superplane/pkg/usage"
 	"gorm.io/gorm"
 )
 
@@ -26,6 +27,7 @@ type SuperPlaneCanvasTool struct {
 	registry       *registry.Registry
 	webhookBaseURL string
 	authService    authorization.Authorization
+	usageService   usage.Service
 }
 
 type SuperPlaneCanvasToolOptions struct {
@@ -33,6 +35,7 @@ type SuperPlaneCanvasToolOptions struct {
 	Registry       *registry.Registry
 	WebhookBaseURL string
 	AuthService    authorization.Authorization
+	UsageService   usage.Service
 }
 
 func NewSuperPlaneCanvasTool(opts SuperPlaneCanvasToolOptions) *SuperPlaneCanvasTool {
@@ -41,6 +44,7 @@ func NewSuperPlaneCanvasTool(opts SuperPlaneCanvasToolOptions) *SuperPlaneCanvas
 		registry:       opts.Registry,
 		webhookBaseURL: opts.WebhookBaseURL,
 		authService:    opts.AuthService,
+		usageService:   opts.UsageService,
 	}
 }
 
@@ -202,7 +206,7 @@ func (t *SuperPlaneCanvasTool) updateDraft(ctx context.Context, session agents.A
 
 	if err := grpcCanvases.ApplyRepositorySpecFileOperations(
 		ctx,
-		nil,
+		t.usageService,
 		t.encryptor,
 		t.registry,
 		session.OrganizationID,

--- a/pkg/agents/tools/superplane_canvas_tool.go
+++ b/pkg/agents/tools/superplane_canvas_tool.go
@@ -1,0 +1,509 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/database"
+	grpcCanvases "github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/pkg/registry"
+	"gorm.io/gorm"
+)
+
+const SuperPlaneCanvasToolName = "superplane_canvas"
+
+type SuperPlaneCanvasTool struct {
+	encryptor      crypto.Encryptor
+	registry       *registry.Registry
+	webhookBaseURL string
+	authService    authorization.Authorization
+}
+
+type SuperPlaneCanvasToolOptions struct {
+	Encryptor      crypto.Encryptor
+	Registry       *registry.Registry
+	WebhookBaseURL string
+	AuthService    authorization.Authorization
+}
+
+func NewSuperPlaneCanvasTool(opts SuperPlaneCanvasToolOptions) *SuperPlaneCanvasTool {
+	return &SuperPlaneCanvasTool{
+		encryptor:      opts.Encryptor,
+		registry:       opts.Registry,
+		webhookBaseURL: opts.WebhookBaseURL,
+		authService:    opts.AuthService,
+	}
+}
+
+func (t *SuperPlaneCanvasTool) CustomToolName() string {
+	return SuperPlaneCanvasToolName
+}
+
+func (t *SuperPlaneCanvasTool) ExecuteCustomTool(ctx context.Context, session agents.AgentSessionContext, toolUse agents.CustomToolUse) agents.CustomToolResult {
+	if toolUse.Name != SuperPlaneCanvasToolName {
+		return customToolError(toolUse.ID, fmt.Sprintf("unsupported custom tool %q", toolUse.Name))
+	}
+
+	var input superPlaneCanvasToolInput
+	if err := json.Unmarshal([]byte(toolUse.Input), &input); err != nil {
+		return customToolError(toolUse.ID, fmt.Sprintf("invalid input: %v", err))
+	}
+	if err := t.validateSessionBoundInput(session, input.CanvasID); err != nil {
+		return customToolError(toolUse.ID, err.Error())
+	}
+
+	authedCtx := authentication.SetUserIdInMetadata(ctx, session.UserID)
+	var payload any
+	var err error
+
+	switch strings.TrimSpace(input.Action) {
+	case "read":
+		payload, err = t.read(authedCtx, session, input)
+	case "update_draft":
+		payload, err = t.updateDraft(authedCtx, session, input)
+	case "list_integrations":
+		payload, err = t.listIntegrations(session)
+	default:
+		err = fmt.Errorf("unsupported action %q", input.Action)
+	}
+	if err != nil {
+		return customToolError(toolUse.ID, err.Error())
+	}
+
+	content, err := json.Marshal(payload)
+	if err != nil {
+		return customToolError(toolUse.ID, fmt.Sprintf("encode result: %v", err))
+	}
+
+	return agents.CustomToolResult{
+		CustomToolUseID: toolUse.ID,
+		Content:         string(content),
+	}
+}
+
+func (t *SuperPlaneCanvasTool) validateSessionBoundInput(session agents.AgentSessionContext, requestedCanvasID string) error {
+	if strings.TrimSpace(session.CanvasID) == "" || strings.TrimSpace(session.OrganizationID) == "" || strings.TrimSpace(session.UserID) == "" {
+		return fmt.Errorf("agent session context is incomplete")
+	}
+	requestedCanvasID = strings.TrimSpace(requestedCanvasID)
+	if requestedCanvasID != "" && requestedCanvasID != session.CanvasID {
+		return fmt.Errorf("canvas_id %q is outside this agent session", requestedCanvasID)
+	}
+	return nil
+}
+
+func (t *SuperPlaneCanvasTool) read(ctx context.Context, session agents.AgentSessionContext, input superPlaneCanvasToolInput) (superPlaneCanvasReadResult, error) {
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return superPlaneCanvasReadResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	canvas, err := models.FindCanvas(uuid.MustParse(session.OrganizationID), canvasID)
+	if err != nil {
+		return superPlaneCanvasReadResult{}, fmt.Errorf("load canvas: %w", err)
+	}
+
+	draft, err := ownedDraftVersion(canvasID, uuid.MustParse(session.UserID))
+	if err != nil {
+		return superPlaneCanvasReadResult{}, fmt.Errorf("load draft: %w", err)
+	}
+
+	versionID := ""
+	source := "live"
+	if input.UseDraft == nil || *input.UseDraft {
+		if draft != nil {
+			versionID = draft.ID.String()
+			source = "draft"
+		}
+	}
+
+	canvasYAML, err := grpcCanvases.ReadRepositorySpecFile(ctx, session.OrganizationID, session.CanvasID, versionID, grpcCanvases.CanvasYAMLRepositoryPath)
+	if err != nil {
+		return superPlaneCanvasReadResult{}, fmt.Errorf("read canvas yaml: %w", err)
+	}
+
+	result := superPlaneCanvasReadResult{
+		Action:     "read",
+		CanvasID:   session.CanvasID,
+		Source:     source,
+		VersionID:  versionID,
+		Summary:    summarizeCanvasVersion(canvas, selectedVersion(canvas, draft, source)),
+		CanvasYAML: canvasYAML,
+	}
+
+	if draft != nil {
+		result.Draft = &superPlaneCanvasDraftResult{
+			VersionID:   draft.ID.String(),
+			DisplayName: draft.DisplayName,
+			BranchName:  stringValue(draft.BranchName),
+		}
+	}
+
+	if input.IncludeConsole {
+		consoleYAML, consoleErr := grpcCanvases.ReadRepositorySpecFile(ctx, session.OrganizationID, session.CanvasID, versionID, grpcCanvases.ConsoleYAMLRepositoryPath)
+		if consoleErr != nil {
+			return superPlaneCanvasReadResult{}, fmt.Errorf("read console yaml: %w", consoleErr)
+		}
+		result.ConsoleYAML = consoleYAML
+	}
+
+	if input.IncludeIntegrations {
+		integrations, integrationsErr := t.connectedIntegrations(uuid.MustParse(session.OrganizationID))
+		if integrationsErr != nil {
+			return superPlaneCanvasReadResult{}, integrationsErr
+		}
+		result.Integrations = integrations
+	}
+
+	return result, nil
+}
+
+func (t *SuperPlaneCanvasTool) updateDraft(ctx context.Context, session agents.AgentSessionContext, input superPlaneCanvasToolInput) (superPlaneCanvasUpdateResult, error) {
+	if t.encryptor == nil || t.registry == nil || t.authService == nil {
+		return superPlaneCanvasUpdateResult{}, fmt.Errorf("custom tool executor is missing canvas update dependencies")
+	}
+
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return superPlaneCanvasUpdateResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	draft, err := ensureOwnedDraftVersion(canvasID, uuid.MustParse(session.UserID))
+	if err != nil {
+		return superPlaneCanvasUpdateResult{}, fmt.Errorf("ensure draft: %w", err)
+	}
+
+	operations := []*pb.CanvasRepositoryFileOperation{}
+	hasCanvasUpdate := strings.TrimSpace(input.CanvasYAML) != ""
+	if hasCanvasUpdate {
+		operations = append(operations, &pb.CanvasRepositoryFileOperation{
+			Path:    grpcCanvases.CanvasYAMLRepositoryPath,
+			Content: []byte(input.CanvasYAML),
+		})
+	}
+	if strings.TrimSpace(input.ConsoleYAML) != "" {
+		operations = append(operations, &pb.CanvasRepositoryFileOperation{
+			Path:    grpcCanvases.ConsoleYAMLRepositoryPath,
+			Content: []byte(input.ConsoleYAML),
+		})
+	}
+	if len(operations) == 0 {
+		return superPlaneCanvasUpdateResult{}, fmt.Errorf("canvas_yaml or console_yaml is required for update_draft")
+	}
+
+	if err := grpcCanvases.ApplyRepositorySpecFileOperations(
+		ctx,
+		nil,
+		t.encryptor,
+		t.registry,
+		session.OrganizationID,
+		session.CanvasID,
+		draft.ID.String(),
+		t.webhookBaseURL,
+		t.authService,
+		resolveCustomToolAutoLayout(input.AutoLayout, hasCanvasUpdate),
+		operations,
+	); err != nil {
+		return superPlaneCanvasUpdateResult{}, err
+	}
+
+	updated, err := models.FindCanvasVersion(canvasID, draft.ID)
+	if err != nil {
+		return superPlaneCanvasUpdateResult{}, fmt.Errorf("load updated draft: %w", err)
+	}
+
+	return superPlaneCanvasUpdateResult{
+		Action:     "update_draft",
+		CanvasID:   session.CanvasID,
+		VersionID:  updated.ID.String(),
+		Draft:      superPlaneCanvasDraftResult{VersionID: updated.ID.String(), DisplayName: updated.DisplayName, BranchName: stringValue(updated.BranchName)},
+		NodeIssues: collectNodeIssues(updated.Nodes),
+		Summary:    summarizeCanvasVersion(nil, updated),
+	}, nil
+}
+
+func (t *SuperPlaneCanvasTool) listIntegrations(session agents.AgentSessionContext) (superPlaneCanvasIntegrationsResult, error) {
+	orgID, err := uuid.Parse(session.OrganizationID)
+	if err != nil {
+		return superPlaneCanvasIntegrationsResult{}, fmt.Errorf("invalid session organization id: %w", err)
+	}
+	integrations, err := t.connectedIntegrations(orgID)
+	if err != nil {
+		return superPlaneCanvasIntegrationsResult{}, err
+	}
+	return superPlaneCanvasIntegrationsResult{
+		Action:       "list_integrations",
+		CanvasID:     session.CanvasID,
+		Integrations: integrations,
+	}, nil
+}
+
+func (t *SuperPlaneCanvasTool) connectedIntegrations(orgID uuid.UUID) ([]superPlaneCanvasIntegrationResult, error) {
+	integrations, err := models.ListIntegrations(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("list integrations: %w", err)
+	}
+
+	result := make([]superPlaneCanvasIntegrationResult, 0, len(integrations))
+	for _, integration := range integrations {
+		result = append(result, superPlaneCanvasIntegrationResult{
+			ID:     integration.ID.String(),
+			Name:   integration.InstallationName,
+			Vendor: integration.AppName,
+			State:  integration.State,
+		})
+	}
+	return result, nil
+}
+
+func ownedDraftVersion(canvasID, userID uuid.UUID) (*models.CanvasVersion, error) {
+	drafts, err := models.ListDraftCanvasVersions(canvasID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range drafts {
+		if models.IsUserOwnedDraftVersion(&drafts[i], userID) && models.IsRegisteredDraftVersion(&drafts[i]) {
+			return &drafts[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func ensureOwnedDraftVersion(canvasID, userID uuid.UUID) (*models.CanvasVersion, error) {
+	if draft, err := ownedDraftVersion(canvasID, userID); err != nil || draft != nil {
+		return draft, err
+	}
+
+	var draft *models.CanvasVersion
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		created, createErr := models.CreateDraftBranchFromLiveInTransaction(tx, canvasID, userID, "", nil, nil)
+		draft = created
+		return createErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return draft, nil
+}
+
+func selectedVersion(canvas *models.Canvas, draft *models.CanvasVersion, source string) *models.CanvasVersion {
+	if source == "draft" {
+		return draft
+	}
+	if canvas == nil || canvas.LiveVersionID == nil {
+		return nil
+	}
+	version, err := models.FindCanvasVersion(canvas.ID, *canvas.LiveVersionID)
+	if err != nil {
+		return nil
+	}
+	return version
+}
+
+func summarizeCanvasVersion(canvas *models.Canvas, version *models.CanvasVersion) superPlaneCanvasSummary {
+	summary := superPlaneCanvasSummary{}
+	if canvas != nil {
+		summary.CanvasName = canvas.Name
+	}
+	if version == nil {
+		return summary
+	}
+	if summary.CanvasName == "" {
+		summary.CanvasName = version.Name
+	}
+	summary.NodeCount = len(version.Nodes)
+	summary.EdgeCount = len(version.Edges)
+	summary.Nodes = summarizeNodes(version.Nodes, 20)
+	return summary
+}
+
+func summarizeNodes(nodes []models.Node, limit int) []superPlaneCanvasNodeSummary {
+	count := len(nodes)
+	if count > limit {
+		count = limit
+	}
+	result := make([]superPlaneCanvasNodeSummary, 0, count)
+	for i := 0; i < count; i++ {
+		result = append(result, superPlaneCanvasNodeSummary{
+			ID:        nodes[i].ID,
+			Name:      nodes[i].Name,
+			Type:      nodes[i].Type,
+			Component: nodeRefName(nodes[i].Ref),
+			Issue:     firstNonEmptyString(stringPtrValue(nodes[i].ErrorMessage), stringPtrValue(nodes[i].WarningMessage)),
+		})
+	}
+	return result
+}
+
+func collectNodeIssues(nodes []models.Node) []superPlaneCanvasNodeIssue {
+	issues := []superPlaneCanvasNodeIssue{}
+	for _, node := range nodes {
+		if node.ErrorMessage != nil && strings.TrimSpace(*node.ErrorMessage) != "" {
+			issues = append(issues, superPlaneCanvasNodeIssue{NodeID: node.ID, NodeName: node.Name, Severity: "error", Message: strings.TrimSpace(*node.ErrorMessage)})
+		}
+		if node.WarningMessage != nil && strings.TrimSpace(*node.WarningMessage) != "" {
+			issues = append(issues, superPlaneCanvasNodeIssue{NodeID: node.ID, NodeName: node.Name, Severity: "warning", Message: strings.TrimSpace(*node.WarningMessage)})
+		}
+	}
+	return issues
+}
+
+func resolveCustomToolAutoLayout(input *superPlaneCanvasAutoLayoutInput, hasCanvasUpdate bool) *pb.CanvasAutoLayout {
+	if input == nil {
+		if !hasCanvasUpdate {
+			return nil
+		}
+		return &pb.CanvasAutoLayout{
+			Algorithm: pb.CanvasAutoLayout_ALGORITHM_HORIZONTAL,
+			Scope:     pb.CanvasAutoLayout_SCOPE_FULL_CANVAS,
+		}
+	}
+
+	layout := &pb.CanvasAutoLayout{
+		Algorithm: pb.CanvasAutoLayout_ALGORITHM_HORIZONTAL,
+		NodeIds:   append([]string(nil), input.NodeIDs...),
+	}
+
+	switch strings.TrimSpace(input.Scope) {
+	case "full_canvas", "full-canvas":
+		layout.Scope = pb.CanvasAutoLayout_SCOPE_FULL_CANVAS
+	case "connected_component", "connected-component":
+		layout.Scope = pb.CanvasAutoLayout_SCOPE_CONNECTED_COMPONENT
+	}
+
+	return layout
+}
+
+func nodeRefName(ref models.NodeRef) string {
+	switch {
+	case ref.Component != nil:
+		return ref.Component.Name
+	case ref.Trigger != nil:
+		return ref.Trigger.Name
+	case ref.Blueprint != nil:
+		return ref.Blueprint.ID
+	case ref.Widget != nil:
+		return ref.Widget.Name
+	default:
+		return ""
+	}
+}
+
+func customToolError(toolUseID, message string) agents.CustomToolResult {
+	content, _ := json.Marshal(map[string]string{"error": message})
+	return agents.CustomToolResult{
+		CustomToolUseID: toolUseID,
+		Content:         string(content),
+		IsError:         true,
+	}
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+type superPlaneCanvasToolInput struct {
+	Action              string                           `json:"action"`
+	CanvasID            string                           `json:"canvas_id,omitempty"`
+	UseDraft            *bool                            `json:"use_draft,omitempty"`
+	IncludeConsole      bool                             `json:"include_console,omitempty"`
+	IncludeIntegrations bool                             `json:"include_integrations,omitempty"`
+	CanvasYAML          string                           `json:"canvas_yaml,omitempty"`
+	ConsoleYAML         string                           `json:"console_yaml,omitempty"`
+	AutoLayout          *superPlaneCanvasAutoLayoutInput `json:"auto_layout,omitempty"`
+}
+
+type superPlaneCanvasAutoLayoutInput struct {
+	Scope   string   `json:"scope,omitempty"`
+	NodeIDs []string `json:"node_ids,omitempty"`
+}
+
+type superPlaneCanvasReadResult struct {
+	Action       string                              `json:"action"`
+	CanvasID     string                              `json:"canvas_id"`
+	Source       string                              `json:"source"`
+	VersionID    string                              `json:"version_id,omitempty"`
+	Draft        *superPlaneCanvasDraftResult        `json:"draft,omitempty"`
+	Summary      superPlaneCanvasSummary             `json:"summary"`
+	CanvasYAML   string                              `json:"canvas_yaml"`
+	ConsoleYAML  string                              `json:"console_yaml,omitempty"`
+	Integrations []superPlaneCanvasIntegrationResult `json:"integrations,omitempty"`
+}
+
+type superPlaneCanvasUpdateResult struct {
+	Action     string                      `json:"action"`
+	CanvasID   string                      `json:"canvas_id"`
+	VersionID  string                      `json:"version_id"`
+	Draft      superPlaneCanvasDraftResult `json:"draft"`
+	Summary    superPlaneCanvasSummary     `json:"summary"`
+	NodeIssues []superPlaneCanvasNodeIssue `json:"node_issues,omitempty"`
+}
+
+type superPlaneCanvasIntegrationsResult struct {
+	Action       string                              `json:"action"`
+	CanvasID     string                              `json:"canvas_id"`
+	Integrations []superPlaneCanvasIntegrationResult `json:"integrations"`
+}
+
+type superPlaneCanvasDraftResult struct {
+	VersionID   string `json:"version_id"`
+	DisplayName string `json:"display_name,omitempty"`
+	BranchName  string `json:"branch_name,omitempty"`
+}
+
+type superPlaneCanvasSummary struct {
+	CanvasName string                        `json:"canvas_name,omitempty"`
+	NodeCount  int                           `json:"node_count"`
+	EdgeCount  int                           `json:"edge_count"`
+	Nodes      []superPlaneCanvasNodeSummary `json:"nodes,omitempty"`
+}
+
+type superPlaneCanvasNodeSummary struct {
+	ID        string `json:"id"`
+	Name      string `json:"name,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Component string `json:"component,omitempty"`
+	Issue     string `json:"issue,omitempty"`
+}
+
+type superPlaneCanvasNodeIssue struct {
+	NodeID   string `json:"node_id"`
+	NodeName string `json:"node_name,omitempty"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type superPlaneCanvasIntegrationResult struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Vendor string `json:"vendor"`
+	State  string `json:"state"`
+}

--- a/pkg/agents/tools/superplane_canvas_tool_test.go
+++ b/pkg/agents/tools/superplane_canvas_tool_test.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+)
+
+func TestResolveCustomToolAutoLayout_DefaultsGraphUpdatesToFullCanvas(t *testing.T) {
+	layout := resolveCustomToolAutoLayout(nil, true)
+
+	require.NotNil(t, layout)
+	assert.Equal(t, pb.CanvasAutoLayout_ALGORITHM_HORIZONTAL, layout.Algorithm)
+	assert.Equal(t, pb.CanvasAutoLayout_SCOPE_FULL_CANVAS, layout.Scope)
+	assert.Empty(t, layout.NodeIds)
+}
+
+func TestResolveCustomToolAutoLayout_SkipsConsoleOnlyUpdates(t *testing.T) {
+	assert.Nil(t, resolveCustomToolAutoLayout(nil, false))
+}
+
+func TestResolveCustomToolAutoLayout_PreservesExplicitSettings(t *testing.T) {
+	layout := resolveCustomToolAutoLayout(&superPlaneCanvasAutoLayoutInput{
+		Scope:   "connected_component",
+		NodeIDs: []string{"node-1"},
+	}, true)
+
+	require.NotNil(t, layout)
+	assert.Equal(t, pb.CanvasAutoLayout_ALGORITHM_HORIZONTAL, layout.Algorithm)
+	assert.Equal(t, pb.CanvasAutoLayout_SCOPE_CONNECTED_COMPONENT, layout.Scope)
+	assert.Equal(t, []string{"node-1"}, layout.NodeIds)
+}
+
+func TestSummarizeNodes_UsesYamlComponentFieldName(t *testing.T) {
+	summary := summarizeNodes([]models.Node{
+		{
+			ID:   "node-1",
+			Name: "Notify",
+			Type: "TYPE_ACTION",
+			Ref:  models.NodeRef{Component: &models.ComponentRef{Name: "slack.sendTextMessage"}},
+		},
+	}, 20)
+
+	require.Len(t, summary, 1)
+	assert.Equal(t, "slack.sendTextMessage", summary[0].Component)
+
+	data, err := json.Marshal(summary[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"component":"slack.sendTextMessage"`)
+	assert.NotContains(t, string(data), `"ref"`)
+}

--- a/pkg/agents/tools/superplane_canvas_tool_test.go
+++ b/pkg/agents/tools/superplane_canvas_tool_test.go
@@ -1,14 +1,54 @@
 package tools
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/agents"
+	grpcCanvases "github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
+	"github.com/superplanehq/superplane/pkg/usage"
+	"github.com/superplanehq/superplane/test/support"
 )
+
+type rejectingCanvasUsageService struct{}
+
+func (rejectingCanvasUsageService) Enabled() bool { return true }
+func (rejectingCanvasUsageService) SetupAccount(context.Context, string) (*usagepb.SetupAccountResponse, error) {
+	return nil, nil
+}
+func (rejectingCanvasUsageService) SetupOrganization(context.Context, string, string, usage.SetupOrganizationDetails) (*usagepb.SetupOrganizationResponse, error) {
+	return nil, nil
+}
+func (rejectingCanvasUsageService) DescribeAccountLimits(context.Context, string) (*usagepb.DescribeAccountLimitsResponse, error) {
+	return nil, nil
+}
+func (rejectingCanvasUsageService) DescribeOrganizationLimits(context.Context, string) (*usagepb.DescribeOrganizationLimitsResponse, error) {
+	return nil, nil
+}
+func (rejectingCanvasUsageService) DescribeOrganizationUsage(context.Context, string) (*usagepb.DescribeOrganizationUsageResponse, error) {
+	return nil, nil
+}
+func (rejectingCanvasUsageService) CheckAccountLimits(context.Context, string, *usagepb.AccountState) (*usagepb.CheckAccountLimitsResponse, error) {
+	return &usagepb.CheckAccountLimitsResponse{Allowed: true}, nil
+}
+func (rejectingCanvasUsageService) CheckOrganizationLimits(context.Context, string, *usagepb.OrganizationState, *usagepb.CanvasState) (*usagepb.CheckOrganizationLimitsResponse, error) {
+	return &usagepb.CheckOrganizationLimitsResponse{
+		Allowed: false,
+		Violations: []*usagepb.LimitViolation{
+			{
+				Limit:           usagepb.LimitName_LIMIT_NAME_MAX_NODES_PER_CANVAS,
+				ConfiguredLimit: 1,
+				CurrentValue:    2,
+			},
+		},
+	}, nil
+}
 
 func TestResolveCustomToolAutoLayout_DefaultsGraphUpdatesToFullCanvas(t *testing.T) {
 	layout := resolveCustomToolAutoLayout(nil, true)
@@ -52,4 +92,47 @@ func TestSummarizeNodes_UsesYamlComponentFieldName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"component":"slack.sendTextMessage"`)
 	assert.NotContains(t, string(data), `"ref"`)
+}
+
+func TestSuperPlaneCanvasTool_UpdateDraftEnforcesUsageLimits(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	canvasYAML, err := grpcCanvases.ReadRepositorySpecFile(
+		context.Background(),
+		r.Organization.ID.String(),
+		canvas.ID.String(),
+		"",
+		grpcCanvases.CanvasYAMLRepositoryPath,
+	)
+	require.NoError(t, err)
+
+	input, err := json.Marshal(map[string]string{
+		"action":      "update_draft",
+		"canvas_yaml": canvasYAML,
+	})
+	require.NoError(t, err)
+
+	tool := NewSuperPlaneCanvasTool(SuperPlaneCanvasToolOptions{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		UsageService:   rejectingCanvasUsageService{},
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	result := tool.ExecuteCustomTool(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, agents.CustomToolUse{
+		ID:    "tool-1",
+		Name:  SuperPlaneCanvasToolName,
+		Input: string(input),
+	})
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Content, "canvas node limit exceeded")
 }

--- a/pkg/agents/tools/superplane_component_schema_tool.go
+++ b/pkg/agents/tools/superplane_component_schema_tool.go
@@ -1,0 +1,497 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+const SuperPlaneComponentSchemaToolName = "superplane_component_schema"
+
+const (
+	componentSchemaDefaultLimit = 40
+	componentSchemaExampleLimit = 1600
+)
+
+type SuperPlaneComponentSchemaTool struct {
+	registry *registry.Registry
+}
+
+func NewSuperPlaneComponentSchemaTool(registry *registry.Registry) *SuperPlaneComponentSchemaTool {
+	return &SuperPlaneComponentSchemaTool{registry: registry}
+}
+
+func (t *SuperPlaneComponentSchemaTool) CustomToolName() string {
+	return SuperPlaneComponentSchemaToolName
+}
+
+func (t *SuperPlaneComponentSchemaTool) ExecuteCustomTool(_ context.Context, _ agents.AgentSessionContext, toolUse agents.CustomToolUse) agents.CustomToolResult {
+	if toolUse.Name != SuperPlaneComponentSchemaToolName {
+		return customToolError(toolUse.ID, fmt.Sprintf("unsupported custom tool %q", toolUse.Name))
+	}
+	if t.registry == nil {
+		return customToolError(toolUse.ID, "component schema registry is not configured")
+	}
+
+	var input superPlaneComponentSchemaInput
+	if err := json.Unmarshal([]byte(toolUse.Input), &input); err != nil {
+		return customToolError(toolUse.ID, fmt.Sprintf("invalid input: %v", err))
+	}
+
+	payload := t.lookup(input)
+	content, err := json.Marshal(payload)
+	if err != nil {
+		return customToolError(toolUse.ID, fmt.Sprintf("encode result: %v", err))
+	}
+
+	return agents.CustomToolResult{
+		CustomToolUseID: toolUse.ID,
+		Content:         string(content),
+	}
+}
+
+func (t *SuperPlaneComponentSchemaTool) lookup(input superPlaneComponentSchemaInput) superPlaneComponentSchemaResult {
+	limit := input.Limit
+	if limit <= 0 || limit > componentSchemaDefaultLimit {
+		limit = componentSchemaDefaultLimit
+	}
+
+	seen := map[string]struct{}{}
+	components := []superPlaneComponentSchema{}
+	missing := []string{}
+	omitted := []string{}
+	truncated := false
+
+	for _, key := range normalizedList(input.ComponentKeys) {
+		component, err := t.lookupComponent(key, input.IncludeExamples)
+		if err != nil {
+			missing = append(missing, key)
+			continue
+		}
+		var limitHit bool
+		components, limitHit = appendUniqueComponent(components, seen, component, limit)
+		if limitHit {
+			omitted = append(omitted, key)
+			truncated = true
+		}
+	}
+
+	for _, vendor := range normalizedList(input.Vendors) {
+		for _, component := range t.vendorComponents(vendor, false) {
+			var limitHit bool
+			components, limitHit = appendUniqueComponent(components, seen, component, limit)
+			truncated = truncated || limitHit
+		}
+	}
+
+	query := strings.ToLower(strings.TrimSpace(input.Query))
+	if query != "" {
+		for _, component := range t.allComponents(false) {
+			if componentMatchesQuery(component, query) {
+				var limitHit bool
+				components, limitHit = appendUniqueComponent(components, seen, component, limit)
+				truncated = truncated || limitHit
+			}
+		}
+	}
+
+	sort.Slice(components, func(i, j int) bool { return components[i].Key < components[j].Key })
+	notes := []string{
+		"Use output_channels.name exactly in edge channel values; labels are display-only.",
+		"Components with requires_integration need a connected integration instance before running.",
+		"Do not read mounted component docs for these components unless validation reports an unfamiliar field or channel.",
+		"Examples are included only for exact component_keys lookups to keep broad vendor/query results compact.",
+	}
+	if truncated {
+		notes = append(notes, "Result was truncated by limit; request omitted component_keys explicitly or raise limit up to 40 if you need more.")
+	}
+
+	return superPlaneComponentSchemaResult{
+		Action:     "lookup",
+		Components: components,
+		Missing:    missing,
+		Omitted:    omitted,
+		Truncated:  truncated,
+		Notes:      notes,
+	}
+}
+
+func (t *SuperPlaneComponentSchemaTool) lookupComponent(key string, includeExamples bool) (superPlaneComponentSchema, error) {
+	if action, err := t.registry.GetAction(key); err == nil {
+		return actionSchema(action, integrationVendor(key), includeExamples), nil
+	}
+	if trigger, err := t.registry.GetTrigger(key); err == nil {
+		return triggerSchema(trigger, integrationVendor(key), includeExamples), nil
+	}
+	if widget, err := t.registry.GetWidget(key); err == nil {
+		return widgetSchema(widget), nil
+	}
+	return superPlaneComponentSchema{}, fmt.Errorf("component %s not found", key)
+}
+
+func (t *SuperPlaneComponentSchemaTool) vendorComponents(vendor string, includeExamples bool) []superPlaneComponentSchema {
+	integration, err := t.registry.GetIntegration(vendor)
+	if err != nil {
+		return nil
+	}
+
+	components := []superPlaneComponentSchema{}
+	for _, trigger := range integration.Triggers() {
+		components = append(components, triggerSchema(trigger, vendor, includeExamples))
+	}
+	for _, action := range integration.Actions() {
+		components = append(components, actionSchema(action, vendor, includeExamples))
+	}
+	sort.Slice(components, func(i, j int) bool { return components[i].Key < components[j].Key })
+	return components
+}
+
+func (t *SuperPlaneComponentSchemaTool) allComponents(includeExamples bool) []superPlaneComponentSchema {
+	components := []superPlaneComponentSchema{}
+	for _, trigger := range t.registry.ListTriggers() {
+		components = append(components, triggerSchema(trigger, "", includeExamples))
+	}
+	for _, action := range t.registry.ListActions() {
+		components = append(components, actionSchema(action, "", includeExamples))
+	}
+	for _, widget := range t.registry.ListWidgets() {
+		components = append(components, widgetSchema(widget))
+	}
+	for _, integration := range t.registry.ListIntegrations() {
+		components = append(components, t.vendorComponents(integration.Name(), includeExamples)...)
+	}
+	sort.Slice(components, func(i, j int) bool { return components[i].Key < components[j].Key })
+	return components
+}
+
+func actionSchema(action core.Action, vendor string, includeExamples bool) superPlaneComponentSchema {
+	outputChannels := outputChannelSchemas(safeActionOutputChannels(action))
+	if len(outputChannels) == 0 {
+		outputChannels = outputChannelSchemas([]core.OutputChannel{core.DefaultOutputChannel})
+	}
+
+	schema := superPlaneComponentSchema{
+		Key:                 action.Name(),
+		Kind:                "action",
+		Label:               action.Label(),
+		Description:         action.Description(),
+		RequiresIntegration: vendor,
+		Configuration:       fieldSchemas(safeActionConfiguration(action)),
+		OutputChannels:      outputChannels,
+	}
+	if includeExamples {
+		schema.ExampleOutput = compactJSON(safeActionExampleOutput(action), componentSchemaExampleLimit)
+	}
+	return schema
+}
+
+func triggerSchema(trigger core.Trigger, vendor string, includeExamples bool) superPlaneComponentSchema {
+	schema := superPlaneComponentSchema{
+		Key:                 trigger.Name(),
+		Kind:                "trigger",
+		Label:               trigger.Label(),
+		Description:         trigger.Description(),
+		RequiresIntegration: vendor,
+		Configuration:       fieldSchemas(safeTriggerConfiguration(trigger)),
+		OutputChannels:      outputChannelSchemas([]core.OutputChannel{core.DefaultOutputChannel}),
+	}
+	if includeExamples {
+		schema.ExampleData = compactJSON(safeTriggerExampleData(trigger), componentSchemaExampleLimit)
+	}
+	return schema
+}
+
+func widgetSchema(widget core.Widget) superPlaneComponentSchema {
+	return superPlaneComponentSchema{
+		Key:           widget.Name(),
+		Kind:          "widget",
+		Label:         widget.Label(),
+		Description:   widget.Description(),
+		Configuration: fieldSchemas(safeWidgetConfiguration(widget)),
+	}
+}
+
+func fieldSchemas(fields []configuration.Field) []superPlaneComponentField {
+	result := make([]superPlaneComponentField, 0, len(fields))
+	for _, field := range fields {
+		schema := superPlaneComponentField{
+			Name:               field.Name,
+			Type:               field.Type,
+			Label:              field.Label,
+			Description:        truncateString(field.Description, 300),
+			Required:           field.Required,
+			Default:            field.Default,
+			RequiredWhen:       requiredConditionSchemas(field.RequiredConditions),
+			VisibleWhen:        visibilityConditionSchemas(field.VisibilityConditions),
+			Options:            fieldOptions(field.TypeOptions),
+			ResourceType:       resourceType(field.TypeOptions),
+			ListItemDefinition: listItemDefinition(field.TypeOptions),
+		}
+		result = append(result, schema)
+	}
+	return result
+}
+
+func outputChannelSchemas(channels []core.OutputChannel) []superPlaneOutputChannel {
+	result := make([]superPlaneOutputChannel, 0, len(channels))
+	for _, channel := range channels {
+		name := channel.Name
+		if name == "" {
+			name = core.DefaultOutputChannel.Name
+		}
+		result = append(result, superPlaneOutputChannel{
+			Name:        name,
+			Label:       channel.Label,
+			Description: truncateString(channel.Description, 200),
+		})
+	}
+	return result
+}
+
+func requiredConditionSchemas(conditions []configuration.RequiredCondition) []superPlaneFieldCondition {
+	result := make([]superPlaneFieldCondition, 0, len(conditions))
+	for _, condition := range conditions {
+		result = append(result, superPlaneFieldCondition{
+			Field:  condition.Field,
+			Values: append([]string(nil), condition.Values...),
+		})
+	}
+	return result
+}
+
+func visibilityConditionSchemas(conditions []configuration.VisibilityCondition) []superPlaneFieldCondition {
+	result := make([]superPlaneFieldCondition, 0, len(conditions))
+	for _, condition := range conditions {
+		result = append(result, superPlaneFieldCondition{
+			Field:  condition.Field,
+			Values: append([]string(nil), condition.Values...),
+		})
+	}
+	return result
+}
+
+func safeActionOutputChannels(action core.Action) (channels []core.OutputChannel) {
+	defer func() {
+		if recover() != nil {
+			channels = nil
+		}
+	}()
+	return action.OutputChannels(nil)
+}
+
+func safeActionConfiguration(action core.Action) (fields []configuration.Field) {
+	defer func() {
+		if recover() != nil {
+			fields = nil
+		}
+	}()
+	return action.Configuration()
+}
+
+func safeActionExampleOutput(action core.Action) (output map[string]any) {
+	defer func() {
+		if recover() != nil {
+			output = nil
+		}
+	}()
+	return action.ExampleOutput()
+}
+
+func safeTriggerConfiguration(trigger core.Trigger) (fields []configuration.Field) {
+	defer func() {
+		if recover() != nil {
+			fields = nil
+		}
+	}()
+	return trigger.Configuration()
+}
+
+func safeTriggerExampleData(trigger core.Trigger) (data map[string]any) {
+	defer func() {
+		if recover() != nil {
+			data = nil
+		}
+	}()
+	return trigger.ExampleData()
+}
+
+func safeWidgetConfiguration(widget core.Widget) (fields []configuration.Field) {
+	defer func() {
+		if recover() != nil {
+			fields = nil
+		}
+	}()
+	return widget.Configuration()
+}
+
+func fieldOptions(options *configuration.TypeOptions) []superPlaneFieldOption {
+	if options == nil {
+		return nil
+	}
+	source := []configuration.FieldOption{}
+	switch {
+	case options.Select != nil:
+		source = options.Select.Options
+	case options.MultiSelect != nil:
+		source = options.MultiSelect.Options
+	case options.AnyPredicateList != nil:
+		source = options.AnyPredicateList.Operators
+	}
+
+	result := make([]superPlaneFieldOption, 0, len(source))
+	for _, option := range source {
+		result = append(result, superPlaneFieldOption{
+			Label:       option.Label,
+			Value:       option.Value,
+			Description: truncateString(option.Description, 160),
+		})
+	}
+	return result
+}
+
+func resourceType(options *configuration.TypeOptions) string {
+	if options == nil || options.Resource == nil {
+		return ""
+	}
+	return options.Resource.Type
+}
+
+func listItemDefinition(options *configuration.TypeOptions) []superPlaneComponentField {
+	if options == nil || options.List == nil || options.List.ItemDefinition == nil {
+		return nil
+	}
+	return fieldSchemas(options.List.ItemDefinition.Schema)
+}
+
+func appendUniqueComponent(
+	components []superPlaneComponentSchema,
+	seen map[string]struct{},
+	component superPlaneComponentSchema,
+	limit int,
+) ([]superPlaneComponentSchema, bool) {
+	if _, ok := seen[component.Key]; ok {
+		return components, false
+	}
+	if len(components) >= limit {
+		return components, true
+	}
+	seen[component.Key] = struct{}{}
+	return append(components, component), false
+}
+
+func normalizedList(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" && !slices.Contains(normalized, value) {
+			normalized = append(normalized, value)
+		}
+	}
+	return normalized
+}
+
+func integrationVendor(componentKey string) string {
+	parts := strings.SplitN(componentKey, ".", 2)
+	if len(parts) == 2 {
+		return parts[0]
+	}
+	return ""
+}
+
+func componentMatchesQuery(component superPlaneComponentSchema, query string) bool {
+	haystack := strings.ToLower(strings.Join([]string{
+		component.Key,
+		component.Kind,
+		component.Label,
+		component.Description,
+		component.RequiresIntegration,
+	}, " "))
+	return strings.Contains(haystack, query)
+}
+
+func compactJSON(value any, limit int) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return truncateString(string(data), limit)
+}
+
+func truncateString(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "..."
+}
+
+type superPlaneComponentSchemaInput struct {
+	ComponentKeys   []string `json:"component_keys,omitempty"`
+	Vendors         []string `json:"vendors,omitempty"`
+	Query           string   `json:"query,omitempty"`
+	IncludeExamples bool     `json:"include_examples,omitempty"`
+	Limit           int      `json:"limit,omitempty"`
+}
+
+type superPlaneComponentSchemaResult struct {
+	Action     string                      `json:"action"`
+	Components []superPlaneComponentSchema `json:"components"`
+	Missing    []string                    `json:"missing,omitempty"`
+	Omitted    []string                    `json:"omitted,omitempty"`
+	Truncated  bool                        `json:"truncated,omitempty"`
+	Notes      []string                    `json:"notes,omitempty"`
+}
+
+type superPlaneComponentSchema struct {
+	Key                 string                     `json:"key"`
+	Kind                string                     `json:"kind"`
+	Label               string                     `json:"label,omitempty"`
+	Description         string                     `json:"description,omitempty"`
+	RequiresIntegration string                     `json:"requires_integration,omitempty"`
+	Configuration       []superPlaneComponentField `json:"configuration,omitempty"`
+	OutputChannels      []superPlaneOutputChannel  `json:"output_channels,omitempty"`
+	ExampleData         string                     `json:"example_data,omitempty"`
+	ExampleOutput       string                     `json:"example_output,omitempty"`
+}
+
+type superPlaneComponentField struct {
+	Name               string                     `json:"name"`
+	Type               string                     `json:"type"`
+	Label              string                     `json:"label,omitempty"`
+	Description        string                     `json:"description,omitempty"`
+	Required           bool                       `json:"required"`
+	Default            any                        `json:"default,omitempty"`
+	ResourceType       string                     `json:"resource_type,omitempty"`
+	Options            []superPlaneFieldOption    `json:"options,omitempty"`
+	RequiredWhen       []superPlaneFieldCondition `json:"required_when,omitempty"`
+	VisibleWhen        []superPlaneFieldCondition `json:"visible_when,omitempty"`
+	ListItemDefinition []superPlaneComponentField `json:"list_item_definition,omitempty"`
+}
+
+type superPlaneFieldOption struct {
+	Label       string `json:"label"`
+	Value       string `json:"value"`
+	Description string `json:"description,omitempty"`
+}
+
+type superPlaneFieldCondition struct {
+	Field  string   `json:"field"`
+	Values []string `json:"values"`
+}
+
+type superPlaneOutputChannel struct {
+	Name        string `json:"name"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/pkg/agents/tools/superplane_component_schema_tool.go
+++ b/pkg/agents/tools/superplane_component_schema_tool.go
@@ -88,7 +88,10 @@ func (t *SuperPlaneComponentSchemaTool) lookup(input superPlaneComponentSchemaIn
 		for _, component := range t.vendorComponents(vendor, false) {
 			var limitHit bool
 			components, limitHit = appendUniqueComponent(components, seen, component, limit)
-			truncated = truncated || limitHit
+			if limitHit {
+				omitted = append(omitted, component.Key)
+				truncated = true
+			}
 		}
 	}
 
@@ -98,7 +101,10 @@ func (t *SuperPlaneComponentSchemaTool) lookup(input superPlaneComponentSchemaIn
 			if componentMatchesQuery(component, query) {
 				var limitHit bool
 				components, limitHit = appendUniqueComponent(components, seen, component, limit)
-				truncated = truncated || limitHit
+				if limitHit {
+					omitted = append(omitted, component.Key)
+					truncated = true
+				}
 			}
 		}
 	}

--- a/pkg/agents/tools/superplane_component_schema_tool_test.go
+++ b/pkg/agents/tools/superplane_component_schema_tool_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/crypto"
+	"github.com/superplanehq/superplane/pkg/registry"
+	"github.com/superplanehq/superplane/pkg/registryimports"
+)
+
+var _ = registryimports.Loaded
+
+func TestSuperPlaneComponentSchemaTool_ReturnsExactSlackSchema(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		ComponentKeys: []string{"slack.waitForButtonClick"},
+	})
+
+	require.Empty(t, result.Missing)
+	require.Len(t, result.Components, 1)
+
+	component := result.Components[0]
+	assert.Equal(t, "slack.waitForButtonClick", component.Key)
+	assert.Equal(t, "action", component.Kind)
+	assert.Equal(t, "slack", component.RequiresIntegration)
+	assert.ElementsMatch(t, []string{"channel", "message", "buttons", "timeout"}, componentFieldNames(component.Configuration))
+	assert.ElementsMatch(t, []string{"received", "timeout"}, outputChannelNames(component.OutputChannels))
+	assert.Contains(t, result.Notes, "Use output_channels.name exactly in edge channel values; labels are display-only.")
+	assert.NotContains(t, result.Notes, "Use output_channels.name exactly in edge sourceName values; labels are display-only.")
+}
+
+func TestSuperPlaneComponentSchemaTool_ReturnsCoreComponentSchema(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		ComponentKeys: []string{"wait"},
+	})
+
+	require.Empty(t, result.Missing)
+	require.Len(t, result.Components, 1)
+
+	component := result.Components[0]
+	assert.Equal(t, "wait", component.Key)
+	assert.Equal(t, "action", component.Kind)
+	assert.Empty(t, component.RequiresIntegration)
+	assert.Contains(t, componentFieldNames(component.Configuration), "mode")
+	assert.Contains(t, componentFieldNames(component.Configuration), "waitFor")
+	assert.Contains(t, componentFieldNames(component.Configuration), "unit")
+	assert.Contains(t, outputChannelNames(component.OutputChannels), "default")
+}
+
+func TestSuperPlaneComponentSchemaTool_ReturnsVendorComponents(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		Vendors:         []string{"slack"},
+		IncludeExamples: true,
+		Limit:           5,
+	})
+
+	require.NotEmpty(t, result.Components)
+	for _, component := range result.Components {
+		assert.Equal(t, "slack", component.RequiresIntegration)
+		assert.Contains(t, component.Key, "slack.")
+		assert.Empty(t, component.ExampleOutput)
+		assert.Empty(t, component.ExampleData)
+	}
+}
+
+func TestSuperPlaneComponentSchemaTool_ReportsMissingKeys(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		ComponentKeys: []string{"missing.component"},
+	})
+
+	assert.Empty(t, result.Components)
+	assert.Equal(t, []string{"missing.component"}, result.Missing)
+}
+
+func TestSuperPlaneComponentSchemaTool_ReportsOmittedValidKeysWhenLimited(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		ComponentKeys: []string{"wait", "noop"},
+		Limit:         1,
+	})
+
+	require.Len(t, result.Components, 1)
+	assert.Equal(t, "wait", result.Components[0].Key)
+	assert.Empty(t, result.Missing)
+	assert.Equal(t, []string{"noop"}, result.Omitted)
+	assert.True(t, result.Truncated)
+	assert.Contains(t, result.Notes, "Result was truncated by limit; request omitted component_keys explicitly or raise limit up to 40 if you need more.")
+}
+
+func newComponentSchemaTool(t *testing.T) *SuperPlaneComponentSchemaTool {
+	t.Helper()
+
+	reg, err := registry.NewRegistry(&crypto.NoOpEncryptor{}, registry.HTTPOptions{})
+	require.NoError(t, err)
+	return NewSuperPlaneComponentSchemaTool(reg)
+}
+
+func executeComponentSchemaTool(t *testing.T, tool *SuperPlaneComponentSchemaTool, input superPlaneComponentSchemaInput) superPlaneComponentSchemaResult {
+	t.Helper()
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	toolResult := tool.ExecuteCustomTool(context.Background(), agents.AgentSessionContext{}, agents.CustomToolUse{
+		ID:    "toolu_schema",
+		Name:  SuperPlaneComponentSchemaToolName,
+		Input: string(data),
+	})
+	require.False(t, toolResult.IsError)
+
+	var result superPlaneComponentSchemaResult
+	require.NoError(t, json.Unmarshal([]byte(toolResult.Content), &result))
+	return result
+}
+
+func componentFieldNames(fields []superPlaneComponentField) []string {
+	names := make([]string, 0, len(fields))
+	for _, field := range fields {
+		names = append(names, field.Name)
+	}
+	return names
+}
+
+func outputChannelNames(channels []superPlaneOutputChannel) []string {
+	names := make([]string, 0, len(channels))
+	for _, channel := range channels {
+		names = append(names, channel.Name)
+	}
+	return names
+}

--- a/pkg/agents/tools/superplane_component_schema_tool_test.go
+++ b/pkg/agents/tools/superplane_component_schema_tool_test.go
@@ -100,6 +100,38 @@ func TestSuperPlaneComponentSchemaTool_ReportsOmittedValidKeysWhenLimited(t *tes
 	assert.Contains(t, result.Notes, "Result was truncated by limit; request omitted component_keys explicitly or raise limit up to 40 if you need more.")
 }
 
+func TestSuperPlaneComponentSchemaTool_ReportsOmittedVendorMatchesWhenLimited(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		Vendors: []string{"slack"},
+		Limit:   1,
+	})
+
+	require.Len(t, result.Components, 1)
+	require.NotEmpty(t, result.Omitted)
+	assert.True(t, result.Truncated)
+	for _, key := range result.Omitted {
+		assert.Contains(t, key, "slack.")
+	}
+}
+
+func TestSuperPlaneComponentSchemaTool_ReportsOmittedQueryMatchesWhenLimited(t *testing.T) {
+	tool := newComponentSchemaTool(t)
+
+	result := executeComponentSchemaTool(t, tool, superPlaneComponentSchemaInput{
+		Query: "slack",
+		Limit: 1,
+	})
+
+	require.Len(t, result.Components, 1)
+	require.NotEmpty(t, result.Omitted)
+	assert.True(t, result.Truncated)
+	for _, key := range result.Omitted {
+		assert.NotEmpty(t, key)
+	}
+}
+
 func newComponentSchemaTool(t *testing.T) *SuperPlaneComponentSchemaTool {
 	t.Helper()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -203,6 +203,20 @@ func startWorkers(
 		go w.Start(context.Background())
 	}
 
+	var workerUsageService usage.Service
+	getWorkerUsageService := func() usage.Service {
+		if workerUsageService != nil {
+			return workerUsageService
+		}
+
+		service, err := usage.NewServiceFromEnv()
+		if err != nil {
+			log.Fatalf("failed to initialize usage service worker dependency: %v", err)
+		}
+		workerUsageService = service
+		return workerUsageService
+	}
+
 	if os.Getenv("START_ORGANIZATION_CLEANUP_WORKER") == "yes" {
 		log.Println("Starting Organization Cleanup Worker")
 
@@ -218,6 +232,7 @@ func startWorkers(
 				Registry:       registry,
 				WebhookBaseURL: getWebhookBaseURL(baseURL),
 				AuthService:    authService,
+				UsageService:   getWorkerUsageService(),
 			}),
 			agenttools.NewSuperPlaneComponentSchemaTool(registry),
 		))
@@ -225,10 +240,7 @@ func startWorkers(
 	}
 
 	if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" || os.Getenv("START_USAGE_SYNC_WORKER") == "yes" {
-		usageService, err := usage.NewServiceFromEnv()
-		if err != nil {
-			log.Fatalf("failed to initialize usage service worker dependency: %v", err)
-		}
+		usageService := getWorkerUsageService()
 
 		if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" && usageService.Enabled() {
 			log.Println("Starting Event Retention Worker")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/agents/anthropic"
+	agenttools "github.com/superplanehq/superplane/pkg/agents/tools"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/crypto"
@@ -211,7 +212,15 @@ func startWorkers(
 
 	if agentProvider != nil && os.Getenv("START_AGENT_STREAM_WORKER") != "no" {
 		log.Println("Starting Agent Stream Worker")
-		w := workers.NewAgentStreamWorker(agentProvider, rabbitMQURL)
+		w := workers.NewAgentStreamWorker(agentProvider, rabbitMQURL, agents.NewCustomToolRouter(
+			agenttools.NewSuperPlaneCanvasTool(agenttools.SuperPlaneCanvasToolOptions{
+				Encryptor:      encryptor,
+				Registry:       registry,
+				WebhookBaseURL: getWebhookBaseURL(baseURL),
+				AuthService:    authService,
+			}),
+			agenttools.NewSuperPlaneComponentSchemaTool(registry),
+		))
 		go w.Start(context.Background())
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,17 +204,32 @@ func startWorkers(
 	}
 
 	var workerUsageService usage.Service
-	getWorkerUsageService := func() usage.Service {
+	initWorkerUsageService := func() (usage.Service, error) {
 		if workerUsageService != nil {
-			return workerUsageService
+			return workerUsageService, nil
 		}
 
 		service, err := usage.NewServiceFromEnv()
 		if err != nil {
-			log.Fatalf("failed to initialize usage service worker dependency: %v", err)
+			return nil, err
 		}
 		workerUsageService = service
-		return workerUsageService
+		return workerUsageService, nil
+	}
+	getRequiredWorkerUsageService := func() usage.Service {
+		service, err := initWorkerUsageService()
+		if err != nil {
+			log.Fatalf("failed to initialize usage service worker dependency: %v", err)
+		}
+		return service
+	}
+	getOptionalWorkerUsageService := func() usage.Service {
+		service, err := initWorkerUsageService()
+		if err != nil {
+			log.Printf("usage service unavailable for agent canvas tool: %v", err)
+			return nil
+		}
+		return service
 	}
 
 	if os.Getenv("START_ORGANIZATION_CLEANUP_WORKER") == "yes" {
@@ -232,7 +247,7 @@ func startWorkers(
 				Registry:       registry,
 				WebhookBaseURL: getWebhookBaseURL(baseURL),
 				AuthService:    authService,
-				UsageService:   getWorkerUsageService(),
+				UsageService:   getOptionalWorkerUsageService(),
 			}),
 			agenttools.NewSuperPlaneComponentSchemaTool(registry),
 		))
@@ -240,7 +255,7 @@ func startWorkers(
 	}
 
 	if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" || os.Getenv("START_USAGE_SYNC_WORKER") == "yes" {
-		usageService := getWorkerUsageService()
+		usageService := getRequiredWorkerUsageService()
 
 		if os.Getenv("START_EVENT_RETENTION_WORKER") == "yes" && usageService.Enabled() {
 			log.Println("Starting Event Retention Worker")


### PR DESCRIPTION
## Summary
- register managed-agent custom tool definitions in the Anthropic agent config sync
- add `superplane_canvas` for session-bound canvas read, integration listing, and draft-only updates
- add `superplane_component_schema` for registry-backed component/schema lookups to reduce mounted-file reads
- wire the custom tool router into server startup

Closes #5254
Refs #5255

## Validation
- `make format.go`
- `make test PKG_TEST_PACKAGES='./pkg/models ./pkg/agents/... ./pkg/workers ./pkg/grpc/actions/agents'`
- `make lint`
- `make check.build.app`
- `make format.js`
- `make check.build.ui`
- post-rebase: `make test PKG_TEST_PACKAGES='./pkg/models ./pkg/agents/... ./pkg/workers ./pkg/grpc/actions/agents'`
- post-rebase: `make lint`
- post-rebase: `make check.build.app`
- post-rebase: `make check.build.ui`