### PR TITLE
feat: add github.addPullRequestReviewers component

### DIFF
--- a/docs/components/GitHub.mdx
+++ b/docs/components/GitHub.mdx
@@ -28,6 +28,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard title="Add Issue Assignee" href="#add-issue-assignee" description="Add assignees to a GitHub issue" />
   <LinkCard title="Add Issue Label" href="#add-issue-label" description="Add labels to a GitHub issue" />
+  <LinkCard title="Add Pull Request Reviewers" href="#add-pull-request-reviewers" description="Add reviewers to a GitHub pull request" />
   <LinkCard title="Add Reaction" href="#add-reaction" description="Add a reaction to a GitHub comment" />
   <LinkCard title="Create Deployment" href="#create-deployment" description="Create a GitHub deployment for a ref and environment (enables the PR deployment UI)" />
   <LinkCard title="Create Deployment Status" href="#create-deployment-status" description="Update the status of a GitHub deployment (success, failure, inactive, etc.)" />
@@ -1944,6 +1945,78 @@ Returns the full list of labels currently on the issue after the addition.
   ],
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "github.labels"
+}
+```
+
+<a id="add-pull-request-reviewers"></a>
+
+## Add Pull Request Reviewers
+
+**Component key:** `github.addPullRequestReviewers`
+
+The Add Pull Request Reviewers component adds individual users and/or teams as reviewers on a GitHub pull request.
+
+### Use Cases
+
+- **Automated reviewer assignment**: Request review from the relevant team when a pull request is opened
+- **Escalation workflows**: Add additional reviewers when a pull request needs attention
+- **On-call routing**: Request review from the current on-call engineer after checks pass
+
+### Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to add reviewers to. Expressions are supported.
+- **Reviewers**: GitHub usernames to request as reviewers
+- **Team Reviewers**: Team slugs to request as team reviewers (optional)
+
+At least one reviewer or team reviewer is required.
+
+### Output
+
+Returns the updated pull request object with the current requested reviewers.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "base": {
+      "label": "acme:main",
+      "ref": "main"
+    },
+    "created_at": "2026-04-22T10:00:00Z",
+    "draft": false,
+    "head": {
+      "label": "acme:feature-branch",
+      "ref": "feature-branch"
+    },
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "id": 1234567890,
+    "number": 42,
+    "requested_reviewers": [
+      {
+        "html_url": "https://github.com/octocat",
+        "id": 1,
+        "login": "octocat"
+      }
+    ],
+    "requested_teams": [
+      {
+        "html_url": "https://github.com/orgs/acme/teams/justice-league",
+        "id": 1,
+        "slug": "justice-league"
+      }
+    ],
+    "state": "open",
+    "title": "Add new feature",
+    "user": {
+      "html_url": "https://github.com/octocat",
+      "id": 1,
+      "login": "octocat"
+    }
+  },
+  "timestamp": "2026-04-22T10:00:00.000000000Z",
+  "type": "github.pullRequest"
 }
 ```
 

--- a/pkg/integrations/github/capability_mapper.go
+++ b/pkg/integrations/github/capability_mapper.go
@@ -133,6 +133,7 @@ func NewCapabilityMapper() *CapabilityMapper {
 					{ReadOnly: false, Action: &pulls.AddReaction{}},
 					{ReadOnly: false, Action: &pulls.CreatePullRequest{}},
 					{ReadOnly: false, Action: &pulls.MergePullRequest{}},
+					{ReadOnly: false, Action: &pulls.AddPullRequestReviewers{}},
 				},
 			},
 		},

--- a/pkg/integrations/github/common/client.go
+++ b/pkg/integrations/github/common/client.go
@@ -172,6 +172,10 @@ func (c *Client) MergePullRequest(ctx context.Context, repository string, pullNu
 	return c.underlying.PullRequests.Merge(ctx, c.owner, repository, pullNumber, commitMessage, options)
 }
 
