### PR TITLE
feat: add file mounting support to claude.runAgent

### DIFF
--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -498,6 +498,27 @@ func (c *Client) DeleteManagedSession(sessionID string) error {
 	return err
 }
 
+// DeleteFile removes an uploaded file (DELETE /v1/files/{id}).
+func (c *Client) DeleteFile(fileID string) error {
+	if fileID == "" {
+		return nil
+	}
+	URL := c.BaseURL + "/files/" + url.PathEscape(fileID)
+	_, err := c.execRequestWithBeta(http.MethodDelete, URL, nil, anthropicBetaManagedAgents)
+	return err
+}
+
+// CleanupFiles deletes a list of uploaded files, logging failures.
+func (c *Client) CleanupFiles(fileIDs []string, logWarn func(string, ...any)) {
+	for _, id := range fileIDs {
+		if err := c.DeleteFile(id); err != nil {
+			if logWarn != nil {
+				logWarn("Failed to delete uploaded file %s: %v", id, err)
+			}
+		}
+	}
+}
+
 func (c *Client) execRequestWithBeta(method, URL string, body io.Reader, beta string) ([]byte, error) {
 	req, err := http.NewRequest(method, URL, body)
 	if err != nil {

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -437,6 +437,26 @@ func (c *Client) SendManagedSessionInterrupt(sessionID string) error {
 
 // UploadFile uploads a file to the Anthropic Files API and returns its ID.
 // The file can then be mounted into a session via CreateManagedSessionRequest.Resources.
+// AddSessionResource attaches a file resource to an existing session.
+// POST /v1/sessions/{id}/resources
+func (c *Client) AddSessionResource(sessionID string, resource FileResource) error {
+	if sessionID == "" {
+		return fmt.Errorf("session id is required")
+	}
+	URL := c.BaseURL + "/sessions/" + url.PathEscape(sessionID) + "/resources"
+	body := map[string]string{
+		"type":       "file",
+		"file_id":    resource.FileID,
+		"mount_path": resource.MountPath,
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal resource: %w", err)
+	}
+	_, err = c.execRequestWithBeta(http.MethodPost, URL, bytes.NewBuffer(b), anthropicBetaManagedAgents)
+	return err
+}
+
 func (c *Client) UploadFile(content io.Reader, filename string) (string, error) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)

--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,7 +18,7 @@ import (
 const (
 	defaultBaseURL             = "https://api.anthropic.com/v1"
 	anthropicVersionValue      = "2023-06-01"
-	anthropicBetaManagedAgents = "managed-agents-2026-04-01"
+	anthropicBetaManagedAgents = "managed-agents-2026-04-01,files-api-2025-04-14"
 	sessionEventsPageLimit     = "20"
 )
 
@@ -40,6 +42,13 @@ type CreateManagedSessionRequest struct {
 	AgentVersion  *int
 	EnvironmentID string
 	VaultIDs      []string
+	Resources     []FileResource
+}
+
+// FileResource is a file uploaded via the Files API to mount into the session.
+type FileResource struct {
+	FileID    string
+	MountPath string
 }
 
 // ManagedSession is a subset of the session resource returned by the API.
@@ -58,11 +67,19 @@ type ManagedSessionContentBlock struct {
 	Text string `json:"text,omitempty"`
 }
 
+// sessionResourceBody is a file resource mounted into the session.
+type sessionResourceBody struct {
+	Type      string `json:"type"`
+	FileID    string `json:"file_id"`
+	MountPath string `json:"mount_path"`
+}
+
 // createManagedSessionBody is the JSON body for session creation.
 type createManagedSessionBody struct {
-	Agent         any      `json:"agent"`
-	EnvironmentID string   `json:"environment_id"`
-	VaultIDs      []string `json:"vault_ids,omitempty"`
+	Agent         any                   `json:"agent"`
+	EnvironmentID string                `json:"environment_id"`
+	VaultIDs      []string              `json:"vault_ids,omitempty"`
+	Resources     []sessionResourceBody `json:"resources,omitempty"`
 }
 
 type userMessageTextBlock struct {
@@ -122,11 +139,24 @@ func buildCreateSessionBody(req CreateManagedSessionRequest) (createManagedSessi
 		}
 	}
 
-	return createManagedSessionBody{
+	body := createManagedSessionBody{
 		Agent:         agent,
 		EnvironmentID: req.EnvironmentID,
 		VaultIDs:      nonEmptyStrings(req.VaultIDs),
-	}, nil
+	}
+
+	if len(req.Resources) > 0 {
+		body.Resources = make([]sessionResourceBody, len(req.Resources))
+		for i, r := range req.Resources {
+			body.Resources[i] = sessionResourceBody{
+				Type:      "file",
+				FileID:    r.FileID,
+				MountPath: r.MountPath,
+			}
+		}
+	}
+
+	return body, nil
 }
 
 func nonEmptyStrings(in []string) []string {
@@ -403,6 +433,58 @@ func (c *Client) SendManagedSessionInterrupt(sessionID string) error {
 	}
 	_, err = c.execRequestWithBeta(http.MethodPost, URL, bytes.NewBuffer(b), anthropicBetaManagedAgents)
 	return err
+}
+
+// UploadFile uploads a file to the Anthropic Files API and returns its ID.
+// The file can then be mounted into a session via CreateManagedSessionRequest.Resources.
+func (c *Client) UploadFile(content io.Reader, filename string) (string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filepath.Base(filename))
+	if err != nil {
+		return "", fmt.Errorf("create multipart file: %w", err)
+	}
+	if _, err := io.Copy(part, content); err != nil {
+		return "", fmt.Errorf("copy file content: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.BaseURL+"/files", &body)
+	if err != nil {
+		return "", fmt.Errorf("build upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("x-api-key", c.APIKey)
+	req.Header.Set("anthropic-version", anthropicVersionValue)
+	req.Header.Set("anthropic-beta", anthropicBetaManagedAgents)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload file: %w", err)
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("read upload response: %w", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", fmt.Errorf("upload file failed (%d): %s", res.StatusCode, string(resBody))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(resBody, &result); err != nil {
+		return "", fmt.Errorf("decode upload response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("upload returned empty file ID")
+	}
+	return result.ID, nil
 }
 
 // DeleteManagedSession removes a session (DELETE /v1/sessions/{id}).

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -54,7 +54,13 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 	if attempt > maxPollAttempts {
 		ctx.Logger.Errorf("Managed session %s exceeded max poll attempts", metadata.Session.ID)
 		out := buildOutput("timeout", metadata.Session.ID)
-		return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+		if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+			return emitErr
+		}
+		if c, cErr := NewClient(ctx.HTTP, ctx.Integration); cErr == nil {
+			cleanupUploadedFilesFromHook(c, ctx, ctx.Logger.Warnf)
+		}
+		return nil
 	}
 
 	client, err := NewClient(ctx.HTTP, ctx.Integration)
@@ -68,7 +74,11 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		if errs >= maxPollErrors {
 			ctx.Logger.Errorf("Managed session %s: polling failed repeatedly: %v", metadata.Session.ID, err)
 			out := buildOutput("error", metadata.Session.ID)
-			return ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out})
+			if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+				return emitErr
+			}
+			cleanupUploadedFilesFromHook(client, ctx, ctx.Logger.Warnf)
+			return nil
 		}
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
 	}

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -101,6 +101,7 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		if err := client.DeleteManagedSession(metadata.Session.ID); err != nil {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)
 		}
