### PR TITLE
feat: add AWS Prometheus Managed Service rule groups management components

### DIFF
--- a/docs/components/AWS.mdx
+++ b/docs/components/AWS.mdx
@@ -62,9 +62,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
   <LinkCard title="ECS • Stop Task" href="#ecs-•-stop-task" description="Stop a running AWS ECS task" />
   <LinkCard title="ECS • Update Service" href="#ecs-•-update-service" description="Update an AWS ECS service configuration" />
   <LinkCard title="Lambda • Run Function" href="#lambda-•-run-function" description="Invoke a Lambda function, optionally creating it from inline JavaScript" />
+  <LinkCard title="Prometheus • Create Rule Group Namespace" href="#prometheus-•-create-rule-group-namespace" description="Create a rule group namespace in an Amazon Managed Service for Prometheus workspace" />
   <LinkCard title="Prometheus • Create Workspace" href="#prometheus-•-create-workspace" description="Create an Amazon Managed Service for Prometheus workspace" />
+  <LinkCard title="Prometheus • Delete Rule Group Namespace" href="#prometheus-•-delete-rule-group-namespace" description="Delete a rule group namespace from an Amazon Managed Service for Prometheus workspace" />
   <LinkCard title="Prometheus • Delete Workspace" href="#prometheus-•-delete-workspace" description="Delete an Amazon Managed Service for Prometheus workspace" />
+  <LinkCard title="Prometheus • Get Rule Group Namespace" href="#prometheus-•-get-rule-group-namespace" description="Get a rule group namespace from an Amazon Managed Service for Prometheus workspace" />
   <LinkCard title="Prometheus • Get Workspace" href="#prometheus-•-get-workspace" description="Get an Amazon Managed Service for Prometheus workspace" />
+  <LinkCard title="Prometheus • Update Rule Group Namespace" href="#prometheus-•-update-rule-group-namespace" description="Update a rule group namespace in an Amazon Managed Service for Prometheus workspace" />
   <LinkCard title="Prometheus • Update Workspace" href="#prometheus-•-update-workspace" description="Update a Prometheus workspace alias" />
   <LinkCard title="Route 53 • Create DNS Record" href="#route-53-•-create-dns-record" description="Create a DNS record in an AWS Route 53 hosted zone" />
   <LinkCard title="Route 53 • Delete DNS Record" href="#route-53-•-delete-dns-record" description="Delete a DNS record from an AWS Route 53 hosted zone" />
@@ -2546,6 +2550,39 @@ The Run Lambda component invokes a Lambda function.
 }
 ```
 
+<a id="prometheus-•-create-rule-group-namespace"></a>
+
+## Prometheus • Create Rule Group Namespace
+
+**Component key:** `aws.prometheus.createRuleGroupNamespace`
+
+The Create Rule Group Namespace component creates a rule group namespace in an Amazon Managed Service for Prometheus workspace.
+
+### Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Namespace Name**: Name for the new rule group namespace
+- **Rule Groups YAML**: Prometheus rule groups YAML file content
+- **Client Token**: Optional idempotency token
+- **Tags**: Optional rule group namespace tags
+
+### Example Output
+
+```json
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "name": "example-rule-group-namespace"
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:25:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace"
+}
+```
+
 <a id="prometheus-•-create-workspace"></a>
 
 ## Prometheus • Create Workspace
@@ -2584,6 +2621,36 @@ The Create Workspace component creates an Amazon Managed Service for Prometheus 
 }
 ```
 
+<a id="prometheus-•-delete-rule-group-namespace"></a>
+
+## Prometheus • Delete Rule Group Namespace
+
+**Component key:** `aws.prometheus.deleteRuleGroupNamespace`
+
+The Delete Rule Group Namespace component deletes one rule group namespace and its rule groups definition.
+
+### Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace
+- **Client Token**: Optional idempotency token
+
+### Example Output
+
+```json
+{
+  "data": {
+    "deleted": true,
+    "namespace": "example-rule-group-namespace",
+    "workspaceAlias": "example-workspace",
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:30:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace.deleted"
+}
+```
+
 <a id="prometheus-•-delete-workspace"></a>
 
 ## Prometheus • Delete Workspace
@@ -2612,6 +2679,42 @@ AWS does not immediately delete metrics data that has already been ingested. It 
   },
   "timestamp": "2026-01-01T00:15:00.000000000Z",
   "type": "aws.prometheus.workspace.deleted"
+}
+```
+
+<a id="prometheus-•-get-rule-group-namespace"></a>
+
+## Prometheus • Get Rule Group Namespace
+
+**Component key:** `aws.prometheus.getRuleGroupNamespace`
+
+The Get Rule Group Namespace component retrieves one rule group namespace from an Amazon Managed Service for Prometheus workspace.
+
+### Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace
+
+### Example Output
+
+```json
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "createdAt": "2026-01-01T00:35:00Z",
+      "data": "Z3JvdXBzOgogIC0gbmFtZTogZXhhbXBsZV9yZWNvcmRpbmdfcnVsZXMKICAgIGludGVydmFsOiAzMHMKICAgIHJ1bGVzOgogICAgICAtIHJlY29yZDogZXhhbXBsZTpyZXF1ZXN0c19wZXJfc2Vjb25kOnJhdGUxbQogICAgICAgIGV4cHI6IHwKICAgICAgICAgIHN1bShyYXRlKGV4YW1wbGVfcmVxdWVzdHNfdG90YWxbMW1dKSkKCiAgLSBuYW1lOiBleGFtcGxlX2FsZXJ0aW5nX3J1bGVzCiAgICBpbnRlcnZhbDogMzBzCiAgICBydWxlczoKICAgICAgLSBhbGVydDogRXhhbXBsZUhpZ2hSZXF1ZXN0UmF0ZQogICAgICAgIGV4cHI6IHwKICAgICAgICAgIHN1bShyYXRlKGV4YW1wbGVfcmVxdWVzdHNfdG90YWxbMW1dKSkgPiAxMDAKICAgICAgICBmb3I6IDFtCiAgICAgICAgbGFiZWxzOgogICAgICAgICAgc2V2ZXJpdHk6IHdhcm5pbmcKICAgICAgICAgIHNlcnZpY2U6IGV4YW1wbGUKICAgICAgICBhbm5vdGF0aW9uczoKICAgICAgICAgIHN1bW1hcnk6ICJFeGFtcGxlIGhpZ2ggcmVxdWVzdCByYXRlIgogICAgICAgICAgZGVzY3JpcHRpb246ICJUaGUgZXhhbXBsZSBzZXJ2aWNlIGlzIHJlY2VpdmluZyBtb3JlIHRoYW4gMTAwIHJlcXVlc3RzIHBlciBzZWNvbmQuIgo=",
+      "modifiedAt": "2026-01-01T00:40:00Z",
+      "name": "example-rule-group-namespace",
+      "status": {
+        "statusCode": "ACTIVE"
+      }
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:45:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace"
 }
 ```
 
@@ -2649,6 +2752,38 @@ The Get Workspace component retrieves details for an Amazon Managed Service for 
   },
   "timestamp": "2026-01-01T00:05:00.000000000Z",
   "type": "aws.prometheus.workspace"
+}
+```
+
+<a id="prometheus-•-update-rule-group-namespace"></a>
+
+## Prometheus • Update Rule Group Namespace
+
+**Component key:** `aws.prometheus.updateRuleGroupNamespace`
+
+The Update Rule Group Namespace component updates the rule groups YAML for an existing Amazon Managed Service for Prometheus rule group namespace.
+
+### Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace
+- **Rule Groups YAML**: New Prometheus rule groups YAML file content
+- **Client Token**: Optional idempotency token
+
+### Example Output
+
+```json
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "name": "example-rule-group-namespace"
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:50:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace.updated"
 }
 ```
 

--- a/pkg/configuration/expressionvalidation/canvas.go
+++ b/pkg/configuration/expressionvalidation/canvas.go
@@ -79,6 +79,10 @@ func validateNodeExpressions(nodeID, nodeName string, config map[string]any, fie
 }
 
 func validateString(fieldPath string, field configuration.Field, value string, knownNodeNames map[string]struct{}) []ExpressionError {
+	if isLiteralTextField(field) {
+		return nil
+	}
+
 	if field.Type == configuration.FieldTypeString &&
 		field.TypeOptions != nil &&
 		field.TypeOptions.String != nil &&
@@ -124,6 +128,14 @@ func validateString(fieldPath string, field configuration.Field, value string, k
 		}
 	}
 	return errs
+}
+
+func isLiteralTextField(field configuration.Field) bool {
+	return field.Type == configuration.FieldTypeText &&
+		field.TypeOptions != nil &&
+		field.TypeOptions.Text != nil &&
+		field.TypeOptions.Text.AllowExpressions != nil &&
+		!*field.TypeOptions.Text.AllowExpressions
 }
 
 var startTemplatePayloadFieldPattern = regexp.MustCompile(`^templates\[\d+\]\.payload(\.|$)`)

--- a/pkg/configuration/expressionvalidation/canvas_test.go
+++ b/pkg/configuration/expressionvalidation/canvas_test.go
@@ -53,6 +53,26 @@ func TestValidateNodeExpressions_FieldTypes(t *testing.T) {
 		assertOneError(t, errs, "message", "unknown node reference 'Missing'")
 	})
 