+func (c *Client) AddPullRequestReviewers(ctx context.Context, repository string, pullNumber int, reviewers github.ReviewersRequest) (*github.PullRequest, *github.Response, error) {
+	return c.underlying.PullRequests.RequestReviewers(ctx, c.owner, repository, pullNumber, reviewers)
+}
+
 func (c *Client) CreateStatus(ctx context.Context, repository string, sha string, status github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
 	return c.underlying.Repositories.CreateStatus(ctx, c.owner, repository, sha, status)
 }

--- a/pkg/integrations/github/components/pulls/add_pull_request_reviewers.go
+++ b/pkg/integrations/github/components/pulls/add_pull_request_reviewers.go
@@ -1,0 +1,304 @@
+package pulls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/github/common"
+)
+
+type AddPullRequestReviewers struct{}
+
+type AddPullRequestReviewersConfiguration struct {
+	Repository    string   `mapstructure:"repository" json:"repository"`
+	PullNumber    any      `mapstructure:"pullNumber" json:"pullNumber"`
+	Reviewers     []string `mapstructure:"reviewers" json:"reviewers"`
+	TeamReviewers []string `mapstructure:"teamReviewers" json:"teamReviewers"`
+}
+
+type addPullRequestReviewersInput struct {
+	Repository    string
+	PullNumber    int
+	Reviewers     []string
+	TeamReviewers []string
+}
+
+func (c *AddPullRequestReviewers) Name() string {
+	return "github.addPullRequestReviewers"
+}
+
+func (c *AddPullRequestReviewers) Label() string {
+	return "Add Pull Request Reviewers"
+}
+
+func (c *AddPullRequestReviewers) Description() string {
+	return "Add reviewers to a GitHub pull request"
+}
+
+func (c *AddPullRequestReviewers) Documentation() string {
+	return `The Add Pull Request Reviewers component adds individual users and/or teams as reviewers on a GitHub pull request.
+
+## Use Cases
+
+- **Automated reviewer assignment**: Request review from the relevant team when a pull request is opened
+- **Escalation workflows**: Add additional reviewers when a pull request needs attention
+- **On-call routing**: Request review from the current on-call engineer after checks pass
+
+## Configuration
+
+- **Repository**: Select the GitHub repository containing the pull request
+- **Pull Request Number**: Pull request number to add reviewers to. Expressions are supported.
+- **Reviewers**: GitHub usernames to request as reviewers
+- **Team Reviewers**: Team slugs to request as team reviewers (optional)
+
+At least one reviewer or team reviewer is required.
+
+## Output
+
+Returns the updated pull request object with the current requested reviewers.`
+}
+
+func (c *AddPullRequestReviewers) Icon() string {
+	return "github"
+}
+
+func (c *AddPullRequestReviewers) Color() string {
+	return "gray"
+}
+
+func (c *AddPullRequestReviewers) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *AddPullRequestReviewers) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:     "repository",
+			Label:    "Repository",
+			Type:     configuration.FieldTypeIntegrationResource,
+			Required: true,
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: true,
+				},
+			},
+		},
+		{
+			Name:        "pullNumber",
+			Label:       "Pull Request Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "42 or {{event.data.pull_request.number}}",
+			Description: "Pull request number to add reviewers to. Supports expressions.",
+		},
+		{
+			Name:        "reviewers",
+			Label:       "Reviewers",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "GitHub usernames to request as reviewers (e.g. octocat)",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Reviewer",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+		{
+			Name:        "teamReviewers",
+			Label:       "Team Reviewers",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "Team slugs to request as team reviewers (e.g. justice-league)",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Team",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *AddPullRequestReviewers) Setup(ctx core.SetupContext) error {
+	var config AddPullRequestReviewersConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if err := validateAddPullRequestReviewersSetup(config); err != nil {
+		return err
+	}
+
+	return common.EnsureRepoInMetadata(
+		ctx.Metadata,
+		ctx.Integration,
+		ctx.HTTP,
+		ctx.Configuration,
+	)
+}
+
+func (c *AddPullRequestReviewers) Execute(ctx core.ExecutionContext) error {
+	var config AddPullRequestReviewersConfiguration
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	input, err := buildAddPullRequestReviewersInput(config)
+	if err != nil {
+		return err
+	}
+
+	client, err := common.NewClient(ctx.Integration, ctx.HTTP)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GitHub client: %w", err)
+	}
+
+	request := github.ReviewersRequest{
+		Reviewers:     input.Reviewers,
+		TeamReviewers: input.TeamReviewers,
+	}
+
+	pullRequest, _, err := client.AddPullRequestReviewers(
+		context.Background(),
+		input.Repository,
+		input.PullNumber,
+		request,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add pull request reviewers: %w", explainGitHubError(err))
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"github.pullRequest",
+		[]any{pullRequest},
+	)
+}
+
+func (c *AddPullRequestReviewers) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *AddPullRequestReviewers) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return 200, nil, nil
+}
+
+func (c *AddPullRequestReviewers) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *AddPullRequestReviewers) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *AddPullRequestReviewers) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *AddPullRequestReviewers) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func validateAddPullRequestReviewersSetup(config AddPullRequestReviewersConfiguration) error {
+	if strings.TrimSpace(config.Repository) == "" {
+		return errors.New("repository is required")
+	}
+
+	if pullNumberText(config.PullNumber) == "" {
+		return errors.New("pull request number is required")
+	}
+
+	if err := validateReviewerLists(config.Reviewers, config.TeamReviewers); err != nil {
+		return err
+	}
+
+	if common.IsExpression(pullNumberText(config.PullNumber)) {
+		return nil
+	}
+
+	_, err := parsePullNumber(config.PullNumber)
+	return err
+}
+
+func buildAddPullRequestReviewersInput(config AddPullRequestReviewersConfiguration) (*addPullRequestReviewersInput, error) {
+	if strings.TrimSpace(config.Repository) == "" {
+		return nil, errors.New("repository is required")
+	}
+
+	pullNumber, err := parsePullNumber(config.PullNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	reviewers, teamReviewers, err := normalizeReviewerLists(config.Reviewers, config.TeamReviewers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &addPullRequestReviewersInput{
+		Repository:    strings.TrimSpace(config.Repository),
+		PullNumber:    pullNumber,
+		Reviewers:     reviewers,
+		TeamReviewers: teamReviewers,
+	}, nil
+}
+
+func validateReviewerLists(reviewers, teamReviewers []string) error {
+	normalizedReviewers, normalizedTeams, err := normalizeReviewerLists(reviewers, teamReviewers)
+	if err != nil {
+		return err
+	}
+
+	if len(normalizedReviewers) == 0 && len(normalizedTeams) == 0 {
+		return errors.New("at least one reviewer or team reviewer is required")
+	}
+
+	return nil
+}
+
+func normalizeReviewerLists(reviewers, teamReviewers []string) ([]string, []string, error) {
+	normalizedReviewers := sanitizeReviewerUsernames(reviewers)
+	normalizedTeams := sanitizeTeamSlugs(teamReviewers)
+
+	if len(normalizedReviewers) == 0 && len(normalizedTeams) == 0 {
+		return nil, nil, errors.New("at least one reviewer or team reviewer is required")
+	}
+
+	return normalizedReviewers, normalizedTeams, nil
+}
+
+func sanitizeReviewerUsernames(reviewers []string) []string {
+	sanitized := common.SanitizeAssignees(reviewers)
+	result := make([]string, 0, len(sanitized))
+	for _, reviewer := range sanitized {
+		trimmed := strings.TrimSpace(reviewer)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func sanitizeTeamSlugs(teamReviewers []string) []string {
+	result := make([]string, 0, len(teamReviewers))
+	for _, team := range teamReviewers {
+		trimmed := strings.TrimSpace(team)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/pkg/integrations/github/components/pulls/add_pull_request_reviewers_test.go
+++ b/pkg/integrations/github/components/pulls/add_pull_request_reviewers_test.go
@@ -1,0 +1,238 @@
+package pulls
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	contexts "github.com/superplanehq/superplane/test/support/contexts"
+	mocks "github.com/superplanehq/superplane/test/support/mocks/github"
+)
+
+func Test__AddPullRequestReviewers__Setup(t *testing.T) {
+	component := AddPullRequestReviewers{}
+
+	validConfig := func(overrides map[string]any) map[string]any {
+		config := map[string]any{
+			"repository": "hello",
+			"pullNumber": "42",
+			"reviewers":  []string{"octocat"},
+		}
+		for key, value := range overrides {
+			config[key] = value
+		}
+		return config
+	}
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"repository": ""}),
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": ""}),
+		})
+
+		require.ErrorContains(t, err, "pull request number is required")
+	})
+
+	t.Run("literal pull request number must be positive", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration:   &contexts.IntegrationContext{},
+			Metadata:      &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{"pullNumber": "0"}),
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("at least one reviewer or team reviewer is required", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Integration: &contexts.IntegrationContext{},
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{
+				"reviewers":     []string{},
+				"teamReviewers": []string{},
+			}),
+		})
+
+		require.ErrorContains(t, err, "at least one reviewer or team reviewer is required")
+	})
+
+	t.Run("team reviewers alone are accepted", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{
+				"reviewers":     []string{},
+				"teamReviewers": []string{"justice-league"},
+			}),
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("expression pull request number is accepted at setup", func(t *testing.T) {
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusOK, `{
+					"id": 123456,
+					"name": "hello",
+					"html_url": "https://github.com/testhq/hello"
+				}`),
+			},
+		}
+
+		err := component.Setup(core.SetupContext{
+			Integration: mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:        httpCtx,
+			Metadata:    &contexts.MetadataContext{},
+			Configuration: validConfig(map[string]any{
+				"pullNumber": `{{$["github.onPullRequest"].data.pull_request.number}}`,
+			}),
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__AddPullRequestReviewers__Execute(t *testing.T) {
+	component := AddPullRequestReviewers{}
+
+	t.Run("fails when configuration decode fails", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration:  "not a map",
+		})
+
+		require.ErrorContains(t, err, "failed to decode configuration")
+	})
+
+	t.Run("repository is required", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "",
+				"pullNumber": "42",
+				"reviewers":  []string{"octocat"},
+			},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("pull request number must be positive", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository": "hello",
+				"pullNumber": "-1",
+				"reviewers":  []string{"octocat"},
+			},
+		})
+
+		require.ErrorContains(t, err, "pull request number must be a positive integer")
+	})
+
+	t.Run("at least one reviewer or team reviewer is required", func(t *testing.T) {
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			ExecutionState: &contexts.ExecutionStateContext{},
+			Configuration: map[string]any{
+				"repository":    "hello",
+				"pullNumber":    "42",
+				"reviewers":     []string{},
+				"teamReviewers": []string{},
+			},
+		})
+
+		require.ErrorContains(t, err, "at least one reviewer or team reviewer is required")
+	})
+
+	t.Run("emits the updated pull request", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{}
+		httpCtx := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				mocks.GitHubResponse(http.StatusCreated, `{
+					"id": 1234567890,
+					"number": 42,
+					"title": "Add new feature",
+					"state": "open",
+					"html_url": "https://github.com/testhq/hello/pull/42",
+					"requested_reviewers": [
+						{
+							"login": "octocat",
+							"id": 1,
+							"html_url": "https://github.com/octocat"
+						}
+					],
+					"requested_teams": [
+						{
+							"slug": "justice-league",
+							"id": 1,
+							"html_url": "https://github.com/orgs/testhq/teams/justice-league"
+						}
+					]
+				}`),
+			},
+		}
+
+		err := component.Execute(core.ExecutionContext{
+			Integration:    mocks.IntegrationContextForNewSetupFlow(),
+			HTTP:           httpCtx,
+			ExecutionState: executionState,
+			Configuration: map[string]any{
+				"repository":    "hello",
+				"pullNumber":    "42",
+				"reviewers":     []string{"@octocat"},
+				"teamReviewers": []string{"justice-league"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, executionState.Passed)
+		require.Equal(t, core.DefaultOutputChannel.Name, executionState.Channel)
+		require.Equal(t, "github.pullRequest", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+		require.Len(t, httpCtx.Requests, 1)
+
+		request := httpCtx.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/repos/testhq/hello/pulls/42/requested_reviewers", request.URL.Path)
+
+		requestBody := readJSONBody(t, request)
+		assert.Equal(t, []any{"octocat"}, requestBody["reviewers"])
+		assert.Equal(t, []any{"justice-league"}, requestBody["team_reviewers"])
+
+		payload := executionState.Payloads[0].(map[string]any)
+		pullRequest := payload["data"].(*github.PullRequest)
+		assert.Equal(t, 42, pullRequest.GetNumber())
+		assert.Equal(t, "Add new feature", pullRequest.GetTitle())
+		assert.Equal(t, "open", pullRequest.GetState())
+	})
+}

--- a/pkg/integrations/github/components/pulls/example.go
+++ b/pkg/integrations/github/components/pulls/example.go
@@ -28,6 +28,9 @@ var exampleOutputCreatePullRequestBytes []byte
 //go:embed payloads/merge_pull_request.json
 var exampleOutputMergePullRequestBytes []byte
 
+//go:embed payloads/add_pull_request_reviewers.json
+var exampleOutputAddPullRequestReviewersBytes []byte
+
 var exampleOutputAddReactionOnce sync.Once
 var exampleOutputAddReaction map[string]any
 
@@ -39,6 +42,9 @@ var exampleOutputCreatePullRequest map[string]any
 
 var exampleOutputMergePullRequestOnce sync.Once
 var exampleOutputMergePullRequest map[string]any
+
+var exampleOutputAddPullRequestReviewersOnce sync.Once
+var exampleOutputAddPullRequestReviewers map[string]any
 
 var exampleDataOnPullRequestOnce sync.Once
 var exampleDataOnPullRequest map[string]any
@@ -94,5 +100,13 @@ func (c *MergePullRequest) ExampleOutput() map[string]any {
 		&exampleOutputMergePullRequestOnce,
 		exampleOutputMergePullRequestBytes,
 		&exampleOutputMergePullRequest,
+	)
+}
+
+func (c *AddPullRequestReviewers) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputAddPullRequestReviewersOnce,
+		exampleOutputAddPullRequestReviewersBytes,
+		&exampleOutputAddPullRequestReviewers,
 	)
 }

