### PR TITLE
chore: do not use /canvases/:id/events endpoint in UI anymore

### DIFF
--- a/web_src/src/hooks/canvasInfiniteCache.spec.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.spec.ts
@@ -1,21 +1,13 @@
 import type { InfiniteData } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
-import type {
-  CanvasesCanvasEvent,
-  CanvasesCanvasEventWithExecutions,
-  CanvasesCanvasNodeExecution,
-  CanvasesCanvasRun,
-} from "@/api-client";
+import type { CanvasesCanvasNodeExecution, CanvasesCanvasRun } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
 import {
   executionToRef,
   parseRunsFiltersFromQueryKey,
   runMatchesFilters,
-  upsertExecutionIntoInfiniteEventsData,
   upsertExecutionIntoInfiniteRunsData,
-  upsertRootEventIntoInfiniteData,
   upsertRunIntoInfiniteData,
-  type InfiniteEventsPage,
   type InfiniteRunsPage,
 } from "./canvasInfiniteCache";
 
@@ -36,26 +28,6 @@ function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun 
 function makeInfiniteRunsData(runs: CanvasesCanvasRun[], totalCount = runs.length): InfiniteData<InfiniteRunsPage> {
   return {
     pages: [{ runs, totalCount, hasNextPage: false }],
-    pageParams: [undefined],
-  };
-}
-
-function makeEvent(overrides: Partial<CanvasesCanvasEventWithExecutions> = {}): CanvasesCanvasEventWithExecutions {
-  return {
-    id: "event-1",
-    nodeId: "trigger-1",
-    createdAt: "2026-06-01T12:00:00.000Z",
-    executions: [],
-    ...overrides,
-  };
-}
-
-function makeInfiniteEventsData(
-  events: CanvasesCanvasEventWithExecutions[],
-  totalCount = events.length,
-): InfiniteData<InfiniteEventsPage> {
-  return {
-    pages: [{ events, totalCount, hasNextPage: false }],
     pageParams: [undefined],
   };
 }
@@ -161,50 +133,8 @@ describe("upsertRunIntoInfiniteData", () => {
   });
 });
 
