### PR TITLE
fix: Sanitize SQL traces from sensitive data

### DIFF
--- a/pkg/database/gorm_logger_timeout.go
+++ b/pkg/database/gorm_logger_timeout.go
@@ -65,7 +65,7 @@ func (w *gormTimeoutLogger) Trace(
 		span.SetAttributes(
 			semconv.DBSystemNamePostgreSQL,
 			attribute.String("db.operation", dbOperation(sql)),
-			attribute.String("db.statement", truncateSQL(sql)),
+			attribute.String("db.statement", truncateSQL(sanitizeSQLStatement(sql))),
 			attribute.Int64("db.rows_affected", rowsAffected),
 		)
 		if err != nil {
@@ -77,6 +77,14 @@ func (w *gormTimeoutLogger) Trace(
 	}
 
 	w.base.Trace(ctx, begin, fc, err)
+}
+
+func (w *gormTimeoutLogger) ParamsFilter(
+	ctx context.Context,
+	sql string,
+	params ...interface{},
+) (string, []interface{}) {
+	return sql, redactSQLParams(params...)
 }
 
 func dbOperation(sql string) string {

--- a/pkg/database/gorm_trace_test.go
+++ b/pkg/database/gorm_trace_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	gormlogger "gorm.io/gorm/logger"
@@ -51,7 +52,9 @@ func TestGormTimeoutLoggerTraceRecordsDatabaseSpan(t *testing.T) {
 	logger := newGormTimeoutLogger(gormlogger.Discard)
 	begin := time.Now().Add(-10 * time.Millisecond)
 	logger.Trace(ctx, begin, func() (string, int64) {
-		return "SELECT * FROM users WHERE id = $1", 1
+		sql, params := `SELECT * FROM "secrets" WHERE "secrets"."value" = $1`, []interface{}{"super-secret-token"}
+		sql, params = logger.(*gormTimeoutLogger).ParamsFilter(ctx, sql, params...)
+		return `SELECT * FROM "secrets" WHERE "secrets"."value" = '` + params[0].(string) + `'`, 1
 	}, nil)
 	parent.End()
 
@@ -60,12 +63,26 @@ func TestGormTimeoutLoggerTraceRecordsDatabaseSpan(t *testing.T) {
 
 	var dbSpan tracetest.SpanStub
 	for _, span := range spans {
-		if span.Name == "db.select users" {
+		if strings.HasPrefix(span.Name, "db.select") && strings.Contains(span.Name, "secrets") {
 			dbSpan = span
 			break
 		}
 	}
-	require.Equal(t, "db.select users", dbSpan.Name)
+	require.NotEmpty(t, dbSpan.Name)
+
+	statement := attributeValue(dbSpan.Attributes, "db.statement")
+	require.NotEmpty(t, statement)
+	assert.NotContains(t, statement, "super-secret-token")
+	assert.Contains(t, statement, `'?'`)
+}
+
+func attributeValue(attrs []attribute.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
 }
 
 func TestGormTimeoutLoggerTraceDelegatesWithoutRecordingSpan(t *testing.T) {

--- a/pkg/database/sql_sanitize.go
+++ b/pkg/database/sql_sanitize.go
@@ -1,0 +1,164 @@
+package database
+
+import (
+	"reflect"
+	"strings"
+	"time"
+)
+
+const redactedSQLLiteral = "'?'"
+
+func redactSQLParams(params ...interface{}) []interface{} {
+	if len(params) == 0 {
+		return params
+	}
+
+	redacted := make([]interface{}, len(params))
+	for i, param := range params {
+		redacted[i] = redactSQLParam(param)
+	}
+
+	return redacted
+}
+
+func redactSQLParam(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return typed
+	case string:
+		return "?"
+	case []byte:
+		return "?"
+	case time.Time:
+		return "?"
+	case *time.Time:
+		if typed == nil {
+			return nil
+		}
+		return "?"
+	default:
+		rv := reflect.ValueOf(value)
+		if !rv.IsValid() {
+			return nil
+		}
+		if rv.Kind() == reflect.Ptr {
+			if rv.IsNil() {
+				return nil
+			}
+			return redactSQLParam(rv.Elem().Interface())
+		}
+		if isNumericKind(rv.Kind()) {
+			return value
+		}
+		return "?"
+	}
+}
+
+func isNumericKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeSQLStatement(sql string) string {
+	if sql == "" {
+		return sql
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(sql))
+
+	for i := 0; i < len(sql); {
+		if sql[i] == '$' {
+			if end, ok := readDollarQuotedString(sql, i); ok {
+				builder.WriteString(redactedSQLLiteral)
+				i = end
+				continue
+			}
+		}
+
+		if (sql[i] == 'E' || sql[i] == 'e') && i+1 < len(sql) && sql[i+1] == '\'' {
+			end := readSingleQuotedString(sql, i+1)
+			builder.WriteString(redactedSQLLiteral)
+			i = end
+			continue
+		}
+
+		if sql[i] == '\'' {
+			end := readSingleQuotedString(sql, i)
+			literal := sql[i:end]
+			if literal == redactedSQLLiteral {
+				builder.WriteString(literal)
+			} else {
+				builder.WriteString(redactedSQLLiteral)
+			}
+			i = end
+			continue
+		}
+
+		builder.WriteByte(sql[i])
+		i++
+	}
+
+	return builder.String()
+}
+
+func readSingleQuotedString(sql string, start int) int {
+	if start >= len(sql) || sql[start] != '\'' {
+		return start + 1
+	}
+
+	i := start + 1
+	for i < len(sql) {
+		if sql[i] != '\'' {
+			i++
+			continue
+		}
+		if i+1 < len(sql) && sql[i+1] == '\'' {
+			i += 2
+			continue
+		}
+		return i + 1
+	}
+
+	return len(sql)
+}
+
+func readDollarQuotedString(sql string, start int) (int, bool) {
+	if start >= len(sql) || sql[start] != '$' {
+		return start, false
+	}
+
+	tagEnd := strings.IndexByte(sql[start+1:], '$')
+	if tagEnd < 0 {
+		return start, false
+	}
+
+	tagEnd += start + 1
+	tag := sql[start : tagEnd+1]
+	if tag == "$$" {
+		bodyEnd := strings.Index(sql[tagEnd+1:], "$$")
+		if bodyEnd < 0 {
+			return start, false
+		}
+		return tagEnd + 1 + bodyEnd + 2, true
+	}
+
+	bodyEnd := strings.Index(sql[tagEnd+1:], tag)
+	if bodyEnd < 0 {
+		return start, false
+	}
+
+	return tagEnd + 1 + bodyEnd + len(tag), true
+}

--- a/pkg/database/sql_sanitize_test.go
+++ b/pkg/database/sql_sanitize_test.go
@@ -1,0 +1,56 @@
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactSQLParams(t *testing.T) {
+	now := time.Now()
+	params := redactSQLParams(
+		"secret-token",
+		[]byte("binary-secret"),
+		42,
+		true,
+		now,
+		&now,
+		nil,
+	)
+
+	assert.Equal(t, "?", params[0])
+	assert.Equal(t, "?", params[1])
+	assert.Equal(t, 42, params[2])
+	assert.Equal(t, true, params[3])
+	assert.Equal(t, "?", params[4])
+	assert.Equal(t, "?", params[5])
+	assert.Nil(t, params[6])
+}
+
+func TestSanitizeSQLStatementRedactsStringLiterals(t *testing.T) {
+	sql := `SELECT * FROM "secrets" WHERE "secrets"."value" = 'super-secret' AND "secrets"."name" = 'O''Reilly'`
+	want := `SELECT * FROM "secrets" WHERE "secrets"."value" = '?' AND "secrets"."name" = '?'`
+
+	assert.Equal(t, want, sanitizeSQLStatement(sql))
+}
+
+func TestSanitizeSQLStatementRedactsEscapesAndDollarQuotes(t *testing.T) {
+	sql := `SELECT E'\\xdeadbeef' AS payload, $$multi
+line secret$$ AS body`
+	want := `SELECT '?' AS payload, '?' AS body`
+
+	assert.Equal(t, want, sanitizeSQLStatement(sql))
+}
+
+func TestSanitizeSQLStatementPreservesAlreadyRedactedLiterals(t *testing.T) {
+	sql := `SELECT * FROM users WHERE email = '?' AND id = 42`
+
+	assert.Equal(t, sql, sanitizeSQLStatement(sql))
+}
+
+func TestSanitizeSQLStatementPreservesStructureWithoutLiterals(t *testing.T) {
+	sql := `SELECT * FROM users WHERE id = $1 AND deleted_at IS NULL`
+
+	assert.Equal(t, sql, sanitizeSQLStatement(sql))
+}


### PR DESCRIPTION
## Summary
- Redacts GORM query parameters via `ParamsFilter` before `Explain` inlines values into SQL strings
- Scrubs remaining string literals (single-quoted, `E'...'`, dollar-quoted) from `db.statement` before export to OTel
- Closes #5449

GORM's logger always calls `Dialector.Explain`, which embeds bound parameter values into the SQL string used for tracing. This change ensures secrets, tokens, and user data are not exported to Dash0/Cloud Monitoring/etc.

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/database`
- [x] `make lint`
- [ ] Verify a traced DB query in dev shows `db.statement` with `'?'` placeholders instead of literal values


Made with [Cursor](https://cursor.com)