--- a/pkg/integrations/github/components/pulls/payloads/add_pull_request_reviewers.json
+++ b/pkg/integrations/github/components/pulls/payloads/add_pull_request_reviewers.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "id": 1234567890,
+    "number": 42,
+    "title": "Add new feature",
+    "state": "open",
+    "draft": false,
+    "html_url": "https://github.com/acme/widgets/pull/42",
+    "created_at": "2026-04-22T10:00:00Z",
+    "requested_reviewers": [
+      {
+        "login": "octocat",
+        "id": 1,
+        "html_url": "https://github.com/octocat"
+      }
+    ],
+    "requested_teams": [
+      {
+        "slug": "justice-league",
+        "id": 1,
+        "html_url": "https://github.com/orgs/acme/teams/justice-league"
+      }
+    ],
+    "head": {
+      "ref": "feature-branch",
+      "label": "acme:feature-branch"
+    },
+    "base": {
+      "ref": "main",
+      "label": "acme:main"
+    },
+    "user": {
+      "login": "octocat",
+      "id": 1,
+      "html_url": "https://github.com/octocat"
+    }
+  },
+  "timestamp": "2026-04-22T10:00:00.000000000Z",
+  "type": "github.pullRequest"
+}

--- a/pkg/integrations/github/github.go
+++ b/pkg/integrations/github/github.go
@@ -129,6 +129,7 @@ func (g *GitHub) Actions() []core.Action {
 		&pulls.CreateReview{},
 		&pulls.CreatePullRequest{},
 		&pulls.MergePullRequest{},
+		&pulls.AddPullRequestReviewers{},
 		&pulls.AddReaction{},
 		&statuses.GetCombinedCommitStatus{},
 		&statuses.PublishCommitStatus{},

--- a/web_src/src/pages/app/mappers/github/add_pull_request_reviewers.spec.ts
+++ b/web_src/src/pages/app/mappers/github/add_pull_request_reviewers.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo } from "../types";
+import { addPullRequestReviewersMapper } from "./add_pull_request_reviewers";
+
+describe("addPullRequestReviewersMapper", () => {
+  it("shows a curated reviewer summary", () => {
+    const details = addPullRequestReviewersMapper.getExecutionDetails(
+      buildDetailsContext({
+        configuration: {
+          repository: "hello",
+          pullNumber: "42",
+          reviewers: ["octocat"],
+          teamReviewers: ["justice-league"],
+        },
+        outputs: {
+          default: [
+            {
+              data: {
+                number: 42,
+                title: "Add new feature",
+                state: "open",
+                html_url: "https://github.com/testhq/hello/pull/42",
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Created At": expect.any(String),
+      Repository: "hello",
+      "Pull Request": "#42",
+      "Pull Request URL": "https://github.com/testhq/hello/pull/42",
+      Reviewers: "octocat",
+      "Team Reviewers": "justice-league",
+      Title: "Add new feature",
+      State: "open",
+    });
+  });
+});
+
+function buildDetailsContext(execution: Partial<ExecutionInfo>): ExecutionDetailsContext {
+  const node: NodeInfo = {
+    id: "node-1",
+    name: "Add pull request reviewers",
+    componentName: "github.addPullRequestReviewers",
+    isCollapsed: false,
+    metadata: {
+      repository: {
+        id: "123456",
+        name: "hello",
+        url: "https://github.com/testhq/hello",
+      },
+    },
+  };
+
+  return {
+    nodes: [node],
+    node,
+    execution: {
+      id: "exec-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: "RESULT_REASON_OK",
+      resultMessage: "",
+      metadata: {},
+      configuration: {},
+      rootEvent: undefined,
+      ...execution,
+    },
+  };
+}

--- a/web_src/src/pages/app/mappers/github/add_pull_request_reviewers.ts
+++ b/web_src/src/pages/app/mappers/github/add_pull_request_reviewers.ts
@@ -1,0 +1,106 @@
+import type React from "react";
+import type { ComponentBaseProps } from "@/ui/componentBase";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import { stringOrDash } from "../utils";
+import { baseProps } from "./base";
+import type { BaseNodeMetadata } from "./types";
+import { buildGithubExecutionSubtitle } from "./utils";
+
+interface AddPullRequestReviewersConfiguration {
+  repository?: string;
+  pullNumber?: string | number;
+  reviewers?: string[];
+  teamReviewers?: string[];
+}
+
+interface PullRequestOutput {
+  number?: number;
+  title?: string;
+  state?: string;
+  html_url?: string;
+}
+
+export const addPullRequestReviewersMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    return baseProps(context.nodes, context.node, context.componentDefinition, context.lastExecutions);
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return buildGithubExecutionSubtitle(context.execution);
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const configuration = addPullRequestReviewersConfiguration(context);
+    const pullRequest = addPullRequestReviewersOutput(context);
+    const repositoryURL = repositoryUrl(context);
+    const pullNumber = configuration.pullNumber ?? pullRequest?.number;
+
+    return {
+      "Created At": context.execution.createdAt ? new Date(context.execution.createdAt).toLocaleString() : "-",
+      Repository: stringOrDash(configuration.repository || repositoryName(context)),
+      "Pull Request": formatPullRequestNumber(pullNumber),
+      "Pull Request URL": stringOrDash(pullRequest?.html_url || pullRequestUrl(repositoryURL, pullNumber)),
+      Reviewers: formatList(configuration.reviewers),
+      "Team Reviewers": formatList(configuration.teamReviewers),
+      Title: stringOrDash(pullRequest?.title),
+      State: stringOrDash(pullRequest?.state),
+    };
+  },
+};
+
+function addPullRequestReviewersConfiguration(context: ExecutionDetailsContext): AddPullRequestReviewersConfiguration {
+  return (
+    ((context.execution.configuration || context.node.configuration || {}) as
+      | AddPullRequestReviewersConfiguration
+      | undefined) || {}
+  );
+}
+
+function addPullRequestReviewersOutput(context: ExecutionDetailsContext): PullRequestOutput | undefined {
+  const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+  return outputs?.default?.[0]?.data as PullRequestOutput | undefined;
+}
+
+function repositoryName(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.name;
+}
+
+function repositoryUrl(context: ExecutionDetailsContext): string | undefined {
+  const metadata = context.node.metadata as BaseNodeMetadata | undefined;
+  return metadata?.repository?.url;
+}
+
+function formatPullRequestNumber(value: string | number | undefined): string {
+  if (value === undefined || value === "") {
+    return "-";
+  }
+
+  const text = String(value);
+  return text.startsWith("#") ? text : `#${text}`;
+}
+
+function pullRequestUrl(
+  repositoryURL: string | undefined,
+  pullNumber: string | number | undefined,
+): string | undefined {
+  if (!repositoryURL || pullNumber === undefined || pullNumber === "") {
+    return undefined;
+  }
+
+  return `${repositoryURL}/pull/${String(pullNumber).replace(/^#/, "")}`;
+}
+
+function formatList(values: string[] | undefined): string {
+  if (!values || values.length === 0) {
+    return "-";
+  }
+
+  return values.join(", ");
+}

--- a/web_src/src/pages/app/mappers/github/index.ts
+++ b/web_src/src/pages/app/mappers/github/index.ts
@@ -25,6 +25,7 @@ import { getRepositoryPermissionMapper } from "./get_repository_permission";
 import { createReviewMapper } from "./create_review";
 import { createPullRequestMapper } from "./create_pull_request";
 import { mergePullRequestMapper } from "./merge_pull_request";
+import { addPullRequestReviewersMapper } from "./add_pull_request_reviewers";
 import { getWorkflowUsageMapper } from "./get_workflow_usage";
 import { labelsMapper } from "./labels";
 import { addReactionMapper } from "./add_reaction";
@@ -41,6 +42,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   createReview: buildActionStateRegistry("created"),
   createPullRequest: buildActionStateRegistry("created"),
   mergePullRequest: buildActionStateRegistry("merged"),
+  addPullRequestReviewers: buildActionStateRegistry("added"),
   publishCommitStatus: buildActionStateRegistry("published"),
   createDeployment: buildActionStateRegistry("created"),
   createDeploymentStatus: buildActionStateRegistry("created"),
@@ -67,6 +69,7 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   createReview: createReviewMapper,
   createPullRequest: createPullRequestMapper,
   mergePullRequest: mergePullRequestMapper,
+  addPullRequestReviewers: addPullRequestReviewersMapper,
   runWorkflow: runWorkflowMapper,
   publishCommitStatus: publishCommitStatusMapper,
   createDeployment: createDeploymentMapper,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#5304](https://github.com/superplanehq/superplane/issues/5304) by adding a new GitHub action component to add reviewers on a pull request.

- **Component key:** `github.addPullRequestReviewers`
- **Label:** Add Pull Request Reviewers

## Configuration

| Field | Description |
|-------|-------------|
| `repository` | GitHub repository containing the pull request |
| `pullNumber` | Pull request number (supports expressions) |
| `reviewers` | GitHub usernames to request as reviewers |
| `teamReviewers` | Team slugs to request as team reviewers (optional) |

At least one reviewer or team reviewer is required.

## Changes

- Backend component with Setup/Execute validation and unit tests
- GitHub client wrapper for `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers`
- Registration in GitHub integration actions and capability mapper (Pull Requests permission)
- Frontend mapper with execution details (reviewers, team reviewers, PR URL, title, state)
- Example output payload and documentation in `docs/components/GitHub.mdx`

## Output

Emits `github.pullRequest` with the updated pull request object returned by GitHub.

## Testing

- `go test ./pkg/integrations/github/components/pulls/ -run AddPullRequestReviewers` — all tests pass
- Frontend mapper spec added following existing GitHub PR mapper patterns
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abd7dba8-5efb-4ab4-a114-4d1495817157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abd7dba8-5efb-4ab4-a114-4d1495817157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

