### PR TITLE
fix: collapsible var panels on widgets

### DIFF
--- a/web_src/src/hooks/useResponsiveRailCollapse.ts
+++ b/web_src/src/hooks/useResponsiveRailCollapse.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Width below which the rail auto-collapses. Chosen so a typical 2-column
+ * panel card on the console grid (which gives the editor roughly 480-560px
+ * of inner width on the narrower configurations) collapses the rail, while
+ * a 3-column-wide card keeps it expanded.
+ */
+const NARROW_BREAKPOINT_PX = 520;
+
+/**
+ * Drive a rail's "collapsed" state from the observed width of a container
+ * element while still letting the user override the auto choice manually.
+ *
+ * Behavior:
+ *  - Observes the element attached via `containerRef` with a `ResizeObserver`.
+ *  - `isNarrow` is `true` when the measured width is below the breakpoint.
+ *    A width of `0` (e.g. before mount, or in jsdom where `ResizeObserver`
+ *    is a no-op stub from `test/setup.ts`) is treated as "not narrow" so the
+ *    rail stays expanded by default in tests.
+ *  - The manual override is cleared whenever `isNarrow` flips, so dragging
+ *    the panel back to a wider size re-applies the auto behavior (and vice
+ *    versa) without leaving the user stuck in a stale forced state.
+ */
+export function useResponsiveRailCollapse(): {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  collapsed: boolean;
+  toggle: () => void;
+} {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isNarrow, setIsNarrow] = useState(false);
+  const [override, setOverride] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const update = () => {
+      const width = element.getBoundingClientRect().width;
+      setIsNarrow(width > 0 && width < NARROW_BREAKPOINT_PX);
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  // Reset the manual override whenever the breakpoint is crossed so resizing
+  // back to a different size honors the auto choice again.
+  useEffect(() => {
+    setOverride(null);
+  }, [isNarrow]);
+
+  const collapsed = override ?? isNarrow;
+  const toggle = useCallback(() => {
+    setOverride((prev) => !(prev ?? isNarrow));
+  }, [isNarrow]);
+
+  return { containerRef, collapsed, toggle };
+}

--- a/web_src/src/pages/app/console/HtmlPanelEditor.tsx
+++ b/web_src/src/pages/app/console/HtmlPanelEditor.tsx
@@ -5,6 +5,7 @@ import type { editor as MonacoEditor } from "monaco-editor";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useResponsiveRailCollapse } from "@/hooks/useResponsiveRailCollapse";
 import { cn } from "@/lib/utils";
 
 import { HtmlBody, HtmlBodyLoading } from "./HtmlBody";
