### PR TITLE
chore: add Dash0 page observability across routed screens

### DIFF
--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -31,6 +31,7 @@ import AccountsListAdmin from "./pages/admin/AccountsList";
 import InstallationSettingsAdmin from "./pages/admin/InstallationSettings";
 import RunnerTasksAdmin from "./pages/admin/RunnerTasks";
 import ImpersonationBanner from "./components/ImpersonationBanner";
+import { usePageObservability } from "./hooks/usePageObservability";
 
 // Create a client
 const queryClient = new QueryClient({
@@ -73,6 +74,7 @@ function App() {
 function AppRouter() {
   return (
     <BrowserRouter>
+      <PageObservabilityScope />
       <div className="flex h-dvh flex-col overflow-hidden">
         <ImpersonationBanner />
         <div className="flex-1 overflow-auto">
@@ -126,6 +128,11 @@ function AppRouter() {
       </div>
     </BrowserRouter>
   );
+}
+
+function PageObservabilityScope() {
+  usePageObservability();
+  return null;
 }
 
 function OrganizationScope() {

--- a/web_src/src/dash0.spec.ts
+++ b/web_src/src/dash0.spec.ts
@@ -38,6 +38,9 @@ describe("dash0 init", () => {
           authToken: "test-token",
         },
         ignoreUrls: [/\/ws\//],
+        pageViewInstrumentation: expect.objectContaining({
+          generateMetadata: expect.any(Function),
+        }),
       }),
     );
   });

--- a/web_src/src/dash0.ts
+++ b/web_src/src/dash0.ts
@@ -1,4 +1,5 @@
 import { init } from "@dash0/sdk-web";
+import { pageObservabilityMetadata } from "@/lib/dash0Observability";
 
 interface Dash0Window extends Window {
   SUPERPLANE_DASH0_OTLP_ENDPOINT?: string;
@@ -22,5 +23,8 @@ if (endpointUrl && authToken) {
       authToken,
     },
     ignoreUrls: [/\/ws\//],
+    pageViewInstrumentation: {
+      generateMetadata: (url) => pageObservabilityMetadata(url.pathname),
+    },
   });
 }

--- a/web_src/src/hooks/usePageObservability.ts
+++ b/web_src/src/hooks/usePageObservability.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import {
+  clearPageObservabilityTag,
+  sendPageObservabilityStart,
+  setPageObservabilityTag,
+} from "@/lib/dash0Observability";
+import { resolvePageObservability } from "@/lib/pageObservability";
+
+export function usePageObservability(): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    const context = resolvePageObservability(location.pathname);
+    if (!context) {
+      clearPageObservabilityTag();
+      return;
+    }
+
+    setPageObservabilityTag(context.pageKey);
+    sendPageObservabilityStart(context.pageKey, context.attributes);
+
+    return () => {
+      clearPageObservabilityTag();
+    };
+  }, [location.pathname]);
+}

--- a/web_src/src/hooks/useReportPageReady.spec.tsx
+++ b/web_src/src/hooks/useReportPageReady.spec.tsx
@@ -18,11 +18,7 @@ function createWrapper(path: string) {
     return createElement(
       MemoryRouter,
       { initialEntries: [path] },
-      createElement(
-        Routes,
-        null,
-        createElement(Route, { path: "/:organizationId", element: children }),
-      ),
+      createElement(Routes, null, createElement(Route, { path: "/:organizationId", element: children })),
     );
   };
 }

