### PR TITLE
fix: keep run timestamp visible with long titles

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/RunRow.tsx
+++ b/web_src/src/components/CanvasToolSidebar/RunRow.tsx
@@ -58,7 +58,7 @@ export function RunRow({
         className="absolute inset-0 z-0"
         aria-label={title}
       />
-      <span className="pointer-events-none relative z-0 flex w-full items-center gap-1.5">
+      <span className="pointer-events-none relative z-0 flex min-w-0 flex-1 items-center gap-1.5">
         <RunNodeIcon
           iconSrc={iconSrc}
           iconSlug={iconSlug}


### PR DESCRIPTION
The run row's inner span used w-full, forcing it to consume the entire row width and pushing the timestamp off-screen for long titles. Use min-w-0 flex-1 so the title truncates while the timestamp stays visible.