### PR TITLE
fix: Add Pagination for Widgets with Runs Datasource

### DIFF
--- a/web_src/src/pages/app/console/DataSourceForm.tsx
+++ b/web_src/src/pages/app/console/DataSourceForm.tsx
@@ -11,6 +11,13 @@ interface DataSourceFormProps {
   onChange: (next: ChartPanelDataSource) => void;
   /** Hide the limit input (e.g. number panels that aggregate everything). */
   hideLimit?: boolean;
+  /**
+   * Whether the consuming widget supports progressive loading (table panel).
+   * When `true`, a blank limit means "load all rows on demand" rather than
+   * being silently substituted with a default cap — so `setKind` leaves the
+   * limit undefined and the input's placeholder advertises "Load all".
+   */
+  loadAllWhenBlank?: boolean;
 }
 
 /**
@@ -18,7 +25,7 @@ interface DataSourceFormProps {
  * number form editors. Switching `kind` resets the kind-specific fields to
  * sensible defaults so the resulting object always matches the validator.
  */
-export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormProps) {
+export function DataSourceForm({ value, onChange, hideLimit, loadAllWhenBlank }: DataSourceFormProps) {
   const ctx = useConsoleContext();
   const nodes = ctx?.nodes ?? [];
   const canvasId = ctx?.canvasId;
@@ -31,9 +38,9 @@ export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormPro
     if (kind === "memory") {
       onChange({ kind: "memory", namespace: "" });
     } else if (kind === "runs") {
-      onChange({ kind: "runs", limit: 100 });
+      onChange(loadAllWhenBlank ? { kind: "runs" } : { kind: "runs", limit: 100 });
     } else {
-      onChange({ kind: "executions", limit: 50 });
+      onChange(loadAllWhenBlank ? { kind: "executions" } : { kind: "executions", limit: 50 });
     }
   };
 
@@ -54,9 +61,20 @@ export function DataSourceForm({ value, onChange, hideLimit }: DataSourceFormPro
       </div>
 
       {value.kind === "runs" ? (
-        <DataSourceRunsFields value={value} hideLimit={hideLimit} onChange={onChange} />
+        <DataSourceRunsFields
+          value={value}
+          hideLimit={hideLimit}
+          loadAllWhenBlank={loadAllWhenBlank}
+          onChange={onChange}
+        />
       ) : value.kind === "executions" ? (
-        <DataSourceExecutionsFields value={value} hideLimit={hideLimit} nodes={nodes} onChange={onChange} />
+        <DataSourceExecutionsFields
+          value={value}
+          hideLimit={hideLimit}
+          loadAllWhenBlank={loadAllWhenBlank}
+          nodes={nodes}
+          onChange={onChange}
+        />
       ) : (
         <DataSourceMemoryFields
           value={value}

--- a/web_src/src/pages/app/console/TablePanelCard.tsx
+++ b/web_src/src/pages/app/console/TablePanelCard.tsx
@@ -61,13 +61,23 @@ function TablePanelBody({ content }: { content: TablePanelContent }) {
 }
 
 function TablePanelDataBound({ content, canvasId }: { content: TablePanelContent; canvasId: string }) {
-  const { rows, isLoading, error } = useWidgetData(
+  const { rows, isLoading, error, hasMore, isFetchingMore, loadMore } = useWidgetData(
     canvasId,
     content.dataSource,
     renderNeedsRunNodeOutputs(content.render),
+    true,
   );
   if (error) return <PanelError message={error} />;
-  return <WidgetTable render={content.render} rows={rows} isLoading={isLoading} />;
+  return (
+    <WidgetTable
+      render={content.render}
+      rows={rows}
+      isLoading={isLoading}
+      hasMore={hasMore}
+      isFetchingMore={isFetchingMore}
+      onLoadMore={loadMore}
+    />
+  );
 }
 
 function PanelError({ message }: { message: string }) {

--- a/web_src/src/pages/app/console/TablePanelForm.tsx
+++ b/web_src/src/pages/app/console/TablePanelForm.tsx
@@ -35,7 +35,11 @@ export function TablePanelForm({ value, onChange }: TablePanelFormProps) {
   return (
     <div className="space-y-4">
       <TablePanelTitleField value={value} onChange={onChange} />
-      <DataSourceForm value={value.dataSource} onChange={(dataSource) => onChange({ ...value, dataSource })} />
+      <DataSourceForm
+        value={value.dataSource}
+        onChange={(dataSource) => onChange({ ...value, dataSource })}
+        loadAllWhenBlank
+      />
       <TablePanelMemorySourcePicker value={value} canvasId={canvasId} onChange={onChange} />
       <TablePanelColumnsSection value={value} fields={fields} fieldOptions={fieldOptions} actions={actions} />
       <TablePanelFiltersSection value={value} fieldOptions={fieldOptions} actions={actions} />

--- a/web_src/src/pages/app/console/dataSourceFormFields.tsx
+++ b/web_src/src/pages/app/console/dataSourceFormFields.tsx
@@ -90,7 +90,7 @@ function LimitField({
   defaultPlaceholder: string;
   onChange: (limit: number | undefined) => void;
 }) {
-  const placeholder = loadAllWhenBlank ? "Load all" : defaultPlaceholder;
+  const placeholder = loadAllWhenBlank ? "On demand" : defaultPlaceholder;
   return (
     <div className="space-y-1.5">
       <Label className="text-xs font-medium text-slate-600">Limit</Label>
@@ -104,7 +104,8 @@ function LimitField({
       />
       {loadAllWhenBlank ? (
         <p className="text-[11px] text-slate-500">
-          Leave blank to load all rows. Use the "Load more" button or scroll to reveal additional rows.
+          Leave blank to load rows on demand — scroll or use the "Load more" button to reveal more. Very long histories
+          are capped for performance; set a number to fix how many rows are fetched.
         </p>
       ) : null}
     </div>

--- a/web_src/src/pages/app/console/dataSourceFormFields.tsx
+++ b/web_src/src/pages/app/console/dataSourceFormFields.tsx
@@ -8,41 +8,36 @@ import type { ChartPanelDataSource } from "./panelTypes";
 export function DataSourceRunsFields({
   value,
   hideLimit,
+  loadAllWhenBlank,
   onChange,
 }: {
   value: Extract<ChartPanelDataSource, { kind: "runs" }>;
   hideLimit?: boolean;
+  loadAllWhenBlank?: boolean;
   onChange: (next: ChartPanelDataSource) => void;
 }) {
   if (hideLimit) return null;
 
   return (
-    <div className="space-y-1.5">
-      <Label className="text-xs font-medium text-slate-600">Limit</Label>
-      <Input
-        type="number"
-        min={1}
-        value={value.limit ?? ""}
-        onChange={(e) =>
-          onChange({
-            ...value,
-            limit: e.target.value === "" ? undefined : Number(e.target.value),
-          })
-        }
-        placeholder="100"
-      />
-    </div>
+    <LimitField
+      value={value.limit}
+      loadAllWhenBlank={loadAllWhenBlank}
+      defaultPlaceholder="100"
+      onChange={(limit) => onChange({ ...value, limit })}
+    />
   );
 }
 
 export function DataSourceExecutionsFields({
   value,
   hideLimit,
+  loadAllWhenBlank,
   nodes,
   onChange,
 }: {
   value: Extract<ChartPanelDataSource, { kind: "executions" }>;
   hideLimit?: boolean;
+  loadAllWhenBlank?: boolean;
   nodes: SuperplaneComponentsNode[];
   onChange: (next: ChartPanelDataSource) => void;
 }) {
@@ -73,23 +68,46 @@ export function DataSourceExecutionsFields({
         </Select>
       </div>
       {hideLimit ? null : (
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-slate-600">Limit</Label>
-          <Input
-            type="number"
-            min={1}
-            value={value.limit ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...value,
-                limit: e.target.value === "" ? undefined : Number(e.target.value),
-              })
-            }
-            placeholder="50"
-          />
-        </div>
+        <LimitField
+          value={value.limit}
+          loadAllWhenBlank={loadAllWhenBlank}
+          defaultPlaceholder="50"
+          onChange={(limit) => onChange({ ...value, limit })}
+        />
       )}
     </>
+  );
+}
+
+function LimitField({
+  value,
+  loadAllWhenBlank,
+  defaultPlaceholder,
+  onChange,
+}: {
+  value: number | undefined;
+  loadAllWhenBlank: boolean | undefined;
+  defaultPlaceholder: string;
+  onChange: (limit: number | undefined) => void;
+}) {
+  const placeholder = loadAllWhenBlank ? "Load all" : defaultPlaceholder;
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium text-slate-600">Limit</Label>
+      <Input
+        type="number"
+        min={1}
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+        placeholder={placeholder}
+        data-testid="data-source-limit"
+      />
+      {loadAllWhenBlank ? (
+        <p className="text-[11px] text-slate-500">
+          Leave blank to load all rows. Use the "Load more" button or scroll to reveal additional rows.
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/web_src/src/pages/app/console/panelTypes.spec.ts
+++ b/web_src/src/pages/app/console/panelTypes.spec.ts
@@ -205,6 +205,44 @@ describe("validatePanelContent — table", () => {
   });
 });
 
+describe("normalizeTablePanelContent — data source limits", () => {
+  it("preserves an explicit numeric limit for runs and executions", () => {
+    const runs = normalizeTablePanelContent({
+      dataSource: { kind: "runs", limit: 250 },
+      render: { kind: "table", columns: [] },
+    });
+    expect(runs.dataSource).toEqual({ kind: "runs", limit: 250 });
+
+    const executions = normalizeTablePanelContent({
+      dataSource: { kind: "executions", node: "deploy", limit: 75 },
+      render: { kind: "table", columns: [] },
+    });
+    expect(executions.dataSource).toEqual({ kind: "executions", node: "deploy", limit: 75 });
+  });
+
+  it("leaves limit undefined when not provided, so blank means 'load all'", () => {
+    const runs = normalizeTablePanelContent({
+      dataSource: { kind: "runs" },
+      render: { kind: "table", columns: [] },
+    });
+    expect(runs.dataSource).toEqual({ kind: "runs", limit: undefined });
+
+    const executions = normalizeTablePanelContent({
+      dataSource: { kind: "executions" },
+      render: { kind: "table", columns: [] },
+    });
+    expect(executions.dataSource).toEqual({ kind: "executions", node: undefined, limit: undefined });
+  });
+
+  it("drops a non-numeric limit rather than coercing it to a default", () => {
+    const runs = normalizeTablePanelContent({
+      dataSource: { kind: "runs", limit: "many" },
+      render: { kind: "table", columns: [] },
+    });
+    expect(runs.dataSource).toEqual({ kind: "runs", limit: undefined });
+  });
+});
+
 describe("normalizeTablePanelContent — rowStyles round-trip", () => {
   it("preserves valid rowStyles entries verbatim", () => {
     const normalized = normalizeTablePanelContent({

--- a/web_src/src/pages/app/console/panelTypes.ts
+++ b/web_src/src/pages/app/console/panelTypes.ts
@@ -474,7 +474,7 @@ function normalizeTableWhere(raw: unknown): WidgetTableFilter[] | undefined {
 function normalizeTableDataSource(raw: unknown): TablePanelDataSource {
   const ds = asObject(raw);
   if (ds?.kind === "executions") return normalizeExecutionsDataSource(ds);
-  if (ds?.kind === "runs") return { kind: "runs", limit: typeof ds.limit === "number" ? ds.limit : 100 };
+  if (ds?.kind === "runs") return { kind: "runs", limit: optionalNumber(ds.limit) };
   if (ds?.kind === "memory") return normalizeMemoryDataSource(ds);
   return { kind: "memory", namespace: "" };
 }
@@ -483,8 +483,12 @@ function normalizeExecutionsDataSource(ds: Record<string, unknown>): TablePanelD
   return {
     kind: "executions",
     node: stringOrUndefined(ds.node),
-    limit: typeof ds.limit === "number" ? ds.limit : 50,
+    limit: optionalNumber(ds.limit),
   };
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function normalizeMemoryDataSource(ds: Record<string, unknown>): TablePanelDataSource {

--- a/web_src/src/pages/app/console/widget/WidgetTable.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTable.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useMemo, useState, type UIEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type UIEvent } from "react";
 import { ExternalLink, Loader2, Play, Plus, RefreshCw, Square, Table2, Trash2 } from "lucide-react";
 
 import { formatTimestampInUserTimezone } from "@/lib/timezone";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 
 import { useConsoleContext, resolveConsoleNode } from "../ConsoleContext";
 import { applyTableWhere } from "./evalTableWhere";
@@ -55,6 +54,9 @@ const ACTION_ICONS = {
   "external-link": ExternalLink,
 } as const;
 
+/** Distance from the bottom (px) at which scrolling auto-requests more rows. */
+const AUTO_LOAD_SCROLL_THRESHOLD_PX = 160;
+
 export function WidgetTable({ render, rows, isLoading, hasMore, isFetchingMore, onLoadMore }: WidgetTableProps) {
   const ctx = useConsoleContext();
   const recordRows = useMemo(
@@ -81,16 +83,28 @@ export function WidgetTable({ render, rows, isLoading, hasMore, isFetchingMore, 
     return Array.from(ids);
   }, [render.rowActions, ctx]);
 
-  const handleScrollLoadMore = useAutoLoadMoreOnScroll({
-    hasMore,
-    isLoading: isFetchingMore,
-    onLoadMore,
-  });
+  // Auto-load more rows as the user scrolls near the bottom. The table's
+  // `loadMore()` is dual-mode: it usually just widens the display window over
+  // rows already in the infinite-query cache (no network fetch), and only
+  // sometimes triggers an actual page fetch. So we can't rely on a fetching
+  // flag flipping to re-arm the guard (it would stay armed forever after a
+  // cache-only reveal). Instead we re-arm whenever the rendered row set grows
+  // or a fetch settles, which covers both modes.
+  const loadMoreRequestedRef = useRef(false);
+  useEffect(() => {
+    loadMoreRequestedRef.current = false;
+  }, [rows.length, isFetchingMore]);
+
   const onScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
-      handleScrollLoadMore(event.currentTarget);
+      const el = event.currentTarget;
+      if (!hasMore || !onLoadMore || isFetchingMore || loadMoreRequestedRef.current) return;
+      const remainingScroll = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (remainingScroll > AUTO_LOAD_SCROLL_THRESHOLD_PX) return;
+      loadMoreRequestedRef.current = true;
+      onLoadMore();
     },
-    [handleScrollLoadMore],
+    [hasMore, onLoadMore, isFetchingMore],
   );
 
   if (isLoading) return <WidgetSpinner />;
@@ -110,9 +124,17 @@ export function WidgetTable({ render, rows, isLoading, hasMore, isFetchingMore, 
     );
   }
   if (filtered.length === 0) {
+    // The current pages produced no matching rows, but later server pages
+    // might — so keep the "Load more" affordance available instead of
+    // dead-ending on the empty message.
     return (
-      <div className="p-4 text-center text-xs text-slate-500" data-testid="widget-table-empty">
-        {render.emptyMessage ?? "No data to display."}
+      <div data-testid="widget-table-empty-wrap">
+        <div className="p-4 text-center text-xs text-slate-500" data-testid="widget-table-empty">
+          {render.emptyMessage ?? "No data to display."}
+        </div>
+        {hasMore && onLoadMore ? (
+          <LoadMoreFooter isFetchingMore={Boolean(isFetchingMore)} onLoadMore={onLoadMore} />
+        ) : null}
       </div>
     );
   }

--- a/web_src/src/pages/app/console/widget/WidgetTable.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTable.tsx
@@ -141,65 +141,96 @@ export function WidgetTable({ render, rows, isLoading, hasMore, isFetchingMore, 
 
   return (
     <WidgetTableActionLockProvider triggerNodeIds={triggerNodeIds}>
-      <div className="overflow-auto" data-testid="widget-table" onScroll={onScroll}>
-        <table className="w-full border-collapse text-xs">
-          <thead className="bg-slate-50">
-            <tr>
-              {render.columns.map((col, i) => (
-                <th
-                  key={`${col.field}-${i}`}
-                  className="border-b border-slate-200 px-3 py-1.5 text-left font-semibold text-slate-700"
-                >
-                  {col.label ?? col.field}
-                </th>
-              ))}
-              {render.rowActions && render.rowActions.length > 0 ? (
-                <th className="border-b border-slate-200 px-3 py-1.5 text-right font-semibold text-slate-700">
-                  Actions
-                </th>
-              ) : null}
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((row, idx) => {
-              const rowKey = rowKeyForRow(row, idx);
-              const toneClass = resolveRowStyle?.(row);
-              return (
-                <tr
-                  key={rowKey}
-                  data-row-tone={toneClass ? "true" : undefined}
-                  className={cn(
-                    "border-b border-slate-100 last:border-0",
-                    // Drop the default hover wash when a tone is applied so the
-                    // tint isn't overridden — the row already has a deliberate
-                    // background and a hover bg would mask it.
-                    toneClass ? toneClass : "hover:bg-slate-50/60",
-                  )}
-                >
-                  {render.columns.map((col, ci) => (
-                    <Cell key={`${col.field}-${ci}`} col={col} row={row} />
-                  ))}
-                  {render.rowActions && render.rowActions.length > 0 ? (
-                    <td className="px-3 py-1.5 text-right">
-                      <div className="inline-flex items-center gap-1">
-                        {render.rowActions
-                          .filter((action) => evaluateRowShow(action.show, row))
-                          .map((action, ai) => (
-                            <RowActionButton key={ai} action={action} row={row} rowKey={rowKey} />
-                          ))}
-                      </div>
-                    </td>
-                  ) : null}
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-        {hasMore && onLoadMore ? (
-          <LoadMoreFooter isFetchingMore={Boolean(isFetchingMore)} onLoadMore={onLoadMore} />
-        ) : null}
-      </div>
+      <WidgetTableGrid
+        render={render}
+        filtered={filtered}
+        resolveRowStyle={resolveRowStyle}
+        hasMore={hasMore}
+        isFetchingMore={isFetchingMore}
+        onLoadMore={onLoadMore}
+        onScroll={onScroll}
+      />
     </WidgetTableActionLockProvider>
+  );
+}
+
+interface WidgetTableGridProps {
+  render: WidgetTableRender;
+  filtered: Record<string, unknown>[];
+  resolveRowStyle: ReturnType<typeof makeRowStyleResolver>;
+  hasMore?: boolean;
+  isFetchingMore?: boolean;
+  onLoadMore?: () => void;
+  onScroll: (event: UIEvent<HTMLDivElement>) => void;
+}
+
+function WidgetTableGrid({
+  render,
+  filtered,
+  resolveRowStyle,
+  hasMore,
+  isFetchingMore,
+  onLoadMore,
+  onScroll,
+}: WidgetTableGridProps) {
+  const hasActions = Boolean(render.rowActions && render.rowActions.length > 0);
+  return (
+    <div className="overflow-auto" data-testid="widget-table" onScroll={onScroll}>
+      <table className="w-full border-collapse text-xs">
+        <thead className="bg-slate-50">
+          <tr>
+            {render.columns.map((col, i) => (
+              <th
+                key={`${col.field}-${i}`}
+                className="border-b border-slate-200 px-3 py-1.5 text-left font-semibold text-slate-700"
+              >
+                {col.label ?? col.field}
+              </th>
+            ))}
+            {hasActions ? (
+              <th className="border-b border-slate-200 px-3 py-1.5 text-right font-semibold text-slate-700">Actions</th>
+            ) : null}
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((row, idx) => {
+            const rowKey = rowKeyForRow(row, idx);
+            const toneClass = resolveRowStyle?.(row);
+            return (
+              <tr
+                key={rowKey}
+                data-row-tone={toneClass ? "true" : undefined}
+                className={cn(
+                  "border-b border-slate-100 last:border-0",
+                  // Drop the default hover wash when a tone is applied so the
+                  // tint isn't overridden — the row already has a deliberate
+                  // background and a hover bg would mask it.
+                  toneClass ? toneClass : "hover:bg-slate-50/60",
+                )}
+              >
+                {render.columns.map((col, ci) => (
+                  <Cell key={`${col.field}-${ci}`} col={col} row={row} />
+                ))}
+                {hasActions ? (
+                  <td className="px-3 py-1.5 text-right">
+                    <div className="inline-flex items-center gap-1">
+                      {render.rowActions
+                        ?.filter((action) => evaluateRowShow(action.show, row))
+                        .map((action, ai) => (
+                          <RowActionButton key={ai} action={action} row={row} rowKey={rowKey} />
+                        ))}
+                    </div>
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {hasMore && onLoadMore ? (
+        <LoadMoreFooter isFetchingMore={Boolean(isFetchingMore)} onLoadMore={onLoadMore} />
+      ) : null}
+    </div>
   );
 }
 

--- a/web_src/src/pages/app/console/widget/WidgetTable.tsx
+++ b/web_src/src/pages/app/console/widget/WidgetTable.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react";
-import { ExternalLink, Loader2, Play, RefreshCw, Square, Table2, Trash2 } from "lucide-react";
+import { useCallback, useMemo, useState, type UIEvent } from "react";
+import { ExternalLink, Loader2, Play, Plus, RefreshCw, Square, Table2, Trash2 } from "lucide-react";
 
 import { formatTimestampInUserTimezone } from "@/lib/timezone";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { useAutoLoadMoreOnScroll } from "@/components/CanvasToolSidebar/useAutoLoadMoreOnScroll";
 
 import { useConsoleContext, resolveConsoleNode } from "../ConsoleContext";
 import { applyTableWhere } from "./evalTableWhere";
@@ -24,6 +25,15 @@ interface WidgetTableProps {
   render: WidgetTableRender;
   rows: unknown[];
   isLoading: boolean;
+  /**
+   * Progressive-pagination affordances. When `hasMore` is true the footer
+   * shows a "Load more" button and the scrollable area auto-fetches as the
+   * user scrolls near the bottom. Wired only by the table panel; chart and
+   * number panels render the full configured limit at once.
+   */
+  hasMore?: boolean;
+  isFetchingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
 const STATUS_PILL_CLASS: Record<string, string> = {
@@ -45,7 +55,7 @@ const ACTION_ICONS = {
   "external-link": ExternalLink,
 } as const;
 
-export function WidgetTable({ render, rows, isLoading }: WidgetTableProps) {
+export function WidgetTable({ render, rows, isLoading, hasMore, isFetchingMore, onLoadMore }: WidgetTableProps) {
   const ctx = useConsoleContext();
   const recordRows = useMemo(
     () => rows.filter((r): r is Record<string, unknown> => Boolean(r) && typeof r === "object" && !Array.isArray(r)),
@@ -70,6 +80,18 @@ export function WidgetTable({ render, rows, isLoading }: WidgetTableProps) {
     }
     return Array.from(ids);
   }, [render.rowActions, ctx]);
+
+  const handleScrollLoadMore = useAutoLoadMoreOnScroll({
+    hasMore,
+    isLoading: isFetchingMore,
+    onLoadMore,
+  });
+  const onScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      handleScrollLoadMore(event.currentTarget);
+    },
+    [handleScrollLoadMore],
+  );
 
   if (isLoading) return <WidgetSpinner />;
   if (render.columns.length === 0) {
@@ -97,7 +119,7 @@ export function WidgetTable({ render, rows, isLoading }: WidgetTableProps) {
 
   return (
     <WidgetTableActionLockProvider triggerNodeIds={triggerNodeIds}>
-      <div className="overflow-auto" data-testid="widget-table">
+      <div className="overflow-auto" data-testid="widget-table" onScroll={onScroll}>
         <table className="w-full border-collapse text-xs">
           <thead className="bg-slate-50">
             <tr>
@@ -151,8 +173,33 @@ export function WidgetTable({ render, rows, isLoading }: WidgetTableProps) {
             })}
           </tbody>
         </table>
+        {hasMore && onLoadMore ? (
+          <LoadMoreFooter isFetchingMore={Boolean(isFetchingMore)} onLoadMore={onLoadMore} />
+        ) : null}
       </div>
     </WidgetTableActionLockProvider>
+  );
+}
+
+function LoadMoreFooter({ isFetchingMore, onLoadMore }: { isFetchingMore: boolean; onLoadMore: () => void }) {
+  return (
+    <div
+      className="flex items-center justify-center border-t border-slate-100 bg-slate-50/60 px-3 py-2"
+      data-testid="widget-table-load-more"
+    >
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={onLoadMore}
+        disabled={isFetchingMore}
+        className="h-7 gap-1 text-xs"
+        data-testid="widget-table-load-more-button"
+      >
+        {isFetchingMore ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
+        {isFetchingMore ? "Loading…" : "Load more"}
+      </Button>
+    </div>
   );
 }
 

--- a/web_src/src/pages/app/console/widget/useWidgetData.displayWindow.spec.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.displayWindow.spec.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { INITIAL_EAGER_ROWS, LOAD_MORE_STEP } from "./widgetPagination";
+import { useDisplayWindow } from "./useWidgetData";
+
+describe("useDisplayWindow — non-progressive callers", () => {
+  it("renders the full effective limit and tracks live limit increases", () => {
+    const { result, rerender } = renderHook(
+      ({ effectiveLimit }) => useDisplayWindow({ dataSourceKind: "runs", progressive: false, effectiveLimit }),
+      { initialProps: { effectiveLimit: 50 } },
+    );
+
+    expect(result.current.displaySlice).toBe(50);
+
+    // Regression guard: raising the limit live must take effect immediately
+    // (no remount), not stay clamped to the stale initial display count.
+    rerender({ effectiveLimit: 200 });
+    expect(result.current.displaySlice).toBe(200);
+
+    rerender({ effectiveLimit: 25 });
+    expect(result.current.displaySlice).toBe(25);
+  });
+
+  it("ignores loadMore (no progressive window)", () => {
+    const { result } = renderHook(() =>
+      useDisplayWindow({ dataSourceKind: "runs", progressive: false, effectiveLimit: 100 }),
+    );
+
+    act(() => result.current.loadMore());
+    expect(result.current.displaySlice).toBe(100);
+  });
+});
+
+describe("useDisplayWindow — progressive callers", () => {
+  it("starts at the eager window and grows by LOAD_MORE_STEP up to a finite limit", () => {
+    const { result } = renderHook(() =>
+      useDisplayWindow({ dataSourceKind: "runs", progressive: true, effectiveLimit: INITIAL_EAGER_ROWS + 150 }),
+    );
+
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS);
+
+    act(() => result.current.loadMore());
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS + LOAD_MORE_STEP);
+
+    // Caps at the configured limit rather than overshooting.
+    act(() => result.current.loadMore());
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS + 150);
+  });
+
+  it("does not reset the window when only the limit changes", () => {
+    const { result, rerender } = renderHook(
+      ({ effectiveLimit }) => useDisplayWindow({ dataSourceKind: "runs", progressive: true, effectiveLimit }),
+      { initialProps: { effectiveLimit: Number.POSITIVE_INFINITY } },
+    );
+
+    act(() => result.current.loadMore());
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS + LOAD_MORE_STEP);
+
+    rerender({ effectiveLimit: 1000 });
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS + LOAD_MORE_STEP);
+  });
+
+  it("resets the window when the data source kind changes", () => {
+    const { result, rerender } = renderHook(
+      ({ dataSourceKind }) =>
+        useDisplayWindow({ dataSourceKind, progressive: true, effectiveLimit: Number.POSITIVE_INFINITY }),
+      { initialProps: { dataSourceKind: "runs" as "runs" | "executions" } },
+    );
+
+    act(() => result.current.loadMore());
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS + LOAD_MORE_STEP);
+
+    rerender({ dataSourceKind: "executions" });
+    expect(result.current.displayCount).toBe(INITIAL_EAGER_ROWS);
+  });
+});

--- a/web_src/src/pages/app/console/widget/useWidgetData.pagination.spec.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.pagination.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_AGGREGATE_LIMIT,
+  INITIAL_EAGER_ROWS,
+  WIDGET_MAX_EAGER_PAGES,
+  computeDisplaySlice,
+  computeEffectiveLimit,
+  computeInitialDisplayCount,
+  computeWidgetHasMore,
+  isWidgetQueryLoading,
+  shouldFetchNextWidgetPage,
+} from "./useWidgetData";
+
+describe("computeEffectiveLimit", () => {
+  it("returns the raw limit when it is a positive finite number", () => {
+    expect(computeEffectiveLimit(50, false)).toBe(50);
+    expect(computeEffectiveLimit(250, true)).toBe(250);
+  });
+
+  it("falls back to Infinity for progressive callers with a blank limit", () => {
+    expect(computeEffectiveLimit(undefined, true)).toBe(Number.POSITIVE_INFINITY);
+    expect(computeEffectiveLimit(0, true)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("falls back to DEFAULT_AGGREGATE_LIMIT for non-progressive callers with a blank limit", () => {
+    expect(computeEffectiveLimit(undefined, false)).toBe(DEFAULT_AGGREGATE_LIMIT);
+    expect(computeEffectiveLimit(-5, false)).toBe(DEFAULT_AGGREGATE_LIMIT);
+  });
+});
+
+describe("computeInitialDisplayCount", () => {
+  it("returns the full effective limit for non-progressive callers", () => {
+    expect(computeInitialDisplayCount(50, false)).toBe(50);
+    expect(computeInitialDisplayCount(500, false)).toBe(500);
+  });
+
+  it("returns INITIAL_EAGER_ROWS for progressive callers with an unbounded limit", () => {
+    expect(computeInitialDisplayCount(Number.POSITIVE_INFINITY, true)).toBe(INITIAL_EAGER_ROWS);
+  });
+
+  it("clamps the initial window to a finite effective limit", () => {
+    expect(computeInitialDisplayCount(30, true)).toBe(30);
+    expect(computeInitialDisplayCount(INITIAL_EAGER_ROWS * 2, true)).toBe(INITIAL_EAGER_ROWS);
+  });
+});
+
+describe("computeDisplaySlice", () => {
+  it("clamps display count to the effective limit", () => {
+    expect(computeDisplaySlice(150, 100)).toBe(100);
+    expect(computeDisplaySlice(50, 100)).toBe(50);
+    expect(computeDisplaySlice(50, Number.POSITIVE_INFINITY)).toBe(50);
+  });
+});
+
+describe("computeWidgetHasMore", () => {
+  const baseInput = {
+    progressive: true,
+    displayCount: 100,
+    effectiveLimit: Number.POSITIVE_INFINITY,
+    loadedRowCount: 100,
+    hasNextPage: false as boolean | undefined,
+    pageCount: 4,
+  };
+
+  it("returns false for non-progressive callers", () => {
+    expect(computeWidgetHasMore({ ...baseInput, progressive: false, hasNextPage: true })).toBe(false);
+  });
+
+  it("returns false when displayCount has caught up to the effective limit", () => {
+    expect(computeWidgetHasMore({ ...baseInput, displayCount: 100, effectiveLimit: 100, hasNextPage: true })).toBe(
+      false,
+    );
+  });
+
+  it("returns true when more loaded rows can be revealed without fetching", () => {
+    expect(computeWidgetHasMore({ ...baseInput, loadedRowCount: 200, hasNextPage: false })).toBe(true);
+  });
+
+  it("returns true when more pages can still be fetched within the page budget", () => {
+    expect(computeWidgetHasMore({ ...baseInput, hasNextPage: true, pageCount: 4 })).toBe(true);
+  });
+
+  it("returns false when the eager-page budget is exhausted and no extra rows are loaded", () => {
+    expect(computeWidgetHasMore({ ...baseInput, hasNextPage: true, pageCount: WIDGET_MAX_EAGER_PAGES })).toBe(false);
+  });
+
+  it("treats hasNextPage===undefined the same as false", () => {
+    expect(computeWidgetHasMore({ ...baseInput, hasNextPage: undefined })).toBe(false);
+  });
+});
+
+describe("shouldFetchNextWidgetPage", () => {
+  const baseInput = {
+    enabled: true,
+    fillTarget: 100,
+    loadedRowCount: 25,
+    pageCount: 1,
+    hasNextPage: true as boolean | undefined,
+    isFetchingNextPage: false,
+    isFetching: false,
+  };
+
+  it("fetches when below the fill target with budget and no in-flight request", () => {
+    expect(shouldFetchNextWidgetPage(baseInput)).toBe(true);
+  });
+
+  it("does not fetch when disabled", () => {
+    expect(shouldFetchNextWidgetPage({ ...baseInput, enabled: false })).toBe(false);
+  });
+
+  it("does not fetch when there is no next page", () => {
+    expect(shouldFetchNextWidgetPage({ ...baseInput, hasNextPage: false })).toBe(false);
+  });
+
+  it("does not fetch while a fetch is already in flight", () => {
+    expect(shouldFetchNextWidgetPage({ ...baseInput, isFetchingNextPage: true })).toBe(false);
+    expect(shouldFetchNextWidgetPage({ ...baseInput, isFetching: true })).toBe(false);
+  });
+
+  it("does not fetch when the fill target is already satisfied", () => {
+    expect(shouldFetchNextWidgetPage({ ...baseInput, loadedRowCount: 100 })).toBe(false);
+  });
+
+  it("does not fetch beyond the page budget", () => {
+    expect(shouldFetchNextWidgetPage({ ...baseInput, pageCount: WIDGET_MAX_EAGER_PAGES })).toBe(false);
+  });
+});
+
+describe("isWidgetQueryLoading", () => {
+  const baseInput = {
+    queryIsLoading: false,
+    enabled: true,
+    hasNextPage: true as boolean | undefined,
+    loadedRowCount: 25,
+    fillTarget: 100,
+    pageCount: 1,
+    isFetchingNextPage: true,
+    isFetching: true,
+  };
+
+  it("reports loading while the initial fill is still in progress", () => {
+    expect(isWidgetQueryLoading(baseInput)).toBe(true);
+  });
+
+  it("reports loading when the underlying query reports its initial fetch", () => {
+    expect(isWidgetQueryLoading({ ...baseInput, queryIsLoading: true, isFetchingNextPage: false })).toBe(true);
+  });
+
+  it("stops reporting loading once the fill target is satisfied", () => {
+    expect(isWidgetQueryLoading({ ...baseInput, loadedRowCount: 100 })).toBe(false);
+  });
+
+  it("stops reporting loading when there are no more pages", () => {
+    expect(isWidgetQueryLoading({ ...baseInput, hasNextPage: false })).toBe(false);
+  });
+
+  it("respects the eager-page budget", () => {
+    expect(isWidgetQueryLoading({ ...baseInput, pageCount: WIDGET_MAX_EAGER_PAGES })).toBe(false);
+  });
+});

--- a/web_src/src/pages/app/console/widget/useWidgetData.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/api-client";
+import type { CanvasesCanvasNodeExecution } from "@/api-client";
 import {
   useCanvasMemoryEntries,
   useEventExecutionsBatch,
@@ -8,10 +8,43 @@ import {
   useInfiniteCanvasRuns,
 } from "@/hooks/useCanvasData";
 
-import { resolveConsoleNode, useConsoleContext } from "../ConsoleContext";
-import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
+import { resolveConsoleNode, useConsoleContext, type ConsoleContextValue } from "../ConsoleContext";
 import { flattenMemoryEntries } from "./memoryRow";
 import type { WidgetDataSource, WidgetRender } from "./types";
+import {
+  LOAD_MORE_STEP,
+  computeDisplaySlice,
+  computeEffectiveLimit,
+  computeInitialDisplayCount,
+  computeWidgetHasMore,
+  isWidgetQueryLoading,
+  useEagerInfinitePagination,
+} from "./widgetPagination";
+import { buildNodeNameMap, collectExecutionRows, collectRunRows } from "./widgetRowCollection";
+
+// Re-export the row-collection and pagination helpers from this module so the
+// existing spec imports (and any external callers) keep working after the
+// split. Keep this section narrow — new helpers should be added to their
+// home modules and imported from there directly.
+export {
+  DEFAULT_AGGREGATE_LIMIT,
+  INITIAL_EAGER_ROWS,
+  LOAD_MORE_STEP,
+  WIDGET_MAX_EAGER_PAGES,
+  computeDisplaySlice,
+  computeEffectiveLimit,
+  computeInitialDisplayCount,
+  computeWidgetHasMore,
+  isWidgetQueryLoading,
+  shouldFetchNextWidgetPage,
+} from "./widgetPagination";
+export {
+  buildDollarNodes,
+  buildNodeNameMap,
+  collectExecutionRows,
+  collectRunRows,
+  lastOutputData,
+} from "./widgetRowCollection";
 
 export interface WidgetDataResult {
   rows: unknown[];
@@ -19,16 +52,23 @@ export interface WidgetDataResult {
   error?: string;
   /** Server-reported total for sources that expose one (currently `runs`). */
   totalCount?: number;
+  /**
+   * Whether more rows can be revealed by calling `loadMore()`. Only meaningful
+   * for progressive callers (the table widget). `false` for chart/number
+   * panels that always render against the full configured limit.
+   */
+  hasMore?: boolean;
+  /**
+   * `true` while a `loadMore()`-triggered (or scroll-triggered) fetch is in
+   * flight, distinct from the initial fill which is reported via `isLoading`.
+   */
+  isFetchingMore?: boolean;
+  /**
+   * Grow the per-widget display window by `LOAD_MORE_STEP` rows (capped at
+   * the configured limit, if any). No-op for non-progressive callers.
+   */
+  loadMore?: () => void;
 }
-
-/**
- * Upper bound on how many event pages a widget will eagerly pull through
- * the infinite query before giving up. Each page returns 25 events, so 20
- * pages covers up to ~500 events — comfortably more than the row `limit`
- * any dashboard panel currently asks for, while bounding memory and
- * network cost for canvases with very long histories.
- */
-const EXECUTIONS_MAX_EAGER_PAGES = 20;
 
 /**
  * Reactively fetch the dataset for a widget based on its declared data source.
@@ -38,16 +78,18 @@ const EXECUTIONS_MAX_EAGER_PAGES = 20;
  * - `memory` reads from the canvas memory entries and filters to the requested
  *   namespace. When `fieldPath` is set, rows are flat-mapped to the value at
  *   that path (lists are spread, scalars become single-row entries).
- * - `runs` reads from the canvas runs query and exposes the API totalCount,
- *   which makes Number panels report the canvas run count without depending
- *   on how many pages have been loaded.
+ * - `runs` reads from the canvas runs infinite query and exposes the API
+ *   totalCount, which makes Number panels report the canvas run count without
+ *   depending on how many pages have been loaded.
  * - `executions` reads from the infinite canvas events query and flattens
  *   their `executions[]` arrays. When a `node` reference is set, only matching
- *   executions are returned. Pages are fetched eagerly until we have enough
- *   rows to satisfy `limit` or the canvas has no more events — without this,
- *   the visible row count fluctuates non-monotonically when a manual run
- *   prepends a new (still-empty) event that pushes an older event-with-
- *   executions off the loaded first page.
+ *   executions are returned.
+ *
+ * Both `runs` and `executions` eagerly fetch pages until the per-widget
+ * display window is satisfied or `WIDGET_MAX_EAGER_PAGES` is reached. Without
+ * this, the runs widget would silently piggyback on whichever other consumer
+ * (e.g. the canvas Runs sidebar) happened to paginate the shared infinite-
+ * query cache, so the visible row count would jump non-monotonically.
  *
  * `needsNodeOutputs` controls the `runs` per-node side-load. Resolving
  * `$["node"].outputs` requires a `ListEventExecutions` call per visible run
@@ -58,152 +100,58 @@ const EXECUTIONS_MAX_EAGER_PAGES = 20;
  * side-load resolved even though it never reads per-node data. Defaults to
  * `true` so a caller that forgets to pass it keeps the safe (fully-loaded)
  * behavior.
+ *
+ * `progressive` opts a caller into the per-widget pagination UX: the widget
+ * starts at `INITIAL_EAGER_ROWS` and grows via `loadMore()` (button or scroll)
+ * up to the configured `limit` (or unbounded when blank). Charts and numbers
+ * stay non-progressive — they always aggregate against the full configured
+ * limit at once, since partial aggregates would flash incorrect KPIs.
  */
 export function useWidgetData(
   canvasId: string,
   dataSource: WidgetDataSource,
   needsNodeOutputs: boolean = true,
+  progressive: boolean = false,
 ): WidgetDataResult {
   const ctx = useConsoleContext();
+  const rawLimit = dataSource.kind === "memory" ? undefined : dataSource.limit;
+  const effectiveLimit = computeEffectiveLimit(rawLimit, progressive);
+  const initialFillTarget = computeInitialDisplayCount(effectiveLimit, progressive);
 
-  const memoryEnabled = dataSource.kind === "memory";
-  const memoryQuery = useCanvasMemoryEntries(canvasId, memoryEnabled);
-
-  const executionsEnabled = dataSource.kind === "executions";
-  const eventsQuery = useInfiniteCanvasEvents(canvasId, executionsEnabled);
-  const runsEnabled = dataSource.kind === "runs";
-  const runsQuery = useInfiniteCanvasRuns(canvasId, {}, runsEnabled);
-
-  const executionLimit = dataSource.kind === "executions" ? (dataSource.limit ?? 50) : 0;
-  const runsLimit = dataSource.kind === "runs" ? (dataSource.limit ?? 50) : 0;
-
-  /**
-   * Trigger additional infinite-query pages while we don't have enough
-   * executions to satisfy the widget's `limit` and the canvas still has
-   * more events to give us. We re-evaluate after each page arrives, which
-   * naturally backs off once `executionRows` reaches the limit or
-   * `hasNextPage` flips to false. Capped at `EXECUTIONS_MAX_EAGER_PAGES`
-   * to bound work for very long canvas histories.
-   */
-  const {
-    data: eventsData,
-    isLoading: eventsIsLoading,
-    isFetching: eventsIsFetching,
-    isFetchingNextPage: eventsIsFetchingNextPage,
-    hasNextPage: eventsHasNextPage,
-    fetchNextPage: eventsFetchNextPage,
-    error: eventsError,
-  } = eventsQuery;
-
-  const eagerPageCount = eventsData?.pages?.length ?? 0;
-  const eagerExecutionCount = useMemo(() => {
-    if (!executionsEnabled) return 0;
-    const pages = eventsData?.pages ?? [];
-    let count = 0;
-    for (const page of pages) {
-      for (const event of page?.events ?? []) {
-        count += event.executions?.length ?? 0;
-      }
-    }
-    return count;
-  }, [executionsEnabled, eventsData]);
-
-  useEagerExecutionPagination({
-    executionsEnabled,
-    executionLimit,
-    eagerExecutionCount,
-    eagerPageCount,
-    eventsHasNextPage,
-    eventsIsFetchingNextPage,
-    eventsIsFetching,
-    eventsFetchNextPage,
+  const { displayCount, displaySlice, loadMore } = useDisplayWindow({
+    dataSourceKind: dataSource.kind,
+    progressive,
+    effectiveLimit,
   });
 
-  const memoryRows = useMemo(() => {
-    if (dataSource.kind !== "memory") return [];
-    return flattenMemoryEntries(memoryQuery.data ?? [], dataSource.namespace, dataSource.fieldPath);
-  }, [dataSource, memoryQuery.data]);
-
-  const executionRows = useMemo(() => {
-    if (dataSource.kind !== "executions") return [];
-    const pages = eventsData?.pages ?? [];
-    const targetNode = dataSource.node ? resolveConsoleNode(ctx, dataSource.node) : undefined;
-    const targetNodeId = targetNode?.node.id;
-    const nodeNameById = buildNodeNameMap(ctx?.nodes);
-    return collectExecutionRows(pages, targetNodeId, nodeNameById, executionLimit);
-  }, [dataSource, eventsData, ctx, executionLimit]);
-
-  // Collect unique root-event ids for the visible run page so we can lazy-
-  // fetch their per-node executions (with `outputs`) via `ListEventExecutions`.
-  // The runs API only returns lightweight execution refs without outputs, so
-  // we have to side-load the full executions to support `$["node"].outputs`.
-  const runRootEventIds = useMemo(() => {
-    if (dataSource.kind !== "runs" || !needsNodeOutputs) return [] as string[];
-    const seen = new Set<string>();
-    const ids: string[] = [];
-    let count = 0;
-    for (const page of runsQuery.data?.pages ?? []) {
-      for (const run of page?.runs ?? []) {
-        if (count >= runsLimit) break;
-        count++;
-        const id = run.rootEvent?.id;
-        if (id && !seen.has(id)) {
-          seen.add(id);
-          ids.push(id);
-        }
-      }
-      if (count >= runsLimit) break;
-    }
-    return ids;
-  }, [dataSource, runsQuery.data, runsLimit, needsNodeOutputs]);
-
-  const { queries: runExecutionQueries, isLoading: runExecutionsLoading } = useEventExecutionsBatch(
+  const memoryResult = useMemoryDataSourceResult(canvasId, dataSource);
+  const executionsResult = useExecutionsDataSourceResult({
     canvasId,
-    runRootEventIds,
-  );
-
-  const executionsByRootEventId = useMemo(() => {
-    const map = new Map<string, CanvasesCanvasNodeExecution[]>();
-    runRootEventIds.forEach((eventId, index) => {
-      const data = runExecutionQueries[index]?.data;
-      if (!data?.executions) return;
-      map.set(eventId, data.executions as CanvasesCanvasNodeExecution[]);
-    });
-    return map;
-  }, [runRootEventIds, runExecutionQueries]);
-
-  const runRows = useMemo(() => {
-    if (dataSource.kind !== "runs") return [];
-    const pages = runsQuery.data?.pages ?? [];
-    const nodeNameById = buildNodeNameMap(ctx?.nodes);
-    return collectRunRows(pages, nodeNameById, runsLimit, executionsByRootEventId);
-  }, [dataSource, runsQuery.data, ctx, runsLimit, executionsByRootEventId]);
-
-  // Treat ongoing eager pagination as part of the initial load so panels
-  // (especially `count` aggregations) don't flash an intermediate value
-  // before the rest of the pages settle.
-  const executionsLoading = isExecutionQueryLoading({
-    eventsIsLoading,
-    executionsEnabled,
-    eventsHasNextPage,
-    eagerExecutionCount,
-    executionLimit,
-    eagerPageCount,
-    eventsIsFetchingNextPage,
-    eventsIsFetching,
-  });
-
-  return resultForDataSource({
     dataSource,
-    memoryRows,
-    memoryQuery,
-    runRows,
-    runsQuery,
-    runExecutionsLoading,
-    executionRows,
-    executionsLoading,
-    eventsError,
+    ctx,
+    progressive,
+    displayCount,
+    displaySlice,
+    effectiveLimit,
+    initialFillTarget,
+    loadMore,
   });
+  const runsResult = useRunsDataSourceResult({
+    canvasId,
+    dataSource,
+    ctx,
+    needsNodeOutputs,
+    progressive,
+    displayCount,
+    displaySlice,
+    effectiveLimit,
+    initialFillTarget,
+    loadMore,
+  });
+
+  if (dataSource.kind === "memory") return memoryResult;
+  if (dataSource.kind === "runs") return runsResult;
+  return executionsResult;
 }
 
 /**
@@ -231,383 +179,279 @@ export function renderNeedsRunNodeOutputs(render: WidgetRender | undefined): boo
   return RUN_NODE_REF_RE.test(JSON.stringify(render));
 }
 
-function useEagerExecutionPagination({
-  executionsEnabled,
-  executionLimit,
-  eagerExecutionCount,
-  eagerPageCount,
-  eventsHasNextPage,
-  eventsIsFetchingNextPage,
-  eventsIsFetching,
-  eventsFetchNextPage,
+/**
+ * Per-widget display window state. Tracks the current visible row count,
+ * resets it on a meaningful "widget identity" change (data source kind or
+ * `progressive` toggle), and exposes a `loadMore()` that bumps the count
+ * up to the configured limit. Limit edits intentionally do not reset the
+ * window — the slice clamps via `computeDisplaySlice` and we'd rather not
+ * yank the user back to the first page just because they bumped the limit
+ * input.
+ */
+function useDisplayWindow({
+  dataSourceKind,
+  progressive,
+  effectiveLimit,
 }: {
-  executionsEnabled: boolean;
-  executionLimit: number;
-  eagerExecutionCount: number;
-  eagerPageCount: number;
-  eventsHasNextPage: boolean | undefined;
-  eventsIsFetchingNextPage: boolean;
-  eventsIsFetching: boolean;
-  eventsFetchNextPage: () => unknown;
+  dataSourceKind: WidgetDataSource["kind"];
+  progressive: boolean;
+  effectiveLimit: number;
 }) {
+  const [displayCount, setDisplayCount] = useState(() => computeInitialDisplayCount(effectiveLimit, progressive));
+  const lastIdentityRef = useRef<{ kind: WidgetDataSource["kind"]; progressive: boolean }>({
+    kind: dataSourceKind,
+    progressive,
+  });
   useEffect(() => {
-    if (
-      !shouldFetchNextExecutionPage({
-        executionsEnabled,
-        executionLimit,
-        eagerExecutionCount,
-        eagerPageCount,
-        eventsHasNextPage,
-        eventsIsFetchingNextPage,
-        eventsIsFetching,
-      })
-    ) {
-      return;
-    }
-    void eventsFetchNextPage();
-  }, [
-    executionsEnabled,
-    executionLimit,
-    eagerExecutionCount,
-    eagerPageCount,
-    eventsHasNextPage,
-    eventsIsFetchingNextPage,
-    eventsIsFetching,
-    eventsFetchNextPage,
-  ]);
+    const last = lastIdentityRef.current;
+    if (last.kind === dataSourceKind && last.progressive === progressive) return;
+    lastIdentityRef.current = { kind: dataSourceKind, progressive };
+    setDisplayCount(computeInitialDisplayCount(effectiveLimit, progressive));
+  }, [dataSourceKind, progressive, effectiveLimit]);
+
+  const loadMore = useCallback(() => {
+    if (!progressive) return;
+    setDisplayCount((c) => {
+      const next = c + LOAD_MORE_STEP;
+      return Number.isFinite(effectiveLimit) ? Math.min(next, effectiveLimit) : next;
+    });
+  }, [progressive, effectiveLimit]);
+
+  return {
+    displayCount,
+    displaySlice: computeDisplaySlice(displayCount, effectiveLimit),
+    loadMore,
+  };
 }
 
-function shouldFetchNextExecutionPage({
-  executionsEnabled,
-  executionLimit,
-  eagerExecutionCount,
-  eagerPageCount,
-  eventsHasNextPage,
-  eventsIsFetchingNextPage,
-  eventsIsFetching,
-}: {
-  executionsEnabled: boolean;
-  executionLimit: number;
-  eagerExecutionCount: number;
-  eagerPageCount: number;
-  eventsHasNextPage: boolean | undefined;
-  eventsIsFetchingNextPage: boolean;
-  eventsIsFetching: boolean;
-}): boolean {
-  if (!executionsEnabled || !eventsHasNextPage) return false;
-  if (eventsIsFetchingNextPage || eventsIsFetching) return false;
-  if (eagerExecutionCount >= executionLimit) return false;
-  return eagerPageCount < EXECUTIONS_MAX_EAGER_PAGES;
+function useMemoryDataSourceResult(canvasId: string, dataSource: WidgetDataSource): WidgetDataResult {
+  const enabled = dataSource.kind === "memory";
+  const query = useCanvasMemoryEntries(canvasId, enabled);
+  const rows = useMemo(() => {
+    if (dataSource.kind !== "memory") return [];
+    return flattenMemoryEntries(query.data ?? [], dataSource.namespace, dataSource.fieldPath);
+  }, [dataSource, query.data]);
+  return { rows, isLoading: query.isLoading, error: errorMessage(query.error) };
 }
 
-function isExecutionQueryLoading({
-  eventsIsLoading,
-  executionsEnabled,
-  eventsHasNextPage,
-  eagerExecutionCount,
-  executionLimit,
-  eagerPageCount,
-  eventsIsFetchingNextPage,
-  eventsIsFetching,
-}: {
-  eventsIsLoading: boolean;
-  executionsEnabled: boolean;
-  eventsHasNextPage: boolean | undefined;
-  eagerExecutionCount: number;
-  executionLimit: number;
-  eagerPageCount: number;
-  eventsIsFetchingNextPage: boolean;
-  eventsIsFetching: boolean;
-}): boolean {
-  if (eventsIsLoading) return true;
-  return (
-    executionsEnabled &&
-    eventsHasNextPage === true &&
-    eagerExecutionCount < executionLimit &&
-    eagerPageCount < EXECUTIONS_MAX_EAGER_PAGES &&
-    (eventsIsFetchingNextPage || eventsIsFetching)
-  );
-}
-
-function resultForDataSource({
+function useExecutionsDataSourceResult({
+  canvasId,
   dataSource,
-  memoryRows,
-  memoryQuery,
-  runRows,
-  runsQuery,
-  runExecutionsLoading,
-  executionRows,
-  executionsLoading,
-  eventsError,
+  ctx,
+  progressive,
+  displayCount,
+  displaySlice,
+  effectiveLimit,
+  initialFillTarget,
+  loadMore,
 }: {
+  canvasId: string;
   dataSource: WidgetDataSource;
-  memoryRows: unknown[];
-  memoryQuery: { isLoading: boolean; error: unknown };
-  runRows: unknown[];
-  runsQuery: { isLoading: boolean; error: unknown; data?: { pages?: Array<{ totalCount?: number }> } };
-  runExecutionsLoading: boolean;
-  executionRows: unknown[];
-  executionsLoading: boolean;
-  eventsError: unknown;
+  ctx: ConsoleContextValue | undefined;
+  progressive: boolean;
+  displayCount: number;
+  displaySlice: number;
+  effectiveLimit: number;
+  initialFillTarget: number;
+  loadMore: () => void;
 }): WidgetDataResult {
-  if (dataSource.kind === "memory") {
-    return { rows: memoryRows, isLoading: memoryQuery.isLoading, error: errorMessage(memoryQuery.error) };
-  }
-  if (dataSource.kind === "runs") {
-    // Treat the per-run execution side-loads as part of the initial load so
-    // count/aggregate panels don't flash with empty `$` references before
-    // the executions resolve.
-    return {
-      rows: runRows,
-      isLoading: runsQuery.isLoading || runExecutionsLoading,
-      error: errorMessage(runsQuery.error),
-      totalCount: runsQuery.data?.pages?.[0]?.totalCount,
-    };
-  }
-  return { rows: executionRows, isLoading: executionsLoading, error: errorMessage(eventsError) };
+  const enabled = dataSource.kind === "executions";
+  const query = useInfiniteCanvasEvents(canvasId, enabled);
+  // Memoize `pages` so empty-array fallback identity stays stable across
+  // renders — keeps the downstream `useMemo` deps from busting every cycle.
+  const pages = useMemo(() => query.data?.pages ?? [], [query.data]);
+  const pageCount = pages.length;
+
+  const loadedRowCount = useMemo(() => {
+    if (!enabled) return 0;
+    let count = 0;
+    for (const page of pages) {
+      for (const event of page?.events ?? []) {
+        count += event.executions?.length ?? 0;
+      }
+    }
+    return count;
+  }, [enabled, pages]);
+
+  useEagerInfinitePagination({
+    enabled,
+    fillTarget: displaySlice,
+    loadedRowCount,
+    pageCount,
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isFetching: query.isFetching,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  const rows = useMemo(() => {
+    if (dataSource.kind !== "executions") return [];
+    const targetNode = dataSource.node ? resolveConsoleNode(ctx, dataSource.node) : undefined;
+    const targetNodeId = targetNode?.node.id;
+    const nodeNameById = buildNodeNameMap(ctx?.nodes);
+    return collectExecutionRows(pages, targetNodeId, nodeNameById, displaySlice);
+  }, [dataSource, pages, ctx, displaySlice]);
+
+  const isLoading = isWidgetQueryLoading({
+    queryIsLoading: query.isLoading,
+    enabled,
+    hasNextPage: query.hasNextPage,
+    loadedRowCount,
+    fillTarget: initialFillTarget,
+    pageCount,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isFetching: query.isFetching,
+  });
+
+  const hasMore = computeWidgetHasMore({
+    progressive,
+    displayCount,
+    effectiveLimit,
+    loadedRowCount,
+    hasNextPage: query.hasNextPage,
+    pageCount,
+  });
+
+  const isFetchingMore = enabled && query.isFetchingNextPage && !isLoading && hasMore;
+  const paginationFields = progressive ? { hasMore, isFetchingMore, loadMore } : {};
+  return { rows, isLoading, error: errorMessage(query.error), ...paginationFields };
+}
+
+function useRunsDataSourceResult({
+  canvasId,
+  dataSource,
+  ctx,
+  needsNodeOutputs,
+  progressive,
+  displayCount,
+  displaySlice,
+  effectiveLimit,
+  initialFillTarget,
+  loadMore,
+}: {
+  canvasId: string;
+  dataSource: WidgetDataSource;
+  ctx: ConsoleContextValue | undefined;
+  needsNodeOutputs: boolean;
+  progressive: boolean;
+  displayCount: number;
+  displaySlice: number;
+  effectiveLimit: number;
+  initialFillTarget: number;
+  loadMore: () => void;
+}): WidgetDataResult {
+  const enabled = dataSource.kind === "runs";
+  const query = useInfiniteCanvasRuns(canvasId, {}, enabled);
+  // Memoize `pages` so empty-array fallback identity stays stable across
+  // renders — keeps the downstream `useMemo` deps from busting every cycle.
+  const pages = useMemo(() => query.data?.pages ?? [], [query.data]);
+  const pageCount = pages.length;
+
+  const loadedRowCount = useMemo(() => {
+    if (!enabled) return 0;
+    let count = 0;
+    for (const page of pages) count += page?.runs?.length ?? 0;
+    return count;
+  }, [enabled, pages]);
+
+  useEagerInfinitePagination({
+    enabled,
+    fillTarget: displaySlice,
+    loadedRowCount,
+    pageCount,
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isFetching: query.isFetching,
+    fetchNextPage: query.fetchNextPage,
+  });
+
+  // Collect unique root-event ids for the visible run page so we can lazy-
+  // fetch their per-node executions (with `outputs`) via `ListEventExecutions`.
+  // The runs API only returns lightweight execution refs without outputs, so
+  // we have to side-load the full executions to support `$["node"].outputs`.
+  const runRootEventIds = useMemo(() => {
+    if (dataSource.kind !== "runs" || !needsNodeOutputs) return [] as string[];
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    let count = 0;
+    for (const page of pages) {
+      for (const run of page?.runs ?? []) {
+        if (count >= displaySlice) break;
+        count++;
+        const id = run.rootEvent?.id;
+        if (id && !seen.has(id)) {
+          seen.add(id);
+          ids.push(id);
+        }
+      }
+      if (count >= displaySlice) break;
+    }
+    return ids;
+  }, [dataSource, pages, displaySlice, needsNodeOutputs]);
+
+  const { queries: runExecutionQueries, isLoading: runExecutionsLoading } = useEventExecutionsBatch(
+    canvasId,
+    runRootEventIds,
+  );
+
+  const executionsByRootEventId = useMemo(() => {
+    const map = new Map<string, CanvasesCanvasNodeExecution[]>();
+    runRootEventIds.forEach((eventId, index) => {
+      const data = runExecutionQueries[index]?.data;
+      if (!data?.executions) return;
+      map.set(eventId, data.executions as CanvasesCanvasNodeExecution[]);
+    });
+    return map;
+  }, [runRootEventIds, runExecutionQueries]);
+
+  const rows = useMemo(() => {
+    if (dataSource.kind !== "runs") return [];
+    const nodeNameById = buildNodeNameMap(ctx?.nodes);
+    return collectRunRows(pages, nodeNameById, displaySlice, executionsByRootEventId);
+  }, [dataSource, pages, ctx, displaySlice, executionsByRootEventId]);
+
+  const initialFillLoading = isWidgetQueryLoading({
+    queryIsLoading: query.isLoading,
+    enabled,
+    hasNextPage: query.hasNextPage,
+    loadedRowCount,
+    fillTarget: initialFillTarget,
+    pageCount,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isFetching: query.isFetching,
+  });
+
+  // In progressive mode the table stays mounted across `Load more` clicks,
+  // each of which appends more root-event ids to `runRootEventIds` and
+  // re-flips `runExecutionsLoading` to true. Gating `isLoading` on it would
+  // hide the already-rendered rows behind a spinner every time the user
+  // grows the window, so progressive callers absorb side-loads as
+  // background work — the affected `$["node"]` cells render `-` until they
+  // resolve. Non-progressive callers (chart/number) keep the existing
+  // strict gate so partial aggregates don't flash.
+  const sideLoadsBlock = !progressive && runExecutionsLoading;
+  const isLoading = initialFillLoading || sideLoadsBlock;
+
+  const hasMore = computeWidgetHasMore({
+    progressive,
+    displayCount,
+    effectiveLimit,
+    loadedRowCount,
+    hasNextPage: query.hasNextPage,
+    pageCount,
+  });
+
+  const isFetchingMore = enabled && query.isFetchingNextPage && !isLoading && hasMore;
+  const paginationFields = progressive ? { hasMore, isFetchingMore, loadMore } : {};
+  return {
+    rows,
+    isLoading,
+    error: errorMessage(query.error),
+    totalCount: query.data?.pages?.[0]?.totalCount,
+    ...paginationFields,
+  };
 }
 
 function errorMessage(error: unknown): string | undefined {
   return error ? String(error) : undefined;
-}
-
-/**
- * Walk the loaded event pages and synthesize the row objects the dashboard's
- * table / chart / number renderers consume. Each row carries the raw
- * execution fields plus four derived conveniences:
- *
- * - `status`: lowercase canonical status string (see {@link deriveExecutionStatus}).
- * - `nodeName`: friendly node label resolved per-row via `nodeNameById`,
- *   falling back to the raw `nodeId` when the canvas no longer contains
- *   that node (e.g. it was deleted after the execution ran).
- * - `durationMs`: created-to-updated elapsed time in milliseconds.
- * - `payload`: the data carried by the parent (root) event — i.e. the
- *   payload the node received. Shared by every execution under that event.
- *
- * Iteration stops as soon as `rows.length >= limit`.
- */
-export function collectExecutionRows(
-  pages: Array<
-    | {
-        events?: Array<{
-          data?: Record<string, unknown>;
-          executions?: Array<
-            Record<string, unknown> & {
-              nodeId?: string;
-              state?: string;
-              result?: string;
-              createdAt?: string;
-              updatedAt?: string;
-            }
-          >;
-        }>;
-      }
-    | undefined
-  >,
-  targetNodeId: string | undefined,
-  nodeNameById: Map<string, string>,
-  limit: number,
-): unknown[] {
-  const rows: unknown[] = [];
-  for (const page of pages) {
-    for (const event of page?.events ?? []) {
-      for (const exec of event.executions ?? []) {
-        if (targetNodeId && exec.nodeId !== targetNodeId) continue;
-        rows.push({
-          ...exec,
-          status: deriveExecutionStatus(exec.state, exec.result),
-          nodeName: (exec.nodeId && nodeNameById.get(exec.nodeId)) || exec.nodeId,
-          durationMs:
-            exec.updatedAt && exec.createdAt ? Date.parse(exec.updatedAt) - Date.parse(exec.createdAt) : undefined,
-          payload: event.data,
-        });
-        if (rows.length >= limit) return rows;
-      }
-    }
-  }
-  return rows;
-}
-
-/**
- * Walk the loaded run pages and synthesize the row objects the dashboard's
- * widgets consume. Each row carries the raw `CanvasesCanvasRun` fields plus
- * a few derived conveniences mirroring what `RunsList` shows:
- *
- * - `status`: lowercase canonical status string (see {@link deriveRunStatus}).
- * - `nodeName`: friendly label of the node that initiated the run, resolved
- *   from `rootEvent.nodeId` via `nodeNameById`. Falls back to the raw
- *   `nodeId` when the canvas no longer contains that node.
- * - `payload`: alias for `rootEvent.data` — the initial payload that
- *   triggered the run. Exposed at the top level so authors don't have to
- *   type `rootEvent.data.*` for the common case.
- * - `durationMs`: created-to-finished elapsed time in milliseconds. Mirrors
- *   the executions row's `durationMs` so authors can write
- *   `field: durationMs, format: duration` for a friendly run-duration cell
- *   without having to write CEL date arithmetic.
- * - `$` / `DOLLAR_REWRITE_IDENTIFIER`: a map keyed by node display name
- *   pointing at each node's full execution (with `outputs` and a `data`
- *   shortcut for the latest output event). Lets authors write
- *   `$["deploy-prod"].outputs.url` in literal field paths and the same
- *   syntax in `{{ }}` CEL templates (the CEL compiler rewrites `$` to
- *   `__runNodes__` since cel-js doesn't accept `$` as an identifier).
- *
- * The raw `rootEvent`, `executions`, timestamps, etc. remain reachable via
- * dot paths (`getValueAtPath`) because we spread the full run into the row.
- *
- * Iteration stops as soon as `rows.length >= limit`.
- */
-type RunRowSource = Record<string, unknown> & {
-  state?: string;
-  result?: string;
-  createdAt?: string;
-  finishedAt?: string;
-  rootEvent?: {
-    id?: string;
-    nodeId?: string;
-    data?: Record<string, unknown>;
-  };
-};
-
-function buildRunRow(
-  run: RunRowSource,
-  nodeNameById: Map<string, string>,
-  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
-): unknown {
-  const rootEvent = run.rootEvent;
-  const nodeId = rootEvent?.nodeId;
-  const executions = (rootEvent?.id && executionsByRootEventId?.get(rootEvent.id)) || undefined;
-  const dollarNodes = buildDollarNodes(executions, nodeNameById);
-  return {
-    ...run,
-    status: deriveRunStatus(run.state, run.result),
-    nodeName: (nodeId && nodeNameById.get(nodeId)) || nodeId,
-    payload: rootEvent?.data,
-    durationMs: run.finishedAt && run.createdAt ? Date.parse(run.finishedAt) - Date.parse(run.createdAt) : undefined,
-    $: dollarNodes,
-    [DOLLAR_REWRITE_IDENTIFIER]: dollarNodes,
-  };
-}
-
-export function collectRunRows(
-  pages: Array<{ runs?: RunRowSource[] } | undefined>,
-  nodeNameById: Map<string, string>,
-  limit: number,
-  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
-): unknown[] {
-  const rows: unknown[] = [];
-  for (const page of pages) {
-    for (const run of page?.runs ?? []) {
-      rows.push(buildRunRow(run, nodeNameById, executionsByRootEventId));
-      if (rows.length >= limit) return rows;
-    }
-  }
-  return rows;
-}
-
-/**
- * Build the `$` map for a single run row. Keys are node display names so
- * authors can write `$["deploy-prod"]` in expressions; falls back to the
- * `nodeId` when the canvas no longer contains that node (e.g. it was
- * deleted). The value spreads the full execution and adds a `data` shortcut
- * mirroring the canvas-side `$['Node Name'].data` semantics.
- */
-export function buildDollarNodes(
-  executions: CanvasesCanvasNodeExecution[] | undefined,
-  nodeNameById: Map<string, string>,
-): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  if (!executions) return out;
-  for (const exec of executions) {
-    if (!exec.nodeId) continue;
-    const name = nodeNameById.get(exec.nodeId) || exec.nodeId;
-    out[name] = {
-      ...exec,
-      data: lastOutputData(exec.outputs),
-    };
-  }
-  return out;
-}
-
-/**
- * Pick the most useful single payload from an execution's `outputs` map.
- * Mirrors how the canvas backend resolves `$['Node Name'].data`: prefer the
- * `default` channel, otherwise the first available channel; take the last
- * event in that channel (most recent emission). When the event itself is
- * an envelope-shaped object with a `.data` field, unwrap it; otherwise
- * return the event verbatim. Returns `undefined` for missing or empty
- * outputs so widget cells render `-`.
- */
-export function lastOutputData(outputs: Record<string, unknown> | undefined): unknown {
-  if (!outputs) return undefined;
-  const channels = Object.keys(outputs);
-  if (channels.length === 0) return undefined;
-  const channel = channels.includes("default") ? "default" : channels[0];
-  const events = outputs[channel];
-  if (!Array.isArray(events) || events.length === 0) return undefined;
-  const last = events[events.length - 1];
-  if (last && typeof last === "object" && !Array.isArray(last) && "data" in last) {
-    return (last as { data: unknown }).data;
-  }
-  return last;
-}
-
-/**
- * Build a `nodeId -> friendly name` lookup from the canvas nodes available
- * on the dashboard context. We index by id only (not name) because event
- * executions always carry `nodeId`. Falls back to the node id when the
- * canvas node has no `name`, so the widget never shows a blank label.
- */
-export function buildNodeNameMap(nodes: SuperplaneComponentsNode[] | undefined): Map<string, string> {
-  const map = new Map<string, string>();
-  if (!nodes) return map;
-  for (const node of nodes) {
-    if (!node.id) continue;
-    map.set(node.id, node.name || node.id);
-  }
-  return map;
-}
-
-/**
- * Collapse the API `state` / `result` enum pair into the lowercase status
- * vocabulary the rest of the dashboard speaks: `passed`, `failed`,
- * `cancelled`, `running`, `pending`, `unknown`. Matches the lookup tables in
- * `WidgetTable` (`STATUS_PILL_CLASS`) and `NodePanelCard` (`STATUS_CLASS`).
- */
-function deriveExecutionStatus(
-  state: string | undefined,
-  result: string | undefined,
-): "passed" | "failed" | "cancelled" | "running" | "pending" | "unknown" {
-  if (state === "STATE_PENDING") return "pending";
-  if (state === "STATE_STARTED") return "running";
-  if (state === "STATE_FINISHED") {
-    switch (result) {
-      case "RESULT_PASSED":
-        return "passed";
-      case "RESULT_FAILED":
-        return "failed";
-      case "RESULT_CANCELLED":
-        return "cancelled";
-      default:
-        return "unknown";
-    }
-  }
-  return "unknown";
-}
-
-/**
- * Collapse the run `state` / `result` enum pair into the lowercase status
- * vocabulary used across the dashboard and RunsList. Mirrors `getRunStatus`
- * in `ui/Runs/runPresentation.ts`. Runs have a smaller state machine than
- * executions — no separate `pending` step — so a started run that has not
- * yet produced a result maps to `running`.
- */
-function deriveRunStatus(
-  state: string | undefined,
-  result: string | undefined,
-): "passed" | "failed" | "cancelled" | "running" | "unknown" {
-  if (state === "STATE_STARTED") return "running";
-  if (result === "RESULT_FAILED") return "failed";
-  if (result === "RESULT_CANCELLED") return "cancelled";
-  if (result === "RESULT_PASSED" || state === "STATE_FINISHED") return "passed";
-  return "unknown";
 }

--- a/web_src/src/pages/app/console/widget/useWidgetData.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.ts
@@ -184,11 +184,18 @@ export function renderNeedsRunNodeOutputs(render: WidgetRender | undefined): boo
  * resets it on a meaningful "widget identity" change (data source kind or
  * `progressive` toggle), and exposes a `loadMore()` that bumps the count
  * up to the configured limit. Limit edits intentionally do not reset the
- * window — the slice clamps via `computeDisplaySlice` and we'd rather not
- * yank the user back to the first page just because they bumped the limit
- * input.
+ * progressive window — the slice clamps via `computeDisplaySlice` and we'd
+ * rather not yank the user back to the first page just because they bumped
+ * the limit input.
+ *
+ * Non-progressive callers (chart, number) have no "Load more" UX, so they
+ * always render against the full `effectiveLimit`. We deliberately bypass
+ * the `displayCount` state for them: the state only resets on an identity
+ * change, so reusing it would clamp the slice to a stale (smaller) value
+ * when the author raises the limit live — making the panel silently ignore
+ * the increase until it remounts.
  */
-function useDisplayWindow({
+export function useDisplayWindow({
   dataSourceKind,
   progressive,
   effectiveLimit,
@@ -216,6 +223,10 @@ function useDisplayWindow({
       return Number.isFinite(effectiveLimit) ? Math.min(next, effectiveLimit) : next;
     });
   }, [progressive, effectiveLimit]);
+
+  if (!progressive) {
+    return { displayCount: effectiveLimit, displaySlice: effectiveLimit, loadMore };
+  }
 
   return {
     displayCount,
@@ -262,16 +273,28 @@ function useExecutionsDataSourceResult({
   const pages = useMemo(() => query.data?.pages ?? [], [query.data]);
   const pageCount = pages.length;
 
+  const targetNodeId = useMemo(() => {
+    if (dataSource.kind !== "executions" || !dataSource.node) return undefined;
+    return resolveConsoleNode(ctx, dataSource.node)?.node.id;
+  }, [dataSource, ctx]);
+
+  // Count only the executions that survive the node filter so the eager
+  // fill target and the "Load more" affordance track the *visible* rows.
+  // Counting every loaded execution would otherwise show a "Load more"
+  // button that reveals nothing for a node with sparse executions.
   const loadedRowCount = useMemo(() => {
     if (!enabled) return 0;
     let count = 0;
     for (const page of pages) {
       for (const event of page?.events ?? []) {
-        count += event.executions?.length ?? 0;
+        for (const exec of event.executions ?? []) {
+          if (targetNodeId && exec.nodeId !== targetNodeId) continue;
+          count++;
+        }
       }
     }
     return count;
-  }, [enabled, pages]);
+  }, [enabled, pages, targetNodeId]);
 
   useEagerInfinitePagination({
     enabled,
@@ -286,11 +309,9 @@ function useExecutionsDataSourceResult({
 
   const rows = useMemo(() => {
     if (dataSource.kind !== "executions") return [];
-    const targetNode = dataSource.node ? resolveConsoleNode(ctx, dataSource.node) : undefined;
-    const targetNodeId = targetNode?.node.id;
     const nodeNameById = buildNodeNameMap(ctx?.nodes);
     return collectExecutionRows(pages, targetNodeId, nodeNameById, displaySlice);
-  }, [dataSource, pages, ctx, displaySlice]);
+  }, [dataSource, pages, ctx, targetNodeId, displaySlice]);
 
   const isLoading = isWidgetQueryLoading({
     queryIsLoading: query.isLoading,

--- a/web_src/src/pages/app/console/widget/widgetPagination.ts
+++ b/web_src/src/pages/app/console/widget/widgetPagination.ts
@@ -1,0 +1,198 @@
+/**
+ * Per-widget pagination helpers shared across the runs/executions data
+ * sources. Keeps `useWidgetData` focused on orchestration while the pure
+ * limit/slice/should-fetch math lives here (and stays trivially unit-testable
+ * via `useWidgetData.pagination.spec.ts`).
+ */
+
+import { useEffect } from "react";
+
+/**
+ * Upper bound on how many infinite-query pages a widget will eagerly pull
+ * before giving up. Each page returns 25 rows, so 20 pages covers up to ~500
+ * rows — more than any dashboard panel currently asks for, while bounding
+ * memory and network cost for canvases with very long histories.
+ *
+ * Applied to both `executions` (events feed) and `runs` (canvas runs feed)
+ * data sources so the widget never falls back on shared-cache pagination
+ * driven by other consumers (e.g. the canvas Runs sidebar).
+ */
+export const WIDGET_MAX_EAGER_PAGES = 20;
+
+/**
+ * How many rows the progressive table widget eagerly fills on first render
+ * before showing the "Load more" affordance. Picked to comfortably exceed a
+ * typical viewport so the user sees a scrollbar without having to click.
+ */
+export const INITIAL_EAGER_ROWS = 100;
+
+/**
+ * Step size used by `loadMore()` to grow the per-widget display window.
+ */
+export const LOAD_MORE_STEP = 100;
+
+/**
+ * Default cap applied to non-progressive callers (chart, number) when the
+ * data source's `limit` is left undefined. Keeps aggregations bounded so a
+ * blank limit on a chart doesn't silently pull every page in the canvas.
+ */
+export const DEFAULT_AGGREGATE_LIMIT = 100;
+
+/**
+ * Resolve the data source's user-configured limit to a concrete row cap.
+ *
+ * - `progressive` (the table widget): a missing/non-positive limit means
+ *   "load all rows on demand", expressed as `Infinity`. The widget pages in
+ *   chunks via `loadMore` so this never translates to an unbounded fetch on
+ *   its own — `WIDGET_MAX_EAGER_PAGES` still caps total work.
+ * - non-progressive (chart, number): a missing/non-positive limit falls
+ *   back to `DEFAULT_AGGREGATE_LIMIT` so aggregated panels stay bounded.
+ */
+export function computeEffectiveLimit(rawLimit: number | undefined, progressive: boolean): number {
+  if (typeof rawLimit === "number" && rawLimit > 0) return rawLimit;
+  return progressive ? Number.POSITIVE_INFINITY : DEFAULT_AGGREGATE_LIMIT;
+}
+
+/**
+ * Initial value for the per-widget display window. Non-progressive callers
+ * always render against the full effective limit (no `loadMore` UI), so
+ * their `displayCount` is fixed at `effectiveLimit` from the start.
+ */
+export function computeInitialDisplayCount(effectiveLimit: number, progressive: boolean): number {
+  if (!progressive) return effectiveLimit;
+  if (!Number.isFinite(effectiveLimit)) return INITIAL_EAGER_ROWS;
+  return Math.min(INITIAL_EAGER_ROWS, effectiveLimit);
+}
+
+/**
+ * The number of rows to slice out of the loaded pages for the current
+ * render. Always clamps to `effectiveLimit` even when `displayCount`
+ * temporarily exceeds it (e.g. the user lowered the limit live).
+ */
+export function computeDisplaySlice(displayCount: number, effectiveLimit: number): number {
+  return Math.min(displayCount, effectiveLimit);
+}
+
+/**
+ * Whether the progressive widget should expose a "Load more" affordance:
+ * either there are already-loaded rows we haven't shown yet, or there are
+ * more pages to fetch and we still have eager-page budget. Returns `false`
+ * for non-progressive callers (they always fill to their configured limit).
+ */
+export function computeWidgetHasMore({
+  progressive,
+  displayCount,
+  effectiveLimit,
+  loadedRowCount,
+  hasNextPage,
+  pageCount,
+}: {
+  progressive: boolean;
+  displayCount: number;
+  effectiveLimit: number;
+  loadedRowCount: number;
+  hasNextPage: boolean | undefined;
+  pageCount: number;
+}): boolean {
+  if (!progressive) return false;
+  if (displayCount >= effectiveLimit) return false;
+  const canShowMoreLoaded = loadedRowCount > displayCount;
+  const canFetchMore = hasNextPage === true && pageCount < WIDGET_MAX_EAGER_PAGES;
+  return canShowMoreLoaded || canFetchMore;
+}
+
+/**
+ * Drives widget-owned eager pagination of an infinite query: fetches pages
+ * until the current `fillTarget` is reached, the source runs out of pages,
+ * or `WIDGET_MAX_EAGER_PAGES` is hit. Re-runs after each page arrives so
+ * `loadMore` (bumping `fillTarget`) flows through the same mechanism with
+ * no special-case fetch path.
+ */
+export function useEagerInfinitePagination({
+  enabled,
+  fillTarget,
+  loadedRowCount,
+  pageCount,
+  hasNextPage,
+  isFetchingNextPage,
+  isFetching,
+  fetchNextPage,
+}: {
+  enabled: boolean;
+  fillTarget: number;
+  loadedRowCount: number;
+  pageCount: number;
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  isFetching: boolean;
+  fetchNextPage: () => unknown;
+}) {
+  useEffect(() => {
+    if (
+      !shouldFetchNextWidgetPage({
+        enabled,
+        fillTarget,
+        loadedRowCount,
+        pageCount,
+        hasNextPage,
+        isFetchingNextPage,
+        isFetching,
+      })
+    ) {
+      return;
+    }
+    void fetchNextPage();
+  }, [enabled, fillTarget, loadedRowCount, pageCount, hasNextPage, isFetchingNextPage, isFetching, fetchNextPage]);
+}
+
+export function shouldFetchNextWidgetPage({
+  enabled,
+  fillTarget,
+  loadedRowCount,
+  pageCount,
+  hasNextPage,
+  isFetchingNextPage,
+  isFetching,
+}: {
+  enabled: boolean;
+  fillTarget: number;
+  loadedRowCount: number;
+  pageCount: number;
+  hasNextPage: boolean | undefined;
+  isFetchingNextPage: boolean;
+  isFetching: boolean;
+}): boolean {
+  if (!enabled || !hasNextPage) return false;
+  if (isFetchingNextPage || isFetching) return false;
+  if (loadedRowCount >= fillTarget) return false;
+  return pageCount < WIDGET_MAX_EAGER_PAGES;
+}
+
+export function isWidgetQueryLoading({
+  queryIsLoading,
+  enabled,
+  hasNextPage,
+  loadedRowCount,
+  fillTarget,
+  pageCount,
+  isFetchingNextPage,
+  isFetching,
+}: {
+  queryIsLoading: boolean;
+  enabled: boolean;
+  hasNextPage: boolean | undefined;
+  loadedRowCount: number;
+  fillTarget: number;
+  pageCount: number;
+  isFetchingNextPage: boolean;
+  isFetching: boolean;
+}): boolean {
+  if (queryIsLoading) return true;
+  return (
+    enabled &&
+    hasNextPage === true &&
+    loadedRowCount < fillTarget &&
+    pageCount < WIDGET_MAX_EAGER_PAGES &&
+    (isFetchingNextPage || isFetching)
+  );
+}

--- a/web_src/src/pages/app/console/widget/widgetRowCollection.ts
+++ b/web_src/src/pages/app/console/widget/widgetRowCollection.ts
@@ -1,0 +1,251 @@
+/**
+ * Row collection + derived-field helpers shared by the table, chart, and
+ * number renderers. Pure functions over loaded infinite-query pages — kept
+ * separate from `useWidgetData` so each can be exercised in isolation by
+ * its spec file.
+ */
+
+import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/api-client";
+
+import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
+
+/**
+ * Walk the loaded event pages and synthesize the row objects the dashboard's
+ * table / chart / number renderers consume. Each row carries the raw
+ * execution fields plus four derived conveniences:
+ *
+ * - `status`: lowercase canonical status string (see {@link deriveExecutionStatus}).
+ * - `nodeName`: friendly node label resolved per-row via `nodeNameById`,
+ *   falling back to the raw `nodeId` when the canvas no longer contains
+ *   that node (e.g. it was deleted after the execution ran).
+ * - `durationMs`: created-to-updated elapsed time in milliseconds.
+ * - `payload`: the data carried by the parent (root) event — i.e. the
+ *   payload the node received. Shared by every execution under that event.
+ *
+ * Iteration stops as soon as `rows.length >= limit`.
+ */
+export function collectExecutionRows(
+  pages: Array<
+    | {
+        events?: Array<{
+          data?: Record<string, unknown>;
+          executions?: Array<
+            Record<string, unknown> & {
+              nodeId?: string;
+              state?: string;
+              result?: string;
+              createdAt?: string;
+              updatedAt?: string;
+            }
+          >;
+        }>;
+      }
+    | undefined
+  >,
+  targetNodeId: string | undefined,
+  nodeNameById: Map<string, string>,
+  limit: number,
+): unknown[] {
+  const rows: unknown[] = [];
+  for (const page of pages) {
+    for (const event of page?.events ?? []) {
+      for (const exec of event.executions ?? []) {
+        if (targetNodeId && exec.nodeId !== targetNodeId) continue;
+        rows.push({
+          ...exec,
+          status: deriveExecutionStatus(exec.state, exec.result),
+          nodeName: (exec.nodeId && nodeNameById.get(exec.nodeId)) || exec.nodeId,
+          durationMs:
+            exec.updatedAt && exec.createdAt ? Date.parse(exec.updatedAt) - Date.parse(exec.createdAt) : undefined,
+          payload: event.data,
+        });
+        if (rows.length >= limit) return rows;
+      }
+    }
+  }
+  return rows;
+}
+
+/**
+ * Walk the loaded run pages and synthesize the row objects the dashboard's
+ * widgets consume. Each row carries the raw `CanvasesCanvasRun` fields plus
+ * a few derived conveniences mirroring what `RunsList` shows:
+ *
+ * - `status`: lowercase canonical status string (see {@link deriveRunStatus}).
+ * - `nodeName`: friendly label of the node that initiated the run, resolved
+ *   from `rootEvent.nodeId` via `nodeNameById`. Falls back to the raw
+ *   `nodeId` when the canvas no longer contains that node.
+ * - `payload`: alias for `rootEvent.data` — the initial payload that
+ *   triggered the run. Exposed at the top level so authors don't have to
+ *   type `rootEvent.data.*` for the common case.
+ * - `durationMs`: created-to-finished elapsed time in milliseconds. Mirrors
+ *   the executions row's `durationMs` so authors can write
+ *   `field: durationMs, format: duration` for a friendly run-duration cell
+ *   without having to write CEL date arithmetic.
+ * - `$` / `DOLLAR_REWRITE_IDENTIFIER`: a map keyed by node display name
+ *   pointing at each node's full execution (with `outputs` and a `data`
+ *   shortcut for the latest output event). Lets authors write
+ *   `$["deploy-prod"].outputs.url` in literal field paths and the same
+ *   syntax in `{{ }}` CEL templates (the CEL compiler rewrites `$` to
+ *   `__runNodes__` since cel-js doesn't accept `$` as an identifier).
+ *
+ * The raw `rootEvent`, `executions`, timestamps, etc. remain reachable via
+ * dot paths (`getValueAtPath`) because we spread the full run into the row.
+ *
+ * Iteration stops as soon as `rows.length >= limit`.
+ */
+export type RunRowSource = Record<string, unknown> & {
+  state?: string;
+  result?: string;
+  createdAt?: string;
+  finishedAt?: string;
+  rootEvent?: {
+    id?: string;
+    nodeId?: string;
+    data?: Record<string, unknown>;
+  };
+};
+
+function buildRunRow(
+  run: RunRowSource,
+  nodeNameById: Map<string, string>,
+  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
+): unknown {
+  const rootEvent = run.rootEvent;
+  const nodeId = rootEvent?.nodeId;
+  const executions = (rootEvent?.id && executionsByRootEventId?.get(rootEvent.id)) || undefined;
+  const dollarNodes = buildDollarNodes(executions, nodeNameById);
+  return {
+    ...run,
+    status: deriveRunStatus(run.state, run.result),
+    nodeName: (nodeId && nodeNameById.get(nodeId)) || nodeId,
+    payload: rootEvent?.data,
+    durationMs: run.finishedAt && run.createdAt ? Date.parse(run.finishedAt) - Date.parse(run.createdAt) : undefined,
+    $: dollarNodes,
+    [DOLLAR_REWRITE_IDENTIFIER]: dollarNodes,
+  };
+}
+
+export function collectRunRows(
+  pages: Array<{ runs?: RunRowSource[] } | undefined>,
+  nodeNameById: Map<string, string>,
+  limit: number,
+  executionsByRootEventId?: Map<string, CanvasesCanvasNodeExecution[]>,
+): unknown[] {
+  const rows: unknown[] = [];
+  for (const page of pages) {
+    for (const run of page?.runs ?? []) {
+      rows.push(buildRunRow(run, nodeNameById, executionsByRootEventId));
+      if (rows.length >= limit) return rows;
+    }
+  }
+  return rows;
+}
+
+/**
+ * Build the `$` map for a single run row. Keys are node display names so
+ * authors can write `$["deploy-prod"]` in expressions; falls back to the
+ * `nodeId` when the canvas no longer contains that node (e.g. it was
+ * deleted). The value spreads the full execution and adds a `data` shortcut
+ * mirroring the canvas-side `$['Node Name'].data` semantics.
+ */
+export function buildDollarNodes(
+  executions: CanvasesCanvasNodeExecution[] | undefined,
+  nodeNameById: Map<string, string>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!executions) return out;
+  for (const exec of executions) {
+    if (!exec.nodeId) continue;
+    const name = nodeNameById.get(exec.nodeId) || exec.nodeId;
+    out[name] = {
+      ...exec,
+      data: lastOutputData(exec.outputs),
+    };
+  }
+  return out;
+}
+
+/**
+ * Pick the most useful single payload from an execution's `outputs` map.
+ * Mirrors how the canvas backend resolves `$['Node Name'].data`: prefer the
+ * `default` channel, otherwise the first available channel; take the last
+ * event in that channel (most recent emission). When the event itself is
+ * an envelope-shaped object with a `.data` field, unwrap it; otherwise
+ * return the event verbatim. Returns `undefined` for missing or empty
+ * outputs so widget cells render `-`.
+ */
+export function lastOutputData(outputs: Record<string, unknown> | undefined): unknown {
+  if (!outputs) return undefined;
+  const channels = Object.keys(outputs);
+  if (channels.length === 0) return undefined;
+  const channel = channels.includes("default") ? "default" : channels[0];
+  const events = outputs[channel];
+  if (!Array.isArray(events) || events.length === 0) return undefined;
+  const last = events[events.length - 1];
+  if (last && typeof last === "object" && !Array.isArray(last) && "data" in last) {
+    return (last as { data: unknown }).data;
+  }
+  return last;
+}
+
+/**
+ * Build a `nodeId -> friendly name` lookup from the canvas nodes available
+ * on the dashboard context. We index by id only (not name) because event
+ * executions always carry `nodeId`. Falls back to the node id when the
+ * canvas node has no `name`, so the widget never shows a blank label.
+ */
+export function buildNodeNameMap(nodes: SuperplaneComponentsNode[] | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!nodes) return map;
+  for (const node of nodes) {
+    if (!node.id) continue;
+    map.set(node.id, node.name || node.id);
+  }
+  return map;
+}
+
+/**
+ * Collapse the API `state` / `result` enum pair into the lowercase status
+ * vocabulary the rest of the dashboard speaks: `passed`, `failed`,
+ * `cancelled`, `running`, `pending`, `unknown`. Matches the lookup tables in
+ * `WidgetTable` (`STATUS_PILL_CLASS`) and `NodePanelCard` (`STATUS_CLASS`).
+ */
+function deriveExecutionStatus(
+  state: string | undefined,
+  result: string | undefined,
+): "passed" | "failed" | "cancelled" | "running" | "pending" | "unknown" {
+  if (state === "STATE_PENDING") return "pending";
+  if (state === "STATE_STARTED") return "running";
+  if (state === "STATE_FINISHED") {
+    switch (result) {
+      case "RESULT_PASSED":
+        return "passed";
+      case "RESULT_FAILED":
+        return "failed";
+      case "RESULT_CANCELLED":
+        return "cancelled";
+      default:
+        return "unknown";
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Collapse the run `state` / `result` enum pair into the lowercase status
+ * vocabulary used across the dashboard and RunsList. Mirrors `getRunStatus`
+ * in `ui/Runs/runPresentation.ts`. Runs have a smaller state machine than
+ * executions — no separate `pending` step — so a started run that has not
+ * yet produced a result maps to `running`.
+ */
+function deriveRunStatus(
+  state: string | undefined,
+  result: string | undefined,
+): "passed" | "failed" | "cancelled" | "running" | "unknown" {
+  if (state === "STATE_STARTED") return "running";
+  if (result === "RESULT_FAILED") return "failed";
+  if (result === "RESULT_CANCELLED") return "cancelled";
+  if (result === "RESULT_PASSED" || state === "STATE_FINISHED") return "passed";
+  return "unknown";
+}


### PR DESCRIPTION
## Summary
Ensures widgets using runs as datasource can paginate through the data.

Resolves #5466 