--- a/web_src/src/hooks/useReportPageReady.spec.tsx
+++ b/web_src/src/hooks/useReportPageReady.spec.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+const { sendPageObservabilityReady } = vi.hoisted(() => ({
+  sendPageObservabilityReady: vi.fn(),
+}));
+
+vi.mock("@/lib/dash0Observability", () => ({
+  sendPageObservabilityReady,
+}));
+
+import { useReportPageReady } from "@/hooks/useReportPageReady";
+
+function createWrapper(path: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      MemoryRouter,
+      { initialEntries: [path] },
+      createElement(
+        Routes,
+        null,
+        createElement(Route, { path: "/:organizationId", element: children }),
+      ),
+    );
+  };
+}
+
+describe("useReportPageReady", () => {
+  beforeEach(() => {
+    sendPageObservabilityReady.mockClear();
+  });
+
+  it("sends ready once when ready becomes true", async () => {
+    const { rerender } = renderHook(({ ready }) => useReportPageReady(ready, { canvas_count: 2 }), {
+      wrapper: createWrapper("/org-1"),
+      initialProps: { ready: false },
+    });
+
+    expect(sendPageObservabilityReady).not.toHaveBeenCalled();
+
+    rerender({ ready: true });
+
+    await waitFor(() => {
+      expect(sendPageObservabilityReady).toHaveBeenCalledWith(
+        "organizationHomePage",
+        expect.objectContaining({
+          organization_id: "org-1",
+          canvas_count: 2,
+        }),
+      );
+    });
+
+    rerender({ ready: true });
+    expect(sendPageObservabilityReady).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web_src/src/hooks/useReportPageReady.ts
+++ b/web_src/src/hooks/useReportPageReady.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { sendPageObservabilityReady, type PageReadyAttributes } from "@/lib/dash0Observability";
+import { resolvePageObservability } from "@/lib/pageObservability";
+
+export function useReportPageReady(ready: boolean, attributes?: PageReadyAttributes): void {
+  const location = useLocation();
+  const reportedRef = useRef(false);
+  const attributesRef = useRef(attributes);
+  attributesRef.current = attributes;
+
+  useEffect(() => {
+    reportedRef.current = false;
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!ready || reportedRef.current) {
+      return;
+    }
+
+    const context = resolvePageObservability(location.pathname);
+    if (!context) {
+      return;
+    }
+
+    reportedRef.current = true;
+    sendPageObservabilityReady(context.pageKey, {
+      ...context.attributes,
+      ...(attributesRef.current ?? {}),
+    });
+  }, [ready, location.pathname]);
+}

--- a/web_src/src/lib/dash0Observability.ts
+++ b/web_src/src/lib/dash0Observability.ts
@@ -1,0 +1,73 @@
+import { addSignalAttribute, removeSignalAttribute, sendEvent } from "@dash0/sdk-web";
+import { isDash0Enabled } from "@/dash0";
+import { PAGE_OBSERVABILITY_ATTRIBUTE, resolvePageObservability } from "@/lib/pageObservability";
+
+export type PageReadyAttributes = Record<string, string | number | boolean>;
+
+let pageStartTimeMs: number | null = null;
+
+export function setPageObservabilityTag(pageKey: string): void {
+  if (!isDash0Enabled) {
+    return;
+  }
+
+  removeSignalAttribute(PAGE_OBSERVABILITY_ATTRIBUTE);
+  addSignalAttribute(PAGE_OBSERVABILITY_ATTRIBUTE, pageKey);
+}
+
+export function clearPageObservabilityTag(): void {
+  if (!isDash0Enabled) {
+    return;
+  }
+
+  removeSignalAttribute(PAGE_OBSERVABILITY_ATTRIBUTE);
+}
+
+export function markPageObservabilityStart(): void {
+  pageStartTimeMs = performance.now();
+}
+
+export function sendPageObservabilityStart(pageKey: string, attributes: Record<string, string>): void {
+  if (!isDash0Enabled) {
+    return;
+  }
+
+  markPageObservabilityStart();
+  sendEvent(`${pageKey}.start`, {
+    title: `Page start: ${pageKey}`,
+    attributes,
+  });
+}
+
+export function sendPageObservabilityReady(pageKey: string, attributes: PageReadyAttributes): void {
+  if (!isDash0Enabled) {
+    return;
+  }
+
+  const readyAttributes: PageReadyAttributes = { ...attributes };
+  if (pageStartTimeMs != null) {
+    readyAttributes.duration_ms = Math.round(performance.now() - pageStartTimeMs);
+  }
+
+  sendEvent(`${pageKey}.ready`, {
+    title: `Page ready: ${pageKey}`,
+    attributes: readyAttributes,
+  });
+}
+
+export function pageObservabilityMetadata(
+  pathname: string,
+): { title?: string; attributes?: Record<string, string> } | undefined {
+  const context = resolvePageObservability(pathname);
+  if (!context) {
+    return undefined;
+  }
+
+  return {
+    title: context.pageKey,
+    attributes: {
+      [PAGE_OBSERVABILITY_ATTRIBUTE]: context.pageKey,
+      ...context.attributes,
+    },
+  };
+}

--- a/web_src/src/lib/pageObservability.spec.ts
+++ b/web_src/src/lib/pageObservability.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolvePageObservability } from "@/lib/pageObservability";
+
+describe("resolvePageObservability", () => {
+  it("maps top-level routes", () => {
+    expect(resolvePageObservability("/")).toEqual({ pageKey: "organizationSelect", attributes: {} });
+    expect(resolvePageObservability("/login")).toEqual({ pageKey: "login", attributes: {} });
+    expect(resolvePageObservability("/create")).toEqual({ pageKey: "organizationCreate", attributes: {} });
+    expect(resolvePageObservability("/setup")).toEqual({ pageKey: "ownerSetup", attributes: {} });
+    expect(resolvePageObservability("/install")).toEqual({ pageKey: "install", attributes: {} });
+  });
+
+  it("maps invite links", () => {
+    expect(resolvePageObservability("/invite/abc123")).toEqual({
+      pageKey: "inviteAccept",
+      attributes: { invite_token: "abc123" },
+    });
+  });
+
+  it("maps admin routes", () => {
+    expect(resolvePageObservability("/admin")).toEqual({ pageKey: "adminOrganizations", attributes: {} });
+    expect(resolvePageObservability("/admin/accounts")).toEqual({ pageKey: "adminAccounts", attributes: {} });
+    expect(resolvePageObservability("/admin/organizations/org-1")).toEqual({
+      pageKey: "adminOrganizationDetail",
+      attributes: { organization_id: "org-1" },
+    });
+  });
+
+  it("maps organization home and canvas routes", () => {
+    expect(resolvePageObservability("/org-1")).toEqual({
+      pageKey: "organizationHomePage",
+      attributes: { organization_id: "org-1" },
+    });
+    expect(resolvePageObservability("/org-1/apps/new")).toEqual({
+      pageKey: "newApp",
+      attributes: { organization_id: "org-1" },
+    });
+    expect(resolvePageObservability("/org-1/apps/canvas-1")).toEqual({
+      pageKey: "canvas",
+      attributes: { organization_id: "org-1", canvas_id: "canvas-1" },
+    });
+    expect(resolvePageObservability("/org-1/apps/canvas-1/settings")).toEqual({
+      pageKey: "canvasSettings",
+      attributes: { organization_id: "org-1", canvas_id: "canvas-1" },
+    });
+    expect(resolvePageObservability("/org-1/canvases/canvas-1")).toEqual({
+      pageKey: "canvas",
+      attributes: { organization_id: "org-1", canvas_id: "canvas-1" },
+    });
+  });
+
+  it("maps settings routes", () => {
+    expect(resolvePageObservability("/org-1/settings/general")).toEqual({
+      pageKey: "settingsGeneral",
+      attributes: { organization_id: "org-1" },
+    });
+    expect(resolvePageObservability("/org-1/settings/integrations/slack/setup")).toEqual({
+      pageKey: "settingsIntegrationSetup",
+      attributes: { organization_id: "org-1", integration_name: "slack" },
+    });
+    expect(resolvePageObservability("/org-1/settings/groups/admins/members")).toEqual({
+      pageKey: "settingsGroupMembers",
+      attributes: { organization_id: "org-1", group_name: "admins" },
+    });
+  });
+});

--- a/web_src/src/lib/pageObservability.ts
+++ b/web_src/src/lib/pageObservability.ts
@@ -1,0 +1,173 @@
+export const PAGE_OBSERVABILITY_ATTRIBUTE = "superplane.page";
+
+export type PageObservabilityContext = {
+  pageKey: string;
+  attributes: Record<string, string>;
+};
+
+export function resolvePageObservability(pathname: string): PageObservabilityContext | null {
+  const segments = pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return { pageKey: "organizationSelect", attributes: {} };
+  }
+
+  const [first, second, third, fourth] = segments;
+
+  if (first === "login") {
+    return { pageKey: "login", attributes: {} };
+  }
+
+  if (first === "create") {
+    return { pageKey: "organizationCreate", attributes: {} };
+  }
+
+  if (first === "setup") {
+    return { pageKey: "ownerSetup", attributes: {} };
+  }
+
+  if (first === "install") {
+    return { pageKey: "install", attributes: {} };
+  }
+
+  if (first === "invite" && second) {
+    return { pageKey: "inviteAccept", attributes: { invite_token: second } };
+  }
+
+  if (first === "admin") {
+    if (second === "accounts") {
+      return { pageKey: "adminAccounts", attributes: {} };
+    }
+
+    if (second === "settings") {
+      return { pageKey: "adminSettings", attributes: {} };
+    }
+
+    if (second === "runner-tasks") {
+      return { pageKey: "adminRunnerTasks", attributes: {} };
+    }
+
+    if (second === "organizations" && third) {
+      return { pageKey: "adminOrganizationDetail", attributes: { organization_id: third } };
+    }
+
+    return { pageKey: "adminOrganizations", attributes: {} };
+  }
+
+  const organizationId = first;
+  const organizationAttributes = { organization_id: organizationId };
+
+  if (segments.length === 1) {
+    return { pageKey: "organizationHomePage", attributes: organizationAttributes };
+  }
+
+  if (second === "apps") {
+    if (third === "new") {
+      return { pageKey: "newApp", attributes: organizationAttributes };
+    }
+
+    if (third && fourth === "settings") {
+      return {
+        pageKey: "canvasSettings",
+        attributes: { ...organizationAttributes, canvas_id: third },
+      };
+    }
+
+    if (third) {
+      return {
+        pageKey: "canvas",
+        attributes: { ...organizationAttributes, canvas_id: third },
+      };
+    }
+  }
+
+  if (second === "canvases" && third) {
+    if (fourth === "settings") {
+      return {
+        pageKey: "canvasSettings",
+        attributes: { ...organizationAttributes, canvas_id: third },
+      };
+    }
+
+    return {
+      pageKey: "canvas",
+      attributes: { ...organizationAttributes, canvas_id: third },
+    };
+  }
+
+  if (second === "settings") {
+    return resolveSettingsPageObservability(organizationId, segments.slice(2));
+  }
+
+  return null;
+}
+
+function resolveSettingsPageObservability(organizationId: string, segments: string[]): PageObservabilityContext {
+  const organizationAttributes = { organization_id: organizationId };
+
+  if (segments.length === 0) {
+    return { pageKey: "settingsGeneral", attributes: organizationAttributes };
+  }
+
+  const [section, ...rest] = segments;
+
+  switch (section) {
+    case "general":
+      return { pageKey: "settingsGeneral", attributes: organizationAttributes };
+    case "members":
+      return { pageKey: "settingsMembers", attributes: organizationAttributes };
+    case "groups":
+      if (rest[0] && rest[1] === "members") {
+        return {
+          pageKey: "settingsGroupMembers",
+          attributes: { ...organizationAttributes, group_name: rest[0] },
+        };
+      }
+      return { pageKey: "settingsGroups", attributes: organizationAttributes };
+    case "create-group":
+      return { pageKey: "settingsCreateGroup", attributes: organizationAttributes };
+    case "roles":
+      return { pageKey: "settingsRoles", attributes: organizationAttributes };
+    case "create-role":
+      return {
+        pageKey: "settingsCreateRole",
+        attributes: rest[0] ? { ...organizationAttributes, role_name: rest[0] } : organizationAttributes,
+      };
+    case "integrations":
+      if (!rest[0]) {
+        return { pageKey: "settingsIntegrations", attributes: organizationAttributes };
+      }
+      if (rest[1] === "setup") {
+        return {
+          pageKey: "settingsIntegrationSetup",
+          attributes: { ...organizationAttributes, integration_name: rest[0] },
+        };
+      }
+      return {
+        pageKey: "settingsIntegrationDetail",
+        attributes: { ...organizationAttributes, integration_id: rest[0] },
+      };
+    case "secrets":
+      if (rest[0]) {
+        return {
+          pageKey: "settingsSecretDetail",
+          attributes: { ...organizationAttributes, secret_id: rest[0] },
+        };
+      }
+      return { pageKey: "settingsSecrets", attributes: organizationAttributes };
+    case "service-accounts":
+      if (rest[0]) {
+        return {
+          pageKey: "settingsServiceAccountDetail",
+          attributes: { ...organizationAttributes, service_account_id: rest[0] },
+        };
+      }
+      return { pageKey: "settingsServiceAccounts", attributes: organizationAttributes };
+    case "profile":
+      return { pageKey: "settingsProfile", attributes: organizationAttributes };
+    case "billing":
+      return { pageKey: "settingsUsage", attributes: organizationAttributes };
+    default:
+      return { pageKey: "settingsUnknown", attributes: organizationAttributes };
+  }
+}

--- a/web_src/src/pages/admin/AccountsList.tsx
+++ b/web_src/src/pages/admin/AccountsList.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@/components/Text/text";
 import { Button } from "@/components/ui/button";
 import { useAccount } from "@/contexts/useAccount";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { showErrorToast } from "@/lib/toast";
 import { Eye } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
@@ -151,6 +152,8 @@ const AccountsList: React.FC = () => {
       setSortDirection(field === "name" || field === "email" ? "asc" : "desc");
     }
   };
