### PR TITLE
feat: proper polling with event completeness check and messages array

### DIFF
--- a/docs/components/Claude.mdx
+++ b/docs/components/Claude.mdx
@@ -47,6 +47,10 @@ Emits a finished payload with **session** status, **session id**, and the final 
 {
   "data": {
     "lastMessage": "Finished the requested task.",
+    "messages": [
+      "Let me check the documentation...",
+      "Finished the requested task."
+    ],
     "sessionId": "sess_01ExampleManagedSession",
     "status": "idle"
   },

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -208,6 +208,86 @@ func (c *Client) listManagedSessionEventsPage(sessionID, page string) ([]Managed
 	return out.Data, out.NextPage, nil
 }
 
+// SessionMessages holds all agent messages and completion status from a session's events.
+type SessionMessages struct {
+	Messages    []string // all agent.message texts in chronological order
+	LastMessage string   // the final agent.message text
+	Complete    bool     // true if session.status_idle or session.status_terminated is in the events
+}
+
+func (c *Client) GetSessionMessages(sessionID string) (*SessionMessages, error) {
+	result := &SessionMessages{}
+	page := ""
+	var allEvents []ManagedSessionEvent
+
+	// Fetch all events (desc order from API)
+	for {
+		events, nextPage, err := c.listManagedSessionEventsPage(sessionID, page)
+		if err != nil {
+			return nil, err
+		}
+		allEvents = append(allEvents, events...)
+		if nextPage == "" {
+			break
+		}
+		page = nextPage
+	}
+
+	// Check for terminal event (events are in desc order, so status_idle is first)
+	for _, e := range allEvents {
+		if e.Type == "session.status_idle" || e.Type == "session.status_terminated" {
+			result.Complete = true
+			break
+		}
+	}
+
+	// Collect agent messages in chronological order (reverse the desc list)
+	for i := len(allEvents) - 1; i >= 0; i-- {
+		e := allEvents[i]
+		if e.Type == "agent.message" || e.Type == "assistant.message" {
+			text := lastAgentMessageFromEvents([]ManagedSessionEvent{e})
+			if text != "" {
+				result.Messages = append(result.Messages, text)
+			}
+		}
+	}
+
+	if len(result.Messages) > 0 {
+		result.LastMessage = result.Messages[len(result.Messages)-1]
+	}
+
+	return result, nil
+}
+
+// GetSessionMessagesWithRetry polls until events are fully written
+// (session.status_idle present) or retries are exhausted.
+func (c *Client) GetSessionMessagesWithRetry(sessionID string, attempts int, delay time.Duration) (*SessionMessages, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var result *SessionMessages
+	for i := 0; i < attempts; i++ {
+		var err error
+		result, err = c.GetSessionMessages(sessionID)
+		if err != nil {
+			return nil, err
+		}
+
+		// If events are fully written, we have everything
+		if result.Complete {
+			return result, nil
+		}
+
+		if i < attempts-1 {
+			time.Sleep(delay)
+		}
+	}
+
+	return result, nil
+}
+
+// Deprecated: use GetSessionMessages instead.
 func (c *Client) GetLastManagedSessionAgentMessage(sessionID string) (string, []ManagedSessionEvent, error) {
 	seen := []ManagedSessionEvent{}
 	page := ""

--- a/pkg/integrations/claude/runagent/example_output.json
+++ b/pkg/integrations/claude/runagent/example_output.json
@@ -2,7 +2,11 @@
   "data": {
     "status": "idle",
     "sessionId": "sess_01ExampleManagedSession",
-    "lastMessage": "Finished the requested task."
+    "lastMessage": "Finished the requested task.",
+    "messages": [
+      "Let me check the documentation...",
+      "Finished the requested task."
+    ]
   },
   "timestamp": "2026-04-26T12:00:00Z",
   "type": "claude.runAgent.finished"

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -85,13 +85,12 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 	if isSessionTerminal(sess.Status) {
 		sm, err := client.GetSessionMessagesWithRetry(metadata.Session.ID, finalMessageReads, finalMessageDelay)
 		if err != nil {
-			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v", metadata.Session.ID, err)
+			ctx.Logger.Warnf("Failed to fetch messages for session %s: %v. Retrying poll.", metadata.Session.ID, err)
+			return a.scheduleNextPoll(ctx, attempt+1, errs+1)
 		}
-		if sm != nil && !sm.Complete {
-			ctx.Logger.Warnf("Events not fully written for session %s after retries", metadata.Session.ID)
-		}
-		if sm != nil && sm.LastMessage == "" {
-			ctx.Logger.Warnf("No final agent message found for managed session %s", metadata.Session.ID)
+		if sm == nil || !sm.Complete {
+			ctx.Logger.Warnf("Events not complete for session %s after retries. Retrying poll.", metadata.Session.ID)
+			return a.scheduleNextPoll(ctx, attempt+1, errs)
 		}
 
 		out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
@@ -99,7 +98,6 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 			return emitErr
 		}
 
-		// Delete session only after successful emit
 		if err := client.DeleteManagedSession(metadata.Session.ID); err != nil {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)
 		}

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -94,13 +94,16 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 			ctx.Logger.Warnf("No final agent message found for managed session %s", metadata.Session.ID)
 		}
 
-		// Clean up the session
+		out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
+		if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+			return emitErr
+		}
+
+		// Delete session only after successful emit
 		if err := client.DeleteManagedSession(metadata.Session.ID); err != nil {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)
 		}
