### PR TITLE
fix: recover agent sessions after provider stalls

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -361,6 +361,46 @@ func TestSendMessage_RequiresSessionID(t *testing.T) {
 	require.Error(t, p.SendMessage(context.Background(), "", "hi", agents.SendMessageOptions{}))
 }
 
+func TestSendMessage_MapsWaitingOnToolResultsToBusySession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Invalid user.message event at events[0]: waiting on responses to events [sevt_012]; only user.tool_result may be sent"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_abc", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrSessionBusy)
+}
+
+func TestSendMessage_MapsArchivedSessionToUnavailableSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"not_found_error","message":"session has been archived"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_archived", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrProviderSessionUnavailable)
+}
+
+func TestSendMessage_DoesNotTreatBadRequestNotFoundMessageAsUnavailableSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"tool target not found"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_live", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, agents.ErrProviderSessionUnavailable)
+	assert.Contains(t, err.Error(), "anthropic: send message")
+}
+
 func TestDefineOutcome_PrependsPreambleToDescription(t *testing.T) {
 	var capturedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -104,6 +105,12 @@ func (p *Provider) SendMessage(ctx context.Context, providerSessionID, message s
 		},
 	}
 	if _, err := p.client.executeHTTP(ctx, http.MethodPost, "/sessions/"+providerSessionID+"/events", body); err != nil {
+		if isSessionAwaitingToolResults(err) {
+			return fmt.Errorf("%w: %w", agents.ErrSessionBusy, err)
+		}
+		if isProviderSessionUnavailable(err) {
+			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
+		}
 		return fmt.Errorf("anthropic: send message: %w", err)
 	}
 	return nil
@@ -119,6 +126,9 @@ func (p *Provider) InterruptSession(ctx context.Context, providerSessionID strin
 		},
 	}
 	if _, err := p.client.executeHTTP(ctx, http.MethodPost, "/sessions/"+providerSessionID+"/events", body); err != nil {
+		if isProviderSessionUnavailable(err) {
+			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
+		}
 		return fmt.Errorf("anthropic: interrupt session: %w", err)
 	}
 	return nil
@@ -142,6 +152,12 @@ func (p *Provider) DefineOutcome(ctx context.Context, providerSessionID string, 
 		"events": []map[string]any{event},
 	}
 	if _, err := p.client.executeHTTP(ctx, http.MethodPost, "/sessions/"+providerSessionID+"/events", body); err != nil {
+		if isSessionAwaitingToolResults(err) {
+			return fmt.Errorf("%w: %w", agents.ErrSessionBusy, err)
+		}
+		if isProviderSessionUnavailable(err) {
+			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
+		}
 		return fmt.Errorf("anthropic: define outcome: %w", err)
 	}
 	return nil
@@ -180,6 +196,22 @@ func (p *Provider) SendCustomToolResults(ctx context.Context, providerSessionID 
 	return nil
 }
 
