### PR TITLE
fix: restore trigger run node details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 ## Pull Request Guidelines
 
 - PR titles must follow Conventional Commits and include a release-type prefix: `feat:`, `fix:`, `chore:`, or `docs:` (CI enforces this).
+- All commits must include a DCO sign-off trailer (`Signed-off-by: Name <email>`). Use `git commit -s` or `git commit --amend -s` when creating or updating commits.
 
 ## Build, Test, and Development Commands
 

--- a/web_src/src/ui/Runs/runNodeDetailModel.spec.ts
+++ b/web_src/src/ui/Runs/runNodeDetailModel.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getAdjacentRunNodeId, isRunNodeDetailTabAvailable, resolveRunNodeDetailTab } from "./runNodeDetailModel";
+import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import {
+  buildTriggerTabData,
+  getAdjacentRunNodeId,
+  isRunNodeDetailTabAvailable,
+  resolveRunNodeDetailTab,
+} from "./runNodeDetailModel";
 
 const allTabs = {
   hasDetailsSection: true,
@@ -50,3 +56,97 @@ describe("getAdjacentRunNodeId", () => {
     expect(getAdjacentRunNodeId(chain, "node-b", "next")).toBeNull();
   });
 });
+
+describe("buildTriggerTabData", () => {
+  it("uses trigger mapper details for trigger nodes", () => {
+    const run = buildGithubCommitStatusRun();
+    const node = buildTriggerNode("github.onCommitStatus");
+
+    const tabData = buildTriggerTabData(run, node);
+
+    expect(tabData.details).toMatchObject({
+      State: "success",
+      Context: "ci/semaphoreci/pr: Operately - Build & Test",
+      Description: "The build passed on Semaphore 2.0.",
+      SHA: "43a3f0a1ac3ba8bc45e1b858c557094af374eddb",
+      "Commit message": "Adjust skills",
+      "Commit author": "Rockyy174",
+      Branches: "-",
+      Repository: "operately/operately",
+      "Status creator": "shiroyasha",
+      "Commit URL": "https://github.com/operately/operately/commit/43a3f0a1ac3ba8bc45e1b858c557094af374eddb",
+      "Target URL": "https://operately.semaphoreci.com/workflows/5128f711",
+    });
+    expect(tabData.details).not.toHaveProperty("Channel");
+    expect(tabData.details).not.toHaveProperty("Triggered at");
+    expect(tabData.payload).toEqual(run.rootEvent?.data);
+  });
+
+  it("falls back to generic trigger details when the event has no mapper details", () => {
+    const run: CanvasesCanvasRun = {
+      rootEvent: {
+        id: "event-1",
+        nodeId: "trigger-1",
+        channel: "default",
+        customName: "Manual run",
+        createdAt: new Date().toISOString(),
+        data: {},
+      },
+    };
+
+    const tabData = buildTriggerTabData(run, buildTriggerNode("unknown.trigger"));
+
+    expect(tabData.details).toEqual({
+      Channel: "default",
+      Name: "Manual run",
+      "Triggered at": run.rootEvent?.createdAt,
+    });
+  });
+});
+
+function buildTriggerNode(component: string): ComponentsNode {
+  return {
+    id: "trigger-1",
+    name: component,
+    type: "TYPE_TRIGGER",
+    component,
+  };
+}
+
+function buildGithubCommitStatusRun(): CanvasesCanvasRun {
+  return {
+    rootEvent: {
+      id: "event-1",
+      nodeId: "trigger-1",
+      channel: "default",
+      createdAt: new Date().toISOString(),
+      data: {
+        type: "github.status",
+        data: {
+          state: "success",
+          context: "ci/semaphoreci/pr: Operately - Build & Test",
+          description: "The build passed on Semaphore 2.0.",
+          sha: "43a3f0a1ac3ba8bc45e1b858c557094af374eddb",
+          branches: [],
+          repository: {
+            full_name: "operately/operately",
+          },
+          sender: {
+            login: "shiroyasha",
+          },
+          target_url: "https://operately.semaphoreci.com/workflows/5128f711",
+          commit: {
+            sha: "43a3f0a1ac3ba8bc45e1b858c557094af374eddb",
+            html_url: "https://github.com/operately/operately/commit/43a3f0a1ac3ba8bc45e1b858c557094af374eddb",
+            author: {
+              login: "Rockyy174",
+            },
+            commit: {
+              message: "Adjust skills",
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/web_src/src/ui/Runs/runNodeDetailModel.ts
+++ b/web_src/src/ui/Runs/runNodeDetailModel.ts
@@ -4,8 +4,8 @@ import type {
   SuperplaneComponentsNode as ComponentsNode,
 } from "@/api-client";
 import { flattenObject } from "@/lib/utils";
-import { getExecutionDetails, getState, getStateMap } from "@/pages/app/mappers";
-import { buildExecutionInfo } from "@/pages/app/utils";
+import { getExecutionDetails, getState, getStateMap, getTriggerRenderer } from "@/pages/app/mappers";
+import { buildEventInfo, buildExecutionInfo } from "@/pages/app/utils";
 import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
 
 export type RunNodeDetailTabKey = "details" | "payload" | "configuration";
@@ -194,15 +194,13 @@ export function buildTriggerTabData(
   run: CanvasesCanvasRun,
   workflowNode: ComponentsNode | undefined,
 ): RunNodeDetailTabData {
-  const details: Record<string, unknown> = {};
   const rootEvent = run.rootEvent;
-
-  if (rootEvent?.channel) details.Channel = rootEvent.channel;
-  if (rootEvent?.customName) details.Name = rootEvent.customName;
-  if (rootEvent?.createdAt) details["Triggered at"] = rootEvent.createdAt;
+  const mappedDetails = buildTriggerEventDetails(rootEvent, workflowNode);
+  const fallbackDetails = buildFallbackTriggerEventDetails(rootEvent);
+  const details = Object.keys(mappedDetails).length > 0 ? mappedDetails : fallbackDetails;
 
   const tabData: RunNodeDetailTabData = {
-    details: Object.keys(details).length > 0 ? details : undefined,
+    details: Object.keys(details).length > 0 ? filterEmptyDetailEntries(details) : undefined,
     payload: rootEvent?.data && Object.keys(rootEvent.data).length > 0 ? rootEvent.data : undefined,
   };
 
@@ -215,6 +213,26 @@ export function buildTriggerTabData(
   }
 
   return tabData;
+}
+
+function buildTriggerEventDetails(
+  rootEvent: CanvasesCanvasRun["rootEvent"],
+  workflowNode: ComponentsNode | undefined,
+): Record<string, unknown> {
+  if (!rootEvent) return {};
+
+  const triggerRenderer = getTriggerRenderer(workflowComponentName(workflowNode));
+  return triggerRenderer.getRootEventValues({ event: buildEventInfo(rootEvent) });
+}
+
+function buildFallbackTriggerEventDetails(rootEvent: CanvasesCanvasRun["rootEvent"]): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+
+  if (rootEvent?.channel) details.Channel = rootEvent.channel;
+  if (rootEvent?.customName) details.Name = rootEvent.customName;
+  if (rootEvent?.createdAt) details["Triggered at"] = rootEvent.createdAt;
+
+  return details;
 }
 
 export function isErrorValue(value: unknown): value is { __type: "error"; message: string } {


### PR DESCRIPTION
## Summary

- Restore trigger-specific details in the new run node details panel.
- Keep raw root event data in the Payload tab and preserve generic details as a fallback for unmapped triggers.
- Add regression coverage for `github.onCommitStatus`, matching the issue screenshots.

Fixes #5317

