### PR TITLE
fix: react to execution.finished messages in node queue worker

### DIFF
--- a/pkg/workers/node_queue_worker.go
+++ b/pkg/workers/node_queue_worker.go
@@ -32,17 +32,28 @@ type NodeQueueWorker struct {
 	semaphore   *semaphore.Weighted
 	logger      *log.Entry
 
-	rabbitMQURL string
-	consumer    *tackle.Consumer
+	rabbitMQURL               string
+	queueItemConsumer         *tackle.Consumer
+	executionFinishedConsumer *tackle.Consumer
 }
 
 func NewNodeQueueWorker(registry *registry.Registry, gitProvider gitprovider.Provider, rabbitMQURL string) *NodeQueueWorker {
+	logger := log.WithFields(log.Fields{"worker": "NodeQueueWorker"})
+
+	queueItemConsumer := tackle.NewConsumer()
+	queueItemConsumer.SetLogger(logging.NewTackleLogger(logger))
+
+	executionFinishedConsumer := tackle.NewConsumer()
+	executionFinishedConsumer.SetLogger(logging.NewTackleLogger(logger))
+
 	return &NodeQueueWorker{
-		registry:    registry,
-		gitProvider: gitProvider,
-		rabbitMQURL: rabbitMQURL,
-		semaphore:   semaphore.NewWeighted(25),
-		logger:      log.WithFields(log.Fields{"worker": "NodeQueueWorker"}),
+		registry:                  registry,
+		gitProvider:               gitProvider,
+		rabbitMQURL:               rabbitMQURL,
+		semaphore:                 semaphore.NewWeighted(25),
+		logger:                    logger,
+		queueItemConsumer:         queueItemConsumer,
+		executionFinishedConsumer: executionFinishedConsumer,
 	}
 }
 
