### PR TITLE
feat(agent): surface async agent activity in the chat

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -825,10 +825,14 @@ func TestStreamEvents_SessionErrorDoesNotStopStream(t *testing.T) {
 		return nil
 	}))
 
-	require.Len(t, received, 2)
-	assert.Equal(t, agents.ProviderEventAssistantMessage, received[0].Type)
-	assert.Equal(t, "Recovered", received[0].Text)
-	assert.Equal(t, agents.ProviderEventTurnCompleted, received[1].Type)
+	// session.error surfaces as a non-terminal notice; the stream keeps going
+	// and the recovered assistant message + turn completion still arrive.
+	require.Len(t, received, 3)
+	assert.Equal(t, agents.ProviderEventSessionNotice, received[0].Type)
+	assert.Equal(t, "An internal service error occurred", received[0].ErrorMessage)
+	assert.Equal(t, agents.ProviderEventAssistantMessage, received[1].Type)
+	assert.Equal(t, "Recovered", received[1].Text)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[2].Type)
 }
 
 func TestStreamEvents_SkipsMalformed(t *testing.T) {

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -61,9 +61,9 @@ func mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
 	case "session.status_terminated":
 		return sessionFailedEvent(raw), true
 	case "session.error":
-		// Managed Agents can emit recoverable internal errors and keep the
-		// session running; only status_terminated is terminal for us.
-		return agents.ProviderEvent{}, false
+		// Recoverable error: surface a notice but keep streaming. Only
+		// status_terminated is terminal.
+		return sessionNoticeEvent(raw), true
 	case "span.outcome_evaluation_start":
 		return outcomeEvaluationStartEvent(raw), true
 	case "agent.thread_message_sent":
@@ -135,6 +135,17 @@ func sessionFailedEvent(raw anthropicEvent) agents.ProviderEvent {
 	return agents.ProviderEvent{
 		Type:         agents.ProviderEventSessionFailed,
 		ErrorMessage: msg,
+	}
+}
+
+func sessionNoticeEvent(raw anthropicEvent) agents.ProviderEvent {
+	msg := "the agent hit a recoverable error and is retrying"
+	if raw.Error != nil && raw.Error.Message != "" {
+		msg = raw.Error.Message
+	}
+	return agents.ProviderEvent{
+		Type:         agents.ProviderEventSessionNotice,
+		ErrorMessage: redactSensitive(msg),
 	}
 }
 

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -18,10 +18,12 @@ const (
 	ProviderEventCustomToolResultsRequired ProviderEventType = "custom_tool_results_required"
 	ProviderEventTurnCompleted             ProviderEventType = "turn_completed"
 	ProviderEventSessionFailed             ProviderEventType = "session_failed"
-	ProviderEventOutcomeEvaluation         ProviderEventType = "outcome_evaluation"
-	ProviderEventOutcomeEvaluationStart    ProviderEventType = "outcome_evaluation_start"
-	ProviderEventThreadMessageSent         ProviderEventType = "thread_message_sent"
-	ProviderEventThreadMessageReceived     ProviderEventType = "thread_message_received"
+	// Recoverable provider error; the session keeps running.
+	ProviderEventSessionNotice          ProviderEventType = "session_notice"
+	ProviderEventOutcomeEvaluation      ProviderEventType = "outcome_evaluation"
+	ProviderEventOutcomeEvaluationStart ProviderEventType = "outcome_evaluation_start"
+	ProviderEventThreadMessageSent      ProviderEventType = "thread_message_sent"
+	ProviderEventThreadMessageReceived  ProviderEventType = "thread_message_received"
 )
 
 type ProviderEvent struct {

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -473,6 +473,9 @@ func handleProviderEvent(
 		return persistSubagentEvent(sessionID, evt, models.AgentToolStatusStarted, "tool_started", publish)
 	case agents.ProviderEventThreadMessageReceived:
 		return persistSubagentEvent(sessionID, evt, models.AgentToolStatusFinished, "tool_finished", publish)
+	case agents.ProviderEventSessionNotice:
+		// Ephemeral notice: no status change, no DB row, stream continues.
+		publish(messages.AgentSessionEventMessage{Event: "session_notice", Error: evt.ErrorMessage})
 	case agents.ProviderEventSessionFailed:
 		// Don't publish here — the post-loop block owns
 		// session_failed broadcasting so it stays single-source.

--- a/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentConversationTranscript.tsx
@@ -12,6 +12,7 @@ const STICKY_USER_MESSAGE_MAX_LINES = 4;
 
 export const ConversationTranscript = memo(function ConversationTranscript({
   error,
+  notice,
   canvasId,
   organizationId,
   messageGroups,
@@ -23,6 +24,7 @@ export const ConversationTranscript = memo(function ConversationTranscript({
   showThinking,
 }: {
   error: string | null;
+  notice?: string | null;
   canvasId: string;
   organizationId: string;
   messageGroups: MessageGroup[];
@@ -64,6 +66,7 @@ export const ConversationTranscript = memo(function ConversationTranscript({
           </>
         )}
         {showThinking ? <ThinkingRow /> : null}
+        {notice ? <p className="px-3 py-2 text-sm text-amber-600">{notice}</p> : null}
         {error ? <p className="px-3 py-2 text-sm text-red-600">{error}</p> : null}
       </div>
     </div>
@@ -279,13 +282,31 @@ function truncateQuestion(question: string): string {
   return question.length > 200 ? `${question.slice(0, 200)}…` : question;
 }
 
+// The `superplane_app` tool's `update_draft` action edits the canvas — label it
+// "Editing canvas" rather than a generic "Running command".
+function isCanvasEditMessage(message: AgentMessage): boolean {
+  if (message.toolName !== "superplane_app") return false;
+  try {
+    return (JSON.parse(message.content) as { action?: string })?.action === "update_draft";
+  } catch {
+    return message.content.includes("update_draft");
+  }
+}
+
 function ToolGroupRow({ messages }: { messages: AgentMessage[] }) {
   const hasRunning = messages.some((message) => message.toolStatus === "started");
+  const editRunning = messages.some((message) => message.toolStatus === "started" && isCanvasEditMessage(message));
+  const editedAny = messages.some(isCanvasEditMessage);
   const [expanded, setExpanded] = useState(hasRunning);
   const count = messages.length;
-  const label = hasRunning
-    ? `Running command${count > 1 ? ` (${count})` : ""}...`
-    : `Ran ${count} command${count !== 1 ? "s" : ""}`;
+  let label: string;
+  if (hasRunning) {
+    // Only call it "Editing canvas" when an edit is the tool actually running,
+    // so a finished edit next to another running tool isn't mislabeled.
+    label = editRunning ? "Editing canvas…" : `Running command${count > 1 ? ` (${count})` : ""}...`;
+  } else {
+    label = editedAny ? "Edited canvas" : `Ran ${count} command${count !== 1 ? "s" : ""}`;
+  }
 
   useEffect(() => {
     setExpanded(hasRunning);

--- a/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/AgentTabPanel.tsx
@@ -117,6 +117,7 @@ function ChatConversation({
   const outcomeMutation = useDefineAgentOutcome(organizationId);
   const [status, setStatus] = useState<string>(initialStatus || "idle");
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [outcomeState, setOutcomeState] = useStoredOutcomeState(chatId);
   const rawMessages = useConversationMessages(messagesQuery.data);
   const { account } = useContext(AccountContext);
@@ -165,10 +166,14 @@ function ChatConversation({
     interruptMutation,
     sendMutation,
     setError,
+    setNotice,
     setOutcomeState,
   });
 
-  const wsCallbacks = useMemo(() => createWebsocketCallbacks(setStatus, setError, setOutcomeState), [setOutcomeState]);
+  const wsCallbacks = useMemo(
+    () => createWebsocketCallbacks(setStatus, setError, setOutcomeState, setNotice),
+    [setOutcomeState],
+  );
   useAgentSessionWebsocket(chatId, organizationId, wsCallbacks);
 
   const scrollRef = useChatScroll(messagesQuery, chatId, messages.length, showThinking);
@@ -181,6 +186,7 @@ function ChatConversation({
     <div className="flex min-h-0 flex-1 flex-col">
       <ConversationTranscript
         error={error}
+        notice={notice}
         canvasId={canvasId}
         organizationId={organizationId}
         messageGroups={messageGroups}
@@ -295,6 +301,7 @@ function useConversationHandlers({
   interruptMutation,
   sendMutation,
   setError,
+  setNotice,
   setOutcomeState: _setOutcomeState,
 }: {
   agentMode: AgentMode;
@@ -303,6 +310,7 @@ function useConversationHandlers({
   interruptMutation: ReturnType<typeof useInterruptAgentChat>;
   sendMutation: ReturnType<typeof useSendAgentChatMessage>;
   setError: (value: string | null) => void;
+  setNotice: (value: string | null) => void;
   setOutcomeState: (update: OutcomeState | null | ((prev: OutcomeState | null) => OutcomeState | null)) => void;
 }): ConversationHandlers {
   // React Query mutation objects are new on every render; keep latest refs in
@@ -316,12 +324,13 @@ function useConversationHandlers({
       const { sendMutation: send } = mutationsRef.current;
       if (!content.trim() || send.isPending) return;
       setError(null);
+      setNotice(null);
       await send.mutateAsync({ chatId, content, mode: agentMode }).catch((error) => {
         setError(error instanceof Error ? error.message : "failed to send message");
         throw error;
       });
     },
-    [agentMode, chatId, setError],
+    [agentMode, chatId, setError, setNotice],
   );
 
   const handleStop = useCallback(() => {

--- a/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
+++ b/web_src/src/components/CanvasToolSidebar/agentConversationState.ts
@@ -88,6 +88,7 @@ export function createWebsocketCallbacks(
   setStatus: (value: string) => void,
   setError: (value: string | null) => void,
   setOutcomeState: (update: OutcomeState | null | ((prev: OutcomeState | null) => OutcomeState | null)) => void,
+  setNotice?: (value: string | null) => void,
 ) {
   return {
     onPersistedMessage: (message: AgentMessage) => {
@@ -98,6 +99,10 @@ export function createWebsocketCallbacks(
     onStatusChange: (next: string, error?: string) => {
       setStatus(next || "idle");
       setError(error ?? null);
+      setNotice?.(null); // turn boundary clears any stale notice
+    },
+    onNotice: (message: string) => {
+      setNotice?.(message || "The agent hit a recoverable error and is retrying.");
     },
     onOutcomeEvent: (phase: "start" | "end", evaluation: OutcomeEvaluationPayload) => {
       setOutcomeState((prev) => {

--- a/web_src/src/components/CanvasToolSidebar/types.ts
+++ b/web_src/src/components/CanvasToolSidebar/types.ts
@@ -34,6 +34,11 @@ export type AgentSessionWebsocketEvent =
     }
   | {
       sessionId: string;
+      event: "session_notice";
+      error?: string;
+    }
+  | {
+      sessionId: string;
       event: "outcome_evaluation_start" | "outcome_evaluation_end";
       extra?: {
         iteration?: number;

--- a/web_src/src/hooks/useAgentSessionWebsocket.spec.ts
+++ b/web_src/src/hooks/useAgentSessionWebsocket.spec.ts
@@ -187,6 +187,15 @@ describe("useAgentSessionWebsocket", () => {
     expect(onStatus).toHaveBeenNthCalledWith(3, "failed", "boom");
   });
 
+  it("forwards a session_notice to onNotice without changing status", () => {
+    const onNotice = vi.fn();
+    const onStatus = vi.fn();
+    render({ onNotice, onStatusChange: onStatus });
+    emit("session_notice", { sessionId: "session-1", error: "transient provider error" });
+    expect(onNotice).toHaveBeenCalledWith("transient provider error");
+    expect(onStatus).not.toHaveBeenCalled();
+  });
+
   it("ignores malformed payloads without crashing", () => {
     const onPersisted = vi.fn();
     render({ onPersistedMessage: onPersisted });

--- a/web_src/src/hooks/useAgentSessionWebsocket.ts
+++ b/web_src/src/hooks/useAgentSessionWebsocket.ts
@@ -29,6 +29,9 @@ function dispatchAgentEvent(
     case "session_failed":
       handleStatusEvent(data, callbacks);
       return;
+    case "session_notice":
+      callbacks.onNotice?.(data.error ?? "");
+      return;
     case "outcome_evaluation_start":
     case "outcome_evaluation_end":
       handleOutcomeEvent(data, callbacks);
@@ -81,6 +84,8 @@ export type AgentStreamCallbacks = {
   onPersistedMessage?: (message: AgentMessage) => void;
   onStatusChange?: (status: string, error?: string) => void;
   onOutcomeEvent?: (event: "start" | "end", evaluation: OutcomeEvaluation) => void;
+  /** A recoverable, non-terminal provider notice (session.error). */
+  onNotice?: (message: string) => void;
 };
 
 export function useAgentSessionWebsocket(


### PR DESCRIPTION
Closes #5465

## What
Agent activity was a binary `streaming`/`idle` state, and recoverable provider errors (`session.error`) were silently dropped — users couldn't tell what the agent was doing or when it hit a transient hiccup.

## Changes
**Backend**
- New non-terminal `ProviderEventSessionNotice`. `session.error` (previously dropped in `anthropic/events.go`) now maps to it; `session.status_terminated` stays the only terminal path.
- The stream worker publishes a `session_notice` event **without** changing session status, persisting a DB row, or stopping the stream.

**Frontend**
- `session_notice` flows through the WS hook to a transient **amber** inline notice, distinct from the fatal red error, auto-cleared on the next turn boundary.
- The agent's `superplane_app` `update_draft` tool calls now render as **"Editing canvas"** instead of "Running command".

## Tests
- `anthropic_test.go` — `session.error` emits one `session_notice` and the stream continues.
- `useAgentSessionWebsocket.spec.ts` — `session_notice` dispatches to `onNotice` without touching status.

## Notes
Backend Go build/tests couldn't run in my environment because the branch's generated protobuf/swagger is stale (pre-existing, unrelated) — run `make gen` then `go test ./pkg/agents/... ./pkg/workers/...` to exercise the new mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)