### PR TITLE
feat: add Twilio integration (makeCall, sendSMS, onInboundSMS)

### DIFF
--- a/docs/components/Twilio.mdx
+++ b/docs/components/Twilio.mdx
@@ -1,0 +1,150 @@
+---
+title: "Twilio"
+---
+
+Make phone calls, send SMS, and receive inbound messages with Twilio
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+## Triggers
+
+<CardGrid>
+  <LinkCard title="On Inbound SMS" href="#on-inbound-sms" description="Receive inbound SMS messages via Twilio webhook" />
+</CardGrid>
+
+## Actions
+
+<CardGrid>
+  <LinkCard title="Make Call" href="#make-call" description="Place an outbound phone call with a text-to-speech message" />
+  <LinkCard title="Send SMS" href="#send-sms" description="Send an outbound SMS message" />
+</CardGrid>
+
+## Instructions
+
+To set up the Twilio integration:
+
+1. Log in to the **Twilio Console** (https://console.twilio.com)
+2. Copy your **Account SID** and **Auth Token** from the dashboard
+3. Get or buy a **Twilio phone number** with Voice and SMS capabilities
+4. Paste all three values in the fields below
+
+The phone number must be in E.164 format (e.g. +15551234567).
+
+<a id="on-inbound-sms"></a>
+
+## On Inbound SMS
+
+**Trigger key:** `twilio.onInboundSMS`
+
+The **On Inbound SMS** trigger fires when an SMS is received on your Twilio phone number.
+
+### Setup
+
+1. Configure this trigger on your canvas
+2. Copy the webhook URL shown after publishing
+3. In the Twilio Console, go to your phone number settings
+4. Set the **Messaging** webhook URL to the copied URL
+
+### Event Data
+
+Each inbound SMS includes:
+- **from**: Sender phone number
+- **to**: Your Twilio phone number that received the message
+- **body**: The SMS message text
+- **messageSid**: Twilio message ID
+- **numMedia**: Number of media attachments
+
+### Use Cases
+
+- **Chatbot workflows**: Respond to inbound text messages
+- **Acknowledgment flows**: On-call engineers can reply to alerts via SMS
+- **Data collection**: Collect responses via text message
+
+### Example Data
+
+```json
+{
+  "body": "ACK - I'm looking into it",
+  "from": "+15551234567",
+  "messageSid": "SM1234567890abcdef1234567890abcdef",
+  "numMedia": "0",
+  "to": "+15559876543"
+}
+```
+
+<a id="make-call"></a>
+
+## Make Call
+
+**Component key:** `twilio.makeCall`
+
+The **Make Call** component places an outbound phone call and speaks a text-to-speech message to the recipient.
+
+### Use Cases
+
+- **Incident alerting**: Call the on-call engineer when a critical alert fires
+- **Escalation**: Call a backup contact if the primary doesn't answer
+- **Notifications**: Voice notifications for time-sensitive events
+
+### Configuration
+
+- **To**: Destination phone number in E.164 format (e.g. +15551234567)
+- **Message**: The text message to speak via TTS when the call is answered
+- **Timeout**: How many seconds to ring before giving up (default: 30)
+
+### Output Channels
+
+- **answered**: The call was answered (status = completed)
+- **no-answer**: The call was not answered (status = no-answer, busy, or failed)
+
+### Output
+
+Returns the call SID, final status, destination number, and call duration.
+
+### Example Output
+
+```json
+{
+  "callSid": "CA1234567890abcdef1234567890abcdef",
+  "duration": "12",
+  "from": "+15559876543",
+  "status": "completed",
+  "to": "+15551234567"
+}
+```
+
+<a id="send-sms"></a>
+
+## Send SMS
+
+**Component key:** `twilio.sendSMS`
+
+The **Send SMS** component sends a text message to a phone number.
+
+### Use Cases
+
+- **Alert fallback**: Send an SMS when a phone call goes unanswered
+- **Notifications**: Quick status updates via text
+- **Confirmations**: Send confirmation codes or summaries
+
+### Configuration
+
+- **To**: Destination phone number in E.164 format (e.g. +15551234567)
+- **Body**: The SMS message text (max 1600 characters)
+
+### Output
+
+Returns the message SID, delivery status, and message details.
+
+### Example Output
+
+```json
+{
+  "body": "Alert: Production database CPU at 95%",
+  "from": "+15559876543",
+  "messageSid": "SM1234567890abcdef1234567890abcdef",
+  "status": "queued",
+  "to": "+15551234567"
+}
+```
+

--- a/pkg/integrations/twilio/client.go
+++ b/pkg/integrations/twilio/client.go
@@ -1,0 +1,179 @@
+package twilio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const twilioAPIBase = "https://api.twilio.com/2010-04-01"
+
+type Client struct {
+	AccountSID string
+	AuthToken  string
+	FromNumber string
+}
+
+func NewClient(ctx core.IntegrationContext) (*Client, error) {
+	accountSID, err := ctx.GetConfig("accountSid")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account SID: %w", err)
+	}
+	authToken, err := ctx.GetConfig("authToken")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get auth token: %w", err)
+	}
+	fromNumber, err := ctx.GetConfig("fromNumber")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get from number: %w", err)
+	}
+
+	return &Client{
+		AccountSID: string(accountSID),
+		AuthToken:  string(authToken),
+		FromNumber: string(fromNumber),
+	}, nil
+}
+
+// CallResponse is the response from creating a call.
+type CallResponse struct {
+	SID         string `json:"sid"`
+	Status      string `json:"status"`
+	To          string `json:"to"`
+	From        string `json:"from"`
+	DateCreated string `json:"date_created"`
+	Duration    string `json:"duration"`
+}
+
+// MessageResponse is the response from sending an SMS.
+type MessageResponse struct {
+	SID         string `json:"sid"`
+	Status      string `json:"status"`
+	To          string `json:"to"`
+	From        string `json:"from"`
+	Body        string `json:"body"`
+	DateCreated string `json:"date_created"`
+}
+
+// AccountResponse is used to verify credentials.
+type AccountResponse struct {
+	SID          string `json:"sid"`
+	FriendlyName string `json:"friendly_name"`
+	Status       string `json:"status"`
+}
+
+// MakeCall places an outbound call with a TTS message.
+func (c *Client) MakeCall(to, message string, timeout int) (*CallResponse, error) {
+	twiml := fmt.Sprintf("<Response><Say>%s</Say></Response>", xmlEscape(message))
+
+	data := url.Values{}
+	data.Set("To", to)
+	data.Set("From", c.FromNumber)
+	data.Set("Twiml", twiml)
+	if timeout > 0 {
+		data.Set("Timeout", fmt.Sprintf("%d", timeout))
+	}
+
+	endpoint := fmt.Sprintf("%s/Accounts/%s/Calls.json", twilioAPIBase, c.AccountSID)
+	body, err := c.doPost(endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("make call: %w", err)
+	}
+
+	var resp CallResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &resp, nil
+}
+
+// SendSMS sends an outbound SMS message.
+func (c *Client) SendSMS(to, messageBody string) (*MessageResponse, error) {
+	data := url.Values{}
+	data.Set("To", to)
+	data.Set("From", c.FromNumber)
+	data.Set("Body", messageBody)
+
+	endpoint := fmt.Sprintf("%s/Accounts/%s/Messages.json", twilioAPIBase, c.AccountSID)
+	body, err := c.doPost(endpoint, data)
+	if err != nil {
+		return nil, fmt.Errorf("send SMS: %w", err)
+	}
+
+	var resp MessageResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode SMS response: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetAccount verifies the credentials by fetching account info.
+func (c *Client) GetAccount() (*AccountResponse, error) {
+	endpoint := fmt.Sprintf("%s/Accounts/%s.json", twilioAPIBase, c.AccountSID)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.AccountSID, c.AuthToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("twilio API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var account AccountResponse
+	if err := json.Unmarshal(body, &account); err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (c *Client) doPost(endpoint string, data url.Values) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.AccountSID, c.AuthToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("twilio API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func xmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return s
+}

--- a/pkg/integrations/twilio/example.go
+++ b/pkg/integrations/twilio/example.go
@@ -1,0 +1,31 @@
+package twilio
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func getExampleOutput(name string) map[string]any {
+	return loadJSON(fmt.Sprintf("example_output_%s.json", name))
+}
+
+func getExampleData(name string) map[string]any {
+	return loadJSON(fmt.Sprintf("example_data_%s.json", name))
+}
+
+func loadJSON(filename string) map[string]any {
+	_, currentFile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(currentFile)
+	data, err := os.ReadFile(filepath.Join(dir, filename))
+	if err != nil {
+		return map[string]any{}
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return map[string]any{}
+	}
+	return result
+}

--- a/pkg/integrations/twilio/example_data_on_inbound_sms.json
+++ b/pkg/integrations/twilio/example_data_on_inbound_sms.json
@@ -1,0 +1,7 @@
+{
+  "from": "+15551234567",
+  "to": "+15559876543",
+  "body": "ACK - I'm looking into it",
+  "messageSid": "SM1234567890abcdef1234567890abcdef",
+  "numMedia": "0"
+}

--- a/pkg/integrations/twilio/example_output_make_call.json
+++ b/pkg/integrations/twilio/example_output_make_call.json
@@ -1,0 +1,7 @@
+{
+  "callSid": "CA1234567890abcdef1234567890abcdef",
+  "status": "completed",
+  "to": "+15551234567",
+  "from": "+15559876543",
+  "duration": "12"
+}

--- a/pkg/integrations/twilio/example_output_send_sms.json
+++ b/pkg/integrations/twilio/example_output_send_sms.json
@@ -1,0 +1,7 @@
+{
+  "messageSid": "SM1234567890abcdef1234567890abcdef",
+  "status": "queued",
+  "to": "+15551234567",
+  "from": "+15559876543",
+  "body": "Alert: Production database CPU at 95%"
+}

--- a/pkg/integrations/twilio/make_call.go
+++ b/pkg/integrations/twilio/make_call.go
@@ -1,0 +1,163 @@
+package twilio
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type MakeCall struct{}
+
+type MakeCallConfig struct {
+	To      string `json:"to" mapstructure:"to"`
+	Message string `json:"message" mapstructure:"message"`
+	Timeout int    `json:"timeout" mapstructure:"timeout"`
+}
+
+func (c *MakeCall) Name() string  { return "twilio.makeCall" }
+func (c *MakeCall) Label() string { return "Make Call" }
+
+func (c *MakeCall) Description() string {
+	return "Place an outbound phone call with a text-to-speech message"
+}
+
+func (c *MakeCall) Documentation() string {
+	return `The **Make Call** component places an outbound phone call and speaks a text-to-speech message to the recipient.
+
+## Use Cases
+
+- **Incident alerting**: Call the on-call engineer when a critical alert fires
+- **Escalation**: Call a backup contact if the primary doesn't answer
+- **Notifications**: Voice notifications for time-sensitive events
+
+## Configuration
+
+- **To**: Destination phone number in E.164 format (e.g. +15551234567)
+- **Message**: The text message to speak via TTS when the call is answered
+- **Timeout**: How many seconds to ring before giving up (default: 30)
+
+## Output Channels
+
+- **answered**: The call was answered (status = completed)
+- **no-answer**: The call was not answered (status = no-answer, busy, or failed)
+
+## Output
+
+Returns the call SID, final status, destination number, and call duration.`
+}
+
+func (c *MakeCall) Icon() string  { return "phone" }
+func (c *MakeCall) Color() string { return "#F22F46" }
+
+func (c *MakeCall) ExampleOutput() map[string]any {
+	return getExampleOutput("make_call")
+}
+
+func (c *MakeCall) OutputChannels(config any) []core.OutputChannel {
+	return []core.OutputChannel{
+		{Name: "answered", Label: "Answered"},
+		{Name: "no-answer", Label: "No Answer"},
+	}
+}
+
+func (c *MakeCall) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "to",
+			Label:       "To",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "+15551234567",
+			Description: "Destination phone number (E.164 format)",
+		},
+		{
+			Name:        "message",
+			Label:       "Message",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "Text-to-speech message to speak when the call is answered",
+		},
+		{
+			Name:        "timeout",
+			Label:       "Timeout",
+			Type:        configuration.FieldTypeNumber,
+			Required:    false,
+			Default:     "30",
+			Description: "How many seconds to ring before giving up (default: 30)",
+		},
+	}
+}
+
+func (c *MakeCall) Setup(ctx core.SetupContext) error {
+	var config MakeCallConfig
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if strings.TrimSpace(config.To) == "" {
+		return fmt.Errorf("to is required")
+	}
+	if !strings.HasPrefix(config.To, "+") {
+		return fmt.Errorf("phone number must be in E.164 format (e.g. +15551234567)")
+	}
+	if strings.TrimSpace(config.Message) == "" {
+		return fmt.Errorf("message is required")
+	}
+
+	return nil
+}
+
+func (c *MakeCall) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *MakeCall) Execute(ctx core.ExecutionContext) error {
+	var config MakeCallConfig
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	timeout := config.Timeout
+	if timeout <= 0 {
+		timeout = 30
+	}
+
+	resp, err := client.MakeCall(config.To, config.Message, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to make call: %w", err)
+	}
+
+	output := map[string]any{
+		"callSid":  resp.SID,
+		"status":   resp.Status,
+		"to":       resp.To,
+		"from":     resp.From,
+		"duration": resp.Duration,
+	}
+
+	channel := "answered"
+	if resp.Status == "no-answer" || resp.Status == "busy" || resp.Status == "failed" || resp.Status == "canceled" {
+		channel = "no-answer"
+	}
+
+	return ctx.ExecutionState.Emit(channel, "twilio.call.completed", []any{output})
+}
+
+func (c *MakeCall) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *MakeCall) Cancel(ctx core.ExecutionContext) error      { return nil }
+func (c *MakeCall) Cleanup(ctx core.SetupContext) error         { return nil }
+func (c *MakeCall) Hooks() []core.Hook                          { return []core.Hook{} }
+func (c *MakeCall) HandleHook(ctx core.ActionHookContext) error { return nil }