-
-		out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
-		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+		return nil
 	}
 
 	return a.scheduleNextPoll(ctx, attempt+1, 0)

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -41,9 +41,6 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 	if metadata.Session == nil || metadata.Session.ID == "" {
 		return nil
 	}
-	if isSessionTerminal(metadata.Session.Status) {
-		return nil
-	}
 
 	attempt := 1
 	errs := 0
@@ -76,9 +73,8 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 
-	mergeSessionIntoMetadata(&metadata, sess)
-	_ = ctx.Metadata.Set(metadata)
-
+	// Don't write terminal status to metadata yet — we only persist it
+	// after a successful emit to avoid blocking future poll retries.
 	if sess == nil {
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
@@ -97,6 +93,10 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
 			return emitErr
 		}
+
+		// Only persist terminal status after successful emit
+		mergeSessionIntoMetadata(&metadata, sess)
+		_ = ctx.Metadata.Set(metadata)
 
 		if err := client.DeleteManagedSession(metadata.Session.ID); err != nil {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -83,14 +83,23 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}
 	if isSessionTerminal(sess.Status) {
-		lastMessage, events, err := client.GetLastManagedSessionAgentMessageWithRetry(metadata.Session.ID, finalMessageReads, finalMessageDelay)
+		sm, err := client.GetSessionMessagesWithRetry(metadata.Session.ID, finalMessageReads, finalMessageDelay)
 		if err != nil {
-			ctx.Logger.Warnf("Failed to fetch final message for managed session %s: %v", metadata.Session.ID, err)
+			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v", metadata.Session.ID, err)
 		}
-		if err == nil && lastMessage == "" {
-			ctx.Logger.Warnf("No final agent message found for managed session %s. Event types: %s", metadata.Session.ID, managedSessionEventTypes(events))
+		if sm != nil && !sm.Complete {
+			ctx.Logger.Warnf("Events not fully written for session %s after retries", metadata.Session.ID)
 		}
-		out := buildOutput(sess.Status, metadata.Session.ID, lastMessage)
+		if sm != nil && sm.LastMessage == "" {
+			ctx.Logger.Warnf("No final agent message found for managed session %s", metadata.Session.ID)
+		}
+
+		// Clean up the session
+		if err := client.DeleteManagedSession(metadata.Session.ID); err != nil {
+			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)
+		}
+
+		out := buildOutputFromSessionMessages(sess.Status, metadata.Session.ID, sm)
 		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
 	}
 

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -167,12 +167,16 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v", session.ID, err)
 		}
 
+		out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
+		if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+			return emitErr
+		}
+
+		// Delete session only after successful emit
 		if err := client.DeleteManagedSession(session.ID); err != nil {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
 		}
