### PR TITLE
fix: clarify agent canvas edge fields

### DIFF
--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -296,6 +296,7 @@ Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` section 6
 | `intervalSeconds: 0` | `intervalSeconds: 1` | Minimum is 1 |
 | `timezone: "UTC"` | `timezone: "0"` | Must be numeric offset, not IANA name |
 | Missing `metadata.id` | Always include `metadata.id: <app-id>` | Required for updates — get from app context |
+| `edges: [{source: a, target: b}]` | `edges: [{sourceId: a, targetId: b, channel: default}]` | Canvas YAML is strict; `source` and `target` are invalid fields |
 | Using integration without ID | Add `integration: {id: "..."}` | Check `integrations list` |
 | `start` with `configuration: {}` | `templates: [{name, payload, parameters?}]` | Manual Run needs templates for the UI Run button and hook execution |
 

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -102,7 +102,7 @@ Rules:
   message: Draft ready — added retry logic to Call Target API
   :::
 
-- You can add, remove, or modify nodes and edges.
+- You can add, remove, or modify nodes and edges. In canvas.yaml edges, always use canonical fields "sourceId", "targetId", and "channel"; never use "source", "target", "from", or "to", because update_draft rejects unknown proto fields.
 - You can update the app Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Prefer 'superplane_app' with include_console for reads and console_yaml for draft updates. Use 'superplane apps console get ... -o yaml' and 'superplane apps console set ... -f console.yaml --draft-id <draft-id>' only as a fallback.
 - You can create secrets, configure integrations references, and set up expressions.
 - For direct app edits, prefer the shortest reliable path: use 'superplane_app' to read the draft app once, list integrations only if integration IDs are needed, make the draft update, then report the result.


### PR DESCRIPTION
## Summary
- clarify that canvas YAML edges must use sourceId, targetId, and channel
- add the same warning to refreshed build-mode instructions to avoid invalid update_draft payloads

## Verification
- make format.go
- make lint
- make check.build.app
- make test PKG_TEST_PACKAGES='./pkg/agents'