### PR TITLE
fix: harden e2e database reset

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -159,36 +159,19 @@ func connect() *gorm.DB {
 
 func TruncateTables() error {
 	return Conn().Exec(`
-		truncate table
-			secrets,
-			account_magic_codes,
-			account_password_auth,
-			accounts,
-			account_providers,
-			users,
-			organizations,
-			organization_invitations,
-			organization_invite_links,
-			app_installations,
-			app_installation_secrets,
-			app_installation_requests,
-			app_installation_subscriptions,
-			casbin_rule,
-			role_metadata,
-			group_metadata,
-			installation_metadata,
-			blueprints,
-			workflows,
-			workflow_runs,
-			workflow_nodes,
-			workflow_events,
-			workflow_node_execution_kvs,
-			workflow_node_executions,
-			workflow_node_queue_items,
-			workflow_node_requests,
-			webhooks,
-			agent_sessions,
-			agent_session_messages
-		restart identity cascade;
+		DO $$
+		DECLARE
+			tables text;
+		BEGIN
+			SELECT string_agg(format('%I', tablename), ', ' ORDER BY tablename)
+			INTO tables
+			FROM pg_tables
+			WHERE schemaname = 'public'
+			  AND tablename != 'schema_migrations';
+
+			IF tables IS NOT NULL THEN
+				EXECUTE 'TRUNCATE TABLE ' || tables || ' RESTART IDENTITY CASCADE';
+			END IF;
+		END$$;
 	`).Error
 }

--- a/test/e2e/session/test_session.go
+++ b/test/e2e/session/test_session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	pw "github.com/playwright-community/playwright-go"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
@@ -19,6 +21,8 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/e2e/queries"
 )
+
+const postgresDeadlockDetected = "40P01"
 
 // TestSession handles per-test actions: db, auth, and page ops.
 type TestSession struct {
@@ -120,22 +124,26 @@ func (s *TestSession) Sleep(ms int) {
 }
 
 func (s *TestSession) resetDatabase() {
-	sql := `DO $$
-    DECLARE r RECORD;
-    BEGIN
-        FOR r IN (
-            SELECT tablename
-            FROM pg_tables
-            WHERE schemaname = 'public'
-              AND tablename NOT IN ('schema_migrations')
-        ) LOOP
-            EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' RESTART IDENTITY CASCADE';
-        END LOOP;
-    END$$;`
+	const maxAttempts = 3
 
-	if err := database.Conn().Exec(sql).Error; err != nil {
-		s.t.Fatalf("reset database: %v", err)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := database.TruncateTables()
+		if err == nil {
+			return
+		}
+
+		if !isPostgresDeadlock(err) || attempt == maxAttempts {
+			s.t.Fatalf("reset database: %v", err)
+		}
+
+		s.t.Logf("reset database deadlocked; retrying attempt %d/%d: %v", attempt+1, maxAttempts, err)
+		time.Sleep(time.Duration(attempt) * 200 * time.Millisecond)
 	}
+}
+
+func isPostgresDeadlock(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == postgresDeadlockDetected
 }
 
 func (s *TestSession) Login() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the E2E reset path behind issue #5306 by using the shared database truncation helper instead of per-table dynamic truncates.
- Updates the shared truncation helper to truncate all current public tables in a single ordered statement, excluding `schema_migrations`.
- Retries only PostgreSQL deadlock errors (`40P01`) during E2E database reset.

## Investigation
- Semaphore job `6b8ac23a-6e45-4904-967b-8c535dd1387b` passed overall, but the JUnit artifact showed `TestCanvasPage/collapsing_and_expanding_a_node_on_canvas` failed before canvas interaction during database reset.
- Failure was `ERROR: deadlock detected (SQLSTATE 40P01)` while the old reset loop truncated public tables one at a time.

## Testing
- `make format.go`
- `docker compose -f docker-compose.dev.yml exec app gotestsum --format short --junitfile /tmp/issue-5306-canvas-page.xml --packages=./test/e2e -- -run '^TestCanvasPage$' -count=3 -p 1 -timeout 30m`
- `make lint && make check.build.app`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca8c4d51-08ca-4b16-9fc2-e3cea2d63558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca8c4d51-08ca-4b16-9fc2-e3cea2d63558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