+func isSessionAwaitingToolResults(err error) bool {
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(apiErr.Message, "waiting on responses to events")
+}
+
+func isProviderSessionUnavailable(err error) bool {
+	var apiErr *apiError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusGone
+}
+
 func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, onEvent func(agents.ProviderEvent) error) error {
 	if providerSessionID == "" {
 		return fmt.Errorf("anthropic: provider session id is required")
@@ -187,6 +219,9 @@ func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, o
 
 	body, err := p.client.openStream(ctx, "/sessions/"+providerSessionID+"/events/stream")
 	if err != nil {
+		if isProviderSessionUnavailable(err) {
+			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
+		}
 		return fmt.Errorf("anthropic: open stream: %w", err)
 	}
 	defer body.Close()

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -164,3 +164,5 @@ type ProviderSessionCleaner interface {
 }
 
 var ErrSessionAlreadyTerminated = errors.New("agent session already terminated")
+var ErrSessionBusy = errors.New("agent session is still processing")
+var ErrProviderSessionUnavailable = errors.New("provider session is unavailable")

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -130,6 +130,9 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 	if err != nil {
 		return fmt.Errorf("get session: %w", err)
 	}
+	if session.Status == models.AgentSessionStatusStreaming {
+		return s.handleBusySession(sessionID, organizationID, userID)
+	}
 
 	preamble, err := s.buildPreamble(session, organizationID, userID, ModeBuilder)
 	if err != nil {
@@ -142,7 +145,31 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 		MaxIterations:   maxIterations,
 		ContextPreamble: preamble,
 	}); err != nil {
-		return fmt.Errorf("define outcome: %w", err)
+		if errors.Is(err, ErrSessionBusy) {
+			return s.handleBusySession(sessionID, organizationID, userID)
+		}
+		if errors.Is(err, ErrProviderSessionUnavailable) {
+			recovered, recoverErr := s.recoverProviderSession(ctx, session)
+			if recoverErr != nil {
+				if errors.Is(recoverErr, ErrSessionBusy) {
+					return s.handleBusySession(sessionID, organizationID, userID)
+				}
+				return recoverErr
+			}
+			if err := s.provider.DefineOutcome(ctx, recovered.ProviderSessionID, DefineOutcomeOptions{
+				Description:     description,
+				Rubric:          rubric,
+				MaxIterations:   maxIterations,
+				ContextPreamble: preamble,
+			}); err != nil {
+				if errors.Is(err, ErrSessionBusy) {
+					return s.handleBusySession(sessionID, organizationID, userID)
+				}
+				return fmt.Errorf("define outcome after provider session recovery: %w", err)
+			}
+		} else {
+			return fmt.Errorf("define outcome: %w", err)
+		}
 	}
 
 	// Mark session as streaming and start the stream worker to pick up events
@@ -176,8 +203,27 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 	}
 
 	if err := s.provider.SendMessage(ctx, session.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
-		_ = models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusFailed)
-		return nil, fmt.Errorf("forward to provider: %w", err)
+		if errors.Is(err, ErrSessionBusy) {
+			return nil, s.handleBusySession(sessionID, organizationID, userID)
+		}
+		if errors.Is(err, ErrProviderSessionUnavailable) {
+			recovered, recoverErr := s.recoverProviderSession(ctx, session)
+			if recoverErr != nil {
+				if errors.Is(recoverErr, ErrSessionBusy) {
+					return nil, s.handleBusySession(sessionID, organizationID, userID)
+				}
+				return nil, recoverErr
+			}
+			if err := s.provider.SendMessage(ctx, recovered.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
+				if errors.Is(err, ErrSessionBusy) {
+					return nil, s.handleBusySession(sessionID, organizationID, userID)
+				}
+				return nil, fmt.Errorf("send message after provider session recovery: %w", err)
+			}
+		} else {
+			_ = models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusFailed)
+			return nil, fmt.Errorf("forward to provider: %w", err)
+		}
 	}
 
 	messageRole := models.AgentMessageRoleUser
@@ -201,6 +247,122 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		return nil, err
 	}
 	return persisted, nil
