### PR TITLE
feat: profiling in dev env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,16 @@
 # OTEL_GRPC_PORT=4317
 # OTEL_HTTP_PORT=4318
 
+## Performance profiling (Go pprof)
+##
+## When PPROF_ENABLED=yes the dev server exposes net/http/pprof endpoints at
+## http://localhost:${PPROF_PORT}/debug/pprof/ for CPU, heap, goroutine, block,
+## and mutex profiles. Defaults to on in the dev compose file; set to anything
+## other than "yes" to disable. The endpoint is unauthenticated, so keep it off
+## outside local development. See docs/contributing/profiling.md.
+# PPROF_ENABLED=yes
+# PPROF_PORT=6060
+
 ## Database timeout overrides
 ##
 ## Values can be Go durations such as 60s/2m or integer milliseconds.

--- a/.env.multi-instance.example
+++ b/.env.multi-instance.example
@@ -22,6 +22,7 @@
 # BASE_URL=http://localhost:8000
 # WEBHOOKS_BASE_URL=http://localhost:8000
 # SUPERGIT_PORT=8080
+# PPROF_PORT=6060
 
 ## ===== Instance B =====
 # PUBLIC_API_PORT=8001
@@ -37,6 +38,7 @@
 # BASE_URL=http://localhost:8001
 # WEBHOOKS_BASE_URL=http://localhost:8001
 # SUPERGIT_PORT=8081
+# PPROF_PORT=6061
 
 ## ===== Instance C =====
 # PUBLIC_API_PORT=8002
@@ -52,6 +54,7 @@
 # BASE_URL=http://localhost:8002
 # WEBHOOKS_BASE_URL=http://localhost:8002
 # SUPERGIT_PORT=8082
+# PPROF_PORT=6062
 
 ## ===== Instance D =====
 # PUBLIC_API_PORT=8003
@@ -67,6 +70,7 @@
 # BASE_URL=http://localhost:8003
 # WEBHOOKS_BASE_URL=http://localhost:8003
 # SUPERGIT_PORT=8083
+# PPROF_PORT=6063
 
 ## ===== Instance E =====
 # PUBLIC_API_PORT=8004
@@ -82,3 +86,4 @@
 # BASE_URL=http://localhost:8004
 # WEBHOOKS_BASE_URL=http://localhost:8004
 # SUPERGIT_PORT=8084
+# PPROF_PORT=6064

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - Targeted backend tests: `make test PKG_TEST_PACKAGES=./pkg/workers`
 - Targeted E2E tests: `make e2e E2E_TEST_PACKAGES=./test/e2e/workflows`
 - For E2E test authoring, see [docs/contributing/e2e-tests.md](docs/contributing/e2e-tests.md)
+- For performance profiling of the dev server, see [docs/contributing/profiling.md](docs/contributing/profiling.md)
 - After updating UI code, always run `make check.build.ui` to verify everything is correct
 - After editing JS code, always run `make format.js` to make sure that the files are consistently formatted
 - After editing Golang code, always run `make format.go` to make sure that files are consistently formatted

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 
 MAKE=make
 MAKEFLAGS+=--no-print-directory
+
+# Auto-source local overrides from .env so host-side targets (e.g. profiling)
+# see the same values docker compose interpolates from it. Command-line
+# overrides still take precedence, and a missing .env file is ignored.
+-include .env
+export
+
 DB_NAME=superplane
 DB_PASSWORD=the-cake-is-a-lie
 BASE_URL?=https://app.superplane.com

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test test.coverage test.license.check check.generated.artifacts dev.up dev.setup dev.setup.app dev.server dev.server.fg
+.PHONY: lint test test.coverage test.license.check check.generated.artifacts dev.up dev.setup dev.setup.app dev.server dev.server.fg profile.cpu profile.heap profile.goroutines
 
 MAKE=make
 MAKEFLAGS+=--no-print-directory
@@ -200,6 +200,19 @@ check.coverage.go:
 
 check.coverage.go.baseline.update:
 	go run ./scripts/check_go_coverage_budget.go --profile coverage-go.out --update-baseline
