### PR TITLE
feat: add beta badge with support hover panel in header

### DIFF
--- a/web_src/src/components/OrganizationMenuButton.tsx
+++ b/web_src/src/components/OrganizationMenuButton.tsx
@@ -11,6 +11,7 @@ import {
   Key,
   Lock,
   LogOut,
+  Mail,
   Menu,
   Plug,
   Settings,
@@ -23,6 +24,9 @@ import { Link } from "react-router-dom";
 import { PermissionTooltip } from "@/components/PermissionGate";
 import { usePermissions } from "@/contexts/usePermissions";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { IntegrationIcon } from "@/ui/componentSidebar/integrationIcons";
 import { posthog } from "@/posthog";
 
 interface OrganizationMenuButtonProps {
@@ -297,6 +301,44 @@ export function OrganizationMenuButton({ organizationId, className }: Organizati
           </TooltipTrigger>
           <TooltipContent>Homepage</TooltipContent>
         </Tooltip>
+        <HoverCard openDelay={100} closeDelay={150}>
+          <HoverCardTrigger asChild>
+            <Badge className="cursor-pointer border-transparent bg-blue-500 text-[10px] uppercase tracking-wide text-white hover:bg-blue-600">
+              Beta
+            </Badge>
+          </HoverCardTrigger>
+          <HoverCardContent align="start" className="w-72">
+            <p className="text-sm font-semibold text-gray-800">We're just getting started!</p>
+            <p className="mt-1 text-[13px] text-gray-500">SuperPlane is in beta. We'd love your feedback:</p>
+            <div className="mt-3 flex flex-col">
+              <a
+                href="https://github.com/superplanehq/superplane/issues/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-gray-500 hover:bg-sky-100 hover:text-gray-800"
+              >
+                <IntegrationIcon integrationName="github" />
+                <span>Log an issue</span>
+              </a>
+              <a
+                href="https://discord.superplane.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-gray-500 hover:bg-sky-100 hover:text-gray-800"
+              >
+                <IntegrationIcon integrationName="discord" />
+                <span>Chat on Discord</span>
+              </a>
+              <a
+                href="mailto:support@superplane.com"
+                className="group flex items-center gap-2 rounded-md px-1.5 py-1 text-sm font-medium text-gray-500 hover:bg-sky-100 hover:text-gray-800"
+              >
+                <Mail size={16} className="text-gray-500 transition group-hover:text-gray-800" />
+                <span>Send us an email</span>
+              </a>
+            </div>
+          </HoverCardContent>
+        </HoverCard>
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Summary
- Add a blue "Beta" badge to the right of the homepage logo in the header (`OrganizationMenuButton`, shared by the home shell and canvas header).
- On hover, the badge opens a panel titled "We're just getting started!" with the description "SuperPlane is in beta. We'd love your feedback:" and three support links:
  - Log an issue (GitHub) -> https://github.com/superplanehq/superplane/issues/new
  - Chat on Discord -> https://discord.superplane.com/
  - Send us an email -> mailto:support@superplane.com
- GitHub and Discord rows reuse existing integration logos via `IntegrationIcon`; email uses the lucide `Mail` icon.

## Test plan
- [x] Verify the Beta badge appears to the right of the logo on the home page and canvas header.
- [x] Hover the badge and confirm the panel shows the title, description, and three links.
- [x] Confirm each link opens the correct destination in a new tab (email opens mail client).
- [x] `make check.build.ui` passes.