### PR TITLE
feat: add Cloudsmith base integration

### DIFF
--- a/docs/components/Cloudsmith.mdx
+++ b/docs/components/Cloudsmith.mdx
@@ -1,0 +1,94 @@
+---
+title: "Cloudsmith"
+---
+
+Automate repository, package, and artifact management on Cloudsmith
+
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+## Actions
+
+<CardGrid>
+  <LinkCard title="Get Repository" href="#get-repository" description="Fetch details of a Cloudsmith repository" />
+</CardGrid>
+
+## Instructions
+
+## Cloudsmith Service Account API Key
+
+SuperPlane authenticates to Cloudsmith using a service account API key, which is not tied to an individual user.
+
+1. In the Cloudsmith web dashboard, go to the **Accounts** tab and click on **Services**
+2. Click on **New Service**. Give the servie a name like **Superplane** and optional description. Assign the **Manager** role to the service.
+3. Click on **Create Service** and copy the generated API key.
+4. Paste the API key below.
+5. To give the service access to any repository, click on your Repository and then **Settings** → **Access control → Privileges for specific services**
+
+<a id="get-repository"></a>
+
+## Get Repository
+
+**Component key:** `cloudsmith.getRepository`
+
+The Get Repository component retrieves detailed information about a specific Cloudsmith repository.
+
+### Use Cases
+
+- **Status checks**: Verify a repository exists and is reachable before publishing or promoting packages
+- **Information retrieval**: Read repository visibility, namespace, and configuration
+- **Storage monitoring**: Track storage usage, package counts, and download metrics
+- **Compliance checks**: Inspect quarantined or policy-violating package counts before downstream actions
+
+### Configuration
+
+- **Repository**: The repository to retrieve (required, supports expressions). The value is the repository identifier in the form `owner/repository`.
+
+### Output
+
+Returns the repository object including:
+- **name**: A descriptive name for the repository
+- **slug**: The slug that identifies the repository in URIs
+- **namespace**: The namespace (owner) the repository belongs to
+- **repository_type_str**: The visibility of the repository (Public, Private, Open-Source)
+- **storage_region**: The Cloudsmith region in which package files are stored
+- **size** / **size_str**: The calculated storage size of the repository
+- **package_count**: The number of packages in the repository
+- **num_downloads**: The number of downloads for packages in the repository
+- **num_quarantined_packages**: The number of quarantined packages
+- **num_policy_violated_packages**: The number of packages with policy violations
+
+### Example Output
+
+```json
+{
+  "data": {
+    "cdn_url": "https://dl.cloudsmith.io/public/acme/production",
+    "content_kind": "Standard",
+    "created_at": "2026-01-15T09:42:11.123456Z",
+    "description": "Production packages for the ACME platform",
+    "is_open_source": false,
+    "is_private": true,
+    "is_public": false,
+    "name": "Production",
+    "namespace": "acme",
+    "namespace_url": "https://api.cloudsmith.io/v1/namespaces/acme/",
+    "num_downloads": 18234,
+    "num_policy_violated_packages": 2,
+    "num_quarantined_packages": 1,
+    "package_count": 312,
+    "package_group_count": 47,
+    "repository_type_str": "Private",
+    "self_html_url": "https://cloudsmith.io/~acme/repos/production/",
+    "self_url": "https://api.cloudsmith.io/v1/repos/acme/production/",
+    "self_webapp_url": "https://cloudsmith.io/~acme/repos/production/",
+    "size": 524288000,
+    "size_str": "500.0 MB",
+    "slug": "production",
+    "slug_perm": "abcdef123456",
+    "storage_region": "us-ohio"
+  },
+  "timestamp": "2026-03-12T21:13:32.946693411Z",
+  "type": "cloudsmith.repository.fetched"
+}
+```
+

--- a/pkg/integrations/cloudsmith/client.go
+++ b/pkg/integrations/cloudsmith/client.go
@@ -141,20 +141,33 @@ func (c *Client) GetRepository(owner, identifier string) (*Repository, error) {
 	return &repository, nil
 }
 