-describe("upsertRootEventIntoInfiniteData", () => {
-  it("maps root events and inserts them at the top of page 0", () => {
-    const old = makeInfiniteEventsData([makeEvent({ id: "event-old", createdAt: "2026-06-01T11:00:00.000Z" })], 1);
-    const incoming: CanvasesCanvasEvent = {
-      id: "event-new",
-      nodeId: "trigger-1",
-      root: true,
-      createdAt: "2026-06-01T12:00:00.000Z",
-      customName: "Deploy",
-    };
-
-    const next = upsertRootEventIntoInfiniteData(old, incoming)!;
-
-    expect(next.pages[0]?.events?.[0]).toMatchObject({
-      id: "event-new",
-      customName: "Deploy",
-      executions: [],
-    });
-    expect(next.pages[0]?.totalCount).toBe(2);
-  });
-
-  it("preserves existing executions when the same root event is upserted again", () => {
-    const old = makeInfiniteEventsData([
-      makeEvent({
-        executions: [{ id: "execution-1", nodeId: "node-1", state: "STATE_STARTED" }],
-      }),
-    ]);
-    const incoming: CanvasesCanvasEvent = {
-      id: "event-1",
-      nodeId: "trigger-1",
-      root: true,
-      createdAt: "2026-06-01T12:00:00.000Z",
-    };
-
-    const next = upsertRootEventIntoInfiniteData(old, incoming)!;
-
-    expect(next.pages[0]?.events?.[0]?.executions).toEqual([
-      { id: "execution-1", nodeId: "node-1", state: "STATE_STARTED" },
-    ]);
-  });
-});
-
 describe("execution cache patching", () => {
-  it("maps executions to refs and upserts them into matching events and runs", () => {
+  it("maps executions to refs and upserts them into matching runs", () => {
     const execution: CanvasesCanvasNodeExecution = {
       id: "execution-1",
       nodeId: "node-1",
@@ -226,18 +156,15 @@ describe("execution cache patching", () => {
       updatedAt: "2026-06-01T12:01:00.000Z",
     });
 
-    const eventsOld = makeInfiniteEventsData([makeEvent({ id: "event-1" })]);
-    const eventsNext = upsertExecutionIntoInfiniteEventsData(eventsOld, execution)!;
-    expect(eventsNext.pages[0]?.events?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
-
     const runsOld = makeInfiniteRunsData([makeRun({ rootEvent: { id: "event-1", nodeId: "trigger-1" } })]);
     const runsNext = upsertExecutionIntoInfiniteRunsData(runsOld, execution)!;
     expect(runsNext.pages[0]?.runs?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
   });
 
   it("ignores stale execution updates", () => {
-    const old = makeInfiniteEventsData([
-      makeEvent({
+    const old = makeInfiniteRunsData([
+      makeRun({
+        rootEvent: { id: "event-1", nodeId: "trigger-1" },
         executions: [
           {
             id: "execution-1",
@@ -256,8 +183,8 @@ describe("execution cache patching", () => {
       rootEvent: { id: "event-1", nodeId: "trigger-1" },
     };
 
-    const next = upsertExecutionIntoInfiniteEventsData(old, incoming);
+    const next = upsertExecutionIntoInfiniteRunsData(old, incoming);
 
-    expect(next?.pages[0]?.events?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
+    expect(next?.pages[0]?.runs?.[0]?.executions?.[0]?.state).toBe("STATE_FINISHED");
   });
 });

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -1,7 +1,5 @@
 import type { InfiniteData } from "@tanstack/react-query";
 import type {
-  CanvasesCanvasEvent,
-  CanvasesCanvasEventWithExecutions,
   CanvasesCanvasNodeExecution,
   CanvasesCanvasNodeExecutionRef,
   CanvasesCanvasRun,
@@ -12,13 +10,6 @@ import type { CanvasRunsFilters } from "./useCanvasData";
 
 export type InfiniteRunsPage = {
   runs?: CanvasesCanvasRun[];
-  totalCount?: number;
-  hasNextPage?: boolean;
-  lastTimestamp?: string;
-};
-
-export type InfiniteEventsPage = {
-  events?: CanvasesCanvasEventWithExecutions[];
   totalCount?: number;
   hasNextPage?: boolean;
   lastTimestamp?: string;
@@ -186,69 +177,6 @@ export function upsertRunIntoInfiniteData(
   return { ...old, pages };
 }
 
-export function canvasEventToEventWithExecutions(event: CanvasesCanvasEvent): CanvasesCanvasEventWithExecutions {
-  return {
-    id: event.id,
-    canvasId: event.canvasId,
-    nodeId: event.nodeId,
-    channel: event.channel,
-    customName: event.customName,
-    data: event.data,
-    createdAt: event.createdAt,
-    executions: [],
-  };
-}
-
-function findEventLocation(
-  pages: InfiniteEventsPage[],
-  eventId: string,
-): { pageIndex: number; eventIndex: number } | null {
-  for (let pageIndex = 0; pageIndex < pages.length; pageIndex += 1) {
-    const eventIndex = pages[pageIndex].events?.findIndex((event) => event.id === eventId) ?? -1;
-    if (eventIndex !== -1) {
-      return { pageIndex, eventIndex };
-    }
-  }
-
-  return null;
-}
-
-export function upsertRootEventIntoInfiniteData(
-  old: InfiniteData<InfiniteEventsPage> | undefined,
-  event: CanvasesCanvasEvent,
-): InfiniteData<InfiniteEventsPage> | undefined {
-  if (!old || !event.id) {
-    return old;
-  }
-
-  const mappedEvent = canvasEventToEventWithExecutions(event);
-  const pages = old.pages.map((page) => ({
-    ...page,
-    events: page.events ? [...page.events] : [],
-  }));
-  const location = findEventLocation(pages, event.id);
-
-  if (location) {
-    const existing = pages[location.pageIndex].events![location.eventIndex];
-    pages[location.pageIndex].events![location.eventIndex] = {
-      ...mappedEvent,
-      executions: existing.executions ?? [],
-    };
-    return { ...old, pages };
-  }
-
-  if (pages.length === 0) {
-    return {
-      ...old,
-      pages: [{ events: [mappedEvent], totalCount: 1, hasNextPage: false }],
-    };
-  }
-
-  pages[0].events = [mappedEvent, ...(pages[0].events ?? [])];
-  bumpTotalCountOnAllPages(pages, 1);
-  return { ...old, pages };
-}
-
 export function executionToRef(execution: CanvasesCanvasNodeExecution): CanvasesCanvasNodeExecutionRef {
   return {
     id: execution.id,
@@ -302,37 +230,6 @@ export function upsertExecutionRef(
   const next = executions.slice();
   next[index] = incoming;
   return next;
-}
-
-export function upsertExecutionIntoInfiniteEventsData(
-  old: InfiniteData<InfiniteEventsPage> | undefined,
-  execution: CanvasesCanvasNodeExecution,
-): InfiniteData<InfiniteEventsPage> | undefined {
-  const rootEventId = execution.rootEvent?.id;
-  if (!old || !rootEventId) {
-    return old;
-  }
-
-  const executionRef = executionToRef(execution);
-  const pages = old.pages.map((page) => ({
-    ...page,
-    events: page.events ? [...page.events] : [],
-  }));
-
-  for (const page of pages) {
-    const eventIndex = page.events?.findIndex((event) => event.id === rootEventId) ?? -1;
-    if (eventIndex === -1) {
-      continue;
-    }
-
-    page.events![eventIndex] = {
-      ...page.events![eventIndex],
-      executions: upsertExecutionRef(page.events![eventIndex].executions ?? [], executionRef),
-    };
-    return { ...old, pages };
-  }
-
-  return old;
 }
 
 function findRunByRootEventId(

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -17,7 +17,6 @@ import {
   canvasesDeleteCanvas,
   canvasesPublishCanvasVersion,
   canvasesListNodeExecutions,
-  canvasesListCanvasEvents,
   canvasesListRuns,
   canvasesListCanvasMemories,
   canvasesDeleteCanvasMemory,
@@ -202,9 +201,6 @@ export const canvasKeys = {
       ...(states || []),
       ...(limit === undefined ? [] : [limit]),
     ] as const,
-  events: () => [...canvasKeys.all, "events"] as const,
-  eventList: (canvasId: string, limit?: number) => [...canvasKeys.events(), canvasId, limit] as const,
-  infiniteEvents: (canvasId: string) => [...canvasKeys.events(), canvasId, "infinite"] as const,
   runs: () => [...canvasKeys.all, "runs"] as const,
   infiniteRuns: (canvasId: string, filters?: CanvasRunsFilters) =>
     [
@@ -1123,43 +1119,6 @@ export const useDeleteCanvas = (organizationId: string) => {
       queryClient.invalidateQueries({ queryKey: canvasKeys.list(organizationId) });
       analytics.canvasDelete(canvasId, organizationId, nodeCount);
     },
-  });
-};
-
-export const useInfiniteCanvasEvents = (canvasId: string, enabled = true) => {
-  const limit = 25;
-
-  return useInfiniteQuery({
-    queryKey: canvasKeys.infiniteEvents(canvasId),
-    queryFn: async ({ pageParam }: { pageParam?: string }) => {
-      const response = await canvasesListCanvasEvents(
-        withOrganizationHeader({
-          path: { canvasId },
-          query: {
-            limit,
-            ...(pageParam ? { before: pageParam } : {}),
-          },
-        }),
-      );
-      return response.data;
-    },
-    getNextPageParam: (lastPage, allPages) => {
-      const currentLoadedCount = allPages.reduce((acc, page) => acc + (page?.events?.length || 0), 0);
-      const totalCount = lastPage?.totalCount || 0;
-
-      if (currentLoadedCount >= totalCount) return undefined;
-
-      if (lastPage?.events && lastPage.events.length > 0) {
-        const lastEvent = lastPage.events[lastPage.events.length - 1];
-        return lastEvent.createdAt;
-      }
-      return undefined;
-    },
-    initialPageParam: undefined as string | undefined,
-    staleTime: 0,
-    refetchInterval: 60_000,
-    refetchOnWindowFocus: false,
-    enabled: !!canvasId && enabled,
   });
 };
 

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -5,7 +5,7 @@ import { createElement } from "react";
 import type { ReactNode } from "react";
 import type { CanvasesCanvasRun } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
-import type { InfiniteEventsPage, InfiniteRunsPage } from "@/hooks/canvasInfiniteCache";
+import type { InfiniteRunsPage } from "@/hooks/canvasInfiniteCache";
 
 const { useWebSocketMock, nodeExecutionStoreMock } = vi.hoisted(() => ({
   useWebSocketMock: vi.fn(),
@@ -88,13 +88,6 @@ function getInvalidationPredicates(invalidateQueriesSpy: ReturnType<typeof vi.sp
   return predicates.filter((predicate: unknown): predicate is QueryPredicate => typeof predicate === "function");
 }
 
-function seedInfiniteEvents(queryClient: QueryClient, events: InfiniteEventsPage["events"] = []) {
-  queryClient.setQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId), {
-    pages: [{ events, totalCount: events?.length ?? 0, hasNextPage: false }],
-    pageParams: [undefined],
-  });
-}
-
 function seedInfiniteRuns(
   queryClient: QueryClient,
   runs: CanvasesCanvasRun[] = [],
@@ -111,10 +104,16 @@ afterEach(() => {
 });
 
 describe("useCanvasWebsocket", () => {
-  it("patches root workflow events into the infinite events cache", async () => {
+  it("does not patch root workflow events into the infinite runs cache", async () => {
     const queryClient = new QueryClient();
-    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
-    seedInfiniteEvents(queryClient, [{ id: "event-old", nodeId: testNodeId, executions: [] }]);
+    seedInfiniteRuns(queryClient, [
+      {
+        id: "run-old",
+        canvasId: testCanvasId,
+        rootEvent: { id: "event-old", nodeId: testNodeId },
+        executions: [],
+      },
+    ]);
 
     renderCanvasWebsocketHook(queryClient);
     emitWebsocketMessage("event_created", {
@@ -127,32 +126,12 @@ describe("useCanvasWebsocket", () => {
     await flushMessageQueue();
 
     await waitFor(() => {
-      const data = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId));
-      expect(data?.pages[0]?.events?.map((event) => event.id)).toEqual(["event-new", "event-old"]);
-    });
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
-  });
-
-  it("does not patch non-root workflow events into the infinite events cache", async () => {
-    const queryClient = new QueryClient();
-    seedInfiniteEvents(queryClient, [{ id: "event-old", nodeId: testNodeId, executions: [] }]);
-
-    renderCanvasWebsocketHook(queryClient);
-    emitWebsocketMessage("workflow_event_created", {
-      id: "event-1",
-      nodeId: testNodeId,
-      root: false,
-    });
-
-    await flushMessageQueue();
-
-    await waitFor(() => {
-      const data = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(canvasKeys.infiniteEvents(testCanvasId));
-      expect(data?.pages[0]?.events?.map((event) => event.id)).toEqual(["event-old"]);
+      const data = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId));
+      expect(data?.pages[0]?.runs?.map((run) => run.rootEvent?.id)).toEqual(["event-old"]);
     });
   });
 
-  it("does not invalidate infinite events query for queue_item_created", async () => {
+  it("does not invalidate infinite runs query for queue_item_created", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -164,10 +143,10 @@ describe("useCanvasWebsocket", () => {
 
     await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
-  it("does not invalidate infinite events query for queue_item_consumed", async () => {
+  it("does not invalidate infinite runs query for queue_item_consumed", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -179,13 +158,12 @@ describe("useCanvasWebsocket", () => {
 
     await flushMessageQueue();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
+    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
-  it("patches execution events into infinite events and runs caches", async () => {
+  it("patches execution events into infinite runs cache", async () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
-    seedInfiniteEvents(queryClient, [{ id: "event-1", nodeId: testNodeId, executions: [] }]);
     seedInfiniteRuns(queryClient, [
       {
         id: "run-1",
@@ -208,14 +186,9 @@ describe("useCanvasWebsocket", () => {
     await flushMessageQueue();
 
     await waitFor(() => {
-      const eventsData = queryClient.getQueryData<InfiniteData<InfiniteEventsPage>>(
-        canvasKeys.infiniteEvents(testCanvasId),
-      );
       const runsData = queryClient.getQueryData<InfiniteData<InfiniteRunsPage>>(canvasKeys.infiniteRuns(testCanvasId));
-      expect(eventsData?.pages[0]?.events?.[0]?.executions?.[0]?.id).toBe("execution-1");
       expect(runsData?.pages[0]?.runs?.[0]?.executions?.[0]?.id).toBe("execution-1");
     });
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
@@ -245,18 +218,17 @@ describe("useCanvasWebsocket", () => {
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
-  it("does not invalidate runs or events on initial websocket connect", () => {
+  it("does not invalidate runs on initial websocket connect", () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
     renderCanvasWebsocketHook(queryClient);
     emitWebSocketOpen();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(0);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(0);
   });
 
-  it("invalidates runs and events on websocket reconnect", () => {
+  it("invalidates runs on websocket reconnect", () => {
     const queryClient = new QueryClient();
     const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
 
@@ -264,7 +236,6 @@ describe("useCanvasWebsocket", () => {
     emitWebSocketOpen();
     emitWebSocketOpen();
 
-    expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteEvents(testCanvasId))).toHaveLength(1);
     expect(getInvalidationCalls(invalidateQueriesSpy, canvasKeys.infiniteRuns(testCanvasId))).toHaveLength(1);
   });
 

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -10,11 +10,8 @@ import type {
 import { useNodeExecutionStore } from "@/stores/nodeExecutionStore";
 import {
   parseRunsFiltersFromQueryKey,
-  upsertExecutionIntoInfiniteEventsData,
   upsertExecutionIntoInfiniteRunsData,
-  upsertRootEventIntoInfiniteData,
   upsertRunIntoInfiniteData,
-  type InfiniteEventsPage,
   type InfiniteRunsPage,
 } from "./canvasInfiniteCache";
 import { canvasKeys } from "./useCanvasData";
@@ -119,22 +116,8 @@ export function useCanvasWebsocket(
     [queryClient, canvasId],
   );
 
-  const patchRootEventInCache = useCallback(
-    (event: CanvasesCanvasEvent) => {
-      queryClient.setQueriesData<InfiniteData<InfiniteEventsPage>>(
-        { queryKey: canvasKeys.infiniteEvents(canvasId) },
-        (old) => upsertRootEventIntoInfiniteData(old, event),
-      );
-    },
-    [queryClient, canvasId],
-  );
-
   const patchExecutionInCache = useCallback(
     (execution: CanvasesCanvasNodeExecution) => {
-      queryClient.setQueriesData<InfiniteData<InfiniteEventsPage>>(
-        { queryKey: canvasKeys.infiniteEvents(canvasId) },
-        (old) => upsertExecutionIntoInfiniteEventsData(old, execution),
-      );
       queryClient.setQueriesData<InfiniteData<InfiniteRunsPage>>(
         { queryKey: canvasKeys.infiniteRuns(canvasId) },
         (old) => upsertExecutionIntoInfiniteRunsData(old, execution),
@@ -170,14 +153,6 @@ export function useCanvasWebsocket(
           if (payload && "nodeId" in payload && payload.nodeId) {
             const workflowEvent = payload as CanvasesCanvasEvent;
             nodeExecutionStore.updateNodeEvent(workflowEvent.nodeId!, workflowEvent);
-
-            /*
-             * Root canvas events are upserted into the infinite events cache
-             * instead of triggering a refetch.
-             */
-            if (workflowEvent.root) {
-              patchRootEventInCache(workflowEvent);
-            }
 
             onNodeEvent?.(workflowEvent.nodeId!, data.event);
             onWorkflowEvent?.(workflowEvent, data.event);
@@ -315,7 +290,6 @@ export function useCanvasWebsocket(
       processRuntimeEvents,
       organizationId,
       patchRunInCache,
-      patchRootEventInCache,
       patchExecutionInCache,
       invalidateMemoryEntries,
     ],
@@ -403,9 +377,6 @@ export function useCanvasWebsocket(
       return;
     }
 
-    queryClient.invalidateQueries({
-      queryKey: canvasKeys.infiniteEvents(canvasId),
-    });
     queryClient.invalidateQueries({
       queryKey: canvasKeys.infiniteRuns(canvasId),
     });

--- a/web_src/src/pages/app/ErrorsConsoleContent.tsx
+++ b/web_src/src/pages/app/ErrorsConsoleContent.tsx
@@ -1,15 +1,20 @@
 import React, { useMemo } from "react";
 import { CircleX } from "lucide-react";
 import type {
-  CanvasesCanvasEventWithExecutions,
   CanvasesCanvasNodeExecutionRef,
+  CanvasesCanvasRun,
   SuperplaneComponentsNode as ComponentsNode,
 } from "@/api-client";
 import { TimeAgo } from "@/components/TimeAgo";
 import { cn, resolveIcon } from "@/lib/utils";
 import { getHeaderIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
 import type { SidebarEvent } from "@/ui/componentSidebar/types";
-import { findNode, getStatusBadgeProps, resolveNodeIconSlug } from "@/pages/app/lib/canvas-runs";
+import {
+  findNode,
+  getRunRootEventForDisplay,
+  getStatusBadgeProps,
+  resolveNodeIconSlug,
+} from "@/pages/app/lib/canvas-runs";
 import { buildTriggerSidebarEvent } from "./utils";
 
 function NodeIcon({
@@ -58,7 +63,8 @@ function ErrorItemRow({
 }: {
   item: {
     execution: CanvasesCanvasNodeExecutionRef;
-    event: CanvasesCanvasEventWithExecutions;
+    run: CanvasesCanvasRun;
+    rootEventId: string;
     node: ComponentsNode | undefined;
     triggerNode: ComponentsNode | undefined;
   };
@@ -74,13 +80,14 @@ function ErrorItemRow({
 }) {
   const nodeName = item.node?.name || item.execution.nodeId || "Unknown";
   const { badgeColor, label } = getStatusBadgeProps("error");
-  const triggerSidebarEvent = buildTriggerSidebarEvent(item.event, item.triggerNode);
+  const rootEvent = getRunRootEventForDisplay(item.run);
+  const triggerSidebarEvent = rootEvent ? buildTriggerSidebarEvent(rootEvent, item.triggerNode) : undefined;
 
   const handleSelect = () => {
-    if (onExecutionSelect && item.execution.id && item.event.id && item.execution.nodeId) {
+    if (onExecutionSelect && item.execution.id && item.rootEventId && item.execution.nodeId) {
       onExecutionSelect({
         nodeId: item.execution.nodeId,
-        eventId: item.event.id,
+        eventId: item.rootEventId,
         executionId: item.execution.id,
         triggerEvent: triggerSidebarEvent,
       });
@@ -132,7 +139,7 @@ function ErrorItemRow({
 }
 
 export function ErrorsConsoleContent({
-  events,
+  runs,
   nodes,
   componentIconMap = {},
   searchQuery,
@@ -140,7 +147,7 @@ export function ErrorsConsoleContent({
   onExecutionSelect,
   onAcknowledgeErrors,
 }: {
-  events: CanvasesCanvasEventWithExecutions[];
+  runs: CanvasesCanvasRun[];
   nodes: ComponentsNode[];
   componentIconMap?: Record<string, string>;
   searchQuery: string;
@@ -157,32 +164,36 @@ export function ErrorsConsoleContent({
     const query = searchQuery.trim().toLowerCase();
     const items: {
       execution: CanvasesCanvasNodeExecutionRef;
-      event: CanvasesCanvasEventWithExecutions;
+      run: CanvasesCanvasRun;
+      rootEventId: string;
       node: ComponentsNode | undefined;
       triggerNode: ComponentsNode | undefined;
     }[] = [];
 
-    for (const event of events) {
-      const triggerNode = nodes.find((n) => n.id === event.nodeId);
-      for (const exec of event.executions || []) {
+    for (const run of runs) {
+      const rootEventId = run.rootEvent?.id;
+      if (!rootEventId) continue;
+
+      const triggerNode = nodes.find((n) => n.id === run.rootEvent?.nodeId);
+      for (const exec of run.executions || []) {
         if (exec.result !== "RESULT_FAILED") continue;
         if (exec.resultReason === "RESULT_REASON_ERROR_RESOLVED") continue;
 
         const node = findNode(nodes, exec.nodeId);
 
         if (query) {
-          const searchable = [node?.name, exec.nodeId, exec.resultMessage, event.id]
+          const searchable = [node?.name, exec.nodeId, exec.resultMessage, rootEventId]
             .filter(Boolean)
             .join(" ")
             .toLowerCase();
           if (!searchable.includes(query)) continue;
         }
 
-        items.push({ execution: exec, event, node, triggerNode });
+        items.push({ execution: exec, run, rootEventId, node, triggerNode });
       }
     }
     return items;
-  }, [events, nodes, searchQuery]);
+  }, [runs, nodes, searchQuery]);
 
   const allErrorIds = useMemo(() => errorItems.map((item) => item.execution.id!).filter(Boolean), [errorItems]);
 

--- a/web_src/src/pages/app/console/useConsoleTriggerNode.ts
+++ b/web_src/src/pages/app/console/useConsoleTriggerNode.ts
@@ -48,7 +48,6 @@ export function useConsoleTriggerNode({
 
 function invalidateConsoleTriggerQueries(queryClient: QueryClient, canvasId: string, nodeId: string) {
   queryClient.invalidateQueries({ queryKey: canvasKeys.nodeExecution(canvasId, nodeId) });
-  queryClient.invalidateQueries({ queryKey: canvasKeys.infiniteEvents(canvasId) });
   queryClient.invalidateQueries({ queryKey: canvasKeys.infiniteRuns(canvasId) });
   queryClient.invalidateQueries({ queryKey: canvasKeys.canvasMemoryEntries(canvasId) });
 }

--- a/web_src/src/pages/app/console/widget/useWidgetData.executionRows.spec.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.executionRows.spec.ts
@@ -12,9 +12,11 @@ const NODES: SuperplaneComponentsNode[] = [
 
 const PAGES = [
   {
-    events: [
+    runs: [
       {
-        data: { pr_number: 42, branch: "main" },
+        rootEvent: {
+          data: { pr_number: 42, branch: "main" },
+        },
         executions: [
           { id: "exec-1", nodeId: "node-a", state: "STATE_FINISHED", result: "RESULT_PASSED" },
           { id: "exec-2", nodeId: "node-b", state: "STATE_STARTED" },
@@ -84,18 +86,19 @@ describe("collectExecutionRows nodeName resolution", () => {
     expect(rows.map((r) => r.status)).toEqual(["passed", "running", "failed", "pending"]);
   });
 
-  it("attaches the parent event's data as the row payload", () => {
+  it("attaches the run root event data as the row payload", () => {
     const rows = collectExecutionRows(PAGES, undefined, buildNodeNameMap(NODES), 10) as ExecutionRow[];
     for (const row of rows) {
       expect(row.payload).toEqual({ pr_number: 42, branch: "main" });
     }
   });
 
-  it("leaves payload undefined when the parent event has no data", () => {
+  it("leaves payload undefined when the run root event has no data", () => {
     const pages = [
       {
-        events: [
+        runs: [
           {
+            rootEvent: {},
             executions: [{ id: "exec-x", nodeId: "node-a", state: "STATE_STARTED" }],
           },
         ],

--- a/web_src/src/pages/app/console/widget/useWidgetData.ts
+++ b/web_src/src/pages/app/console/widget/useWidgetData.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CanvasesCanvasNodeExecution } from "@/api-client";
-import {
-  useCanvasMemoryEntries,
-  useEventExecutionsBatch,
-  useInfiniteCanvasEvents,
-  useInfiniteCanvasRuns,
-} from "@/hooks/useCanvasData";
+import { useCanvasMemoryEntries, useEventExecutionsBatch, useInfiniteCanvasRuns } from "@/hooks/useCanvasData";
 
 import { resolveConsoleNode, useConsoleContext, type ConsoleContextValue } from "../ConsoleContext";
 import { flattenMemoryEntries } from "./memoryRow";
@@ -267,7 +262,7 @@ function useExecutionsDataSourceResult({
   loadMore: () => void;
 }): WidgetDataResult {
   const enabled = dataSource.kind === "executions";
-  const query = useInfiniteCanvasEvents(canvasId, enabled);
+  const query = useInfiniteCanvasRuns(canvasId, {}, enabled);
   // Memoize `pages` so empty-array fallback identity stays stable across
   // renders — keeps the downstream `useMemo` deps from busting every cycle.
   const pages = useMemo(() => query.data?.pages ?? [], [query.data]);
@@ -286,8 +281,8 @@ function useExecutionsDataSourceResult({
     if (!enabled) return 0;
     let count = 0;
     for (const page of pages) {
-      for (const event of page?.events ?? []) {
-        for (const exec of event.executions ?? []) {
+      for (const run of page?.runs ?? []) {
+        for (const exec of run.executions ?? []) {
           if (targetNodeId && exec.nodeId !== targetNodeId) continue;
           count++;
         }

--- a/web_src/src/pages/app/console/widget/widgetRowCollection.ts
+++ b/web_src/src/pages/app/console/widget/widgetRowCollection.ts
@@ -10,25 +10,23 @@ import type { CanvasesCanvasNodeExecution, SuperplaneComponentsNode } from "@/ap
 import { DOLLAR_REWRITE_IDENTIFIER } from "./celExpr";
 
 /**
- * Walk the loaded event pages and synthesize the row objects the dashboard's
- * table / chart / number renderers consume. Each row carries the raw
- * execution fields plus four derived conveniences:
+ * Walk the loaded run pages and synthesize execution row objects for the
+ * dashboard's table / chart / number renderers. Each row carries the raw
+ * execution fields plus derived conveniences:
  *
  * - `status`: lowercase canonical status string (see {@link deriveExecutionStatus}).
- * - `nodeName`: friendly node label resolved per-row via `nodeNameById`,
- *   falling back to the raw `nodeId` when the canvas no longer contains
- *   that node (e.g. it was deleted after the execution ran).
+ * - `nodeName`: friendly node label resolved per-row via `nodeNameById`.
  * - `durationMs`: created-to-updated elapsed time in milliseconds.
- * - `payload`: the data carried by the parent (root) event — i.e. the
- *   payload the node received. Shared by every execution under that event.
+ * - `payload`: the data carried by the run's root event — i.e. the payload
+ *   the node received.
  *
  * Iteration stops as soon as `rows.length >= limit`.
  */
 export function collectExecutionRows(
   pages: Array<
     | {
-        events?: Array<{
-          data?: Record<string, unknown>;
+        runs?: Array<{
+          rootEvent?: { data?: Record<string, unknown> };
           executions?: Array<
             Record<string, unknown> & {
               nodeId?: string;
@@ -48,8 +46,8 @@ export function collectExecutionRows(
 ): unknown[] {
   const rows: unknown[] = [];
   for (const page of pages) {
-    for (const event of page?.events ?? []) {
-      for (const exec of event.executions ?? []) {
+    for (const run of page?.runs ?? []) {
+      for (const exec of run.executions ?? []) {
         if (targetNodeId && exec.nodeId !== targetNodeId) continue;
         rows.push({
           ...exec,
@@ -57,7 +55,7 @@ export function collectExecutionRows(
           nodeName: (exec.nodeId && nodeNameById.get(exec.nodeId)) || exec.nodeId,
           durationMs:
             exec.updatedAt && exec.createdAt ? Date.parse(exec.updatedAt) - Date.parse(exec.createdAt) : undefined,
-          payload: event.data,
+          payload: run.rootEvent?.data,
         });
         if (rows.length >= limit) return rows;
       }

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -41,7 +41,6 @@ import {
   useUpdateCanvasMemoryNamespace,
   usePublishCanvasVersion,
   useEventExecutions,
-  useInfiniteCanvasEvents,
   useInfiniteCanvasRuns,
   useInfiniteCanvasLiveVersions,
   useTriggers,
@@ -218,7 +217,7 @@ function refreshLiveCanvasAfterVersionSelection({
       refetchType: "all",
     }),
     queryClient.invalidateQueries({
-      queryKey: canvasKeys.eventList(canvasId, 50),
+      queryKey: canvasKeys.infiniteRuns(canvasId),
       refetchType: "all",
     }),
   ]).then(() => {
@@ -551,21 +550,7 @@ export function AppPage() {
     () => (isRunInspectionMode && selectedRunId ? {} : statusFiltersToApiFilters(runStatusFilters)),
     [isRunInspectionMode, selectedRunId, runStatusFilters],
   );
-  const infiniteEventsQuery = useInfiniteCanvasEvents(canvasId!, showLiveActivity);
   const infiniteRunsQuery = useInfiniteCanvasRuns(canvasId!, runApiFilters, showLiveActivity);
-  const runsEventsData = useMemo(() => {
-    const pages = infiniteEventsQuery.data?.pages || [];
-    const seen = new Set<string>();
-    const events = pages
-      .flatMap((page) => page?.events || [])
-      .filter((e) => {
-        if (!e.id || seen.has(e.id)) return false;
-        seen.add(e.id);
-        return true;
-      });
-    const totalCount = pages[0]?.totalCount || 0;
-    return { events, totalCount };
-  }, [infiniteEventsQuery.data]);
   const runsData = useMemo(() => {
     const pages = infiniteRunsQuery.data?.pages || [];
     const seen = new Set<string>();
@@ -4553,7 +4538,7 @@ export function AppPage() {
       setIsResolvingErrors(true);
       try {
         await resolveExecutionErrors(canvasId, executionIds);
-        await queryClient.invalidateQueries({ queryKey: [...canvasKeys.events(), canvasId] });
+        await queryClient.invalidateQueries({ queryKey: canvasKeys.infiniteRuns(canvasId) });
         await queryClient.invalidateQueries({ queryKey: canvasKeys.nodeExecutions() });
         showSuccessToast("Errors acknowledged");
       } catch {
@@ -5119,7 +5104,7 @@ export function AppPage() {
           components={allComponents}
           triggers={allTriggers}
           logEntries={logEntries}
-          runsEvents={showLiveActivity ? runsEventsData.events : []}
+          logRuns={isViewingLiveVersion ? runsData.runs : []}
           runsNodes={canvasNodes}
           runsComponentIconMap={componentIconMap}
           onRunNodeSelect={handleLogRunNodeSelect}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -551,6 +551,7 @@ export function AppPage() {
     [isRunInspectionMode, selectedRunId, runStatusFilters],
   );
   const infiniteRunsQuery = useInfiniteCanvasRuns(canvasId!, runApiFilters, showLiveActivity);
+  const infiniteLogRunsQuery = useInfiniteCanvasRuns(canvasId!, {}, isViewingLiveVersion);
   const runsData = useMemo(() => {
     const pages = infiniteRunsQuery.data?.pages || [];
     const seen = new Set<string>();
@@ -564,6 +565,18 @@ export function AppPage() {
     const totalCount = pages[0]?.totalCount || 0;
     return { runs, totalCount };
   }, [infiniteRunsQuery.data]);
+  const logRunsData = useMemo(() => {
+    const pages = infiniteLogRunsQuery.data?.pages || [];
+    const seen = new Set<string>();
+    const runs = pages
+      .flatMap((page) => page?.runs || [])
+      .filter((run): run is CanvasesCanvasRun => {
+        if (!run.id || seen.has(run.id)) return false;
+        seen.add(run.id);
+        return true;
+      });
+    return { runs };
+  }, [infiniteLogRunsQuery.data]);
   const selectedRun = useMemo(
     () => runsData.runs.find((run) => run.id === selectedRunId) || null,
     [runsData.runs, selectedRunId],
@@ -5104,7 +5117,7 @@ export function AppPage() {
           components={allComponents}
           triggers={allTriggers}
           logEntries={logEntries}
-          logRuns={isViewingLiveVersion ? runsData.runs : []}
+          logRuns={isViewingLiveVersion ? logRunsData.runs : []}
           runsNodes={canvasNodes}
           runsComponentIconMap={componentIconMap}
           onRunNodeSelect={handleLogRunNodeSelect}

--- a/web_src/src/pages/app/lib/canvas-runs.spec.ts
+++ b/web_src/src/pages/app/lib/canvas-runs.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { CanvasesCanvasEventWithExecutions, CanvasesCanvasNodeExecutionRef } from "@/api-client";
+import type { CanvasesCanvasNodeExecutionRef, CanvasesCanvasRun } from "@/api-client";
 import { makeComponentsNode } from "@/test/factories";
-import { filterRunEvents, getAggregateStatus } from "./canvas-runs";
+import { filterRuns, getAggregateStatus } from "./canvas-runs";
 
 function makeExecutionRef(overrides: Partial<CanvasesCanvasNodeExecutionRef> = {}): CanvasesCanvasNodeExecutionRef {
   return {
@@ -13,18 +13,23 @@ function makeExecutionRef(overrides: Partial<CanvasesCanvasNodeExecutionRef> = {
   } as CanvasesCanvasNodeExecutionRef;
 }
 
-function makeEvent(overrides: Partial<CanvasesCanvasEventWithExecutions> = {}): CanvasesCanvasEventWithExecutions {
+function makeRun(overrides: Partial<CanvasesCanvasRun> = {}): CanvasesCanvasRun {
   return {
-    id: "event-1",
-    nodeId: "trigger-1",
+    id: "run-1",
+    canvasId: "canvas-1",
     createdAt: "2026-04-01T12:00:00.000Z",
-    data: {
-      data: {},
-      type: "event",
+    rootEvent: {
+      id: "event-1",
+      nodeId: "trigger-1",
+      createdAt: "2026-04-01T12:00:00.000Z",
+      data: {
+        data: {},
+        type: "event",
+      },
     },
     executions: [makeExecutionRef()],
     ...overrides,
-  } as CanvasesCanvasEventWithExecutions;
+  } as CanvasesCanvasRun;
 }
 
 describe("getAggregateStatus", () => {
@@ -89,7 +94,7 @@ describe("getAggregateStatus", () => {
   });
 });
 
-describe("filterRunEvents", () => {
+describe("filterRuns", () => {
   const nodes = [
     makeComponentsNode({
       id: "trigger-1",
@@ -111,67 +116,77 @@ describe("filterRunEvents", () => {
     }),
   ];
 
-  it("returns all events when the status filter is all", () => {
-    const events = [
-      makeEvent({
-        id: "event-success",
+  it("returns all runs when the status filter is all", () => {
+    const runs = [
+      makeRun({
+        id: "run-success",
+        rootEvent: { id: "event-success", nodeId: "trigger-1" },
         executions: [makeExecutionRef({ nodeId: "node-success" })],
       }),
-      makeEvent({
-        id: "event-failed",
+      makeRun({
+        id: "run-failed",
+        rootEvent: { id: "event-failed", nodeId: "trigger-1" },
         executions: [makeExecutionRef({ nodeId: "node-failed", result: "RESULT_FAILED" })],
       }),
-      makeEvent({
-        id: "event-queued",
+      makeRun({
+        id: "run-queued",
+        rootEvent: { id: "event-queued", nodeId: "trigger-1" },
         executions: [],
       }),
     ];
 
-    expect(filterRunEvents(events, nodes, "all", "")).toEqual(events);
+    expect(filterRuns(runs, nodes, "all", "")).toEqual(runs);
   });
 
   it("matches completed filter for both completed and cancelled runs", () => {
-    const completedEvent = makeEvent({
-      id: "event-completed",
+    const completedRun = makeRun({
+      id: "run-completed",
+      rootEvent: { id: "event-completed", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-success", result: "RESULT_PASSED" })],
     });
-    const cancelledEvent = makeEvent({
-      id: "event-cancelled",
+    const cancelledRun = makeRun({
+      id: "run-cancelled",
+      rootEvent: { id: "event-cancelled", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-success", result: "RESULT_CANCELLED" })],
     });
-    const failedEvent = makeEvent({
-      id: "event-failed",
+    const failedRun = makeRun({
+      id: "run-failed",
+      rootEvent: { id: "event-failed", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-failed", result: "RESULT_FAILED" })],
     });
 
-    expect(filterRunEvents([completedEvent, cancelledEvent, failedEvent], nodes, "completed", "")).toEqual([
-      completedEvent,
-      cancelledEvent,
+    expect(filterRuns([completedRun, cancelledRun, failedRun], nodes, "completed", "")).toEqual([
+      completedRun,
+      cancelledRun,
     ]);
   });
 
   it("matches error, running, and queued filters from aggregate statuses", () => {
-    const failedEvent = makeEvent({
-      id: "event-failed",
+    const failedRun = makeRun({
+      id: "run-failed",
+      rootEvent: { id: "event-failed", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-failed", result: "RESULT_FAILED" })],
     });
-    const runningEvent = makeEvent({
-      id: "event-running",
+    const runningRun = makeRun({
+      id: "run-running",
+      rootEvent: { id: "event-running", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-running", state: "STATE_STARTED", result: undefined })],
     });
-    const queuedEvent = makeEvent({
-      id: "event-queued",
+    const queuedRun = makeRun({
+      id: "run-queued",
+      rootEvent: { id: "event-queued", nodeId: "trigger-1" },
       executions: [],
     });
 
-    expect(filterRunEvents([failedEvent, runningEvent, queuedEvent], nodes, "errors", "")).toEqual([failedEvent]);
-    expect(filterRunEvents([failedEvent, runningEvent, queuedEvent], nodes, "running", "")).toEqual([runningEvent]);
-    expect(filterRunEvents([failedEvent, runningEvent, queuedEvent], nodes, "queued", "")).toEqual([queuedEvent]);
+    expect(filterRuns([failedRun, runningRun, queuedRun], nodes, "errors", "")).toEqual([failedRun]);
+    expect(filterRuns([failedRun, runningRun, queuedRun], nodes, "running", "")).toEqual([runningRun]);
+    expect(filterRuns([failedRun, runningRun, queuedRun], nodes, "queued", "")).toEqual([queuedRun]);
   });
 
   it("matches search queries against event ids, node names, and execution messages", () => {
-    const searchableEvent = makeEvent({
-      id: "event-searchable",
+    const searchableRun = makeRun({
+      id: "run-searchable",
+      rootEvent: { id: "event-searchable", nodeId: "trigger-1" },
       executions: [
         makeExecutionRef({
           nodeId: "node-failed",
@@ -180,26 +195,29 @@ describe("filterRunEvents", () => {
         }),
       ],
     });
-    const otherEvent = makeEvent({
-      id: "event-other",
+    const otherRun = makeRun({
+      id: "run-other",
+      rootEvent: { id: "event-other", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-success", resultMessage: "Everything passed" })],
     });
 
-    expect(filterRunEvents([searchableEvent, otherEvent], nodes, "all", "searchABLE")).toEqual([searchableEvent]);
-    expect(filterRunEvents([searchableEvent, otherEvent], nodes, "all", "run checks")).toEqual([searchableEvent]);
-    expect(filterRunEvents([searchableEvent, otherEvent], nodes, "all", "TIMED OUT")).toEqual([searchableEvent]);
+    expect(filterRuns([searchableRun, otherRun], nodes, "all", "searchABLE")).toEqual([searchableRun]);
+    expect(filterRuns([searchableRun, otherRun], nodes, "all", "run checks")).toEqual([searchableRun]);
+    expect(filterRuns([searchableRun, otherRun], nodes, "all", "TIMED OUT")).toEqual([searchableRun]);
   });
 
   it("applies status filtering before search matching", () => {
-    const failedEvent = makeEvent({
-      id: "event-failed",
+    const failedRun = makeRun({
+      id: "run-failed",
+      rootEvent: { id: "event-failed", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-failed", result: "RESULT_FAILED" })],
     });
-    const completedEvent = makeEvent({
-      id: "event-completed",
+    const completedRun = makeRun({
+      id: "run-completed",
+      rootEvent: { id: "event-completed", nodeId: "trigger-1" },
       executions: [makeExecutionRef({ nodeId: "node-success", resultMessage: "Run checks finished" })],
     });
 
-    expect(filterRunEvents([failedEvent, completedEvent], nodes, "errors", "run checks")).toEqual([failedEvent]);
+    expect(filterRuns([failedRun, completedRun], nodes, "errors", "run checks")).toEqual([failedRun]);
   });
 });

--- a/web_src/src/pages/app/lib/canvas-runs.ts
+++ b/web_src/src/pages/app/lib/canvas-runs.ts
@@ -1,8 +1,10 @@
 import type {
+  CanvasesCanvasEvent,
   CanvasesCanvasEventWithExecutions,
   CanvasesCanvasNodeExecution,
   CanvasesCanvasNodeExecutionRef,
   CanvasesCanvasNodeQueueItem,
+  CanvasesCanvasRun,
   SuperplaneComponentsNode as ComponentsNode,
 } from "@/api-client";
 import { formatDuration } from "@/lib/duration";
@@ -114,17 +116,36 @@ export function getStatusBadgeProps(status: string) {
 
 export type RunsStatusFilter = "all" | "completed" | "errors" | "running" | "queued";
 
-export function filterRunEvents(
-  events: CanvasesCanvasEventWithExecutions[],
+export function getRunRootEventForDisplay(run: CanvasesCanvasRun): CanvasesCanvasEventWithExecutions | null {
+  const rootEvent = run.rootEvent;
+  if (!rootEvent?.id) {
+    return null;
+  }
+
+  return {
+    id: rootEvent.id,
+    canvasId: run.canvasId,
+    nodeId: rootEvent.nodeId,
+    channel: rootEvent.channel,
+    customName: rootEvent.customName,
+    data: rootEvent.data,
+    createdAt: rootEvent.createdAt,
+    executions: run.executions,
+  };
+}
+
+export function filterRuns(
+  runs: CanvasesCanvasRun[],
   nodes: ComponentsNode[],
   statusFilter: RunsStatusFilter,
   searchQuery: string,
-) {
+): CanvasesCanvasRun[] {
   const query = searchQuery.trim().toLowerCase();
-  return events.filter((event) => {
-    const executions = event.executions || [];
+  return runs.filter((run) => {
+    const executions = run.executions || [];
     if (statusFilter !== "all" && !matchesStatusFilter(executions, statusFilter)) return false;
-    if (query && !matchesSearchQuery(event, executions, nodes, query)) return false;
+    const rootEvent = getRunRootEventForDisplay(run);
+    if (query && rootEvent && !matchesSearchQuery(rootEvent, executions, nodes, query)) return false;
     return true;
   });
 }
@@ -165,10 +186,10 @@ function matchesSearchQuery(
   return searchableText.includes(query);
 }
 
-export function countUnacknowledgedErrors(events: CanvasesCanvasEventWithExecutions[]): number {
+export function countUnacknowledgedErrors(runs: CanvasesCanvasRun[]): number {
   let count = 0;
-  for (const event of events) {
-    for (const exec of event.executions || []) {
+  for (const run of runs) {
+    for (const exec of run.executions || []) {
       if (exec.result === "RESULT_FAILED" && exec.resultReason !== "RESULT_REASON_ERROR_RESOLVED") {
         count++;
       }
@@ -183,25 +204,27 @@ export function findNode(nodes: ComponentsNode[], nodeId: string | undefined): C
   return nodes.find((n) => n.id === nodeId) || nodes.find((n) => n.id === baseNodeId);
 }
 
-export function mergeQueueItemsWithEvents(
-  events: CanvasesCanvasEventWithExecutions[],
+export function mergeQueueItemsWithRuns(
+  runs: CanvasesCanvasRun[],
   nodeQueueItemsMap: Record<string, CanvasesCanvasNodeQueueItem[]>,
 ): {
   queueItemsByEventId: Record<string, CanvasesCanvasNodeQueueItem[]>;
-  allEvents: CanvasesCanvasEventWithExecutions[];
+  allRuns: CanvasesCanvasRun[];
 } {
   const map: Record<string, CanvasesCanvasNodeQueueItem[]> = {};
   const orphansByEvent: Record<
     string,
     { event: CanvasesCanvasNodeQueueItem["rootEvent"]; items: CanvasesCanvasNodeQueueItem[] }
   > = {};
-  const eventIds = new Set(events.map((e) => e.id));
+  const rootEventIds = new Set(
+    runs.map((run) => run.rootEvent?.id).filter((eventId): eventId is string => Boolean(eventId)),
+  );
 
   for (const items of Object.values(nodeQueueItemsMap)) {
     for (const item of items) {
       const eventId = item.rootEvent?.id;
       if (!eventId) continue;
-      if (eventIds.has(eventId)) {
+      if (rootEventIds.has(eventId)) {
         if (!map[eventId]) map[eventId] = [];
         map[eventId].push(item);
       } else {
@@ -211,29 +234,34 @@ export function mergeQueueItemsWithEvents(
     }
   }
 
-  const orphanEvents: CanvasesCanvasEventWithExecutions[] = Object.entries(orphansByEvent).map(
+  const orphanRuns: CanvasesCanvasRun[] = Object.entries(orphansByEvent).map(
     ([eventId, { event: rootEvent, items }]) => ({
       id: eventId,
       canvasId: items[0]?.canvasId,
-      nodeId: rootEvent?.nodeId,
-      channel: rootEvent?.channel,
-      data: rootEvent?.data as Record<string, unknown> | undefined,
-      createdAt: rootEvent?.createdAt,
+      rootEvent: rootEvent as CanvasesCanvasEvent | undefined,
       executions: [],
     }),
   );
 
-  if (orphanEvents.length === 0) return { queueItemsByEventId: map, allEvents: events };
+  if (orphanRuns.length === 0) return { queueItemsByEventId: map, allRuns: runs };
 
   for (const [eventId, { items }] of Object.entries(orphansByEvent)) {
     map[eventId] = items;
   }
 
-  const merged = [...orphanEvents, ...events];
+  const merged = [...orphanRuns, ...runs];
   merged.sort((a, b) => {
-    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    const ta = a.createdAt
+      ? new Date(a.createdAt).getTime()
+      : a.rootEvent?.createdAt
+        ? new Date(a.rootEvent.createdAt).getTime()
+        : 0;
+    const tb = b.createdAt
+      ? new Date(b.createdAt).getTime()
+      : b.rootEvent?.createdAt
+        ? new Date(b.rootEvent.createdAt).getTime()
+        : 0;
     return tb - ta;
   });
-  return { queueItemsByEventId: map, allEvents: merged };
+  return { queueItemsByEventId: map, allRuns: merged };
 }

--- a/web_src/src/ui/CanvasLogSidebar/index.tsx
+++ b/web_src/src/ui/CanvasLogSidebar/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ChevronDown, ChevronRight, CircleAlert, CircleX, Search, X } from "lucide-react";
 
-import type { CanvasesCanvasEventWithExecutions, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
+import type { CanvasesCanvasRun, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
 import { Button } from "@/components/ui/button";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { cn } from "@/lib/utils";
@@ -44,7 +44,7 @@ export interface CanvasLogSidebarProps {
   counts: LogCounts;
   activeTab?: ConsoleTab;
   onTabChange?: (tab: ConsoleTab) => void;
-  runsEvents?: CanvasesCanvasEventWithExecutions[];
+  logRuns?: CanvasesCanvasRun[];
   runsNodes?: ComponentsNode[];
   runsComponentIconMap?: Record<string, string>;
   onRunNodeSelect?: (nodeId: string) => void;
@@ -90,7 +90,7 @@ export function CanvasLogSidebar({
   counts,
   activeTab: controlledTab,
   onTabChange,
-  runsEvents = [],
+  logRuns = [],
   runsNodes = [],
   runsComponentIconMap = {},
   onRunNodeSelect,
@@ -231,7 +231,7 @@ export function CanvasLogSidebar({
     [setSidebarHeight, sidebarHeight],
   );
 
-  const unacknowledgedCount = useMemo(() => countUnacknowledgedErrors(runsEvents), [runsEvents]);
+  const unacknowledgedCount = useMemo(() => countUnacknowledgedErrors(logRuns), [logRuns]);
 
   if (!isOpen) {
     return null;
@@ -351,7 +351,7 @@ export function CanvasLogSidebar({
 
         {activeTab === "errors" ? (
           <ErrorsConsoleContent
-            events={runsEvents}
+            runs={logRuns}
             nodes={runsNodes}
             componentIconMap={runsComponentIconMap}
             searchQuery={searchValue}

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -39,9 +39,8 @@ import {
 
 import type {
   CanvasChangesetChange,
-  CanvasesCanvasEventWithExecutions,
-  CanvasesCanvasNodeExecution,
   CanvasesCanvasRun,
+  CanvasesCanvasNodeExecution,
   ActionsAction,
   ComponentsIntegrationRef,
   SuperplaneComponentsNode as ComponentsNode,
@@ -293,7 +292,7 @@ export interface CanvasPageProps {
   onDuplicateNodes?: (nodeIds: string[]) => void;
   onAutoLayoutNodes?: (nodeIds: string[]) => void;
   onEdgeDelete?: (edgeIds: string[]) => void;
-  runsEvents?: CanvasesCanvasEventWithExecutions[];
+  logRuns?: CanvasesCanvasRun[];
   runsNodes?: ComponentsNode[];
   runsComponentIconMap?: Record<string, string>;
   toolSidebarRunsContent?: React.ReactNode;
@@ -1634,7 +1633,7 @@ function CanvasPage(props: CanvasPageProps) {
                   runParticipantNodeIds={props.runParticipantNodeIds}
                   runSelectedNodeId={props.isRunInspectionMode ? props.runNodeDetailNodeId : null}
                   runNodeDetailPaneOpen={bottomDetailPaneOpen}
-                  runsEvents={props.runsEvents}
+                  logRuns={props.logRuns}
                   runsNodes={props.runsNodes}
                   runsComponentIconMap={props.runsComponentIconMap}
                   onRunNodeSelect={props.onRunNodeSelect}
@@ -2270,7 +2269,7 @@ function CanvasContent({
   runParticipantNodeIds,
   runSelectedNodeId,
   runNodeDetailPaneOpen,
-  runsEvents,
+  logRuns,
   runsNodes,
   runsComponentIconMap,
   onRunNodeSelect,
@@ -2329,7 +2328,7 @@ function CanvasContent({
   runParticipantNodeIds?: string[];
   runSelectedNodeId?: string | null;
   runNodeDetailPaneOpen?: boolean;
-  runsEvents?: CanvasesCanvasEventWithExecutions[];
+  logRuns?: CanvasesCanvasRun[];
   runsNodes?: ComponentsNode[];
   runsComponentIconMap?: Record<string, string>;
   onRunNodeSelect?: (nodeId: string) => void;
@@ -2426,7 +2425,7 @@ function CanvasContent({
     localStorage.setItem(CONSOLE_HEIGHT_STORAGE_KEY, String(logSidebarHeight));
   }, [logSidebarHeight]);
 
-  const unacknowledgedErrorCount = useMemo(() => countUnacknowledgedErrors(runsEvents || []), [runsEvents]);
+  const unacknowledgedErrorCount = useMemo(() => countUnacknowledgedErrors(logRuns || []), [logRuns]);
 
   useEffect(() => {
     if (!showBottomStatusControls) {
@@ -3553,7 +3552,7 @@ function CanvasContent({
           counts={logCounts}
           activeTab={consoleTab}
           onTabChange={setConsoleTab}
-          runsEvents={runsEvents}
+          logRuns={logRuns}
           runsNodes={runsNodes}
           runsComponentIconMap={runsComponentIconMap}
           onRunNodeSelect={onRunNodeSelect}


### PR DESCRIPTION
Related to https://github.com/superplanehq/superplane/issues/5521

First step before removing that endpoint is updating the UI to use only the /runs endpoint.