--- a/pkg/integrations/twilio/on_inbound_sms.go
+++ b/pkg/integrations/twilio/on_inbound_sms.go
@@ -1,0 +1,139 @@
+package twilio
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type OnInboundSMS struct{}
+
+func (t *OnInboundSMS) Name() string  { return "twilio.onInboundSMS" }
+func (t *OnInboundSMS) Label() string { return "On Inbound SMS" }
+
+func (t *OnInboundSMS) Description() string {
+	return "Receive inbound SMS messages via Twilio webhook"
+}
+
+func (t *OnInboundSMS) Documentation() string {
+	return `The **On Inbound SMS** trigger fires when an SMS is received on your Twilio phone number.
+
+## Setup
+
+1. Configure this trigger on your canvas
+2. Copy the webhook URL shown after publishing
+3. In the Twilio Console, go to your phone number settings
+4. Set the **Messaging** webhook URL to the copied URL
+
+## Event Data
+
+Each inbound SMS includes:
+- **from**: Sender phone number
+- **to**: Your Twilio phone number that received the message
+- **body**: The SMS message text
+- **messageSid**: Twilio message ID
+- **numMedia**: Number of media attachments
+
+## Use Cases
+
+- **Chatbot workflows**: Respond to inbound text messages
+- **Acknowledgment flows**: On-call engineers can reply to alerts via SMS
+- **Data collection**: Collect responses via text message`
+}
+
+func (t *OnInboundSMS) Icon() string  { return "message-square" }
+func (t *OnInboundSMS) Color() string { return "#F22F46" }
+
+func (t *OnInboundSMS) ExampleData() map[string]any {
+	return getExampleData("on_inbound_sms")
+}
+
+func (t *OnInboundSMS) Configuration() []configuration.Field {
+	return []configuration.Field{}
+}
+
+func (t *OnInboundSMS) Setup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *OnInboundSMS) Cleanup(ctx core.TriggerContext) error {
+	return nil
+}
+
+func (t *OnInboundSMS) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (t *OnInboundSMS) HandleHook(ctx core.TriggerHookContext) (map[string]any, error) {
+	return nil, nil
+}
+
+func (t *OnInboundSMS) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	// Parse the form-encoded body from Twilio
+	params, err := url.ParseQuery(string(ctx.Body))
+	if err != nil {
+		return http.StatusBadRequest, nil, fmt.Errorf("failed to parse form: %w", err)
+	}
+
+	from := params.Get("From")
+	to := params.Get("To")
+	body := params.Get("Body")
+	messageSid := params.Get("MessageSid")
+	numMedia := params.Get("NumMedia")
+
+	if messageSid == "" || from == "" {
+		return http.StatusBadRequest, nil, fmt.Errorf("missing required fields")
+	}
+
+	payload := map[string]any{
+		"from":       from,
+		"to":         to,
+		"body":       body,
+		"messageSid": messageSid,
+		"numMedia":   numMedia,
+	}
+
+	ctx.Events.Emit("twilio.sms.received", payload)
+
+	// Respond with empty TwiML to acknowledge
+	twiml := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response></Response>"
+	return http.StatusOK, &core.WebhookResponseBody{
+		ContentType: "application/xml",
+		Body:        []byte(twiml),
+	}, nil
+}
+
+// ValidateSignature verifies the Twilio request signature.
+// See: https://www.twilio.com/docs/usage/security#validating-requests
+func ValidateSignature(authToken, requestURL, signature string, params map[string]string) bool {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString(requestURL)
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString(params[k])
+	}
+
+	mac := hmac.New(sha1.New, []byte(authToken))
+	mac.Write([]byte(b.String()))
+	expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+// Keep json import used for potential future use
+var _ = json.Marshal