-// ListRepositories returns every repository the authenticated user can access.
+const repositoryPageSize = 100
+
+// ListRepositories returns every repository the authenticated user can access,
+// following all pages until the API returns a page smaller than repositoryPageSize.
 func (c *Client) ListRepositories() ([]Repository, error) {
-	requestURL := fmt.Sprintf("%s/repos/?page_size=1000", c.BaseURL)
-	responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
-	if err != nil {
-		return nil, err
+	var all []Repository
+
+	for page := 1; ; page++ {
+		requestURL := fmt.Sprintf("%s/repos/?page=%d&page_size=%d", c.BaseURL, page, repositoryPageSize)
+		responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var repositories []Repository
+		if err := json.Unmarshal(responseBody, &repositories); err != nil {
+			return nil, fmt.Errorf("error parsing response: %v", err)
+		}
+
+		all = append(all, repositories...)
+
+		if len(repositories) < repositoryPageSize {
+			break
+		}
 	}
 
-	var repositories []Repository
-	if err := json.Unmarshal(responseBody, &repositories); err != nil {
-		return nil, fmt.Errorf("error parsing response: %v", err)
-	}
-
-	return repositories, nil
+	return all, nil
 }
 
 var errInvalidRepositoryID = errors.New("must be in the form 'owner/repository'")

--- a/pkg/integrations/cloudsmith/client.go
+++ b/pkg/integrations/cloudsmith/client.go
@@ -1,0 +1,235 @@
+package cloudsmith
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const baseURL = "https://api.cloudsmith.io/v1"
+
+// Client is a thin wrapper around the Cloudsmith v1 HTTP API.
+type Client struct {
+	APIKey  string
+	http    core.HTTPContext
+	BaseURL string
+}
+
+type APIError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("request got %d code: %s", e.StatusCode, string(e.Body))
+}
+
+func NewClient(http core.HTTPContext, ctx core.IntegrationContext) (*Client, error) {
+	apiKey, err := ctx.GetConfig("apiKey")
+	if err != nil {
+		return nil, fmt.Errorf("error finding API key: %v", err)
+	}
+
+	return &Client{
+		APIKey:  string(apiKey),
+		http:    http,
+		BaseURL: baseURL,
+	}, nil
+}
+
+func (c *Client) execRequest(method, requestURL string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, requestURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("error building request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", c.APIKey)
+
+	res, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %v", err)
+	}
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %v", err)
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, &APIError{
+			StatusCode: res.StatusCode,
+			Body:       responseBody,
+		}
+	}
+
+	return responseBody, nil
+}
+
+type User struct {
+	Authenticated bool   `json:"authenticated"`
+	Email         string `json:"email"`
+	Name          string `json:"name"`
+	Slug          string `json:"slug"`
+}
+
+// GetSelf validates the API key by fetching the authenticated user.
+func (c *Client) GetSelf() (*User, error) {
+	requestURL := fmt.Sprintf("%s/user/self/", c.BaseURL)
+	responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var user User
+	if err := json.Unmarshal(responseBody, &user); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &user, nil
+}
+
+// Repository holds the Cloudsmith repository fields most useful for workflows.
+type Repository struct {
+	Name                      string `json:"name"`
+	Slug                      string `json:"slug"`
+	SlugPerm                  string `json:"slug_perm"`
+	Namespace                 string `json:"namespace"`
+	NamespaceURL              string `json:"namespace_url"`
+	Description               string `json:"description"`
+	RepositoryType            string `json:"repository_type_str"`
+	ContentKind               string `json:"content_kind"`
+	StorageRegion             string `json:"storage_region"`
+	CDNUrl                    string `json:"cdn_url"`
+	SelfURL                   string `json:"self_url"`
+	SelfHTMLUrl               string `json:"self_html_url"`
+	SelfWebappURL             string `json:"self_webapp_url"`
+	IsPrivate                 bool   `json:"is_private"`
+	IsPublic                  bool   `json:"is_public"`
+	IsOpenSource              bool   `json:"is_open_source"`
+	Size                      int64  `json:"size"`
+	SizeStr                   string `json:"size_str"`
+	PackageCount              int64  `json:"package_count"`
+	PackageGroupCount         int64  `json:"package_group_count"`
+	NumDownloads              int64  `json:"num_downloads"`
+	NumQuarantinedPackages    int64  `json:"num_quarantined_packages"`
+	NumPolicyViolatedPackages int64  `json:"num_policy_violated_packages"`
+	CreatedAt                 string `json:"created_at"`
+}
+
+// GetRepository fetches a single repository identified by namespace (owner) and slug.
+func (c *Client) GetRepository(owner, identifier string) (*Repository, error) {
+	requestURL := fmt.Sprintf("%s/repos/%s/%s/", c.BaseURL, url.PathEscape(owner), url.PathEscape(identifier))
+	responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var repository Repository
+	if err := json.Unmarshal(responseBody, &repository); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return &repository, nil
+}
+
+// ListRepositories returns every repository the authenticated user can access.
+func (c *Client) ListRepositories() ([]Repository, error) {
+	requestURL := fmt.Sprintf("%s/repos/?page_size=1000", c.BaseURL)
+	responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var repositories []Repository
+	if err := json.Unmarshal(responseBody, &repositories); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return repositories, nil
+}
+
+var errInvalidRepositoryID = errors.New("must be in the form 'owner/repository'")
+
+// parseRepositoryID splits a Cloudsmith repository identifier of the form
+// "owner/repository" into its namespace (owner) and slug (identifier) parts.
+func parseRepositoryID(raw string) (owner string, identifier string, err error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", "", errInvalidRepositoryID
+	}
+
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 {
+		return "", "", errInvalidRepositoryID
+	}
+
+	owner = strings.TrimSpace(parts[0])
+	identifier = strings.TrimSpace(parts[1])
+	if owner == "" || identifier == "" {
+		return "", "", errInvalidRepositoryID
+	}
+
+	return owner, identifier, nil
+}
+
+// RepositoryNodeMetadata caches the human-readable repository name so the UI can
+// display it without re-fetching from the API on every render.
+type RepositoryNodeMetadata struct {
+	RepositoryID        string `json:"repositoryId" mapstructure:"repositoryId"`
+	RepositoryName      string `json:"repositoryName" mapstructure:"repositoryName"`
+	RepositoryNamespace string `json:"repositoryNamespace" mapstructure:"repositoryNamespace"`
+	RepositorySlug      string `json:"repositorySlug" mapstructure:"repositorySlug"`
+}
+
+// resolveRepositoryMetadata stores display metadata for the selected repository.
+// Expressions are stored verbatim because they can only be resolved at execution time.
+func resolveRepositoryMetadata(ctx core.SetupContext, repositoryID string) error {
+	if strings.Contains(repositoryID, "{{") {
+		return ctx.Metadata.Set(RepositoryNodeMetadata{
+			RepositoryID:   repositoryID,
+			RepositoryName: repositoryID,
+		})
+	}
+
+	owner, identifier, err := parseRepositoryID(repositoryID)
+	if err != nil {
+		return fmt.Errorf("invalid repository %q: %w", repositoryID, err)
+	}
+
+	var existing RepositoryNodeMetadata
+	decodeErr := mapstructure.Decode(ctx.Metadata.Get(), &existing)
+	if decodeErr == nil && existing.RepositoryID == repositoryID && existing.RepositoryName != "" {
+		return nil
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	repository, err := client.GetRepository(owner, identifier)
+	if err != nil {
+		return fmt.Errorf("failed to fetch repository %q: %w", repositoryID, err)
+	}
+
+	name := repository.Name
+	if name == "" {
+		name = identifier
+	}
+
+	return ctx.Metadata.Set(RepositoryNodeMetadata{
+		RepositoryID:        repositoryID,
+		RepositoryName:      name,
+		RepositoryNamespace: owner,
+		RepositorySlug:      identifier,
+	})
+}

--- a/pkg/integrations/cloudsmith/client_test.go
+++ b/pkg/integrations/cloudsmith/client_test.go
@@ -1,0 +1,50 @@
+package cloudsmith
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test__parseRepositoryID(t *testing.T) {
+	t.Run("valid owner/repository", func(t *testing.T) {
+		owner, identifier, err := parseRepositoryID("acme/production")
+
+		require.NoError(t, err)
+		assert.Equal(t, "acme", owner)
+		assert.Equal(t, "production", identifier)
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		owner, identifier, err := parseRepositoryID("  acme / production  ")
+
+		require.NoError(t, err)
+		assert.Equal(t, "acme", owner)
+		assert.Equal(t, "production", identifier)
+	})
+
+	t.Run("empty value returns error", func(t *testing.T) {
+		_, _, err := parseRepositoryID("")
+
+		require.ErrorIs(t, err, errInvalidRepositoryID)
+	})
+
+	t.Run("missing slug returns error", func(t *testing.T) {
+		_, _, err := parseRepositoryID("acme")
+
+		require.ErrorIs(t, err, errInvalidRepositoryID)
+	})
+
+	t.Run("too many segments returns error", func(t *testing.T) {
+		_, _, err := parseRepositoryID("acme/team/production")
+
+		require.ErrorIs(t, err, errInvalidRepositoryID)
+	})
+
+	t.Run("blank segment returns error", func(t *testing.T) {
+		_, _, err := parseRepositoryID("acme/")
+
+		require.ErrorIs(t, err, errInvalidRepositoryID)
+	})
+}

--- a/pkg/integrations/cloudsmith/cloudsmith.go
+++ b/pkg/integrations/cloudsmith/cloudsmith.go
@@ -1,0 +1,128 @@
+package cloudsmith
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/registry"
+)
+
+func init() {
+	registry.RegisterIntegration("cloudsmith", &Cloudsmith{})
+}
+
+type Cloudsmith struct{}
+
+type Configuration struct {
+	APIKey string `json:"apiKey"`
+}
+
+type Metadata struct {
+	UserSlug  string `json:"userSlug"`
+	UserName  string `json:"userName"`
+	UserEmail string `json:"userEmail"`
+}
+
+func (c *Cloudsmith) Name() string {
+	return "cloudsmith"
+}
+
+func (c *Cloudsmith) Label() string {
+	return "Cloudsmith"
+}
+
+func (c *Cloudsmith) Icon() string {
+	return "cloudsmith"
+}
+
+func (c *Cloudsmith) Description() string {
+	return "Automate repository, package, and artifact management on Cloudsmith"
+}
+
+func (c *Cloudsmith) Instructions() string {
+	return `## Cloudsmith Service Account API Key
+
+SuperPlane authenticates to Cloudsmith using a service account API key, which is not tied to an individual user.
+
+1. In the Cloudsmith web dashboard, go to the **Accounts** tab and click on **Services**
+2. Click on **New Service**. Give the servie a name like **Superplane** and optional description. Assign the **Manager** role to the service.
+3. Click on **Create Service** and copy the generated API key.
+4. Paste the API key below.
+5. To give the service access to any repository, click on your Repository and then **Settings** → **Access control → Privileges for specific services**
+`
+}
+
+func (c *Cloudsmith) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "apiKey",
+			Label:       "API Key",
+			Type:        configuration.FieldTypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Cloudsmith service account API key",
+		},
+	}
+}
+
+func (c *Cloudsmith) Actions() []core.Action {
+	return []core.Action{
+		&GetRepository{},
+	}
+}
+
+func (c *Cloudsmith) Triggers() []core.Trigger {
+	return []core.Trigger{}
+}
+
+func (c *Cloudsmith) Sync(ctx core.SyncContext) error {
+	config := Configuration{}
+	err := mapstructure.Decode(ctx.Configuration, &config)
+	if err != nil {
+		return fmt.Errorf("failed to decode config: %v", err)
+	}
+
+	if config.APIKey == "" {
+		return fmt.Errorf("apiKey is required")
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	user, err := client.GetSelf()
+	if err != nil {
+		return fmt.Errorf("error validating API key: %v", err)
+	}
+
+	if !user.Authenticated {
+		return fmt.Errorf("API key is not valid")
+	}
+
+	ctx.Integration.SetMetadata(Metadata{
+		UserSlug:  user.Slug,
+		UserName:  user.Name,
+		UserEmail: user.Email,
+	})
+	ctx.Integration.Ready()
+	return nil
+}
+
+func (c *Cloudsmith) Cleanup(ctx core.IntegrationCleanupContext) error {
+	return nil
+}
+
+func (c *Cloudsmith) HandleRequest(ctx core.HTTPRequestContext) {
+	// no-op
+}
+
+func (c *Cloudsmith) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (c *Cloudsmith) HandleHook(ctx core.IntegrationHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudsmith/cloudsmith_test.go
+++ b/pkg/integrations/cloudsmith/cloudsmith_test.go
@@ -1,0 +1,109 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Cloudsmith__Sync(t *testing.T) {
+	integration := &Cloudsmith{}
+
+	t.Run("missing apiKey returns error", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{},
+			Integration:   &contexts.IntegrationContext{},
+		})
+
+		require.ErrorContains(t, err, "apiKey is required")
+	})
+
+	t.Run("valid apiKey sets metadata and marks ready", func(t *testing.T) {
+		integrationCtx := &contexts.IntegrationContext{
+			Configuration: map[string]any{
+				"apiKey": "test-key",
+			},
+		}
+
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"apiKey": "test-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"authenticated": true,
+							"slug": "service-account",
+							"name": "SuperPlane Service Account",
+							"email": "service@acme.test"
+						}`)),
+					},
+				},
+			},
+			Integration: integrationCtx,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ready", integrationCtx.State)
+
+		metadata, ok := integrationCtx.Metadata.(Metadata)
+		require.True(t, ok)
+		assert.Equal(t, "service-account", metadata.UserSlug)
+		assert.Equal(t, "SuperPlane Service Account", metadata.UserName)
+		assert.Equal(t, "service@acme.test", metadata.UserEmail)
+	})
+
+	t.Run("unauthenticated response returns error", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"apiKey": "test-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"authenticated": false}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "not valid")
+	})
+
+	t.Run("invalid apiKey (401) returns error", func(t *testing.T) {
+		err := integration.Sync(core.SyncContext{
+			Configuration: map[string]any{
+				"apiKey": "bad-key",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusUnauthorized,
+						Body:       io.NopCloser(strings.NewReader(`{"detail":"Invalid api key."}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "bad-key",
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "error validating API key")
+	})
+}

