### PR TITLE
fix(canvas): recover gracefully when a draft is deleted out from under the UI

### DIFF
--- a/web_src/src/hooks/useCanvasData.spec.ts
+++ b/web_src/src/hooks/useCanvasData.spec.ts
@@ -11,6 +11,7 @@ const {
   canvasesCommitCanvasStaging,
   canvasesDiscardCanvasStaging,
   canvasesDescribeCanvasVersion,
+  canvasesListCanvasVersions,
 } = vi.hoisted(() => ({
   canvasFoldersUpdateCanvasFolder: vi.fn(),
   canvasesListRuns: vi.fn(),
@@ -18,6 +19,7 @@ const {
   canvasesCommitCanvasStaging: vi.fn(),
   canvasesDiscardCanvasStaging: vi.fn(),
   canvasesDescribeCanvasVersion: vi.fn(),
+  canvasesListCanvasVersions: vi.fn(),
 }));
 
 vi.mock("../api-client/sdk.gen", async (importOriginal) => {
@@ -30,11 +32,13 @@ vi.mock("../api-client/sdk.gen", async (importOriginal) => {
     canvasesCommitCanvasStaging,
     canvasesDiscardCanvasStaging,
     canvasesDescribeCanvasVersion,
+    canvasesListCanvasVersions,
   };
 });
 
 import {
   canvasKeys,
+  ensureDraftVersionExists,
   useInfiniteCanvasRuns,
   useUpdateCanvasConsole,
   useUpdateCanvasFolderMembership,
@@ -441,5 +445,43 @@ describe("useUpdateCanvasConsole", () => {
     expect(queryClient.getQueryData(dashboardKey)).toMatchObject({
       panels: [{ id: "panel-1", type: "markdown", content: { title: "Before" } }],
     });
+  });
+});
+
+describe("ensureDraftVersionExists", () => {
+  beforeEach(() => {
+    canvasesListCanvasVersions.mockReset();
+  });
+
+  it("returns true when the draft version is still present", async () => {
+    canvasesListCanvasVersions.mockResolvedValue({
+      data: { versions: [{ metadata: { id: "v-1" } }, { metadata: { id: "v-2" } }] },
+    });
+    const queryClient = new QueryClient();
+
+    const exists = await ensureDraftVersionExists(queryClient, "org-1", "canvas-1", "v-2");
+
+    expect(exists).toBe(true);
+    expect(canvasesListCanvasVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when the draft version is gone", async () => {
+    canvasesListCanvasVersions.mockResolvedValue({
+      data: { versions: [{ metadata: { id: "v-1" } }] },
+    });
+    const queryClient = new QueryClient();
+
+    const exists = await ensureDraftVersionExists(queryClient, "org-1", "canvas-1", "deleted");
+
+    expect(exists).toBe(false);
+  });
+
+  it("short-circuits to false without calling the API when args are missing", async () => {
+    const queryClient = new QueryClient();
+
+    const exists = await ensureDraftVersionExists(queryClient, "org-1", "canvas-1", "");
+
+    expect(exists).toBe(false);
+    expect(canvasesListCanvasVersions).not.toHaveBeenCalled();
   });
 });

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -56,6 +56,7 @@ import type {
 } from "../api-client/types.gen";
 import { withOrganizationHeader } from "../lib/withOrganizationHeader";
 import { registerLocalStagingWrite } from "../lib/canvasStagingEcho";
+import { draftVersionId } from "../lib/draftVersion";
 import { analytics } from "../lib/analytics";
 import { isPublishedVersion } from "../pages/app/lib/canvas-versions";
 import {
@@ -959,6 +960,37 @@ export const useListDraftBranches = (organizationId: string, canvasId: string, e
     },
     enabled: enabled && !!organizationId && !!canvasId,
   });
+};
+
+// Refetches the draft branches and reports whether the given version still
+// exists, so commit/publish can pre-check a possibly-stale draft id.
+export const ensureDraftVersionExists = async (
+  queryClient: QueryClient,
+  organizationId: string,
+  canvasId: string,
+  versionId: string,
+): Promise<boolean> => {
+  if (!organizationId || !canvasId || !versionId) {
+    return false;
+  }
+
+  const branches = await queryClient.fetchQuery({
+    queryKey: canvasKeys.draftBranches(canvasId),
+    queryFn: async () => {
+      const response = await canvasesListCanvasVersions(
+        withOrganizationHeader({
+          path: { canvasId },
+          query: { state: "STATE_DRAFT" },
+        }),
+      );
+      return response.data?.versions ?? [];
+    },
+    // Always hit the network — a cached list (app-wide 5-min staleTime) could
+    // still contain a draft that was just deleted, defeating the guard.
+    staleTime: 0,
+  });
+
+  return branches.some((branch) => draftVersionId(branch) === versionId);
 };
 
 export const useCreateDraftBranch = (organizationId: string, canvasId: string) => {

--- a/web_src/src/lib/toast.ts
+++ b/web_src/src/lib/toast.ts
@@ -15,3 +15,11 @@ export const showErrorToast = (message: string): void => {
 export const showSuccessToast = (message: string): void => {
   toast.success(message);
 };
+
+/**
+ * Show a standardized informational toast notification (non-error, non-success)
+ * @param message - The message to display
+ */
+export const showInfoToast = (message: string): void => {
+  toast.info(message);
+};

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -114,7 +114,7 @@ import { CanvasVersionNodeDiffDialog, type CanvasVersionNodeDiffContext } from "
 import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary } from "./draftNodeDiff";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
-import { activateDraftVersion, clearPublishedDraftVersion as clearDraftVersion } from "./lib/draft-spec-cache";
+import { activateDraftVersion } from "./lib/draft-spec-cache";
 import {
   isDraftVersion,
   isPublishedVersion,
@@ -173,6 +173,7 @@ import {
   prepareData,
   prepareSidebarData,
 } from "./workflowPageHelpers";
+import { useDraftRecovery } from "./useDraftRecovery";
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
@@ -4076,63 +4077,29 @@ export function AppPage() {
     ]);
   }, [organizationId, canvasId, queryClient]);
 