@@ -104,6 +105,15 @@ export function HtmlPanelEditor({
 
   const [previewCollapsed, setPreviewCollapsed] = useState(false);
 
+  // Variables rail collapses automatically when the parent widget is narrow.
+  // The manual toggle wins until the breakpoint flips again, at which point
+  // the auto behavior takes over so resizes always honor the current width.
+  const {
+    containerRef: gridRef,
+    collapsed: variablesCollapsed,
+    toggle: toggleVariablesCollapsed,
+  } = useResponsiveRailCollapse();
+
   return (
     <div className="flex h-full w-full flex-col gap-0 overflow-hidden rounded-lg border border-slate-950/15 bg-white">
       <div className="flex items-center gap-2 rounded-t-lg px-2 py-1">
@@ -118,7 +128,13 @@ export function HtmlPanelEditor({
           data-testid="console-html-title-editor"
         />
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(260px,360px)]">
+      <div
+        ref={gridRef}
+        className={cn(
+          "grid min-h-0 flex-1 grid-cols-1 gap-0",
+          variablesCollapsed ? "grid-cols-[minmax(0,1fr)_auto]" : "grid-cols-[minmax(0,1fr)_minmax(220px,320px)]",
+        )}
+      >
         <div className="flex min-h-0 min-w-0 flex-col border-r border-slate-950/10">
           <HtmlCodeEditor
             ref={codeEditorRef}
@@ -144,6 +160,8 @@ export function HtmlPanelEditor({
           errors={errors}
           isLoading={isLoading}
           onInsertSnippet={(snippet) => codeEditorRef.current?.insertAtCursor(snippet)}
+          collapsed={variablesCollapsed}
+          onToggleCollapsed={toggleVariablesCollapsed}
         />
       </div>
       <div className="flex items-center justify-between gap-2 rounded-b-lg border-t border-slate-950/10 bg-slate-50/50 px-3 py-1.5">

--- a/web_src/src/pages/app/console/MarkdownPanelEditor.tsx
+++ b/web_src/src/pages/app/console/MarkdownPanelEditor.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { useResponsiveRailCollapse } from "@/hooks/useResponsiveRailCollapse";
 import { cn } from "@/lib/utils";
 
 import { MarkdownBody, MarkdownBodyLoading } from "./MarkdownBody";
@@ -100,6 +101,15 @@ export function MarkdownPanelEditor({
   // vertical space, useful on shorter panel cards.
   const [previewCollapsed, setPreviewCollapsed] = useState(false);
 
+  // Variables rail collapses automatically when the parent widget is narrow.
+  // The manual toggle wins until the breakpoint flips again, at which point
+  // the auto behavior takes over so resizes always honor the current width.
+  const {
+    containerRef: gridRef,
+    collapsed: variablesCollapsed,
+    toggle: toggleVariablesCollapsed,
+  } = useResponsiveRailCollapse();
+
   const insertAtCursor = (snippet: string) => {
     const el = textareaRef.current;
     if (!el) {
@@ -131,7 +141,13 @@ export function MarkdownPanelEditor({
           data-testid="console-markdown-title-editor"
         />
       </div>
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(260px,360px)]">
+      <div
+        ref={gridRef}
+        className={cn(
+          "grid min-h-0 flex-1 grid-cols-1 gap-0",
+          variablesCollapsed ? "grid-cols-[minmax(0,1fr)_auto]" : "grid-cols-[minmax(0,1fr)_minmax(220px,320px)]",
+        )}
+      >
         <div className="flex min-h-0 min-w-0 flex-col border-r border-slate-950/10">
           <Textarea
             ref={textareaRef}
@@ -159,6 +175,8 @@ export function MarkdownPanelEditor({
           errors={errors}
           isLoading={isLoading}
           onInsertSnippet={insertAtCursor}
+          collapsed={variablesCollapsed}
+          onToggleCollapsed={toggleVariablesCollapsed}
         />
       </div>
       <div className="flex items-center justify-between gap-2 rounded-b-lg border-t border-slate-950/10 bg-slate-50/50 px-3 py-1.5">

--- a/web_src/src/pages/app/console/MarkdownPanelEditor.tsx
+++ b/web_src/src/pages/app/console/MarkdownPanelEditor.tsx
@@ -110,22 +110,8 @@ export function MarkdownPanelEditor({
     toggle: toggleVariablesCollapsed,
   } = useResponsiveRailCollapse();
 
-  const insertAtCursor = (snippet: string) => {
-    const el = textareaRef.current;
-    if (!el) {
-      setDraftBody(draftBody + snippet);
-      return;
-    }
-    const start = el.selectionStart ?? draftBody.length;
-    const end = el.selectionEnd ?? draftBody.length;
-    const next = draftBody.slice(0, start) + snippet + draftBody.slice(end);
-    setDraftBody(next);
-    requestAnimationFrame(() => {
-      el.focus();
-      const caret = start + snippet.length;
-      el.setSelectionRange(caret, caret);
-    });
-  };
+  const insertAtCursor = (snippet: string) =>
+    insertSnippetAtTextareaCursor(textareaRef.current, draftBody, snippet, setDraftBody);
 
   return (
     <div className="flex h-full w-full flex-col gap-0 overflow-hidden rounded-lg border border-slate-950/15 bg-white">
@@ -201,6 +187,33 @@ export function MarkdownPanelEditor({
       </div>
     </div>
   );
+}
+
+/**
+ * Insert `snippet` at the textarea's current selection (replacing any
+ * selected range), updating both the controlled value via `setBody` and
+ * restoring focus + caret after the React re-render. Falls back to an
+ * append when the element isn't mounted yet — matches the behavior the
+ * inline implementation had before this was extracted.
+ */
+function insertSnippetAtTextareaCursor(
+  el: HTMLTextAreaElement | null,
+  body: string,
+  snippet: string,
+  setBody: (next: string) => void,
+) {
+  if (!el) {
+    setBody(body + snippet);
+    return;
+  }
+  const start = el.selectionStart ?? body.length;
+  const end = el.selectionEnd ?? body.length;
+  setBody(body.slice(0, start) + snippet + body.slice(end));
+  requestAnimationFrame(() => {
+    el.focus();
+    const caret = start + snippet.length;
+    el.setSelectionRange(caret, caret);
+  });
 }
 
 /**

--- a/web_src/src/pages/app/console/MarkdownVariablesPanel.tsx
+++ b/web_src/src/pages/app/console/MarkdownVariablesPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -78,6 +78,8 @@ export function MarkdownVariablesPanel({
   errors,
   isLoading,
   onInsertSnippet,
+  collapsed = false,
+  onToggleCollapsed,
 }: {
   canvasId: string;
   draftBody: string;
@@ -87,6 +89,10 @@ export function MarkdownVariablesPanel({
   errors: MarkdownVariableError[];
   isLoading: boolean;
   onInsertSnippet: (snippet: string) => void;
+  /** When `true`, render the slim collapsed strip instead of the full rail. */
+  collapsed?: boolean;
+  /** Toggle the collapsed state. Required when `collapsed` is used. */
+  onToggleCollapsed?: () => void;
 }) {
   void _draftBody;
   const updateVariable = (index: number, next: MarkdownVariable) => {
@@ -127,6 +133,10 @@ export function MarkdownVariablesPanel({
     return dups;
   }, [draftVariables]);
 
+  if (collapsed) {
+    return <CollapsedVariablesStrip count={draftVariables.length} onToggleCollapsed={onToggleCollapsed} />;
+  }
+
   return (
     <div
       // `min-h-0 min-w-0` ensures the panel can shrink to its grid track even
@@ -136,9 +146,24 @@ export function MarkdownVariablesPanel({
       className="flex min-h-0 min-w-0 flex-col bg-slate-50/40 text-xs text-slate-700"
       data-testid="console-markdown-variables"
     >
-      <div className="flex items-center justify-between border-b border-slate-950/10 px-3 py-2">
-        <Label className="text-xs font-semibold uppercase tracking-wide text-slate-600">Variables</Label>
-        <Button type="button" size="sm" variant="outline" className="h-7 gap-1" onClick={addVariable}>
+      <div className="flex items-center justify-between gap-1 border-b border-slate-950/10 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-1">
+          {onToggleCollapsed ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={onToggleCollapsed}
+              aria-label="Collapse variables"
+              className="h-6 w-6 shrink-0 text-slate-500 hover:text-slate-700"
+              data-testid="console-markdown-variables-collapse"
+            >
+              <ChevronRight className="size-3.5" />
+            </Button>
+          ) : null}
+          <Label className="truncate text-xs font-semibold uppercase tracking-wide text-slate-600">Variables</Label>
+        </div>
+        <Button type="button" size="sm" variant="outline" className="h-7 shrink-0 gap-1" onClick={addVariable}>
           <Plus className="size-3.5" />
           Add
         </Button>
@@ -167,6 +192,40 @@ export function MarkdownVariablesPanel({
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Slim vertical strip shown in place of the full variables rail when the
+ * panel is collapsed (either auto-collapsed because the parent widget is
+ * narrow, or because the author explicitly hid the rail). Clicking anywhere
+ * on the strip re-expands the rail; the count badge is just an
+ * at-a-glance affordance so the author knows whether there are variables to
+ * come back to.
+ */
+function CollapsedVariablesStrip({ count, onToggleCollapsed }: { count: number; onToggleCollapsed?: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggleCollapsed}
+      aria-label="Expand variables"
+      aria-expanded={false}
+      className="flex h-full w-9 shrink-0 flex-col items-center gap-2 border-l border-slate-950/10 bg-slate-50/40 py-2 text-slate-500 hover:bg-slate-100/60 hover:text-slate-700"
+      data-testid="console-markdown-variables-expand"
+    >
+      <ChevronLeft className="size-3.5" />
+      <span
+        className="text-[10px] font-semibold uppercase tracking-wide"
+        style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
+      >
+        Variables
+      </span>
+      {count > 0 ? (
+        <span className="mt-1 rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-medium text-slate-600">
+          {count}
+        </span>
+      ) : null}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
Updates the variables panel to be collapsible and a little responsive on the HTML/Markdown widgets.

Resolves #5266 