### PR TITLE
feat: decouple canvas nav views and polish agent toggle

### DIFF
--- a/test/e2e/agent_test.go
+++ b/test/e2e/agent_test.go
@@ -200,22 +200,10 @@ func (s *agentSteps) openAgent() {
 	s.waitForToolSidebarOpen()
 
 	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.clickAgentTab()
 	s.waitForAgentInput()
 	s.waitForSendCall(func(call support.AgentProviderSendMessageCall) bool {
 		return isAgentSystemMessage(call.Message)
 	})
-}
-
-func (s *agentSteps) clickAgentTab() {
-	tab := q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Agent")`).Run(s.session)
-	require.Eventually(s.t, func() bool {
-		visible, err := tab.IsVisible()
-		if err != nil || !visible {
-			return false
-		}
-		return tab.Click(pw.LocatorClickOptions{Timeout: pw.Float(1000)}) == nil
-	}, agentWaitTimeout, agentPollInterval)
 }
 
 func (s *agentSteps) waitForAgentInput() {

--- a/test/e2e/canvas_change_requests_test.go
+++ b/test/e2e/canvas_change_requests_test.go
@@ -177,8 +177,8 @@ func (s *canvasChangeRequestSteps) createChangeRequest() {
 }
 
 func (s *canvasChangeRequestSteps) openCreatedChangeRequestFromList() {
-	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.session.AssertVisible(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"][aria-selected="true"]:has-text("Versions")`))
+	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
+	s.session.AssertVisible(q.Locator(`[data-testid="canvas-view-mode-versions"][aria-current="page"]`))
 
 	// Pending rows are tagged in CanvasVersionControlSidebar (data-testid) so we do not rely on
 	// accessible-name collisions between pending and live preview rows or on :has() CSS support.

--- a/test/e2e/runs_view_test.go
+++ b/test/e2e/runs_view_test.go
@@ -161,8 +161,8 @@ func (s *runsViewSteps) givenOlderPublishedVersions(count int) {
 
 func (s *runsViewSteps) thenTheFinishedRunIsVisible() {
 	require.NotNil(s.t, s.run, "expected run to be created")
-	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.session.AssertVisible(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"][aria-selected="true"]:has-text("Runs")`))
+	s.session.AssertVisible(q.TestID("canvas-runs-sidebar"))
+	s.session.AssertVisible(q.Locator(`[data-testid="canvas-view-mode-runs"][aria-current="page"]`))
 	s.session.AssertVisible(q.TestID("node-start-header"))
 	s.session.AssertVisible(q.TestID("node-output-header"))
 	s.session.AssertURLContains("view=runs")
@@ -188,24 +188,22 @@ func (s *runsViewSteps) whenICloseRunNodeDetails() {
 }
 
 func (s *runsViewSteps) whenIEnterEditModeFromRuns() {
-	// The Agent tab is feature-flagged; switch back through another always-visible tool tab.
-	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
+	s.session.Click(q.TestID("canvas-view-mode-live"))
 	s.session.Click(q.TestID("canvas-edit-button"))
 }
 
 func (s *runsViewSteps) whenIOpenVersionsSidebar() {
-	s.session.AssertVisible(q.TestID("canvas-tool-sidebar"))
-	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
-	s.session.AssertVisible(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"][aria-selected="true"]:has-text("Versions")`))
+	s.session.Click(q.TestID("canvas-view-mode-versions"))
+	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
+	s.session.AssertVisible(q.Locator(`[data-testid="canvas-view-mode-versions"][aria-current="page"]`))
 }
 
 func (s *runsViewSteps) thenRunsLoadMoreButtonIsHidden() {
-	s.session.AssertHidden(q.Locator(`[data-testid="canvas-tool-sidebar"] button:has-text("Load more")`))
+	s.session.AssertHidden(q.Locator(`[data-testid="canvas-runs-sidebar"] button:has-text("Load more")`))
 }
 
 func (s *runsViewSteps) thenVersionsLoadMoreButtonIsHidden() {
-	s.session.AssertHidden(q.Locator(`[data-testid="canvas-tool-sidebar"] button:has-text("Load older versions")`))
+	s.session.AssertHidden(q.Locator(`[data-testid="canvas-versions-sidebar"] button:has-text("Load older versions")`))
 }
 
 func (s *runsViewSteps) thenRunsSidebarRowCountIsAtLeast(expected int) {

--- a/test/e2e/shared/canvas_steps.go
+++ b/test/e2e/shared/canvas_steps.go
@@ -74,11 +74,11 @@ func (s *CanvasSteps) ExitEditMode() {
 	s.session.Sleep(500)
 }
 
-// OpenVersionsSidebar opens the Versions tab in the canvas tool sidebar.
+// OpenVersionsSidebar opens the Versions view via the canvas header tab.
 func (s *CanvasSteps) OpenVersionsSidebar() {
-	s.waitForToolSidebarOpen()
-	s.session.Click(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"]:has-text("Versions")`))
-	s.session.AssertVisible(q.Locator(`[data-testid="canvas-tool-sidebar"] [role="tab"][aria-selected="true"]:has-text("Versions")`))
+	s.session.Click(q.TestID("canvas-view-mode-versions"))
+	s.session.AssertVisible(q.TestID("canvas-versions-sidebar"))
+	s.session.AssertVisible(q.Locator(`[data-testid="canvas-view-mode-versions"][aria-current="page"]`))
 	s.session.Sleep(300)
 }
 

--- a/web_src/src/components/CanvasRunsSidebar/index.tsx
+++ b/web_src/src/components/CanvasRunsSidebar/index.tsx
@@ -8,7 +8,7 @@ export interface CanvasRunsSidebarProps {
 }
 
 export function CanvasRunsSidebar({ isOpen, children }: CanvasRunsSidebarProps) {
-  const { sidebarRef, width, isResizing, handleMouseDown } = useRunsSidebarWidth();
+  const { sidebarRef, width, isResizing, handleMouseDown } = useRunsSidebarWidth(isOpen);
 
   if (!isOpen) {
     return null;

--- a/web_src/src/components/CanvasRunsSidebar/index.tsx
+++ b/web_src/src/components/CanvasRunsSidebar/index.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { useRunsSidebarWidth } from "./useRunsSidebarWidth";
+
+export interface CanvasRunsSidebarProps {
+  isOpen: boolean;
+  children: ReactNode;
+}
+
+export function CanvasRunsSidebar({ isOpen, children }: CanvasRunsSidebarProps) {
+  const { sidebarRef, width, isResizing, handleMouseDown } = useRunsSidebarWidth();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <aside
+      ref={sidebarRef}
+      data-testid="canvas-runs-sidebar"
+      className="relative z-21 flex h-full shrink-0 flex-col border-r border-border bg-white"
+      style={{ width }}
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+      <div
+        onMouseDown={handleMouseDown}
+        className="group absolute top-0 right-0 bottom-0 z-30 w-4 cursor-col-resize bg-transparent"
+        style={{ marginRight: "-8px" }}
+        data-testid="canvas-runs-sidebar-resize-handle"
+      >
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute top-0 bottom-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-slate-950/50",
+            isResizing && "bg-slate-950/50",
+          )}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const RUNS_SIDEBAR_WIDTH_STORAGE_KEY = "runs-sidebar-width";
+export const RUNS_SIDEBAR_MIN_WIDTH = 300;
+export const RUNS_SIDEBAR_DEFAULT_WIDTH = 380;
+
+function readPersistedWidth(): number {
+  if (typeof window === "undefined") return RUNS_SIDEBAR_DEFAULT_WIDTH;
+  try {
+    const saved = window.localStorage.getItem(RUNS_SIDEBAR_WIDTH_STORAGE_KEY);
+    const parsed = saved ? Number.parseInt(saved, 10) : Number.NaN;
+    if (!Number.isFinite(parsed)) return RUNS_SIDEBAR_DEFAULT_WIDTH;
+    return Math.max(RUNS_SIDEBAR_MIN_WIDTH, parsed);
+  } catch {
+    return RUNS_SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+function persistWidth(value: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RUNS_SIDEBAR_WIDTH_STORAGE_KEY, String(value));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function useRunsSidebarWidth() {
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(readPersistedWidth);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const handleMouseDown = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = sidebarRef.current?.getBoundingClientRect();
+      const left = rect?.left ?? 0;
+      const next = Math.max(RUNS_SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left));
+      setWidth(next);
+      persistWidth(next);
+    };
+
+    const handleMouseUp = () => setIsResizing(false);
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing]);
+
+  return { sidebarRef, width, isResizing, handleMouseDown };
+}

--- a/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
@@ -1,65 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuxiliarySidebarWidth } from "@/stores/useAuxiliarySidebarWidth";
 
 export const RUNS_SIDEBAR_WIDTH_STORAGE_KEY = "runs-sidebar-width";
 export const RUNS_SIDEBAR_MIN_WIDTH = 300;
 export const RUNS_SIDEBAR_DEFAULT_WIDTH = 380;
 
-function readPersistedWidth(): number {
-  if (typeof window === "undefined") return RUNS_SIDEBAR_DEFAULT_WIDTH;
-  try {
-    const saved = window.localStorage.getItem(RUNS_SIDEBAR_WIDTH_STORAGE_KEY);
-    const parsed = saved ? Number.parseInt(saved, 10) : Number.NaN;
-    if (!Number.isFinite(parsed)) return RUNS_SIDEBAR_DEFAULT_WIDTH;
-    return Math.max(RUNS_SIDEBAR_MIN_WIDTH, parsed);
-  } catch {
-    return RUNS_SIDEBAR_DEFAULT_WIDTH;
-  }
-}
-
-function persistWidth(value: number): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(RUNS_SIDEBAR_WIDTH_STORAGE_KEY, String(value));
-  } catch {
-    // ignore storage errors
-  }
-}
-
-export function useRunsSidebarWidth() {
-  const sidebarRef = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(readPersistedWidth);
-  const [isResizing, setIsResizing] = useState(false);
-
-  const handleMouseDown = useCallback((event: React.MouseEvent) => {
-    event.preventDefault();
-    setIsResizing(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isResizing) return;
-
-    const handleMouseMove = (event: MouseEvent) => {
-      const rect = sidebarRef.current?.getBoundingClientRect();
-      const left = rect?.left ?? 0;
-      const next = Math.max(RUNS_SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left));
-      setWidth(next);
-      persistWidth(next);
-    };
-
-    const handleMouseUp = () => setIsResizing(false);
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [isResizing]);
-
-  return { sidebarRef, width, isResizing, handleMouseDown };
+export function useRunsSidebarWidth(isOpen: boolean) {
+  return useAuxiliarySidebarWidth(isOpen, RUNS_SIDEBAR_WIDTH_STORAGE_KEY, RUNS_SIDEBAR_DEFAULT_WIDTH);
 }

--- a/web_src/src/components/CanvasToolSidebar/EmptyToolTab.tsx
+++ b/web_src/src/components/CanvasToolSidebar/EmptyToolTab.tsx
@@ -1,3 +1,0 @@
-export function EmptyToolTab() {
-  return <div className="min-h-0 flex-1" aria-hidden />;
-}

--- a/web_src/src/components/CanvasToolSidebar/events.ts
+++ b/web_src/src/components/CanvasToolSidebar/events.ts
@@ -1,6 +1,6 @@
 export const CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT = "canvas-tool-sidebar:select-tab";
 
-export type CanvasToolSidebarTab = "agent" | "runs" | "versions";
+export type CanvasToolSidebarTab = "agent";
 
 export function openCanvasToolSidebarTab(tab: CanvasToolSidebarTab) {
   window.dispatchEvent(new CustomEvent(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, { detail: { tab } }));
@@ -8,6 +8,6 @@ export function openCanvasToolSidebarTab(tab: CanvasToolSidebarTab) {
 
 export function canvasToolSidebarTabFromEvent(event: Event): CanvasToolSidebarTab | null {
   const tab = (event as CustomEvent<{ tab?: CanvasToolSidebarTab }>).detail?.tab;
-  if (tab === "agent" || tab === "runs" || tab === "versions") return tab;
+  if (tab === "agent") return tab;
   return null;
 }

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -1,7 +1,8 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CanvasToolSidebar } from ".";
+import { CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT } from "./events";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
@@ -85,203 +86,34 @@ describe("CanvasToolSidebar", () => {
     sessionStorage.clear();
   });
 
-  it("enters runs mode from the runs tab", () => {
-    const onSelectRuns = vi.fn();
+  it("renders the agent panel when the sidebar is open", async () => {
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
 
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState()}
-        mode="version-live"
-        onSelectRuns={onSelectRuns}
-        runsContent={<div>Runs content</div>}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("tab", { name: "Runs" }));
-
-    expect(onSelectRuns).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Runs content")).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText("Ask the agent…")).toBeInTheDocument();
   });
 
-  it("exits runs mode when switching back to the agent tab", () => {
-    const onExitRunsMode = vi.fn();
+  it("does not render when managed agents are disabled", () => {
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })} />);
 
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState()}
-        mode="runs"
-        onExitRunsMode={onExitRunsMode}
-        runsContent={<div>Runs content</div>}
-      />,
-    );
-
-    expect(screen.getByText("Runs content")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("tab", { name: "Agent" }));
-
-    expect(onExitRunsMode).toHaveBeenCalledTimes(1);
-    expect(screen.getByPlaceholderText("Ask the agent…")).toBeInTheDocument();
-  });
-
-  it("hides the agent tab when managed agents are disabled", () => {
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Runs" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Versions" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByText("Versions content")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("Ask the agent…")).not.toBeInTheDocument();
   });
 
-  it("opens version control on first open when managed agents are disabled", async () => {
-    const onOpenVersionControl = vi.fn();
-    const onVersionControlAutoOpened = vi.fn();
+  it("does not render while the sidebar is closed", () => {
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ isToolSidebarOpen: false })} />);
 
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
-        mode="version-live"
-        onOpenVersionControl={onOpenVersionControl}
-        onVersionControlAutoOpened={onVersionControlAutoOpened}
-      />,
-    );
-
-    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    await waitFor(() => expect(onOpenVersionControl).toHaveBeenCalledTimes(1));
-    expect(onVersionControlAutoOpened).toHaveBeenCalledTimes(1);
+    expect(screen.queryByPlaceholderText("Ask the agent…")).not.toBeInTheDocument();
   });
 
-  it("does not auto-open version control while the sidebar is closed", () => {
-    const onOpenVersionControl = vi.fn();
-    const onVersionControlAutoOpened = vi.fn();
+  it("opens the sidebar when the agent tab event is dispatched", () => {
     const openToolSidebar = vi.fn();
 
     render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState({
-          isAgentEnabled: false,
-          isToolSidebarOpen: false,
-          openToolSidebar,
-        })}
-        mode="version-live"
-        onOpenVersionControl={onOpenVersionControl}
-        onVersionControlAutoOpened={onVersionControlAutoOpened}
-      />,
+      <CanvasToolSidebar toolSidebarState={makeToolSidebarState({ isToolSidebarOpen: false, openToolSidebar })} />,
     );
 
-    expect(screen.queryByRole("tab", { name: "Versions" })).not.toBeInTheDocument();
-    expect(openToolSidebar).not.toHaveBeenCalled();
-    expect(onOpenVersionControl).not.toHaveBeenCalled();
-    expect(onVersionControlAutoOpened).not.toHaveBeenCalled();
-  });
+    window.dispatchEvent(new CustomEvent(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, { detail: { tab: "agent" } }));
 
