### PR TITLE
fix: See in Editor button works without page refresh

### DIFF
--- a/pkg/integrations/claude/runagent/client.go
+++ b/pkg/integrations/claude/runagent/client.go
@@ -539,6 +539,71 @@ func (c *Client) CleanupFiles(fileIDs []string, logWarn func(string, ...any)) {
 	}
 }
 
+// CreateVault creates a temporary vault and returns its ID.
+func (c *Client) CreateVault(displayName string, metadata map[string]string) (string, error) {
+	payload := map[string]any{"display_name": displayName}
+	if len(metadata) > 0 {
+		payload["metadata"] = metadata
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal vault request: %w", err)
+	}
+	respBody, err := c.execRequestWithBeta(http.MethodPost, c.BaseURL+"/vaults", bytes.NewBuffer(b), anthropicBetaManagedAgents)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode vault response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("vault creation returned empty ID")
+	}
+	return result.ID, nil
+}
+
+// CreateEnvVarCredential adds an environment_variable credential to a vault.
+// The secret is injected at the network egress layer; the agent never sees the raw value.
+func (c *Client) CreateEnvVarCredential(vaultID, displayName, envName, secretValue string, allowedHosts []string) error {
+	if vaultID == "" || envName == "" || secretValue == "" {
+		return fmt.Errorf("vaultID, envName, and secretValue are required")
+	}
+	networking := map[string]any{"type": "unrestricted"}
+	if len(allowedHosts) > 0 {
+		networking = map[string]any{
+			"type":          "limited",
+			"allowed_hosts": allowedHosts,
+		}
+	}
+	payload := map[string]any{
+		"display_name": displayName,
+		"auth": map[string]any{
+			"type":         "environment_variable",
+			"secret_name":  envName,
+			"secret_value": secretValue,
+			"networking":   networking,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal credential request: %w", err)
+	}
+	_, err = c.execRequestWithBeta(http.MethodPost, c.BaseURL+"/vaults/"+url.PathEscape(vaultID)+"/credentials", bytes.NewBuffer(b), anthropicBetaManagedAgents)
+	return err
+}
+
+// DeleteVault removes a vault and its credentials.
+func (c *Client) DeleteVault(vaultID string) error {
+	if vaultID == "" {
+		return nil
+	}
+	_, err := c.execRequestWithBeta(http.MethodDelete, c.BaseURL+"/vaults/"+url.PathEscape(vaultID), nil, anthropicBetaManagedAgents)
+	return err
+}
+
 func (c *Client) execRequestWithBeta(method, URL string, body io.Reader, beta string) ([]byte, error) {
 	req, err := http.NewRequest(method, URL, body)
 	if err != nil {

--- a/pkg/integrations/claude/runagent/monitor.go
+++ b/pkg/integrations/claude/runagent/monitor.go
@@ -59,6 +59,7 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 		}
 		if c, cErr := NewClient(ctx.HTTP, ctx.Integration); cErr == nil {
 			cleanupUploadedFilesFromHook(c, ctx, ctx.Logger.Warnf)
+			cleanupManagedVaultFromHook(c, ctx, ctx.Logger.Warnf)
 		}
 		return nil
 	}
@@ -78,6 +79,7 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 				return emitErr
 			}
 			cleanupUploadedFilesFromHook(client, ctx, ctx.Logger.Warnf)
+			cleanupManagedVaultFromHook(client, ctx, ctx.Logger.Warnf)
 			return nil
 		}
 		return a.scheduleNextPoll(ctx, attempt+1, errs)
@@ -112,6 +114,7 @@ func (a *RunAgent) poll(ctx core.ActionHookContext) error {
 			ctx.Logger.Warnf("Failed to delete managed session %s: %v", metadata.Session.ID, err)
 		}
 		cleanupUploadedFilesFromHook(client, ctx, ctx.Logger.Warnf)
+		cleanupManagedVaultFromHook(client, ctx, ctx.Logger.Warnf)
 		return nil
 	}
 
