### PR TITLE
fix: improve agent draft feedback and runs sidebar resizing

### DIFF
--- a/web_src/src/components/AgentSidebar/ChatComposer.tsx
+++ b/web_src/src/components/AgentSidebar/ChatComposer.tsx
@@ -22,6 +22,11 @@ type ChatComposerProps = {
   runs?: CanvasesCanvasRun[];
 };
 
+const modePlaceholder = {
+  builder: "Describe the change to build...",
+  operator: "Ask the agent…",
+} as const;
+
 export function ChatComposer({
   onSend,
   onStop,
@@ -118,7 +123,7 @@ export function ChatComposer({
           setValue={setValue}
           setCursorPos={setCursorPos}
           onKeyDown={handleKeyDown}
-          placeholder="Ask the agent…"
+          placeholder={modePlaceholder[agentMode]}
           textareaRef={textareaRef}
           backdropRef={backdropRef}
         />

--- a/web_src/src/components/AgentSidebar/useDraftActions.spec.ts
+++ b/web_src/src/components/AgentSidebar/useDraftActions.spec.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDraftActions } from "./useDraftActions";
+import type { AgentMessage } from "@/components/CanvasToolSidebar/types";
+
+function message(overrides: Partial<AgentMessage>): AgentMessage {
+  return {
+    id: "message-1",
+    role: "assistant",
+    content: "",
+    toolName: "",
+    toolCallId: "",
+    toolStatus: "",
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function draftActionsContent(versionId: string): string {
+  return ["Draft ready", "", ":::draft-actions", `versionId: ${versionId}`, "message: Draft ready", ":::"].join("\n");
+}
+
+function mockDraftVersion(state = "STATE_DRAFT") {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      return new Response(JSON.stringify({ version: { metadata: { state } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+}
+
+describe("useDraftActions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the latest draft action visible after a follow-up user message", async () => {
+    mockDraftVersion();
+
+    const { result } = renderHook(() =>
+      useDraftActions({
+        messages: [
+          message({ id: "assistant-1", role: "assistant", content: draftActionsContent("draft-1") }),
+          message({ id: "user-1", role: "user", content: "Make one more change" }),
+        ],
+        canvasId: "canvas-1",
+        organizationId: "org-1",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.latestDraft?.versionId).toBe("draft-1"));
+  });
+
+  it("hides draft actions when the version is no longer a draft", async () => {
+    mockDraftVersion("STATE_PUBLISHED");
+
+    const { result } = renderHook(() =>
+      useDraftActions({
+        messages: [message({ id: "assistant-1", role: "assistant", content: draftActionsContent("draft-1") })],
+        canvasId: "canvas-1",
+        organizationId: "org-1",
+      }),
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(result.current.latestDraft).toBeNull();
+  });
+});

--- a/web_src/src/components/AgentSidebar/useDraftActions.ts
+++ b/web_src/src/components/AgentSidebar/useDraftActions.ts
@@ -249,9 +249,6 @@ async function processVersionUpdate({
 function findLatestDraftAction(messages: AgentMessage[], dismissedVersionIds: Set<string>): DraftActionsSegment | null {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
-    if (message.role === "user") {
-      return null;
-    }
     if (message.role !== "assistant") {
       continue;
     }

--- a/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.spec.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DraftActionsWidget } from "./DraftActionsWidget";
+
+describe("DraftActionsWidget", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches a view event when the user asks to see changes", async () => {
+    const user = userEvent.setup();
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
+
+    render(<DraftActionsWidget versionId="draft-1" canvasId="canvas-1" organizationId="org-1" isEditing={false} />);
+
+    await user.click(screen.getByRole("button", { name: /see changes/i }));
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent:view-version",
+        detail: { versionId: "draft-1" },
+      }),
+    );
+  });
+});

--- a/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.tsx
+++ b/web_src/src/components/AgentSidebar/widgets/DraftActionsWidget.tsx
@@ -66,7 +66,7 @@ export function DraftActionsWidget({
           disabled={busy !== null}
         >
           <Eye size={12} />
-          See in Editor
+          See changes
         </Button>
       )}
       <Button

--- a/web_src/src/components/CanvasRunsSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasRunsSidebar/index.spec.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSidebarLayoutStore } from "@/stores/sidebarLayoutStore";
+import { CanvasRunsSidebar } from ".";
+
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+function renderRunsSidebar() {
+  return render(
+    <CanvasRunsSidebar isOpen>
+      <div>Runs</div>
+    </CanvasRunsSidebar>,
+  );
+}
+
+describe("CanvasRunsSidebar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setViewportWidth(1280);
+    useSidebarLayoutStore.getState().hydrateFromStorage();
+  });
+
+  it("starts with a compact default width", async () => {
+    renderRunsSidebar();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("canvas-runs-sidebar")).toHaveStyle({ width: "300px" });
+    });
+  });
+
+  it("resizes from the drag start width instead of the moving left edge", async () => {
+    setViewportWidth(1400);
+    localStorage.setItem("runs-sidebar-width", "300");
+    useSidebarLayoutStore.setState({
+      leftMountCount: 1,
+      leftWidth: 600,
+      rightMountCount: 0,
+      auxLeftMountCount: 0,
+      auxLeftWidth: 300,
+    });
+
+    renderRunsSidebar();
+
+    const sidebar = screen.getByTestId("canvas-runs-sidebar");
+    sidebar.getBoundingClientRect = () =>
+      ({
+        left: useSidebarLayoutStore.getState().leftWidth,
+        right: useSidebarLayoutStore.getState().leftWidth + useSidebarLayoutStore.getState().auxLeftWidth,
+        top: 0,
+        bottom: 0,
+        width: useSidebarLayoutStore.getState().auxLeftWidth,
+        height: 0,
+        x: useSidebarLayoutStore.getState().leftWidth,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    await waitFor(() => {
+      expect(useSidebarLayoutStore.getState().auxLeftMountCount).toBe(1);
+    });
+
+    fireEvent.mouseDown(screen.getByTestId("canvas-runs-sidebar-resize-handle"), { clientX: 900 });
+    await waitFor(() => {
+      expect(useSidebarLayoutStore.getState().isAuxLeftResizing).toBe(true);
+    });
+
+    fireEvent.mouseMove(document, { clientX: 920 });
+    useSidebarLayoutStore.setState({ leftWidth: 580 });
+    fireEvent.mouseMove(document, { clientX: 920 });
+    fireEvent.mouseUp(document);
+
+    await waitFor(() => {
+      const state = useSidebarLayoutStore.getState();
+      expect(state.auxLeftWidth).toBe(320);
+    });
+  });
+});

--- a/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
+++ b/web_src/src/components/CanvasRunsSidebar/useRunsSidebarWidth.ts
@@ -3,7 +3,7 @@ import { useAuxiliarySidebarWidth } from "@/stores/useAuxiliarySidebarWidth";
 
 export const RUNS_SIDEBAR_WIDTH_STORAGE_KEY = "runs-sidebar-width";
 export const RUNS_SIDEBAR_MIN_WIDTH = AUX_SIDEBAR_MIN_WIDTH;
