### PR TITLE
fix: runs req rate

### DIFF
--- a/web_src/src/hooks/canvasInfiniteCache.spec.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.spec.ts
@@ -1,0 +1,263 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import type {
+  CanvasesCanvasEvent,
+  CanvasesCanvasEventWithExecutions,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasRun,
+} from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+import {
+  executionToRef,
+  parseRunsFiltersFromQueryKey,
+  runMatchesFilters,
+  upsertExecutionIntoInfiniteEventsData,
+  upsertExecutionIntoInfiniteRunsData,
+  upsertRootEventIntoInfiniteData,
+  upsertRunIntoInfiniteData,
+  type InfiniteEventsPage,
+  type InfiniteRunsPage,
+} from "./canvasInfiniteCache";
+
+function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun {
+  return {
+    id: "run-1",
+    canvasId: "canvas-1",
+    state: "STATE_STARTED",
+    result: "RESULT_UNKNOWN",
+    createdAt: "2026-06-01T12:00:00.000Z",
+    updatedAt: "2026-06-01T12:00:00.000Z",
+    rootEvent: { id: "event-1", nodeId: "trigger-1", createdAt: "2026-06-01T12:00:00.000Z" },
+    executions: [],
+    ...overrides,
+  };
+}
+
+function makeInfiniteRunsData(runs: CanvasesCanvasRun[], totalCount = runs.length): InfiniteData<InfiniteRunsPage> {
+  return {
+    pages: [{ runs, totalCount, hasNextPage: false }],
+    pageParams: [undefined],
+  };
+}
+
+function makeEvent(overrides: Partial<CanvasesCanvasEventWithExecutions> = {}): CanvasesCanvasEventWithExecutions {
+  return {
+    id: "event-1",
+    nodeId: "trigger-1",
+    createdAt: "2026-06-01T12:00:00.000Z",
+    executions: [],
+    ...overrides,
+  };
+}
+
+function makeInfiniteEventsData(
+  events: CanvasesCanvasEventWithExecutions[],
+  totalCount = events.length,
+): InfiniteData<InfiniteEventsPage> {
+  return {
+    pages: [{ events, totalCount, hasNextPage: false }],
+    pageParams: [undefined],
+  };
+}
+
+describe("parseRunsFiltersFromQueryKey", () => {
+  it("parses state and result filters from infinite run query keys", () => {
+    const queryKey = canvasKeys.infiniteRuns("canvas-1", {
+      states: ["STATE_STARTED"],
+      results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+    });
+
+    expect(parseRunsFiltersFromQueryKey(queryKey)).toEqual({
+      states: ["STATE_STARTED"],
+      results: ["RESULT_FAILED", "RESULT_CANCELLED"],
+    });
+  });
+
+  it("returns empty filters for unfiltered infinite run query keys", () => {
+    expect(parseRunsFiltersFromQueryKey(canvasKeys.infiniteRuns("canvas-1"))).toEqual({});
+  });
+});
+
+describe("runMatchesFilters", () => {
+  it("matches runs against state and result filters", () => {
+    const run = makeRun({ state: "STATE_FINISHED", result: "RESULT_PASSED" });
+
+    expect(runMatchesFilters(run, {})).toBe(true);
+    expect(runMatchesFilters(run, { states: ["STATE_FINISHED"] })).toBe(true);
+    expect(runMatchesFilters(run, { results: ["RESULT_PASSED"] })).toBe(true);
+    expect(runMatchesFilters(run, { states: ["STATE_STARTED"] })).toBe(false);
+    expect(runMatchesFilters(run, { results: ["RESULT_FAILED"] })).toBe(false);
+  });
+});
+
+describe("upsertRunIntoInfiniteData", () => {
+  it("inserts a matching run at the top and bumps totalCount", () => {
+    const existing = makeRun({ id: "run-old", createdAt: "2026-06-01T11:00:00.000Z" });
+    const incoming = makeRun({ id: "run-new", createdAt: "2026-06-01T12:00:00.000Z" });
+    const old = makeInfiniteRunsData([existing], 1);
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {})!;
+
+    expect(next.pages[0]?.runs?.map((run) => run.id)).toEqual(["run-new", "run-old"]);
+    expect(next.pages[0]?.totalCount).toBe(2);
+  });
+
+  it("updates an existing run when the incoming payload is newer", () => {
+    const old = makeInfiniteRunsData([
+      makeRun({
+        state: "STATE_STARTED",
+        updatedAt: "2026-06-01T12:00:00.000Z",
+      }),
+    ]);
+    const incoming = makeRun({
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {})!;
+
+    expect(next.pages[0]?.runs?.[0]?.state).toBe("STATE_FINISHED");
+    expect(next.pages[0]?.runs?.[0]?.result).toBe("RESULT_PASSED");
+    expect(next.pages[0]?.totalCount).toBe(1);
+  });
+
+  it("rejects stale run_started updates after run_finished", () => {
+    const old = makeInfiniteRunsData([
+      makeRun({
+        state: "STATE_FINISHED",
+        result: "RESULT_PASSED",
+        updatedAt: "2026-06-01T12:01:00.000Z",
+      }),
+    ]);
+    const incoming = makeRun({
+      state: "STATE_STARTED",
+      result: "RESULT_UNKNOWN",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const next = upsertRunIntoInfiniteData(old, incoming, {});
+
+    expect(next).toBe(old);
+  });
+
+  it("removes a run that no longer matches the active filter", () => {
+    const old = makeInfiniteRunsData([
+      makeRun({
+        state: "STATE_STARTED",
+        updatedAt: "2026-06-01T12:00:00.000Z",
+      }),
+    ]);
+    const incoming = makeRun({
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const next = upsertRunIntoInfiniteData(old, incoming, { states: ["STATE_STARTED"] })!;
+
+    expect(next.pages[0]?.runs).toEqual([]);
+    expect(next.pages[0]?.totalCount).toBe(0);
+  });
+});
+
+describe("upsertRootEventIntoInfiniteData", () => {
+  it("maps root events and inserts them at the top of page 0", () => {
+    const old = makeInfiniteEventsData([makeEvent({ id: "event-old", createdAt: "2026-06-01T11:00:00.000Z" })], 1);
+    const incoming: CanvasesCanvasEvent = {
+      id: "event-new",
+      nodeId: "trigger-1",
+      root: true,
+      createdAt: "2026-06-01T12:00:00.000Z",
+      customName: "Deploy",
+    };
+
+    const next = upsertRootEventIntoInfiniteData(old, incoming)!;
+
+    expect(next.pages[0]?.events?.[0]).toMatchObject({
+      id: "event-new",
+      customName: "Deploy",
+      executions: [],
+    });
+    expect(next.pages[0]?.totalCount).toBe(2);
+  });
+
+  it("preserves existing executions when the same root event is upserted again", () => {
+    const old = makeInfiniteEventsData([
+      makeEvent({
+        executions: [{ id: "execution-1", nodeId: "node-1", state: "STATE_STARTED" }],
+      }),
+    ]);
+    const incoming: CanvasesCanvasEvent = {
+      id: "event-1",
+      nodeId: "trigger-1",
+      root: true,
+      createdAt: "2026-06-01T12:00:00.000Z",
+    };
+
+    const next = upsertRootEventIntoInfiniteData(old, incoming)!;
+
+    expect(next.pages[0]?.events?.[0]?.executions).toEqual([
+      { id: "execution-1", nodeId: "node-1", state: "STATE_STARTED" },
+    ]);
+  });
+});
+
+describe("execution cache patching", () => {
+  it("maps executions to refs and upserts them into matching events and runs", () => {
+    const execution: CanvasesCanvasNodeExecution = {
+      id: "execution-1",
+      nodeId: "node-1",
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      createdAt: "2026-06-01T12:00:00.000Z",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+      rootEvent: { id: "event-1", nodeId: "trigger-1", createdAt: "2026-06-01T12:00:00.000Z" },
+    };
+
+    expect(executionToRef(execution)).toEqual({
+      id: "execution-1",
+      nodeId: "node-1",
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+      resultReason: undefined,
+      resultMessage: undefined,
+      createdAt: "2026-06-01T12:00:00.000Z",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+    });
+
+    const eventsOld = makeInfiniteEventsData([makeEvent({ id: "event-1" })]);
+    const eventsNext = upsertExecutionIntoInfiniteEventsData(eventsOld, execution)!;
+    expect(eventsNext.pages[0]?.events?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
+
+    const runsOld = makeInfiniteRunsData([makeRun({ rootEvent: { id: "event-1", nodeId: "trigger-1" } })]);
+    const runsNext = upsertExecutionIntoInfiniteRunsData(runsOld, execution)!;
+    expect(runsNext.pages[0]?.runs?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
+  });
+
+  it("ignores stale execution updates", () => {
+    const old = makeInfiniteEventsData([
+      makeEvent({
+        executions: [
+          {
+            id: "execution-1",
+            nodeId: "node-1",
+            state: "STATE_FINISHED",
+            updatedAt: "2026-06-01T12:02:00.000Z",
+          },
+        ],
+      }),
+    ]);
+    const incoming: CanvasesCanvasNodeExecution = {
+      id: "execution-1",
+      nodeId: "node-1",
+      state: "STATE_STARTED",
+      updatedAt: "2026-06-01T12:01:00.000Z",
+      rootEvent: { id: "event-1", nodeId: "trigger-1" },
+    };
+
+    const next = upsertExecutionIntoInfiniteEventsData(old, incoming);
+
+    expect(next?.pages[0]?.events?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
+  });
+});

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -1,0 +1,377 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import type {
+  CanvasesCanvasEvent,
+  CanvasesCanvasEventWithExecutions,
+  CanvasesCanvasNodeExecution,
+  CanvasesCanvasNodeExecutionRef,
+  CanvasesCanvasRun,
+  CanvasesCanvasRunResult,
+  CanvasesCanvasRunState,
+} from "@/api-client";
+import type { CanvasRunsFilters } from "./useCanvasData";
+
+export type InfiniteRunsPage = {
+  runs?: CanvasesCanvasRun[];
+  totalCount?: number;
+  hasNextPage?: boolean;
+  lastTimestamp?: string;
+};
+
+export type InfiniteEventsPage = {
+  events?: CanvasesCanvasEventWithExecutions[];
+  totalCount?: number;
+  hasNextPage?: boolean;
+  lastTimestamp?: string;
+};
+
+const RUN_STATE_ORDER: Record<CanvasesCanvasRunState, number> = {
+  STATE_UNKNOWN: 0,
+  STATE_STARTED: 1,
+  STATE_FINISHED: 2,
+};
+
+const EXECUTION_STATE_ORDER: Record<string, number> = {
+  STATE_UNKNOWN: 0,
+  STATE_PENDING: 1,
+  STATE_STARTED: 2,
+  STATE_FINISHED: 3,
+};
+
+export function parseRunsFiltersFromQueryKey(queryKey: readonly unknown[]): CanvasRunsFilters {
+  const infiniteIndex = queryKey.indexOf("infinite");
+  if (infiniteIndex === -1) {
+    return {};
+  }
+
+  const filters: CanvasRunsFilters = {};
+  let index = infiniteIndex + 1;
+
+  if (queryKey[index] === "states") {
+    index += 1;
+    const states: CanvasesCanvasRunState[] = [];
+    while (index < queryKey.length && queryKey[index] !== "results") {
+      states.push(queryKey[index] as CanvasesCanvasRunState);
+      index += 1;
+    }
+    if (states.length > 0) {
+      filters.states = states;
+    }
+  }
+
+  if (queryKey[index] === "results") {
+    index += 1;
+    const results: CanvasesCanvasRunResult[] = [];
+    while (index < queryKey.length) {
+      results.push(queryKey[index] as CanvasesCanvasRunResult);
+      index += 1;
+    }
+    if (results.length > 0) {
+      filters.results = results;
+    }
+  }
+
+  return filters;
+}
+
+export function runMatchesFilters(run: CanvasesCanvasRun, filters: CanvasRunsFilters): boolean {
+  if (filters.states?.length && (!run.state || !filters.states.includes(run.state))) {
+    return false;
+  }
+
+  if (filters.results?.length && (!run.result || !filters.results.includes(run.result))) {
+    return false;
+  }
+
+  return true;
+}
+
+function parseTimestamp(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function shouldAcceptRunUpdate(existing: CanvasesCanvasRun, incoming: CanvasesCanvasRun): boolean {
+  const existingUpdatedAt = parseTimestamp(existing.updatedAt);
+  const incomingUpdatedAt = parseTimestamp(incoming.updatedAt);
+
+  if (incomingUpdatedAt < existingUpdatedAt) {
+    return false;
+  }
+
+  if (incomingUpdatedAt > existingUpdatedAt) {
+    return true;
+  }
+
+  const existingState = RUN_STATE_ORDER[existing.state ?? "STATE_UNKNOWN"] ?? 0;
+  const incomingState = RUN_STATE_ORDER[incoming.state ?? "STATE_UNKNOWN"] ?? 0;
+  return incomingState >= existingState;
+}
+
+function bumpTotalCountOnAllPages<T extends { totalCount?: number }>(pages: T[], delta: number): void {
+  for (const page of pages) {
+    page.totalCount = Math.max(0, (page.totalCount ?? 0) + delta);
+  }
+}
+
+function findRunLocation(pages: InfiniteRunsPage[], runId: string): { pageIndex: number; runIndex: number } | null {
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+    const runIndex = pages[pageIndex].runs?.findIndex((run) => run.id === runId) ?? -1;
+    if (runIndex !== -1) {
+      return { pageIndex, runIndex };
+    }
+  }
+
+  return null;
+}
+
+function insertRunSorted(runs: CanvasesCanvasRun[], run: CanvasesCanvasRun): CanvasesCanvasRun[] {
+  const runCreatedAt = parseTimestamp(run.createdAt);
+  const insertIndex = runs.findIndex((existingRun) => parseTimestamp(existingRun.createdAt) < runCreatedAt);
+  if (insertIndex === -1) {
+    return [...runs, run];
+  }
+
+  return [...runs.slice(0, insertIndex), run, ...runs.slice(insertIndex)];
+}
+
+export function upsertRunIntoInfiniteData(
+  old: InfiniteData<InfiniteRunsPage> | undefined,
+  run: CanvasesCanvasRun,
+  filters: CanvasRunsFilters,
+): InfiniteData<InfiniteRunsPage> | undefined {
+  if (!old) {
+    return old;
+  }
+
+  const pages = old.pages.map((page) => ({
+    ...page,
+    runs: page.runs ? [...page.runs] : [],
+  }));
+  const location = findRunLocation(pages, run.id ?? "");
+  const matches = runMatchesFilters(run, filters);
+
+  if (matches) {
+    if (location) {
+      const existing = pages[location.pageIndex].runs![location.runIndex];
+      if (!shouldAcceptRunUpdate(existing, run)) {
+        return old;
+      }
+
+      pages[location.pageIndex].runs![location.runIndex] = run;
+      return { ...old, pages };
+    }
+
+    if (pages.length === 0) {
+      return {
+        ...old,
+        pages: [{ runs: [run], totalCount: 1, hasNextPage: false }],
+      };
+    }
+
+    pages[0].runs = insertRunSorted(pages[0].runs ?? [], run);
+    bumpTotalCountOnAllPages(pages, 1);
+    return { ...old, pages };
+  }
+
+  if (!location) {
+    return old;
+  }
+
+  pages[location.pageIndex].runs!.splice(location.runIndex, 1);
+  bumpTotalCountOnAllPages(pages, -1);
+  return { ...old, pages };
+}
+
+export function canvasEventToEventWithExecutions(event: CanvasesCanvasEvent): CanvasesCanvasEventWithExecutions {
+  return {
+    id: event.id,
+    canvasId: event.canvasId,
+    nodeId: event.nodeId,
+    channel: event.channel,
+    customName: event.customName,
+    data: event.data,
+    createdAt: event.createdAt,
+    executions: [],
+  };
+}
+
+function findEventLocation(
+  pages: InfiniteEventsPage[],
+  eventId: string,
+): { pageIndex: number; eventIndex: number } | null {
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+    const eventIndex = pages[pageIndex].events?.findIndex((event) => event.id === eventId) ?? -1;
+    if (eventIndex !== -1) {
+      return { pageIndex, eventIndex };
+    }
+  }
+
+  return null;
+}
+
+export function upsertRootEventIntoInfiniteData(
+  old: InfiniteData<InfiniteEventsPage> | undefined,
+  event: CanvasesCanvasEvent,
+): InfiniteData<InfiniteEventsPage> | undefined {
+  if (!old || !event.id) {
+    return old;
+  }
+
+  const mappedEvent = canvasEventToEventWithExecutions(event);
+  const pages = old.pages.map((page) => ({
+    ...page,
+    events: page.events ? [...page.events] : [],
+  }));
+  const location = findEventLocation(pages, event.id);
+
+  if (location) {
+    const existing = pages[location.pageIndex].events![location.eventIndex];
+    pages[location.pageIndex].events![location.eventIndex] = {
+      ...mappedEvent,
+      executions: existing.executions ?? [],
+    };
+    return { ...old, pages };
+  }
+
+  if (pages.length === 0) {
+    return {
+      ...old,
+      pages: [{ events: [mappedEvent], totalCount: 1, hasNextPage: false }],
+    };
+  }
+
+  pages[0].events = [mappedEvent, ...(pages[0].events ?? [])];
+  bumpTotalCountOnAllPages(pages, 1);
+  return { ...old, pages };
+}
+
+export function executionToRef(execution: CanvasesCanvasNodeExecution): CanvasesCanvasNodeExecutionRef {
+  return {
+    id: execution.id,
+    nodeId: execution.nodeId,
+    state: execution.state,
+    result: execution.result,
+    resultReason: execution.resultReason,
+    resultMessage: execution.resultMessage,
+    createdAt: execution.createdAt,
+    updatedAt: execution.updatedAt,
+  };
+}
+
+function shouldAcceptExecutionRefUpdate(
+  existing: CanvasesCanvasNodeExecutionRef,
+  incoming: CanvasesCanvasNodeExecutionRef,
+): boolean {
+  const existingUpdatedAt = parseTimestamp(existing.updatedAt);
+  const incomingUpdatedAt = parseTimestamp(incoming.updatedAt);
+
+  if (incomingUpdatedAt < existingUpdatedAt) {
+    return false;
+  }
+
+  if (incomingUpdatedAt > existingUpdatedAt) {
+    return true;
+  }
+
+  const existingState = EXECUTION_STATE_ORDER[existing.state ?? "STATE_UNKNOWN"] ?? 0;
+  const incomingState = EXECUTION_STATE_ORDER[incoming.state ?? "STATE_UNKNOWN"] ?? 0;
+  return incomingState >= existingState;
+}
+
+export function upsertExecutionRef(
+  executions: CanvasesCanvasNodeExecutionRef[],
+  incoming: CanvasesCanvasNodeExecutionRef,
+) {
+  if (!incoming.id) {
+    return executions;
+  }
+
+  const index = executions.findIndex((execution) => execution.id === incoming.id);
+  if (index === -1) {
+    return [...executions, incoming];
+  }
+
+  if (!shouldAcceptExecutionRefUpdate(executions[index], incoming)) {
+    return executions;
+  }
+
+  const next = executions.slice();
+  next[index] = incoming;
+  return next;
+}
+
+export function upsertExecutionIntoInfiniteEventsData(
+  old: InfiniteData<InfiniteEventsPage> | undefined,
+  execution: CanvasesCanvasNodeExecution,
+): InfiniteData<InfiniteEventsPage> | undefined {
+  const rootEventId = execution.rootEvent?.id;
+  if (!old || !rootEventId) {
+    return old;
+  }
+
+  const executionRef = executionToRef(execution);
+  const pages = old.pages.map((page) => ({
+    ...page,
+    events: page.events ? [...page.events] : [],
+  }));
+
+  for (const page of pages) {
+    const eventIndex = page.events?.findIndex((event) => event.id === rootEventId) ?? -1;
+    if (eventIndex === -1) {
+      continue;
+    }
+
+    page.events![eventIndex] = {
+      ...page.events![eventIndex],
+      executions: upsertExecutionRef(page.events![eventIndex].executions ?? [], executionRef),
+    };
+    return { ...old, pages };
+  }
+
+  return old;
+}
+
+function findRunByRootEventId(
+  pages: InfiniteRunsPage[],
+  rootEventId: string,
+): { pageIndex: number; runIndex: number } | null {
+  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
+    const runIndex = pages[pageIndex].runs?.findIndex((run) => run.rootEvent?.id === rootEventId) ?? -1;
+    if (runIndex !== -1) {
+      return { pageIndex, runIndex };
+    }
+  }
+
+  return null;
+}
+
+export function upsertExecutionIntoInfiniteRunsData(
+  old: InfiniteData<InfiniteRunsPage> | undefined,
+  execution: CanvasesCanvasNodeExecution,
+): InfiniteData<InfiniteRunsPage> | undefined {
+  const rootEventId = execution.rootEvent?.id;
+  if (!old || !rootEventId) {
+    return old;
+  }
+
+  const executionRef = executionToRef(execution);
+  const pages = old.pages.map((page) => ({
+    ...page,
+    runs: page.runs ? [...page.runs] : [],
+  }));
+  const location = findRunByRootEventId(pages, rootEventId);
+  if (!location) {
+    return old;
+  }
+
+  const run = pages[location.pageIndex].runs![location.runIndex];
+  pages[location.pageIndex].runs![location.runIndex] = {
+    ...run,
+    executions: upsertExecutionRef(run.executions ?? [], executionRef),
+  };
+  return { ...old, pages };
+}

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -1360,6 +1360,7 @@ export const useInfiniteCanvasEvents = (canvasId: string, enabled = true) => {
     },
     initialPageParam: undefined as string | undefined,
     staleTime: 0,
+    refetchInterval: 60_000,
     refetchOnWindowFocus: false,
     enabled: !!canvasId && enabled,
   });
@@ -1398,6 +1399,7 @@ export const useInfiniteCanvasRuns = (canvasId: string, filters: CanvasRunsFilte
     },
     initialPageParam: undefined as string | undefined,
     staleTime: 0,
+    refetchInterval: 60_000,
     refetchOnWindowFocus: false,
     enabled: !!canvasId && enabled,
   });

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createElement } from "react";
 import type { ReactNode } from "react";
 import { canvasKeys } from "@/hooks/useCanvasData";