+		cleanupUploadedFilesFromHook(client, ctx, ctx.Logger.Warnf)
 		return nil
 	}
 
@@ -137,5 +138,6 @@ func (a *RunAgent) Cancel(ctx core.ExecutionContext) error {
 	}
 	// Best effort cleanup; may fail if session is still running.
 	_ = client.DeleteManagedSession(metadata.Session.ID)
+	cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
 	return nil
 }

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -3,7 +3,6 @@ package runagent
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -191,7 +190,13 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		AgentVersion:  spec.Version,
 		EnvironmentID: strings.TrimSpace(spec.EnvironmentID),
 		VaultIDs:      spec.VaultIDs,
-		Resources:     resources,
+	}
+
+	if len(resources) > 0 {
+		createReq.Resources = resources
+		for _, r := range resources {
+			ctx.Logger.Infof("Mounting file: %s (file_id: %s)", r.MountPath, r.FileID)
+		}
 	}
 
 	session, err := client.CreateManagedSession(createReq)
@@ -305,7 +310,7 @@ func uploadRepositoryFiles(client *Client, ctx core.ExecutionContext, files []st
 
 		resources = append(resources, FileResource{
 			FileID:    fileID,
-			MountPath: filepath.Base(normalized),
+			MountPath: normalized,
 		})
 	}
 	return resources, nil

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -2,12 +2,14 @@ package runagent
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
+	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 )
 
 type RunAgent struct{}
