### PR TITLE
fix: stop emailing approvers automatically

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -290,7 +290,7 @@ The Approval component pauses workflow execution and waits for manual approval f
 
 1. When the Approval component executes, it creates approval requirements based on the configured approvers
 2. The workflow pauses and waits for all required approvals
-3. Approvers receive notifications and can approve or reject from the workflow UI
+3. Approvers can approve or reject from the workflow UI
 4. Once all approvals are collected, the workflow continues:
    - **Approved channel**: All required approvers approved
    - **Rejected channel**: At least one approver rejected

--- a/pkg/components/approval/approval.go
+++ b/pkg/components/approval/approval.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
-	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/pkg/registry"
 )
 
@@ -332,7 +330,7 @@ func (a *Approval) Documentation() string {
 
 1. When the Approval component executes, it creates approval requirements based on the configured approvers
 2. The workflow pauses and waits for all required approvals
-3. Approvers receive notifications and can approve or reject from the workflow UI
+3. Approvers can approve or reject from the workflow UI
 4. Once all approvals are collected, the workflow continues:
    - **Approved channel**: All required approvers approved
    - **Rejected channel**: At least one approver rejected
@@ -512,14 +510,6 @@ func (a *Approval) Execute(ctx core.ExecutionContext) error {
 			"approval.finished",
 			[]any{executionMetadata},
 		)
-	}
-
-	if ctx.Notifications != nil {
-		if err := a.notifyApprovers(ctx, executionMetadata); err != nil {
-			if ctx.Logger != nil {
-				ctx.Logger.Warnf("failed to send approval notification: %v", err)
-			}
-		}
 	}
 
 	return nil
@@ -707,70 +697,6 @@ func (a *Approval) Cancel(ctx core.ExecutionContext) error {
 
 func (a *Approval) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
 	return http.StatusOK, nil, nil
-}
-
-func (a *Approval) notifyApprovers(ctx core.ExecutionContext, metadata *Metadata) error {
-	url := fmt.Sprintf(
-		"%s/%s/canvases/%s?sidebar=1&node=%s",
-		strings.TrimRight(ctx.BaseURL, "/"),
-		ctx.OrganizationID,
-		ctx.WorkflowID,
-		ctx.NodeID,
-	)
-
-	title := fmt.Sprintf("Approval required: %s — %s", ctx.CanvasName, ctx.NodeName)
-	body := fmt.Sprintf(
-		"An approval is waiting for you.\n\nCanvas: %s\nApproval: %s",
-		ctx.CanvasName,
-		ctx.NodeName,
-	)
-
-	receivers := core.NotificationReceivers{}
-	emailSet := map[string]struct{}{}
-	groupSet := map[string]struct{}{}
-	roleSet := map[string]struct{}{}
-
-	for _, record := range metadata.Records {
-		if record.State != StatePending {
-			continue
-		}
-
-		switch record.Type {
-		case ItemTypeAnyone:
-			roleSet[models.RoleOrgViewer] = struct{}{}
-			roleSet[models.RoleOrgAdmin] = struct{}{}
-			roleSet[models.RoleOrgOwner] = struct{}{}
-
-		case ItemTypeUser:
-			if record.User != nil && record.User.Email != "" {
-				emailSet[record.User.Email] = struct{}{}
-			}
-
-		case ItemTypeRole:
-			if record.RoleRef != nil && record.RoleRef.Name != "" {
-				roleSet[record.RoleRef.Name] = struct{}{}
-			}
-
-		case ItemTypeGroup:
-			if record.GroupRef != nil && record.GroupRef.Name != "" {
-				groupSet[record.GroupRef.Name] = struct{}{}
-			}
-		}
-	}
-
-	receivers.Emails = mapKeys(emailSet)
-	receivers.Groups = mapKeys(groupSet)
-	receivers.Roles = mapKeys(roleSet)
-
-	return ctx.Notifications.Send(title, body, url, "Open approval", receivers)
-}
-
-func mapKeys(input map[string]struct{}) []string {
-	result := make([]string, 0, len(input))
-	for key := range input {
-		result = append(result, key)
-	}
-	return result
 }
 
 func (a *Approval) Cleanup(ctx core.SetupContext) error {

--- a/pkg/components/approval/approval_test.go
+++ b/pkg/components/approval/approval_test.go
@@ -504,31 +504,6 @@ func TestApproval_Execute(t *testing.T) {
 		assert.NotNil(t, metadataCtx.Metadata)
 	})
 
-	t.Run("with pending items publishes approval notification", func(t *testing.T) {
-		stateCtx := &contexts.ExecutionStateContext{}
-		metadataCtx := &contexts.MetadataContext{}
-		notificationCtx := &contexts.NotificationContext{Messages: []contexts.Notification{}}
-
-		ctx := core.ExecutionContext{
-			WorkflowID:   "workflow-1",
-			NodeMetadata: &contexts.MetadataContext{},
-			Configuration: map[string]any{
-				"items": []any{
-					map[string]any{
-						"type": "anyone",
-					},
-				},
-			},
-			Metadata:       metadataCtx,
-			ExecutionState: stateCtx,
-			Notifications:  notificationCtx,
-		}
-
-		err := approval.Execute(ctx)
-		require.NoError(t, err)
-		assert.Len(t, notificationCtx.Messages, 1)
-	})
-
 	t.Run("with role and group items creates records", func(t *testing.T) {
 		stateCtx := &contexts.ExecutionStateContext{}
 		metadataCtx := &contexts.MetadataContext{}


### PR DESCRIPTION
## Summary
- remove automatic approval notification emails from the approval component
- remove the approval test that expected notification delivery
- keep the shared notification context because it is still used by Send Email and execution contexts

Closes #5283

## Tests
- go test ./pkg/components/approval
- make format.go
- make test PKG_TEST_PACKAGES=./pkg/components/approval
- make lint && make check.build.app