-  const handlePublishVersion = useCallback(async () => {
-    if (!organizationId || !canvasId || !activeCanvasVersionId) {
-      return;
-    }
-
-    setIsPreparingVersionAction(true);
-    try {
-      const isReady = await ensureVersionActionDraftReady(
-        "Unable to prepare the latest version changes for publishing",
-      );
-      if (!isReady) {
-        return;
-      }
-
-      const versionIdToPublish = activeCanvasVersionIdRef.current;
-      if (!versionIdToPublish) {
-        return;
-      }
-
-      // Publish operates on the committed draft row, so flush any staged spec
-      // edits into the version before promoting it to live.
-      consoleMutationGenerationRef.current += 1;
-      await commitCanvasStagingMutation.mutateAsync();
-
-      await publishCanvasVersionMutation.mutateAsync(versionIdToPublish);
-      activeCanvasVersionIdRef.current = "";
-      clearDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, versionIdToPublish);
-      exitToLive();
-      setSearchParams((current) => {
-        const next = new URLSearchParams(current);
-        next.delete("version");
-        next.delete("branch");
-        return clearComponentSidebarSearchParams(next);
-      });
-      await refreshLatestLiveCanvasData();
-      showSuccessToast("Version published");
-    } catch (error) {
-      showErrorToast(getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to publish version")));
-    } finally {
-      setIsPreparingVersionAction(false);
-    }
-  }, [
-    organizationId,
-    canvasId,
-    activeCanvasVersionId,
-    ensureVersionActionDraftReady,
-    publishCanvasVersionMutation,
-    commitCanvasStagingMutation,
-    refreshLatestLiveCanvasData,
-    setSearchParams,
-    exitToLive,
-  ]);
-
   const cancelPendingCanvasSaves = useCallback(() => {
     canvasSaveSessionRef.current += 1;
     clearQueuedCanvasSave();
   }, [clearQueuedCanvasSave]);
