### PR TITLE
fix: Exclude PostHog events from Dash0 web telemetry

### DIFF
--- a/web_src/src/dash0.spec.ts
+++ b/web_src/src/dash0.spec.ts
@@ -37,7 +37,7 @@ describe("dash0 init", () => {
           url: "https://ingress.us-west-2.aws.dash0.com:4318",
           authToken: "test-token",
         },
-        ignoreUrls: [/\/ws\//],
+        ignoreUrls: [/\/ws\//, /posthog\.com/],
       }),
     );
   });
@@ -54,6 +54,17 @@ describe("dash0 init", () => {
         serviceName: "superplane-web",
       }),
     );
+  });
+
+  it("ignores PostHog analytics traffic", async () => {
+    (window as Window & { SUPERPLANE_DASH0_OTLP_ENDPOINT?: string }).SUPERPLANE_DASH0_OTLP_ENDPOINT =
+      "https://ingress.us-west-2.aws.dash0.com:4318";
+    (window as Window & { SUPERPLANE_DASH0_AUTH_TOKEN?: string }).SUPERPLANE_DASH0_AUTH_TOKEN = "test-token";
+
+    await import("@/dash0");
+
+    const ignoreUrls = init.mock.calls[0]?.[0]?.ignoreUrls as RegExp[];
+    expect(ignoreUrls.some((pattern) => pattern.test("https://us.i.posthog.com/e/"))).toBe(true);
   });
 
   it("does not call init when endpoint is missing", async () => {

--- a/web_src/src/dash0.ts
+++ b/web_src/src/dash0.ts
@@ -13,6 +13,8 @@ const authToken = dash0Window?.SUPERPLANE_DASH0_AUTH_TOKEN?.trim();
 
 export const isDash0Enabled = !!(endpointUrl && authToken);
 
+const dash0IgnoredUrls = [/\/ws\//, /posthog\.com/];
+
 if (endpointUrl && authToken) {
   init({
     serviceName: dash0Window?.SUPERPLANE_DASH0_SERVICE_NAME?.trim() || "superplane-web",
@@ -21,6 +23,6 @@ if (endpointUrl && authToken) {
       url: endpointUrl,
       authToken,
     },
-    ignoreUrls: [/\/ws\//],
+    ignoreUrls: dash0IgnoredUrls,
   });
 }


### PR DESCRIPTION
## Summary
- Adds `posthog.com` to Dash0 web SDK `ignoreUrls` so PostHog analytics fetch requests are not exported as OTel spans
- Closes #5491

Dash0's fetch instrumentation was capturing PostHog `/e/` and related API calls as high-volume, low-signal telemetry. WebSocket traffic was already ignored; this extends the same pattern to PostHog.

## Test plan
- [x] Updated `dash0.spec.ts` to assert PostHog URLs are ignored
- [ ] With Dash0 + PostHog enabled in dev, confirm PostHog requests no longer appear as fetch spans in Dash0


Made with [Cursor](https://cursor.com)