--- a/pkg/integrations/cloudsmith/example.go
+++ b/pkg/integrations/cloudsmith/example.go
@@ -1,0 +1,18 @@
+package cloudsmith
+
+import (
+	_ "embed"
+	"sync"
+
+	"github.com/superplanehq/superplane/pkg/utils"
+)
+
+//go:embed example_output_get_repository.json
+var exampleOutputGetRepositoryBytes []byte
+
+var exampleOutputGetRepositoryOnce sync.Once
+var exampleOutputGetRepository map[string]any
+
+func (g *GetRepository) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetRepositoryOnce, exampleOutputGetRepositoryBytes, &exampleOutputGetRepository)
+}

--- a/pkg/integrations/cloudsmith/example_output_get_repository.json
+++ b/pkg/integrations/cloudsmith/example_output_get_repository.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "cdn_url": "https://dl.cloudsmith.io/public/acme/production",
+    "content_kind": "Standard",
+    "created_at": "2026-01-15T09:42:11.123456Z",
+    "description": "Production packages for the ACME platform",
+    "is_open_source": false,
+    "is_private": true,
+    "is_public": false,
+    "name": "Production",
+    "namespace": "acme",
+    "namespace_url": "https://api.cloudsmith.io/v1/namespaces/acme/",
+    "num_downloads": 18234,
+    "num_policy_violated_packages": 2,
+    "num_quarantined_packages": 1,
+    "package_count": 312,
+    "package_group_count": 47,
+    "repository_type_str": "Private",
+    "self_html_url": "https://cloudsmith.io/~acme/repos/production/",
+    "self_url": "https://api.cloudsmith.io/v1/repos/acme/production/",
+    "self_webapp_url": "https://cloudsmith.io/~acme/repos/production/",
+    "size": 524288000,
+    "size_str": "500.0 MB",
+    "slug": "production",
+    "slug_perm": "abcdef123456",
+    "storage_region": "us-ohio"
+  },
+  "timestamp": "2026-03-12T21:13:32.946693411Z",
+  "type": "cloudsmith.repository.fetched"
+}

