### PR TITLE
fix: prevent agent template fields in canvas yaml

### DIFF
--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -89,7 +89,7 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			},
 			"canvas_yaml": {
 				Type:        "string",
-				Description: "For update_draft. Complete canonical canvas.yaml content to save.",
+				Description: "For update_draft. Complete canonical live canvas.yaml content to save. Unknown fields are rejected; do not include template-only or UI-only fields such as metadata.isTemplate.",
 			},
 			"console_yaml": {
 				Type:        "string",

--- a/pkg/agents/agent_tools/schema_test.go
+++ b/pkg/agents/agent_tools/schema_test.go
@@ -57,6 +57,17 @@ func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
 	assert.Contains(t, schema.Properties, "execution_id")
 }
 
+func TestAppAgentToolSchemaWarnsAgainstTemplateFieldsInCanvasYAML(t *testing.T) {
+	tool := NewAppAgentTool(AppAgentToolOptions{})
+
+	schema := tool.InputSchema()
+	canvasYAMLSchema := schema.Properties["canvas_yaml"]
+
+	assert.Contains(t, canvasYAMLSchema.Description, "canonical live canvas.yaml")
+	assert.Contains(t, canvasYAMLSchema.Description, "Unknown fields are rejected")
+	assert.Contains(t, canvasYAMLSchema.Description, "metadata.isTemplate")
+}
+
 func TestComponentSchemaAgentTool_ReturnsCoreComponentSchema(t *testing.T) {
 	tool := newComponentSchemaTool(t)
 

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -290,9 +290,14 @@ Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` section 6
 | Using integration without ID | Add `integration: {id: "..."}` | Check `superplane_app` list_integrations |
 | `start` with `configuration: {}` | `templates: [{name, payload, parameters?}]` | Manual Run needs templates for the UI Run button and hook execution |
 
+### Strict Canvas YAML
+
+`canvas_yaml` passed to `superplane_app` action `update_draft` must be canonical live Canvas YAML. The parser rejects unknown fields; never include template-only or UI-only fields such as `metadata.isTemplate`. If `update_draft` returns an `unknown field` error, remove the non-canonical field and retry with canonical YAML.
+
 ## Error Handling
 
 - If update returns "configuration errors" → app was saved but broken. Fix nodes and re-submit.
+- If update returns "unknown field" → app was not saved. Remove non-canonical canvas YAML fields such as `metadata.isTemplate` and retry once.
 - If "integration is required" → node needs a connected integration. Show the integration button and ask the user.
 - If a native component isn't available → offer alternatives: core components, different vendor, or placeholder with `noop`.
 

--- a/pkg/agents/anthropic/agent_prompt_test.go
+++ b/pkg/agents/anthropic/agent_prompt_test.go
@@ -1,0 +1,15 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultAgentPromptWarnsAgainstTemplateFieldsInCanvasYAML(t *testing.T) {
+	prompt := DefaultAgentPrompt()
+
+	assert.Contains(t, prompt, "canonical live Canvas YAML")
+	assert.Contains(t, prompt, "metadata.isTemplate")
+	assert.Contains(t, prompt, "unknown field")
+}

--- a/pkg/canvas/yaml/canvas_test.go
+++ b/pkg/canvas/yaml/canvas_test.go
@@ -27,3 +27,19 @@ spec:
 `))
 	require.Error(t, err)
 }
+
+func TestParseCanvasResourceRejectsTemplateMetadata(t *testing.T) {
+	_, err := ParseCanvasResource([]byte(`apiVersion: v1
+kind: Canvas
+metadata:
+  id: canvas-id
+  name: test
+  isTemplate: true
+spec:
+  nodes: []
+  edges: []
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+	assert.Contains(t, err.Error(), "isTemplate")
+}


### PR DESCRIPTION
## Summary
- keep YAML specs mounted and add a compact strict canvas YAML guardrail to the Anthropic agent prompt
- warn the superplane_app tool schema that update_draft rejects unknown/template fields like metadata.isTemplate
- add regressions for prompt/schema guidance and parser rejection of metadata.isTemplate

## Tests
- go test ./pkg/canvas/yaml
- go test ./pkg/agents/anthropic
- go test ./pkg/agents/agent_tools
- make lint
- make check.build.app