-  it("does not auto-open version control after it already auto-opened for the canvas", () => {
-    const onOpenVersionControl = vi.fn();
-    const onVersionControlAutoOpened = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
-        mode="version-live"
-        hasAutoOpenedVersionControl={true}
-        onOpenVersionControl={onOpenVersionControl}
-        onVersionControlAutoOpened={onVersionControlAutoOpened}
-      />,
-    );
-
-    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    expect(onOpenVersionControl).not.toHaveBeenCalled();
-    expect(onVersionControlAutoOpened).not.toHaveBeenCalled();
-  });
-
-  it("does not switch from runs mode to the agent tab when managed agents are disabled", () => {
-    const onExitRunsMode = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState({ isAgentEnabled: false })}
-        mode="runs"
-        onExitRunsMode={onExitRunsMode}
-        runsContent={<div>Runs content</div>}
-      />,
-    );
-
-    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
-    expect(screen.getByText("Runs content")).toBeInTheDocument();
-  });
-
-  it("keeps versions selected when version control closes and managed agents are disabled", () => {
-    const toolSidebarState = makeToolSidebarState({ isAgentEnabled: false });
-    const { rerender } = render(
-      <CanvasToolSidebar
-        toolSidebarState={toolSidebarState}
-        isVersionControlOpen={true}
-        runsContent={<div>Runs content</div>}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    expect(screen.queryByRole("tab", { name: "Agent" })).not.toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByText("Versions content")).toBeInTheDocument();
-
-    rerender(
-      <CanvasToolSidebar
-        toolSidebarState={toolSidebarState}
-        isVersionControlOpen={false}
-        runsContent={<div>Runs content</div>}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    expect(screen.getByRole("tab", { name: "Versions" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByText("Versions content")).toBeInTheDocument();
-  });
-
-  it("enters versions from the versions tab", () => {
-    const onOpenVersionControl = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState()}
-        mode="version-live"
-        isVersionControlOpen={false}
-        onOpenVersionControl={onOpenVersionControl}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
-
-    expect(onOpenVersionControl).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Versions content")).toBeInTheDocument();
-  });
-
-  it("exits versions when switching back to the agent tab", () => {
-    const onCloseVersionControl = vi.fn();
-
-    render(
-      <CanvasToolSidebar
-        toolSidebarState={makeToolSidebarState()}
-        mode="version-live"
-        isVersionControlOpen={true}
-        onCloseVersionControl={onCloseVersionControl}
-        versionsContent={<div>Versions content</div>}
-      />,
-    );
-
-    expect(screen.getByText("Versions content")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("tab", { name: "Agent" }));
-
-    expect(onCloseVersionControl).toHaveBeenCalledTimes(1);
-    expect(screen.getByPlaceholderText("Ask the agent…")).toBeInTheDocument();
+    expect(openToolSidebar).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-render agent messages while typing in the composer", async () => {
@@ -289,13 +121,11 @@ describe("CanvasToolSidebar", () => {
 
     render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
 
-    // Initial message render.
     const messages = await screen.findAllByTestId("rich-message");
     expect(messages).toHaveLength(2);
     expect(messages[1]).toHaveTextContent("Hello from the agent");
     expect(richMessageRenderSpy).toHaveBeenCalledTimes(2);
 
-    // Typing only updates local composer state, so the message list should not re-render.
     await user.type(screen.getByTestId("agent-input"), "typing...");
     expect(richMessageRenderSpy).toHaveBeenCalledTimes(2);
   });
@@ -316,36 +146,12 @@ describe("CanvasToolSidebar", () => {
     await user.type(input, "first");
     await user.click(screen.getByTestId("agent-send-message-button"));
 
-    // While the first send is still pending, user can type a new message.
     await user.type(input, "second");
     expect(input).toHaveValue("second");
 
-    // Resolve the first send; the new draft should remain.
     await act(async () => {
       resolveSend?.();
     });
     expect(input).toHaveValue("second");
-  });
-
-  it("allows sending while an outcome is still active after the chat turn ends", async () => {
-    const user = userEvent.setup();
-    sessionStorage.setItem(
-      "outcome-chat-1",
-      JSON.stringify({
-        title: "Build plan",
-        criteria: [],
-        iteration: 1,
-        maxIterations: 3,
-        phase: "building",
-        log: [{ phase: "building" }],
-      }),
-    );
-
-    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
-
-    expect(screen.getByTestId("agent-stop-button")).toBeInTheDocument();
-
-    await user.type(screen.getByTestId("agent-input"), "Keep going");
-    expect(screen.getByTestId("agent-send-message-button")).toBeEnabled();
   });
 });

--- a/web_src/src/components/CanvasToolSidebar/index.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.tsx
@@ -1,269 +1,42 @@
-import { History, Rabbit, Sparkles } from "lucide-react";
-import { useCallback, useEffect, useRef, useState, type MutableRefObject, type ReactNode } from "react";
+import { useEffect } from "react";
 import { AgentTabPanel } from "./AgentTabPanel";
-import { EmptyToolTab } from "./EmptyToolTab";
 import { CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, canvasToolSidebarTabFromEvent } from "./events";
-import type { CanvasToolSidebarTab } from "./events";
 import { SidebarShell } from "./SidebarShell";
-import { ToolTabsHeader } from "./ToolTabsHeader";
 import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
-
-const TAB_AGENT = "agent",
-  TAB_RUNS = "runs",
-  TAB_VERSIONS = "versions";
-
-type CanvasToolSidebarMode = "default" | "version-live" | "version-edit" | "runs" | "console" | "memory" | "files";
 
 export interface CanvasToolSidebarProps {
   toolSidebarState: CanvasToolSidebarState;
-  mode?: CanvasToolSidebarMode;
-  onSelectRuns?: () => void;
-  onExitRunsMode?: () => void;
-  runsContent?: ReactNode;
-  isVersionControlOpen?: boolean;
-  onOpenVersionControl?: () => void;
-  hasAutoOpenedVersionControl?: boolean;
-  onVersionControlAutoOpened?: () => void;
-  onCloseVersionControl?: () => void;
-  versionsContent?: ReactNode;
 }
 
-export function CanvasToolSidebar({
-  toolSidebarState,
-  mode = "default",
-  onSelectRuns,
-  onExitRunsMode,
-  runsContent,
-  isVersionControlOpen,
-  onOpenVersionControl,
-  hasAutoOpenedVersionControl,
-  onVersionControlAutoOpened,
-  onCloseVersionControl,
-  versionsContent,
-}: CanvasToolSidebarProps) {
-  if (!toolSidebarState.showToolSidebarToggle || !toolSidebarState.canvasId) {
+export function CanvasToolSidebar({ toolSidebarState }: CanvasToolSidebarProps) {
+  useCanvasToolSidebarTabEvents(toolSidebarState);
+
+  if (!toolSidebarState.showToolSidebarToggle || !toolSidebarState.canvasId || !toolSidebarState.isAgentEnabled) {
+    return null;
+  }
+
+  if (!toolSidebarState.isToolSidebarOpen) {
     return null;
   }
 
   return (
-    <OpenCanvasToolSidebar
-      toolSidebarState={toolSidebarState}
-      mode={mode}
-      onSelectRuns={onSelectRuns}
-      onExitRunsMode={onExitRunsMode}
-      runsContent={runsContent}
-      isVersionControlOpen={isVersionControlOpen}
-      onOpenVersionControl={onOpenVersionControl}
-      hasAutoOpenedVersionControl={hasAutoOpenedVersionControl}
-      onVersionControlAutoOpened={onVersionControlAutoOpened}
-      onCloseVersionControl={onCloseVersionControl}
-      versionsContent={versionsContent}
-    />
-  );
-}
-
-function OpenCanvasToolSidebar({
-  toolSidebarState,
-  mode = "default",
-  onSelectRuns,
-  onExitRunsMode,
-  runsContent,
-  isVersionControlOpen,
-  onOpenVersionControl,
-  hasAutoOpenedVersionControl,
-  onVersionControlAutoOpened,
-  onCloseVersionControl,
-  versionsContent,
-}: CanvasToolSidebarProps) {
-  const hasAgentTab = toolSidebarState.isAgentEnabled;
-  const isToolSidebarOpen = toolSidebarState.isToolSidebarOpen;
-  const hasAutoOpenedVersionControlInMountRef = useRef(false);
-  const [activeTab, setActiveTab] = useState<CanvasToolSidebarTab>(() =>
-    defaultToolTab(mode, Boolean(isVersionControlOpen), hasAgentTab),
-  );
-  const handleTabSelect = useCallback(
-    (nextTab: typeof TAB_AGENT | typeof TAB_RUNS | typeof TAB_VERSIONS) => {
-      if (nextTab === TAB_AGENT && !hasAgentTab) return;
-
-      setActiveTab(nextTab);
-
-      if (nextTab === TAB_RUNS) {
-        if (isVersionControlOpen) onCloseVersionControl?.();
-        if (mode !== "runs") {
-          toolSidebarState.openToolSidebar();
-          onSelectRuns?.();
-        }
-        return;
-      }
-
-      if (mode === "runs") onExitRunsMode?.();
-
-      if (nextTab === TAB_VERSIONS) {
-        if (!isVersionControlOpen) {
-          toolSidebarState.openToolSidebar();
-          onOpenVersionControl?.();
-        }
-        return;
-      }
-
-      toolSidebarState.openToolSidebar();
-      if (isVersionControlOpen) onCloseVersionControl?.();
-    },
-    [
-      hasAgentTab,
-      isVersionControlOpen,
-      mode,
-      onCloseVersionControl,
-      onExitRunsMode,
-      onOpenVersionControl,
-      onSelectRuns,
-      toolSidebarState,
-    ],
-  );
-
-  useEffect(() => {
-    if (mode === "runs") {
-      setActiveTab(TAB_RUNS);
-      return;
-    }
-    if (isVersionControlOpen) {
-      setActiveTab(TAB_VERSIONS);
-      return;
-    }
-    setActiveTab((currentTab) => {
-      if (currentTab === TAB_AGENT && !hasAgentTab) return TAB_VERSIONS;
-      if ((currentTab === TAB_RUNS || currentTab === TAB_VERSIONS) && hasAgentTab) return TAB_AGENT;
-      return currentTab;
-    });
-  }, [hasAgentTab, isVersionControlOpen, mode]);
-
-  useAutoOpenVersionControl({
-    activeTab,
-    hasAgentTab,
-    hasAutoOpenedVersionControl,
-    hasAutoOpenedVersionControlInMountRef,
-    isToolSidebarOpen,
-    isVersionControlOpen,
-    mode,
-    onOpenVersionControl,
-    onVersionControlAutoOpened,
-    toolSidebarState,
-  });
-
-  useCanvasToolSidebarTabEvents(handleTabSelect);
-
-  const tabs = [
-    ...(hasAgentTab ? [{ value: TAB_AGENT, label: "Agent", icon: Sparkles }] : []),
-    { value: TAB_RUNS, label: "Runs", icon: Rabbit },
-    { value: TAB_VERSIONS, label: "Versions", icon: History },
-  ] as const;
-
-  if (!isToolSidebarOpen) return null;
-
-  return (
     <SidebarShell>
-      <div className="flex min-h-0 flex-1 flex-col gap-0">
-        <ToolTabsHeader
-          tabs={tabs}
-          activeTab={activeTab}
-          onSelectTab={(value) => handleTabSelect(value as typeof TAB_AGENT | typeof TAB_RUNS | typeof TAB_VERSIONS)}
-        />
-
-        {activeTab === TAB_AGENT && hasAgentTab ? (
-          <div className="m-0 flex min-h-0 flex-1 flex-col overflow-hidden" role="tabpanel">
-            <AgentTabPanel toolSidebarState={toolSidebarState} />
-          </div>
-        ) : null}
-        {activeTab === TAB_RUNS ? (
-          <div className="m-0 flex min-h-0 flex-1 flex-col" role="tabpanel">
-            {runsContent ?? <EmptyToolTab />}
-          </div>
-        ) : null}
-        {activeTab === TAB_VERSIONS ? (
-          <div className="m-0 flex min-h-0 flex-1 flex-col" role="tabpanel">
-            {versionsContent ?? <EmptyToolTab />}
-          </div>
-        ) : null}
+      <div className="m-0 flex min-h-0 flex-1 flex-col overflow-hidden" role="tabpanel">
+        <AgentTabPanel toolSidebarState={toolSidebarState} />
       </div>
     </SidebarShell>
   );
 }
 
-function defaultToolTab(
-  mode: CanvasToolSidebarMode,
-  isVersionControlOpen: boolean,
-  hasAgentTab: boolean,
-): CanvasToolSidebarTab {
-  if (mode === "runs") return TAB_RUNS;
-  if (isVersionControlOpen) return TAB_VERSIONS;
-  if (hasAgentTab) return TAB_AGENT;
-  return TAB_VERSIONS;
-}
-
-function useAutoOpenVersionControl({
-  activeTab,
-  hasAgentTab,
-  hasAutoOpenedVersionControl,
-  hasAutoOpenedVersionControlInMountRef,
-  isToolSidebarOpen,
-  isVersionControlOpen,
-  mode,
-  onOpenVersionControl,
-  onVersionControlAutoOpened,
-  toolSidebarState,
-}: {
-  activeTab: CanvasToolSidebarTab;
-  hasAgentTab: boolean;
-  hasAutoOpenedVersionControl?: boolean;
-  hasAutoOpenedVersionControlInMountRef: MutableRefObject<boolean>;
-  isToolSidebarOpen: boolean;
-  isVersionControlOpen?: boolean;
-  mode: CanvasToolSidebarMode;
-  onOpenVersionControl?: () => void;
-  onVersionControlAutoOpened?: () => void;
-  toolSidebarState: CanvasToolSidebarState;
-}) {
-  useEffect(() => {
-    if (
-      hasAgentTab ||
-      !isToolSidebarOpen ||
-      isVersionControlOpen ||
-      mode === "runs" ||
-      activeTab !== TAB_VERSIONS ||
-      !onOpenVersionControl ||
-      hasAutoOpenedVersionControl ||
-      hasAutoOpenedVersionControlInMountRef.current
-    ) {
-      return;
-    }
-
-    hasAutoOpenedVersionControlInMountRef.current = true;
-    onVersionControlAutoOpened?.();
-    toolSidebarState.openToolSidebar();
-    onOpenVersionControl();
-  }, [
-    activeTab,
-    hasAgentTab,
-    hasAutoOpenedVersionControl,
-    hasAutoOpenedVersionControlInMountRef,
-    isToolSidebarOpen,
-    isVersionControlOpen,
-    mode,
-    onOpenVersionControl,
-    onVersionControlAutoOpened,
-    toolSidebarState,
-  ]);
-}
-
-function useCanvasToolSidebarTabEvents(handleTabSelect: (tab: CanvasToolSidebarTab) => void) {
+function useCanvasToolSidebarTabEvents(toolSidebarState: CanvasToolSidebarState) {
   useEffect(() => {
     const onSelectTab = (event: Event) => {
       const tab = canvasToolSidebarTabFromEvent(event);
-      if (!tab) return;
-      handleTabSelect(tab);
+      if (tab !== "agent") return;
+      toolSidebarState.openToolSidebar();
     };
 
     window.addEventListener(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, onSelectTab);
     return () => window.removeEventListener(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, onSelectTab);
-  }, [handleTabSelect]);
+  }, [toolSidebarState]);
 }

--- a/web_src/src/components/CanvasVersionsSidebar/index.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/index.tsx
@@ -8,7 +8,7 @@ export interface CanvasVersionsSidebarProps {
 }
 
 export function CanvasVersionsSidebar({ isOpen, children }: CanvasVersionsSidebarProps) {
-  const { sidebarRef, width, isResizing, handleMouseDown } = useVersionsSidebarWidth();
+  const { sidebarRef, width, isResizing, handleMouseDown } = useVersionsSidebarWidth(isOpen);
 
   if (!isOpen) {
     return null;

--- a/web_src/src/components/CanvasVersionsSidebar/index.tsx
+++ b/web_src/src/components/CanvasVersionsSidebar/index.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { useVersionsSidebarWidth } from "./useVersionsSidebarWidth";
+
+export interface CanvasVersionsSidebarProps {
+  isOpen: boolean;
+  children: ReactNode;
+}
+
+export function CanvasVersionsSidebar({ isOpen, children }: CanvasVersionsSidebarProps) {
+  const { sidebarRef, width, isResizing, handleMouseDown } = useVersionsSidebarWidth();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <aside
+      ref={sidebarRef}
+      data-testid="canvas-versions-sidebar"
+      className="relative z-21 flex h-full shrink-0 flex-col border-r border-border bg-white"
+      style={{ width }}
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+      <div
+        onMouseDown={handleMouseDown}
+        className="group absolute top-0 right-0 bottom-0 z-30 w-4 cursor-col-resize bg-transparent"
+        style={{ marginRight: "-8px" }}
+        data-testid="canvas-versions-sidebar-resize-handle"
+      >
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute top-0 bottom-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-slate-950/50",
+            isResizing && "bg-slate-950/50",
+          )}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/web_src/src/components/CanvasVersionsSidebar/useVersionsSidebarWidth.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useVersionsSidebarWidth.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY = "versions-sidebar-width";
+export const VERSIONS_SIDEBAR_MIN_WIDTH = 300;
+export const VERSIONS_SIDEBAR_DEFAULT_WIDTH = 380;
+
+function readPersistedWidth(): number {
+  if (typeof window === "undefined") return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
+  try {
+    const saved = window.localStorage.getItem(VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY);
+    const parsed = saved ? Number.parseInt(saved, 10) : Number.NaN;
+    if (!Number.isFinite(parsed)) return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
+    return Math.max(VERSIONS_SIDEBAR_MIN_WIDTH, parsed);
+  } catch {
+    return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
+  }
+}
+
+function persistWidth(value: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY, String(value));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function useVersionsSidebarWidth() {
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(readPersistedWidth);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const handleMouseDown = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = sidebarRef.current?.getBoundingClientRect();
+      const left = rect?.left ?? 0;
+      const next = Math.max(VERSIONS_SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left));
+      setWidth(next);
+      persistWidth(next);
+    };
+
+    const handleMouseUp = () => setIsResizing(false);
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing]);
+
+  return { sidebarRef, width, isResizing, handleMouseDown };
+}

--- a/web_src/src/components/CanvasVersionsSidebar/useVersionsSidebarWidth.ts
+++ b/web_src/src/components/CanvasVersionsSidebar/useVersionsSidebarWidth.ts
@@ -1,65 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuxiliarySidebarWidth } from "@/stores/useAuxiliarySidebarWidth";
 
 export const VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY = "versions-sidebar-width";
 export const VERSIONS_SIDEBAR_MIN_WIDTH = 300;
 export const VERSIONS_SIDEBAR_DEFAULT_WIDTH = 380;
 
