### PR TITLE
feat: Loop component

### DIFF
--- a/docs/components/Core.mdx
+++ b/docs/components/Core.mdx
@@ -28,6 +28,7 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="GraphQL Request" href="#graph-ql-request" description="Send a GraphQL query to an HTTP endpoint (GraphQL over JSON POST)" />
   <LinkCard title="HTTP Request" href="#http-request" description="Make HTTP requests" />
   <LinkCard title="If" href="#if" description="Route events based on expression" />
+  <LinkCard title="Loop" href="#loop" description="Repeat downstream steps until a condition is met" />
   <LinkCard title="Merge" href="#merge" description="Merge multiple upstream inputs and forward" />
   <LinkCard title="No Operation" href="#no-operation" description="Just pass events through without any additional processing" />
   <LinkCard title="Read Memory" href="#read-memory" description="Find values from canvas memory by namespace and field matches" />
@@ -670,6 +671,77 @@ The expression has access to:
   "data": {},
   "timestamp": "2026-01-16T17:56:16.680755501Z",
   "type": "if.executed"
+}
+```
+
+<a id="loop"></a>
+
+## Loop
+
+**Component key:** `loop`
+
+The Loop component runs downstream steps repeatedly until an exit condition becomes true.
+
+### Use Cases
+
+- Poll an API until a resource reaches a ready state
+- Retry a workflow segment until validation passes
+- Paginate through results until all pages are processed
+- Run approval or review cycles until consensus is reached
+
+### How It Works
+
+1. On the first run, Loop emits to the **Next** channel and starts the loop session
+2. Connect downstream nodes to the Next output and wire the last step back to Loop
+3. When those steps finish, Loop evaluates the **Until Expression**
+4. If the expression is `true`, Loop emits on **Done** and the loop ends
+5. If the expression is `false`, Loop emits on **Next** again for another iteration
+
+### Wiring
+
+```
+Trigger → Loop → Step A → Step B ──┐
+              ↑                    │
+              └────────────────────┘
+```
+
+Edges back into Loop are allowed so downstream steps can return control for the next condition check.
+
+### Output Channels
+
+- **Done**: Emitted once when the loop stops. Payload is under `data.done` with `iterations`, `stopReason` (`conditionTrue` or `max_iterations`), and `elapsedMs`
+- **Next**: Emitted at the start of each iteration. Payload is under `data.next` with `iteration` and `maxIterations`
+
+### Limits
+
+- **Max Iterations** caps how many iterations are allowed (default 100, maximum 500)
+- **Timeout** caps the total wall-clock time of a single run (default 3600s, maximum 86400s). If the loop is still running when the timeout elapses, the run fails. This prevents a stuck run (e.g. downstream never reports back) from blocking subsequent runs on the node.
+
+### Delay Between Iterations
+
+Optionally wait before starting the next iteration. Uses the same fixed or exponential backoff strategies as the HTTP component retry settings. The first iteration always starts immediately; delays apply between subsequent iterations only.
+
+### Expression Environment
+
+The until expression has access to:
+
+- **$**: The run context data, including outputs from the latest iteration
+- **root()**: Access root event data
+- **previous()**: Access previous node outputs
+
+### Example Output
+
+```json
+{
+  "data": {
+    "done": {
+      "elapsedMs": 4521,
+      "iterations": 3,
+      "stopReason": "conditionTrue"
+    }
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z",
+  "type": "loop.done"
 }
 ```
 

--- a/pkg/components/loop/example.go
+++ b/pkg/components/loop/example.go
@@ -1,18 +1,18 @@
 package loop
 
-import (
-	_ "embed"
-	"sync"
-
-	"github.com/superplanehq/superplane/pkg/utils"
-)
-
-//go:embed example_output.json
-var exampleOutputBytes []byte
-
-var exampleOutputOnce sync.Once
-var parsedExampleOutput map[string]any
+const exampleTimestamp = "2026-01-16T17:56:16.680755501Z"
 
 func exampleOutput() map[string]any {
-	return utils.UnmarshalEmbeddedJSON(&exampleOutputOnce, exampleOutputBytes, &parsedExampleOutput)
+	return map[string]any{
+		"next": map[string]any{
+			"type":      PayloadTypeNext,
+			"data":      nextPayload(1, defaultMaxIterations),
+			"timestamp": exampleTimestamp,
+		},
+		"done": map[string]any{
+			"type":      PayloadTypeDone,
+			"data":      donePayload(3, StopReasonConditionMet, 4521),
+			"timestamp": exampleTimestamp,
+		},
+	}
 }

--- a/pkg/components/loop/example.go
+++ b/pkg/components/loop/example.go
@@ -1,0 +1,18 @@
+package loop
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output.json
+var exampleOutputBytes []byte
+
+var exampleOutputOnce sync.Once
+var parsedExampleOutput map[string]any
+
+func exampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputOnce, exampleOutputBytes, &parsedExampleOutput)
+}

--- a/pkg/components/loop/example.go
+++ b/pkg/components/loop/example.go
@@ -4,15 +4,8 @@ const exampleTimestamp = "2026-01-16T17:56:16.680755501Z"
 
 func exampleOutput() map[string]any {
 	return map[string]any{
-		"next": map[string]any{
-			"type":      PayloadTypeNext,
-			"data":      nextPayload(1, defaultMaxIterations),
-			"timestamp": exampleTimestamp,
-		},
-		"done": map[string]any{
-			"type":      PayloadTypeDone,
-			"data":      donePayload(3, StopReasonConditionMet, 4521),
-			"timestamp": exampleTimestamp,
-		},
+		"type":      PayloadTypeDone,
+		"data":      donePayload(3, StopReasonConditionMet, 4521),
+		"timestamp": exampleTimestamp,
 	}
 }

--- a/pkg/components/loop/example_output.json
+++ b/pkg/components/loop/example_output.json
@@ -1,0 +1,8 @@
+{
+  "type": "loop.next",
+  "data": {
+    "iteration": 1,
+    "maxIterations": 100
+  },
+  "timestamp": "2026-01-16T17:56:16.680755501Z"
+}

--- a/pkg/components/loop/example_output.json
+++ b/pkg/components/loop/example_output.json
@@ -1,8 +1,0 @@
-{
-  "type": "loop.next",
-  "data": {
-    "iteration": 1,
-    "maxIterations": 100
-  },
-  "timestamp": "2026-01-16T17:56:16.680755501Z"
-}

--- a/pkg/components/loop/loop.go
+++ b/pkg/components/loop/loop.go
@@ -62,14 +62,11 @@ type DelaySpec struct {
 }
 
 type ExecutionMetadata struct {
-	Iteration int       `json:"iteration"`
-	Active    bool      `json:"active"`
-	StartedAt time.Time `json:"startedAt"`
-}
-
-type IterationExecutionMetadata struct {
-	Iteration     int `json:"iteration"`
-	MaxIterations int `json:"maxIterations"`
+	Iteration                int       `json:"iteration"`
+	MaxIterations            int       `json:"maxIterations"`
+	Active                   bool      `json:"active"`
+	StartedAt                time.Time `json:"startedAt"`
+	WaitingBetweenIterations bool      `json:"waitingBetweenIterations,omitempty"`
 }
 
 func (c *Loop) Name() string {
@@ -256,68 +253,79 @@ func (c *Loop) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error
 		return nil, err
 	}
 
-	anchor, err := ctx.FindExecutionByKV(loopSessionKey, ctx.RootEventID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find loop session: %w", err)
-	}
-
-	if anchor == nil {
-		return c.startLoop(ctx, spec)
-	}
-
-	return c.handleFeedback(ctx, spec, anchor)
-}
-
-func (c *Loop) startLoop(ctx core.ProcessQueueContext, spec Spec) (*uuid.UUID, error) {
-	executionCtx, err := ctx.CreateExecution()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create loop execution: %w", err)
-	}
-
-	if err := executionCtx.ExecutionState.SetKV(loopSessionKey, ctx.RootEventID); err != nil {
-		return nil, fmt.Errorf("failed to store loop session: %w", err)
-	}
-
-	md := ExecutionMetadata{
-		Iteration: 1,
-		Active:    true,
-		StartedAt: time.Now(),
-	}
-	if err := executionCtx.Metadata.Set(md); err != nil {
-		return nil, fmt.Errorf("failed to set loop metadata: %w", err)
-	}
-
-	if err := ctx.DequeueItem(); err != nil {
-		return nil, fmt.Errorf("failed to dequeue item: %w", err)
-	}
-
-	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
-		return nil, fmt.Errorf("failed to update node state: %w", err)
-	}
-
-	return &executionCtx.ID, executionCtx.ExecutionState.Emit(
-		ChannelNameNext,
-		PayloadTypeNext,
-		[]any{nextPayload(md.Iteration, spec.MaxIterations)},
-	)
-}
-
-func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, anchor *core.ExecutionContext) (*uuid.UUID, error) {
-	if anchor.ExecutionState.IsFinished() == false {
-		return nil, fmt.Errorf("loop session execution is still running")
-	}
-
-	md, err := readMetadata(anchor)
+	executionCtx, isNew, err := c.findOrCreateSession(ctx, spec)
 	if err != nil {
 		return nil, err
 	}
 
+	if executionCtx.ExecutionState.IsFinished() {
+		if err := ctx.DequeueItem(); err != nil {
+			return nil, fmt.Errorf("failed to dequeue item: %w", err)
+		}
+		return nil, nil
+	}
+
 	if err := ctx.DequeueItem(); err != nil {
 		return nil, fmt.Errorf("failed to dequeue item: %w", err)
 	}
 
 	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
 		return nil, fmt.Errorf("failed to update node state: %w", err)
+	}
+
+	if isNew {
+		md, err := readMetadata(executionCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		return &executionCtx.ID, executionCtx.ExecutionState.EmitAndContinue(
+			ChannelNameNext,
+			PayloadTypeNext,
+			[]any{nextPayload(md.Iteration, spec.MaxIterations)},
+		)
+	}
+
+	return c.handleFeedback(ctx, spec, executionCtx)
+}
+
+func (c *Loop) findOrCreateSession(ctx core.ProcessQueueContext, spec Spec) (*core.ExecutionContext, bool, error) {
+	executionCtx, err := ctx.FindExecutionByKV(loopSessionKey, ctx.RootEventID)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to find loop session: %w", err)
+	}
+
+	if executionCtx != nil {
+		return executionCtx, false, nil
+	}
+
+	executionCtx, err = ctx.CreateExecution()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create loop execution: %w", err)
+	}
+
+	if err := executionCtx.ExecutionState.SetKV(loopSessionKey, ctx.RootEventID); err != nil {
+		return nil, false, fmt.Errorf("failed to store loop session: %w", err)
+	}
+
+	md := ExecutionMetadata{
+		Iteration:     1,
+		MaxIterations: spec.MaxIterations,
+		Active:        true,
+		StartedAt:     time.Now(),
+	}
+	if err := executionCtx.Metadata.Set(md); err != nil {
+		return nil, false, fmt.Errorf("failed to set loop metadata: %w", err)
+	}
+
+	return executionCtx, true, nil
+}
+
+func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, anchor *core.ExecutionContext) (*uuid.UUID, error) {
+
+	md, err := readMetadata(anchor)
+	if err != nil {
+		return nil, err
 	}
 
 	if !md.Active {
@@ -342,51 +350,39 @@ func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, anchor *c
 		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
 	}
 
-	executionCtx, err := ctx.CreateExecution()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create loop iteration execution: %w", err)
-	}
-
-	return c.emitNextIteration(executionCtx, spec, md.Iteration)
+	return c.emitNextIteration(anchor, spec, md)
 }
 
-func (c *Loop) emitNextIteration(executionCtx *core.ExecutionContext, spec Spec, iteration int) (*uuid.UUID, error) {
-	delay := iterationDelay(spec.DelayBetweenIterations, iteration)
+func (c *Loop) emitNextIteration(anchor *core.ExecutionContext, spec Spec, md ExecutionMetadata) (*uuid.UUID, error) {
+	delay := iterationDelay(spec.DelayBetweenIterations, md.Iteration)
 	if delay <= 0 {
-		return &executionCtx.ID, executionCtx.ExecutionState.Emit(
+		return &anchor.ID, anchor.ExecutionState.EmitAndContinue(
 			ChannelNameNext,
 			PayloadTypeNext,
-			[]any{nextPayload(iteration, spec.MaxIterations)},
+			[]any{nextPayload(md.Iteration, spec.MaxIterations)},
 		)
 	}
 
-	iterMd := IterationExecutionMetadata{
-		Iteration:     iteration,
-		MaxIterations: spec.MaxIterations,
-	}
-	if err := executionCtx.Metadata.Set(iterMd); err != nil {
-		return nil, fmt.Errorf("failed to set iteration metadata: %w", err)
+	md.WaitingBetweenIterations = true
+	if err := anchor.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to set loop waiting metadata: %w", err)
 	}
 
-	if err := executionCtx.Requests.ScheduleActionCall(nextIterationHook, map[string]any{}, delay); err != nil {
+	if err := anchor.Requests.ScheduleActionCall(nextIterationHook, map[string]any{}, delay); err != nil {
 		return nil, fmt.Errorf("failed to schedule next iteration: %w", err)
 	}
 
-	return &executionCtx.ID, nil
+	return &anchor.ID, nil
 }
 
-func (c *Loop) completeLoop(ctx core.ProcessQueueContext, anchor *core.ExecutionContext, md ExecutionMetadata, stopReason string) (*uuid.UUID, error) {
+func (c *Loop) completeLoop(_ core.ProcessQueueContext, anchor *core.ExecutionContext, md ExecutionMetadata, stopReason string) (*uuid.UUID, error) {
 	md.Active = false
+	md.WaitingBetweenIterations = false
 	if err := anchor.Metadata.Set(md); err != nil {
 		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
 	}
 
-	executionCtx, err := ctx.CreateExecution()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create loop completion execution: %w", err)
-	}
-
-	return &executionCtx.ID, executionCtx.ExecutionState.Emit(
+	return &anchor.ID, anchor.ExecutionState.Emit(
 		ChannelNameDone,
 		PayloadTypeDone,
 		[]any{donePayload(md.Iteration, stopReason, loopElapsedMilliseconds(md))},
@@ -524,16 +520,34 @@ func (c *Loop) handleNextIteration(ctx core.ActionHookContext) error {
 		return nil
 	}
 
-	var iterMd IterationExecutionMetadata
-	if err := mapstructure.Decode(ctx.Metadata.Get(), &iterMd); err != nil {
-		return fmt.Errorf("failed to decode iteration metadata: %w", err)
+	md, err := readHookMetadata(ctx)
+	if err != nil {
+		return err
 	}
 
-	return ctx.ExecutionState.Emit(
+	md.WaitingBetweenIterations = false
+	if err := ctx.Metadata.Set(md); err != nil {
+		return fmt.Errorf("failed to update loop metadata: %w", err)
+	}
+
+	return ctx.ExecutionState.EmitAndContinue(
 		ChannelNameNext,
 		PayloadTypeNext,
-		[]any{nextPayload(iterMd.Iteration, iterMd.MaxIterations)},
+		[]any{nextPayload(md.Iteration, md.MaxIterations)},
 	)
+}
+
+func readHookMetadata(ctx core.ActionHookContext) (ExecutionMetadata, error) {
+	raw, err := json.Marshal(ctx.Metadata.Get())
+	if err != nil {
+		return ExecutionMetadata{}, fmt.Errorf("failed to marshal loop metadata: %w", err)
+	}
+
+	md := ExecutionMetadata{}
+	if err := json.Unmarshal(raw, &md); err != nil {
+		return ExecutionMetadata{}, fmt.Errorf("failed to decode loop metadata: %w", err)
+	}
+	return md, nil
 }
 
 func iterationDelay(delay *DelaySpec, iteration int) time.Duration {

--- a/pkg/components/loop/loop.go
+++ b/pkg/components/loop/loop.go
@@ -114,8 +114,8 @@ Edges back into Loop are allowed so downstream steps can return control for the 
 
 ## Output Channels
 
-- **Done**: Emitted once when the loop stops. The payload includes ` + "`iterations`" + `, ` + "`stopReason`" + ` (` + "`conditionTrue`" + ` or ` + "`max_iterations`" + `), and ` + "`elapsedMs`" + `
-- **Next**: Emitted at the start of each iteration
+- **Done**: Emitted once when the loop stops. Payload is under ` + "`data.done`" + ` with ` + "`iterations`" + `, ` + "`stopReason`" + ` (` + "`conditionTrue`" + ` or ` + "`max_iterations`" + `), and ` + "`elapsedMs`" + `
+- **Next**: Emitted at the start of each iteration. Payload is under ` + "`data.next`" + ` with ` + "`iteration`" + ` and ` + "`maxIterations`" + `
 
 ## Limits
 
@@ -435,16 +435,20 @@ func readMetadata(executionCtx *core.ExecutionContext) (ExecutionMetadata, error
 
 func nextPayload(iteration, maxIterations int) map[string]any {
 	return map[string]any{
-		"iteration":     iteration,
-		"maxIterations": maxIterations,
+		"next": map[string]any{
+			"iteration":     iteration,
+			"maxIterations": maxIterations,
+		},
 	}
 }
 
 func donePayload(iterations int, stopReason string, elapsedMs int64) map[string]any {
 	return map[string]any{
-		"iterations": iterations,
-		"stopReason": stopReason,
-		"elapsedMs":  elapsedMs,
+		"done": map[string]any{
+			"iterations": iterations,
+			"stopReason": stopReason,
+			"elapsedMs":  elapsedMs,
+		},
 	}
 }
 

--- a/pkg/components/loop/loop.go
+++ b/pkg/components/loop/loop.go
@@ -1,0 +1,560 @@
+package loop
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+const ComponentName = "loop"
+
+const (
+	loopSessionKey    = "loop_session"
+	nextIterationHook = "nextIteration"
+
+	ChannelNameNext = "next"
+	ChannelNameDone = "done"
+
+	PayloadTypeNext = "loop.next"
+	PayloadTypeDone = "loop.done"
+)
+
+const (
+	DelayStrategyFixed       = "fixed"
+	DelayStrategyExponential = "exponential"
+
+	DelayMinIntervalSeconds = 1
+	DelayMaxIntervalSeconds = 300
+)
+
+const defaultMaxIterations = 100
+
+const (
+	StopReasonConditionMet  = "conditionTrue"
+	StopReasonMaxIterations = "max_iterations"
+)
+
+func init() {
+	registry.RegisterAction(ComponentName, &Loop{})
+}
+
+type Loop struct{}
+
+type Spec struct {
+	UntilExpression        string     `json:"untilExpression"`
+	MaxIterations          int        `json:"maxIterations"`
+	DelayBetweenIterations *DelaySpec `json:"delayBetweenIterations,omitempty"`
+}
+
+type DelaySpec struct {
+	Enabled         bool   `json:"enabled" mapstructure:"enabled"`
+	Strategy        string `json:"strategy" mapstructure:"strategy"`
+	IntervalSeconds int    `json:"intervalSeconds" mapstructure:"intervalSeconds"`
+}
+
+type ExecutionMetadata struct {
+	Iteration int       `json:"iteration"`
+	Active    bool      `json:"active"`
+	StartedAt time.Time `json:"startedAt"`
+}
+
+type IterationExecutionMetadata struct {
+	Iteration     int `json:"iteration"`
+	MaxIterations int `json:"maxIterations"`
+}
+
+func (c *Loop) Name() string {
+	return ComponentName
+}
+
+func (c *Loop) Label() string {
+	return "Loop"
+}
+
+func (c *Loop) Description() string {
+	return "Repeat downstream steps until a condition is met"
+}
+
+func (c *Loop) Documentation() string {
+	return `The Loop component runs downstream steps repeatedly until an exit condition becomes true.
+
+## Use Cases
+
+- Poll an API until a resource reaches a ready state
+- Retry a workflow segment until validation passes
+- Paginate through results until all pages are processed
+- Run approval or review cycles until consensus is reached
+
+## How It Works
+
+1. On the first run, Loop emits to the **Next** channel and starts the loop session
+2. Connect downstream nodes to the Next output and wire the last step back to Loop
+3. When those steps finish, Loop evaluates the **Until Expression**
+4. If the expression is ` + "`true`" + `, Loop emits on **Done** and the loop ends
+5. If the expression is ` + "`false`" + `, Loop emits on **Next** again for another iteration
+
+## Wiring
+
+` + "```" + `
+Trigger → Loop → Step A → Step B ──┐
+              ↑                    │
+              └────────────────────┘
+` + "```" + `
+
+Edges back into Loop are allowed so downstream steps can return control for the next condition check.
+
+## Output Channels
+
+- **Done**: Emitted once when the loop stops. The payload includes ` + "`iterations`" + `, ` + "`stopReason`" + ` (` + "`conditionTrue`" + ` or ` + "`max_iterations`" + `), and ` + "`elapsedMs`" + `
+- **Next**: Emitted at the start of each iteration
+
+## Limits
+
+- **Max Iterations** caps how many iterations are allowed (default ` + fmt.Sprintf("%d", defaultMaxIterations) + `, maximum ` + fmt.Sprintf("%d", core.MaxEmitCount) + `)
+
+## Delay Between Iterations
+
+Optionally wait before starting the next iteration. Uses the same fixed or exponential backoff strategies as the HTTP component retry settings. The first iteration always starts immediately; delays apply between subsequent iterations only.
+
+## Expression Environment
+
+The until expression has access to:
+
+- **$**: The run context data, including outputs from the latest iteration
+- **root()**: Access root event data
+- **previous()**: Access previous node outputs`
+}
+
+func (c *Loop) Icon() string {
+	return "refresh-cw"
+}
+
+func (c *Loop) Color() string {
+	return "indigo"
+}
+
+func (c *Loop) ExampleOutput() map[string]any {
+	return exampleOutput()
+}
+
+func (c *Loop) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{Name: ChannelNameDone, Label: "Done"},
+		{Name: ChannelNameNext, Label: "Next"},
+	}
+}
+
+func (c *Loop) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "untilExpression",
+			Label:       "Until Expression",
+			Type:        configuration.FieldTypeExpression,
+			Description: "Boolean expression that must evaluate to true to stop looping",
+			Required:    true,
+		},
+		{
+			Name:        "maxIterations",
+			Label:       "Max Iterations",
+			Type:        configuration.FieldTypeNumber,
+			Description: "Maximum number of iterations before the loop stops",
+			Default:     defaultMaxIterations,
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: intPtr(1),
+					Max: intPtr(core.MaxEmitCount),
+				},
+			},
+		},
+		{
+			Name:        "delayBetweenIterations",
+			Type:        configuration.FieldTypeObject,
+			Label:       "Delay between iterations",
+			Required:    false,
+			Description: "Wait before starting the next iteration",
+			TypeOptions: &configuration.TypeOptions{
+				Object: &configuration.ObjectTypeOptions{
+					Schema: []configuration.Field{
+						{
+							Name:        "enabled",
+							Label:       "Enable delay",
+							Type:        configuration.FieldTypeBool,
+							Required:    false,
+							Default:     false,
+							Description: "Wait between loop iterations before emitting on Next again.",
+						},
+						{
+							Name:        "strategy",
+							Type:        configuration.FieldTypeSelect,
+							Label:       "Strategy",
+							Required:    false,
+							Default:     DelayStrategyFixed,
+							Description: "Delay strategy",
+							TypeOptions: &configuration.TypeOptions{
+								Select: &configuration.SelectTypeOptions{
+									Options: []configuration.FieldOption{
+										{Label: "Fixed", Value: DelayStrategyFixed},
+										{Label: "Exponential", Value: DelayStrategyExponential},
+									},
+								},
+							},
+							VisibilityConditions: []configuration.VisibilityCondition{
+								{Field: "enabled", Values: []string{"true"}},
+							},
+						},
+						{
+							Name:        "intervalSeconds",
+							Label:       "Delay interval (seconds)",
+							Type:        configuration.FieldTypeNumber,
+							Required:    false,
+							Default:     15,
+							Description: "Seconds to wait before the next iteration",
+							TypeOptions: &configuration.TypeOptions{
+								Number: &configuration.NumberTypeOptions{
+									Min: intPtr(DelayMinIntervalSeconds),
+									Max: intPtr(DelayMaxIntervalSeconds),
+								},
+							},
+							VisibilityConditions: []configuration.VisibilityCondition{
+								{Field: "enabled", Values: []string{"true"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *Loop) Setup(ctx core.SetupContext) error {
+	spec, err := decodeSpec(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+	return validateSpec(spec)
+}
+
+func (c *Loop) Execute(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *Loop) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	spec, err := decodeSpec(ctx.Configuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if err := validateSpec(spec); err != nil {
+		return nil, err
+	}
+
+	anchor, err := ctx.FindExecutionByKV(loopSessionKey, ctx.RootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find loop session: %w", err)
+	}
+
+	if anchor == nil {
+		return c.startLoop(ctx, spec)
+	}
+
+	return c.handleFeedback(ctx, spec, anchor)
+}
+
+func (c *Loop) startLoop(ctx core.ProcessQueueContext, spec Spec) (*uuid.UUID, error) {
+	executionCtx, err := ctx.CreateExecution()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create loop execution: %w", err)
+	}
+
+	if err := executionCtx.ExecutionState.SetKV(loopSessionKey, ctx.RootEventID); err != nil {
+		return nil, fmt.Errorf("failed to store loop session: %w", err)
+	}
+
+	md := ExecutionMetadata{
+		Iteration: 1,
+		Active:    true,
+		StartedAt: time.Now(),
+	}
+	if err := executionCtx.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to set loop metadata: %w", err)
+	}
+
+	if err := ctx.DequeueItem(); err != nil {
+		return nil, fmt.Errorf("failed to dequeue item: %w", err)
+	}
+
+	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
+		return nil, fmt.Errorf("failed to update node state: %w", err)
+	}
+
+	return &executionCtx.ID, executionCtx.ExecutionState.Emit(
+		ChannelNameNext,
+		PayloadTypeNext,
+		[]any{nextPayload(md.Iteration, spec.MaxIterations)},
+	)
+}
+
+func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, anchor *core.ExecutionContext) (*uuid.UUID, error) {
+	if anchor.ExecutionState.IsFinished() == false {
+		return nil, fmt.Errorf("loop session execution is still running")
+	}
+
+	md, err := readMetadata(anchor)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ctx.DequeueItem(); err != nil {
+		return nil, fmt.Errorf("failed to dequeue item: %w", err)
+	}
+
+	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
+		return nil, fmt.Errorf("failed to update node state: %w", err)
+	}
+
+	if !md.Active {
+		return nil, nil
+	}
+
+	done, err := evaluateUntil(spec.UntilExpression, ctx.Expressions)
+	if err != nil {
+		return c.failLoop(anchor, md, err.Error())
+	}
+
+	if done {
+		return c.completeLoop(ctx, anchor, md, StopReasonConditionMet)
+	}
+
+	if md.Iteration >= spec.MaxIterations {
+		return c.completeLoop(ctx, anchor, md, StopReasonMaxIterations)
+	}
+
+	md.Iteration++
+	if err := anchor.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
+	}
+
+	executionCtx, err := ctx.CreateExecution()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create loop iteration execution: %w", err)
+	}
+
+	return c.emitNextIteration(executionCtx, spec, md.Iteration)
+}
+
+func (c *Loop) emitNextIteration(executionCtx *core.ExecutionContext, spec Spec, iteration int) (*uuid.UUID, error) {
+	delay := iterationDelay(spec.DelayBetweenIterations, iteration)
+	if delay <= 0 {
+		return &executionCtx.ID, executionCtx.ExecutionState.Emit(
+			ChannelNameNext,
+			PayloadTypeNext,
+			[]any{nextPayload(iteration, spec.MaxIterations)},
+		)
+	}
+
+	iterMd := IterationExecutionMetadata{
+		Iteration:     iteration,
+		MaxIterations: spec.MaxIterations,
+	}
+	if err := executionCtx.Metadata.Set(iterMd); err != nil {
+		return nil, fmt.Errorf("failed to set iteration metadata: %w", err)
+	}
+
+	if err := executionCtx.Requests.ScheduleActionCall(nextIterationHook, map[string]any{}, delay); err != nil {
+		return nil, fmt.Errorf("failed to schedule next iteration: %w", err)
+	}
+
+	return &executionCtx.ID, nil
+}
+
+func (c *Loop) completeLoop(ctx core.ProcessQueueContext, anchor *core.ExecutionContext, md ExecutionMetadata, stopReason string) (*uuid.UUID, error) {
+	md.Active = false
+	if err := anchor.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
+	}
+
+	executionCtx, err := ctx.CreateExecution()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create loop completion execution: %w", err)
+	}
+
+	return &executionCtx.ID, executionCtx.ExecutionState.Emit(
+		ChannelNameDone,
+		PayloadTypeDone,
+		[]any{donePayload(md.Iteration, stopReason, loopElapsedMilliseconds(md))},
+	)
+}
+
+func (c *Loop) failLoop(anchor *core.ExecutionContext, md ExecutionMetadata, message string) (*uuid.UUID, error) {
+	md.Active = false
+	if err := anchor.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
+	}
+
+	if err := anchor.ExecutionState.Fail("error", message); err != nil {
+		return nil, err
+	}
+
+	return &anchor.ID, nil
+}
+
+func evaluateUntil(expression string, expressions core.ExpressionContext) (bool, error) {
+	output, err := expressions.Run(expression)
+	if err != nil {
+		return false, fmt.Errorf("until expression evaluation failed: %w", err)
+	}
+
+	done, ok := output.(bool)
+	if !ok {
+		return false, fmt.Errorf("until expression must evaluate to boolean, got %T: %v", output, output)
+	}
+
+	return done, nil
+}
+
+func readMetadata(executionCtx *core.ExecutionContext) (ExecutionMetadata, error) {
+	md := ExecutionMetadata{}
+	if err := mapstructure.Decode(executionCtx.Metadata.Get(), &md); err != nil {
+		return ExecutionMetadata{}, fmt.Errorf("failed to decode loop metadata: %w", err)
+	}
+	return md, nil
+}
+
+func nextPayload(iteration, maxIterations int) map[string]any {
+	return map[string]any{
+		"iteration":     iteration,
+		"maxIterations": maxIterations,
+	}
+}
+
+func donePayload(iterations int, stopReason string, elapsedMs int64) map[string]any {
+	return map[string]any{
+		"iterations": iterations,
+		"stopReason": stopReason,
+		"elapsedMs":  elapsedMs,
+	}
+}
+
+func loopElapsedMilliseconds(md ExecutionMetadata) int64 {
+	if md.StartedAt.IsZero() {
+		return 0
+	}
+
+	return time.Since(md.StartedAt).Milliseconds()
+}
+
+func decodeSpec(raw any) (Spec, error) {
+	var spec Spec
+	if err := mapstructure.Decode(raw, &spec); err != nil {
+		return Spec{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+	if spec.MaxIterations == 0 {
+		spec.MaxIterations = defaultMaxIterations
+	}
+	return spec, nil
+}
+
+func validateSpec(spec Spec) error {
+	if spec.UntilExpression == "" {
+		return fmt.Errorf("untilExpression is required")
+	}
+	if spec.MaxIterations < 1 {
+		return fmt.Errorf("maxIterations must be at least 1")
+	}
+	if spec.MaxIterations > core.MaxEmitCount {
+		return fmt.Errorf("maxIterations cannot exceed %d", core.MaxEmitCount)
+	}
+
+	return validateDelaySpec(spec.DelayBetweenIterations)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func (c *Loop) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *Loop) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *Loop) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *Loop) Hooks() []core.Hook {
+	return []core.Hook{
+		{
+			Name: nextIterationHook,
+			Type: core.HookTypeInternal,
+		},
+	}
+}
+
+func (c *Loop) HandleHook(ctx core.ActionHookContext) error {
+	switch ctx.Name {
+	case nextIterationHook:
+		return c.handleNextIteration(ctx)
+	default:
+		return fmt.Errorf("unknown hook: %s", ctx.Name)
+	}
+}
+
+func (c *Loop) handleNextIteration(ctx core.ActionHookContext) error {
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	var iterMd IterationExecutionMetadata
+	if err := mapstructure.Decode(ctx.Metadata.Get(), &iterMd); err != nil {
+		return fmt.Errorf("failed to decode iteration metadata: %w", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		ChannelNameNext,
+		PayloadTypeNext,
+		[]any{nextPayload(iterMd.Iteration, iterMd.MaxIterations)},
+	)
+}
+
+func iterationDelay(delay *DelaySpec, iteration int) time.Duration {
+	if delay == nil || !delay.Enabled || iteration < 2 {
+		return 0
+	}
+
+	switch delay.Strategy {
+	case DelayStrategyExponential:
+		return time.Duration(delay.IntervalSeconds) * time.Second * time.Duration(math.Pow(2, float64(iteration-2)))
+	default:
+		return time.Duration(delay.IntervalSeconds) * time.Second
+	}
+}
+
+func validateDelaySpec(delay *DelaySpec) error {
+	if delay == nil || !delay.Enabled {
+		return nil
+	}
+
+	if delay.Strategy != DelayStrategyFixed && delay.Strategy != DelayStrategyExponential {
+		return fmt.Errorf("invalid delay strategy: %s", delay.Strategy)
+	}
+
+	if delay.IntervalSeconds < DelayMinIntervalSeconds {
+		return fmt.Errorf("delay interval seconds must be greater than or equal to %d", DelayMinIntervalSeconds)
+	}
+
+	if delay.IntervalSeconds > DelayMaxIntervalSeconds {
+		return fmt.Errorf("delay interval seconds must be less than or equal to %d", DelayMaxIntervalSeconds)
+	}
+
+	return nil
+}

--- a/pkg/components/loop/loop.go
+++ b/pkg/components/loop/loop.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -420,8 +421,13 @@ func evaluateUntil(expression string, expressions core.ExpressionContext) (bool,
 }
 
 func readMetadata(executionCtx *core.ExecutionContext) (ExecutionMetadata, error) {
+	raw, err := json.Marshal(executionCtx.Metadata.Get())
+	if err != nil {
+		return ExecutionMetadata{}, fmt.Errorf("failed to marshal loop metadata: %w", err)
+	}
+
 	md := ExecutionMetadata{}
-	if err := mapstructure.Decode(executionCtx.Metadata.Get(), &md); err != nil {
+	if err := json.Unmarshal(raw, &md); err != nil {
 		return ExecutionMetadata{}, fmt.Errorf("failed to decode loop metadata: %w", err)
 	}
 	return md, nil

--- a/pkg/components/loop/loop.go
+++ b/pkg/components/loop/loop.go
@@ -20,6 +20,7 @@ const ComponentName = "loop"
 const (
 	loopSessionKey    = "loop_session"
 	nextIterationHook = "nextIteration"
+	timeoutHook       = "timeout"
 
 	ChannelNameNext = "next"
 	ChannelNameDone = "done"
@@ -39,6 +40,16 @@ const (
 const defaultMaxIterations = 100
 
 const (
+	// DefaultTimeoutSeconds caps the total wall-clock time of a single loop run
+	// when one is not configured. It exists so a loop can never get stuck
+	// forever (e.g. downstream never reports back), which would also block every
+	// subsequent run on the node since runs are serialized.
+	DefaultTimeoutSeconds = 3600
+	TimeoutMinSeconds     = 1
+	TimeoutMaxSeconds     = 86400
+)
+
+const (
 	StopReasonConditionMet  = "conditionTrue"
 	StopReasonMaxIterations = "max_iterations"
 )
@@ -52,6 +63,7 @@ type Loop struct{}
 type Spec struct {
 	UntilExpression        string     `json:"untilExpression"`
 	MaxIterations          int        `json:"maxIterations"`
+	TimeoutSeconds         int        `json:"timeoutSeconds" mapstructure:"timeoutSeconds"`
 	DelayBetweenIterations *DelaySpec `json:"delayBetweenIterations,omitempty"`
 }
 
@@ -117,6 +129,7 @@ Edges back into Loop are allowed so downstream steps can return control for the 
 ## Limits
 
 - **Max Iterations** caps how many iterations are allowed (default ` + fmt.Sprintf("%d", defaultMaxIterations) + `, maximum ` + fmt.Sprintf("%d", core.MaxEmitCount) + `)
+- **Timeout** caps the total wall-clock time of a single run (default ` + fmt.Sprintf("%d", DefaultTimeoutSeconds) + `s, maximum ` + fmt.Sprintf("%d", TimeoutMaxSeconds) + `s). If the loop is still running when the timeout elapses, the run fails. This prevents a stuck run (e.g. downstream never reports back) from blocking subsequent runs on the node.
 
 ## Delay Between Iterations
 
@@ -169,6 +182,20 @@ func (c *Loop) Configuration() []configuration.Field {
 				Number: &configuration.NumberTypeOptions{
 					Min: intPtr(1),
 					Max: intPtr(core.MaxEmitCount),
+				},
+			},
+		},
+		{
+			Name:        "timeoutSeconds",
+			Label:       "Timeout (seconds)",
+			Type:        configuration.FieldTypeNumber,
+			Required:    true,
+			Default:     DefaultTimeoutSeconds,
+			Description: "Maximum total wall-clock time for a single loop run. The run fails if it is still looping after this many seconds.",
+			TypeOptions: &configuration.TypeOptions{
+				Number: &configuration.NumberTypeOptions{
+					Min: intPtr(TimeoutMinSeconds),
+					Max: intPtr(TimeoutMaxSeconds),
 				},
 			},
 		},
@@ -253,59 +280,43 @@ func (c *Loop) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error
 		return nil, err
 	}
 
-	executionCtx, isNew, err := c.findOrCreateSession(ctx, spec)
+	session, err := ctx.FindExecutionByKV(loopSessionKey, ctx.RootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find loop session: %w", err)
+	}
+
+	if session == nil {
+		return c.startLoop(ctx, spec)
+	}
+
+	return c.handleFeedback(ctx, spec, session)
+}
+
+func (c *Loop) startLoop(ctx core.ProcessQueueContext, spec Spec) (*uuid.UUID, error) {
+	//
+	// Only one loop run per node may be active at a time. If another run is
+	// still looping, push this start to the back of the queue and try later.
+	//
+	active, err := c.hasActiveSession(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	if executionCtx.ExecutionState.IsFinished() {
-		if err := ctx.DequeueItem(); err != nil {
-			return nil, fmt.Errorf("failed to dequeue item: %w", err)
+	if active {
+		if ctx.DeferQueueItem != nil {
+			if err := ctx.DeferQueueItem(); err != nil {
+				return nil, fmt.Errorf("failed to defer queue item: %w", err)
+			}
 		}
-		return nil, nil
+		return nil, core.ErrQueueItemDeferred
 	}
 
-	if err := ctx.DequeueItem(); err != nil {
-		return nil, fmt.Errorf("failed to dequeue item: %w", err)
-	}
-
-	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
-		return nil, fmt.Errorf("failed to update node state: %w", err)
-	}
-
-	if isNew {
-		md, err := readMetadata(executionCtx)
-		if err != nil {
-			return nil, err
-		}
-
-		return &executionCtx.ID, executionCtx.ExecutionState.EmitAndContinue(
-			ChannelNameNext,
-			PayloadTypeNext,
-			[]any{nextPayload(md.Iteration, spec.MaxIterations)},
-		)
-	}
-
-	return c.handleFeedback(ctx, spec, executionCtx)
-}
-
-func (c *Loop) findOrCreateSession(ctx core.ProcessQueueContext, spec Spec) (*core.ExecutionContext, bool, error) {
-	executionCtx, err := ctx.FindExecutionByKV(loopSessionKey, ctx.RootEventID)
+	session, err := ctx.CreateExecution()
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to find loop session: %w", err)
+		return nil, fmt.Errorf("failed to create loop execution: %w", err)
 	}
 
-	if executionCtx != nil {
-		return executionCtx, false, nil
-	}
-
-	executionCtx, err = ctx.CreateExecution()
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to create loop execution: %w", err)
-	}
-
-	if err := executionCtx.ExecutionState.SetKV(loopSessionKey, ctx.RootEventID); err != nil {
-		return nil, false, fmt.Errorf("failed to store loop session: %w", err)
+	if err := session.ExecutionState.SetKV(loopSessionKey, ctx.RootEventID); err != nil {
+		return nil, fmt.Errorf("failed to store loop session: %w", err)
 	}
 
 	md := ExecutionMetadata{
@@ -314,43 +325,92 @@ func (c *Loop) findOrCreateSession(ctx core.ProcessQueueContext, spec Spec) (*co
 		Active:        true,
 		StartedAt:     time.Now(),
 	}
-	if err := executionCtx.Metadata.Set(md); err != nil {
-		return nil, false, fmt.Errorf("failed to set loop metadata: %w", err)
+	if err := session.Metadata.Set(md); err != nil {
+		return nil, fmt.Errorf("failed to set loop metadata: %w", err)
 	}
 
-	return executionCtx, true, nil
+	//
+	// Arm a single timeout for the whole run. If the loop is still active when it
+	// fires, the run has run too long and is failed (see handleTimeout). This
+	// guarantees the session always terminates, so it can never block later runs.
+	//
+	if err := session.Requests.ScheduleActionCall(timeoutHook, map[string]any{}, time.Duration(spec.TimeoutSeconds)*time.Second); err != nil {
+		return nil, fmt.Errorf("failed to schedule loop timeout: %w", err)
+	}
+
+	if err := c.dequeueAndReady(ctx); err != nil {
+		return nil, err
+	}
+
+	return &session.ID, session.ExecutionState.EmitAndContinue(
+		ChannelNameNext,
+		PayloadTypeNext,
+		[]any{nextPayload(md.Iteration, spec.MaxIterations)},
+	)
 }
 
-func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, anchor *core.ExecutionContext) (*uuid.UUID, error) {
+// hasActiveSession reports whether this node already has a loop run in progress.
+// A session execution stays unfinished for the whole loop and only finishes on
+// done/fail, so an active run is simply a running execution on the node.
+func (c *Loop) hasActiveSession(ctx core.ProcessQueueContext) (bool, error) {
+	if ctx.HasRunningExecutions == nil {
+		return false, nil
+	}
 
-	md, err := readMetadata(anchor)
+	active, err := ctx.HasRunningExecutions()
+	if err != nil {
+		return false, fmt.Errorf("failed to check for active loop session: %w", err)
+	}
+
+	return active, nil
+}
+
+func (c *Loop) handleFeedback(ctx core.ProcessQueueContext, spec Spec, session *core.ExecutionContext) (*uuid.UUID, error) {
+	if err := c.dequeueAndReady(ctx); err != nil {
+		return nil, err
+	}
+
+	//
+	// The loop already finished (done/failed). Ignore late feedback.
+	//
+	if session.ExecutionState.IsFinished() {
+		return nil, nil
+	}
+
+	md, err := readMetadata(session)
 	if err != nil {
 		return nil, err
 	}
 
-	if !md.Active {
-		return nil, nil
-	}
-
 	done, err := evaluateUntil(spec.UntilExpression, ctx.Expressions)
 	if err != nil {
-		return c.failLoop(anchor, md, err.Error())
+		return c.failLoop(session, md, err.Error())
 	}
 
 	if done {
-		return c.completeLoop(ctx, anchor, md, StopReasonConditionMet)
+		return c.completeLoop(session, md, StopReasonConditionMet)
 	}
 
 	if md.Iteration >= spec.MaxIterations {
-		return c.completeLoop(ctx, anchor, md, StopReasonMaxIterations)
+		return c.completeLoop(session, md, StopReasonMaxIterations)
 	}
 
 	md.Iteration++
-	if err := anchor.Metadata.Set(md); err != nil {
+	if err := session.Metadata.Set(md); err != nil {
 		return nil, fmt.Errorf("failed to update loop metadata: %w", err)
 	}
 
-	return c.emitNextIteration(anchor, spec, md)
+	return c.emitNextIteration(session, spec, md)
+}
+
+func (c *Loop) dequeueAndReady(ctx core.ProcessQueueContext) error {
+	if err := ctx.DequeueItem(); err != nil {
+		return fmt.Errorf("failed to dequeue item: %w", err)
+	}
+	if err := ctx.UpdateNodeState(models.CanvasNodeStateReady); err != nil {
+		return fmt.Errorf("failed to update node state: %w", err)
+	}
+	return nil
 }
 
 func (c *Loop) emitNextIteration(anchor *core.ExecutionContext, spec Spec, md ExecutionMetadata) (*uuid.UUID, error) {
@@ -375,7 +435,7 @@ func (c *Loop) emitNextIteration(anchor *core.ExecutionContext, spec Spec, md Ex
 	return &anchor.ID, nil
 }
 
-func (c *Loop) completeLoop(_ core.ProcessQueueContext, anchor *core.ExecutionContext, md ExecutionMetadata, stopReason string) (*uuid.UUID, error) {
+func (c *Loop) completeLoop(anchor *core.ExecutionContext, md ExecutionMetadata, stopReason string) (*uuid.UUID, error) {
 	md.Active = false
 	md.WaitingBetweenIterations = false
 	if err := anchor.Metadata.Set(md); err != nil {
@@ -464,6 +524,9 @@ func decodeSpec(raw any) (Spec, error) {
 	if spec.MaxIterations == 0 {
 		spec.MaxIterations = defaultMaxIterations
 	}
+	if spec.TimeoutSeconds == 0 {
+		spec.TimeoutSeconds = DefaultTimeoutSeconds
+	}
 	return spec, nil
 }
 
@@ -476,6 +539,12 @@ func validateSpec(spec Spec) error {
 	}
 	if spec.MaxIterations > core.MaxEmitCount {
 		return fmt.Errorf("maxIterations cannot exceed %d", core.MaxEmitCount)
+	}
+	if spec.TimeoutSeconds < TimeoutMinSeconds {
+		return fmt.Errorf("timeoutSeconds must be at least %d", TimeoutMinSeconds)
+	}
+	if spec.TimeoutSeconds > TimeoutMaxSeconds {
+		return fmt.Errorf("timeoutSeconds cannot exceed %d", TimeoutMaxSeconds)
 	}
 
 	return validateDelaySpec(spec.DelayBetweenIterations)
@@ -503,6 +572,10 @@ func (c *Loop) Hooks() []core.Hook {
 			Name: nextIterationHook,
 			Type: core.HookTypeInternal,
 		},
+		{
+			Name: timeoutHook,
+			Type: core.HookTypeInternal,
+		},
 	}
 }
 
@@ -510,9 +583,41 @@ func (c *Loop) HandleHook(ctx core.ActionHookContext) error {
 	switch ctx.Name {
 	case nextIterationHook:
 		return c.handleNextIteration(ctx)
+	case timeoutHook:
+		return c.handleTimeout(ctx)
 	default:
 		return fmt.Errorf("unknown hook: %s", ctx.Name)
 	}
+}
+
+func (c *Loop) handleTimeout(ctx core.ActionHookContext) error {
+	//
+	// The loop already finished (done/failed) before the timeout fired.
+	//
+	if ctx.ExecutionState.IsFinished() {
+		return nil
+	}
+
+	spec, err := decodeSpec(ctx.Configuration)
+	if err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	md, err := readHookMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
+	md.Active = false
+	md.WaitingBetweenIterations = false
+	if err := ctx.Metadata.Set(md); err != nil {
+		return fmt.Errorf("failed to update loop metadata: %w", err)
+	}
+
+	return ctx.ExecutionState.Fail("timeout", fmt.Sprintf(
+		"loop exceeded maximum processing time of %ds after %d iteration(s)",
+		spec.TimeoutSeconds, md.Iteration,
+	))
 }
 
 func (c *Loop) handleNextIteration(ctx core.ActionHookContext) error {

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -176,7 +176,7 @@ func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 	assert.Equal(t, ChannelNameDone, iterationExecState.Channel)
 	assert.Equal(t, PayloadTypeDone, iterationExecState.Type)
 
-	donePayload := iterationExecState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	donePayload := iterationExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
 	assert.Equal(t, 2, donePayload["iterations"])
 	assert.Equal(t, StopReasonConditionMet, donePayload["stopReason"])
 	elapsedMs, ok := donePayload["elapsedMs"].(int64)
@@ -302,7 +302,7 @@ func TestLoopHandleNextIterationHook(t *testing.T) {
 	assert.Equal(t, ChannelNameNext, execState.Channel)
 	assert.Equal(t, PayloadTypeNext, execState.Type)
 
-	payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)["next"].(map[string]any)
 	assert.Equal(t, 3, payload["iteration"])
 	assert.Equal(t, 10, payload["maxIterations"])
 }
@@ -368,7 +368,7 @@ func TestLoopHandleFeedbackCompletesAtMaxIterations(t *testing.T) {
 	assert.Equal(t, doneExecutionID, *id)
 	assert.Equal(t, ChannelNameDone, doneExecState.Channel)
 
-	payload := doneExecState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	payload := doneExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
 	assert.Equal(t, 3, payload["iterations"])
 	assert.Equal(t, StopReasonMaxIterations, payload["stopReason"])
 	elapsedMs, ok := payload["elapsedMs"].(int64)
@@ -419,14 +419,14 @@ func TestLoopExampleOutput(t *testing.T) {
 
 	next, ok := output["next"].(map[string]any)
 	require.True(t, ok)
-	nextData, ok := next["data"].(map[string]any)
+	nextData, ok := next["data"].(map[string]any)["next"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, PayloadTypeNext, next["type"])
 	assert.Equal(t, 1, nextData["iteration"])
 
 	done, ok := output["done"].(map[string]any)
 	require.True(t, ok)
-	doneData, ok := done["data"].(map[string]any)
+	doneData, ok := done["data"].(map[string]any)["done"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, PayloadTypeDone, done["type"])
 	assert.Equal(t, 3, doneData["iterations"])

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -1,0 +1,411 @@
+package loop
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func TestLoopSetup(t *testing.T) {
+	component := &Loop{}
+
+	t.Run("requires until expression", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{Configuration: map[string]any{}})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "untilExpression is required")
+	})
+
+	t.Run("accepts valid configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"maxIterations":   10,
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts delay between iterations configuration", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"delayBetweenIterations": map[string]any{
+					"enabled":         true,
+					"strategy":        DelayStrategyExponential,
+					"intervalSeconds": 10,
+				},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("accepts one second delay interval", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"delayBetweenIterations": map[string]any{
+					"enabled":         true,
+					"strategy":        DelayStrategyFixed,
+					"intervalSeconds": 1,
+				},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects invalid delay strategy", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"delayBetweenIterations": map[string]any{
+					"enabled":         true,
+					"strategy":        "random",
+					"intervalSeconds": 10,
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid delay strategy")
+	})
+}
+
+func TestLoopStartLoop(t *testing.T) {
+	component := &Loop{}
+	execState := &contexts.ExecutionStateContext{}
+	execMetadata := &contexts.MetadataContext{}
+	rootEventID := uuid.New().String()
+	executionID := uuid.New()
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: rootEventID,
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return nil, nil
+		},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			return &core.ExecutionContext{
+				ID:             executionID,
+				Metadata:       execMetadata,
+				ExecutionState: execState,
+			}, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, executionID, *id)
+	assert.Equal(t, rootEventID, execState.KVs[loopSessionKey])
+	md, ok := execMetadata.Metadata.(ExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, 1, md.Iteration)
+	assert.True(t, md.Active)
+	assert.True(t, execState.Passed)
+	assert.Equal(t, ChannelNameNext, execState.Channel)
+}
+
+func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
+	component := &Loop{}
+	anchorMetadata := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{
+			Iteration: 2,
+			Active:    true,
+			StartedAt: time.Now().Add(-2 * time.Second),
+		},
+	}
+	iterationExecState := &contexts.ExecutionStateContext{}
+	iterationID := uuid.New()
+	anchorID := uuid.New()
+
+	anchor := &core.ExecutionContext{
+		ID:             anchorID,
+		Metadata:       anchorMetadata,
+		ExecutionState: &finishedExecutionState{},
+	}
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return anchor, nil
+		},
+		Expressions: &contexts.ExpressionContext{Output: true},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			return &core.ExecutionContext{
+				ID:             iterationID,
+				ExecutionState: iterationExecState,
+			}, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, iterationID, *id)
+	assert.Equal(t, ChannelNameDone, iterationExecState.Channel)
+	assert.Equal(t, PayloadTypeDone, iterationExecState.Type)
+
+	donePayload := iterationExecState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	assert.Equal(t, 2, donePayload["iterations"])
+	assert.Equal(t, StopReasonConditionMet, donePayload["stopReason"])
+	elapsedMs, ok := donePayload["elapsedMs"].(int64)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, elapsedMs, int64(2000))
+	md, ok := anchorMetadata.Metadata.(ExecutionMetadata)
+	require.True(t, ok)
+	assert.False(t, md.Active)
+}
+
+func TestLoopHandleFeedbackRepeatsNextWhenUntilIsFalse(t *testing.T) {
+	component := &Loop{}
+	anchorMetadata := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{Iteration: 1, Active: true},
+	}
+	iterationExecState := &contexts.ExecutionStateContext{}
+	iterationID := uuid.New()
+
+	anchor := &core.ExecutionContext{
+		ID:             uuid.New(),
+		Metadata:       anchorMetadata,
+		ExecutionState: &finishedExecutionState{},
+	}
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+			"maxIterations":   5,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return anchor, nil
+		},
+		Expressions: &contexts.ExpressionContext{Output: false},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			return &core.ExecutionContext{
+				ID:             iterationID,
+				ExecutionState: iterationExecState,
+			}, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, ChannelNameNext, iterationExecState.Channel)
+	md, ok := anchorMetadata.Metadata.(ExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, 2, md.Iteration)
+}
+
+func TestLoopHandleFeedbackSchedulesDelayBeforeNextIteration(t *testing.T) {
+	component := &Loop{}
+	anchorMetadata := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{Iteration: 1, Active: true},
+	}
+	iterationMetadata := &contexts.MetadataContext{}
+	scheduled := &scheduledRequestContext{}
+	iterationID := uuid.New()
+
+	anchor := &core.ExecutionContext{
+		ID:             uuid.New(),
+		Metadata:       anchorMetadata,
+		ExecutionState: &finishedExecutionState{},
+	}
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+			"maxIterations":   5,
+			"delayBetweenIterations": map[string]any{
+				"enabled":         true,
+				"strategy":        DelayStrategyFixed,
+				"intervalSeconds": 15,
+			},
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return anchor, nil
+		},
+		Expressions: &contexts.ExpressionContext{Output: false},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			return &core.ExecutionContext{
+				ID:       iterationID,
+				Metadata: iterationMetadata,
+				Requests: scheduled,
+			}, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.True(t, scheduled.called)
+	assert.Equal(t, nextIterationHook, scheduled.actionName)
+	assert.Equal(t, 15*time.Second, scheduled.interval)
+
+	iterMd, ok := iterationMetadata.Metadata.(IterationExecutionMetadata)
+	require.True(t, ok)
+	assert.Equal(t, 2, iterMd.Iteration)
+	assert.Equal(t, 5, iterMd.MaxIterations)
+}
+
+func TestLoopHandleNextIterationHook(t *testing.T) {
+	component := &Loop{}
+	execState := &contexts.ExecutionStateContext{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: nextIterationHook,
+		Metadata: &contexts.MetadataContext{
+			Metadata: IterationExecutionMetadata{
+				Iteration:     3,
+				MaxIterations: 10,
+			},
+		},
+		ExecutionState: execState,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ChannelNameNext, execState.Channel)
+	assert.Equal(t, PayloadTypeNext, execState.Type)
+
+	payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	assert.Equal(t, 3, payload["iteration"])
+	assert.Equal(t, 10, payload["maxIterations"])
+}
+
+func TestIterationDelay(t *testing.T) {
+	delay := &DelaySpec{
+		Enabled:         true,
+		Strategy:        DelayStrategyFixed,
+		IntervalSeconds: 15,
+	}
+
+	assert.Equal(t, time.Duration(0), iterationDelay(delay, 1))
+	assert.Equal(t, 15*time.Second, iterationDelay(delay, 2))
+	assert.Equal(t, 15*time.Second, iterationDelay(delay, 4))
+
+	delay.Strategy = DelayStrategyExponential
+	assert.Equal(t, 15*time.Second, iterationDelay(delay, 2))
+	assert.Equal(t, 30*time.Second, iterationDelay(delay, 3))
+	assert.Equal(t, 60*time.Second, iterationDelay(delay, 4))
+}
+
+func TestLoopHandleFeedbackCompletesAtMaxIterations(t *testing.T) {
+	component := &Loop{}
+	anchorMetadata := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{
+			Iteration: 3,
+			Active:    true,
+			StartedAt: time.Now().Add(-1500 * time.Millisecond),
+		},
+	}
+	doneExecState := &contexts.ExecutionStateContext{}
+	doneExecutionID := uuid.New()
+
+	anchor := &core.ExecutionContext{
+		ID:             uuid.New(),
+		Metadata:       anchorMetadata,
+		ExecutionState: &finishedExecutionState{},
+	}
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+			"maxIterations":   3,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return anchor, nil
+		},
+		Expressions: &contexts.ExpressionContext{Output: false},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			return &core.ExecutionContext{
+				ID:             doneExecutionID,
+				ExecutionState: doneExecState,
+			}, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, id)
+	assert.Equal(t, doneExecutionID, *id)
+	assert.Equal(t, ChannelNameDone, doneExecState.Channel)
+
+	payload := doneExecState.Payloads[0].(map[string]any)["data"].(map[string]any)
+	assert.Equal(t, 3, payload["iterations"])
+	assert.Equal(t, StopReasonMaxIterations, payload["stopReason"])
+	elapsedMs, ok := payload["elapsedMs"].(int64)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, elapsedMs, int64(1500))
+
+	md, ok := anchorMetadata.Metadata.(ExecutionMetadata)
+	require.True(t, ok)
+	assert.False(t, md.Active)
+}
+
+type finishedExecutionState struct {
+	contexts.ExecutionStateContext
+}
+
+func (f *finishedExecutionState) IsFinished() bool {
+	return true
+}
+
+func (f *finishedExecutionState) SetKV(key, value string) error { return nil }
+func (f *finishedExecutionState) GetKV(key string) (string, error) {
+	return "", core.ErrExecutionKVNotFound
+}
+func (f *finishedExecutionState) Emit(channel, payloadType string, payloads []any) error {
+	return f.ExecutionStateContext.Emit(channel, payloadType, payloads)
+}
+func (f *finishedExecutionState) Pass() error { return f.ExecutionStateContext.Pass() }
+func (f *finishedExecutionState) Fail(reason, message string) error {
+	return f.ExecutionStateContext.Fail(reason, message)
+}
+
+type scheduledRequestContext struct {
+	called     bool
+	actionName string
+	interval   time.Duration
+}
+
+func (s *scheduledRequestContext) ScheduleActionCall(actionName string, parameters map[string]any, interval time.Duration) error {
+	s.called = true
+	s.actionName = actionName
+	s.interval = interval
+	return nil
+}
+
+func TestLoopExecuteIsNoOp(t *testing.T) {
+	component := &Loop{}
+	err := component.Execute(core.ExecutionContext{})
+	require.NoError(t, err)
+}
+
+func TestLoopHandleWebhook(t *testing.T) {
+	component := &Loop{}
+	status, body, err := component.HandleWebhook(core.WebhookRequestContext{})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Nil(t, body)
+}

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -59,6 +59,28 @@ func TestLoopSetup(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("rejects negative timeout", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"timeoutSeconds":  -5,
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "timeoutSeconds must be at least")
+	})
+
+	t.Run("rejects timeout above maximum", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"untilExpression": `$["Checker"].ready == true`,
+				"timeoutSeconds":  TimeoutMaxSeconds + 1,
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "timeoutSeconds cannot exceed")
+	})
+
 	t.Run("rejects invalid delay strategy", func(t *testing.T) {
 		err := component.Setup(core.SetupContext{
 			Configuration: map[string]any{
@@ -79,6 +101,7 @@ func TestLoopStartLoop(t *testing.T) {
 	component := &Loop{}
 	execState := &contexts.ExecutionStateContext{}
 	execMetadata := &contexts.MetadataContext{}
+	scheduled := &scheduledRequestContext{}
 	rootEventID := uuid.New().String()
 	executionID := uuid.New()
 
@@ -86,6 +109,7 @@ func TestLoopStartLoop(t *testing.T) {
 		RootEventID: rootEventID,
 		Configuration: map[string]any{
 			"untilExpression": `$["Checker"].ready == true`,
+			"timeoutSeconds":  120,
 		},
 		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
 			return nil, nil
@@ -94,6 +118,7 @@ func TestLoopStartLoop(t *testing.T) {
 			return &core.ExecutionContext{
 				ID:             executionID,
 				Metadata:       execMetadata,
+				Requests:       scheduled,
 				ExecutionState: execState,
 			}, nil
 		},
@@ -112,6 +137,40 @@ func TestLoopStartLoop(t *testing.T) {
 	assert.True(t, md.Active)
 	assert.False(t, execState.Finished)
 	assert.Equal(t, ChannelNameNext, execState.Channel)
+	assert.True(t, scheduled.called)
+	assert.Equal(t, timeoutHook, scheduled.actionName)
+	assert.Equal(t, 120*time.Second, scheduled.interval)
+}
+
+func TestLoopStartDeferredWhenAnotherSessionActive(t *testing.T) {
+	component := &Loop{}
+	deferred := false
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return nil, nil
+		},
+		HasRunningExecutions: func() (bool, error) {
+			return true, nil
+		},
+		DeferQueueItem: func() error {
+			deferred = true
+			return nil
+		},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			t.Fatal("CreateExecution should not be called when deferring")
+			return nil, nil
+		},
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.ErrorIs(t, err, core.ErrQueueItemDeferred)
+	assert.Nil(t, id)
+	assert.True(t, deferred)
 }
 
 func TestReadMetadataFromPersistedJSON(t *testing.T) {
@@ -333,6 +392,47 @@ func TestLoopHandleNextIterationHook(t *testing.T) {
 	payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)["next"].(map[string]any)
 	assert.Equal(t, 3, payload["iteration"])
 	assert.Equal(t, 10, payload["maxIterations"])
+}
+
+func TestLoopHandleTimeoutHookFailsActiveLoop(t *testing.T) {
+	component := &Loop{}
+	execState := &contexts.ExecutionStateContext{}
+	execMetadata := &contexts.MetadataContext{
+		Metadata: ExecutionMetadata{Iteration: 4, MaxIterations: 10, Active: true},
+	}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: timeoutHook,
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+			"timeoutSeconds":  30,
+		},
+		Metadata:       execMetadata,
+		ExecutionState: execState,
+	})
+	require.NoError(t, err)
+	assert.True(t, execState.Finished)
+	assert.False(t, execState.Passed)
+	assert.Equal(t, "timeout", execState.FailureReason)
+	assert.Contains(t, execState.FailureMessage, "30s")
+
+	md, ok := execMetadata.Metadata.(ExecutionMetadata)
+	require.True(t, ok)
+	assert.False(t, md.Active)
+}
+
+func TestLoopHandleTimeoutHookIgnoresFinishedLoop(t *testing.T) {
+	component := &Loop{}
+
+	err := component.HandleHook(core.ActionHookContext{
+		Name: timeoutHook,
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+		},
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: &finishedExecutionState{},
+	})
+	require.NoError(t, err)
 }
 
 func TestIterationDelay(t *testing.T) {

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -547,18 +547,15 @@ func TestLoopExampleOutput(t *testing.T) {
 	component := &Loop{}
 	output := component.ExampleOutput()
 
-	next, ok := output["next"].(map[string]any)
-	require.True(t, ok)
-	nextData, ok := next["data"].(map[string]any)["next"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, PayloadTypeNext, next["type"])
-	assert.Equal(t, 1, nextData["iteration"])
+	// The example output is a single payload in the standard envelope format
+	assert.Equal(t, PayloadTypeDone, output["type"])
+	assert.NotEmpty(t, output["timestamp"])
 
-	done, ok := output["done"].(map[string]any)
+	data, ok := output["data"].(map[string]any)
 	require.True(t, ok)
-	doneData, ok := done["data"].(map[string]any)["done"].(map[string]any)
+
+	doneData, ok := data["done"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, PayloadTypeDone, done["type"])
 	assert.Equal(t, 3, doneData["iterations"])
 	assert.Equal(t, StopReasonConditionMet, doneData["stopReason"])
 	assert.Equal(t, int64(4521), doneData["elapsedMs"])

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -114,6 +114,23 @@ func TestLoopStartLoop(t *testing.T) {
 	assert.Equal(t, ChannelNameNext, execState.Channel)
 }
 
+func TestReadMetadataFromPersistedJSON(t *testing.T) {
+	startedAt := time.Now().Add(-3 * time.Second).UTC().Format(time.RFC3339Nano)
+	md, err := readMetadata(&core.ExecutionContext{
+		Metadata: &contexts.MetadataContext{
+			Metadata: map[string]any{
+				"iteration": float64(2),
+				"active":    true,
+				"startedAt": startedAt,
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, md.Iteration)
+	assert.True(t, md.Active)
+	assert.False(t, md.StartedAt.IsZero())
+}
+
 func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 	component := &Loop{}
 	anchorMetadata := &contexts.MetadataContext{
@@ -394,6 +411,27 @@ func (s *scheduledRequestContext) ScheduleActionCall(actionName string, paramete
 	s.actionName = actionName
 	s.interval = interval
 	return nil
+}
+
+func TestLoopExampleOutput(t *testing.T) {
+	component := &Loop{}
+	output := component.ExampleOutput()
+
+	next, ok := output["next"].(map[string]any)
+	require.True(t, ok)
+	nextData, ok := next["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, PayloadTypeNext, next["type"])
+	assert.Equal(t, 1, nextData["iteration"])
+
+	done, ok := output["done"].(map[string]any)
+	require.True(t, ok)
+	doneData, ok := done["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, PayloadTypeDone, done["type"])
+	assert.Equal(t, 3, doneData["iterations"])
+	assert.Equal(t, StopReasonConditionMet, doneData["stopReason"])
+	assert.Equal(t, int64(4521), doneData["elapsedMs"])
 }
 
 func TestLoopExecuteIsNoOp(t *testing.T) {

--- a/pkg/components/loop/loop_test.go
+++ b/pkg/components/loop/loop_test.go
@@ -110,7 +110,7 @@ func TestLoopStartLoop(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 1, md.Iteration)
 	assert.True(t, md.Active)
-	assert.True(t, execState.Passed)
+	assert.False(t, execState.Finished)
 	assert.Equal(t, ChannelNameNext, execState.Channel)
 }
 
@@ -135,19 +135,19 @@ func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 	component := &Loop{}
 	anchorMetadata := &contexts.MetadataContext{
 		Metadata: ExecutionMetadata{
-			Iteration: 2,
-			Active:    true,
-			StartedAt: time.Now().Add(-2 * time.Second),
+			Iteration:     2,
+			MaxIterations: 100,
+			Active:        true,
+			StartedAt:     time.Now().Add(-2 * time.Second),
 		},
 	}
-	iterationExecState := &contexts.ExecutionStateContext{}
-	iterationID := uuid.New()
+	anchorExecState := &contexts.ExecutionStateContext{}
 	anchorID := uuid.New()
 
 	anchor := &core.ExecutionContext{
 		ID:             anchorID,
 		Metadata:       anchorMetadata,
-		ExecutionState: &finishedExecutionState{},
+		ExecutionState: anchorExecState,
 	}
 
 	ctx := core.ProcessQueueContext{
@@ -160,10 +160,8 @@ func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 		},
 		Expressions: &contexts.ExpressionContext{Output: true},
 		CreateExecution: func() (*core.ExecutionContext, error) {
-			return &core.ExecutionContext{
-				ID:             iterationID,
-				ExecutionState: iterationExecState,
-			}, nil
+			t.Fatal("feedback must reuse the session execution")
+			return nil, nil
 		},
 		DequeueItem:     func() error { return nil },
 		UpdateNodeState: func(state string) error { return nil },
@@ -172,11 +170,12 @@ func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 	id, err := component.ProcessQueueItem(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, id)
-	assert.Equal(t, iterationID, *id)
-	assert.Equal(t, ChannelNameDone, iterationExecState.Channel)
-	assert.Equal(t, PayloadTypeDone, iterationExecState.Type)
+	assert.Equal(t, anchorID, *id)
+	assert.Equal(t, ChannelNameDone, anchorExecState.Channel)
+	assert.Equal(t, PayloadTypeDone, anchorExecState.Type)
+	assert.True(t, anchorExecState.Finished)
 
-	donePayload := iterationExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
+	donePayload := anchorExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
 	assert.Equal(t, 2, donePayload["iterations"])
 	assert.Equal(t, StopReasonConditionMet, donePayload["stopReason"])
 	elapsedMs, ok := donePayload["elapsedMs"].(int64)
@@ -190,15 +189,15 @@ func TestLoopHandleFeedbackCompletesWhenUntilIsTrue(t *testing.T) {
 func TestLoopHandleFeedbackRepeatsNextWhenUntilIsFalse(t *testing.T) {
 	component := &Loop{}
 	anchorMetadata := &contexts.MetadataContext{
-		Metadata: ExecutionMetadata{Iteration: 1, Active: true},
+		Metadata: ExecutionMetadata{Iteration: 1, MaxIterations: 5, Active: true},
 	}
-	iterationExecState := &contexts.ExecutionStateContext{}
-	iterationID := uuid.New()
+	anchorExecState := &contexts.ExecutionStateContext{}
+	anchorID := uuid.New()
 
 	anchor := &core.ExecutionContext{
-		ID:             uuid.New(),
+		ID:             anchorID,
 		Metadata:       anchorMetadata,
-		ExecutionState: &finishedExecutionState{},
+		ExecutionState: anchorExecState,
 	}
 
 	ctx := core.ProcessQueueContext{
@@ -212,10 +211,8 @@ func TestLoopHandleFeedbackRepeatsNextWhenUntilIsFalse(t *testing.T) {
 		},
 		Expressions: &contexts.ExpressionContext{Output: false},
 		CreateExecution: func() (*core.ExecutionContext, error) {
-			return &core.ExecutionContext{
-				ID:             iterationID,
-				ExecutionState: iterationExecState,
-			}, nil
+			t.Fatal("feedback must reuse the session execution")
+			return nil, nil
 		},
 		DequeueItem:     func() error { return nil },
 		UpdateNodeState: func(state string) error { return nil },
@@ -224,7 +221,9 @@ func TestLoopHandleFeedbackRepeatsNextWhenUntilIsFalse(t *testing.T) {
 	id, err := component.ProcessQueueItem(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, id)
-	assert.Equal(t, ChannelNameNext, iterationExecState.Channel)
+	assert.Equal(t, anchorID, *id)
+	assert.Equal(t, ChannelNameNext, anchorExecState.Channel)
+	assert.False(t, anchorExecState.Finished)
 	md, ok := anchorMetadata.Metadata.(ExecutionMetadata)
 	require.True(t, ok)
 	assert.Equal(t, 2, md.Iteration)
@@ -233,16 +232,16 @@ func TestLoopHandleFeedbackRepeatsNextWhenUntilIsFalse(t *testing.T) {
 func TestLoopHandleFeedbackSchedulesDelayBeforeNextIteration(t *testing.T) {
 	component := &Loop{}
 	anchorMetadata := &contexts.MetadataContext{
-		Metadata: ExecutionMetadata{Iteration: 1, Active: true},
+		Metadata: ExecutionMetadata{Iteration: 1, MaxIterations: 5, Active: true},
 	}
-	iterationMetadata := &contexts.MetadataContext{}
 	scheduled := &scheduledRequestContext{}
-	iterationID := uuid.New()
+	anchorID := uuid.New()
 
 	anchor := &core.ExecutionContext{
-		ID:             uuid.New(),
+		ID:             anchorID,
 		Metadata:       anchorMetadata,
-		ExecutionState: &finishedExecutionState{},
+		Requests:       scheduled,
+		ExecutionState: &contexts.ExecutionStateContext{},
 	}
 
 	ctx := core.ProcessQueueContext{
@@ -261,11 +260,8 @@ func TestLoopHandleFeedbackSchedulesDelayBeforeNextIteration(t *testing.T) {
 		},
 		Expressions: &contexts.ExpressionContext{Output: false},
 		CreateExecution: func() (*core.ExecutionContext, error) {
-			return &core.ExecutionContext{
-				ID:       iterationID,
-				Metadata: iterationMetadata,
-				Requests: scheduled,
-			}, nil
+			t.Fatal("feedback must reuse the session execution")
+			return nil, nil
 		},
 		DequeueItem:     func() error { return nil },
 		UpdateNodeState: func(state string) error { return nil },
@@ -274,14 +270,44 @@ func TestLoopHandleFeedbackSchedulesDelayBeforeNextIteration(t *testing.T) {
 	id, err := component.ProcessQueueItem(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, id)
+	assert.Equal(t, anchorID, *id)
 	assert.True(t, scheduled.called)
 	assert.Equal(t, nextIterationHook, scheduled.actionName)
 	assert.Equal(t, 15*time.Second, scheduled.interval)
 
-	iterMd, ok := iterationMetadata.Metadata.(IterationExecutionMetadata)
+	md, ok := anchorMetadata.Metadata.(ExecutionMetadata)
 	require.True(t, ok)
-	assert.Equal(t, 2, iterMd.Iteration)
-	assert.Equal(t, 5, iterMd.MaxIterations)
+	assert.Equal(t, 2, md.Iteration)
+	assert.True(t, md.WaitingBetweenIterations)
+}
+
+func TestLoopHandleFeedbackIgnoresStaleFeedbackWhenFinished(t *testing.T) {
+	component := &Loop{}
+	anchor := &core.ExecutionContext{
+		ID:             uuid.New(),
+		Metadata:       &contexts.MetadataContext{},
+		ExecutionState: &finishedExecutionState{},
+	}
+
+	ctx := core.ProcessQueueContext{
+		RootEventID: uuid.New().String(),
+		Configuration: map[string]any{
+			"untilExpression": `$["Checker"].ready == true`,
+		},
+		FindExecutionByKV: func(key, value string) (*core.ExecutionContext, error) {
+			return anchor, nil
+		},
+		CreateExecution: func() (*core.ExecutionContext, error) {
+			t.Fatal("stale feedback must not create a new execution")
+			return nil, nil
+		},
+		DequeueItem:     func() error { return nil },
+		UpdateNodeState: func(state string) error { return nil },
+	}
+
+	id, err := component.ProcessQueueItem(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, id)
 }
 
 func TestLoopHandleNextIterationHook(t *testing.T) {
@@ -291,9 +317,10 @@ func TestLoopHandleNextIterationHook(t *testing.T) {
 	err := component.HandleHook(core.ActionHookContext{
 		Name: nextIterationHook,
 		Metadata: &contexts.MetadataContext{
-			Metadata: IterationExecutionMetadata{
+			Metadata: ExecutionMetadata{
 				Iteration:     3,
 				MaxIterations: 10,
+				Active:        true,
 			},
 		},
 		ExecutionState: execState,
@@ -301,6 +328,7 @@ func TestLoopHandleNextIterationHook(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ChannelNameNext, execState.Channel)
 	assert.Equal(t, PayloadTypeNext, execState.Type)
+	assert.False(t, execState.Finished)
 
 	payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)["next"].(map[string]any)
 	assert.Equal(t, 3, payload["iteration"])
@@ -328,18 +356,19 @@ func TestLoopHandleFeedbackCompletesAtMaxIterations(t *testing.T) {
 	component := &Loop{}
 	anchorMetadata := &contexts.MetadataContext{
 		Metadata: ExecutionMetadata{
-			Iteration: 3,
-			Active:    true,
-			StartedAt: time.Now().Add(-1500 * time.Millisecond),
+			Iteration:     3,
+			MaxIterations: 3,
+			Active:        true,
+			StartedAt:     time.Now().Add(-1500 * time.Millisecond),
 		},
 	}
-	doneExecState := &contexts.ExecutionStateContext{}
-	doneExecutionID := uuid.New()
+	anchorExecState := &contexts.ExecutionStateContext{}
+	anchorID := uuid.New()
 
 	anchor := &core.ExecutionContext{
-		ID:             uuid.New(),
+		ID:             anchorID,
 		Metadata:       anchorMetadata,
-		ExecutionState: &finishedExecutionState{},
+		ExecutionState: anchorExecState,
 	}
 
 	ctx := core.ProcessQueueContext{
@@ -353,10 +382,8 @@ func TestLoopHandleFeedbackCompletesAtMaxIterations(t *testing.T) {
 		},
 		Expressions: &contexts.ExpressionContext{Output: false},
 		CreateExecution: func() (*core.ExecutionContext, error) {
-			return &core.ExecutionContext{
-				ID:             doneExecutionID,
-				ExecutionState: doneExecState,
-			}, nil
+			t.Fatal("feedback must reuse the session execution")
+			return nil, nil
 		},
 		DequeueItem:     func() error { return nil },
 		UpdateNodeState: func(state string) error { return nil },
@@ -365,10 +392,10 @@ func TestLoopHandleFeedbackCompletesAtMaxIterations(t *testing.T) {
 	id, err := component.ProcessQueueItem(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, id)
-	assert.Equal(t, doneExecutionID, *id)
-	assert.Equal(t, ChannelNameDone, doneExecState.Channel)
+	assert.Equal(t, anchorID, *id)
+	assert.Equal(t, ChannelNameDone, anchorExecState.Channel)
 
-	payload := doneExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
+	payload := anchorExecState.Payloads[0].(map[string]any)["data"].(map[string]any)["done"].(map[string]any)
 	assert.Equal(t, 3, payload["iterations"])
 	assert.Equal(t, StopReasonMaxIterations, payload["stopReason"])
 	elapsedMs, ok := payload["elapsedMs"].(int64)
@@ -394,6 +421,9 @@ func (f *finishedExecutionState) GetKV(key string) (string, error) {
 }
 func (f *finishedExecutionState) Emit(channel, payloadType string, payloads []any) error {
 	return f.ExecutionStateContext.Emit(channel, payloadType, payloads)
+}
+func (f *finishedExecutionState) EmitAndContinue(channel, payloadType string, payloads []any) error {
+	return f.ExecutionStateContext.EmitAndContinue(channel, payloadType, payloads)
 }
 func (f *finishedExecutionState) Pass() error { return f.ExecutionStateContext.Pass() }
 func (f *finishedExecutionState) Fail(reason, message string) error {

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -100,6 +100,11 @@ type ExecutionStateContext interface {
 	Emit(channel, payloadType string, payloads []any) error
 
 	/*
+	 * Emit a payload but keep the execution active for further work.
+	 */
+	EmitAndContinue(channel, payloadType string, payloads []any) error
+
+	/*
 	 * Pass the execution, without emitting any payloads from it.
 	 */
 	Pass() error

--- a/pkg/core/component.go
+++ b/pkg/core/component.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrSecretKeyNotFound   = errors.New("secret or key not found")
 	ErrExecutionKVNotFound = errors.New("execution kv not found")
+	ErrQueueItemDeferred   = errors.New("queue item deferred")
 )
 
 /*
@@ -148,6 +149,11 @@ type ProcessQueueContext struct {
 	DequeueItem func() error
 
 	//
+	// Defers the queue item by moving it to the back of the node queue.
+	//
+	DeferQueueItem func() error
+
+	//
 	// Updates the state of the node
 	//
 	UpdateNodeState func(state string) error
@@ -162,6 +168,12 @@ type ProcessQueueContext struct {
 	// Returns an ExecutionContext.
 	//
 	FindExecutionByKV func(key string, value string) (*ExecutionContext, error)
+
+	//
+	// HasRunningExecutions reports whether this node currently has any
+	// unfinished (running) executions.
+	//
+	HasRunningExecutions func() (bool, error)
 
 	//
 	// DefaultProcessing performs the default processing for the queue item.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -22,7 +22,6 @@ func released() *bool {
 
 var registry = []Feature{
 	{ID: "runner", Label: "Runners", Description: "Sandboxed Runners"},
-	{ID: "loop", Label: "Loop", Description: "Repeat downstream steps until a condition is met"},
 	{ID: FeatureClaudeManagedAgents, Label: "Claude Managed Agents", Description: "Chat with a Claude-powered agent against the canvas", Released: released()},
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -22,6 +22,7 @@ func released() *bool {
 
 var registry = []Feature{
 	{ID: "runner", Label: "Runners", Description: "Sandboxed Runners"},
+	{ID: "loop", Label: "Loop", Description: "Repeat downstream steps until a condition is met"},
 	{ID: FeatureClaudeManagedAgents, Label: "Claude Managed Agents", Description: "Chat with a Claude-powered agent against the canvas", Released: released()},
 }
 

--- a/pkg/grpc/actions/canvases/changesets/common.go
+++ b/pkg/grpc/actions/canvases/changesets/common.go
@@ -9,22 +9,21 @@ import (
 // Verify if the workflow is acyclic using
 // topological sort algorithm - kahn's - to detect cycles
 func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
+	loopNodeIDs := loopNodeIDSet(nodes)
 
-	//
-	// Build adjacency list
-	//
 	graph := make(map[string][]string)
 	inDegree := make(map[string]int)
 
-	//
-	// Initialize all nodesm and build the graph
-	//
 	for _, node := range nodes {
 		graph[node.ID] = []string{}
 		inDegree[node.ID] = 0
 	}
 
 	for _, edge := range edges {
+		if _, isLoopNode := loopNodeIDs[edge.TargetID]; isLoopNode {
+			continue
+		}
+
 		graph[edge.SourceID] = append(graph[edge.SourceID], edge.TargetID)
 		inDegree[edge.TargetID]++
 	}
@@ -57,4 +56,14 @@ func CheckForCycles(nodes []models.Node, edges []models.Edge) error {
 	}
 
 	return nil
+}
+
+func loopNodeIDSet(nodes []models.Node) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, node := range nodes {
+		if node.Ref.Component != nil && node.Ref.Component.Name == "loop" {
+			ids[node.ID] = struct{}{}
+		}
+	}
+	return ids
 }

--- a/pkg/grpc/actions/canvases/changesets/common_test.go
+++ b/pkg/grpc/actions/canvases/changesets/common_test.go
@@ -1,0 +1,37 @@
+package changesets_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/canvases/changesets"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+func TestCheckForCycles_AllowsFeedbackIntoLoop(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "trigger", Ref: models.NodeRef{Trigger: &models.TriggerRef{Name: "start"}}},
+		{ID: "loop", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}},
+		{ID: "worker", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "trigger", TargetID: "loop", Channel: "default"},
+		{SourceID: "loop", TargetID: "worker", Channel: "next"},
+		{SourceID: "worker", TargetID: "loop", Channel: "default"},
+	}
+
+	require.NoError(t, changesets.CheckForCycles(nodes, edges))
+}
+
+func TestCheckForCycles_RejectsCyclesWithoutLoop(t *testing.T) {
+	nodes := []models.Node{
+		{ID: "node-a", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+		{ID: "node-b", Ref: models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}},
+	}
+	edges := []models.Edge{
+		{SourceID: "node-a", TargetID: "node-b", Channel: "default"},
+		{SourceID: "node-b", TargetID: "node-a", Channel: "default"},
+	}
+
+	require.Error(t, changesets.CheckForCycles(nodes, edges))
+}

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -543,6 +543,55 @@ func (e *CanvasNodeExecution) PassInTransaction(tx *gorm.DB, channelOutputs map[
 	return events, nil
 }
 
+func (e *CanvasNodeExecution) EmitOutputsInTransaction(tx *gorm.DB, channelOutputs map[string][]any) ([]CanvasEvent, error) {
+	now := time.Now()
+
+	events := []CanvasEvent{}
+	for channel, outputs := range channelOutputs {
+		for _, event := range outputs {
+			events = append(events, CanvasEvent{
+				WorkflowID:  e.WorkflowID,
+				NodeID:      e.NodeID,
+				Channel:     channel,
+				Data:        NewJSONValue(event),
+				ExecutionID: &e.ID,
+				RunID:       e.RunID,
+				State:       CanvasEventStatePending,
+				CreatedAt:   &now,
+			})
+		}
+	}
+
+	if len(events) > 0 {
+		err := tx.Create(&events).Error
+		if err != nil {
+			return nil, fmt.Errorf("failed to create events: %w", err)
+		}
+	}
+
+	node, err := FindCanvasNode(tx, e.WorkflowID, e.NodeID)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	if node != nil {
+		if node.State != CanvasNodeStatePaused {
+			err = node.UpdateState(tx, CanvasNodeStateReady)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if e.State == CanvasNodeExecutionStatePending {
+		if err := e.StartInTransaction(tx); err != nil {
+			return nil, err
+		}
+	}
+
+	return events, nil
+}
+
 func (e *CanvasNodeExecution) Fail(reason, message string) error {
 	return database.Conn().Transaction(func(tx *gorm.DB) error {
 		return e.FailInTransaction(tx, reason, message)

--- a/pkg/registryimports/registryimports.go
+++ b/pkg/registryimports/registryimports.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/components/graphql"
 	_ "github.com/superplanehq/superplane/pkg/components/http"
 	_ "github.com/superplanehq/superplane/pkg/components/if"
+	_ "github.com/superplanehq/superplane/pkg/components/loop"
 	_ "github.com/superplanehq/superplane/pkg/components/merge"
 	_ "github.com/superplanehq/superplane/pkg/components/noop"
 	_ "github.com/superplanehq/superplane/pkg/components/readmemory"

--- a/pkg/workers/contexts/execution_output_lookup.go
+++ b/pkg/workers/contexts/execution_output_lookup.go
@@ -18,12 +18,14 @@ type executionOutputLookup struct {
 	eventsByID            map[uuid.UUID]models.CanvasEvent
 	eventsByExecutionID   map[uuid.UUID][]models.CanvasEvent
 	consumedEventByParent map[uuid.UUID]uuid.UUID
+	incomingEventID       *uuid.UUID
 }
 
 func newExecutionOutputLookup(
 	tx *gorm.DB,
 	runChain []models.CanvasNodeExecution,
 	executionIDs []uuid.UUID,
+	incomingEventID *uuid.UUID,
 ) (executionOutputLookup, error) {
 	consumedEventByParent := consumedEventByParentFromRunChain(runChain)
 
@@ -36,6 +38,7 @@ func newExecutionOutputLookup(
 		eventsByID:            indexEventsByID(events),
 		eventsByExecutionID:   indexEventsByExecutionID(events),
 		consumedEventByParent: consumedEventByParent,
+		incomingEventID:       incomingEventID,
 	}, nil
 }
 
@@ -55,6 +58,14 @@ func (l executionOutputLookup) outputEvent(executionID uuid.UUID) (models.Canvas
 	case 1:
 		return matched[0], true, nil
 	default:
+		if l.incomingEventID != nil {
+			for _, event := range matched {
+				if event.ID == *l.incomingEventID {
+					return event, true, nil
+				}
+			}
+		}
+
 		return models.CanvasEvent{}, false, fmt.Errorf(
 			"execution %s has ambiguous outputs (%d events)",
 			executionID,

--- a/pkg/workers/contexts/execution_output_lookup_test.go
+++ b/pkg/workers/contexts/execution_output_lookup_test.go
@@ -82,6 +82,30 @@ func Test_outputEvent_singleOutput(t *testing.T) {
 	assert.Equal(t, eventID, event.ID)
 }
 
+func Test_outputEvent_resolvesByIncomingEventID(t *testing.T) {
+	executionID := uuid.New()
+	firstEventID := uuid.New()
+	secondEventID := uuid.New()
+	now := time.Now()
+
+	events := []models.CanvasEvent{
+		{ID: firstEventID, ExecutionID: &executionID, CreatedAt: &now},
+		{ID: secondEventID, ExecutionID: &executionID, CreatedAt: &now},
+	}
+
+	lookup := executionOutputLookup{
+		eventsByID:            indexEventsByID(events),
+		eventsByExecutionID:   indexEventsByExecutionID(events),
+		consumedEventByParent: nil,
+		incomingEventID:       &secondEventID,
+	}
+
+	event, ok, err := lookup.outputEvent(executionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, secondEventID, event.ID)
+}
+
 func Test_outputEvent_ambiguousWithoutConsumedEvent(t *testing.T) {
 	executionID := uuid.New()
 	now := time.Now()

--- a/pkg/workers/contexts/execution_state_context.go
+++ b/pkg/workers/contexts/execution_state_context.go
@@ -88,6 +88,46 @@ func (s *ExecutionStateContext) Emit(channel, payloadType string, payloads []any
 	return nil
 }
 
+func (s *ExecutionStateContext) EmitAndContinue(channel, payloadType string, payloads []any) error {
+	if len(payloads) > core.MaxEmitCount {
+		return fmt.Errorf("cannot emit %d events (max %d per execution)", len(payloads), core.MaxEmitCount)
+	}
+
+	outputs := map[string][]any{
+		channel: {},
+	}
+
+	for _, payload := range payloads {
+		event := map[string]any{
+			"type":      payloadType,
+			"timestamp": time.Now(),
+			"data":      payload,
+		}
+
+		data, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %w", err)
+		}
+
+		if len(data) > s.maxPayloadSize {
+			return fmt.Errorf("event payload too large: %d bytes (max %d)", len(data), s.maxPayloadSize)
+		}
+
+		outputs[channel] = append(outputs[channel], json.RawMessage(data))
+	}
+
+	newEvents, err := s.execution.EmitOutputsInTransaction(s.tx, outputs)
+	if err != nil {
+		return err
+	}
+
+	if s.onNewEvents != nil {
+		s.onNewEvents(newEvents)
+	}
+
+	return nil
+}
+
 func (s *ExecutionStateContext) Fail(reason, message string) error {
 	err := s.execution.FailInTransaction(s.tx, reason, message)
 	return err

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -25,6 +25,7 @@ type NodeConfigurationBuilder struct {
 	workflowID          uuid.UUID
 	nodeID              string
 	previousExecutionID *uuid.UUID
+	incomingEventID     *uuid.UUID
 	rootEventID         *uuid.UUID
 	rootPayload         any
 	input               any
@@ -63,6 +64,11 @@ func (b *NodeConfigurationBuilder) WithRootPayload(payload any) *NodeConfigurati
 
 func (b *NodeConfigurationBuilder) WithPreviousExecution(previousExecutionID *uuid.UUID) *NodeConfigurationBuilder {
 	b.previousExecutionID = previousExecutionID
+	return b
+}
+
+func (b *NodeConfigurationBuilder) WithIncomingEventID(incomingEventID *uuid.UUID) *NodeConfigurationBuilder {
+	b.incomingEventID = incomingEventID
 	return b
 }
 
@@ -436,6 +442,7 @@ func (b *NodeConfigurationBuilder) BuildExecutionMessageChain() (map[string]any,
 			b.tx,
 			linearExecutions,
 			executionIDsFromExecutions(executionsInChain),
+			b.incomingEventID,
 		)
 		if err != nil {
 			return nil, err
@@ -811,6 +818,7 @@ func (b *NodeConfigurationBuilder) populateFromExecutions(
 		b.tx,
 		chainExecutions,
 		unionExecutionIDs(referencedExecutionIDs, executionIDsFromExecutions(chainExecutions)),
+		b.incomingEventID,
 	)
 	if err != nil {
 		return err
@@ -943,6 +951,7 @@ func (b *NodeConfigurationBuilder) resolveFromExecutions(depth int, step int, ha
 		b.tx,
 		executionsInChain,
 		executionIDsFromExecutions(executionsInChain),
+		b.incomingEventID,
 	)
 	if err != nil {
 		return step, nil, err

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -363,9 +363,38 @@ func (b *NodeConfigurationBuilder) buildMessageChain(referencedNodes []string) (
 		if err != nil {
 			return nil, err
 		}
+
+		//
+		// listExecutionsInChain merges the current execution's linear lineage
+		// (walked via previous_execution_id) with every run-wide execution of
+		// upstream nodes. When the graph has a feedback cycle (e.g. a loop whose
+		// body points back at the loop), an upstream node has one execution per
+		// iteration, so the same name maps to many executions in the run. We must
+		// bind each name to the execution in the *current* lineage; otherwise
+		// expressions like a loop's until-condition would read a stale
+		// iteration's output. So a linear-chain execution always wins over a
+		// run-wide upstream match for the same node.
+		//
+		linearExecutions, err := b.listLinearExecutionsInChain()
+		if err != nil {
+			return nil, err
+		}
+		linearExecutionIDs := make(map[uuid.UUID]struct{}, len(linearExecutions))
+		for _, execution := range linearExecutions {
+			linearExecutionIDs[execution.ID] = struct{}{}
+		}
+
 		executionByNodeID = make(map[string]models.CanvasNodeExecution, len(executionsInChain))
 		for _, execution := range executionsInChain {
 			executionChainNodeIDs = append(executionChainNodeIDs, execution.NodeID)
+
+			if existing, ok := executionByNodeID[execution.NodeID]; ok {
+				_, existingIsLinear := linearExecutionIDs[existing.ID]
+				_, candidateIsLinear := linearExecutionIDs[execution.ID]
+				if existingIsLinear && !candidateIsLinear {
+					continue
+				}
+			}
 			executionByNodeID[execution.NodeID] = execution
 		}
 	}

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -323,6 +323,77 @@ func Test_NodeConfigurationBuilder_NodeNameNotUnique_UsesClosestInChain(t *testi
 	assert.Equal(t, "second-filter", result["field"])
 }
 
+// Test_NodeConfigurationBuilder_CyclicFeedback_UsesCurrentLineage guards against
+// a loop reading a stale iteration's body output. A loop body forms a feedback
+// cycle (loop -> body -> loop), so the body node is reachable "upstream" of the
+// loop and has one execution per iteration. When the loop evaluates an
+// expression (e.g. its until-condition) for the current feedback, $[body] must
+// resolve to the current iteration's output, not an older one.
+func Test_NodeConfigurationBuilder_CyclicFeedback_UsesCurrentLineage(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	// start -> loop -> body -> loop (feedback). The cycle makes "body" upstream
+	// of "loop", so all of body's per-iteration executions are in scope.
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: "start", Name: "start", Type: models.NodeTypeTrigger},
+			{
+				NodeID: "loop",
+				Name:   "loop",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "loop"}}),
+			},
+			{
+				NodeID: "body",
+				Name:   "body",
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}}),
+			},
+		},
+		[]models.Edge{
+			{SourceID: "start", TargetID: "loop", Channel: "default"},
+			{SourceID: "loop", TargetID: "body", Channel: "next"},
+			{SourceID: "body", TargetID: "loop", Channel: "success"},
+		},
+	)
+
+	rootEvent := support.EmitCanvasEventForNode(t, canvas.ID, "start", "default", nil)
+
+	// The long-lived loop session. Each body iteration branches off it (as in the
+	// real feedback-model loop), so the body executions are siblings.
+	loopExecution := support.CreateCanvasNodeExecution(t, canvas.ID, "loop", rootEvent.ID, rootEvent.ID, nil)
+
+	body1 := support.CreateNextNodeExecution(t, canvas.ID, "body", rootEvent.ID, rootEvent.ID, &loopExecution.ID)
+	support.EmitCanvasEventForNodeWithData(t, canvas.ID, "body", "success", &body1.ID, map[string]any{"result": "tail"})
+
+	body2 := support.CreateNextNodeExecution(t, canvas.ID, "body", rootEvent.ID, rootEvent.ID, &loopExecution.ID)
+	support.EmitCanvasEventForNodeWithData(t, canvas.ID, "body", "success", &body2.ID, map[string]any{"result": "tail"})
+
+	// Current iteration: body flips "head". The feedback into the loop is this event.
+	body3 := support.CreateNextNodeExecution(t, canvas.ID, "body", rootEvent.ID, rootEvent.ID, &loopExecution.ID)
+	body3Event := support.EmitCanvasEventForNodeWithData(t, canvas.ID, "body", "success", &body3.ID, map[string]any{"result": "head"})
+
+	// Evaluate from the loop's perspective for the current feedback (body3).
+	builder := NewNodeConfigurationBuilder(database.Conn(), canvas.ID).
+		WithNodeID("loop").
+		WithRootEvent(&rootEvent.ID).
+		WithPreviousExecution(&body3.ID).
+		WithIncomingEventID(&body3Event.ID)
+
+	// $[body] must be the current iteration (head), not the oldest (tail).
+	value, err := builder.ResolveExpression(`$["body"].result`)
+	require.NoError(t, err)
+	assert.Equal(t, "head", value)
+
+	done, err := builder.ResolveExpression(`$["body"].result == "head"`)
+	require.NoError(t, err)
+	assert.Equal(t, true, done)
+}
+
 func Test_NodeConfigurationBuilder_NodeNameNotUnique_NoneInChain(t *testing.T) {
 	r := support.Setup(t)
 	defer r.Close()

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -47,6 +47,7 @@ func BuildProcessQueueContext(
 		WithNodeID(node.NodeID).
 		WithRootEvent(&queueItem.RootEventID).
 		WithPreviousExecution(event.ExecutionID).
+		WithIncomingEventID(&event.ID).
 		WithInput(map[string]any{event.NodeID: event.Data.Data()})
 	if len(configFields) > 0 {
 		configBuilder = configBuilder.WithConfigurationFields(configFields)
@@ -75,6 +76,7 @@ func BuildProcessQueueContext(
 	builder := NewNodeConfigurationBuilder(tx, queueItem.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&queueItem.RootEventID).
+		WithIncomingEventID(&event.ID).
 		WithInput(map[string]any{event.NodeID: event.Data.Data()})
 	if event.ExecutionID != nil {
 		builder = builder.WithPreviousExecution(event.ExecutionID)

--- a/pkg/workers/contexts/process_queue_context.go
+++ b/pkg/workers/contexts/process_queue_context.go
@@ -157,6 +157,17 @@ func BuildProcessQueueContext(
 		return queueItem.Delete(tx)
 	}
 
+	//
+	// The node queue is a FIFO ordered by created_at (see CanvasNode.FirstQueueItem),
+	// so deferring an item is simply moving it to the tail by stamping created_at to
+	// now. This lets other already-queued items (e.g. feedback for an in-progress run)
+	// be processed ahead of it, instead of the worker re-picking this same item forever.
+	//
+	ctx.DeferQueueItem = func() error {
+		now := time.Now()
+		return tx.Model(queueItem).Update("created_at", &now).Error
+	}
+
 	ctx.UpdateNodeState = func(state string) error {
 		return node.UpdateState(tx, state)
 	}
@@ -268,6 +279,14 @@ func BuildProcessQueueContext(
 			Notifications:  NewNotificationContext(tx, orgUUID, execution.WorkflowID),
 			CanvasMemory:   NewCanvasMemoryContext(tx, execution.WorkflowID),
 		}, nil
+	}
+
+	ctx.HasRunningExecutions = func() (bool, error) {
+		count, err := models.CountRunningExecutionsForNodeInTransaction(tx, node.WorkflowID, node.NodeID)
+		if err != nil {
+			return false, err
+		}
+		return count > 0, nil
 	}
 
 	return ctx, nil

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -355,6 +355,7 @@ func (w *NodeExecutor) executeActionNode(tx *gorm.DB, execution *models.CanvasNo
 	builder := contexts.NewNodeConfigurationBuilder(tx, execution.WorkflowID).
 		WithNodeID(node.NodeID).
 		WithRootEvent(&execution.RootEventID).
+		WithIncomingEventID(&execution.EventID).
 		WithInput(map[string]any{inputEvent.NodeID: input})
 	if execution.PreviousExecutionID != nil {
 		builder = builder.WithPreviousExecution(execution.PreviousExecutionID)

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -276,6 +276,11 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		return nil, nil, fmt.Errorf("unsupported node type: %s", node.Type)
 	}
 
+	if errors.Is(err, core.ErrQueueItemDeferred) {
+		logger.Info("Queue item deferred")
+		return nil, nil, nil
+	}
+
 	return []*uuid.UUID{executionID}, queueItem, err
 }
 

--- a/test/support/contexts/contexts.go
+++ b/test/support/contexts/contexts.go
@@ -284,6 +284,24 @@ func (c *ExecutionStateContext) Emit(channel, payloadType string, payloads []any
 	return nil
 }
 
+func (c *ExecutionStateContext) EmitAndContinue(channel, payloadType string, payloads []any) error {
+	c.Finished = false
+	c.Passed = true
+	c.Channel = channel
+	c.Type = payloadType
+
+	wrappedPayloads := make([]any, 0, len(payloads))
+	for _, payload := range payloads {
+		wrappedPayloads = append(wrappedPayloads, map[string]any{
+			"type":      payloadType,
+			"timestamp": time.Now(),
+			"data":      payload,
+		})
+	}
+	c.Payloads = wrappedPayloads
+	return nil
+}
+
 func (c *ExecutionStateContext) Fail(reason, message string) error {
 	c.Finished = true
 	c.Passed = false

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -253,6 +253,7 @@ import { sshMapper, SSH_STATE_REGISTRY } from "./ssh";
 import { runnerMapper, RUNNER_STATE_REGISTRY } from "./runner";
 import { waitCustomFieldRenderer, waitMapper, WAIT_STATE_REGISTRY } from "./wait";
 import { approvalMapper, APPROVAL_STATE_REGISTRY } from "./approval";
+import { loopMapper, LOOP_STATE_REGISTRY } from "./loop";
 import { mergeMapper, MERGE_STATE_REGISTRY } from "./merge";
 import { sendEmailMapper, SEND_EMAIL_STATE_REGISTRY } from "./sendEmail";
 import { DEFAULT_STATE_REGISTRY } from "./stateRegistry";
@@ -279,6 +280,7 @@ const componentBaseMappers: Record<string, ComponentBaseMapper> = {
   updateMemory: updateMemoryMapper,
   upsertMemory: upsertMemoryMapper,
   if: ifMapper,
+  loop: loopMapper,
   http: httpMapper,
   graphql: graphqlMapper,
   ssh: sshMapper,
@@ -447,6 +449,7 @@ const eventStateRegistries: Record<string, EventStateRegistry> = {
   filter: FILTER_STATE_REGISTRY,
   forEach: FOR_EACH_STATE_REGISTRY,
   if: IF_STATE_REGISTRY,
+  loop: LOOP_STATE_REGISTRY,
   timeGate: TIME_GATE_STATE_REGISTRY,
   wait: WAIT_STATE_REGISTRY,
   merge: MERGE_STATE_REGISTRY,

--- a/web_src/src/pages/app/mappers/loop.ts
+++ b/web_src/src/pages/app/mappers/loop.ts
@@ -157,19 +157,21 @@ export const loopMapper: ComponentBaseMapper = {
 
     const doneOutput = (context.execution.outputs as LoopOutputs | undefined)?.done?.[0]?.data as
       | {
-          iterations?: number;
-          stopReason?: string;
-          elapsedMs?: number;
+          done?: {
+            iterations?: number;
+            stopReason?: string;
+            elapsedMs?: number;
+          };
         }
       | undefined;
-    if (typeof doneOutput?.iterations === "number") {
-      details.Iterations = doneOutput.iterations;
+    if (typeof doneOutput?.done?.iterations === "number") {
+      details.Iterations = doneOutput.done.iterations;
     }
-    if (doneOutput?.stopReason) {
-      details["Stop reason"] = doneOutput.stopReason;
+    if (doneOutput?.done?.stopReason) {
+      details["Stop reason"] = doneOutput.done.stopReason;
     }
-    if (typeof doneOutput?.elapsedMs === "number") {
-      details["Elapsed (ms)"] = doneOutput.elapsedMs;
+    if (typeof doneOutput?.done?.elapsedMs === "number") {
+      details["Elapsed (ms)"] = doneOutput.done.elapsedMs;
     }
 
     if (configuration.delayBetweenIterations?.enabled) {

--- a/web_src/src/pages/app/mappers/loop.ts
+++ b/web_src/src/pages/app/mappers/loop.ts
@@ -46,7 +46,8 @@ function isWaitingBetweenIterations(execution: ExecutionInfo): boolean {
     return false;
   }
 
-  return isIterationExecutionMetadata(execution.metadata);
+  const metadata = execution.metadata as LoopMetadata | undefined;
+  return metadata?.waitingBetweenIterations === true;
 }
 
 export const loopStateFunction: StateFunction = (execution: ExecutionInfo): EventState => {
@@ -103,12 +104,9 @@ type DelaySpec = {
 
 type LoopMetadata = {
   iteration?: number;
-  active?: boolean;
-};
-
-type IterationExecutionMetadata = {
-  iteration?: number;
   maxIterations?: number;
+  active?: boolean;
+  waitingBetweenIterations?: boolean;
 };
 
 export const loopMapper: ComponentBaseMapper = {
@@ -136,9 +134,6 @@ export const loopMapper: ComponentBaseMapper = {
   getExecutionDetails(context: ExecutionDetailsContext): Record<string, string | number | boolean> {
     const configuration = context.execution.configuration as LoopConfiguration;
     const sessionMetadata = isLoopSessionMetadata(context.execution.metadata) ? context.execution.metadata : undefined;
-    const iterationMetadata = isIterationExecutionMetadata(context.execution.metadata)
-      ? context.execution.metadata
-      : undefined;
     const details: Record<string, string | number | boolean> = {
       "Evaluated at": context.execution.createdAt ? formatTimestampInUserTimezone(context.execution.createdAt) : "-",
       "Until expression": configuration.untilExpression ?? "-",
@@ -151,8 +146,8 @@ export const loopMapper: ComponentBaseMapper = {
     if (typeof sessionMetadata?.active === "boolean") {
       details.Active = sessionMetadata.active;
     }
-    if (typeof iterationMetadata?.iteration === "number") {
-      details.Iteration = iterationMetadata.iteration;
+    if (sessionMetadata?.waitingBetweenIterations) {
+      details["Waiting between iterations"] = true;
     }
 
     const doneOutput = (context.execution.outputs as LoopOutputs | undefined)?.done?.[0]?.data as
@@ -187,10 +182,6 @@ export const loopMapper: ComponentBaseMapper = {
 
 function isLoopSessionMetadata(metadata: unknown): metadata is LoopMetadata {
   return typeof metadata === "object" && metadata !== null && "active" in metadata;
-}
-
-function isIterationExecutionMetadata(metadata: unknown): metadata is IterationExecutionMetadata {
-  return typeof metadata === "object" && metadata !== null && "maxIterations" in metadata;
 }
 
 function getLoopEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {

--- a/web_src/src/pages/app/mappers/loop.ts
+++ b/web_src/src/pages/app/mappers/loop.ts
@@ -93,6 +93,7 @@ export const LOOP_STATE_REGISTRY: EventStateRegistry = {
 type LoopConfiguration = {
   untilExpression?: string;
   maxIterations?: number;
+  timeoutSeconds?: number;
   delayBetweenIterations?: DelaySpec;
 };
 
@@ -138,6 +139,7 @@ export const loopMapper: ComponentBaseMapper = {
       "Evaluated at": context.execution.createdAt ? formatTimestampInUserTimezone(context.execution.createdAt) : "-",
       "Until expression": configuration.untilExpression ?? "-",
       "Max iterations": configuration.maxIterations ?? 100,
+      "Timeout (s)": configuration.timeoutSeconds ?? 3600,
     };
 
     if (typeof sessionMetadata?.iteration === "number") {

--- a/web_src/src/pages/app/mappers/loop.ts
+++ b/web_src/src/pages/app/mappers/loop.ts
@@ -1,0 +1,218 @@
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  EventStateRegistry,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  StateFunction,
+  SubtitleContext,
+} from "./types";
+import type { ComponentBaseProps, EventSection, EventState, EventStateMap } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import { getTriggerRenderer, getState, getStateMap } from ".";
+import type React from "react";
+import { getBackgroundColorClass, getColorClass } from "@/lib/colors";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { formatTimestampInUserTimezone } from "@/lib/timezone";
+
+type LoopOutputs = Record<string, OutputPayload[]>;
+
+export const LOOP_STATE_MAP: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  done: {
+    icon: "circle-check",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+  },
+  next: {
+    icon: "refresh-cw",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-indigo-100",
+    badgeColor: "bg-indigo-500",
+  },
+  waiting: {
+    icon: "clock",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-orange-100",
+    badgeColor: "bg-yellow-600",
+  },
+};
+
+function isWaitingBetweenIterations(execution: ExecutionInfo): boolean {
+  if (execution.state !== "STATE_PENDING" && execution.state !== "STATE_STARTED") {
+    return false;
+  }
+
+  return isIterationExecutionMetadata(execution.metadata);
+}
+
+export const loopStateFunction: StateFunction = (execution: ExecutionInfo): EventState => {
+  if (!execution) return "neutral";
+
+  if (
+    execution.resultMessage &&
+    (execution.resultReason === "RESULT_REASON_ERROR" ||
+      (execution.result === "RESULT_FAILED" && execution.resultReason !== "RESULT_REASON_ERROR_RESOLVED"))
+  ) {
+    return "error";
+  }
+
+  if (execution.result === "RESULT_CANCELLED") {
+    return "cancelled";
+  }
+
+  if (execution.state === "STATE_PENDING" || execution.state === "STATE_STARTED") {
+    if (isWaitingBetweenIterations(execution)) {
+      return "waiting";
+    }
+    return "running";
+  }
+
+  if (execution.state === "STATE_FINISHED" && execution.result === "RESULT_PASSED") {
+    const outputs = execution.outputs as LoopOutputs | undefined;
+    if (Array.isArray(outputs?.done) && outputs.done.length > 0) {
+      return "done";
+    }
+    if (Array.isArray(outputs?.next) && outputs.next.length > 0) {
+      return "next";
+    }
+  }
+
+  return "failed";
+};
+
+export const LOOP_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: LOOP_STATE_MAP,
+  getState: loopStateFunction,
+};
+
+type LoopConfiguration = {
+  untilExpression?: string;
+  maxIterations?: number;
+  delayBetweenIterations?: DelaySpec;
+};
+
+type DelaySpec = {
+  enabled?: boolean;
+  strategy?: "fixed" | "exponential";
+  intervalSeconds?: number;
+};
+
+type LoopMetadata = {
+  iteration?: number;
+  active?: boolean;
+};
+
+type IterationExecutionMetadata = {
+  iteration?: number;
+  maxIterations?: number;
+};
+
+export const loopMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const componentName = context.componentDefinition.name || "loop";
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+
+    return {
+      iconSlug: context.componentDefinition.icon ?? "refresh-cw",
+      iconColor: getColorClass(context.componentDefinition.color ?? "indigo"),
+      collapsed: context.node.isCollapsed,
+      collapsedBackground: getBackgroundColorClass("white"),
+      title: context.node.name || context.componentDefinition.label || context.componentDefinition.name || "Loop",
+      eventSections: lastExecution ? getLoopEventSections(context.nodes, lastExecution, componentName) : undefined,
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string | number | boolean> {
+    const configuration = context.execution.configuration as LoopConfiguration;
+    const sessionMetadata = isLoopSessionMetadata(context.execution.metadata) ? context.execution.metadata : undefined;
+    const iterationMetadata = isIterationExecutionMetadata(context.execution.metadata)
+      ? context.execution.metadata
+      : undefined;
+    const details: Record<string, string | number | boolean> = {
+      "Evaluated at": context.execution.createdAt ? formatTimestampInUserTimezone(context.execution.createdAt) : "-",
+      "Until expression": configuration.untilExpression ?? "-",
+      "Max iterations": configuration.maxIterations ?? 100,
+    };
+
+    if (typeof sessionMetadata?.iteration === "number") {
+      details["Current iteration"] = sessionMetadata.iteration;
+    }
+    if (typeof sessionMetadata?.active === "boolean") {
+      details.Active = sessionMetadata.active;
+    }
+    if (typeof iterationMetadata?.iteration === "number") {
+      details.Iteration = iterationMetadata.iteration;
+    }
+
+    const doneOutput = (context.execution.outputs as LoopOutputs | undefined)?.done?.[0]?.data as
+      | {
+          iterations?: number;
+          stopReason?: string;
+          elapsedMs?: number;
+        }
+      | undefined;
+    if (typeof doneOutput?.iterations === "number") {
+      details.Iterations = doneOutput.iterations;
+    }
+    if (doneOutput?.stopReason) {
+      details["Stop reason"] = doneOutput.stopReason;
+    }
+    if (typeof doneOutput?.elapsedMs === "number") {
+      details["Elapsed (ms)"] = doneOutput.elapsedMs;
+    }
+
+    if (configuration.delayBetweenIterations?.enabled) {
+      const strategy = configuration.delayBetweenIterations.strategy ?? "fixed";
+      const interval = configuration.delayBetweenIterations.intervalSeconds ?? 0;
+      details["Delay strategy"] = strategy;
+      details["Delay interval (s)"] = interval;
+    }
+
+    return details;
+  },
+};
+
+function isLoopSessionMetadata(metadata: unknown): metadata is LoopMetadata {
+  return typeof metadata === "object" && metadata !== null && "active" in metadata;
+}
+
+function isIterationExecutionMetadata(metadata: unknown): metadata is IterationExecutionMetadata {
+  return typeof metadata === "object" && metadata !== null && "maxIterations" in metadata;
+}
+
+function getLoopEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  const rootEvent = execution.rootEvent;
+  if (!rootEvent?.id || !execution.createdAt) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === rootEvent.nodeId);
+  if (!rootTriggerNode?.componentName) {
+    return [];
+  }
+
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode.componentName);
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: rootEvent });
+  const createdAt = new Date(execution.createdAt);
+
+  return [
+    {
+      receivedAt: createdAt,
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(createdAt),
+      eventState: getState(componentName)(execution),
+      eventId: rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/ui/CanvasPage/edgePath.spec.ts
+++ b/web_src/src/ui/CanvasPage/edgePath.spec.ts
@@ -32,7 +32,7 @@ describe("isBackwardEdge", () => {
 
 describe("getUpwardBackwardGutterY", () => {
   it("places the gutter just below the target row", () => {
-    expect(getUpwardBackwardGutterY(268, 118)).toBe(308);
+    expect(getUpwardBackwardGutterY(268, 118)).toBe(388);
   });
 });
 
@@ -104,7 +104,7 @@ describe("getCanvasEdgePath", () => {
 
     expect(path).not.toContain("C");
     expect(path).toContain("924,268");
-    expect(path).toContain("308");
+    expect(path).toContain("388");
     expect(path).toContain("200 118");
   });
 });

--- a/web_src/src/ui/CanvasPage/edgePath.ts
+++ b/web_src/src/ui/CanvasPage/edgePath.ts
@@ -2,7 +2,7 @@ import { Position, getBezierPath, getSmoothStepPath } from "@xyflow/react";
 
 const BACKWARD_ROUTE_OFFSET = 80;
 const BACKWARD_ROUTE_TARGET_BIAS = 0.75;
-const CANVAS_NODE_HEIGHT = 200;
+const CANVAS_NODE_HEIGHT = 280;
 const MIN_DISTANCE_FROM_TARGET_TOP = 50;
 const MIN_DISTANCE_FROM_SOURCE_BOTTOM = 50;
 const SAME_ROW_TOLERANCE = 40;


### PR DESCRIPTION
fixes https://github.com/superplanehq/superplane/issues/1468

Leaving some notes about dubious decisions:

### Queue Item Deffering

The loop component needs to process queue items out of order to support serialized loop sessions. Here is an example:

```
start -> loop -> work ... ->
       ^                   |
       +-------------------+ 
```

If I click `start` two times in a row and create two "loop sessions" my queue on the loop component will contain:

1/ start 1 event
2/ start 2 event

But, I need to process all feedback events for "start 1" first, before processing the "start 2" queue item.

This is currently done using two questionable decisions:

1/ deferring by bumping created_at

When we defer, we are bumping the `created_at` timestamp on the queue item. 
This is dubious because it is rewriting what happened in the real world. 

I opted for this to avoid making larger scale changes in the queue processing system.

2/ deffering is done by a sentinel error

This is less problematic because this is just code, but still a bit 🐟.
The proper way would be to have a enum in the process queue item that signals to the processing system what happened.

This unfortunately requires a bigger change and rewriting every place where we use this interface.

### Cycle detection

I'm attempting to leave some guardrails to avoid random cycles in the graph.
Adding an exception only for the loop nodes.

Questinable if this is really needed. Once we go loop, we can forget about DAGs.