### PR TITLE
docs: clarify cloud VM paths and startup in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,11 @@ The dev environment is entirely Docker-based. The VM needs Docker installed (wit
 ### Key gotchas
 
 - The `app` container starts with `sleep infinity` by default. You must explicitly run `make dev.server` to start the API + UI stack.
-- All `make` commands must be run from the `/agent/repos/superplane` directory.
+- All `make` commands must be run from the repository root (`/workspace` in cloud VMs).
 - The Docker daemon must be started manually in cloud VMs: `sudo dockerd &>/tmp/dockerd.log &` — wait ~3-4 seconds before issuing Docker commands.
 - After Docker daemon starts, ensure the socket is accessible: `sudo chmod 666 /var/run/docker.sock`.
 - Owner setup is enabled by default (`OWNER_SETUP_ENABLED=yes`). On first UI load at `http://localhost:8000`, you'll be prompted to create an admin account with email/password.
 - `BLOCK_SIGNUP=yes` is the default, so only the owner setup flow works for account creation (no open registration).
 - If `make dev.setup` fails on `go mod download` with missing files, run `make dev.clean.go.cache` then `make dev.setup.go`.
 - The `make dev.setup` Makefile target already creates and migrates both `superplane_dev` and `superplane_test` databases.
+- On a fresh cloud VM, start the Docker daemon (`sudo dockerd &>/tmp/dockerd.log &`, then `sudo chmod 666 /var/run/docker.sock`) before any `make` targets. The VM update script runs `make dev.up` and `make dev.setup`; run `make dev.server` separately to start the API + UI after setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies cloud VM development instructions discovered during environment setup:

- Use `/workspace` as the repository root for `make` commands (replacing the outdated `/agent/repos/superplane` path).
- Document Docker daemon startup before running `make` targets on fresh cloud VMs.
- Note that the VM update script runs `make dev.up` and `make dev.setup`, while `make dev.server` must be run separately to start the API + UI stack.

## Test plan

- [x] Verified dev environment setup on cloud VM using updated instructions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8299afd-8b35-4c22-b0ff-8285fe9e5eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8299afd-8b35-4c22-b0ff-8285fe9e5eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

