### PR TITLE
feat: Make Runners generally available

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,7 +21,6 @@ func released() *bool {
 }
 
 var registry = []Feature{
-	{ID: "runner", Label: "Runners", Description: "Sandboxed Runners"},
 	{ID: FeatureClaudeManagedAgents, Label: "Claude Managed Agents", Description: "Chat with a Claude-powered agent against the canvas", Released: released()},
 }
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -8,11 +8,11 @@ import (
 
 func Test__Get(t *testing.T) {
 	t.Run("known id returns feature and true", func(t *testing.T) {
-		f, ok := Get("runner")
+		f, ok := Get(FeatureClaudeManagedAgents)
 		assert.True(t, ok)
-		assert.Equal(t, "runner", f.ID)
-		assert.Equal(t, "Runners", f.Label)
-		assert.Equal(t, "Sandboxed Runners", f.Description)
+		assert.Equal(t, FeatureClaudeManagedAgents, f.ID)
+		assert.Equal(t, "Claude Managed Agents", f.Label)
+		assert.Equal(t, "Chat with a Claude-powered agent against the canvas", f.Description)
 	})
 
 	t.Run("unknown id returns zero value and false", func(t *testing.T) {
@@ -28,7 +28,7 @@ func Test__Get(t *testing.T) {
 }
 
 func Test__Exists(t *testing.T) {
-	assert.True(t, Exists("runner"))
+	assert.True(t, Exists(FeatureClaudeManagedAgents))
 	assert.False(t, Exists("does-not-exist"))
 	assert.False(t, Exists(""))
 }
@@ -49,7 +49,11 @@ func Test__IsReleased(t *testing.T) {
 	})
 
 	t.Run("registered id with nil Released is not released", func(t *testing.T) {
-		assert.False(t, IsReleased("runner"))
+		original := registry
+		t.Cleanup(func() { registry = original })
+
+		registry = []Feature{{ID: "preview", Label: "Preview", Description: "Preview feature"}}
+		assert.False(t, IsReleased("preview"))
 	})
 
 	t.Run("registered id with Released=&true is released", func(t *testing.T) {

--- a/pkg/models/organization_experimental_features_test.go
+++ b/pkg/models/organization_experimental_features_test.go
@@ -27,44 +27,44 @@ func Test__ExperimentalFeatures(t *testing.T) {
 		org, err := CreateOrganization("expfeat-enable", "")
 		require.NoError(t, err)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"runner"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{"exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
 
 		reloaded, err = FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.Equal(t, []string{"runner"}, []string(reloaded.EnabledExperimentalFeatures))
+		assert.Equal(t, []string{"exp-feature"}, []string(reloaded.EnabledExperimentalFeatures))
 	})
 
 	t.Run("Disable removes the feature and is idempotent", func(t *testing.T) {
 		org, err := CreateOrganization("expfeat-disable", "")
 		require.NoError(t, err)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
-		require.NoError(t, DisableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
+		require.NoError(t, DisableExperimentalFeature(org.ID, "exp-feature"))
 
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
 		assert.Empty(t, []string(reloaded.EnabledExperimentalFeatures))
 
 		// Disabling again is a no-op.
-		require.NoError(t, DisableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, DisableExperimentalFeature(org.ID, "exp-feature"))
 	})
 
 	t.Run("Organization.HasExperimentalFeature respects enabled list", func(t *testing.T) {
 		org, err := CreateOrganization("expfeat-has", "")
 		require.NoError(t, err)
 
-		assert.False(t, org.HasExperimentalFeature("runner"))
+		assert.False(t, org.HasExperimentalFeature("exp-feature"))
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
 		reloaded, err := FindOrganizationByID(org.ID.String())
 		require.NoError(t, err)
-		assert.True(t, reloaded.HasExperimentalFeature("runner"))
+		assert.True(t, reloaded.HasExperimentalFeature("exp-feature"))
 	})
 
 	t.Run("released features short-circuit to true regardless of stored list", func(t *testing.T) {
@@ -85,13 +85,13 @@ func Test__ExperimentalFeatures(t *testing.T) {
 		org, err := CreateOrganization("expfeat-load", "")
 		require.NoError(t, err)
 
-		ok, err := HasExperimentalFeature(org.ID, "runner")
+		ok, err := HasExperimentalFeature(org.ID, "exp-feature")
 		require.NoError(t, err)
 		assert.False(t, ok)
 
-		require.NoError(t, EnableExperimentalFeature(org.ID, "runner"))
+		require.NoError(t, EnableExperimentalFeature(org.ID, "exp-feature"))
 
-		ok, err = HasExperimentalFeature(org.ID, "runner")
+		ok, err = HasExperimentalFeature(org.ID, "exp-feature")
 		require.NoError(t, err)
 		assert.True(t, ok)
 	})

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
@@ -797,20 +798,20 @@ func TestAdminEnableOrgExperimentalFeature(t *testing.T) {
 	server, r, token := setupAdminTestServer(t)
 
 	t.Cleanup(func() {
-		_ = models.DisableExperimentalFeature(r.Organization.ID, "runner")
+		_ = models.DisableExperimentalFeature(r.Organization.ID, features.FeatureClaudeManagedAgents)
 	})
 
 	t.Run("enables a known feature", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "POST",
-			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runner",
+			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/" + features.FeatureClaudeManagedAgents,
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusOK, response.Code)
 
 		reloaded, err := models.FindOrganizationByID(r.Organization.ID.String())
 		require.NoError(t, err)
-		assert.Contains(t, []string(reloaded.EnabledExperimentalFeatures), "runner")
+		assert.Contains(t, []string(reloaded.EnabledExperimentalFeatures), features.FeatureClaudeManagedAgents)
 	})
 
 	t.Run("rejects unknown feature ids", func(t *testing.T) {
@@ -825,7 +826,7 @@ func TestAdminEnableOrgExperimentalFeature(t *testing.T) {
 	t.Run("returns 404 for non-existent org", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "POST",
-			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runner",
+			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/" + features.FeatureClaudeManagedAgents,
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusNotFound, response.Code)
@@ -836,18 +837,18 @@ func TestAdminDisableOrgExperimentalFeature(t *testing.T) {
 	server, r, token := setupAdminTestServer(t)
 
 	t.Run("disables a previously enabled feature", func(t *testing.T) {
-		require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, "runner"))
+		require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureClaudeManagedAgents))
 
 		response := execRequest(server, requestParams{
 			method:     "DELETE",
-			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/runner",
+			path:       "/admin/api/organizations/" + r.Organization.ID.String() + "/experimental-features/" + features.FeatureClaudeManagedAgents,
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusOK, response.Code)
 
 		reloaded, err := models.FindOrganizationByID(r.Organization.ID.String())
 		require.NoError(t, err)
-		assert.NotContains(t, []string(reloaded.EnabledExperimentalFeatures), "runner")
+		assert.NotContains(t, []string(reloaded.EnabledExperimentalFeatures), features.FeatureClaudeManagedAgents)
 	})
 
 	t.Run("is idempotent for ids not currently enabled", func(t *testing.T) {
@@ -862,7 +863,7 @@ func TestAdminDisableOrgExperimentalFeature(t *testing.T) {
 	t.Run("returns 404 for non-existent org", func(t *testing.T) {
 		response := execRequest(server, requestParams{
 			method:     "DELETE",
-			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/runner",
+			path:       "/admin/api/organizations/00000000-0000-0000-0000-000000000000/experimental-features/" + features.FeatureClaudeManagedAgents,
 			authCookie: token,
 		})
 		assert.Equal(t, http.StatusNotFound, response.Code)

--- a/pkg/public/experimental_features_test.go
+++ b/pkg/public/experimental_features_test.go
@@ -33,7 +33,7 @@ func TestListExperimentalFeatures(t *testing.T) {
 			id, _ := f["id"].(string)
 			ids = append(ids, id)
 		}
-		assert.Contains(t, ids, "runner")
+		assert.Contains(t, ids, "claude_managed_agents")
 	})
 
 	t.Run("rejects unauthenticated requests", func(t *testing.T) {

--- a/web_src/src/hooks/useComponentData.ts
+++ b/web_src/src/hooks/useComponentData.ts
@@ -26,11 +26,7 @@ export const useComponents = (organizationId: string) => {
     },
     select: (data) => {
       return (data || []).filter((action) => {
-        const name = action.name || "";
-        const featureID =
-          name === "runner" || name === "runnerJS" || name === "runnerPython" || name === "runnerBash"
-            ? "runner"
-            : name;
+        const featureID = action.name || "";
         const isExperimental = experimentalFeatures.includes(featureID);
         const isEnabled = enabledExperimentalFeatures.includes(featureID);
 


### PR DESCRIPTION
## Summary
- Removes the `runner` experimental feature from the registry
- Drops UI gating in `useComponentData` that hid runner components unless the org had the feature enabled
- Updates related tests to use `claude_managed_agents` or generic feature IDs

Runners (`runner`, `runnerBash`, `runnerJS`, `runnerPython`) are now available to all organizations by default.

## Test plan
- [ ] Runner components appear in the building blocks sidebar for orgs without the experimental feature enabled
- [ ] Admin experimental features page no longer lists Runners as a toggleable feature
- [ ] Existing runner workflows continue to execute normally
- [ ] `make test PKG_TEST_PACKAGES=./pkg/features` passes


Made with [Cursor](https://cursor.com)