### PR TITLE
feat: surface connected integrations at top of integrations page

### DIFF
--- a/web_src/src/pages/organization/settings/Integrations.tsx
+++ b/web_src/src/pages/organization/settings/Integrations.tsx
@@ -132,7 +132,14 @@ export function Integrations({ organizationId }: IntegrationsProps) {
       });
     });
 
-    return [...catalogByProvider.values()].sort((a, b) => a.providerLabel.localeCompare(b.providerLabel));
+    return [...catalogByProvider.values()].sort((a, b) => {
+      const aHasInstances = a.instances.length > 0;
+      const bHasInstances = b.instances.length > 0;
+      if (aHasInstances !== bHasInstances) {
+        return aHasInstances ? -1 : 1;
+      }
+      return a.providerLabel.localeCompare(b.providerLabel);
+    });
   }, [availableIntegrations, connectedInstancesByProvider]);
   const filteredIntegrationCatalog = useMemo(() => {
     const normalizedQuery = filterQuery.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Sort the integrations list on `/settings/integrations` so providers with one or more connected instances (in any state: ready, error, pending) appear at the top, making them easier to find.
- Alphabetical ordering is preserved within both the "connected" and "not connected" groups.
- Uses data already present on each catalog item; no API or data-shape changes. The search filter preserves this order.

## Test plan
- [x] `make format.js` passes
- [x] `make check.build.ui` passes
- [x] On `/settings/integrations`, confirm integrations with connected instances appear first, alphabetical within each group