@@ -51,19 +62,28 @@ func (w *NodeQueueWorker) Name() string {
 }
 
 func (w *NodeQueueWorker) Start(ctx context.Context) {
-	go w.StartRabbitMQConsumer(ctx)
+	go w.startConsumerLoop(
+		ctx,
+		w.queueItemConsumer,
+		messages.CanvasExchange+"."+messages.CanvasQueueItemCreatedRoutingKey+"."+w.Name(),
+		messages.CanvasExchange,
+		messages.CanvasQueueItemCreatedRoutingKey,
+		w.ConsumeQueueItemCreated,
+	)
+
+	go w.startConsumerLoop(
+		ctx,
+		w.executionFinishedConsumer,
+		messages.ExecutionsExchange+"."+messages.ExecutionFinishedRoutingKey+"."+w.Name(),
+		messages.ExecutionsExchange,
+		messages.ExecutionFinishedRoutingKey,
+		w.ConsumeExecutionFinished,
+	)
 
 	//
-	// Differently from the other workers, the NodeQueueWorker needs to be
-	// aware of two things: queue items being created and nodes becoming ready.
+	// Slow safety-net poll in case RabbitMQ is not working.
 	//
-	// Since we don't have events for nodes becoming ready, we need to poll still,
-	// so we cannot decrease this interval yet.
-	//
-	// Once we have events for nodes becoming ready,
-	// we can make this worker react to both events.
-	//
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
 	for {
@@ -101,35 +121,54 @@ func (w *NodeQueueWorker) Start(ctx context.Context) {
 	}
 }
 
-func (w *NodeQueueWorker) StartRabbitMQConsumer(ctx context.Context) {
+func (w *NodeQueueWorker) startConsumerLoop(
+	ctx context.Context,
+	consumer *tackle.Consumer,
+	serviceName string,
+	exchangeName string,
+	routingKey string,
+	handler func(tackle.Delivery) error,
+) {
 	options := tackle.Options{
 		URL:            w.rabbitMQURL,
 		ConnectionName: w.Name(),
-		RemoteExchange: messages.CanvasExchange,
-		Service:        messages.CanvasExchange + "." + messages.CanvasQueueItemCreatedRoutingKey + "." + w.Name(),
-		RoutingKey:     messages.CanvasQueueItemCreatedRoutingKey,
+		RemoteExchange: exchangeName,
+		Service:        serviceName,
+		RoutingKey:     routingKey,
 	}
 
-	consumer := tackle.NewConsumer()
-	consumer.SetLogger(logging.NewTackleLogger(w.logger))
-	w.consumer = consumer
-
 	for {
-		log.Infof("Connecting to RabbitMQ queue for %s events", messages.CanvasQueueItemCreatedRoutingKey)
+		if ctx.Err() != nil {
+			return
+		}
 
-		err := w.consumer.Start(&options, w.Consume)
+		log.Infof("Connecting to RabbitMQ queue for %s events", routingKey)
+
+		err := consumer.Start(&options, handler)
+		if ctx.Err() != nil {
+			return
+		}
+
 		if err != nil {
-			w.logger.Errorf("Error consuming messages from %s: %v", messages.CanvasQueueItemCreatedRoutingKey, err)
-			time.Sleep(5 * time.Second)
+			w.logger.Errorf("Error consuming messages from %s: %v", routingKey, err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Second):
+			}
 			continue
 		}
 
-		w.logger.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", messages.CanvasQueueItemCreatedRoutingKey)
-		time.Sleep(5 * time.Second)
+		w.logger.Warnf("Connection to RabbitMQ closed for %s, reconnecting...", routingKey)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
 	}
 }
 
-func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
+func (w *NodeQueueWorker) ConsumeQueueItemCreated(delivery tackle.Delivery) error {
 	start := time.Now()
 
 	data := &pb.CanvasNodeQueueItemMessage{}
@@ -145,31 +184,53 @@ func (w *NodeQueueWorker) Consume(delivery tackle.Delivery) error {
 		return err
 	}
 
-	node, err := models.FindCanvasNode(database.Conn(), canvasID, data.NodeId)
+	return w.tryProcessReadyNode(canvasID, data.NodeId, start)
+}
+
+func (w *NodeQueueWorker) ConsumeExecutionFinished(delivery tackle.Delivery) error {
+	start := time.Now()
+
+	data := &pb.CanvasNodeExecutionMessage{}
+	err := proto.Unmarshal(delivery.Body(), data)
+	if err != nil {
+		w.logger.Errorf("Error unmarshaling canvas execution finished message: %v", err)
+		return err
+	}
+
+	canvasID, err := uuid.Parse(data.CanvasId)
+	if err != nil {
+		w.logger.Errorf("Error parsing canvas id: %v", err)
+		return err
+	}
+
+	return w.tryProcessReadyNode(canvasID, data.NodeId, start)
+}
+
+func (w *NodeQueueWorker) tryProcessReadyNode(canvasID uuid.UUID, nodeID string, attemptStart time.Time) error {
+	node, err := models.FindCanvasNode(database.Conn(), canvasID, nodeID)
 	if err != nil {
 		w.logger.Errorf("Error finding canvas node: %v", err)
 		return err
 	}
 
 	//
-	// New queue item created for a node that is not ready, we should skip it.
+	// Node is not ready yet, skip it. For queue-item-created messages this happens
+	// when a new item arrives while the node is still executing. For
+	// execution-finished messages this can happen when the node is paused.
 	//
 	if node.State != models.CanvasNodeStateReady {
 		w.logger.Infof("Node %s is not ready, skipping", node.NodeID)
 		telemetry.RecordQueueWorkerNodeProcessing(
 			context.Background(),
-			time.Since(start),
+			time.Since(attemptStart),
 			executorOutcomeSkipped,
 			executorReasonNone,
 		)
 		return nil
 	}
 
-	//
-	// Node is ready for processing, let's lock it and process it.
-	//
 	logger := logging.WithNode(w.logger, *node)
-	return w.LockAndProcessNode(logger, *node, start)
+	return w.LockAndProcessNode(logger, *node, attemptStart)
 }
 
 func (w *NodeQueueWorker) LockAndProcessNode(logger *log.Entry, node models.CanvasNode, attemptStart time.Time) error {

--- a/pkg/workers/node_queue_worker_test.go
+++ b/pkg/workers/node_queue_worker_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/renderedtext/go-tackle"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,8 +13,10 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
+	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	testconsumer "github.com/superplanehq/superplane/test/consumer"
 	"github.com/superplanehq/superplane/test/support"
+	"google.golang.org/protobuf/proto"
 	"gorm.io/datatypes"
 )
 
@@ -507,4 +510,109 @@ func Test__NodeQueueWorker_ConfigurationBuildFailure(t *testing.T) {
 
 	// Verify execution message was published
 	assert.True(t, executionConsumer.HasReceivedMessage())
+}
+
+func Test__NodeQueueWorker_ProcessesNextQueueItemOnExecutionFinished(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	amqpURL, _ := config.RabbitMQURL()
+	worker := NewNodeQueueWorker(r.Registry, r.GitProvider, amqpURL)
+	logger := log.NewEntry(log.New())
+
+	triggerNode := "trigger-1"
+	componentNode := "component-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{NodeID: triggerNode, Type: models.NodeTypeTrigger},
+			{NodeID: componentNode, Type: models.NodeTypeComponent, Ref: datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: "noop"}})},
+		},
+		[]models.Edge{
+			{SourceID: triggerNode, TargetID: componentNode, Channel: "default"},
+		},
+	)
+
+	oldEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+	newEvent := support.EmitCanvasEventForNode(t, canvas.ID, triggerNode, "default", nil)
+
+	oldTime := time.Now().Add(-5 * time.Minute)
+	newTime := time.Now()
+	oldQueueItem := models.CanvasNodeQueueItem{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		RootEventID: oldEvent.ID,
+		EventID:     oldEvent.ID,
+		CreatedAt:   &oldTime,
+	}
+	newQueueItem := models.CanvasNodeQueueItem{
+		ID:          uuid.New(),
+		WorkflowID:  canvas.ID,
+		NodeID:      componentNode,
+		RootEventID: newEvent.ID,
+		EventID:     newEvent.ID,
+		CreatedAt:   &newTime,
+	}
+	require.NoError(t, database.Conn().Create(&oldQueueItem).Error)
+	require.NoError(t, database.Conn().Create(&newQueueItem).Error)
+
+	node, err := models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+
+	//
+	// Process the first queue item while the node is ready.
+	//
+	require.NoError(t, worker.LockAndProcessNode(logger, *node, time.Now()))
+
+	executions, err := models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 1)
+	require.Equal(t, oldEvent.ID, executions[0].EventID)
+	require.Equal(t, models.CanvasNodeExecutionStatePending, executions[0].State)
+
+	node, err = models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeStateProcessing, node.State)
+
+	queueItems, err := models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, queueItems, 1)
+	assert.Equal(t, newEvent.ID, queueItems[0].EventID)
+
+	//
+	// Finish the execution so the node becomes ready again.
+	//
+	execution := executions[0]
+	require.NoError(t, execution.Start())
+	_, err = execution.Pass(nil)
+	require.NoError(t, err)
+
+	node, err = models.FindCanvasNode(database.Conn(), canvas.ID, componentNode)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeStateReady, node.State)
+
+	//
+	// Simulate the execution.finished RabbitMQ message emitted by the executor.
+	//
+	finishedMessage, err := proto.Marshal(&pb.CanvasNodeExecutionMessage{
+		Id:       execution.ID.String(),
+		CanvasId: canvas.ID.String(),
+		NodeId:   componentNode,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, worker.ConsumeExecutionFinished(tackle.NewFakeDelivery(finishedMessage)))
+
+	executions, err = models.ListNodeExecutions(canvas.ID, componentNode, nil, nil, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, executions, 2)
+	assert.Equal(t, newEvent.ID, executions[0].EventID)
+	assert.Equal(t, models.CanvasNodeExecutionStatePending, executions[0].State)
+
+	queueItems, err = models.ListNodeQueueItems(canvas.ID, componentNode, 10, nil)
+	require.NoError(t, err)
+	assert.Empty(t, queueItems)
 }


### PR DESCRIPTION
Fixes https://github.com/superplanehq/superplane/issues/5388

NodeQueueWorker polls the database every 1s. That is a lot of load on the DB. We can fix that by making the worker listen to execution.finished messages as well as the queue item created messages it already listens to:
- On queue item message: when a node is ready, create execution for the new queue item. Helpful when node has nothing in queue, nothing executing, and just got a new queue item.
- On execution.finished message: when a queue item is created, the node might already be executing something. If that happens, the node queue worker ignores the message, and right now, the poller is responsible for taking care of processing the next queue item when the node becomes ready quickly. If we react to the execution.finished message, we can react quickly without needing a short polling interval.