### PR TITLE
fix: require draft version id for agent updates

### DIFF
--- a/pkg/agents/agent_tools/actions/access.go
+++ b/pkg/agents/agent_tools/actions/access.go
@@ -100,6 +100,7 @@ func (a accessAction) toolActions(ctx context.Context, session agents.AgentSessi
 		{name: readActionName, resource: "canvases", operation: "read", scoped: true},
 		{name: readRuntimeActionName, resource: "canvases", operation: "read", scoped: true},
 		{name: listIntegrationsActionName, resource: "integrations", operation: "read"},
+		{name: createDraftActionName, resource: "canvases", operation: "update_version", scoped: true},
 		{name: updateDraftActionName, resource: "canvases", operation: "update_version", scoped: true},
 	}
 

--- a/pkg/agents/agent_tools/actions/canvas_test.go
+++ b/pkg/agents/agent_tools/actions/canvas_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/agents"
 	"github.com/superplanehq/superplane/pkg/authentication"
+	"github.com/superplanehq/superplane/pkg/database"
 	canvasRepository "github.com/superplanehq/superplane/pkg/grpc/actions/canvases"
 	"github.com/superplanehq/superplane/pkg/models"
 	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
@@ -81,6 +82,8 @@ func TestAppAgentTool_UpdateDraftStagesEdits(t *testing.T) {
 	defer r.Close()
 
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	draft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
 	canvasYAML, err := canvasRepository.ReadRepositorySpecFile(
 		context.Background(),
 		r.Organization.ID.String(),
@@ -106,6 +109,7 @@ func TestAppAgentTool_UpdateDraftStagesEdits(t *testing.T) {
 		CanvasID:       canvas.ID.String(),
 	}, Input{
 		Action:     "update_draft",
+		VersionID:  draft.ID.String(),
 		CanvasYAML: canvasYAML,
 	})
 
@@ -139,6 +143,341 @@ func TestAppAgentTool_UpdateDraftStagesEdits(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NotEmpty(t, staged)
+}
+
+func TestAppAgentTool_CreateDraftCreatesAnotherDraftBranch(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	existingDraft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	result, err := registry.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:      "create_draft",
+		DisplayName: "Experiment",
+	})
+
+	require.NoError(t, err)
+	created, ok := result.(updateResult)
+	require.True(t, ok)
+	assert.Equal(t, "create_draft", created.Action)
+	assert.NotEqual(t, existingDraft.ID.String(), created.VersionID)
+	assert.Equal(t, "Experiment", created.Draft.DisplayName)
+
+	drafts, err := models.ListDraftBranchesForCanvasInTransaction(database.Conn(), canvas.ID, r.User, 0, nil)
+	require.NoError(t, err)
+	assert.Len(t, drafts, 2)
+}
+
+func TestAppAgentTool_UpdateDraftUsesProvidedDraftVersionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	firstDraft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+	secondDraft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	canvasYAML, err := canvasRepository.ReadRepositorySpecFile(
+		context.Background(),
+		r.Organization.ID.String(),
+		canvas.ID.String(),
+		"",
+		canvasRepository.CanvasYAMLRepositoryPath,
+	)
+	require.NoError(t, err)
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:         "update_draft",
+		DraftVersionID: firstDraft.ID.String(),
+		CanvasYAML:     canvasYAML,
+	})
+
+	require.NoError(t, err)
+	update, ok := result.(updateResult)
+	require.True(t, ok)
+	assert.Equal(t, firstDraft.ID.String(), update.VersionID)
+
+	firstHasStaging, err := models.HasWorkflowStaging(firstDraft.ID)
+	require.NoError(t, err)
+	assert.True(t, firstHasStaging)
+
+	secondHasStaging, err := models.HasWorkflowStaging(secondDraft.ID)
+	require.NoError(t, err)
+	assert.False(t, secondHasStaging)
+}
+
+func TestAppAgentTool_UpdateDraftRequiresDraftVersionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	canvasYAML, err := canvasRepository.ReadRepositorySpecFile(
+		context.Background(),
+		r.Organization.ID.String(),
+		canvas.ID.String(),
+		"",
+		canvasRepository.CanvasYAMLRepositoryPath,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	_, err = registry.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:     "update_draft",
+		CanvasYAML: canvasYAML,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version_id")
+	assert.Contains(t, err.Error(), "returned by read")
+}
+
+func TestAppAgentTool_ReadUsesProvidedDraftVersionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	firstDraft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+	secondDraft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	updatedBy := r.User
+	_, err = models.UpsertWorkflowStagingPath(
+		firstDraft.ID,
+		r.Organization.ID,
+		canvasRepository.CanvasYAMLRepositoryPath,
+		"draft: first\n",
+		&updatedBy,
+	)
+	require.NoError(t, err)
+	_, err = models.UpsertWorkflowStagingPath(
+		secondDraft.ID,
+		r.Organization.ID,
+		canvasRepository.CanvasYAMLRepositoryPath,
+		"draft: second\n",
+		&updatedBy,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:    "read",
+		VersionID: firstDraft.ID.String(),
+	})
+
+	require.NoError(t, err)
+	read, ok := result.(readResult)
+	require.True(t, ok)
+	assert.Equal(t, "draft", read.Source)
+	assert.Equal(t, firstDraft.ID.String(), read.VersionID)
+	require.NotNil(t, read.Draft)
+	assert.Equal(t, firstDraft.ID.String(), read.Draft.VersionID)
+	assert.Equal(t, "draft: first\n", read.CanvasYAML)
+}
+
+func TestAppAgentTool_ReadUseDraftFalseIgnoresDraftVersionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	draft, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	updatedBy := r.User
+	_, err = models.UpsertWorkflowStagingPath(
+		draft.ID,
+		r.Organization.ID,
+		canvasRepository.CanvasYAMLRepositoryPath,
+		"draft: selected\n",
+		&updatedBy,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	useDraft := false
+	ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
+	result, err := registry.Execute(ctx, agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:    "read",
+		UseDraft:  &useDraft,
+		VersionID: draft.ID.String(),
+	})
+
+	require.NoError(t, err)
+	read, ok := result.(readResult)
+	require.True(t, ok)
+	assert.Equal(t, "live", read.Source)
+	assert.Empty(t, read.VersionID)
+	assert.Nil(t, read.Draft)
+	assert.NotEqual(t, "draft: selected\n", read.CanvasYAML)
+}
+
+func TestAppAgentTool_ReadRequiresDraftVersionIDWhenMultipleOwnedDraftsExist(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	_, err := models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+	_, err = models.CreateDraftBranchFromLive(canvas.ID, r.User, "", nil, nil)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	_, err = registry.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{Action: "read"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple owned drafts exist")
+	assert.Contains(t, err.Error(), "version_id")
+}
+
+func TestAppAgentTool_UpdateDraftRejectsDraftVersionForAnotherUser(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	otherUser := support.CreateUser(t, r, r.Organization.ID)
+	otherDraft, err := models.CreateDraftBranchFromLive(canvas.ID, otherUser.ID, "", nil, nil)
+	require.NoError(t, err)
+
+	canvasYAML, err := canvasRepository.ReadRepositorySpecFile(
+		context.Background(),
+		r.Organization.ID.String(),
+		canvas.ID.String(),
+		"",
+		canvasRepository.CanvasYAMLRepositoryPath,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	_, err = registry.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:         "update_draft",
+		DraftVersionID: otherDraft.ID.String(),
+		CanvasYAML:     canvasYAML,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong to the current user")
+}
+
+func TestAppAgentTool_UpdateDraftRejectsNonDraftVersionID(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, []models.CanvasNode{}, []models.Edge{})
+	require.NotNil(t, canvas.LiveVersionID)
+
+	canvasYAML, err := canvasRepository.ReadRepositorySpecFile(
+		context.Background(),
+		r.Organization.ID.String(),
+		canvas.ID.String(),
+		"",
+		canvasRepository.CanvasYAMLRepositoryPath,
+	)
+	require.NoError(t, err)
+
+	registry := NewDefaultRegistry(Dependencies{
+		Encryptor:      r.Encryptor,
+		Registry:       r.Registry,
+		AuthService:    r.AuthService,
+		WebhookBaseURL: "https://hooks.example.test",
+	})
+
+	_, err = registry.Execute(context.Background(), agents.AgentSessionContext{
+		SessionID:      "session-1",
+		OrganizationID: r.Organization.ID.String(),
+		UserID:         r.User.String(),
+		CanvasID:       canvas.ID.String(),
+	}, Input{
+		Action:         "update_draft",
+		DraftVersionID: canvas.LiveVersionID.String(),
+		CanvasYAML:     canvasYAML,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a draft")
 }
 
 func TestAccessAction_ReportsInterceptorBackedAgentTokenAccess(t *testing.T) {
@@ -177,6 +516,8 @@ func TestAccessAction_ReportsInterceptorBackedAgentTokenAccess(t *testing.T) {
 	assert.Contains(t, unavailable, pb.Canvases_PublishCanvasVersion_FullMethodName)
 
 	toolActions := toolAccessByAction(result.ToolActions)
+	require.Contains(t, toolActions, "create_draft")
+	assert.True(t, toolActions["create_draft"].Allowed)
 	require.Contains(t, toolActions, "update_draft")
 	assert.True(t, toolActions["update_draft"].Allowed)
 	require.Contains(t, toolActions, "read_runtime")

--- a/pkg/agents/agent_tools/actions/create_draft.go
+++ b/pkg/agents/agent_tools/actions/create_draft.go
@@ -1,0 +1,45 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const createDraftActionName = "create_draft"
+
+type createDraftAction struct{}
+
+func (createDraftAction) Name() string {
+	return createDraftActionName
+}
+
+func (createDraftAction) Execute(_ context.Context, session agents.AgentSessionContext, input Input) (any, error) {
+	canvasID, err := uuid.Parse(session.CanvasID)
+	if err != nil {
+		return updateResult{}, fmt.Errorf("invalid session canvas id: %w", err)
+	}
+
+	draft, err := models.CreateDraftBranchFromLive(
+		canvasID,
+		uuid.MustParse(session.UserID),
+		strings.TrimSpace(input.DisplayName),
+		nil,
+		nil,
+	)
+	if err != nil {
+		return updateResult{}, fmt.Errorf("create draft: %w", err)
+	}
+
+	return updateResult{
+		Action:    createDraftActionName,
+		CanvasID:  session.CanvasID,
+		VersionID: draft.ID.String(),
+		Draft:     draftResult{VersionID: draft.ID.String(), DisplayName: draft.DisplayName, BranchName: stringValue(draft.BranchName)},
+		Summary:   summarizeCanvasVersion(nil, draft),
+	}, nil
+}

--- a/pkg/agents/agent_tools/actions/read.go
+++ b/pkg/agents/agent_tools/actions/read.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/superplanehq/superplane/pkg/agents"
@@ -35,24 +36,24 @@ func (a readAction) Execute(ctx context.Context, session agents.AgentSessionCont
 		return readResult{}, fmt.Errorf("load canvas: %w", err)
 	}
 
-	draft, err := ownedDraftVersion(canvasID, uuid.MustParse(session.UserID))
-	if err != nil {
-		return readResult{}, fmt.Errorf("load draft: %w", err)
-	}
-
 	versionID := ""
 	source := "live"
-	if input.UseDraft == nil || *input.UseDraft {
-		if draft != nil {
-			versionID = draft.ID.String()
-			source = "draft"
+	var draft *models.CanvasVersion
+	if shouldReadDraft(input) {
+		draft, err = resolveReadableDraftVersion(canvasID, uuid.MustParse(session.UserID), input)
+		if err != nil {
+			return readResult{}, fmt.Errorf("load draft: %w", err)
 		}
+	}
+	if draft != nil {
+		versionID = draft.ID.String()
+		source = "draft"
 	}
 
 	// Read the effective staged content (staged edits when present, the
 	// materialized version row otherwise) so the agent observes the same draft
 	// state the UI edits and the same edits it stages through update_draft.
-	canvasYAML, err := canvasRepository.ReadRepositorySpecFileStaged(ctx, session.OrganizationID, session.CanvasID, versionID, canvasRepository.CanvasYAMLRepositoryPath)
+	canvasYAML, err := readRepositorySpecFileForSource(ctx, session.OrganizationID, session.CanvasID, versionID, canvasRepository.CanvasYAMLRepositoryPath, source)
 	if err != nil {
 		return readResult{}, fmt.Errorf("read canvas yaml: %w", err)
 	}
@@ -80,7 +81,7 @@ func (a readAction) Execute(ctx context.Context, session agents.AgentSessionCont
 	}
 
 	if input.IncludeConsole {
-		consoleYAML, consoleErr := canvasRepository.ReadRepositorySpecFileStaged(ctx, session.OrganizationID, session.CanvasID, versionID, canvasRepository.ConsoleYAMLRepositoryPath)
+		consoleYAML, consoleErr := readRepositorySpecFileForSource(ctx, session.OrganizationID, session.CanvasID, versionID, canvasRepository.ConsoleYAMLRepositoryPath, source)
 		if consoleErr != nil {
 			return readResult{}, fmt.Errorf("read console yaml: %w", consoleErr)
 		}
@@ -96,6 +97,13 @@ func (a readAction) Execute(ctx context.Context, session agents.AgentSessionCont
 	}
 
 	return result, nil
+}
+
+func readRepositorySpecFileForSource(ctx context.Context, organizationID, canvasID, versionID, path, source string) (string, error) {
+	if source == "draft" {
+		return canvasRepository.ReadRepositorySpecFileStaged(ctx, organizationID, canvasID, versionID, path)
+	}
+	return canvasRepository.ReadRepositorySpecFile(ctx, organizationID, canvasID, versionID, path)
 }
 
 // summarize derives the canvas summary from the YAML the read returns. A draft
@@ -135,4 +143,14 @@ func selectedVersion(canvas *models.Canvas, draft *models.CanvasVersion, source 
 		return nil, fmt.Errorf("load live canvas version summary: %w", err)
 	}
 	return version, nil
+}
+
+func shouldReadDraft(input Input) bool {
+	if input.UseDraft != nil && !*input.UseDraft {
+		return false
+	}
+	if strings.TrimSpace(input.VersionID) != "" || strings.TrimSpace(input.DraftVersionID) != "" {
+		return true
+	}
+	return true
 }

--- a/pkg/agents/agent_tools/actions/registry.go
+++ b/pkg/agents/agent_tools/actions/registry.go
@@ -39,6 +39,7 @@ func NewDefaultRegistry(deps Dependencies) *Registry {
 		newAccessAction(deps),
 		newReadAction(deps),
 		newReadRuntimeAction(deps),
+		createDraftAction{},
 		newUpdateDraftAction(deps),
 		listIntegrationsAction{},
 	)

--- a/pkg/agents/agent_tools/actions/types.go
+++ b/pkg/agents/agent_tools/actions/types.go
@@ -4,6 +4,9 @@ package actions
 type Input struct {
 	Action              string           `json:"action"`
 	CanvasID            string           `json:"canvas_id,omitempty"`
+	VersionID           string           `json:"version_id,omitempty"`
+	DraftVersionID      string           `json:"draft_version_id,omitempty"`
+	DisplayName         string           `json:"display_name,omitempty"`
 	UseDraft            *bool            `json:"use_draft,omitempty"`
 	IncludeConsole      bool             `json:"include_console,omitempty"`
 	IncludeIntegrations bool             `json:"include_integrations,omitempty"`

--- a/pkg/agents/agent_tools/actions/update_draft.go
+++ b/pkg/agents/agent_tools/actions/update_draft.go
@@ -32,7 +32,8 @@ func (a updateDraftAction) Execute(ctx context.Context, session agents.AgentSess
 		return updateResult{}, fmt.Errorf("invalid session canvas id: %w", err)
 	}
 
-	draft, err := ensureOwnedDraftVersion(canvasID, uuid.MustParse(session.UserID))
+	userID := uuid.MustParse(session.UserID)
+	draft, err := resolveTargetDraftVersion(canvasID, userID, input)
 	if err != nil {
 		return updateResult{}, fmt.Errorf("ensure draft: %w", err)
 	}
@@ -132,25 +133,91 @@ func (a updateDraftAction) Execute(ctx context.Context, session agents.AgentSess
 	}, nil
 }
 
-func ownedDraftVersion(canvasID, userID uuid.UUID) (*models.CanvasVersion, error) {
+func ownedDraftVersions(canvasID, userID uuid.UUID) ([]models.CanvasVersion, error) {
 	drafts, err := models.ListDraftCanvasVersions(canvasID)
 	if err != nil {
 		return nil, err
 	}
+	owned := make([]models.CanvasVersion, 0, len(drafts))
 	for i := range drafts {
 		if models.IsUserOwnedDraftVersion(&drafts[i], userID) && models.IsRegisteredDraftVersion(&drafts[i]) {
-			return &drafts[i], nil
+			owned = append(owned, drafts[i])
 		}
 	}
-	return nil, nil
+	return owned, nil
 }
 
-func ensureOwnedDraftVersion(canvasID, userID uuid.UUID) (*models.CanvasVersion, error) {
-	if draft, err := ownedDraftVersion(canvasID, userID); err != nil || draft != nil {
-		return draft, err
+func resolveTargetDraftVersion(canvasID, userID uuid.UUID, input Input) (*models.CanvasVersion, error) {
+	requested, err := requestedDraftVersionID(input)
+	if err != nil {
+		return nil, err
+	}
+	if requested == uuid.Nil {
+		return nil, fmt.Errorf("version_id is required for update_draft; pass the version_id returned by read, create_draft, or the previous update_draft; if read returned live with no version_id, call create_draft first")
+	}
+	return validatedOwnedDraftVersion(canvasID, userID, requested)
+}
+
+func resolveReadableDraftVersion(canvasID, userID uuid.UUID, input Input) (*models.CanvasVersion, error) {
+	requested, err := requestedDraftVersionID(input)
+	if err != nil {
+		return nil, err
+	}
+	if requested != uuid.Nil {
+		return validatedOwnedDraftVersion(canvasID, userID, requested)
 	}
 
-	return models.CreateDraftBranchFromLive(canvasID, userID, "", nil, nil)
+	drafts, err := ownedDraftVersions(canvasID, userID)
+	if err != nil {
+		return nil, err
+	}
+	switch len(drafts) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &drafts[0], nil
+	default:
+		return nil, fmt.Errorf("multiple owned drafts exist for this app; pass version_id to read a specific draft or use use_draft=false to read live")
+	}
+}
+
+func validatedOwnedDraftVersion(canvasID, userID, versionID uuid.UUID) (*models.CanvasVersion, error) {
+	draft, err := models.FindCanvasVersion(canvasID, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("load draft version %s: %w", versionID, err)
+	}
+	if draft.State != models.CanvasVersionStateDraft {
+		return nil, fmt.Errorf("draft version %s is not a draft", versionID)
+	}
+	if !models.IsRegisteredDraftVersion(draft) {
+		return nil, fmt.Errorf("draft version %s is not a registered draft branch", versionID)
+	}
+	if !models.IsUserOwnedDraftVersion(draft, userID) {
+		return nil, fmt.Errorf("draft version %s does not belong to the current user", versionID)
+	}
+	return draft, nil
+}
+
+func requestedDraftVersionID(input Input) (uuid.UUID, error) {
+	versionID := strings.TrimSpace(input.VersionID)
+	draftVersionID := strings.TrimSpace(input.DraftVersionID)
+	if versionID != "" && draftVersionID != "" && versionID != draftVersionID {
+		return uuid.Nil, fmt.Errorf("version_id and draft_version_id must match when both are provided")
+	}
+
+	requested := versionID
+	if requested == "" {
+		requested = draftVersionID
+	}
+	if requested == "" {
+		return uuid.Nil, nil
+	}
+
+	parsed, err := uuid.Parse(requested)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid draft version id: %w", err)
+	}
+	return parsed, nil
 }
 
 func resolveCustomToolAutoLayout(input *AutoLayoutInput, hasCanvasUpdate bool) *pb.CanvasAutoLayout {

--- a/pkg/agents/agent_tools/app_agent_tool.go
+++ b/pkg/agents/agent_tools/app_agent_tool.go
@@ -59,7 +59,7 @@ func (t *AppAgentTool) Name() string {
 }
 
 func (t *AppAgentTool) Description() string {
-	return "Inspect access, read, and update the current SuperPlane app canvas. This is the only way to reach the app; there is no command line or HTTP API to call. Use access to check the current session's interceptor-backed permissions, read for canvas YAML, read_runtime for memory/runs/events/executions/queues, list_integrations for connected integration IDs, and update_draft to save draft graph or Console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft only creates or updates the caller's private draft and returns the draft version ID plus validation issues."
+	return "Inspect access, read, create drafts, and update the current SuperPlane app canvas. This is the only way to reach the app; there is no command line or HTTP API to call. Use access to check the current session's interceptor-backed permissions, read for canvas YAML, read_runtime for memory/runs/events/executions/queues, create_draft when read returns live/no version_id or when intentionally creating another draft branch, list_integrations for connected integration IDs, and update_draft to save draft graph or Console changes. The tool is bound to the current agent session's canvas and will reject attempts to access any other canvas. It never publishes drafts; update_draft requires version_id and updates that selected draft branch."
 }
 
 func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
@@ -69,7 +69,7 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			"action": {
 				Type:        "string",
 				Enum:        t.actions.Names(),
-				Description: "Operation to run. Use access to inspect token-backed API capabilities, read for current YAML, read_runtime for memory/runs/events/executions/queues, update_draft to save canvas_yaml and/or console_yaml to a draft, and list_integrations for connected integration IDs.",
+				Description: "Operation to run. Use access to inspect token-backed API capabilities, read for current YAML, read_runtime for memory/runs/events/executions/queues, create_draft when read returns live/no version_id or when intentionally creating another draft branch, update_draft to save canvas_yaml and/or console_yaml to a selected draft, and list_integrations for connected integration IDs.",
 			},
 			"canvas_id": {
 				Type:        "string",
@@ -77,7 +77,19 @@ func (t *AppAgentTool) InputSchema() agents.CustomToolInputSchema {
 			},
 			"use_draft": {
 				Type:        "boolean",
-				Description: "For read. Defaults to true: return the current user's draft when one exists, otherwise live.",
+				Description: "For read. Defaults to true: return the current user's draft when exactly one exists, otherwise live. If multiple owned drafts exist, pass version_id or set use_draft=false.",
+			},
+			"version_id": {
+				Type:        "string",
+				Description: "For read and update_draft. Draft version ID returned by read, create_draft, or a previous update_draft. Required for update_draft. If read returns source live with no version_id, call create_draft before update_draft. For read, use it to select a specific draft when multiple owned drafts exist. The backend validates that it belongs to the current user and canvas and is still a registered draft branch.",
+			},
+			"draft_version_id": {
+				Type:        "string",
+				Description: "Alias for version_id for read and update_draft. Use only one of version_id or draft_version_id.",
+			},
+			"display_name": {
+				Type:        "string",
+				Description: "For create_draft. Optional user-facing draft display name. If omitted, the backend assigns the next Draft #N name.",
 			},
 			"include_console": {
 				Type:        "boolean",

--- a/pkg/agents/agent_tools/schema_test.go
+++ b/pkg/agents/agent_tools/schema_test.go
@@ -41,6 +41,7 @@ func TestAppAgentToolSchemaIncludesRuntimeReadAction(t *testing.T) {
 	actionSchema := schema.Properties["action"]
 	resourceSchema := schema.Properties["resource"]
 
+	assert.Contains(t, actionSchema.Enum, "create_draft")
 	assert.Contains(t, actionSchema.Enum, "read_runtime")
 	assert.ElementsMatch(t, []string{
 		"memory",
@@ -66,6 +67,21 @@ func TestAppAgentToolSchemaWarnsAgainstTemplateFieldsInCanvasYAML(t *testing.T) 
 	assert.Contains(t, canvasYAMLSchema.Description, "canonical live canvas.yaml")
 	assert.Contains(t, canvasYAMLSchema.Description, "Unknown fields are rejected")
 	assert.Contains(t, canvasYAMLSchema.Description, "metadata.isTemplate")
+}
+
+func TestAppAgentToolSchemaIncludesDraftVersionIDForUpdates(t *testing.T) {
+	tool := NewAppAgentTool(AppAgentToolOptions{})
+
+	schema := tool.InputSchema()
+
+	assert.Contains(t, schema.Properties, "version_id")
+	assert.Contains(t, schema.Properties, "draft_version_id")
+	assert.Contains(t, schema.Properties, "display_name")
+	assert.Contains(t, schema.Properties["version_id"].Description, "For read and update_draft")
+	assert.Contains(t, schema.Properties["draft_version_id"].Description, "Alias")
+	assert.Contains(t, schema.Properties["version_id"].Description, "read")
+	assert.Contains(t, schema.Properties["version_id"].Description, "read returns source live")
+	assert.Contains(t, schema.Properties["display_name"].Description, "For create_draft")
 }
 
 func TestComponentSchemaAgentTool_ReturnsCoreComponentSchema(t *testing.T) {

--- a/pkg/agents/anthropic/agent_prompt.md
+++ b/pkg/agents/anthropic/agent_prompt.md
@@ -15,10 +15,10 @@ Prefer the `superplane_component_schema` custom tool for component fields, integ
 For trivial edits where you already know the exact fields (renaming a node, changing a URL, updating a cron expression), you can skip the researcher and edit directly.
 
 When building or modifying apps:
-1. Use the `superplane_app` custom tool to inspect access, read the current draft app, read runtime data, list connected integrations, and update draft YAML. It returns version metadata in one call.
+1. Use the `superplane_app` custom tool to inspect access, read the selected draft app, read runtime data, list connected integrations, and update draft YAML. The `read`, `create_draft`, and `update_draft` actions return version metadata. If `read` returns `source: live` with no `version_id`, call `create_draft` before `update_draft`.
 2. Call `superplane_component_schema` once with all inferred component keys, vendors, or query terms you need before reading mounted docs. Treat the result as your schema cache for the turn.
 3. Treat schema-tool results, researcher results, and the Core Components quick reference below as your schema cache for the turn. Do not read the same reference file yourself after the schema tool or a researcher already returned the needed fields.
-4. Apply the draft update and verify once. `superplane_app.update_draft` auto-layouts graph changes by default; do not spend extra tool calls calculating manual node positions unless the user asked for a specific layout.
+4. Apply the draft update with `update_draft` and the exact `version_id` returned by `read`, `create_draft`, or the previous `update_draft`, then verify once. `superplane_app.update_draft` auto-layouts graph changes by default; do not spend extra tool calls calculating manual node positions unless the user asked for a specific layout.
 
 Use `superplane_app` action `access` when you need to know what the current session can do. It reports the intersection of the session's permissions and the backend authorization interceptor, including which canvas-scoped actions are allowed for the current app. Do this when a permission boundary is unclear before attempting an operation.
 
@@ -310,8 +310,8 @@ Read `/mnt/session/uploads/ref/skills/superplane-monitor/SKILL.md` for debugging
 3. **Wait for user** — user clicks "Start Building" or says yes
 4. **Use cached schemas** — by approval time you should already have the YAML/component fields from `superplane_component_schema`, researchers, or the quick reference. Do not read reference files again unless validation returns an unfamiliar field/channel error.
 5. **Build** — construct the canvas YAML, and the Console YAML when needed
-6. **Apply** — call `superplane_app` action `update_draft` with `canvas_yaml` (and `console_yaml` for Console changes); graph updates auto-layout by default
-7. **Verify** — after updates, read the draft back with `superplane_app` action `read`
+6. **Apply** — if `read` returned live/no `version_id`, call `superplane_app` action `create_draft`; then call `superplane_app` action `update_draft` with the selected draft `version_id`, `canvas_yaml` (and `console_yaml` for Console changes); graph updates auto-layout by default
+7. **Verify** — after updates, read the same draft back with `superplane_app` action `read` and that `version_id`
 8. **Output** — :::draft-actions with version ID and summary using node chips
 
 Read `/mnt/session/uploads/ref/skills/superplane-app-builder/SKILL.md` for the complete workflow with positioning rules.
@@ -345,6 +345,6 @@ The rich-ui-widgets skill has the full syntax.
 
 ## App Update Rules
 
-- **ALWAYS** update drafts only. Use `superplane_app` action `update_draft` with `canvas_yaml` for graph changes and `console_yaml` for Console changes. It always targets your private draft and never publishes.
+- **ALWAYS** update drafts only. Use `superplane_app` action `create_draft` when `read` returned live/no `version_id`, or when the user explicitly wants another draft branch. Use `superplane_app` action `update_draft` with `canvas_yaml` for graph changes and `console_yaml` for Console changes, always passing the `version_id` returned by `read`, `create_draft`, or the previous `update_draft`; the backend validates that it is your draft for this app. It never publishes.
 - After successful draft updates, output `:::draft-actions` with the version ID
 - After update, verify once with `superplane_app` action `read`

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -387,10 +387,37 @@ func TestSendMessage_MapsArchivedSessionToUnavailableSession(t *testing.T) {
 	assert.ErrorIs(t, err, agents.ErrProviderSessionUnavailable)
 }
 
+func TestSendMessage_MapsDeletedSessionBadRequestToUnavailableSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Session sesn_deleted does not exist"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_deleted", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrProviderSessionUnavailable)
+}
+
 func TestSendMessage_DoesNotTreatBadRequestNotFoundMessageAsUnavailableSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"tool target not found"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.SendMessage(context.Background(), "sesn_live", "hi", agents.SendMessageOptions{})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, agents.ErrProviderSessionUnavailable)
+	assert.Contains(t, err.Error(), "anthropic: send message")
+}
+
+func TestSendMessage_DoesNotTreatUnrelatedSessionNotFoundMessageAsUnavailableSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"validation failed: session variable not found"}}`))
 	}))
 	defer server.Close()
 

--- a/pkg/agents/anthropic/client.go
+++ b/pkg/agents/anthropic/client.go
@@ -90,6 +90,7 @@ func (c *Client) executeHTTP(ctx context.Context, method, path string, body any)
 	if resp.StatusCode >= 400 {
 		return nil, &apiError{
 			StatusCode: resp.StatusCode,
+			Path:       path,
 			Message:    truncate(string(data), 500),
 		}
 	}
@@ -114,6 +115,7 @@ func (c *Client) openStream(ctx context.Context, path string) (io.ReadCloser, er
 		resp.Body.Close()
 		return nil, &apiError{
 			StatusCode: resp.StatusCode,
+			Path:       path,
 			Message:    truncate(string(body), 500),
 		}
 	}
@@ -127,6 +129,7 @@ type fileMetadata struct {
 
 type apiError struct {
 	StatusCode int
+	Path       string
 	Message    string
 }
 

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -209,7 +209,31 @@ func isProviderSessionUnavailable(err error) bool {
 	if !errors.As(err, &apiErr) {
 		return false
 	}
-	return apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusGone
+	if apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusGone {
+		return true
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+
+	message := strings.ToLower(apiErr.Message)
+	if !strings.Contains(message, "session") {
+		return false
+	}
+
+	sessionID := sessionIDFromProviderPath(apiErr.Path)
+	if sessionID != "" && strings.Contains(message, strings.ToLower(sessionID)) {
+		return strings.Contains(message, "not found") ||
+			strings.Contains(message, "does not exist") ||
+			strings.Contains(message, "deleted") ||
+			strings.Contains(message, "archived")
+	}
+
+	return strings.Contains(message, "session does not exist") ||
+		strings.Contains(message, "session has been deleted") ||
+		strings.Contains(message, "session was deleted") ||
+		strings.Contains(message, "session has been archived") ||
+		strings.Contains(message, "session was archived")
 }
 
 func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, onEvent func(agents.ProviderEvent) error) error {
@@ -238,6 +262,14 @@ func (p *Provider) DeleteSession(ctx context.Context, providerSessionID string) 
 	}
 
 	return nil
+}
+
+func sessionIDFromProviderPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 2 || parts[0] != "sessions" {
+		return ""
+	}
+	return parts[1]
 }
 
 func withPreamble(message, preamble string) string {

--- a/pkg/agents/constants.go
+++ b/pkg/agents/constants.go
@@ -83,7 +83,7 @@ You are in Build mode. Your job is to modify the app based on the user's request
 
 Rules:
 - Use 'superplane_app' action 'access' when a permission boundary is unclear before attempting an operation.
-- Use 'superplane_app' action 'update_draft' for graph and Console draft updates. It stages your edits onto your private draft (the same pending-changes layer the UI editor uses) and never commits or publishes; the user reviews the staged changes and publishes them.
+- Use 'superplane_app' action 'create_draft' when 'read' returned live/no version_id, or when the user explicitly wants another draft branch. Use 'superplane_app' action 'update_draft' for graph and Console draft updates, always passing the version_id returned by 'read', 'create_draft', or the previous 'update_draft' so the backend updates that exact draft branch. It stages your edits onto a draft (the same pending-changes layer the UI editor uses) and never commits or publishes; the user reviews the staged changes and publishes them.
 - After a successful draft update, output a :::draft-actions block with the version ID so the user can review or publish:
 
   :::draft-actions

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -509,7 +509,7 @@ func getDraftStatus(canvasID uuid.UUID) string {
 				draftCreatedAt(draft),
 			)
 		}
-		result += "These drafts may belong to other sessions or users. To make changes, use 'superplane_app' action 'update_draft'; it automatically targets your own private draft, creating one from the live version if needed. Do not assume an unrelated draft is yours.\n"
+		result += "These drafts may belong to other sessions or users. To continue a known draft branch, pass its version_id to 'superplane_app' actions 'read' and 'update_draft'. update_draft always requires version_id. Use 'create_draft' when read returned live/no version_id, or when the user explicitly wants another draft branch. Do not assume an unrelated draft is yours.\n"
 		return result
 	}
 
@@ -620,7 +620,7 @@ func appendDraftSnapshotStatus(builder *strings.Builder, draft *models.CanvasVer
 	return "draft", true
 }
 
-const noActiveDraftStatus = "[Draft Status]\nNo active drafts. If you recently created a draft and it is no longer here, it was discarded by the user. Your changes were NOT published."
+const noActiveDraftStatus = "[Draft Status]\nNo active drafts. If you need to edit the app, call 'superplane_app' action 'create_draft' first, then pass the returned version_id to 'update_draft'. If you recently created a draft and it is no longer here, it was discarded by the user. Your changes were NOT published."
 
 func draftCreatedAt(draft models.CanvasVersion) string {
 	if draft.CreatedAt == nil {

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -526,6 +526,7 @@ func TestService_DefineOutcome_RefreshesPreambleForBuildLoop(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "[Agent Mode: BUILD]")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "Use 'superplane_app' action 'update_draft'")
+	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "create_draft' when 'read' returned live/no version_id")
 	assert.Contains(t, provider.lastOutcomeOpts.ContextPreamble, "ref/docs/prd/console-and-widgets.md")
 	assert.NotContains(t, provider.lastOutcomeOpts.ContextPreamble, "api_token:")
 	assert.NotContains(t, provider.lastOutcomeOpts.ContextPreamble, "superplane apps")


### PR DESCRIPTION
## Summary
- require agents to pass a draft version ID when updating drafts
- add create_draft for intentionally creating another draft branch
- make read target a specific draft version and reject ambiguous multi-draft reads
- recover deleted Anthropic managed-agent sessions by mapping missing/deleted session errors to provider-session recovery

## Test plan
- make format.go
- make test PKG_TEST_PACKAGES="./pkg/agents ./pkg/agents/agent_tools ./pkg/agents/agent_tools/actions ./pkg/agents/anthropic ./pkg/models"
- make test PKG_TEST_PACKAGES="./pkg/agents/anthropic ./pkg/agents"
- make lint && make check.build.app