+	t.Run("literal text with prometheus annotations passes", func(t *testing.T) {
+		allowExpressions := false
+		fields := []configuration.Field{
+			{
+				Name: "data",
+				Type: configuration.FieldTypeText,
+				TypeOptions: &configuration.TypeOptions{
+					Text: &configuration.TextTypeOptions{AllowExpressions: &allowExpressions},
+				},
+			},
+		}
+
+		errs := validateNodeExpressions("n1", "Rules", map[string]any{
+			"data": `summary: "High CPU usage for {{ $labels.component }} with value {{ $value }}"`,
+		}, fields, knownSet())
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %+v", errs)
+		}
+	})
+
 	t.Run("expression bare literals pass", func(t *testing.T) {
 		fields := []configuration.Field{{Name: "value", Type: configuration.FieldTypeExpression}}
 		for _, raw := range []string{"true", "default", "ok", "down", "1 + 2", `"plain"`, `$["Build"].x + 1`} {

--- a/pkg/configuration/field.go
+++ b/pkg/configuration/field.go
@@ -162,6 +162,8 @@ type TextTypeOptions struct {
 	MaxLength *int `json:"maxLength,omitempty"`
 	// Language is the Monaco editor language id (e.g. "javascript", "python").
 	Language string `json:"language,omitempty"`
+	// When false, the field is treated as literal text and expression placeholders are preserved.
+	AllowExpressions *bool `json:"allowExpressions,omitempty"`
 }
 
 /*

--- a/pkg/grpc/actions/common.go
+++ b/pkg/grpc/actions/common.go
@@ -121,6 +121,9 @@ func textTypeOptionsToProto(opts *configuration.TextTypeOptions) *configpb.TextT
 	if opts.Language != "" {
 		pbOpts.Language = &opts.Language
 	}
+	if opts.AllowExpressions != nil {
+		pbOpts.AllowExpressions = opts.AllowExpressions
+	}
 
 	return pbOpts
 }
@@ -419,6 +422,9 @@ func protoToTextTypeOptions(pbOpts *configpb.TextTypeOptions) *configuration.Tex
 
 	if pbOpts.Language != nil {
 		opts.Language = *pbOpts.Language
+	}
+	if pbOpts.AllowExpressions != nil {
+		opts.AllowExpressions = pbOpts.AllowExpressions
 	}
 
 	return opts

--- a/pkg/grpc/actions/common_test.go
+++ b/pkg/grpc/actions/common_test.go
@@ -138,6 +138,35 @@ func TestConfigurationFieldToProto(t *testing.T) {
 		require.NotNil(t, field2.TypeOptions.List.MaxItems, "expected MaxItems to be set after roundtrip")
 		assert.Equal(t, maxItems, *field2.TypeOptions.List.MaxItems)
 	})
+
+	t.Run("roundtrip text type options with AllowExpressions preserves field", func(t *testing.T) {
+		allowExpressions := false
+
+		field := configuration.Field{
+			Name:  "data",
+			Label: "Rule Groups YAML",
+			Type:  configuration.FieldTypeText,
+			TypeOptions: &configuration.TypeOptions{
+				Text: &configuration.TextTypeOptions{
+					Language:         "yaml",
+					AllowExpressions: &allowExpressions,
+				},
+			},
+		}
+
+		pbField := ConfigurationFieldToProto(field)
+		require.NotNil(t, pbField.TypeOptions)
+		require.NotNil(t, pbField.TypeOptions.Text)
+		require.NotNil(t, pbField.TypeOptions.Text.AllowExpressions)
+		assert.False(t, *pbField.TypeOptions.Text.AllowExpressions)
+
+		field2 := ProtoToConfigurationField(pbField)
+		require.NotNil(t, field2.TypeOptions)
+		require.NotNil(t, field2.TypeOptions.Text)
+		require.NotNil(t, field2.TypeOptions.Text.AllowExpressions)
+		assert.False(t, *field2.TypeOptions.Text.AllowExpressions)
+		assert.Equal(t, "yaml", field2.TypeOptions.Text.Language)
+	})
 }
 
 func TestSerializeTriggersAddsDefaultRunTitleExpression(t *testing.T) {

--- a/pkg/integrations/aws/aws.go
+++ b/pkg/integrations/aws/aws.go
@@ -185,6 +185,10 @@ func (a *AWS) Actions() []core.Action {
 		&prometheus.GetWorkspace{},
 		&prometheus.UpdateWorkspace{},
 		&prometheus.DeleteWorkspace{},
+		&prometheus.CreateRuleGroupNamespace{},
+		&prometheus.GetRuleGroupNamespace{},
+		&prometheus.UpdateRuleGroupNamespace{},
+		&prometheus.DeleteRuleGroupNamespace{},
 		&lambda.RunFunction{},
 		&sqs.SendMessage{},
 		&sqs.GetQueue{},
@@ -365,7 +369,7 @@ func (a *AWS) showBrowserAction(ctx core.SyncContext) error {
 - Add permissions for the integration to manage EventBridge connections, API destinations, and rules. To get started, you can use the **AmazonEventBridgeFullAccess** managed policy
 - Add permissions for the integration manage IAM roles needed for itself. To get started, you can use the **IAMFullAccess** managed policy
 - Add permissions for the integration to manage SQS. To get started, you can use the **AmazonSQSFullAccess** managed policy
-- Add permissions for Amazon Managed Service for Prometheus workspaces if you use Prometheus components. At minimum, the workspace picker requires **aps:ListWorkspaces**; the workspace components also need **aps:CreateWorkspace**, **aps:DescribeWorkspace**, **aps:UpdateWorkspaceAlias**, and **aps:DeleteWorkspace** for their respective operations.
+- Add permissions for Amazon Managed Service for Prometheus if you use Prometheus components. At minimum, the workspace picker requires **aps:ListWorkspaces**. Workspace components also need **aps:CreateWorkspace**, **aps:DescribeWorkspace**, **aps:UpdateWorkspaceAlias**, and **aps:DeleteWorkspace**. Rule group namespace components need **aps:CreateRuleGroupsNamespace**, **aps:DescribeRuleGroupsNamespace**, **aps:ListRuleGroupsNamespaces**, **aps:PutRuleGroupsNamespace**, and **aps:DeleteRuleGroupsNamespace**.
 - Depending on the SuperPlane actions and triggers you will use, different permissions will be needed. Include the ones you need.
 - Give it a name and description, and create it
 

--- a/pkg/integrations/aws/prometheus/client.go
+++ b/pkg/integrations/aws/prometheus/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -64,6 +65,40 @@ type CreateWorkspaceResponse struct {
 	Status      WorkspaceStatus   `json:"status"`
 	Tags        map[string]string `json:"tags,omitempty"`
 	WorkspaceID string            `json:"workspaceId"`
+}
+
+type RuleGroupsNamespaceStatus struct {
+	StatusCode   string `json:"statusCode"`
+	StatusReason string `json:"statusReason,omitempty"`
+}
+
+type RuleGroupsNamespaceSummary struct {
+	Arn        string                    `json:"arn"`
+	CreatedAt  common.FloatTime          `json:"createdAt,omitempty"`
+	ModifiedAt common.FloatTime          `json:"modifiedAt,omitempty"`
+	Name       string                    `json:"name"`
+	Status     RuleGroupsNamespaceStatus `json:"status"`
+	Tags       map[string]string         `json:"tags,omitempty"`
+}
+
+type RuleGroupsNamespaceDescription struct {
+	RuleGroupsNamespaceSummary
+	Data string `json:"data"`
+}
+
+type CreateRuleGroupsNamespaceInput struct {
+	WorkspaceID string
+	Name        string
+	Data        string
+	ClientToken string
+	Tags        []common.Tag
+}
+
+type PutRuleGroupsNamespaceInput struct {
+	WorkspaceID string
+	Name        string
+	Data        string
+	ClientToken string
 }
 
 func NewClient(httpCtx core.HTTPContext, credentials *aws.Credentials, region string) *Client {
@@ -131,6 +166,81 @@ func (c *Client) DeleteWorkspace(workspaceID string, clientToken string) error {
 	return c.requestJSON(http.MethodDelete, "/workspaces/"+url.PathEscape(workspaceID), query, nil, nil)
 }
 
+func (c *Client) CreateRuleGroupsNamespace(input CreateRuleGroupsNamespaceInput) (*RuleGroupsNamespaceSummary, error) {
+	payload := map[string]any{
+		"name": input.Name,
+		"data": base64.StdEncoding.EncodeToString([]byte(input.Data)),
+	}
+	if input.ClientToken != "" {
+		payload["clientToken"] = input.ClientToken
+	}
+	if tags := tagsForAPI(input.Tags); len(tags) > 0 {
+		payload["tags"] = tags
+	}
+
+	response := RuleGroupsNamespaceSummary{}
+	if err := c.requestJSON(
+		http.MethodPost,
+		"/workspaces/"+url.PathEscape(input.WorkspaceID)+"/rulegroupsnamespaces",
+		url.Values{},
+		payload,
+		&response,
+	); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) DescribeRuleGroupsNamespace(workspaceID string, name string) (*RuleGroupsNamespaceDescription, error) {
+	var response struct {
+		RuleGroupsNamespace RuleGroupsNamespaceDescription `json:"ruleGroupsNamespace"`
+	}
+
+	if err := c.requestJSON(
+		http.MethodGet,
+		ruleGroupsNamespacePath(workspaceID, name),
+		url.Values{},
+		nil,
+		&response,
+	); err != nil {
+		return nil, err
+	}
+
+	return &response.RuleGroupsNamespace, nil
+}
+
+func (c *Client) PutRuleGroupsNamespace(input PutRuleGroupsNamespaceInput) (*RuleGroupsNamespaceSummary, error) {
+	payload := map[string]any{
+		"data": base64.StdEncoding.EncodeToString([]byte(input.Data)),
+	}
+	if input.ClientToken != "" {
+		payload["clientToken"] = input.ClientToken
+	}
+
+	response := RuleGroupsNamespaceSummary{}
+	if err := c.requestJSON(
+		http.MethodPut,
+		ruleGroupsNamespacePath(input.WorkspaceID, input.Name),
+		url.Values{},
+		payload,
+		&response,
+	); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) DeleteRuleGroupsNamespace(workspaceID string, name string, clientToken string) error {
+	query := url.Values{}
+	if clientToken != "" {
+		query.Set("clientToken", clientToken)
+	}
+
+	return c.requestJSON(http.MethodDelete, ruleGroupsNamespacePath(workspaceID, name), query, nil, nil)
+}
+
 func (c *Client) ListWorkspaces(alias string) ([]WorkspaceSummary, error) {
 	workspaces := []WorkspaceSummary{}
 	nextToken := ""
@@ -162,6 +272,45 @@ func (c *Client) ListWorkspaces(alias string) ([]WorkspaceSummary, error) {
 	}
 
 	return workspaces, nil
+}
+
+func (c *Client) ListRuleGroupsNamespaces(workspaceID string, name string) ([]RuleGroupsNamespaceSummary, error) {
+	namespaces := []RuleGroupsNamespaceSummary{}
+	nextToken := ""
+
+	for {
+		query := url.Values{}
+		query.Set("maxResults", maxResults)
+		if name != "" {
+			query.Set("name", name)
+		}
+		if nextToken != "" {
+			query.Set("nextToken", nextToken)
+		}
+
+		var response struct {
+			NextToken            string                       `json:"nextToken"`
+			RuleGroupsNamespaces []RuleGroupsNamespaceSummary `json:"ruleGroupsNamespaces"`
+		}
+		if err := c.requestJSON(
+			http.MethodGet,
+			"/workspaces/"+url.PathEscape(workspaceID)+"/rulegroupsnamespaces",
+			query,
+			nil,
+			&response,
+		); err != nil {
+			return nil, err
+		}
+
+		namespaces = append(namespaces, response.RuleGroupsNamespaces...)
+		if response.NextToken == "" {
+			break
+		}
+
+		nextToken = response.NextToken
+	}
+
+	return namespaces, nil
 }
 
 func (c *Client) requestJSON(method string, path string, query url.Values, payload any, out any) error {
@@ -218,6 +367,10 @@ func (c *Client) requestJSON(method string, path string, query url.Values, paylo
 
 func (c *Client) endpoint() string {
 	return fmt.Sprintf("https://aps.%s.amazonaws.com", c.region)
+}
+
+func ruleGroupsNamespacePath(workspaceID string, name string) string {
+	return "/workspaces/" + url.PathEscape(workspaceID) + "/rulegroupsnamespaces/" + url.PathEscape(name)
 }
 
 func (c *Client) signRequest(req *http.Request, payload []byte) error {

--- a/pkg/integrations/aws/prometheus/common.go
+++ b/pkg/integrations/aws/prometheus/common.go
@@ -10,7 +10,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
 )
 
-const workspaceResourceType = "prometheus.workspace"
+const (
+	workspaceResourceType           = "prometheus.workspace"
+	ruleGroupsNamespaceResourceType = "prometheus.ruleGroupNamespace"
+)
 
 type workspaceConfiguration struct {
 	Region      string `json:"region" mapstructure:"region"`
@@ -18,10 +21,24 @@ type workspaceConfiguration struct {
 	ClientToken string `json:"clientToken" mapstructure:"clientToken"`
 }
 
+type ruleGroupsNamespaceConfiguration struct {
+	Region      string `json:"region" mapstructure:"region"`
+	WorkspaceID string `json:"workspace" mapstructure:"workspace"`
+	Name        string `json:"namespace" mapstructure:"namespace"`
+	ClientToken string `json:"clientToken" mapstructure:"clientToken"`
+}
+
 type WorkspaceNodeMetadata struct {
 	Region         string `json:"region" mapstructure:"region"`
 	WorkspaceID    string `json:"workspaceId" mapstructure:"workspaceId"`
 	WorkspaceAlias string `json:"workspaceAlias" mapstructure:"workspaceAlias"`
+}
+
+type RuleGroupsNamespaceNodeMetadata struct {
+	Region         string `json:"region" mapstructure:"region"`
+	WorkspaceID    string `json:"workspaceId" mapstructure:"workspaceId"`
+	WorkspaceAlias string `json:"workspaceAlias" mapstructure:"workspaceAlias"`
+	Namespace      string `json:"namespace" mapstructure:"namespace"`
 }
 
 func regionField() configuration.Field {
@@ -68,6 +85,91 @@ func workspaceField(label string, description string) configuration.Field {
 	}
 }
 
+func ruleGroupsNamespaceField(label string, description string) configuration.Field {
+	return configuration.Field{
+		Name:        "namespace",
+		Label:       label,
+		Type:        configuration.FieldTypeIntegrationResource,
+		Required:    true,
+		Description: description,
+		VisibilityConditions: []configuration.VisibilityCondition{
+			{
+				Field:  "workspace",
+				Values: []string{"*"},
+			},
+		},
+		TypeOptions: &configuration.TypeOptions{
+			Resource: &configuration.ResourceTypeOptions{
+				Type: ruleGroupsNamespaceResourceType,
+				Parameters: []configuration.ParameterRef{
+					{
+						Name: "region",
+						ValueFrom: &configuration.ParameterValueFrom{
+							Field: "region",
+						},
+					},
+					{
+						Name: "workspace",
+						ValueFrom: &configuration.ParameterValueFrom{
+							Field: "workspace",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ruleGroupsNamespaceNameField() configuration.Field {
+	return configuration.Field{
+		Name:        "name",
+		Label:       "Namespace Name",
+		Type:        configuration.FieldTypeString,
+		Required:    true,
+		Description: "Name for the rule group namespace",
+		TypeOptions: &configuration.TypeOptions{
+			String: &configuration.StringTypeOptions{
+				MaxLength: func() *int { max := 128; return &max }(),
+			},
+		},
+	}
+}
+
+func ruleGroupsNamespaceDataField() configuration.Field {
+	allowExpressions := false
+
+	return configuration.Field{
+		Name:        "data",
+		Label:       "Rule Groups YAML",
+		Type:        configuration.FieldTypeText,
+		Required:    true,
+		Description: "Prometheus rule groups YAML for the namespace",
+		TypeOptions: &configuration.TypeOptions{
+			Text: &configuration.TextTypeOptions{
+				Language:         "yaml",
+				AllowExpressions: &allowExpressions,
+			},
+		},
+	}
+}
+
+func ruleGroupsNamespaceOutput(namespace *RuleGroupsNamespaceSummary) map[string]any {
+	if namespace == nil {
+		return nil
+	}
+
+	output := map[string]any{
+		"arn":  namespace.Arn,
+		"name": namespace.Name,
+	}
+
+	if len(namespace.Tags) > 0 {
+		output["tags"] = namespace.Tags
+	}
+
+	return output
+}
+
 func aliasField(required bool, description string) configuration.Field {
 	return configuration.Field{
 		Name:        "alias",
@@ -111,7 +213,7 @@ func tagsField() configuration.Field {
 		Label:       "Tags",
 		Type:        configuration.FieldTypeList,
 		Required:    false,
-		Description: "Tags to associate with the workspace",
+		Description: "Tags to associate with the resource",
 		TypeOptions: &configuration.TypeOptions{
 			List: &configuration.ListTypeOptions{
 				ItemLabel: "Tag",
@@ -157,6 +259,30 @@ func decodeWorkspaceConfiguration(rawConfiguration any) (workspaceConfiguration,
 	return config, nil
 }
 
+func decodeRuleGroupsNamespaceConfiguration(rawConfiguration any) (ruleGroupsNamespaceConfiguration, error) {
+	config := ruleGroupsNamespaceConfiguration{}
+	if err := mapstructure.Decode(rawConfiguration, &config); err != nil {
+		return ruleGroupsNamespaceConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Region = strings.TrimSpace(config.Region)
+	config.WorkspaceID = strings.TrimSpace(config.WorkspaceID)
+	config.Name = strings.TrimSpace(config.Name)
+	config.ClientToken = strings.TrimSpace(config.ClientToken)
+
+	if config.Region == "" {
+		return ruleGroupsNamespaceConfiguration{}, fmt.Errorf("region is required")
+	}
+	if config.WorkspaceID == "" {
+		return ruleGroupsNamespaceConfiguration{}, fmt.Errorf("workspace is required")
+	}
+	if config.Name == "" {
+		return ruleGroupsNamespaceConfiguration{}, fmt.Errorf("namespace is required")
+	}
+
+	return config, nil
+}
+
 func workspaceClient(ctx core.ExecutionContext, region string) (*Client, error) {
 	creds, err := common.CredentialsFromInstallation(ctx.Integration)
 	if err != nil {
@@ -186,6 +312,31 @@ func resolveWorkspaceNodeMetadata(ctx core.SetupContext, config workspaceConfigu
 }
 
 func setWorkspaceNodeMetadata(ctx core.SetupContext, metadata WorkspaceNodeMetadata) error {
+	if ctx.Metadata == nil {
+		return nil
+	}
+
+	return ctx.Metadata.Set(metadata)
+}
+
+func resolveRuleGroupsNamespaceNodeMetadata(
+	ctx core.SetupContext,
+	config ruleGroupsNamespaceConfiguration,
+) RuleGroupsNamespaceNodeMetadata {
+	workspace := workspaceConfiguration{
+		Region:      config.Region,
+		WorkspaceID: config.WorkspaceID,
+	}
+
+	return RuleGroupsNamespaceNodeMetadata{
+		Region:         config.Region,
+		WorkspaceID:    config.WorkspaceID,
+		WorkspaceAlias: resolveWorkspaceNodeMetadata(ctx, workspace).WorkspaceAlias,
+		Namespace:      config.Name,
+	}
+}
+
+func setRuleGroupsNamespaceNodeMetadata(ctx core.SetupContext, metadata RuleGroupsNamespaceNodeMetadata) error {
 	if ctx.Metadata == nil {
 		return nil
 	}

--- a/pkg/integrations/aws/prometheus/create_rule_group_namespace.go
+++ b/pkg/integrations/aws/prometheus/create_rule_group_namespace.go
@@ -1,0 +1,172 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/integrations/aws/common"
+)
+
+type CreateRuleGroupNamespace struct{}
+
+type CreateRuleGroupNamespaceConfiguration struct {
+	Region      string       `json:"region" mapstructure:"region"`
+	WorkspaceID string       `json:"workspace" mapstructure:"workspace"`
+	Name        string       `json:"name" mapstructure:"name"`
+	Data        string       `json:"data" mapstructure:"data"`
+	ClientToken string       `json:"clientToken" mapstructure:"clientToken"`
+	Tags        []common.Tag `json:"tags" mapstructure:"tags"`
+}
+
+func (c *CreateRuleGroupNamespace) Name() string {
+	return "aws.prometheus.createRuleGroupNamespace"
+}
+
+func (c *CreateRuleGroupNamespace) Label() string {
+	return "Prometheus • Create Rule Group Namespace"
+}
+
+func (c *CreateRuleGroupNamespace) Description() string {
+	return "Create a rule group namespace in an Amazon Managed Service for Prometheus workspace"
+}
+
+func (c *CreateRuleGroupNamespace) Documentation() string {
+	return `The Create Rule Group Namespace component creates a rule group namespace in an Amazon Managed Service for Prometheus workspace.
+
+## Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Namespace Name**: Name for the new rule group namespace
+- **Rule Groups YAML**: Prometheus rule groups YAML file content
+- **Client Token**: Optional idempotency token
+- **Tags**: Optional rule group namespace tags`
+}
+
+func (c *CreateRuleGroupNamespace) Icon() string {
+	return "aws"
+}
+
+func (c *CreateRuleGroupNamespace) Color() string {
+	return "gray"
+}
+
+func (c *CreateRuleGroupNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *CreateRuleGroupNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		workspaceField("Workspace", "Prometheus workspace to create the rule group namespace in"),
+		ruleGroupsNamespaceNameField(),
+		ruleGroupsNamespaceDataField(),
+		clientTokenField(),
+		tagsField(),
+	}
+}
+
+func (c *CreateRuleGroupNamespace) Setup(ctx core.SetupContext) error {
+	config, err := c.decodeConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	return setRuleGroupsNamespaceNodeMetadata(ctx, resolveRuleGroupsNamespaceNodeMetadata(ctx, ruleGroupsNamespaceConfiguration{
+		Region:      config.Region,
+		WorkspaceID: config.WorkspaceID,
+		Name:        config.Name,
+	}))
+}
+
+func (c *CreateRuleGroupNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *CreateRuleGroupNamespace) Execute(ctx core.ExecutionContext) error {
+	config, err := c.decodeConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := workspaceClient(ctx, config.Region)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := client.CreateRuleGroupsNamespace(CreateRuleGroupsNamespaceInput{
+		WorkspaceID: config.WorkspaceID,
+		Name:        config.Name,
+		Data:        config.Data,
+		ClientToken: config.ClientToken,
+		Tags:        config.Tags,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Prometheus rule group namespace: %w", err)
+	}
+
+	output := map[string]any{
+		"ruleGroupNamespace": ruleGroupsNamespaceOutput(namespace),
+		"workspaceId":        config.WorkspaceID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"aws.prometheus.ruleGroupNamespace",
+		[]any{output},
+	)
+}
+
+func (c *CreateRuleGroupNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *CreateRuleGroupNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *CreateRuleGroupNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *CreateRuleGroupNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *CreateRuleGroupNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *CreateRuleGroupNamespace) decodeConfiguration(rawConfiguration any) (CreateRuleGroupNamespaceConfiguration, error) {
+	config := CreateRuleGroupNamespaceConfiguration{}
+	if err := mapstructure.Decode(rawConfiguration, &config); err != nil {
+		return CreateRuleGroupNamespaceConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Region = strings.TrimSpace(config.Region)
+	config.WorkspaceID = strings.TrimSpace(config.WorkspaceID)
+	config.Name = strings.TrimSpace(config.Name)
+	config.Data = strings.TrimSpace(config.Data)
+	config.ClientToken = strings.TrimSpace(config.ClientToken)
+	config.Tags = common.NormalizeTags(config.Tags)
+
+	if config.Region == "" {
+		return CreateRuleGroupNamespaceConfiguration{}, fmt.Errorf("region is required")
+	}
+	if config.WorkspaceID == "" {
+		return CreateRuleGroupNamespaceConfiguration{}, fmt.Errorf("workspace is required")
+	}
+	if config.Name == "" {
+		return CreateRuleGroupNamespaceConfiguration{}, fmt.Errorf("name is required")
+	}
+	if config.Data == "" {
+		return CreateRuleGroupNamespaceConfiguration{}, fmt.Errorf("rule groups YAML is required")
+	}
+
+	return config, nil
+}

--- a/pkg/integrations/aws/prometheus/create_rule_group_namespace_test.go
+++ b/pkg/integrations/aws/prometheus/create_rule_group_namespace_test.go
@@ -1,0 +1,140 @@
+package prometheus
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__CreateRuleGroupNamespace__Setup(t *testing.T) {
+	component := &CreateRuleGroupNamespace{}
+
+	t.Run("missing data -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"name":      "application-rules",
+				"data":      " ",
+			},
+		})
+
+		require.ErrorContains(t, err, "rule groups YAML is required")
+	})
+
+	t.Run("valid configuration -> stores metadata", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"workspace": {
+							"alias": "metrics",
+							"arn": "arn:aws:aps:us-east-1:123456789012:workspace/ws-abc123",
+							"status": {"statusCode": "ACTIVE"},
+							"workspaceId": "ws-abc123"
+						}
+					}`)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"name":      "application-rules",
+				"data":      "groups: []",
+			},
+			HTTP:        httpContext,
+			Integration: validIntegrationContext(),
+			Metadata:    metadata,
+		})
+
+		require.NoError(t, err)
+		stored, ok := metadata.Get().(RuleGroupsNamespaceNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "us-east-1", stored.Region)
+		assert.Equal(t, "ws-abc123", stored.WorkspaceID)
+		assert.Equal(t, "metrics", stored.WorkspaceAlias)
+		assert.Equal(t, "application-rules", stored.Namespace)
+	})
+}
+
+func Test__CreateRuleGroupNamespace__Execute(t *testing.T) {
+	component := &CreateRuleGroupNamespace{}
+
+	t.Run("valid request -> emits namespace", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusAccepted,
+					Body: io.NopCloser(strings.NewReader(`{
+						"arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+						"createdAt": null,
+						"modifiedAt": null,
+						"name": "application-rules",
+						"status": {"statusCode": "CREATING"},
+						"tags": {"env": "prod"}
+					}`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":      "us-east-1",
+				"workspace":   "ws-abc123",
+				"name":        " application-rules ",
+				"data":        "groups: []",
+				"clientToken": "token-1",
+				"tags": []any{
+					map[string]any{"key": "env", "value": "prod"},
+				},
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration:    validIntegrationContext(),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws.prometheus.ruleGroupNamespace", execState.Type)
+
+		payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+		namespace, ok := payload["ruleGroupNamespace"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "application-rules", namespace["name"])
+		assert.Equal(t, "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules", namespace["arn"])
+		assert.Equal(t, map[string]string{"env": "prod"}, namespace["tags"])
+		assert.NotContains(t, namespace, "status")
+		assert.NotContains(t, namespace, "createdAt")
+		assert.NotContains(t, namespace, "modifiedAt")
+		assert.Equal(t, "ws-abc123", payload["workspaceId"])
+
+		require.Len(t, httpContext.Requests, 1)
+		request := httpContext.Requests[0]
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces/ws-abc123/rulegroupsnamespaces", request.URL.String())
+
+		requestBody, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+
+		sentPayload := map[string]any{}
+		err = json.Unmarshal(requestBody, &sentPayload)
+		require.NoError(t, err)
+		assert.Equal(t, "application-rules", sentPayload["name"])
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("groups: []")), sentPayload["data"])
+		assert.Equal(t, "token-1", sentPayload["clientToken"])
+		assert.Equal(t, map[string]any{"env": "prod"}, sentPayload["tags"])
+	})
+}

--- a/pkg/integrations/aws/prometheus/delete_rule_group_namespace.go
+++ b/pkg/integrations/aws/prometheus/delete_rule_group_namespace.go
@@ -1,0 +1,132 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type DeleteRuleGroupNamespace struct{}
+
+func (c *DeleteRuleGroupNamespace) Name() string {
+	return "aws.prometheus.deleteRuleGroupNamespace"
+}
+
+func (c *DeleteRuleGroupNamespace) Label() string {
+	return "Prometheus • Delete Rule Group Namespace"
+}
+
+func (c *DeleteRuleGroupNamespace) Description() string {
+	return "Delete a rule group namespace from an Amazon Managed Service for Prometheus workspace"
+}
+
+func (c *DeleteRuleGroupNamespace) Documentation() string {
+	return `The Delete Rule Group Namespace component deletes one rule group namespace and its rule groups definition.
+
+## Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace
+- **Client Token**: Optional idempotency token`
+}
+
+func (c *DeleteRuleGroupNamespace) Icon() string {
+	return "aws"
+}
+
+func (c *DeleteRuleGroupNamespace) Color() string {
+	return "gray"
+}
+
+func (c *DeleteRuleGroupNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *DeleteRuleGroupNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		workspaceField("Workspace", "Prometheus workspace containing the rule group namespace"),
+		ruleGroupsNamespaceField("Rule Group Namespace", "Rule group namespace to delete"),
+		clientTokenField(),
+	}
+}
+
+func (c *DeleteRuleGroupNamespace) Setup(ctx core.SetupContext) error {
+	config, err := decodeRuleGroupsNamespaceConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	return setRuleGroupsNamespaceNodeMetadata(ctx, resolveRuleGroupsNamespaceNodeMetadata(ctx, config))
+}
+
+func (c *DeleteRuleGroupNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *DeleteRuleGroupNamespace) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeRuleGroupsNamespaceConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := workspaceClient(ctx, config.Region)
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteRuleGroupsNamespace(config.WorkspaceID, config.Name, config.ClientToken); err != nil {
+		return fmt.Errorf("failed to delete Prometheus rule group namespace: %w", err)
+	}
+
+	output := map[string]any{
+		"workspaceId":    config.WorkspaceID,
+		"workspaceAlias": ruleGroupsNamespaceWorkspaceAliasFromExecution(ctx),
+		"namespace":      config.Name,
+		"deleted":        true,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"aws.prometheus.ruleGroupNamespace.deleted",
+		[]any{output},
+	)
+}
+
+func (c *DeleteRuleGroupNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *DeleteRuleGroupNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *DeleteRuleGroupNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *DeleteRuleGroupNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *DeleteRuleGroupNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func ruleGroupsNamespaceWorkspaceAliasFromExecution(ctx core.ExecutionContext) string {
+	if ctx.NodeMetadata == nil {
+		return ""
+	}
+
+	metadata := RuleGroupsNamespaceNodeMetadata{}
+	if err := mapstructure.Decode(ctx.NodeMetadata.Get(), &metadata); err != nil {
+		return ""
+	}
+
+	return metadata.WorkspaceAlias
+}

--- a/pkg/integrations/aws/prometheus/delete_rule_group_namespace_test.go
+++ b/pkg/integrations/aws/prometheus/delete_rule_group_namespace_test.go
@@ -1,0 +1,86 @@
+package prometheus
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__DeleteRuleGroupNamespace__Setup(t *testing.T) {
+	component := &DeleteRuleGroupNamespace{}
+
+	t.Run("missing namespace -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": " ",
+			},
+		})
+
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("valid configuration -> ok", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": "application-rules",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__DeleteRuleGroupNamespace__Execute(t *testing.T) {
+	component := &DeleteRuleGroupNamespace{}
+
+	t.Run("valid request -> emits delete result", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusAccepted,
+					Body:       io.NopCloser(strings.NewReader("")),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":      "us-east-1",
+				"workspace":   "ws-abc123",
+				"namespace":   "application-rules",
+				"clientToken": "token-1",
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration:    validIntegrationContext(),
+			NodeMetadata: &contexts.MetadataContext{Metadata: RuleGroupsNamespaceNodeMetadata{
+				WorkspaceAlias: "metrics",
+			}},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws.prometheus.ruleGroupNamespace.deleted", execState.Type)
+
+		payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+		assert.Equal(t, "ws-abc123", payload["workspaceId"])
+		assert.Equal(t, "metrics", payload["workspaceAlias"])
+		assert.Equal(t, "application-rules", payload["namespace"])
+		assert.Equal(t, true, payload["deleted"])
+
+		require.Len(t, httpContext.Requests, 1)
+		request := httpContext.Requests[0]
+		assert.Equal(t, http.MethodDelete, request.Method)
+		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces/ws-abc123/rulegroupsnamespaces/application-rules?clientToken=token-1", request.URL.String())
+	})
+}

--- a/pkg/integrations/aws/prometheus/example.go
+++ b/pkg/integrations/aws/prometheus/example.go
@@ -31,6 +31,30 @@ var exampleOutputDeleteWorkspaceBytes []byte
 var exampleOutputDeleteWorkspaceOnce sync.Once
 var exampleOutputDeleteWorkspace map[string]any
 
+//go:embed example_output_create_rule_group_namespace.json
+var exampleOutputCreateRuleGroupNamespaceBytes []byte
+
+var exampleOutputCreateRuleGroupNamespaceOnce sync.Once
+var exampleOutputCreateRuleGroupNamespace map[string]any
+
+//go:embed example_output_get_rule_group_namespace.json
+var exampleOutputGetRuleGroupNamespaceBytes []byte
+
+var exampleOutputGetRuleGroupNamespaceOnce sync.Once
+var exampleOutputGetRuleGroupNamespace map[string]any
+
+//go:embed example_output_update_rule_group_namespace.json
+var exampleOutputUpdateRuleGroupNamespaceBytes []byte
+
+var exampleOutputUpdateRuleGroupNamespaceOnce sync.Once
+var exampleOutputUpdateRuleGroupNamespace map[string]any
+
+//go:embed example_output_delete_rule_group_namespace.json
+var exampleOutputDeleteRuleGroupNamespaceBytes []byte
+
+var exampleOutputDeleteRuleGroupNamespaceOnce sync.Once
+var exampleOutputDeleteRuleGroupNamespace map[string]any
+
 func (c *CreateWorkspace) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(
 		&exampleOutputCreateWorkspaceOnce,
@@ -60,5 +84,37 @@ func (c *DeleteWorkspace) ExampleOutput() map[string]any {
 		&exampleOutputDeleteWorkspaceOnce,
 		exampleOutputDeleteWorkspaceBytes,
 		&exampleOutputDeleteWorkspace,
+	)
+}
+
+func (c *CreateRuleGroupNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputCreateRuleGroupNamespaceOnce,
+		exampleOutputCreateRuleGroupNamespaceBytes,
+		&exampleOutputCreateRuleGroupNamespace,
+	)
+}
+
+func (c *GetRuleGroupNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputGetRuleGroupNamespaceOnce,
+		exampleOutputGetRuleGroupNamespaceBytes,
+		&exampleOutputGetRuleGroupNamespace,
+	)
+}
+
+func (c *UpdateRuleGroupNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputUpdateRuleGroupNamespaceOnce,
+		exampleOutputUpdateRuleGroupNamespaceBytes,
+		&exampleOutputUpdateRuleGroupNamespace,
+	)
+}
+
+func (c *DeleteRuleGroupNamespace) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(
+		&exampleOutputDeleteRuleGroupNamespaceOnce,
+		exampleOutputDeleteRuleGroupNamespaceBytes,
+		&exampleOutputDeleteRuleGroupNamespace,
 	)
 }

--- a/pkg/integrations/aws/prometheus/example_output_create_rule_group_namespace.json
+++ b/pkg/integrations/aws/prometheus/example_output_create_rule_group_namespace.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "name": "example-rule-group-namespace"
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:25:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace"
+}

--- a/pkg/integrations/aws/prometheus/example_output_delete_rule_group_namespace.json
+++ b/pkg/integrations/aws/prometheus/example_output_delete_rule_group_namespace.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "deleted": true,
+    "namespace": "example-rule-group-namespace",
+    "workspaceAlias": "example-workspace",
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:30:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace.deleted"
+}

--- a/pkg/integrations/aws/prometheus/example_output_get_rule_group_namespace.json
+++ b/pkg/integrations/aws/prometheus/example_output_get_rule_group_namespace.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "createdAt": "2026-01-01T00:35:00Z",
+      "data": "Z3JvdXBzOgogIC0gbmFtZTogZXhhbXBsZV9yZWNvcmRpbmdfcnVsZXMKICAgIGludGVydmFsOiAzMHMKICAgIHJ1bGVzOgogICAgICAtIHJlY29yZDogZXhhbXBsZTpyZXF1ZXN0c19wZXJfc2Vjb25kOnJhdGUxbQogICAgICAgIGV4cHI6IHwKICAgICAgICAgIHN1bShyYXRlKGV4YW1wbGVfcmVxdWVzdHNfdG90YWxbMW1dKSkKCiAgLSBuYW1lOiBleGFtcGxlX2FsZXJ0aW5nX3J1bGVzCiAgICBpbnRlcnZhbDogMzBzCiAgICBydWxlczoKICAgICAgLSBhbGVydDogRXhhbXBsZUhpZ2hSZXF1ZXN0UmF0ZQogICAgICAgIGV4cHI6IHwKICAgICAgICAgIHN1bShyYXRlKGV4YW1wbGVfcmVxdWVzdHNfdG90YWxbMW1dKSkgPiAxMDAKICAgICAgICBmb3I6IDFtCiAgICAgICAgbGFiZWxzOgogICAgICAgICAgc2V2ZXJpdHk6IHdhcm5pbmcKICAgICAgICAgIHNlcnZpY2U6IGV4YW1wbGUKICAgICAgICBhbm5vdGF0aW9uczoKICAgICAgICAgIHN1bW1hcnk6ICJFeGFtcGxlIGhpZ2ggcmVxdWVzdCByYXRlIgogICAgICAgICAgZGVzY3JpcHRpb246ICJUaGUgZXhhbXBsZSBzZXJ2aWNlIGlzIHJlY2VpdmluZyBtb3JlIHRoYW4gMTAwIHJlcXVlc3RzIHBlciBzZWNvbmQuIgo=",
+      "modifiedAt": "2026-01-01T00:40:00Z",
+      "name": "example-rule-group-namespace",
+      "status": {
+        "statusCode": "ACTIVE"
+      }
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:45:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace"
+}

--- a/pkg/integrations/aws/prometheus/example_output_update_rule_group_namespace.json
+++ b/pkg/integrations/aws/prometheus/example_output_update_rule_group_namespace.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "ruleGroupNamespace": {
+      "arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-33333333-3333-4333-8333-333333333333/example-rule-group-namespace",
+      "name": "example-rule-group-namespace"
+    },
+    "workspaceId": "ws-33333333-3333-4333-8333-333333333333"
+  },
+  "timestamp": "2026-01-01T00:50:00.000000000Z",
+  "type": "aws.prometheus.ruleGroupNamespace.updated"
+}

--- a/pkg/integrations/aws/prometheus/get_rule_group_namespace.go
+++ b/pkg/integrations/aws/prometheus/get_rule_group_namespace.go
@@ -1,0 +1,115 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetRuleGroupNamespace struct{}
+
+func (c *GetRuleGroupNamespace) Name() string {
+	return "aws.prometheus.getRuleGroupNamespace"
+}
+
+func (c *GetRuleGroupNamespace) Label() string {
+	return "Prometheus • Get Rule Group Namespace"
+}
+
+func (c *GetRuleGroupNamespace) Description() string {
+	return "Get a rule group namespace from an Amazon Managed Service for Prometheus workspace"
+}
+
+func (c *GetRuleGroupNamespace) Documentation() string {
+	return `The Get Rule Group Namespace component retrieves one rule group namespace from an Amazon Managed Service for Prometheus workspace.
+
+## Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace`
+}
+
+func (c *GetRuleGroupNamespace) Icon() string {
+	return "aws"
+}
+
+func (c *GetRuleGroupNamespace) Color() string {
+	return "gray"
+}
+
+func (c *GetRuleGroupNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *GetRuleGroupNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		workspaceField("Workspace", "Prometheus workspace containing the rule group namespace"),
+		ruleGroupsNamespaceField("Rule Group Namespace", "Rule group namespace to retrieve"),
+	}
+}
+
+func (c *GetRuleGroupNamespace) Setup(ctx core.SetupContext) error {
+	config, err := decodeRuleGroupsNamespaceConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	return setRuleGroupsNamespaceNodeMetadata(ctx, resolveRuleGroupsNamespaceNodeMetadata(ctx, config))
+}
+
+func (c *GetRuleGroupNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *GetRuleGroupNamespace) Execute(ctx core.ExecutionContext) error {
+	config, err := decodeRuleGroupsNamespaceConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := workspaceClient(ctx, config.Region)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := client.DescribeRuleGroupsNamespace(config.WorkspaceID, config.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get Prometheus rule group namespace: %w", err)
+	}
+
+	output := map[string]any{
+		"ruleGroupNamespace": namespace,
+		"workspaceId":        config.WorkspaceID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"aws.prometheus.ruleGroupNamespace",
+		[]any{output},
+	)
+}
+
+func (c *GetRuleGroupNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *GetRuleGroupNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *GetRuleGroupNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *GetRuleGroupNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *GetRuleGroupNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/aws/prometheus/get_rule_group_namespace_test.go
+++ b/pkg/integrations/aws/prometheus/get_rule_group_namespace_test.go
@@ -1,0 +1,118 @@
+package prometheus
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetRuleGroupNamespace__Setup(t *testing.T) {
+	component := &GetRuleGroupNamespace{}
+
+	t.Run("missing namespace -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": " ",
+			},
+		})
+
+		require.ErrorContains(t, err, "namespace is required")
+	})
+
+	t.Run("valid configuration -> stores metadata", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"workspace": {
+							"alias": "metrics",
+							"arn": "arn:aws:aps:us-east-1:123456789012:workspace/ws-abc123",
+							"status": {"statusCode": "ACTIVE"},
+							"workspaceId": "ws-abc123"
+						}
+					}`)),
+				},
+			},
+		}
+
+		metadata := &contexts.MetadataContext{}
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": "application-rules",
+			},
+			HTTP:        httpContext,
+			Integration: validIntegrationContext(),
+			Metadata:    metadata,
+		})
+
+		require.NoError(t, err)
+		stored, ok := metadata.Get().(RuleGroupsNamespaceNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "metrics", stored.WorkspaceAlias)
+		assert.Equal(t, "application-rules", stored.Namespace)
+	})
+}
+
+func Test__GetRuleGroupNamespace__Execute(t *testing.T) {
+	component := &GetRuleGroupNamespace{}
+
+	t.Run("valid request -> emits namespace", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"ruleGroupsNamespace": {
+							"arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+							"createdAt": 1717846800,
+							"data": "Z3JvdXBzOiBbXQ==",
+							"modifiedAt": 1717847100,
+							"name": "application-rules",
+							"status": {"statusCode": "ACTIVE"},
+							"tags": {"env": "prod"}
+						}
+					}`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": "application-rules",
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration:    validIntegrationContext(),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws.prometheus.ruleGroupNamespace", execState.Type)
+
+		payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+		namespace, ok := payload["ruleGroupNamespace"].(*RuleGroupsNamespaceDescription)
+		require.True(t, ok)
+		assert.Equal(t, "application-rules", namespace.Name)
+		assert.Equal(t, "ACTIVE", namespace.Status.StatusCode)
+		assert.Equal(t, "Z3JvdXBzOiBbXQ==", namespace.Data)
+		assert.Equal(t, "ws-abc123", payload["workspaceId"])
+
+		require.Len(t, httpContext.Requests, 1)
+		request := httpContext.Requests[0]
+		assert.Equal(t, http.MethodGet, request.Method)
+		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces/ws-abc123/rulegroupsnamespaces/application-rules", request.URL.String())
+	})
+}

--- a/pkg/integrations/aws/prometheus/resources.go
+++ b/pkg/integrations/aws/prometheus/resources.go
@@ -42,3 +42,38 @@ func ListWorkspaces(ctx core.ListResourcesContext, resourceType string) ([]core.
 
 	return resources, nil
 }
+
+func ListRuleGroupsNamespaces(ctx core.ListResourcesContext, resourceType string) ([]core.IntegrationResource, error) {
+	creds, err := common.CredentialsFromInstallation(ctx.Integration)
+	if err != nil {
+		return nil, err
+	}
+
+	region := strings.TrimSpace(ctx.Parameters["region"])
+	if region == "" {
+		return nil, fmt.Errorf("region is required")
+	}
+
+	workspaceID := strings.TrimSpace(ctx.Parameters["workspace"])
+	if workspaceID == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+
+	name := strings.TrimSpace(ctx.Parameters["name"])
+	client := NewClient(ctx.HTTP, creds, region)
+	namespaces, err := client.ListRuleGroupsNamespaces(workspaceID, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Prometheus rule group namespaces: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		resources = append(resources, core.IntegrationResource{
+			Type: resourceType,
+			Name: namespace.Name,
+			ID:   namespace.Name,
+		})
+	}
+
+	return resources, nil
+}

--- a/pkg/integrations/aws/prometheus/resources_test.go
+++ b/pkg/integrations/aws/prometheus/resources_test.go
@@ -55,3 +55,50 @@ func Test__ListWorkspaces(t *testing.T) {
 		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces?maxResults=1000", httpContext.Requests[0].URL.String())
 	})
 }
+
+func Test__ListRuleGroupsNamespaces(t *testing.T) {
+	t.Run("missing workspace -> error", func(t *testing.T) {
+		_, err := ListRuleGroupsNamespaces(core.ListResourcesContext{
+			Integration: validIntegrationContext(),
+			Parameters: map[string]string{
+				"region": "us-east-1",
+			},
+		}, ruleGroupsNamespaceResourceType)
+
+		require.ErrorContains(t, err, "workspace is required")
+	})
+
+	t.Run("valid request -> returns namespace resources", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"ruleGroupsNamespaces": [
+							{"name": "application-rules", "status": {"statusCode": "ACTIVE"}},
+							{"name": "platform-rules", "status": {"statusCode": "CREATING"}}
+						]
+					}`)),
+				},
+			},
+		}
+
+		resources, err := ListRuleGroupsNamespaces(core.ListResourcesContext{
+			HTTP:        httpContext,
+			Integration: validIntegrationContext(),
+			Parameters: map[string]string{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+			},
+		}, ruleGroupsNamespaceResourceType)
+
+		require.NoError(t, err)
+		assert.Equal(t, []core.IntegrationResource{
+			{Type: ruleGroupsNamespaceResourceType, Name: "application-rules", ID: "application-rules"},
+			{Type: ruleGroupsNamespaceResourceType, Name: "platform-rules", ID: "platform-rules"},
+		}, resources)
+
+		require.Len(t, httpContext.Requests, 1)
+		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces/ws-abc123/rulegroupsnamespaces?maxResults=1000", httpContext.Requests[0].URL.String())
+	})
+}

--- a/pkg/integrations/aws/prometheus/update_rule_group_namespace.go
+++ b/pkg/integrations/aws/prometheus/update_rule_group_namespace.go
@@ -1,0 +1,166 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type UpdateRuleGroupNamespace struct{}
+
+type UpdateRuleGroupNamespaceConfiguration struct {
+	Region      string `json:"region" mapstructure:"region"`
+	WorkspaceID string `json:"workspace" mapstructure:"workspace"`
+	Name        string `json:"namespace" mapstructure:"namespace"`
+	Data        string `json:"data" mapstructure:"data"`
+	ClientToken string `json:"clientToken" mapstructure:"clientToken"`
+}
+
+func (c *UpdateRuleGroupNamespace) Name() string {
+	return "aws.prometheus.updateRuleGroupNamespace"
+}
+
+func (c *UpdateRuleGroupNamespace) Label() string {
+	return "Prometheus • Update Rule Group Namespace"
+}
+
+func (c *UpdateRuleGroupNamespace) Description() string {
+	return "Update a rule group namespace in an Amazon Managed Service for Prometheus workspace"
+}
+
+func (c *UpdateRuleGroupNamespace) Documentation() string {
+	return `The Update Rule Group Namespace component updates the rule groups YAML for an existing Amazon Managed Service for Prometheus rule group namespace.
+
+## Configuration
+
+- **Region**: AWS region of the workspace
+- **Workspace**: Target workspace
+- **Rule Group Namespace**: Target rule group namespace
+- **Rule Groups YAML**: New Prometheus rule groups YAML file content
+- **Client Token**: Optional idempotency token`
+}
+
+func (c *UpdateRuleGroupNamespace) Icon() string {
+	return "aws"
+}
+
+func (c *UpdateRuleGroupNamespace) Color() string {
+	return "gray"
+}
+
+func (c *UpdateRuleGroupNamespace) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *UpdateRuleGroupNamespace) Configuration() []configuration.Field {
+	return []configuration.Field{
+		regionField(),
+		workspaceField("Workspace", "Prometheus workspace containing the rule group namespace"),
+		ruleGroupsNamespaceField("Rule Group Namespace", "Rule group namespace to update"),
+		ruleGroupsNamespaceDataField(),
+		clientTokenField(),
+	}
+}
+
+func (c *UpdateRuleGroupNamespace) Setup(ctx core.SetupContext) error {
+	config, err := c.decodeConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	return setRuleGroupsNamespaceNodeMetadata(ctx, resolveRuleGroupsNamespaceNodeMetadata(ctx, ruleGroupsNamespaceConfiguration{
+		Region:      config.Region,
+		WorkspaceID: config.WorkspaceID,
+		Name:        config.Name,
+	}))
+}
+
+func (c *UpdateRuleGroupNamespace) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *UpdateRuleGroupNamespace) Execute(ctx core.ExecutionContext) error {
+	config, err := c.decodeConfiguration(ctx.Configuration)
+	if err != nil {
+		return err
+	}
+
+	client, err := workspaceClient(ctx, config.Region)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := client.PutRuleGroupsNamespace(PutRuleGroupsNamespaceInput{
+		WorkspaceID: config.WorkspaceID,
+		Name:        config.Name,
+		Data:        config.Data,
+		ClientToken: config.ClientToken,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update Prometheus rule group namespace: %w", err)
+	}
+
+	output := map[string]any{
+		"ruleGroupNamespace": ruleGroupsNamespaceOutput(namespace),
+		"workspaceId":        config.WorkspaceID,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"aws.prometheus.ruleGroupNamespace.updated",
+		[]any{output},
+	)
+}
+
+func (c *UpdateRuleGroupNamespace) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *UpdateRuleGroupNamespace) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (c *UpdateRuleGroupNamespace) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (c *UpdateRuleGroupNamespace) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *UpdateRuleGroupNamespace) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}
+
+func (c *UpdateRuleGroupNamespace) decodeConfiguration(rawConfiguration any) (UpdateRuleGroupNamespaceConfiguration, error) {
+	config := UpdateRuleGroupNamespaceConfiguration{}
+	if err := mapstructure.Decode(rawConfiguration, &config); err != nil {
+		return UpdateRuleGroupNamespaceConfiguration{}, fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	config.Region = strings.TrimSpace(config.Region)
+	config.WorkspaceID = strings.TrimSpace(config.WorkspaceID)
+	config.Name = strings.TrimSpace(config.Name)
+	config.Data = strings.TrimSpace(config.Data)
+	config.ClientToken = strings.TrimSpace(config.ClientToken)
+
+	if config.Region == "" {
+		return UpdateRuleGroupNamespaceConfiguration{}, fmt.Errorf("region is required")
+	}
+	if config.WorkspaceID == "" {
+		return UpdateRuleGroupNamespaceConfiguration{}, fmt.Errorf("workspace is required")
+	}
+	if config.Name == "" {
+		return UpdateRuleGroupNamespaceConfiguration{}, fmt.Errorf("namespace is required")
+	}
+	if config.Data == "" {
+		return UpdateRuleGroupNamespaceConfiguration{}, fmt.Errorf("rule groups YAML is required")
+	}
+
+	return config, nil
+}

--- a/pkg/integrations/aws/prometheus/update_rule_group_namespace_test.go
+++ b/pkg/integrations/aws/prometheus/update_rule_group_namespace_test.go
@@ -1,0 +1,106 @@
+package prometheus
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__UpdateRuleGroupNamespace__Setup(t *testing.T) {
+	component := &UpdateRuleGroupNamespace{}
+
+	t.Run("missing data -> error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": "application-rules",
+				"data":      " ",
+			},
+		})
+
+		require.ErrorContains(t, err, "rule groups YAML is required")
+	})
+
+	t.Run("valid configuration -> ok", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"region":    "us-east-1",
+				"workspace": "ws-abc123",
+				"namespace": "application-rules",
+				"data":      "groups: []",
+			},
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func Test__UpdateRuleGroupNamespace__Execute(t *testing.T) {
+	component := &UpdateRuleGroupNamespace{}
+
+	t.Run("valid request -> emits namespace", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusAccepted,
+					Body: io.NopCloser(strings.NewReader(`{
+						"arn": "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+						"createdAt": null,
+						"modifiedAt": null,
+						"name": "application-rules",
+						"status": {"statusCode": "UPDATING"}
+					}`)),
+				},
+			},
+		}
+
+		execState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"region":      "us-east-1",
+				"workspace":   "ws-abc123",
+				"namespace":   " application-rules ",
+				"data":        "groups: []",
+				"clientToken": "token-1",
+			},
+			HTTP:           httpContext,
+			ExecutionState: execState,
+			Integration:    validIntegrationContext(),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "aws.prometheus.ruleGroupNamespace.updated", execState.Type)
+
+		payload := execState.Payloads[0].(map[string]any)["data"].(map[string]any)
+		namespace, ok := payload["ruleGroupNamespace"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "application-rules", namespace["name"])
+		assert.Equal(t, "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules", namespace["arn"])
+		assert.NotContains(t, namespace, "status")
+		assert.NotContains(t, namespace, "createdAt")
+		assert.NotContains(t, namespace, "modifiedAt")
+
+		require.Len(t, httpContext.Requests, 1)
+		request := httpContext.Requests[0]
+		assert.Equal(t, http.MethodPut, request.Method)
+		assert.Equal(t, "https://aps.us-east-1.amazonaws.com/workspaces/ws-abc123/rulegroupsnamespaces/application-rules", request.URL.String())
+
+		requestBody, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+
+		sentPayload := map[string]any{}
+		err = json.Unmarshal(requestBody, &sentPayload)
+		require.NoError(t, err)
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("groups: []")), sentPayload["data"])
+		assert.Equal(t, "token-1", sentPayload["clientToken"])
+	})
+}

--- a/pkg/integrations/aws/resources.go
+++ b/pkg/integrations/aws/resources.go
@@ -100,6 +100,9 @@ func (a *AWS) ListResources(resourceType string, ctx core.ListResourcesContext) 
 	case "prometheus.workspace":
 		return prometheus.ListWorkspaces(ctx, resourceType)
 
+	case "prometheus.ruleGroupNamespace":
+		return prometheus.ListRuleGroupsNamespaces(ctx, resourceType)
+
 	case "route53.hostedZone":
 		return route53.ListHostedZones(ctx, resourceType)
 

--- a/pkg/workers/contexts/node_configuration_builder.go
+++ b/pkg/workers/contexts/node_configuration_builder.go
@@ -138,6 +138,10 @@ func (b *NodeConfigurationBuilder) resolveWithSchema(config map[string]any, fiel
 }
 
 func (b *NodeConfigurationBuilder) resolveFieldValue(value any, field configuration.Field) (any, error) {
+	if isLiteralTextField(field) {
+		return value, nil
+	}
+
 	if field.TypeOptions != nil {
 		if field.TypeOptions.Object != nil && len(field.TypeOptions.Object.Schema) > 0 {
 			if obj, ok := asAnyMap(value); ok {
@@ -153,6 +157,14 @@ func (b *NodeConfigurationBuilder) resolveFieldValue(value any, field configurat
 	}
 
 	return b.resolveValue(value)
+}
+
+func isLiteralTextField(field configuration.Field) bool {
+	return field.Type == configuration.FieldTypeText &&
+		field.TypeOptions != nil &&
+		field.TypeOptions.Text != nil &&
+		field.TypeOptions.Text.AllowExpressions != nil &&
+		!*field.TypeOptions.Text.AllowExpressions
 }
 
 func (b *NodeConfigurationBuilder) resolveListItems(list []any, itemDef *configuration.ListItemDefinition) ([]any, error) {

--- a/pkg/workers/contexts/node_configuration_builder_test.go
+++ b/pkg/workers/contexts/node_configuration_builder_test.go
@@ -8,11 +8,37 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/datatypes"
 )
+
+func Test_NodeConfigurationBuilder_LiteralTextFieldPreservesTemplates(t *testing.T) {
+	allowExpressions := false
+	builder := NewNodeConfigurationBuilder(nil, uuid.New()).
+		WithConfigurationFields([]configuration.Field{
+			{
+				Name: "data",
+				Type: configuration.FieldTypeText,
+				TypeOptions: &configuration.TypeOptions{
+					Text: &configuration.TextTypeOptions{AllowExpressions: &allowExpressions},
+				},
+			},
+			{Name: "name", Type: configuration.FieldTypeString},
+		})
+
+	ruleYAML := `summary: "High CPU usage for {{ $labels.component }} with value {{ $value }}"`
+	result, err := builder.Build(map[string]any{
+		"data": ruleYAML,
+		"name": "{{ \"rules\" }}",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, ruleYAML, result["data"])
+	assert.Equal(t, "rules", result["name"])
+}
 
 func Test_NodeConfigurationBuilder_WorkflowLevelNode_Root(t *testing.T) {
 	r := support.Setup(t)

--- a/protos/configuration.proto
+++ b/protos/configuration.proto
@@ -55,6 +55,7 @@ message TextTypeOptions {
   optional int32 min_length = 1;
   optional int32 max_length = 2;
   optional string language = 3;
+  optional bool allow_expressions = 4;
 }
 
 message TimeTypeOptions {

--- a/web_src/src/pages/app/mappers/aws/index.ts
+++ b/web_src/src/pages/app/mappers/aws/index.ts
@@ -57,7 +57,16 @@ import { enableImageMapper } from "./ec2/enable_image";
 import { disableImageMapper } from "./ec2/disable_image";
 import { enableImageDeprecationMapper } from "./ec2/enable_image_deprecation";
 import { disableImageDeprecationMapper } from "./ec2/disable_image_deprecation";
-import { createWorkspaceMapper, deleteWorkspaceMapper, getWorkspaceMapper, updateWorkspaceMapper } from "./prometheus";
+import {
+  createRuleGroupNamespaceMapper,
+  createWorkspaceMapper,
+  deleteRuleGroupNamespaceMapper,
+  deleteWorkspaceMapper,
+  getRuleGroupNamespaceMapper,
+  getWorkspaceMapper,
+  updateRuleGroupNamespaceMapper,
+  updateWorkspaceMapper,
+} from "./prometheus";
 
 export const componentMappers: Record<string, ComponentBaseMapper> = {
   "codepipeline.getPipeline": getPipelineMapper,
@@ -78,6 +87,10 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   "prometheus.getWorkspace": getWorkspaceMapper,
   "prometheus.updateWorkspace": updateWorkspaceMapper,
   "prometheus.deleteWorkspace": deleteWorkspaceMapper,
+  "prometheus.createRuleGroupNamespace": createRuleGroupNamespaceMapper,
+  "prometheus.getRuleGroupNamespace": getRuleGroupNamespaceMapper,
+  "prometheus.updateRuleGroupNamespace": updateRuleGroupNamespaceMapper,
+  "prometheus.deleteRuleGroupNamespace": deleteRuleGroupNamespaceMapper,
   "codeArtifact.copyPackageVersions": copyPackageVersionsMapper,
   "codeArtifact.createRepository": createRepositoryMapper,
   "codeArtifact.deletePackageVersions": deletePackageVersionsMapper,
@@ -148,6 +161,10 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   "prometheus.getWorkspace": buildActionStateRegistry("retrieved"),
   "prometheus.updateWorkspace": buildActionStateRegistry("updated"),
   "prometheus.deleteWorkspace": buildActionStateRegistry("deleted"),
+  "prometheus.createRuleGroupNamespace": buildActionStateRegistry("created"),
+  "prometheus.getRuleGroupNamespace": buildActionStateRegistry("retrieved"),
+  "prometheus.updateRuleGroupNamespace": buildActionStateRegistry("updated"),
+  "prometheus.deleteRuleGroupNamespace": buildActionStateRegistry("deleted"),
   "codeArtifact.copyPackageVersions": buildActionStateRegistry("copied"),
   "codeArtifact.createRepository": buildActionStateRegistry("created"),
   "codeArtifact.deletePackageVersions": buildActionStateRegistry("deleted"),

--- a/web_src/src/pages/app/mappers/aws/prometheus/common.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/common.ts
@@ -21,6 +21,11 @@ export interface WorkspaceStatus {
   statusCode?: string;
 }
 
+export interface RuleGroupNamespaceStatus {
+  statusCode?: string;
+  statusReason?: string;
+}
+
 export interface PrometheusWorkspace {
   alias?: string;
   arn?: string;
@@ -35,10 +40,32 @@ export interface WorkspaceOutput {
   workspace?: PrometheusWorkspace;
 }
 
+export interface RuleGroupNamespace {
+  arn?: string;
+  createdAt?: number | string;
+  data?: string;
+  modifiedAt?: number | string;
+  name?: string;
+  status?: RuleGroupNamespaceStatus;
+  tags?: Record<string, string>;
+}
+
+export interface RuleGroupNamespaceOutput {
+  ruleGroupNamespace?: RuleGroupNamespace;
+  workspaceAlias?: string;
+  workspaceId?: string;
+  namespace?: string;
+  deleted?: boolean;
+}
+
 export interface WorkspaceNodeMetadata {
   region?: string;
   workspaceId?: string;
   workspaceAlias?: string;
+}
+
+export interface RuleGroupNamespaceNodeMetadata extends WorkspaceNodeMetadata {
+  namespace?: string;
 }
 
 export function buildPrometheusComponentProps(
@@ -127,6 +154,33 @@ export function workspaceExecutionDetails(
   return details;
 }
 
+export function ruleGroupNamespaceExecutionDetails(
+  namespace: RuleGroupNamespace | undefined,
+  execution: ExecutionInfo,
+  options: {
+    timestampLabel: string;
+    fallbackName?: string;
+    timestampSource?: "created" | "completed";
+    showStatus?: boolean;
+  },
+): Record<string, string> {
+  const details: Record<string, string> = {
+    [options.timestampLabel]: stringOrDash(formatExecutionTimestamp(execution, options.timestampSource)),
+  };
+
+  if (!namespace) {
+    details.Namespace = stringOrDash(options.fallbackName);
+    return details;
+  }
+
+  details.Namespace = stringOrDash(namespace.name ?? options.fallbackName);
+  if (options.showStatus ?? true) {
+    details.Status = stringOrDash(namespace.status?.statusCode);
+  }
+
+  return details;
+}
+
 export function formatExecutionTimestamp(
   execution: ExecutionInfo,
   timestampSource: "created" | "completed" = "completed",
@@ -142,6 +196,11 @@ export function formatExecutionTimestamp(
 export function workspaceAliasFromMetadata(node: NodeInfo): string | undefined {
   const metadata = node.metadata as WorkspaceNodeMetadata | undefined;
   return metadata?.workspaceAlias?.trim() || undefined;
+}
+
+export function ruleGroupNamespaceFromMetadata(node: NodeInfo): string | undefined {
+  const metadata = node.metadata as RuleGroupNamespaceNodeMetadata | undefined;
+  return metadata?.namespace?.trim() || undefined;
 }
 
 export function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {

--- a/web_src/src/pages/app/mappers/aws/prometheus/create_rule_group_namespace.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/create_rule_group_namespace.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { eventStateRegistry } from "..";
+import { buildComponentCtx, buildDetailsCtx, buildExecution, buildOutput } from "./common";
+import { createRuleGroupNamespaceMapper } from "./create_rule_group_namespace";
+
+describe("createRuleGroupNamespaceMapper.props", () => {
+  it("includes namespace, workspace alias, and region metadata", () => {
+    const props = createRuleGroupNamespaceMapper.props(
+      buildComponentCtx({
+        componentName: "prometheus.createRuleGroupNamespace",
+        configuration: {
+          region: "us-east-1",
+          workspace: "ws-abc123",
+          name: "application-rules",
+        },
+        metadata: { workspaceAlias: "metrics" },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "file-text", label: "application-rules" }),
+        expect.objectContaining({ icon: "activity", label: "metrics" }),
+        expect.objectContaining({ icon: "globe", label: "us-east-1" }),
+      ]),
+    );
+  });
+});
+
+describe("createRuleGroupNamespaceMapper.getExecutionDetails", () => {
+  it("maps create namespace output", () => {
+    const details = createRuleGroupNamespaceMapper.getExecutionDetails(
+      buildDetailsCtx({
+        node: {
+          configuration: { name: "application-rules" },
+        },
+        execution: {
+          outputs: {
+            default: [
+              buildOutput({
+                ruleGroupNamespace: {
+                  name: "application-rules",
+                  arn: "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+                  status: { statusCode: "CREATING" },
+                },
+              }),
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(Object.keys(details)[0]).toBe("Created At");
+    expect(details).toEqual({
+      "Created At": new Date("2026-06-08T09:00:00Z").toLocaleString(),
+      Namespace: "application-rules",
+    });
+  });
+});
+
+describe("eventStateRegistry.prometheus.createRuleGroupNamespace", () => {
+  it("maps success to created", () => {
+    expect(eventStateRegistry["prometheus.createRuleGroupNamespace"].getState(buildExecution())).toBe("created");
+  });
+});

--- a/web_src/src/pages/app/mappers/aws/prometheus/create_rule_group_namespace.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/create_rule_group_namespace.ts
@@ -1,0 +1,57 @@
+import type { ComponentBaseMapper, ExecutionDetailsContext, NodeInfo, SubtitleContext } from "../../types";
+import type React from "react";
+import type { MetadataItem } from "@/ui/metadataList";
+import {
+  buildPrometheusComponentProps,
+  firstOutputData,
+  MAX_METADATA_ITEMS,
+  prometheusSubtitle,
+  type RuleGroupNamespaceOutput,
+  ruleGroupNamespaceExecutionDetails,
+  workspaceAliasFromMetadata,
+} from "./common";
+
+interface CreateRuleGroupNamespaceConfiguration {
+  region?: string;
+  workspace?: string;
+  name?: string;
+}
+
+export const createRuleGroupNamespaceMapper: ComponentBaseMapper = {
+  props(context) {
+    return buildPrometheusComponentProps(context, createRuleGroupNamespaceMetadataList(context.node));
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = firstOutputData<RuleGroupNamespaceOutput>(context.execution.outputs);
+    const config = context.node.configuration as CreateRuleGroupNamespaceConfiguration | undefined;
+    return ruleGroupNamespaceExecutionDetails(data?.ruleGroupNamespace, context.execution, {
+      timestampLabel: "Created At",
+      fallbackName: config?.name,
+      timestampSource: "created",
+      showStatus: false,
+    });
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return prometheusSubtitle(context);
+  },
+};
+
+function createRuleGroupNamespaceMetadataList(node: NodeInfo): MetadataItem[] {
+  const config = node.configuration as CreateRuleGroupNamespaceConfiguration | undefined;
+  const items: MetadataItem[] = [];
+  const workspaceAlias = workspaceAliasFromMetadata(node);
+
+  if (config?.name) {
+    items.push({ icon: "file-text", label: config.name });
+  }
+  if (workspaceAlias || config?.workspace) {
+    items.push({ icon: "activity", label: workspaceAlias ?? config?.workspace ?? "" });
+  }
+  if (config?.region) {
+    items.push({ icon: "globe", label: config.region });
+  }
+
+  return items.slice(0, MAX_METADATA_ITEMS);
+}

--- a/web_src/src/pages/app/mappers/aws/prometheus/delete_rule_group_namespace.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/delete_rule_group_namespace.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { eventStateRegistry } from "..";
+import { buildComponentCtx, buildDetailsCtx, buildExecution, buildOutput } from "./common";
+import { deleteRuleGroupNamespaceMapper } from "./delete_rule_group_namespace";
+
+describe("deleteRuleGroupNamespaceMapper.props", () => {
+  it("includes namespace, workspace alias, and region metadata", () => {
+    const props = deleteRuleGroupNamespaceMapper.props(
+      buildComponentCtx({
+        componentName: "prometheus.deleteRuleGroupNamespace",
+        configuration: {
+          region: "us-east-1",
+          workspace: "ws-abc123",
+          namespace: "application-rules",
+        },
+        metadata: { workspaceAlias: "metrics", namespace: "application-rules" },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "file-text", label: "application-rules" }),
+        expect.objectContaining({ icon: "activity", label: "metrics" }),
+        expect.objectContaining({ icon: "globe", label: "us-east-1" }),
+      ]),
+    );
+  });
+});
+
+describe("deleteRuleGroupNamespaceMapper.getExecutionDetails", () => {
+  it("maps delete namespace output", () => {
+    const details = deleteRuleGroupNamespaceMapper.getExecutionDetails(
+      buildDetailsCtx({
+        execution: {
+          outputs: {
+            default: [buildOutput({ namespace: "application-rules", deleted: true })],
+          },
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Deleted At": new Date("2026-06-08T09:01:00Z").toLocaleString(),
+      Namespace: "application-rules",
+      Status: "Deleted",
+    });
+  });
+});
+
+describe("eventStateRegistry.prometheus.deleteRuleGroupNamespace", () => {
+  it("maps success to deleted", () => {
+    expect(eventStateRegistry["prometheus.deleteRuleGroupNamespace"].getState(buildExecution())).toBe("deleted");
+  });
+});

--- a/web_src/src/pages/app/mappers/aws/prometheus/delete_rule_group_namespace.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/delete_rule_group_namespace.ts
@@ -1,0 +1,31 @@
+import type { ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../../types";
+import type React from "react";
+import { stringOrDash } from "../../utils";
+import {
+  buildPrometheusComponentProps,
+  firstOutputData,
+  formatExecutionTimestamp,
+  prometheusSubtitle,
+  ruleGroupNamespaceFromMetadata,
+  type RuleGroupNamespaceOutput,
+} from "./common";
+import { ruleGroupNamespaceMetadataList } from "./get_rule_group_namespace";
+
+export const deleteRuleGroupNamespaceMapper: ComponentBaseMapper = {
+  props(context) {
+    return buildPrometheusComponentProps(context, ruleGroupNamespaceMetadataList(context.node));
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = firstOutputData<RuleGroupNamespaceOutput>(context.execution.outputs);
+    return {
+      "Deleted At": stringOrDash(formatExecutionTimestamp(context.execution)),
+      Namespace: stringOrDash(data?.namespace ?? ruleGroupNamespaceFromMetadata(context.node)),
+      Status: data?.deleted ? "Deleted" : "-",
+    };
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return prometheusSubtitle(context);
+  },
+};

--- a/web_src/src/pages/app/mappers/aws/prometheus/get_rule_group_namespace.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/get_rule_group_namespace.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { eventStateRegistry } from "..";
+import { buildComponentCtx, buildDetailsCtx, buildExecution, buildOutput } from "./common";
+import { getRuleGroupNamespaceMapper } from "./get_rule_group_namespace";
+
+describe("getRuleGroupNamespaceMapper.props", () => {
+  it("includes namespace, workspace alias, and region metadata", () => {
+    const props = getRuleGroupNamespaceMapper.props(
+      buildComponentCtx({
+        componentName: "prometheus.getRuleGroupNamespace",
+        configuration: {
+          region: "us-east-1",
+          workspace: "ws-abc123",
+          namespace: "application-rules",
+        },
+        metadata: { workspaceAlias: "metrics", namespace: "application-rules" },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "file-text", label: "application-rules" }),
+        expect.objectContaining({ icon: "activity", label: "metrics" }),
+        expect.objectContaining({ icon: "globe", label: "us-east-1" }),
+      ]),
+    );
+  });
+});
+
+describe("getRuleGroupNamespaceMapper.getExecutionDetails", () => {
+  it("maps get namespace output without rule YAML data", () => {
+    const details = getRuleGroupNamespaceMapper.getExecutionDetails(
+      buildDetailsCtx({
+        node: {
+          metadata: { namespace: "application-rules" },
+        },
+        execution: {
+          outputs: {
+            default: [
+              buildOutput({
+                ruleGroupNamespace: {
+                  name: "application-rules",
+                  arn: "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+                  data: "Z3JvdXBzOiBbXQ==",
+                  status: { statusCode: "ACTIVE" },
+                },
+              }),
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Retrieved At": new Date("2026-06-08T09:01:00Z").toLocaleString(),
+      Namespace: "application-rules",
+      Status: "ACTIVE",
+    });
+    expect(details.Data).toBeUndefined();
+  });
+});
+
+describe("eventStateRegistry.prometheus.getRuleGroupNamespace", () => {
+  it("maps success to retrieved", () => {
+    expect(eventStateRegistry["prometheus.getRuleGroupNamespace"].getState(buildExecution())).toBe("retrieved");
+  });
+});

--- a/web_src/src/pages/app/mappers/aws/prometheus/get_rule_group_namespace.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/get_rule_group_namespace.ts
@@ -1,0 +1,56 @@
+import type { ComponentBaseMapper, ExecutionDetailsContext, NodeInfo, SubtitleContext } from "../../types";
+import type React from "react";
+import type { MetadataItem } from "@/ui/metadataList";
+import {
+  buildPrometheusComponentProps,
+  firstOutputData,
+  MAX_METADATA_ITEMS,
+  prometheusSubtitle,
+  ruleGroupNamespaceExecutionDetails,
+  ruleGroupNamespaceFromMetadata,
+  type RuleGroupNamespaceOutput,
+  workspaceAliasFromMetadata,
+} from "./common";
+
+interface RuleGroupNamespaceConfiguration {
+  region?: string;
+  workspace?: string;
+  namespace?: string;
+}
+
+export const getRuleGroupNamespaceMapper: ComponentBaseMapper = {
+  props(context) {
+    return buildPrometheusComponentProps(context, ruleGroupNamespaceMetadataList(context.node));
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = firstOutputData<RuleGroupNamespaceOutput>(context.execution.outputs);
+    return ruleGroupNamespaceExecutionDetails(data?.ruleGroupNamespace, context.execution, {
+      timestampLabel: "Retrieved At",
+      fallbackName: ruleGroupNamespaceFromMetadata(context.node),
+    });
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return prometheusSubtitle(context);
+  },
+};
+
+export function ruleGroupNamespaceMetadataList(node: NodeInfo): MetadataItem[] {
+  const config = node.configuration as RuleGroupNamespaceConfiguration | undefined;
+  const items: MetadataItem[] = [];
+  const namespace = ruleGroupNamespaceFromMetadata(node) ?? config?.namespace;
+  const workspaceAlias = workspaceAliasFromMetadata(node);
+
+  if (namespace) {
+    items.push({ icon: "file-text", label: namespace });
+  }
+  if (workspaceAlias || config?.workspace) {
+    items.push({ icon: "activity", label: workspaceAlias ?? config?.workspace ?? "" });
+  }
+  if (config?.region) {
+    items.push({ icon: "globe", label: config.region });
+  }
+
+  return items.slice(0, MAX_METADATA_ITEMS);
+}

--- a/web_src/src/pages/app/mappers/aws/prometheus/index.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/index.ts
@@ -1,4 +1,8 @@
+export { createRuleGroupNamespaceMapper } from "./create_rule_group_namespace";
 export { createWorkspaceMapper } from "./create_workspace";
+export { deleteRuleGroupNamespaceMapper } from "./delete_rule_group_namespace";
 export { deleteWorkspaceMapper } from "./delete_workspace";
+export { getRuleGroupNamespaceMapper } from "./get_rule_group_namespace";
 export { getWorkspaceMapper } from "./get_workspace";
+export { updateRuleGroupNamespaceMapper } from "./update_rule_group_namespace";
 export { updateWorkspaceMapper } from "./update_workspace";

--- a/web_src/src/pages/app/mappers/aws/prometheus/update_rule_group_namespace.spec.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/update_rule_group_namespace.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { eventStateRegistry } from "..";
+import { buildComponentCtx, buildDetailsCtx, buildExecution, buildOutput } from "./common";
+import { updateRuleGroupNamespaceMapper } from "./update_rule_group_namespace";
+
+describe("updateRuleGroupNamespaceMapper.props", () => {
+  it("includes namespace, workspace alias, and region metadata", () => {
+    const props = updateRuleGroupNamespaceMapper.props(
+      buildComponentCtx({
+        componentName: "prometheus.updateRuleGroupNamespace",
+        configuration: {
+          region: "us-east-1",
+          workspace: "ws-abc123",
+          namespace: "application-rules",
+        },
+        metadata: { workspaceAlias: "metrics", namespace: "application-rules" },
+      }),
+    );
+
+    expect(props.metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ icon: "file-text", label: "application-rules" }),
+        expect.objectContaining({ icon: "activity", label: "metrics" }),
+        expect.objectContaining({ icon: "globe", label: "us-east-1" }),
+      ]),
+    );
+  });
+});
+
+describe("updateRuleGroupNamespaceMapper.getExecutionDetails", () => {
+  it("maps update namespace output", () => {
+    const details = updateRuleGroupNamespaceMapper.getExecutionDetails(
+      buildDetailsCtx({
+        node: {
+          metadata: { namespace: "application-rules" },
+        },
+        execution: {
+          outputs: {
+            default: [
+              buildOutput({
+                ruleGroupNamespace: {
+                  name: "application-rules",
+                  arn: "arn:aws:aps:us-east-1:123456789012:rulegroupsnamespace/ws-abc123/application-rules",
+                  status: { statusCode: "UPDATING" },
+                },
+              }),
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(details).toEqual({
+      "Updated At": new Date("2026-06-08T09:01:00Z").toLocaleString(),
+      Namespace: "application-rules",
+    });
+  });
+});
+
+describe("eventStateRegistry.prometheus.updateRuleGroupNamespace", () => {
+  it("maps success to updated", () => {
+    expect(eventStateRegistry["prometheus.updateRuleGroupNamespace"].getState(buildExecution())).toBe("updated");
+  });
+});

--- a/web_src/src/pages/app/mappers/aws/prometheus/update_rule_group_namespace.ts
+++ b/web_src/src/pages/app/mappers/aws/prometheus/update_rule_group_namespace.ts
@@ -1,0 +1,31 @@
+import type { ComponentBaseMapper, ExecutionDetailsContext, SubtitleContext } from "../../types";
+import type React from "react";
+import {
+  buildPrometheusComponentProps,
+  firstOutputData,
+  prometheusSubtitle,
+  type RuleGroupNamespaceOutput,
+  ruleGroupNamespaceExecutionDetails,
+  ruleGroupNamespaceFromMetadata,
+} from "./common";
+import { ruleGroupNamespaceMetadataList } from "./get_rule_group_namespace";
+
+export const updateRuleGroupNamespaceMapper: ComponentBaseMapper = {
+  props(context) {
+    return buildPrometheusComponentProps(context, ruleGroupNamespaceMetadataList(context.node));
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, string> {
+    const data = firstOutputData<RuleGroupNamespaceOutput>(context.execution.outputs);
+    return ruleGroupNamespaceExecutionDetails(data?.ruleGroupNamespace, context.execution, {
+      timestampLabel: "Updated At",
+      fallbackName: ruleGroupNamespaceFromMetadata(context.node),
+      timestampSource: "completed",
+      showStatus: false,
+    });
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    return prometheusSubtitle(context);
+  },
+};

--- a/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/TextFieldRenderer.tsx
@@ -110,12 +110,13 @@ const CodeTextFieldRenderer: React.FC<FieldRendererProps & { language: string }>
   value,
   onChange,
   autocompleteExampleObj,
+  allowExpressions = false,
   language,
 }) => {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
   const { handleEditorMount } = useMonacoExpressionAutocomplete({
-    autocompleteExampleObj,
+    autocompleteExampleObj: allowExpressions ? autocompleteExampleObj : undefined,
     languageId: language,
   });
 

--- a/web_src/src/ui/configurationFieldRenderer/index.tsx
+++ b/web_src/src/ui/configurationFieldRenderer/index.tsx
@@ -163,10 +163,7 @@ export const ConfigurationFieldRenderer = ({
     [isTogglable, field, onChange, parsedDefaultValue],
   );
 
-  // Check visibility conditions
-  const isVisible = React.useMemo(() => {
-    return isFieldVisible(field, allValues);
-  }, [field, allValues]);
+  const isVisible = React.useMemo(() => isFieldVisible(field, allValues), [field, allValues]);
 
   // Check if field is conditionally required
   const isRequired = React.useMemo(() => {
@@ -285,10 +282,11 @@ export const ConfigurationFieldRenderer = ({
   }
 
   const fieldAllowsExpressions =
-    allowExpressions && !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false);
+    allowExpressions &&
+    !(field.type === "string" && field.typeOptions?.string?.allowExpressions === false) &&
+    !(field.type === "text" && field.typeOptions?.text?.allowExpressions === false);
   const runTitlePresentation = getRunTitlePresentation(field.name, isEnabled);
-  // `field.label` arrives as an empty string (not undefined) when a component omits it,
-  // so fall back to the field name whenever the label is blank.
+  // Fall back to the field name when a component omits the label.
   const fieldLabel = runTitlePresentation?.label || field.label || field.name;
   const fieldDescription = runTitlePresentation?.description ?? field.description;
 


### PR DESCRIPTION
## What changed

Added AWS Managed Prometheus rule group namespace components:
- **CreateRuleGroupNamespace**
- **GetRuleGroupNamespace**
- **UpdateRuleGroupNamespace**
- **DeleteRuleGroupNamespace**

## Why

To support managing Amazon Managed Service for Prometheus rule group namespaces directly from SuperPlane workflows.

## How

### Backend
- Added AWS Prometheus rule group namespace component implementations.
- Added client methods for create, describe, update, delete, and list namespace resources.
- Added examples and backend tests for the new components.
- Preserved Prometheus rule template syntax in namespace data by disabling expression compilation where needed.

### Frontend
- Added mapper components and tests for create, get, update, and delete rule group namespaces.
- Added namespace picker support using workspace and namespace metadata.
- Added concise execution details and component card metadata for the new components.
- Updated AWS component registration and documentation.

## Demo
[Screencast from 2026-06-11 16-20-12.webm](https://github.com/user-attachments/assets/c737f77b-bfe5-49fb-8562-4fbaba57e7dc)
