### PR TITLE
feat: add agent app access and runtime read tools

### DIFF
--- a/pkg/agents/agent_tools/actions/access.go
+++ b/pkg/agents/agent_tools/actions/access.go
@@ -1,0 +1,257 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/jwt"
+)
+
+const accessActionName = "access"
+
+type accessAction struct {
+	auth organizationPermissionChecker
+}
+
+func newAccessAction(deps Dependencies) accessAction {
+	return accessAction{auth: deps.AuthService}
+}
+
+type organizationPermissionChecker interface {
+	CheckOrganizationPermission(userID, orgID, resource, action string) (bool, error)
+}
+
+func (a accessAction) Name() string {
+	return accessActionName
+}
+
+func (a accessAction) Execute(_ context.Context, session agents.AgentSessionContext, _ Input) (any, error) {
+	if strings.TrimSpace(session.CanvasID) == "" {
+		return accessResult{}, fmt.Errorf("session canvas id is required")
+	}
+
+	permissions := agents.AgentTokenPermissions(session.CanvasID)
+	scopes := agents.AgentTokenScopes(session.CanvasID)
+	accessible, unavailable, err := a.apiAccess(session, permissions)
+	if err != nil {
+		return accessResult{}, err
+	}
+
+	return accessResult{
+		Action:         accessActionName,
+		CanvasID:       session.CanvasID,
+		OrganizationID: session.OrganizationID,
+		UserID:         session.UserID,
+		TokenScopes:    scopes,
+		ToolActions:    a.toolActions(session, permissions),
+		Accessible:     accessible,
+		Unavailable:    unavailable,
+		Notes: []string{
+			"Accessible API methods are the intersection of organization RBAC and the scoped agent token permissions enforced by the authorization interceptor.",
+			"Canvas-scoped token permissions only allow API methods whose interceptor rule can resolve this session canvas_id.",
+			"Draft graph and Console edits are allowed through canvases:update_version on this canvas; publishing and live app operations are not included in the agent token.",
+		},
+	}, nil
+}
+
+func (a accessAction) apiAccess(session agents.AgentSessionContext, permissions []jwt.Permission) ([]apiAccessResult, []apiAccessResult, error) {
+	rules := authorization.DefaultAuthorizationRules()
+	methods := sortedRuleMethods(rules)
+	rbac := newRBACCache(a.auth, session.UserID, session.OrganizationID)
+
+	accessible := []apiAccessResult{}
+	unavailable := []apiAccessResult{}
+	for _, method := range methods {
+		rule := rules[method]
+		tokenAllowed, resources, tokenReason := scopedTokenAllowsRule(rule, permissions, session.CanvasID)
+		rbacAllowed, rbacReason, err := rbac.allows(rule.Resource, rule.Action)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		entry := newAPIAccessResult(method, rule, resources)
+		if tokenAllowed && rbacAllowed {
+			accessible = append(accessible, entry)
+			continue
+		}
+
+		entry.Reason = accessDeniedReason(tokenAllowed, tokenReason, rbacAllowed, rbacReason)
+		unavailable = append(unavailable, entry)
+	}
+
+	return accessible, unavailable, nil
+}
+
+func (a accessAction) toolActions(session agents.AgentSessionContext, permissions []jwt.Permission) []toolAccessResult {
+	rbac := newRBACCache(a.auth, session.UserID, session.OrganizationID)
+	actions := []struct {
+		name        string
+		resource    string
+		operation   string
+		scoped      bool
+		description string
+	}{
+		{name: accessActionName, description: "No API permission required; reports this session's token and interceptor access."},
+		{name: readActionName, resource: "canvases", operation: "read", scoped: true},
+		{name: readRuntimeActionName, resource: "canvases", operation: "read", scoped: true},
+		{name: listIntegrationsActionName, resource: "integrations", operation: "read"},
+		{name: updateDraftActionName, resource: "canvases", operation: "update_version", scoped: true},
+	}
+
+	results := make([]toolAccessResult, 0, len(actions))
+	for _, action := range actions {
+		if action.name == accessActionName {
+			results = append(results, toolAccessResult{Action: action.name, Allowed: true, Reason: action.description})
+			continue
+		}
+
+		allowedByToken := permissionAllows(permissions, action.resource, action.operation, action.scoped, session.CanvasID)
+		allowedByRBAC, rbacReason, err := rbac.allows(action.resource, action.operation)
+		result := toolAccessResult{
+			Action:   action.name,
+			Allowed:  allowedByToken && allowedByRBAC && err == nil,
+			Requires: []string{fmt.Sprintf("%s:%s", action.resource, action.operation)},
+		}
+		if err != nil {
+			result.Reason = err.Error()
+		} else if !allowedByToken {
+			result.Reason = "agent token does not grant the required scope"
+		} else if !allowedByRBAC {
+			result.Reason = rbacReason
+		}
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func sortedRuleMethods(rules map[string]authorization.AuthorizationRule) []string {
+	methods := make([]string, 0, len(rules))
+	for method := range rules {
+		methods = append(methods, method)
+	}
+	sort.Strings(methods)
+	return methods
+}
+
+func scopedTokenAllowsRule(rule authorization.AuthorizationRule, permissions []jwt.Permission, canvasID string) (bool, []string, string) {
+	for _, permission := range permissions {
+		if permission.ResourceType != rule.Resource || permission.Action != rule.Action {
+			continue
+		}
+
+		if len(permission.Resources) == 0 {
+			return true, nil, ""
+		}
+
+		if !slices.Contains(permission.Resources, canvasID) {
+			continue
+		}
+
+		if rule.ResourceResolver == nil {
+			return false, nil, "agent token is resource-scoped, but this API method is not resource-scoped by the interceptor"
+		}
+
+		return true, []string{canvasID}, ""
+	}
+
+	return false, nil, "agent token does not grant this resource and operation"
+}
+
+func permissionAllows(permissions []jwt.Permission, resource, operation string, scoped bool, canvasID string) bool {
+	for _, permission := range permissions {
+		if permission.ResourceType != resource || permission.Action != operation {
+			continue
+		}
+		if len(permission.Resources) == 0 {
+			return true
+		}
+		return scoped && slices.Contains(permission.Resources, canvasID)
+	}
+	return false
+}
+
+func newAPIAccessResult(method string, rule authorization.AuthorizationRule, resources []string) apiAccessResult {
+	service, rpc := splitFullMethodName(method)
+	return apiAccessResult{
+		Method:    method,
+		Service:   service,
+		RPC:       rpc,
+		Resource:  rule.Resource,
+		Operation: rule.Action,
+		Resources: resources,
+	}
+}
+
+func splitFullMethodName(method string) (string, string) {
+	trimmed := strings.TrimPrefix(method, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+func accessDeniedReason(tokenAllowed bool, tokenReason string, rbacAllowed bool, rbacReason string) string {
+	reasons := []string{}
+	if !tokenAllowed {
+		reasons = append(reasons, tokenReason)
+	}
+	if !rbacAllowed {
+		reasons = append(reasons, rbacReason)
+	}
+	return strings.Join(reasons, "; ")
+}
+
+type rbacCache struct {
+	auth           organizationPermissionChecker
+	userID         string
+	organizationID string
+	decisions      map[string]rbacDecision
+}
+
+type rbacDecision struct {
+	allowed bool
+	reason  string
+	err     error
+}
+
+func newRBACCache(auth organizationPermissionChecker, userID, organizationID string) *rbacCache {
+	return &rbacCache{
+		auth:           auth,
+		userID:         userID,
+		organizationID: organizationID,
+		decisions:      map[string]rbacDecision{},
+	}
+}
+
+func (c *rbacCache) allows(resource, operation string) (bool, string, error) {
+	key := resource + ":" + operation
+	if decision, ok := c.decisions[key]; ok {
+		return decision.allowed, decision.reason, decision.err
+	}
+
+	decision := c.check(resource, operation)
+	c.decisions[key] = decision
+	return decision.allowed, decision.reason, decision.err
+}
+
+func (c *rbacCache) check(resource, operation string) rbacDecision {
+	if c.auth == nil {
+		return rbacDecision{allowed: false, reason: "authorization service is unavailable"}
+	}
+
+	allowed, err := c.auth.CheckOrganizationPermission(c.userID, c.organizationID, resource, operation)
+	if err != nil {
+		return rbacDecision{err: fmt.Errorf("check RBAC permission %s:%s: %w", resource, operation, err)}
+	}
+	if !allowed {
+		return rbacDecision{reason: "user RBAC does not grant this resource and operation"}
+	}
+	return rbacDecision{allowed: true}
+}

--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
+	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/usage"
 	"github.com/superplanehq/superplane/test/support"
 )
@@ -146,4 +147,106 @@ func TestAppAgentTool_UpdateDraftEnforcesUsageLimits(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canvas node limit exceeded")
+}
+
+func TestAccessAction_ReportsInterceptorBackedAgentTokenAccess(t *testing.T) {
+	organizationID := uuid.NewString()
+	userID := uuid.NewString()
+	canvasID := uuid.NewString()
+	action := accessAction{auth: allowingPermissionChecker{}}
+
+	payload, err := action.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: organizationID,
+		UserID:         userID,
+		CanvasID:       canvasID,
+	}, Input{})
+
+	require.NoError(t, err)
+	result, ok := payload.(accessResult)
+	require.True(t, ok)
+
+	assert.Equal(t, "access", result.Action)
+	assert.Equal(t, canvasID, result.CanvasID)
+	assert.ElementsMatch(t, []string{
+		"org:read",
+		"integrations:read",
+		"canvases:read:" + canvasID,
+		"canvases:update_version:" + canvasID,
+	}, result.TokenScopes)
+
+	accessible := apiAccessByMethod(result.Accessible)
+	unavailable := apiAccessByMethod(result.Unavailable)
+
+	assert.Contains(t, accessible, pb.Canvases_ListRuns_FullMethodName)
+	assert.Equal(t, []string{canvasID}, accessible[pb.Canvases_ListRuns_FullMethodName].Resources)
+	assert.Contains(t, accessible, pb.Canvases_CreateCanvasVersion_FullMethodName)
+	assert.Contains(t, unavailable, pb.Canvases_ListCanvases_FullMethodName)
+	assert.Contains(t, unavailable, pb.Canvases_PublishCanvasVersion_FullMethodName)
+
+	toolActions := toolAccessByAction(result.ToolActions)
+	require.Contains(t, toolActions, "update_draft")
+	assert.True(t, toolActions["update_draft"].Allowed)
+	require.Contains(t, toolActions, "read_runtime")
+	assert.True(t, toolActions["read_runtime"].Allowed)
+}
+
+func TestReadRuntimeAction_ParseFilters(t *testing.T) {
+	runStates, err := parseRunStates([]string{"started", "STATE_FINISHED"})
+	require.NoError(t, err)
+	assert.Equal(t, []pb.CanvasRun_State{pb.CanvasRun_STATE_STARTED, pb.CanvasRun_STATE_FINISHED}, runStates)
+
+	runResults, err := parseRunResults([]string{"passed", "RESULT_CANCELLED"})
+	require.NoError(t, err)
+	assert.Equal(t, []pb.CanvasRun_Result{pb.CanvasRun_RESULT_PASSED, pb.CanvasRun_RESULT_CANCELLED}, runResults)
+
+	executionStates, err := parseExecutionStates([]string{"pending", "STATE_STARTED", "finished"})
+	require.NoError(t, err)
+	assert.Equal(t, []pb.CanvasNodeExecution_State{
+		pb.CanvasNodeExecution_STATE_PENDING,
+		pb.CanvasNodeExecution_STATE_STARTED,
+		pb.CanvasNodeExecution_STATE_FINISHED,
+	}, executionStates)
+
+	executionResults, err := parseExecutionResults([]string{"passed", "RESULT_FAILED"})
+	require.NoError(t, err)
+	assert.Equal(t, []pb.CanvasNodeExecution_Result{pb.CanvasNodeExecution_RESULT_PASSED, pb.CanvasNodeExecution_RESULT_FAILED}, executionResults)
+}
+
+func TestReadRuntimeAction_RejectsUnknownResource(t *testing.T) {
+	action := readRuntimeAction{
+		registry: &registry.Registry{},
+		auth:     allowingPermissionChecker{},
+	}
+
+	_, err := action.Execute(context.Background(), agents.AgentSessionContext{
+		OrganizationID: uuid.NewString(),
+		UserID:         uuid.NewString(),
+		CanvasID:       uuid.NewString(),
+	}, Input{Resource: "secrets"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported runtime resource")
+}
+
+type allowingPermissionChecker struct{}
+
+func (allowingPermissionChecker) CheckOrganizationPermission(_, _, _, _ string) (bool, error) {
+	return true, nil
+}
+
+func apiAccessByMethod(entries []apiAccessResult) map[string]apiAccessResult {
+	result := make(map[string]apiAccessResult, len(entries))
+	for _, entry := range entries {
+		result[entry.Method] = entry
+	}
+	return result
+}
+
+func toolAccessByAction(entries []toolAccessResult) map[string]toolAccessResult {
+	result := make(map[string]toolAccessResult, len(entries))
+	for _, entry := range entries {
+		result[entry.Action] = entry
+	}
+	return result
 }

--- a/pkg/agents/agent_tools/actions/read_runtime.go
+++ b/pkg/agents/agent_tools/actions/read_runtime.go
@@ -1,0 +1,286 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/agents"
+	canvasactions "github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
+	"github.com/superplanehq/superplane/pkg/registry"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const readRuntimeActionName = "read_runtime"
+
+var runtimeResources = []string{
+	"memory",
+	"runs",
+	"canvas_events",
+	"event_executions",
+	"node_executions",
+	"node_queue_items",
+	"node_events",
+	"child_executions",
+}
+
+type readRuntimeAction struct {
+	registry *registry.Registry
+	auth     organizationPermissionChecker
+}
+
+func newReadRuntimeAction(deps Dependencies) readRuntimeAction {
+	return readRuntimeAction{
+		registry: deps.Registry,
+		auth:     deps.AuthService,
+	}
+}
+
+func (a readRuntimeAction) Name() string {
+	return readRuntimeActionName
+}
+
+func (a readRuntimeAction) Execute(ctx context.Context, session agents.AgentSessionContext, input Input) (any, error) {
+	if a.registry == nil {
+		return runtimeReadResult{}, fmt.Errorf("component registry is not configured")
+	}
+	if err := a.checkReadPermission(session); err != nil {
+		return runtimeReadResult{}, err
+	}
+
+	resource := strings.TrimSpace(input.Resource)
+	if resource == "" {
+		resource = "memory"
+	}
+	if !slices.Contains(runtimeResources, resource) {
+		return runtimeReadResult{}, fmt.Errorf("unsupported runtime resource %q", input.Resource)
+	}
+
+	payload, err := a.read(ctx, session, input, resource)
+	if err != nil {
+		return runtimeReadResult{}, err
+	}
+
+	return runtimeReadResult{
+		Action:   readRuntimeActionName,
+		CanvasID: session.CanvasID,
+		Resource: resource,
+		Payload:  payload,
+	}, nil
+}
+
+func (a readRuntimeAction) checkReadPermission(session agents.AgentSessionContext) error {
+	if a.auth == nil {
+		return fmt.Errorf("authorization service is unavailable")
+	}
+
+	allowed, err := a.auth.CheckOrganizationPermission(session.UserID, session.OrganizationID, "canvases", "read")
+	if err != nil {
+		return fmt.Errorf("check canvases:read permission: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("user RBAC does not grant canvases:read")
+	}
+	return nil
+}
+
+func (a readRuntimeAction) read(ctx context.Context, session agents.AgentSessionContext, input Input, resource string) (any, error) {
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	before, err := parseRuntimeBefore(input.Before)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resource {
+	case "memory":
+		response, err := canvasactions.ListCanvasMemories(ctx, a.registry, session.OrganizationID, session.CanvasID)
+		if err != nil {
+			return nil, err
+		}
+		return filterMemoryResponse(response, input.Namespace)
+	case "runs":
+		states, err := parseRunStates(input.States)
+		if err != nil {
+			return nil, err
+		}
+		results, err := parseRunResults(input.Results)
+		if err != nil {
+			return nil, err
+		}
+		return protoPayload(canvasactions.ListRuns(ctx, a.registry, canvasID, input.Limit, before, states, results))
+	case "canvas_events":
+		return protoPayload(canvasactions.ListCanvasEvents(ctx, a.registry, canvasID, input.Limit, before))
+	case "event_executions":
+		if strings.TrimSpace(input.EventID) == "" {
+			return nil, fmt.Errorf("event_id is required for event_executions")
+		}
+		return protoPayload(canvasactions.ListEventExecutions(ctx, a.registry, session.CanvasID, input.EventID))
+	case "node_executions":
+		if strings.TrimSpace(input.NodeID) == "" {
+			return nil, fmt.Errorf("node_id is required for node_executions")
+		}
+		states, err := parseExecutionStates(input.States)
+		if err != nil {
+			return nil, err
+		}
+		results, err := parseExecutionResults(input.Results)
+		if err != nil {
+			return nil, err
+		}
+		return protoPayload(canvasactions.ListNodeExecutions(ctx, a.registry, session.CanvasID, input.NodeID, states, results, input.Limit, before))
+	case "node_queue_items":
+		if strings.TrimSpace(input.NodeID) == "" {
+			return nil, fmt.Errorf("node_id is required for node_queue_items")
+		}
+		return protoPayload(canvasactions.ListNodeQueueItems(ctx, a.registry, session.CanvasID, input.NodeID, input.Limit, before))
+	case "node_events":
+		if strings.TrimSpace(input.NodeID) == "" {
+			return nil, fmt.Errorf("node_id is required for node_events")
+		}
+		return protoPayload(canvasactions.ListNodeEvents(ctx, a.registry, canvasID, input.NodeID, input.Limit, before))
+	case "child_executions":
+		if strings.TrimSpace(input.ExecutionID) == "" {
+			return nil, fmt.Errorf("execution_id is required for child_executions")
+		}
+		executionID, err := uuid.Parse(input.ExecutionID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid execution_id: %w", err)
+		}
+		return protoPayload(canvasactions.ListChildExecutions(ctx, a.registry, canvasID, executionID))
+	default:
+		return nil, fmt.Errorf("unsupported runtime resource %q", resource)
+	}
+}
+
+func filterMemoryResponse(response *pb.ListCanvasMemoriesResponse, namespace string) (any, error) {
+	if strings.TrimSpace(namespace) == "" {
+		return protoPayload(response, nil)
+	}
+
+	filtered := &pb.ListCanvasMemoriesResponse{}
+	for _, item := range response.GetItems() {
+		if item.GetNamespace() == namespace {
+			filtered.Items = append(filtered.Items, item)
+		}
+	}
+	return protoPayload(filtered, nil)
+}
+
+func protoPayload(response proto.Message, err error) (any, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("marshal runtime response: %w", err)
+	}
+
+	var payload any
+	if err := json.Unmarshal(bytes, &payload); err != nil {
+		return nil, fmt.Errorf("decode runtime response: %w", err)
+	}
+	return payload, nil
+}
+
+func parseRuntimeBefore(value string) (*timestamppb.Timestamp, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339, trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("before must be an RFC3339 timestamp: %w", err)
+	}
+	return timestamppb.New(parsed), nil
+}
+
+func parseRunStates(values []string) ([]pb.CanvasRun_State, error) {
+	states := make([]pb.CanvasRun_State, 0, len(values))
+	for _, value := range values {
+		switch normalizeRuntimeFilter(value) {
+		case "started":
+			states = append(states, pb.CanvasRun_STATE_STARTED)
+		case "finished":
+			states = append(states, pb.CanvasRun_STATE_FINISHED)
+		case "":
+		default:
+			return nil, fmt.Errorf("unsupported run state %q", value)
+		}
+	}
+	return states, nil
+}
+
+func parseRunResults(values []string) ([]pb.CanvasRun_Result, error) {
+	results := make([]pb.CanvasRun_Result, 0, len(values))
+	for _, value := range values {
+		switch normalizeRuntimeFilter(value) {
+		case "passed":
+			results = append(results, pb.CanvasRun_RESULT_PASSED)
+		case "failed":
+			results = append(results, pb.CanvasRun_RESULT_FAILED)
+		case "cancelled", "canceled":
+			results = append(results, pb.CanvasRun_RESULT_CANCELLED)
+		case "":
+		default:
+			return nil, fmt.Errorf("unsupported run result %q", value)
+		}
+	}
+	return results, nil
+}
+
+func parseExecutionStates(values []string) ([]pb.CanvasNodeExecution_State, error) {
+	states := make([]pb.CanvasNodeExecution_State, 0, len(values))
+	for _, value := range values {
+		switch normalizeRuntimeFilter(value) {
+		case "pending":
+			states = append(states, pb.CanvasNodeExecution_STATE_PENDING)
+		case "started":
+			states = append(states, pb.CanvasNodeExecution_STATE_STARTED)
+		case "finished":
+			states = append(states, pb.CanvasNodeExecution_STATE_FINISHED)
+		case "":
+		default:
+			return nil, fmt.Errorf("unsupported execution state %q", value)
+		}
+	}
+	return states, nil
+}
+
+func parseExecutionResults(values []string) ([]pb.CanvasNodeExecution_Result, error) {
+	results := make([]pb.CanvasNodeExecution_Result, 0, len(values))
+	for _, value := range values {
+		switch normalizeRuntimeFilter(value) {
+		case "passed":
+			results = append(results, pb.CanvasNodeExecution_RESULT_PASSED)
+		case "failed":
+			results = append(results, pb.CanvasNodeExecution_RESULT_FAILED)
+		case "":
+		default:
+			return nil, fmt.Errorf("unsupported execution result %q", value)
+		}
+	}
+	return results, nil
+}
+
+func normalizeRuntimeFilter(value string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	normalized = strings.TrimPrefix(normalized, "state_")
+	normalized = strings.TrimPrefix(normalized, "result_")
+	return normalized
+}

--- a/pkg/agents/agent_tools/actions/registry.go
+++ b/pkg/agents/agent_tools/actions/registry.go
@@ -36,7 +36,9 @@ type Registry struct {
 // NewDefaultRegistry creates the standard superplane_app action registry.
 func NewDefaultRegistry(deps Dependencies) *Registry {
 	return NewRegistry(
+		newAccessAction(deps),
 		readAction{},
+		newReadRuntimeAction(deps),
 		newUpdateDraftAction(deps),
 		listIntegrationsAction{},
 	)

--- a/pkg/agents/agent_tools/actions/types.go
+++ b/pkg/agents/agent_tools/actions/types.go
@@ -10,6 +10,15 @@ type Input struct {
 	CanvasYAML          string           `json:"canvas_yaml,omitempty"`
 	ConsoleYAML         string           `json:"console_yaml,omitempty"`
 	AutoLayout          *AutoLayoutInput `json:"auto_layout,omitempty"`
+	Resource            string           `json:"resource,omitempty"`
+	Namespace           string           `json:"namespace,omitempty"`
+	NodeID              string           `json:"node_id,omitempty"`
+	EventID             string           `json:"event_id,omitempty"`
+	ExecutionID         string           `json:"execution_id,omitempty"`
+	Limit               uint32           `json:"limit,omitempty"`
+	Before              string           `json:"before,omitempty"`
+	States              []string         `json:"states,omitempty"`
+	Results             []string         `json:"results,omitempty"`
 }
 
 // AutoLayoutInput configures optional backend auto-layout for draft updates.
@@ -43,6 +52,42 @@ type integrationsResult struct {
 	Action       string              `json:"action"`
 	CanvasID     string              `json:"canvas_id"`
 	Integrations []integrationResult `json:"integrations"`
+}
+
+type runtimeReadResult struct {
+	Action   string `json:"action"`
+	CanvasID string `json:"canvas_id"`
+	Resource string `json:"resource"`
+	Payload  any    `json:"payload"`
+}
+
+type accessResult struct {
+	Action         string             `json:"action"`
+	CanvasID       string             `json:"canvas_id"`
+	OrganizationID string             `json:"organization_id"`
+	UserID         string             `json:"user_id"`
+	TokenScopes    []string           `json:"token_scopes"`
+	ToolActions    []toolAccessResult `json:"tool_actions"`
+	Accessible     []apiAccessResult  `json:"accessible"`
+	Unavailable    []apiAccessResult  `json:"unavailable,omitempty"`
+	Notes          []string           `json:"notes,omitempty"`
+}
+
+type toolAccessResult struct {
+	Action   string   `json:"action"`
+	Allowed  bool     `json:"allowed"`
+	Requires []string `json:"requires,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
+type apiAccessResult struct {
+	Method    string   `json:"method"`
+	Service   string   `json:"service,omitempty"`
+	RPC       string   `json:"rpc,omitempty"`
+	Resource  string   `json:"resource"`
+	Operation string   `json:"operation"`
+	Resources []string `json:"resources,omitempty"`
+	Reason    string   `json:"reason,omitempty"`
 }
 
 type draftResult struct {

--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -59,7 +59,7 @@ func (t *AppAgentTool) Name() string {
 }
 
 func (t *AppAgentTool) Description() string {
-	return "Read and update the current SuperPlane app canvas without invoking the SuperPlane CLI. Use this tool before shell commands when you need the canvas YAML, console YAML, connected integration IDs, or when you need to save draft graph or console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues."
+	return "Inspect access, read, and update the current SuperPlane app canvas without invoking the SuperPlane CLI. Use access to check the current agent token's interceptor-backed API permissions, read for canvas YAML, read_runtime for memory/runs/events/executions/queues, list_integrations for connected integration IDs, and update_draft to save draft graph or Console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues."
 }
 
 func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
@@ -69,7 +69,7 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			"action": {
 				Type:        "string",
 				Enum:        t.actions.Names(),
-				Description: "Operation to run. Use read for current YAML, update_draft to save canvas_yaml and/or console_yaml to a draft, and list_integrations for connected integration IDs.",
+				Description: "Operation to run. Use access to inspect token-backed API capabilities, read for current YAML, read_runtime for memory/runs/events/executions/queues, update_draft to save canvas_yaml and/or console_yaml to a draft, and list_integrations for connected integration IDs.",
 			},
 			"canvas_id": {
 				Type:        "string",
@@ -108,6 +108,45 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 						Items: &agents.CustomToolInputSchema{Type: "string"},
 					},
 				},
+			},
+			"resource": {
+				Type:        "string",
+				Enum:        []string{"memory", "runs", "canvas_events", "event_executions", "node_executions", "node_queue_items", "node_events", "child_executions"},
+				Description: "For read_runtime. Defaults to memory. Selects the canvas-scoped runtime data to read.",
+			},
+			"namespace": {
+				Type:        "string",
+				Description: "For read_runtime resource memory. Optional client-side namespace filter, matching the CLI behavior.",
+			},
+			"node_id": {
+				Type:        "string",
+				Description: "For read_runtime resources node_executions, node_queue_items, and node_events.",
+			},
+			"event_id": {
+				Type:        "string",
+				Description: "For read_runtime resource event_executions.",
+			},
+			"execution_id": {
+				Type:        "string",
+				Description: "For read_runtime resource child_executions.",
+			},
+			"limit": {
+				Type:        "integer",
+				Description: "For read_runtime paginated resources. Backend defaults apply when omitted.",
+			},
+			"before": {
+				Type:        "string",
+				Description: "For read_runtime paginated resources. RFC3339 timestamp cursor.",
+			},
+			"states": {
+				Type:        "array",
+				Description: "For read_runtime resources runs and node_executions. Use started/finished for runs; pending/started/finished for node executions.",
+				Items:       &agents.CustomToolInputSchema{Type: "string"},
+			},
+			"results": {
+				Type:        "array",
+				Description: "For read_runtime resources runs and node_executions. Use passed/failed/cancelled for runs; passed/failed for node executions.",
+				Items:       &agents.CustomToolInputSchema{Type: "string"},
 			},
 		},
 		Required: []string{"action"},

--- a/pkg/agents/agent_tools/schema_test.go
+++ b/pkg/agents/agent_tools/schema_test.go
@@ -34,6 +34,30 @@ func TestComponentSchemaAgentTool_ReturnsExactSlackSchema(t *testing.T) {
 	assert.NotContains(t, result.Notes, "Use output_channels.name exactly in edge sourceName values; labels are display-only.")
 }
 
+func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
+	tool := NewAppAgentTool(AppAgentToolOptions{})
+
+	schema := tool.InputSchema()
+	actionSchema := schema.Properties["action"]
+	resourceSchema := schema.Properties["resource"]
+
+	assert.Contains(t, actionSchema.Enum, "read_runtime")
+	assert.ElementsMatch(t, []string{
+		"memory",
+		"runs",
+		"canvas_events",
+		"event_executions",
+		"node_executions",
+		"node_queue_items",
+		"node_events",
+		"child_executions",
+	}, resourceSchema.Enum)
+	assert.Contains(t, schema.Properties, "namespace")
+	assert.Contains(t, schema.Properties, "node_id")
+	assert.Contains(t, schema.Properties, "event_id")
+	assert.Contains(t, schema.Properties, "execution_id")
+}
+
 func TestComponentSchemaAgentTool_ReturnsCoreComponentSchema(t *testing.T) {
 	tool := newComponentSchemaTool(t)
 

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -15,10 +15,14 @@ Prefer the `superplane_component_schema` custom tool for component fields, integ
 For trivial edits where you already know the exact fields (renaming a node, changing a URL, updating a cron expression), you can skip the researcher and edit directly.
 
 When building or modifying apps:
-1. Prefer the `superplane_app` custom tool to read the current draft app, list connected integrations, and update draft YAML. It avoids CLI startup and returns version metadata in one call.
+1. Prefer the `superplane_app` custom tool to inspect access, read the current draft app, read runtime data, list connected integrations, and update draft YAML. It avoids CLI startup and returns version metadata in one call.
 2. Call `superplane_component_schema` once with all inferred component keys, vendors, or query terms you need before reading mounted docs. Treat the result as your schema cache for the turn.
 3. Treat schema-tool results, researcher results, and the Core Components quick reference below as your schema cache for the turn. Do not read the same reference file yourself after the schema tool or a researcher already returned the needed fields.
 4. Apply the draft update and verify once. `superplane_app.update_draft` auto-layouts graph changes by default; do not spend extra tool calls calculating manual node positions unless the user asked for a specific layout.
+
+Use `superplane_app` action `access` when you need to know what the current agent token can call. It reports the intersection of the token scopes and the backend authorization interceptor, including which canvas-scoped API methods are allowed for the current app. Do this before trying CLI/API operations whose permission boundary is unclear.
+
+Use `superplane_app` action `read_runtime` for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. Prefer it over CLI/API calls for runtime inspection.
 
 For Console edits, prefer `superplane_app` with `include_console: true`, then update with `console_yaml`. Use CLI console get/set only as a fallback if the custom tool fails.
 

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -3,6 +3,8 @@ package agents
 import (
 	"strings"
 	"time"
+
+	"github.com/superplanehq/superplane/pkg/jwt"
 )
 
 type Mode string
@@ -13,6 +15,19 @@ const (
 )
 
 const agentTokenTTL = 1 * time.Hour
+
+func AgentTokenPermissions(canvasID string) []jwt.Permission {
+	return []jwt.Permission{
+		{ResourceType: "org", Action: "read"},
+		{ResourceType: "integrations", Action: "read"},
+		{ResourceType: "canvases", Action: "read", Resources: []string{canvasID}},
+		{ResourceType: "canvases", Action: "update_version", Resources: []string{canvasID}},
+	}
+}
+
+func AgentTokenScopes(canvasID string) []string {
+	return jwt.ScopesFromPermissions(AgentTokenPermissions(canvasID))
+}
 
 const preambleTemplate = "[SuperPlane session context — refreshed every turn; always use the latest values]\n" +
 	"canvas_id: %s\n" +
@@ -33,6 +48,10 @@ const preambleTemplate = "[SuperPlane session context — refreshed every turn; 
 	"  - integrations:read\n" +
 	"  - canvases:read:%s\n" +
 	"  - canvases:update_version:%s\n" +
+	"\n" +
+	"To inspect what these scopes allow, call `superplane_app` with\n" +
+	"action `access`. It reports the scoped-token permissions as the\n" +
+	"backend authorization interceptor applies them to this app.\n" +
 	"\n" +
 	"The canvases:update_version scope is limited to draft app version\n" +
 	"editing. Draft version editing includes app graph updates and console\n" +
@@ -74,6 +93,7 @@ const builderModeInstructions = `[Agent Mode: BUILD]
 You are in Build mode. Your job is to modify the app based on the user's request.
 
 Rules:
+- Use 'superplane_app' action 'access' before CLI/API operations whose permission boundary is unclear.
 - Prefer 'superplane_app' action 'update_draft' for graph and Console draft updates. If you must use the CLI fallback, use "superplane apps canvas update --draft-id <draft-id>" — never publish directly.
 - After a successful draft update, output a :::draft-actions block with the version ID so the user can review or publish:
 
@@ -86,7 +106,7 @@ Rules:
 - You can update the app Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Prefer 'superplane_app' with include_console for reads and console_yaml for draft updates. Use 'superplane apps console get ... -o yaml' and 'superplane apps console set ... -f console.yaml --draft-id <draft-id>' only as a fallback.
 - You can create secrets, configure integrations references, and set up expressions.
 - For direct app edits, prefer the shortest reliable path: use 'superplane_app' to read the draft app once, list integrations only if integration IDs are needed, make the draft update, then report the result.
-- Prefer the 'superplane_app' custom tool for canvas reads, draft updates, and connected integration lists. It avoids CLI startup and returns the current YAML plus version metadata in one call. Graph updates through 'superplane_app' auto-layout by default, so do not manually calculate node positions unless the user asks for a specific layout.
+- Prefer the 'superplane_app' custom tool for canvas reads, runtime reads, draft updates, and connected integration lists. Use action 'read_runtime' for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. It avoids CLI startup and returns the current YAML plus version metadata in one call. Graph updates through 'superplane_app' auto-layout by default, so do not manually calculate node positions unless the user asks for a specific layout.
 - When reading an app for build work, save it once to a local file such as '/tmp/current-canvas.yaml' and inspect that file locally with 'rg', 'yq', 'sed', or an editor. Do not run repeated 'superplane apps canvas get ... | grep ...' commands against the same draft. Re-fetch only after you update the draft.
 - When editing the Console, use the Console YAML already returned by 'superplane_app' when available. Read ref/skills/superplane-cli/references/console-yaml-spec.md and ref/docs/prd/console-and-widgets.md only if the task needs widget details you do not already know. Do not repeatedly run 'superplane apps console get ... | grep ...' against the same draft.
 - When shell is still the right tool, batch independent commands in one bash call with 'set -euo pipefail'. For multi-step YAML transforms or mounted-reference inspection, write and run one short Python script that reads known files, applies all needed searches/extractions, and prints one compact summary. Do not chain multiple ls/grep/sed/cat/read calls against the same reference set.
@@ -104,7 +124,8 @@ You are in Ask mode. Your job is to help the user understand and monitor their a
 
 Rules:
 - NEVER modify the app. No creates, no updates, no deletes.
-- You CAN read app state, list runs, inspect executions, check node status, and explain how things work.
+- Use 'superplane_app' action 'access' before CLI/API operations whose permission boundary is unclear.
+- You CAN read app state, list memory, list runs, inspect events/executions/queues, check node status, and explain how things work. Prefer 'superplane_app' action 'read_runtime' for these runtime reads before using CLI/API fallbacks.
 - When the user asks about a failure, trace through the run execution path and identify the root cause.
 - If the user explicitly asks you to make a change, let them know you can't do that in Ask mode and they need to switch to Build mode.
 - Use charts, tables, and mermaid diagrams to visualize run data and app topology when helpful.

--- a/pkg/agents/constants_test.go
+++ b/pkg/agents/constants_test.go
@@ -1,0 +1,18 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentTokenScopes(t *testing.T) {
+	canvasID := "canvas-123"
+
+	assert.ElementsMatch(t, []string{
+		"org:read",
+		"integrations:read",
+		"canvases:read:" + canvasID,
+		"canvases:update_version:" + canvasID,
+	}, AgentTokenScopes(canvasID))
+}

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -467,12 +467,7 @@ func (s *Service) mintAgentToken(organizationID, userID, canvasID string) (strin
 		Subject: userID,
 		OrgID:   organizationID,
 		Purpose: "agent-builder",
-		Scopes: jwt.ScopesFromPermissions([]jwt.Permission{
-			{ResourceType: "org", Action: "read"},
-			{ResourceType: "integrations", Action: "read"},
-			{ResourceType: "canvases", Action: "read", Resources: []string{canvasID}},
-			{ResourceType: "canvases", Action: "update_version", Resources: []string{canvasID}},
-		}),
+		Scopes:  AgentTokenScopes(canvasID),
 	}
 	token, err := s.jwtSigner.GenerateScopedToken(claims, agentTokenTTL)
 	if err != nil {

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -83,6 +83,13 @@ func canvasResourceResolver(req any) []string {
 }
 
 func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterceptor {
+	return &AuthorizationInterceptor{
+		authService: authService,
+		rules:       DefaultAuthorizationRules(),
+	}
+}
+
+func DefaultAuthorizationRules() map[string]AuthorizationRule {
 	rules := map[string]AuthorizationRule{
 		// Secrets rules
 		pbSecrets.Secrets_CreateSecret_FullMethodName:     {Resource: "secrets", Action: "create", DomainType: models.DomainTypeOrganization},
@@ -439,10 +446,7 @@ func NewAuthorizationInterceptor(authService Authorization) *AuthorizationInterc
 		pbServiceAccounts.ServiceAccounts_RegenerateServiceAccountToken_FullMethodName: {Resource: "service_accounts", Action: "update", DomainType: models.DomainTypeOrganization},
 	}
 
-	return &AuthorizationInterceptor{
-		authService: authService,
-		rules:       rules,
-	}
+	return rules
 }
 
 func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {


### PR DESCRIPTION
## Summary
- add superplane_app access reporting based on the authorization interceptor and agent token scopes
- add read_runtime for canvas-scoped memory, runs, events, executions, and queue reads
- update agent prompts and tool schema to prefer app tools over CLI/API fallbacks

## Verification
- make format.go
- make lint
- make check.build.app
- make test PKG_TEST_PACKAGES='./pkg/agents/agent_tools/actions ./pkg/agents/agent_tools ./pkg/agents ./pkg/authorization'