@@ -28,17 +28,18 @@ import { useCanvasWebsocket } from "@/hooks/useCanvasWebsocket";
 const testCanvasId = "canvas-1";
 const testOrganizationId = "org-1";
 const testNodeId = "node-1";
+const INVALIDATION_DEBOUNCE_MS = 1000;
 
-function getOnMessageHandler() {
+function getWebsocketHandler<T extends (...args: never[]) => unknown>(handlerName: "onMessage" | "onOpen"): T {
   const call = useWebSocketMock.mock.calls.at(-1);
-  if (!call || !call[1]?.onMessage) {
-    throw new Error("Websocket onMessage handler was not registered");
+  if (!call || !call[1]?.[handlerName]) {
+    throw new Error(`Websocket ${handlerName} handler was not registered`);
   }
-  return call[1].onMessage as (event: MessageEvent<unknown>) => void;
+  return call[1][handlerName] as T;
 }
 
 function emitWebsocketMessage(event: string, payload: unknown) {
-  const onMessage = getOnMessageHandler();
+  const onMessage = getWebsocketHandler<(event: MessageEvent<unknown>) => void>("onMessage");
 
   act(() => {
     onMessage(
@@ -49,6 +50,14 @@ function emitWebsocketMessage(event: string, payload: unknown) {
   });
 }
 
+function emitWebSocketOpen() {
+  const onOpen = getWebsocketHandler<() => void>("onOpen");
+
+  act(() => {
+    onOpen();
+  });
+}
+
 function renderCanvasWebsocketHook(queryClient: QueryClient) {
   return renderHook(() => useCanvasWebsocket(testCanvasId, testOrganizationId), {
     wrapper: ({ children }: { children: ReactNode }) =>
@@ -56,12 +65,30 @@ function renderCanvasWebsocketHook(queryClient: QueryClient) {
   });
 }
 
+async function flushMessageQueueAndDebouncedInvalidations() {
+  await act(async () => {
+    await vi.runAllTimersAsync();
+  });
+}
+
+function getInvalidationCalls(invalidateQueriesSpy: ReturnType<typeof vi.spyOn>, queryKey: readonly unknown[]) {
+  return invalidateQueriesSpy.mock.calls.filter((call: unknown[]) => {
+    const args = call[0] as { queryKey?: readonly unknown[] };
+    return JSON.stringify(args.queryKey) === JSON.stringify(queryKey);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
 describe("useCanvasWebsocket", () => {
-  it("invalidates infinite events query for root workflow events", async () => {
+  it("debounces infinite events invalidation for root workflow events", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -72,11 +99,11 @@ describe("useCanvasWebsocket", () => {
       root: true,
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteEvents(testCanvasId),
-      });
-    });
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
   });
 
   it("does not invalidate infinite events query for non-root workflow events", async () => {
@@ -90,11 +117,9 @@ describe("useCanvasWebsocket", () => {
       root: false,
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteEvents(testCanvasId),
-      });
-    });
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
   });
 
   it("does not invalidate infinite events query for queue_item_created", async () => {
@@ -107,11 +132,9 @@ describe("useCanvasWebsocket", () => {
       nodeId: testNodeId,
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteEvents(testCanvasId),
-      });
-    });
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
   });
 
   it("does not invalidate infinite events query for queue_item_consumed", async () => {
@@ -124,14 +147,12 @@ describe("useCanvasWebsocket", () => {
       nodeId: testNodeId,
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteEvents(testCanvasId),
-      });
-    });
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
   });
 
-  it("invalidates infinite events query for execution events", async () => {
+  it("debounces infinite events invalidation for execution events", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -141,14 +162,14 @@ describe("useCanvasWebsocket", () => {
       nodeId: testNodeId,
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteEvents(testCanvasId),
-      });
-    });
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
   });
 
-  it("invalidates infinite runs query for run events", async () => {
+  it("invalidates infinite runs immediately for run events", () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -160,14 +181,113 @@ describe("useCanvasWebsocket", () => {
       result: "RESULT_PASSED",
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: canvasKeys.infiniteRuns(testCanvasId),
-      });
-    });
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 
-  it("invalidates version and console queries for canvas version updates", async () => {
+  it("coalesces debounced websocket invalidations into one flush per query", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+
+    emitWebsocketMessage("event_created", {
+      id: "event-1",
+      nodeId: testNodeId,
+      root: true,
+    });
+    emitWebsocketMessage("execution_created", {
+      id: "execution-1",
+      nodeId: testNodeId,
+    });
+
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+  });
+
+  it("does not duplicate runs invalidation when run events arrive during a debounce window", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+
+    emitWebsocketMessage("execution_created", {
+      id: "execution-1",
+      nodeId: testNodeId,
+    });
+    emitWebsocketMessage("run_finished", {
+      id: "run-1",
+      canvasId: testCanvasId,
+      state: "STATE_FINISHED",
+      result: "RESULT_PASSED",
+    });
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+
+    await flushMessageQueueAndDebouncedInvalidations();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+  });
+
+  it("resets debounce timer on subsequent invalidation requests", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+    emitWebsocketMessage("event_created", {
+      id: "event-1",
+      nodeId: testNodeId,
+      root: true,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INVALIDATION_DEBOUNCE_MS - 100);
+    });
+
+    emitWebsocketMessage("execution_created", {
+      id: "execution-1",
+      nodeId: testNodeId,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(INVALIDATION_DEBOUNCE_MS - 100);
+    });
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+  });
+
+  it("does not invalidate runs or events on initial websocket connect", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+    emitWebSocketOpen();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
+  });
+
+  it("invalidates runs and events on websocket reconnect", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+
+    renderCanvasWebsocketHook(queryClient);
+    emitWebSocketOpen();
+    emitWebSocketOpen();
+
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+  });
+
+  it("invalidates version and console queries for canvas version updates", () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -177,13 +297,11 @@ describe("useCanvasWebsocket", () => {
       versionId: "version-1",
     });
 
-    await waitFor(() => {
-      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: canvasKeys.versionList(testCanvasId),
-      });
-      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: canvasKeys.consoleAll(testCanvasId),
-      });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: canvasKeys.versionList(testCanvasId),
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: canvasKeys.consoleAll(testCanvasId),
     });
   });
 });

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -1,9 +1,11 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider, type InfiniteData } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElement } from "react";
 import type { ReactNode } from "react";