-function readPersistedWidth(): number {
-  if (typeof window === "undefined") return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
-  try {
-    const saved = window.localStorage.getItem(VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY);
-    const parsed = saved ? Number.parseInt(saved, 10) : Number.NaN;
-    if (!Number.isFinite(parsed)) return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
-    return Math.max(VERSIONS_SIDEBAR_MIN_WIDTH, parsed);
-  } catch {
-    return VERSIONS_SIDEBAR_DEFAULT_WIDTH;
-  }
-}
-
-function persistWidth(value: number): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY, String(value));
-  } catch {
-    // ignore storage errors
-  }
-}
-
-export function useVersionsSidebarWidth() {
-  const sidebarRef = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(readPersistedWidth);
-  const [isResizing, setIsResizing] = useState(false);
-
-  const handleMouseDown = useCallback((event: React.MouseEvent) => {
-    event.preventDefault();
-    setIsResizing(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isResizing) return;
-
-    const handleMouseMove = (event: MouseEvent) => {
-      const rect = sidebarRef.current?.getBoundingClientRect();
-      const left = rect?.left ?? 0;
-      const next = Math.max(VERSIONS_SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left));
-      setWidth(next);
-      persistWidth(next);
-    };
-
-    const handleMouseUp = () => setIsResizing(false);
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [isResizing]);
-
-  return { sidebarRef, width, isResizing, handleMouseDown };
+export function useVersionsSidebarWidth(isOpen: boolean) {
+  return useAuxiliarySidebarWidth(isOpen, VERSIONS_SIDEBAR_WIDTH_STORAGE_KEY, VERSIONS_SIDEBAR_DEFAULT_WIDTH);
 }

--- a/web_src/src/components/GlobalCommandPalette/actions.ts
+++ b/web_src/src/components/GlobalCommandPalette/actions.ts
@@ -36,7 +36,7 @@ type CurrentCanvasActionParams = {
   canvasId: string | null;
   currentCanvasName: string;
   goTo: (href: string) => void;
-  goToCurrentCanvasView: (view?: "console" | "memory" | "runs") => void;
+  goToCurrentCanvasView: (view?: "console" | "memory" | "runs" | "versions") => void;
   openCurrentCanvasToolTab: (tab: CanvasToolSidebarTab) => void;
   organizationId: string | null;
   showToolTabCommands: boolean;
@@ -132,6 +132,14 @@ export function buildCurrentCanvasActions({
       keywords: ["runs", "executions"],
     },
     {
+      id: "current-canvas-versions",
+      label: "Versions",
+      description: currentCanvasName,
+      icon: History,
+      onSelect: () => goToCurrentCanvasView("versions"),
+      keywords: ["versions", "version history", "change requests"],
+    },
+    {
       id: "current-canvas-memory",
       label: "Memory",
       description: currentCanvasName,
@@ -149,17 +157,6 @@ export function buildCurrentCanvasActions({
       keywords: ["canvas", "settings"],
     },
   ];
-
-  if (showToolTabCommands) {
-    actions.splice(4, 0, {
-      id: "current-canvas-versions",
-      label: "Versions",
-      description: currentCanvasName,
-      icon: History,
-      onSelect: () => openCurrentCanvasToolTab("versions"),
-      keywords: ["versions", "version history", "change requests"],
-    });
-  }
 
   if (agentEnabled && showToolTabCommands) {
     actions.splice(1, 0, {

--- a/web_src/src/pages/app/canvasToolSidebarPanelContent.tsx
+++ b/web_src/src/pages/app/canvasToolSidebarPanelContent.tsx
@@ -1,0 +1,77 @@
+import type {
+  CanvasChangeManagement,
+  CanvasesCanvasChangeRequest,
+  CanvasesCanvasVersion,
+  CanvasesCanvasRun,
+  SuperplaneComponentsNode as ComponentsNode,
+} from "@/api-client";
+import { RunsTabPanel } from "@/components/CanvasToolSidebar/RunsTabPanel";
+import { VersionsTabPanel } from "@/components/CanvasToolSidebar/VersionsTabPanel";
+import type { CanvasVersionNodeDiffContext } from "@/pages/app/CanvasVersionNodeDiffDialog";
+import type { ReactNode } from "react";
+import type { RunStatusFilter } from "@/ui/Runs/runPresentation";
+
+export interface CanvasRunsSidebarPanelConfig {
+  isOpen: boolean;
+  canvasId: string;
+  runs: CanvasesCanvasRun[];
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+  onBackToRunList?: () => void;
+  initialOpenDetail?: boolean;
+  detailDismissedForRunId?: string | null;
+  selectedNodeId?: string | null;
+  onSelectNode?: (nodeId: string) => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  onLoadMore?: () => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+  workflowNodes?: ComponentsNode[];
+  componentIconMap?: Record<string, string>;
+  onStatusFiltersChange?: (filters: RunStatusFilter[]) => void;
+}
+
+export interface CanvasVersionsSidebarPanelConfig {
+  isOpen: boolean;
+  scrollPersistenceKey?: string;
+  liveCanvasVersionId?: string;
+  selectedCanvasVersion?: CanvasesCanvasVersion | null;
+  pendingApprovalVersions?: Array<{
+    version: CanvasesCanvasVersion;
+    changeRequest: CanvasesCanvasChangeRequest;
+  }>;
+  rejectedVersions?: Array<{
+    version: CanvasesCanvasVersion;
+    changeRequest: CanvasesCanvasChangeRequest;
+  }>;
+  liveVersions: CanvasesCanvasVersion[];
+  liveVersionChangeRequestsByVersionId?: Map<string, CanvasesCanvasChangeRequest>;
+  canUpdateCanvas: boolean;
+  isTemplate: boolean;
+  canvasDeletedRemotely: boolean;
+  onUseVersion: (versionID: string) => void;
+  onVersionNodeDiffContextChange: (context: CanvasVersionNodeDiffContext | null) => void;
+  onLoadMoreLiveVersions?: () => void;
+  loadMoreLiveVersionsDisabled?: boolean;
+  loadMoreLiveVersionsPending?: boolean;
+  changeRequestApprovalConfig?: CanvasChangeManagement;
+  draftBranches?: CanvasesCanvasVersion[];
+  activeDraftBranch?: string | null;
+  onOpenDraftBranch?: (branchName: string) => void;
+  onDeleteDraftBranch?: (versionId: string) => void;
+  deleteDraftBranchPending?: boolean;
+}
+
+export function renderCanvasRunsSidebarPanel(config: CanvasRunsSidebarPanelConfig): ReactNode {
+  if (!config.isOpen) return null;
+  const { isOpen: _isOpen, ...props } = config;
+  return <RunsTabPanel {...props} />;
+}
+
+export function renderCanvasVersionsSidebarPanel(config: CanvasVersionsSidebarPanelConfig): ReactNode {
+  if (!config.isOpen) return null;
+  const { isOpen: _isOpen, ...props } = config;
+  return <VersionsTabPanel {...props} />;
+}

--- a/web_src/src/pages/app/console/useConsoleModeActions.ts
+++ b/web_src/src/pages/app/console/useConsoleModeActions.ts
@@ -6,6 +6,7 @@ interface ConsoleModeActionsConfig {
   setIsConsoleAddPanelOpen: (value: boolean) => void;
   setIsConsoleYamlOpen: (value: boolean) => void;
   setIsRunsMode: (value: boolean) => void;
+  setIsVersionsMode: (value: boolean) => void;
   setIsMemoryMode: (value: boolean) => void;
   setIsFilesMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
@@ -17,6 +18,7 @@ export function useConsoleModeActions({
   setIsConsoleAddPanelOpen,
   setIsConsoleYamlOpen,
   setIsRunsMode,
+  setIsVersionsMode,
   setIsMemoryMode,
   setIsFilesMode,
   setSelectedRunId,
@@ -25,11 +27,20 @@ export function useConsoleModeActions({
   const handleSelectConsoleMode = useCallback(() => {
     setIsConsoleMode(true);
     setIsRunsMode(false);
+    setIsVersionsMode(false);
     setIsMemoryMode(false);
     setIsFilesMode(false);
     setSelectedRunId(null);
     setSearchParams(toConsoleSearchParams, { replace: true });
-  }, [setIsConsoleMode, setIsFilesMode, setIsMemoryMode, setIsRunsMode, setSearchParams, setSelectedRunId]);
+  }, [
+    setIsConsoleMode,
+    setIsFilesMode,
+    setIsMemoryMode,
+    setIsRunsMode,
+    setIsVersionsMode,
+    setSearchParams,
+    setSelectedRunId,
+  ]);
 
   const handleExitConsoleMode = useCallback(() => {
     setIsConsoleMode(false);

--- a/web_src/src/pages/app/console/widget/useWidgetData.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.ts
@@ -456,25 +456,40 @@ export function collectExecutionRows(
  *
  * Iteration stops as soon as `rows.length >= limit`.
  */
+type RunRowSource = Record<string, unknown> & {
+  state?: string;
+  result?: string;
+  createdAt?: string;
+  finishedAt?: string;
+  rootEvent?: {
+    id?: string;
+    nodeId?: string;
+    data?: Record<string, unknown>;
+  };
+};
+
+function buildRunRow(
+  run: RunRowSource,
+  nodeNameById: Map<string, string>,
+  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
+): unknown {
+  const rootEvent = run.rootEvent;
+  const nodeId = rootEvent?.nodeId;
+  const executions = (rootEvent?.id && executionsByRootEventId?.get(rootEvent.id)) || undefined;
+  const dollarNodes = buildDollarNodes(executions, nodeNameById);
+  return {
+    ...run,
+    status: deriveRunStatus(run.state, run.result),
+    nodeName: (nodeId && nodeNameById.get(nodeId)) || nodeId,
+    payload: rootEvent?.data,
+    durationMs: run.finishedAt && run.createdAt ? Date.parse(run.finishedAt) - Date.parse(run.createdAt) : undefined,
+    $: dollarNodes,
+    [DOLLAR_REWRITE_IDENTIFIER]: dollarNodes,
+  };
+}
+
 export function collectRunRows(
-  pages: Array<
-    | {
-        runs?: Array<
-          Record<string, unknown> & {
-            state?: string;
-            result?: string;
-            createdAt?: string;
-            finishedAt?: string;
-            rootEvent?: {
-              id?: string;
-              nodeId?: string;
-              data?: Record<string, unknown>;
-            };
-          }
-        >;
-      }
-    | undefined
-  >,
+  pages: Array<{ runs?: RunRowSource[] } | undefined>,
   nodeNameById: Map<string, string>,
   limit: number,
   executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
@@ -482,20 +497,7 @@ export function collectRunRows(
   const rows: unknown[] = [];
   for (const page of pages) {
     for (const run of page?.runs ?? []) {
-      const rootEvent = run.rootEvent;
-      const nodeId = rootEvent?.nodeId;
-      const executions = (rootEvent?.id && executionsByRootEventId?.get(rootEvent.id)) || undefined;
-      const dollarNodes = buildDollarNodes(executions, nodeNameById);
-      rows.push({
-        ...run,
-        status: deriveRunStatus(run.state, run.result),
-        nodeName: (nodeId && nodeNameById.get(nodeId)) || nodeId,
-        payload: rootEvent?.data,
-        durationMs:
-          run.finishedAt && run.createdAt ? Date.parse(run.finishedAt) - Date.parse(run.createdAt) : undefined,
-        $: dollarNodes,
-        [DOLLAR_REWRITE_IDENTIFIER]: dollarNodes,
-      });
+      rows.push(buildRunRow(run, nodeNameById, executionsByRootEventId));
       if (rows.length >= limit) return rows;
     }
   }

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -97,6 +97,7 @@ import { CanvasYamlModal } from "./CanvasYamlModal";
 import { useWorkflowViewSearchParams } from "./useWorkflowViewSearchParams";
 import { useFilesModeActions } from "./files/useFilesModeActions";
 import { resolveFilesHeaderVersionActions, useFilesHeaderState } from "./files/useFilesHeaderState";
+import { useVersionsModeActions } from "./useVersionsModeActions";
 import { useMemoryModeActions } from "./useMemoryModeActions";
 import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
 import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
@@ -164,7 +165,6 @@ import {
   prepareSidebarData,
 } from "./workflowPageHelpers";
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
-const CANVAS_VERSION_CONTROL_STORAGE_KEY = "canvas-version-control-open";
 const LOCAL_CANVAS_LIFECYCLE_ECHO_TTL_MS = 5000;
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
@@ -188,6 +188,8 @@ export function AppPage() {
   const {
     isRunsMode,
     setIsRunsMode,
+    isVersionsMode,
+    setIsVersionsMode,
     setIsConsoleMode,
     isMemoryMode,
     setIsMemoryMode,
@@ -199,6 +201,17 @@ export function AppPage() {
     selectedRunId,
     setSelectedRunId,
   } = useWorkflowViewSearchParams(searchParams, setSearchParams);
+  const { handleSelectVersionsMode, handleExitVersionsMode } = useVersionsModeActions({
+    setIsVersionsMode,
+    setIsConsoleMode,
+    setIsConsoleAddPanelOpen,
+    setIsConsoleYamlOpen,
+    setIsRunsMode,
+    setIsMemoryMode,
+    setIsFilesMode,
+    setSelectedRunId,
+    setSearchParams,
+  });
   const {
     openRunDetailOnMount,
     runDetailNodeId,
@@ -633,9 +646,6 @@ export function AppPage() {
   const canActOnCanvas = canUpdateCanvas && !isTemplate && !canvasDeletedRemotely;
   const isReadOnly = !canActOnCanvas || !hasEditableVersion;
   const [isUseTemplateOpen, setIsUseTemplateOpen] = useState(false);
-  const [isVersionControlOpen, setIsVersionControlOpen] = useState(() =>
-    readStoredBoolean(CANVAS_VERSION_CONTROL_STORAGE_KEY),
-  );
   /** After creating a change request, hide draft Discard until the user enters edit mode again. */
   const [suppressUnpublishedDraftDiscard, setSuppressUnpublishedDraftDiscard] = useState(false);
   const [isYamlViewModalOpen, setIsYamlViewModalOpen] = useState(false);
@@ -665,15 +675,6 @@ export function AppPage() {
   const hasFitToViewRef = useRef(false);
   const runsHasFitToViewRef = useRef(false);
   const hasSyncedVersionFromURLRef = useRef(false);
-  const autoOpenedVersionControlCanvasIdsRef = useRef<Set<string>>(new Set());
-  const hasAutoOpenedVersionControl = Boolean(canvasId && autoOpenedVersionControlCanvasIdsRef.current.has(canvasId));
-  const handleVersionControlAutoOpened = useCallback(() => {
-    if (!canvasId) {
-      return;
-    }
-
-    autoOpenedVersionControlCanvasIdsRef.current.add(canvasId);
-  }, [canvasId]);
 
   /**
    * Capture the initial node focus from the URL so we only zoom once.
@@ -730,12 +731,6 @@ export function AppPage() {
   const [isAutoLayoutOnUpdateEnabled, setIsAutoLayoutOnUpdateEnabled] = useState(() =>
     readStoredBoolean(CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY),
   );
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(CANVAS_VERSION_CONTROL_STORAGE_KEY, JSON.stringify(isVersionControlOpen));
-    }
-  }, [isVersionControlOpen]);
 
   useEffect(() => {
     if (!isCreateChangeRequestMode) {
@@ -4197,12 +4192,15 @@ export function AppPage() {
     [handleActOnChangeRequest],
   );
 
-  const handleGoToVersioningToResolveConflicts = useCallback((changeRequestId: string) => {
-    setVersionNodeDiffContext(null);
-    setSelectedChangeRequestId(changeRequestId);
-    setResolvingConflictChangeRequestId(changeRequestId);
-    setIsVersionControlOpen(true);
-  }, []);
+  const handleGoToVersioningToResolveConflicts = useCallback(
+    (changeRequestId: string) => {
+      setVersionNodeDiffContext(null);
+      setSelectedChangeRequestId(changeRequestId);
+      setResolvingConflictChangeRequestId(changeRequestId);
+      handleSelectVersionsMode();
+    },
+    [handleSelectVersionsMode],
+  );
 
   const handleOpenAwaitingApprovalNodeDiff = useCallback(() => {
     if (!selectedCanvasVersionID) {
@@ -4256,7 +4254,7 @@ export function AppPage() {
       onPublish: () => handlePublishChangeRequest(changeRequestId),
       onOpenVersioningTab: () => {
         setSelectedChangeRequestId(changeRequestId);
-        setIsVersionControlOpen(true);
+        handleSelectVersionsMode();
       },
       onViewNodeDiff: handleOpenAwaitingApprovalNodeDiff,
       canAct: canActOnCanvas,
@@ -4271,6 +4269,7 @@ export function AppPage() {
     handleApproveChangeRequest,
     handleRejectChangeRequest,
     handlePublishChangeRequest,
+    handleSelectVersionsMode,
     handleOpenAwaitingApprovalNodeDiff,
     canActOnCanvas,
     actOnCanvasChangeRequestMutation.isPending,
@@ -4535,7 +4534,7 @@ export function AppPage() {
         if (changeRequestID) {
           setSelectedChangeRequestId(changeRequestID);
         }
-        setIsVersionControlOpen(true);
+        handleSelectVersionsMode();
         setSuppressUnpublishedDraftDiscard(true);
         showSuccessToast("Change request created");
       } catch (error) {
@@ -4552,6 +4551,7 @@ export function AppPage() {
       queryClient,
       liveCanvasVersionId,
       handleUseVersion,
+      handleSelectVersionsMode,
     ],
   );
 
@@ -4719,6 +4719,7 @@ export function AppPage() {
     }
 
     setIsRunsMode(true);
+    setIsVersionsMode(false);
     setIsMemoryMode(false);
     setIsFilesMode(false);
     setSearchParams(
@@ -4739,6 +4740,7 @@ export function AppPage() {
     setIsFilesMode,
     setIsMemoryMode,
     setIsRunsMode,
+    setIsVersionsMode,
     setSearchParams,
   ]);
 
@@ -4757,19 +4759,12 @@ export function AppPage() {
     );
   }, [setIsRunsMode, setSearchParams, setSelectedRunId, setRunDetailNodeId]);
 
-  const handleOpenVersionControl = useCallback(() => {
-    setIsVersionControlOpen(true);
-  }, []);
-
-  const handleCloseVersionControl = useCallback(() => {
-    setIsVersionControlOpen(false);
-  }, []);
-
   const { handleSelectConsoleMode, handleExitConsoleMode } = useConsoleModeActions({
     setIsConsoleMode,
     setIsConsoleAddPanelOpen,
     setIsConsoleYamlOpen,
     setIsRunsMode,
+    setIsVersionsMode,
     setIsMemoryMode,
     setIsFilesMode,
     setSearchParams,
@@ -4782,6 +4777,7 @@ export function AppPage() {
     setIsConsoleAddPanelOpen,
     setIsConsoleYamlOpen,
     setIsRunsMode,
+    setIsVersionsMode,
     setIsFilesMode,
     setSearchParams,
     setSelectedRunId,
@@ -4793,6 +4789,7 @@ export function AppPage() {
     setIsConsoleAddPanelOpen,
     setIsConsoleYamlOpen,
     setIsRunsMode,
+    setIsVersionsMode,
     setIsMemoryMode,
     setSelectedRunId,
     setSearchParams,
@@ -4814,6 +4811,7 @@ export function AppPage() {
     handleExitMemoryMode,
     handleExitFilesMode,
     handleExitRunsMode,
+    handleExitVersionsMode,
     handleToggleEditMode,
     setIsConsoleAddPanelOpen,
     setIsConsoleYamlOpen,
@@ -4821,9 +4819,12 @@ export function AppPage() {
 
   const { handleEnterEditModeFromHeader, handleExitEditModeFromHeader } = useWorkflowHeaderEditActions({
     isRunsMode,
+    isVersionsMode,
     handleExitRunsMode,
+    handleExitVersionsMode,
     handleToggleEditMode,
     setIsRunsMode,
+    setIsVersionsMode,
     setSelectedRunId,
     setRunDetailNodeId,
     setSearchParams,
@@ -5365,15 +5366,11 @@ export function AppPage() {
           showCanvasSettingsMenu={canUpdateCanvas}
           onSeeCurrentVersion={handleSeeCurrentVersion}
           awaitingApprovalBanner={awaitingApprovalBanner}
-          isVersionControlOpen={isVersionControlOpen}
-          onOpenVersionControl={handleOpenVersionControl}
-          hasAutoOpenedVersionControl={hasAutoOpenedVersionControl}
-          onVersionControlAutoOpened={handleVersionControlAutoOpened}
-          onCloseVersionControl={handleCloseVersionControl}
           showBottomStatusControls={showBottomStatusControls}
           hideAddControls={hideAddControls}
           hideCanvasToolSidebar={isTemplate}
           onSelectMemory={isTemplate ? undefined : handleSelectMemoryMode}
+          onSelectVersions={isTemplate ? undefined : handleSelectVersionsMode}
           nodes={nodes}
           edges={renderedEdges}
           organizationId={organizationId}
@@ -5466,7 +5463,6 @@ export function AppPage() {
           enterEditModeDisabledTooltip={enterEditModeDisabledTooltip}
           onExitEditMode={handleExitEditModeFromHeader}
           onSelectRuns={isTemplate ? undefined : handleSelectRunsMode}
-          onExitRunsMode={handleExitRunsMode}
           onSelectConsole={isTemplate ? undefined : handleSelectConsoleMode}
           onSelectFiles={isTemplate ? undefined : handleSelectFilesMode}
           filesHeaderActionsSlotId={filesHeaderActionsSlotId}
@@ -5530,31 +5526,33 @@ export function AppPage() {
             ) : null
           }
           toolSidebarVersionsContent={
-            <VersionsTabPanel
-              scrollPersistenceKey={canvasId}
-              liveCanvasVersionId={effectiveLiveCanvasVersionId}
-              selectedCanvasVersion={selectedCanvasVersion}
-              pendingApprovalVersions={pendingApprovalVersions}
-              liveVersions={liveVersions}
-              liveVersionChangeRequestsByVersionId={liveVersionChangeRequestsByVersionId}
-              canUpdateCanvas={canUpdateCanvas}
-              isTemplate={isTemplate}
-              canvasDeletedRemotely={canvasDeletedRemotely}
-              onUseVersion={handleUseVersionFromVersionPanel}
-              onVersionNodeDiffContextChange={setVersionNodeDiffContext}
-              onLoadMoreLiveVersions={hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined}
-              loadMoreLiveVersionsDisabled={!hasMoreLiveVersions || isLoadingMoreLiveVersions}
-              loadMoreLiveVersionsPending={isLoadingMoreLiveVersions}
-              changeRequestApprovalConfig={
-                liveCanvasVersion?.spec?.changeManagement ?? liveCanvas?.spec?.changeManagement
-              }
-              rejectedVersions={rejectedVersions}
-              draftBranches={draftBranches}
-              activeDraftBranch={resolvedActiveBranch}
-              onOpenDraftBranch={handleContinueDraftBranch}
-              onDeleteDraftBranch={handleDeleteDraftBranch}
-              deleteDraftBranchPending={deleteDraftBranchMutation.isPending}
-            />
+            isVersionsMode ? (
+              <VersionsTabPanel
+                scrollPersistenceKey={canvasId}
+                liveCanvasVersionId={effectiveLiveCanvasVersionId}
+                selectedCanvasVersion={selectedCanvasVersion}
+                pendingApprovalVersions={pendingApprovalVersions}
+                liveVersions={liveVersions}
+                liveVersionChangeRequestsByVersionId={liveVersionChangeRequestsByVersionId}
+                canUpdateCanvas={canUpdateCanvas}
+                isTemplate={isTemplate}
+                canvasDeletedRemotely={canvasDeletedRemotely}
+                onUseVersion={handleUseVersionFromVersionPanel}
+                onVersionNodeDiffContextChange={setVersionNodeDiffContext}
+                onLoadMoreLiveVersions={hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined}
+                loadMoreLiveVersionsDisabled={!hasMoreLiveVersions || isLoadingMoreLiveVersions}
+                loadMoreLiveVersionsPending={isLoadingMoreLiveVersions}
+                changeRequestApprovalConfig={
+                  liveCanvasVersion?.spec?.changeManagement ?? liveCanvas?.spec?.changeManagement
+                }
+                rejectedVersions={rejectedVersions}
+                draftBranches={draftBranches}
+                activeDraftBranch={resolvedActiveBranch}
+                onOpenDraftBranch={handleContinueDraftBranch}
+                onDeleteDraftBranch={handleDeleteDraftBranch}
+                deleteDraftBranchPending={deleteDraftBranchMutation.isPending}
+              />
+            ) : null
           }
           focusRequest={focusRequest}
           onExecutionChainHandled={handleExecutionChainHandled}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -24,8 +24,10 @@ import type {
 import { canvasesApplyCanvasVersionChangeset, canvasesReemitTriggerEvent, canvasesUpdateNodePause } from "@/api-client";
 import { useOrganizationRoles, useOrganizationUsers } from "@/hooks/useOrganizationData";
 import { Button } from "@/components/ui/button";
-import { RunsTabPanel } from "@/components/CanvasToolSidebar/RunsTabPanel";
-import { VersionsTabPanel } from "@/components/CanvasToolSidebar/VersionsTabPanel";
+import {
+  renderCanvasRunsSidebarPanel,
+  renderCanvasVersionsSidebarPanel,
+} from "@/pages/app/canvasToolSidebarPanelContent";
 import { usePermissions } from "@/contexts/usePermissions";
 import { useComponents } from "@/hooks/useComponentData";
 import {
@@ -5299,6 +5301,52 @@ export function AppPage() {
         ? resolvedActiveBranch
         : undefined;
 
+  const toolSidebarRunsContent = renderCanvasRunsSidebarPanel({
+    isOpen: isRunsMode,
+    canvasId: canvasId!,
+    runs: runsData.runs,
+    selectedRunId,
+    onSelectRun: handleSelectRun,
+    onBackToRunList: handleBackToRunList,
+    initialOpenDetail: openRunDetailOnMount,
+    detailDismissedForRunId,
+    selectedNodeId: runDetailNodeId,
+    onSelectNode: setRunDetailNodeId,
+    hasNextPage: !!infiniteRunsQuery.hasNextPage,
+    isFetchingNextPage: infiniteRunsQuery.isFetchingNextPage,
+    onLoadMore: () => infiniteRunsQuery.fetchNextPage(),
+    isLoading: infiniteRunsQuery.isLoading,
+    isError: infiniteRunsQuery.isError,
+    onRetry: () => infiniteRunsQuery.refetch(),
+    workflowNodes: canvasNodes,
+    componentIconMap,
+    onStatusFiltersChange: setRunStatusFilters,
+  });
+  const toolSidebarVersionsContent = renderCanvasVersionsSidebarPanel({
+    isOpen: isVersionsMode,
+    scrollPersistenceKey: canvasId,
+    liveCanvasVersionId: effectiveLiveCanvasVersionId,
+    selectedCanvasVersion,
+    pendingApprovalVersions,
+    liveVersions,
+    liveVersionChangeRequestsByVersionId,
+    canUpdateCanvas,
+    isTemplate,
+    canvasDeletedRemotely,
+    onUseVersion: handleUseVersionFromVersionPanel,
+    onVersionNodeDiffContextChange: setVersionNodeDiffContext,
+    onLoadMoreLiveVersions: hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined,
+    loadMoreLiveVersionsDisabled: !hasMoreLiveVersions || isLoadingMoreLiveVersions,
+    loadMoreLiveVersionsPending: isLoadingMoreLiveVersions,
+    changeRequestApprovalConfig: liveCanvasVersion?.spec?.changeManagement ?? liveCanvas?.spec?.changeManagement,
+    rejectedVersions,
+    draftBranches,
+    activeDraftBranch: resolvedActiveBranch,
+    onOpenDraftBranch: handleContinueDraftBranch,
+    onDeleteDraftBranch: handleDeleteDraftBranch,
+    deleteDraftBranchPending: deleteDraftBranchMutation.isPending,
+  });
+
   return (
     <>
       <div className="relative h-full w-full">
@@ -5501,59 +5549,8 @@ export function AppPage() {
           onRunExecutionSelect={handleLogRunExecutionSelect}
           onAcknowledgeErrors={canUpdateCanvas && isViewingLiveVersion ? handleAcknowledgeErrors : undefined}
           onNodeClick={isRunsMode ? handleRunCanvasNodeClick : undefined}
-          toolSidebarRunsContent={
-            isRunsMode ? (
-              <RunsTabPanel
-                canvasId={canvasId!}
-                runs={runsData.runs}
-                selectedRunId={selectedRunId}
-                onSelectRun={handleSelectRun}
-                onBackToRunList={handleBackToRunList}
-                initialOpenDetail={openRunDetailOnMount}
-                detailDismissedForRunId={detailDismissedForRunId}
-                selectedNodeId={runDetailNodeId}
-                onSelectNode={setRunDetailNodeId}
-                hasNextPage={!!infiniteRunsQuery.hasNextPage}
-                isFetchingNextPage={infiniteRunsQuery.isFetchingNextPage}
-                onLoadMore={() => infiniteRunsQuery.fetchNextPage()}
-                isLoading={infiniteRunsQuery.isLoading}
-                isError={infiniteRunsQuery.isError}
-                onRetry={() => infiniteRunsQuery.refetch()}
-                workflowNodes={canvasNodes}
-                componentIconMap={componentIconMap}
-                onStatusFiltersChange={setRunStatusFilters}
-              />
-            ) : null
-          }
-          toolSidebarVersionsContent={
-            isVersionsMode ? (
-              <VersionsTabPanel
-                scrollPersistenceKey={canvasId}
-                liveCanvasVersionId={effectiveLiveCanvasVersionId}
-                selectedCanvasVersion={selectedCanvasVersion}
-                pendingApprovalVersions={pendingApprovalVersions}
-                liveVersions={liveVersions}
-                liveVersionChangeRequestsByVersionId={liveVersionChangeRequestsByVersionId}
-                canUpdateCanvas={canUpdateCanvas}
-                isTemplate={isTemplate}
-                canvasDeletedRemotely={canvasDeletedRemotely}
-                onUseVersion={handleUseVersionFromVersionPanel}
-                onVersionNodeDiffContextChange={setVersionNodeDiffContext}
-                onLoadMoreLiveVersions={hasMoreLiveVersions ? () => canvasLiveVersionsQuery.fetchNextPage() : undefined}
-                loadMoreLiveVersionsDisabled={!hasMoreLiveVersions || isLoadingMoreLiveVersions}
-                loadMoreLiveVersionsPending={isLoadingMoreLiveVersions}
-                changeRequestApprovalConfig={
-                  liveCanvasVersion?.spec?.changeManagement ?? liveCanvas?.spec?.changeManagement
-                }
-                rejectedVersions={rejectedVersions}
-                draftBranches={draftBranches}
-                activeDraftBranch={resolvedActiveBranch}
-                onOpenDraftBranch={handleContinueDraftBranch}
-                onDeleteDraftBranch={handleDeleteDraftBranch}
-                deleteDraftBranchPending={deleteDraftBranchMutation.isPending}
-              />
-            ) : null
-          }
+          toolSidebarRunsContent={toolSidebarRunsContent}
+          toolSidebarVersionsContent={toolSidebarVersionsContent}
           focusRequest={focusRequest}
           onExecutionChainHandled={handleExecutionChainHandled}
         />

--- a/web_src/src/pages/app/useMemoryModeActions.ts
+++ b/web_src/src/pages/app/useMemoryModeActions.ts
@@ -7,6 +7,7 @@ interface MemoryModeActionsConfig {
   setIsConsoleAddPanelOpen: (value: boolean) => void;
   setIsConsoleYamlOpen: (value: boolean) => void;
   setIsRunsMode: (value: boolean) => void;
+  setIsVersionsMode: (value: boolean) => void;
   setIsFilesMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
   setSearchParams: SetURLSearchParams;
@@ -18,6 +19,7 @@ export function useMemoryModeActions({
   setIsConsoleAddPanelOpen,
   setIsConsoleYamlOpen,
   setIsRunsMode,
+  setIsVersionsMode,
   setIsFilesMode,
   setSelectedRunId,
   setSearchParams,
@@ -28,6 +30,7 @@ export function useMemoryModeActions({
     setIsConsoleAddPanelOpen(false);
     setIsConsoleYamlOpen(false);
     setIsRunsMode(false);
+    setIsVersionsMode(false);
     setIsFilesMode(false);
     setSelectedRunId(null);
     setSearchParams(toMemorySearchParams, { replace: true });
@@ -38,6 +41,7 @@ export function useMemoryModeActions({
     setIsFilesMode,
     setIsMemoryMode,
     setIsRunsMode,
+    setIsVersionsMode,
     setSearchParams,
     setSelectedRunId,
   ]);

--- a/web_src/src/pages/app/useVersionsModeActions.ts
+++ b/web_src/src/pages/app/useVersionsModeActions.ts
@@ -1,39 +1,39 @@
 import { useCallback } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
-interface FilesModeActionsConfig {
-  setIsFilesMode: (value: boolean) => void;
+interface VersionsModeActionsConfig {
+  setIsVersionsMode: (value: boolean) => void;
   setIsConsoleMode: (value: boolean) => void;
   setIsConsoleAddPanelOpen: (value: boolean) => void;
   setIsConsoleYamlOpen: (value: boolean) => void;
   setIsRunsMode: (value: boolean) => void;
-  setIsVersionsMode: (value: boolean) => void;
   setIsMemoryMode: (value: boolean) => void;
+  setIsFilesMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
   setSearchParams: SetURLSearchParams;
 }
 
-export function useFilesModeActions({
-  setIsFilesMode,
+export function useVersionsModeActions({
+  setIsVersionsMode,
   setIsConsoleMode,
   setIsConsoleAddPanelOpen,
   setIsConsoleYamlOpen,
   setIsRunsMode,
-  setIsVersionsMode,
   setIsMemoryMode,
+  setIsFilesMode,
   setSelectedRunId,
   setSearchParams,
-}: FilesModeActionsConfig) {
-  const handleSelectFilesMode = useCallback(() => {
-    setIsFilesMode(true);
+}: VersionsModeActionsConfig) {
+  const handleSelectVersionsMode = useCallback(() => {
+    setIsVersionsMode(true);
     setIsConsoleMode(false);
     setIsConsoleAddPanelOpen(false);
     setIsConsoleYamlOpen(false);
     setIsRunsMode(false);
-    setIsVersionsMode(false);
     setIsMemoryMode(false);
+    setIsFilesMode(false);
     setSelectedRunId(null);
-    setSearchParams(toFilesSearchParams, { replace: true });
+    setSearchParams(toVersionsSearchParams, { replace: true });
   }, [
     setIsConsoleAddPanelOpen,
     setIsConsoleMode,
@@ -42,30 +42,30 @@ export function useFilesModeActions({
     setIsMemoryMode,
     setIsRunsMode,
     setIsVersionsMode,
-    setSearchParams,
     setSelectedRunId,
+    setSearchParams,
   ]);
 
-  const handleExitFilesMode = useCallback(() => {
-    setIsFilesMode(false);
-    setSearchParams(removeFilesSearchParam, { replace: true });
-  }, [setIsFilesMode, setSearchParams]);
+  const handleExitVersionsMode = useCallback(() => {
+    setIsVersionsMode(false);
+    setSearchParams(removeVersionsSearchParam, { replace: true });
+  }, [setIsVersionsMode, setSearchParams]);
 
-  return { handleSelectFilesMode, handleExitFilesMode };
+  return { handleSelectVersionsMode, handleExitVersionsMode };
 }
 
-function toFilesSearchParams(current: URLSearchParams): URLSearchParams {
+function toVersionsSearchParams(current: URLSearchParams): URLSearchParams {
   const next = new URLSearchParams(current);
-  next.set("view", "files");
+  next.set("view", "versions");
   next.delete("run");
   next.delete("sidebar");
   next.delete("node");
+  next.delete("file");
   return next;
 }
 
-function removeFilesSearchParam(current: URLSearchParams): URLSearchParams {
+function removeVersionsSearchParam(current: URLSearchParams): URLSearchParams {
   const next = new URLSearchParams(current);
   next.delete("view");
-  next.delete("file");
   return next;
 }

--- a/web_src/src/pages/app/useWorkflowHeaderEditActions.spec.ts
+++ b/web_src/src/pages/app/useWorkflowHeaderEditActions.spec.ts
@@ -7,9 +7,12 @@ import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
 function renderWorkflowHeaderEditActions(overrides: Partial<Parameters<typeof useWorkflowHeaderEditActions>[0]> = {}) {
   const config = {
     isRunsMode: false,
+    isVersionsMode: false,
     handleExitRunsMode: vi.fn(),
+    handleExitVersionsMode: vi.fn(),
     handleToggleEditMode: vi.fn().mockResolvedValue(undefined),
     setIsRunsMode: vi.fn(),
+    setIsVersionsMode: vi.fn(),
     setSelectedRunId: vi.fn(),
     setRunDetailNodeId: vi.fn(),
     setSearchParams: vi.fn() as unknown as SetURLSearchParams,
@@ -66,9 +69,12 @@ describe("useWorkflowHeaderEditActions", () => {
     renderHook(() =>
       useWorkflowHeaderEditActions({
         isRunsMode: false,
+        isVersionsMode: false,
         handleExitRunsMode: vi.fn(),
+        handleExitVersionsMode: vi.fn(),
         handleToggleEditMode,
         setIsRunsMode: vi.fn(),
+        setIsVersionsMode: vi.fn(),
         setSelectedRunId: vi.fn(),
         setRunDetailNodeId: vi.fn(),
         setSearchParams: setSearchParams as unknown as SetURLSearchParams,

--- a/web_src/src/pages/app/useWorkflowHeaderEditActions.ts
+++ b/web_src/src/pages/app/useWorkflowHeaderEditActions.ts
@@ -19,9 +19,12 @@ interface WorkflowStartupActionsConfig {
 
 interface WorkflowHeaderEditActionsConfig {
   isRunsMode: boolean;
+  isVersionsMode: boolean;
   handleExitRunsMode: () => void;
+  handleExitVersionsMode: () => void;
   handleToggleEditMode: () => Promise<void>;
   setIsRunsMode: (value: boolean) => void;
+  setIsVersionsMode: (value: boolean) => void;
   setSelectedRunId: (value: string | null) => void;
   setRunDetailNodeId: (value: string | null) => void;
   setSearchParams: SetURLSearchParams;
@@ -30,9 +33,12 @@ interface WorkflowHeaderEditActionsConfig {
 
 export function useWorkflowHeaderEditActions({
   isRunsMode,
+  isVersionsMode,
   handleExitRunsMode,
+  handleExitVersionsMode,
   handleToggleEditMode,
   setIsRunsMode,
+  setIsVersionsMode,
   setSelectedRunId,
   setRunDetailNodeId,
   setSearchParams,
@@ -44,18 +50,34 @@ export function useWorkflowHeaderEditActions({
       setSelectedRunId(null);
       setRunDetailNodeId(null);
       setSearchParams(clearRunsViewSearchParams, { replace: true });
+    } else if (isVersionsMode) {
+      setIsVersionsMode(false);
+      setSearchParams(clearVersionsViewSearchParams, { replace: true });
     }
 
     await handleToggleEditMode();
-  }, [handleToggleEditMode, isRunsMode, setIsRunsMode, setRunDetailNodeId, setSearchParams, setSelectedRunId]);
+  }, [
+    handleToggleEditMode,
+    isRunsMode,
+    isVersionsMode,
+    setIsRunsMode,
+    setIsVersionsMode,
+    setRunDetailNodeId,
+    setSearchParams,
+    setSelectedRunId,
+  ]);
 
   const handleExitEditModeFromHeader = useCallback(async () => {
     if (isRunsMode) {
       handleExitRunsMode();
       return;
     }
+    if (isVersionsMode) {
+      handleExitVersionsMode();
+      return;
+    }
     await handleToggleEditMode();
-  }, [handleExitRunsMode, handleToggleEditMode, isRunsMode]);
+  }, [handleExitRunsMode, handleExitVersionsMode, handleToggleEditMode, isRunsMode, isVersionsMode]);
 
   useAutoEditMode(startup, handleToggleEditMode, setSearchParams);
   useAutoPlaceholderNode(startup);
@@ -94,6 +116,12 @@ function useAutoEditMode(
       );
     });
   }, [searchParams, setSearchParams, hasEditableVersion, canUpdateCanvas, canvasLoaded, handleToggleEditMode]);
+}
+
+function clearVersionsViewSearchParams(current: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(current);
+  next.delete("view");
+  return next;
 }
 
 function clearRunsViewSearchParams(current: URLSearchParams): URLSearchParams {

--- a/web_src/src/pages/app/useWorkflowViewModeActions.ts
+++ b/web_src/src/pages/app/useWorkflowViewModeActions.ts
@@ -7,6 +7,7 @@ interface WorkflowViewModeActionsConfig {
   isMemoryMode: boolean;
   isFilesMode: boolean;
   isRunsMode: boolean;
+  isVersionsMode: boolean;
   hasEditableVersion: boolean;
   isTemplate: boolean;
   canUpdateCanvas: boolean;
@@ -15,6 +16,7 @@ interface WorkflowViewModeActionsConfig {
   handleExitMemoryMode: () => void;
   handleExitFilesMode: () => void;
   handleExitRunsMode: () => void;
+  handleExitVersionsMode: () => void;
   handleToggleEditMode: () => Promise<void>;
   setIsConsoleAddPanelOpen: (value: boolean) => void;
   setIsConsoleYamlOpen: (value: boolean) => void;
@@ -25,6 +27,7 @@ export function useWorkflowViewModeActions({
   isMemoryMode,
   isFilesMode,
   isRunsMode,
+  isVersionsMode,
   hasEditableVersion,
   isTemplate,
   canUpdateCanvas,
@@ -33,6 +36,7 @@ export function useWorkflowViewModeActions({
   handleExitMemoryMode,
   handleExitFilesMode,
   handleExitRunsMode,
+  handleExitVersionsMode,
   handleToggleEditMode,
   setIsConsoleAddPanelOpen,
   setIsConsoleYamlOpen,
@@ -52,16 +56,22 @@ export function useWorkflowViewModeActions({
     }
     if (isRunsMode) {
       handleExitRunsMode();
+      return;
+    }
+    if (isVersionsMode) {
+      handleExitVersionsMode();
     }
   }, [
     handleExitConsoleMode,
     handleExitFilesMode,
     handleExitMemoryMode,
     handleExitRunsMode,
+    handleExitVersionsMode,
     isConsoleMode,
     isFilesMode,
     isMemoryMode,
     isRunsMode,
+    isVersionsMode,
   ]);
 
   const handleConsoleAddPanelRequest = useCallback(async () => {

--- a/web_src/src/pages/app/useWorkflowViewSearchParams.spec.ts
+++ b/web_src/src/pages/app/useWorkflowViewSearchParams.spec.ts
@@ -41,4 +41,20 @@ describe("useWorkflowViewSearchParams", () => {
 
     expect(result.current.selectedRunId).toBe("run-42");
   });
+
+  it("accepts legacy dashboard view links and migrates them to console", () => {
+    const setSearchParams = vi.fn();
+    const { result } = renderHook(() =>
+      useWorkflowViewSearchParams(makeSearchParams({ view: "dashboard" }), setSearchParams),
+    );
+
+    expect(result.current.isConsoleMode).toBe(true);
+    expect(setSearchParams).toHaveBeenCalledTimes(1);
+
+    const updater = setSearchParams.mock.calls[0]?.[0] as (current: URLSearchParams) => URLSearchParams;
+    const next = updater(makeSearchParams({ view: "dashboard", run: "run-42" }));
+
+    expect(next.get("view")).toBe("console");
+    expect(next.get("run")).toBe("run-42");
+  });
 });

--- a/web_src/src/pages/app/useWorkflowViewSearchParams.spec.ts
+++ b/web_src/src/pages/app/useWorkflowViewSearchParams.spec.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useWorkflowViewSearchParams } from "./useWorkflowViewSearchParams";
+
+function makeSearchParams(params: Record<string, string> = {}) {
+  return new URLSearchParams(params);
+}
+
+describe("useWorkflowViewSearchParams", () => {
+  it("derives runs and versions mode from the URL on the same render", () => {
+    const setSearchParams = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ searchParams }) => useWorkflowViewSearchParams(searchParams, setSearchParams),
+      { initialProps: { searchParams: makeSearchParams() } },
+    );
+
+    expect(result.current.isRunsMode).toBe(false);
+    expect(result.current.isVersionsMode).toBe(false);
+
+    rerender({ searchParams: makeSearchParams({ view: "runs" }) });
+
+    expect(result.current.isRunsMode).toBe(true);
+    expect(result.current.isVersionsMode).toBe(false);
+
+    rerender({ searchParams: makeSearchParams({ view: "versions" }) });
+
+    expect(result.current.isRunsMode).toBe(false);
+    expect(result.current.isVersionsMode).toBe(true);
+  });
+
+  it("derives selectedRunId from the run search param on the same render", () => {
+    const setSearchParams = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ searchParams }) => useWorkflowViewSearchParams(searchParams, setSearchParams),
+      { initialProps: { searchParams: makeSearchParams({ view: "runs" }) } },
+    );
+
+    expect(result.current.selectedRunId).toBeNull();
+
+    rerender({ searchParams: makeSearchParams({ view: "runs", run: "run-42" }) });
+
+    expect(result.current.selectedRunId).toBe("run-42");
+  });
+});

--- a/web_src/src/pages/app/useWorkflowViewSearchParams.ts
+++ b/web_src/src/pages/app/useWorkflowViewSearchParams.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 
 /**
@@ -14,32 +14,30 @@ function isConsoleView(view: string): boolean {
 }
 
 /**
- * Keeps runs/console/memory/files view mode and selected run in sync with `view` and `run` search params.
+ * Keeps console UI state and selected run in sync with `view` and `run` search params.
+ * View mode flags are derived directly from the URL so they match header chrome on the
+ * same render (including browser back/forward), without waiting for a post-render effect.
  */
 export function useWorkflowViewSearchParams(searchParams: URLSearchParams, setSearchParams: SetURLSearchParams) {
-  const [isRunsMode, setIsRunsMode] = useState(() => searchParams.get("view") === "runs");
-  const [isVersionsMode, setIsVersionsMode] = useState(() => searchParams.get("view") === "versions");
-  const [isConsoleMode, setIsConsoleMode] = useState(() => isConsoleView(searchParams.get("view") ?? ""));
-  const [isMemoryMode, setIsMemoryMode] = useState(() => searchParams.get("view") === "memory");
-  const [isFilesMode, setIsFilesMode] = useState(() => searchParams.get("view") === "files");
-  const [isConsoleAddPanelOpen, setIsConsoleAddPanelOpen] = useState(false);
-  const [isConsoleYamlOpen, setIsConsoleYamlOpen] = useState(false);
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(() => searchParams.get("run"));
-
   const viewParam = searchParams.get("view") ?? "";
   const runParam = searchParams.get("run") ?? "";
   const consoleViewActive = isConsoleView(viewParam);
+
+  const isRunsMode = viewParam === "runs";
+  const isVersionsMode = viewParam === "versions";
+  const isMemoryMode = viewParam === "memory";
+  const isFilesMode = viewParam === "files";
+  const isConsoleMode = consoleViewActive;
+  const selectedRunId = runParam || null;
+
+  const [isConsoleAddPanelOpen, setIsConsoleAddPanelOpen] = useState(false);
+  const [isConsoleYamlOpen, setIsConsoleYamlOpen] = useState(false);
 
   const setSearchParamsRef = useRef(setSearchParams);
   setSearchParamsRef.current = setSearchParams;
 
   useEffect(() => {
-    setIsRunsMode(viewParam === "runs");
-    setIsVersionsMode(viewParam === "versions");
-    setIsMemoryMode(viewParam === "memory");
-    setIsFilesMode(viewParam === "files");
     if (consoleViewActive) {
-      setIsConsoleMode(true);
       // Migrate legacy `?view=dashboard` to the canonical `?view=console`
       // in-place so the address bar and any future link sharing reflect
       // the renamed feature without breaking existing bookmarks.
@@ -57,31 +55,30 @@ export function useWorkflowViewSearchParams(searchParams: URLSearchParams, setSe
         );
       }
     } else {
-      setIsConsoleMode(false);
-    }
-    setSelectedRunId(runParam || null);
-    if (!consoleViewActive) {
       setIsConsoleAddPanelOpen(false);
       setIsConsoleYamlOpen(false);
     }
-  }, [viewParam, runParam, consoleViewActive]);
+  }, [viewParam, consoleViewActive]);
+
+  const noopSetBoolean = useCallback((_value: boolean) => {}, []);
+  const noopSetSelectedRunId = useCallback((_value: string | null) => {}, []);
 
   return {
     isRunsMode,
-    setIsRunsMode,
+    setIsRunsMode: noopSetBoolean,
     isVersionsMode,
-    setIsVersionsMode,
+    setIsVersionsMode: noopSetBoolean,
     isConsoleMode,
-    setIsConsoleMode,
+    setIsConsoleMode: noopSetBoolean,
     isMemoryMode,
-    setIsMemoryMode,
+    setIsMemoryMode: noopSetBoolean,
     isFilesMode,
-    setIsFilesMode,
+    setIsFilesMode: noopSetBoolean,
     isConsoleAddPanelOpen,
     setIsConsoleAddPanelOpen,
     isConsoleYamlOpen,
     setIsConsoleYamlOpen,
     selectedRunId,
-    setSelectedRunId,
+    setSelectedRunId: noopSetSelectedRunId,
   };
 }

--- a/web_src/src/pages/app/useWorkflowViewSearchParams.ts
+++ b/web_src/src/pages/app/useWorkflowViewSearchParams.ts
@@ -7,7 +7,7 @@ import type { SetURLSearchParams } from "react-router-dom";
  * in-flight links) and silently rewritten to the canonical `console` value.
  */
 const CONSOLE_VIEW = "console";
-const LEGACY_CONSOLE_VIEW = "console";
+const LEGACY_CONSOLE_VIEW = "dashboard";
 
 function isConsoleView(view: string): boolean {
   return view === CONSOLE_VIEW || view === LEGACY_CONSOLE_VIEW;

--- a/web_src/src/pages/app/useWorkflowViewSearchParams.ts
+++ b/web_src/src/pages/app/useWorkflowViewSearchParams.ts
@@ -18,6 +18,7 @@ function isConsoleView(view: string): boolean {
  */
 export function useWorkflowViewSearchParams(searchParams: URLSearchParams, setSearchParams: SetURLSearchParams) {
   const [isRunsMode, setIsRunsMode] = useState(() => searchParams.get("view") === "runs");
+  const [isVersionsMode, setIsVersionsMode] = useState(() => searchParams.get("view") === "versions");
   const [isConsoleMode, setIsConsoleMode] = useState(() => isConsoleView(searchParams.get("view") ?? ""));
   const [isMemoryMode, setIsMemoryMode] = useState(() => searchParams.get("view") === "memory");
   const [isFilesMode, setIsFilesMode] = useState(() => searchParams.get("view") === "files");
@@ -34,6 +35,7 @@ export function useWorkflowViewSearchParams(searchParams: URLSearchParams, setSe
 
   useEffect(() => {
     setIsRunsMode(viewParam === "runs");
+    setIsVersionsMode(viewParam === "versions");
     setIsMemoryMode(viewParam === "memory");
     setIsFilesMode(viewParam === "files");
     if (consoleViewActive) {
@@ -67,6 +69,8 @@ export function useWorkflowViewSearchParams(searchParams: URLSearchParams, setSe
   return {
     isRunsMode,
     setIsRunsMode,
+    isVersionsMode,
+    setIsVersionsMode,
     isConsoleMode,
     setIsConsoleMode,
     isMemoryMode,

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "console" | "memory" | "files";
+export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "versions" | "console" | "memory" | "files";
 export type WorkflowCanvasStateMode = "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
 
 const CONSOLE_VIEW = "console";
@@ -15,6 +15,7 @@ export function getWorkflowViewFlagsFromSearchParams(searchParams: URLSearchPara
   const view = searchParams.get("view") ?? "";
   return {
     isRunsMode: view === "runs",
+    isVersionsMode: view === "versions",
     isMemoryMode: view === "memory",
     isFilesMode: view === "files",
     isConsoleMode: isConsoleViewParam(view),
@@ -51,11 +52,13 @@ export function clearComponentSidebarSearchParams(params: URLSearchParams): URLS
 export function getWorkflowHeaderMode({
   isConsoleMode,
   isRunsMode,
+  isVersionsMode,
   isMemoryMode,
   isFilesMode,
 }: {
   isConsoleMode: boolean;
   isRunsMode: boolean;
+  isVersionsMode: boolean;
   isMemoryMode: boolean;
   isFilesMode: boolean;
 }): WorkflowHeaderMode {
@@ -73,6 +76,10 @@ export function getWorkflowHeaderMode({
 
   if (isRunsMode) {
     return "runs";
+  }
+
+  if (isVersionsMode) {
+    return "versions";
   }
 
   return "version-live";
@@ -105,6 +112,7 @@ export function getWorkflowCanvasStateMode({
 export function getWorkflowViewPresentation({
   isConsoleMode,
   isRunsMode,
+  isVersionsMode,
   isMemoryMode,
   isFilesMode,
   isTemplate,
@@ -114,6 +122,7 @@ export function getWorkflowViewPresentation({
 }: {
   isConsoleMode: boolean;
   isRunsMode: boolean;
+  isVersionsMode: boolean;
   isMemoryMode: boolean;
   isFilesMode: boolean;
   isTemplate: boolean;
@@ -124,7 +133,7 @@ export function getWorkflowViewPresentation({
   const hideNonCanvasChrome = isRunsMode || isMemoryMode || isFilesMode;
 
   return {
-    headerMode: getWorkflowHeaderMode({ isConsoleMode, isRunsMode, isMemoryMode, isFilesMode }),
+    headerMode: getWorkflowHeaderMode({ isConsoleMode, isRunsMode, isVersionsMode, isMemoryMode, isFilesMode }),
     canvasStateMode: getWorkflowCanvasStateMode({
       hasEditableVersion,
       isViewingPendingApprovalVersion,

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -3,6 +3,24 @@ import { useMemo } from "react";
 export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "versions" | "console" | "memory" | "files";
 export type WorkflowCanvasStateMode = "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
 
+const PANEL_HEADER_MODES = new Set<WorkflowHeaderMode>(["runs", "versions", "memory", "files"]);
+
+export function isPanelHeaderMode(headerMode: WorkflowHeaderMode): boolean {
+  return PANEL_HEADER_MODES.has(headerMode);
+}
+
+export function blocksBuildingBlocksShortcut(headerMode: WorkflowHeaderMode): boolean {
+  return headerMode === "console" || isPanelHeaderMode(headerMode);
+}
+
+export function allowsBuildingBlocksSidebar(headerMode: WorkflowHeaderMode): boolean {
+  return headerMode !== "console" && !isPanelHeaderMode(headerMode);
+}
+
+export function isRunsOrVersionsHeaderMode(headerMode: WorkflowHeaderMode): boolean {
+  return headerMode === "runs" || headerMode === "versions";
+}
+
 const CONSOLE_VIEW = "console";
 const LEGACY_CONSOLE_VIEW = "dashboard";
 

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -130,7 +130,7 @@ export function getWorkflowViewPresentation({
   isViewingPendingApprovalVersion: boolean;
   isViewingCurrentLiveVersion: boolean;
 }) {
-  const hideNonCanvasChrome = isRunsMode || isMemoryMode || isFilesMode;
+  const hideNonCanvasChrome = isRunsMode || isVersionsMode || isMemoryMode || isFilesMode;
 
   return {
     headerMode: getWorkflowHeaderMode({ isConsoleMode, isRunsMode, isVersionsMode, isMemoryMode, isFilesMode }),
@@ -141,7 +141,7 @@ export function getWorkflowViewPresentation({
     }),
     showBottomStatusControls: !isTemplate && !hideNonCanvasChrome,
     hideAddControls: isTemplate || hideNonCanvasChrome,
-    readOnlyViewModes: isRunsMode || isFilesMode,
+    readOnlyViewModes: isRunsMode || isVersionsMode || isFilesMode,
   };
 }
 

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -1,9 +1,18 @@
 import { useMemo } from "react";
 
 export type WorkflowHeaderMode = "version-live" | "version-edit" | "runs" | "versions" | "console" | "memory" | "files";
+export type CanvasPageHeaderMode = WorkflowHeaderMode | "default";
 export type WorkflowCanvasStateMode = "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
 
 const PANEL_HEADER_MODES = new Set<WorkflowHeaderMode>(["runs", "versions", "memory", "files"]);
+
+export function normalizeCanvasHeaderMode(headerMode: CanvasPageHeaderMode | undefined): WorkflowHeaderMode {
+  if (!headerMode || headerMode === "default") {
+    return "version-live";
+  }
+
+  return headerMode;
+}
 
 export function isPanelHeaderMode(headerMode: WorkflowHeaderMode): boolean {
   return PANEL_HEADER_MODES.has(headerMode);

--- a/web_src/src/stores/sidebarLayoutConstraints.ts
+++ b/web_src/src/stores/sidebarLayoutConstraints.ts
@@ -1,0 +1,156 @@
+export const SIDEBAR_MIN_WIDTH = 300;
+export const MIDDLE_MIN_WIDTH = 220;
+
+export interface SidebarLayoutSnapshot {
+  leftWidth: number;
+  rightWidth: number;
+  auxLeftWidth: number;
+  leftMountCount: number;
+  rightMountCount: number;
+  auxLeftMountCount: number;
+}
+
+function leftIsMounted(state: SidebarLayoutSnapshot): boolean {
+  return state.leftMountCount > 0;
+}
+
+function rightIsMounted(state: SidebarLayoutSnapshot): boolean {
+  return state.rightMountCount > 0;
+}
+
+function auxLeftIsMounted(state: SidebarLayoutSnapshot): boolean {
+  return state.auxLeftMountCount > 0;
+}
+
+function shrinkLeftPanelsToFit(
+  leftMounted: boolean,
+  auxMounted: boolean,
+  leftWidth: number,
+  auxLeftWidth: number,
+  allowedLeftTotal: number,
+): { leftWidth: number; auxLeftWidth: number } {
+  const currentLeftTotal = (leftMounted ? leftWidth : 0) + (auxMounted ? auxLeftWidth : 0);
+  if (currentLeftTotal <= allowedLeftTotal) {
+    return { leftWidth, auxLeftWidth };
+  }
+
+  let nextLeft = leftWidth;
+  let nextAux = auxLeftWidth;
+  let overflow = currentLeftTotal - allowedLeftTotal;
+
+  if (auxMounted && auxLeftWidth > SIDEBAR_MIN_WIDTH) {
+    const auxShrink = Math.min(overflow, auxLeftWidth - SIDEBAR_MIN_WIDTH);
+    nextAux = auxLeftWidth - auxShrink;
+    overflow -= auxShrink;
+  }
+
+  if (overflow > 0 && leftMounted && leftWidth > SIDEBAR_MIN_WIDTH) {
+    nextLeft = Math.max(SIDEBAR_MIN_WIDTH, leftWidth - overflow);
+  }
+
+  return { leftWidth: nextLeft, auxLeftWidth: nextAux };
+}
+
+function sidebarCap(viewport: number, reservedWidth: number): number {
+  return Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - reservedWidth);
+}
+
+export function computeResizeLeft(state: SidebarLayoutSnapshot, target: number, viewport: number) {
+  const otherMounted = rightIsMounted(state);
+  const auxMounted = auxLeftIsMounted(state);
+  const auxFloor = auxMounted ? state.auxLeftWidth : 0;
+  const otherFloor = otherMounted ? SIDEBAR_MIN_WIDTH : 0;
+  const maxLeft = sidebarCap(viewport, otherFloor + auxFloor);
+  const nextLeft = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxLeft, Math.round(target)));
+
+  let nextRight = state.rightWidth;
+  if (otherMounted) {
+    const allowedRight = sidebarCap(viewport, nextLeft + auxFloor);
+    if (state.rightWidth > allowedRight) nextRight = allowedRight;
+  }
+
+  return { nextLeft, nextRight, nextAuxLeft: state.auxLeftWidth };
+}
+
+export function computeResizeRight(state: SidebarLayoutSnapshot, target: number, viewport: number) {
+  const leftMounted = leftIsMounted(state);
+  const auxMounted = auxLeftIsMounted(state);
+  const leftTotal = (leftMounted ? state.leftWidth : 0) + (auxMounted ? state.auxLeftWidth : 0);
+  const maxRight = sidebarCap(viewport, leftTotal);
+  const nextRight = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxRight, Math.round(target)));
+
+  if (!leftMounted && !auxMounted) {
+    return { nextLeft: state.leftWidth, nextRight, nextAuxLeft: state.auxLeftWidth };
+  }
+
+  const minLeftTotal = leftMounted && auxMounted ? SIDEBAR_MIN_WIDTH * 2 : SIDEBAR_MIN_WIDTH;
+  const allowedLeftTotal = Math.max(minLeftTotal, viewport - MIDDLE_MIN_WIDTH - nextRight);
+  const shrunk = shrinkLeftPanelsToFit(leftMounted, auxMounted, state.leftWidth, state.auxLeftWidth, allowedLeftTotal);
+
+  return { nextLeft: shrunk.leftWidth, nextRight, nextAuxLeft: shrunk.auxLeftWidth };
+}
+
+export function computeResizeAuxLeft(state: SidebarLayoutSnapshot, target: number, viewport: number) {
+  const leftMounted = leftIsMounted(state);
+  const rightMounted = rightIsMounted(state);
+  const leftFloor = leftMounted ? state.leftWidth : 0;
+  const maxAux = sidebarCap(viewport, leftFloor + (rightMounted ? state.rightWidth : 0));
+  const nextAux = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxAux, Math.round(target)));
+
+  let nextRight = state.rightWidth;
+  if (rightMounted) {
+    const allowedRight = sidebarCap(viewport, leftFloor + nextAux);
+    if (state.rightWidth > allowedRight) nextRight = allowedRight;
+  }
+
+  let nextLeft = state.leftWidth;
+  if (leftMounted) {
+    const allowedLeft = sidebarCap(viewport, nextAux + (rightMounted ? nextRight : 0));
+    if (state.leftWidth > allowedLeft) nextLeft = allowedLeft;
+  }
+
+  return { nextLeft, nextRight, nextAuxLeft: nextAux };
+}
+
+function mountedLeftWidth(leftActive: boolean, left: number, auxActive: boolean, aux: number): number {
+  return (leftActive ? left : 0) + (auxActive ? aux : 0);
+}
+
+function capSidebarWidth(active: boolean, current: number, cap: number): number {
+  return active && current > cap ? cap : current;
+}
+
+export function computeRecomputeForViewport(state: SidebarLayoutSnapshot, viewport: number) {
+  const leftActive = leftIsMounted(state);
+  const rightActive = rightIsMounted(state);
+  const auxActive = auxLeftIsMounted(state);
+
+  let nextLeft = state.leftWidth;
+  let nextRight = state.rightWidth;
+  let nextAux = state.auxLeftWidth;
+
+  const mountedTotal = mountedLeftWidth(leftActive, nextLeft, auxActive, nextAux) + (rightActive ? nextRight : 0);
+  if (mountedTotal + MIDDLE_MIN_WIDTH <= viewport) {
+    return { nextLeft, nextRight, nextAuxLeft: nextAux, changed: false };
+  }
+
+  nextRight = capSidebarWidth(
+    rightActive,
+    nextRight,
+    sidebarCap(viewport, mountedLeftWidth(leftActive, nextLeft, auxActive, nextAux)),
+  );
+  nextAux = capSidebarWidth(
+    auxActive,
+    nextAux,
+    sidebarCap(viewport, (leftActive ? nextLeft : 0) + (rightActive ? nextRight : 0)),
+  );
+  nextLeft = capSidebarWidth(
+    leftActive,
+    nextLeft,
+    sidebarCap(viewport, (auxActive ? nextAux : 0) + (rightActive ? nextRight : 0)),
+  );
+
+  const changed = nextLeft !== state.leftWidth || nextRight !== state.rightWidth || nextAux !== state.auxLeftWidth;
+
+  return { nextLeft, nextRight, nextAuxLeft: nextAux, changed };
+}

--- a/web_src/src/stores/sidebarLayoutStore.ts
+++ b/web_src/src/stores/sidebarLayoutStore.ts
@@ -1,5 +1,13 @@
 import { useEffect } from "react";
 import { create } from "zustand";
+import {
+  computeRecomputeForViewport,
+  computeResizeAuxLeft,
+  computeResizeLeft,
+  computeResizeRight,
+  SIDEBAR_MIN_WIDTH,
+  type SidebarLayoutSnapshot,
+} from "./sidebarLayoutConstraints";
 
 /**
  * Shared layout store for the canvas page's left and right sidebars.
@@ -18,8 +26,7 @@ import { create } from "zustand";
  * existing local storage values are honored.
  */
 
-export const SIDEBAR_MIN_WIDTH = 300;
-export const MIDDLE_MIN_WIDTH = 220;
+export { MIDDLE_MIN_WIDTH, SIDEBAR_MIN_WIDTH } from "./sidebarLayoutConstraints";
 
 const LEFT_STORAGE_KEY = "agent-sidebar-width";
 const RIGHT_STORAGE_KEY = "componentSidebarWidth";
@@ -53,14 +60,8 @@ function persistWidth(key: string, value: number): void {
   }
 }
 
-interface SidebarLayoutState {
-  leftWidth: number;
-  rightWidth: number;
-  auxLeftWidth: number;
+interface SidebarLayoutState extends SidebarLayoutSnapshot {
   auxLeftStorageKey: string | null;
-  leftMountCount: number;
-  rightMountCount: number;
-  auxLeftMountCount: number;
   isLeftResizing: boolean;
   isRightResizing: boolean;
   isAuxLeftResizing: boolean;
@@ -71,46 +72,33 @@ interface SidebarLayoutState {
   setLeftResizing: (resizing: boolean) => void;
   setRightResizing: (resizing: boolean) => void;
   setAuxLeftResizing: (resizing: boolean) => void;
-
-  /**
-   * Drive the left sidebar to {@link target} px. Pushes the right sidebar
-   * down to {@link SIDEBAR_MIN_WIDTH} when needed; will not violate the
-   * middle-section minimum.
-   */
   resizeLeft: (target: number) => void;
-  /**
-   * Mirrors {@link resizeLeft} for the right sidebar.
-   */
   resizeRight: (target: number) => void;
-  /**
-   * Mirrors {@link resizeLeft} for the runs/versions auxiliary sidebar.
-   */
   resizeAuxLeft: (target: number) => void;
-
-  /**
-   * Recompute widths against the current viewport, shrinking sidebars (right
-   * first, then auxiliary left, then agent left) only if necessary. Called on
-   * window resize.
-   */
   recomputeForViewport: () => void;
-
-  /**
-   * Re-read both widths from localStorage and reset transient flags. Useful
-   * from tests that mutate storage between renders.
-   */
   hydrateFromStorage: () => void;
 }
 
-function leftIsMounted(state: SidebarLayoutState): boolean {
-  return state.leftMountCount > 0;
-}
+function applyWidthUpdate(
+  state: SidebarLayoutState,
+  set: (partial: Partial<SidebarLayoutState>) => void,
+  next: { nextLeft: number; nextRight: number; nextAuxLeft: number },
+) {
+  if (
+    next.nextLeft === state.leftWidth &&
+    next.nextRight === state.rightWidth &&
+    next.nextAuxLeft === state.auxLeftWidth
+  ) {
+    return;
+  }
 
-function rightIsMounted(state: SidebarLayoutState): boolean {
-  return state.rightMountCount > 0;
-}
+  if (next.nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, next.nextLeft);
+  if (next.nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, next.nextRight);
+  if (next.nextAuxLeft !== state.auxLeftWidth && state.auxLeftStorageKey) {
+    persistWidth(state.auxLeftStorageKey, next.nextAuxLeft);
+  }
 
-function auxLeftIsMounted(state: SidebarLayoutState): boolean {
-  return state.auxLeftMountCount > 0;
+  set({ leftWidth: next.nextLeft, rightWidth: next.nextRight, auxLeftWidth: next.nextAuxLeft });
 }
 
 export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
@@ -157,103 +145,17 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
 
   resizeLeft: (target) => {
     const state = get();
-    const viewport = getViewportWidth();
-    const otherMounted = rightIsMounted(state);
-    const auxMounted = auxLeftIsMounted(state);
-
-    const auxFloor = auxMounted ? state.auxLeftWidth : 0;
-    const otherFloor = otherMounted ? SIDEBAR_MIN_WIDTH : 0;
-    const maxLeft = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - otherFloor - auxFloor);
-    const nextLeft = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxLeft, Math.round(target)));
-
-    let nextRight = state.rightWidth;
-    if (otherMounted) {
-      const allowedRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - nextLeft - auxFloor);
-      if (state.rightWidth > allowedRight) nextRight = allowedRight;
-    }
-
-    if (nextLeft === state.leftWidth && nextRight === state.rightWidth) return;
-
-    persistWidth(LEFT_STORAGE_KEY, nextLeft);
-    if (nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, nextRight);
-    set({ leftWidth: nextLeft, rightWidth: nextRight });
+    applyWidthUpdate(state, set, computeResizeLeft(state, target, getViewportWidth()));
   },
 
   resizeRight: (target) => {
     const state = get();
-    const viewport = getViewportWidth();
-    const leftMounted = leftIsMounted(state);
-    const auxMounted = auxLeftIsMounted(state);
-
-    const leftTotal = (leftMounted ? state.leftWidth : 0) + (auxMounted ? state.auxLeftWidth : 0);
-    const maxRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - leftTotal);
-    const nextRight = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxRight, Math.round(target)));
-
-    let nextLeft = state.leftWidth;
-    let nextAuxLeft = state.auxLeftWidth;
-    if (leftMounted || auxMounted) {
-      const allowedLeftTotal = Math.max(
-        leftMounted && auxMounted ? SIDEBAR_MIN_WIDTH * 2 : SIDEBAR_MIN_WIDTH,
-        viewport - MIDDLE_MIN_WIDTH - nextRight,
-      );
-      const currentLeftTotal = (leftMounted ? state.leftWidth : 0) + (auxMounted ? state.auxLeftWidth : 0);
-      if (currentLeftTotal > allowedLeftTotal) {
-        let overflow = currentLeftTotal - allowedLeftTotal;
-        if (auxMounted && state.auxLeftWidth > SIDEBAR_MIN_WIDTH) {
-          const auxShrink = Math.min(overflow, state.auxLeftWidth - SIDEBAR_MIN_WIDTH);
-          nextAuxLeft = state.auxLeftWidth - auxShrink;
-          overflow -= auxShrink;
-        }
-        if (overflow > 0 && leftMounted && state.leftWidth > SIDEBAR_MIN_WIDTH) {
-          nextLeft = Math.max(SIDEBAR_MIN_WIDTH, state.leftWidth - overflow);
-        }
-      }
-    }
-
-    if (nextRight === state.rightWidth && nextLeft === state.leftWidth && nextAuxLeft === state.auxLeftWidth) return;
-
-    persistWidth(RIGHT_STORAGE_KEY, nextRight);
-    if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
-    if (nextAuxLeft !== state.auxLeftWidth && state.auxLeftStorageKey) {
-      persistWidth(state.auxLeftStorageKey, nextAuxLeft);
-    }
-    set({ leftWidth: nextLeft, rightWidth: nextRight, auxLeftWidth: nextAuxLeft });
+    applyWidthUpdate(state, set, computeResizeRight(state, target, getViewportWidth()));
   },
 
   resizeAuxLeft: (target) => {
     const state = get();
-    const viewport = getViewportWidth();
-    const leftMounted = leftIsMounted(state);
-    const rightMounted = rightIsMounted(state);
-    const leftFloor = leftMounted ? state.leftWidth : 0;
-
-    const maxAux = Math.max(
-      SIDEBAR_MIN_WIDTH,
-      viewport - MIDDLE_MIN_WIDTH - leftFloor - (rightMounted ? state.rightWidth : 0),
-    );
-    const nextAux = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxAux, Math.round(target)));
-
-    let nextRight = state.rightWidth;
-    if (rightMounted) {
-      const allowedRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - leftFloor - nextAux);
-      if (state.rightWidth > allowedRight) nextRight = allowedRight;
-    }
-
-    let nextLeft = state.leftWidth;
-    if (leftMounted) {
-      const allowedLeft = Math.max(
-        SIDEBAR_MIN_WIDTH,
-        viewport - MIDDLE_MIN_WIDTH - nextAux - (rightMounted ? nextRight : 0),
-      );
-      if (state.leftWidth > allowedLeft) nextLeft = allowedLeft;
-    }
-
-    if (nextAux === state.auxLeftWidth && nextRight === state.rightWidth && nextLeft === state.leftWidth) return;
-
-    if (state.auxLeftStorageKey) persistWidth(state.auxLeftStorageKey, nextAux);
-    if (nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, nextRight);
-    if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
-    set({ auxLeftWidth: nextAux, rightWidth: nextRight, leftWidth: nextLeft });
+    applyWidthUpdate(state, set, computeResizeAuxLeft(state, target, getViewportWidth()));
   },
 
   hydrateFromStorage: () => {
@@ -273,48 +175,9 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
 
   recomputeForViewport: () => {
     const state = get();
-    const viewport = getViewportWidth();
-    const leftActive = leftIsMounted(state);
-    const rightActive = rightIsMounted(state);
-    const auxActive = auxLeftIsMounted(state);
-
-    let nextLeft = state.leftWidth;
-    let nextRight = state.rightWidth;
-    let nextAux = state.auxLeftWidth;
-
-    const total = (leftActive ? nextLeft : 0) + (auxActive ? nextAux : 0) + (rightActive ? nextRight : 0);
-    if (total + MIDDLE_MIN_WIDTH <= viewport) return;
-
-    // Shrink the right sidebar first since it overlays the canvas.
-    if (rightActive) {
-      const cap = Math.max(
-        SIDEBAR_MIN_WIDTH,
-        viewport - MIDDLE_MIN_WIDTH - (leftActive ? nextLeft : 0) - (auxActive ? nextAux : 0),
-      );
-      if (nextRight > cap) nextRight = cap;
-    }
-    if (auxActive) {
-      const cap = Math.max(
-        SIDEBAR_MIN_WIDTH,
-        viewport - MIDDLE_MIN_WIDTH - (leftActive ? nextLeft : 0) - (rightActive ? nextRight : 0),
-      );
-      if (nextAux > cap) nextAux = cap;
-    }
-    if (leftActive) {
-      const cap = Math.max(
-        SIDEBAR_MIN_WIDTH,
-        viewport - MIDDLE_MIN_WIDTH - (auxActive ? nextAux : 0) - (rightActive ? nextRight : 0),
-      );
-      if (nextLeft > cap) nextLeft = cap;
-    }
-
-    if (nextLeft === state.leftWidth && nextRight === state.rightWidth && nextAux === state.auxLeftWidth) return;
-    if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
-    if (nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, nextRight);
-    if (nextAux !== state.auxLeftWidth && state.auxLeftStorageKey) {
-      persistWidth(state.auxLeftStorageKey, nextAux);
-    }
-    set({ leftWidth: nextLeft, rightWidth: nextRight, auxLeftWidth: nextAux });
+    const result = computeRecomputeForViewport(state, getViewportWidth());
+    if (!result.changed) return;
+    applyWidthUpdate(state, set, result);
   },
 }));
 

--- a/web_src/src/stores/sidebarLayoutStore.ts
+++ b/web_src/src/stores/sidebarLayoutStore.ts
@@ -11,6 +11,9 @@ import { create } from "zustand";
  * refusing to grow further. Dragging back does NOT restore the pushed
  * sidebar — that is intentional, matching how most resizable splitters work.
  *
+ * Runs/Versions panels register as an auxiliary left sidebar so their combined
+ * width with the agent sidebar respects the same canvas minimum.
+ *
  * Persistence keys are kept identical to the pre-refactor implementation so
  * existing local storage values are honored.
  */
@@ -53,15 +56,21 @@ function persistWidth(key: string, value: number): void {
 interface SidebarLayoutState {
   leftWidth: number;
   rightWidth: number;
+  auxLeftWidth: number;
+  auxLeftStorageKey: string | null;
   leftMountCount: number;
   rightMountCount: number;
+  auxLeftMountCount: number;
   isLeftResizing: boolean;
   isRightResizing: boolean;
+  isAuxLeftResizing: boolean;
 
   registerLeft: () => () => void;
   registerRight: () => () => void;
+  registerAuxLeft: (storageKey: string, defaultWidth: number) => () => void;
   setLeftResizing: (resizing: boolean) => void;
   setRightResizing: (resizing: boolean) => void;
+  setAuxLeftResizing: (resizing: boolean) => void;
 
   /**
    * Drive the left sidebar to {@link target} px. Pushes the right sidebar
@@ -73,10 +82,15 @@ interface SidebarLayoutState {
    * Mirrors {@link resizeLeft} for the right sidebar.
    */
   resizeRight: (target: number) => void;
+  /**
+   * Mirrors {@link resizeLeft} for the runs/versions auxiliary sidebar.
+   */
+  resizeAuxLeft: (target: number) => void;
 
   /**
    * Recompute widths against the current viewport, shrinking sidebars (right
-   * first, then left) only if necessary. Called on window resize.
+   * first, then auxiliary left, then agent left) only if necessary. Called on
+   * window resize.
    */
   recomputeForViewport: () => void;
 
@@ -95,13 +109,21 @@ function rightIsMounted(state: SidebarLayoutState): boolean {
   return state.rightMountCount > 0;
 }
 
+function auxLeftIsMounted(state: SidebarLayoutState): boolean {
+  return state.auxLeftMountCount > 0;
+}
+
 export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
   leftWidth: readPersistedWidth(LEFT_STORAGE_KEY, DEFAULT_LEFT_WIDTH),
   rightWidth: readPersistedWidth(RIGHT_STORAGE_KEY, DEFAULT_RIGHT_WIDTH),
+  auxLeftWidth: DEFAULT_LEFT_WIDTH,
+  auxLeftStorageKey: null,
   leftMountCount: 0,
   rightMountCount: 0,
+  auxLeftMountCount: 0,
   isLeftResizing: false,
   isRightResizing: false,
+  isAuxLeftResizing: false,
 
   registerLeft: () => {
     set((state) => ({ leftMountCount: state.leftMountCount + 1 }));
@@ -115,21 +137,38 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
     return () => set((state) => ({ rightMountCount: Math.max(0, state.rightMountCount - 1) }));
   },
 
+  registerAuxLeft: (storageKey, defaultWidth) => {
+    set((state) => ({
+      auxLeftMountCount: state.auxLeftMountCount + 1,
+      auxLeftStorageKey: storageKey,
+      auxLeftWidth: readPersistedWidth(storageKey, defaultWidth),
+    }));
+    get().recomputeForViewport();
+    return () =>
+      set((state) => ({
+        auxLeftMountCount: Math.max(0, state.auxLeftMountCount - 1),
+        auxLeftStorageKey: state.auxLeftMountCount <= 1 ? null : state.auxLeftStorageKey,
+      }));
+  },
+
   setLeftResizing: (resizing) => set({ isLeftResizing: resizing }),
   setRightResizing: (resizing) => set({ isRightResizing: resizing }),
+  setAuxLeftResizing: (resizing) => set({ isAuxLeftResizing: resizing }),
 
   resizeLeft: (target) => {
     const state = get();
     const viewport = getViewportWidth();
     const otherMounted = rightIsMounted(state);
+    const auxMounted = auxLeftIsMounted(state);
 
+    const auxFloor = auxMounted ? state.auxLeftWidth : 0;
     const otherFloor = otherMounted ? SIDEBAR_MIN_WIDTH : 0;
-    const maxLeft = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - otherFloor);
+    const maxLeft = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - otherFloor - auxFloor);
     const nextLeft = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxLeft, Math.round(target)));
 
     let nextRight = state.rightWidth;
     if (otherMounted) {
-      const allowedRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - nextLeft);
+      const allowedRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - nextLeft - auxFloor);
       if (state.rightWidth > allowedRight) nextRight = allowedRight;
     }
 
@@ -143,33 +182,92 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
   resizeRight: (target) => {
     const state = get();
     const viewport = getViewportWidth();
-    const otherMounted = leftIsMounted(state);
+    const leftMounted = leftIsMounted(state);
+    const auxMounted = auxLeftIsMounted(state);
 
-    const otherFloor = otherMounted ? SIDEBAR_MIN_WIDTH : 0;
-    const maxRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - otherFloor);
+    const leftTotal = (leftMounted ? state.leftWidth : 0) + (auxMounted ? state.auxLeftWidth : 0);
+    const maxRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - leftTotal);
     const nextRight = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxRight, Math.round(target)));
 
     let nextLeft = state.leftWidth;
-    if (otherMounted) {
-      const allowedLeft = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - nextRight);
-      if (state.leftWidth > allowedLeft) nextLeft = allowedLeft;
+    let nextAuxLeft = state.auxLeftWidth;
+    if (leftMounted || auxMounted) {
+      const allowedLeftTotal = Math.max(
+        leftMounted && auxMounted ? SIDEBAR_MIN_WIDTH * 2 : SIDEBAR_MIN_WIDTH,
+        viewport - MIDDLE_MIN_WIDTH - nextRight,
+      );
+      const currentLeftTotal = (leftMounted ? state.leftWidth : 0) + (auxMounted ? state.auxLeftWidth : 0);
+      if (currentLeftTotal > allowedLeftTotal) {
+        let overflow = currentLeftTotal - allowedLeftTotal;
+        if (auxMounted && state.auxLeftWidth > SIDEBAR_MIN_WIDTH) {
+          const auxShrink = Math.min(overflow, state.auxLeftWidth - SIDEBAR_MIN_WIDTH);
+          nextAuxLeft = state.auxLeftWidth - auxShrink;
+          overflow -= auxShrink;
+        }
+        if (overflow > 0 && leftMounted && state.leftWidth > SIDEBAR_MIN_WIDTH) {
+          nextLeft = Math.max(SIDEBAR_MIN_WIDTH, state.leftWidth - overflow);
+        }
+      }
     }
 
-    if (nextRight === state.rightWidth && nextLeft === state.leftWidth) return;
+    if (nextRight === state.rightWidth && nextLeft === state.leftWidth && nextAuxLeft === state.auxLeftWidth) return;
 
     persistWidth(RIGHT_STORAGE_KEY, nextRight);
     if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
-    set({ leftWidth: nextLeft, rightWidth: nextRight });
+    if (nextAuxLeft !== state.auxLeftWidth && state.auxLeftStorageKey) {
+      persistWidth(state.auxLeftStorageKey, nextAuxLeft);
+    }
+    set({ leftWidth: nextLeft, rightWidth: nextRight, auxLeftWidth: nextAuxLeft });
+  },
+
+  resizeAuxLeft: (target) => {
+    const state = get();
+    const viewport = getViewportWidth();
+    const leftMounted = leftIsMounted(state);
+    const rightMounted = rightIsMounted(state);
+    const leftFloor = leftMounted ? state.leftWidth : 0;
+
+    const maxAux = Math.max(
+      SIDEBAR_MIN_WIDTH,
+      viewport - MIDDLE_MIN_WIDTH - leftFloor - (rightMounted ? state.rightWidth : 0),
+    );
+    const nextAux = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxAux, Math.round(target)));
+
+    let nextRight = state.rightWidth;
+    if (rightMounted) {
+      const allowedRight = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - leftFloor - nextAux);
+      if (state.rightWidth > allowedRight) nextRight = allowedRight;
+    }
+
+    let nextLeft = state.leftWidth;
+    if (leftMounted) {
+      const allowedLeft = Math.max(
+        SIDEBAR_MIN_WIDTH,
+        viewport - MIDDLE_MIN_WIDTH - nextAux - (rightMounted ? nextRight : 0),
+      );
+      if (state.leftWidth > allowedLeft) nextLeft = allowedLeft;
+    }
+
+    if (nextAux === state.auxLeftWidth && nextRight === state.rightWidth && nextLeft === state.leftWidth) return;
+
+    if (state.auxLeftStorageKey) persistWidth(state.auxLeftStorageKey, nextAux);
+    if (nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, nextRight);
+    if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
+    set({ auxLeftWidth: nextAux, rightWidth: nextRight, leftWidth: nextLeft });
   },
 
   hydrateFromStorage: () => {
     set({
       leftWidth: readPersistedWidth(LEFT_STORAGE_KEY, DEFAULT_LEFT_WIDTH),
       rightWidth: readPersistedWidth(RIGHT_STORAGE_KEY, DEFAULT_RIGHT_WIDTH),
+      auxLeftWidth: DEFAULT_LEFT_WIDTH,
+      auxLeftStorageKey: null,
       leftMountCount: 0,
       rightMountCount: 0,
+      auxLeftMountCount: 0,
       isLeftResizing: false,
       isRightResizing: false,
+      isAuxLeftResizing: false,
     });
   },
 
@@ -178,28 +276,45 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
     const viewport = getViewportWidth();
     const leftActive = leftIsMounted(state);
     const rightActive = rightIsMounted(state);
-    const effectiveLeft = leftActive ? state.leftWidth : 0;
-    const effectiveRight = rightActive ? state.rightWidth : 0;
-
-    if (effectiveLeft + effectiveRight + MIDDLE_MIN_WIDTH <= viewport) return;
+    const auxActive = auxLeftIsMounted(state);
 
     let nextLeft = state.leftWidth;
     let nextRight = state.rightWidth;
+    let nextAux = state.auxLeftWidth;
+
+    const total = (leftActive ? nextLeft : 0) + (auxActive ? nextAux : 0) + (rightActive ? nextRight : 0);
+    if (total + MIDDLE_MIN_WIDTH <= viewport) return;
 
     // Shrink the right sidebar first since it overlays the canvas.
     if (rightActive) {
-      const cap = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - (leftActive ? nextLeft : 0));
+      const cap = Math.max(
+        SIDEBAR_MIN_WIDTH,
+        viewport - MIDDLE_MIN_WIDTH - (leftActive ? nextLeft : 0) - (auxActive ? nextAux : 0),
+      );
       if (nextRight > cap) nextRight = cap;
     }
+    if (auxActive) {
+      const cap = Math.max(
+        SIDEBAR_MIN_WIDTH,
+        viewport - MIDDLE_MIN_WIDTH - (leftActive ? nextLeft : 0) - (rightActive ? nextRight : 0),
+      );
+      if (nextAux > cap) nextAux = cap;
+    }
     if (leftActive) {
-      const cap = Math.max(SIDEBAR_MIN_WIDTH, viewport - MIDDLE_MIN_WIDTH - (rightActive ? nextRight : 0));
+      const cap = Math.max(
+        SIDEBAR_MIN_WIDTH,
+        viewport - MIDDLE_MIN_WIDTH - (auxActive ? nextAux : 0) - (rightActive ? nextRight : 0),
+      );
       if (nextLeft > cap) nextLeft = cap;
     }
 
-    if (nextLeft === state.leftWidth && nextRight === state.rightWidth) return;
+    if (nextLeft === state.leftWidth && nextRight === state.rightWidth && nextAux === state.auxLeftWidth) return;
     if (nextLeft !== state.leftWidth) persistWidth(LEFT_STORAGE_KEY, nextLeft);
     if (nextRight !== state.rightWidth) persistWidth(RIGHT_STORAGE_KEY, nextRight);
-    set({ leftWidth: nextLeft, rightWidth: nextRight });
+    if (nextAux !== state.auxLeftWidth && state.auxLeftStorageKey) {
+      persistWidth(state.auxLeftStorageKey, nextAux);
+    }
+    set({ leftWidth: nextLeft, rightWidth: nextRight, auxLeftWidth: nextAux });
   },
 }));
 
@@ -213,6 +328,18 @@ export function useSidebarMount(side: "left" | "right"): void {
   const registerLeft = useSidebarLayoutStore((s) => s.registerLeft);
   const registerRight = useSidebarLayoutStore((s) => s.registerRight);
   useEffect(() => (side === "left" ? registerLeft() : registerRight()), [side, registerLeft, registerRight]);
+}
+
+/**
+ * Subscribe the runs/versions auxiliary sidebar to the layout store. Only
+ * registers while {@link isOpen} is true so closed panels do not consume width.
+ */
+export function useAuxLeftSidebarMount(isOpen: boolean, storageKey: string, defaultWidth: number): void {
+  const registerAuxLeft = useSidebarLayoutStore((s) => s.registerAuxLeft);
+  useEffect(() => {
+    if (!isOpen) return;
+    return registerAuxLeft(storageKey, defaultWidth);
+  }, [isOpen, storageKey, defaultWidth, registerAuxLeft]);
 }
 
 /**
@@ -235,6 +362,8 @@ export function useSidebarLayoutViewport(): void {
  */
 export function useEffectiveLeftSidebarWidth(): number {
   const leftWidth = useSidebarLayoutStore((state) => state.leftWidth);
+  const auxLeftWidth = useSidebarLayoutStore((state) => state.auxLeftWidth);
   const leftMounted = useSidebarLayoutStore((state) => state.leftMountCount > 0);
-  return leftMounted ? leftWidth : 0;
+  const auxLeftMounted = useSidebarLayoutStore((state) => state.auxLeftMountCount > 0);
+  return (leftMounted ? leftWidth : 0) + (auxLeftMounted ? auxLeftWidth : 0);
 }

--- a/web_src/src/stores/sidebarLayoutStore.ts
+++ b/web_src/src/stores/sidebarLayoutStore.ts
@@ -187,10 +187,13 @@ export const useSidebarLayoutStore = create<SidebarLayoutState>((set, get) => ({
  * (component / building-blocks). When unmounted the store decrements the mount
  * count so its constraints reflect the actual on-screen geometry.
  */
-export function useSidebarMount(side: "left" | "right"): void {
+export function useSidebarMount(side: "left" | "right", active = true): void {
   const registerLeft = useSidebarLayoutStore((s) => s.registerLeft);
   const registerRight = useSidebarLayoutStore((s) => s.registerRight);
-  useEffect(() => (side === "left" ? registerLeft() : registerRight()), [side, registerLeft, registerRight]);
+  useEffect(() => {
+    if (!active) return;
+    return side === "left" ? registerLeft() : registerRight();
+  }, [active, side, registerLeft, registerRight]);
 }
 
 /**

--- a/web_src/src/stores/useAuxiliarySidebarWidth.ts
+++ b/web_src/src/stores/useAuxiliarySidebarWidth.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  SIDEBAR_MIN_WIDTH,
+  useAuxLeftSidebarMount,
+  useSidebarLayoutStore,
+  useSidebarLayoutViewport,
+} from "@/stores/sidebarLayoutStore";
+
+export function useAuxiliarySidebarWidth(isOpen: boolean, storageKey: string, defaultWidth: number) {
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const width = useSidebarLayoutStore((state) => state.auxLeftWidth);
+  const isResizing = useSidebarLayoutStore((state) => state.isAuxLeftResizing);
+  const setAuxLeftResizing = useSidebarLayoutStore((state) => state.setAuxLeftResizing);
+  const resizeAuxLeft = useSidebarLayoutStore((state) => state.resizeAuxLeft);
+
+  useAuxLeftSidebarMount(isOpen, storageKey, defaultWidth);
+  useSidebarLayoutViewport();
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      setAuxLeftResizing(true);
+    },
+    [setAuxLeftResizing],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = sidebarRef.current?.getBoundingClientRect();
+      const left = rect?.left ?? 0;
+      resizeAuxLeft(Math.max(SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left)));
+    };
+
+    const handleMouseUp = () => setAuxLeftResizing(false);
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing, resizeAuxLeft, setAuxLeftResizing]);
+
+  return { sidebarRef, width, isResizing, handleMouseDown };
+}

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -132,6 +132,32 @@ export function Header(props: HeaderProps) {
   );
 }
 
+interface PageHeaderBarProps {
+  organizationId?: string;
+  headerTitle: string;
+  showCanvasSettingsMenu?: boolean;
+  mode?: HeaderMode;
+  isEditing?: boolean;
+  hasUnpublishedDraftChanges?: boolean;
+  onExitEditMode?: () => void;
+  exitEditModeDisabled?: boolean;
+  exitEditModeDisabledTooltip?: string;
+  onEnterEditMode?: () => void;
+  enterEditModeDisabled?: boolean;
+  enterEditModeDisabledTooltip?: string;
+  onDiscardDraftAndStartEdit?: () => void;
+  unpublishedDraftUpdatedAt?: string;
+  startEditingDrafts?: CanvasesCanvasVersion[];
+  startEditingDefaultDraft?: CanvasesCanvasVersion | null;
+  startEditingMenuOpen?: boolean;
+  onStartEditingMenuOpenChange?: (open: boolean) => void;
+  onContinueDraftBranch?: (branchName: string) => void;
+  onCreateDraftBranch?: () => void;
+  createDraftBranchPending?: boolean;
+  activeDraftBranchLabel?: string;
+  activeDraftBranchShortSha?: string;
+}
+
 function PageHeader({
   organizationId,
   headerTitle,
@@ -156,31 +182,7 @@ function PageHeader({
   activeDraftBranchLabel,
   activeDraftBranchShortSha,
   showCanvasSettingsMenu = true,
-}: {
-  organizationId?: string;
-  headerTitle: string;
-  showCanvasSettingsMenu?: boolean;
-  mode?: HeaderMode;
-  isEditing?: boolean;
-  hasUnpublishedDraftChanges?: boolean;
-  onExitEditMode?: () => void;
-  exitEditModeDisabled?: boolean;
-  exitEditModeDisabledTooltip?: string;
-  onEnterEditMode?: () => void;
-  enterEditModeDisabled?: boolean;
-  enterEditModeDisabledTooltip?: string;
-  onDiscardDraftAndStartEdit?: () => void;
-  unpublishedDraftUpdatedAt?: string;
-  startEditingDrafts?: CanvasesCanvasVersion[];
-  startEditingDefaultDraft?: CanvasesCanvasVersion | null;
-  startEditingMenuOpen?: boolean;
-  onStartEditingMenuOpenChange?: (open: boolean) => void;
-  onContinueDraftBranch?: (branchName: string) => void;
-  onCreateDraftBranch?: () => void;
-  createDraftBranchPending?: boolean;
-  activeDraftBranchLabel?: string;
-  activeDraftBranchShortSha?: string;
-}) {
+}: PageHeaderBarProps) {
   const {
     workflowId,
     canvasId: canvasIdParam,

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -7,7 +7,15 @@ import { CanvasProjectSwitcher } from "./components/CanvasProjectSwitcher";
 import { CanvasToolSidebarTrigger } from "./components/CanvasToolSidebarTrigger";
 import { SecondaryHeaderActions, EditModeTopHeaderActions, LiveModeTopHeaderActions } from "./HeaderSecondaryActions";
 
-export type HeaderMode = "default" | "version-live" | "version-edit" | "runs" | "console" | "memory" | "files";
+export type HeaderMode =
+  | "default"
+  | "version-live"
+  | "version-edit"
+  | "runs"
+  | "versions"
+  | "console"
+  | "memory"
+  | "files";
 
 export interface HeaderProps {
   /** Shown centered in the top bar (canvas or template display name). May be undefined while the canvas is still loading. */
@@ -52,6 +60,10 @@ export interface HeaderProps {
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectConsole?: () => void;
+  /** Provided when Runs is available as a first-class tab; opens the Runs view. */
+  onSelectRuns?: () => void;
+  /** Provided when Versions is available as a first-class tab; opens the Versions view. */
+  onSelectVersions?: () => void;
   /** Provided when Memory is available as a first-class tab; opens the Memory view. */
   onSelectMemory?: () => void;
   /** Provided when Files is available as a first-class tab; opens the Files view. */
@@ -218,7 +230,10 @@ function PageHeader({
             />
           </div>
         ) : null}
-        {mode !== "runs" && !isEditing && (onEnterEditMode || startEditingDrafts !== undefined) ? (
+        {mode !== "runs" &&
+        mode !== "versions" &&
+        !isEditing &&
+        (onEnterEditMode || startEditingDrafts !== undefined) ? (
           <LiveModeTopHeaderActions
             onEnterEditMode={onEnterEditMode}
             enterEditModeDisabled={enterEditModeDisabled}
@@ -256,6 +271,8 @@ function SecondaryHeader(props: HeaderProps) {
               mode={canvasViewMode}
               onSelectLive={props.onSelectCanvasView}
               onSelectConsole={props.onSelectConsole}
+              onSelectRuns={props.onSelectRuns}
+              onSelectVersions={props.onSelectVersions}
               onSelectMemory={props.onSelectMemory}
               onSelectFiles={props.onSelectFiles}
               editing={editing}
@@ -272,7 +289,13 @@ function SecondaryHeader(props: HeaderProps) {
 }
 
 function shouldShowCanvasViewModeToggle(props: HeaderProps): boolean {
-  if (!props.onSelectConsole && !props.onSelectMemory && !props.onSelectFiles) {
+  if (
+    !props.onSelectConsole &&
+    !props.onSelectRuns &&
+    !props.onSelectVersions &&
+    !props.onSelectMemory &&
+    !props.onSelectFiles
+  ) {
     return false;
   }
 
@@ -284,6 +307,7 @@ function isCanvasViewMode(mode: HeaderMode | undefined): boolean {
     mode === "version-live" ||
     mode === "version-edit" ||
     mode === "runs" ||
+    mode === "versions" ||
     mode === "console" ||
     mode === "memory" ||
     mode === "files"
@@ -291,7 +315,7 @@ function isCanvasViewMode(mode: HeaderMode | undefined): boolean {
 }
 
 function getCanvasViewMode(mode: HeaderMode | undefined): CanvasMode {
-  if (mode === "runs" || mode === "console" || mode === "memory" || mode === "files") {
+  if (mode === "runs" || mode === "versions" || mode === "console" || mode === "memory" || mode === "files") {
     return mode;
   }
 

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.spec.tsx
@@ -34,6 +34,95 @@ describe("CanvasModeToggle", () => {
     expect(onSelectLive).toHaveBeenCalledTimes(2);
   });
 
+  it("invokes onSelectRuns when clicking the Runs tab", async () => {
+    const user = userEvent.setup();
+    const onSelectRuns = vi.fn();
+
+    render(
+      <CanvasModeToggle
+        mode="version-live"
+        onSelectLive={vi.fn()}
+        onSelectConsole={vi.fn()}
+        onSelectRuns={onSelectRuns}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    await user.click(screen.getByRole("link", { name: "Runs" }));
+
+    expect(onSelectRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the Runs tab when onSelectRuns is not provided", () => {
+    render(<CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectConsole={vi.fn()} />, {
+      wrapper: routerWrapper,
+    });
+
+    expect(screen.queryByRole("link", { name: "Runs" })).not.toBeInTheDocument();
+  });
+
+  it("invokes onSelectVersions when clicking the Versions tab", async () => {
+    const user = userEvent.setup();
+    const onSelectVersions = vi.fn();
+
+    render(
+      <CanvasModeToggle
+        mode="version-live"
+        onSelectLive={vi.fn()}
+        onSelectConsole={vi.fn()}
+        onSelectVersions={onSelectVersions}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    await user.click(screen.getByRole("link", { name: "Versions" }));
+
+    expect(onSelectVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the Versions tab when onSelectVersions is not provided", () => {
+    render(<CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectConsole={vi.fn()} />, {
+      wrapper: routerWrapper,
+    });
+
+    expect(screen.queryByRole("link", { name: "Versions" })).not.toBeInTheDocument();
+  });
+
+  it("orders tabs as Canvas, Runs, Versions, then Console and shows a divider before the secondary group", () => {
+    render(
+      <CanvasModeToggle
+        mode="version-live"
+        onSelectLive={vi.fn()}
+        onSelectConsole={vi.fn()}
+        onSelectRuns={vi.fn()}
+        onSelectVersions={vi.fn()}
+        onSelectMemory={vi.fn()}
+        onSelectFiles={vi.fn()}
+      />,
+      { wrapper: routerWrapper },
+    );
+
+    const tabs = screen.getAllByRole("link");
+    expect(tabs.map((tab) => tab.textContent?.replace(/\s+/g, " ").trim())).toEqual([
+      "Canvas",
+      "Runs",
+      "Versions",
+      "Console",
+      "Memory",
+      "Files",
+    ]);
+    expect(screen.getByTestId("canvas-view-mode-group-divider")).toBeInTheDocument();
+  });
+
+  it("hides the group divider when only the canvas workflow tabs are shown", () => {
+    render(
+      <CanvasModeToggle mode="version-live" onSelectLive={vi.fn()} onSelectRuns={vi.fn()} onSelectVersions={vi.fn()} />,
+      { wrapper: routerWrapper },
+    );
+
+    expect(screen.queryByTestId("canvas-view-mode-group-divider")).not.toBeInTheDocument();
+  });
+
   it("invokes onSelectMemory when clicking the Memory tab", async () => {
     const user = userEvent.setup();
     const onSelectMemory = vi.fn();

--- a/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasModeToggle.tsx
@@ -3,12 +3,14 @@ import { isNormalClick } from "@/lib/linkHelpers";
 import { cn } from "@/lib/utils";
 import { Link, useParams } from "react-router-dom";
 
-export type CanvasMode = "version-live" | "version-edit" | "runs" | "console" | "memory" | "files";
+export type CanvasMode = "version-live" | "version-edit" | "runs" | "versions" | "console" | "memory" | "files";
 
 interface CanvasModeToggleProps {
   mode: CanvasMode;
   onSelectLive: () => void;
   onSelectConsole?: () => void;
+  onSelectRuns?: () => void;
+  onSelectVersions?: () => void;
   onSelectMemory?: () => void;
   onSelectFiles?: () => void;
   editing?: boolean;
@@ -18,9 +20,10 @@ interface CanvasModeToggleProps {
 
 const CANVAS_TAB = "canvas";
 const CONSOLE_TAB = "console";
+const RUNS_TAB = "runs";
+const VERSIONS_TAB = "versions";
 const MEMORY_TAB = "memory";
 const FILES_TAB = "files";
-const RUNS_MODE = "runs";
 
 const BASE_TAB_CLASSES =
   "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-full border border-transparent px-2.5 py-1 text-[13px] font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50";
@@ -32,9 +35,10 @@ const EDITING_INACTIVE_CLASSES = "bg-transparent text-blue-800/80 hover:text-blu
 
 const MODE_TO_TAB: Record<string, string> = {
   console: CONSOLE_TAB,
+  runs: RUNS_TAB,
+  versions: VERSIONS_TAB,
   memory: MEMORY_TAB,
   files: FILES_TAB,
-  runs: RUNS_MODE,
 };
 
 /** On normal clicks, prevent Link navigation and use the callback (which preserves query params via setSearchParams). */
@@ -61,10 +65,23 @@ function tabClasses(selected: string, value: string, editing: boolean) {
   return cn(BASE_TAB_CLASSES, stateClass);
 }
 
+function GroupDivider() {
+  return (
+    <span
+      aria-hidden="true"
+      role="separator"
+      className="mx-2 h-7 w-px shrink-0 bg-slate-950/15"
+      data-testid="canvas-view-mode-group-divider"
+    />
+  );
+}
+
 export function CanvasModeToggle({
   mode,
   onSelectLive,
   onSelectConsole,
+  onSelectRuns,
+  onSelectVersions,
   onSelectMemory,
   onSelectFiles,
   editing = false,
@@ -73,8 +90,11 @@ export function CanvasModeToggle({
 }: CanvasModeToggleProps) {
   const { organizationId, appId } = useParams<{ organizationId: string; appId: string }>();
   const showConsole = Boolean(onSelectConsole);
+  const showRuns = Boolean(onSelectRuns);
+  const showVersions = Boolean(onSelectVersions);
   const showMemory = Boolean(onSelectMemory);
   const showFiles = Boolean(onSelectFiles);
+  const showSecondaryGroup = showConsole || showMemory || showFiles;
   const selected = modeToTab(mode);
   const baseHref = organizationId && appId ? appPath(organizationId, appId) : "#";
   const tabHref = (view?: string) => (view ? `${baseHref}?view=${view}` : baseHref);
@@ -87,6 +107,44 @@ export function CanvasModeToggle({
         editing ? "bg-blue-50" : "bg-slate-100",
       )}
     >
+      <Link
+        to={tabHref()}
+        onClick={(e) => handleTabClick(e, selected === CANVAS_TAB, () => void onSelectLive())}
+        className={tabClasses(selected, CANVAS_TAB, editing)}
+        data-testid="canvas-view-mode-live"
+        aria-label={editing ? "Canvas (editing)" : "Canvas"}
+        aria-current={selected === CANVAS_TAB ? "page" : undefined}
+      >
+        <span className="inline-flex items-center gap-1.5">
+          Canvas
+          <DraftDot show={hasDraft} editing={editing} testId="canvas-view-mode-live-draft-dot" />
+        </span>
+      </Link>
+      {showRuns ? (
+        <Link
+          to={tabHref("runs")}
+          onClick={(e) => handleTabClick(e, selected === RUNS_TAB, () => void onSelectRuns?.())}
+          className={tabClasses(selected, RUNS_TAB, editing)}
+          data-testid="canvas-view-mode-runs"
+          aria-label="Runs"
+          aria-current={selected === RUNS_TAB ? "page" : undefined}
+        >
+          Runs
+        </Link>
+      ) : null}
+      {showVersions ? (
+        <Link
+          to={tabHref("versions")}
+          onClick={(e) => handleTabClick(e, selected === VERSIONS_TAB, () => void onSelectVersions?.())}
+          className={tabClasses(selected, VERSIONS_TAB, editing)}
+          data-testid="canvas-view-mode-versions"
+          aria-label="Versions"
+          aria-current={selected === VERSIONS_TAB ? "page" : undefined}
+        >
+          Versions
+        </Link>
+      ) : null}
+      {showSecondaryGroup ? <GroupDivider /> : null}
       {showConsole ? (
         <Link
           to={tabHref("console")}
@@ -102,19 +160,6 @@ export function CanvasModeToggle({
           </span>
         </Link>
       ) : null}
-      <Link
-        to={tabHref()}
-        onClick={(e) => handleTabClick(e, selected === CANVAS_TAB, () => void onSelectLive())}
-        className={tabClasses(selected, CANVAS_TAB, editing)}
-        data-testid="canvas-view-mode-live"
-        aria-label={editing ? "Canvas (editing)" : "Canvas"}
-        aria-current={selected === CANVAS_TAB ? "page" : undefined}
-      >
-        <span className="inline-flex items-center gap-1.5">
-          Canvas
-          <DraftDot show={hasDraft} editing={editing} testId="canvas-view-mode-live-draft-dot" />
-        </span>
-      </Link>
       {showMemory ? (
         <Link
           to={tabHref("memory")}

--- a/web_src/src/ui/CanvasPage/components/CanvasToolSidebarTrigger.tsx
+++ b/web_src/src/ui/CanvasPage/components/CanvasToolSidebarTrigger.tsx
@@ -1,8 +1,9 @@
 import type { CanvasToolSidebarState } from "@/components/CanvasToolSidebar/useCanvasToolSidebarState";
 import { Button as UIButton } from "@/components/ui/button";
 import { useShortcutLabel } from "@/hooks/useShortcutLabel";
+import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { PanelLeft, PanelLeftDashed } from "lucide-react";
+import { Sparkle, Sparkles } from "lucide-react";
 
 export type CanvasToolSidebarTriggerProps = {
   toolSidebarState: CanvasToolSidebarState;
@@ -11,30 +12,35 @@ export type CanvasToolSidebarTriggerProps = {
 export function CanvasToolSidebarTrigger({ toolSidebarState }: CanvasToolSidebarTriggerProps) {
   const { showToolSidebarToggle, isToolSidebarOpen, handleToolSidebarToggle } = toolSidebarState;
   const shortcutLabel = useShortcutLabel("B");
-  const label = `Toggle Sidebar (${shortcutLabel})`;
+  const label = `Toggle Agent (${shortcutLabel})`;
 
   if (!showToolSidebarToggle) {
     return null;
   }
 
   return (
-    <div className="relative z-10 -ml-2 flex shrink-0 items-center">
+    <div className="relative z-10 -ml-0.5 flex h-7 shrink-0 items-center">
       <Tooltip delayDuration={350}>
         <TooltipTrigger asChild>
           <UIButton
             type="button"
             variant="ghost"
             size="icon-xs"
-            className="rounded-md border-0 p-0 shadow-none transition-colors focus-visible:bg-slate-100 text-slate-900 hover:bg-slate-100 hover:text-slate-900"
+            className={cn(
+              "h-7 min-h-7 w-7 rounded-full border-0 p-0 shadow-none transition-colors",
+              isToolSidebarOpen
+                ? "bg-violet-100 hover:bg-violet-100 focus-visible:bg-violet-100"
+                : "bg-slate-100 text-slate-500 hover:bg-slate-100 hover:text-foreground focus-visible:bg-slate-100",
+            )}
             aria-label={label}
             aria-pressed={isToolSidebarOpen}
             data-testid="canvas-tool-sidebar-toggle"
             onClick={handleToolSidebarToggle}
           >
             {isToolSidebarOpen ? (
-              <PanelLeft className="size-3.5 shrink-0" />
+              <Sparkles className="size-3.5 shrink-0 text-violet-600" />
             ) : (
-              <PanelLeftDashed className="size-3.5 shrink-0" />
+              <Sparkle className="size-3.5 shrink-0" />
             )}
           </UIButton>
         </TooltipTrigger>

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -61,6 +61,12 @@ import { buildSidebarComponentDocsPayload } from "@/lib/componentDocsUrl";
 import { parseDefaultValues } from "@/lib/components";
 import { countUnacknowledgedErrors } from "@/pages/app/lib/canvas-runs";
 import { findFreePositionInViewport } from "@/pages/app/lib/find-free-position-in-viewport";
+import {
+  allowsBuildingBlocksSidebar,
+  blocksBuildingBlocksShortcut,
+  isPanelHeaderMode,
+  isRunsOrVersionsHeaderMode,
+} from "@/pages/app/viewState";
 import { CANVAS_NODE_FALLBACK_MESSAGE } from "@/pages/app/mappers/safeMappers";
 import { Sentry } from "@/sentry";
 import { useSidebarLayoutStore, useSidebarMount } from "@/stores/sidebarLayoutStore";
@@ -1181,11 +1187,7 @@ function CanvasPage(props: CanvasPageProps) {
       readOnly ||
       Boolean(props.hideAddControls) ||
       !props.isEditing ||
-      props.headerMode === "console" ||
-      props.headerMode === "memory" ||
-      props.headerMode === "files" ||
-      props.headerMode === "runs" ||
-      props.headerMode === "versions" ||
+      blocksBuildingBlocksShortcut(props.headerMode ?? "version-live") ||
       state.componentSidebar.isOpen,
     isSidebarOpen: isBuildingBlocksSidebarOpen,
     onOpen: handleBuildingBlocksShortcutOpen,
@@ -1289,7 +1291,7 @@ function CanvasPage(props: CanvasPageProps) {
           props.headerMode === "memory" ||
           props.headerMode === "files") &&
           "sp-canvas-live",
-        (props.headerMode === "runs" || props.headerMode === "versions") && "sp-canvas-live",
+        isRunsOrVersionsHeaderMode(props.headerMode ?? "version-live") && "sp-canvas-live",
         props.isEditing && "sp-canvas-editing",
       )}
     >
@@ -1364,10 +1366,7 @@ function CanvasPage(props: CanvasPageProps) {
           {props.toolSidebarVersionsContent ?? null}
         </CanvasVersionsSidebar>
 
-        {props.headerMode === "runs" ||
-        props.headerMode === "versions" ||
-        props.headerMode === "memory" ||
-        props.headerMode === "files" ? null : props.isEditing ? (
+        {isPanelHeaderMode(props.headerMode ?? "version-live") ? null : props.isEditing ? (
           props.headerMode === "console" ? null : (
             <RightSideControls
               mode="edit"
@@ -1390,11 +1389,7 @@ function CanvasPage(props: CanvasPageProps) {
             isOpen={
               isBuildingBlocksSidebarOpen &&
               !!props.isEditing &&
-              props.headerMode !== "console" &&
-              props.headerMode !== "memory" &&
-              props.headerMode !== "files" &&
-              props.headerMode !== "runs" &&
-              props.headerMode !== "versions"
+              allowsBuildingBlocksSidebar(props.headerMode ?? "version-live")
             }
             onToggle={handleSidebarToggle}
             blocks={props.buildingBlocks || []}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -66,6 +66,7 @@ import {
   blocksBuildingBlocksShortcut,
   isPanelHeaderMode,
   isRunsOrVersionsHeaderMode,
+  normalizeCanvasHeaderMode,
 } from "@/pages/app/viewState";
 import { CANVAS_NODE_FALLBACK_MESSAGE } from "@/pages/app/mappers/safeMappers";
 import { Sentry } from "@/sentry";
@@ -773,6 +774,7 @@ const nodeTypes = {
 function CanvasPage(props: CanvasPageProps) {
   const state = useCanvasState(props);
   const readOnly = props.readOnly ?? false;
+  const workflowHeaderMode = normalizeCanvasHeaderMode(props.headerMode);
   const [currentTab, setCurrentTab] = useState<"latest" | "settings" | "docs">(() =>
     props.canvasStateMode === "editing" ? "settings" : "latest",
   );
@@ -1187,7 +1189,7 @@ function CanvasPage(props: CanvasPageProps) {
       readOnly ||
       Boolean(props.hideAddControls) ||
       !props.isEditing ||
-      blocksBuildingBlocksShortcut(props.headerMode ?? "version-live") ||
+      blocksBuildingBlocksShortcut(workflowHeaderMode) ||
       state.componentSidebar.isOpen,
     isSidebarOpen: isBuildingBlocksSidebarOpen,
     onOpen: handleBuildingBlocksShortcutOpen,
@@ -1291,7 +1293,7 @@ function CanvasPage(props: CanvasPageProps) {
           props.headerMode === "memory" ||
           props.headerMode === "files") &&
           "sp-canvas-live",
-        isRunsOrVersionsHeaderMode(props.headerMode ?? "version-live") && "sp-canvas-live",
+        isRunsOrVersionsHeaderMode(workflowHeaderMode) && "sp-canvas-live",
         props.isEditing && "sp-canvas-editing",
       )}
     >
@@ -1366,7 +1368,7 @@ function CanvasPage(props: CanvasPageProps) {
           {props.toolSidebarVersionsContent ?? null}
         </CanvasVersionsSidebar>
 
-        {isPanelHeaderMode(props.headerMode ?? "version-live") ? null : props.isEditing ? (
+        {isPanelHeaderMode(workflowHeaderMode) ? null : props.isEditing ? (
           props.headerMode === "console" ? null : (
             <RightSideControls
               mode="edit"
@@ -1389,7 +1391,7 @@ function CanvasPage(props: CanvasPageProps) {
             isOpen={
               isBuildingBlocksSidebarOpen &&
               !!props.isEditing &&
-              allowsBuildingBlocksSidebar(props.headerMode ?? "version-live")
+              allowsBuildingBlocksSidebar(workflowHeaderMode)
             }
             onToggle={handleSidebarToggle}
             blocks={props.buildingBlocks || []}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1185,6 +1185,7 @@ function CanvasPage(props: CanvasPageProps) {
       props.headerMode === "memory" ||
       props.headerMode === "files" ||
       props.headerMode === "runs" ||
+      props.headerMode === "versions" ||
       state.componentSidebar.isOpen,
     isSidebarOpen: isBuildingBlocksSidebarOpen,
     onOpen: handleBuildingBlocksShortcutOpen,
@@ -1364,6 +1365,7 @@ function CanvasPage(props: CanvasPageProps) {
         </CanvasVersionsSidebar>
 
         {props.headerMode === "runs" ||
+        props.headerMode === "versions" ||
         props.headerMode === "memory" ||
         props.headerMode === "files" ? null : props.isEditing ? (
           props.headerMode === "console" ? null : (
@@ -1391,7 +1393,8 @@ function CanvasPage(props: CanvasPageProps) {
               props.headerMode !== "console" &&
               props.headerMode !== "memory" &&
               props.headerMode !== "files" &&
-              props.headerMode !== "runs"
+              props.headerMode !== "runs" &&
+              props.headerMode !== "versions"
             }
             onToggle={handleSidebarToggle}
             blocks={props.buildingBlocks || []}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1388,11 +1388,7 @@ function CanvasPage(props: CanvasPageProps) {
         )}
         {props.hideAddControls || !isBuildingBlocksSidebarOpen ? null : (
           <BuildingBlocksSidebar
-            isOpen={
-              isBuildingBlocksSidebarOpen &&
-              !!props.isEditing &&
-              allowsBuildingBlocksSidebar(workflowHeaderMode)
-            }
+            isOpen={isBuildingBlocksSidebarOpen && !!props.isEditing && allowsBuildingBlocksSidebar(workflowHeaderMode)}
             onToggle={handleSidebarToggle}
             blocks={props.buildingBlocks || []}
             integrations={props.integrations}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -50,6 +50,8 @@ import type {
   OrganizationsIntegration,
   TriggersTrigger,
 } from "@/api-client";
+import { CanvasRunsSidebar } from "@/components/CanvasRunsSidebar";
+import { CanvasVersionsSidebar } from "@/components/CanvasVersionsSidebar";
 import { CanvasToolSidebar } from "@/components/CanvasToolSidebar";
 import {
   useCanvasToolSidebarState,
@@ -184,7 +186,7 @@ export interface CanvasPageProps {
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;
   discardVersionDisabledTooltip?: string;
-  headerMode?: "default" | "version-live" | "version-edit" | "runs" | "console" | "memory" | "files";
+  headerMode?: "default" | "version-live" | "version-edit" | "runs" | "versions" | "console" | "memory" | "files";
   /** Node settings sidebar: canvas uses debounced autosave without closing the panel after each save. */
   configurationSaveMode?: "manual" | "auto";
   onEnterEditMode?: () => void;
@@ -196,7 +198,7 @@ export interface CanvasPageProps {
   /** Switches back to the Canvas tab without changing edit mode. */
   onSelectCanvasView?: () => void;
   onSelectRuns?: () => void;
-  onExitRunsMode?: () => void;
+  onSelectVersions?: () => void;
   onSelectConsole?: () => void;
   /** Switches the canvas surface to the Memory tab. Omitted on templates. */
   onSelectMemory?: () => void;
@@ -230,15 +232,10 @@ export interface CanvasPageProps {
   canvasStateMode?: "default" | "editing" | "previewing-previous-version" | "awaiting-approval";
   /** When true, enables inline rename and app settings in the project switcher. */
   showCanvasSettingsMenu?: boolean;
-  isVersionControlOpen?: boolean;
-  onOpenVersionControl?: () => void;
-  hasAutoOpenedVersionControl?: boolean;
-  onVersionControlAutoOpened?: () => void;
-  onCloseVersionControl?: () => void;
   showBottomStatusControls?: boolean;
   readOnly?: boolean;
   hideAddControls?: boolean;
-  /** Hide the Agent / Runs / Versions left panel toggle (templates only); runs view keeps the tool sidebar visible. */
+  /** Hide the Agent / Versions left panel toggle (templates only). */
   hideCanvasToolSidebar?: boolean;
   canReadIntegrations?: boolean;
   canCreateIntegrations?: boolean;
@@ -808,44 +805,13 @@ function CanvasPage(props: CanvasPageProps) {
     return props.nodes.length === 0;
   });
 
-  const forceEnableToolSidebar = Boolean(
-    props.onSelectRuns ||
-      props.onOpenVersionControl ||
-      props.toolSidebarRunsContent ||
-      props.toolSidebarVersionsContent ||
-      props.headerMode === "runs" ||
-      props.isVersionControlOpen,
-  );
   const toolSidebarState = useCanvasToolSidebarState({
     isEditing: props.isEditing,
-    forceEnable: forceEnableToolSidebar,
     hideCanvasToolSidebar: props.hideCanvasToolSidebar ?? false,
     readOnly,
     canvasId: props.canvasId,
     organizationId: props.organizationId,
-    onBeforeClose: () => {
-      if (props.headerMode === "runs") props.onExitRunsMode?.();
-      if (props.isVersionControlOpen) props.onCloseVersionControl?.();
-    },
   });
-  const { isToolSidebarOpen, openToolSidebar } = toolSidebarState;
-  const previousHeaderModeRef = useRef<CanvasPageProps["headerMode"] | undefined>(undefined);
-
-  useEffect(() => {
-    if (props.headerMode === "runs" && previousHeaderModeRef.current !== "runs" && !isToolSidebarOpen)
-      openToolSidebar();
-
-    previousHeaderModeRef.current = props.headerMode;
-  }, [isToolSidebarOpen, openToolSidebar, props.headerMode]);
-
-  useEffect(() => {
-    if (props.isVersionControlOpen && !isToolSidebarOpen) openToolSidebar();
-  }, [isToolSidebarOpen, openToolSidebar, props.isVersionControlOpen]);
-
-  const handleSelectRuns = () => {
-    openToolSidebar();
-    props.onSelectRuns?.();
-  };
 
   const initialCanvasZoom = props.nodes.length === 0 ? DEFAULT_CANVAS_ZOOM : 1;
   const [canvasZoom, setCanvasZoom] = useState(initialCanvasZoom);
@@ -1322,7 +1288,7 @@ function CanvasPage(props: CanvasPageProps) {
           props.headerMode === "memory" ||
           props.headerMode === "files") &&
           "sp-canvas-live",
-        props.headerMode === "runs" && "sp-canvas-live",
+        (props.headerMode === "runs" || props.headerMode === "versions") && "sp-canvas-live",
         props.isEditing && "sp-canvas-editing",
       )}
     >
@@ -1359,6 +1325,8 @@ function CanvasPage(props: CanvasPageProps) {
           exitEditModeDisabled={props.exitEditModeDisabled}
           exitEditModeDisabledTooltip={props.exitEditModeDisabledTooltip}
           onSelectConsole={props.onSelectConsole}
+          onSelectRuns={props.onSelectRuns}
+          onSelectVersions={props.onSelectVersions}
           onSelectMemory={props.onSelectMemory}
           onSelectFiles={props.onSelectFiles}
           filesHeaderActionsSlotId={props.filesHeaderActionsSlotId}
@@ -1385,19 +1353,15 @@ function CanvasPage(props: CanvasPageProps) {
 
       {/* Main content area with sidebar and canvas */}
       <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <CanvasToolSidebar
-          toolSidebarState={toolSidebarState}
-          mode={props.headerMode}
-          onSelectRuns={handleSelectRuns}
-          onExitRunsMode={props.onExitRunsMode}
-          runsContent={props.toolSidebarRunsContent}
-          isVersionControlOpen={props.isVersionControlOpen}
-          onOpenVersionControl={props.onOpenVersionControl}
-          hasAutoOpenedVersionControl={props.hasAutoOpenedVersionControl}
-          onVersionControlAutoOpened={props.onVersionControlAutoOpened}
-          onCloseVersionControl={props.onCloseVersionControl}
-          versionsContent={props.toolSidebarVersionsContent}
-        />
+        <CanvasToolSidebar toolSidebarState={toolSidebarState} />
+
+        <CanvasRunsSidebar isOpen={props.headerMode === "runs"}>
+          {props.toolSidebarRunsContent ?? null}
+        </CanvasRunsSidebar>
+
+        <CanvasVersionsSidebar isOpen={props.headerMode === "versions"}>
+          {props.toolSidebarVersionsContent ?? null}
+        </CanvasVersionsSidebar>
 
         {props.headerMode === "runs" ||
         props.headerMode === "memory" ||
@@ -1927,6 +1891,8 @@ function CanvasContentHeader({
   exitEditModeDisabled,
   exitEditModeDisabledTooltip,
   onSelectConsole,
+  onSelectRuns,
+  onSelectVersions,
   onSelectMemory,
   onSelectFiles,
   filesHeaderActionsSlotId,
@@ -1988,6 +1954,8 @@ function CanvasContentHeader({
   exitEditModeDisabled?: boolean;
   exitEditModeDisabledTooltip?: string;
   onSelectConsole?: () => void;
+  onSelectRuns?: () => void;
+  onSelectVersions?: () => void;
   onSelectMemory?: () => void;
   onSelectFiles?: () => void;
   filesHeaderActionsSlotId?: string;
@@ -2049,6 +2017,8 @@ function CanvasContentHeader({
       exitEditModeDisabled={exitEditModeDisabled}
       exitEditModeDisabledTooltip={exitEditModeDisabledTooltip}
       onSelectConsole={onSelectConsole}
+      onSelectRuns={onSelectRuns}
+      onSelectVersions={onSelectVersions}
       onSelectMemory={onSelectMemory}
       onSelectFiles={onSelectFiles}
       filesHeaderActionsSlotId={filesHeaderActionsSlotId}

--- a/web_src/src/ui/componentSidebar/index.spec.tsx
+++ b/web_src/src/ui/componentSidebar/index.spec.tsx
@@ -123,25 +123,29 @@ vi.mock("@/pages/app/utils", () => ({
 
 import { ComponentSidebar } from "./index";
 
+function defaultSidebarProps(
+  props?: Partial<React.ComponentProps<typeof ComponentSidebar>>,
+): React.ComponentProps<typeof ComponentSidebar> {
+  return {
+    isOpen: true,
+    canvasMode: "live",
+    latestEvents: [],
+    nextInQueueEvents: [],
+    totalInQueueCount: 0,
+    totalInHistoryCount: 0,
+    showSettingsTab: true,
+    nodeName: "Node",
+    nodeConfiguration: {},
+    nodeConfigurationFields: [],
+    workflowNodes: [],
+    actions: [],
+    triggers: [],
+    ...props,
+  };
+}
+
 function renderSidebar(props?: Partial<React.ComponentProps<typeof ComponentSidebar>>) {
-  return render(
-    <ComponentSidebar
-      isOpen={true}
-      canvasMode="live"
-      latestEvents={[]}
-      nextInQueueEvents={[]}
-      totalInQueueCount={0}
-      totalInHistoryCount={0}
-      showSettingsTab={true}
-      nodeName="Node"
-      nodeConfiguration={{}}
-      nodeConfigurationFields={[]}
-      workflowNodes={[]}
-      actions={[]}
-      triggers={[]}
-      {...props}
-    />,
-  );
+  return render(<ComponentSidebar {...defaultSidebarProps(props)} />);
 }
 
 describe("ComponentSidebar", () => {
@@ -158,6 +162,20 @@ describe("ComponentSidebar", () => {
     const sidebar = container.firstElementChild as HTMLElement | null;
     expect(sidebar).toBeTruthy();
     expect(sidebar?.style.width).toBe("380px");
+  });
+
+  it("does not reserve layout width while closed", async () => {
+    const { rerender } = renderSidebar({ isOpen: false });
+
+    await waitFor(() => {
+      expect(useSidebarLayoutStore.getState().rightMountCount).toBe(0);
+    });
+
+    rerender(<ComponentSidebar {...defaultSidebarProps({ isOpen: true })} />);
+
+    await waitFor(() => {
+      expect(useSidebarLayoutStore.getState().rightMountCount).toBe(1);
+    });
   });
 
   it("keeps width within resize bounds when pointer resize events fire", async () => {

--- a/web_src/src/ui/componentSidebar/index.tsx
+++ b/web_src/src/ui/componentSidebar/index.tsx
@@ -226,7 +226,7 @@ export const ComponentSidebar = ({
   const isResizing = useSidebarLayoutStore((state) => state.isRightResizing);
   const setRightResizing = useSidebarLayoutStore((state) => state.setRightResizing);
   const resizeRight = useSidebarLayoutStore((state) => state.resizeRight);
-  useSidebarMount("right");
+  useSidebarMount("right", Boolean(isOpen));
   useSidebarLayoutViewport();
   const sidebarRef = useRef<HTMLDivElement>(null);
   const activeResizePointerIdRef = useRef<number | null>(null);


### PR DESCRIPTION
Move Runs and Versions into first-class header tabs with dedicated side panels, reserve the tool sidebar for the agent, and refine the mode toggle grouping and agent button styling.