-export const RUNS_SIDEBAR_DEFAULT_WIDTH = 380;
+export const RUNS_SIDEBAR_DEFAULT_WIDTH = 300;
 
 export function useRunsSidebarWidth(isOpen: boolean) {
   return useAuxiliarySidebarWidth(isOpen, RUNS_SIDEBAR_WIDTH_STORAGE_KEY, RUNS_SIDEBAR_DEFAULT_WIDTH);

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -64,22 +64,6 @@ type ConversationHandlers = {
   handleStartBuilding: (rubric: { title: string; criteria: string[]; categories?: RubricCategory[] }) => Promise<void>;
 };
 
-const autoOpenedDraftKeys = new Set<string>();
-
-function draftAutoOpenKey(canvasId: string, versionId: string): string {
-  return `${canvasId}:${versionId}`;
-}
-
-function shouldDispatchDraftReady(canvasId: string, versionId: string): boolean {
-  const key = draftAutoOpenKey(canvasId, versionId);
-  if (autoOpenedDraftKeys.has(key)) {
-    return false;
-  }
-
-  autoOpenedDraftKeys.add(key);
-  return true;
-}
-
 export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasToolSidebarState }) {
   const canvasId = toolSidebarState.canvasId ?? "";
   const organizationId = toolSidebarState.organizationId ?? "";
@@ -400,10 +384,6 @@ function DraftActionsBar({
 
   useEffect(() => {
     if (!latestDraft) {
-      return;
-    }
-
-    if (!shouldDispatchDraftReady(canvasId, latestDraft.versionId)) {
       return;
     }
 

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -217,7 +217,7 @@ function ChatConversation({
         sending={agentBusy}
         sendPending={sendMutation.isPending}
         stopping={interruptMutation.isPending}
-        statusLabel={statusLabel(status)}
+        statusLabel={sendMutation.isPending ? "Starting agent..." : statusLabel(status)}
         agentMode={agentMode}
         onModeSwitch={onModeSwitch}
         modeDisabled={modeDisabled}
@@ -374,6 +374,7 @@ function DraftActionsBar({
   outcomePassed,
   onVersionPublished,
 }: DraftActionsBarProps) {
+  const notifiedDraftVersionId = useRef<string | null>(null);
   const { latestDraft, dismiss } = useDraftActions({
     messages,
     canvasId,
@@ -381,6 +382,20 @@ function DraftActionsBar({
     outcomePassed,
     onVersionPublished,
   });
+
+  useEffect(() => {
+    if (!latestDraft) {
+      notifiedDraftVersionId.current = null;
+      return;
+    }
+
+    if (notifiedDraftVersionId.current === latestDraft.versionId) {
+      return;
+    }
+
+    notifiedDraftVersionId.current = latestDraft.versionId;
+    window.dispatchEvent(new CustomEvent("agent:draft-ready", { detail: { versionId: latestDraft.versionId } }));
+  }, [latestDraft]);
 
   if (!latestDraft) return null;
 

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -64,6 +64,22 @@ type ConversationHandlers = {
   handleStartBuilding: (rubric: { title: string; criteria: string[]; categories?: RubricCategory[] }) => Promise<void>;
 };
 
+const autoOpenedDraftKeys = new Set<string>();
+
+function draftAutoOpenKey(canvasId: string, versionId: string): string {
+  return `${canvasId}:${versionId}`;
+}
+
+function shouldDispatchDraftReady(canvasId: string, versionId: string): boolean {
+  const key = draftAutoOpenKey(canvasId, versionId);
+  if (autoOpenedDraftKeys.has(key)) {
+    return false;
+  }
+
+  autoOpenedDraftKeys.add(key);
+  return true;
+}
+
 export function AgentTabPanel({ toolSidebarState }: { toolSidebarState: CanvasToolSidebarState }) {
   const canvasId = toolSidebarState.canvasId ?? "";
   const organizationId = toolSidebarState.organizationId ?? "";
@@ -374,7 +390,6 @@ function DraftActionsBar({
   outcomePassed,
   onVersionPublished,
 }: DraftActionsBarProps) {
-  const notifiedDraftVersionId = useRef<string | null>(null);
   const { latestDraft, dismiss } = useDraftActions({
     messages,
     canvasId,
@@ -385,17 +400,15 @@ function DraftActionsBar({
 
   useEffect(() => {
     if (!latestDraft) {
-      notifiedDraftVersionId.current = null;
       return;
     }
 
-    if (notifiedDraftVersionId.current === latestDraft.versionId) {
+    if (!shouldDispatchDraftReady(canvasId, latestDraft.versionId)) {
       return;
     }
 
-    notifiedDraftVersionId.current = latestDraft.versionId;
     window.dispatchEvent(new CustomEvent("agent:draft-ready", { detail: { versionId: latestDraft.versionId } }));
-  }, [latestDraft]);
+  }, [canvasId, latestDraft]);
 
   if (!latestDraft) return null;
 

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -151,7 +151,7 @@ export function statusLabel(status: string): string {
     case "streaming":
       return "Agent is running...";
     case "failed":
-      return "Last turn failed";
+      return "Message failed. Try again.";
     case "terminated":
       return "Session ended";
     default:

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -7,16 +7,13 @@ import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
 
-const { sendMutation, chatState, draftActionState } = vi.hoisted(() => ({
+const { sendMutation, chatState } = vi.hoisted(() => ({
   sendMutation: {
     isPending: false,
     mutateAsync: vi.fn(),
   },
   chatState: {
     status: "idle",
-  },
-  draftActionState: {
-    latestDraft: null as { type: "draft-actions"; versionId: string; message?: string } | null,
   },
 }));
 
@@ -63,13 +60,6 @@ vi.mock("@/hooks/useAgentSessionWebsocket", () => ({
   useAgentSessionWebsocket: () => undefined,
 }));
 
-vi.mock("@/components/AgentSidebar/useDraftActions", () => ({
-  useDraftActions: () => ({
-    latestDraft: draftActionState.latestDraft,
-    dismiss: vi.fn(),
-  }),
-}));
-
 vi.mock("@/components/AgentSidebar/widgets/RichMessage", () => ({
   RichMessage: ({ content }: { content: string }) => {
     richMessageRenderSpy();
@@ -99,7 +89,6 @@ describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
     chatState.status = "idle";
-    draftActionState.latestDraft = null;
     sendMutation.isPending = false;
     sendMutation.mutateAsync.mockReset();
     sendMutation.mutateAsync.mockResolvedValue(null);
@@ -147,29 +136,6 @@ describe("CanvasToolSidebar", () => {
     window.dispatchEvent(new CustomEvent(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, { detail: { tab: "agent" } }));
 
     expect(openToolSidebar).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not dispatch draft ready again after the agent tab remounts", async () => {
-    const onDraftReady = vi.fn();
-    draftActionState.latestDraft = {
-      type: "draft-actions",
-      versionId: "draft-remount-test",
-      message: "Changes ready",
-    };
-    window.addEventListener("agent:draft-ready", onDraftReady);
-
-    const { rerender } = render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
-
-    await screen.findByText("Changes ready");
-    expect(onDraftReady).toHaveBeenCalledTimes(1);
-
-    rerender(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ isToolSidebarOpen: false })} />);
-    rerender(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
-
-    await screen.findByText("Changes ready");
-    expect(onDraftReady).toHaveBeenCalledTimes(1);
-
-    window.removeEventListener("agent:draft-ready", onDraftReady);
   });
 
   it("does not re-render agent messages while typing in the composer", async () => {

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -107,7 +107,7 @@ describe("CanvasToolSidebar", () => {
 
     render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
 
-    expect(await screen.findByText("Last turn failed")).toBeInTheDocument();
+    expect(await screen.findByText("Message failed. Try again.")).toBeInTheDocument();
     await user.type(screen.getByTestId("agent-input"), "retry");
     await user.click(screen.getByTestId("agent-send-message-button"));
 

--- a/web_src/src/components/CanvasToolSidebar/index.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/index.spec.tsx
@@ -7,13 +7,16 @@ import type { CanvasToolSidebarState } from "./useCanvasToolSidebarState";
 
 const richMessageRenderSpy = vi.fn();
 
-const { sendMutation, chatState } = vi.hoisted(() => ({
+const { sendMutation, chatState, draftActionState } = vi.hoisted(() => ({
   sendMutation: {
     isPending: false,
     mutateAsync: vi.fn(),
   },
   chatState: {
     status: "idle",
+  },
+  draftActionState: {
+    latestDraft: null as { type: "draft-actions"; versionId: string; message?: string } | null,
   },
 }));
 
@@ -60,6 +63,13 @@ vi.mock("@/hooks/useAgentSessionWebsocket", () => ({
   useAgentSessionWebsocket: () => undefined,
 }));
 
+vi.mock("@/components/AgentSidebar/useDraftActions", () => ({
+  useDraftActions: () => ({
+    latestDraft: draftActionState.latestDraft,
+    dismiss: vi.fn(),
+  }),
+}));
+
 vi.mock("@/components/AgentSidebar/widgets/RichMessage", () => ({
   RichMessage: ({ content }: { content: string }) => {
     richMessageRenderSpy();
@@ -89,6 +99,7 @@ describe("CanvasToolSidebar", () => {
   beforeEach(() => {
     richMessageRenderSpy.mockClear();
     chatState.status = "idle";
+    draftActionState.latestDraft = null;
     sendMutation.isPending = false;
     sendMutation.mutateAsync.mockReset();
     sendMutation.mutateAsync.mockResolvedValue(null);
@@ -136,6 +147,29 @@ describe("CanvasToolSidebar", () => {
     window.dispatchEvent(new CustomEvent(CANVAS_TOOL_SIDEBAR_SELECT_TAB_EVENT, { detail: { tab: "agent" } }));
 
     expect(openToolSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch draft ready again after the agent tab remounts", async () => {
+    const onDraftReady = vi.fn();
+    draftActionState.latestDraft = {
+      type: "draft-actions",
+      versionId: "draft-remount-test",
+      message: "Changes ready",
+    };
+    window.addEventListener("agent:draft-ready", onDraftReady);
+
+    const { rerender } = render(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    await screen.findByText("Changes ready");
+    expect(onDraftReady).toHaveBeenCalledTimes(1);
+
+    rerender(<CanvasToolSidebar toolSidebarState={makeToolSidebarState({ isToolSidebarOpen: false })} />);
+    rerender(<CanvasToolSidebar toolSidebarState={makeToolSidebarState()} />);
+
+    await screen.findByText("Changes ready");
+    expect(onDraftReady).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("agent:draft-ready", onDraftReady);
   });
 
   it("does not re-render agent messages while typing in the composer", async () => {

--- a/web_src/src/hooks/useAgentChats.spec.tsx
+++ b/web_src/src/hooks/useAgentChats.spec.tsx
@@ -121,4 +121,114 @@ describe("useAgentChatMessages", () => {
       expect(data?.pages[0]?.messages[0]?.id).toBe("optimistic-message-1");
     });
   });
+
+  it("drops an optimistic message when the initial fetch returns the persisted user message", async () => {
+    type ListAgentChatMessagesResult = Awaited<ReturnType<typeof agentsListAgentChatMessages>>;
+    let resolveList: ((value: ListAgentChatMessagesResult) => void) | undefined;
+    vi.mocked(agentsListAgentChatMessages).mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }) as ReturnType<typeof agentsListAgentChatMessages>,
+    );
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useAgentChatMessages("chat-1", "org-1", true), {
+      wrapper: wrapper(queryClient),
+    });
+
+    queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"), {
+      pages: [
+        {
+          messages: [
+            {
+              id: "optimistic-message-1",
+              role: "user",
+              content: "Build this",
+              toolName: "",
+              toolCallId: "",
+              toolStatus: "",
+              createdAt: new Date().toISOString(),
+            },
+          ],
+          hasMore: false,
+        },
+      ],
+      pageParams: [""],
+    });
+
+    if (!resolveList) {
+      throw new Error("list promise was not created");
+    }
+
+    resolveList({
+      data: {
+        messages: [{ id: "server-message-1", role: "user", content: "Build this" }],
+        hasMore: false,
+      },
+      request: new Request("https://superplane.test"),
+      response: new Response(),
+    } as ListAgentChatMessagesResult);
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
+      expect(data?.pages[0]?.messages).toHaveLength(1);
+      expect(data?.pages[0]?.messages[0]?.id).toBe("server-message-1");
+    });
+  });
+
+  it("keeps extra optimistic messages when repeated sends share the same content", async () => {
+    type ListAgentChatMessagesResult = Awaited<ReturnType<typeof agentsListAgentChatMessages>>;
+    let resolveList: ((value: ListAgentChatMessagesResult) => void) | undefined;
+    vi.mocked(agentsListAgentChatMessages).mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }) as ReturnType<typeof agentsListAgentChatMessages>,
+    );
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useAgentChatMessages("chat-1", "org-1", true), {
+      wrapper: wrapper(queryClient),
+    });
+
+    const makeOptimisticMessage = (id: string) => ({
+      id,
+      role: "user" as const,
+      content: "Build this",
+      toolName: "",
+      toolCallId: "",
+      toolStatus: "",
+      createdAt: new Date().toISOString(),
+    });
+
+    queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"), {
+      pages: [
+        {
+          messages: [makeOptimisticMessage("optimistic-message-1"), makeOptimisticMessage("optimistic-message-2")],
+          hasMore: false,
+        },
+      ],
+      pageParams: [""],
+    });
+
+    if (!resolveList) {
+      throw new Error("list promise was not created");
+    }
+
+    resolveList({
+      data: {
+        messages: [{ id: "server-message-1", role: "user", content: "Build this" }],
+        hasMore: false,
+      },
+      request: new Request("https://superplane.test"),
+      response: new Response(),
+    } as ListAgentChatMessagesResult);
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
+      expect(data?.pages[0]?.messages.map((message) => message.id)).toEqual([
+        "server-message-1",
+        "optimistic-message-2",
+      ]);
+    });
+  });
 });

--- a/web_src/src/hooks/useAgentChats.spec.tsx
+++ b/web_src/src/hooks/useAgentChats.spec.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider, type InfiniteData } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { agentsSendAgentChatMessage } from "@/api-client/sdk.gen";
+import type { AgentMessagesPage } from "./useAgentChats";
+import { agentChatKeys, useSendAgentChatMessage } from "./useAgentChats";
+
+vi.mock("@/api-client/sdk.gen", () => ({
+  agentsSendAgentChatMessage: vi.fn(),
+}));
+
+function wrapper(queryClient: QueryClient) {
+  return function TestQueryClientProvider({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useSendAgentChatMessage", () => {
+  it("adds a local user message before the send request resolves", async () => {
+    type SendAgentChatMessageResult = Awaited<ReturnType<typeof agentsSendAgentChatMessage>>;
+    let resolveSend: ((value: SendAgentChatMessageResult) => void) | undefined;
+    vi.mocked(agentsSendAgentChatMessage).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSend = resolve;
+      }) as ReturnType<typeof agentsSendAgentChatMessage>,
+    );
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"), {
+      pages: [{ messages: [], hasMore: false }],
+      pageParams: [""],
+    });
+
+    const { result } = renderHook(() => useSendAgentChatMessage("org-1", "canvas-1"), {
+      wrapper: wrapper(queryClient),
+    });
+
+    const sendPromise = result.current.mutateAsync({ chatId: "chat-1", content: "Build this", mode: "builder" });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
+      expect(data?.pages[0]?.messages[0]?.content).toBe("Build this");
+    });
+
+    if (!resolveSend) {
+      throw new Error("send promise was not created");
+    }
+
+    resolveSend({
+      data: {
+        message: {
+          id: "server-message-1",
+          role: "user",
+          content: "Build this",
+        },
+      },
+      request: new Request("https://superplane.test"),
+      response: new Response(),
+    } as SendAgentChatMessageResult);
+    await sendPromise;
+
+    const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
+    expect(data?.pages[0]?.messages).toHaveLength(1);
+    expect(data?.pages[0]?.messages[0]?.id).toBe("server-message-1");
+  });
+});

--- a/web_src/src/hooks/useAgentChats.spec.tsx
+++ b/web_src/src/hooks/useAgentChats.spec.tsx
@@ -2,11 +2,12 @@ import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider, type InfiniteData } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { agentsSendAgentChatMessage } from "@/api-client/sdk.gen";
+import { agentsListAgentChatMessages, agentsSendAgentChatMessage } from "@/api-client/sdk.gen";
 import type { AgentMessagesPage } from "./useAgentChats";
-import { agentChatKeys, useSendAgentChatMessage } from "./useAgentChats";
+import { agentChatKeys, useAgentChatMessages, useSendAgentChatMessage } from "./useAgentChats";
 
 vi.mock("@/api-client/sdk.gen", () => ({
+  agentsListAgentChatMessages: vi.fn(),
   agentsSendAgentChatMessage: vi.fn(),
 }));
 
@@ -63,5 +64,61 @@ describe("useSendAgentChatMessage", () => {
     const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
     expect(data?.pages[0]?.messages).toHaveLength(1);
     expect(data?.pages[0]?.messages[0]?.id).toBe("server-message-1");
+  });
+});
+
+describe("useAgentChatMessages", () => {
+  it("keeps optimistic messages when the initial fetch resolves after send starts", async () => {
+    type ListAgentChatMessagesResult = Awaited<ReturnType<typeof agentsListAgentChatMessages>>;
+    let resolveList: ((value: ListAgentChatMessagesResult) => void) | undefined;
+    vi.mocked(agentsListAgentChatMessages).mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }) as ReturnType<typeof agentsListAgentChatMessages>,
+    );
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    renderHook(() => useAgentChatMessages("chat-1", "org-1", true), {
+      wrapper: wrapper(queryClient),
+    });
+
+    queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"), {
+      pages: [
+        {
+          messages: [
+            {
+              id: "optimistic-message-1",
+              role: "user",
+              content: "Build this",
+              toolName: "",
+              toolCallId: "",
+              toolStatus: "",
+              createdAt: new Date().toISOString(),
+            },
+          ],
+          hasMore: false,
+        },
+      ],
+      pageParams: [""],
+    });
+
+    if (!resolveList) {
+      throw new Error("list promise was not created");
+    }
+
+    resolveList({
+      data: {
+        messages: [],
+        hasMore: false,
+      },
+      request: new Request("https://superplane.test"),
+      response: new Response(),
+    } as ListAgentChatMessagesResult);
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages("chat-1"));
+      expect(data?.pages[0]?.messages).toHaveLength(1);
+      expect(data?.pages[0]?.messages[0]?.id).toBe("optimistic-message-1");
+    });
   });
 });

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -153,11 +153,40 @@ function mergePendingOptimisticMessages(
   }
 
   const messageIds = new Set(messages.map((message) => message.id));
-  return [...messages, ...optimisticMessages.filter((message) => !messageIds.has(message.id))];
+  const persistedUserMessageCounts = new Map<string, number>();
+  for (const message of messages) {
+    if (isOptimisticAgentMessage(message) || message.role !== "user") {
+      continue;
+    }
+
+    const key = optimisticMessageMatchKey(message);
+    persistedUserMessageCounts.set(key, (persistedUserMessageCounts.get(key) ?? 0) + 1);
+  }
+
+  const pendingMessages = optimisticMessages.filter((message) => {
+    if (messageIds.has(message.id)) {
+      return false;
+    }
+
+    const key = optimisticMessageMatchKey(message);
+    const persistedCount = persistedUserMessageCounts.get(key) ?? 0;
+    if (persistedCount === 0) {
+      return true;
+    }
+
+    persistedUserMessageCounts.set(key, persistedCount - 1);
+    return false;
+  });
+
+  return [...messages, ...pendingMessages];
 }
 
 function isOptimisticAgentMessage(message: AgentMessage): boolean {
   return message.id.startsWith("optimistic-");
+}
+
+function optimisticMessageMatchKey(message: AgentMessage): string {
+  return `${message.role}:${message.content}`;
 }
 
 export function useInterruptAgentChat(organizationId: string | undefined) {

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -49,6 +49,8 @@ export function useCanvasAgentChat(
 export type AgentMessagesPage = { messages: AgentMessage[]; hasMore: boolean };
 
 export function useAgentChatMessages(chatId: string | null, organizationId: string | undefined, enabled: boolean) {
+  const queryClient = useQueryClient();
+
   return useInfiniteQuery({
     queryKey: agentChatKeys.messages(chatId ?? ""),
     enabled: enabled && Boolean(chatId),
@@ -62,6 +64,16 @@ export function useAgentChatMessages(chatId: string | null, organizationId: stri
         }),
       );
       const messages = (response.data?.messages ?? []).map(fromApiMessage).filter((m): m is AgentMessage => m !== null);
+      if (!pageParam && chatId) {
+        return {
+          messages: mergePendingOptimisticMessages(
+            messages,
+            queryClient.getQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages(chatId)),
+          ),
+          hasMore: Boolean(response.data?.hasMore),
+        };
+      }
+
       return { messages, hasMore: Boolean(response.data?.hasMore) };
     },
     getNextPageParam: (lastPage) => {
@@ -129,6 +141,23 @@ export function useSendAgentChatMessage(organizationId: string | undefined, canv
       }
     },
   });
