### PR TITLE
fix: Move Memory Notification to Websocket

### DIFF
--- a/pkg/grpc/actions/canvases/cancel_execution.go
+++ b/pkg/grpc/actions/canvases/cancel_execution.go
@@ -38,6 +38,11 @@ func CancelExecution(ctx context.Context, authService authorization.Authorizatio
 		return nil, status.Error(codes.NotFound, "execution not found")
 	}
 
+	memoryChanged := false
+	onMemoryChanged := func() {
+		memoryChanged = true
+	}
+
 	err = database.Conn().Transaction(func(tx *gorm.DB) error {
 		node, err := models.FindCanvasNode(tx, workflowID, execution.NodeID)
 
@@ -45,7 +50,7 @@ func CancelExecution(ctx context.Context, authService authorization.Authorizatio
 			return status.Error(codes.NotFound, "Node not found for execution")
 		}
 
-		err = cancelExecutionInTransaction(tx, authService, encryptor, organizationID, registry, execution, node, user)
+		err = cancelExecutionInTransaction(tx, authService, encryptor, organizationID, registry, execution, node, user, onMemoryChanged)
 
 		if err != nil {
 			return status.Error(codes.Internal, "It was not possible to cancel the execution")
@@ -60,10 +65,16 @@ func CancelExecution(ctx context.Context, authService authorization.Authorizatio
 
 	messages.NewCanvasExecutionMessage(workflowID.String(), execution.ID.String(), execution.NodeID).Publish()
 
+	if memoryChanged {
+		if err := messages.NewCanvasMemoryUpdatedMessage(workflowID.String()).PublishMemoryUpdated(); err != nil {
+			log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
+		}
+	}
+
 	return &pb.CancelExecutionResponse{}, nil
 }
 
-func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authorization, encryptor crypto.Encryptor, organizationID string, registry *registry.Registry, execution *models.CanvasNodeExecution, node *models.CanvasNode, user *models.User) error {
+func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authorization, encryptor crypto.Encryptor, organizationID string, registry *registry.Registry, execution *models.CanvasNodeExecution, node *models.CanvasNode, user *models.User, onMemoryChanged func()) error {
 	if node.Type != models.NodeTypeComponent {
 		return nil
 	}
@@ -96,7 +107,7 @@ func cancelExecutionInTransaction(tx *gorm.DB, authService authorization.Authori
 			Requests:       contexts.NewExecutionRequestContext(tx, execution),
 			Auth:           contexts.NewAuthReader(tx, orgUUID, authService, user),
 			Notifications:  contexts.NewNotificationContext(tx, orgUUID, execution.WorkflowID),
-			CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID),
+			CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID).WithChangeCallback(onMemoryChanged),
 		}
 
 		if node.AppInstallationID != nil {

--- a/pkg/grpc/actions/canvases/create_canvas_memory_namespace.go
+++ b/pkg/grpc/actions/canvases/create_canvas_memory_namespace.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -78,6 +80,10 @@ func CreateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 			return nil, statusErr.Err()
 		}
 		return nil, status.Error(codes.Internal, "failed to create canvas memory namespace")
+	}
+
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 
 	items := make([]*pb.CanvasMemory, 0, len(stored))

--- a/pkg/grpc/actions/canvases/delete_canvas_memory.go
+++ b/pkg/grpc/actions/canvases/delete_canvas_memory.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -39,6 +41,10 @@ func DeleteCanvasMemory(ctx context.Context, registry *registry.Registry, organi
 
 	if err := models.DeleteCanvasMemory(canvasUUID, entryUUID); err != nil {
 		return nil, status.Error(codes.Internal, "failed to delete canvas memory")
+	}
+
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 
 	return &pb.DeleteCanvasMemoryResponse{}, nil

--- a/pkg/grpc/actions/canvases/update_canvas_memory_namespace.go
+++ b/pkg/grpc/actions/canvases/update_canvas_memory_namespace.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
@@ -106,6 +108,10 @@ func UpdateCanvasMemoryNamespace(ctx context.Context, registry *registry.Registr
 			return nil, statusErr.Err()
 		}
 		return nil, status.Error(codes.Internal, "failed to update canvas memory namespace")
+	}
+
+	if err := messages.NewCanvasMemoryUpdatedMessage(canvasUUID.String()).PublishMemoryUpdated(); err != nil {
+		log.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
 	}
 
 	items := make([]*pb.CanvasMemory, 0, len(stored))