+}
+
+func (s *Service) handleBusySession(sessionID, organizationID, userID uuid.UUID) error {
+	if err := s.enqueueStreamAfterBusySession(sessionID, organizationID, userID); err != nil {
+		return err
+	}
+	return ErrSessionBusy
+}
+
+func (s *Service) enqueueStreamAfterBusySession(sessionID, organizationID, userID uuid.UUID) error {
+	if err := models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusStreaming); err != nil {
+		return fmt.Errorf("mark busy agent session as streaming: %w", err)
+	}
+	return s.enqueueStream(sessionID, organizationID, userID)
+}
+
+func (s *Service) recoverProviderSession(ctx context.Context, stale *models.AgentSession) (*models.AgentSession, error) {
+	target, err := s.providerSessionRecoveryTarget(stale)
+	if err != nil {
+		return nil, fmt.Errorf("recover provider session: %w", err)
+	}
+	if target.recovered != nil {
+		return target.recovered, nil
+	}
+
+	upstream, err := s.provider.CreateSession(ctx, CreateSessionOptions{
+		Title: sessionTitle(target.organizationID, target.canvasID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recover provider session: create provider session: %w", err)
+	}
+
+	recovered, err := s.installRecoveredProviderSession(stale, upstream.ProviderSessionID)
+	if err != nil {
+		s.cleanupProviderSession(ctx, upstream.ProviderSessionID)
+		return nil, fmt.Errorf("recover provider session: %w", err)
+	}
+	if recovered.ProviderSessionID != upstream.ProviderSessionID {
+		s.cleanupProviderSession(ctx, upstream.ProviderSessionID)
+	}
+	return recovered, nil
+}
+
+type providerSessionRecoveryTarget struct {
+	organizationID uuid.UUID
+	canvasID       uuid.UUID
+	recovered      *models.AgentSession
+}
+
+func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession) (*providerSessionRecoveryTarget, error) {
+	target := &providerSessionRecoveryTarget{}
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		locked, err := models.LockAgentSessionInTransaction(tx, stale.ID)
+		if err != nil {
+			return err
+		}
+		if locked.Status == models.AgentSessionStatusStreaming {
+			return ErrSessionBusy
+		}
+		if locked.ProviderSessionID != stale.ProviderSessionID {
+			target.recovered = locked
+			return nil
+		}
+
+		target.organizationID = locked.OrganizationID
+		target.canvasID = locked.CanvasID
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, providerSessionID string) (*models.AgentSession, error) {
+	var recovered *models.AgentSession
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		locked, err := models.LockAgentSessionInTransaction(tx, stale.ID)
+		if err != nil {
+			return err
+		}
+		if locked.Status == models.AgentSessionStatusStreaming {
+			return ErrSessionBusy
+		}
+		if locked.ProviderSessionID != stale.ProviderSessionID {
+			recovered = locked
+			return nil
+		}
+
+		if err := models.UpdateAgentSessionProviderSessionInTransaction(
+			tx,
+			locked.ID,
+			providerSessionID,
+			models.AgentSessionStatusIdle,
+		); err != nil {
+			return err
+		}
+		locked.ProviderSessionID = providerSessionID
+		locked.Status = models.AgentSessionStatusIdle
+		recovered = locked
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return recovered, nil
+}
+
+func (s *Service) cleanupProviderSession(ctx context.Context, providerSessionID string) {
+	cleaner, ok := s.provider.(ProviderSessionCleaner)
+	if !ok {
+		return
+	}
+	if err := cleaner.DeleteSession(ctx, providerSessionID); err != nil {
+		log.WithError(err).WithField("provider_session_id", providerSessionID).Warn("failed to clean up unused recovered provider session")
+	}
 }
 
 func (s *Service) buildPreamble(session *models.AgentSession, organizationID, userID uuid.UUID, mode Mode) (string, error) {

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
+	"gorm.io/gorm"
 )
 
 type blockingProvider struct {
@@ -51,11 +52,16 @@ type fakeProvider struct {
 	mu               sync.Mutex
 	createCalled     int
 	sendCalled       int
+	sentSessions     []string
+	defineSessions   []string
 	lastPreamble     string
 	lastOutcomeOpts  agents.DefineOutcomeOptions
 	createSessionErr error
+	createHook       func() error
 	sendErr          error
+	sendErrs         []error
 	defineOutcomeErr error
+	defineErrs       []error
 }
 
 func (f *fakeProvider) Name() string { return testProviderName }
@@ -67,14 +73,25 @@ func (f *fakeProvider) CreateSession(_ context.Context, _ agents.CreateSessionOp
 	if f.createSessionErr != nil {
 		return nil, f.createSessionErr
 	}
+	if f.createHook != nil {
+		if err := f.createHook(); err != nil {
+			return nil, err
+		}
+	}
 	return &agents.CreateSessionResult{ProviderSessionID: "provider-session-" + uuid.NewString()}, nil
 }
 
-func (f *fakeProvider) SendMessage(_ context.Context, _ string, _ string, opts agents.SendMessageOptions) error {
+func (f *fakeProvider) SendMessage(_ context.Context, providerSessionID string, _ string, opts agents.SendMessageOptions) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sendCalled++
+	f.sentSessions = append(f.sentSessions, providerSessionID)
 	f.lastPreamble = opts.ContextPreamble
+	if len(f.sendErrs) > 0 {
+		err := f.sendErrs[0]
+		f.sendErrs = f.sendErrs[1:]
+		return err
+	}
 	return f.sendErr
 }
 
@@ -82,9 +99,15 @@ func (f *fakeProvider) InterruptSession(_ context.Context, _ string) error {
 	return nil
 }
 
-func (f *fakeProvider) DefineOutcome(_ context.Context, _ string, opts agents.DefineOutcomeOptions) error {
+func (f *fakeProvider) DefineOutcome(_ context.Context, providerSessionID string, opts agents.DefineOutcomeOptions) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.defineSessions = append(f.defineSessions, providerSessionID)
+	if len(f.defineErrs) > 0 {
+		err := f.defineErrs[0]
+		f.defineErrs = f.defineErrs[1:]
+		return err
+	}
 	if f.defineOutcomeErr != nil {
 		return f.defineOutcomeErr
 	}
@@ -251,6 +274,173 @@ func TestService_SendMessage_ReturnsPersistedUserMessage(t *testing.T) {
 	assert.Equal(t, "hello", persisted.Content)
 }
 
+func TestService_SendMessage_AllowsFollowUpWhenSessionIsStreaming(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusStreaming))
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, 1, provider.sendCalled)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_ProviderBusyKeepsSessionStreaming(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{sendErr: agents.ErrSessionBusy}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.ErrorIs(t, err, agents.ErrSessionBusy)
+	require.Nil(t, persisted)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_RecreatesUnavailableProviderSession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{
+		sendErrs: []error{agents.ErrProviderSessionUnavailable, nil},
+	}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	originalProviderSessionID := session.ProviderSessionID
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	require.Len(t, provider.sentSessions, 2)
+	assert.Equal(t, originalProviderSessionID, provider.sentSessions[0])
+	assert.Equal(t, refreshed.ProviderSessionID, provider.sentSessions[1])
+	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{
+		sendErrs: []error{agents.ErrProviderSessionUnavailable, agents.ErrSessionBusy},
+	}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.ErrorIs(t, err, agents.ErrSessionBusy)
+	require.Nil(t, persisted)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	require.Len(t, provider.sentSessions, 2)
+	assert.NotEqual(t, session.ProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_DoesNotHoldSessionLockWhileCreatingRecoveredProviderSession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	var sessionID uuid.UUID
+	provider := &fakeProvider{
+		sendErrs: []error{agents.ErrProviderSessionUnavailable, nil},
+		createHook: func() error {
+			if sessionID == uuid.Nil {
+				return nil
+			}
+			return database.Conn().Transaction(func(tx *gorm.DB) error {
+				_, err := models.LockAgentSessionInTransaction(tx, sessionID)
+				return err
+			})
+		},
+	}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	sessionID = session.ID
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+}
+
+func TestService_DefineOutcome_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{
+		defineErrs: []error{agents.ErrProviderSessionUnavailable, agents.ErrSessionBusy},
+	}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	err = svc.DefineOutcome(context.Background(), r.Organization.ID, r.User, session.ID, "build", "- done", 1)
+	require.ErrorIs(t, err, agents.ErrSessionBusy)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	require.Len(t, provider.defineSessions, 2)
+	assert.NotEqual(t, session.ProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_RecoversFailedSession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusFailed))
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "retry")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, 1, provider.sendCalled)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
 func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
