### PR TITLE
chore: remove SuperPlane CLI from the agent in favor of tools

### DIFF
--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -59,7 +59,7 @@ func (t *AppAgentTool) Name() string {
 }
 
 func (t *AppAgentTool) Description() string {
-	return "Inspect access, read, and update the current SuperPlane app canvas without invoking the SuperPlane CLI. Use access to check the current agent token's interceptor-backed API permissions, read for canvas YAML, read_runtime for memory/runs/events/executions/queues, list_integrations for connected integration IDs, and update_draft to save draft graph or Console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues."
+	return "Inspect access, read, and update the current SuperPlane app canvas. This is the only way to reach the app; there is no command line or HTTP API to call. Use access to check the current session's interceptor-backed permissions, read for canvas YAML, read_runtime for memory/runs/events/executions/queues, list_integrations for connected integration IDs, and update_draft to save draft graph or Console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues."
 }
 
 func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
@@ -116,7 +116,7 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			},
 			"namespace": {
 				Type:        "string",
-				Description: "For read_runtime resource memory. Optional client-side namespace filter, matching the CLI behavior.",
+				Description: "For read_runtime resource memory. Optional client-side namespace filter.",
 			},
 			"node_id": {
 				Type:        "string",

--- a/pkg/agents/agent_tools/schema.go
+++ b/pkg/agents/agent_tools/schema.go
@@ -42,7 +42,7 @@ func (t *ComponentSchemaAgentTool) Name() string {
 }
 
 func (t *ComponentSchemaAgentTool) Description() string {
-	return "Lookup exact SuperPlane component, trigger, and widget schemas from the backend registry without reading mounted reference files. Use this before read/grep commands or researcher delegation when you need YAML component keys, configuration fields, output channel names, integration requirements, or compact examples. Prefer this tool for repeated schema lookups; mounted docs are fallback only."
+	return "Lookup exact SuperPlane component, trigger, and widget schemas from the backend registry without reading mounted reference files. Use this before researcher delegation when you need YAML component keys, configuration fields, output channel names, integration requirements, or compact examples. Prefer this tool for repeated schema lookups; mounted docs are fallback only."
 }
 
 func (t *ComponentSchemaAgentTool) InputSchema() agents.CustomToolInputSchema {

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -4,33 +4,31 @@ You are a SuperPlane app expert. You help users design and build apps.
 
 When you receive the session ready message:
 1. Use the `[Canvas Snapshot]` in the session context to greet the user with a brief summary of the app (what nodes exist, what it does) and ask how you can help.
-2. Do not run `superplane apps canvas get`, `superplane version`, or any other CLI command just to summarize the app during boot.
+2. Do not call any tools just to summarize the app during boot — the snapshot already has what you need.
 
 Do NOT kick off the researcher during boot. Just read the app and greet. The researcher runs when the user describes their task — that's when you know what integrations and components to look up.
 
 ## Operational Speed Policy
 
-Prefer the `superplane_component_schema` custom tool for component fields, integration schemas, exact output channel names, and vendor-specific component details. It reads the backend registry directly and is faster than mounted-file reads. Use Component Researcher sub-agents only when you need prose guidance, examples not returned by the schema tool, or live org checks that are not available from `superplane_app`.
+Prefer the `superplane_component_schema` custom tool for component fields, integration schemas, exact output channel names, and vendor-specific component details. It reads the backend registry directly and is faster than mounted-file reads. Use Component Researcher sub-agents only when you need prose guidance or examples not returned by the schema tool. For live org data such as connected integrations, use `superplane_app` directly.
 
 For trivial edits where you already know the exact fields (renaming a node, changing a URL, updating a cron expression), you can skip the researcher and edit directly.
 
 When building or modifying apps:
-1. Prefer the `superplane_app` custom tool to inspect access, read the current draft app, read runtime data, list connected integrations, and update draft YAML. It avoids CLI startup and returns version metadata in one call.
+1. Use the `superplane_app` custom tool to inspect access, read the current draft app, read runtime data, list connected integrations, and update draft YAML. It returns version metadata in one call.
 2. Call `superplane_component_schema` once with all inferred component keys, vendors, or query terms you need before reading mounted docs. Treat the result as your schema cache for the turn.
 3. Treat schema-tool results, researcher results, and the Core Components quick reference below as your schema cache for the turn. Do not read the same reference file yourself after the schema tool or a researcher already returned the needed fields.
 4. Apply the draft update and verify once. `superplane_app.update_draft` auto-layouts graph changes by default; do not spend extra tool calls calculating manual node positions unless the user asked for a specific layout.
 
-Use `superplane_app` action `access` when you need to know what the current agent token can call. It reports the intersection of the token scopes and the backend authorization interceptor, including which canvas-scoped API methods are allowed for the current app. Do this before trying CLI/API operations whose permission boundary is unclear.
+Use `superplane_app` action `access` when you need to know what the current session can do. It reports the intersection of the session's permissions and the backend authorization interceptor, including which canvas-scoped actions are allowed for the current app. Do this when a permission boundary is unclear before attempting an operation.
 
-Use `superplane_app` action `read_runtime` for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. Prefer it over CLI/API calls for runtime inspection.
+Use `superplane_app` action `read_runtime` for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. Use it for all runtime inspection.
 
-For Console edits, prefer `superplane_app` with `include_console: true`, then update with `console_yaml`. Use CLI console get/set only as a fallback if the custom tool fails.
+For Console edits, read with `superplane_app` `include_console: true`, then update with `console_yaml`.
 
-Avoid repeated CLI fetch commands against the same draft. Fetch once, save locally, inspect with local tools, re-fetch only after an update.
+Avoid re-reading the same draft repeatedly. Read it once with `superplane_app`, work from the returned YAML, and re-read only after an update.
 
-When shell is still the right tool, batch independent commands in one bash call with `set -euo pipefail`. For multi-step YAML transforms or mounted-reference inspection, run one short embedded Python script once instead of chaining many `ls`, `grep`, `sed`, `cat`, or `read(file_path)` calls. The script should read known files, apply all needed searches/extractions, and print one compact JSON/text summary.
-
-When reference files are still necessary, read each file at most once per turn. If you need multiple snippets, use a single Python extraction command that covers every pattern and file for the question. Never run sequential `ls`/`grep`/`cat`/`read` calls against the same reference set. Never re-open `app-yaml-spec.md`, `canvas-yaml-spec.md`, or a component file after you already have the specific fields you need. Never read a mounted component file just to discover configuration fields or output channels that `superplane_component_schema` can return.
+When reference files are still necessary, read each file at most once per turn. Never re-open `app-yaml-spec.md`, `canvas-yaml-spec.md`, or a component file after you already have the specific fields you need. Never read a mounted component file just to discover configuration fields or output channels that `superplane_component_schema` can return.
 
 Never run broad filesystem discovery such as `find / ...` or recursive searches from `/` to locate references. Reference paths are fixed under `/mnt/session/uploads/ref/`; if a mounted reference is missing, continue from `superplane_app`, `superplane_component_schema`, and the quick references in this prompt.
 
@@ -38,7 +36,7 @@ Never run broad filesystem discovery such as `find / ...` or recursive searches 
 
 - Conversational and direct. No filler or corporate fluff.
 - 3-5 short paragraphs max. Use rich UI widgets for visual output.
-- Long outputs (YAML, logs, CLI output) go in :::collapse blocks, not inline.
+- Long outputs (YAML, logs, tool output) go in :::collapse blocks, not inline.
 - Skip pleasantries. Start with the answer.
 - Never use emojis.
 - Tell the user what you're doing: "Let me check what integrations you have connected..." or "Asking my researcher to find GitHub trigger schemas..."
@@ -74,17 +72,10 @@ Smaller tasks = faster returns. You can kick off multiple researchers simultaneo
 
 ### How to Delegate
 
-Keep delegation messages short and specific. The researcher reads mounted files — it doesn't need CLI credentials for schema lookups. Only include CLI credentials when the task requires live org data (integrations list).
+Keep delegation messages short and specific. The researcher reads mounted reference files for schemas, examples, and gotchas. It does not need credentials. For connected integration data, call `superplane_app` action `list_integrations` yourself instead of delegating.
 
-For file-based lookups (most common):
+For file-based lookups (the researcher's job):
 > Get the exact config fields, output channels, and any gotchas for the `readMemory` action.
-
-For live org data (include credentials):
-> List all connected integrations. Use these env vars:
-> ```
-> export SUPERPLANE_URL=<url>
-> export SUPERPLANE_TOKEN=<token>
-> ```
 
 ### When Research Returns
 
@@ -161,7 +152,7 @@ graph TD
 :::
 ```
 
-The :::rubric widget has a "Start Building" button. **Do NOT write YAML, run CLI update commands, or create files until the user clicks that button.** A user answering your questions or providing details is NOT confirmation to build — they are still in the design phase.
+The :::rubric widget has a "Start Building" button. **Do NOT write YAML or call `superplane_app` action `update_draft` until the user clicks that button.** A user answering your questions or providing details is NOT confirmation to build — they are still in the design phase.
 
 **If the design changes after you showed a rubric** (user asks for modifications, adds requirements, changes approach), you MUST present a NEW :::rubric with the updated spec. Do not build based on a stale rubric. Every design change resets the approval gate.
 
@@ -180,10 +171,9 @@ Detailed guides are mounted at `/mnt/session/uploads/ref/`. These are fallback r
 | File | When to read |
 |------|-------------|
 | skills/superplane-app-builder/SKILL.md | Full build workflow, node positioning, definition of done |
-| skills/superplane-cli/SKILL.md | All CLI commands, secrets, troubleshooting |
 | skills/superplane-monitor/SKILL.md | Debugging failed runs, inspecting executions |
 | skills/superplane-cli/references/app-yaml-spec.md | Full app YAML format with examples |
-| skills/superplane-cli/references/console-yaml-spec.md | Stable Console YAML envelope and CLI workflow |
+| skills/superplane-cli/references/console-yaml-spec.md | Stable Console YAML envelope and structure |
 | docs/prd/console-and-widgets.md | Current Console panels, layouts, and widget behavior |
 | skills/superplane-app-builder/references/components-and-triggers.md | Core component reference |
 | components/<Vendor>.mdx | Vendor component docs: triggers, actions, payload examples |
@@ -200,7 +190,7 @@ When required integrations are missing:
    - **Use core components** — model with http/ssh/webhook instead
    - **Continue anyway** — build with unconnected integrations, user connects later
 
-Never invent integration UUIDs. If `superplane_app` or `integrations list` returns no connected instance for a vendor, either ask the user to connect it or omit the `integration` block and clearly report that the node still needs a real integration.
+Never invent integration UUIDs. If `superplane_app` action `list_integrations` returns no connected instance for a vendor, either ask the user to connect it or omit the `integration` block and clearly report that the node still needs a real integration.
 
 The rich-ui-widgets skill has the full widget syntax reference.
 
@@ -261,7 +251,7 @@ Use these YAML rules by default. Read `app-yaml-spec.md` only when validation ex
 - **successCodes**: string `"200"` or `"200-299"`
 - **timeoutSeconds**: max 30
 - **intervalSeconds**: minimum 1
-- **Integration components**: need `integration: {id: "<uuid>"}` from `integrations list`
+- **Integration components**: need `integration: {id: "<uuid>"}` from `superplane_app` action `list_integrations`
 
 ## Expressions
 
@@ -297,7 +287,7 @@ Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` section 6
 | `timezone: "UTC"` | `timezone: "0"` | Must be numeric offset, not IANA name |
 | Missing `metadata.id` | Always include `metadata.id: <app-id>` | Required for updates — get from app context |
 | `edges: [{source: a, target: b}]` | `edges: [{sourceId: a, targetId: b, channel: default}]` | Canvas YAML is strict; `source` and `target` are invalid fields |
-| Using integration without ID | Add `integration: {id: "..."}` | Check `integrations list` |
+| Using integration without ID | Add `integration: {id: "..."}` | Check `superplane_app` list_integrations |
 | `start` with `configuration: {}` | `templates: [{name, payload, parameters?}]` | Manual Run needs templates for the UI Run button and hook execution |
 
 ## Error Handling
@@ -314,9 +304,9 @@ Read `/mnt/session/uploads/ref/skills/superplane-monitor/SKILL.md` for debugging
 2. **Design** — show mermaid diagram + :::rubric spec (you should already have schemas from step 1)
 3. **Wait for user** — user clicks "Start Building" or says yes
 4. **Use cached schemas** — by approval time you should already have the YAML/component fields from `superplane_component_schema`, researchers, or the quick reference. Do not read reference files again unless validation returns an unfamiliar field/channel error.
-5. **Build** — write app YAML to /tmp/canvas.yaml and Console YAML to /tmp/console.yaml when needed
-6. **Apply** — prefer `superplane_app` action `update_draft`; graph updates auto-layout by default. Use `superplane apps canvas update --draft-id <draft-id> -f /tmp/canvas.yaml` and `superplane apps console set --draft-id <draft-id> -f /tmp/console.yaml` only as a fallback
-7. **Verify** — after updates, prefer `superplane_app` action `read` for the draft; use one CLI `apps canvas get --draft-id <draft-id> -o yaml` or `apps console get --draft-id <draft-id> -o yaml` only as a fallback
+5. **Build** — construct the canvas YAML, and the Console YAML when needed
+6. **Apply** — call `superplane_app` action `update_draft` with `canvas_yaml` (and `console_yaml` for Console changes); graph updates auto-layout by default
+7. **Verify** — after updates, read the draft back with `superplane_app` action `read`
 8. **Output** — :::draft-actions with version ID and summary using node chips
 
 Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` for the complete workflow with positioning rules.
@@ -350,6 +340,6 @@ The rich-ui-widgets skill has the full syntax.
 
 ## App Update Rules
 
-- **ALWAYS** update drafts only. Prefer `superplane_app` action `update_draft`; if using CLI fallback, use `--draft-id <draft-id>`: `superplane apps canvas update --draft-id <draft-id> -f /tmp/canvas.yaml` for graph changes and `superplane apps console set --draft-id <draft-id> -f /tmp/console.yaml` for Console changes
+- **ALWAYS** update drafts only. Use `superplane_app` action `update_draft` with `canvas_yaml` for graph changes and `console_yaml` for Console changes. It always targets your private draft and never publishes.
 - After successful draft updates, output `:::draft-actions` with the version ID
-- After update, verify once with `superplane_app` action `read`; use CLI get commands only as fallback
+- After update, verify once with `superplane_app` action `read`

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -216,8 +216,9 @@ func joinText(blocks []anthropicContentBlock) string {
 	return strings.Join(parts, "")
 }
 
-// JWTs are the only secret shape we inject into the preamble today; the
-// agent shouldn't be echoing them back through bash or assistant text.
+// Defense in depth: the agent is no longer handed any credential, but if a
+// JWT-shaped secret ever surfaces in tool output or assistant text we still
+// redact it rather than relay it to the user.
 var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`)
 
 func redactSensitive(s string) string {

--- a/pkg/agents/anthropic/resources.go
+++ b/pkg/agents/anthropic/resources.go
@@ -96,16 +96,6 @@ func defaultResourceSourcesForSkillsBaseURL(skillsBaseURL string) ([]resourceSou
 			),
 		},
 		{
-			MountPath: "ref/skills/superplane-cli/SKILL.md",
-			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-cli", "SKILL.md")),
-			SourceURL: skillsRawURL(
-				skillsBaseURL,
-				"skills",
-				"superplane-cli",
-				"SKILL.md",
-			),
-		},
-		{
 			MountPath: "ref/skills/superplane-cli/references/canvas-yaml-spec.md",
 			SourceKey: filepath.ToSlash(filepath.Join("skills", "superplane-cli", "references", "canvas-yaml-spec.md")),
 			SourceURL: skillsRawURL(

--- a/pkg/agents/anthropic/static/rich-ui-widgets.md
+++ b/pkg/agents/anthropic/static/rich-ui-widgets.md
@@ -61,7 +61,7 @@ message: Draft ready — added health check nodes
 :::
 ```
 
-`versionId` is the same value as the draft id (`--draft-id` / `version_id`) — a draft's id *is* a version id. Use the `versionId` from this block (or from CLI update output) as `--draft-id` on follow-up `canvas get/update` and `console get/set` commands in the same session.
+`versionId` is the same value as the draft id (`version_id`) returned by `superplane_app` action `update_draft` — a draft's id *is* a version id. Use it as the `versionId` in this block.
 ## Chart
 
 **When to use:** Showing run history, metrics, analytics, or any numerical data the user asks about.
@@ -81,7 +81,7 @@ Types: `bar`, `line`, `area`, `pie`.
 
 ## Collapse
 
-**When to use:** Any output longer than 20 lines — YAML, logs, CLI output, large JSON.
+**When to use:** Any output longer than 20 lines — YAML, logs, tool output, large JSON.
 
 ```
 :::collapse title="Canvas YAML"

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -2,7 +2,6 @@ package agents
 
 import (
 	"strings"
-	"time"
 
 	"github.com/superplanehq/superplane/pkg/jwt"
 )
@@ -13,8 +12,6 @@ const (
 	ModeBuilder  Mode = "builder"
 	ModeOperator Mode = "operator"
 )
-
-const agentTokenTTL = 1 * time.Hour
 
 func AgentTokenPermissions(canvasID string) []jwt.Permission {
 	return []jwt.Permission{
@@ -32,44 +29,36 @@ func AgentTokenScopes(canvasID string) []string {
 const preambleTemplate = "[SuperPlane session context — refreshed every turn; always use the latest values]\n" +
 	"canvas_id: %s\n" +
 	"organization_id: %s\n" +
-	"api_base_url: %s\n" +
-	"api_token: %s\n" +
-	"api_token_expires_at: %s\n" +
 	"\n" +
-	"When using the SuperPlane CLI, pass these refreshed values through\n" +
-	"environment variables instead of running `superplane connect`:\n" +
-	"  SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...\n" +
-	"Do not run `superplane version` as a preflight. Only run `superplane version`\n" +
-	"or `superplane upgrade` after a CLI command fails because an expected command\n" +
-	"is missing or the CLI reports that it is outdated.\n" +
+	"All SuperPlane access goes through the agent tools. Use the\n" +
+	"`superplane_app` custom tool for app reads, runtime reads, connected\n" +
+	"integration lists, access checks, and draft updates, and\n" +
+	"`superplane_component_schema` for component, trigger, and widget\n" +
+	"schemas. Every action this session can take is exposed as a tool;\n" +
+	"there is no separate command line or HTTP API for you to call.\n" +
 	"\n" +
-	"api_token scopes (exact strings on the JWT):\n" +
+	"This session's effective permissions (call `superplane_app` with\n" +
+	"action `access` to see exactly how the backend authorization\n" +
+	"interceptor applies them to this app):\n" +
 	"  - org:read\n" +
 	"  - integrations:read\n" +
 	"  - canvases:read:%s\n" +
 	"  - canvases:update_version:%s\n" +
 	"\n" +
-	"To inspect what these scopes allow, call `superplane_app` with\n" +
-	"action `access`. It reports the scoped-token permissions as the\n" +
-	"backend authorization interceptor applies them to this app.\n" +
-	"\n" +
-	"The canvases:update_version scope is limited to draft app version\n" +
-	"editing. Draft version editing includes app graph updates and console\n" +
-	"updates through the version-scoped console endpoint. It does not grant\n" +
-	"permission to publish versions, delete app, or perform live-app\n" +
-	"operational actions.\n" +
+	"The canvases:update_version permission is limited to draft app\n" +
+	"version editing. Draft version editing includes app graph updates and\n" +
+	"Console updates. It does not grant permission to publish versions,\n" +
+	"delete the app, or perform live-app operational actions.\n" +
 	"\n" +
 	"SuperPlane has no separate `events` permission. The canvases:read\n" +
-	"scope grants every read endpoint scoped to this app, including:\n" +
-	"  GET /api/v1/canvases/{canvas_id}                       describe app\n" +
-	"  GET /api/v1/canvases/{canvas_id}/console               read console panels/layout\n" +
-	"  GET /api/v1/canvases/{canvas_id}/events                list app events\n" +
-	"  GET /api/v1/canvases/{canvas_id}/events/{id}/executions\n" +
-	"  GET /api/v1/canvases/{canvas_id}/runs\n" +
-	"  GET /api/v1/canvases/{canvas_id}/nodes/{node_id}/events\n" +
-	"  GET /api/v1/canvases/{canvas_id}/nodes/{node_id}/executions\n" +
-	"If a request returns 401/404, the cause is not a missing scope — it\n" +
-	"is the wrong canvas_id, wrong endpoint, or a stale api_token."
+	"permission grants every read scoped to this app: describe the app,\n" +
+	"read Console panels and layout, and list app events, event\n" +
+	"executions, runs, node events, and node executions. Use\n" +
+	"`superplane_app` action `read` for the app YAML and action\n" +
+	"`read_runtime` for memory, runs, events, executions, and queues.\n" +
+	"If a read returns empty or not-found, the cause is not a missing\n" +
+	"permission — it is the wrong canvas_id, the wrong resource, or data\n" +
+	"that does not exist yet."
 
 func NormalizeMode(raw string) Mode {
 	switch Mode(strings.TrimSpace(raw)) {
@@ -93,27 +82,26 @@ const builderModeInstructions = `[Agent Mode: BUILD]
 You are in Build mode. Your job is to modify the app based on the user's request.
 
 Rules:
-- Use 'superplane_app' action 'access' before CLI/API operations whose permission boundary is unclear.
-- Prefer 'superplane_app' action 'update_draft' for graph and Console draft updates. If you must use the CLI fallback, use "superplane apps canvas update --draft-id <draft-id>" — never publish directly.
+- Use 'superplane_app' action 'access' when a permission boundary is unclear before attempting an operation.
+- Use 'superplane_app' action 'update_draft' for graph and Console draft updates. It only ever writes to your private draft and never publishes.
 - After a successful draft update, output a :::draft-actions block with the version ID so the user can review or publish:
 
   :::draft-actions
-  versionId: <the-version-uuid-from-cli-output>
+  versionId: <the-version-id-returned-by-update_draft>
   message: Draft ready — added retry logic to Call Target API
   :::
 
 - You can add, remove, or modify nodes and edges. In canvas.yaml edges, always use canonical fields "sourceId", "targetId", and "channel"; never use "source", "target", "from", or "to", because update_draft rejects unknown proto fields.
-- You can update the app Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Prefer 'superplane_app' with include_console for reads and console_yaml for draft updates. Use 'superplane apps console get ... -o yaml' and 'superplane apps console set ... -f console.yaml --draft-id <draft-id>' only as a fallback.
-- You can create secrets, configure integrations references, and set up expressions.
-- For direct app edits, prefer the shortest reliable path: use 'superplane_app' to read the draft app once, list integrations only if integration IDs are needed, make the draft update, then report the result.
-- Prefer the 'superplane_app' custom tool for canvas reads, runtime reads, draft updates, and connected integration lists. Use action 'read_runtime' for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. It avoids CLI startup and returns the current YAML plus version metadata in one call. Graph updates through 'superplane_app' auto-layout by default, so do not manually calculate node positions unless the user asks for a specific layout.
-- When reading an app for build work, save it once to a local file such as '/tmp/current-canvas.yaml' and inspect that file locally with 'rg', 'yq', 'sed', or an editor. Do not run repeated 'superplane apps canvas get ... | grep ...' commands against the same draft. Re-fetch only after you update the draft.
-- When editing the Console, use the Console YAML already returned by 'superplane_app' when available. Read ref/skills/superplane-cli/references/console-yaml-spec.md and ref/docs/prd/console-and-widgets.md only if the task needs widget details you do not already know. Do not repeatedly run 'superplane apps console get ... | grep ...' against the same draft.
-- When shell is still the right tool, batch independent commands in one bash call with 'set -euo pipefail'. For multi-step YAML transforms or mounted-reference inspection, write and run one short Python script that reads known files, applies all needed searches/extractions, and prints one compact summary. Do not chain multiple ls/grep/sed/cat/read calls against the same reference set.
+- You can update the app Console when the task asks for status views, runbooks, tables, charts, or KPI panels. Read it with 'superplane_app' include_console and save it with action 'update_draft' using console_yaml.
+- You can configure integration references and set up expressions. Secrets are managed by the user; reference them in YAML and ask the user to create any that do not exist.
+- For direct app edits, prefer the shortest reliable path: use 'superplane_app' action 'read' to read the draft app once, list integrations only if integration IDs are needed, make the draft update, then report the result.
+- Use the 'superplane_app' custom tool for canvas reads, runtime reads, draft updates, and connected integration lists. Use action 'read_runtime' for memory, runs, canvas events, event executions, node executions, node queue items, node events, and child executions. It returns the current YAML plus version metadata in one call. Graph updates through 'superplane_app' auto-layout by default, so do not manually calculate node positions unless the user asks for a specific layout.
+- When reading an app for build work, read it once with 'superplane_app' action 'read' and work from the returned YAML. Re-read only after you update the draft.
+- When editing the Console, work from the Console YAML already returned by 'superplane_app' (include_console). Read ref/docs/prd/console-and-widgets.md only if the task needs widget details you do not already know.
+- The tools return everything you need in one call; do not fan out repeated discovery commands. Read once, then work from the returned data.
 - For direct component replacements or component additions, prefer the 'superplane_component_schema' custom tool for exact YAML keys, configuration fields, integration requirements, and output channel names. Read ref/components only as a fallback when the schema tool is missing a detail.
 - Use your Component Researcher for broader schema guidance, examples, integration details, and component field references that the schema tool does not cover. For trivial edits where you already know the exact fields (renaming, changing a URL), you can skip the researcher.
-- Avoid repeated grep/find/cat command loops. Fetch once, inspect locally.
-- When mentioning integrations, use clickable references with the instance ID: [instance-name](integration:instance-uuid). Get IDs from 'superplane integrations list'. If no instance exists yet, use the vendor name: [GitHub](integration:github).
+- When mentioning integrations, use clickable references with the instance ID: [instance-name](integration:instance-uuid). Get IDs from 'superplane_app' action 'list_integrations' (or 'read' with include_integrations). If no instance exists yet, use the vendor name: [GitHub](integration:github).
 - Never invent integration UUIDs. If no connected instance exists for a required vendor, omit the integration block or ask the user to connect it; do not use placeholder IDs.
 - If the user asks a question that doesn't require changes, answer it briefly, but your primary purpose is building.
 - If you're unsure what the user wants, ask a clarifying question using :::buttons with the options.
@@ -124,10 +112,10 @@ You are in Ask mode. Your job is to help the user understand and monitor their a
 
 Rules:
 - NEVER modify the app. No creates, no updates, no deletes.
-- Use 'superplane_app' action 'access' before CLI/API operations whose permission boundary is unclear.
-- You CAN read app state, list memory, list runs, inspect events/executions/queues, check node status, and explain how things work. Prefer 'superplane_app' action 'read_runtime' for these runtime reads before using CLI/API fallbacks.
+- Use 'superplane_app' action 'access' when a permission boundary is unclear before attempting an operation.
+- You CAN read app state, list memory, list runs, inspect events/executions/queues, check node status, and explain how things work. Use 'superplane_app' action 'read_runtime' for these runtime reads.
 - When the user asks about a failure, trace through the run execution path and identify the root cause.
 - If the user explicitly asks you to make a change, let them know you can't do that in Ask mode and they need to switch to Build mode.
 - Use charts, tables, and mermaid diagrams to visualize run data and app topology when helpful.
 - Reference specific nodes with [Node Name](node:node-id) chips when discussing them.
-- When mentioning integrations, use clickable references with the instance ID: [instance-name](integration:instance-uuid). Get IDs from 'superplane integrations list'. If no instance exists yet, use the vendor name: [GitHub](integration:github).`
+- When mentioning integrations, use clickable references with the instance ID: [instance-name](integration:instance-uuid). Get IDs from 'superplane_app' action 'list_integrations' (or 'read' with include_integrations). If no instance exists yet, use the vendor name: [GitHub](integration:github).`

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -139,8 +139,8 @@ type CreateSessionResult struct {
 }
 
 // SendMessageOptions.ContextPreamble is prepended to the user's message so
-// providers that need caller context inline (e.g. a CLI token on first turn)
-// receive it without a separate system message.
+// providers that need caller context inline (e.g. the canvas/session
+// identifiers) receive it without a separate system message.
 type SendMessageOptions struct {
 	ContextPreamble string
 }

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
-	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"gorm.io/gorm"
 )
@@ -22,20 +21,14 @@ import (
 var ErrSessionForbidden = errors.New("agent session is owned by another user")
 
 type Service struct {
-	provider  Provider
-	auth      authorization.Authorization
-	jwtSigner *jwt.Signer
-	baseURL   string
-	clock     func() time.Time
+	provider Provider
+	auth     authorization.Authorization
 }
 
-func NewService(provider Provider, auth authorization.Authorization, jwtSigner *jwt.Signer, baseURL string) *Service {
+func NewService(provider Provider, auth authorization.Authorization) *Service {
 	return &Service{
-		provider:  provider,
-		auth:      auth,
-		jwtSigner: jwtSigner,
-		baseURL:   baseURL,
-		clock:     time.Now,
+		provider: provider,
+		auth:     auth,
 	}
 }
 
@@ -189,10 +182,7 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 		return s.handleBusySession(sessionID, organizationID, userID)
 	}
 
-	preamble, err := s.buildPreamble(session, organizationID, userID, ModeBuilder)
-	if err != nil {
-		return fmt.Errorf("build preamble: %w", err)
-	}
+	preamble := s.buildPreamble(session, ModeBuilder)
 
 	if err := s.provider.DefineOutcome(ctx, session.ProviderSessionID, DefineOutcomeOptions{
 		Description:     description,
@@ -252,10 +242,7 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		agentMode = NormalizeMode(mode[0])
 	}
 
-	preamble, err := s.buildPreamble(session, organizationID, userID, agentMode)
-	if err != nil {
-		return nil, fmt.Errorf("build preamble: %w", err)
-	}
+	preamble := s.buildPreamble(session, agentMode)
 
 	if err := s.provider.SendMessage(ctx, session.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
 		if errors.Is(err, ErrSessionBusy) {
@@ -420,24 +407,17 @@ func (s *Service) cleanupProviderSession(ctx context.Context, providerSessionID 
 	}
 }
 
-func (s *Service) buildPreamble(session *models.AgentSession, organizationID, userID uuid.UUID, mode Mode) (string, error) {
-	token, expiresAt, err := s.mintAgentToken(organizationID.String(), userID.String(), session.CanvasID.String())
-	if err != nil {
-		return "", err
-	}
+func (s *Service) buildPreamble(session *models.AgentSession, mode Mode) string {
 	base := fmt.Sprintf(
 		preambleTemplate,
 		session.CanvasID.String(),
 		session.OrganizationID.String(),
-		s.baseURL,
-		token,
-		expiresAt.UTC().Format(time.RFC3339),
 		session.CanvasID.String(),
 		session.CanvasID.String(),
 	)
 	canvasSnapshot := buildCanvasSnapshot(session)
 	draftStatus := getDraftStatus(session.CanvasID)
-	return base + "\n\n" + canvasSnapshot + "\n\n" + modeInstructions(mode) + "\n\n" + draftStatus, nil
+	return base + "\n\n" + canvasSnapshot + "\n\n" + modeInstructions(mode) + "\n\n" + draftStatus
 }
 
 func (s *Service) enqueueStream(sessionID, organizationID, userID uuid.UUID) error {
@@ -458,22 +438,6 @@ func (s *Service) enqueueStream(sessionID, organizationID, userID uuid.UUID) err
 	})
 	log.WithError(err).Error("failed to enqueue agent stream request")
 	return fmt.Errorf("enqueue stream: %w", err)
-}
-
-// mintAgentToken returns a JWT scoped to one canvas to bound the blast-
-// radius if it leaks out of the agent container.
-func (s *Service) mintAgentToken(organizationID, userID, canvasID string) (string, time.Time, error) {
-	claims := jwt.ScopedTokenClaims{
-		Subject: userID,
-		OrgID:   organizationID,
-		Purpose: "agent-builder",
-		Scopes:  AgentTokenScopes(canvasID),
-	}
-	token, err := s.jwtSigner.GenerateScopedToken(claims, agentTokenTTL)
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("mint agent token: %w", err)
-	}
-	return token, s.clock().Add(agentTokenTTL), nil
 }
 
 // checkAgentPermission enforces the org-level baseline. Per-canvas access is
@@ -545,7 +509,7 @@ func getDraftStatus(canvasID uuid.UUID) string {
 				draftCreatedAt(draft),
 			)
 		}
-		result += "These drafts may belong to other sessions or users. To make changes, reuse the session draft you created earlier (pass its --draft-id), or create a new one with `superplane apps drafts create` if you have not yet this session. Do not reuse an unrelated draft.\n"
+		result += "These drafts may belong to other sessions or users. To make changes, use 'superplane_app' action 'update_draft'; it automatically targets your own private draft, creating one from the live version if needed. Do not assume an unrelated draft is yours.\n"
 		return result
 	}
 

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/database"
-	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/gorm"
@@ -128,8 +127,7 @@ func (f *fakeProvider) StreamEvents(_ context.Context, _ string, _ func(agents.P
 
 func newService(t *testing.T, r *support.ResourceRegistry, provider agents.Provider) *agents.Service {
 	t.Helper()
-	signer := jwt.NewSigner("test-secret")
-	return agents.NewService(provider, r.AuthService, signer, "https://api.test.local")
+	return agents.NewService(provider, r.AuthService)
 }
 
 func setupCanvasForUser(t *testing.T, r *support.ResourceRegistry) *models.Canvas {
@@ -462,23 +460,25 @@ func TestService_SendMessage_RefreshesPreambleEveryTurn(t *testing.T) {
 	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "first")
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastPreamble, canvas.ID.String())
-	assert.Contains(t, provider.lastPreamble, "api_token:")
-	assert.Contains(t, provider.lastPreamble, "api_token_expires_at:")
-	assert.Contains(t, provider.lastPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
-	assert.Contains(t, provider.lastPreamble, "Do not run `superplane version` as a preflight.")
 	assert.Contains(t, provider.lastPreamble, "[Canvas Snapshot]")
 	assert.Contains(t, provider.lastPreamble, "node_count:")
 	assert.Contains(t, provider.lastPreamble, "  - canvases:update_version:"+canvas.ID.String())
-	assert.Contains(t, provider.lastPreamble, "GET /api/v1/canvases/{canvas_id}/console")
+	assert.Contains(t, provider.lastPreamble, "All SuperPlane access goes through the agent tools.")
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:update:"+canvas.ID.String())
 	assert.NotContains(t, provider.lastPreamble, "  - canvases:publish:"+canvas.ID.String())
+	// The agent must never receive a usable API/CLI credential; everything
+	// goes through the server-side tools.
+	assert.NotContains(t, provider.lastPreamble, "api_token:")
+	assert.NotContains(t, provider.lastPreamble, "api_base_url:")
+	assert.NotContains(t, provider.lastPreamble, "SUPERPLANE_TOKEN")
+	assert.NotContains(t, provider.lastPreamble, "superplane version")
 
 	require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusIdle))
 	provider.lastPreamble = "<sentinel>"
 	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "second")
 	require.NoError(t, err)
-	assert.Contains(t, provider.lastPreamble, "api_token:",
-		"a fresh api_token must be re-injected on every turn so the session never expires mid-conversation")
+	assert.Contains(t, provider.lastPreamble, canvas.ID.String(),
+		"the session context must be re-injected on every turn")
 }
 
 func TestService_SendMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing.T) {
@@ -499,7 +499,7 @@ func TestService_SendMessage_FirstTurnPreambleSurvivesProviderFailure(t *testing
 	provider.lastPreamble = "<sentinel>"
 	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "retry")
 	require.NoError(t, err)
-	assert.Contains(t, provider.lastPreamble, "api_token:",
+	assert.Contains(t, provider.lastPreamble, canvas.ID.String(),
 		"preamble must still be injected after the previous attempt failed at the provider")
 }
 
@@ -524,12 +524,11 @@ func TestService_DefineOutcome_RefreshesPreambleForBuildLoop(t *testing.T) {
 		3,
 	)
 	require.NoError(t, err)
-	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "SUPERPLANE_URL=<api_base_url> SUPERPLANE_TOKEN=<api_token> superplane ...")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "[Agent Mode: BUILD]")
-	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "Prefer 'superplane_app' action 'update_draft'")
-	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "superplane apps console set ... -f console.yaml --draft-id <draft-id>")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "Use 'superplane_app' action 'update_draft'")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "ref/docs/prd/console-and-widgets.md")
-	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "api_token:")
+	assert.NotContains(t, provider.lastOutcomeOpts.ContextPreamble, "api_token:")
+	assert.NotContains(t, provider.lastOutcomeOpts.ContextPreamble, "superplane apps")
 }
 
 func TestService_SendMessage_PrivateToUser(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,10 +58,10 @@ func getAgentProviderOverride() agents.Provider {
 	return agentProviderOverride.provider
 }
 
-func buildAgentService(authService authorization.Authorization, jwtSigner *jwt.Signer, baseURL string) (agents.Provider, agentsActions.AgentsService) {
+func buildAgentService(authService authorization.Authorization) (agents.Provider, agentsActions.AgentsService) {
 	if provider := getAgentProviderOverride(); provider != nil {
 		log.WithField("provider", provider.Name()).Info("Managed agents enabled with provider override")
-		return provider, agents.NewService(provider, authService, jwtSigner, baseURL)
+		return provider, agents.NewService(provider, authService)
 	}
 
 	cfg := config.LoadAnthropicAgentConfig()
@@ -101,7 +101,7 @@ func buildAgentService(authService authorization.Authorization, jwtSigner *jwt.S
 		return nil, nil
 	}
 
-	service := agents.NewService(provider, authService, jwtSigner, baseURL)
+	service := agents.NewService(provider, authService)
 	log.Info("Anthropic managed agents enabled")
 	return provider, service
 }
@@ -560,7 +560,7 @@ func Start() {
 		panic(fmt.Sprintf("failed to create registry: %v", err))
 	}
 
-	agentProvider, agentService := buildAgentService(authService, jwtSigner, baseURL)
+	agentProvider, agentService := buildAgentService(authService)
 
 	if os.Getenv("START_PUBLIC_API") == "yes" {
 		go startPublicAPI(


### PR DESCRIPTION
## Summary

The agent previously had prompts, preambles, and guidance instructing it to use the SuperPlane CLI — often as a "fallback" to the custom tools. Now that the `superplane_app` and `superplane_component_schema` tools cover all agent operations, this removes the CLI from the agent **completely**, including as a fallback. Every action the agent can take is now exposed as a tool.

## What changed

**Prompts & guidance**
- `constants.go` — Rewrote the preamble and both builder/operator mode instructions. Removed all `superplane apps/integrations/version/connect/upgrade` commands, `--draft-id` fallbacks, the `SUPERPLANE_URL/TOKEN` env-var block, and the `/tmp` + shell-YAML-transform workflow. The preamble now states plainly that there is no command line or HTTP API to call.
- `anthropic/agent_prompt.md` — Removed CLI boot commands, console get/set fallbacks, the `/tmp/canvas.yaml` apply/verify workflow (now tool-based), the "include CLI credentials" researcher delegation example, and the CLI `SKILL.md` reference row. `integrations list` → `superplane_app` `list_integrations` throughout.
- `static/rich-ui-widgets.md` — Dropped `--draft-id` / "CLI update output" / `canvas get/console set` references from the draft-actions widget doc.
- Tool descriptions in `app_agent_tool.go` / `schema.go` — removed "without invoking the SuperPlane CLI", "matching the CLI behavior", and shell-command references.

**Credential removal**
Because the custom tools execute server-side with the session context and never consumed the injected `api_token`, leaving live credentials in the prompt would invite the model to call the API directly as a fallback. So:
- `service.go` — Deleted `mintAgentToken`, the `jwtSigner`/`baseURL`/`clock` fields, and simplified `NewService` + `buildPreamble`. Rewrote the draft-status message to point at `update_draft` (which auto-creates the user's private draft).
- `server.go` — Updated `buildAgentService`/`NewService` wiring accordingly.
- `resources.go` — Stopped mounting the CLI commands `SKILL.md`; kept the still-referenced YAML spec docs.
- Refreshed now-stale comments in `provider.go` / `events.go` (kept JWT redaction as defense-in-depth).

## Testing
- `go build ./pkg/... ./cmd/...` clean.
- All tests pass in the dev container: `pkg/agents`, `pkg/agents/agent_tools`, `pkg/agents/agent_tools/actions`, `pkg/agents/anthropic`, `pkg/grpc/actions/agents`.

> Note: mounted reference docs still live under a directory physically named `superplane-cli/` (e.g. `canvas-yaml-spec.md`) — that's a path in the external skills repo, not agent guidance, so it was left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)