### PR TITLE
fix: increase retry window for fetching runAgent final message

### DIFF
--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -235,16 +235,19 @@ func (c *Client) GetLastManagedSessionAgentMessageWithRetry(sessionID string, at
 	var events []ManagedSessionEvent
 	for i := 0; i < attempts; i++ {
 		var err error
-		message, events, err := c.GetLastManagedSessionAgentMessage(sessionID)
+		var message string
+		message, events, err = c.GetLastManagedSessionAgentMessage(sessionID)
 		if err != nil {
 			return "", events, err
 		}
 
-		if message != "" || i == attempts-1 {
+		if message != "" {
 			return message, events, nil
 		}
 
-		time.Sleep(delay)
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
 	}
 	return "", events, nil
 }

--- a/pkg/integrations/claude/runagent/types.go
+++ b/pkg/integrations/claude/runagent/types.go
@@ -11,8 +11,8 @@ const (
 	maxPollInterval         = 5 * time.Minute
 	maxPollAttempts         = 200
 	maxPollErrors           = 5
-	finalMessageReads       = 5
-	finalMessageDelay       = time.Second
+	finalMessageReads       = 15
+	finalMessageDelay       = 2 * time.Second
 )
 
 // Spec is the workflow node configuration for claude.runAgent.


### PR DESCRIPTION
## Problem

The `claude.runAgent` component returns `lastMessage: ""` despite the agent producing a response (#5278).

**Root cause:** Anthropic's events API is eventually consistent. `session.status_idle` appears ~1-2 seconds before `agent.message` events are queryable. The previous retry (5 × 1s = 5s) wasn't enough.

Also found a variable shadowing bug — `message, events, err :=` inside the loop created new local vars instead of assigning to outer `events`.

## Changes

- Increase retry to 15 × 2s (30s max wait)
- Fix variable shadowing bug
- Simple retry loop

Fixes #5278