+
+  useReportPageReady(!loading || accounts.length > 0);
 
   if (loading && accounts.length === 0)
     return (

--- a/web_src/src/pages/admin/InstallationSettings.tsx
+++ b/web_src/src/pages/admin/InstallationSettings.tsx
@@ -2,6 +2,7 @@ import { Text } from "@/components/Text/text";
 import { Input, InputGroup } from "@/components/Input/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { Switch } from "@/ui/switch";
 import React, { useCallback, useEffect, useState } from "react";
@@ -525,6 +526,8 @@ const InstallationSettings: React.FC = () => {
     saveNetworkSettings,
     saveSMTPSettings,
   } = useInstallationSettingsState();
+
+  useReportPageReady(!loading || !!settings);
 
   if (loading && !settings) {
     return (

--- a/web_src/src/pages/admin/OrganizationDetail.tsx
+++ b/web_src/src/pages/admin/OrganizationDetail.tsx
@@ -1,12 +1,15 @@
 import { ArrowLeft } from "lucide-react";
 import React from "react";
 import { Link, useParams } from "react-router-dom";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { OrgCanvasesTable } from "./OrgCanvasesTable";
 import { OrgExperimentalFeaturesTable } from "./OrgExperimentalFeaturesTable";
 import { OrgUsersTable } from "./OrgUsersTable";
 
 const OrganizationDetail: React.FC = () => {
   const { orgId } = useParams<{ orgId: string }>();
+
+  useReportPageReady(true);
 
   return (
     <div>

--- a/web_src/src/pages/admin/OrganizationsList.tsx
+++ b/web_src/src/pages/admin/OrganizationsList.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@/components/Text/text";
 import { Building, Palette, User } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Link } from "react-router-dom";
 import AdminPagination from "./AdminPagination";
 import AdminSearchHeader from "./AdminSearchHeader";
@@ -150,6 +151,8 @@ const OrganizationsList: React.FC = () => {
       setSortDirection(field === "name" ? "asc" : "desc");
     }
   };
+
+  useReportPageReady(!loading || organizations.length > 0);
 
   if (loading && organizations.length === 0) {
     return (

--- a/web_src/src/pages/admin/RunnerTasks.tsx
+++ b/web_src/src/pages/admin/RunnerTasks.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@/components/Text/text";
 import { formatRelativeTime } from "@/lib/timezone";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { showErrorToast } from "@/lib/toast";
 import { Terminal } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
@@ -154,6 +155,8 @@ const RunnerTasks: React.FC = () => {
 
     return () => window.clearInterval(interval);
   }, [loadTasks]);
+
+  useReportPageReady(!loading || configured !== null);
 
   if (loading && configured === null) {
     return (

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -60,6 +60,7 @@ import { useCanvasDraftBranchActions } from "./useCanvasDraftBranchActions";
 import { useCanvasDraftBranchQueries, useResolvedActiveDraftBranch } from "./useCanvasDraftBranchData";
 import { useNodeHistory } from "@/hooks/useNodeHistory";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { useQueueHistory } from "@/hooks/useQueueHistory";
 import { analytics } from "@/lib/analytics";
 import { appPath } from "@/lib/appPaths";
@@ -4507,6 +4508,10 @@ export function AppPage() {
     !!activeCanvasVersionId &&
     !draftSpecToRender &&
     (loadedCanvasVersionLoading || loadedCanvasVersionFetching || !loadedCanvasVersion?.spec);
+
+  useReportPageReady(!isInitialCanvasBootstrapLoading && !!canvas, {
+    failed: !canvas && !canvasLoading && !isDraftCanvasLoading,
+  });
 
   // Keep full-screen loading only for initial bootstrap.
   // Version switches should not unmount the page.

--- a/web_src/src/pages/auth/InviteLinkAccept.tsx
+++ b/web_src/src/pages/auth/InviteLinkAccept.tsx
@@ -6,6 +6,7 @@ import { useAccount } from "@/contexts/useAccount";
 import { showErrorToast } from "@/lib/toast";
 import { analytics } from "@/lib/analytics";
 import { getUsageLimitNotice, getUsageLimitToastMessage } from "@/lib/usageLimits";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 
 type AcceptStatus = "idle" | "loading" | "error";
 
@@ -16,6 +17,10 @@ export default function InviteLinkAccept() {
   const [status, setStatus] = useState<AcceptStatus>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const hasSubmitted = useRef(false);
+
+  useReportPageReady(!loading && status !== "loading", {
+    failed: status === "error",
+  });
 
   useEffect(() => {
     if (loading || hasSubmitted.current) {

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -6,6 +6,7 @@ import { LoadingButton } from "@/components/ui/loading-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAccount } from "../../contexts/useAccount";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import {
   readLastUsedLoginMethod,
   recordLastUsedLoginMethod,
@@ -222,6 +223,11 @@ export const Login: React.FC = () => {
   const activeProviders = allowedProviders.filter((provider) => providers.includes(provider));
   const hasProviders = activeProviders.length > 0;
   const canSignup = authConfig.signupEnabled || inviteToken;
+
+  useReportPageReady(!configLoading && !accountLoading, {
+    failed: !!configError,
+  });
+
   const canSignupWithPassword = authConfig.passwordLoginEnabled && canSignup;
   const canLoginWithPassword = authConfig.passwordLoginEnabled;
   const redirectQuery = safeRedirect ? `?redirect=${encodeURIComponent(safeRedirect)}` : "";

--- a/web_src/src/pages/auth/OrganizationCreate.tsx
+++ b/web_src/src/pages/auth/OrganizationCreate.tsx
@@ -9,11 +9,14 @@ import { LoadingButton } from "@/components/ui/loading-button";
 import { getUsageLimitNotice } from "@/lib/usageLimits";
 import { getResponseErrorMessage } from "@/lib/errors";
 import { analytics } from "@/lib/analytics";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 
 const OrganizationCreate: React.FC = () => {
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useReportPageReady(true);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/web_src/src/pages/auth/OrganizationSelect.tsx
+++ b/web_src/src/pages/auth/OrganizationSelect.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { getUsageLimitNotice } from "@/lib/usageLimits";
 import { Text } from "../../components/Text/text";
 import { useAccount } from "../../contexts/useAccount";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 
 interface Organization {
   id: string;
@@ -98,6 +99,11 @@ const OrganizationSelect: React.FC = () => {
 
     fetchOrganizations();
   }, [account, accountLoading, location.pathname, location.search, navigate, fetchOrganizations]);
+
+  useReportPageReady(!loading && !accountLoading, {
+    organization_count: organizations.length,
+    failed: !!error,
+  });
 
   const createOrganizationDisabled = organizationCreationStatus?.allowed === false;
   const createOrganizationTooltip =

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -5,6 +5,7 @@ import { OwnerStep } from "./ownerSetup/OwnerStep";
 import { PrivateNetworkStep } from "./ownerSetup/PrivateNetworkStep";
 import { SmtpPromptStep } from "./ownerSetup/SmtpPromptStep";
 import { SmtpConfigStep } from "./ownerSetup/SmtpConfigStep";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 
 const OWNER_SETUP_SURVEY_NAME = "Owner Setup Survey";
 
@@ -28,6 +29,8 @@ const OwnerSetup: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useReportPageReady(true);
 
   const isEmailValid = (email: string) => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/web_src/src/pages/canvas/settings/index.tsx
+++ b/web_src/src/pages/canvas/settings/index.tsx
@@ -3,6 +3,7 @@ import { usePermissions } from "@/contexts/usePermissions";
 import { useCanvas, useUpdateCanvas } from "@/hooks/useCanvasData";
 import { useOrganization } from "@/hooks/useOrganizationData";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Loader2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -21,6 +22,10 @@ export function CanvasSettingsPage() {
 
   const { data: organization } = useOrganization(organizationId, canReadOrg);
   const { data: canvas, isLoading: canvasLoading, error: canvasError } = useCanvas(organizationId, canvasId);
+
+  useReportPageReady(!canvasLoading && !!canvas && !!organizationId && !!organization, {
+    failed: !!canvasError,
+  });
 
   if (!organizationId || !canvasId || !organization) {
     return <ErrorView organizationId={organizationId} error="Missing organization or canvas." />;

--- a/web_src/src/pages/home/NewAppPage.tsx
+++ b/web_src/src/pages/home/NewAppPage.tsx
@@ -1,9 +1,11 @@
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { HomePageShell } from "./HomePageShell";
 import { ZeroStatePage } from "./ZeroStatePage";
 
 export function NewAppPage() {
   usePageTitle(["New App"]);
+  useReportPageReady(true);
 
   return (
     <HomePageShell>

--- a/web_src/src/pages/home/index.tsx
+++ b/web_src/src/pages/home/index.tsx
@@ -1,5 +1,6 @@
 import { usePermissions } from "@/contexts/usePermissions";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Palette } from "lucide-react";
 import { useState } from "react";
 import { Navigate, useParams } from "react-router-dom";
@@ -40,7 +41,14 @@ export function HomePage() {
   const canUpdateCanvases = canAct("canvases", "update");
   const canDeleteCanvases = canAct("canvases", "delete");
 
-  if (isLoading || (isFetching && canvases.length === 0 && canvasFolders.length === 0)) {
+  const isHomePageLoading = isLoading || (isFetching && canvases.length === 0 && canvasFolders.length === 0);
+  useReportPageReady(!isHomePageLoading && !!account && !!organizationId, {
+    canvas_count: canvases.length,
+    folder_count: canvasFolders.length,
+    failed: !!canvasError,
+  });
+
+  if (isHomePageLoading) {
     return <LoadingView />;
   }
 

--- a/web_src/src/pages/install/index.tsx
+++ b/web_src/src/pages/install/index.tsx
@@ -1,5 +1,6 @@
 import AuthGuard from "@/components/AuthGuard";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { parseGitHubRepoParam } from "@/lib/githubRepo";
 import { useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -42,6 +43,10 @@ function InstallPageContent() {
   // Set org once loaded
   const effectiveOrgId = organizationId || defaultOrganizationId;
   const showOrgPicker = organizations.length > 1;
+
+  useReportPageReady(!isLoading, {
+    failed: !!(loadError || !preview || !repoParam),
+  });
 
   if (isLoading) {
     return <InstallLoadingView message="Loading installation..." />;

--- a/web_src/src/pages/organization/settings/CreateGroupPage.tsx
+++ b/web_src/src/pages/organization/settings/CreateGroupPage.tsx
@@ -1,5 +1,6 @@
 import { Heading } from "@/components/Heading/heading";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Icon } from "../../../components/Icon";
@@ -21,6 +22,8 @@ export function CreateGroupPage() {
 
   const { data: roles = [], isLoading: loadingRoles } = useOrganizationRoles(orgId || "");
   const createGroupMutation = useCreateGroup(orgId || "");
+
+  useReportPageReady(!loadingRoles);
 
   const sortedRoles = useMemo(() => {
     const defaultRoles = new Set(["org_admin", "org_owner", "org_viewer"]);

--- a/web_src/src/pages/organization/settings/CreateRolePage.tsx
+++ b/web_src/src/pages/organization/settings/CreateRolePage.tsx
@@ -2,6 +2,7 @@ import { Heading } from "@/components/Heading/heading";
 import { NotFoundPage } from "@/components/NotFoundPage";
 import { usePermissions } from "@/contexts/usePermissions";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Description, Label } from "../../../components/Fieldset/fieldset";
@@ -330,6 +331,10 @@ export function CreateRolePage() {
   const canUpdateRoles = canAct("roles", "update");
 
   usePageTitle([isReadOnly ? "View Role" : isEditMode ? "Edit Role" : "Create Role"]);
+
+  useReportPageReady((!isEditMode || !isLoading) && !permissionsLoading, {
+    failed: !!error,
+  });
 
   const handleCategoryToggle = (permissions: Permission[]) => {
     if (isReadOnly) return;

--- a/web_src/src/pages/organization/settings/General.tsx
+++ b/web_src/src/pages/organization/settings/General.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Trash2 } from "lucide-react";
 import { useParams } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import type { OrganizationsOrganization } from "../../../api-client/types.gen";
 import { Field, Fieldset, Label } from "../../../components/Fieldset/fieldset";
 import { Heading } from "../../../components/Heading/heading";
@@ -19,6 +20,7 @@ export function General({ organization }: GeneralProps) {
   const { organizationId } = useParams<{ organizationId: string }>();
   const { canAct, isLoading: permissionsLoading } = usePermissions();
   usePageTitle(["Settings"]);
+  useReportPageReady(!permissionsLoading);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [name, setName] = useState(organization.metadata?.name || "");
   const [deleteConfirmation, setDeleteConfirmation] = useState("");

--- a/web_src/src/pages/organization/settings/GroupMembersPage.tsx
+++ b/web_src/src/pages/organization/settings/GroupMembersPage.tsx
@@ -1,4 +1,5 @@
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
@@ -57,6 +58,10 @@ export function GroupMembersPage() {
 
   const loading = loadingGroup || loadingMembers;
   const error = groupError || membersError;
+
+  useReportPageReady(!loading && !permissionsLoading, {
+    failed: !!error,
+  });
 
   const handleBackToGroups = () => {
     navigate(`/${orgId}/settings/groups`);

--- a/web_src/src/pages/organization/settings/Groups.tsx
+++ b/web_src/src/pages/organization/settings/Groups.tsx
@@ -2,6 +2,7 @@ import { formatRelativeTime } from "@/lib/timezone";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Icon } from "../../../components/Icon";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Link } from "../../../components/Link/link";
@@ -46,6 +47,10 @@ export function Groups({ organizationId }: GroupsProps) {
   const canDeleteGroups = canAct("groups", "delete");
 
   const error = groupsError || rolesError;
+
+  useReportPageReady(!loadingGroups && !permissionsLoading, {
+    failed: !!error,
+  });
 
   const handleCreateGroup = () => {
     if (!canCreateGroups) return;

--- a/web_src/src/pages/organization/settings/Integrations.tsx
+++ b/web_src/src/pages/organization/settings/Integrations.tsx
@@ -2,6 +2,7 @@ import { Loader2, Plug, Search, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import {
   useAvailableIntegrations,
   useConnectedIntegrations,
@@ -62,6 +63,9 @@ export function Integrations({ organizationId }: IntegrationsProps) {
   const createIntegrationMutation = useCreateIntegration(organizationId, "integrations_page");
 
   const isLoading = loadingAvailable || loadingInstalled;
+
+  useReportPageReady(!isLoading && !permissionsLoading);
+
   const integrationNames = useMemo(() => {
     return new Set(
       organizationIntegrations.map((integration) => integration.metadata?.name?.trim()).filter(Boolean) as string[],

--- a/web_src/src/pages/organization/settings/Members.tsx
+++ b/web_src/src/pages/organization/settings/Members.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { usePermissions } from "@/contexts/usePermissions";
 import { Avatar } from "../../../components/Avatar/avatar";
 import { Badge } from "../../../components/Badge/badge";
@@ -73,6 +74,11 @@ export function Members({ organizationId }: MembersProps) {
   const resetInviteLinkMutation = useResetOrganizationInviteLink(organizationId);
 
   const error = usersError || rolesError;
+
+  useReportPageReady(!loadingMembers && !loadingRoles && !permissionsLoading, {
+    failed: !!error,
+  });
+
   const ownerIds = useMemo(() => {
     const ids = users
       .filter((user) => user.status?.roles?.some((role) => role.roleName === "org_owner"))

--- a/web_src/src/pages/organization/settings/Profile.tsx
+++ b/web_src/src/pages/organization/settings/Profile.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { meRegenerateToken } from "@/api-client/sdk.gen";
 import { Avatar } from "@/components/Avatar/avatar";
 import { Heading } from "@/components/Heading/heading";
@@ -30,6 +31,10 @@ export function Profile() {
 
   const errorMessage =
     actionError || (meError instanceof Error ? meError.message : meError ? "Failed to load profile" : null);
+
+  useReportPageReady(!loading, {
+    failed: !!errorMessage,
+  });
 
   const handleRegenerateToken = async () => {
     try {

--- a/web_src/src/pages/organization/settings/Roles.tsx
+++ b/web_src/src/pages/organization/settings/Roles.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import type { RolesRole } from "../../../api-client/types.gen";
 import { Icon } from "../../../components/Icon";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../../components/Table/table";
@@ -26,6 +27,10 @@ export function Roles({ organizationId }: RolesProps) {
   const canCreateRoles = canAct("roles", "create");
   const canUpdateRoles = canAct("roles", "update");
   const canDeleteRoles = canAct("roles", "delete");
+
+  useReportPageReady(!loadingRoles && !permissionsLoading, {
+    failed: !!error,
+  });
 
   const roleHref = (role: RolesRole) => `/${organizationId}/settings/create-role/${role.metadata?.name}`;
 

--- a/web_src/src/pages/organization/settings/SecretDetail.tsx
+++ b/web_src/src/pages/organization/settings/SecretDetail.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumbs } from "@/components/Breadcrumbs/breadcrumbs";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { Textarea } from "@/components/Textarea/textarea";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,6 +28,11 @@ export function SecretDetail({ organizationId }: SecretDetailProps) {
 
   const { data: secret, isLoading, error } = useSecret(organizationId, "DOMAIN_TYPE_ORGANIZATION", secretId || "");
   usePageTitle(["Secrets", secret?.metadata?.name]);
+
+  useReportPageReady(!isLoading && !!secretId, {
+    failed: !!error,
+  });
+
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingKeyName, setEditingKeyName] = useState("");
   const [editingValue, setEditingValue] = useState("");

--- a/web_src/src/pages/organization/settings/Secrets.tsx
+++ b/web_src/src/pages/organization/settings/Secrets.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@/components/Icon";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Link } from "@/components/Link/link";
 import { Textarea } from "@/components/Textarea/textarea";
@@ -37,6 +38,8 @@ export function Secrets({ organizationId }: SecretsProps) {
 
   const { data: secrets = [], isLoading } = useSecrets(organizationId, "DOMAIN_TYPE_ORGANIZATION");
   const createSecretMutation = useCreateSecret(organizationId, "DOMAIN_TYPE_ORGANIZATION");
+
+  useReportPageReady(!isLoading && !permissionsLoading);
 
   const handleCreateClick = () => {
     if (!canCreateSecrets) return;

--- a/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccountDetail.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@/components/Icon";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
@@ -36,6 +37,8 @@ export function ServiceAccountDetail({ organizationId }: ServiceAccountDetailPro
   const updateMutation = useUpdateServiceAccount(organizationId);
   const deleteMutation = useDeleteServiceAccount(organizationId);
   const regenerateTokenMutation = useRegenerateServiceAccountToken(organizationId);
+
+  useReportPageReady(!isLoading && !permissionsLoading && !!id);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState("");

--- a/web_src/src/pages/organization/settings/ServiceAccounts.tsx
+++ b/web_src/src/pages/organization/settings/ServiceAccounts.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@/components/Icon";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { Link } from "@/components/Link/link";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/Table/table";
@@ -36,6 +37,8 @@ export function ServiceAccounts({ organizationId }: ServiceAccountsProps) {
   const { data: serviceAccounts = [], isLoading } = useServiceAccounts(organizationId);
   const createMutation = useCreateServiceAccount(organizationId);
   const deleteMutation = useDeleteServiceAccount(organizationId);
+
+  useReportPageReady(!isLoading && !permissionsLoading);
 
   const handleCreateClick = () => {
     if (!canCreate) return;

--- a/web_src/src/pages/organization/settings/Usage.tsx
+++ b/web_src/src/pages/organization/settings/Usage.tsx
@@ -3,6 +3,7 @@ import { Navigate } from "react-router-dom";
 import { Activity, Cpu, Database, Gauge, Layers3, Users } from "lucide-react";
 import type { OrganizationsDescribeUsageResponse, OrganizationsOrganizationLimits } from "@/api-client/types.gen";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { useOrganizationUsage, useOrganizationUsers } from "@/hooks/useOrganizationData";
 import { useConnectedIntegrations } from "@/hooks/useIntegrations";
 import { isUsagePageForced } from "@/lib/env";
@@ -35,6 +36,10 @@ export function Usage({ organizationId }: UsageProps) {
   const forceUsagePage = isUsagePageForced();
   const anyLoading = [isLoading, isLoadingUsers, isLoadingIntegrations].some(Boolean);
   const anyError = [error, usersError, integrationsError].find(Boolean);
+
+  useReportPageReady(!anyLoading, {
+    failed: !!anyError,
+  });
 
   if (anyLoading) {
     return (

--- a/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/index.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationDetailsRoute/index.tsx
@@ -1,4 +1,5 @@
 import { useIntegration } from "@/hooks/useIntegrations";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { LegacyIntegrationDetails } from "./LegacyIntegrationDetails";
@@ -13,6 +14,10 @@ export function IntegrationDetailsRoute({ organizationId }: IntegrationDetailsRo
   const { integrationId } = useParams<{ integrationId: string }>();
   const { data: integration, isLoading, error } = useIntegration(organizationId, integrationId || "");
   const integrationsHref = `/${organizationId}/settings/integrations`;
+
+  useReportPageReady(!isLoading, {
+    failed: !!(error || !integration),
+  });
 
   if (isLoading) {
     return (

--- a/web_src/src/pages/organization/settings/components/IntegrationSetup/index.tsx
+++ b/web_src/src/pages/organization/settings/components/IntegrationSetup/index.tsx
@@ -1,5 +1,6 @@
 import { SetupView } from "./SetupView";
 import { useIntegrationSetupController } from "./useIntegrationSetupController";
+import { useReportPageReady } from "@/hooks/useReportPageReady";
 
 interface IntegrationSetupProps {
   organizationId: string;
@@ -7,6 +8,8 @@ interface IntegrationSetupProps {
 
 export function IntegrationSetup({ organizationId }: IntegrationSetupProps) {
   const setup = useIntegrationSetupController(organizationId);
+
+  useReportPageReady(!setup.queries.isAvailableIntegrationsLoading);
 
   return <SetupView setup={setup} />;
 }


### PR DESCRIPTION
## Summary
- Add a central route-to-page-key map and `usePageObservability` hook that tags Dash0 signals with `superplane.page` and emits `{pageKey}.start` on navigation.
- Add `useReportPageReady` so each routed screen reports `{pageKey}.ready` with `duration_ms` and page-specific attributes (counts, failure state, etc.).
- Wire page view metadata in Dash0 init so page views share the same page key attributes.

## Test plan
- [x] `npm run test -- --run src/lib/pageObservability.spec.ts src/hooks/useReportPageReady.spec.tsx src/dash0.spec.ts`
- [ ] Visit org home in staging with Dash0 web enabled and filter on `superplane.page = organizationHomePage`
- [ ] Confirm `organizationHomePage.start` and `organizationHomePage.ready` appear with `duration_ms`


Made with [Cursor](https://cursor.com)