@@ -276,6 +466,7 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())
 
+	require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusIdle))
 	provider.lastPreamble = "<sentinel>"
 	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "second")
 	require.NoError(t, err)
@@ -379,6 +570,7 @@ func TestService_ListMessages_TailPagination(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		_, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "m")
 		require.NoError(t, err)
+		require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusIdle))
 	}
 
 	latest, err := svc.ListMessages(session.ID, uuid.Nil, 2)

--- a/pkg/grpc/actions/agents/define_agent_outcome.go
+++ b/pkg/grpc/actions/agents/define_agent_outcome.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	agentservice "github.com/superplanehq/superplane/pkg/agents"
 	pb "github.com/superplanehq/superplane/pkg/protos/agents"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -34,6 +35,9 @@ func DefineAgentOutcome(ctx context.Context, svc AgentsService, orgID, userID st
 	if err := svc.DefineOutcome(ctx, org, user, chatID, req.Description, req.Rubric, maxIter); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, status.Error(codes.NotFound, "agent chat not found")
+		}
+		if errors.Is(err, agentservice.ErrSessionBusy) {
+			return nil, status.Error(codes.FailedPrecondition, "agent is still processing the previous turn")
 		}
 		log.WithError(err).WithField("chat_id", chatID).Error("failed to define agent outcome")
 		return nil, status.Error(codes.Internal, "failed to define agent outcome")

--- a/pkg/grpc/actions/agents/send_agent_chat_message.go
+++ b/pkg/grpc/actions/agents/send_agent_chat_message.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	agentservice "github.com/superplanehq/superplane/pkg/agents"
 	pb "github.com/superplanehq/superplane/pkg/protos/agents"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,6 +30,9 @@ func SendAgentChatMessage(ctx context.Context, svc AgentsService, orgID, userID 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, status.Error(codes.NotFound, "agent chat not found")
+		}
+		if errors.Is(err, agentservice.ErrSessionBusy) {
+			return nil, status.Error(codes.FailedPrecondition, "agent is still processing the previous turn")
 		}
 		log.WithError(err).WithField("chat_id", chatID).Error("failed to send agent chat message")
 		return nil, status.Error(codes.Internal, "failed to send agent chat message")

--- a/pkg/grpc/actions/agents/send_agent_chat_message_test.go
+++ b/pkg/grpc/actions/agents/send_agent_chat_message_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	agentservice "github.com/superplanehq/superplane/pkg/agents"
 	actionsagents "github.com/superplanehq/superplane/pkg/grpc/actions/agents"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/agents"