+
+#
+# Performance profiling against the running dev server (PPROF_ENABLED=yes).
+# See docs/contributing/profiling.md
+#
+profile.cpu:
+	$(COMPOSE) exec app go tool pprof -top "http://localhost:$${PPROF_PORT:-6060}/debug/pprof/profile?seconds=$${SECONDS:-30}"
+
+profile.heap:
+	$(COMPOSE) exec app go tool pprof -top "http://localhost:$${PPROF_PORT:-6060}/debug/pprof/heap"
+
+profile.goroutines:
+	$(COMPOSE) exec app curl -s "http://localhost:$${PPROF_PORT:-6060}/debug/pprof/goroutine?debug=2"
 
 
 storybook:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -100,6 +100,8 @@ services:
       OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel:4317"
       OTEL_SERVICE_NAME: "superplane-dev"
+      PPROF_ENABLED: ${PPROF_ENABLED:-yes}
+      PPROF_PORT: ${PPROF_PORT:-6060}
       OWNER_SETUP_ENABLED: "yes"
       USAGE_GRPC_URL: ${USAGE_GRPC_URL:-}
       VITE_FORCE_USAGE_PAGE: ${VITE_FORCE_USAGE_PAGE:-true}
@@ -128,6 +130,7 @@ services:
       - ${STORYBOOK_PORT:-6006}:${STORYBOOK_PORT:-6006}
       - ${PUBLIC_API_PORT:-8000}:${PUBLIC_API_PORT:-8000}
       - ${INTERNAL_API_PORT:-50051}:${INTERNAL_API_PORT:-50051}
+      - ${PPROF_PORT:-6060}:${PPROF_PORT:-6060}
 
     links:
       - db:db

--- a/docs/contributing/multi-instance-dev.md
+++ b/docs/contributing/multi-instance-dev.md
@@ -39,5 +39,6 @@ These are the ports you can override per repo:
 | PgWeb | `PGWEB_PORT` | `8081` | `8082` |
 | RabbitMQ | `RABBITMQ_PORT` | `5672` | `5673` |
 | RabbitMQ UI | `RABBITMQ_MANAGEMENT_PORT` | `15672` | `15673` |
+| pprof | `PPROF_PORT` | `6060` | `6061` |
 | Base URL | `BASE_URL` | `http://localhost:8000` | `http://localhost:8001` |
 | Webhooks base URL | `WEBHOOKS_BASE_URL` | `http://localhost:8000` | `http://localhost:8001` |

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -1,0 +1,79 @@
+---
+title: Performance Profiling
+---
+
+# Performance Profiling
+
+The dev server exposes Go's [`net/http/pprof`](https://pkg.go.dev/net/http/pprof) endpoints so you can capture CPU, heap, goroutine, and contention profiles of the running backend. The whole application (public API, internal gRPC API, and all workers) runs as a single process, so one pprof server covers everything.
+
+## How it is wired
+
+The pprof HTTP server is started in [`pkg/server/server.go`](../../pkg/server/server.go) and is gated by environment variables:
+
+| Env var | Default (dev) | Purpose |
+| --- | --- | --- |
+| `PPROF_ENABLED` | `yes` | Starts the pprof server only when set to `yes`. |
+| `PPROF_PORT` | `6060` | Port the pprof server listens on. |
+
+In the dev environment these default to on, and the port is published from the `app` container in [`docker-compose.dev.yml`](../../docker-compose.dev.yml). The endpoint is **unauthenticated** and exposes internal runtime details, so it is intentionally off by default in production: the release deployment does not set `PPROF_ENABLED`, so leave it unset there.
+
+When enabled, the server also turns on block and mutex contention sampling (`runtime.SetBlockProfileRate` and `runtime.SetMutexProfileFraction`) so the `/debug/pprof/block` and `/debug/pprof/mutex` profiles are populated.
+
+## Capturing profiles
+
+Make sure the dev server is running (`make dev.up` then `make dev.server`). The port is published to the host, so you can hit it from either the host or inside the container.
+
+### Makefile helpers
+
+```bash
+# 30-second CPU profile (override with SECONDS=<n>)
+make profile.cpu
+
+# Heap (in-use memory) profile
+make profile.heap
+
+# Quick dump of all goroutines (useful for stuck/leaked goroutines)
+make profile.goroutines
+```
+
+### Raw pprof / curl
+
+```bash
+# CPU profile for 30s
+go tool pprof "http://localhost:6060/debug/pprof/profile?seconds=30"
+
+# Heap snapshot
+go tool pprof "http://localhost:6060/debug/pprof/heap"
+
+# Goroutine dump
+curl "http://localhost:6060/debug/pprof/goroutine?debug=2"
+```
+
+If you don't have the Go toolchain on the host, run the same commands inside the container:
+
+```bash
+docker compose -f docker-compose.dev.yml exec app \
+  go tool pprof "http://localhost:6060/debug/pprof/profile?seconds=30"
+```
+
+### Interactive flame graphs
+
+For the interactive web UI (requires `graphviz` installed locally):
+
+```bash
+go tool pprof -http=:8082 "http://localhost:6060/debug/pprof/profile?seconds=30"
+```
+
+This opens a browser with flame graphs, call graphs, and source views.
+
+## Profile types
+
+| Endpoint | What it shows |
+| --- | --- |
+| `/debug/pprof/profile` | CPU usage sampled over a time window (`?seconds=N`). |
+| `/debug/pprof/heap` | In-use and allocated heap memory. |
+| `/debug/pprof/goroutine` | Stack traces of all current goroutines. |
+| `/debug/pprof/block` | Where goroutines block on synchronization primitives. |
+| `/debug/pprof/mutex` | Lock contention. |
+
+Browse `http://localhost:6060/debug/pprof/` for the full index.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,7 +3,11 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
+	// Registers pprof handlers on http.DefaultServeMux, served by startPprofServer.
+	_ "net/http/pprof"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -464,9 +468,32 @@ func setupOtelMetrics() {
 	}
 }
 