+import type { CanvasesCanvasRun } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
+import type { InfiniteEventsPage, InfiniteRunsPage } from "@/hooks/canvasInfiniteCache";
 
 const { useWebSocketMock, nodeExecutionStoreMock } = vi.hoisted(() => ({
   useWebSocketMock: vi.fn(),
@@ -28,7 +30,6 @@ import { useCanvasWebsocket } from "@/hooks/useCanvasWebsocket";
 const testCanvasId = "canvas-1";
 const testOrganizationId = "org-1";
 const testNodeId = "node-1";
-const INVALIDATION_DEBOUNCE_MS = 1000;
 
 function getWebsocketHandler<T extends (...args: never[]) => unknown>(handlerName: "onMessage" | "onOpen"): T {
   const call = useWebSocketMock.mock.calls.at(-1);
@@ -65,9 +66,9 @@ function renderCanvasWebsocketHook(queryClient: QueryClient) {
   });
 }
 
-async function flushMessageQueueAndDebouncedInvalidations() {
+async function flushMessageQueue() {
   await act(async () => {
-    await vi.runAllTimersAsync();
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -78,37 +79,54 @@ function getInvalidationCalls(invalidateQueriesSpy: ReturnType<typeof vi.spyOn>,
   });
 }
 
-beforeEach(() => {
-  vi.useFakeTimers();
-});
+function seedInfiniteEvents(queryClient: QueryClient, events: InfiniteEventsPage["events"] = []) {
+  queryClient.setQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId), {
+    pages: [{ events, totalCount: events?.length ?? 0, hasNextPage: false }],
+    pageParams: [undefined],
+  });
+}
+
+function seedInfiniteRuns(
+  queryClient: QueryClient,
+  runs: CanvasesCanvasRun[] = [],
+  filters?: Parameters<typeof canvasKeys.infiniteRuns>[1],
+) {
+  queryClient.setQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId, filters), {
+    pages: [{ runs, totalCount: runs.length, hasNextPage: false }],
+    pageParams: [undefined],
+  });
+}
 
 afterEach(() => {
-  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
 describe("useCanvasWebsocket", () => {
-  it("debounces infinite events invalidation for root workflow events", async () => {
+  it("patches root workflow events into the infinite events cache", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteEvents(queryClient, [{ id: "event-old", nodeId: testNodeId, executions: [] }]);
 
     renderCanvasWebsocketHook(queryClient);
     emitWebsocketMessage("event_created", {
-      id: "event-1",
+      id: "event-new",
       nodeId: testNodeId,
       root: true,
+      createdAt: "2026-06-01T12:00:00.000Z",
     });
 
+    await flushMessageQueue();
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId));
+      expect(data?.pages[0]?.events?.map((event) => event.id)).toEqual(["event-new", "event-old"]);
+    });
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
-
-    await flushMessageQueueAndDebouncedInvalidations();
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
   });
 
-  it("does not invalidate infinite events query for non-root workflow events", async () => {
+  it("does not patch non-root workflow events into the infinite events cache", async () => {
     const queryClient = new QueryClient();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteEvents(queryClient, [{ id: "event-old", nodeId: testNodeId, executions: [] }]);
 
     renderCanvasWebsocketHook(queryClient);
     emitWebsocketMessage("workflow_event_created", {
@@ -117,9 +135,12 @@ describe("useCanvasWebsocket", () => {
       root: false,
     });
 
-    await flushMessageQueueAndDebouncedInvalidations();
+    await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+    await waitFor(() => {
+      const data = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId));
+      expect(data?.pages[0]?.events?.map((event) => event.id)).toEqual(["event-old"]);
+    });
   });
 
   it("does not invalidate infinite events query for queue_item_created", async () => {
@@ -132,7 +153,7 @@ describe("useCanvasWebsocket", () => {
       nodeId: testNodeId,
     });
 
-    await flushMessageQueueAndDebouncedInvalidations();
+    await flushMessageQueue();
 
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
   });
@@ -147,31 +168,53 @@ describe("useCanvasWebsocket", () => {
       nodeId: testNodeId,
     });
 
-    await flushMessageQueueAndDebouncedInvalidations();
+    await flushMessageQueue();
 
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
   });
 
-  it("debounces infinite events invalidation for execution events", async () => {
+  it("patches execution events into infinite events and runs caches", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteEvents(queryClient, [{ id: "event-1", nodeId: testNodeId, executions: [] }]);
+    seedInfiniteRuns(queryClient, [
+      {
+        id: "run-1",
+        canvasId: testCanvasId,
+        state: "STATE_STARTED",
+        rootEvent: { id: "event-1", nodeId: testNodeId },
+        executions: [],
+      },
+    ]);
 
     renderCanvasWebsocketHook(queryClient);
     emitWebsocketMessage("execution_created", {
       id: "execution-1",
       nodeId: testNodeId,
+      state: "STATE_PENDING",
+      updatedAt: "2026-06-01T12:00:00.000Z",
+      rootEvent: { id: "event-1", nodeId: testNodeId },
     });
 
+    await flushMessageQueue();
+
+    await waitFor(() => {
+      const eventsData = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(
+        canvasKeys.infiniteEvents(testCanvasId),
+      );
+      const runsData = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId));
+      expect(eventsData?.pages[0]?.events?.[0]?.executions?.[0]?.id).toBe("execution-1");
+      expect(runsData?.pages[0]?.runs?.[0]?.executions?.[0]?.id).toBe("execution-1");
+    });
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
-
-    await flushMessageQueueAndDebouncedInvalidations();
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
-  it("invalidates infinite runs immediately for run events", () => {
+  it("patches run events into all infinite runs cache variants", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    seedInfiniteRuns(queryClient, []);
+    seedInfiniteRuns(queryClient, [], { states: ["STATE_STARTED"] });
 
     renderCanvasWebsocketHook(queryClient);
     emitWebsocketMessage("run_finished", {
@@ -179,89 +222,18 @@ describe("useCanvasWebsocket", () => {
       canvasId: testCanvasId,
       state: "STATE_FINISHED",
       result: "RESULT_PASSED",
+      createdAt: "2026-06-01T12:00:00.000Z",
+      updatedAt: "2026-06-01T12:01:00.000Z",
     });
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
-  });
+    const allRuns = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId));
+    const startedRuns = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(
+      canvasKeys.infiniteRuns(testCanvasId, { states: ["STATE_STARTED"] }),
+    );
 
-  it("coalesces debounced websocket invalidations into one flush per query", async () => {
-    const queryClient = new QueryClient();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
-
-    renderCanvasWebsocketHook(queryClient);
-
-    emitWebsocketMessage("event_created", {
-      id: "event-1",
-      nodeId: testNodeId,
-      root: true,
-    });
-    emitWebsocketMessage("execution_created", {
-      id: "execution-1",
-      nodeId: testNodeId,
-    });
-
-    await flushMessageQueueAndDebouncedInvalidations();
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
-  });
-
-  it("does not duplicate runs invalidation when run events arrive during a debounce window", async () => {
-    const queryClient = new QueryClient();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
-
-    renderCanvasWebsocketHook(queryClient);
-
-    emitWebsocketMessage("execution_created", {
-      id: "execution-1",
-      nodeId: testNodeId,
-    });
-    emitWebsocketMessage("run_finished", {
-      id: "run-1",
-      canvasId: testCanvasId,
-      state: "STATE_FINISHED",
-      result: "RESULT_PASSED",
-    });
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
-
-    await flushMessageQueueAndDebouncedInvalidations();
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
-  });
-
-  it("resets debounce timer on subsequent invalidation requests", async () => {
-    const queryClient = new QueryClient();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
-
-    renderCanvasWebsocketHook(queryClient);
-    emitWebsocketMessage("event_created", {
-      id: "event-1",
-      nodeId: testNodeId,
-      root: true,
-    });
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(INVALIDATION_DEBOUNCE_MS - 100);
-    });
-
-    emitWebsocketMessage("execution_created", {
-      id: "execution-1",
-      nodeId: testNodeId,
-    });
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(INVALIDATION_DEBOUNCE_MS - 100);
-    });
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
-
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
+    expect(allRuns?.pages[0]?.runs?.[0]?.state).toBe("STATE_FINISHED");
+    expect(startedRuns?.pages[0]?.runs).toEqual([]);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
   it("does not invalidate runs or events on initial websocket connect", () => {

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -12,6 +12,8 @@ import { canvasKeys } from "./useCanvasData";
 
 const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/`;
 
+const INVALIDATION_DEBOUNCE_MS = 1000;
+
 type CanvasWebsocketPayload = {
   canvasId: string;
   versionId?: string;
@@ -52,6 +54,54 @@ export function useCanvasWebsocket(
   const messageQueues = useRef<Map<string, QueuedMessage[]>>(new Map());
   const processingNodes = useRef<Set<string>>(new Set());
 
+  const runsDirty = useRef(false);
+  const eventsDirty = useRef(false);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasConnectedOnce = useRef(false);
+
+  const flushInvalidations = useCallback(() => {
+    flushTimerRef.current = null;
+
+    if (eventsDirty.current) {
+      eventsDirty.current = false;
+      queryClient.invalidateQueries({
+        queryKey: canvasKeys.infiniteEvents(canvasId),
+      });
+    }
+
+    if (runsDirty.current) {
+      runsDirty.current = false;
+      queryClient.invalidateQueries({
+        queryKey: canvasKeys.infiniteRuns(canvasId),
+      });
+    }
+  }, [queryClient, canvasId]);
+
+  const invalidateRunsNow = useCallback(() => {
+    runsDirty.current = false;
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.infiniteRuns(canvasId),
+    });
+  }, [queryClient, canvasId]);
+
+  const scheduleRunsEventsInvalidation = useCallback(
+    (target: "events" | "runs" | "both") => {
+      if (target === "events" || target === "both") {
+        eventsDirty.current = true;
+      }
+      if (target === "runs" || target === "both") {
+        runsDirty.current = true;
+      }
+
+      if (flushTimerRef.current !== null) {
+        clearTimeout(flushTimerRef.current);
+      }
+
+      flushTimerRef.current = setTimeout(flushInvalidations, INVALIDATION_DEBOUNCE_MS);
+    },
+    [flushInvalidations],
+  );
+
   const processMessage = useCallback(
     (data: QueuedMessage["data"]) => {
       const payload = data.payload;
@@ -73,9 +123,7 @@ export function useCanvasWebsocket(
              * if the event being received is a root canvas event.
              */
             if (workflowEvent.root) {
-              queryClient.invalidateQueries({
-                queryKey: canvasKeys.infiniteEvents(canvasId),
-              });
+              scheduleRunsEventsInvalidation("events");
             }
 
             onNodeEvent?.(workflowEvent.nodeId!, data.event);
@@ -95,13 +143,7 @@ export function useCanvasWebsocket(
 
               nodeExecutionStore.updateNodeExecution(storeNodeId, execution);
 
-              queryClient.invalidateQueries({
-                queryKey: canvasKeys.infiniteEvents(canvasId),
-              });
-
-              queryClient.invalidateQueries({
-                queryKey: canvasKeys.infiniteRuns(canvasId),
-              });
+              scheduleRunsEventsInvalidation("both");
 
               if (execution.rootEvent?.id) {
                 queryClient.invalidateQueries({
@@ -136,9 +178,7 @@ export function useCanvasWebsocket(
             break;
           }
 
-          queryClient.invalidateQueries({
-            queryKey: canvasKeys.infiniteRuns(canvasId),
-          });
+          invalidateRunsNow();
           break;
         }
         case "canvas_updated":
@@ -199,6 +239,8 @@ export function useCanvasWebsocket(
       shouldApplyCanvasUpdate,
       processRuntimeEvents,
       organizationId,
+      scheduleRunsEventsInvalidation,
+      invalidateRunsNow,
     ],
   );
 
@@ -285,11 +327,28 @@ export function useCanvasWebsocket(
     [processMessage, processQueue],
   );
 
+  const handleWebSocketOpen = useCallback(() => {
+    if (!hasConnectedOnce.current) {
+      hasConnectedOnce.current = true;
+      return;
+    }
+
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.infiniteEvents(canvasId),
+    });
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.infiniteRuns(canvasId),
+    });
+  }, [queryClient, canvasId]);
+
   // Cleanup on unmount
   useEffect(() => {
     const queues = messageQueues.current;
     const processing = processingNodes.current;
     return () => {
+      if (flushTimerRef.current !== null) {
+        clearTimeout(flushTimerRef.current);
+      }
       queues.clear();
       processing.clear();
     };
@@ -302,7 +361,7 @@ export function useCanvasWebsocket(
       reconnectAttempts: Number.POSITIVE_INFINITY,
       heartbeat: false,
       reconnectInterval: 3000,
-      onOpen: () => {},
+      onOpen: handleWebSocketOpen,
       onError: () => {},
       onClose: () => {},
       share: false,

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import useWebSocket from "react-use-websocket";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type {
   CanvasesCanvasNodeExecution,
   CanvasesCanvasEvent,
@@ -8,11 +8,18 @@ import type {
   CanvasesCanvasRun,
 } from "@/api-client";
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
+import {
+  parseRunsFiltersFromQueryKey,
+  upsertExecutionIntoInfiniteEventsData,
+  upsertExecutionIntoInfiniteRunsData,
+  upsertRootEventIntoInfiniteData,
+  upsertRunIntoInfiniteData,
+  type InfiniteEventsPage,
+  type InfiniteRunsPage,
+} from "./canvasInfiniteCache";
 import { canvasKeys } from "./useCanvasData";
 
 const SOCKET_SERVER_URL = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws/`;
-
-const INVALIDATION_DEBOUNCE_MS = 1000;
 
 type CanvasWebsocketPayload = {
   canvasId: string;
@@ -54,52 +61,51 @@ export function useCanvasWebsocket(
   const messageQueues = useRef<Map<string, QueuedMessage[]>>(new Map());
   const processingNodes = useRef<Set<string>>(new Set());
 
-  const runsDirty = useRef(false);
-  const eventsDirty = useRef(false);
-  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasConnectedOnce = useRef(false);
 
-  const flushInvalidations = useCallback(() => {
-    flushTimerRef.current = null;
-
-    if (eventsDirty.current) {
-      eventsDirty.current = false;
-      queryClient.invalidateQueries({
-        queryKey: canvasKeys.infiniteEvents(canvasId),
-      });
-    }
-
-    if (runsDirty.current) {
-      runsDirty.current = false;
-      queryClient.invalidateQueries({
+  const patchRunInCache = useCallback(
+    (run: CanvasesCanvasRun) => {
+      const queries = queryClient.getQueriesData<InfiniteData<InfiniteRunsPage>>({
         queryKey: canvasKeys.infiniteRuns(canvasId),
       });
-    }
-  }, [queryClient, canvasId]);
 
-  const invalidateRunsNow = useCallback(() => {
-    runsDirty.current = false;
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.infiniteRuns(canvasId),
-    });
-  }, [queryClient, canvasId]);
+      for (const [queryKey, data] of queries) {
+        if (!data) {
+          continue;
+        }
 
-  const scheduleRunsEventsInvalidation = useCallback(
-    (target: "events" | "runs" | "both") => {
-      if (target === "events" || target === "both") {
-        eventsDirty.current = true;
+        const filters = parseRunsFiltersFromQueryKey(queryKey);
+        const next = upsertRunIntoInfiniteData(data, run, filters);
+        if (next !== data) {
+          queryClient.setQueryData(queryKey, next);
+        }
       }
-      if (target === "runs" || target === "both") {
-        runsDirty.current = true;
-      }
-
-      if (flushTimerRef.current !== null) {
-        clearTimeout(flushTimerRef.current);
-      }
-
-      flushTimerRef.current = setTimeout(flushInvalidations, INVALIDATION_DEBOUNCE_MS);
     },
-    [flushInvalidations],
+    [queryClient, canvasId],
+  );
+
+  const patchRootEventInCache = useCallback(
+    (event: CanvasesCanvasEvent) => {
+      queryClient.setQueriesData<InfiniteData<InfiniteEventsPage>>(
+        { queryKey: canvasKeys.infiniteEvents(canvasId) },
+        (old) => upsertRootEventIntoInfiniteData(old, event),
+      );
+    },
+    [queryClient, canvasId],
+  );
+
+  const patchExecutionInCache = useCallback(
+    (execution: CanvasesCanvasNodeExecution) => {
+      queryClient.setQueriesData<InfiniteData<InfiniteEventsPage>>(
+        { queryKey: canvasKeys.infiniteEvents(canvasId) },
+        (old) => upsertExecutionIntoInfiniteEventsData(old, execution),
+      );
+      queryClient.setQueriesData<InfiniteData<InfiniteRunsPage>>(
+        { queryKey: canvasKeys.infiniteRuns(canvasId) },
+        (old) => upsertExecutionIntoInfiniteRunsData(old, execution),
+      );
+    },
+    [queryClient, canvasId],
   );
 
   const processMessage = useCallback(
@@ -119,11 +125,11 @@ export function useCanvasWebsocket(
             nodeExecutionStore.updateNodeEvent(workflowEvent.nodeId!, workflowEvent);
 
             /*
-             * We only invalidate the canvas root events query
-             * if the event being received is a root canvas event.
+             * Root canvas events are upserted into the infinite events cache
+             * instead of triggering a refetch.
              */
             if (workflowEvent.root) {
-              scheduleRunsEventsInvalidation("events");
+              patchRootEventInCache(workflowEvent);
             }
 
             onNodeEvent?.(workflowEvent.nodeId!, data.event);
@@ -143,7 +149,7 @@ export function useCanvasWebsocket(
 
               nodeExecutionStore.updateNodeExecution(storeNodeId, execution);
 
-              scheduleRunsEventsInvalidation("both");
+              patchExecutionInCache(execution);
 
               if (execution.rootEvent?.id) {
                 queryClient.invalidateQueries({
@@ -178,7 +184,7 @@ export function useCanvasWebsocket(
             break;
           }
 
-          invalidateRunsNow();
+          patchRunInCache(run);
           break;
         }
         case "canvas_updated":
@@ -239,8 +245,9 @@ export function useCanvasWebsocket(
       shouldApplyCanvasUpdate,
       processRuntimeEvents,
       organizationId,
-      scheduleRunsEventsInvalidation,
-      invalidateRunsNow,
+      patchRunInCache,
+      patchRootEventInCache,
+      patchExecutionInCache,
     ],
   );
 
@@ -346,9 +353,6 @@ export function useCanvasWebsocket(
     const queues = messageQueues.current;
     const processing = processingNodes.current;
     return () => {
-      if (flushTimerRef.current !== null) {
-        clearTimeout(flushTimerRef.current);
-      }
       queues.clear();
       processing.clear();
     };


### PR DESCRIPTION
Resolves https://github.com/superplanehq/superplane/issues/5400

Eliminates the request storm to `/runs` and `/events` on the Canvas page. Today the load is websocket-invalidation-driven: every execution/run/event message calls `invalidateQueries`, and React Query refetches every loaded page of every active filter variant. The backend already broadcasts the full serialized objects over the websocket, so the browser was discarding them and refetching.

This PR delivers **PR1** (amplification relief + safety nets) and **PR2** (cache-patching from websocket payloads) from the request-reduction plan. Memory polling is left unchanged. PR3 (single-run GET endpoint + `maxPages` bound) is a follow-up.

## Changes
### Amplification relief + safety nets

- **Coalesce websocket invalidations** in `useCanvasWebsocket.ts`: accumulate `runsDirty`/`eventsDirty` flags in refs and flush via a trailing ~1s timer instead of invalidating inline per message, collapsing a burst of N messages into 1 refetch per query. `run_started`/`run_finished` stay immediate so the runs panel updates promptly.
- **Reconnect resync**: in the `useWebSocket` `onOpen` handler, skip the first connect (ref guard) and on subsequent reconnects invalidate `infiniteRuns`/`infiniteEvents` once, covering messages missed while disconnected.
- **Low-frequency backstop**: `refetchInterval: 60000` on both `useInfiniteCanvasRuns` and `useInfiniteCanvasEvents`. React Query pauses interval refetch when the tab is hidden, giving visibility gating for free.

### Cache-patch from websocket payloads (the real fix)

Drives the runs/events lists directly from the websocket payloads so steady-state HTTP to `/runs` and `/events` drops to ~0 during a run.

- **New `canvasInfiniteCache.ts` helpers**:
  - `runMatchesFilters(run, filters)` for `states`/`results`.
  - `upsertRunIntoInfiniteData(old, run, filters)`: id-replace or sorted-insert (runs are timestamp-desc), `totalCount` bookkeeping, an `updatedAt`/state idempotency guard so a late `run_started` cannot clobber `run_finished`, and removal/decrement when a run no longer matches. Filters are parsed from the query key.
  - root-event mapping (`CanvasEvent` -> `CanvasEventWithExecutions` with `executions: []`).
  - an execution->ref upsert for nested run/event executions.
- **`run_started`/`run_finished`** now `setQueriesData`-upsert across all mounted `infiniteRuns` variants instead of invalidating.
- **Root `event_created`/`workflow_event_created`** insert into `infiniteEvents` page 0 with a `totalCount` bump.
- **`execution_*`** patches the matching `event.executions` (correlated via `rootEvent.id`) and `run.executions` (via root event correlation).
- Removes the per-message debounced invalidation path; keeps the PR1 reconnect resync and 60s backstop refetch as correctness nets.

## Results

A simple canvas: one trigger node wired to 3 no-op nodes - one root event creates 1 run with 3 executions. Testing how many API requests are triggered in response to a run.

| Endpoint | Requests (Before) | Requests (After this PR) |
| --- | ---: | ---: |
| `/run` | 1 | 1 |
| `/runs` | 16 | 0 |
| `/events` | 10 | 0 |
| **Total** | **27** | **1** |

After the fix, only one request is sent from the browser (/run which triggers manual run). All run-time workflow data is read from WebSocket payloads.