--- a/pkg/integrations/twilio/send_sms.go
+++ b/pkg/integrations/twilio/send_sms.go
@@ -1,0 +1,142 @@
+package twilio
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type SendSMS struct{}
+
+type SendSMSConfig struct {
+	To   string `json:"to" mapstructure:"to"`
+	Body string `json:"body" mapstructure:"body"`
+}
+
+func (c *SendSMS) Name() string  { return "twilio.sendSMS" }
+func (c *SendSMS) Label() string { return "Send SMS" }
+
+func (c *SendSMS) Description() string {
+	return "Send an outbound SMS message"
+}
+
+func (c *SendSMS) Documentation() string {
+	return `The **Send SMS** component sends a text message to a phone number.
+
+## Use Cases
+
+- **Alert fallback**: Send an SMS when a phone call goes unanswered
+- **Notifications**: Quick status updates via text
+- **Confirmations**: Send confirmation codes or summaries
+
+## Configuration
+
+- **To**: Destination phone number in E.164 format (e.g. +15551234567)
+- **Body**: The SMS message text (max 1600 characters)
+
+## Output
+
+Returns the message SID, delivery status, and message details.`
+}
+
+func (c *SendSMS) Icon() string  { return "message-square" }
+func (c *SendSMS) Color() string { return "#F22F46" }
+
+func (c *SendSMS) ExampleOutput() map[string]any {
+	return getExampleOutput("send_sms")
+}
+
+func (c *SendSMS) OutputChannels(config any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (c *SendSMS) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "to",
+			Label:       "To",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "+15551234567",
+			Description: "Destination phone number (E.164 format)",
+		},
+		{
+			Name:        "body",
+			Label:       "Message",
+			Type:        configuration.FieldTypeText,
+			Required:    true,
+			Description: "SMS message text (max 1600 characters)",
+		},
+	}
+}
+
+func (c *SendSMS) Setup(ctx core.SetupContext) error {
+	var config SendSMSConfig
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	if strings.TrimSpace(config.To) == "" {
+		return fmt.Errorf("to is required")
+	}
+	if !strings.HasPrefix(config.To, "+") {
+		return fmt.Errorf("phone number must be in E.164 format (e.g. +15551234567)")
+	}
+	if strings.TrimSpace(config.Body) == "" {
+		return fmt.Errorf("body is required")
+	}
+	if len(config.Body) > 1600 {
+		return fmt.Errorf("message exceeds maximum length of 1600 characters")
+	}
+
+	return nil
+}
+
+func (c *SendSMS) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (c *SendSMS) Execute(ctx core.ExecutionContext) error {
+	var config SendSMSConfig
+	if err := mapstructure.Decode(ctx.Configuration, &config); err != nil {
+		return fmt.Errorf("failed to decode configuration: %w", err)
+	}
+
+	client, err := NewClient(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.SendSMS(config.To, config.Body)
+	if err != nil {
+		return fmt.Errorf("failed to send SMS: %w", err)
+	}
+
+	output := map[string]any{
+		"messageSid": resp.SID,
+		"status":     resp.Status,
+		"to":         resp.To,
+		"from":       resp.From,
+		"body":       resp.Body,
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"twilio.sms.sent",
+		[]any{output},
+	)
+}
+
+func (c *SendSMS) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (c *SendSMS) Cancel(ctx core.ExecutionContext) error      { return nil }
+func (c *SendSMS) Cleanup(ctx core.SetupContext) error         { return nil }
+func (c *SendSMS) Hooks() []core.Hook                          { return []core.Hook{} }
+func (c *SendSMS) HandleHook(ctx core.ActionHookContext) error { return nil }

--- a/pkg/integrations/twilio/twilio.go
+++ b/pkg/integrations/twilio/twilio.go
@@ -1,0 +1,114 @@
+package twilio
+
+import (
+	"fmt"
+
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("twilio", &Twilio{})
+}
+
+type Twilio struct{}
+
+func (t *Twilio) Name() string  { return "twilio" }
+func (t *Twilio) Label() string { return "Twilio" }
+func (t *Twilio) Icon() string  { return "twilio" }
+
+func (t *Twilio) Description() string {
+	return "Make phone calls, send SMS, and receive inbound messages with Twilio"
+}
+
+func (t *Twilio) Instructions() string {
+	return `To set up the Twilio integration:
+
+1. Log in to the **Twilio Console** (https://console.twilio.com)
+2. Copy your **Account SID** and **Auth Token** from the dashboard
+3. Get or buy a **Twilio phone number** with Voice and SMS capabilities
+4. Paste all three values in the fields below
+
+The phone number must be in E.164 format (e.g. +15551234567).`
+}
+
+func (t *Twilio) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "accountSid",
+			Label:       "Account SID",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Description: "Twilio Account SID from the Console dashboard",
+		},
+		{
+			Name:        "authToken",
+			Label:       "Auth Token",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Twilio Auth Token from the Console dashboard",
+		},
+		{
+			Name:        "fromNumber",
+			Label:       "From Number",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Placeholder: "+15551234567",
+			Description: "Twilio phone number for outbound calls and SMS (E.164 format)",
+		},
+	}
+}
+
+func (t *Twilio) Actions() []core.Action {
+	return []core.Action{
+		&MakeCall{},
+		&SendSMS{},
+	}
+}
+
+func (t *Twilio) Triggers() []core.Trigger {
+	return []core.Trigger{
+		&OnInboundSMS{},
+	}
+}
+
+func (t *Twilio) Sync(ctx core.SyncContext) error {
+	client, err := NewClient(ctx.Integration)
+	if err != nil {
+		return err
+	}
+
+	account, err := client.GetAccount()
+	if err != nil {
+		return fmt.Errorf("failed to verify Twilio credentials: %v", err)
+	}
+
+	ctx.Integration.SetMetadata(map[string]string{
+		"accountSid":   account.SID,
+		"friendlyName": account.FriendlyName,
+		"status":       account.Status,
+	})
+
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (t *Twilio) HandleRequest(ctx core.HTTPRequestContext) {}
+
+func (t *Twilio) Cleanup(ctx core.IntegrationCleanupContext) error {
+	return nil
+}
+
+func (t *Twilio) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	return []core.IntegrationResource{}, nil
+}
+
+func (t *Twilio) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (t *Twilio) HandleHook(ctx core.IntegrationHookContext) error {
+	return nil
+}