-
-		out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
-		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+		return nil
 	}
 
 	ctx.Logger.Infof("Started Managed Agent session %s. Waiting for completion (polling)...", session.ID)

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -162,14 +162,16 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 	_ = ctx.Metadata.Set(metadata)
 
 	if refreshed != nil && isSessionTerminal(refreshed.Status) {
-		lastMessage, events, err := client.GetLastManagedSessionAgentMessageWithRetry(session.ID, finalMessageReads, finalMessageDelay)
+		sm, err := client.GetSessionMessagesWithRetry(session.ID, finalMessageReads, finalMessageDelay)
 		if err != nil {
-			ctx.Logger.Warnf("Failed to fetch final message for managed session %s: %v", session.ID, err)
+			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v", session.ID, err)
 		}
-		if err == nil && lastMessage == "" {
-			ctx.Logger.Warnf("No final agent message found for managed session %s. Event types: %s", session.ID, managedSessionEventTypes(events))
+
+		if err := client.DeleteManagedSession(session.ID); err != nil {
+			ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
 		}
-		out := buildOutput(refreshed.Status, session.ID, lastMessage)
+
+		out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
 		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
 	}
 

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -164,19 +164,19 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 	if refreshed != nil && isSessionTerminal(refreshed.Status) {
 		sm, err := client.GetSessionMessagesWithRetry(session.ID, finalMessageReads, finalMessageDelay)
 		if err != nil {
-			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v", session.ID, err)
+			ctx.Logger.Warnf("Failed to fetch messages for managed session %s: %v. Scheduling poll.", session.ID, err)
+		} else if sm != nil && sm.Complete {
+			out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
+			if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+				return emitErr
+			}
+			if err := client.DeleteManagedSession(session.ID); err != nil {
+				ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
+			}
+			return nil
+		} else {
+			ctx.Logger.Warnf("Events not complete for session %s after retries. Scheduling poll.", session.ID)
 		}
-
-		out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
-		if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
-			return emitErr
-		}
-
-		// Delete session only after successful emit
-		if err := client.DeleteManagedSession(session.ID); err != nil {
-			ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
-		}
-		return nil
 	}
 
 	ctx.Logger.Infof("Started Managed Agent session %s. Waiting for completion (polling)...", session.ID)

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -153,13 +153,12 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to send user message: %w", err)
 	}
 
-	// Refresh status after work may have already progressed.
+	// Check if session already finished (fast tasks).
+	// Don't write terminal status to metadata yet — only after emit.
 	refreshed, err := client.GetManagedSession(session.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get session: %w", err)
 	}
-	mergeSessionIntoMetadata(&metadata, refreshed)
-	_ = ctx.Metadata.Set(metadata)
 
 	if refreshed != nil && isSessionTerminal(refreshed.Status) {
 		sm, err := client.GetSessionMessagesWithRetry(session.ID, finalMessageReads, finalMessageDelay)
@@ -170,6 +169,9 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
 				return emitErr
 			}
+			// Persist terminal status only after successful emit
+			mergeSessionIntoMetadata(&metadata, refreshed)
+			_ = ctx.Metadata.Set(metadata)
 			if err := client.DeleteManagedSession(session.ID); err != nil {
 				ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
 			}

