### PR TITLE
chore: more metrics for event router and node queue worker

### DIFF
--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -17,17 +17,21 @@ var (
 	meter        = otel.Meter("superplane")
 	metricsReady atomic.Bool
 
-	queueWorkerTickHistogram       metric.Float64Histogram
-	queueWorkerNodesCountHistogram metric.Int64Histogram
-	queueWorkerStuckItems          metric.Int64Histogram
+	queueWorkerTickHistogram         metric.Float64Histogram
+	queueWorkerNodesCountHistogram   metric.Int64Histogram
+	queueWorkerNodesCounter          metric.Int64Counter
+	queueWorkerNodeDurationHistogram metric.Float64Histogram
+	queueWorkerStuckItems            metric.Int64Histogram
 
 	executorWorkerTickHistogram              metric.Float64Histogram
 	executorWorkerNodesCountHistogram        metric.Int64Histogram
 	executorWorkerExecutionsCounter          metric.Int64Counter
 	executorWorkerExecutionDurationHistogram metric.Float64Histogram
 
-	eventWorkerTickHistogram        metric.Float64Histogram
-	eventWorkerEventsCountHistogram metric.Int64Histogram
+	eventWorkerTickHistogram          metric.Float64Histogram
+	eventWorkerEventsCountHistogram   metric.Int64Histogram
+	eventWorkerEventsCounter          metric.Int64Counter
+	eventWorkerEventDurationHistogram metric.Float64Histogram
 
 	nodeRequestWorkerTickHistogram          metric.Float64Histogram
 	nodeRequestWorkerRequestsCountHistogram metric.Int64Histogram
@@ -98,6 +102,24 @@ func InitMetrics(ctx context.Context) error {
 		return err
 	}
 
+	queueWorkerNodesCounter, err = meter.Int64Counter(
+		"queue_worker.nodes.total",
+		metric.WithDescription("WorkflowNodeQueueWorker node processing outcomes"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	queueWorkerNodeDurationHistogram, err = meter.Float64Histogram(
+		"queue_worker.node.duration.seconds",
+		metric.WithDescription("Duration of WorkflowNodeQueueWorker node processing"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return err
+	}
+
 	executorWorkerTickHistogram, err = meter.Float64Histogram(
 		"executor_worker.tick.duration.seconds",
 		metric.WithDescription("Duration of each WorkflowNodeExecutor tick"),
@@ -147,6 +169,24 @@ func InitMetrics(ctx context.Context) error {
 		"event_worker.tick.events.pending",
 		metric.WithDescription("Number of pending workflow events each tick"),
 		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	eventWorkerEventsCounter, err = meter.Int64Counter(
+		"event_worker.events.total",
+		metric.WithDescription("WorkflowEventRouter event processing outcomes"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	eventWorkerEventDurationHistogram, err = meter.Float64Histogram(
+		"event_worker.event.duration.seconds",
+		metric.WithDescription("Duration of WorkflowEventRouter event processing"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return err
@@ -338,6 +378,26 @@ func RecordQueueWorkerNodesCount(ctx context.Context, count int) {
 	queueWorkerNodesCountHistogram.Record(ctx, int64(count))
 }
 
+func RecordQueueWorkerNodeProcessing(ctx context.Context, d time.Duration, outcome, reason string) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	attrs := metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("reason", reason),
+	)
+
+	queueWorkerNodesCounter.Add(ctx, 1, attrs)
+	queueWorkerNodeDurationHistogram.Record(
+		ctx,
+		d.Seconds(),
+		metric.WithAttributes(
+			attribute.String("outcome", outcome),
+		),
+	)
+}
+
 func RecordExecutorWorkerTickDuration(ctx context.Context, d time.Duration) {
 	if !metricsReady.Load() {
 		return
@@ -390,6 +450,26 @@ func RecordEventWorkerEventsCount(ctx context.Context, count int) {
 	}
 
 	eventWorkerEventsCountHistogram.Record(ctx, int64(count))
+}
+
+func RecordEventWorkerEventProcessing(ctx context.Context, d time.Duration, outcome, reason string) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	attrs := metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("reason", reason),
+	)
+
+	eventWorkerEventsCounter.Add(ctx, 1, attrs)
+	eventWorkerEventDurationHistogram.Record(
+		ctx,
+		d.Seconds(),
+		metric.WithAttributes(
+			attribute.String("outcome", outcome),
+		),
+	)
 }
 
 func RecordNodeRequestWorkerTickDuration(ctx context.Context, d time.Duration) {

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -65,10 +65,11 @@ func (w *EventRouter) Start(ctx context.Context) {
 				}
 
 				go func(event models.CanvasEvent) {
+					attemptStart := time.Now()
 					logger := logging.ForEvent(w.logger, event)
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessEvent(logger, event); err != nil {
+					if err := w.LockAndProcessEvent(logger, event, attemptStart); err != nil {
 						logger.Errorf("Error processing event: %v", err)
 					}
 				}(event)
@@ -108,6 +109,8 @@ func (w *EventRouter) StartRabbitMQConsumer(ctx context.Context) {
 }
 
 func (w *EventRouter) Consume(delivery tackle.Delivery) error {
+	start := time.Now()
+
 	data := &pb.CanvasNodeEventMessage{}
 	err := proto.Unmarshal(delivery.Body(), data)
 	if err != nil {
@@ -129,11 +132,17 @@ func (w *EventRouter) Consume(delivery tackle.Delivery) error {
 
 	if event.State == models.CanvasEventStateRouted {
 		w.logger.Infof("Event %s is already routed - skipping", event.ID)
+		telemetry.RecordEventWorkerEventProcessing(
+			context.Background(),
+			time.Since(start),
+			executorOutcomeSkipped,
+			executorReasonNone,
+		)
 		return nil
 	}
 
 	logger := logging.ForEvent(w.logger, *event)
-	err = w.LockAndProcessEvent(logger, *event)
+	err = w.LockAndProcessEvent(logger, *event, start)
 	if err != nil {
 		logger.Errorf("Error processing event: %v", err)
 		return err
@@ -142,19 +151,39 @@ func (w *EventRouter) Consume(delivery tackle.Delivery) error {
 	return nil
 }
 
-func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.CanvasEvent) error {
+func (w *EventRouter) LockAndProcessEvent(logger *log.Entry, event models.CanvasEvent, attemptStart time.Time) error {
+	//
+	// For every event we process, we track the following metrics:
+	// - outcome: success, failed, skipped
+	// - reason: none, locked, deadlock, not_found, internal
+	//
+	metricOutcome := executorOutcomeSuccess
+	metricReason := executorReasonNone
+	defer func() {
+		telemetry.RecordEventWorkerEventProcessing(
+			context.Background(),
+			time.Since(attemptStart),
+			metricOutcome,
+			metricReason,
+		)
+	}()
+
 	var createdQueueItems []models.CanvasNodeQueueItem
 	var execution *models.CanvasNodeExecution
 	var runID uuid.UUID
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		event, err := models.LockCanvasEvent(tx, event.ID)
+		lockedEvent, err := models.LockCanvasEvent(tx, event.ID)
 		if err != nil {
 			logger.Info("Event already being processed - skipping")
+			metricOutcome = executorOutcomeSkipped
+			metricReason = executorReasonLocked
 			return nil
 		}
 
-		createdQueueItems, execution, runID, err = w.processEvent(tx, logger, event)
+		createdQueueItems, execution, runID, err = w.processEvent(tx, logger, lockedEvent)
 		if err != nil {
+			metricOutcome = executorOutcomeFailed
+			metricReason = classifyProcessError(err)
 			return err
 		}
 

--- a/pkg/workers/event_router_test.go
+++ b/pkg/workers/event_router_test.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ func Test__EventRouter_ProcessRootEvent(t *testing.T) {
 	// Create the root event for the trigger node, and process it.
 	//
 	event := support.EmitCanvasEventForNode(t, canvas.ID, node1, "default", nil)
-	err := router.LockAndProcessEvent(logger, *event)
+	err := router.LockAndProcessEvent(logger, *event, time.Now())
 	require.NoError(t, err)
 
 	//
@@ -114,7 +115,7 @@ func Test__EventRouter_DoesNotRouteEventForSoftDeletedOrganization(t *testing.T)
 		assert.NotEqual(t, event.ID, pending.ID)
 	}
 
-	require.NoError(t, router.LockAndProcessEvent(logger, *event))
+	require.NoError(t, router.LockAndProcessEvent(logger, *event, time.Now()))
 
 	updatedEvent, err := models.FindCanvasEvent(event.ID)
 	require.NoError(t, err)
@@ -181,7 +182,7 @@ func Test__EventRouter_ProcessExecutionEvent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	outputEvent := events[0]
-	err = router.LockAndProcessEvent(logger, outputEvent)
+	err = router.LockAndProcessEvent(logger, outputEvent, time.Now())
 	require.NoError(t, err)
 
 	updatedEvent, err := models.FindCanvasEvent(outputEvent.ID)
@@ -235,7 +236,7 @@ func Test__EventRouter_ProcessTerminalExecutionEventFinishesRun(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 
-	err = router.LockAndProcessEvent(logger, events[0])
+	err = router.LockAndProcessEvent(logger, events[0], time.Now())
 	require.NoError(t, err)
 
 	updatedRun, err := models.FindCanvasRunByRootEventInTransaction(database.Conn(), triggerEvent.ID)

--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -87,9 +87,10 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 				}
 
 				go func(node models.CanvasNode) {
+					attemptStart := time.Now()
 					defer w.semaphore.Release(1)
 
-					if err := w.LockAndProcessNode(logger, node); err != nil {
+					if err := w.LockAndProcessNode(logger, node, attemptStart); err != nil {
 						logger.Errorf("Error processing: %v", err)
 					}
 				}(node)
@@ -129,6 +130,8 @@ func (w *NodeQueueWorker) StartRabbitMQConsumer(ctx context.Context) {
 }
 
 func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
+	start := time.Now()
+
 	data := &pb.CanvasNodeQueueItemMessage{}
 	err := proto.Unmarshal(delivery.Body(), data)
 	if err != nil {
@@ -153,6 +156,12 @@ func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
 	//
 	if node.State != models.CanvasNodeStateReady {
 		w.logger.Infof("Node %s is not ready, skipping", node.NodeID)
+		telemetry.RecordQueueWorkerNodeProcessing(
+			context.Background(),
+			time.Since(start),
+			executorOutcomeSkipped,
+			executorReasonNone,
+		)
 		return nil
 	}
 
@@ -160,10 +169,26 @@ func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
 	// Node is ready for processing, let's lock it and process it.
 	//
 	logger := logging.WithNode(w.logger, *node)
-	return w.LockAndProcessNode(logger, *node)
+	return w.LockAndProcessNode(logger, *node, start)
 }
 
-func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.CanvasNode) error {
+func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.CanvasNode, attemptStart time.Time) error {
+	//
+	// For every node we process, we track the following metrics:
+	// - outcome: success, failed, skipped
+	// - reason: none, locked, deadlock, not_found, internal
+	//
+	metricOutcome := executorOutcomeSuccess
+	metricReason := executorReasonNone
+	defer func() {
+		telemetry.RecordQueueWorkerNodeProcessing(
+			context.Background(),
+			time.Since(attemptStart),
+			metricOutcome,
+			metricReason,
+		)
+	}()
+
 	var executionIDs []*uuid.UUID
 	var queueItem *models.CanvasNodeQueueItem
 
@@ -176,11 +201,19 @@ func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.Canv
 		n, err := models.LockCanvasNode(tx, node.WorkflowID, node.NodeID)
 		if err != nil {
 			logger.Info("Node already being processed - skipping")
+			metricOutcome = executorOutcomeSkipped
+			metricReason = executorReasonLocked
 			return nil
 		}
 
 		executionIDs, queueItem, err = w.processNode(tx, logger, n, onNewEvents)
-		return err
+		if err != nil {
+			metricOutcome = executorOutcomeFailed
+			metricReason = classifyProcessError(err)
+			return err
+		}
+
+		return nil
 	})
 
 	if err == nil {
@@ -227,7 +260,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 	logger = logging.WithQueueItem(logger, *queueItem)
 	logger.Info("Processing queue item")
 
-	configFields, err := w.configurationFieldsForNode(tx, node)
+	configFields, err := w.configurationFieldsForNode(node)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -255,7 +288,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 		// we create a failed execution and delete the queue item.
 		//
 		logger.Errorf("Error building configuration for node execution: %v", configErr.Error())
-		executions, err := w.handleNodeConfigurationError(tx, logger, configErr, onNewEvents)
+		executions, err := w.handleNodeConfigurationError(tx, configErr, onNewEvents)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -283,7 +316,7 @@ func (w *NodeQueueWorker) processNode(tx *gorm.DB, logger *log.Entry, node *mode
 	return []*uuid.UUID{executionID}, queueItem, err
 }
 
-func (w *NodeQueueWorker) configurationFieldsForNode(tx *gorm.DB, node *models.CanvasNode) ([]configuration.Field, error) {
+func (w *NodeQueueWorker) configurationFieldsForNode(node *models.CanvasNode) ([]configuration.Field, error) {
 	ref := node.Ref.Data()
 	switch node.Type {
 	case models.NodeTypeComponent:
@@ -317,7 +350,7 @@ func (w *NodeQueueWorker) processComponentNode(ctx *core.ProcessQueueContext, no
 	return action.ProcessQueueItem(*ctx)
 }
 
-func (w *NodeQueueWorker) handleNodeConfigurationError(tx *gorm.DB, logger *log.Entry, configErr *contexts.ConfigurationBuildError, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, error) {
+func (w *NodeQueueWorker) handleNodeConfigurationError(tx *gorm.DB, configErr *contexts.ConfigurationBuildError, onNewEvents func([]models.CanvasEvent)) ([]*uuid.UUID, error) {
 	err := configErr.QueueItem.Delete(tx)
 	if err != nil {
 		return nil, err

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -81,7 +81,7 @@ func Test__NodeQueueWorker_ComponentNodeQueueIsProcessed(t *testing.T) {
 	// - Node state is updated to processing
 	// - Queue item is deleted
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
 	// Verify execution was created with pending state
@@ -150,7 +150,7 @@ func Test__NodeQueueWorker_DoesNotProcessQueueForSoftDeletedOrganization(t *test
 	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
 	require.NoError(t, err)
 
-	require.NoError(t, worker.LockAndProcessNode(logger, *node))
+	require.NoError(t, worker.LockAndProcessNode(logger, *node, time.Now()))
 
 	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
 	require.NoError(t, err)
@@ -245,7 +245,7 @@ func Test__NodeQueueWorker_PicksOldestQueueItem(t *testing.T) {
 	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
 	require.NoError(t, err)
 
-	err = worker.LockAndProcessNode(logger, *node)
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
 	// Verify the execution was created with the oldest event
@@ -311,7 +311,7 @@ func Test__NodeQueueWorker_EmptyQueue(t *testing.T) {
 	//
 	// Process the node with an empty queue - this should succeed but do nothing.
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
 	// Verify no executions were created
@@ -379,13 +379,13 @@ func Test__NodeQueueWorker_PreventsConcurrentProcessing(t *testing.T) {
 	go func() {
 		worker1 := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
 		logger := log.NewEntry(log.New())
-		results <- worker1.LockAndProcessNode(logger, *node)
+		results <- worker1.LockAndProcessNode(logger, *node, time.Now())
 	}()
 
 	go func() {
 		worker2 := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
 		logger := log.NewEntry(log.New())
-		results <- worker2.LockAndProcessNode(logger, *node)
+		results <- worker2.LockAndProcessNode(logger, *node, time.Now())
 	}()
 
 	// Collect results - both should succeed (return nil)
@@ -480,7 +480,7 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 	// - Node state should remain ready (not updated to processing)
 	// - Queue item should be deleted
 	//
-	err = worker.LockAndProcessNode(logger, *node)
+	err = worker.LockAndProcessNode(logger, *node, time.Now())
 	require.NoError(t, err)
 
 	// Verify execution was created with finished state and failed result


### PR DESCRIPTION
Adding similar metrics as the ones we added for NodeExecutor in https://github.com/superplanehq/superplane/pull/5404