### PR TITLE
fix: skip redundant org load in auth interceptor

### DIFF
--- a/pkg/authorization/experimental_features.go
+++ b/pkg/authorization/experimental_features.go
@@ -1,0 +1,103 @@
+package authorization
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const experimentalFeatureCacheTTL = 15 * time.Minute
+
+var (
+	orgExperimentalFeatureCache sync.Map
+	experimentalFeatureCacheNow = time.Now
+)
+
+type experimentalFeatureCacheEntry struct {
+	enabled   bool
+	expiresAt time.Time
+}
+
+func orgExperimentalFeatureCacheKey(orgID uuid.UUID, featureID string) string {
+	return orgID.String() + "/" + featureID
+}
+
+// SetOrgExperimentalFeatureCache records whether a feature is enabled for an
+// organization in the authorization cache. Entries expire after 15 minutes.
+func SetOrgExperimentalFeatureCache(orgID uuid.UUID, featureID string, enabled bool) {
+	orgExperimentalFeatureCache.Store(orgExperimentalFeatureCacheKey(orgID, featureID), experimentalFeatureCacheEntry{
+		enabled:   enabled,
+		expiresAt: experimentalFeatureCacheNow().Add(experimentalFeatureCacheTTL),
+	})
+}
+
+func cachedOrgExperimentalFeatureEnabled(orgID uuid.UUID, featureID string) (enabled bool, ok bool) {
+	key := orgExperimentalFeatureCacheKey(orgID, featureID)
+	value, loaded := orgExperimentalFeatureCache.Load(key)
+	if !loaded {
+		return false, false
+	}
+
+	entry, ok := value.(experimentalFeatureCacheEntry)
+	if !ok {
+		orgExperimentalFeatureCache.Delete(key)
+		return false, false
+	}
+
+	if experimentalFeatureCacheNow().After(entry.expiresAt) {
+		orgExperimentalFeatureCache.Delete(key)
+		return false, false
+	}
+
+	return entry.enabled, true
+}
+
+func clearOrgExperimentalFeatureCacheForTest() {
+	orgExperimentalFeatureCache.Range(func(key, _ any) bool {
+		orgExperimentalFeatureCache.Delete(key)
+		return true
+	})
+}
+
+func orgHasExperimentalFeature(orgID uuid.UUID, featureID string) (bool, error) {
+	if features.IsReleased(featureID) {
+		return true, nil
+	}
+
+	if enabled, ok := cachedOrgExperimentalFeatureEnabled(orgID, featureID); ok && enabled {
+		return true, nil
+	}
+
+	enabled, err := models.HasExperimentalFeature(orgID, featureID)
+	if err != nil {
+		return false, err
+	}
+
+	SetOrgExperimentalFeatureCache(orgID, featureID, enabled)
+	return enabled, nil
+}
+
+func checkRequiredExperimentalFeatures(ctx context.Context, orgID string, rule AuthorizationRule) error {
+	orgUUID, err := uuid.Parse(orgID)
+	if err != nil {
+		return status.Error(codes.NotFound, "organization not found")
+	}
+
+	for _, featureID := range rule.RequiredExperimentalFeatures {
+		enabled, err := orgHasExperimentalFeature(orgUUID, featureID)
+		if err != nil {
+			return status.Error(codes.NotFound, "organization not found")
+		}
+		if !enabled {
+			return status.Error(codes.PermissionDenied, "required experimental feature is not enabled")
+		}
+	}
+
+	return nil
+}