--- a/pkg/integrations/cloudsmith/get_repository.go
+++ b/pkg/integrations/cloudsmith/get_repository.go
@@ -1,0 +1,162 @@
+package cloudsmith
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetRepository struct{}
+
+type GetRepositorySpec struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+}
+
+func (g *GetRepository) Name() string {
+	return "cloudsmith.getRepository"
+}
+
+func (g *GetRepository) Label() string {
+	return "Get Repository"
+}
+
+func (g *GetRepository) Description() string {
+	return "Fetch details of a Cloudsmith repository"
+}
+
+func (g *GetRepository) Documentation() string {
+	return `The Get Repository component retrieves detailed information about a specific Cloudsmith repository.
+
+## Use Cases
+
+- **Status checks**: Verify a repository exists and is reachable before publishing or promoting packages
+- **Information retrieval**: Read repository visibility, namespace, and configuration
+- **Storage monitoring**: Track storage usage, package counts, and download metrics
+- **Compliance checks**: Inspect quarantined or policy-violating package counts before downstream actions
+
+## Configuration
+
+- **Repository**: The repository to retrieve (required, supports expressions). The value is the repository identifier in the form ` + "`owner/repository`" + `.
+
+## Output
+
+Returns the repository object including:
+- **name**: A descriptive name for the repository
+- **slug**: The slug that identifies the repository in URIs
+- **namespace**: The namespace (owner) the repository belongs to
+- **repository_type_str**: The visibility of the repository (Public, Private, Open-Source)
+- **storage_region**: The Cloudsmith region in which package files are stored
+- **size** / **size_str**: The calculated storage size of the repository
+- **package_count**: The number of packages in the repository
+- **num_downloads**: The number of downloads for packages in the repository
+- **num_quarantined_packages**: The number of quarantined packages
+- **num_policy_violated_packages**: The number of packages with policy violations`
+}
+
+func (g *GetRepository) Icon() string {
+	return "info"
+}
+
+func (g *GetRepository) Color() string {
+	return "gray"
+}
+
+func (g *GetRepository) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetRepository) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "repository",
+			Label:       "Repository",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The repository to retrieve",
+			Placeholder: "Select repository",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: false,
+				},
+			},
+		},
+	}
+}
+
+func (g *GetRepository) Setup(ctx core.SetupContext) error {
+	spec := GetRepositorySpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Repository == "" {
+		return errors.New("repository is required")
+	}
+
+	err = resolveRepositoryMetadata(ctx, spec.Repository)
+	if err != nil {
+		return fmt.Errorf("error resolving repository metadata: %v", err)
+	}
+
+	return nil
+}
+
+func (g *GetRepository) Execute(ctx core.ExecutionContext) error {
+	spec := GetRepositorySpec{}
+	err := mapstructure.Decode(ctx.Configuration, &spec)
+	if err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	owner, identifier, err := parseRepositoryID(spec.Repository)
+	if err != nil {
+		return fmt.Errorf("invalid repository %q: %w", spec.Repository, err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	repository, err := client.GetRepository(owner, identifier)
+	if err != nil {
+		return fmt.Errorf("failed to get repository: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudsmith.repository.fetched",
+		[]any{repository},
+	)
+}
+
+func (g *GetRepository) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetRepository) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetRepository) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (g *GetRepository) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (g *GetRepository) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *GetRepository) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudsmith/get_repository_test.go
+++ b/pkg/integrations/cloudsmith/get_repository_test.go
@@ -1,0 +1,196 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetRepository__Setup(t *testing.T) {
+	component := &GetRepository{}
+
+	t.Run("missing repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("empty repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("expression repository is stored without API call", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "{{ $.trigger.data.repository }}",
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(RepositoryNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "{{ $.trigger.data.repository }}", metadata.RepositoryName)
+	})
+
+	t.Run("malformed repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "no-namespace",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "owner/repository")
+	})
+
+	t.Run("valid repository resolves metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"name": "Production",
+							"slug": "production",
+							"namespace": "acme"
+						}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(RepositoryNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+		assert.Equal(t, "acme", metadata.RepositoryNamespace)
+		assert.Equal(t, "production", metadata.RepositorySlug)
+	})
+}
+
+func Test__GetRepository__Execute(t *testing.T) {
+	component := &GetRepository{}
+
+	t.Run("successful fetch emits repository data", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"name": "Production",
+						"slug": "production",
+						"namespace": "acme",
+						"repository_type_str": "Private",
+						"is_private": true,
+						"size": 524288000,
+						"size_str": "500.0 MB",
+						"package_count": 312,
+						"num_downloads": 18234
+					}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "cloudsmith.repository.fetched", executionState.Type)
+		assert.Len(t, executionState.Payloads, 1)
+	})
+
+	t.Run("invalid repository format returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "no-namespace",
+			},
+			HTTP: &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid repository")
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("repository not found (404) returns error", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"detail":"Not found."}`)),
+				},
+			},
+		}
+
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/missing",
+			},
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get repository")
+		assert.False(t, executionState.Passed)
+	})
+}

--- a/pkg/integrations/cloudsmith/list_resources.go
+++ b/pkg/integrations/cloudsmith/list_resources.go
@@ -1,0 +1,44 @@
+package cloudsmith
+
+import (
+	"fmt"
+
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+func (c *Cloudsmith) ListResources(resourceType string, ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	switch resourceType {
+	case "repository":
+		return listRepositories(ctx)
+	default:
+		return []core.IntegrationResource{}, nil
+	}
+}
+
+func listRepositories(ctx core.ListResourcesContext) ([]core.IntegrationResource, error) {
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %w", err)
+	}
+
+	repositories, err := client.ListRepositories()
+	if err != nil {
+		return nil, fmt.Errorf("error listing repositories: %w", err)
+	}
+
+	resources := make([]core.IntegrationResource, 0, len(repositories))
+	for _, repository := range repositories {
+		name := repository.Name
+		if name == "" {
+			name = repository.Slug
+		}
+
+		resources = append(resources, core.IntegrationResource{
+			Type: "repository",
+			Name: fmt.Sprintf("%s/%s", repository.Namespace, name),
+			ID:   fmt.Sprintf("%s/%s", repository.Namespace, repository.Slug),
+		})
+	}
+
+	return resources, nil
+}

--- a/pkg/integrations/cloudsmith/list_resources_test.go
+++ b/pkg/integrations/cloudsmith/list_resources_test.go
@@ -1,0 +1,106 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__Cloudsmith__ListResources(t *testing.T) {
+	integration := &Cloudsmith{}
+
+	t.Run("unknown resource type returns empty list", func(t *testing.T) {
+		resources, err := integration.ListResources("unknown", core.ListResourcesContext{
+			HTTP:        &contexts.HTTPContext{},
+			Integration: &contexts.IntegrationContext{},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+
+	t.Run("repository lists namespace-scoped resources", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`[
+						{"name": "Production", "slug": "production", "namespace": "acme"},
+						{"name": "Staging", "slug": "staging", "namespace": "acme"}
+					]`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("repository", core.ListResourcesContext{
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+		assert.Equal(t, "repository", resources[0].Type)
+		assert.Equal(t, "acme/Production", resources[0].Name)
+		assert.Equal(t, "acme/production", resources[0].ID)
+		assert.Equal(t, "acme/staging", resources[1].ID)
+	})
+
+	t.Run("falls back to slug when name is empty", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`[
+						{"name": "", "slug": "production", "namespace": "acme"}
+					]`)),
+				},
+			},
+		}
+
+		resources, err := integration.ListResources("repository", core.ListResourcesContext{
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+		assert.Equal(t, "acme/production", resources[0].Name)
+	})
+
+	t.Run("API error is propagated", func(t *testing.T) {
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"detail":"server error"}`)),
+				},
+			},
+		}
+
+		_, err := integration.ListResources("repository", core.ListResourcesContext{
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error listing repositories")
+	})
+}

