### PR TITLE
fix: retry e2e database reset deadlocks

### DIFF
--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	pw "github.com/playwright-community/playwright-go"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
@@ -31,6 +33,14 @@ type TestSession struct {
 	OrgID   uuid.UUID
 	Account *models.Account
 }
+
+const (
+	resetDatabaseAttempts     = 5
+	resetDatabaseRetryBackoff = 200 * time.Millisecond
+
+	postgresDeadlockDetectedCode = "40P01"
+	postgresLockNotAvailableCode = "55P03"
+)
 
 func NewTestSession(t *testing.T, context pw.BrowserContext, page pw.Page, timeoutMs float64, baseURL string) *TestSession {
 	sess := &TestSession{
@@ -133,9 +143,38 @@ func (s *TestSession) resetDatabase() {
         END LOOP;
     END$$;`
 
-	if err := database.Conn().Exec(sql).Error; err != nil {
-		s.t.Fatalf("reset database: %v", err)
+	var lastErr error
+	for attempt := 1; attempt <= resetDatabaseAttempts; attempt++ {
+		lastErr = database.Conn().Exec(sql).Error
+		if lastErr == nil {
+			return
+		}
+
+		if !isRetryableResetDatabaseError(lastErr) {
+			break
+		}
+
+		if attempt == resetDatabaseAttempts {
+			break
+		}
+
+		s.t.Logf("retrying database reset after retryable database error on attempt %d/%d: %v", attempt, resetDatabaseAttempts, lastErr)
+		time.Sleep(time.Duration(attempt) * resetDatabaseRetryBackoff)
 	}
+
+	s.t.Fatalf("reset database: %v", lastErr)
+}
+
+func isRetryableResetDatabaseError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == postgresDeadlockDetectedCode || pgErr.Code == postgresLockNotAvailableCode
+	}
+
+	message := err.Error()
+	return strings.Contains(message, "deadlock detected") ||
+		strings.Contains(message, "SQLSTATE "+postgresDeadlockDetectedCode) ||
+		strings.Contains(message, "SQLSTATE "+postgresLockNotAvailableCode)
 }
 
 func (s *TestSession) Login() {

--- a/test/e2e/session/test_session_test.go
+++ b/test/e2e/session/test_session_test.go
@@ -1,0 +1,36 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetryableResetDatabaseError(t *testing.T) {
+	t.Run("deadlock detected postgres error", func(t *testing.T) {
+		err := fmt.Errorf("reset failed: %w", &pgconn.PgError{Code: postgresDeadlockDetectedCode})
+
+		require.True(t, isRetryableResetDatabaseError(err))
+	})
+
+	t.Run("lock timeout postgres error", func(t *testing.T) {
+		err := &pgconn.PgError{Code: postgresLockNotAvailableCode}
+
+		require.True(t, isRetryableResetDatabaseError(err))
+	})
+
+	t.Run("deadlock detected log message", func(t *testing.T) {
+		err := errors.New("ERROR: deadlock detected (SQLSTATE 40P01)")
+
+		require.True(t, isRetryableResetDatabaseError(err))
+	})
+
+	t.Run("non retryable error", func(t *testing.T) {
+		err := errors.New("syntax error")
+
+		require.False(t, isRetryableResetDatabaseError(err))
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Investigated issue #5306 and confirmed the reported canvas subtest failed during E2E database reset, not during a UI assertion.
- Retry E2E database reset when PostgreSQL reports deadlock or lock-timeout errors from transient worker overlap.
- Add focused coverage for retryable reset error classification.

## Testing
- `gofmt -w test/e2e/session/test_session.go test/e2e/session/test_session_test.go`
- `go test ./test/e2e/session` *(blocked in this checkout: generated `pkg/protos/...` packages are absent; Docker is also unavailable here, so `make dev.setup`/Docker-based verification cannot be run in this VM).*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a88a28-505e-49ef-bc67-4a28b9e8a120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a88a28-505e-49ef-bc67-4a28b9e8a120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

