### PR TITLE
fix: stabilize canvas node collapse toggle

### DIFF
--- a/test/e2e/canvas_page_test.go
+++ b/test/e2e/canvas_page_test.go
@@ -56,8 +56,10 @@ func TestCanvasPage(t *testing.T) {
 		steps.assertIsNodeExpanded("Hello")
 		steps.toggleNodeViewOnCanvas("Hello")
 		steps.assertIsNodeCollapsed("Hello")
+		steps.assertNodeCollapsedInDraft("Hello", true)
 		steps.toggleNodeViewOnCanvas("Hello")
 		steps.assertIsNodeExpanded("Hello")
+		steps.assertNodeCollapsedInDraft("Hello", false)
 	})
 
 	t.Run("deleting a node from a canvas", func(t *testing.T) {
@@ -274,6 +276,23 @@ func (s *CanvasPageSteps) assertIsNodeExpanded(nodeName string) {
 	s.session.AssertVisible(selector)
 }
 
+func (s *CanvasPageSteps) assertNodeCollapsedInDraft(nodeName string, collapsed bool) {
+	require.Eventually(s.t, func() bool {
+		draft := s.canvas.FindCurrentDraft()
+		if draft == nil {
+			return false
+		}
+
+		for _, node := range draft.Nodes {
+			if node.Name == nodeName {
+				return node.IsCollapsed == collapsed
+			}
+		}
+
+		return false
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 func (s *CanvasPageSteps) assertNodeIsAdded(nodeName string) {
 	s.session.AssertText(nodeName)
 }
@@ -300,9 +319,8 @@ func (s *CanvasPageSteps) toggleNodeViewOnCanvas(nodeName string) {
 	)
 
 	s.session.HoverOver(node)
-	s.session.Sleep(100)
+	s.session.AssertVisible(toggleButton)
 	s.session.Click(toggleButton)
-	s.session.Sleep(300)
 }
 
 func (s *CanvasPageSteps) deleteNodeFromCanvas(nodeName string) {

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -787,6 +787,8 @@ export function AppPage() {
         return;
       }
 
+      canvasRef.current = updatedWorkflow;
+      canvasContentVersionIdRef.current = activeCanvasVersionId;
       queryClient.setQueryData(canvasKeys.detail(organizationId, canvasId), updatedWorkflow);
 
       if (!isViewingDraftVersion || !activeCanvasVersionId || !updatedWorkflow.spec) {
@@ -3657,16 +3659,17 @@ export function AppPage() {
 
   const handleNodeCollapseChange = useCallback(
     async (nodeId: string, collapsed: boolean) => {
-      if (!canvas || !organizationId || !canvasId) return;
+      const currentWorkflow = canvasRef.current ?? canvas;
+      if (!currentWorkflow || !organizationId || !canvasId) return;
 
-      const currentNode = canvas.spec?.nodes?.find((node) => node.id === nodeId);
+      const currentNode = currentWorkflow.spec?.nodes?.find((node) => node.id === nodeId);
       if (!currentNode) return;
 
       if (currentNode.isCollapsed === collapsed) {
         return;
       }
 
-      const updatedNodes = canvas.spec?.nodes?.map((node) =>
+      const updatedNodes = currentWorkflow.spec?.nodes?.map((node) =>
         node.id === nodeId
           ? {
               ...node,
@@ -3676,9 +3679,9 @@ export function AppPage() {
       );
 
       const updatedWorkflow = {
-        ...canvas,
+        ...currentWorkflow,
         spec: {
-          ...canvas.spec,
+          ...currentWorkflow.spec,
           nodes: updatedNodes,
         },
       };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Investigates flaky issue #5306 for `TestCanvasPage/collapsing_and_expanding_a_node_on_canvas`.
- Keeps the app page workflow ref synchronized when applying local canvas updates so rapid collapse/expand toggles compose saves from the latest local state.
- Hardens the E2E helper by waiting for the hover-revealed toggle action and asserting the draft persisted collapsed state after each toggle.

## Validation
- `gofmt -w test/e2e/canvas_page_test.go`
- `test -z "$(gofmt -l \"test/e2e/canvas_page_test.go\")"`
- `make format.js`
- `npm run format:check -- "src/pages/app/index.tsx"`

## Blocked checks
- `make check.build.ui` could not run because this VM does not have the `docker` binary.
- Local `npm run build` could not complete because generated `web_src/src/api-client` and `api/swagger/superplane.swagger.json` are absent in this checkout.
- Targeted `go test ./test/e2e -run 'TestCanvasPage/collapsing_and_expanding_a_node_on_canvas' -count=1` could not compile because generated `pkg/protos/...` packages are absent in this checkout.

These generated artifacts are normally produced by `make dev.setup`/codegen inside the Docker dev environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b6e6dd0-9b37-470f-bb1e-8ee56e2b9046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b6e6dd0-9b37-470f-bb1e-8ee56e2b9046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