--- a/pkg/integrations/cloudsmith/list_resources_test.go
+++ b/pkg/integrations/cloudsmith/list_resources_test.go
@@ -1,6 +1,7 @@
 package cloudsmith
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -11,6 +12,22 @@ import (
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
+
+// repoPage builds a JSON array of n repositories with sequential slugs (repo-1, repo-2, …).
+func repoPage(n int) string {
+	items := make([]string, n)
+	for i := range items {
+		items[i] = fmt.Sprintf(`{"name":"Repo %d","slug":"repo-%d","namespace":"acme"}`, i+1, i+1)
+	}
+	return "[" + strings.Join(items, ",") + "]"
+}
+
+func okResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
 
 func Test__Cloudsmith__ListResources(t *testing.T) {
 	integration := &Cloudsmith{}
@@ -28,13 +45,10 @@ func Test__Cloudsmith__ListResources(t *testing.T) {
 	t.Run("repository lists namespace-scoped resources", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(strings.NewReader(`[
-						{"name": "Production", "slug": "production", "namespace": "acme"},
-						{"name": "Staging", "slug": "staging", "namespace": "acme"}
-					]`)),
-				},
+				okResponse(`[
+					{"name": "Production", "slug": "production", "namespace": "acme"},
+					{"name": "Staging", "slug": "staging", "namespace": "acme"}
+				]`),
 			},
 		}
 
@@ -58,12 +72,7 @@ func Test__Cloudsmith__ListResources(t *testing.T) {
 	t.Run("falls back to slug when name is empty", func(t *testing.T) {
 		httpContext := &contexts.HTTPContext{
 			Responses: []*http.Response{
-				{
-					StatusCode: http.StatusOK,
-					Body: io.NopCloser(strings.NewReader(`[
-						{"name": "", "slug": "production", "namespace": "acme"}
-					]`)),
-				},
+				okResponse(`[{"name": "", "slug": "production", "namespace": "acme"}]`),
 			},
 		}
 
@@ -79,6 +88,28 @@ func Test__Cloudsmith__ListResources(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resources, 1)
 		assert.Equal(t, "acme/production", resources[0].Name)
+	})
+
+	t.Run("fetches all pages until partial page is returned", func(t *testing.T) {
+		// First page is full (repositoryPageSize items); second page is partial.
+		httpContext := &contexts.HTTPContext{
+			Responses: []*http.Response{
+				okResponse(repoPage(repositoryPageSize)),
+				okResponse(repoPage(3)),
+			},
+		}
+
+		resources, err := integration.ListResources("repository", core.ListResourcesContext{
+			HTTP: httpContext,
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{
+					"apiKey": "test-key",
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resources, repositoryPageSize+3)
 	})
 
 	t.Run("API error is propagated", func(t *testing.T) {

--- a/pkg/registryimports/registryimports.go
+++ b/pkg/registryimports/registryimports.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/superplanehq/superplane/pkg/integrations/circleci"
 	_ "github.com/superplanehq/superplane/pkg/integrations/claude"
 	_ "github.com/superplanehq/superplane/pkg/integrations/cloudflare"
+	_ "github.com/superplanehq/superplane/pkg/integrations/cloudsmith"
 	_ "github.com/superplanehq/superplane/pkg/integrations/coolify"
 	_ "github.com/superplanehq/superplane/pkg/integrations/cursor"
 	_ "github.com/superplanehq/superplane/pkg/integrations/dash0"

--- a/web_src/src/assets/icons/integrations/cloudsmith.svg
+++ b/web_src/src/assets/icons/integrations/cloudsmith.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <title>Cloudsmith</title>
+  <path fill="#2A6FE1" d="M24 10.667v2.667L13.333 24h-2.666L0 13.334v-2.667L10.667 0h2.666L24 10.667Zm-12 6.869a5.535 5.535 0 1 0 0-11.07 5.535 5.535 0 0 0 0 11.07Z"/>
+</svg>

--- a/web_src/src/lib/integrationDisplayName.ts
+++ b/web_src/src/lib/integrationDisplayName.ts
@@ -15,6 +15,7 @@ const INTEGRATION_TYPE_DISPLAY_NAMES: Record<string, string> = {
   discord: "Discord",
   datadog: "DataDog",
   cloudflare: "Cloudflare",
+  cloudsmith: "Cloudsmith",
   semaphore: "Semaphore",
   rootly: "Rootly",
   incident: "Incident",

--- a/web_src/src/pages/app/mappers/cloudsmith/get_repository.spec.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_repository.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { getRepositoryMapper } from "./get_repository";
+import { buildDetailsCtx, buildOutput, buildRepositoryData } from "./test_helpers";
+
+describe("getRepositoryMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getRepositoryMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => getRepositoryMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns Executed At without repository fields when output data is missing", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildOutput(undefined)] } } });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Name"]).toBeUndefined();
+  });
+
+  it("extracts the key repository fields", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(buildRepositoryData())] } },
+    });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Name"]).toBe("Production");
+    expect(details["Namespace"]).toBe("acme");
+    expect(details["Size"]).toBe("500.0 MB");
+    expect(details["Packages"]).toBe("312");
+    expect(details["Downloads"]).toBe("18234");
+    expect(details["Quarantined Packages"]).toBe("1");
+    expect(details["Policy Violations"]).toBe("2");
+  });
+
+  it("shows at most six fields when compliance counts are zero", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput(buildRepositoryData({ num_quarantined_packages: 0, num_policy_violated_packages: 0 }))],
+        },
+      },
+    });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(Object.keys(details)).toHaveLength(6);
+  });
+
+  it("falls back to raw byte size when size_str is missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(buildRepositoryData({ size_str: undefined, size: 1024 }))] } },
+    });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(details["Size"]).toBe("1024 bytes");
+  });
+
+  it("omits compliance counts when they are zero", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput(buildRepositoryData({ num_quarantined_packages: 0, num_policy_violated_packages: 0 }))],
+        },
+      },
+    });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(details["Quarantined Packages"]).toBeUndefined();
+    expect(details["Policy Violations"]).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/app/mappers/cloudsmith/get_repository.spec.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_repository.spec.ts
@@ -30,9 +30,22 @@ describe("getRepositoryMapper.getExecutionDetails", () => {
     expect(details["Namespace"]).toBe("acme");
     expect(details["Size"]).toBe("500.0 MB");
     expect(details["Packages"]).toBe("312");
-    expect(details["Downloads"]).toBe("18234");
+    expect(details["URL"]).toBe("https://cloudsmith.io/~acme/repos/production/");
+    expect(details["Downloads"]).toBeUndefined();
     expect(details["Quarantined Packages"]).toBe("1");
     expect(details["Policy Violations"]).toBe("2");
+  });
+
+  it("omits URL when self_webapp_url is missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: {
+        outputs: {
+          default: [buildOutput(buildRepositoryData({ self_webapp_url: undefined }))],
+        },
+      },
+    });
+    const details = getRepositoryMapper.getExecutionDetails(ctx);
+    expect(details["URL"]).toBeUndefined();
   });
 
   it("shows at most six fields when compliance counts are zero", () => {

--- a/web_src/src/pages/app/mappers/cloudsmith/get_repository.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_repository.ts
@@ -1,0 +1,106 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudsmithIcon from "@/assets/icons/integrations/cloudsmith.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import type { GetRepositoryConfiguration, RepositoryData, RepositoryNodeMetadata } from "./types";
+
+export const getRepositoryMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudsmith";
+
+    return {
+      iconSrc: cloudsmithIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? baseEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: metadataList(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const repository = outputs?.default?.[0]?.data as RepositoryData | undefined;
+    if (!repository) return details;
+
+    addRepositoryDetails(details, repository);
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function addRepositoryDetails(details: Record<string, string>, repository: RepositoryData): void {
+  details["Name"] = repository.name || "-";
+  details["Namespace"] = repository.namespace || "-";
+  details["Size"] = repository.size_str || (repository.size != null ? `${repository.size} bytes` : "-");
+  details["Packages"] = repository.package_count != null ? String(repository.package_count) : "-";
+  details["Downloads"] = repository.num_downloads != null ? String(repository.num_downloads) : "-";
+
+  if (repository.num_quarantined_packages) {
+    details["Quarantined Packages"] = String(repository.num_quarantined_packages);
+  }
+
+  if (repository.num_policy_violated_packages) {
+    details["Policy Violations"] = String(repository.num_policy_violated_packages);
+  }
+}
+
+function metadataList(node: NodeInfo): MetadataItem[] {
+  const metadata: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as RepositoryNodeMetadata | undefined;
+  const configuration = node.configuration as GetRepositoryConfiguration | undefined;
+
+  if (nodeMetadata?.repositoryName) {
+    metadata.push({ icon: "package", label: nodeMetadata.repositoryName });
+  } else if (configuration?.repository) {
+    metadata.push({ icon: "package", label: configuration.repository });
+  }
+
+  return metadata;
+}
+
+function baseEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  if (!execution.rootEvent || !execution.createdAt || !execution.rootEvent.id) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/get_repository.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_repository.ts
@@ -60,7 +60,9 @@ function addRepositoryDetails(details: Record<string, string>, repository: Repos
   details["Namespace"] = repository.namespace || "-";
   details["Size"] = repository.size_str || (repository.size != null ? `${repository.size} bytes` : "-");
   details["Packages"] = repository.package_count != null ? String(repository.package_count) : "-";
-  details["Downloads"] = repository.num_downloads != null ? String(repository.num_downloads) : "-";
+  if (repository.self_webapp_url) {
+    details["URL"] = repository.self_webapp_url;
+  }
 
   if (repository.num_quarantined_packages) {
     details["Quarantined Packages"] = String(repository.num_quarantined_packages);

--- a/web_src/src/pages/app/mappers/cloudsmith/index.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/index.ts
@@ -1,0 +1,13 @@
+import type { ComponentBaseMapper, EventStateRegistry, TriggerRenderer } from "../types";
+import { buildActionStateRegistry } from "../utils";
+import { getRepositoryMapper } from "./get_repository";
+
+export const componentMappers: Record<string, ComponentBaseMapper> = {
+  getRepository: getRepositoryMapper,
+};
+
+export const triggerRenderers: Record<string, TriggerRenderer> = {};
+
+export const eventStateRegistry: Record<string, EventStateRegistry> = {
+  getRepository: buildActionStateRegistry("fetched"),
+};

--- a/web_src/src/pages/app/mappers/cloudsmith/test_helpers.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/test_helpers.ts
@@ -60,6 +60,7 @@ export function buildRepositoryData(overrides?: Partial<RepositoryData>): Reposi
     num_quarantined_packages: 1,
     num_policy_violated_packages: 2,
     self_html_url: "https://cloudsmith.io/~acme/repos/production/",
+    self_webapp_url: "https://cloudsmith.io/~acme/repos/production/",
     ...overrides,
   };
 }

--- a/web_src/src/pages/app/mappers/cloudsmith/test_helpers.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/test_helpers.ts
@@ -1,0 +1,65 @@
+import type { ExecutionDetailsContext, ExecutionInfo, NodeInfo, OutputPayload } from "../types";
+import type { RepositoryData } from "./types";
+
+export function buildNode(overrides?: Partial<NodeInfo>): NodeInfo {
+  return {
+    id: "node-1",
+    name: "Get Repository",
+    componentName: "cloudsmith.getRepository",
+    isCollapsed: false,
+    configuration: {},
+    metadata: {},
+    ...overrides,
+  };
+}
+
+export function buildOutput(data: unknown): OutputPayload {
+  return {
+    type: "cloudsmith.repository.fetched",
+    timestamp: new Date().toISOString(),
+    data,
+  };
+}
+
+export function buildExecution(overrides?: Partial<ExecutionInfo>): ExecutionInfo {
+  return {
+    id: "exec-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    state: "STATE_FINISHED",
+    result: "RESULT_PASSED",
+    resultReason: "RESULT_REASON_OK",
+    resultMessage: "",
+    metadata: {},
+    configuration: {},
+    rootEvent: undefined,
+    ...overrides,
+  };
+}
+
+export function buildDetailsCtx(overrides?: {
+  node?: Partial<NodeInfo>;
+  execution?: Partial<ExecutionInfo>;
+}): ExecutionDetailsContext {
+  const node = buildNode(overrides?.node);
+  return { nodes: [node], node, execution: buildExecution(overrides?.execution) };
+}
+
+export function buildRepositoryData(overrides?: Partial<RepositoryData>): RepositoryData {
+  return {
+    name: "Production",
+    slug: "production",
+    namespace: "acme",
+    repository_type_str: "Private",
+    is_private: true,
+    storage_region: "us-ohio",
+    size: 524288000,
+    size_str: "500.0 MB",
+    package_count: 312,
+    num_downloads: 18234,
+    num_quarantined_packages: 1,
+    num_policy_violated_packages: 2,
+    self_html_url: "https://cloudsmith.io/~acme/repos/production/",
+    ...overrides,
+  };
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/types.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/types.ts
@@ -1,0 +1,37 @@
+export interface RepositoryNodeMetadata {
+  repositoryId?: string;
+  repositoryName?: string;
+  repositoryNamespace?: string;
+  repositorySlug?: string;
+}
+
+export interface GetRepositoryConfiguration {
+  repository: string;
+}
+
+export interface RepositoryData {
+  name?: string;
+  slug?: string;
+  slug_perm?: string;
+  namespace?: string;
+  namespace_url?: string;
+  description?: string;
+  repository_type_str?: string;
+  content_kind?: string;
+  storage_region?: string;
+  cdn_url?: string;
+  self_url?: string;
+  self_html_url?: string;
+  self_webapp_url?: string;
+  is_private?: boolean;
+  is_public?: boolean;
+  is_open_source?: boolean;
+  size?: number;
+  size_str?: string;
+  package_count?: number;
+  package_group_count?: number;
+  num_downloads?: number;
+  num_quarantined_packages?: number;
+  num_policy_violated_packages?: number;
+  created_at?: string;
+}

--- a/web_src/src/pages/app/mappers/index.ts
+++ b/web_src/src/pages/app/mappers/index.ts
@@ -61,6 +61,11 @@ import {
   eventStateRegistry as cloudflareEventStateRegistry,
 } from "./cloudflare/index";
 import {
+  componentMappers as cloudsmithComponentMappers,
+  triggerRenderers as cloudsmithTriggerRenderers,
+  eventStateRegistry as cloudsmithEventStateRegistry,
+} from "./cloudsmith/index";
+import {
   componentMappers as datadogComponentMappers,
   triggerRenderers as datadogTriggerRenderers,
   eventStateRegistry as datadogEventStateRegistry,
@@ -300,6 +305,7 @@ const componentBaseMappers: Record<string, ComponentBaseMapper> = {
 
 const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
   cloudflare: cloudflareComponentMappers,
+  cloudsmith: cloudsmithComponentMappers,
   digitalocean: digitaloceanComponentMappers,
   semaphore: semaphoreComponentMappers,
   github: githubComponentMappers,
@@ -348,6 +354,7 @@ const appMappers: Record<string, Record<string, ComponentBaseMapper>> = {
 
 const appTriggerRenderers: Record<string, Record<string, TriggerRenderer>> = {
   cloudflare: cloudflareTriggerRenderers,
+  cloudsmith: cloudsmithTriggerRenderers,
   digitalocean: digitaloceanTriggerRenderers,
   semaphore: semaphoreTriggerRenderers,
   github: githubTriggerRenderers,
@@ -395,6 +402,7 @@ const appTriggerRenderers: Record<string, Record<string, TriggerRenderer>> = {
 
 const appEventStateRegistries: Record<string, Record<string, EventStateRegistry>> = {
   cloudflare: cloudflareEventStateRegistry,
+  cloudsmith: cloudsmithEventStateRegistry,
   digitalocean: digitaloceanEventStateRegistry,
   semaphore: semaphoreEventStateRegistry,
   github: githubEventStateRegistry,

--- a/web_src/src/ui/componentSidebar/integrationIconMaps.ts
+++ b/web_src/src/ui/componentSidebar/integrationIconMaps.ts
@@ -14,6 +14,7 @@ import awsCodeArtifactIcon from "@/assets/icons/integrations/aws.codeartifact.sv
 import awsPrometheusIcon from "@/assets/icons/integrations/aws.prometheus.svg";
 import azureIcon from "@/assets/icons/integrations/azure.svg";
 import cloudflareIcon from "@/assets/icons/integrations/cloudflare.svg";
+import cloudsmithIcon from "@/assets/icons/integrations/cloudsmith.svg";
 import coolifyIcon from "@/assets/icons/integrations/coolify.svg";
 import dash0Icon from "@/assets/icons/integrations/dash0.svg";
 import datadogIcon from "@/assets/icons/integrations/datadog.svg";
@@ -72,6 +73,7 @@ export const INTEGRATION_APP_LOGO_MAP: Record<string, string> = {
   circleci: circleciIcon,
   azure: azureIcon,
   cloudflare: cloudflareIcon,
+  cloudsmith: cloudsmithIcon,
   coolify: coolifyIcon,
   dash0: dash0Icon,
   datadog: datadogIcon,
@@ -122,6 +124,7 @@ export const APP_LOGO_MAP: Record<string, string | Record<string, string>> = {
   bitbucket: bitbucketIcon,
   circleci: circleciIcon,
   cloudflare: cloudflareIcon,
+  cloudsmith: cloudsmithIcon,
   coolify: coolifyIcon,
   dash0: dash0Icon,
   datadog: datadogIcon,


### PR DESCRIPTION
Resolves: #5510 

## What changed

Added a new **Cloudsmith** integration with service-account API key authentication and an initial **Get Repository** action component. Users can connect Cloudsmith, pick a repository from a resource dropdown, and retrieve repository details (name, namespace, storage usage, package counts, downloads, and compliance metrics) inside SuperPlane workflows.

## Why

Teams publishing packages to Cloudsmith often need to automate follow-up actions such as checking repository status, monitoring storage and package metrics, and reacting to quarantined or policy-violating packages. This integration provides the foundation for those workflows by connecting SuperPlane to Cloudsmith and exposing repository retrieval as a workflow building block.

## How

### Backend

- Added `pkg/integrations/cloudsmith/` with:
  - **`cloudsmith.go`** — integration registration, `apiKey` configuration (sensitive), setup instructions for a Manager-role service account, and `Sync()` validation via `GET /user/self/`
  - **`client.go`** — Cloudsmith v1 API client (
  - **`get_repository.go`** — `cloudsmith.getRepository` action 
  - **`list_resources.go`** — repository resource listing for the configuration dropdown
- Registered the integration in `pkg/registryimports/registryimports.go`
- Added backend tests (27 passing) covering Sync, Get Repository Setup/Execute, list resources, and repository ID parsing

### Frontend

- Added Cloudsmith SVG icon and wired it into `integrationIconMaps.ts` and `integrationDisplayName.ts`
- Added `web_src/src/pages/app/mappers/cloudsmith/` with:
  - **`get_repository.ts`** — node mapper with repository metadata badge and a focused Details tab (Executed At, Name, Namespace, Size, Url, optional compliance fields when present)
  - **`types.ts`**, **`index.ts`**, and **`test_helpers.ts`**
- Registered Cloudsmith mappers and state registry in `web_src/src/pages/app/mappers/index.ts`
- Added frontend spec tests (7 passing) for execution details rendering

## Demo
[Screencast From 2026-06-16 11-24-41.webm](https://github.com/user-attachments/assets/a13d2344-0809-4f22-9514-d95e75bd8007)
