### PR TITLE
fix: canvas edit-mode staging bugs (cross-tab sync, diff badge, commit flash, changeManagement diff)

### DIFF
--- a/pkg/grpc/actions/canvases/apply_canvas_auto_layout.go
+++ b/pkg/grpc/actions/canvases/apply_canvas_auto_layout.go
@@ -87,5 +87,7 @@ func ApplyCanvasAutoLayout(
 		return nil, err
 	}
 
+	publishStagingUpdated(canvas.ID, version.ID)
+
 	return &pb.ApplyCanvasAutoLayoutResponse{StagingSummary: state}, nil
 }

--- a/pkg/grpc/actions/canvases/discard_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/discard_canvas_staging.go
@@ -16,7 +16,7 @@ func DiscardCanvasStaging(
 	versionID string,
 	paths []string,
 ) (*pb.DiscardCanvasStagingResponse, error) {
-	_, version, _, err := loadOwnedDraftVersion(ctx, organizationID, canvasID, versionID)
+	canvas, version, _, err := loadOwnedDraftVersion(ctx, organizationID, canvasID, versionID)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +29,8 @@ func DiscardCanvasStaging(
 	if err != nil {
 		return nil, err
 	}
+
+	publishStagingUpdated(canvas.ID, version.ID)
 
 	return &pb.DiscardCanvasStagingResponse{StagingSummary: state}, nil
 }

--- a/pkg/grpc/actions/canvases/workflow_staging.go
+++ b/pkg/grpc/actions/canvases/workflow_staging.go
@@ -6,14 +6,25 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 )
+
+// publishStagingUpdated notifies other tabs/replicas that a draft version's
+// staging layer changed so they can refetch staged caches. Failures are logged
+// but never block the staging write.
+func publishStagingUpdated(canvasID, versionID uuid.UUID) {
+	if err := messages.NewCanvasVersionUpdatedMessage(canvasID.String(), versionID.String()).PublishStagingUpdated(); err != nil {
+		log.Errorf("failed to publish canvas staging updated RabbitMQ message: %v", err)
+	}
+}
 
 // loadOwnedDraftVersion resolves the canvas and draft version for a staging
 // write/commit/discard, enforcing that the caller owns the registered draft.
@@ -184,6 +195,8 @@ func StageRepositorySpecFileOperations(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to load staging: %v", err)
 	}
+
+	publishStagingUpdated(canvas.ID, version.ID)
 
 	return buildStagingSummary(version.ID, rows), nil
 }

--- a/pkg/grpc/actions/messages/canvas.go
+++ b/pkg/grpc/actions/messages/canvas.go
@@ -9,6 +9,7 @@ const (
 	CanvasCreatedRoutingKey        = "canvas-created"
 	CanvasUpdatedRoutingKey        = "canvas-updated"
 	CanvasVersionUpdatedRoutingKey = "canvas-version-updated"
+	CanvasStagingUpdatedRoutingKey = "canvas-staging-updated"
 	CanvasDeletedRoutingKey        = "canvas-deleted"
 )
 
@@ -77,4 +78,8 @@ func (m CanvasMessage) PublishDeleted() error {
 
 func (m CanvasVersionMessage) PublishVersionUpdated() error {
 	return Publish(CanvasExchange, CanvasVersionUpdatedRoutingKey, toBytes(m.message))
+}
+
+func (m CanvasVersionMessage) PublishStagingUpdated() error {
+	return Publish(CanvasExchange, CanvasStagingUpdatedRoutingKey, toBytes(m.message))
 }

--- a/pkg/workers/event_distributer.go
+++ b/pkg/workers/event_distributer.go
@@ -60,6 +60,7 @@ func (e *EventDistributer) Start() error {
 		{messages.CanvasExchange, messages.CanvasQueueItemConsumedRoutingKey, e.createHandler(eventdistributer.HandleQueueItemConsumed)},
 		{messages.CanvasExchange, messages.CanvasUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasUpdated)},
 		{messages.CanvasExchange, messages.CanvasVersionUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasVersionUpdated)},
+		{messages.CanvasExchange, messages.CanvasStagingUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasStagingUpdated)},
 		{messages.CanvasExchange, messages.CanvasDeletedRoutingKey, e.createHandler(eventdistributer.HandleCanvasDeleted)},
 		{messages.CanvasExchange, messages.AgentSessionEventRoutingKey, e.createHandler(eventdistributer.HandleAgentSessionEvent)},
 	}