--- a/pkg/integrations/claude/runagent/run_agent_test.go
+++ b/pkg/integrations/claude/runagent/run_agent_test.go
@@ -50,7 +50,8 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"running"}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"user.message","content":[{"type":"text","text":"Hello"}]},{"type":"agent.message","content":[{"type":"text","text":"Done"}]}],"next_page":null}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":"Done"}]},{"type":"user.message","content":[{"type":"text","text":"Hello"}]}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 		},
 	}
 	integrationCtx := &contexts.IntegrationContext{
@@ -79,7 +80,7 @@ func Test__RunAgent__Execute__syncIdle(t *testing.T) {
 	assert.Equal(t, "Done", executionState.Payloads[0].(map[string]any)["data"].(OutputPayload).LastMessage)
 	assert.Equal(t, "", requestsCtx.Action)
 
-	require.Len(t, httpContext.Requests, 4)
+	require.Len(t, httpContext.Requests, 5) // create, send, get status, get events, delete
 	assert.Equal(t, "POST", httpContext.Requests[0].Method)
 	assert.Contains(t, httpContext.Requests[0].URL.Path, "/sessions")
 	assert.Equal(t, anthropicBetaManagedAgents, httpContext.Requests[0].Header.Get("anthropic-beta"))
@@ -128,7 +129,8 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	httpContext := &contexts.HTTPContext{
 		Responses: []*http.Response{
 			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"id":"sess_1","status":"idle"}`))},
-			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"agent.message","content":[{"type":"text","text":"Final"}]},{"type":"agent.message","content":[{"type":"text","text":"Earlier"}]}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[{"type":"session.status_idle"},{"type":"agent.message","content":[{"type":"text","text":"Final"}]},{"type":"agent.message","content":[{"type":"text","text":"Earlier"}]}]}`))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))},
 		},
 	}
 	integrationCtx := &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "k"}}
@@ -154,6 +156,7 @@ func Test__RunAgent__poll__terminal(t *testing.T) {
 	require.True(t, executionState.Finished)
 	assert.Equal(t, "idle", executionState.Payloads[0].(map[string]any)["data"].(OutputPayload).Status)
 	assert.Equal(t, "Final", executionState.Payloads[0].(map[string]any)["data"].(OutputPayload).LastMessage)
+	assert.Equal(t, []string{"Earlier", "Final"}, executionState.Payloads[0].(map[string]any)["data"].(OutputPayload).Messages)
 }
 
 func Test__RunAgent__poll__timeout(t *testing.T) {

--- a/pkg/integrations/claude/runagent/types.go
+++ b/pkg/integrations/claude/runagent/types.go
@@ -38,13 +38,26 @@ type SessionMetadata struct {
 
 // OutputPayload is emitted on the default channel when the run completes.
 type OutputPayload struct {
-	Status      string `json:"status"`
-	SessionID   string `json:"sessionId"`
-	LastMessage string `json:"lastMessage"`
+	Status      string   `json:"status"`
+	SessionID   string   `json:"sessionId"`
+	LastMessage string   `json:"lastMessage"`
+	Messages    []string `json:"messages"`
 }
 
 func isSessionTerminal(status string) bool {
 	return status == sessionStatusIdle || status == sessionStatusTerminated
+}
+
+func buildOutputFromSessionMessages(status, sessionID string, sm *SessionMessages) OutputPayload {
+	out := OutputPayload{
+		Status:    status,
+		SessionID: sessionID,
+	}
+	if sm != nil {
+		out.LastMessage = sm.LastMessage
+		out.Messages = sm.Messages
+	}
+	return out
 }
 
 func buildOutput(status, sessionID string, lastMessage ...string) OutputPayload {


### PR DESCRIPTION
## Problem

The `claude.runAgent` component returns empty or intermediate `lastMessage` because the events list API is eventually consistent (#5278). The session goes `idle` before `agent.message` events are queryable.

## Root cause

The previous approach: poll session status → idle → fetch events → hope agent.message is there. But events are written asynchronously and may not be queryable yet.

## Solution

**Check for event completeness, not just message presence.**

When `session.status_idle` appears IN the events list (not just the session status endpoint), ALL events including ALL `agent.message` events are guaranteed to be present.

### New approach:
1. Poll session status → `idle`
2. Fetch events, check if `session.status_idle` is in the events list
3. If yes → events are complete, extract all messages
4. If no → retry (events still being written)

### Changes:
- `GetSessionMessages()` — fetches all events, checks for terminal event, collects all agent messages in chronological order
- `GetSessionMessagesWithRetry()` — polls until `Complete == true`
- `SessionMessages` struct — `Messages []string`, `LastMessage string`, `Complete bool`
- Output includes `messages` array alongside `lastMessage`
- Session deleted after successful emit
- Updated tests and example output

Fixes #5278
Replaces #5280 (streaming approach was scrapped — team decided polling is the right pattern)