--- a/pkg/grpc/actions/messages/canvas.go
+++ b/pkg/grpc/actions/messages/canvas.go
@@ -11,6 +11,7 @@ const (
 	CanvasVersionUpdatedRoutingKey = "canvas-version-updated"
 	CanvasStagingUpdatedRoutingKey = "canvas-staging-updated"
 	CanvasDeletedRoutingKey        = "canvas-deleted"
+	CanvasMemoryUpdatedRoutingKey  = "canvas-memory-updated"
 )
 
 type CanvasMessage struct {
@@ -54,6 +55,16 @@ func NewCanvasDeletedMessage(canvasID string, organizationID string) CanvasMessa
 	}
 }
 
+func NewCanvasMemoryUpdatedMessage(canvasID string) CanvasMessage {
+	return CanvasMessage{
+		message: &pb.CanvasMessage{
+			Id:        canvasID,
+			CanvasId:  canvasID,
+			Timestamp: timestamppb.Now(),
+		},
+	}
+}
+
 func NewCanvasVersionUpdatedMessage(canvasID string, versionID string) CanvasVersionMessage {
 	return CanvasVersionMessage{
 		message: &pb.CanvasVersionMessage{
@@ -74,6 +85,10 @@ func (m CanvasMessage) PublishUpdated() error {
 
 func (m CanvasMessage) PublishDeleted() error {
 	return Publish(CanvasExchange, CanvasDeletedRoutingKey, toBytes(m.message))
+}
+
+func (m CanvasMessage) PublishMemoryUpdated() error {
+	return Publish(CanvasExchange, CanvasMemoryUpdatedRoutingKey, toBytes(m.message))
 }
 
 func (m CanvasVersionMessage) PublishVersionUpdated() error {

--- a/pkg/workers/contexts/canvas_memory_context.go
+++ b/pkg/workers/contexts/canvas_memory_context.go
@@ -11,12 +11,27 @@ import (
 )
 
 type CanvasMemoryContext struct {
-	tx       *gorm.DB
-	canvasID uuid.UUID
+	tx        *gorm.DB
+	canvasID  uuid.UUID
+	onChanged func()
 }
 
 func NewCanvasMemoryContext(tx *gorm.DB, canvasID uuid.UUID) *CanvasMemoryContext {
 	return &CanvasMemoryContext{tx: tx, canvasID: canvasID}
+}
+
+// WithChangeCallback registers a callback invoked whenever a mutating operation
+// (Add/Delete/Update/UpdateNamespace) succeeds. Used to signal callers that
+// memory was modified so they can publish a websocket event post-commit.
+func (c *CanvasMemoryContext) WithChangeCallback(onChanged func()) *CanvasMemoryContext {
+	c.onChanged = onChanged
+	return c
+}
+
+func (c *CanvasMemoryContext) notifyChanged() {
+	if c.onChanged != nil {
+		c.onChanged()
+	}
 }
 
 func (c *CanvasMemoryContext) Add(namespace string, values any) error {
@@ -39,6 +54,7 @@ func (c *CanvasMemoryContext) AddRecord(namespace string, values any) (core.Canv
 		return core.CanvasMemoryRecord{}, err
 	}
 
+	c.notifyChanged()
 	return canvasMemoryRecord(record), nil
 }
 
@@ -93,6 +109,10 @@ func (c *CanvasMemoryContext) Delete(namespace string, matches map[string]any) (
 		return nil, err
 	}
 
+	if len(records) > 0 {
+		c.notifyChanged()
+	}
+
 	deletedValues := make([]any, 0, len(records))
 	for _, record := range records {
 		deletedValues = append(deletedValues, record.Values.Data())
@@ -125,6 +145,10 @@ func (c *CanvasMemoryContext) UpdateRecords(namespace string, matches map[string
 		return nil, err
 	}
 
+	if len(records) > 0 {
+		c.notifyChanged()
+	}
+
 	return canvasMemoryRecords(records), nil
 }
 
@@ -150,6 +174,10 @@ func (c *CanvasMemoryContext) UpdateNamespaceRecords(namespace string, values ma
 	records, err := models.UpdateCanvasMemoriesByNamespaceInTransaction(c.tx, c.canvasID, namespace, values)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(records) > 0 {
+		c.notifyChanged()
 	}
 
 	return canvasMemoryRecords(records), nil

--- a/pkg/workers/event_distributer.go
+++ b/pkg/workers/event_distributer.go
@@ -62,6 +62,7 @@ func (e *EventDistributer) Start() error {
 		{messages.CanvasExchange, messages.CanvasVersionUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasVersionUpdated)},
 		{messages.CanvasExchange, messages.CanvasStagingUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasStagingUpdated)},
 		{messages.CanvasExchange, messages.CanvasDeletedRoutingKey, e.createHandler(eventdistributer.HandleCanvasDeleted)},
+		{messages.CanvasExchange, messages.CanvasMemoryUpdatedRoutingKey, e.createHandler(eventdistributer.HandleCanvasMemoryUpdated)},
 		{messages.CanvasExchange, messages.AgentSessionEventRoutingKey, e.createHandler(eventdistributer.HandleAgentSessionEvent)},
 	}
 

--- a/pkg/workers/eventdistributer/canvas.go
+++ b/pkg/workers/eventdistributer/canvas.go
@@ -15,6 +15,7 @@ const (
 	CanvasVersionUpdatedEvent = "canvas_version_updated"
 	CanvasStagingUpdatedEvent = "staging_updated"
 	CanvasDeletedEvent        = "canvas_deleted"
+	CanvasMemoryUpdatedEvent  = "memory_updated"
 )
 
 type CanvasStatePayload struct {
@@ -34,6 +35,10 @@ func HandleCanvasUpdated(messageBody []byte, wsHub *ws.Hub) error {
 
 func HandleCanvasDeleted(messageBody []byte, wsHub *ws.Hub) error {
 	return handleCanvasState(messageBody, wsHub, CanvasDeletedEvent)
+}
+
+func HandleCanvasMemoryUpdated(messageBody []byte, wsHub *ws.Hub) error {
+	return handleCanvasState(messageBody, wsHub, CanvasMemoryUpdatedEvent)
 }
 
 func HandleCanvasVersionUpdated(messageBody []byte, wsHub *ws.Hub) error {

--- a/pkg/workers/node_executor.go
+++ b/pkg/workers/node_executor.go
@@ -198,6 +198,15 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		newEvents = append(newEvents, events...)
 	}
 
+	//
+	// We also track whether memory was modified during the execution so we can
+	// broadcast a memory_updated event after the transaction commits.
+	//
+	var memoryChangedCanvasID uuid.UUID
+	onMemoryChanged := func(canvasID uuid.UUID) {
+		memoryChangedCanvasID = canvasID
+	}
+
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		//
 		// Try to lock the execution record for update.
@@ -234,7 +243,7 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		}
 
 		metricComponent = node.ComponentName()
-		processErr := w.executeActionNode(tx, execution, node, onNewEvents)
+		processErr := w.executeActionNode(tx, execution, node, onNewEvents, onMemoryChanged)
 		if processErr != nil {
 			metricOutcome = executorOutcomeFailed
 			metricReason = classifyAttemptFailure(processErr, execution)
@@ -257,10 +266,16 @@ func (w *NodeExecutor) LockAndProcessNodeExecution(id uuid.UUID) error {
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
+	if memoryChangedCanvasID != uuid.Nil {
+		if err := messages.NewCanvasMemoryUpdatedMessage(memoryChangedCanvasID.String()).PublishMemoryUpdated(); err != nil {
+			w.logger.Errorf("failed to publish canvas memory updated RabbitMQ message: %v", err)
+		}
+	}
+
 	return nil
 }
 
-func (w *NodeExecutor) executeActionNode(tx *gorm.DB, execution *models.CanvasNodeExecution, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent)) error {
+func (w *NodeExecutor) executeActionNode(tx *gorm.DB, execution *models.CanvasNodeExecution, node *models.CanvasNode, onNewEvents func([]models.CanvasEvent), onMemoryChanged func(uuid.UUID)) error {
 	logger := logging.WithExecution(
 		logging.WithNode(w.logger, *node),
 		execution,
@@ -321,10 +336,11 @@ func (w *NodeExecutor) executeActionNode(tx *gorm.DB, execution *models.CanvasNo
 		Auth:           contexts.NewAuthReader(tx, workflow.OrganizationID, w.authService, nil),
 		Notifications:  contexts.NewNotificationContext(tx, workflow.OrganizationID, execution.WorkflowID),
 		Secrets:        contexts.NewSecretsContext(tx, workflow.OrganizationID, w.encryptor),
-		CanvasMemory:   contexts.NewCanvasMemoryContext(tx, execution.WorkflowID),
-		Files:          contexts.NewRepositoryFilesContext(w.gitProvider, execution.WorkflowID),
-		Webhook:        contexts.NewNodeWebhookContext(context.Background(), tx, w.encryptor, node, w.webhookBaseURL),
-		Expressions:    contexts.NewExpressionContext(builder),
+		CanvasMemory: contexts.NewCanvasMemoryContext(tx, execution.WorkflowID).
+			WithChangeCallback(func() { onMemoryChanged(execution.WorkflowID) }),
+		Files:       contexts.NewRepositoryFilesContext(w.gitProvider, execution.WorkflowID),
+		Webhook:     contexts.NewNodeWebhookContext(context.Background(), tx, w.encryptor, node, w.webhookBaseURL),
+		Expressions: contexts.NewExpressionContext(builder),
 	}
 
 	if node.AppInstallationID != nil {

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -1457,6 +1457,11 @@ function normalizeCanvasMemorySource(source: string | undefined): CanvasMemoryEn
 }
 
 export const useCanvasMemoryEntries = (canvasId: string, enabled = true) => {
+  // Memory updates are pushed via the `memory_updated` websocket event
+  // (see useCanvasWebsocket), so we no longer poll on an interval. The
+  // websocket handler invalidates this query whenever memory changes from a
+  // node execution, manual mutation, or another tab; a reconnect also
+  // invalidates so we never miss updates received while disconnected.
   return useQuery({
     queryKey: canvasKeys.canvasMemoryEntries(canvasId),
     queryFn: async () => {
@@ -1476,7 +1481,6 @@ export const useCanvasMemoryEntries = (canvasId: string, enabled = true) => {
       }));
     },
     refetchOnWindowFocus: false,
-    refetchInterval: 3000,
     enabled: !!canvasId && enabled,
   });
 };

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -125,6 +125,12 @@ export function useCanvasWebsocket(
     [queryClient, canvasId],
   );
 
+  const invalidateMemoryEntries = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.canvasMemoryEntries(canvasId),
+    });
+  }, [queryClient, canvasId]);
+
   const processMessage = useCallback(
     (data: QueuedMessage["data"]) => {
       const payload = data.payload;
@@ -269,13 +275,9 @@ export function useCanvasWebsocket(
           // another tab). Invalidate the shared memory cache so the Memory tab
           // and any memory-bound widget refetches once.
           const memoryMessage = payload as Partial<CanvasWebsocketPayload>;
-          if (!memoryMessage.canvasId || memoryMessage.canvasId !== canvasId) {
-            break;
+          if (memoryMessage.canvasId === canvasId) {
+            invalidateMemoryEntries();
           }
-
-          queryClient.invalidateQueries({
-            queryKey: canvasKeys.canvasMemoryEntries(canvasId),
-          });
           break;
         }
         default:
@@ -297,6 +299,7 @@ export function useCanvasWebsocket(
       patchRunInCache,
       patchRootEventInCache,
       patchExecutionInCache,
+      invalidateMemoryEntries,
     ],
   );
 
@@ -390,10 +393,8 @@ export function useCanvasWebsocket(
     });
     // Refresh memory in case mutations happened while we were disconnected; we
     // no longer poll, so the websocket is the only push channel.
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.canvasMemoryEntries(canvasId),
-    });
-  }, [queryClient, canvasId]);
+    invalidateMemoryEntries();
+  }, [queryClient, canvasId, invalidateMemoryEntries]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -133,7 +133,10 @@ export function useCanvasWebsocket(
       // Staging events fire while editing a draft (not the live version), so they
       // must bypass the runtime-event gate that is disabled outside the live view.
       const isCanvasStagingEvent = data.event === "staging_updated";
-      if (!isCanvasLifecycleEvent && !isCanvasStagingEvent && !processRuntimeEvents) {
+      // Memory updates can happen from manual mutations regardless of the live
+      // view, so they bypass the runtime-event gate as well.
+      const isMemoryUpdatedEvent = data.event === "memory_updated";
+      if (!isCanvasLifecycleEvent && !isCanvasStagingEvent && !isMemoryUpdatedEvent && !processRuntimeEvents) {
         return;
       }
 
@@ -261,6 +264,20 @@ export function useCanvasWebsocket(
           }
           break;
         }
+        case "memory_updated": {
+          // Canvas memory changed (from a node execution, manual mutation, or
+          // another tab). Invalidate the shared memory cache so the Memory tab
+          // and any memory-bound widget refetches once.
+          const memoryMessage = payload as Partial<CanvasWebsocketPayload>;
+          if (!memoryMessage.canvasId || memoryMessage.canvasId !== canvasId) {
+            break;
+          }
+
+          queryClient.invalidateQueries({
+            queryKey: canvasKeys.canvasMemoryEntries(canvasId),
+          });
+          break;
+        }
         default:
           break;
       }
