### PR TITLE
feat: add ref-scoped reads to git provider

### DIFF
--- a/pkg/git/codestorage/provider.go
+++ b/pkg/git/codestorage/provider.go
@@ -130,14 +130,14 @@ func (p *Provider) DeleteRepository(ctx context.Context, repoID string) error {
 	return nil
 }
 
-func (p *Provider) ListFiles(ctx context.Context, repoID string) ([]string, error) {
+func (p *Provider) ListFiles(ctx context.Context, repoID, ref string) ([]string, error) {
 	repo, err := p.repo(repoID)
 	if err != nil {
 		return nil, err
 	}
 
 	result, err := repo.ListFiles(ctx, codestorage.ListFilesOptions{
-		Ref: p.defaultBranch,
+		Ref: provider.RefOrDefault(ref, p.defaultBranch),
 	})
 
 	if err != nil {
@@ -147,7 +147,7 @@ func (p *Provider) ListFiles(ctx context.Context, repoID string) ([]string, erro
 	return result.Paths, nil
 }
 
-func (p *Provider) GetFile(ctx context.Context, repoID string, path string) (io.ReadCloser, error) {
+func (p *Provider) GetFile(ctx context.Context, repoID, path, ref string) (io.ReadCloser, error) {
 	filePath, err := provider.NormalizePath(path)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (p *Provider) GetFile(ctx context.Context, repoID string, path string) (io.
 
 	resp, err := repo.FileStream(ctx, codestorage.GetFileOptions{
 		Path: filePath,
-		Ref:  p.defaultBranch,
+		Ref:  provider.RefOrDefault(ref, p.defaultBranch),
 	})
 
 	if err != nil {
@@ -220,14 +220,14 @@ func (p *Provider) Commit(ctx context.Context, repoID string, options provider.C
 	return result.CommitSHA, nil
 }
 
-func (p *Provider) Head(ctx context.Context, repoID string) (string, error) {
+func (p *Provider) Head(ctx context.Context, repoID, ref string) (string, error) {
 	repo, err := p.repo(repoID)
 	if err != nil {
 		return "", err
 	}
 
 	commit, err := repo.GetCommit(ctx, codestorage.GetCommitOptions{
-		SHA: p.defaultBranch,
+		SHA: provider.RefOrDefault(ref, p.defaultBranch),
 	})
 
 	if err != nil {

--- a/pkg/git/inmemory/provider.go
+++ b/pkg/git/inmemory/provider.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/superplanehq/superplane/pkg/git/provider"
 )
@@ -26,8 +27,9 @@ type Provider struct {
 }
 
 type repositoryState struct {
-	files   map[string][]byte
-	headSHA string
+	defaultBranch string
+	branches      map[string]string
+	snapshots     map[string]map[string][]byte
 }
 
 func NewProvider() *Provider {
@@ -49,11 +51,17 @@ func (p *Provider) CreateRepository(_ context.Context, repoID string) (*provider
 		return nil, provider.ErrInvalidRepositoryID
 	}
 
+	headSHA := initialHeadSHA(repoID)
 	p.repositories[repoID] = &repositoryState{
-		files: map[string][]byte{
-			"README.md": {},
+		defaultBranch: "main",
+		branches: map[string]string{
+			"main": headSHA,
 		},
-		headSHA: initialHeadSHA(repoID),
+		snapshots: map[string]map[string][]byte{
+			headSHA: cloneFiles(map[string][]byte{
+				"README.md": {},
+			}),
+		},
 	}
 
 	return &provider.Repository{ID: repoID}, nil
@@ -64,24 +72,34 @@ func (p *Provider) DeleteRepository(_ context.Context, repoID string) error {
 	return nil
 }
 
-func (p *Provider) ListFiles(_ context.Context, repoID string) ([]string, error) {
+func (p *Provider) ListFiles(_ context.Context, repoID, ref string) ([]string, error) {
 	repository, err := p.repository(repoID)
 	if err != nil {
 		return nil, err
 	}
 
-	paths := slices.Collect(maps.Keys(repository.files))
+	files, err := repository.filesAtRef(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := slices.Collect(maps.Keys(files))
 	sort.Strings(paths)
 	return paths, nil
 }
 
-func (p *Provider) GetFile(_ context.Context, repoID string, path string) (io.ReadCloser, error) {
+func (p *Provider) GetFile(_ context.Context, repoID, path, ref string) (io.ReadCloser, error) {
 	repository, err := p.repository(repoID)
 	if err != nil {
 		return nil, err
 	}
 
-	content, ok := repository.files[path]
+	files, err := repository.filesAtRef(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	content, ok := files[path]
 	if !ok {
 		return nil, provider.ErrInvalidPath
 	}
@@ -95,13 +113,24 @@ func (p *Provider) Commit(_ context.Context, repoID string, options provider.Com
 		return "", err
 	}
 
-	if options.ExpectedHeadSHA != repository.headSHA {
+	branch := provider.RefOrDefault(options.Branch, repository.defaultBranch)
+	currentHead, ok := repository.branches[branch]
+	if !ok {
+		return "", provider.ErrInvalidRef
+	}
+
+	if options.ExpectedHeadSHA != "" && options.ExpectedHeadSHA != currentHead {
 		return "", provider.ErrExpectedHeadMismatch
+	}
+
+	files, err := repository.filesAtRef(currentHead)
+	if err != nil {
+		return "", err
 	}
 
 	for _, operation := range options.Operations {
 		if operation.Delete {
-			delete(repository.files, operation.Path)
+			delete(files, operation.Path)
 			continue
 		}
 
@@ -110,20 +139,22 @@ func (p *Provider) Commit(_ context.Context, repoID string, options provider.Com
 			return "", fmt.Errorf("read file content: %w", err)
 		}
 
-		repository.files[operation.Path] = content
+		files[operation.Path] = content
 	}
 
-	repository.headSHA = nextHeadSHA(repository.headSHA, options.Message)
-	return repository.headSHA, nil
+	newSHA := nextHeadSHA(currentHead, options.Message)
+	repository.snapshots[newSHA] = files
+	repository.branches[branch] = newSHA
+	return newSHA, nil
 }
 
-func (p *Provider) Head(_ context.Context, repoID string) (string, error) {
+func (p *Provider) Head(_ context.Context, repoID, ref string) (string, error) {
 	repository, err := p.repository(repoID)
 	if err != nil {
 		return "", err
 	}
 
-	return repository.headSHA, nil
+	return repository.resolveRef(ref)
 }
 
 func (p *Provider) repository(repoID string) (*repositoryState, error) {
@@ -135,12 +166,51 @@ func (p *Provider) repository(repoID string) (*repositoryState, error) {
 	return repository, nil
 }
 
+func (r *repositoryState) resolveRef(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		ref = r.defaultBranch
+	}
+
+	if sha, ok := r.branches[ref]; ok {
+		return sha, nil
+	}
+
+	if _, ok := r.snapshots[ref]; ok {
+		return ref, nil
+	}
+
+	return "", provider.ErrInvalidRef
+}
+
+func (r *repositoryState) filesAtRef(ref string) (map[string][]byte, error) {
+	sha, err := r.resolveRef(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	files, ok := r.snapshots[sha]
+	if !ok {
+		return nil, provider.ErrInvalidRef
+	}
+
+	return cloneFiles(files), nil
+}
+
+func cloneFiles(files map[string][]byte) map[string][]byte {
+	cloned := make(map[string][]byte, len(files))
+	for path, content := range files {
+		cloned[path] = append([]byte(nil), content...)
+	}
+	return cloned
+}
+
 func initialHeadSHA(repoID string) string {
 	sum := sha256.Sum256([]byte("initial:" + repoID))
-	return hex.EncodeToString(sum[:8])
+	return hex.EncodeToString(sum[:20])
 }
 
 func nextHeadSHA(currentHeadSHA, message string) string {
 	sum := sha256.Sum256([]byte(currentHeadSHA + ":" + message))
-	return hex.EncodeToString(sum[:8])
+	return hex.EncodeToString(sum[:20])
 }

--- a/pkg/git/inmemory/provider_test.go
+++ b/pkg/git/inmemory/provider_test.go
@@ -23,7 +23,7 @@ func TestProviderRepositoryLifecycle(t *testing.T) {
 	_, err := p.CreateRepository(ctx, repoID)
 	require.NoError(t, err)
 
-	headSHA, err := p.Head(ctx, repoID)
+	headSHA, err := p.Head(ctx, repoID, "")
 	require.NoError(t, err)
 
 	commitSHA, err := p.Commit(ctx, repoID, provider.CommitOptions{
@@ -40,11 +40,11 @@ func TestProviderRepositoryLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, commitSHA)
 
-	files, err := p.ListFiles(ctx, repoID)
+	files, err := p.ListFiles(ctx, repoID, "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"README.md", "docs/guide.md"}, files)
 
-	reader, err := p.GetFile(ctx, repoID, "docs/guide.md")
+	reader, err := p.GetFile(ctx, repoID, "docs/guide.md", "")
 	require.NoError(t, err)
 	content, err := io.ReadAll(reader)
 	require.NoError(t, err)
@@ -58,6 +58,6 @@ func TestProviderRepositoryLifecycle(t *testing.T) {
 	require.ErrorIs(t, err, provider.ErrExpectedHeadMismatch)
 
 	require.NoError(t, p.DeleteRepository(ctx, repoID))
-	_, err = p.Head(ctx, repoID)
+	_, err = p.Head(ctx, repoID, "")
 	require.ErrorIs(t, err, provider.ErrInvalidRepositoryID)
 }

--- a/pkg/git/provider/provider.go
+++ b/pkg/git/provider/provider.go
@@ -28,6 +28,7 @@ const ReservedSuperPlanePath = ".superplane"
 var (
 	ErrInvalidPath          = errors.New("invalid file path")
 	ErrInvalidRepositoryID  = errors.New("invalid repository path")
+	ErrInvalidRef           = errors.New("invalid git ref")
 	ErrReservedPath         = errors.New("path is reserved for SuperPlane")
 	ErrInvalidCommit        = errors.New("invalid commit")
 	ErrExpectedHeadMismatch = errors.New("expected head sha does not match current branch head")
@@ -56,10 +57,10 @@ type Provider interface {
 	//
 	// File management methods
 	//
-	ListFiles(ctx context.Context, repoID string) ([]string, error)
-	GetFile(ctx context.Context, repoID string, path string) (io.ReadCloser, error)
+	ListFiles(ctx context.Context, repoID, ref string) ([]string, error)
+	GetFile(ctx context.Context, repoID, path, ref string) (io.ReadCloser, error)
 	Commit(ctx context.Context, repoID string, options CommitOptions) (string, error)
-	Head(ctx context.Context, repoID string) (string, error)
+	Head(ctx context.Context, repoID, ref string) (string, error)
 }
 
 type RepositoryOptions struct {

--- a/pkg/git/supergit/provider.go
+++ b/pkg/git/supergit/provider.go
@@ -64,17 +64,17 @@ func (p *Provider) DeleteRepository(ctx context.Context, repoID string) error {
 	return p.client.deleteRepo(ctx, repoID)
 }
 
-func (p *Provider) ListFiles(ctx context.Context, repoID string) ([]string, error) {
-	return p.client.listFiles(ctx, repoID, p.defaultBranch)
+func (p *Provider) ListFiles(ctx context.Context, repoID, ref string) ([]string, error) {
+	return p.client.listFiles(ctx, repoID, provider.RefOrDefault(ref, p.defaultBranch))
 }
 
-func (p *Provider) GetFile(ctx context.Context, repoID string, path string) (io.ReadCloser, error) {
+func (p *Provider) GetFile(ctx context.Context, repoID, path, ref string) (io.ReadCloser, error) {
 	filePath, err := provider.NormalizePath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return p.client.getFile(ctx, repoID, filePath, p.defaultBranch)
+	return p.client.getFile(ctx, repoID, filePath, provider.RefOrDefault(ref, p.defaultBranch))
 }
 
 func (p *Provider) Commit(ctx context.Context, repoID string, options provider.CommitOptions) (string, error) {
@@ -107,8 +107,8 @@ func (p *Provider) Commit(ctx context.Context, repoID string, options provider.C
 	return result.Commit.CommitSHA, nil
 }
 
-func (p *Provider) Head(ctx context.Context, repoID string) (string, error) {
-	commit, err := p.client.getCommit(ctx, repoID, p.defaultBranch)
+func (p *Provider) Head(ctx context.Context, repoID, ref string) (string, error) {
+	commit, err := p.client.getCommit(ctx, repoID, provider.RefOrDefault(ref, p.defaultBranch))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_repository_files_test.go
@@ -152,7 +152,7 @@ func Test__CommitCanvasRepositoryFiles(t *testing.T) {
 	t.Run("commits files with authenticated user as author", func(t *testing.T) {
 		ctx := authentication.SetUserIdInMetadata(context.Background(), r.User.String())
 		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
-		headSHA, err := r.GitProvider.Head(ctx, repository.RepoID)
+		headSHA, err := r.GitProvider.Head(ctx, repository.RepoID, "")
 		require.NoError(t, err)
 
 		response, err := commitCanvasRepositoryFilesForTest(
@@ -171,14 +171,14 @@ func Test__CommitCanvasRepositoryFiles(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, response.CommitSha)
 
-		reader, err := r.GitProvider.GetFile(ctx, repository.RepoID, "README.md")
+		reader, err := r.GitProvider.GetFile(ctx, repository.RepoID, "README.md", "")
 		require.NoError(t, err)
 		content, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		require.NoError(t, reader.Close())
 		assert.Equal(t, "hello world", string(content))
 
-		files, err := r.GitProvider.ListFiles(ctx, repository.RepoID)
+		files, err := r.GitProvider.ListFiles(ctx, repository.RepoID, "")
 		require.NoError(t, err)
 		assert.Equal(t, []string{"README.md"}, files)
 	})

--- a/pkg/grpc/actions/canvases/commit_canvas_staging.go
+++ b/pkg/grpc/actions/canvases/commit_canvas_staging.go
@@ -171,7 +171,7 @@ func commitStagedGitFiles(
 
 	// Commit on top of the current branch head. Staging does not track a head
 	// SHA per file, so resolve it just before committing.
-	headSHA, err := gitProvider.Head(ctx, repository.RepoID)
+	headSHA, err := gitProvider.Head(ctx, repository.RepoID, "")
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to resolve repository head: %v", err)
 	}
@@ -229,7 +229,7 @@ func snapshotGitFilesBeforeCommit(
 	for _, operation := range gitOps {
 		path := operation.GetPath()
 		if operation.GetDelete() {
-			reader, readErr := gitProvider.GetFile(ctx, repository.RepoID, path)
+			reader, readErr := gitProvider.GetFile(ctx, repository.RepoID, path, "")
 			if readErr != nil {
 				return nil, status.Errorf(codes.FailedPrecondition, "cannot snapshot %q before staged delete: %v", path, readErr)
 			}
@@ -248,7 +248,7 @@ func snapshotGitFilesBeforeCommit(
 			continue
 		}
 
-		reader, readErr := gitProvider.GetFile(ctx, repository.RepoID, path)
+		reader, readErr := gitProvider.GetFile(ctx, repository.RepoID, path, "")
 		if readErr != nil {
 			revertOps = append(revertOps, gitprovider.FileOperation{
 				Path:   path,

--- a/pkg/grpc/actions/canvases/get_canvas_repository.go
+++ b/pkg/grpc/actions/canvases/get_canvas_repository.go
@@ -44,7 +44,7 @@ func GetCanvasRepository(ctx context.Context, gitProvider git.Provider, organiza
 	//
 	var headSha string
 	if repository.Status == models.RepositoryStatusReady {
-		headSha, err = gitProvider.Head(ctx, repository.RepoID)
+		headSha, err = gitProvider.Head(ctx, repository.RepoID, "")
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get repository head sha: %v", err)
 		}

--- a/pkg/grpc/actions/canvases/list_canvas_repository_files.go
+++ b/pkg/grpc/actions/canvases/list_canvas_repository_files.go
@@ -35,7 +35,7 @@ func ListCanvasRepositoryFiles(ctx context.Context, gitProvider git.Provider, or
 	repositoryPaths := []string{}
 	repository, err := models.FindRepository(orgID, canvasID)
 	if err == nil {
-		files, listErr := gitProvider.ListFiles(ctx, repository.RepoID)
+		files, listErr := gitProvider.ListFiles(ctx, repository.RepoID, "")
 		if listErr != nil {
 			return nil, status.Errorf(codes.Internal, "failed to list repository files: %v", listErr)
 		}

--- a/pkg/grpc/actions/canvases/workflow_staging_handlers_test.go
+++ b/pkg/grpc/actions/canvases/workflow_staging_handlers_test.go
@@ -175,7 +175,7 @@ func TestStageArbitraryRepositoryFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, resp.GetStagingSummary().GetHasStaging())
 
-	reader, err := r.GitProvider.GetFile(ctx, repository.RepoID, "README.md")
+	reader, err := r.GitProvider.GetFile(ctx, repository.RepoID, "README.md", "")
 	require.NoError(t, err)
 	committed, err := io.ReadAll(reader)
 	require.NoError(t, err)

--- a/pkg/public/repository_file_download.go
+++ b/pkg/public/repository_file_download.go
@@ -218,7 +218,7 @@ func (s *Server) writeRepositoryGitFile(
 		return errRepositoryNotFound
 	}
 
-	reader, fileErr := s.gitProvider.GetFile(ctx, repository.RepoID, path)
+	reader, fileErr := s.gitProvider.GetFile(ctx, repository.RepoID, path, "")
 	if fileErr != nil {
 		log.Errorf("Failed to get file %s in canvas %s: %v", path, canvasID.String(), fileErr)
 		return errRepositoryFileReadFailed

--- a/pkg/public/repository_file_download_test.go
+++ b/pkg/public/repository_file_download_test.go
@@ -128,7 +128,7 @@ func Test__RepositoryFileDownload(t *testing.T) {
 
 	t.Run("returns file contents", func(t *testing.T) {
 		canvas, repository := support.CreateCanvasWithRepository(t, r, models.RepositoryStatusReady, true)
-		headSHA, err := r.GitProvider.Head(context.Background(), repository.RepoID)
+		headSHA, err := r.GitProvider.Head(context.Background(), repository.RepoID, "")
 		require.NoError(t, err)
 
 		_, err = r.GitProvider.Commit(context.Background(), repository.RepoID, git.CommitOptions{

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -73,11 +73,11 @@ func (p *cleanupGitProvider) DeleteRepository(_ context.Context, repoID string) 
 	return p.err
 }
 
-func (p *cleanupGitProvider) ListFiles(context.Context, string) ([]string, error) {
+func (p *cleanupGitProvider) ListFiles(context.Context, string, string) ([]string, error) {
 	return nil, errors.New("not used")
 }
 
-func (p *cleanupGitProvider) GetFile(context.Context, string, string) (io.ReadCloser, error) {
+func (p *cleanupGitProvider) GetFile(context.Context, string, string, string) (io.ReadCloser, error) {
 	return nil, errors.New("not used")
 }
 
@@ -85,7 +85,7 @@ func (p *cleanupGitProvider) Commit(context.Context, string, git.CommitOptions) 
 	return "", errors.New("not used")
 }
 
-func (p *cleanupGitProvider) Head(context.Context, string) (string, error) {
+func (p *cleanupGitProvider) Head(context.Context, string, string) (string, error) {
 	return "", errors.New("not used")
 }
 

--- a/pkg/workers/contexts/repository_files_context.go
+++ b/pkg/workers/contexts/repository_files_context.go
@@ -82,7 +82,7 @@ func (c *repositoryFilesContext) List() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.gitProvider.ListFiles(context.Background(), repoID)
+	return c.gitProvider.ListFiles(context.Background(), repoID, "")
 }
 
 func (c *repositoryFilesContext) Read(path string) (io.ReadCloser, error) {
@@ -90,5 +90,5 @@ func (c *repositoryFilesContext) Read(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return c.gitProvider.GetFile(context.Background(), repoID, path)
+	return c.gitProvider.GetFile(context.Background(), repoID, path, "")
 }


### PR DESCRIPTION
Extends the git `Provider` interface so `ListFiles`, `GetFile`, and `Head` accept a `ref`, allowing reads and head resolution at an arbitrary branch/commit instead of only the default branch. Existing callers pass an empty ref, preserving current behavior.

This is a foundational, behavior-preserving prerequisite for the upcoming git-backed canvas materialization work. Branch management operations (`CreateBranch`/`MergeBranch`/`DeleteBranch`/`ListBranches`) are intentionally left for a follow-up PR.

## Changes

- `provider`: add `ref` to `ListFiles`/`GetFile`/`Head`; add `ErrInvalidRef`.
- `inmemory`: model repositories as branches over content snapshots keyed by SHA so refs resolve correctly.
- `codestorage` / `supergit`: thread `ref` through existing read calls.
- Update all callers to pass `ref=""`.