@@ -149,5 +152,6 @@ func (a *RunAgent) Cancel(ctx core.ExecutionContext) error {
 	// Best effort cleanup; may fail if session is still running.
 	_ = client.DeleteManagedSession(metadata.Session.ID)
 	cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
+	cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 	return nil
 }

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -285,14 +285,17 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 	metadata := ExecutionMetadata{}
 	mergeSessionIntoMetadata(&metadata, session)
 	if err := ctx.Metadata.Set(metadata); err != nil {
+		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to set execution metadata: %w", err)
 	}
 
 	if err := ctx.ExecutionState.SetKV("managed_session_id", session.ID); err != nil {
+		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to set managed_session_id: %w", err)
 	}
 
 	if err := client.SendManagedSessionUserMessage(session.ID, spec.Prompt); err != nil {
+		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to send user message: %w", err)
 	}
 
@@ -300,6 +303,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 	// Don't write terminal status to metadata yet — only after emit.
 	refreshed, err := client.GetManagedSession(session.ID)
 	if err != nil {
+		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to get session: %w", err)
 	}
 
@@ -310,6 +314,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		} else if sm != nil && sm.Complete {
 			out := buildOutputFromSessionMessages(refreshed.Status, session.ID, sm)
 			if emitErr := ctx.ExecutionState.Emit(defaultChannel, payloadType, []any{out}); emitErr != nil {
+				cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 				return emitErr
 			}
 			// Persist terminal status only after successful emit

--- a/pkg/integrations/claude/runagent/run_agent.go
+++ b/pkg/integrations/claude/runagent/run_agent.go
@@ -114,6 +114,53 @@ func (a *RunAgent) Configuration() []configuration.Field {
 				},
 			},
 		},