+}
+
+function mergePendingOptimisticMessages(
+  messages: AgentMessage[],
+  currentData: InfiniteData<AgentMessagesPage> | undefined,
+): AgentMessage[] {
+  const optimisticMessages = currentData?.pages.flatMap((page) => page.messages).filter(isOptimisticAgentMessage) ?? [];
+  if (optimisticMessages.length === 0) {
+    return messages;
+  }
+
+  const messageIds = new Set(messages.map((message) => message.id));
+  return [...messages, ...optimisticMessages.filter((message) => !messageIds.has(message.id))];
+}
+
+function isOptimisticAgentMessage(message: AgentMessage): boolean {
+  return message.id.startsWith("optimistic-");
 }
 
 export function useInterruptAgentChat(organizationId: string | undefined) {

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -207,7 +207,7 @@ export function useInterruptAgentChat(organizationId: string | undefined) {
 // tool rows flicker mid-stream.
 export function upsertAgentMessageInCache(queryClient: QueryClient, chatId: string, message: AgentMessage): void {
   queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages(chatId), (prev) => {
-    if (!prev) return { pages: [{ messages: [message], hasMore: false }], pageParams: [""] };
+    if (!prev) return prev;
     const pages = prev.pages.map((p) => ({ ...p, messages: p.messages.slice() }));
     for (const page of pages) {
       const idx = page.messages.findIndex((m) => m.id === message.id);

--- a/web_src/src/hooks/useAgentChats.ts
+++ b/web_src/src/hooks/useAgentChats.ts
@@ -14,6 +14,7 @@ import {
 } from "@/api-client/sdk.gen";
 import type { AgentMode } from "@/components/AgentSidebar/agentMode";
 import { fromApiChat, fromApiMessage, type AgentChat, type AgentMessage } from "@/components/CanvasToolSidebar/types";
+import { analytics } from "@/lib/analytics";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 
 export const agentChatKeys = {
@@ -70,7 +71,7 @@ export function useAgentChatMessages(chatId: string | null, organizationId: stri
   });
 }
 
-export function useSendAgentChatMessage(organizationId: string | undefined, _canvasId: string | undefined) {
+export function useSendAgentChatMessage(organizationId: string | undefined, canvasId: string | undefined) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ chatId, content, mode }: { chatId: string; content: string; mode?: AgentMode }) => {
@@ -83,8 +84,49 @@ export function useSendAgentChatMessage(organizationId: string | undefined, _can
       );
       return fromApiMessage(response.data?.message);
     },
-    onSuccess: (data, variables) => {
+    onMutate: ({ chatId, content, mode }) => {
+      const submittedAt = Date.now();
+      const optimisticMessage: AgentMessage = {
+        id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        role: "user",
+        content,
+        toolName: "",
+        toolCallId: "",
+        toolStatus: "",
+        createdAt: new Date().toISOString(),
+      };
+      upsertAgentMessageInCache(queryClient, chatId, optimisticMessage);
+      analytics.agentMessageSendSubmitted(chatId, canvasId, organizationId, mode);
+      return { mode, optimisticMessageId: optimisticMessage.id, submittedAt };
+    },
+    onSuccess: (data, variables, context) => {
+      if (context?.optimisticMessageId) {
+        removeAgentMessageFromCache(queryClient, variables.chatId, context.optimisticMessageId);
+      }
+      if (context?.submittedAt) {
+        analytics.agentMessageSendAcknowledged(
+          variables.chatId,
+          canvasId,
+          organizationId,
+          context.mode,
+          Date.now() - context.submittedAt,
+        );
+      }
       if (data) upsertAgentMessageInCache(queryClient, variables.chatId, data);
+    },
+    onError: (_error, variables, context) => {
+      if (context?.optimisticMessageId) {
+        removeAgentMessageFromCache(queryClient, variables.chatId, context.optimisticMessageId);
+      }
+      if (context?.submittedAt) {
+        analytics.agentMessageSendFailed(
+          variables.chatId,
+          canvasId,
+          organizationId,
+          context.mode,
+          Date.now() - context.submittedAt,
+        );
+      }
     },
   });
 }
@@ -107,7 +149,7 @@ export function useInterruptAgentChat(organizationId: string | undefined) {
 // tool rows flicker mid-stream.
 export function upsertAgentMessageInCache(queryClient: QueryClient, chatId: string, message: AgentMessage): void {
   queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages(chatId), (prev) => {
-    if (!prev) return prev;
+    if (!prev) return { pages: [{ messages: [message], hasMore: false }], pageParams: [""] };
     const pages = prev.pages.map((p) => ({ ...p, messages: p.messages.slice() }));
     for (const page of pages) {
       const idx = page.messages.findIndex((m) => m.id === message.id);
@@ -121,6 +163,20 @@ export function upsertAgentMessageInCache(queryClient: QueryClient, chatId: stri
     }
     pages[0].messages.push(message);
     return { ...prev, pages };
+  });
+}
+
+function removeAgentMessageFromCache(queryClient: QueryClient, chatId: string, messageId: string): void {
+  queryClient.setQueryData<InfiniteData<AgentMessagesPage>>(agentChatKeys.messages(chatId), (prev) => {
+    if (!prev) return prev;
+
+    return {
+      ...prev,
+      pages: prev.pages.map((page) => ({
+        ...page,
+        messages: page.messages.filter((message) => message.id !== messageId),
+      })),
+    };
   });
 }
 

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -107,6 +107,52 @@ export const analytics = {
     posthog.capture("canvas:version_publish", { canvas_id: canvasId, organization_id: organizationId });
   },
 
+  agentMessageSendSubmitted: (
+    chatId: string,
+    canvasId: string | undefined,
+    organizationId: string | undefined,
+    mode: string | undefined,
+  ) => {
+    posthog.capture("agent:message_send_submitted", {
+      chat_id: chatId,
+      canvas_id: canvasId,
+      organization_id: organizationId,
+      mode,
+    });
+  },
+
+  agentMessageSendAcknowledged: (
+    chatId: string,
+    canvasId: string | undefined,
+    organizationId: string | undefined,
+    mode: string | undefined,
+    durationMs: number,
+  ) => {
+    posthog.capture("agent:message_send_acknowledged", {
+      chat_id: chatId,
+      canvas_id: canvasId,
+      organization_id: organizationId,
+      mode,
+      duration_ms: durationMs,
+    });
+  },
+
+  agentMessageSendFailed: (
+    chatId: string,
+    canvasId: string | undefined,
+    organizationId: string | undefined,
+    mode: string | undefined,
+    durationMs: number,
+  ) => {
+    posthog.capture("agent:message_send_failed", {
+      chat_id: chatId,
+      canvas_id: canvasId,
+      organization_id: organizationId,
+      mode,
+      duration_ms: durationMs,
+    });
+  },
+
   integrationConnectStart: (
     integration: string,
     source: "node_configuration" | "integrations_page",

--- a/web_src/src/pages/app/draftNodeDiff.tsx
+++ b/web_src/src/pages/app/draftNodeDiff.tsx
@@ -89,6 +89,87 @@ function comparableNode(node: Record<string, unknown>) {
   };
 }
 
+function nodesByID(nodes: Array<Record<string, unknown>>): Map<string, Record<string, unknown>> {
+  const map = new Map<string, Record<string, unknown>>();
+  nodes.forEach((node) => {
+    const nodeID = String(node.id || "");
+    if (nodeID) {
+      map.set(nodeID, node);
+    }
+  });
+  return map;
+}
+
+function formatDiffValueLines(value: unknown): string[] {
+  const normalizedValue = value === undefined ? null : value;
+  return yaml
+    .dump(normalizedValue, {
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: true,
+    })
+    .trimEnd()
+    .split("\n");
+}
+
+function buildYamlFieldLines(prefix: "+" | "-", key: string, value: unknown): DraftDiffLine[] {
+  const valueLines = formatDiffValueLines(value);
+  if (valueLines.length === 1) {
+    return [{ prefix, text: `${key}: ${valueLines[0]}` }];
+  }
+
+  return [{ prefix, text: `${key}:` }, ...valueLines.map((line) => ({ prefix, text: `  ${line}` }))];
+}
+
+function buildNodeLines(prefix: "+" | "-", node: Record<string, unknown>): DraftDiffLine[] {
+  const nodeComparable = comparableNode(node) as Record<string, unknown>;
+  const keys = ["id", ...Object.keys(nodeComparable).sort((left, right) => left.localeCompare(right))];
+  const nodeFilePath = `nodes/${String(node.id || "unknown")}.yaml`;
+  const header: DraftDiffLine[] = [
+    { prefix: "meta", text: `diff --git a/${nodeFilePath} b/${nodeFilePath}` },
+    { prefix: "meta", text: `--- ${prefix === "-" ? `a/${nodeFilePath}` : "/dev/null"}` },
+    { prefix: "meta", text: `+++ ${prefix === "+" ? `b/${nodeFilePath}` : "/dev/null"}` },
+    { prefix: "context", text: "@@ -1,0 +1,0 @@" },
+  ];
+
+  return keys.flatMap((key) => {
+    const value = key === "id" ? node.id : nodeComparable[key];
+    return [...(key === "id" ? header : []), ...buildYamlFieldLines(prefix, key, value)];
+  });
+}
+
+function buildUpdatedLines(
+  previousNode: Record<string, unknown>,
+  currentNode: Record<string, unknown>,
+): DraftDiffLine[] {
+  const previousComparable = comparableNode(previousNode) as Record<string, unknown>;
+  const currentComparable = comparableNode(currentNode) as Record<string, unknown>;
+  const allKeys = ["id", ...Object.keys({ ...previousComparable, ...currentComparable })].sort((left, right) =>
+    left.localeCompare(right),
+  );
+
+  const nodeFilePath = `nodes/${String(currentNode.id || previousNode.id || "unknown")}.yaml`;
+  const lines: DraftDiffLine[] = [
+    { prefix: "meta", text: `diff --git a/${nodeFilePath} b/${nodeFilePath}` },
+    { prefix: "meta", text: `--- a/${nodeFilePath}` },
+    { prefix: "meta", text: `+++ b/${nodeFilePath}` },
+    { prefix: "context", text: "@@ -1,0 +1,0 @@" },
+  ];
+
+  allKeys.forEach((key) => {
+    const previousValue = key === "id" ? previousNode.id : previousComparable[key];
+    const currentValue = key === "id" ? currentNode.id : currentComparable[key];
+    if (JSON.stringify(previousValue) === JSON.stringify(currentValue)) {
+      return;
+    }
+
+    lines.push(...buildYamlFieldLines("-", key, previousValue));
+    lines.push(...buildYamlFieldLines("+", key, currentValue));
+  });
+
+  return lines;
+}
+
 /** True when draft workflow graph differs from live (nodes and/or edges). */
 export function hasDraftVersusLiveGraphDiff(
   liveVersion?: CanvasesCanvasVersion,
@@ -109,89 +190,8 @@ export function buildDraftNodeDiffSummary(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const draftNodes = (draftVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
 
-  const byID = (nodes: Array<Record<string, unknown>>): Map<string, Record<string, unknown>> => {
-    const map = new Map<string, Record<string, unknown>>();
-    nodes.forEach((node) => {
-      const nodeID = String(node.id || "");
-      if (nodeID) {
-        map.set(nodeID, node);
-      }
-    });
-    return map;
-  };
-
-  const formatDiffValueLines = (value: unknown): string[] => {
-    const normalizedValue = value === undefined ? null : value;
-    return yaml
-      .dump(normalizedValue, {
-        lineWidth: -1,
-        noRefs: true,
-        sortKeys: true,
-      })
-      .trimEnd()
-      .split("\n");
-  };
-
-  const buildYamlFieldLines = (prefix: "+" | "-", key: string, value: unknown): DraftDiffLine[] => {
-    const valueLines = formatDiffValueLines(value);
-    if (valueLines.length === 1) {
-      return [{ prefix, text: `${key}: ${valueLines[0]}` }];
-    }
-
-    return [{ prefix, text: `${key}:` }, ...valueLines.map((line) => ({ prefix, text: `  ${line}` }))];
-  };
-
-  const buildNodeLines = (prefix: "+" | "-", node: Record<string, unknown>): DraftDiffLine[] => {
-    const nodeComparable = comparableNode(node) as Record<string, unknown>;
-    const keys = ["id", ...Object.keys(nodeComparable).sort((left, right) => left.localeCompare(right))];
-    const nodeFilePath = `nodes/${String(node.id || "unknown")}.yaml`;
-    const header: DraftDiffLine[] = [
-      { prefix: "meta", text: `diff --git a/${nodeFilePath} b/${nodeFilePath}` },
-      { prefix: "meta", text: `--- ${prefix === "-" ? `a/${nodeFilePath}` : "/dev/null"}` },
-      { prefix: "meta", text: `+++ ${prefix === "+" ? `b/${nodeFilePath}` : "/dev/null"}` },
-      { prefix: "context", text: "@@ -1,0 +1,0 @@" },
-    ];
-
-    return keys.flatMap((key) => {
-      const value = key === "id" ? node.id : nodeComparable[key];
-      return [...(key === "id" ? header : []), ...buildYamlFieldLines(prefix, key, value)];
-    });
-  };
-
-  const buildUpdatedLines = (
-    previousNode: Record<string, unknown>,
-    currentNode: Record<string, unknown>,
-  ): DraftDiffLine[] => {
-    const previousComparable = comparableNode(previousNode) as Record<string, unknown>;
-    const currentComparable = comparableNode(currentNode) as Record<string, unknown>;
-    const allKeys = ["id", ...Object.keys({ ...previousComparable, ...currentComparable })].sort((left, right) =>
-      left.localeCompare(right),
-    );
-
-    const nodeFilePath = `nodes/${String(currentNode.id || previousNode.id || "unknown")}.yaml`;
-    const lines: DraftDiffLine[] = [
-      { prefix: "meta", text: `diff --git a/${nodeFilePath} b/${nodeFilePath}` },
-      { prefix: "meta", text: `--- a/${nodeFilePath}` },
-      { prefix: "meta", text: `+++ b/${nodeFilePath}` },
-      { prefix: "context", text: "@@ -1,0 +1,0 @@" },
-    ];
-
-    allKeys.forEach((key) => {
-      const previousValue = key === "id" ? previousNode.id : previousComparable[key];
-      const currentValue = key === "id" ? currentNode.id : currentComparable[key];
-      if (JSON.stringify(previousValue) === JSON.stringify(currentValue)) {
-        return;
-      }
-
-      lines.push(...buildYamlFieldLines("-", key, previousValue));
-      lines.push(...buildYamlFieldLines("+", key, currentValue));
-    });
-
-    return lines;
-  };
-
-  const liveByID = byID(liveNodes);
-  const draftByID = byID(draftNodes);
+  const liveByID = nodesByID(liveNodes);
+  const draftByID = nodesByID(draftNodes);
   const allNodeIDs = Array.from(new Set([...liveByID.keys(), ...draftByID.keys()])).sort((left, right) =>
     left.localeCompare(right),
   );
@@ -259,17 +259,6 @@ export function buildDraftDiffMap(
   const liveNodes = (liveVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
   const draftNodes = (draftVersion?.spec?.nodes || []) as Array<Record<string, unknown>>;
 
-  const byID = (nodes: Array<Record<string, unknown>>) => {
-    const map = new Map<string, Record<string, unknown>>();
-    nodes.forEach((node) => {
-      const id = String(node.id || "");
-      if (id) {
-        map.set(id, node);
-      }
-    });
-    return map;
-  };
-
   const functionalSnapshot = (node: Record<string, unknown>) =>
     JSON.stringify({
       name: node.name || null,
@@ -280,8 +269,8 @@ export function buildDraftDiffMap(
       integrationId: getComparableIntegrationId(node),
     });
 
-  const liveByID = byID(liveNodes);
-  const draftByID = byID(draftNodes);
+  const liveByID = nodesByID(liveNodes);
+  const draftByID = nodesByID(draftNodes);
   const allNodeIDs = new Set([...liveByID.keys(), ...draftByID.keys()]);
   const statusMap: Record<string, DraftDiffStatus> = {};
 

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -1,7 +1,7 @@
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import debounce from "lodash.debounce";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -102,6 +102,7 @@ import { useMemoryModeActions } from "./useMemoryModeActions";
 import { useVersionsModeActions } from "./useVersionsModeActions";
 import { useWorkflowHeaderEditActions } from "./useWorkflowHeaderEditActions";
 import { useWorkflowViewModeActions } from "./useWorkflowViewModeActions";
+import { useAgentDraftEditor } from "./useAgentDraftEditor";
 import { shouldClearRunDetailNode } from "./runInspectionSync";
 import { useStaleRunInspectionUrlCleanup } from "./useStaleRunInspectionUrlCleanup";
 import { CanvasChangeRequestConflictResolver } from "./CanvasChangeRequestConflictResolver";
@@ -172,6 +173,72 @@ const LOCAL_CANVAS_LIFECYCLE_ECHO_TTL_MS = 5000;
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
 const EMPTY_CANVAS_EDGES: ComponentsEdge[] = [];
+
+function updateCanvasDetailForSelectedVersion({
+  queryClient,
+  organizationId,
+  canvasId,
+  isCurrentLive,
+  version,
+  liveCanvasVersion,
+  liveCanvas,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  isCurrentLive: boolean;
+  version: CanvasesCanvasVersion;
+  liveCanvasVersion?: CanvasesCanvasVersion;
+  liveCanvas?: CanvasesCanvas | null;
+}) {
+  queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
+    if (!current) {
+      return current;
+    }
+
+    if (isCurrentLive) {
+      return { ...current, spec: liveCanvasVersion?.spec || liveCanvas?.spec };
+    }
+
+    if (!version.spec) {
+      return current;
+    }
+
+    return { ...current, spec: { ...current.spec, ...version.spec } };
+  });
+}
+
+function refreshLiveCanvasAfterVersionSelection({
+  queryClient,
+  organizationId,
+  canvasId,
+  activeCanvasVersionIdRef,
+  initializeFromWorkflow,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  activeCanvasVersionIdRef: { current: string };
+  initializeFromWorkflow: (canvas: CanvasesCanvas) => void;
+}) {
+  void Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.detail(organizationId, canvasId),
+      refetchType: "all",
+    }),
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.eventList(canvasId, 50),
+      refetchType: "all",
+    }),
+  ]).then(() => {
+    const refreshedLiveCanvas = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    if (!refreshedLiveCanvas || activeCanvasVersionIdRef.current !== "") {
+      return;
+    }
+
+    initializeFromWorkflow(refreshedLiveCanvas);
+  });
+}
 
 export function AppPage() {
   const { organizationId, appId } = useParams<{
@@ -2595,20 +2662,6 @@ export function AppPage() {
     return () => window.removeEventListener("agent:open-integration", handler);
   }, []);
 
-  // Listen for "See in Editor" from draft-actions widget
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const { versionId } = (e as CustomEvent).detail;
-      if (!versionId) return;
-      const version = selectableVersionsById.get(versionId);
-      if (version) {
-        setActiveCanvasVersion(version);
-      }
-    };
-    window.addEventListener("agent:view-version", handler);
-    return () => window.removeEventListener("agent:view-version", handler);
-  }, [selectableVersionsById]);
-
   const handleIntegrationCreated = useCallback(
     async (integrationId: string, instanceName: string) => {
       if (!canvas || !organizationId || !canvasId || !integrationDialogName) return;
@@ -4304,15 +4357,9 @@ export function AppPage() {
     ],
   );
 
-  const handleUseVersion = useCallback(
-    (versionID: string) => {
+  const activateCanvasVersionForEditing = useCallback(
+    (versionID: string, version: CanvasesCanvasVersion) => {
       if (!organizationId || !canvasId) {
-        return;
-      }
-
-      const version = selectableVersionsById.get(versionID);
-      if (!version) {
-        showErrorToast("Version not found");
         return;
       }
 
@@ -4382,65 +4429,35 @@ export function AppPage() {
         exitToLive();
       }
 
-      queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) => {
-        if (!current) {
-          return current;
-        }
-
-        if (isCurrentLive) {
-          const liveSpec = liveCanvasVersion?.spec || liveCanvas?.spec;
-          return {
-            ...current,
-            spec: liveSpec,
-          };
-        }
-
-        if (!version.spec) {
-          return current;
-        }
-        return {
-          ...current,
-          spec: { ...current.spec, ...version.spec },
-        };
+      updateCanvasDetailForSelectedVersion({
+        queryClient,
+        organizationId,
+        canvasId,
+        isCurrentLive,
+        version,
+        liveCanvasVersion,
+        liveCanvas,
       });
 
       if (isCurrentLive) {
-        // Refresh live data in background to pick up latest status/events.
-        void Promise.all([
-          queryClient.invalidateQueries({
-            queryKey: canvasKeys.detail(organizationId, canvasId),
-            refetchType: "all",
-          }),
-          queryClient.invalidateQueries({
-            queryKey: canvasKeys.eventList(canvasId, 50),
-            refetchType: "all",
-          }),
-        ]).then(() => {
-          const refreshedLiveCanvas = queryClient.getQueryData<CanvasesCanvas>(
-            canvasKeys.detail(organizationId, canvasId),
-          );
-          if (!refreshedLiveCanvas) {
-            return;
-          }
-
-          if (activeCanvasVersionIdRef.current !== "") {
-            return;
-          }
-
-          initializeFromWorkflow(refreshedLiveCanvas);
+        refreshLiveCanvasAfterVersionSelection({
+          queryClient,
+          organizationId,
+          canvasId,
+          activeCanvasVersionIdRef,
+          initializeFromWorkflow,
         });
       }
     },
     [
       organizationId,
       canvasId,
-      selectableVersionsById,
       currentUserId,
       pendingApprovalVersionIds,
       effectiveLiveCanvasVersionId,
       liveCanvasVersionId,
-      liveCanvasVersion?.spec,
-      liveCanvas?.spec,
+      liveCanvasVersion,
+      liveCanvas,
       queryClient,
       setSearchParams,
       canvasChangeRequests,
@@ -4452,6 +4469,23 @@ export function AppPage() {
       activateBranch,
       exitToLive,
     ],
+  );
+
+  const handleUseVersion = useCallback(
+    (versionID: string) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      const version = selectableVersionsById.get(versionID);
+      if (!version) {
+        showErrorToast("Version not found");
+        return;
+      }
+
+      activateCanvasVersionForEditing(versionID, version);
+    },
+    [activateCanvasVersionForEditing, canvasId, organizationId, selectableVersionsById],
   );
 
   const handleSeeCurrentVersion = useCallback(() => {
@@ -4477,6 +4511,25 @@ export function AppPage() {
     },
     [handleUseVersion, hasEditableVersion, hasPendingLocalCanvasState],
   );
+
+  const { headerMode, canvasStateMode, showBottomStatusControls, hideAddControls, readOnlyViewModes } =
+    getWorkflowViewPresentation({
+      ...urlViewFlags,
+      hasEditableVersion,
+      isViewingPendingApprovalVersion,
+      isViewingCurrentLiveVersion,
+    });
+
+  useAgentDraftEditor({
+    canvasId,
+    headerMode,
+    selectableVersionsById,
+    hasEditableVersion,
+    hasPendingLocalCanvasState,
+    activeCanvasVersionIdRef,
+    activateCanvasVersionForEditing,
+    setSuppressUnpublishedDraftDiscard,
+  });
 
   const handleSubmitCreateChangeRequest = useCallback(
     async ({ title, description }: { title: string; description: string }) => {
@@ -5143,13 +5196,6 @@ export function AppPage() {
     isPreparingVersionAction,
     hasDraftDiffVersusLive: !!latestDraftVersion && hasDraftDiffVersusLive,
   });
-  const { headerMode, canvasStateMode, showBottomStatusControls, hideAddControls, readOnlyViewModes } =
-    getWorkflowViewPresentation({
-      ...urlViewFlags,
-      hasEditableVersion,
-      isViewingPendingApprovalVersion,
-      isViewingCurrentLiveVersion,
-    });
   const exitEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely || !hasEditableVersion;
   const exitEditModeDisabledTooltip = getExitEditModeDisabledTooltip({
     canUpdateCanvas,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4360,7 +4360,7 @@ export function AppPage() {
   const activateCanvasVersionForEditing = useCallback(
     (versionID: string, version: CanvasesCanvasVersion) => {
       if (!organizationId || !canvasId) {
-        return;
+        return false;
       }
 
       setIsCreateChangeRequestMode(false);
@@ -4374,7 +4374,7 @@ export function AppPage() {
         (!!liveCanvasVersionId && versionId === liveCanvasVersionId);
       if (!isOwnedDraft && !isPublished && !isPendingApprovalVersion) {
         showErrorToast("You can only use your edit version, open change requests, or published live history");
-        return;
+        return false;
       }
 
       if (isCurrentLive) {
@@ -4448,6 +4448,8 @@ export function AppPage() {
           initializeFromWorkflow,
         });
       }
+
+      return true;
     },
     [
       organizationId,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -4525,6 +4525,7 @@ export function AppPage() {
   useAgentDraftEditor({
     canvasId,
     headerMode,
+    isRunInspectionMode: urlViewFlags.isRunInspectionMode,
     selectableVersionsById,
     hasEditableVersion,
     hasPendingLocalCanvasState,

--- a/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
+++ b/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CanvasesCanvasVersion } from "@/api-client";
+import type { CanvasPageHeaderMode } from "./viewState";
+import { useAgentDraftEditor } from "./useAgentDraftEditor";
+
+vi.mock("@/lib/toast", () => ({
+  showErrorToast: vi.fn(),
+}));
+
+vi.mock("./lib/repository-spec-files", () => ({
+  fetchCanvasVersionWithSpec: vi.fn(),
+}));
+
+function makeDraftVersion(versionId: string): CanvasesCanvasVersion {
+  return {
+    metadata: {
+      id: versionId,
+      state: "STATE_DRAFT",
+    },
+    spec: {
+      nodes: [],
+    },
+  } as CanvasesCanvasVersion;
+}
+
+function dispatchDraftReady(versionId: string) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent("agent:draft-ready", { detail: { versionId } }));
+  });
+}
+
+function setupHook({
+  canvasId,
+  versionId,
+  headerMode = "version-live",
+  hasEditableVersion = false,
+  hasPendingLocalCanvasState = false,
+  activeCanvasVersionId = "live-version",
+}: {
+  canvasId: string;
+  versionId: string;
+  headerMode?: CanvasPageHeaderMode;
+  hasEditableVersion?: boolean;
+  hasPendingLocalCanvasState?: boolean;
+  activeCanvasVersionId?: string;
+}) {
+  const queryClient = new QueryClient();
+  const activeCanvasVersionIdRef = { current: activeCanvasVersionId };
+  const activateCanvasVersionForEditing = vi.fn();
+  const setSuppressUnpublishedDraftDiscard = vi.fn();
+  const selectableVersionsById = new Map<string, CanvasesCanvasVersion>([[versionId, makeDraftVersion(versionId)]]);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  const initialProps = {
+    canvasId,
+    headerMode,
+    selectableVersionsById,
+    hasEditableVersion,
+    hasPendingLocalCanvasState,
+    activeCanvasVersionIdRef,
+    activateCanvasVersionForEditing,
+    setSuppressUnpublishedDraftDiscard,
+  };
+
+  const hook = renderHook((props) => useAgentDraftEditor(props), { initialProps, wrapper });
+
+  return {
+    ...hook,
+    activeCanvasVersionIdRef,
+    activateCanvasVersionForEditing,
+    selectableVersionsById,
+    setSuppressUnpublishedDraftDiscard,
+    updateProps: (overrides: Partial<typeof initialProps>) => hook.rerender({ ...initialProps, ...overrides }),
+  };
+}
+
+describe("useAgentDraftEditor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retries skipped auto-open when the user returns to the workflow tab", async () => {
+    const versionId = "draft-retry-workflow-tab";
+    const hook = setupHook({
+      canvasId: "canvas-retry-workflow-tab",
+      versionId,
+      headerMode: "memory",
+    });
+
+    dispatchDraftReady(versionId);
+
+    await act(async () => undefined);
+    expect(hook.activateCanvasVersionForEditing).not.toHaveBeenCalled();
+
+    hook.updateProps({ headerMode: "version-live" });
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
+    expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledWith(
+      versionId,
+      hook.selectableVersionsById.get(versionId),
+    );
+  });
+
+  it("retries skipped auto-open after local draft conflicts clear", async () => {
+    const versionId = "draft-retry-conflict-clear";
+    const hook = setupHook({
+      canvasId: "canvas-retry-conflict-clear",
+      versionId,
+      hasEditableVersion: true,
+      hasPendingLocalCanvasState: true,
+      activeCanvasVersionId: "other-draft",
+    });
+
+    dispatchDraftReady(versionId);
+
+    await act(async () => undefined);
+    expect(hook.activateCanvasVersionForEditing).not.toHaveBeenCalled();
+
+    hook.updateProps({ hasPendingLocalCanvasState: false });
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
+    expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledWith(
+      versionId,
+      hook.selectableVersionsById.get(versionId),
+    );
+  });
+
+  it("does not auto-open the same draft again after a successful auto-open", async () => {
+    const versionId = "draft-open-once";
+    const hook = setupHook({
+      canvasId: "canvas-open-once",
+      versionId,
+    });
+
+    dispatchDraftReady(versionId);
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
+
+    dispatchDraftReady(versionId);
+
+    await act(async () => undefined);
+    expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
+++ b/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
@@ -39,6 +39,7 @@ function setupHook({
   hasEditableVersion = false,
   hasPendingLocalCanvasState = false,
   activeCanvasVersionId = "live-version",
+  activateCanvasVersionForEditing = vi.fn(() => true),
 }: {
   canvasId: string;
   versionId: string;
@@ -46,10 +47,10 @@ function setupHook({
   hasEditableVersion?: boolean;
   hasPendingLocalCanvasState?: boolean;
   activeCanvasVersionId?: string;
+  activateCanvasVersionForEditing?: (versionId: string, version: CanvasesCanvasVersion) => boolean;
 }) {
   const queryClient = new QueryClient();
   const activeCanvasVersionIdRef = { current: activeCanvasVersionId };
-  const activateCanvasVersionForEditing = vi.fn();
   const setSuppressUnpublishedDraftDiscard = vi.fn();
   const selectableVersionsById = new Map<string, CanvasesCanvasVersion>([[versionId, makeDraftVersion(versionId)]]);
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -145,5 +146,24 @@ describe("useAgentDraftEditor", () => {
 
     await act(async () => undefined);
     expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries auto-open when activation does not apply the draft", async () => {
+    const versionId = "draft-activation-skipped";
+    const activateCanvasVersionForEditing = vi.fn(() => false);
+    const hook = setupHook({
+      canvasId: "canvas-activation-skipped",
+      versionId,
+      activateCanvasVersionForEditing,
+    });
+
+    dispatchDraftReady(versionId);
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
+
+    activateCanvasVersionForEditing.mockReturnValue(true);
+    hook.updateProps({ hasPendingLocalCanvasState: true });
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(2));
   });
 });

--- a/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
+++ b/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
@@ -36,6 +36,7 @@ function setupHook({
   canvasId,
   versionId,
   headerMode = "version-live",
+  isRunInspectionMode = false,
   hasEditableVersion = false,
   hasPendingLocalCanvasState = false,
   activeCanvasVersionId = "live-version",
@@ -44,6 +45,7 @@ function setupHook({
   canvasId: string;
   versionId: string;
   headerMode?: CanvasPageHeaderMode;
+  isRunInspectionMode?: boolean;
   hasEditableVersion?: boolean;
   hasPendingLocalCanvasState?: boolean;
   activeCanvasVersionId?: string;
@@ -60,6 +62,7 @@ function setupHook({
   const initialProps = {
     canvasId,
     headerMode,
+    isRunInspectionMode,
     selectableVersionsById,
     hasEditableVersion,
     hasPendingLocalCanvasState,
@@ -99,6 +102,28 @@ describe("useAgentDraftEditor", () => {
     expect(hook.activateCanvasVersionForEditing).not.toHaveBeenCalled();
 
     hook.updateProps({ headerMode: "version-live" });
+
+    await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
+    expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledWith(
+      versionId,
+      hook.selectableVersionsById.get(versionId),
+    );
+  });
+
+  it("retries skipped auto-open after run inspection ends", async () => {
+    const versionId = "draft-retry-run-inspection";
+    const hook = setupHook({
+      canvasId: "canvas-retry-run-inspection",
+      versionId,
+      isRunInspectionMode: true,
+    });
+
+    dispatchDraftReady(versionId);
+
+    await act(async () => undefined);
+    expect(hook.activateCanvasVersionForEditing).not.toHaveBeenCalled();
+
+    hook.updateProps({ isRunInspectionMode: false });
 
     await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
     expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledWith(

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -22,6 +22,7 @@ function agentDraftAutoOpenKey(canvasId: string, versionId: string): string {
 type UseAgentDraftEditorArgs = {
   canvasId: string;
   headerMode: CanvasPageHeaderMode;
+  isRunInspectionMode: boolean;
   selectableVersionsById: Map<string, CanvasesCanvasVersion>;
   hasEditableVersion: boolean;
   hasPendingLocalCanvasState: boolean;
@@ -129,6 +130,7 @@ function usePendingAgentDraftAutoOpen({
 export function useAgentDraftEditor({
   canvasId,
   headerMode,
+  isRunInspectionMode,
   selectableVersionsById,
   hasEditableVersion,
   hasPendingLocalCanvasState,
@@ -145,7 +147,7 @@ export function useAgentDraftEditor({
         return "unavailable";
       }
 
-      if (source === "auto" && !isCanvasWorkflowTab(headerMode)) {
+      if (source === "auto" && (!isCanvasWorkflowTab(headerMode) || isRunInspectionMode)) {
         return "skipped";
       }
 
@@ -186,6 +188,7 @@ export function useAgentDraftEditor({
       hasEditableVersion,
       hasPendingLocalCanvasState,
       headerMode,
+      isRunInspectionMode,
       loadAgentDraftVersion,
       setSuppressUnpublishedDraftDiscard,
     ],

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { CanvasesCanvasVersion } from "@/api-client";
 import { showErrorToast } from "@/lib/toast";
@@ -10,6 +10,14 @@ import { isDraftVersion } from "./lib/canvas-versions";
 import { fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
 
 type AgentDraftOpenSource = "auto" | "button";
+type AgentDraftOpenResult = "opened" | "skipped" | "unavailable";
+type LoadAgentDraftVersion = (versionId: string) => Promise<CanvasesCanvasVersion | null>;
+
+const autoOpenedAgentDraftKeys = new Set<string>();
+
+function agentDraftAutoOpenKey(canvasId: string, versionId: string): string {
+  return `${canvasId}:${versionId}`;
+}
 
 type UseAgentDraftEditorArgs = {
   canvasId: string;
@@ -22,19 +30,13 @@ type UseAgentDraftEditorArgs = {
   setSuppressUnpublishedDraftDiscard: (value: boolean) => void;
 };
 
-export function useAgentDraftEditor({
-  canvasId,
-  headerMode,
-  selectableVersionsById,
-  hasEditableVersion,
-  hasPendingLocalCanvasState,
-  activeCanvasVersionIdRef,
-  activateCanvasVersionForEditing,
-  setSuppressUnpublishedDraftDiscard,
-}: UseAgentDraftEditorArgs) {
+function useLoadAgentDraftVersion(
+  canvasId: string,
+  selectableVersionsById: Map<string, CanvasesCanvasVersion>,
+): LoadAgentDraftVersion {
   const queryClient = useQueryClient();
 
-  const loadAgentDraftVersion = useCallback(
+  return useCallback(
     async (versionId: string): Promise<CanvasesCanvasVersion | null> => {
       const cachedVersion = selectableVersionsById.get(versionId);
       if (cachedVersion) {
@@ -76,47 +78,108 @@ export function useAgentDraftEditor({
     },
     [canvasId, queryClient, selectableVersionsById],
   );
+}
+
+function usePendingAgentDraftAutoOpen({
+  canvasId,
+  pendingAutoOpenVersionId,
+  setPendingAutoOpenVersionId,
+  openAgentDraftVersion,
+}: {
+  canvasId: string;
+  pendingAutoOpenVersionId: string | null;
+  setPendingAutoOpenVersionId: Dispatch<SetStateAction<string | null>>;
+  openAgentDraftVersion: (versionId: string, source: "auto") => Promise<AgentDraftOpenResult>;
+}) {
+  useEffect(() => {
+    if (!pendingAutoOpenVersionId || !canvasId) {
+      return;
+    }
+
+    const key = agentDraftAutoOpenKey(canvasId, pendingAutoOpenVersionId);
+    if (autoOpenedAgentDraftKeys.has(key)) {
+      setPendingAutoOpenVersionId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    void openAgentDraftVersion(pendingAutoOpenVersionId, "auto").then((result) => {
+      if (cancelled) {
+        return;
+      }
+
+      if (result === "opened") {
+        autoOpenedAgentDraftKeys.add(key);
+        setPendingAutoOpenVersionId(null);
+        return;
+      }
+
+      if (result === "unavailable") {
+        setPendingAutoOpenVersionId(null);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canvasId, openAgentDraftVersion, pendingAutoOpenVersionId, setPendingAutoOpenVersionId]);
+}
+
+export function useAgentDraftEditor({
+  canvasId,
+  headerMode,
+  selectableVersionsById,
+  hasEditableVersion,
+  hasPendingLocalCanvasState,
+  activeCanvasVersionIdRef,
+  activateCanvasVersionForEditing,
+  setSuppressUnpublishedDraftDiscard,
+}: UseAgentDraftEditorArgs) {
+  const [pendingAutoOpenVersionId, setPendingAutoOpenVersionId] = useState<string | null>(null);
+  const loadAgentDraftVersion = useLoadAgentDraftVersion(canvasId, selectableVersionsById);
 
   const openAgentDraftVersion = useCallback(
-    async (versionId: string, source: AgentDraftOpenSource) => {
+    async (versionId: string, source: AgentDraftOpenSource): Promise<AgentDraftOpenResult> => {
       if (!versionId) {
-        return;
+        return "unavailable";
       }
 
       if (source === "auto" && !isCanvasWorkflowTab(headerMode)) {
-        return;
+        return "skipped";
       }
 
       if (activeCanvasVersionIdRef.current === versionId && hasEditableVersion) {
-        return;
+        return "opened";
       }
 
       if (hasEditableVersion && hasPendingLocalCanvasState && activeCanvasVersionIdRef.current !== versionId) {
         if (source === "auto") {
-          return;
+          return "skipped";
         }
 
         const shouldSwitch = window.confirm(
           "You have unsaved changes in the current draft. Switch to the agent draft and discard those unsaved changes?",
         );
         if (!shouldSwitch) {
-          return;
+          return "skipped";
         }
       }
 
       const version = await loadAgentDraftVersion(versionId);
       if (!version) {
         showErrorToast("Draft version not found");
-        return;
+        return "unavailable";
       }
 
       if (!isDraftVersion(version)) {
         showErrorToast("Agent draft is no longer available");
-        return;
+        return "unavailable";
       }
 
       setSuppressUnpublishedDraftDiscard(false);
       activateCanvasVersionForEditing(versionId, version);
+      return "opened";
     },
     [
       activateCanvasVersionForEditing,
@@ -129,6 +192,13 @@ export function useAgentDraftEditor({
     ],
   );
 
+  usePendingAgentDraftAutoOpen({
+    canvasId,
+    pendingAutoOpenVersionId,
+    setPendingAutoOpenVersionId,
+    openAgentDraftVersion,
+  });
+
   useEffect(() => {
     const handleViewVersion = (event: Event) => {
       const versionId = (event as CustomEvent<{ versionId?: string }>).detail?.versionId;
@@ -139,7 +209,9 @@ export function useAgentDraftEditor({
     const handleDraftReady = (event: Event) => {
       const versionId = (event as CustomEvent<{ versionId?: string }>).detail?.versionId;
       if (!versionId) return;
-      void openAgentDraftVersion(versionId, "auto");
+      if (!canvasId) return;
+      if (autoOpenedAgentDraftKeys.has(agentDraftAutoOpenKey(canvasId, versionId))) return;
+      setPendingAutoOpenVersionId(versionId);
     };
 
     window.addEventListener("agent:view-version", handleViewVersion);
@@ -148,5 +220,5 @@ export function useAgentDraftEditor({
       window.removeEventListener("agent:view-version", handleViewVersion);
       window.removeEventListener("agent:draft-ready", handleDraftReady);
     };
-  }, [openAgentDraftVersion]);
+  }, [canvasId, openAgentDraftVersion]);
 }

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { CanvasesCanvasVersion } from "@/api-client";
+import { showErrorToast } from "@/lib/toast";
+import { draftVersionId } from "@/lib/draftVersion";
+import { canvasKeys } from "@/hooks/useCanvasData";
+import type { CanvasPageHeaderMode } from "./viewState";
+import { isCanvasWorkflowTab } from "./viewState";
+import { isDraftVersion } from "./lib/canvas-versions";
+import { fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
+
+type AgentDraftOpenSource = "auto" | "button";
+
+type UseAgentDraftEditorArgs = {
+  canvasId: string;
+  headerMode: CanvasPageHeaderMode;
+  selectableVersionsById: Map<string, CanvasesCanvasVersion>;
+  hasEditableVersion: boolean;
+  hasPendingLocalCanvasState: boolean;
+  activeCanvasVersionIdRef: { current: string };
+  activateCanvasVersionForEditing: (versionId: string, version: CanvasesCanvasVersion) => void;
+  setSuppressUnpublishedDraftDiscard: (value: boolean) => void;
+};
+
+export function useAgentDraftEditor({
+  canvasId,
+  headerMode,
+  selectableVersionsById,
+  hasEditableVersion,
+  hasPendingLocalCanvasState,
+  activeCanvasVersionIdRef,
+  activateCanvasVersionForEditing,
+  setSuppressUnpublishedDraftDiscard,
+}: UseAgentDraftEditorArgs) {
+  const queryClient = useQueryClient();
+
+  const loadAgentDraftVersion = useCallback(
+    async (versionId: string): Promise<CanvasesCanvasVersion | null> => {
+      const cachedVersion = selectableVersionsById.get(versionId);
+      if (cachedVersion) {
+        return cachedVersion;
+      }
+
+      if (!canvasId) {
+        return null;
+      }
+
+      try {
+        const loadedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId);
+        if (!loadedVersion?.metadata?.id) {
+          return null;
+        }
+
+        queryClient.setQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, versionId), loadedVersion);
+        queryClient.setQueryData<CanvasesCanvasVersion[]>(canvasKeys.versionList(canvasId), (current = []) => {
+          if (current.some((version) => version.metadata?.id === versionId)) {
+            return current;
+          }
+          return [loadedVersion, ...current];
+        });
+
+        if (isDraftVersion(loadedVersion)) {
+          queryClient.setQueryData<CanvasesCanvasVersion[]>(canvasKeys.draftBranches(canvasId), (current = []) => {
+            if (current.some((branch) => draftVersionId(branch) === versionId)) {
+              return current;
+            }
+            return [loadedVersion, ...current];
+          });
+        }
+
+        return loadedVersion;
+      } catch {
+        showErrorToast("Failed to load draft version");
+        return null;
+      }
+    },
+    [canvasId, queryClient, selectableVersionsById],
+  );
+
+  const openAgentDraftVersion = useCallback(
+    async (versionId: string, source: AgentDraftOpenSource) => {
+      if (!versionId) {
+        return;
+      }
+
+      if (source === "auto" && !isCanvasWorkflowTab(headerMode)) {
+        return;
+      }
+
+      if (activeCanvasVersionIdRef.current === versionId && hasEditableVersion) {
+        return;
+      }
+
+      if (hasEditableVersion && hasPendingLocalCanvasState && activeCanvasVersionIdRef.current !== versionId) {
+        if (source === "auto") {
+          return;
+        }
+
+        const shouldSwitch = window.confirm(
+          "You have unsaved changes in the current draft. Switch to the agent draft and discard those unsaved changes?",
+        );
+        if (!shouldSwitch) {
+          return;
+        }
+      }
+
+      const version = await loadAgentDraftVersion(versionId);
+      if (!version) {
+        showErrorToast("Draft version not found");
+        return;
+      }
+
+      if (!isDraftVersion(version)) {
+        showErrorToast("Agent draft is no longer available");
+        return;
+      }
+
+      setSuppressUnpublishedDraftDiscard(false);
+      activateCanvasVersionForEditing(versionId, version);
+    },
+    [
+      activateCanvasVersionForEditing,
+      activeCanvasVersionIdRef,
+      hasEditableVersion,
+      hasPendingLocalCanvasState,
+      headerMode,
+      loadAgentDraftVersion,
+      setSuppressUnpublishedDraftDiscard,
+    ],
+  );
+
+  useEffect(() => {
+    const handleViewVersion = (event: Event) => {
+      const versionId = (event as CustomEvent<{ versionId?: string }>).detail?.versionId;
+      if (!versionId) return;
+      void openAgentDraftVersion(versionId, "button");
+    };
+
+    const handleDraftReady = (event: Event) => {
+      const versionId = (event as CustomEvent<{ versionId?: string }>).detail?.versionId;
+      if (!versionId) return;
+      void openAgentDraftVersion(versionId, "auto");
+    };
+
+    window.addEventListener("agent:view-version", handleViewVersion);
+    window.addEventListener("agent:draft-ready", handleDraftReady);
+    return () => {
+      window.removeEventListener("agent:view-version", handleViewVersion);
+      window.removeEventListener("agent:draft-ready", handleDraftReady);
+    };
+  }, [openAgentDraftVersion]);
+}

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -26,7 +26,7 @@ type UseAgentDraftEditorArgs = {
   hasEditableVersion: boolean;
   hasPendingLocalCanvasState: boolean;
   activeCanvasVersionIdRef: { current: string };
-  activateCanvasVersionForEditing: (versionId: string, version: CanvasesCanvasVersion) => void;
+  activateCanvasVersionForEditing: (versionId: string, version: CanvasesCanvasVersion) => boolean;
   setSuppressUnpublishedDraftDiscard: (value: boolean) => void;
 };
 
@@ -178,8 +178,7 @@ export function useAgentDraftEditor({
       }
 
       setSuppressUnpublishedDraftDiscard(false);
-      activateCanvasVersionForEditing(versionId, version);
-      return "opened";
+      return activateCanvasVersionForEditing(versionId, version) ? "opened" : "skipped";
     },
     [
       activateCanvasVersionForEditing,

--- a/web_src/src/stores/useAuxiliarySidebarWidth.ts
+++ b/web_src/src/stores/useAuxiliarySidebarWidth.ts
@@ -8,6 +8,7 @@ import {
 
 export function useAuxiliarySidebarWidth(isOpen: boolean, storageKey: string, defaultWidth: number) {
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<{ clientX: number; width: number } | null>(null);
   const width = useSidebarLayoutStore((state) => state.auxLeftWidth);
   const isResizing = useSidebarLayoutStore((state) => state.isAuxLeftResizing);
   const setAuxLeftResizing = useSidebarLayoutStore((state) => state.setAuxLeftResizing);
@@ -19,21 +20,29 @@ export function useAuxiliarySidebarWidth(isOpen: boolean, storageKey: string, de
   const handleMouseDown = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault();
+      dragStartRef.current = { clientX: event.clientX, width };
       setAuxLeftResizing(true);
     },
-    [setAuxLeftResizing],
+    [setAuxLeftResizing, width],
   );
 
   useEffect(() => {
     if (!isResizing) return;
 
     const handleMouseMove = (event: MouseEvent) => {
-      const rect = sidebarRef.current?.getBoundingClientRect();
-      const left = rect?.left ?? 0;
-      resizeAuxLeft(Math.max(AUX_SIDEBAR_MIN_WIDTH, Math.round(event.clientX - left)));
+      const dragStart = dragStartRef.current;
+      if (!dragStart) {
+        return;
+      }
+
+      const targetWidth = dragStart.width + event.clientX - dragStart.clientX;
+      resizeAuxLeft(Math.max(AUX_SIDEBAR_MIN_WIDTH, Math.round(targetWidth)));
     };
 
-    const handleMouseUp = () => setAuxLeftResizing(false);
+    const handleMouseUp = () => {
+      dragStartRef.current = null;
+      setAuxLeftResizing(false);
+    };
 
     document.addEventListener("mousemove", handleMouseMove);
     document.addEventListener("mouseup", handleMouseUp);
@@ -43,6 +52,7 @@ export function useAuxiliarySidebarWidth(isOpen: boolean, storageKey: string, de
     return () => {
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
+      dragStartRef.current = null;
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };


### PR DESCRIPTION
## Summary
- auto-open agent draft changes on the canvas workflow tab and keep `See changes` available after follow-up prompts
- add optimistic chat message rendering plus agent send snappiness analytics
- improve failed/send-pending agent composer copy
- fix Runs sidebar resizing so it no longer expands to max, and start it at a smaller default width

Addresses #5270.

## Validation
- make format.js
- make check.lint.ui
- make check.build.ui
- npm run test:run -- useDraftActions.spec.ts DraftActionsWidget.spec.tsx useAgentChats.spec.tsx CanvasToolSidebar/index.spec.tsx
- npm run test:run -- CanvasRunsSidebar/index.spec.tsx CanvasToolSidebar/RunsTabPanel.spec.tsx