+func startPprofServer() {
+	if os.Getenv("PPROF_ENABLED") != "yes" {
+		return
+	}
+
+	port := os.Getenv("PPROF_PORT")
+	if port == "" {
+		port = "6060"
+	}
+
+	// Sample contention so /debug/pprof/block and /debug/pprof/mutex are useful.
+	runtime.SetBlockProfileRate(1)
+	runtime.SetMutexProfileFraction(5)
+
+	go func() {
+		log.Infof("pprof server listening on :%s", port)
+		if err := http.ListenAndServe("0.0.0.0:"+port, nil); err != nil {
+			log.Warnf("pprof server stopped: %v", err)
+		}
+	}()
+}
+
 func Start() {
 	configureLogging()
 	setupOtelMetrics()
+	startPprofServer()
 
 	telemetry.InitSentry()
 	telemetry.StartBeacon()


### PR DESCRIPTION
Closes https://github.com/superplanehq/superplane/issues/5410

Adds Go `pprof` performance profiling to the dev environment. The whole backend runs as a single process (public API, internal gRPC API, and all workers), so one pprof server covers everything.

- **`pkg/server/server.go`**: New `startPprofServer()`, gated by `PPROF_ENABLED=yes` and served on `PPROF_PORT` (default `6060`). Enables block/mutex contention sampling and registers `net/http/pprof` handlers. Called from `Start()` alongside the OTel metrics setup.
- **`docker-compose.dev.yml`**: Wires `PPROF_ENABLED`/`PPROF_PORT` into the `app` service (default-on in dev) and publishes the port. The release deployment doesn't set `PPROF_ENABLED`, so production stays off.
- **`Makefile`**: Adds `profile.cpu`, `profile.heap`, and `profile.goroutines` targets, and auto-sources `.env` (`-include .env` + `export`) so host-side targets resolve `PPROF_PORT` correctly (a missing `.env` is ignored; command-line overrides still win).
- **`.env.example` / `.env.multi-instance.example`**: Document and default the profiling flag and per-instance ports (A=`6060` ... E=`6064`).
- **Docs**: New `docs/contributing/profiling.md` usage guide, linked from `AGENTS.md` and the multi-instance port map.

The pprof endpoint is unauthenticated and exposes runtime internals, so it is intentionally env-gated and off by default outside local development.

## Test plan

- [x] `make format.go`, `make lint`, and `make check.build.app` pass
- [x] Recreated the app container (`make dev.up`) and confirmed `PPROF_ENABLED`/`PPROF_PORT` are set inside the container
- [x] `http://localhost:<PPROF_PORT>/debug/pprof/` returns HTTP 200 from both host and container
- [x] `make profile.heap` and `make profile.cpu` produce real profiles against the configured port
- [x] Verified multi-instance port override works (server on `6061`, default `6060` no longer mapped)