### PR TITLE
fix: sync draft canvas after remote canvas_version_updated

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1049,9 +1049,6 @@ export function AppPage() {
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
     } else if (activeCanvasVersionId) {
-      // Drop the preserved spec — the user just finished or discarded
-      // their local edits, so Effect 1 must absorb the refetched server
-      // spec rather than keep showing the ref-cached version.
       draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, activeCanvasVersionId) });
     }
@@ -2082,17 +2079,11 @@ export function AppPage() {
           return true;
         }
 
-        // Defer when the user is mid-edit on the version that just changed
-        // remotely — line 1036 absorbs the update once they save/discard.
         if (payload.versionId === activeCanvasVersionId && hasPendingLocalCanvasState) {
           setRemoteCanvasUpdatePending(true);
           return true;
         }
 
-        // Drop the preserved-spec ref entry so Effect 1 falls through to
-        // the freshly-fetched server spec instead of pinning the old one.
-        // Also covers the "not in edit mode" case: when the user later
-        // toggles into this version, the ref won't shadow the new spec.
         draftCanvasSpecsRef.current.delete(payload.versionId);
         invalidateCanvasVersionData(canvasId, payload.versionId);
         return true;

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1049,6 +1049,10 @@ export function AppPage() {
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
     } else if (activeCanvasVersionId) {
+      // Drop the preserved spec — the user just finished or discarded
+      // their local edits, so Effect 1 must absorb the refetched server
+      // spec rather than keep showing the ref-cached version.
+      draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, activeCanvasVersionId) });
     }
 
@@ -2073,13 +2077,24 @@ export function AppPage() {
         // Notify agent sidebar draft-actions hook
         window.dispatchEvent(new CustomEvent("canvas:version-updated", { detail: { versionId: payload.versionId } }));
         invalidateCanvasVersionData(canvasId);
-        if (activeCanvasVersionId && payload.versionId === activeCanvasVersionId) {
-          if (hasPendingLocalCanvasState) {
-            setRemoteCanvasUpdatePending(true);
-            return true;
-          }
-          invalidateCanvasVersionData(canvasId, activeCanvasVersionId);
+
+        if (!payload.versionId) {
+          return true;
         }
+
+        // Defer when the user is mid-edit on the version that just changed
+        // remotely — line 1036 absorbs the update once they save/discard.
+        if (payload.versionId === activeCanvasVersionId && hasPendingLocalCanvasState) {
+          setRemoteCanvasUpdatePending(true);
+          return true;
+        }
+
+        // Drop the preserved-spec ref entry so Effect 1 falls through to
+        // the freshly-fetched server spec instead of pinning the old one.
+        // Also covers the "not in edit mode" case: when the user later
+        // toggles into this version, the ref won't shadow the new spec.
+        draftCanvasSpecsRef.current.delete(payload.versionId);
+        invalidateCanvasVersionData(canvasId, payload.versionId);
         return true;
       }
 


### PR DESCRIPTION
## Summary

User-reported bug: when a draft is updated externally (e.g. by the agent's tool calls or another tab), the displayed canvas doesn't reflect the new draft — both when already in edit mode and when toggling into edit mode afterward.

`draftCanvasSpecsRef` is a per-version "local preserved spec" map that `Effect 1` (around `web_src/src/pages/app/index.tsx:472`) prefers over the React Query response when deciding what to render. The `canvas_version_updated` WS handler was clearing neither the ref nor the specific `versionDetail` cache in two of the three cases:

- **Update is for a different version** than the one the user is on: only `versionList` got invalidated, so the draft's detail cache stayed stale, and the ref entry (if any from a prior edit session) kept shadowing it when the user later toggled into that version.
- **Update is for the active version, no pending edits**: `versionDetail` was invalidated and refetched, but Effect 1 kept reading the old preserved spec from the ref.

## Fix

In `handleCanvasLifecycleEvent` and the deferred-absorption effect:

- Always invalidate the specific version's `versionDetail` and drop its `draftCanvasSpecsRef` entry on `canvas_version_updated`.
- Defer when (and only when) the user has pending local edits on the version that just changed remotely — the line-1036 absorption effect now also drops the ref so the refetch lands.

## Test plan

- [ ] Open a canvas in edit mode. Trigger the agent (or another tab) to update the draft. The change appears without manual refresh.
- [ ] Open a canvas in view (live) mode. Trigger the agent to update the draft. Toggle into edit mode — the latest draft content is shown.
- [ ] Make local edits to a draft. Trigger an external update to that same draft. Local edits are preserved while editing; after save/discard, the next render absorbs the remote update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)