@@ -370,6 +387,11 @@ export function useCanvasWebsocket(
     });
     queryClient.invalidateQueries({
       queryKey: canvasKeys.infiniteRuns(canvasId),
+    });
+    // Refresh memory in case mutations happened while we were disconnected; we
+    // no longer poll, so the websocket is the only push channel.
+    queryClient.invalidateQueries({
+      queryKey: canvasKeys.canvasMemoryEntries(canvasId),
     });
   }, [queryClient, canvasId]);
 


### PR DESCRIPTION
## Summary

Replaces the 3-second HTTP polling of canvas memory with a push-based websocket signal. The backend publishes a `memory_updated` event whenever memory changes (node executions + manual UI mutations), and the frontend invalidates the shared React Query cache so consumers refetch once. The HTTP data shape is unchanged, so the Memory tab and every memory-bound widget keep working as-is.

Resolves #5414

## Changes

**Backend**
- New routing key, message helper, and event-distributer handler for `memory_updated` (broadcast over the existing canvas websocket).
- Publish post-commit from manual mutations (`delete_canvas_memory`, `create_canvas_memory_namespace`, `update_canvas_memory_namespace`).
- `CanvasMemoryContext` gains an opt-in `WithChangeCallback`; `node_executor.go` and `cancel_execution.go` use it to publish after the transaction commits and only when memory actually changed. Constructor signature unchanged, so other call sites work as-is.

**Frontend**
- `useCanvasWebsocket` handles `memory_updated` by invalidating `canvasKeys.canvasMemoryEntries`; bypasses the live-version gate and also invalidates on reconnect.
- `useCanvasMemoryEntries` drops `refetchInterval: 3000`. Existing post-mutation invalidations are kept for instant local feedback.