### PR TITLE
chore: Remove license check from CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,17 +24,6 @@ auto_cancel:
   queued:
     when: branch != 'main'
 blocks:
-  - name: "License Check"
-    dependencies: []
-    run:
-      when: "change_in('/', {exclude: ['/docs/**', '**/*.md', '**/*.mdx'], default_branch: 'main'})"
-    task:
-      jobs:
-        - name: Licence Check
-          commands:
-            - sudo rm -rf tmp/go/pkg/mod tmp/go-build
-            - make test.license.check
-
   - name: "Backend Tests"
     dependencies: []
     run:


### PR DESCRIPTION
## Summary
- Removes the standalone **License Check** block from Semaphore CI
- Closes #5460

The license check step is no longer needed now that SuperPlane has a shipped app. Removing it simplifies the pipeline and reduces CI time.

Local license check tooling (`make test.license.check`, `scripts/license-check.sh`) is unchanged and can still be run manually if needed.

## Test plan
- [ ] CI pipeline runs successfully without the License Check block
- [ ] Backend Tests and Frontend Tests blocks still execute as before


Made with [Cursor](https://cursor.com)