### PR TITLE
fix: cache allowed organization permission checks in auth interceptor

### DIFF
--- a/pkg/authorization/interceptor.go
+++ b/pkg/authorization/interceptor.go
@@ -461,7 +461,7 @@ func (a *AuthorizationInterceptor) UnaryInterceptor() grpc.UnaryServerIntercepto
 		var allowed bool
 		err := telemetry.RunSpan(ctx, "auth.check_permission", func(ctx context.Context) error {
 			var checkErr error
-			allowed, checkErr = a.authService.CheckOrganizationPermission(ctx, userID, organizationID, rule.Resource, rule.Action)
+			allowed, checkErr = checkOrganizationPermission(ctx, a.authService, userID, organizationID, rule.Resource, rule.Action)
 			return checkErr
 		})
 		if err != nil {

--- a/pkg/authorization/organization_permissions.go
+++ b/pkg/authorization/organization_permissions.go
@@ -1,0 +1,76 @@
+package authorization
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const organizationPermissionCacheTTL = 15 * time.Minute
+
+var (
+	organizationPermissionCache    sync.Map
+	organizationPermissionCacheNow = time.Now
+)
+
+type organizationPermissionCacheEntry struct {
+	allowed   bool
+	expiresAt time.Time
+}
+
+func organizationPermissionCacheKey(userID, orgID, resource, action string) string {
+	return userID + "/" + orgID + "/" + resource + "/" + action
+}
+
+func cachedOrganizationPermissionAllowed(userID, orgID, resource, action string) (allowed bool, ok bool) {
+	key := organizationPermissionCacheKey(userID, orgID, resource, action)
+	value, loaded := organizationPermissionCache.Load(key)
+	if !loaded {
+		return false, false
+	}
+
+	entry, ok := value.(organizationPermissionCacheEntry)
+	if !ok {
+		organizationPermissionCache.Delete(key)
+		return false, false
+	}
+
+	if organizationPermissionCacheNow().After(entry.expiresAt) {
+		organizationPermissionCache.Delete(key)
+		return false, false
+	}
+
+	return entry.allowed, true
+}
+
+func setOrganizationPermissionCache(userID, orgID, resource, action string, allowed bool) {
+	organizationPermissionCache.Store(organizationPermissionCacheKey(userID, orgID, resource, action), organizationPermissionCacheEntry{
+		allowed:   allowed,
+		expiresAt: organizationPermissionCacheNow().Add(organizationPermissionCacheTTL),
+	})
+}
+
+func clearOrganizationPermissionCacheForTest() {
+	organizationPermissionCache.Range(func(key, _ any) bool {
+		organizationPermissionCache.Delete(key)
+		return true
+	})
+}
+
+type organizationPermissionChecker interface {
+	CheckOrganizationPermission(ctx context.Context, userID, orgID, resource, action string) (bool, error)
+}
+
+func checkOrganizationPermission(ctx context.Context, auth organizationPermissionChecker, userID, orgID, resource, action string) (bool, error) {
+	if allowed, ok := cachedOrganizationPermissionAllowed(userID, orgID, resource, action); ok && allowed {
+		return true, nil
+	}
+
+	allowed, err := auth.CheckOrganizationPermission(ctx, userID, orgID, resource, action)
+	if err != nil {
+		return false, err
+	}
+
+	setOrganizationPermissionCache(userID, orgID, resource, action, allowed)
+	return allowed, nil
+}

--- a/pkg/authorization/organization_permissions_test.go
+++ b/pkg/authorization/organization_permissions_test.go
@@ -1,0 +1,86 @@
+package authorization
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOrganizationPermission(t *testing.T) {
+	t.Run("cached allowed short-circuits without loading policies", func(t *testing.T) {
+		t.Cleanup(clearOrganizationPermissionCacheForTest)
+
+		userID := "user-123"
+		orgID := "org-456"
+		setOrganizationPermissionCache(userID, orgID, "canvases", "read", true)
+
+		allowed, err := checkOrganizationPermission(context.Background(), denyingPermissionChecker{}, userID, orgID, "canvases", "read")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("cached allowed expires after ttl", func(t *testing.T) {
+		t.Cleanup(clearOrganizationPermissionCacheForTest)
+		originalNow := organizationPermissionCacheNow
+		t.Cleanup(func() { organizationPermissionCacheNow = originalNow })
+
+		start := time.Now()
+		organizationPermissionCacheNow = func() time.Time { return start }
+
+		userID := "user-123"
+		orgID := "org-456"
+		setOrganizationPermissionCache(userID, orgID, "canvases", "read", true)
+
+		cached, ok := cachedOrganizationPermissionAllowed(userID, orgID, "canvases", "read")
+		require.True(t, ok)
+		assert.True(t, cached)
+
+		organizationPermissionCacheNow = func() time.Time { return start.Add(organizationPermissionCacheTTL + time.Minute) }
+
+		cached, ok = cachedOrganizationPermissionAllowed(userID, orgID, "canvases", "read")
+		assert.False(t, ok)
+		assert.False(t, cached)
+	})
+
+	t.Run("cached denied reloads from authorization service", func(t *testing.T) {
+		t.Cleanup(clearOrganizationPermissionCacheForTest)
+
+		userID := "user-123"
+		orgID := "org-456"
+		setOrganizationPermissionCache(userID, orgID, "canvases", "read", false)
+
+		allowed, err := checkOrganizationPermission(context.Background(), allowingPermissionChecker{}, userID, orgID, "canvases", "read")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("authorization service result is cached after load", func(t *testing.T) {
+		t.Cleanup(clearOrganizationPermissionCacheForTest)
+
+		userID := "user-123"
+		orgID := "org-456"
+
+		allowed, err := checkOrganizationPermission(context.Background(), allowingPermissionChecker{}, userID, orgID, "canvases", "read")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+
+		cached, ok := cachedOrganizationPermissionAllowed(userID, orgID, "canvases", "read")
+		require.True(t, ok)
+		assert.True(t, cached)
+	})
+}
+
+type denyingPermissionChecker struct{}
+
+func (denyingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+type allowingPermissionChecker struct{}
+
+func (allowingPermissionChecker) CheckOrganizationPermission(_ context.Context, _, _, _, _ string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
## Summary
- Add `organization_permissions.go` with the same cache semantics as experimental features: trust cached **allowed** for 15 minutes; reload from Casbin on miss or cached denied.
- Wire the gRPC authorization interceptor through `checkOrganizationPermission` instead of calling `CheckOrganizationPermission` directly.
- Keep `AuthService.CheckOrganizationPermission` uncached so role-management tests and other callers still hit Casbin immediately.

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/authorization/...`
- [ ] Confirm `auth.check_permission` Casbin SQL spans drop on repeated canvas/org requests for the same user


Made with [Cursor](https://cursor.com)