### PR TITLE
feat: add CMD+K global command palette

### DIFF
--- a/web_src/src/components/GlobalCommandPalette/actions.ts
+++ b/web_src/src/components/GlobalCommandPalette/actions.ts
@@ -65,7 +65,7 @@ export function buildRootActions({
       onSelect: () => createCanvas(),
       keywords: ["new", "create", "canvas", "project", "workflow"],
     },
-    ...buildOrganizationRootActions(organizationId, organizationName, accountEmail, goTo),
+    ...buildOrganizationRootActions(organizationId, accountEmail, goTo),
     {
       id: "change-organization",
       label: "Change Organization",
@@ -208,7 +208,6 @@ export function buildAdminActions(goTo: (href: string) => void): PaletteAction[]
 
 function buildOrganizationRootActions(
   organizationId: string | null,
-  _organizationName: string,
   accountEmail: string,
   goTo: (href: string) => void,
 ): PaletteAction[] {

--- a/web_src/src/components/GlobalCommandPalette/actions.ts
+++ b/web_src/src/components/GlobalCommandPalette/actions.ts
@@ -1,35 +1,21 @@
 import {
   ArrowRightLeft,
   BookOpen,
-  Boxes,
   CircleUser,
   History,
-  Home,
   LogOut,
   MemoryStick,
   Palette,
   PanelTop,
   PlayCircle,
   Plus,
-  Search,
   Settings,
-  Shield,
   Sparkles,
 } from "lucide-react";
 import type { CanvasToolSidebarTab } from "@/components/CanvasToolSidebar/events";
 import { ADMIN_LINKS, DOCS_URL, ORGANIZATION_SETTINGS_LINKS } from "./constants";
 import { appSettingsPath } from "@/lib/appPaths";
-import type { CommandPage, PaletteAction, PalettePageAction } from "./types";
-
-type RootPageActionParams = {
-  accountInstallationAdmin: boolean;
-  canReadCanvas: boolean;
-  canUpdateCanvas: boolean;
-  canvasId: string | null;
-  currentCanvasName: string;
-  organizationId: string | null;
-  organizationName: string;
-};
+import type { PaletteAction } from "./types";
 
 type RootActionParams = {
   accountEmail: string;
@@ -56,59 +42,6 @@ type CurrentCanvasActionParams = {
   showToolTabCommands: boolean;
 };
 
-export function buildRootPageActions({
-  accountInstallationAdmin,
-  canReadCanvas,
-  canUpdateCanvas,
-  canvasId,
-  currentCanvasName,
-  organizationId,
-  organizationName,
-}: RootPageActionParams): PalettePageAction[] {
-  const actions: PalettePageAction[] = [
-    {
-      id: "open-canvas-page",
-      label: "Open Canvas",
-      description: organizationId ? "Search canvases in this organization" : "Choose an organization first",
-      icon: Search,
-      page: "open-canvas",
-      disabled: !organizationId || !canReadCanvas,
-      keywords: ["canvas", "project", "workflow", "search"],
-    },
-    {
-      id: "organization-settings-page",
-      label: "Organization Settings",
-      description: organizationId ? organizationName : "Choose an organization first",
-      icon: Settings,
-      page: "organization-settings",
-      disabled: !organizationId,
-      keywords: ["members", "groups", "roles", "integrations", "secrets", "service accounts", "billing"],
-    },
-    {
-      id: "canvas-settings-page",
-      label: "Canvas Settings",
-      description: canvasId ? currentCanvasName : "Pick a canvas to configure",
-      icon: Palette,
-      page: "canvas-settings",
-      disabled: !organizationId || !canReadCanvas || !canUpdateCanvas,
-      keywords: ["canvas", "settings", "configuration"],
-    },
-  ];
-
-  if (accountInstallationAdmin) {
-    actions.push({
-      id: "admin-page",
-      label: "Installation Admin",
-      description: "Organizations, accounts, settings, and runner tasks",
-      icon: Shield,
-      page: "admin",
-      keywords: ["admin", "installation", "accounts", "runner"],
-    });
-  }
-
-  return actions;
-}
-
 export function buildRootActions({
   accountEmail,
   canCreateCanvas,
@@ -124,21 +57,13 @@ export function buildRootActions({
   return [
     {
       id: "new-canvas",
-      label: createCanvasPending ? "Creating canvas..." : "New Canvas",
-      description: organizationId ? `Create a blank canvas in ${organizationName}` : "Choose an organization first",
+      label: createCanvasPending ? "Creating app..." : "New App",
+      description: organizationId ? `Create a blank app in ${organizationName}` : "Choose an organization first",
       icon: Plus,
       shortcut: `${shortcutModifier}/`,
       disabled: !canCreateCanvas || createCanvasPending,
       onSelect: () => createCanvas(),
       keywords: ["new", "create", "canvas", "project", "workflow"],
-    },
-    {
-      id: "new-organization",
-      label: "New Organization",
-      description: "Create another organization",
-      icon: Plus,
-      onSelect: () => goTo("/create"),
-      keywords: ["new", "create", "organization", "workspace"],
     },
     ...buildOrganizationRootActions(organizationId, organizationName, accountEmail, goTo),
     {
@@ -184,7 +109,7 @@ export function buildCurrentCanvasActions({
   const actions: PaletteAction[] = [
     {
       id: "current-canvas",
-      label: "Canvas",
+      label: "App",
       description: currentCanvasName,
       icon: Palette,
       onSelect: () => goToCurrentCanvasView(),
@@ -216,7 +141,7 @@ export function buildCurrentCanvasActions({
     },
     {
       id: "current-canvas-settings",
-      label: "Canvas Settings",
+      label: "App Settings",
       description: currentCanvasName,
       icon: Settings,
       disabled: !canUpdateCanvas,
@@ -283,29 +208,13 @@ export function buildAdminActions(goTo: (href: string) => void): PaletteAction[]
 
 function buildOrganizationRootActions(
   organizationId: string | null,
-  organizationName: string,
+  _organizationName: string,
   accountEmail: string,
   goTo: (href: string) => void,
 ): PaletteAction[] {
   if (!organizationId) return [];
 
   return [
-    {
-      id: "go-home",
-      label: "Canvases",
-      description: organizationName,
-      icon: Home,
-      onSelect: () => goTo(`/${organizationId}`),
-      keywords: ["home", "canvases", "projects"],
-    },
-    {
-      id: "templates",
-      label: "Templates",
-      description: "Browse reusable canvases",
-      icon: Boxes,
-      onSelect: () => goTo(`/${organizationId}/templates`),
-      keywords: ["template", "canvas"],
-    },
     {
       id: "profile",
       label: "Profile",
@@ -315,8 +224,4 @@ function buildOrganizationRootActions(
       keywords: ["account", "profile", "user"],
     },
   ];
-}
-
-export function openPageAction(page: CommandPage, onOpenPage: (page: CommandPage) => void) {
-  return () => onOpenPage(page);
 }

--- a/web_src/src/components/GlobalCommandPalette/hooks.ts
+++ b/web_src/src/components/GlobalCommandPalette/hooks.ts
@@ -36,6 +36,7 @@ export function usePalettePermissions(organizationId: string | null, enabled: bo
 
 export function useCommandPaletteShortcuts({
   canvasId,
+  organizationId,
   createCanvas,
   createCanvasDisabled,
   enabled,
@@ -47,6 +48,7 @@ export function useCommandPaletteShortcuts({
   setSearch,
 }: {
   canvasId: string | null;
+  organizationId: string | null;
   createCanvas: () => Promise<void>;
   createCanvasDisabled: boolean;
   enabled: boolean;
@@ -78,7 +80,7 @@ export function useCommandPaletteShortcuts({
     const onKeyDown = (event: KeyboardEvent) => {
       const usesModifier = event.metaKey || event.ctrlKey;
 
-      if (usesModifier && event.key === "k" && !canvasId && !isEditableTarget(event.target)) {
+      if (usesModifier && event.key === "k" && !canvasId && organizationId && !isEditableTarget(event.target)) {
         event.preventDefault();
         setOpen((prev) => !prev);
         return;
@@ -99,7 +101,7 @@ export function useCommandPaletteShortcuts({
 
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [canvasId, createCanvas, createCanvasDisabled, enabled, open, page, search, setOpen, setPage]);
+  }, [canvasId, organizationId, createCanvas, createCanvasDisabled, enabled, open, page, search, setOpen, setPage]);
 }
 
 function toPermissionSet(permissions: AuthorizationPermission[]) {

--- a/web_src/src/components/GlobalCommandPalette/hooks.ts
+++ b/web_src/src/components/GlobalCommandPalette/hooks.ts
@@ -35,6 +35,7 @@ export function usePalettePermissions(organizationId: string | null, enabled: bo
 }
 
 export function useCommandPaletteShortcuts({
+  canvasId,
   createCanvas,
   createCanvasDisabled,
   enabled,
@@ -45,6 +46,7 @@ export function useCommandPaletteShortcuts({
   setPage,
   setSearch,
 }: {
+  canvasId: string | null;
   createCanvas: () => Promise<void>;
   createCanvasDisabled: boolean;
   enabled: boolean;
@@ -76,6 +78,12 @@ export function useCommandPaletteShortcuts({
     const onKeyDown = (event: KeyboardEvent) => {
       const usesModifier = event.metaKey || event.ctrlKey;
 
+      if (usesModifier && event.key === "k" && !canvasId && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        setOpen((prev) => !prev);
+        return;
+      }
+
       if (usesModifier && event.key === COMMAND_SHORTCUT && !isEditableTarget(event.target)) {
         if (createCanvasDisabled) return;
         event.preventDefault();
@@ -91,7 +99,7 @@ export function useCommandPaletteShortcuts({
 
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [createCanvas, createCanvasDisabled, enabled, open, page, search, setOpen, setPage]);
+  }, [canvasId, createCanvas, createCanvasDisabled, enabled, open, page, search, setOpen, setPage]);
 }
 
 function toPermissionSet(permissions: AuthorizationPermission[]) {

--- a/web_src/src/components/GlobalCommandPalette/hooks.ts
+++ b/web_src/src/components/GlobalCommandPalette/hooks.ts
@@ -80,13 +80,7 @@ export function useCommandPaletteShortcuts({
     const onKeyDown = (event: KeyboardEvent) => {
       const usesModifier = event.metaKey || event.ctrlKey;
 
-      if (
-        usesModifier &&
-        event.key === "k" &&
-        !canvasId &&
-        organizationId &&
-        (open || !isEditableTarget(event.target))
-      ) {
+      if (canToggleCommandPalette({ canvasId, event, open, organizationId, usesModifier })) {
         event.preventDefault();
         setOpen((prev) => !prev);
         return;
@@ -121,4 +115,24 @@ function toPermissionSet(permissions: AuthorizationPermission[]) {
       })
       .filter((value): value is string => !!value),
   );
+}
+
+function canToggleCommandPalette({
+  canvasId,
+  event,
+  open,
+  organizationId,
+  usesModifier,
+}: {
+  canvasId: string | null;
+  event: KeyboardEvent;
+  open: boolean;
+  organizationId: string | null;
+  usesModifier: boolean;
+}) {
+  if (!usesModifier) return false;
+  if (event.key !== "k") return false;
+  if (canvasId) return false;
+  if (!organizationId) return false;
+  return open || !isEditableTarget(event.target);
 }

--- a/web_src/src/components/GlobalCommandPalette/hooks.ts
+++ b/web_src/src/components/GlobalCommandPalette/hooks.ts
@@ -80,7 +80,13 @@ export function useCommandPaletteShortcuts({
     const onKeyDown = (event: KeyboardEvent) => {
       const usesModifier = event.metaKey || event.ctrlKey;
 
-      if (usesModifier && event.key === "k" && !canvasId && organizationId && !isEditableTarget(event.target)) {
+      if (
+        usesModifier &&
+        event.key === "k" &&
+        !canvasId &&
+        organizationId &&
+        (open || !isEditableTarget(event.target))
+      ) {
         event.preventDefault();
         setOpen((prev) => !prev);
         return;

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -3,52 +3,43 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type * as ReactRouterDom from "react-router-dom";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GlobalCommandPalette } from ".";
-import { registerCanvasNodeSearchProvider } from "./canvasNodeSearchStore";
 import { openGlobalCommandPalette } from "./controller";
 
-const {
-  accountState,
-  createCanvasMock,
-  defaultAccount,
-  defaultPermissions,
-  featureState,
-  navigateMock,
-  permissionsState,
-} = vi.hoisted(() => {
-  const defaultAccount = {
-    id: "account-1",
-    name: "Ada Lovelace",
-    email: "ada@example.com",
-    avatar_url: "",
-    installation_admin: true,
-    has_password: true,
-  };
-  type Account = typeof defaultAccount;
-  const defaultPermissions = [
-    { resource: "canvases", action: "create" },
-    { resource: "canvases", action: "read" },
-    { resource: "canvases", action: "update" },
-    { resource: "org", action: "read" },
-    { resource: "members", action: "read" },
-    { resource: "service_accounts", action: "read" },
-    { resource: "groups", action: "read" },
-    { resource: "roles", action: "read" },
-    { resource: "integrations", action: "read" },
-    { resource: "secrets", action: "read" },
-  ];
+const { accountState, createCanvasMock, defaultAccount, defaultPermissions, navigateMock, permissionsState } =
+  vi.hoisted(() => {
+    const defaultAccount = {
+      id: "account-1",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      avatar_url: "",
+      installation_admin: true,
+      has_password: true,
+    };
+    type Account = typeof defaultAccount;
+    const defaultPermissions = [
+      { resource: "canvases", action: "create" },
+      { resource: "canvases", action: "read" },
+      { resource: "canvases", action: "update" },
+      { resource: "org", action: "read" },
+      { resource: "members", action: "read" },
+      { resource: "service_accounts", action: "read" },
+      { resource: "groups", action: "read" },
+      { resource: "roles", action: "read" },
+      { resource: "integrations", action: "read" },
+      { resource: "secrets", action: "read" },
+    ];
 
-  return {
-    accountState: { account: defaultAccount as Account | null, loading: false },
-    createCanvasMock: vi.fn(),
-    defaultAccount,
-    defaultPermissions,
-    featureState: { managedAgentsEnabled: true },
-    navigateMock: vi.fn(),
-    permissionsState: { permissions: defaultPermissions },
-  };
-});
+    return {
+      accountState: { account: defaultAccount as Account | null, loading: false },
+      createCanvasMock: vi.fn(),
+      defaultAccount,
+      defaultPermissions,
+      navigateMock: vi.fn(),
+      permissionsState: { permissions: defaultPermissions },
+    };
+  });
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
@@ -115,12 +106,25 @@ vi.mock("@/hooks/useOrganizationData", () => ({
     data: { enabled: true },
     error: null,
   }),
+  useOrganizationInviteLink: () => ({
+    data: { token: "test-invite-token", enabled: true },
+  }),
 }));
 
-vi.mock("@/hooks/useExperimentalFeature", () => ({
-  useExperimentalFeature: () => ({
-    has: (feature: string) => feature === "claude_managed_agents" && featureState.managedAgentsEnabled,
-    enabledExperimentalFeatures: featureState.managedAgentsEnabled ? ["claude_managed_agents"] : [],
+vi.mock("@/hooks/useIntegrations", () => ({
+  useConnectedIntegrations: () => ({
+    data: [
+      {
+        metadata: { id: "int-1", name: "puppies-github", integrationName: "github" },
+        status: { state: "ready" },
+      },
+    ],
+  }),
+}));
+
+vi.mock("@/hooks/useServiceAccounts", () => ({
+  useServiceAccounts: () => ({
+    data: [{ id: "sa-1", name: "deploy-bot" }],
   }),
 }));
 
@@ -128,13 +132,11 @@ vi.mock("@/lib/canvasNameGenerator", () => ({
   generateCanvasName: () => "generated-canvas",
 }));
 
-let unregisterCanvasNodeSearchProvider: (() => void) | undefined;
-
 function openPalette() {
   openGlobalCommandPalette();
 }
 
-function renderPalette(path = "/org-1/apps/canvas-1") {
+function renderPalette(path = "/org-1") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -160,58 +162,20 @@ describe("GlobalCommandPalette", () => {
     createCanvasMock.mockResolvedValue({ data: { canvas: { metadata: { id: "canvas-new" } } } });
     navigateMock.mockReset();
     permissionsState.permissions = [...defaultPermissions];
-    featureState.managedAgentsEnabled = true;
   });
 
-  afterEach(() => {
-    unregisterCanvasNodeSearchProvider?.();
-    unregisterCanvasNodeSearchProvider = undefined;
-  });
-
-  it("opens and shows contextual commands", async () => {
+  it("opens and shows quick links", async () => {
     renderPalette();
 
     openPalette();
 
-    expect(await screen.findByPlaceholderText("Search components and commands")).toBeInTheDocument();
-    expect(screen.getByText("New Canvas")).toBeInTheDocument();
-    expect(screen.getByText("Console")).toBeInTheDocument();
-    expect(screen.getByText("Agent")).toBeInTheDocument();
-    expect(screen.getByText("Versions")).toBeInTheDocument();
-    expect(screen.getByText("Organization Settings")).toBeInTheDocument();
-    expect(screen.getByText("Installation Admin")).toBeInTheDocument();
-  });
-
-  it("hides the agent command when managed agents are disabled", async () => {
-    featureState.managedAgentsEnabled = false;
-    renderPalette();
-
-    openPalette();
-
-    expect(await screen.findByPlaceholderText("Search components and commands")).toBeInTheDocument();
-    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
-    expect(screen.getByText("Versions")).toBeInTheDocument();
-  });
-
-  it("opens current canvas tool tabs from commands", async () => {
-    const user = userEvent.setup();
-    const dispatchEventSpy = vi.spyOn(window, "dispatchEvent");
-    renderPalette("/org-1/apps/canvas-1?view=memory");
-
-    openPalette();
-    await user.click(await screen.findByText("Versions"));
-
-    await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-1");
-      expect(dispatchEventSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "canvas-tool-sidebar:select-tab",
-          detail: { tab: "versions" },
-        }),
-      );
-    });
-
-    dispatchEventSpy.mockRestore();
+    expect(await screen.findByPlaceholderText("Find apps, integrations, and commands...")).toBeInTheDocument();
+    expect(screen.getByText("New App")).toBeInTheDocument();
+    expect(screen.getByText("Copy Invite Link")).toBeInTheDocument();
+    expect(screen.getByText("Apps")).toBeInTheDocument();
+    expect(screen.getByText("Integrations")).toBeInTheDocument();
+    expect(screen.getByText("Go to Docs")).toBeInTheDocument();
+    expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });
 
   it("does not open before the account is available", () => {
@@ -220,73 +184,67 @@ describe("GlobalCommandPalette", () => {
 
     openPalette();
 
-    expect(screen.queryByPlaceholderText("What can we help with?")).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText("Search components and commands")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Find apps, integrations, and commands...")).not.toBeInTheDocument();
   });
 
-  it("does not treat apps/new as a current canvas route", async () => {
-    renderPalette("/org-1/apps/new");
-
-    openPalette();
-
-    expect(await screen.findByPlaceholderText("What can we help with?")).toBeInTheDocument();
-    expect(screen.queryByText("Console")).not.toBeInTheDocument();
-    expect(screen.queryByText("Versions")).not.toBeInTheDocument();
-    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
-  });
-
-  it("opens organization settings as a nested command page", async () => {
+  it("expands app list when clicking Apps", async () => {
     const user = userEvent.setup();
     renderPalette();
 
     openPalette();
-    await user.click(await screen.findByText("Organization Settings"));
-    await user.click(await screen.findByText("Members"));
+    await user.click(await screen.findByText("Apps"));
 
-    expect(navigateMock).toHaveBeenCalledWith("/org-1/settings/members");
+    expect(await screen.findByText("Deploy API")).toBeInTheDocument();
+    expect(screen.getByText("Database Backups")).toBeInTheDocument();
   });
 
-  it("lists canvases when opening canvas settings outside a canvas route", async () => {
+  it("navigates to an app when selected from expanded list", async () => {
     const user = userEvent.setup();
-    renderPalette("/org-1");
+    renderPalette();
 
     openPalette();
-    await user.click(await screen.findByText("Canvas Settings"));
+    await user.click(await screen.findByText("Apps"));
     await user.click(await screen.findByText("Database Backups"));
 
-    expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-2/settings");
+    expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-2");
   });
 
-  it("disables canvas settings commands without canvas update permission", async () => {
-    permissionsState.permissions = defaultPermissions.filter(
-      (permission) => !(permission.resource === "canvases" && permission.action === "update"),
-    );
+  it("searches apps by name", async () => {
+    const user = userEvent.setup();
     renderPalette();
 
     openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "Deploy");
 
-    await screen.findByPlaceholderText("Search components and commands");
-    const settingsItems = screen.getAllByText("Canvas Settings").map((label) => label.closest("[cmdk-item]"));
-
-    expect(settingsItems).toHaveLength(2);
-    settingsItems.forEach((item) => expect(item).toHaveAttribute("data-disabled", "true"));
+    expect(await screen.findByText("Deploy API")).toBeInTheDocument();
   });
 
-  it("uses template route canvas ids for contextual canvas commands", async () => {
-    renderPalette("/org-1/templates/canvas-1");
+  it("searches integrations by name", async () => {
+    const user = userEvent.setup();
+    renderPalette();
 
     openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "puppies");
 
-    expect(await screen.findByPlaceholderText("Search components and commands")).toBeInTheDocument();
-    expect(screen.getByText("Console")).toBeInTheDocument();
+    expect(await screen.findByText("puppies-github")).toBeInTheDocument();
   });
 
-  it("creates a canvas with the quick shortcut", async () => {
+  it("searches service accounts by name", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "deploy-bot");
+
+    expect(await screen.findByText("deploy-bot")).toBeInTheDocument();
+  });
+
+  it("creates an app with the quick shortcut", async () => {
     renderPalette();
 
     openPalette();
     await waitFor(() => {
-      expect(screen.getByText("New Canvas").closest("[cmdk-item]")).not.toHaveAttribute("data-disabled", "true");
+      expect(screen.getByText("New App").closest("[cmdk-item]")).not.toHaveAttribute("data-disabled", "true");
     });
     fireEvent.keyDown(document, { key: "/", metaKey: true });
 
@@ -296,34 +254,16 @@ describe("GlobalCommandPalette", () => {
     expect(navigateMock).toHaveBeenCalledWith("/org-1/apps/canvas-new");
   });
 
-  it("searches canvas components from the root command palette", async () => {
+  it("collapses expanded section when back is clicked", async () => {
     const user = userEvent.setup();
-    const selectNode = vi.fn();
-    unregisterCanvasNodeSearchProvider = registerCanvasNodeSearchProvider({
-      searchNodes: (query) =>
-        [
-          {
-            id: "node-api",
-            label: "Deploy API",
-            iconSlug: "box",
-            keywords: ["deploy api", "node-api"],
-          },
-          {
-            id: "node-worker",
-            label: "Refresh Worker",
-            iconSlug: "box",
-            keywords: ["refresh worker", "node-worker"],
-          },
-        ].filter((node) => node.label.toLowerCase().includes(query.toLowerCase())),
-      selectNode,
-    });
-
     renderPalette();
 
     openPalette();
-    await user.type(await screen.findByPlaceholderText("Search components and commands"), "worker");
-    await user.click(await screen.findByText("Refresh Worker"));
+    await user.click(await screen.findByText("Apps"));
+    expect(await screen.findByText("Deploy API")).toBeInTheDocument();
 
-    expect(selectNode).toHaveBeenCalledWith("node-worker");
+    await user.click(screen.getByText("Back"));
+    expect(screen.queryByText("Deploy API")).not.toBeInTheDocument();
+    expect(screen.getByText("Apps")).toBeInTheDocument();
   });
 });

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -178,6 +178,19 @@ describe("GlobalCommandPalette", () => {
     expect(screen.getByText("Sign Out")).toBeInTheDocument();
   });
 
+  it("closes with CMD+K while the command input is focused", async () => {
+    renderPalette();
+
+    openPalette();
+    const input = await screen.findByPlaceholderText("Find apps, integrations, and commands...");
+    input.focus();
+    fireEvent.keyDown(input, { key: "k", metaKey: true });
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Find apps, integrations, and commands...")).not.toBeInTheDocument();
+    });
+  });
+
   it("does not open before the account is available", () => {
     accountState.account = null;
     renderPalette("/login");

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -136,6 +136,10 @@ vi.mock("@/hooks/useIntegrations", () => ({
         metadata: { id: "int-1", name: "puppies-github", integrationName: "github" },
         status: { state: "ready" },
       },
+      {
+        metadata: { id: "int-2", name: "deploy-alerts", integrationName: "slack" },
+        status: { state: "ready" },
+      },
     ],
   }),
 }));
@@ -269,6 +273,16 @@ describe("GlobalCommandPalette", () => {
     expect(await screen.findByText("Deploy API")).toBeInTheDocument();
   });
 
+  it("searches apps by description", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "Production");
+
+    expect(await screen.findByText("Deploy API")).toBeInTheDocument();
+  });
+
   it("searches integrations by name", async () => {
     const user = userEvent.setup();
     renderPalette();
@@ -277,6 +291,16 @@ describe("GlobalCommandPalette", () => {
     await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "puppies");
 
     expect(await screen.findByText("puppies-github")).toBeInTheDocument();
+  });
+
+  it("searches integrations by provider name", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "slack");
+
+    expect(await screen.findByText("deploy-alerts")).toBeInTheDocument();
   });
 
   it("searches service accounts by name", async () => {

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -313,6 +313,17 @@ describe("GlobalCommandPalette", () => {
     expect(await screen.findByText("deploy-bot")).toBeInTheDocument();
   });
 
+  it("does not match every result by shared category labels", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "service");
+
+    expect(screen.queryByText("deploy-bot")).not.toBeInTheDocument();
+    expect(await screen.findByText("No results found.")).toBeInTheDocument();
+  });
+
   it("searches canvas nodes from the canvas page", async () => {
     const user = userEvent.setup();
     const selectNode = vi.fn();

--- a/web_src/src/components/GlobalCommandPalette/index.spec.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.spec.tsx
@@ -3,43 +3,57 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type * as ReactRouterDom from "react-router-dom";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GlobalCommandPalette } from ".";
+import { registerCanvasNodeSearchProvider } from "./canvasNodeSearchStore";
 import { openGlobalCommandPalette } from "./controller";
 
-const { accountState, createCanvasMock, defaultAccount, defaultPermissions, navigateMock, permissionsState } =
-  vi.hoisted(() => {
-    const defaultAccount = {
-      id: "account-1",
-      name: "Ada Lovelace",
-      email: "ada@example.com",
-      avatar_url: "",
-      installation_admin: true,
-      has_password: true,
-    };
-    type Account = typeof defaultAccount;
-    const defaultPermissions = [
-      { resource: "canvases", action: "create" },
-      { resource: "canvases", action: "read" },
-      { resource: "canvases", action: "update" },
-      { resource: "org", action: "read" },
-      { resource: "members", action: "read" },
-      { resource: "service_accounts", action: "read" },
-      { resource: "groups", action: "read" },
-      { resource: "roles", action: "read" },
-      { resource: "integrations", action: "read" },
-      { resource: "secrets", action: "read" },
-    ];
+const {
+  accountState,
+  createCanvasMock,
+  defaultAccount,
+  defaultPermissions,
+  inviteLinkQueryState,
+  inviteLinkState,
+  navigateMock,
+  permissionsState,
+  writeTextMock,
+} = vi.hoisted(() => {
+  const defaultAccount = {
+    id: "account-1",
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    avatar_url: "",
+    installation_admin: true,
+    has_password: true,
+  };
+  type Account = typeof defaultAccount;
+  const defaultPermissions = [
+    { resource: "canvases", action: "create" },
+    { resource: "canvases", action: "read" },
+    { resource: "canvases", action: "update" },
+    { resource: "org", action: "read" },
+    { resource: "members", action: "read" },
+    { resource: "members", action: "create" },
+    { resource: "service_accounts", action: "read" },
+    { resource: "groups", action: "read" },
+    { resource: "roles", action: "read" },
+    { resource: "integrations", action: "read" },
+    { resource: "secrets", action: "read" },
+  ];
 
-    return {
-      accountState: { account: defaultAccount as Account | null, loading: false },
-      createCanvasMock: vi.fn(),
-      defaultAccount,
-      defaultPermissions,
-      navigateMock: vi.fn(),
-      permissionsState: { permissions: defaultPermissions },
-    };
-  });
+  return {
+    accountState: { account: defaultAccount as Account | null, loading: false },
+    createCanvasMock: vi.fn(),
+    defaultAccount,
+    defaultPermissions,
+    inviteLinkQueryState: { enabledValues: [] as boolean[] },
+    inviteLinkState: { data: { token: "test-invite-token", enabled: true } },
+    navigateMock: vi.fn(),
+    permissionsState: { permissions: defaultPermissions },
+    writeTextMock: vi.fn(),
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof ReactRouterDom>("react-router-dom");
@@ -106,9 +120,13 @@ vi.mock("@/hooks/useOrganizationData", () => ({
     data: { enabled: true },
     error: null,
   }),
-  useOrganizationInviteLink: () => ({
-    data: { token: "test-invite-token", enabled: true },
-  }),
+  useOrganizationInviteLink: (_organizationId: string, enabled: boolean) => {
+    inviteLinkQueryState.enabledValues.push(enabled);
+    return {
+      data: enabled ? inviteLinkState.data : undefined,
+      isLoading: false,
+    };
+  },
 }));
 
 vi.mock("@/hooks/useIntegrations", () => ({
@@ -153,6 +171,15 @@ function renderPalette(path = "/org-1") {
   );
 }
 
+function installClipboardWriteMock() {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: writeTextMock },
+  });
+}
+
+let unregisterCanvasNodeSearchProvider: (() => void) | null = null;
+
 describe("GlobalCommandPalette", () => {
   beforeEach(() => {
     accountState.account = defaultAccount;
@@ -161,7 +188,17 @@ describe("GlobalCommandPalette", () => {
     createCanvasMock.mockReset();
     createCanvasMock.mockResolvedValue({ data: { canvas: { metadata: { id: "canvas-new" } } } });
     navigateMock.mockReset();
+    inviteLinkQueryState.enabledValues = [];
+    inviteLinkState.data = { token: "test-invite-token", enabled: true };
     permissionsState.permissions = [...defaultPermissions];
+    writeTextMock.mockReset();
+    writeTextMock.mockResolvedValue(undefined);
+    installClipboardWriteMock();
+  });
+
+  afterEach(() => {
+    unregisterCanvasNodeSearchProvider?.();
+    unregisterCanvasNodeSearchProvider = null;
   });
 
   it("opens and shows quick links", async () => {
@@ -171,7 +208,7 @@ describe("GlobalCommandPalette", () => {
 
     expect(await screen.findByPlaceholderText("Find apps, integrations, and commands...")).toBeInTheDocument();
     expect(screen.getByText("New App")).toBeInTheDocument();
-    expect(screen.getByText("Copy Invite Link")).toBeInTheDocument();
+    expect(await screen.findByText("Copy Invite Link")).toBeInTheDocument();
     expect(screen.getByText("Apps")).toBeInTheDocument();
     expect(screen.getByText("Integrations")).toBeInTheDocument();
     expect(screen.getByText("Go to Docs")).toBeInTheDocument();
@@ -250,6 +287,104 @@ describe("GlobalCommandPalette", () => {
     await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "deploy-bot");
 
     expect(await screen.findByText("deploy-bot")).toBeInTheDocument();
+  });
+
+  it("searches canvas nodes from the canvas page", async () => {
+    const user = userEvent.setup();
+    const selectNode = vi.fn();
+    unregisterCanvasNodeSearchProvider = registerCanvasNodeSearchProvider({
+      searchNodes: (query) =>
+        query.toLowerCase().includes("deploy")
+          ? [
+              {
+                id: "node-1",
+                label: "Deploy component",
+                iconSlug: "box",
+                keywords: ["deploy component", "node-1"],
+              },
+            ]
+          : [],
+      selectNode,
+    });
+    renderPalette("/org-1/apps/canvas-1");
+
+    openPalette();
+    await user.type(await screen.findByPlaceholderText("Find apps, integrations, and commands..."), "deploy");
+    await user.click(await screen.findByText("Deploy component"));
+
+    expect(selectNode).toHaveBeenCalledWith("node-1");
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Find apps, integrations, and commands...")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not fetch or show the invite command without member create permission", async () => {
+    permissionsState.permissions = defaultPermissions.filter(
+      (permission) => permission.resource !== "members" || permission.action !== "create",
+    );
+    renderPalette();
+
+    openPalette();
+
+    expect(await screen.findByPlaceholderText("Find apps, integrations, and commands...")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(inviteLinkQueryState.enabledValues.length).toBeGreaterThan(0);
+    });
+    expect(inviteLinkQueryState.enabledValues).not.toContain(true);
+    expect(screen.queryByText("Copy Invite Link")).not.toBeInTheDocument();
+  });
+
+  it("disables invite copy when the invite link is inactive", async () => {
+    const user = userEvent.setup();
+    installClipboardWriteMock();
+    inviteLinkState.data = { token: "test-invite-token", enabled: false };
+    renderPalette();
+
+    openPalette();
+    const copyInviteLink = await screen.findByText("Copy Invite Link");
+
+    expect(copyInviteLink.closest("[cmdk-item]")).toHaveAttribute("data-disabled", "true");
+    await user.click(copyInviteLink);
+    expect(writeTextMock).not.toHaveBeenCalled();
+  });
+
+  it("closes after copying the invite link successfully", async () => {
+    const user = userEvent.setup();
+    installClipboardWriteMock();
+    renderPalette();
+
+    openPalette();
+    const copyInviteLink = await screen.findByText("Copy Invite Link");
+    await waitFor(() => {
+      expect(copyInviteLink.closest("[cmdk-item]")).not.toHaveAttribute("data-disabled", "true");
+    });
+    await user.click(copyInviteLink);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("/invite/test-invite-token"));
+    });
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Find apps, integrations, and commands...")).not.toBeInTheDocument();
+    });
+  });
+
+  it("stays open when invite link copy fails", async () => {
+    const user = userEvent.setup();
+    installClipboardWriteMock();
+    writeTextMock.mockRejectedValue(new Error("Clipboard unavailable"));
+    renderPalette();
+
+    openPalette();
+    const copyInviteLink = await screen.findByText("Copy Invite Link");
+    await waitFor(() => {
+      expect(copyInviteLink.closest("[cmdk-item]")).not.toHaveAttribute("data-disabled", "true");
+    });
+    await user.click(copyInviteLink);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("/invite/test-invite-token"));
+    });
+    expect(screen.getByPlaceholderText("Find apps, integrations, and commands...")).toBeInTheDocument();
   });
 
   it("creates an app with the quick shortcut", async () => {

--- a/web_src/src/components/GlobalCommandPalette/index.tsx
+++ b/web_src/src/components/GlobalCommandPalette/index.tsx
@@ -1,14 +1,8 @@
 import { CommandDialog, CommandEmpty, CommandInput, CommandList } from "@/components/ui/command";
 import { useCommandPaletteModel } from "./model";
 import type { CommandPaletteModel } from "./model";
-import {
-  AdminCommandPage,
-  CanvasSettingsPage,
-  OpenCanvasPage,
-  OrganizationSettingsPage,
-  RootCommandPage,
-} from "./pages";
-import { pageTitle } from "./route";
+import { CommandPalettePage } from "./pages";
+import { useCommandPalettePageProps } from "./usePageProps";
 
 export function GlobalCommandPalette() {
   const model = useCommandPaletteModel();
@@ -17,74 +11,27 @@ export function GlobalCommandPalette() {
 }
 
 function CommandPaletteDialog({ model }: { model: CommandPaletteModel }) {
+  const pageProps = useCommandPalettePageProps(model);
+
   return (
     <CommandDialog
       open={model.open}
-      onOpenChange={model.setOpen}
+      onOpenChange={pageProps.handleOpenChange}
       title="Command Palette"
-      description="Search pages, actions, and utilities."
+      description="Search apps, settings, and commands."
       className="top-[12vh] max-h-[min(760px,80vh)] w-[calc(100vw-2rem)] max-w-3xl translate-y-0 overflow-hidden rounded-xl border border-slate-200 bg-white p-0 shadow-2xl sm:top-[14vh]"
       showCloseButton={false}
     >
       <CommandInput
         value={model.search}
-        onValueChange={model.setSearch}
-        placeholder={model.page === "root" ? rootPlaceholder(model.canvasId) : pageTitle(model.page)}
+        onValueChange={pageProps.handleSetSearch}
+        placeholder="Find apps, integrations, and commands..."
         className="h-16 text-lg"
       />
       <CommandList className="max-h-[min(600px,calc(80vh-4rem))] scroll-py-2 px-3 py-3">
-        <CommandEmpty>No commands found.</CommandEmpty>
-        <PalettePageContent model={model} />
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandPalettePage {...pageProps} />
       </CommandList>
     </CommandDialog>
   );
-}
-
-function rootPlaceholder(canvasId: string | null) {
-  return canvasId ? "Search components and commands" : "What can we help with?";
-}
-
-function PalettePageContent({ model }: { model: CommandPaletteModel }) {
-  const onBack = () => {
-    model.setSearch("");
-    model.setPage("root");
-  };
-  const onOpenPage = (page: Parameters<typeof model.setPage>[0]) => {
-    model.setSearch("");
-    model.setPage(page);
-  };
-
-  switch (model.page) {
-    case "organization-settings":
-      return (
-        <OrganizationSettingsPage
-          actions={model.settingsActions}
-          onBack={onBack}
-          organizationName={model.organizationName}
-        />
-      );
-    case "canvas-settings":
-      return (
-        <CanvasSettingsPage
-          {...model.canvasListProps}
-          canvasId={model.canvasId}
-          currentCanvasName={model.currentCanvasName}
-          onBack={onBack}
-        />
-      );
-    case "open-canvas":
-      return <OpenCanvasPage {...model.canvasListProps} onBack={onBack} />;
-    case "admin":
-      return <AdminCommandPage actions={model.adminActions} onBack={onBack} />;
-    default:
-      return (
-        <RootCommandPage
-          canvasNodeSearchActions={model.canvasNodeSearchActions}
-          currentCanvasActions={model.currentCanvasActions}
-          onOpenPage={onOpenPage}
-          rootActions={model.rootActions}
-          rootPageActions={model.rootPageActions}
-        />
-      );
-  }
 }

--- a/web_src/src/components/GlobalCommandPalette/model.ts
+++ b/web_src/src/components/GlobalCommandPalette/model.ts
@@ -8,6 +8,7 @@ import { isUsagePageForced } from "@/lib/env";
 import { showErrorToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { buildAdminActions, buildOrganizationSettingsActions, buildRootActions } from "./actions";
+import { buildCanvasNodeSearchActions, useCanvasNodeSearchProvider } from "./canvasNodeSearchStore";
 import { useCommandPaletteShortcuts, usePalettePermissions } from "./hooks";
 import { useShortcutModifierLabel } from "@/hooks/useShortcutLabel";
 import { getRouteContext } from "./route";
@@ -21,6 +22,8 @@ export type CommandPaletteModel = {
   adminActions: PaletteAction[];
   canvasId: string | null;
   canvasListProps: CanvasCommandListProps;
+  canvasNodeSearchActions: PaletteAction[];
+  canManageInviteLink: boolean;
   currentCanvasName: string;
   open: boolean;
   organizationName: string;
@@ -44,6 +47,7 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
   const shortcutModifier = useShortcutModifierLabel();
   const data = useCommandPaletteData(route.organizationId, route.canvasId, !!account);
   const closePalette = useClosePalette(setOpen, setPage, setSearch);
+  const canvasNodeSearchProvider = useCanvasNodeSearchProvider();
   const navigation = usePaletteNavigation(closePalette, navigate);
   const createCanvas = useCreateCanvasCommand(data, closePalette, navigate, route.organizationId);
   const enabled = !loading && !!account;
@@ -71,6 +75,7 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
   return buildModel({
     accountEmail: account.email,
     canvasId: route.canvasId,
+    canvasNodeSearchProvider,
     closePalette,
     createCanvas,
     data,
@@ -88,6 +93,7 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
 
 type PaletteData = {
   canCreateCanvas: boolean;
+  canManageInviteLink: boolean;
   canReadCanvas: boolean;
   canUpdateCanvas: boolean;
   canvases: CanvasesCanvas[];
@@ -114,11 +120,13 @@ function useCommandPaletteData(
   const createCanvasMutation = useCreateCanvas(queryOrganizationId);
   const currentCanvas = canvases.find((canvas) => canvas.metadata?.id === canvasId);
   const canCreateCanvas = canUsePermission(hasOrganization, permissionState.canAct, "canvases", "create");
+  const canManageInviteLink = canUsePermission(hasOrganization, permissionState.canAct, "members", "create");
   const canReadCanvas = canUsePermission(hasOrganization, permissionState.canAct, "canvases", "read");
   const canUpdateCanvas = canUsePermission(hasOrganization, permissionState.canAct, "canvases", "update");
 
   return {
     canCreateCanvas,
+    canManageInviteLink,
     canReadCanvas,
     canUpdateCanvas,
     canvases,
@@ -206,6 +214,7 @@ function useCreateCanvasCommand(
 function buildModel({
   accountEmail,
   canvasId,
+  canvasNodeSearchProvider,
   closePalette,
   createCanvas,
   data,
@@ -221,6 +230,7 @@ function buildModel({
 }: {
   accountEmail: string;
   canvasId: string | null;
+  canvasNodeSearchProvider: ReturnType<typeof useCanvasNodeSearchProvider>;
   closePalette: () => void;
   createCanvas: () => Promise<void>;
   data: PaletteData;
@@ -243,6 +253,12 @@ function buildModel({
       goTo: navigation.goTo,
       organizationId,
     },
+    canvasNodeSearchActions: buildCanvasNodeSearchActions({
+      closePalette,
+      provider: canvasNodeSearchProvider,
+      query: search,
+    }),
+    canManageInviteLink: data.canManageInviteLink,
     currentCanvasName: data.currentCanvasName,
     open,
     organizationName: data.organizationName,

--- a/web_src/src/components/GlobalCommandPalette/model.ts
+++ b/web_src/src/components/GlobalCommandPalette/model.ts
@@ -16,13 +16,12 @@ import {
   buildCurrentCanvasActions,
   buildOrganizationSettingsActions,
   buildRootActions,
-  buildRootPageActions,
 } from "./actions";
 import { buildCanvasNodeSearchActions, useCanvasNodeSearchProvider } from "./canvasNodeSearchStore";
 import { useCommandPaletteShortcuts, usePalettePermissions } from "./hooks";
 import { useShortcutModifierLabel } from "@/hooks/useShortcutLabel";
 import { getRouteContext } from "./route";
-import type { CanvasCommandListProps, CommandPage, PaletteAction, PalettePageAction } from "./types";
+import type { CanvasCommandListProps, CommandPage, PaletteAction } from "./types";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -39,7 +38,6 @@ export type CommandPaletteModel = {
   organizationName: string;
   page: CommandPage;
   rootActions: PaletteAction[];
-  rootPageActions: PalettePageAction[];
   search: string;
   setOpen: Dispatch<SetStateAction<boolean>>;
   setPage: Dispatch<SetStateAction<CommandPage>>;
@@ -64,6 +62,7 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
   const enabled = !loading && !!account;
 
   useCommandPaletteShortcuts({
+    canvasId: route.canvasId,
     createCanvas,
     createCanvasDisabled: data.createCanvasDisabled,
     enabled,
@@ -83,7 +82,6 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
 
   return buildModel({
     accountEmail: account.email,
-    accountInstallationAdmin: account.installation_admin,
     canvasId: route.canvasId,
     closePalette,
     createCanvas,
@@ -162,7 +160,7 @@ function canUsePermission(
 }
 
 function currentCanvasNameFor(canvas: CanvasesCanvas | undefined) {
-  return canvas?.metadata?.name ?? "Current canvas";
+  return canvas?.metadata?.name ?? "Current app";
 }
 
 function isUsageEnabled(enabled: boolean, error: unknown) {
@@ -240,14 +238,13 @@ function useCreateCanvasCommand(
       closePalette();
       navigate(appPath(organizationId, nextCanvasId));
     } catch (error) {
-      showErrorToast(getUsageLimitToastMessage(error, "Failed to create canvas"));
+      showErrorToast(getUsageLimitToastMessage(error, "Failed to create app"));
     }
   }, [closePalette, data.canCreateCanvas, data.createCanvasMutation, navigate, organizationId]);
 }
 
 function buildModel({
   accountEmail,
-  accountInstallationAdmin,
   canvasId,
   closePalette,
   createCanvas,
@@ -265,7 +262,6 @@ function buildModel({
   showToolTabCommands,
 }: {
   accountEmail: string;
-  accountInstallationAdmin: boolean;
   canvasId: string | null;
   closePalette: () => void;
   createCanvas: () => Promise<void>;
@@ -325,15 +321,6 @@ function buildModel({
         closePalette();
         window.location.href = "/logout";
       },
-    }),
-    rootPageActions: buildRootPageActions({
-      accountInstallationAdmin,
-      canReadCanvas: data.canReadCanvas,
-      canUpdateCanvas: data.canUpdateCanvas,
-      canvasId,
-      currentCanvasName: data.currentCanvasName,
-      organizationId,
-      organizationName: data.organizationName,
     }),
     search,
     setOpen,

--- a/web_src/src/components/GlobalCommandPalette/model.ts
+++ b/web_src/src/components/GlobalCommandPalette/model.ts
@@ -50,6 +50,7 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
 
   useCommandPaletteShortcuts({
     canvasId: route.canvasId,
+    organizationId: route.organizationId,
     createCanvas,
     createCanvasDisabled: data.createCanvasDisabled,
     enabled,
@@ -161,10 +162,7 @@ function useClosePalette(
   }, [setOpen, setPage, setSearch]);
 }
 
-function usePaletteNavigation(
-  closePalette: () => void,
-  navigate: NavigateFunction,
-) {
+function usePaletteNavigation(closePalette: () => void, navigate: NavigateFunction) {
   const goTo = useCallback(
     (href: string) => {
       closePalette();

--- a/web_src/src/components/GlobalCommandPalette/model.ts
+++ b/web_src/src/components/GlobalCommandPalette/model.ts
@@ -1,23 +1,13 @@
 import type { CanvasesCanvas } from "@/api-client";
-import { openCanvasToolSidebarTab } from "@/components/CanvasToolSidebar/events";
-import type { CanvasToolSidebarTab } from "@/components/CanvasToolSidebar/events";
-import { FEATURE_CLAUDE_MANAGED_AGENTS } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { useAccount } from "@/contexts/useAccount";
 import { useCanvases, useCreateCanvas } from "@/hooks/useCanvasData";
-import { useExperimentalFeature } from "@/hooks/useExperimentalFeature";
 import { useOrganization, useOrganizationUsage } from "@/hooks/useOrganizationData";
 import { generateCanvasName } from "@/lib/canvasNameGenerator";
 import { appPath } from "@/lib/appPaths";
 import { isUsagePageForced } from "@/lib/env";
 import { showErrorToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
-import {
-  buildAdminActions,
-  buildCurrentCanvasActions,
-  buildOrganizationSettingsActions,
-  buildRootActions,
-} from "./actions";
-import { buildCanvasNodeSearchActions, useCanvasNodeSearchProvider } from "./canvasNodeSearchStore";
+import { buildAdminActions, buildOrganizationSettingsActions, buildRootActions } from "./actions";
 import { useCommandPaletteShortcuts, usePalettePermissions } from "./hooks";
 import { useShortcutModifierLabel } from "@/hooks/useShortcutLabel";
 import { getRouteContext } from "./route";
@@ -31,8 +21,6 @@ export type CommandPaletteModel = {
   adminActions: PaletteAction[];
   canvasId: string | null;
   canvasListProps: CanvasCommandListProps;
-  canvasNodeSearchActions: PaletteAction[];
-  currentCanvasActions: PaletteAction[];
   currentCanvasName: string;
   open: boolean;
   organizationName: string;
@@ -54,10 +42,9 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
   const [page, setPage] = useState<CommandPage>("root");
   const [search, setSearch] = useState("");
   const shortcutModifier = useShortcutModifierLabel();
-  const canvasNodeSearchProvider = useCanvasNodeSearchProvider();
   const data = useCommandPaletteData(route.organizationId, route.canvasId, !!account);
   const closePalette = useClosePalette(setOpen, setPage, setSearch);
-  const navigation = usePaletteNavigation(route.organizationId, route.canvasId, closePalette, navigate);
+  const navigation = usePaletteNavigation(closePalette, navigate);
   const createCanvas = useCreateCanvasCommand(data, closePalette, navigate, route.organizationId);
   const enabled = !loading && !!account;
 
@@ -85,7 +72,6 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
     canvasId: route.canvasId,
     closePalette,
     createCanvas,
-    canvasNodeSearchProvider,
     data,
     navigation,
     open,
@@ -96,12 +82,10 @@ export function useCommandPaletteModel(): CommandPaletteModel | null {
     setPage,
     setSearch,
     shortcutModifier,
-    showToolTabCommands: !route.isTemplateRoute,
   });
 }
 
 type PaletteData = {
-  agentEnabled: boolean;
   canCreateCanvas: boolean;
   canReadCanvas: boolean;
   canUpdateCanvas: boolean;
@@ -125,7 +109,6 @@ function useCommandPaletteData(
   const { data: organization } = useOrganization(queryOrganizationId);
   const { data: usageStatus, error: usageError } = useOrganizationUsage(queryOrganizationId, hasOrganization);
   const { data: canvases = [], isLoading: canvasesLoading } = useCanvases(queryOrganizationId);
-  const { has: hasExperimentalFeature } = useExperimentalFeature(organizationId ?? undefined);
   const permissionState = usePalettePermissions(organizationId, hasAccount);
   const createCanvasMutation = useCreateCanvas(queryOrganizationId);
   const currentCanvas = canvases.find((canvas) => canvas.metadata?.id === canvasId);
@@ -145,7 +128,6 @@ function useCommandPaletteData(
     organizationName: organization?.metadata?.name ?? "Current organization",
     permissionState,
     usageEnabled: isUsageEnabled(usageStatus?.enabled === true, usageError),
-    agentEnabled: hasExperimentalFeature(FEATURE_CLAUDE_MANAGED_AGENTS),
   };
 }
 
@@ -180,8 +162,6 @@ function useClosePalette(
 }
 
 function usePaletteNavigation(
-  organizationId: string | null,
-  canvasId: string | null,
   closePalette: () => void,
   navigate: NavigateFunction,
 ) {
@@ -201,25 +181,7 @@ function usePaletteNavigation(
     [closePalette],
   );
 
-  const goToCurrentCanvasView = useCallback(
-    (view?: "console" | "memory" | "runs") => {
-      if (!organizationId || !canvasId) return;
-      goTo(appPath(organizationId, canvasId, view ? `?view=${view}` : ""));
-    },
-    [canvasId, goTo, organizationId],
-  );
-
-  const openCurrentCanvasToolTab = useCallback(
-    (tab: CanvasToolSidebarTab) => {
-      if (!organizationId || !canvasId) return;
-      closePalette();
-      navigate(appPath(organizationId, canvasId));
-      window.setTimeout(() => openCanvasToolSidebarTab(tab), 0);
-    },
-    [canvasId, closePalette, navigate, organizationId],
-  );
-
-  return { goTo, goToCurrentCanvasView, openCurrentCanvasToolTab, openExternal };
+  return { goTo, openExternal };
 }
 
 function useCreateCanvasCommand(
@@ -248,7 +210,6 @@ function buildModel({
   canvasId,
   closePalette,
   createCanvas,
-  canvasNodeSearchProvider,
   data,
   navigation,
   open,
@@ -259,13 +220,11 @@ function buildModel({
   setPage,
   setSearch,
   shortcutModifier,
-  showToolTabCommands,
 }: {
   accountEmail: string;
   canvasId: string | null;
   closePalette: () => void;
   createCanvas: () => Promise<void>;
-  canvasNodeSearchProvider: ReturnType<typeof useCanvasNodeSearchProvider>;
   data: PaletteData;
   navigation: ReturnType<typeof usePaletteNavigation>;
   open: boolean;
@@ -276,7 +235,6 @@ function buildModel({
   setPage: Dispatch<SetStateAction<CommandPage>>;
   setSearch: Dispatch<SetStateAction<string>>;
   shortcutModifier: string;
-  showToolTabCommands: boolean;
 }): CommandPaletteModel {
   return {
     adminActions: buildAdminActions(navigation.goTo),
@@ -287,22 +245,6 @@ function buildModel({
       goTo: navigation.goTo,
       organizationId,
     },
-    canvasNodeSearchActions: buildCanvasNodeSearchActions({
-      closePalette,
-      provider: canvasNodeSearchProvider,
-      query: search,
-    }),
-    currentCanvasActions: buildCurrentCanvasActions({
-      agentEnabled: data.agentEnabled,
-      canUpdateCanvas: data.canUpdateCanvas,
-      canvasId,
-      currentCanvasName: data.currentCanvasName,
-      goTo: navigation.goTo,
-      goToCurrentCanvasView: navigation.goToCurrentCanvasView,
-      openCurrentCanvasToolTab: navigation.openCurrentCanvasToolTab,
-      organizationId,
-      showToolTabCommands,
-    }),
     currentCanvasName: data.currentCanvasName,
     open,
     organizationName: data.organizationName,

--- a/web_src/src/components/GlobalCommandPalette/pages.tsx
+++ b/web_src/src/components/GlobalCommandPalette/pages.tsx
@@ -4,11 +4,13 @@ import { ActionItem, CanvasListItems } from "./items";
 import { BookOpen, ChevronLeft, ChevronRight, Key, Link2, LogOut, Palette, Plug, Plus, UserPlus } from "lucide-react";
 import type { CanvasCommandListProps, PaletteAction } from "./types";
 
-type IntegrationItem = {
+export type IntegrationStatus = "ready" | "pending" | "error";
+
+export type IntegrationItem = {
   id: string;
   name: string;
   providerName: string;
-  status: "ready" | "pending" | "error";
+  status: IntegrationStatus;
 };
 
 export type CommandPalettePageProps = {

--- a/web_src/src/components/GlobalCommandPalette/pages.tsx
+++ b/web_src/src/components/GlobalCommandPalette/pages.tsx
@@ -18,6 +18,8 @@ export type CommandPalettePageProps = {
   integrations: IntegrationItem[];
   onCreateApp: () => void;
   onCopyInviteLink: () => void;
+  showCopyInviteLink: boolean;
+  copyInviteLinkDisabled: boolean;
   onExpandApps: () => void;
   onExpandIntegrations: () => void;
   onCollapse: () => void;
@@ -68,10 +70,17 @@ function DefaultView(props: CommandPalettePageProps) {
           <Plus className="mr-2 size-4 shrink-0" />
           <span>{props.createAppLabel}</span>
         </CommandItem>
-        <CommandItem value="copy-invite-link" onSelect={props.onCopyInviteLink} className="cursor-pointer">
-          <Link2 className="mr-2 size-4 shrink-0" />
-          <span>Copy Invite Link</span>
-        </CommandItem>
+        {props.showCopyInviteLink ? (
+          <CommandItem
+            value="copy-invite-link"
+            onSelect={props.onCopyInviteLink}
+            disabled={props.copyInviteLinkDisabled}
+            className="cursor-pointer"
+          >
+            <Link2 className="mr-2 size-4 shrink-0" />
+            <span>Copy Invite Link</span>
+          </CommandItem>
+        ) : null}
       </CommandGroup>
 
       <CommandSeparator className="my-2" />

--- a/web_src/src/components/GlobalCommandPalette/pages.tsx
+++ b/web_src/src/components/GlobalCommandPalette/pages.tsx
@@ -1,175 +1,194 @@
-import { CommandGroup, CommandSeparator } from "@/components/ui/command";
-import { Palette, Settings } from "lucide-react";
-import { openPageAction } from "./actions";
-import { appPath, appSettingsPath } from "@/lib/appPaths";
-import { ActionItem, CanvasListItems, NestedPage, PageItem } from "./items";
-import type { CanvasCommandListProps, CommandPage, PaletteAction, PalettePageAction } from "./types";
+import { CommandGroup, CommandItem, CommandSeparator } from "@/components/ui/command";
+import { appPath } from "@/lib/appPaths";
+import { ActionItem, CanvasListItems } from "./items";
+import { BookOpen, ChevronLeft, ChevronRight, Key, Link2, LogOut, Palette, Plug, Plus, UserPlus } from "lucide-react";
+import type { CanvasCommandListProps, PaletteAction } from "./types";
 
-export function RootCommandPage({
-  currentCanvasActions,
-  canvasNodeSearchActions,
-  onOpenPage,
-  rootActions,
-  rootPageActions,
-}: {
-  currentCanvasActions: PaletteAction[];
-  canvasNodeSearchActions: PaletteAction[];
-  onOpenPage: (page: CommandPage) => void;
-  rootActions: PaletteAction[];
-  rootPageActions: PalettePageAction[];
-}) {
+type IntegrationItem = {
+  id: string;
+  name: string;
+  providerName: string;
+  status: "ready" | "pending" | "error";
+};
+
+export type CommandPalettePageProps = {
+  canvasListProps: CanvasCommandListProps;
+  integrations: IntegrationItem[];
+  onCreateApp: () => void;
+  onCopyInviteLink: () => void;
+  onExpandApps: () => void;
+  onExpandIntegrations: () => void;
+  onCollapse: () => void;
+  onGoToDocs: () => void;
+  onNewServiceAccount: () => void;
+  onNewSecret: () => void;
+  onSignOut: () => void;
+  onConnectIntegration: () => void;
+  onSelectIntegration: (id: string) => void;
+  expandedSection: "apps" | "integrations" | null;
+  createAppLabel: string;
+  createAppDisabled: boolean;
+  // Search mode
+  searchActive: boolean;
+  searchResults: PaletteAction[];
+  handleSetSearch: (value: string) => void;
+  handleOpenChange: (open: boolean) => void;
+};
+
+export function CommandPalettePage(props: CommandPalettePageProps) {
+  if (props.searchActive) {
+    return <SearchResults results={props.searchResults} />;
+  }
+  return <DefaultView {...props} />;
+}
+
+function SearchResults({ results }: { results: PaletteAction[] }) {
+  if (results.length === 0) return null;
+  return (
+    <CommandGroup>
+      {results.map((action) => (
+        <ActionItem key={action.id} action={action} />
+      ))}
+    </CommandGroup>
+  );
+}
+
+function DefaultView(props: CommandPalettePageProps) {
   return (
     <>
-      <CommandGroup heading="Create">
-        {rootActions.slice(0, 2).map((action) => (
-          <ActionItem key={action.id} action={action} />
-        ))}
+      <CommandGroup>
+        <CommandItem
+          value="new-app"
+          onSelect={props.onCreateApp}
+          disabled={props.createAppDisabled}
+          className="cursor-pointer"
+        >
+          <Plus className="mr-2 size-4 shrink-0" />
+          <span>{props.createAppLabel}</span>
+        </CommandItem>
+        <CommandItem value="copy-invite-link" onSelect={props.onCopyInviteLink} className="cursor-pointer">
+          <Link2 className="mr-2 size-4 shrink-0" />
+          <span>Copy Invite Link</span>
+        </CommandItem>
       </CommandGroup>
 
       <CommandSeparator className="my-2" />
 
-      {currentCanvasActions.length > 0 ? (
-        <>
-          <CommandGroup heading="Current Canvas">
-            {currentCanvasActions.map((action) => (
-              <ActionItem key={action.id} action={action} />
-            ))}
-          </CommandGroup>
-          <CommandSeparator className="my-2" />
-        </>
-      ) : null}
+      <CommandGroup heading="Quick Links">
+        {props.expandedSection === "apps" ? (
+          <>
+            <CommandItem value="back-from-apps" onSelect={props.onCollapse} className="cursor-pointer">
+              <ChevronLeft className="mr-2 size-4 shrink-0 text-slate-400" />
+              <span className="text-slate-500">Back</span>
+            </CommandItem>
+            <ExpandedAppList {...props.canvasListProps} />
+          </>
+        ) : (
+          <CommandItem value="search-apps" onSelect={props.onExpandApps} className="cursor-pointer">
+            <Palette className="mr-2 size-4 shrink-0" />
+            <span className="flex-1">Apps</span>
+            <ChevronRight className="ml-auto size-4 shrink-0 text-slate-400" />
+          </CommandItem>
+        )}
 
-      {canvasNodeSearchActions.length > 0 ? (
-        <>
-          <CommandGroup heading="Components">
-            {canvasNodeSearchActions.map((action) => (
-              <ActionItem key={action.id} action={action} />
-            ))}
-          </CommandGroup>
-          <CommandSeparator className="my-2" />
-        </>
-      ) : null}
+        {props.expandedSection === "integrations" ? (
+          <>
+            <CommandItem value="back-from-integrations" onSelect={props.onCollapse} className="cursor-pointer">
+              <ChevronLeft className="mr-2 size-4 shrink-0 text-slate-400" />
+              <span className="text-slate-500">Back</span>
+            </CommandItem>
+            <ExpandedIntegrationList
+              integrations={props.integrations}
+              onConnectNew={props.onConnectIntegration}
+              onSelectIntegration={(id) => {
+                props.onSelectIntegration?.(id);
+              }}
+            />
+          </>
+        ) : (
+          <CommandItem value="connected-integrations" onSelect={props.onExpandIntegrations} className="cursor-pointer">
+            <Plug className="mr-2 size-4 shrink-0" />
+            <span className="flex-1">Integrations</span>
+            <ChevronRight className="ml-auto size-4 shrink-0 text-slate-400" />
+          </CommandItem>
+        )}
 
-      <CommandGroup heading="Navigate">
-        {rootPageActions.map((action) => (
-          <PageItem key={action.id} action={action} onSelect={openPageAction(action.page, onOpenPage)} />
-        ))}
-        {rootActions.slice(2, -2).map((action) => (
-          <ActionItem key={action.id} action={action} />
-        ))}
-      </CommandGroup>
+        <CommandItem value="go-to-docs" onSelect={props.onGoToDocs} className="cursor-pointer">
+          <BookOpen className="mr-2 size-4 shrink-0" />
+          <span>Go to Docs</span>
+        </CommandItem>
 
-      <CommandSeparator className="my-2" />
+        <CommandItem value="new-service-account" onSelect={props.onNewServiceAccount} className="cursor-pointer">
+          <UserPlus className="mr-2 size-4 shrink-0" />
+          <span>New Service Account</span>
+        </CommandItem>
 
-      <CommandGroup heading="Help and Account">
-        {rootActions.slice(-2).map((action) => (
-          <ActionItem key={action.id} action={action} />
-        ))}
+        <CommandItem value="new-secret" onSelect={props.onNewSecret} className="cursor-pointer">
+          <Key className="mr-2 size-4 shrink-0" />
+          <span>New Secret</span>
+        </CommandItem>
+
+        <CommandItem value="sign-out" onSelect={props.onSignOut} className="cursor-pointer">
+          <LogOut className="mr-2 size-4 shrink-0" />
+          <span>Sign Out</span>
+        </CommandItem>
       </CommandGroup>
     </>
   );
 }
 
-export function OrganizationSettingsPage({
-  actions,
-  onBack,
-  organizationName,
-}: {
-  actions: PaletteAction[];
-  onBack: () => void;
-  organizationName: string;
-}) {
-  return (
-    <NestedPage onBack={onBack}>
-      <CommandGroup heading={organizationName}>
-        {actions.map((action) => (
-          <ActionItem key={action.id} action={action} />
-        ))}
-      </CommandGroup>
-    </NestedPage>
-  );
-}
-
-export function CanvasSettingsPage({
-  canvasId,
-  currentCanvasName,
-  onBack,
-  ...canvasListProps
-}: CanvasCommandListProps & {
-  canvasId: string | null;
-  currentCanvasName: string;
-  onBack: () => void;
-}) {
-  const { goTo, organizationId } = canvasListProps;
-
-  return (
-    <NestedPage onBack={onBack}>
-      <CommandGroup heading={canvasId ? "Current Canvas" : "Canvases"}>
-        {canvasId ? (
-          <ActionItem
-            action={{
-              id: "current-canvas-settings",
-              label: currentCanvasName,
-              description: "Open canvas settings",
-              icon: Settings,
-              onSelect: () => organizationId && canvasId && goTo(appSettingsPath(organizationId, canvasId)),
-            }}
-          />
-        ) : null}
-        <CanvasSettingsList {...canvasListProps} />
-      </CommandGroup>
-    </NestedPage>
-  );
-}
-
-export function OpenCanvasPage({ onBack, ...canvasListProps }: CanvasCommandListProps & { onBack: () => void }) {
-  return (
-    <NestedPage onBack={onBack}>
-      <CommandGroup heading="Canvases">
-        <OpenCanvasList {...canvasListProps} />
-      </CommandGroup>
-    </NestedPage>
-  );
-}
-
-export function AdminCommandPage({ actions, onBack }: { actions: PaletteAction[]; onBack: () => void }) {
-  return (
-    <NestedPage onBack={onBack}>
-      <CommandGroup heading="Installation Admin">
-        {actions.map((action) => (
-          <ActionItem key={action.id} action={action} />
-        ))}
-      </CommandGroup>
-    </NestedPage>
-  );
-}
-
-function CanvasSettingsList({ goTo, organizationId, ...props }: CanvasCommandListProps) {
+function ExpandedAppList({ goTo, organizationId, ...props }: CanvasCommandListProps) {
   return (
     <CanvasListItems
       {...props}
-      description="Open canvas settings"
-      emptyLabel="No canvases available."
-      icon={Settings}
-      onSelect={(canvas) => {
-        const id = canvas.metadata?.id;
-        if (organizationId && id) goTo(appSettingsPath(organizationId, id));
-      }}
-    />
-  );
-}
-
-function OpenCanvasList({ goTo, organizationId, ...props }: CanvasCommandListProps) {
-  return (
-    <CanvasListItems
-      {...props}
-      description="Open canvas"
-      emptyLabel="No canvases available."
+      description="Open app"
+      emptyLabel="No apps available."
       icon={Palette}
       onSelect={(canvas) => {
         const id = canvas.metadata?.id;
         if (organizationId && id) goTo(appPath(organizationId, id));
       }}
     />
+  );
+}
+
+function ExpandedIntegrationList({
+  integrations,
+  onConnectNew,
+  onSelectIntegration,
+}: {
+  integrations: IntegrationItem[];
+  onConnectNew: () => void;
+  onSelectIntegration: (id: string) => void;
+}) {
+  return (
+    <>
+      {integrations.map((integration) => (
+        <CommandItem
+          key={integration.id}
+          value={`integration-${integration.name}`}
+          onSelect={() => onSelectIntegration(integration.id)}
+          className="cursor-pointer"
+        >
+          <Plug className="mr-2 size-4 shrink-0" />
+          <span className="flex-1">{integration.name}</span>
+          <span
+            className={`text-xs ${
+              integration.status === "ready"
+                ? "text-green-600"
+                : integration.status === "error"
+                  ? "text-red-500"
+                  : "text-amber-600"
+            }`}
+          >
+            {integration.status}
+          </span>
+        </CommandItem>
+      ))}
+      <CommandItem value="connect-new-integration" onSelect={onConnectNew} className="cursor-pointer">
+        <Plus className="mr-2 size-4 shrink-0 text-slate-400" />
+        <span className="text-slate-500">Connect new integration...</span>
+      </CommandItem>
+    </>
   );
 }

--- a/web_src/src/components/GlobalCommandPalette/route.ts
+++ b/web_src/src/components/GlobalCommandPalette/route.ts
@@ -25,9 +25,9 @@ export function pageTitle(page: CommandPage): string {
     case "organization-settings":
       return "Search organization settings";
     case "canvas-settings":
-      return "Search canvas settings";
+      return "Search app settings";
     case "open-canvas":
-      return "Search canvases";
+      return "Search apps";
     case "admin":
       return "Search admin pages";
     default:

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -145,7 +145,8 @@ function buildSearchResults(
 
   for (const canvas of model.canvasListProps.canvases) {
     const name = canvas.metadata?.name ?? "";
-    if (name.toLowerCase().includes(query)) {
+    const description = canvas.metadata?.description ?? "";
+    if (matchesSearch(query, name, description, "Open app")) {
       results.push({
         id: `app-${canvas.metadata?.id}`,
         label: name,
@@ -157,37 +158,41 @@ function buildSearchResults(
             goTo(appPath(organizationId, id));
           }
         },
-        keywords: [name],
+        keywords: [name, description],
       });
     }
   }
 
   for (const integration of integrations) {
-    if (integration.name.toLowerCase().includes(query)) {
+    if (matchesSearch(query, integration.name, integration.providerName, integration.status, "Integration")) {
       results.push({
         id: `integration-${integration.id}`,
         label: integration.name,
         description: `Integration · ${integration.status}`,
         icon: Plug,
         onSelect: () => goTo(`/${organizationId}/settings/integrations/${integration.id}`),
-        keywords: [integration.name, integration.providerName],
+        keywords: [integration.name, integration.providerName, integration.status],
       });
     }
   }
 
   for (const sa of serviceAccounts) {
     const name = sa.name ?? "";
-    if (name.toLowerCase().includes(query)) {
+    if (matchesSearch(query, name, sa.id, "Service Account")) {
       results.push({
         id: `sa-${sa.id}`,
         label: name,
         description: "Service Account",
         icon: Key,
         onSelect: () => goTo(`/${organizationId}/settings/service-accounts/${sa.id}`),
-        keywords: [name],
+        keywords: [name, sa.id ?? ""],
       });
     }
   }
 
   return results;
+}
+
+function matchesSearch(query: string, ...values: Array<string | undefined>) {
+  return values.some((value) => value?.toLowerCase().includes(query));
 }

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -23,8 +23,9 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   const { data: connectedIntegrations = [] } = useConnectedIntegrations(organizationId, {
     enabled: !!organizationId,
   });
-  const { data: inviteLink } = useOrganizationInviteLink(organizationId, !!organizationId);
+  const { data: inviteLink } = useOrganizationInviteLink(organizationId, !!organizationId && model.canManageInviteLink);
   const { data: serviceAccounts = [] } = useServiceAccounts(organizationId);
+  const inviteLinkToken = inviteLink?.enabled ? inviteLink.token : undefined;
 
   const integrations = useMemo<IntegrationItem[]>(
     () =>
@@ -49,17 +50,19 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   );
 
   const handleCopyInviteLink = useCallback(() => {
-    if (!inviteLink?.token) {
+    if (!inviteLinkToken) {
       toast.error("Invite link not available");
       return;
     }
-    const url = `${window.location.origin}/invite/${inviteLink.token}`;
+    const url = `${window.location.origin}/invite/${inviteLinkToken}`;
     void navigator.clipboard.writeText(url).then(
-      () => toast.success("Invite link copied"),
+      () => {
+        toast.success("Invite link copied");
+        closePalette();
+      },
       () => toast.error("Failed to copy invite link"),
     );
-    closePalette();
-  }, [inviteLink, closePalette]);
+  }, [inviteLinkToken, closePalette]);
 
   const handleSetSearch = useCallback(
     (value: string) => {
@@ -77,6 +80,8 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
       createAction?.onSelect?.();
     },
     onCopyInviteLink: handleCopyInviteLink,
+    showCopyInviteLink: model.canManageInviteLink,
+    copyInviteLinkDisabled: !inviteLinkToken,
     onExpandApps: () => setExpandedSection("apps"),
     onExpandIntegrations: () => setExpandedSection("integrations"),
     onCollapse: () => setExpandedSection(null),
@@ -136,7 +141,7 @@ function buildSearchResults(
 ): PaletteAction[] {
   if (!model.search) return [];
   const query = model.search.toLowerCase();
-  const results: PaletteAction[] = [];
+  const results: PaletteAction[] = [...model.canvasNodeSearchActions];
 
   for (const canvas of model.canvasListProps.canvases) {
     const name = canvas.metadata?.name ?? "";

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -146,7 +146,7 @@ function buildSearchResults(
   for (const canvas of model.canvasListProps.canvases) {
     const name = canvas.metadata?.name ?? "";
     const description = canvas.metadata?.description ?? "";
-    if (matchesSearch(query, name, description, "Open app")) {
+    if (matchesSearch(query, name, description)) {
       results.push({
         id: `app-${canvas.metadata?.id}`,
         label: name,
@@ -164,7 +164,7 @@ function buildSearchResults(
   }
 
   for (const integration of integrations) {
-    if (matchesSearch(query, integration.name, integration.providerName, integration.status, "Integration")) {
+    if (matchesSearch(query, integration.name, integration.providerName, integration.status)) {
       results.push({
         id: `integration-${integration.id}`,
         label: integration.name,
@@ -178,7 +178,7 @@ function buildSearchResults(
 
   for (const sa of serviceAccounts) {
     const name = sa.name ?? "";
-    if (matchesSearch(query, name, sa.id, "Service Account")) {
+    if (matchesSearch(query, name, sa.id)) {
       results.push({
         id: `sa-${sa.id}`,
         label: name,

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DOCS_URL } from "./constants";
 import type { CommandPaletteModel } from "./model";
-import type { CommandPalettePageProps } from "./pages";
+import type { CommandPalettePageProps, IntegrationItem, IntegrationStatus } from "./pages";
 import type { PaletteAction } from "./types";
 
 export function useCommandPalettePageProps(model: CommandPaletteModel): CommandPalettePageProps {
@@ -26,16 +26,13 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   const { data: inviteLink } = useOrganizationInviteLink(organizationId, !!organizationId);
   const { data: serviceAccounts = [] } = useServiceAccounts(organizationId);
 
-  const integrations = useMemo(
+  const integrations = useMemo<IntegrationItem[]>(
     () =>
-      connectedIntegrations.map((i) => ({
-        id: i.metadata?.id ?? "",
-        name: i.metadata?.name ?? i.metadata?.integrationName ?? "Unknown",
-        providerName: i.metadata?.integrationName ?? "",
-        status: (i.status?.state === "ready" ? "ready" : i.status?.state === "error" ? "error" : "pending") as
-          | "ready"
-          | "error"
-          | "pending",
+      connectedIntegrations.map((integration) => ({
+        id: integration.metadata?.id ?? "",
+        name: integration.metadata?.name ?? integration.metadata?.integrationName ?? "Unknown",
+        providerName: integration.metadata?.integrationName ?? "",
+        status: integrationStatusFrom(integration.status?.state),
       })),
     [connectedIntegrations],
   );
@@ -119,21 +116,20 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   };
 }
 
-type IntegrationSearchItem = {
-  id: string;
-  name: string;
-  providerName: string;
-  status: string;
-};
-
 type ServiceAccountSearchItem = {
   id?: string;
   name?: string;
 };
 
+function integrationStatusFrom(state: string | undefined): IntegrationStatus {
+  if (state === "ready") return "ready";
+  if (state === "error") return "error";
+  return "pending";
+}
+
 function buildSearchResults(
   model: CommandPaletteModel,
-  integrations: IntegrationSearchItem[],
+  integrations: IntegrationItem[],
   serviceAccounts: ServiceAccountSearchItem[],
   organizationId: string,
   goTo: (href: string) => void,

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -1,0 +1,186 @@
+import { useConnectedIntegrations } from "@/hooks/useIntegrations";
+import { useOrganizationInviteLink } from "@/hooks/useOrganizationData";
+import { useServiceAccounts } from "@/hooks/useServiceAccounts";
+import { appPath } from "@/lib/appPaths";
+import { Key, Palette, Plug } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { DOCS_URL } from "./constants";
+import type { CommandPaletteModel } from "./model";
+import type { CommandPalettePageProps } from "./pages";
+import type { PaletteAction } from "./types";
+
+export function useCommandPalettePageProps(model: CommandPaletteModel): CommandPalettePageProps {
+  const [expandedSection, setExpandedSection] = useState<"apps" | "integrations" | null>(null);
+  const organizationId = model.canvasListProps.organizationId ?? "";
+
+  const { data: connectedIntegrations = [] } = useConnectedIntegrations(organizationId, {
+    enabled: !!organizationId,
+  });
+  const { data: inviteLink } = useOrganizationInviteLink(organizationId, !!organizationId);
+  const { data: serviceAccounts = [] } = useServiceAccounts(organizationId);
+
+  const integrations = useMemo(
+    () =>
+      connectedIntegrations.map((i) => ({
+        id: i.metadata?.id ?? "",
+        name: i.metadata?.name ?? i.metadata?.integrationName ?? "Unknown",
+        providerName: i.metadata?.integrationName ?? "",
+        status: (i.status?.state === "ready" ? "ready" : i.status?.state === "error" ? "error" : "pending") as
+          | "ready"
+          | "error"
+          | "pending",
+      })),
+    [connectedIntegrations],
+  );
+
+  const closePalette = useCallback(() => {
+    model.setOpen(false);
+    model.setSearch("");
+    setExpandedSection(null);
+  }, [model]);
+
+  const searchResults = useMemo(
+    () => buildSearchResults(model, integrations, serviceAccounts, organizationId, closePalette),
+    [model, integrations, serviceAccounts, organizationId, closePalette],
+  );
+
+  const handleCopyInviteLink = useCallback(() => {
+    if (!inviteLink?.token) {
+      toast.error("Invite link not available");
+      return;
+    }
+    const url = `${window.location.origin}/invite/${inviteLink.token}`;
+    void navigator.clipboard.writeText(url).then(
+      () => toast.success("Invite link copied"),
+      () => toast.error("Failed to copy invite link"),
+    );
+    closePalette();
+  }, [inviteLink, closePalette]);
+
+  const handleSetSearch = useCallback(
+    (value: string) => {
+      model.setSearch(value);
+      if (value) setExpandedSection(null);
+    },
+    [model],
+  );
+
+  return {
+    canvasListProps: model.canvasListProps,
+    integrations,
+    onCreateApp: () => {
+      const createAction = model.rootActions.find((a) => a.id === "new-canvas");
+      createAction?.onSelect?.();
+    },
+    onCopyInviteLink: handleCopyInviteLink,
+    onExpandApps: () => setExpandedSection("apps"),
+    onExpandIntegrations: () => setExpandedSection("integrations"),
+    onCollapse: () => setExpandedSection(null),
+    onGoToDocs: () => {
+      closePalette();
+      window.open(DOCS_URL, "_blank", "noopener,noreferrer");
+    },
+    onNewServiceAccount: () => {
+      closePalette();
+      window.location.href = `/${organizationId}/settings/service-accounts`;
+    },
+    onNewSecret: () => {
+      closePalette();
+      window.location.href = `/${organizationId}/settings/secrets`;
+    },
+    onSignOut: () => {
+      closePalette();
+      window.location.href = "/logout";
+    },
+    onConnectIntegration: () => {
+      closePalette();
+      window.location.href = `/${organizationId}/settings/integrations`;
+    },
+    onSelectIntegration: (id: string) => {
+      closePalette();
+      window.location.href = `/${organizationId}/settings/integrations/${id}`;
+    },
+    expandedSection,
+    createAppLabel: "New App",
+    createAppDisabled: !model.canvasListProps.organizationId,
+    searchActive: !!model.search,
+    searchResults,
+    handleSetSearch,
+    handleOpenChange: (open: boolean) => {
+      model.setOpen(open);
+      if (!open) {
+        model.setSearch("");
+        setExpandedSection(null);
+      }
+    },
+  };
+}
+
+function buildSearchResults(
+  model: CommandPaletteModel,
+  integrations: Array<{ id: string; name: string; providerName: string; status: string }>,
+  serviceAccounts: Array<{ id?: string; name?: string }>,
+  organizationId: string,
+  closePalette: () => void,
+): PaletteAction[] {
+  if (!model.search) return [];
+  const query = model.search.toLowerCase();
+  const results: PaletteAction[] = [];
+
+  for (const canvas of model.canvasListProps.canvases) {
+    const name = canvas.metadata?.name ?? "";
+    if (name.toLowerCase().includes(query)) {
+      results.push({
+        id: `app-${canvas.metadata?.id}`,
+        label: name,
+        description: "Open app",
+        icon: Palette,
+        onSelect: () => {
+          const id = canvas.metadata?.id;
+          if (organizationId && id) {
+            closePalette();
+            window.history.pushState({}, "", appPath(organizationId, id));
+            window.dispatchEvent(new PopStateEvent("popstate"));
+          }
+        },
+        keywords: [name],
+      });
+    }
+  }
+
+  for (const integration of integrations) {
+    if (integration.name.toLowerCase().includes(query)) {
+      results.push({
+        id: `integration-${integration.id}`,
+        label: integration.name,
+        description: `Integration · ${integration.status}`,
+        icon: Plug,
+        onSelect: () => {
+          closePalette();
+          window.location.href = `/${organizationId}/settings/integrations/${integration.id}`;
+        },
+        keywords: [integration.name, integration.providerName],
+      });
+    }
+  }
+
+  for (const sa of serviceAccounts) {
+    const name = sa.name ?? "";
+    if (name.toLowerCase().includes(query)) {
+      results.push({
+        id: `sa-${sa.id}`,
+        label: name,
+        description: "Service Account",
+        icon: Key,
+        onSelect: () => {
+          closePalette();
+          window.location.href = `/${organizationId}/settings/service-accounts/${sa.id}`;
+        },
+        keywords: [name],
+      });
+    }
+  }
+
+  return results;
+}

--- a/web_src/src/components/GlobalCommandPalette/usePageProps.ts
+++ b/web_src/src/components/GlobalCommandPalette/usePageProps.ts
@@ -3,7 +3,7 @@ import { useOrganizationInviteLink } from "@/hooks/useOrganizationData";
 import { useServiceAccounts } from "@/hooks/useServiceAccounts";
 import { appPath } from "@/lib/appPaths";
 import { Key, Palette, Plug } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { DOCS_URL } from "./constants";
 import type { CommandPaletteModel } from "./model";
@@ -13,6 +13,12 @@ import type { PaletteAction } from "./types";
 export function useCommandPalettePageProps(model: CommandPaletteModel): CommandPalettePageProps {
   const [expandedSection, setExpandedSection] = useState<"apps" | "integrations" | null>(null);
   const organizationId = model.canvasListProps.organizationId ?? "";
+  const goTo = model.canvasListProps.goTo;
+
+  // Reset expanded section when palette closes
+  useEffect(() => {
+    if (!model.open) setExpandedSection(null);
+  }, [model.open]);
 
   const { data: connectedIntegrations = [] } = useConnectedIntegrations(organizationId, {
     enabled: !!organizationId,
@@ -41,8 +47,8 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   }, [model]);
 
   const searchResults = useMemo(
-    () => buildSearchResults(model, integrations, serviceAccounts, organizationId, closePalette),
-    [model, integrations, serviceAccounts, organizationId, closePalette],
+    () => buildSearchResults(model, integrations, serviceAccounts, organizationId, goTo),
+    [model, integrations, serviceAccounts, organizationId, goTo],
   );
 
   const handleCopyInviteLink = useCallback(() => {
@@ -82,28 +88,24 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
       window.open(DOCS_URL, "_blank", "noopener,noreferrer");
     },
     onNewServiceAccount: () => {
-      closePalette();
-      window.location.href = `/${organizationId}/settings/service-accounts`;
+      goTo(`/${organizationId}/settings/service-accounts`);
     },
     onNewSecret: () => {
-      closePalette();
-      window.location.href = `/${organizationId}/settings/secrets`;
+      goTo(`/${organizationId}/settings/secrets`);
     },
     onSignOut: () => {
       closePalette();
       window.location.href = "/logout";
     },
     onConnectIntegration: () => {
-      closePalette();
-      window.location.href = `/${organizationId}/settings/integrations`;
+      goTo(`/${organizationId}/settings/integrations`);
     },
     onSelectIntegration: (id: string) => {
-      closePalette();
-      window.location.href = `/${organizationId}/settings/integrations/${id}`;
+      goTo(`/${organizationId}/settings/integrations/${id}`);
     },
     expandedSection,
-    createAppLabel: "New App",
-    createAppDisabled: !model.canvasListProps.organizationId,
+    createAppLabel: model.rootActions.find((a) => a.id === "new-canvas")?.label ?? "New App",
+    createAppDisabled: model.rootActions.find((a) => a.id === "new-canvas")?.disabled ?? true,
     searchActive: !!model.search,
     searchResults,
     handleSetSearch,
@@ -117,12 +119,24 @@ export function useCommandPalettePageProps(model: CommandPaletteModel): CommandP
   };
 }
 
+type IntegrationSearchItem = {
+  id: string;
+  name: string;
+  providerName: string;
+  status: string;
+};
+
+type ServiceAccountSearchItem = {
+  id?: string;
+  name?: string;
+};
+
 function buildSearchResults(
   model: CommandPaletteModel,
-  integrations: Array<{ id: string; name: string; providerName: string; status: string }>,
-  serviceAccounts: Array<{ id?: string; name?: string }>,
+  integrations: IntegrationSearchItem[],
+  serviceAccounts: ServiceAccountSearchItem[],
   organizationId: string,
-  closePalette: () => void,
+  goTo: (href: string) => void,
 ): PaletteAction[] {
   if (!model.search) return [];
   const query = model.search.toLowerCase();
@@ -139,9 +153,7 @@ function buildSearchResults(
         onSelect: () => {
           const id = canvas.metadata?.id;
           if (organizationId && id) {
-            closePalette();
-            window.history.pushState({}, "", appPath(organizationId, id));
-            window.dispatchEvent(new PopStateEvent("popstate"));
+            goTo(appPath(organizationId, id));
           }
         },
         keywords: [name],
@@ -156,10 +168,7 @@ function buildSearchResults(
         label: integration.name,
         description: `Integration · ${integration.status}`,
         icon: Plug,
-        onSelect: () => {
-          closePalette();
-          window.location.href = `/${organizationId}/settings/integrations/${integration.id}`;
-        },
+        onSelect: () => goTo(`/${organizationId}/settings/integrations/${integration.id}`),
         keywords: [integration.name, integration.providerName],
       });
     }
@@ -173,10 +182,7 @@ function buildSearchResults(
         label: name,
         description: "Service Account",
         icon: Key,
-        onSelect: () => {
-          closePalette();
-          window.location.href = `/${organizationId}/settings/service-accounts/${sa.id}`;
-        },
+        onSelect: () => goTo(`/${organizationId}/settings/service-accounts/${sa.id}`),
         keywords: [name],
       });
     }


### PR DESCRIPTION
## Summary

Adds CMD+K keyboard shortcut to open the command palette from any page except the canvas page (which keeps CMD+K for the project switcher).

## Changes

- **CMD+K shortcut** — opens palette on homepage, settings, etc. Canvas page unchanged.
- **Flat design** — no more sub-pages. Everything searchable from one view:
  - New App + Copy Invite Link (top actions)
  - Quick Links: Apps, Integrations, Go to Docs, New Service Account, New Secret, Sign Out
  - Apps and Integrations expand inline with back button
- **Search** — type to filter across apps, integrations, and service accounts with distinct icons
- **Terminology** — renamed "Canvas" to "App" throughout the palette
- **Removed** — New Organization, Templates, Installation Admin, Change Organization

## Testing

1. Go to homepage, press CMD+K — palette opens
2. Type an app name — shows matching app
3. Click Apps — expands inline, click Back to collapse
4. Go to canvas page, press CMD+K — project switcher opens (unchanged)

Closes #5217