@@ -69,6 +70,22 @@ func TestSendAgentChatMessage_TranslatesNotFound(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestSendAgentChatMessage_TranslatesBusySession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	svc := &stubService{
+		sendMessage: func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, string) (*models.AgentSessionMessage, error) {
+			return nil, agentservice.ErrSessionBusy
+		},
+	}
+	_, err := actionsagents.SendAgentChatMessage(context.Background(), svc, r.Organization.ID.String(), r.User.String(), &pb.SendAgentChatMessageRequest{
+		ChatId:  uuid.NewString(),
+		Content: "x",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
 func TestSendAgentChatMessage_MapsBuilderMode(t *testing.T) {

--- a/pkg/grpc/actions/messages/agent_session.go
+++ b/pkg/grpc/actions/messages/agent_session.go
@@ -18,6 +18,7 @@ type AgentStreamRequest struct {
 	SessionID      string `json:"session_id"`
 	OrganizationID string `json:"organization_id"`
 	UserID         string `json:"user_id"`
+	LockRetryCount int    `json:"lock_retry_count,omitempty"`
 }
 
 func PublishAgentStreamRequested(req AgentStreamRequest) error {

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/database"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -119,6 +120,43 @@ func UpdateAgentSessionStatus(sessionID uuid.UUID, status string) error {
 	return UpdateAgentSessionStatusInTransaction(database.Conn(), sessionID, status)
 }
 
+func UpdateAgentSessionStatusIfUnchanged(sessionID uuid.UUID, status string, unchangedSince *time.Time) (bool, error) {
+	return UpdateAgentSessionStatusIfUnchangedInTransaction(database.Conn(), sessionID, status, unchangedSince)
+}
+
+func UpdateAgentSessionProviderSessionInTransaction(tx *gorm.DB, sessionID uuid.UUID, providerSessionID, status string) error {
+	now := time.Now()
+	return tx.Model(&AgentSession{}).
+		Where("id = ?", sessionID).
+		Updates(map[string]any{
+			"provider_session_id": providerSessionID,
+			"status":              status,
+			"last_active_at":      &now,
+			"updated_at":          &now,
+		}).
+		Error
+}
+
+func UpdateAgentSessionStatusIfUnchangedInTransaction(tx *gorm.DB, sessionID uuid.UUID, status string, unchangedSince *time.Time) (bool, error) {
+	now := time.Now()
+	query := tx.Model(&AgentSession{}).Where("id = ?", sessionID)
+	if unchangedSince == nil {
+		query = query.Where("updated_at IS NULL")
+	} else {
+		query = query.Where("updated_at = ?", *unchangedSince)
+	}
+
+	result := query.Updates(map[string]any{
+		"status":         status,
+		"last_active_at": &now,
+		"updated_at":     &now,
+	})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
+}
+
 func DeleteAgentSessionsForCanvasInTransaction(tx *gorm.DB, organizationID, canvasID uuid.UUID) error {
 	return tx.
 		Where("organization_id = ?", organizationID).
@@ -132,6 +170,19 @@ func DeleteAgentSessionsForOrganizationInTransaction(tx *gorm.DB, organizationID
 		Where("organization_id = ?", organizationID).
 		Delete(&AgentSession{}).
 		Error
+}
+
+func LockAgentSessionInTransaction(tx *gorm.DB, sessionID uuid.UUID) (*AgentSession, error) {
+	var session AgentSession
+	err := tx.
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", sessionID).
+		First(&session).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	return &session, nil
 }
 
 // FailStuckStreamingSessions marks any session in "streaming" state whose

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	rabbit "github.com/rabbitmq/amqp091-go"
 	"github.com/renderedtext/go-tackle"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/agents"
@@ -22,8 +23,10 @@ import (
 )
 
 const (
-	agentStreamTimeout   = 15 * time.Minute
-	maxConcurrentStreams = 10
+	agentStreamTimeout         = 15 * time.Minute
+	maxConcurrentStreams       = 10
+	maxLockedStreamReschedules = 10
+	agentStreamService         = "superplane.agent-stream-worker"
 	// stuckStreamGrace pads the per-turn timeout before the cleanup loop
 	// considers a "streaming" row leaked. A turn that legitimately ran for
 	// the full timeout should have been transitioned to idle or failed by
@@ -85,7 +88,7 @@ func (w *AgentStreamWorker) Start(ctx context.Context) {
 		err := consumer.Start(&tackle.Options{
 			URL:            w.rabbitMQURL,
 			RemoteExchange: messages.CanvasExchange,
-			Service:        "superplane.agent-stream-worker",
+			Service:        agentStreamService,
 			RoutingKey:     messages.AgentStreamRequestedRoutingKey,
 		}, func(delivery tackle.Delivery) error {
 			return w.dispatch(ctx, delivery.Body())
@@ -103,9 +106,9 @@ func (w *AgentStreamWorker) Start(ctx context.Context) {
 	}
 }
 
-// dispatch acquires a concurrency slot and the per-session stream lock before
-// ACKing the queue message. If another worker already owns the session lock,
-// it returns an error so the message can be retried instead of dropped.
+// dispatch acquires a concurrency slot before ACKing the queue message. If
+// another worker already owns the session lock, it durably reschedules the
+// message for the retry queue instead of dropping the follow-up turn.
 func (w *AgentStreamWorker) dispatch(ctx context.Context, body []byte) error {
 	select {
 	case w.slots <- struct{}{}:
@@ -116,6 +119,9 @@ func (w *AgentStreamWorker) dispatch(ctx context.Context, body []byte) error {
 	request, err := prepareAgentStreamRequest(ctx, body)
 	if err != nil {
 		<-w.slots
+		if errors.Is(err, errAgentStreamAlreadyLocked) {
+			return w.rescheduleLockedRequest(ctx, body)
+		}
 		return err
 	}
 	if request == nil {
@@ -219,7 +225,7 @@ func prepareAgentStreamRequest(parentCtx context.Context, body []byte) (*lockedA
 		return nil, fmt.Errorf("agent stream: acquire session lock: %w", err)
 	}
 	if !locked {
-		log.WithField("session_id", sessionID).Info("agent stream: stream already in progress, retrying request later")
+		log.WithField("session_id", sessionID).Info("agent stream: stream already in progress, scheduling retry")
 		return nil, errAgentStreamAlreadyLocked
 	}
 
@@ -228,6 +234,51 @@ func prepareAgentStreamRequest(parentCtx context.Context, body []byte) (*lockedA
 		sessionID: sessionID,
 		unlock:    unlock,
 	}, nil
+}
+
+func (w *AgentStreamWorker) rescheduleLockedRequest(ctx context.Context, body []byte) error {
+	retryBody, err := lockedStreamRetryBody(body)
+	if err != nil {
+		return err
+	}
+
+	publisher, err := tackle.NewPublisher(w.rabbitMQURL, tackle.PublisherOptions{})
+	if err != nil {
+		return fmt.Errorf("agent stream: create retry publisher: %w", err)
+	}
+	defer publisher.Close()
+
+	queueName := (&tackle.Options{
+		Service:    agentStreamService,
+		RoutingKey: messages.AgentStreamRequestedRoutingKey,
+	}).GetDelayQueueName()
+
+	if err := publisher.PublishWithContext(ctx, &tackle.PublishParams{
+		Body:       retryBody,
+		Headers:    rabbit.Table{},
+		Exchange:   "",
+		RoutingKey: queueName,
+	}); err != nil {
+		return fmt.Errorf("agent stream: schedule locked request retry: %w", err)
+	}
+	return nil
+}
+
+func lockedStreamRetryBody(body []byte) ([]byte, error) {
+	var req messages.AgentStreamRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("agent stream: decode locked request retry: %w", err)
+	}
+	if req.LockRetryCount >= maxLockedStreamReschedules {
+		return nil, errAgentStreamAlreadyLocked
+	}
+
+	req.LockRetryCount++
+	retryBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("agent stream: encode locked request retry: %w", err)
+	}
+	return retryBody, nil
 }
 
 func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages.AgentStreamRequest, sessionID uuid.UUID) error {
@@ -244,9 +295,13 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 		}).Warn("agent stream: provider mismatch, dropping")
 		return nil
 	}
-
-	ctx, cancel := context.WithTimeout(parentCtx, agentStreamTimeout)
-	defer cancel()
+	if session.Status != models.AgentSessionStatusStreaming {
+		log.WithFields(log.Fields{
+			"session_id": sessionID,
+			"status":     session.Status,
+		}).Info("agent stream: session is no longer streaming, dropping request")
+		return nil
+	}
 
 	publish := func(event messages.AgentSessionEventMessage) {
 		event.SessionID = sessionID.String()
@@ -255,15 +310,64 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 		}
 	}
 
-	publish(messages.AgentSessionEventMessage{Event: "stream_started", Status: models.AgentSessionStatusStreaming})
+	for {
+		turnStartedAt := session.UpdatedAt
+		publish(messages.AgentSessionEventMessage{Event: "stream_started", Status: models.AgentSessionStatusStreaming})
+
+		streamErr := w.streamProviderTurn(parentCtx, session, publish)
+		closeOpenTools(sessionID, publish)
+
+		if streamErr != nil {
+			_ = models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusFailed)
+			publish(messages.AgentSessionEventMessage{
+				Event:  "session_failed",
+				Status: models.AgentSessionStatusFailed,
+				Error:  streamErr.Error(),
+			})
+			log.WithError(streamErr).WithField("session_id", sessionID).Warn("agent stream: provider stream ended with error")
+			return nil
+		}
+
+		markedIdle, err := models.UpdateAgentSessionStatusIfUnchanged(sessionID, models.AgentSessionStatusIdle, turnStartedAt)
+		if err != nil {
+			log.WithError(err).Warn("agent stream: failed to mark session idle")
+			return nil
+		}
+		if markedIdle {
+			return nil
+		}
+
+		session, err = models.FindAgentSession(sessionID)
+		if err != nil {
+			log.WithError(err).WithField("session_id", sessionID).Warn("agent stream: session not found after turn, stopping")
+			return nil
+		}
+		if session.Status != models.AgentSessionStatusStreaming {
+			log.WithFields(log.Fields{
+				"session_id": sessionID,
+				"status":     session.Status,
+			}).Info("agent stream: session changed after turn, stopping")
+			return nil
+		}
+		log.WithField("session_id", sessionID).Info("agent stream: follow-up request arrived while stream was locked, continuing")
+	}
+}
+
+func (w *AgentStreamWorker) streamProviderTurn(
+	parentCtx context.Context,
+	session *models.AgentSession,
+	publish func(messages.AgentSessionEventMessage),
+) error {
+	ctx, cancel := context.WithTimeout(parentCtx, agentStreamTimeout)
+	defer cancel()
 
 	var streamErr error
 	customTools := newCustomToolTurnState()
 
 	for {
 		customTools.clearRequirement()
-		err = w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
-			return handleProviderEvent(sessionID, evt, publish, &streamErr, customTools)
+		err := w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
+			return handleProviderEvent(session.ID, evt, publish, &streamErr, customTools)
 		})
 
 		if errors.Is(err, errCustomToolResultsRequired) {
@@ -273,32 +377,13 @@ func (w *AgentStreamWorker) handleLocked(parentCtx context.Context, req messages
 			streamErr = err
 		}
 		if streamErr != nil || !customTools.resultsRequired {
-			break
+			return streamErr
 		}
 
 		if err := w.executeAndSendCustomToolResults(ctx, session, customTools, publish); err != nil {
-			streamErr = err
-			break
+			return err
 		}
 	}
-
-	closeOpenTools(sessionID, publish)
-
-	if streamErr != nil {
-		_ = models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusFailed)
-		publish(messages.AgentSessionEventMessage{
-			Event:  "session_failed",
-			Status: models.AgentSessionStatusFailed,
-			Error:  streamErr.Error(),
-		})
-		log.WithError(streamErr).WithField("session_id", sessionID).Warn("agent stream: provider stream ended with error")
-		return nil
-	}
-
-	if err := models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusIdle); err != nil {
-		log.WithError(err).Warn("agent stream: failed to mark session idle")
-	}
-	return nil
 }
 
 func handleProviderEvent(

--- a/pkg/workers/agent_stream_worker_test.go
+++ b/pkg/workers/agent_stream_worker_test.go
@@ -116,7 +116,7 @@ func mustCreateSession(t *testing.T, r *support.ResourceRegistry, canvasID uuid.
 	return session
 }
 
-func TestAgentStreamWorker_ReturnsErrorWhenSessionLockIsHeld(t *testing.T) {
+func TestAgentStreamWorker_ContinuesWhenSessionChangesDuringStream(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -126,8 +126,14 @@ func TestAgentStreamWorker_ReturnsErrorWhenSessionLockIsHeld(t *testing.T) {
 		name:        testProvider,
 		streamReady: make(chan struct{}),
 		release:     make(chan struct{}),
-		events: []agents.ProviderEvent{
-			{Type: agents.ProviderEventTurnCompleted},
+		eventBatches: [][]agents.ProviderEvent{
+			{
+				{Type: agents.ProviderEventTurnCompleted},
+			},
+			{
+				{ProviderEventID: "msg-follow-up", Type: agents.ProviderEventAssistantMessage, Text: "second turn"},
+				{Type: agents.ProviderEventTurnCompleted},
+			},
 		},
 	}
 
@@ -140,12 +146,16 @@ func TestAgentStreamWorker_ReturnsErrorWhenSessionLockIsHeld(t *testing.T) {
 	}()
 	<-provider.streamReady
 
-	err := w.Handle(context.Background(), body)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already in progress")
+	require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusStreaming))
 
 	close(provider.release)
 	require.NoError(t, <-firstDone)
+	assert.Equal(t, 2, provider.streamCalls)
+
+	stored, err := models.ListAgentSessionMessagesPage(session.ID, nil, 100)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "second turn", stored[0].Content)
 }
 
 func TestAgentStreamWorker_PersistsAssistantTurn(t *testing.T) {

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -42,6 +42,7 @@ type ChatConversationProps = {
   chatId: string;
   canvasId: string;
   organizationId: string;
+  initialStatus: string;
   agentMode: AgentMode;
   onModeSwitch: (mode: AgentMode) => void;
   isEditing: boolean;
@@ -93,6 +94,7 @@ export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasTo
       chatId={chatId}
       canvasId={canvasId}
       organizationId={organizationId}
+      initialStatus={chatQuery.data?.status ?? "idle"}
       agentMode={toolSidebarState.agentMode}
       onModeSwitch={toolSidebarState.switchAgentMode}
       isEditing={toolSidebarState.isEditing}
@@ -104,6 +106,7 @@ function ChatConversation({
   chatId,
   canvasId,
   organizationId,
+  initialStatus,
   agentMode,
   onModeSwitch,
   isEditing,
@@ -112,13 +115,17 @@ function ChatConversation({
   const sendMutation = useSendAgentChatMessage(organizationId, canvasId);
   const interruptMutation = useInterruptAgentChat(organizationId);
   const outcomeMutation = useDefineAgentOutcome(organizationId);
-  const [status, setStatus] = useState<string>("idle");
+  const [status, setStatus] = useState<string>(initialStatus || "idle");
   const [error, setError] = useState<string | null>(null);
   const [outcomeState, setOutcomeState] = useStoredOutcomeState(chatId);
   const rawMessages = useConversationMessages(messagesQuery.data);
   const { account } = useContext(AccountContext);
   const greetingFirstName = account?.name?.split(" ")[0] ?? "there";
   const bootInitialMessage = useMemo(() => getAgentBootInitialMessage(canvasId), [canvasId]);
+
+  useEffect(() => {
+    setStatus(initialStatus || "idle");
+  }, [initialStatus]);
 
   // Prepend a synthetic greeting as the first message so it never disappears
   const messages = useMemo(() => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -7,10 +7,15 @@ import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
 
-const sendMutation = {
-  isPending: false,
-  mutateAsync: vi.fn(),
-};
+const { sendMutation, chatState } = vi.hoisted(() => ({
+  sendMutation: {
+    isPending: false,
+    mutateAsync: vi.fn(),
+  },
+  chatState: {
+    status: "idle",
+  },
+}));
 
 vi.mock("@/hooks/useCanvasData", () => ({
   useCanvas: () => ({ data: { spec: { nodes: [] } } }),
@@ -20,7 +25,7 @@ vi.mock("@/hooks/useCanvasData", () => ({
 }));
 
 vi.mock("@/hooks/useAgentChats", () => ({
-  useCanvasAgentChat: () => ({ data: { id: "chat-1" }, isLoading: false }),
+  useCanvasAgentChat: () => ({ data: { id: "chat-1", status: chatState.status }, isLoading: false }),
   useAgentChatMessages: () => ({
     data: {
       pages: [
@@ -83,6 +88,10 @@ function makeToolSidebarState(overrides: Partial<CanvasToolSidebarState> = {}) {
 describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
+    chatState.status = "idle";
+    sendMutation.isPending = false;
+    sendMutation.mutateAsync.mockReset();
+    sendMutation.mutateAsync.mockResolvedValue(null);
     sessionStorage.clear();
   });
 
@@ -90,6 +99,19 @@ describe("CanvasToolSidebar", () => {
     render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
 
     expect(await screen.findByPlaceholderText("Ask the agent…")).toBeInTheDocument();
+  });
+
+  it("allows retrying a failed session", async () => {
+    const user = userEvent.setup();
+    chatState.status = "failed";
+
+    render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    expect(await screen.findByText("Last turn failed")).toBeInTheDocument();
+    await user.type(screen.getByTestId("agent-input"), "retry");
+    await user.click(screen.getByTestId("agent-send-message-button"));
+
+    expect(sendMutation.mutateAsync).toHaveBeenCalledWith({ chatId: "chat-1", content: "retry", mode: "operator" });
   });
 
   it("does not render when managed agents are disabled", () => {


### PR DESCRIPTION
## Summary
- return a recoverable busy error when Anthropic is waiting for tool results instead of marking the chat failed
- recreate archived/unavailable Anthropic provider sessions and update the local session external ID before retrying once
- allow failed agent sessions to recover on the next user send and show persisted failed status in the sidebar

## Validation
- make format.go && make format.js
- make test PKG_TEST_PACKAGES=./pkg/agents/...
- make test PKG_TEST_PACKAGES=./pkg/grpc/actions/agents
- make test PKG_TEST_PACKAGES=./pkg/workers
- cd web_src && npm test -- CanvasToolSidebar/index.spec.tsx --run
- make check.build.ui
- make lint && make check.build.app