--- a/pkg/authorization/experimental_features_test.go
+++ b/pkg/authorization/experimental_features_test.go
@@ -1,0 +1,155 @@
+package authorization
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/features"
+	"github.com/superplanehq/superplane/pkg/models"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestOrgHasExperimentalFeature(t *testing.T) {
+	t.Run("released feature short-circuits without cache or database", func(t *testing.T) {
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+
+		enabled, err := orgHasExperimentalFeature(uuid.New(), features.FeatureClaudeManagedAgents)
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("cached enabled short-circuits without loading organization", func(t *testing.T) {
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+
+		orgID := uuid.New()
+		const featureID = "exp-feature"
+		SetOrgExperimentalFeatureCache(orgID, featureID, true)
+
+		enabled, err := orgHasExperimentalFeature(orgID, featureID)
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("cached enabled expires after ttl", func(t *testing.T) {
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+		originalNow := experimentalFeatureCacheNow
+		t.Cleanup(func() { experimentalFeatureCacheNow = originalNow })
+
+		start := time.Now()
+		experimentalFeatureCacheNow = func() time.Time { return start }
+
+		orgID := uuid.New()
+		const featureID = "exp-feature"
+		SetOrgExperimentalFeatureCache(orgID, featureID, true)
+
+		cached, ok := cachedOrgExperimentalFeatureEnabled(orgID, featureID)
+		require.True(t, ok)
+		assert.True(t, cached)
+
+		experimentalFeatureCacheNow = func() time.Time { return start.Add(experimentalFeatureCacheTTL + time.Minute) }
+
+		cached, ok = cachedOrgExperimentalFeatureEnabled(orgID, featureID)
+		assert.False(t, ok)
+		assert.False(t, cached)
+	})
+
+	t.Run("cached disabled reloads from database", func(t *testing.T) {
+		require.NoError(t, database.TruncateTables())
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+
+		org, err := models.CreateOrganization("auth-expfeat-cache-disabled", "")
+		require.NoError(t, err)
+
+		require.NoError(t, models.EnableExperimentalFeature(org.ID, "exp-feature"))
+		SetOrgExperimentalFeatureCache(org.ID, "exp-feature", false)
+
+		enabled, err := orgHasExperimentalFeature(org.ID, "exp-feature")
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("database result is cached after load", func(t *testing.T) {
+		require.NoError(t, database.TruncateTables())
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+
+		org, err := models.CreateOrganization("auth-expfeat-cache-store", "")
+		require.NoError(t, err)
+		require.NoError(t, models.EnableExperimentalFeature(org.ID, "exp-feature"))
+
+		enabled, err := orgHasExperimentalFeature(org.ID, "exp-feature")
+		require.NoError(t, err)
+		assert.True(t, enabled)
+
+		cached, ok := cachedOrgExperimentalFeatureEnabled(org.ID, "exp-feature")
+		require.True(t, ok)
+		assert.True(t, cached)
+	})
+}
+
+func TestCheckRequiredExperimentalFeatures(t *testing.T) {
+	t.Run("released feature passes without organization lookup", func(t *testing.T) {
+		err := checkRequiredExperimentalFeatures(context.Background(), uuid.NewString(), AuthorizationRule{
+			RequiredExperimentalFeatures: []string{features.FeatureClaudeManagedAgents},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("unreleased feature denied when not enabled", func(t *testing.T) {
+		const unreleasedFeature = "test_unreleased_feature"
+		t.Cleanup(features.WithRegistryForTest([]features.Feature{{ID: unreleasedFeature, Label: unreleasedFeature}}))
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+		require.NoError(t, database.TruncateTables())
+
+		org, err := models.CreateOrganization("auth-expfeat-deny", "")
+		require.NoError(t, err)
+
+		err = checkRequiredExperimentalFeatures(context.Background(), org.ID.String(), AuthorizationRule{
+			RequiredExperimentalFeatures: []string{unreleasedFeature},
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	})
+
+	t.Run("unreleased feature allowed when enabled", func(t *testing.T) {
+		const unreleasedFeature = "test_unreleased_feature"
+		t.Cleanup(features.WithRegistryForTest([]features.Feature{{ID: unreleasedFeature, Label: unreleasedFeature}}))
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+		require.NoError(t, database.TruncateTables())
+
+		org, err := models.CreateOrganization("auth-expfeat-allow", "")
+		require.NoError(t, err)
+		require.NoError(t, models.EnableExperimentalFeature(org.ID, unreleasedFeature))
+
+		err = checkRequiredExperimentalFeatures(context.Background(), org.ID.String(), AuthorizationRule{
+			RequiredExperimentalFeatures: []string{unreleasedFeature},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("cache update after disable forces database reload", func(t *testing.T) {
+		const unreleasedFeature = "test_unreleased_feature"
+		t.Cleanup(features.WithRegistryForTest([]features.Feature{{ID: unreleasedFeature, Label: unreleasedFeature}}))
+		t.Cleanup(clearOrgExperimentalFeatureCacheForTest)
+		require.NoError(t, database.TruncateTables())
+
+		org, err := models.CreateOrganization("auth-expfeat-disable-cache", "")
+		require.NoError(t, err)
+		require.NoError(t, models.EnableExperimentalFeature(org.ID, unreleasedFeature))
+		SetOrgExperimentalFeatureCache(org.ID, unreleasedFeature, true)
+
+		require.NoError(t, models.DisableExperimentalFeature(org.ID, unreleasedFeature))
+		SetOrgExperimentalFeatureCache(org.ID, unreleasedFeature, false)
+
+		err = checkRequiredExperimentalFeatures(context.Background(), org.ID.String(), AuthorizationRule{
+			RequiredExperimentalFeatures: []string{unreleasedFeature},
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	})
+}

--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/features"
 	"github.com/superplanehq/superplane/pkg/jwt"
 	"github.com/superplanehq/superplane/pkg/models"
@@ -459,20 +458,10 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 		userID := userMeta[0]
 		organizationID := orgMeta[0]
 
-		var org *models.Organization
-		err := telemetry.RunSpan(ctx, "auth.load_organization", func(ctx context.Context) error {
-			var loadErr error
-			org, loadErr = models.FindOrganizationByIDInTransaction(database.DB(ctx), organizationID)
-			return loadErr
-		})
-		if err != nil {
-			return nil, status.Error(codes.NotFound, "organization not found")
-		}
-
 		var allowed bool
-		err = telemetry.RunSpan(ctx, "auth.check_permission", func(ctx context.Context) error {
+		err := telemetry.RunSpan(ctx, "auth.check_permission", func(ctx context.Context) error {
 			var checkErr error
-			allowed, checkErr = a.authService.CheckOrganizationPermission(ctx, userID, org.ID.String(), rule.Resource, rule.Action)
+			allowed, checkErr = a.authService.CheckOrganizationPermission(ctx, userID, organizationID, rule.Resource, rule.Action)
 			return checkErr
 		})
 		if err != nil {
@@ -480,7 +469,7 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 		}
 
 		if !allowed {
-			log.Warnf("User %s tried to %s %s in organization %s", userID, rule.Action, rule.Resource, org.ID.String())
+			log.Warnf("User %s tried to %s %s in organization %s", userID, rule.Action, rule.Resource, organizationID)
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 
@@ -498,13 +487,13 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 			return nil, status.Error(codes.NotFound, "Not found")
 		}
 
-		if err := checkRequiredExperimentalFeatures(org, rule); err != nil {
+		if err := checkRequiredExperimentalFeatures(ctx, organizationID, rule); err != nil {
 			log.Warnf(
 				"User %s tried to access %s:%s in organization %s without required experimental feature",
 				userID,
 				rule.Resource,
 				rule.Action,
-				org.ID.String(),
+				organizationID,
 			)
 			return nil, err
 		}
@@ -514,15 +503,6 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 		newContext = context.WithValue(newContext, DomainIdContextKey, organizationID)
 		return handler(newContext, req)
 	}
-}
-
-func checkRequiredExperimentalFeatures(org *models.Organization, rule AuthorizationRule) error {
-	for _, featureID := range rule.RequiredExperimentalFeatures {
-		if !org.HasExperimentalFeature(featureID) {
-			return status.Error(codes.PermissionDenied, "required experimental feature is not enabled")
-		}
-	}
-	return nil
 }
 
 func hasRequiredScopedTokenPermission(ctx context.Context, req any, rule AuthorizationRule) bool {

--- a/pkg/authorization/interceptor_test.go
+++ b/pkg/authorization/interceptor_test.go
@@ -11,10 +11,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/models"
 	pbAgents "github.com/superplanehq/superplane/pkg/protos/agents"
 	pbCanvases "github.com/superplanehq/superplane/pkg/protos/canvases"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
-	"gorm.io/datatypes"
 )
 
 func TestDefaultResourceResolver(t *testing.T) {
@@ -246,24 +243,6 @@ func TestAgentRoutesRequireManagedAgentsFeature(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, []string{features.FeatureClaudeManagedAgents}, rule.RequiredExperimentalFeatures)
 	}
-}
-
-func TestCheckRequiredExperimentalFeatures(t *testing.T) {
-	const unreleasedFeature = "test_unreleased_feature"
-	t.Cleanup(features.WithRegistryForTest([]features.Feature{{ID: unreleasedFeature, Label: unreleasedFeature}}))
-
-	rule := AuthorizationRule{
-		RequiredExperimentalFeatures: []string{unreleasedFeature},
-	}
-
-	err := checkRequiredExperimentalFeatures(&models.Organization{}, rule)
-	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
-
-	err = checkRequiredExperimentalFeatures(&models.Organization{
-		EnabledExperimentalFeatures: datatypes.JSONSlice[string]{unreleasedFeature},
-	}, rule)
-	require.NoError(t, err)
 }
 
 func marshalScopes(t *testing.T, scopes []string) string {


### PR DESCRIPTION
## Summary
- Remove the unconditional `auth.load_organization` DB query from the gRPC authorization interceptor; permission checks use `x-organization-id` from metadata directly.
- Add `experimental_features.go` to centralize experimental feature gating with a 15-minute TTL cache (trust cached enabled; reload from DB on miss or cached disabled).
- Move experimental feature tests into a dedicated authorization test file.

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/authorization/...`
- [ ] Verify auth spans in production traces no longer include `auth.load_organization` on canvas/org endpoints
- [ ] Confirm agent routes still enforce experimental features when unreleased


Made with [Cursor](https://cursor.com)