### PR TITLE
feat: add Anthropic agent memory stores

### DIFF
--- a/db/migrations/20260615193406_add-agent-memory-stores.up.sql
+++ b/db/migrations/20260615193406_add-agent-memory-stores.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_memory_stores (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    canvas_id UUID NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+    provider VARCHAR(40) NOT NULL,
+    provider_memory_store_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX agent_memory_stores_scope_provider_idx
+    ON agent_memory_stores (organization_id, user_id, canvas_id, provider);
+
+CREATE INDEX agent_memory_stores_provider_id_idx
+    ON agent_memory_stores (provider, provider_memory_store_id);
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -102,6 +102,24 @@ CREATE TABLE public.accounts (
 
 
 --
+-- Name: agent_memory_stores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.agent_memory_stores (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    organization_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    canvas_id uuid NOT NULL,
+    provider character varying(40) NOT NULL,
+    provider_memory_store_id text NOT NULL,
+    name text NOT NULL,
+    description text DEFAULT ''::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: agent_session_messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -742,6 +760,14 @@ ALTER TABLE ONLY public.accounts
 
 
 --
+-- Name: agent_memory_stores agent_memory_stores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory_stores
+    ADD CONSTRAINT agent_memory_stores_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: agent_session_messages agent_session_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1091,6 +1117,20 @@ ALTER TABLE ONLY public.workflows
 
 ALTER TABLE ONLY public.workflows
     ADD CONSTRAINT workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agent_memory_stores_provider_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX agent_memory_stores_provider_id_idx ON public.agent_memory_stores USING btree (provider, provider_memory_store_id);
+
+
+--
+-- Name: agent_memory_stores_scope_provider_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX agent_memory_stores_scope_provider_idx ON public.agent_memory_stores USING btree (organization_id, user_id, canvas_id, provider);
 
 
 --
@@ -1558,6 +1598,30 @@ ALTER TABLE ONLY public.account_providers
 
 
 --
+-- Name: agent_memory_stores agent_memory_stores_canvas_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory_stores
+    ADD CONSTRAINT agent_memory_stores_canvas_id_fkey FOREIGN KEY (canvas_id) REFERENCES public.workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: agent_memory_stores agent_memory_stores_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory_stores
+    ADD CONSTRAINT agent_memory_stores_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: agent_memory_stores agent_memory_stores_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_memory_stores
+    ADD CONSTRAINT agent_memory_stores_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- Name: agent_session_messages agent_session_messages_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1997,7 +2061,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260615161605	f
+20260615193406	f
 \.
 
 

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -32,6 +32,14 @@ When reference files are still necessary, read each file at most once per turn. 
 
 Never run broad filesystem discovery such as `find / ...` or recursive searches from `/` to locate references. Reference paths are fixed under `/mnt/session/uploads/ref/`; if a mounted reference is missing, continue from `superplane_app`, `superplane_component_schema`, and the quick references in this prompt.
 
+## Durable Memory Store
+
+If a memory store is mounted under `/mnt/memory/`, use it for durable app-scoped context for this user: stable user preferences, app conventions, prior mistakes, and the latest private draft/version ID returned by `superplane_app` for this app.
+
+After every successful `superplane_app.update_draft`, write or update a small memory note with the app/canvas ID, the returned draft `version_id`, and a brief summary of what changed. On later sessions, treat the remembered draft ID as a hint only; the latest `[Canvas Snapshot]`, `[Draft Status]`, and `superplane_app` responses are authoritative. If memory is absent, stale, or conflicts with the current context, continue from `superplane_app`.
+
+Never store secret values, credentials, API tokens, raw user prompts, or large YAML snapshots in memory. It is OK to remember that an integration needs reconnecting or a credential is missing, but not the secret value itself.
+
 ## Communication Style
 
 - Conversational and direct. No filler or corporate fluff.

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -65,6 +65,103 @@ func TestCreateSession_SendsCorrectRequest(t *testing.T) {
 	assert.Equal(t, "sesn_abc", res.ProviderSessionID)
 	assert.Equal(t, "agent-123", capturedBody["agent"])
 	assert.Equal(t, "env-456", capturedBody["environment_id"])
+	assert.NotContains(t, capturedBody, "resources")
+	assert.Equal(t, "test-key", capturedHeaders.Get("x-api-key"))
+	assert.Equal(t, managedAgentsBeta, capturedHeaders.Get("anthropic-beta"))
+}
+
+func TestCreateSession_SendsFileAndMemoryStoreResources(t *testing.T) {
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/sessions", r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"sesn_abc","status":"idle"}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	_, err := p.CreateSession(context.Background(), agents.CreateSessionOptions{
+		Resources: []agents.FileResource{
+			{FileID: "file_123", MountPath: "ref/spec.md"},
+		},
+		MemoryStores: []agents.MemoryStoreResource{
+			{
+				MemoryStoreID: "memstore_123",
+				Access:        agents.MemoryStoreAccessReadWrite,
+				Instructions:  "Use durable app memory.",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resources, ok := capturedBody["resources"].([]any)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+	assert.Equal(t, map[string]any{
+		"type":       "file",
+		"file_id":    "file_123",
+		"mount_path": "ref/spec.md",
+	}, resources[0])
+	assert.Equal(t, map[string]any{
+		"type":            "memory_store",
+		"memory_store_id": "memstore_123",
+		"access":          agents.MemoryStoreAccessReadWrite,
+		"instructions":    "Use durable app memory.",
+	}, resources[1])
+}
+
+func TestCreateMemoryStore_SendsCorrectRequest(t *testing.T) {
+	var capturedBody map[string]any
+	var capturedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/memory_stores", r.URL.Path)
+		capturedHeaders = r.Header.Clone()
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &capturedBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"memstore_123","name":"Memory","description":"Durable memory.","type":"memory_store"}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	store, err := p.CreateMemoryStore(context.Background(), agents.CreateMemoryStoreOptions{
+		Name:        "Memory",
+		Description: "Durable memory.",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "memstore_123", store.ProviderMemoryStoreID)
+	assert.Equal(t, "Memory", capturedBody["name"])
+	assert.Equal(t, "Durable memory.", capturedBody["description"])
+	assert.Equal(t, "test-key", capturedHeaders.Get("x-api-key"))
+	assert.Equal(t, managedAgentsBeta, capturedHeaders.Get("anthropic-beta"))
+}
+
+func TestDeleteMemoryStore_SendsCorrectRequest(t *testing.T) {
+	var capturedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/memory_stores/memstore_123", r.URL.Path)
+		capturedHeaders = r.Header.Clone()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"memstore_123","type":"memory_store"}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.DeleteMemoryStore(context.Background(), "memstore_123")
+	require.NoError(t, err)
+
 	assert.Equal(t, "test-key", capturedHeaders.Get("x-api-key"))
 	assert.Equal(t, managedAgentsBeta, capturedHeaders.Get("anthropic-beta"))
 }
@@ -86,6 +183,9 @@ func TestDefaultAgentPrompt_IsEmbedded(t *testing.T) {
 	prompt := DefaultAgentPrompt()
 	assert.Contains(t, prompt, "You are a SuperPlane app expert")
 	assert.Contains(t, prompt, "## App Update Rules")
+	assert.Contains(t, prompt, "## Durable Memory Store")
+	assert.Contains(t, prompt, "latest private draft/version ID")
+	assert.Contains(t, prompt, "Never store secret values, credentials, API tokens")
 }
 
 func defaultAgentToolsJSON(t *testing.T) string {

--- a/pkg/agents/anthropic/client.go
+++ b/pkg/agents/anthropic/client.go
@@ -125,6 +125,12 @@ type fileMetadata struct {
 	Filename string `json:"filename"`
 }
 
+type memoryStoreMetadata struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 type apiError struct {
 	StatusCode int
 	Message    string
@@ -216,6 +222,31 @@ func (c *Client) listFiles(ctx context.Context) ([]fileMetadata, error) {
 
 func (c *Client) uploadFileContent(ctx context.Context, content []byte, filename string) (fileMetadata, error) {
 	return c.uploadFileReader(ctx, bytes.NewReader(content), filename)
+}
+
+func (c *Client) createMemoryStore(ctx context.Context, name, description string) (memoryStoreMetadata, error) {
+	body := map[string]string{
+		"name":        name,
+		"description": description,
+	}
+	data, err := c.executeHTTP(ctx, http.MethodPost, "/memory_stores", body)
+	if err != nil {
+		return memoryStoreMetadata{}, err
+	}
+
+	var store memoryStoreMetadata
+	if err := json.Unmarshal(data, &store); err != nil {
+		return memoryStoreMetadata{}, fmt.Errorf("decode memory store: %w", err)
+	}
+	if store.ID == "" {
+		return memoryStoreMetadata{}, fmt.Errorf("provider returned empty memory store id")
+	}
+	return store, nil
+}
+
+func (c *Client) deleteMemoryStore(ctx context.Context, memoryStoreID string) error {
+	_, err := c.executeHTTP(ctx, http.MethodDelete, "/memory_stores/"+url.PathEscape(memoryStoreID), nil)
+	return err
 }
 
 func (c *Client) uploadFileReader(ctx context.Context, file io.Reader, filename string) (fileMetadata, error) {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -47,6 +47,24 @@ func New(cfg Config) (*Provider, error) {
 
 func (p *Provider) Name() string { return ProviderName }
 
+func (p *Provider) CreateMemoryStore(ctx context.Context, opts agents.CreateMemoryStoreOptions) (*agents.CreateMemoryStoreResult, error) {
+	store, err := p.client.createMemoryStore(ctx, opts.Name, opts.Description)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: create memory store: %w", err)
+	}
+	return &agents.CreateMemoryStoreResult{ProviderMemoryStoreID: store.ID}, nil
+}
+
+func (p *Provider) DeleteMemoryStore(ctx context.Context, providerMemoryStoreID string) error {
+	if providerMemoryStoreID == "" {
+		return fmt.Errorf("anthropic: memory store id is required")
+	}
+	if err := p.client.deleteMemoryStore(ctx, providerMemoryStoreID); err != nil {
+		return fmt.Errorf("anthropic: delete memory store: %w", err)
+	}
+	return nil
+}
+
 func (p *Provider) CreateSession(ctx context.Context, opts agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
 	body := map[string]any{
 		"agent":          p.agentID,
@@ -58,21 +76,9 @@ func (p *Provider) CreateSession(ctx context.Context, opts agents.CreateSessionO
 	if len(opts.VaultIDs) > 0 {
 		body["vault_ids"] = opts.VaultIDs
 	}
-	// Mount reference files
-	resources := opts.Resources
-	if len(p.resources) > 0 && len(resources) == 0 {
-		resources = p.resources
-	}
+	resources := p.sessionResources(opts)
 	if len(resources) > 0 {
-		fileResources := make([]map[string]string, len(resources))
-		for i, r := range resources {
-			fileResources[i] = map[string]string{
-				"type":       "file",
-				"file_id":    r.FileID,
-				"mount_path": r.MountPath,
-			}
-		}
-		body["resources"] = fileResources
+		body["resources"] = resources
 	}
 	data, err := p.client.executeHTTP(ctx, http.MethodPost, "/sessions", body)
 	if err != nil {
@@ -89,6 +95,37 @@ func (p *Provider) CreateSession(ctx context.Context, opts agents.CreateSessionO
 		return nil, fmt.Errorf("anthropic: provider returned empty session id")
 	}
 	return &agents.CreateSessionResult{ProviderSessionID: resp.ID}, nil
+}
+
+func (p *Provider) sessionResources(opts agents.CreateSessionOptions) []map[string]any {
+	fileResources := opts.Resources
+	if len(p.resources) > 0 && len(fileResources) == 0 {
+		fileResources = p.resources
+	}
+
+	resources := make([]map[string]any, 0, len(fileResources)+len(opts.MemoryStores))
+	for _, r := range fileResources {
+		resources = append(resources, map[string]any{
+			"type":       "file",
+			"file_id":    r.FileID,
+			"mount_path": r.MountPath,
+		})
+	}
+	for _, r := range opts.MemoryStores {
+		resource := map[string]any{
+			"type":            "memory_store",
+			"memory_store_id": r.MemoryStoreID,
+		}
+		if r.Access != "" {
+			resource["access"] = r.Access
+		}
+		if r.Instructions != "" {
+			resource["instructions"] = r.Instructions
+		}
+		resources = append(resources, resource)
+	}
+
+	return resources
 }
 
 func (p *Provider) SendMessage(ctx context.Context, providerSessionID, message string, opts agents.SendMessageOptions) error {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -117,11 +117,32 @@ type FileResource struct {
 	MountPath string
 }
 
+const (
+	MemoryStoreAccessReadOnly  = "read_only"
+	MemoryStoreAccessReadWrite = "read_write"
+)
+
+type MemoryStoreResource struct {
+	MemoryStoreID string
+	Access        string
+	Instructions  string
+}
+
+type CreateMemoryStoreOptions struct {
+	Name        string
+	Description string
+}
+
+type CreateMemoryStoreResult struct {
+	ProviderMemoryStoreID string
+}
+
 type CreateSessionOptions struct {
 	InitialContext string
 	Title          string
 	VaultIDs       []string
 	Resources      []FileResource
+	MemoryStores   []MemoryStoreResource
 }
 
 type DefineOutcomeOptions struct {
@@ -158,6 +179,14 @@ type Provider interface {
 	// cancelled, or onEvent errors. Implementations must not call onEvent
 	// after returning.
 	StreamEvents(ctx context.Context, providerSessionID string, onEvent func(ProviderEvent) error) error
+}
+
+type MemoryStoreCreator interface {
+	CreateMemoryStore(ctx context.Context, opts CreateMemoryStoreOptions) (*CreateMemoryStoreResult, error)
+}
+
+type MemoryStoreCleaner interface {
+	DeleteMemoryStore(ctx context.Context, providerMemoryStoreID string) error
 }
 
 type ProviderSessionCleaner interface {

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -7,22 +7,26 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authorization"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var ErrSessionForbidden = errors.New("agent session is owned by another user")
 
 type Service struct {
-	provider Provider
-	auth     authorization.Authorization
+	provider         Provider
+	auth             authorization.Authorization
+	memoryStoreLocks sync.Map
 }
 
 func NewService(provider Provider, auth authorization.Authorization) *Service {
@@ -46,14 +50,42 @@ func (s *Service) EnsureSession(ctx context.Context, organizationID, userID, can
 		return nil, err
 	}
 	if existing != nil {
+		s.prepareMemoryStoreForExistingSession(ctx, organizationID, userID, canvasID)
 		return existing, nil
 	}
 	return s.provisionSession(ctx, organizationID, userID, canvasID)
 }
 
+func (s *Service) prepareMemoryStoreForExistingSession(ctx context.Context, organizationID, userID, canvasID uuid.UUID) {
+	// Anthropic memory stores attach only when a provider session is created.
+	// For existing sessions, prepare the mapping for the next recovery without
+	// replacing the provider session and losing its current conversation state.
+	if _, err := s.memoryStoresForScope(ctx, organizationID, userID, canvasID); err != nil {
+		log.WithError(err).
+			WithField("provider", s.provider.Name()).
+			WithField("organization_id", organizationID).
+			WithField("user_id", userID).
+			WithField("canvas_id", canvasID).
+			Warn("failed to prepare agent memory store for existing session")
+	}
+}
+
 func (s *Service) provisionSession(ctx context.Context, organizationID, userID, canvasID uuid.UUID) (*models.AgentSession, error) {
-	var session *models.AgentSession
-	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+	session, err := s.existingSessionForProvision(organizationID, userID, canvasID)
+	if err != nil {
+		return nil, fmt.Errorf("ensure session: %w", err)
+	}
+	if session != nil {
+		s.prepareMemoryStoreForExistingSession(ctx, organizationID, userID, canvasID)
+		return session, nil
+	}
+
+	memoryStores, err := s.memoryStoresForScope(ctx, organizationID, userID, canvasID)
+	if err != nil {
+		return nil, fmt.Errorf("ensure session: %w", err)
+	}
+
+	err = database.Conn().Transaction(func(tx *gorm.DB) error {
 		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", ensureSessionLockKey(organizationID, userID, canvasID)).Error; err != nil {
 			return err
 		}
@@ -68,7 +100,10 @@ func (s *Service) provisionSession(ctx context.Context, organizationID, userID, 
 		}
 
 		title := sessionTitle(organizationID, canvasID)
-		upstream, err := s.provider.CreateSession(ctx, CreateSessionOptions{Title: title})
+		upstream, err := s.provider.CreateSession(ctx, CreateSessionOptions{
+			Title:        title,
+			MemoryStores: memoryStores,
+		})
 		if err != nil {
 			return fmt.Errorf("create provider session: %w", err)
 		}
@@ -85,6 +120,26 @@ func (s *Service) provisionSession(ctx context.Context, organizationID, userID, 
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ensure session: %w", err)
+	}
+	return session, nil
+}
+
+func (s *Service) existingSessionForProvision(organizationID, userID, canvasID uuid.UUID) (*models.AgentSession, error) {
+	var session *models.AgentSession
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", ensureSessionLockKey(organizationID, userID, canvasID)).Error; err != nil {
+			return err
+		}
+
+		found, err := findCanvasSession(tx, organizationID, userID, canvasID)
+		if err != nil {
+			return err
+		}
+		session = found
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return session, nil
 }
@@ -314,8 +369,14 @@ func (s *Service) recoverProviderSession(ctx context.Context, stale *models.Agen
 		return target.recovered, nil
 	}
 
+	memoryStores, err := s.memoryStoresForScope(ctx, target.organizationID, target.userID, target.canvasID)
+	if err != nil {
+		return nil, fmt.Errorf("recover provider session: load memory store: %w", err)
+	}
+
 	upstream, err := s.provider.CreateSession(ctx, CreateSessionOptions{
-		Title: sessionTitle(target.organizationID, target.canvasID),
+		Title:        sessionTitle(target.organizationID, target.canvasID),
+		MemoryStores: memoryStores,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("recover provider session: create provider session: %w", err)
@@ -334,6 +395,7 @@ func (s *Service) recoverProviderSession(ctx context.Context, stale *models.Agen
 
 type providerSessionRecoveryTarget struct {
 	organizationID uuid.UUID
+	userID         uuid.UUID
 	canvasID       uuid.UUID
 	recovered      *models.AgentSession
 }
@@ -354,6 +416,7 @@ func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession) (*pr
 		}
 
 		target.organizationID = locked.OrganizationID
+		target.userID = locked.UserID
 		target.canvasID = locked.CanvasID
 		return nil
 	})
@@ -395,6 +458,228 @@ func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, pr
 		return nil, err
 	}
 	return recovered, nil
+}
+
+const (
+	agentMemoryStoreDescription  = "Durable SuperPlane agent memory for one user and one app. Store user preferences, app-specific conventions, the latest private draft version ID, useful lessons, and prior mistakes. Do not store secret values, credentials, API tokens, raw prompts, or large app YAML snapshots."
+	agentMemoryStoreInstructions = "Use this memory only for durable lessons, user preferences, app-specific conventions, the current private draft/version ID returned by superplane_app for this app, and prior mistakes that will help future SuperPlane agent sessions for this same user and app. Treat remembered draft IDs as hints; latest session context and superplane_app responses are authoritative. Never store secret values, credentials, API tokens, raw user prompts, or large app YAML snapshots."
+)
+
+func (s *Service) memoryStoresForScope(
+	ctx context.Context,
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+) ([]MemoryStoreResource, error) {
+	lock := s.memoryStoreLock(organizationID, userID, canvasID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	plan, err := s.memoryStorePlanForScope(organizationID, userID, canvasID)
+	if err != nil {
+		return nil, err
+	}
+	if plan.store != nil {
+		return []MemoryStoreResource{memoryStoreResource(plan.store)}, nil
+	}
+	if !plan.shouldCreate {
+		return nil, nil
+	}
+
+	created, ok := s.createProviderMemoryStore(ctx, organizationID, userID, canvasID)
+	if !ok {
+		return nil, nil
+	}
+
+	store, err := s.saveMemoryStoreMapping(organizationID, userID, canvasID, created.ProviderMemoryStoreID)
+	if err != nil {
+		s.cleanupProviderMemoryStore(ctx, created.ProviderMemoryStoreID)
+		log.WithError(err).
+			WithField("provider", s.provider.Name()).
+			WithField("organization_id", organizationID).
+			WithField("user_id", userID).
+			WithField("canvas_id", canvasID).
+			WithField("provider_memory_store_id", created.ProviderMemoryStoreID).
+			Warn("failed to save agent memory store mapping; continuing without memory")
+		return nil, nil
+	}
+	if store == nil {
+		return nil, nil
+	}
+
+	return []MemoryStoreResource{memoryStoreResource(store)}, nil
+}
+
+type memoryStorePlan struct {
+	store        *models.AgentMemoryStore
+	shouldCreate bool
+}
+
+func (s *Service) memoryStorePlanForScope(organizationID, userID, canvasID uuid.UUID) (*memoryStorePlan, error) {
+	plan := &memoryStorePlan{}
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		enabled := s.agentMemoryEnabledInTransaction(tx, organizationID)
+		if !enabled {
+			return nil
+		}
+
+		if _, ok := s.provider.(MemoryStoreCreator); !ok {
+			log.WithField("provider", s.provider.Name()).Warn("agent memory enabled but provider does not support memory stores")
+			return nil
+		}
+
+		store, err := models.FindAgentMemoryStoreByScopeInTransaction(tx, organizationID, userID, canvasID, s.provider.Name())
+		if err == nil {
+			plan.store = store
+			return nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("find agent memory store: %w", err)
+		}
+
+		plan.shouldCreate = true
+		return nil
+	})
+	return plan, err
+}
+
+func (s *Service) createProviderMemoryStore(
+	ctx context.Context,
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+) (*CreateMemoryStoreResult, bool) {
+	creator, ok := s.provider.(MemoryStoreCreator)
+	if !ok {
+		return nil, false
+	}
+	created, err := creator.CreateMemoryStore(ctx, CreateMemoryStoreOptions{
+		Name:        agentMemoryStoreName(userID, canvasID),
+		Description: agentMemoryStoreDescription,
+	})
+	if err != nil {
+		log.WithError(err).
+			WithField("provider", s.provider.Name()).
+			WithField("organization_id", organizationID).
+			WithField("user_id", userID).
+			WithField("canvas_id", canvasID).
+			Warn("failed to create agent memory store; continuing without memory")
+		return nil, false
+	}
+	if created.ProviderMemoryStoreID == "" {
+		log.WithField("provider", s.provider.Name()).Warn("provider returned empty agent memory store id; continuing without memory")
+		return nil, false
+	}
+
+	return created, true
+}
+
+func (s *Service) saveMemoryStoreMapping(
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+	providerMemoryStoreID string,
+) (*models.AgentMemoryStore, error) {
+	var saved *models.AgentMemoryStore
+	err := database.Conn().Transaction(func(tx *gorm.DB) error {
+		store, err := models.FindAgentMemoryStoreByScopeInTransaction(tx, organizationID, userID, canvasID, s.provider.Name())
+		if err == nil {
+			saved = store
+			return nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("find agent memory store: %w", err)
+		}
+
+		store = &models.AgentMemoryStore{
+			OrganizationID:        organizationID,
+			UserID:                userID,
+			CanvasID:              canvasID,
+			Provider:              s.provider.Name(),
+			ProviderMemoryStoreID: providerMemoryStoreID,
+			Name:                  agentMemoryStoreName(userID, canvasID),
+			Description:           agentMemoryStoreDescription,
+		}
+		if err := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "organization_id"},
+				{Name: "user_id"},
+				{Name: "canvas_id"},
+				{Name: "provider"},
+			},
+			DoNothing: true,
+		}).Create(store).Error; err != nil {
+			return fmt.Errorf("create agent memory store mapping: %w", err)
+		}
+
+		saved, err = models.FindAgentMemoryStoreByScopeInTransaction(tx, organizationID, userID, canvasID, s.provider.Name())
+		if err != nil {
+			return fmt.Errorf("find saved agent memory store mapping: %w", err)
+		}
+		log.WithField("provider", s.provider.Name()).
+			WithField("organization_id", organizationID).
+			WithField("user_id", userID).
+			WithField("canvas_id", canvasID).
+			WithField("provider_memory_store_id", providerMemoryStoreID).
+			Info("created agent memory store")
+		return nil
+	})
+	return saved, err
+}
+
+func (s *Service) cleanupProviderMemoryStore(ctx context.Context, providerMemoryStoreID string) {
+	cleaner, ok := s.provider.(MemoryStoreCleaner)
+	if !ok {
+		log.WithField("provider", s.provider.Name()).
+			WithField("provider_memory_store_id", providerMemoryStoreID).
+			Warn("provider memory store was created but cannot be cleaned up after mapping failure")
+		return
+	}
+	if err := cleaner.DeleteMemoryStore(ctx, providerMemoryStoreID); err != nil {
+		log.WithError(err).
+			WithField("provider", s.provider.Name()).
+			WithField("provider_memory_store_id", providerMemoryStoreID).
+			Warn("failed to clean up provider memory store after mapping failure")
+	}
+}
+
+func (s *Service) agentMemoryEnabledInTransaction(tx *gorm.DB, organizationID uuid.UUID) bool {
+	if features.IsReleased(features.FeatureClaudeManagedAgentMemory) {
+		return true
+	}
+
+	organization, err := models.FindOrganizationByIDInTransaction(tx, organizationID.String())
+	if err != nil {
+		log.WithError(err).WithField("organization_id", organizationID).Warn("failed to check agent memory feature; continuing without memory")
+		return false
+	}
+	return organization.HasExperimentalFeature(features.FeatureClaudeManagedAgentMemory)
+}
+
+func (s *Service) memoryStoreLock(organizationID, userID, canvasID uuid.UUID) *sync.Mutex {
+	key := agentMemoryStoreLockKey(organizationID, userID, canvasID, s.provider.Name())
+	lock, _ := s.memoryStoreLocks.LoadOrStore(key, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+func agentMemoryStoreName(userID uuid.UUID, canvasID uuid.UUID) string {
+	return fmt.Sprintf("SuperPlane canvas memory %s user %s", shortUUID(canvasID), shortUUID(userID))
+}
+
+func shortUUID(id uuid.UUID) string {
+	value := id.String()
+	if len(value) <= 8 {
+		return value
+	}
+	return value[:8]
+}
+
+func memoryStoreResource(store *models.AgentMemoryStore) MemoryStoreResource {
+	return MemoryStoreResource{
+		MemoryStoreID: store.ProviderMemoryStoreID,
+		Access:        MemoryStoreAccessReadWrite,
+		Instructions:  agentMemoryStoreInstructions,
+	}
 }
 
 func (s *Service) cleanupProviderSession(ctx context.Context, providerSessionID string) {
@@ -490,6 +775,16 @@ func ensureSessionLockKey(organizationID, userID, canvasID uuid.UUID) int64 {
 	h.Write(organizationID[:])
 	h.Write(userID[:])
 	h.Write(canvasID[:])
+	return int64(binary.BigEndian.Uint64(h.Sum(nil))) //nolint:gosec // wraparound is fine; we just need a deterministic key
+}
+
+func agentMemoryStoreLockKey(organizationID, userID, canvasID uuid.UUID, provider string) int64 {
+	h := fnv.New64a()
+	h.Write([]byte("agent-memory-store"))
+	h.Write(organizationID[:])
+	h.Write(userID[:])
+	h.Write(canvasID[:])
+	h.Write([]byte(provider))
 	return int64(binary.BigEndian.Uint64(h.Sum(nil))) //nolint:gosec // wraparound is fine; we just need a deterministic key
 }
 

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -6,12 +6,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/models"
 	"github.com/superplanehq/superplane/test/support"
 	"gorm.io/gorm"
@@ -49,15 +51,25 @@ const testProviderName = "test"
 
 type fakeProvider struct {
 	mu                  sync.Mutex
+	name                string
 	createCalled        int
+	memoryStoreCalled   int
+	deleteMemoryCalled  int
 	sendCalled          int
 	interruptCalled     int
 	interruptedSessions []string
+	deletedMemoryStores []string
 	sentSessions        []string
 	defineSessions      []string
+	createOptions       []agents.CreateSessionOptions
+	createMemoryIDs     []string
 	lastPreamble        string
 	lastOutcomeOpts     agents.DefineOutcomeOptions
 	createSessionErr    error
+	createMemoryErr     error
+	createMemoryErrs    []error
+	createMemoryHook    func()
+	deleteMemoryErr     error
 	createHook          func() error
 	sendErr             error
 	sendErrs            []error
@@ -66,12 +78,18 @@ type fakeProvider struct {
 	defineErrs          []error
 }
 
-func (f *fakeProvider) Name() string { return testProviderName }
+func (f *fakeProvider) Name() string {
+	if f.name != "" {
+		return f.name
+	}
+	return testProviderName
+}
 
-func (f *fakeProvider) CreateSession(_ context.Context, _ agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
+func (f *fakeProvider) CreateSession(_ context.Context, opts agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.createCalled++
+	f.createOptions = append(f.createOptions, opts)
 	if f.createSessionErr != nil {
 		return nil, f.createSessionErr
 	}
@@ -81,6 +99,40 @@ func (f *fakeProvider) CreateSession(_ context.Context, _ agents.CreateSessionOp
 		}
 	}
 	return &agents.CreateSessionResult{ProviderSessionID: "provider-session-" + uuid.NewString()}, nil
+}
+
+func (f *fakeProvider) CreateMemoryStore(_ context.Context, _ agents.CreateMemoryStoreOptions) (*agents.CreateMemoryStoreResult, error) {
+	f.mu.Lock()
+	f.memoryStoreCalled++
+	err := f.createMemoryErr
+	if len(f.createMemoryErrs) > 0 {
+		err = f.createMemoryErrs[0]
+		f.createMemoryErrs = f.createMemoryErrs[1:]
+	}
+	providerMemoryStoreID := "memstore-" + uuid.NewString()
+	if len(f.createMemoryIDs) > 0 {
+		providerMemoryStoreID = f.createMemoryIDs[0]
+		f.createMemoryIDs = f.createMemoryIDs[1:]
+	}
+	hook := f.createMemoryHook
+	f.mu.Unlock()
+
+	if hook != nil {
+		hook()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &agents.CreateMemoryStoreResult{ProviderMemoryStoreID: providerMemoryStoreID}, nil
+}
+
+func (f *fakeProvider) DeleteMemoryStore(_ context.Context, providerMemoryStoreID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleteMemoryCalled++
+	f.deletedMemoryStores = append(f.deletedMemoryStores, providerMemoryStoreID)
+	return f.deleteMemoryErr
 }
 
 func (f *fakeProvider) SendMessage(_ context.Context, providerSessionID string, _ string, opts agents.SendMessageOptions) error {
@@ -127,6 +179,12 @@ func (f *fakeProvider) StreamEvents(_ context.Context, _ string, _ func(agents.P
 
 func newService(t *testing.T, r *support.ResourceRegistry, provider agents.Provider) *agents.Service {
 	t.Helper()
+	return agents.NewService(provider, r.AuthService)
+}
+
+func newMemoryService(t *testing.T, r *support.ResourceRegistry, provider agents.Provider) *agents.Service {
+	t.Helper()
+	require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureClaudeManagedAgentMemory))
 	return agents.NewService(provider, r.AuthService)
 }
 
@@ -209,6 +267,214 @@ func TestService_EnsureSession_IsIdempotent(t *testing.T) {
 
 	assert.Equal(t, first.ID, second.ID)
 	assert.Equal(t, 1, provider.createCalled, "second call must not provision a new upstream session")
+}
+
+func TestService_EnsureSession_DoesNotAttachMemoryStoreWithoutFeature(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	assert.Equal(t, 0, provider.memoryStoreCalled)
+	require.Len(t, provider.createOptions, 1)
+	assert.Empty(t, provider.createOptions[0].MemoryStores)
+}
+
+func TestService_EnsureSession_AttachesMemoryStoreWhenEnabled(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newMemoryService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	require.Equal(t, 1, provider.memoryStoreCalled)
+	require.Len(t, provider.createOptions, 1)
+	require.Len(t, provider.createOptions[0].MemoryStores, 1)
+	resource := provider.createOptions[0].MemoryStores[0]
+	assert.NotEmpty(t, resource.MemoryStoreID)
+	assert.Equal(t, agents.MemoryStoreAccessReadWrite, resource.Access)
+	assert.Contains(t, resource.Instructions, "same user and app")
+	assert.Contains(t, resource.Instructions, "current private draft/version ID")
+	assert.Contains(t, resource.Instructions, "Treat remembered draft IDs as hints")
+	assert.Contains(t, resource.Instructions, "Never store secret values, credentials, API tokens")
+
+	store, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	require.NoError(t, err)
+	assert.Equal(t, resource.MemoryStoreID, store.ProviderMemoryStoreID)
+}
+
+func TestService_EnsureSession_ProvisionsMemoryStoreForExistingSessionWhenEnabledLater(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	first, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Len(t, provider.createOptions, 1)
+	assert.Empty(t, provider.createOptions[0].MemoryStores)
+
+	require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureClaudeManagedAgentMemory))
+
+	second, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	assert.Equal(t, first.ID, second.ID)
+	assert.Equal(t, 1, provider.createCalled, "existing provider session must not be replaced just to attach memory")
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+
+	store, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, store.ProviderMemoryStoreID)
+}
+
+func TestService_EnsureSession_PreparesMemoryStoreWhenConcurrentProvisionFindsExistingSession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	reachedCreateSession := make(chan struct{}, 1)
+	releaseCreateSession := make(chan struct{})
+	provider := &fakeProvider{
+		createMemoryErrs: []error{errors.New("temporary memory create failure"), nil},
+		createHook: func() error {
+			select {
+			case reachedCreateSession <- struct{}{}:
+			default:
+			}
+			<-releaseCreateSession
+			return nil
+		},
+	}
+	svc := newMemoryService(t, r, provider)
+
+	type result struct {
+		session *models.AgentSession
+		err     error
+	}
+	results := make(chan result, 2)
+	go func() {
+		session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+		results <- result{session: session, err: err}
+	}()
+
+	<-reachedCreateSession
+	go func() {
+		session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+		results <- result{session: session, err: err}
+	}()
+	close(releaseCreateSession)
+
+	first := <-results
+	second := <-results
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	require.NotNil(t, first.session)
+	require.NotNil(t, second.session)
+	assert.Equal(t, first.session.ID, second.session.ID)
+
+	assert.Equal(t, 1, provider.createCalled)
+	assert.Equal(t, 2, provider.memoryStoreCalled)
+	store, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, store.ProviderMemoryStoreID)
+}
+
+func TestService_EnsureSession_ContinuesWithoutMemoryWhenProviderMemoryFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{createMemoryErr: errors.New("memory unsupported")}
+	svc := newMemoryService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+	require.Len(t, provider.createOptions, 1)
+	assert.Empty(t, provider.createOptions[0].MemoryStores)
+}
+
+func TestService_EnsureSession_CleansUpProviderMemoryStoreWhenMappingSaveFails(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	db := database.Conn()
+	require.NoError(t, db.Exec(`
+		ALTER TABLE agent_memory_stores
+		DROP CONSTRAINT IF EXISTS agent_memory_stores_reject_test_id
+	`).Error)
+	require.NoError(t, db.Exec(`
+		ALTER TABLE agent_memory_stores
+		ADD CONSTRAINT agent_memory_stores_reject_test_id
+		CHECK (provider_memory_store_id <> 'memstore-rejected')
+	`).Error)
+	t.Cleanup(func() {
+		_ = db.Exec(`
+			ALTER TABLE agent_memory_stores
+			DROP CONSTRAINT IF EXISTS agent_memory_stores_reject_test_id
+		`).Error
+	})
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{createMemoryIDs: []string{"memstore-rejected"}}
+	svc := newMemoryService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+	assert.Equal(t, 1, provider.deleteMemoryCalled)
+	assert.Equal(t, []string{"memstore-rejected"}, provider.deletedMemoryStores)
+	require.Len(t, provider.createOptions, 1)
+	assert.Empty(t, provider.createOptions[0].MemoryStores)
+
+	_, err = models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestService_EnsureSession_ReusesMemoryStoreAfterProviderSessionFailure(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{createSessionErr: errors.New("provider boom")}
+	svc := newMemoryService(t, r, provider)
+
+	_, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.Error(t, err)
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+
+	store, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	require.NoError(t, err, "memory store mapping must survive provider session creation failure")
+
+	provider.createSessionErr = nil
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	require.Len(t, provider.createOptions, 2)
+	require.Len(t, provider.createOptions[1].MemoryStores, 1)
+	assert.Equal(t, store.ProviderMemoryStoreID, provider.createOptions[1].MemoryStores[0].MemoryStoreID)
+	assert.Equal(t, 1, provider.memoryStoreCalled, "retry must reuse the committed memory store mapping")
 }
 
 func TestService_EnsureSession_FailsWhenProviderErrors(t *testing.T) {
@@ -346,6 +612,83 @@ func TestService_SendMessage_RecreatesUnavailableProviderSession(t *testing.T) {
 	assert.Equal(t, refreshed.ProviderSessionID, provider.sentSessions[1])
 	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
 	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_ReusesMemoryStoreWhenRecoveringProviderSession(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{
+		sendErrs: []error{agents.ErrProviderSessionUnavailable, nil},
+	}
+	svc := newMemoryService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.Len(t, provider.createOptions, 1)
+	require.Len(t, provider.createOptions[0].MemoryStores, 1)
+	originalStoreID := provider.createOptions[0].MemoryStores[0].MemoryStoreID
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+
+	require.Len(t, provider.createOptions, 2)
+	require.Len(t, provider.createOptions[1].MemoryStores, 1)
+	assert.Equal(t, originalStoreID, provider.createOptions[1].MemoryStores[0].MemoryStoreID)
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+}
+
+func TestService_SendMessage_ConcurrentRecoveryCreatesOneMemoryStore(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NoError(t, models.EnableExperimentalFeature(r.Organization.ID, features.FeatureClaudeManagedAgentMemory))
+
+	provider.sendErrs = []error{
+		agents.ErrProviderSessionUnavailable,
+		agents.ErrProviderSessionUnavailable,
+		nil,
+		nil,
+	}
+	provider.createMemoryHook = func() {
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	type result struct {
+		err error
+	}
+	results := make(chan result, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "hello")
+			results <- result{err: err}
+		}()
+	}
+
+	first := <-results
+	second := <-results
+	require.NoError(t, acceptableConcurrentRecoveryError(first.err))
+	require.NoError(t, acceptableConcurrentRecoveryError(second.err))
+
+	assert.Equal(t, 1, provider.memoryStoreCalled)
+	store, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, testProviderName)
+	require.NoError(t, err)
+	assert.NotEmpty(t, store.ProviderMemoryStoreID)
+}
+
+func acceptableConcurrentRecoveryError(err error) error {
+	if err == nil || errors.Is(err, agents.ErrSessionBusy) {
+		return nil
+	}
+	return err
 }
 
 func TestService_SendMessage_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *testing.T) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -15,6 +15,10 @@ type Feature struct {
 // per-organization basis until the integration is generally available.
 const FeatureClaudeManagedAgents = "claude_managed_agents"
 
+// FeatureClaudeManagedAgentMemory enables Anthropic Managed Agents memory
+// stores for organizations that already use managed agents.
+const FeatureClaudeManagedAgentMemory = "claude_managed_agent_memory"
+
 func released() *bool {
 	v := true
 	return &v
@@ -22,6 +26,7 @@ func released() *bool {
 
 var registry = []Feature{
 	{ID: FeatureClaudeManagedAgents, Label: "Claude Managed Agents", Description: "Chat with a Claude-powered agent against the canvas", Released: released()},
+	{ID: FeatureClaudeManagedAgentMemory, Label: "Claude Managed Agent Memory", Description: "Persist canvas-specific agent memory across managed-agent sessions"},
 }
 
 func All() []Feature {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -15,6 +15,14 @@ func Test__Get(t *testing.T) {
 		assert.Equal(t, "Chat with a Claude-powered agent against the canvas", f.Description)
 	})
 
+	t.Run("memory id returns feature and true", func(t *testing.T) {
+		f, ok := Get(FeatureClaudeManagedAgentMemory)
+		assert.True(t, ok)
+		assert.Equal(t, FeatureClaudeManagedAgentMemory, f.ID)
+		assert.Equal(t, "Claude Managed Agent Memory", f.Label)
+		assert.Nil(t, f.Released)
+	})
+
 	t.Run("unknown id returns zero value and false", func(t *testing.T) {
 		f, ok := Get("does-not-exist")
 		assert.False(t, ok)
@@ -29,6 +37,7 @@ func Test__Get(t *testing.T) {
 
 func Test__Exists(t *testing.T) {
 	assert.True(t, Exists(FeatureClaudeManagedAgents))
+	assert.True(t, Exists(FeatureClaudeManagedAgentMemory))
 	assert.False(t, Exists("does-not-exist"))
 	assert.False(t, Exists(""))
 }

--- a/pkg/models/agent_memory_store.go
+++ b/pkg/models/agent_memory_store.go
@@ -1,0 +1,58 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/database"
+	"gorm.io/gorm"
+)
+
+type AgentMemoryStore struct {
+	ID                    uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
+	OrganizationID        uuid.UUID
+	UserID                uuid.UUID
+	CanvasID              uuid.UUID
+	Provider              string
+	ProviderMemoryStoreID string
+	Name                  string
+	Description           string
+	CreatedAt             *time.Time
+	UpdatedAt             *time.Time
+}
+
+func (AgentMemoryStore) TableName() string { return "agent_memory_stores" }
+
+func CreateAgentMemoryStoreInTransaction(tx *gorm.DB, store *AgentMemoryStore) error {
+	return tx.Create(store).Error
+}
+
+func FindAgentMemoryStoreByScope(
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+	provider string,
+) (*AgentMemoryStore, error) {
+	return FindAgentMemoryStoreByScopeInTransaction(database.Conn(), organizationID, userID, canvasID, provider)
+}
+
+func FindAgentMemoryStoreByScopeInTransaction(
+	tx *gorm.DB,
+	organizationID uuid.UUID,
+	userID uuid.UUID,
+	canvasID uuid.UUID,
+	provider string,
+) (*AgentMemoryStore, error) {
+	var store AgentMemoryStore
+	err := tx.
+		Where("organization_id = ?", organizationID).
+		Where("user_id = ?", userID).
+		Where("canvas_id = ?", canvasID).
+		Where("provider = ?", provider).
+		First(&store).
+		Error
+	if err != nil {
+		return nil, err
+	}
+	return &store, nil
+}

--- a/pkg/models/agent_memory_store_test.go
+++ b/pkg/models/agent_memory_store_test.go
@@ -1,0 +1,97 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestAgentMemoryStoreScopeIsUniquePerProvider(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	store := &models.AgentMemoryStore{
+		OrganizationID:        r.Organization.ID,
+		UserID:                r.User,
+		CanvasID:              canvas.ID,
+		Provider:              "anthropic",
+		ProviderMemoryStoreID: "memstore_1",
+		Name:                  "memory",
+	}
+	require.NoError(t, models.CreateAgentMemoryStoreInTransaction(database.Conn(), store))
+
+	duplicate := &models.AgentMemoryStore{
+		OrganizationID:        r.Organization.ID,
+		UserID:                r.User,
+		CanvasID:              canvas.ID,
+		Provider:              "anthropic",
+		ProviderMemoryStoreID: "memstore_2",
+		Name:                  "memory 2",
+	}
+	require.Error(t, models.CreateAgentMemoryStoreInTransaction(database.Conn(), duplicate))
+}
+
+func TestFindAgentMemoryStoreByScope(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	store := &models.AgentMemoryStore{
+		OrganizationID:        r.Organization.ID,
+		UserID:                r.User,
+		CanvasID:              canvas.ID,
+		Provider:              "anthropic",
+		ProviderMemoryStoreID: "memstore_1",
+		Name:                  "memory",
+	}
+	require.NoError(t, models.CreateAgentMemoryStoreInTransaction(database.Conn(), store))
+
+	found, err := models.FindAgentMemoryStoreByScope(r.Organization.ID, r.User, canvas.ID, "anthropic")
+	require.NoError(t, err)
+	assert.Equal(t, store.ProviderMemoryStoreID, found.ProviderMemoryStoreID)
+}
+
+func TestAgentMemoryStoreCascadesWhenCanvasIsDeleted(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	store := &models.AgentMemoryStore{
+		OrganizationID:        r.Organization.ID,
+		UserID:                r.User,
+		CanvasID:              canvas.ID,
+		Provider:              "anthropic",
+		ProviderMemoryStoreID: "memstore_1",
+		Name:                  "memory",
+	}
+	require.NoError(t, models.CreateAgentMemoryStoreInTransaction(database.Conn(), store))
+	require.NoError(t, database.Conn().Unscoped().Delete(&models.Canvas{}, "id = ?", canvas.ID).Error)
+
+	var count int64
+	require.NoError(t, database.Conn().Model(&models.AgentMemoryStore{}).Where("canvas_id = ?", canvas.ID).Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestAgentMemoryStoreAllowsDifferentCanvasScopes(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	firstCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+	secondCanvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	for _, canvasID := range []uuid.UUID{firstCanvas.ID, secondCanvas.ID} {
+		require.NoError(t, models.CreateAgentMemoryStoreInTransaction(database.Conn(), &models.AgentMemoryStore{
+			OrganizationID:        r.Organization.ID,
+			UserID:                r.User,
+			CanvasID:              canvasID,
+			Provider:              "anthropic",
+			ProviderMemoryStoreID: "memstore_" + canvasID.String(),
+			Name:                  "memory",
+		}))
+	}
+}


### PR DESCRIPTION
## Summary
- add org-scoped experimental feature flag support for Anthropic managed-agent memory stores
- persist user+canvas scoped memory-store mappings and attach them to new/recovered provider sessions
- keep memory provisioning fallback-safe, avoid provider calls inside DB transactions, and prepare mappings for existing sessions
- fix Anthropic memory-store creation endpoint to `/memory_stores`

## Tests
- `make format.go`
- `make test PKG_TEST_PACKAGES="./pkg/agents ./pkg/agents/anthropic ./pkg/models ./pkg/features"`
- `make lint`
- `make check.build.app`