### PR TITLE
fix: use second-appropriate histogram buckets for duration metrics

### DIFF
--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -63,6 +63,28 @@ const (
 	IntegrationSecretOperationUpdate = "update"
 )
 
+// durationSecondsHistogramBoundaries matches Prometheus DefBuckets and is
+// appropriate for latency histograms recorded in seconds. The OTel SDK default
+// boundaries assume milliseconds, which collapses sub-second values into the
+// (0, 5] bucket and makes histogram_quantile estimates misleading.
+var durationSecondsHistogramBoundaries = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+func durationSecondsHistogramView() sdkmetric.Option {
+	return sdkmetric.WithView(sdkmetric.NewView(
+		sdkmetric.Instrument{
+			Name: "*duration.seconds",
+			Unit: "s",
+		},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: durationSecondsHistogramBoundaries,
+			},
+		},
+	))
+}
+
 func InitMetrics(ctx context.Context) error {
 	exporter, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
@@ -79,6 +101,7 @@ func InitMetrics(ctx context.Context) error {
 		sdkmetric.WithReader(
 			sdkmetric.NewPeriodicReader(exporter),
 		),
+		durationSecondsHistogramView(),
 	)
 
 	otel.SetMeterProvider(provider)

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -366,14 +366,6 @@ func (w *EventRouter) processExecutionEvent(
 		return nil, uuid.Nil, err
 	}
 
-	//
-	// If we created any queue items, we know for sure that the run is not finished yet,
-	// so there is no need to lock the run record to check it.
-	//
-	if len(createdQueueItems) > 0 {
-		return createdQueueItems, execution.RunID, nil
-	}
-
 	_, err := models.MaybeFinalizeRunInTransaction(tx, execution.RunID)
 	if err != nil {
 		return nil, uuid.Nil, err

--- a/pkg/workers/event_router.go
+++ b/pkg/workers/event_router.go
@@ -366,6 +366,14 @@ func (w *EventRouter) processExecutionEvent(
 		return nil, uuid.Nil, err
 	}
 
+	//
+	// If we created any queue items, we know for sure that the run is not finished yet,
+	// so there is no need to lock the run record to check it.
+	//
+	if len(createdQueueItems) > 0 {
+		return createdQueueItems, execution.RunID, nil
+	}
+
 	_, err := models.MaybeFinalizeRunInTransaction(tx, execution.RunID)
 	if err != nil {
 		return nil, uuid.Nil, err


### PR DESCRIPTION
### Summary

- Add an OTel metric view with Prometheus DefBuckets for all `*duration.seconds` histograms
- Fixes misleading `histogram_quantile` results (e.g. p50 stuck at ~2.5s) while keeping durations recorded in seconds per OTel conventions

### Context

Worker duration metrics are recorded in seconds, but the OTel SDK default bucket boundaries provide no useful sub-5s resolution. Verified in Dash0: true averages are ~27ms (event worker) and ~206ms (queue worker), while p50 reported 2.5s.