--- a/pkg/registryimports/registryimports.go
+++ b/pkg/registryimports/registryimports.go
@@ -68,6 +68,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/statuspage"
 	_ "github.com/superplanehq/superplane/pkg/integrations/teams"
 	_ "github.com/superplanehq/superplane/pkg/integrations/telegram"
+	_ "github.com/superplanehq/superplane/pkg/integrations/twilio"
 	_ "github.com/superplanehq/superplane/pkg/triggers/schedule"
 	_ "github.com/superplanehq/superplane/pkg/triggers/start"
 	_ "github.com/superplanehq/superplane/pkg/triggers/webhook"


### PR DESCRIPTION
## What

New Twilio integration for voice calls and SMS messaging. Enables incident alerting workflows with phone call escalation.

Closes #5346

## Components

### Actions
- **`twilio.makeCall`** - Place an outbound call with TTS message. Two output channels: `answered` and `no-answer` for escalation flows.
- **`twilio.sendSMS`** - Send an outbound SMS message.

### Trigger
- **`twilio.onInboundSMS`** - Webhook trigger for incoming SMS. Responds with empty TwiML.

## Integration Config
- Account SID, Auth Token (sensitive), From Number (E.164)
- Sync verifies credentials via `GET /Accounts/{sid}.json`

## Example Canvas
```
alert -> twilio.makeCall (on-call)
           -> answered: done
           -> no-answer: twilio.makeCall (escalation)
                           -> answered: done
                           -> no-answer: twilio.sendSMS (both)
```

## Files
- `twilio.go` - integration registration, config, sync
- `client.go` - Twilio REST client (basic auth, TwiML generation)
- `make_call.go` - makeCall action with answered/no-answer channels
- `send_sms.go` - sendSMS action
- `on_inbound_sms.go` - inbound SMS webhook trigger + signature validation
- `example.go` + 3 JSON files - example payloads
- `Twilio.mdx` - auto-generated component docs