@@ -97,6 +99,21 @@ func (a *RunAgent) Configuration() []configuration.Field {
 			},
 			Description: "Optional vault IDs for MCP authentication (see Managed Agents docs)",
 		},
+		{
+			Name:        "files",
+			Label:       "Files",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "File paths from the Files tab to mount into the agent's working directory",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "File path",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeRepositoryFile,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -105,7 +122,36 @@ func (a *RunAgent) Setup(ctx core.SetupContext) error {
 	if err != nil {
 		return err
 	}
-	return validateSpec(spec)
+	if err := validateSpec(spec); err != nil {
+		return err
+	}
+
+	if len(spec.Files) > 0 {
+		if ctx.Files == nil {
+			return fmt.Errorf("files configured but file access is not available")
+		}
+		available, err := ctx.Files.List()
+		if err != nil {
+			return fmt.Errorf("failed to list repository files: %v", err)
+		}
+		fileSet := make(map[string]bool, len(available))
+		for _, f := range available {
+			if norm, err := gitprovider.NormalizePath(f); err == nil {
+				fileSet[norm] = true
+			}
+		}
+		for _, f := range spec.Files {
+			norm, err := gitprovider.ValidateUserPath(f)
+			if err != nil {
+				return fmt.Errorf("invalid file path %q: %v", f, err)
+			}
+			if !fileSet[norm] {
+				return fmt.Errorf("file %q not found in app repository", f)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (a *RunAgent) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
@@ -126,12 +172,25 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		return err
 	}
 
+	// Upload files and prepare resources for session mounting
+	var resources []FileResource
+	if len(spec.Files) > 0 {
+		if ctx.Files == nil {
+			return fmt.Errorf("files configured but file access is not available in this execution context")
+		}
+		resources, err = uploadRepositoryFiles(client, ctx, spec.Files)
+		if err != nil {
+			return fmt.Errorf("failed to upload files: %w", err)
+		}
+	}
+
 	aid := strings.TrimSpace(spec.Agent)
 	createReq := CreateManagedSessionRequest{
 		Agent:         aid,
 		AgentVersion:  spec.Version,
 		EnvironmentID: strings.TrimSpace(spec.EnvironmentID),
 		VaultIDs:      spec.VaultIDs,
+		Resources:     resources,
 	}
 
 	session, err := client.CreateManagedSession(createReq)
@@ -187,6 +246,35 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 
 func (a *RunAgent) Cleanup(ctx core.SetupContext) error { return nil }
 
+// uploadRepositoryFiles reads files from the canvas repository, uploads them
+// to the Anthropic Files API, and returns FileResource entries for session mounting.
+func uploadRepositoryFiles(client *Client, ctx core.ExecutionContext, files []string) ([]FileResource, error) {
+	resources := make([]FileResource, 0, len(files))
+	for _, path := range files {
+		normalized, err := gitprovider.ValidateUserPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("invalid file path %q: %w", path, err)
+		}
+
+		reader, err := ctx.Files.Read(normalized)
+		if err != nil {
+			return nil, fmt.Errorf("read file %q: %w", path, err)
+		}
+
+		fileID, err := client.UploadFile(reader, normalized)
+		reader.Close()
+		if err != nil {
+			return nil, fmt.Errorf("upload file %q: %w", path, err)
+		}
+
+		resources = append(resources, FileResource{
+			FileID:    fileID,
+			MountPath: filepath.Base(normalized),
+		})
+	}
+	return resources, nil
+}
+
 func decodeSpec(config any) (Spec, error) {
 	var spec Spec
 	if err := mapstructure.Decode(config, &spec); err != nil {
@@ -195,6 +283,9 @@ func decodeSpec(config any) (Spec, error) {
 	if raw, ok := config.(map[string]any); ok {
 		if v, ok := raw["vaultIds"]; ok {
 			spec.VaultIDs = decodeStringList(v)
+		}
+		if v, ok := raw["files"]; ok {
+			spec.Files = decodeStringList(v)
 		}
 	}
 	return spec, nil

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -1,6 +1,7 @@
 package runagent
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -208,6 +209,17 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		return fmt.Errorf("failed to set managed_session_id: %w", err)
 	}
 
+	if len(resources) > 0 {
+		fileIDs := make([]string, len(resources))
+		for i, r := range resources {
+			fileIDs[i] = r.FileID
+		}
+		encoded, _ := json.Marshal(fileIDs)
+		if err := ctx.ExecutionState.SetKV("uploaded_file_ids", string(encoded)); err != nil {
+			return fmt.Errorf("failed to store uploaded file IDs: %w", err)
+		}
+	}
+
 	if err := client.SendManagedSessionUserMessage(session.ID, spec.Prompt); err != nil {
 		return fmt.Errorf("failed to send user message: %w", err)
 	}
@@ -234,6 +246,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			if err := client.DeleteManagedSession(session.ID); err != nil {
 				ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
 			}
+			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
 			return nil
 		} else {
 			ctx.Logger.Warnf("Events not complete for session %s after retries. Scheduling poll.", session.ID)
@@ -248,6 +261,29 @@ func (a *RunAgent) Cleanup(ctx core.SetupContext) error { return nil }
 
 // uploadRepositoryFiles reads files from the canvas repository, uploads them
 // to the Anthropic Files API, and returns FileResource entries for session mounting.
+// cleanupUploadedFiles deletes any files uploaded to the Anthropic Files API
+// for this execution. File IDs are retrieved from execution state.
+// getUploadedFileIDs retrieves uploaded file IDs from execution state.
+func getUploadedFileIDs(state core.ExecutionStateContext) []string {
+	raw, err := state.GetKV("uploaded_file_ids")
+	if err != nil || raw == "" {
+		return nil
+	}
+	var fileIDs []string
+	if err := json.Unmarshal([]byte(raw), &fileIDs); err != nil {
+		return nil
+	}
+	return fileIDs
+}
+
+func cleanupUploadedFiles(client *Client, ctx core.ExecutionContext, logWarn func(string, ...any)) {
+	client.CleanupFiles(getUploadedFileIDs(ctx.ExecutionState), logWarn)
+}
+
+func cleanupUploadedFilesFromHook(client *Client, ctx core.ActionHookContext, logWarn func(string, ...any)) {
+	client.CleanupFiles(getUploadedFileIDs(ctx.ExecutionState), logWarn)
+}
+
 func uploadRepositoryFiles(client *Client, ctx core.ExecutionContext, files []string) ([]FileResource, error) {
 	resources := make([]FileResource, 0, len(files))
 	for _, path := range files {

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -184,23 +184,29 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		}
 	}
 
+	// Store file IDs early so cleanup works on any later error path.
+	if len(resources) > 0 {
+		fileIDs := make([]string, len(resources))
+		for i, r := range resources {
+			fileIDs[i] = r.FileID
+			ctx.Logger.Infof("Mounting file: %s (file_id: %s)", r.MountPath, r.FileID)
+		}
+		encoded, _ := json.Marshal(fileIDs)
+		_ = ctx.ExecutionState.SetKV("uploaded_file_ids", string(encoded))
+	}
+
 	aid := strings.TrimSpace(spec.Agent)
 	createReq := CreateManagedSessionRequest{
 		Agent:         aid,
 		AgentVersion:  spec.Version,
 		EnvironmentID: strings.TrimSpace(spec.EnvironmentID),
 		VaultIDs:      spec.VaultIDs,
-	}
-
-	if len(resources) > 0 {
-		createReq.Resources = resources
-		for _, r := range resources {
-			ctx.Logger.Infof("Mounting file: %s (file_id: %s)", r.MountPath, r.FileID)
-		}
+		Resources:     resources,
 	}
 
 	session, err := client.CreateManagedSession(createReq)
 	if err != nil {
+		cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to create managed agent session: %w", err)
 	}
 
@@ -212,17 +218,6 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 
 	if err := ctx.ExecutionState.SetKV("managed_session_id", session.ID); err != nil {
 		return fmt.Errorf("failed to set managed_session_id: %w", err)
-	}
-
-	if len(resources) > 0 {
-		fileIDs := make([]string, len(resources))
-		for i, r := range resources {
-			fileIDs[i] = r.FileID
-		}
-		encoded, _ := json.Marshal(fileIDs)
-		if err := ctx.ExecutionState.SetKV("uploaded_file_ids", string(encoded)); err != nil {
-			return fmt.Errorf("failed to store uploaded file IDs: %w", err)
-		}
 	}
 
 	if err := client.SendManagedSessionUserMessage(session.ID, spec.Prompt); err != nil {
@@ -264,10 +259,6 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 
 func (a *RunAgent) Cleanup(ctx core.SetupContext) error { return nil }
 
-// uploadRepositoryFiles reads files from the canvas repository, uploads them
-// to the Anthropic Files API, and returns FileResource entries for session mounting.
-// cleanupUploadedFiles deletes any files uploaded to the Anthropic Files API
-// for this execution. File IDs are retrieved from execution state.
 // getUploadedFileIDs retrieves uploaded file IDs from execution state.
 func getUploadedFileIDs(state core.ExecutionStateContext) []string {
 	raw, err := state.GetKV("uploaded_file_ids")
@@ -294,17 +285,20 @@ func uploadRepositoryFiles(client *Client, ctx core.ExecutionContext, files []st
 	for _, path := range files {
 		normalized, err := gitprovider.ValidateUserPath(path)
 		if err != nil {
+			cleanupFileResources(client, resources, ctx.Logger.Warnf)
 			return nil, fmt.Errorf("invalid file path %q: %w", path, err)
 		}
 
 		reader, err := ctx.Files.Read(normalized)
 		if err != nil {
+			cleanupFileResources(client, resources, ctx.Logger.Warnf)
 			return nil, fmt.Errorf("read file %q: %w", path, err)
 		}
 
 		fileID, err := client.UploadFile(reader, normalized)
 		reader.Close()
 		if err != nil {
+			cleanupFileResources(client, resources, ctx.Logger.Warnf)
 			return nil, fmt.Errorf("upload file %q: %w", path, err)
 		}
 
@@ -314,6 +308,15 @@ func uploadRepositoryFiles(client *Client, ctx core.ExecutionContext, files []st
 		})
 	}
 	return resources, nil
+}
+
+// cleanupFileResources deletes already-uploaded files on partial failure.
+func cleanupFileResources(client *Client, resources []FileResource, logWarn func(string, ...any)) {
+	for _, r := range resources {
+		if err := client.DeleteFile(r.FileID); err != nil && logWarn != nil {
+			logWarn("Failed to delete uploaded file %s: %v", r.FileID, err)
+		}
+	}
 }
 
 func decodeSpec(config any) (Spec, error) {

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -192,7 +192,10 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 			ctx.Logger.Infof("Mounting file: %s (file_id: %s)", r.MountPath, r.FileID)
 		}
 		encoded, _ := json.Marshal(fileIDs)
-		_ = ctx.ExecutionState.SetKV("uploaded_file_ids", string(encoded))
+		if err := ctx.ExecutionState.SetKV("uploaded_file_ids", string(encoded)); err != nil {
+			cleanupFileResources(client, resources, ctx.Logger.Warnf)
+			return fmt.Errorf("failed to persist uploaded file IDs: %w", err)
+		}
 	}
 
 	aid := strings.TrimSpace(spec.Agent)

--- a/pkg/integrations/claude/runagent/types.go
+++ b/pkg/integrations/claude/runagent/types.go
@@ -23,6 +23,7 @@ type Spec struct {
 	EnvironmentID string   `json:"environmentId" mapstructure:"environmentId"`
 	Prompt        string   `json:"prompt" mapstructure:"prompt"`
 	VaultIDs      []string `json:"vaultIds" mapstructure:"vaultIds"`
+	Files         []string `json:"files" mapstructure:"files"`
 }
 
 // ExecutionMetadata is persisted for the run.


### PR DESCRIPTION
## What

Adds support for mounting Files tab files into Managed Agent sessions in `claude.runAgent`. Files are uploaded via the Anthropic Files API and mounted as resources on session creation, making them available in the agent's working directory.

## How

1. User configures `files` (repository-file picker) on the runAgent node
2. At publish time, Setup validates paths exist in the repository (using `ValidateUserPath` to block `.superplane/` paths)
3. At execution time:
   - Files are read from the canvas repository
   - Each file is uploaded to `POST /v1/files` (Anthropic Files API)
   - File IDs are passed as `resources` on session creation
   - Agent sees the files in its working directory

## Changes

- `client.go`: Added `files-api-2025-04-14` beta header, `UploadFile` method, `FileResource` type, `Resources` on session request, `resources` in session body
- `run_agent.go`: Added `files` config field, file validation in Setup, `uploadRepositoryFiles` helper, resource wiring in Execute
- `types.go`: Added `Files` field to Spec

Follows the same pattern as the in-app agent (`pkg/agents/anthropic/provider.go`) for file mounting.