+
+  const { handlePublishVersion, recoverIfDraftMissing, recoverFromMissingDraft } = useDraftRecovery({
+    organizationId,
+    canvasId,
+    activeCanvasVersionId,
+    activeCanvasVersionIdRef,
+    draftCanvasSpecsRef,
+    setActiveCanvasVersion,
+    setDraftCanvasSpec,
+    exitToLive,
+    setSearchParams,
+    refreshLatestLiveCanvasData,
+    cancelPendingCanvasSaves,
+    ensureVersionActionDraftReady,
+    commitCanvasStagingMutation,
+    publishCanvasVersionMutation,
+    consoleMutationGenerationRef,
+    setIsPreparingVersionAction,
+  });
 
   const handleCanvasDraftRestoredToCommitted = useCallback(
     (_version: CanvasesCanvasVersion) => {
@@ -4163,6 +4130,7 @@ export function AppPage() {
     flushRepositoryFileStaging,
     cancelPendingCanvasSaves,
     onCanvasDraftRestoredToCommitted: handleCanvasDraftRestoredToCommitted,
+    recoverIfDraftMissing,
   });
 
   const handleActOnChangeRequest = useCallback(
@@ -4572,6 +4540,7 @@ export function AppPage() {
     activeCanvasVersionIdRef,
     activateCanvasVersionForEditing,
     setSuppressUnpublishedDraftDiscard,
+    onActiveDraftMissing: recoverFromMissingDraft,
   });
 
   const handleSubmitCreateChangeRequest = useCallback(

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -3,6 +3,20 @@ import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 
 import { dematerializeCanvasSpec, dematerializeConsoleSpec } from "./workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
+import { isNotFoundError } from "../workflowPageHelpers";
+
+// Confirms whether a canvas version still exists. Used to distinguish a deleted
+// version from an incidental repository-file 404, since fetchCanvasVersionWithSpec
+// loads the version and its canvas.yaml in parallel. A non-404 describe error is
+// treated as "exists" so the original failure is surfaced as transient.
+export async function canvasVersionExists(canvasId: string, versionId: string): Promise<boolean> {
+  try {
+    const response = await canvasesDescribeCanvasVersion(withOrganizationHeader({ path: { canvasId, versionId } }));
+    return Boolean(response.data?.version?.metadata?.id);
+  } catch (error) {
+    return !isNotFoundError(error);
+  }
+}
 
 // fetchRepositorySpecFileContent reads a canvas.yaml/console.yaml file. When
 // `stage` is set (only meaningful for a draft version), the server returns the

--- a/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
+++ b/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
@@ -8,10 +8,12 @@ import { useAgentDraftEditor } from "./useAgentDraftEditor";
 
 vi.mock("@/lib/toast", () => ({
   showErrorToast: vi.fn(),
+  showInfoToast: vi.fn(),
 }));
 
 vi.mock("./lib/repository-spec-files", () => ({
   fetchCanvasVersionWithSpec: vi.fn(),
+  canvasVersionExists: vi.fn(),
 }));
 
 function makeDraftVersion(versionId: string): CanvasesCanvasVersion {
@@ -54,6 +56,7 @@ function setupHook({
   const queryClient = new QueryClient();
   const activeCanvasVersionIdRef = { current: activeCanvasVersionId };
   const setSuppressUnpublishedDraftDiscard = vi.fn();
+  const onActiveDraftMissing = vi.fn();
   const selectableVersionsById = new Map<string, CanvasesCanvasVersion>([[versionId, makeDraftVersion(versionId)]]);
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -69,6 +72,7 @@ function setupHook({
     activeCanvasVersionIdRef,
     activateCanvasVersionForEditing,
     setSuppressUnpublishedDraftDiscard,
+    onActiveDraftMissing,
   };
 
   const hook = renderHook((props) => useAgentDraftEditor(props), { initialProps, wrapper });
@@ -79,6 +83,7 @@ function setupHook({
     activateCanvasVersionForEditing,
     selectableVersionsById,
     setSuppressUnpublishedDraftDiscard,
+    onActiveDraftMissing,
     updateProps: (overrides: Partial<typeof initialProps>) => hook.rerender({ ...initialProps, ...overrides }),
   };
 }

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -1,17 +1,21 @@
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { CanvasesCanvasVersion } from "@/api-client";
-import { showErrorToast } from "@/lib/toast";
+import { showErrorToast, showInfoToast } from "@/lib/toast";
 import { draftVersionId } from "@/lib/draftVersion";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import type { CanvasPageHeaderMode } from "./viewState";
 import { isCanvasWorkflowTab } from "./viewState";
 import { isDraftVersion } from "./lib/canvas-versions";
-import { fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
+import { canvasVersionExists, fetchCanvasVersionWithSpec } from "./lib/repository-spec-files";
+import { isNotFoundError } from "./workflowPageHelpers";
 
 type AgentDraftOpenSource = "auto" | "button";
 type AgentDraftOpenResult = "opened" | "skipped" | "unavailable";
-type LoadAgentDraftVersion = (versionId: string) => Promise<CanvasesCanvasVersion | null>;
+// `notFound` distinguishes a genuinely-deleted draft from a transient load
+// failure, so only the former clears the active ref.
+type LoadAgentDraftResult = { version: CanvasesCanvasVersion | null; notFound: boolean };
+type LoadAgentDraftVersion = (versionId: string) => Promise<LoadAgentDraftResult>;
 
 const autoOpenedAgentDraftKeys = new Set<string>();
 
@@ -29,6 +33,9 @@ type UseAgentDraftEditorArgs = {
   activeCanvasVersionIdRef: { current: string };
   activateCanvasVersionForEditing: (versionId: string, version: CanvasesCanvasVersion) => boolean;
   setSuppressUnpublishedDraftDiscard: (value: boolean) => void;
+  // Full recovery (clears state + ref, exits to live) when the draft the user is
+  // actively editing turns out to be deleted.
+  onActiveDraftMissing: (versionId: string) => void | Promise<void>;
 };
 
 function useLoadAgentDraftVersion(
@@ -37,21 +44,38 @@ function useLoadAgentDraftVersion(
 ): LoadAgentDraftVersion {
   const queryClient = useQueryClient();
 
+  // Drop a deleted draft id from the cached lists so it stops being offered.
+  const pruneDeadDraft = useCallback(
+    (versionId: string) => {
+      if (!canvasId) {
+        return;
+      }
+      queryClient.setQueryData<CanvasesCanvasVersion[]>(canvasKeys.draftBranches(canvasId), (current = []) =>
+        current.filter((branch) => draftVersionId(branch) !== versionId),
+      );
+      queryClient.setQueryData<CanvasesCanvasVersion[]>(canvasKeys.versionList(canvasId), (current = []) =>
+        current.filter((version) => version.metadata?.id !== versionId),
+      );
+    },
+    [canvasId, queryClient],
+  );
+
   return useCallback(
-    async (versionId: string): Promise<CanvasesCanvasVersion | null> => {
+    async (versionId: string): Promise<LoadAgentDraftResult> => {
       const cachedVersion = selectableVersionsById.get(versionId);
       if (cachedVersion) {
-        return cachedVersion;
+        return { version: cachedVersion, notFound: false };
       }
 
       if (!canvasId) {
-        return null;
+        return { version: null, notFound: false };
       }
 
       try {
         const loadedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId);
         if (!loadedVersion?.metadata?.id) {
-          return null;
+          pruneDeadDraft(versionId);
+          return { version: null, notFound: true };
         }
 
         queryClient.setQueryData<CanvasesCanvasVersion>(canvasKeys.versionDetail(canvasId, versionId), loadedVersion);
@@ -71,13 +95,20 @@ function useLoadAgentDraftVersion(
           });
         }
 
-        return loadedVersion;
-      } catch {
+        return { version: loadedVersion, notFound: false };
+      } catch (error) {
+        // fetchCanvasVersionWithSpec loads the version and its canvas.yaml in
+        // parallel, so a 404 may come from the file, not a deleted version.
+        // Only treat it as a missing draft once the version itself is gone.
+        if (isNotFoundError(error) && !(await canvasVersionExists(canvasId, versionId))) {
+          pruneDeadDraft(versionId);
+          return { version: null, notFound: true };
+        }
         showErrorToast("Failed to load draft version");
-        return null;
+        return { version: null, notFound: false };
       }
     },
-    [canvasId, queryClient, selectableVersionsById],
+    [canvasId, pruneDeadDraft, queryClient, selectableVersionsById],
   );
 }
 
@@ -137,9 +168,31 @@ export function useAgentDraftEditor({
   activeCanvasVersionIdRef,
   activateCanvasVersionForEditing,
   setSuppressUnpublishedDraftDiscard,
+  onActiveDraftMissing,
 }: UseAgentDraftEditorArgs) {
   const [pendingAutoOpenVersionId, setPendingAutoOpenVersionId] = useState<string | null>(null);
   const loadAgentDraftVersion = useLoadAgentDraftVersion(canvasId, selectableVersionsById);
+
+  const handleMissingDraft = useCallback(
+    (versionId: string, source: AgentDraftOpenSource, notFound: boolean): AgentDraftOpenResult => {
+      // A transient load failure already toasted; don't clear state unless the
+      // draft is actually gone.
+      if (!notFound) {
+        return "unavailable";
+      }
+      // If the deleted draft is the one being edited, run full recovery — just
+      // clearing the ref would be undone by the ref<-state sync effect.
+      if (activeCanvasVersionIdRef.current === versionId) {
+        void onActiveDraftMissing(versionId);
+        return "unavailable";
+      }
+      if (source === "button") {
+        showInfoToast("This draft no longer exists.");
+      }
+      return "unavailable";
+    },
+    [activeCanvasVersionIdRef, onActiveDraftMissing],
+  );
 
   const openAgentDraftVersion = useCallback(
     async (versionId: string, source: AgentDraftOpenSource): Promise<AgentDraftOpenResult> => {
@@ -168,10 +221,9 @@ export function useAgentDraftEditor({
         }
       }
 
-      const version = await loadAgentDraftVersion(versionId);
+      const { version, notFound } = await loadAgentDraftVersion(versionId);
       if (!version) {
-        showErrorToast("Draft version not found");
-        return "unavailable";
+        return handleMissingDraft(versionId, source, notFound);
       }
 
       if (!isDraftVersion(version)) {
@@ -185,6 +237,7 @@ export function useAgentDraftEditor({
     [
       activateCanvasVersionForEditing,
       activeCanvasVersionIdRef,
+      handleMissingDraft,
       hasEditableVersion,
       hasPendingLocalCanvasState,
       headerMode,

--- a/web_src/src/pages/app/useDraftRecovery.ts
+++ b/web_src/src/pages/app/useDraftRecovery.ts
@@ -1,0 +1,182 @@
+import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import type { useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { showErrorToast, showInfoToast, showSuccessToast } from "@/lib/toast";
+import { getApiErrorMessage } from "@/lib/errors";
+import { getUsageLimitToastMessage } from "@/lib/usageLimits";
+import { ensureDraftVersionExists } from "@/hooks/useCanvasData";
+
+import { clearPublishedDraftVersion } from "./lib/draft-spec-cache";
+import { clearComponentSidebarSearchParams } from "./viewState";
+import { isNotFoundError } from "./workflowPageHelpers";
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+type SetSearchParams = ReturnType<typeof useSearchParams>[1];
+type CommitMutation = { mutateAsync: () => Promise<unknown> };
+type PublishMutation = { mutateAsync: (versionId: string) => Promise<unknown> };
+
+type UseDraftRecoveryOptions = {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionId: string;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  exitToLive: () => void;
+  setSearchParams: SetSearchParams;
+  refreshLatestLiveCanvasData: () => Promise<void>;
+  cancelPendingCanvasSaves?: () => void;
+  ensureVersionActionDraftReady: (errorMessage: string) => Promise<boolean>;
+  commitCanvasStagingMutation: CommitMutation;
+  publishCanvasVersionMutation: PublishMutation;
+  consoleMutationGenerationRef: MutableRefObject<number>;
+  setIsPreparingVersionAction: Dispatch<SetStateAction<boolean>>;
+};
+
+// Owns the draft publish + exit-to-live + recovery lifecycle, guarding publish
+// against a draft that was deleted out from under it so a stale id can't strand
+// the UI on a "version not found" error.
+export function useDraftRecovery({
+  organizationId,
+  canvasId,
+  activeCanvasVersionId,
+  activeCanvasVersionIdRef,
+  draftCanvasSpecsRef,
+  setActiveCanvasVersion,
+  setDraftCanvasSpec,
+  exitToLive,
+  setSearchParams,
+  refreshLatestLiveCanvasData,
+  cancelPendingCanvasSaves,
+  ensureVersionActionDraftReady,
+  commitCanvasStagingMutation,
+  publishCanvasVersionMutation,
+  consoleMutationGenerationRef,
+  setIsPreparingVersionAction,
+}: UseDraftRecoveryOptions) {
+  const queryClient = useQueryClient();
+
+  // Shared by publish-success and missing-draft recovery so both end identically.
+  const exitDraftToLive = useCallback(
+    async (versionId: string) => {
+      activeCanvasVersionIdRef.current = "";
+      if (versionId) {
+        clearPublishedDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, versionId);
+      }
+      exitToLive();
+      setSearchParams((current) => {
+        const next = new URLSearchParams(current);
+        next.delete("version");
+        next.delete("branch");
+        return clearComponentSidebarSearchParams(next);
+      });
+      await refreshLatestLiveCanvasData();
+    },
+    [
+      activeCanvasVersionIdRef,
+      draftCanvasSpecsRef,
+      exitToLive,
+      refreshLatestLiveCanvasData,
+      setActiveCanvasVersion,
+      setDraftCanvasSpec,
+      setSearchParams,
+    ],
+  );
+
+  // Recoverable state, not a fatal error: return to live with an info toast.
+  const recoverFromMissingDraft = useCallback(
+    async (versionId: string, message = "This draft no longer exists. Returned to the live canvas.") => {
+      cancelPendingCanvasSaves?.();
+      await exitDraftToLive(versionId);
+      // Informational, not a hard failure — the user was cleanly returned to live.
+      showInfoToast(message);
+    },
+    [cancelPendingCanvasSaves, exitDraftToLive],
+  );
+
+  // A NOT_FOUND can also come from unrelated resources (e.g. repository not
+  // found) while the draft still exists, so only recover once the draft itself
+  // is confirmed gone. Returns whether the error was handled as a missing draft.
+  const recoverIfDraftMissing = useCallback(
+    async (error: unknown, versionId: string): Promise<boolean> => {
+      if (!isNotFoundError(error) || !organizationId || !canvasId || !versionId) {
+        return false;
+      }
+      // On a failed existence check, treat the draft as present so the caller
+      // surfaces its normal error instead of an unhandled rejection.
+      const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionId).catch(
+        () => true,
+      );
+      if (draftExists) {
+        return false;
+      }
+      await recoverFromMissingDraft(versionId);
+      return true;
+    },
+    [organizationId, canvasId, queryClient, recoverFromMissingDraft],
+  );
+
+  const handlePublishVersion = useCallback(async () => {
+    if (!organizationId || !canvasId || !activeCanvasVersionId) {
+      return;
+    }
+
+    let versionIdToPublish = "";
+    setIsPreparingVersionAction(true);
+    try {
+      const isReady = await ensureVersionActionDraftReady(
+        "Unable to prepare the latest version changes for publishing",
+      );
+      if (!isReady) {
+        return;
+      }
+
+      // Read the ref only after prepare settles — the user may have left draft
+      // mode while saves were still being flushed.
+      versionIdToPublish = activeCanvasVersionIdRef.current;
+      if (!versionIdToPublish) {
+        return;
+      }
+
+      const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionIdToPublish);
+      if (!draftExists) {
+        await recoverFromMissingDraft(versionIdToPublish);
+        return;
+      }
+
+      // Flush staged edits into the committed row before promoting it to live.
+      consoleMutationGenerationRef.current += 1;
+      await commitCanvasStagingMutation.mutateAsync();
+      await publishCanvasVersionMutation.mutateAsync(versionIdToPublish);
+      await exitDraftToLive(versionIdToPublish);
+      showSuccessToast("Version published");
+    } catch (error) {
+      // The draft can be deleted between the pre-check and the mutation.
+      if (await recoverIfDraftMissing(error, versionIdToPublish)) {
+        return;
+      }
+      showErrorToast(getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to publish version")));
+    } finally {
+      setIsPreparingVersionAction(false);
+    }
+  }, [
+    organizationId,
+    canvasId,
+    activeCanvasVersionId,
+    activeCanvasVersionIdRef,
+    ensureVersionActionDraftReady,
+    queryClient,
+    consoleMutationGenerationRef,
+    commitCanvasStagingMutation,
+    publishCanvasVersionMutation,
+    setIsPreparingVersionAction,
+    exitDraftToLive,
+    recoverFromMissingDraft,
+    recoverIfDraftMissing,
+  ]);
+
+  return { handlePublishVersion, recoverFromMissingDraft, recoverIfDraftMissing };
+}

--- a/web_src/src/pages/app/useDraftStagingActions.ts
+++ b/web_src/src/pages/app/useDraftStagingActions.ts
@@ -28,6 +28,9 @@ type UseDraftStagingActionsOptions = {
   flushRepositoryFileStaging?: () => Promise<void>;
   cancelPendingCanvasSaves?: () => void;
   onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
+  // Recovers from a deleted draft when a mutation fails; returns whether it
+  // handled the error (only true when the draft is confirmed gone).
+  recoverIfDraftMissing?: (error: unknown, versionId: string) => Promise<boolean>;
 };
 
 async function restoreCommittedCanvasDraftState({
@@ -93,6 +96,7 @@ export function useDraftStagingActions({
   flushRepositoryFileStaging,
   cancelPendingCanvasSaves,
   onCanvasDraftRestoredToCommitted,
+  recoverIfDraftMissing,
 }: UseDraftStagingActionsOptions) {
   const queryClient = useQueryClient();
 
@@ -117,6 +121,9 @@ export function useDraftStagingActions({
       setStagingResetNonce((nonce) => nonce + 1);
       showSuccessToast("Changes committed");
     } catch (error) {
+      if (await recoverIfDraftMissing?.(error, activeCanvasVersionId)) {
+        return;
+      }
       showErrorToast(getApiErrorMessage(error, "Failed to commit changes"));
     } finally {
       setIsPreparingVersionAction(false);
@@ -130,6 +137,7 @@ export function useDraftStagingActions({
     ensureVersionActionDraftReady,
     flushRepositoryFileStaging,
     hasEditableVersion,
+    recoverIfDraftMissing,
     queryClient,
     setDraftCanvasSpec,
     setIsPreparingVersionAction,
@@ -160,6 +168,9 @@ export function useDraftStagingActions({
       setStagingResetNonce((nonce) => nonce + 1);
       showSuccessToast("Reverted to last commit");
     } catch (error) {
+      if (await recoverIfDraftMissing?.(error, activeCanvasVersionId)) {
+        return;
+      }
       showErrorToast(getApiErrorMessage(error, "Failed to reset staged changes"));
     } finally {
       setIsPreparingVersionAction(false);
@@ -173,6 +184,7 @@ export function useDraftStagingActions({
     draftCanvasSpecsRef,
     hasEditableVersion,
     onCanvasDraftRestoredToCommitted,
+    recoverIfDraftMissing,
     organizationId,
     queryClient,
     setActiveCanvasVersion,

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -225,8 +225,12 @@ function readErrorField(error: unknown, key: string): unknown {
   return (error as Record<string, unknown>)[key];
 }
 
-/** True when a canvas fetch failed because the canvas does not exist. */
-export function isCanvasLoadNotFoundError(error: unknown): boolean {
+/**
+ * True when an API call failed because the targeted resource does not exist
+ * (HTTP 404 / gRPC NOT_FOUND / "not found" message). Used to turn a stale
+ * draft-version id into a graceful recovery instead of an opaque error.
+ */
+export function isNotFoundError(error: unknown): boolean {
   if (readErrorField(error, "status") === 404) {
     return true;
   }
@@ -246,4 +250,9 @@ export function isCanvasLoadNotFoundError(error: unknown): boolean {
   }
 
   return message.includes("not found") || message.includes("404");
+}
+
+/** True when a canvas fetch failed because the canvas does not exist. */
+export function isCanvasLoadNotFoundError(error: unknown): boolean {
+  return isNotFoundError(error);
 }


### PR DESCRIPTION
Closes #5464

## What
Publishing or committing against a draft that no longer exists — deleted by the agent, another browser tab, or the user — returned a **"version not found"** 404 with no recovery, leaving the canvas/console commit state desynced and every retry failing.

## Changes
- **`ensureDraftVersionExists`** (`useCanvasData.ts`) — refetches draft branches to validate a draft id before commit/publish.
- **`isNotFoundError`** (`workflowPageHelpers.ts`) — generic 404/NOT_FOUND detection; `isCanvasLoadNotFoundError` delegates to it.
- **`useDraftRecovery`** (new) — owns the publish + exit-to-live + recovery lifecycle; publish-success and missing-draft recovery share one path (clear stale ref/spec/URL params → return to live).
- Commit/reset (`useDraftStagingActions`) and the agent draft opener (`useAgentDraftEditor`) detect NotFound and recover/prune the dead id instead of erroring.

Pre-check + a catch branch cover the delete-between-check-and-mutation race. A recovered miss shows an informational toast, not the fatal red error.

## Tests
`useCanvasData.spec.ts` — `ensureDraftVersionExists` present / absent / missing-args.

## Notes
Frontend-only. The agent backend already self-heals (re-resolves/recreates the draft per tool call) — this fixes the UI side that stranded on a stale id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)