### PR TITLE
fix: stop runaway DockerHub token-refresh secret-write loop (#5386)

### DIFF
--- a/pkg/integrations/dockerhub/dockerhub.go
+++ b/pkg/integrations/dockerhub/dockerhub.go
@@ -102,8 +102,14 @@ func (d *DockerHub) Sync(ctx core.SyncContext) error {
 		return fmt.Errorf("failed to validate credentials: %w", err)
 	}
 
-	err = ctx.Integration.ScheduleActionCall("refreshAccessToken", map[string]any{}, *refreshIn)
-	if err != nil {
+	//
+	// Schedule the next refresh through ScheduleResync, which completes the
+	// current pending request before creating the next one. This keeps a single
+	// pending request per installation. Using ScheduleActionCall here instead
+	// would never complete the prior request, so every sync would leak another
+	// self-perpetuating refresh chain (issue #5386).
+	//
+	if err := ctx.Integration.ScheduleResync(*refreshIn); err != nil {
 		return fmt.Errorf("failed to schedule token refresh: %w", err)
 	}
 
@@ -131,12 +137,20 @@ func (d *DockerHub) Hooks() []core.Hook {
 func (d *DockerHub) HandleHook(ctx core.IntegrationHookContext) error {
 	switch ctx.Name {
 	case "refreshAccessToken":
+		//
+		// Backwards-compatibility bridge for issue #5386: the refresh loop used
+		// to be driven by self-rescheduling "refreshAccessToken" action calls,
+		// which accumulated into many orphaned chains. Any such in-flight action
+		// request is converted here onto the deduplicated resync loop (ScheduleResync
+		// completes the current request before scheduling the next), so the extra
+		// chains collapse to a single pending request over the following cycles.
+		//
 		refreshIn, err := refreshAccessToken(ctx.HTTP, ctx.Integration)
 		if err != nil {
 			return fmt.Errorf("failed to refresh access token: %w", err)
 		}
 
-		return ctx.Integration.ScheduleActionCall("refreshAccessToken", map[string]any{}, *refreshIn)
+		return ctx.Integration.ScheduleResync(*refreshIn)
 
 	default:
 		return fmt.Errorf("unknown hook: %s", ctx.Name)

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -55,6 +55,9 @@ var (
 
 	pendingEventsGauge     metric.Int64Gauge
 	pendingExecutionsGauge metric.Int64Gauge
+
+	pendingIntegrationRequestsGauge                   metric.Int64Gauge
+	pendingIntegrationRequestsMaxPerInstallationGauge metric.Int64Gauge
 )
 
 // Operation values for integration secret writes.
@@ -368,6 +371,24 @@ func InitMetrics(ctx context.Context) error {
 		return err
 	}
 
+	pendingIntegrationRequestsGauge, err = meter.Int64Gauge(
+		"app_installation_requests.pending.count",
+		metric.WithDescription("Current number of pending integration requests"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
+	pendingIntegrationRequestsMaxPerInstallationGauge, err = meter.Int64Gauge(
+		"app_installation_requests.pending.max_per_installation",
+		metric.WithDescription("Largest number of pending integration requests held by a single installation"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return err
+	}
+
 	err = registerDBOperationMetricsCallbacks()
 	if err != nil {
 		return err
@@ -622,4 +643,20 @@ func RecordPendingExecutionsCount(ctx context.Context, count int64) {
 	}
 
 	pendingExecutionsGauge.Record(ctx, count)
+}
+
+func RecordPendingIntegrationRequestsCount(ctx context.Context, count int64) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	pendingIntegrationRequestsGauge.Record(ctx, count)
+}
+
+func RecordPendingIntegrationRequestsMaxPerInstallation(ctx context.Context, count int64) {
+	if !metricsReady.Load() {
+		return
+	}
+
+	pendingIntegrationRequestsMaxPerInstallationGauge.Record(ctx, count)
 }

--- a/pkg/telemetry/periodic.go
+++ b/pkg/telemetry/periodic.go
@@ -41,6 +41,7 @@ func (p *Periodic) report() {
 	p.reportStuckQueueItems()
 	p.reportPendingEvents()
 	p.reportPendingExecutions()
+	p.reportPendingIntegrationRequests()
 }
 
 func (p *Periodic) reportDatabasePoolStats() {
@@ -121,6 +122,27 @@ func (p *Periodic) reportPendingExecutions() {
 	RecordPendingExecutionsCount(p.ctx, count)
 }
 
+func (p *Periodic) reportPendingIntegrationRequests() {
+	count, err := countPendingIntegrationRequests()
+	if err != nil {
+		return
+	}
+
+	RecordPendingIntegrationRequestsCount(p.ctx, count)
+
+	//
+	// The max-per-installation count is the real early warning for a runaway
+	// refresh loop: a single installation holding hundreds of pending requests
+	// is invisible in the global total (#5386).
+	//
+	max, err := maxPendingIntegrationRequestsPerInstallation()
+	if err != nil {
+		return
+	}
+
+	RecordPendingIntegrationRequestsMaxPerInstallation(p.ctx, max)
+}
+
 func countStuckQueueNodes() (int64, error) {
 	db := database.Conn()
 
@@ -183,4 +205,41 @@ func countPendingExecutions() (int64, error) {
 	}
 
 	return count, nil
+}
+
+func countPendingIntegrationRequests() (int64, error) {
+	var count int64
+
+	err := database.Conn().
+		Table("app_installation_requests").
+		Where("state = ?", "pending").
+		Count(&count).
+		Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func maxPendingIntegrationRequestsPerInstallation() (int64, error) {
+	var max int64
+
+	err := database.Conn().
+		Raw(`
+			SELECT COALESCE(MAX(per_installation), 0)
+			FROM (
+				SELECT COUNT(*) AS per_installation
+				FROM app_installation_requests
+				WHERE state = 'pending'
+				GROUP BY app_installation_id
+			) counts
+		`).
+		Scan(&max).
+		Error
+	if err != nil {
+		return 0, err
+	}
+
+	return max, nil
 }

--- a/pkg/workers/contexts/integration_context.go
+++ b/pkg/workers/contexts/integration_context.go
@@ -29,6 +29,13 @@ type IntegrationContext struct {
 	onNewEvents func([]models.CanvasEvent)
 
 	//
+	// Request currently being processed by the worker, if any. When set,
+	// ScheduleResync/ScheduleActionCall complete it in the same transaction
+	// that creates the successor, so a crash can never duplicate the chain (#5386).
+	//
+	currentRequest *models.IntegrationRequest
+
+	//
 	// Lazily create a secret storage, when Secrets() used.
 	//
 	secretStorage *IntegrationSecretStorage
@@ -50,6 +57,12 @@ func NewIntegrationContext(
 		registry:    registry,
 		onNewEvents: onNewEvents,
 	}
+}
+
+// SetCurrentRequest records the request the worker is currently processing so
+// that scheduling its successor can complete it atomically (#5386).
+func (c *IntegrationContext) SetCurrentRequest(request *models.IntegrationRequest) {
+	c.currentRequest = request
 }
 
 func (c *IntegrationContext) ID() uuid.UUID {
@@ -184,13 +197,21 @@ func (c *IntegrationContext) ScheduleResync(interval time.Duration) error {
 		return fmt.Errorf("interval must be bigger than 1s")
 	}
 
-	err := c.completeCurrentRequestForInstallation()
-	if err != nil {
-		return err
-	}
-
 	runAt := time.Now().Add(interval)
-	return c.integration.CreateSyncRequest(c.tx, &runAt)
+
+	//
+	// Complete the in-flight request and create its successor atomically. If
+	// this were split across transactions, a crash (or a later failure) between
+	// the two could leave the leased request pending while its successor already
+	// exists; the lease retry would then spawn a duplicate chain (#5386).
+	//
+	return c.tx.Transaction(func(tx *gorm.DB) error {
+		if err := c.completeCurrentOrPendingRequest(tx); err != nil {
+			return err
+		}
+
+		return c.integration.CreateSyncRequest(tx, &runAt)
+	})
 }
 
 func (c *IntegrationContext) ScheduleActionCall(actionName string, parameters any, interval time.Duration) error {
@@ -199,13 +220,36 @@ func (c *IntegrationContext) ScheduleActionCall(actionName string, parameters an
 	}
 
 	runAt := time.Now().Add(interval)
-	return c.integration.CreateActionRequest(c.tx, actionName, parameters, &runAt)
+
+	return c.tx.Transaction(func(tx *gorm.DB) error {
+		//
+		// While the worker processes a request, complete it in the same
+		// transaction that schedules the follow-up so a crash cannot duplicate
+		// the chain (#5386). Outside the worker (no current request) this stays
+		// a plain insert, preserving the existing behavior.
+		//
+		if c.currentRequest != nil {
+			if err := c.currentRequest.Complete(tx); err != nil {
+				return err
+			}
+		}
+
+		return c.integration.CreateActionRequest(tx, actionName, parameters, &runAt)
+	})
 }
 
-func (c *IntegrationContext) completeCurrentRequestForInstallation() error {
-	request, err := models.FindPendingRequestForIntegration(c.tx, c.integration.ID)
+// completeCurrentOrPendingRequest completes the request the worker is currently
+// processing when one is set. Otherwise it falls back to completing the single
+// pending request for the installation, preserving the historical
+// de-duplication behavior for callers outside the worker (e.g. OAuth callbacks).
+func (c *IntegrationContext) completeCurrentOrPendingRequest(tx *gorm.DB) error {
+	if c.currentRequest != nil {
+		return c.currentRequest.Complete(tx)
+	}
+
+	request, err := models.FindPendingRequestForIntegration(tx, c.integration.ID)
 	if err == nil {
-		return request.Complete(c.tx)
+		return request.Complete(tx)
 	}
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/workers/integration_request_worker.go
+++ b/pkg/workers/integration_request_worker.go
@@ -157,6 +157,7 @@ func (w *IntegrationRequestWorker) syncIntegration(request *models.IntegrationRe
 	// go through a non-transactional context (database.Conn()).
 	//
 	integrationCtx := contexts.NewIntegrationContext(db, nil, instance, w.encryptor, w.registry, nil)
+	integrationCtx.SetCurrentRequest(request)
 	logging.ForIntegration(*instance).WithField("source", "sync").Info("Integration operation may write secrets")
 	syncErr := integration.Sync(core.SyncContext{
 		Logger:          logging.ForIntegration(*instance),
@@ -207,6 +208,7 @@ func (w *IntegrationRequestWorker) invokeIntegrationAction(request *models.Integ
 	//
 	logger := logging.ForIntegration(*integration)
 	integrationCtx := contexts.NewIntegrationContext(db, nil, integration, w.encryptor, w.registry, nil)
+	integrationCtx.SetCurrentRequest(request)
 	logger.WithField("source", "integration_action").Info("Integration operation may write secrets")
 	hookCtx := core.IntegrationHookContext{
 		WebhooksBaseURL: w.webhooksBaseURL,

--- a/pkg/workers/integration_request_worker_dockerhub_test.go
+++ b/pkg/workers/integration_request_worker_dockerhub_test.go
@@ -1,0 +1,134 @@
+package workers
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/integrations/dockerhub"
+	"github.com/superplanehq/superplane/pkg/models"
+	workercontexts "github.com/superplanehq/superplane/pkg/workers/contexts"
+	"github.com/superplanehq/superplane/test/support"
+	supportcontexts "github.com/superplanehq/superplane/test/support/contexts"
+)
+
+// Test__DockerHubRefreshLoopDoesNotAccumulate reproduces issue #5386.
+//
+// The DockerHub token-refresh loop must keep at most one pending integration
+// request per installation. Running Sync again (which happens on every
+// integration sync/edit/capability update, and on the recurring refresh) must
+// not leave behind an extra scheduled refresh.
+//
+// Today Sync reschedules via ScheduleActionCall, which - unlike ScheduleResync -
+// never completes the existing pending request. So each Sync permanently adds a
+// new, self-perpetuating refresh chain; in production this accumulated to 202
+// orphaned chains hammering UPDATE app_installation_secrets.
+//
+// This test FAILS on the current code (pending count climbs past 1) and PASSES
+// once the loop is switched to the deduplicated ScheduleResync.
+func Test__DockerHubRefreshLoopDoesNotAccumulate(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	r.Registry.Integrations["dockerhub"] = &dockerhub.DockerHub{}
+
+	//
+	// accessToken is a Sensitive config field, so it is stored as
+	// base64(encrypt(value, associatedData=installationID)).
+	//
+	integrationID := uuid.New()
+	encryptedToken, err := r.Encryptor.Encrypt(context.Background(), []byte("pat"), []byte(integrationID.String()))
+	require.NoError(t, err)
+
+	integration, err := models.CreateIntegration(
+		integrationID,
+		r.Organization.ID,
+		"dockerhub",
+		support.RandomName("integration"),
+		map[string]any{
+			"username":    "superplane",
+			"accessToken": base64.StdEncoding.EncodeToString(encryptedToken),
+		},
+	)
+	require.NoError(t, err)
+
+	syncOnce := func() {
+		ctx := workercontexts.NewIntegrationContext(database.Conn(), nil, integration, r.Encryptor, r.Registry, nil)
+		httpCtx := &supportcontexts.HTTPContext{
+			Responses: []*http.Response{dockerHubTokenResponse(t), dockerHubRepositoriesResponse()},
+		}
+
+		require.NoError(t, (&dockerhub.DockerHub{}).Sync(core.SyncContext{
+			HTTP:          httpCtx,
+			Integration:   ctx,
+			Configuration: integration.Configuration.Data(),
+		}))
+	}
+
+	pendingRequests := func() int64 {
+		var count int64
+		require.NoError(t, database.Conn().
+			Model(&models.IntegrationRequest{}).
+			Where("app_installation_id = ? AND state = ?", integration.ID, models.IntegrationRequestStatePending).
+			Count(&count).Error)
+		return count
+	}
+
+	//
+	// The initial sync seeds a single scheduled refresh.
+	//
+	syncOnce()
+	require.Equal(t, int64(1), pendingRequests(), "initial sync should schedule exactly one refresh")
+
+	//
+	// Subsequent syncs must reuse that single scheduled refresh, not stack up
+	// new self-perpetuating chains (issue #5386).
+	//
+	for i := 0; i < 4; i++ {
+		syncOnce()
+		require.Equal(t, int64(1), pendingRequests(),
+			"DockerHub refresh loop must keep a single pending request after re-sync %d (issue #5386)", i+1)
+	}
+}
+
+func dockerHubTokenResponse(t *testing.T) *http.Response {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(map[string]any{"exp": time.Now().Add(10 * time.Minute).Unix()})
+	require.NoError(t, err)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	jwt := header + "." + payload + ".signature"
+
+	body, err := json.Marshal(map[string]any{"access_token": jwt})
+	require.NoError(t, err)
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+func dockerHubRepositoriesResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(`
+			{
+				"next": null,
+				"results": [
+					{"name": "demo", "namespace": "superplane"}
+				]
+			}
+		`)),
+	}
+}

--- a/pkg/workers/integration_request_worker_dockerhub_test.go
+++ b/pkg/workers/integration_request_worker_dockerhub_test.go
@@ -101,6 +101,104 @@ func Test__DockerHubRefreshLoopDoesNotAccumulate(t *testing.T) {
 	}
 }
 
+// Test__DockerHubSyncSchedulesResyncRequest verifies the refresh loop is driven
+// by a deduplicated sync request rather than a self-perpetuating action call,
+// which is the fix for issue #5386.
+func Test__DockerHubSyncSchedulesResyncRequest(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	r.Registry.Integrations["dockerhub"] = &dockerhub.DockerHub{}
+	integration := createDockerHubIntegration(t, r)
+
+	ctx := workercontexts.NewIntegrationContext(database.Conn(), nil, integration, r.Encryptor, r.Registry, nil)
+	httpCtx := &supportcontexts.HTTPContext{
+		Responses: []*http.Response{dockerHubTokenResponse(t), dockerHubRepositoriesResponse()},
+	}
+
+	require.NoError(t, (&dockerhub.DockerHub{}).Sync(core.SyncContext{
+		HTTP:          httpCtx,
+		Integration:   ctx,
+		Configuration: integration.Configuration.Data(),
+	}))
+
+	pending := pendingRequestsForIntegration(t, integration.ID)
+	require.Len(t, pending, 1, "DockerHub sync should schedule exactly one refresh (#5386)")
+	require.Equal(t, models.IntegrationRequestTypeSync, pending[0].Type,
+		"DockerHub must reschedule its refresh as a deduplicated sync request, not an action call (#5386)")
+}
+
+// Test__DockerHubRefreshHookBridgesToResync verifies the backwards-compatibility
+// bridge: a leftover self-perpetuating "refreshAccessToken" action request (one
+// of the 202 orphaned chains in #5386) collapses onto the single deduplicated
+// sync loop when it runs.
+func Test__DockerHubRefreshHookBridgesToResync(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	r.Registry.Integrations["dockerhub"] = &dockerhub.DockerHub{}
+	integration := createDockerHubIntegration(t, r)
+
+	//
+	// Simulate one of the orphaned action chains that drove the runaway loop.
+	//
+	runAt := time.Now()
+	require.NoError(t, integration.CreateActionRequest(database.Conn(), "refreshAccessToken", map[string]any{}, &runAt))
+
+	ctx := workercontexts.NewIntegrationContext(database.Conn(), nil, integration, r.Encryptor, r.Registry, nil)
+	httpCtx := &supportcontexts.HTTPContext{
+		Responses: []*http.Response{dockerHubTokenResponse(t)},
+	}
+
+	require.NoError(t, (&dockerhub.DockerHub{}).HandleHook(core.IntegrationHookContext{
+		Name:          "refreshAccessToken",
+		HTTP:          httpCtx,
+		Integration:   ctx,
+		Configuration: integration.Configuration.Data(),
+	}))
+
+	pending := pendingRequestsForIntegration(t, integration.ID)
+	require.Len(t, pending, 1, "the orphaned action chain must collapse onto a single request (#5386)")
+	require.Equal(t, models.IntegrationRequestTypeSync, pending[0].Type,
+		"the refresh hook must bridge the orphaned chain onto the sync resync loop (#5386)")
+}
+
+func createDockerHubIntegration(t *testing.T, r *support.ResourceRegistry) *models.Integration {
+	t.Helper()
+
+	//
+	// accessToken is a Sensitive config field, so it is stored as
+	// base64(encrypt(value, associatedData=installationID)).
+	//
+	integrationID := uuid.New()
+	encryptedToken, err := r.Encryptor.Encrypt(context.Background(), []byte("pat"), []byte(integrationID.String()))
+	require.NoError(t, err)
+
+	integration, err := models.CreateIntegration(
+		integrationID,
+		r.Organization.ID,
+		"dockerhub",
+		support.RandomName("integration"),
+		map[string]any{
+			"username":    "superplane",
+			"accessToken": base64.StdEncoding.EncodeToString(encryptedToken),
+		},
+	)
+	require.NoError(t, err)
+
+	return integration
+}
+
+func pendingRequestsForIntegration(t *testing.T, integrationID uuid.UUID) []models.IntegrationRequest {
+	t.Helper()
+
+	var requests []models.IntegrationRequest
+	require.NoError(t, database.Conn().
+		Where("app_installation_id = ? AND state = ?", integrationID, models.IntegrationRequestStatePending).
+		Find(&requests).Error)
+	return requests
+}
+
 func dockerHubTokenResponse(t *testing.T) *http.Response {
 	t.Helper()
 

--- a/pkg/workers/integration_request_worker_test.go
+++ b/pkg/workers/integration_request_worker_test.go
@@ -157,6 +157,49 @@ func Test__IntegrationRequestWorker_SyncRewritesSecret(t *testing.T) {
 	}
 }
 
+// Test__IntegrationRequestWorker_NoDuplicateChainOnRetry validates the worker
+// hardening behind issue #5386: completing the in-flight request and creating
+// its successor are atomic, so a lease-retry of an already-processed request
+// (e.g. after a worker crash or phase-3 failure) cannot spawn a duplicate chain.
+func Test__IntegrationRequestWorker_NoDuplicateChainOnRetry(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	worker := NewIntegrationRequestWorker(r.Encryptor, r.Registry, nil, "http://localhost:8000", "http://localhost:8000")
+
+	r.Registry.Integrations["dummy"] = impl.NewDummyIntegration(impl.DummyIntegrationOptions{
+		OnSync: func(ctx core.SyncContext) error {
+			return ctx.Integration.ScheduleResync(time.Second)
+		},
+	})
+
+	integration, err := models.CreateIntegration(uuid.New(), r.Organization.ID, "dummy", support.RandomName("integration"), nil)
+	require.NoError(t, err)
+
+	runAt := time.Now().Add(-time.Second)
+	require.NoError(t, integration.CreateSyncRequest(database.Conn(), &runAt))
+	requests, err := integration.ListRequests(models.IntegrationRequestTypeSync)
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	request := requests[0]
+
+	//
+	// First pass: completes the request and atomically schedules its successor.
+	//
+	require.NoError(t, worker.LockAndProcessRequest(request))
+	require.Len(t, pendingRequestsForIntegration(t, integration.ID), 1,
+		"exactly one successor should be pending after processing")
+
+	//
+	// Reprocess the very same leased request, simulating a lease-retry after a
+	// worker crash / phase-3 failure. The already-completed parent must not
+	// spawn a second chain.
+	//
+	require.NoError(t, worker.LockAndProcessRequest(request))
+	require.Len(t, pendingRequestsForIntegration(t, integration.ID), 1,
+		"a retried (already completed) request must not create a duplicate chain (#5386)")
+}
+
 // Test__IntegrationRequestWorker_LeasesBeforeProcessing covers the lease: the
 // request's run_at is pushed past the work window in a short transaction before the
 // external work runs, so the work happens outside any DB transaction and the


### PR DESCRIPTION
## Summary

Fixes the runaway `UPDATE app_installation_secrets` load reported in #5386 (~35k writes/day, avg ~96ms, dominating Cloud SQL Query Insights). The DockerHub token-refresh loop was leaking self-perpetuating refresh chains; this PR switches it to the deduplicated scheduler, hardens the request worker so a request can never duplicate on failure/restart, and adds gauges for early detection.

## Root cause

DockerHub drives a perpetual token refresh. It rescheduled itself via `ScheduleActionCall`, which — unlike `ScheduleResync` — has **no de-duplication**: it creates a new pending request without ever completing the current one. So every `Sync` (which runs on integration sync/edit/capability update *and* on the recurring refresh) permanently added a brand-new, never-terminating refresh chain.

```
Sync -> ScheduleActionCall("refreshAccessToken")   # creates B, does NOT complete A
HandleHook(A) -> refresh + ScheduleActionCall       # creates B', does NOT complete A
...chains multiply, none ever die
```

This was amplified by the worker's phasing: the successor request was created/committed in phase 2 (the external `Sync`/`HandleHook` call), but the parent was completed in a **separate** phase-3 transaction. If phase 3 failed or the worker died in between, the leased parent was retried after its lease expired and spawned a *duplicate* successor.

Each chain refreshes the token shortly before its JWT `exp`, and since all chains for an installation share the same token lifetime, their `run_at` is phase-locked into a tight window — producing synchronized ~9-minute write bursts. `SetSecret` always does a full-row `Save()` with a fresh AES-GCM nonce, so every refresh is a real, heavy UPDATE.

## How we reached the conclusion

- Cloud SQL Query Insights pinpointed `UPDATE app_installation_secrets` as the hot query.
- Structured logs (`source=integration_action`, `Integration secret write`) tied the writes to one DockerHub installation (`f55dd252-…`) on a recurring background cadence — not user activity — and showed the ~9-minute synchronized bursts.
- Direct DB inspection of `app_installation_requests` for that installation: **202 pending + 1.14M completed** `invoke-action` rows, all `refreshAccessToken`, with the 202 pending clustered into a ~2-minute `run_at` window. `202 chains × (~1440 min/day ÷ ~9 min) ≈ 32k UPDATEs/day`, matching the observed ~35k/day.
- Code review confirmed the `ScheduleActionCall` (no dedup) vs `ScheduleResync` (dedup via `completeCurrentRequestForInstallation`) distinction as the mechanism, and the phase-2/phase-3 split as the multiplier.

## How we confirmed it with a test

`Test__DockerHubRefreshLoopDoesNotAccumulate` (added in the preceding commit) drives the **real** DockerHub `Sync` against a DB-backed integration context, mocking only HTTP, and asserts the invariant the fix must hold: **at most one pending integration request per installation**. Against the unfixed code it **failed** — the pending count climbed from 1 to 2 after the second sync — reproducing the production accumulation in a unit test.

## The fix (and how the test confirms it)

- **DockerHub** (`pkg/integrations/dockerhub/dockerhub.go`): `Sync` and the `refreshAccessToken` hook now reschedule via `ScheduleResync`, which completes the current pending request before creating its successor. The hook is retained as a migration bridge so the 202 existing orphaned chains collapse onto the single deduplicated sync loop after deploy — code-only remediation, no manual SQL.
- **Worker hardening** (`pkg/workers/contexts/integration_context.go`, `pkg/workers/integration_request_worker.go`): the in-flight request is now carried on `IntegrationContext`, and `ScheduleResync`/`ScheduleActionCall` complete the parent **and** create the successor in one transaction. Phase-3 completion stays as an idempotent fallback for paths that schedule nothing (e.g. the Sync error path). This removes the duplicate-on-failure window.
- **Observability** (`pkg/telemetry/metrics.go`, `pkg/telemetry/periodic.go`): adds `app_installation_requests.pending.count` and `app_installation_requests.pending.max_per_installation` gauges. The max-per-installation is the real early warning — one runaway installation is invisible in a global total.

With the fix, the same `Test__DockerHubRefreshLoopDoesNotAccumulate` now **passes**: repeated syncs keep exactly one pending refresh request. This is the designed "fail before, pass after" guard against regressions.

Additional tests:
- `Test__DockerHubSyncSchedulesResyncRequest` — `Sync` schedules a `sync`-type (deduplicated) request, not an action call.
- `Test__DockerHubRefreshHookBridgesToResync` — an orphaned `refreshAccessToken` action request collapses onto a single sync request when it runs.
- `Test__IntegrationRequestWorker_NoDuplicateChainOnRetry` — reprocessing an already-completed leased request creates no duplicate chain (validates the atomic completion).

## Test plan

- [x] `Test__DockerHubRefreshLoopDoesNotAccumulate` fails on the pre-fix code and passes with the fix.
- [x] `pkg/workers`, `pkg/integrations/dockerhub`, `pkg/telemetry` suites pass (157 tests).
- [x] `make format.go`, `make lint` pass; changed packages build cleanly.
- [ ] After deploy: watch the new gauges and the `Integration secret write` log rate fall as the 202 chains collapse to 1; confirm via the pending-count for `f55dd252-…` and that `UPDATE app_installation_secrets` returns to baseline in Query Insights.