--- a/pkg/workers/eventdistributer/canvas.go
+++ b/pkg/workers/eventdistributer/canvas.go
@@ -13,6 +13,7 @@ import (
 const (
 	CanvasUpdatedEvent        = "canvas_updated"
 	CanvasVersionUpdatedEvent = "canvas_version_updated"
+	CanvasStagingUpdatedEvent = "staging_updated"
 	CanvasDeletedEvent        = "canvas_deleted"
 )
 
@@ -36,21 +37,29 @@ func HandleCanvasDeleted(messageBody []byte, wsHub *ws.Hub) error {
 }
 
 func HandleCanvasVersionUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	return handleCanvasVersion(messageBody, wsHub, CanvasVersionUpdatedEvent)
+}
+
+func HandleCanvasStagingUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	return handleCanvasVersion(messageBody, wsHub, CanvasStagingUpdatedEvent)
+}
+
+func handleCanvasVersion(messageBody []byte, wsHub *ws.Hub, eventName string) error {
 	pbMsg := &pb.CanvasVersionMessage{}
 	if err := proto.Unmarshal(messageBody, pbMsg); err != nil {
-		return fmt.Errorf("failed to unmarshal %s message: %w", CanvasVersionUpdatedEvent, err)
+		return fmt.Errorf("failed to unmarshal %s message: %w", eventName, err)
 	}
 
 	if pbMsg.CanvasId == "" {
-		return fmt.Errorf("missing canvas id in %s message", CanvasVersionUpdatedEvent)
+		return fmt.Errorf("missing canvas id in %s message", eventName)
 	}
 
 	if pbMsg.VersionId == "" {
-		return fmt.Errorf("missing version id in %s message", CanvasVersionUpdatedEvent)
+		return fmt.Errorf("missing version id in %s message", eventName)
 	}
 
 	wsEvent, err := json.Marshal(CanvasStateWebsocketEvent{
-		Event: CanvasVersionUpdatedEvent,
+		Event: eventName,
 		Payload: CanvasStatePayload{
 			ID:        pbMsg.CanvasId,
 			CanvasID:  pbMsg.CanvasId,
@@ -58,11 +67,11 @@ func HandleCanvasVersionUpdated(messageBody []byte, wsHub *ws.Hub) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to marshal %s websocket event: %w", CanvasVersionUpdatedEvent, err)
+		return fmt.Errorf("failed to marshal %s websocket event: %w", eventName, err)
 	}
 
 	wsHub.BroadcastToWorkflow(pbMsg.CanvasId, wsEvent)
-	log.Debugf("Broadcasted %s event to workflow %s", CanvasVersionUpdatedEvent, pbMsg.CanvasId)
+	log.Debugf("Broadcasted %s event to workflow %s", eventName, pbMsg.CanvasId)
 
 	return nil
 }

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -2162,6 +2162,7 @@ export const useCommitCanvasStaging = (organizationId: string, canvasId: string,
       return response.data;
     },
     onSuccess: () => {
+      queryClient.setQueryData(canvasKeys.versionStaging(canvasId, versionId), { hasStaging: false, stagedPaths: [] });
       queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -55,6 +55,7 @@ import type {
   ComponentsPosition,
 } from "../api-client/types.gen";
 import { withOrganizationHeader } from "../lib/withOrganizationHeader";
+import { registerLocalStagingWrite } from "../lib/canvasStagingEcho";
 import { analytics } from "../lib/analytics";
 import { isPublishedVersion } from "../pages/app/lib/canvas-versions";
 import {
@@ -85,6 +86,7 @@ async function stageSpecOperations(
   versionId: string,
   operations: CanvasesCanvasRepositoryFileOperation[],
 ) {
+  registerLocalStagingWrite(canvasId, versionId);
   await canvasesStageCanvasRepositoryFile(
     withOrganizationHeader({
       path: { canvasId, versionId },
@@ -94,6 +96,7 @@ async function stageSpecOperations(
 }
 
 async function discardStagedPaths(canvasId: string, versionId: string, paths: string[]) {
+  registerLocalStagingWrite(canvasId, versionId);
   await canvasesDiscardCanvasStaging(
     withOrganizationHeader({
       path: { canvasId, versionId },
@@ -104,6 +107,7 @@ async function discardStagedPaths(canvasId: string, versionId: string, paths: st
 
 // applyCanvasStagingAutoLayout lays out the staged canvas.yaml and re-stages it.
 async function applyCanvasStagingAutoLayout(canvasId: string, versionId: string, autoLayout: SpecAutoLayout) {
+  registerLocalStagingWrite(canvasId, versionId);
   await canvasesApplyCanvasAutoLayout(
     withOrganizationHeader({
       path: { canvasId, versionId },
@@ -2136,6 +2140,7 @@ export const useCommitCanvasRepositoryFiles = (canvasId: string) => {
 export const useStageCanvasSpecFiles = (canvasId: string, versionId: string) => {
   return useMutation({
     mutationFn: async (operations: CanvasesCanvasRepositoryFileOperation[]) => {
+      registerLocalStagingWrite(canvasId, versionId);
       const response = await canvasesStageCanvasRepositoryFile(
         withOrganizationHeader({
           path: { canvasId, versionId },
@@ -2180,6 +2185,7 @@ export const useDiscardCanvasStaging = (organizationId: string, canvasId: string
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (paths?: string[]) => {
+      registerLocalStagingWrite(canvasId, versionId);
       const response = await canvasesDiscardCanvasStaging(
         withOrganizationHeader({
           path: { canvasId, versionId },
@@ -2209,6 +2215,7 @@ export const useStageRepositoryFiles = (canvasId: string, versionId: string) => 
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (operations: CanvasesCanvasRepositoryFileOperation[]) => {
+      registerLocalStagingWrite(canvasId, versionId);
       const response = await canvasesStageCanvasRepositoryFile(
         withOrganizationHeader({
           path: { canvasId, versionId },
@@ -2240,6 +2247,7 @@ export const useDiscardRepositoryFilePaths = (canvasId: string, versionId: strin
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (paths: string[]) => {
+      registerLocalStagingWrite(canvasId, versionId);
       const response = await canvasesDiscardCanvasStaging(
         withOrganizationHeader({
           path: { canvasId, versionId },

--- a/web_src/src/hooks/useCanvasDraftResync.ts
+++ b/web_src/src/hooks/useCanvasDraftResync.ts
@@ -1,0 +1,182 @@
+import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { fetchCanvasVersionWithSpec } from "@/pages/app/lib/repository-spec-files";
+import { syncCommittedCanvasDraftState } from "@/pages/app/lib/sync-committed-canvas-draft";
+
+import { canvasKeys } from "./useCanvasData";
+
+type CanvasSpec = CanvasesCanvas["spec"] | null;
+
+interface UseCanvasDraftResyncOptions {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasSpec>>;
+  consoleMutationGenerationRef: MutableRefObject<number>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<CanvasSpec>>;
+  setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
+  setHasUnsavedChanges: Dispatch<SetStateAction<boolean>>;
+  setHasNonPositionalUnsavedChanges: Dispatch<SetStateAction<boolean>>;
+  setStagingResetNonce: Dispatch<SetStateAction<number>>;
+}
+
+interface CanvasDraftResync {
+  resyncDraftToCommitted: (versionId: string) => Promise<void>;
+  resyncDraftToStaged: (versionId: string) => Promise<void>;
+}
+
+// Re-applies a draft version's effective spec (committed or staged) to the
+// active editor state after a remote change. The rendered graph reads React
+// state rather than a query cache, so only the actively-edited draft drives a
+// full re-apply; other branches just drop their cached spec so a later switch
+// refetches. Owned by a hook to keep this shared cross-tab sync logic out of
+// the AppPage component body.
+export function useCanvasDraftResync(options: UseCanvasDraftResyncOptions): CanvasDraftResync {
+  const {
+    organizationId,
+    canvasId,
+    activeCanvasVersionIdRef,
+    draftCanvasSpecsRef,
+    consoleMutationGenerationRef,
+    setDraftCanvasSpec,
+    setActiveCanvasVersion,
+    setLastSavedWorkflowSnapshot,
+    setHasUnsavedChanges,
+    setHasNonPositionalUnsavedChanges,
+    setStagingResetNonce,
+  } = options;
+  const queryClient = useQueryClient();
+
+  // Applies an already-loaded spec to the active draft and treats it as the
+  // saved baseline so it is not re-detected as a local edit (which would
+  // re-stage and echo back to the originating tab, creating a feedback loop).
+  const applyResyncedSpec = useCallback(
+    (versionId: string, spec: CanvasSpec) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      if (spec) {
+        draftCanvasSpecsRef.current.set(versionId, spec);
+      } else {
+        draftCanvasSpecsRef.current.delete(versionId);
+      }
+      setDraftCanvasSpec(spec);
+      setActiveCanvasVersion((current) =>
+        current?.metadata?.id === versionId ? { ...current, spec: spec ?? current.spec } : current,
+      );
+
+      const restored = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+      if (restored) {
+        setLastSavedWorkflowSnapshot(restored);
+      }
+      setHasUnsavedChanges(false);
+      setHasNonPositionalUnsavedChanges(false);
+    },
+    [
+      organizationId,
+      canvasId,
+      queryClient,
+      draftCanvasSpecsRef,
+      setDraftCanvasSpec,
+      setActiveCanvasVersion,
+      setLastSavedWorkflowSnapshot,
+      setHasUnsavedChanges,
+      setHasNonPositionalUnsavedChanges,
+    ],
+  );
+
+  // A remote `canvas_version_updated` (e.g. a CLI `apps canvas update`) commits
+  // canvas.yaml into the version row and discards the draft's staging. Refresh
+  // the committed/staged caches and clear the staging indicators so the UI does
+  // not keep showing stale "uncommitted changes" for content that no longer has
+  // any staging on the server.
+  const resyncDraftToCommitted = useCallback(
+    async (versionId: string) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
+
+      if (activeCanvasVersionIdRef.current !== versionId) {
+        draftCanvasSpecsRef.current.delete(versionId);
+        return;
+      }
+
+      consoleMutationGenerationRef.current += 1;
+      const committedVersion = await syncCommittedCanvasDraftState({
+        queryClient,
+        organizationId,
+        canvasId,
+        versionId,
+      });
+      applyResyncedSpec(versionId, committedVersion?.spec ?? null);
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) });
+      setStagingResetNonce((nonce) => nonce + 1);
+    },
+    [
+      organizationId,
+      canvasId,
+      queryClient,
+      activeCanvasVersionIdRef,
+      draftCanvasSpecsRef,
+      consoleMutationGenerationRef,
+      applyResyncedSpec,
+      setStagingResetNonce,
+    ],
+  );
+
+  // A remote `staging_updated` (another tab editing the same draft) changed the
+  // draft's staging layer without committing. The console/files caches and diff
+  // badge refresh through the websocket hook's invalidations, but the rendered
+  // graph reads React state, so the active draft needs its effective staged
+  // spec re-applied here.
+  const resyncDraftToStaged = useCallback(
+    async (versionId: string) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
+
+      if (activeCanvasVersionIdRef.current !== versionId) {
+        draftCanvasSpecsRef.current.delete(versionId);
+        return;
+      }
+
+      consoleMutationGenerationRef.current += 1;
+      const stagedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId, true);
+      const stagedSpec = stagedVersion?.spec ?? null;
+
+      if (stagedVersion) {
+        queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, versionId), stagedVersion);
+      }
+      if (stagedSpec) {
+        queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) =>
+          current ? { ...current, spec: { ...current.spec, ...stagedSpec } } : current,
+        );
+      }
+      applyResyncedSpec(versionId, stagedSpec);
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) });
+      setStagingResetNonce((nonce) => nonce + 1);
+    },
+    [
+      organizationId,
+      canvasId,
+      queryClient,
+      activeCanvasVersionIdRef,
+      draftCanvasSpecsRef,
+      consoleMutationGenerationRef,
+      applyResyncedSpec,
+      setStagingResetNonce,
+    ],
+  );
+
+  return { resyncDraftToCommitted, resyncDraftToStaged };
+}

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -276,4 +276,84 @@ describe("useCanvasWebsocket", () => {
       queryKey: canvasKeys.consoleAll(testCanvasId),
     });
   });
+
+  it("invalidates staged caches for staging_updated events", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    const onCanvasStagingEvent = vi.fn();
+
+    renderHook(
+      () =>
+        useCanvasWebsocket(
+          testCanvasId,
+          testOrganizationId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+          true,
+          onCanvasStagingEvent,
+        ),
+      {
+        wrapper: ({ children }: { children: ReactNode }) =>
+          createElement(QueryClientProvider, { client: queryClient }, children),
+      },
+    );
+
+    emitWebsocketMessage("staging_updated", {
+      canvasId: testCanvasId,
+      versionId: "version-1",
+    });
+
+    expect(onCanvasStagingEvent).toHaveBeenCalledWith(
+      { canvasId: testCanvasId, versionId: "version-1" },
+      "staging_updated",
+    );
+    expect(
+      getInvalidationCalls(invalidateQueriesSpy, canvasKeys.versionStaging(testCanvasId, "version-1")),
+    ).toHaveLength(1);
+    const stagedPredicateCalls = invalidateQueriesSpy.mock.calls.filter((call: unknown[]) => {
+      const args = call[0] as { predicate?: unknown };
+      return typeof args.predicate === "function";
+    });
+    expect(stagedPredicateCalls).toHaveLength(1);
+  });
+
+  it("skips staging invalidation when onCanvasStagingEvent returns false", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+    const onCanvasStagingEvent = vi.fn().mockReturnValue(false);
+
+    renderHook(
+      () =>
+        useCanvasWebsocket(
+          testCanvasId,
+          testOrganizationId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+          true,
+          onCanvasStagingEvent,
+        ),
+      {
+        wrapper: ({ children }: { children: ReactNode }) =>
+          createElement(QueryClientProvider, { client: queryClient }, children),
+      },
+    );
+
+    emitWebsocketMessage("staging_updated", {
+      canvasId: testCanvasId,
+      versionId: "version-1",
+    });
+
+    expect(onCanvasStagingEvent).toHaveBeenCalledOnce();
+    expect(
+      getInvalidationCalls(invalidateQueriesSpy, canvasKeys.versionStaging(testCanvasId, "version-1")),
+    ).toHaveLength(0);
+  });
 });

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -28,6 +28,8 @@ type CanvasWebsocketPayload = {
 
 type CanvasLifecycleEventName = "canvas_updated" | "canvas_version_updated" | "canvas_deleted";
 
+type CanvasStagingEventName = "staging_updated";
+
 type WebsocketPayload =
   | CanvasesCanvasNodeExecution
   | CanvasesCanvasEvent
@@ -53,6 +55,7 @@ export function useCanvasWebsocket(
   shouldApplyCanvasUpdate?: () => boolean,
   processRuntimeEvents = true,
   enabled = true,
+  onCanvasStagingEvent?: (payload: CanvasWebsocketPayload, eventName: CanvasStagingEventName) => boolean | void,
 ): void {
   const nodeExecutionStore = useNodeExecutionStore();
   const queryClient = useQueryClient();
@@ -113,7 +116,10 @@ export function useCanvasWebsocket(
       const payload = data.payload;
       const isCanvasLifecycleEvent =
         data.event === "canvas_updated" || data.event === "canvas_version_updated" || data.event === "canvas_deleted";
-      if (!isCanvasLifecycleEvent && !processRuntimeEvents) {
+      // Staging events fire while editing a draft (not the live version), so they
+      // must bypass the runtime-event gate that is disabled outside the live view.
+      const isCanvasStagingEvent = data.event === "staging_updated";
+      if (!isCanvasLifecycleEvent && !isCanvasStagingEvent && !processRuntimeEvents) {
         return;
       }
 
@@ -225,6 +231,39 @@ export function useCanvasWebsocket(
           queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
           break;
         }
+        case "staging_updated": {
+          // A draft's staging layer changed in another tab (or this one). Refresh
+          // the staged caches so the diff badge, console and files tabs reflect
+          // the uncommitted changes.
+          const stagingMessage = payload as Partial<CanvasWebsocketPayload>;
+          if (!stagingMessage.canvasId || stagingMessage.canvasId !== canvasId || !stagingMessage.versionId) {
+            break;
+          }
+
+          const shouldInvalidateStagingQueries =
+            onCanvasStagingEvent?.(stagingMessage as CanvasWebsocketPayload, "staging_updated") !== false;
+          if (!shouldInvalidateStagingQueries) {
+            break;
+          }
+
+          const versionId = stagingMessage.versionId;
+          queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
+          // versionStagedDetail, consoleStaged and staged repositoryFileContent
+          // keys all end with "staged" and include the version id, so a single
+          // predicate refreshes the editor's effective draft reads without
+          // touching the committed caches.
+          queryClient.invalidateQueries({
+            predicate: (query) => {
+              const key = query.queryKey;
+              return (
+                Array.isArray(key) &&
+                key[key.length - 1] === "staged" &&
+                (key as readonly unknown[]).includes(versionId)
+              );
+            },
+          });
+          break;
+        }
         default:
           break;
       }
@@ -237,6 +276,7 @@ export function useCanvasWebsocket(
       onWorkflowEvent,
       onExecutionEvent,
       onCanvasLifecycleEvent,
+      onCanvasStagingEvent,
       shouldApplyCanvasUpdate,
       processRuntimeEvents,
       organizationId,

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import useWebSocket from "react-use-websocket";
-import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import type {
   CanvasesCanvasNodeExecution,
   CanvasesCanvasEvent,
@@ -43,6 +43,20 @@ interface QueuedMessage {
     payload: WebsocketPayload;
   };
   timestamp: number;
+}
+
+// Refreshes the staged caches for a draft version. versionStagedDetail,
+// consoleStaged and staged repositoryFileContent keys all end with "staged" and
+// include the version id, so a single predicate refreshes the editor's
+// effective draft reads without touching the committed caches.
+function invalidateStagedCanvasQueries(queryClient: QueryClient, canvasId: string, versionId: string): void {
+  queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
+  queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return Array.isArray(key) && key[key.length - 1] === "staged" && (key as readonly unknown[]).includes(versionId);
+    },
+  });
 }
 
 export function useCanvasWebsocket(
@@ -242,26 +256,9 @@ export function useCanvasWebsocket(
 
           const shouldInvalidateStagingQueries =
             onCanvasStagingEvent?.(stagingMessage as CanvasWebsocketPayload, "staging_updated") !== false;
-          if (!shouldInvalidateStagingQueries) {
-            break;
+          if (shouldInvalidateStagingQueries) {
+            invalidateStagedCanvasQueries(queryClient, canvasId, stagingMessage.versionId);
           }
-
-          const versionId = stagingMessage.versionId;
-          queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
-          // versionStagedDetail, consoleStaged and staged repositoryFileContent
-          // keys all end with "staged" and include the version id, so a single
-          // predicate refreshes the editor's effective draft reads without
-          // touching the committed caches.
-          queryClient.invalidateQueries({
-            predicate: (query) => {
-              const key = query.queryKey;
-              return (
-                Array.isArray(key) &&
-                key[key.length - 1] === "staged" &&
-                (key as readonly unknown[]).includes(versionId)
-              );
-            },
-          });
           break;
         }
         default:

--- a/web_src/src/lib/canvasStagingEcho.ts
+++ b/web_src/src/lib/canvasStagingEcho.ts
@@ -1,0 +1,67 @@
+// Suppresses the realtime "staging_updated" echo a tab receives for its own
+// staging writes. Staging writes persist server-side and broadcast to every tab
+// (including the originating one); without this guard the originating tab would
+// refetch staged caches and could clobber newer, still in-flight local edits.
+//
+// State is module-scoped and therefore per-tab: other tabs run their own module
+// instance with an empty registry, so they still react to the broadcast.
+
+const PENDING_ECHO_TTL_MS = 5000;
+
+// Expiry timestamps per `${canvasId}:${versionId}`. Each entry represents one
+// in-flight local staging write awaiting its broadcast echo. A TTL guards
+// against writes that fail (or whose echo never arrives) leaking forever.
+const pendingEchoExpiries = new Map<string, number[]>();
+
+function echoKey(canvasId: string, versionId: string): string {
+  return `${canvasId}:${versionId}`;
+}
+
+function dropExpired(expiries: number[], now: number): void {
+  while (expiries.length > 0 && expiries[0] <= now) {
+    expiries.shift();
+  }
+}
+
+// Registers a staging write issued by this tab so its broadcast echo can be
+// ignored. Call right before issuing the request, since the server may broadcast
+// before the request's HTTP response resolves.
+export function registerLocalStagingWrite(canvasId?: string, versionId?: string): void {
+  if (!canvasId || !versionId) {
+    return;
+  }
+
+  const key = echoKey(canvasId, versionId);
+  const now = Date.now();
+  const expiries = pendingEchoExpiries.get(key) ?? [];
+  dropExpired(expiries, now);
+  expiries.push(now + PENDING_ECHO_TTL_MS);
+  pendingEchoExpiries.set(key, expiries);
+}
+
+// Reports whether the incoming staging_updated event matches a local write from
+// this tab, consuming the registration when it does so a later genuine remote
+// event for the same version is not suppressed.
+export function consumeLocalStagingWrite(canvasId?: string, versionId?: string): boolean {
+  if (!canvasId || !versionId) {
+    return false;
+  }
+
+  const key = echoKey(canvasId, versionId);
+  const expiries = pendingEchoExpiries.get(key);
+  if (!expiries) {
+    return false;
+  }
+
+  dropExpired(expiries, Date.now());
+  if (expiries.length === 0) {
+    pendingEchoExpiries.delete(key);
+    return false;
+  }
+
+  expiries.shift();
+  if (expiries.length === 0) {
+    pendingEchoExpiries.delete(key);
+  }
+  return true;
+}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -70,6 +70,7 @@ import { analytics } from "@/lib/analytics";
 import { appPath } from "@/lib/appPaths";
 import { filterVisibleConfiguration } from "@/lib/components";
 import { getApiErrorMessage } from "@/lib/errors";
+import { consumeLocalStagingWrite } from "@/lib/canvasStagingEcho";
 import { getIntegrationWebhookUrl } from "@/lib/integrationUtils";
 import { DefaultLayoutEngine } from "@/lib/layout";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
@@ -2147,6 +2148,63 @@ export function AppPage() {
     [organizationId, canvasId, queryClient, setLastSavedWorkflowSnapshot],
   );
 
+  // A remote `staging_updated` (another tab editing the same draft) changed the
+  // draft's staging layer without committing. The console/files caches and diff
+  // badge refresh through the websocket hook's invalidations, but the rendered
+  // graph reads `draftCanvasSpec` (React state), so the active draft needs its
+  // effective staged spec re-applied here.
+  const resyncDraftToStaged = useCallback(
+    async (versionId: string) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
+
+      // Only the actively-edited draft drives the rendered graph, so the spec
+      // re-apply is reserved for it. Other branches just drop their cached spec
+      // so a later switch refetches the staged content.
+      if (activeCanvasVersionIdRef.current !== versionId) {
+        draftCanvasSpecsRef.current.delete(versionId);
+        return;
+      }
+
+      consoleMutationGenerationRef.current += 1;
+      const stagedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId, true);
+      const stagedSpec = stagedVersion?.spec ?? null;
+
+      if (stagedVersion) {
+        queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, versionId), stagedVersion);
+      }
+      if (stagedSpec) {
+        queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) =>
+          current ? { ...current, spec: { ...current.spec, ...stagedSpec } } : current,
+        );
+        draftCanvasSpecsRef.current.set(versionId, stagedSpec);
+      } else {
+        draftCanvasSpecsRef.current.delete(versionId);
+      }
+      setDraftCanvasSpec(stagedSpec);
+      setActiveCanvasVersion((current) =>
+        current?.metadata?.id === versionId ? { ...current, spec: stagedSpec ?? current.spec } : current,
+      );
+
+      // Treat the applied staged spec as the saved baseline so it is not
+      // mistaken for a local edit (which would re-stage and echo back to the
+      // originating tab, creating a feedback loop).
+      const restored = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+      if (restored) {
+        setLastSavedWorkflowSnapshot(restored);
+      }
+      setHasUnsavedChanges(false);
+      setHasNonPositionalUnsavedChanges(false);
+
+      await queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) });
+      setStagingResetNonce((nonce) => nonce + 1);
+    },
+    [organizationId, canvasId, queryClient, setLastSavedWorkflowSnapshot],
+  );
+
   const handleCanvasLifecycleEvent = useCallback(
     (payload: { canvasId: string; versionId?: string }, eventName: string) => {
       if (eventName === "canvas_deleted") {
@@ -2213,6 +2271,32 @@ export function AppPage() {
     [isViewingLiveVersion, hasPendingLocalCanvasState, canvasDeletedRemotely],
   );
 
+  const handleCanvasStagingEvent = useCallback(
+    (payload: { canvasId: string; versionId?: string }) => {
+      if (!payload.versionId) {
+        return false;
+      }
+
+      // This tab's own staging writes broadcast back to it; skip the refetch so
+      // it does not clobber newer, still in-flight local edits.
+      if (consumeLocalStagingWrite(canvasId, payload.versionId)) {
+        return false;
+      }
+
+      // Defer when this tab has its own unsaved canvas edits to avoid clobbering
+      // them; the deferred-apply effect refreshes once they settle. The console
+      // and files staged caches still refresh through the websocket hook.
+      if (payload.versionId === activeCanvasVersionId && hasPendingLocalCanvasState) {
+        setRemoteCanvasUpdatePending(true);
+        return true;
+      }
+
+      void resyncDraftToStaged(payload.versionId);
+      return true;
+    },
+    [canvasId, activeCanvasVersionId, hasPendingLocalCanvasState, resyncDraftToStaged],
+  );
+
   useCanvasWebsocket(
     canvasId!,
     organizationId!,
@@ -2223,6 +2307,7 @@ export function AppPage() {
     shouldApplyCanvasUpdate,
     isViewingLiveVersion,
     true,
+    handleCanvasStagingEvent,
   );
 
   const rawLogNodes = canvasNodes;

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -55,6 +55,7 @@ import {
   useWidgets,
 } from "@/hooks/useCanvasData";
 import { useCanvasWebsocket } from "@/hooks/useCanvasWebsocket";
+import { useCanvasDraftResync } from "@/hooks/useCanvasDraftResync";
 import { useAvailableIntegrations, useConnectedIntegrations, useCreateIntegration } from "@/hooks/useIntegrations";
 import { useMe } from "@/hooks/useMe";
 import { draftBranchName, draftDisplayName, draftVersionId } from "@/lib/draftVersion";
@@ -114,7 +115,6 @@ import { getChangeRequestReviewPhase } from "./changeRequestReviewActions";
 import { buildDraftNodeDiffSummary } from "./draftNodeDiff";
 import { shouldPreserveDraftSpec } from "./lib/draft-canvas-sync";
 import { activateDraftVersion, clearPublishedDraftVersion as clearDraftVersion } from "./lib/draft-spec-cache";
-import { syncCommittedCanvasDraftState } from "./lib/sync-committed-canvas-draft";
 import {
   isDraftVersion,
   isPublishedVersion,
@@ -2095,115 +2095,19 @@ export function AppPage() {
     [queryClient],
   );
 
-  // A remote `canvas_version_updated` (e.g. a CLI `apps canvas update`) commits
-  // canvas.yaml into the version row and discards the draft's staging. Refresh
-  // the committed/staged caches and clear the staging indicators so the UI does
-  // not keep showing stale "uncommitted changes" for content that no longer has
-  // any staging on the server.
-  const resyncDraftToCommitted = useCallback(
-    async (versionId: string) => {
-      if (!organizationId || !canvasId) {
-        return;
-      }
-
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
-
-      // Only the actively-edited draft drives the rendered graph and staging
-      // indicators, so the full committed-state resync (and canvas remount via
-      // stagingResetNonce) is reserved for it. Other branches just refresh their
-      // cached staging/version data.
-      if (activeCanvasVersionIdRef.current !== versionId) {
-        draftCanvasSpecsRef.current.delete(versionId);
-        return;
-      }
-
-      consoleMutationGenerationRef.current += 1;
-      const committedVersion = await syncCommittedCanvasDraftState({
-        queryClient,
-        organizationId,
-        canvasId,
-        versionId,
-      });
-
-      const committedSpec = committedVersion?.spec ?? null;
-      if (committedSpec) {
-        draftCanvasSpecsRef.current.set(versionId, committedSpec);
-      } else {
-        draftCanvasSpecsRef.current.delete(versionId);
-      }
-      setDraftCanvasSpec(committedSpec);
-      setActiveCanvasVersion((current) =>
-        current?.metadata?.id === versionId ? { ...current, spec: committedSpec ?? current.spec } : current,
-      );
-      const restored = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
-      if (restored) {
-        setLastSavedWorkflowSnapshot(restored);
-      }
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
-
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) });
-      setStagingResetNonce((nonce) => nonce + 1);
-    },
-    [organizationId, canvasId, queryClient, setLastSavedWorkflowSnapshot],
-  );
-
-  // A remote `staging_updated` (another tab editing the same draft) changed the
-  // draft's staging layer without committing. The console/files caches and diff
-  // badge refresh through the websocket hook's invalidations, but the rendered
-  // graph reads `draftCanvasSpec` (React state), so the active draft needs its
-  // effective staged spec re-applied here.
-  const resyncDraftToStaged = useCallback(
-    async (versionId: string) => {
-      if (!organizationId || !canvasId) {
-        return;
-      }
-
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
-
-      // Only the actively-edited draft drives the rendered graph, so the spec
-      // re-apply is reserved for it. Other branches just drop their cached spec
-      // so a later switch refetches the staged content.
-      if (activeCanvasVersionIdRef.current !== versionId) {
-        draftCanvasSpecsRef.current.delete(versionId);
-        return;
-      }
-
-      consoleMutationGenerationRef.current += 1;
-      const stagedVersion = await fetchCanvasVersionWithSpec(canvasId, versionId, true);
-      const stagedSpec = stagedVersion?.spec ?? null;
-
-      if (stagedVersion) {
-        queryClient.setQueryData(canvasKeys.versionStagedDetail(canvasId, versionId), stagedVersion);
-      }
-      if (stagedSpec) {
-        queryClient.setQueryData<CanvasesCanvas | undefined>(canvasKeys.detail(organizationId, canvasId), (current) =>
-          current ? { ...current, spec: { ...current.spec, ...stagedSpec } } : current,
-        );
-        draftCanvasSpecsRef.current.set(versionId, stagedSpec);
-      } else {
-        draftCanvasSpecsRef.current.delete(versionId);
-      }
-      setDraftCanvasSpec(stagedSpec);
-      setActiveCanvasVersion((current) =>
-        current?.metadata?.id === versionId ? { ...current, spec: stagedSpec ?? current.spec } : current,
-      );
-
-      // Treat the applied staged spec as the saved baseline so it is not
-      // mistaken for a local edit (which would re-stage and echo back to the
-      // originating tab, creating a feedback loop).
-      const restored = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
-      if (restored) {
-        setLastSavedWorkflowSnapshot(restored);
-      }
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
-
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) });
-      setStagingResetNonce((nonce) => nonce + 1);
-    },
-    [organizationId, canvasId, queryClient, setLastSavedWorkflowSnapshot],
-  );
+  const { resyncDraftToCommitted, resyncDraftToStaged } = useCanvasDraftResync({
+    organizationId,
+    canvasId,
+    activeCanvasVersionIdRef,
+    draftCanvasSpecsRef,
+    consoleMutationGenerationRef,
+    setDraftCanvasSpec,
+    setActiveCanvasVersion,
+    setLastSavedWorkflowSnapshot,
+    setHasUnsavedChanges,
+    setHasNonPositionalUnsavedChanges,
+    setStagingResetNonce,
+  });
 
   const handleCanvasLifecycleEvent = useCallback(
     (payload: { canvasId: string; versionId?: string }, eventName: string) => {

--- a/web_src/src/pages/app/lib/canvas-yaml-staging.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.spec.ts
@@ -92,6 +92,56 @@ spec:
     });
   });
 
+  it("canonicalizes change management so default fields do not create spurious diffs", () => {
+    // Live spec as returned by the API: proto3 defaults populated.
+    const live: CanvasesCanvas = {
+      metadata: { id: "canvas-1", name: "galactic-vector", description: "" },
+      spec: {
+        nodes: [],
+        edges: [],
+        changeManagement: {
+          enabled: false,
+          approvals: [{ type: "TYPE_ANYONE", userId: "", roleName: "" }],
+        },
+      },
+    };
+
+    // Draft spec from local edits: defaults omitted.
+    const draft: CanvasesCanvas = {
+      metadata: { id: "canvas-1", name: "galactic-vector", description: "" },
+      spec: {
+        nodes: [],
+        edges: [],
+        changeManagement: {
+          approvals: [{ type: "TYPE_ANYONE" }],
+        },
+      },
+    };
+
+    const liveYaml = buildCanvasYamlFromWorkflow(live);
+    const draftYaml = buildCanvasYamlFromWorkflow(draft);
+
+    expect(liveYaml).toBe(draftYaml);
+    expect(liveYaml).not.toContain("enabled:");
+    expect(liveYaml).not.toContain("userId:");
+    expect(liveYaml).not.toContain("roleName:");
+    expect(liveYaml).toContain("type: TYPE_ANYONE");
+  });
+
+  it("keeps a real change management change visible in the diff", () => {
+    const enabled: CanvasesCanvas = {
+      metadata: { id: "canvas-1", name: "galactic-vector", description: "" },
+      spec: { nodes: [], edges: [], changeManagement: { enabled: true, approvals: [{ type: "TYPE_ANYONE" }] } },
+    };
+    const disabled: CanvasesCanvas = {
+      metadata: { id: "canvas-1", name: "galactic-vector", description: "" },
+      spec: { nodes: [], edges: [], changeManagement: { enabled: false, approvals: [{ type: "TYPE_ANYONE" }] } },
+    };
+
+    expect(buildCanvasYamlFromWorkflow(enabled)).toContain("enabled: true");
+    expect(buildCanvasYamlFromWorkflow(disabled)).not.toContain("enabled:");
+  });
+
   it("quotes position y keys when exporting yaml", () => {
     const workflow: CanvasesCanvas = {
       ...sampleWorkflow,

--- a/web_src/src/pages/app/lib/canvas-yaml-staging.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.ts
@@ -1,5 +1,5 @@
 import * as yaml from "js-yaml";
-import type { CanvasesCanvas } from "@/api-client";
+import type { CanvasChangeManagement, CanvasesCanvas, ChangeManagementApprover } from "@/api-client";
 import type {
   SuperplaneComponentsEdge as ComponentsEdge,
   SuperplaneComponentsNode as ComponentsNode,
@@ -118,7 +118,47 @@ function quoteYamlPositionYKeys(text: string): string {
   return text.replace(/^(\s+)y: /gm, '$1"y": ');
 }
 
+// The live canvas spec comes from the API with proto3 default fields populated
+// (enabled: false, empty userId/roleName), while the locally-edited draft spec
+// omits them. Without canonicalizing, the YAML diff surfaces these defaults as
+// spurious changeManagement edits. Drop falsy enabled and empty approver fields
+// so only real change-management edits appear in the diff.
+function normalizeCanvasYamlChangeManagement(
+  changeManagement: CanvasChangeManagement | undefined,
+): CanvasChangeManagement | undefined {
+  if (!changeManagement) {
+    return undefined;
+  }
+
+  const normalized: CanvasChangeManagement = {};
+  if (changeManagement.enabled) {
+    normalized.enabled = true;
+  }
+
+  const approvals = (changeManagement.approvals ?? []).map(normalizeChangeManagementApprover);
+  if (approvals.length > 0) {
+    normalized.approvals = approvals;
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeChangeManagementApprover(approver: ChangeManagementApprover): ChangeManagementApprover {
+  const normalized: ChangeManagementApprover = {};
+  if (approver.type) {
+    normalized.type = approver.type;
+  }
+  if (approver.userId) {
+    normalized.userId = approver.userId;
+  }
+  if (approver.roleName) {
+    normalized.roleName = approver.roleName;
+  }
+  return normalized;
+}
+
 export function buildCanvasYamlFromWorkflow(workflow: CanvasesCanvas): string {
+  const changeManagement = normalizeCanvasYamlChangeManagement(workflow.spec?.changeManagement);
   const document = {
     apiVersion: "v1",
     kind: "Canvas",
@@ -130,7 +170,7 @@ export function buildCanvasYamlFromWorkflow(workflow: CanvasesCanvas): string {
     spec: {
       nodes: (workflow.spec?.nodes ?? []).map(normalizeCanvasYamlNode),
       edges: (workflow.spec?.edges ?? []).map(normalizeCanvasYamlEdge),
-      ...(workflow.spec?.changeManagement ? { changeManagement: workflow.spec.changeManagement } : {}),
+      ...(changeManagement ? { changeManagement } : {}),
     },
   };
 

--- a/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
+++ b/web_src/src/pages/app/mappers/incident/setSigningSecretSection.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
+import { registerLocalStagingWrite } from "@/lib/canvasStagingEcho";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import { useCanvasId } from "@/hooks/useCanvasId";
 import { encodeRepositoryFileContent } from "../../files/lib/repository-files";
@@ -59,6 +60,7 @@ async function commitUpdatedCanvasVersionYaml(params: {
     spec: params.updatedVersion.spec,
   });
 
+  registerLocalStagingWrite(params.canvasId, params.versionId);
   await canvasesStageCanvasRepositoryFile(
     withOrganizationHeader({
       path: { canvasId: params.canvasId, versionId: params.versionId },

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
@@ -45,4 +45,24 @@ describe("SecondaryHeaderActions", () => {
 
     expect(screen.getByText("+1")).toBeInTheDocument();
   });
+
+  it("keeps the commit controls pending while a commit settles after staging clears", () => {
+    render(
+      <SecondaryHeaderActions
+        canvasName="Canvas"
+        mode="version-edit"
+        isEditing
+        hasStagingChanges={false}
+        commitStagingPending
+        onCommitStaging={vi.fn()}
+        onResetStaging={vi.fn()}
+        onPublishVersion={vi.fn()}
+        toolSidebarState={{} as CanvasToolSidebarState}
+      />,
+    );
+
+    expect(screen.getByTestId("canvas-commit-staging-button")).toBeDisabled();
+    expect(screen.getByTestId("canvas-reset-staging-button")).toBeDisabled();
+    expect(screen.queryByTestId("canvas-publish-version-button")).not.toBeInTheDocument();
+  });
 });

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
@@ -21,4 +21,28 @@ describe("SecondaryHeaderActions", () => {
 
     expect(screen.getByText("+1")).toBeInTheDocument();
   });
+
+  it("shows the canvas diff badge for uncommitted (staged) changes", () => {
+    render(
+      <SecondaryHeaderActions
+        canvasName="Canvas"
+        mode="version-edit"
+        isEditing
+        hasUncommittedCanvasDraftChanges
+        draftVisualDiff={{
+          diffCounts: { added: 1, updated: 0, removed: 0 },
+          diffToggles: {
+            showDeletedNodes: false,
+            toggleShowDeletedNodes: vi.fn(),
+            showEdgeDiff: false,
+            toggleShowEdgeDiff: vi.fn(),
+          },
+        }}
+        onShowDiff={vi.fn()}
+        toolSidebarState={{} as CanvasToolSidebarState}
+      />,
+    );
+
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
 });

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -1,7 +1,7 @@
 import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { Loader2, X } from "lucide-react";
+import { X } from "lucide-react";
 import { Button } from "../button";
 import { DiffSummaryHoverCard } from "./components/DiffSummaryHoverCard";
 import { EnterEditDraftDropdown } from "./components/EnterEditDraftDropdown";
@@ -157,7 +157,11 @@ function EditModePublishDiscardActions({
   | "commitStagingPending"
   | "onResetStaging"
 >) {
-  const showStagingActions = !!hasStagingChanges && !!onCommitStaging;
+  // Keep showing the staging controls while a commit is in flight even after
+  // `hasStagingChanges` optimistically flips false, so the commit button stays
+  // pending/disabled until staging settles and never flashes an enabled
+  // [Reset][Commit] (or a premature Discard/Publish).
+  const showStagingActions = !!onCommitStaging && (!!hasStagingChanges || !!commitStagingPending);
 
   // Staging and committed states are mutually exclusive: while there are staged
   // edits the user can only Reset/Commit them; once everything is committed they
@@ -165,13 +169,6 @@ function EditModePublishDiscardActions({
   if (showStagingActions) {
     return (
       <div className="flex items-center gap-1.5">
-        {commitStagingPending ? (
-          <Loader2
-            className="size-4 shrink-0 animate-spin text-slate-400"
-            aria-label="Committing changes"
-            data-testid="canvas-commit-staging-spinner"
-          />
-        ) : null}
         {onResetStaging ? (
           <ResetStagingButton onReset={() => onResetStaging()} disabled={!!commitStagingPending} />
         ) : null}
@@ -221,8 +218,8 @@ function ResetStagingButton({ onReset, disabled }: { onReset: () => void; disabl
 }
 
 // The label stays fixed (no "Committing…") so the button keeps a constant
-// width while a commit is in flight; the progress spinner lives to the left of
-// the Reset button instead.
+// width while a commit is in flight; the button is disabled instead to signal
+// the in-flight commit.
 function CommitStagingButton({ onCommit, pending }: { onCommit: () => void; pending: boolean }) {
   return (
     <UIButton

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -18,6 +18,8 @@ export function SecondaryHeaderActions({
   saveIsPrimary,
   hasUnpublishedDraftChanges,
   hasUnpublishedConsoleDraftChanges,
+  hasUncommittedCanvasDraftChanges,
+  hasUncommittedConsoleDraftChanges,
   onShowDiff,
   onShowConsoleDiff,
   visualDiffEnabled,
@@ -55,7 +57,9 @@ export function SecondaryHeaderActions({
 
       {isEditing ? (
         <>
-          {onCanvasTab && hasUnpublishedDraftChanges && draftVisualDiff?.diffCounts ? (
+          {onCanvasTab &&
+          (hasUnpublishedDraftChanges || hasUncommittedCanvasDraftChanges) &&
+          draftVisualDiff?.diffCounts ? (
             <DiffSummaryHoverCard
               diffCounts={draftVisualDiff.diffCounts}
               visualDiffEnabled={visualDiffEnabled}
@@ -64,7 +68,9 @@ export function SecondaryHeaderActions({
               onShowDiff={onShowDiff}
             />
           ) : null}
-          {onConsoleTab && hasUnpublishedConsoleDraftChanges && draftConsoleDiff?.diffCounts ? (
+          {onConsoleTab &&
+          (hasUnpublishedConsoleDraftChanges || hasUncommittedConsoleDraftChanges) &&
+          draftConsoleDiff?.diffCounts ? (
             <ConsoleDiffSummaryHoverCard
               draftConsoleDiff={draftConsoleDiff}
               visualDiffEnabled={visualDiffEnabled}


### PR DESCRIPTION
## Summary

Fixes a cluster of canvas edit-mode staging bugs, plus a related diff-rendering artifact.

Fixes #5453.

**Uncommitted changes don't sync across tabs.** Staging writes (canvas/console/file edits, discard, auto-layout) persist server-side but emitted no realtime event, so other tabs editing the same draft never refreshed. The backend now publishes a `canvas-staging-updated` event on every staging write and broadcasts it as a `staging_updated` websocket event. The client refreshes the staged caches and re-applies the effective staged spec to the active draft's rendered graph. A per-tab echo guard (`canvasStagingEcho.ts`) ignores the originating tab's own broadcast so it doesn't clobber in-flight local edits, and tabs with their own unsaved edits defer the refresh.

Fixes #5450.

**`[Reset][Commit]` briefly re-enabled after commit.** The `versionStaging` query is now optimistically cleared on commit success so `hasStagingChanges` flips false immediately instead of lagging behind the commit-pending flag. The staging controls stay disabled until staging settles (the lingering commit spinner is dropped in favor of the disabled-control signal).

Fixes #5451.

**Diff badge ignores uncommitted staged changes.** The canvas/console diff badges are now gated on the uncommitted staged-change flags in addition to the committed unpublished-change flags, so staged edits surface a diff badge before they're committed.

Fixes #5456.

**Weird `changeManagement` diff artifacts on Canvas tab.** The live canvas spec from the API carries proto3 default fields (`enabled: false`, empty `userId`/`roleName`) while the locally-edited draft omits them, producing spurious `changeManagement` edits in the diff. `buildCanvasYamlFromWorkflow` now canonicalizes change management before serialization (dropping falsy `enabled` and empty approver fields) so only real change-management edits appear.

## Changes

**Backend (Go)**
- `pkg/grpc/actions/messages/canvas.go`: `CanvasStagingUpdatedRoutingKey` + `PublishStagingUpdated()`.
- `pkg/workers/eventdistributer/canvas.go`: `staging_updated` event + `HandleCanvasStagingUpdated`.
- `pkg/workers/event_distributer.go`: register the new routing key.
- Publish the event after a successful staging write in `workflow_staging.go`, `discard_canvas_staging.go`, and `apply_canvas_auto_layout.go` (commit is already covered by `canvas_version_updated`).

**Frontend (TS)**
- `useCanvasWebsocket.ts`: handle `staging_updated`, expose `onCanvasStagingEvent` callback, invalidate staged caches.
- `index.tsx`: wire `onCanvasStagingEvent` to resync the active draft with staging echo suppression.
- `useCanvasData.ts`: optimistically clear `versionStaging` on commit success.
- `HeaderSecondaryActions.tsx`: gate diff badges on uncommitted flags; keep commit controls disabled until staging settles.
- `canvas-yaml-staging.ts`: canonicalize change management before YAML serialization.
- New `lib/canvasStagingEcho.ts` echo guard.

## Test plan

- [x] Open the same canvas draft in two browser tabs (A and B) in edit mode. Make a staged change in A (move a node / edit a component / discard / auto-layout). Confirm B reflects the change without a manual refresh, and that A's own in-flight local edits are not clobbered by the echo.
- [x] With staged changes, throttle the network (DevTools → Slow 3G) and click Commit. Confirm the `[Reset][Commit]` controls never flash back to an enabled state during the post-commit refetch window — they stay disabled until staging clears.
- [x] Make a staged (uncommitted) edit on both the canvas and the console. Confirm the diff badge appears before committing, and that the hover card shows the correct counts.
- [x] Open a canvas whose `changeManagement` is disabled/default and enter edit mode. Confirm the diff view shows no spurious `changeManagement` (`enabled`/`userId`/`roleName`) artifacts. Then enable change management and confirm a real `enabled: true` change still appears in the diff.