+		{
+			Name:        "secrets",
+			Label:       "Secrets",
+			Type:        configuration.FieldTypeList,
+			Required:    false,
+			Description: "SuperPlane secrets to inject as environment variables in the agent session. Secrets are injected at the network egress layer and never exposed to the agent.",
+			TypeOptions: &configuration.TypeOptions{
+				List: &configuration.ListTypeOptions{
+					ItemLabel: "Secret",
+					ItemDefinition: &configuration.ListItemDefinition{
+						Type: configuration.FieldTypeObject,
+						Schema: []configuration.Field{
+							{
+								Name:        "envName",
+								Label:       "Environment Variable",
+								Type:        configuration.FieldTypeString,
+								Required:    true,
+								Placeholder: "GITHUB_TOKEN",
+								Description: "Name of the environment variable in the agent session",
+							},
+							{
+								Name:        "value",
+								Label:       "Secret",
+								Type:        configuration.FieldTypeSecretKey,
+								Required:    true,
+								Description: "SuperPlane secret and key to inject",
+							},
+							{
+								Name:        "allowedHosts",
+								Label:       "Allowed Hosts",
+								Type:        configuration.FieldTypeList,
+								Required:    false,
+								Description: "Restrict which domains this secret can be sent to. Leave empty for unrestricted.",
+								TypeOptions: &configuration.TypeOptions{
+									List: &configuration.ListTypeOptions{
+										ItemLabel: "Host",
+										ItemDefinition: &configuration.ListItemDefinition{
+											Type: configuration.FieldTypeString,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -148,6 +195,15 @@ func (a *RunAgent) Setup(ctx core.SetupContext) error {
 			if !fileSet[norm] {
 				return fmt.Errorf("file %q not found in app repository", f)
 			}
+		}
+	}
+
+	for i, s := range spec.Secrets {
+		if strings.TrimSpace(s.EnvName) == "" {
+			return fmt.Errorf("secrets[%d].envName is required", i)
+		}
+		if s.Value.Secret == "" || s.Value.Key == "" {
+			return fmt.Errorf("secrets[%d].value.secret and secrets[%d].value.key are required", i, i)
 		}
 	}
 
@@ -198,18 +254,31 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 		}
 	}
 
+	// Create a temporary vault and inject secrets as environment variables.
+	vaultIDs := append([]string{}, spec.VaultIDs...)
+	if len(spec.Secrets) > 0 {
+		vaultID, vaultErr := provisionSecretsVault(client, ctx, spec.Secrets)
+		if vaultErr != nil {
+			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
+			cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
+			return fmt.Errorf("failed to provision secrets vault: %w", vaultErr)
+		}
+		vaultIDs = append(vaultIDs, vaultID)
+	}
+
 	aid := strings.TrimSpace(spec.Agent)
 	createReq := CreateManagedSessionRequest{
 		Agent:         aid,
 		AgentVersion:  spec.Version,
 		EnvironmentID: strings.TrimSpace(spec.EnvironmentID),
-		VaultIDs:      spec.VaultIDs,
+		VaultIDs:      vaultIDs,
 		Resources:     resources,
 	}
 
 	session, err := client.CreateManagedSession(createReq)
 	if err != nil {
 		cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
+		cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 		return fmt.Errorf("failed to create managed agent session: %w", err)
 	}
 
@@ -250,6 +319,7 @@ func (a *RunAgent) Execute(ctx core.ExecutionContext) error {
 				ctx.Logger.Warnf("Failed to delete managed session %s: %v", session.ID, err)
 			}
 			cleanupUploadedFiles(client, ctx, ctx.Logger.Warnf)
+			cleanupManagedVault(client, ctx, ctx.Logger.Warnf)
 			return nil
 		} else {
 			ctx.Logger.Warnf("Events not complete for session %s after retries. Scheduling poll.", session.ID)
@@ -320,6 +390,70 @@ func cleanupFileResources(client *Client, resources []FileResource, logWarn func
 			logWarn("Failed to delete uploaded file %s: %v", r.FileID, err)
 		}
 	}
+}
+
+// provisionSecretsVault creates a temporary Anthropic vault and adds
+// environment_variable credentials for each configured secret binding.
+// Returns the vault ID for session creation.
+func provisionSecretsVault(client *Client, ctx core.ExecutionContext, secrets []SecretBinding) (string, error) {
+	vaultID, err := client.CreateVault(
+		fmt.Sprintf("superplane-%s", truncateID(ctx.ID.String(), 12)),
+		map[string]string{"superplane_execution": ctx.ID.String()},
+	)
+	if err != nil {
+		return "", fmt.Errorf("create vault: %w", err)
+	}
+
+	// Store vault ID immediately so cleanup works on later errors.
+	if err := ctx.ExecutionState.SetKV("managed_vault_id", vaultID); err != nil {
+		_ = client.DeleteVault(vaultID)
+		return "", fmt.Errorf("persist vault ID: %w", err)
+	}
+
+	for _, s := range secrets {
+		value, err := ctx.Secrets.GetKey(s.Value.Secret, s.Value.Key)
+		if err != nil {
+			_ = client.DeleteVault(vaultID)
+			return "", fmt.Errorf("resolve secret %s/%s: %w", s.Value.Secret, s.Value.Key, err)
+		}
+
+		if err := client.CreateEnvVarCredential(vaultID, s.EnvName, s.EnvName, string(value), s.AllowedHosts); err != nil {
+			_ = client.DeleteVault(vaultID)
+			return "", fmt.Errorf("create credential for %s: %w", s.EnvName, err)
+		}
+		ctx.Logger.Infof("Injected secret as env var: %s", s.EnvName)
+	}
+
+	return vaultID, nil
+}
+
+// cleanupManagedVault deletes the temporary vault created for this execution.
+func cleanupManagedVault(client *Client, ctx core.ExecutionContext, logWarn func(string, ...any)) {
+	vaultID, err := ctx.ExecutionState.GetKV("managed_vault_id")
+	if err != nil || vaultID == "" {
+		return
+	}
+	if err := client.DeleteVault(vaultID); err != nil && logWarn != nil {
+		logWarn("Failed to delete managed vault %s: %v", vaultID, err)
+	}
+}
+
+// cleanupManagedVaultFromHook is the ActionHookContext variant.
+func cleanupManagedVaultFromHook(client *Client, ctx core.ActionHookContext, logWarn func(string, ...any)) {
+	vaultID, err := ctx.ExecutionState.GetKV("managed_vault_id")
+	if err != nil || vaultID == "" {
+		return
+	}
+	if err := client.DeleteVault(vaultID); err != nil && logWarn != nil {
+		logWarn("Failed to delete managed vault %s: %v", vaultID, err)
+	}
+}
+
+func truncateID(id string, maxLen int) string {
+	if len(id) <= maxLen {
+		return id
+	}
+	return id[:maxLen]
 }
 
 func decodeSpec(config any) (Spec, error) {

--- a/pkg/integrations/claude/runagent/types.go
+++ b/pkg/integrations/claude/runagent/types.go
@@ -18,12 +18,26 @@ const (
 // Spec is the workflow node configuration for claude.runAgent.
 type Spec struct {
 	// Agent is the managed agent id (use latest if Version is nil, else pin to Version).
-	Agent         string   `json:"agent" mapstructure:"agent"`
-	Version       *int     `json:"version" mapstructure:"version"`
-	EnvironmentID string   `json:"environmentId" mapstructure:"environmentId"`
-	Prompt        string   `json:"prompt" mapstructure:"prompt"`
-	VaultIDs      []string `json:"vaultIds" mapstructure:"vaultIds"`
-	Files         []string `json:"files" mapstructure:"files"`
+	Agent         string          `json:"agent" mapstructure:"agent"`
+	Version       *int            `json:"version" mapstructure:"version"`
+	EnvironmentID string          `json:"environmentId" mapstructure:"environmentId"`
+	Prompt        string          `json:"prompt" mapstructure:"prompt"`
+	VaultIDs      []string        `json:"vaultIds" mapstructure:"vaultIds"`
+	Files         []string        `json:"files" mapstructure:"files"`
+	Secrets       []SecretBinding `json:"secrets" mapstructure:"secrets"`
+}
+
+// SecretBinding maps a SuperPlane secret to an environment variable in the agent session.
+type SecretBinding struct {
+	EnvName      string    `json:"envName" mapstructure:"envName"`
+	Value        SecretRef `json:"value" mapstructure:"value"`
+	AllowedHosts []string  `json:"allowedHosts" mapstructure:"allowedHosts"`
+}
+
+// SecretRef references a SuperPlane secret by name and key.
+type SecretRef struct {
+	Secret string `json:"secret" mapstructure:"secret"`
+	Key    string `json:"key" mapstructure:"key"`
 }
 
 // ExecutionMetadata is persisted for the run.

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -2574,19 +2574,41 @@ export function AppPage() {
     return () => window.removeEventListener("agent:open-integration", handler);
   }, []);
 
-  // Listen for "See in Editor" from draft-actions widget
+  // Listen for "See in Editor" from draft-actions widget.
+  // When the agent creates a draft, the version may not be loaded yet.
+  // We store the pending ID and pick it up once versions refetch.
+  const pendingViewVersionRef = useRef<string | null>(null);
+
   useEffect(() => {
-    const handler = (e: Event) => {
+    const pending = pendingViewVersionRef.current;
+    if (pending) {
+      const version = selectableVersionsById.get(pending);
+      if (version) {
+        pendingViewVersionRef.current = null;
+        setActiveCanvasVersion(version);
+      }
+    }
+  }, [selectableVersionsById]);
+
+  useEffect(() => {
+    const handler = async (e: Event) => {
       const { versionId } = (e as CustomEvent).detail;
-      if (!versionId) return;
+      if (!versionId || !canvasId) return;
+
       const version = selectableVersionsById.get(versionId);
       if (version) {
         setActiveCanvasVersion(version);
+        return;
       }
+
+      // Version not loaded yet. Store pending ID and refetch.
+      pendingViewVersionRef.current = versionId;
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
     };
     window.addEventListener("agent:view-version", handler);
     return () => window.removeEventListener("agent:view-version", handler);
-  }, [selectableVersionsById]);
+  }, [selectableVersionsById, canvasId, queryClient]);
 
   const handleIntegrationCreated = useCallback(
     async (integrationId: string, instanceName: string) => {


### PR DESCRIPTION
## Problem

When the in-app agent creates a draft version and shows the draft actions widget, clicking "See in Editor" does nothing until the page is refreshed.

## Cause

The `agent:view-version` handler looks up the version in `selectableVersionsById`, which is built from the cached versions query. The agent's newly created draft isn't in the cache yet, so the lookup silently returns nothing.

## Fix

1. If the version is found in cache, switch to it immediately (unchanged)
2. If not found, store the version ID in a `pendingViewVersionRef` and invalidate the versions queries to trigger a refetch
3. A `useEffect` on `selectableVersionsById` picks up the pending ID once the refetched data arrives and switches to the version