### PR TITLE
feat: add branch operations to git provider

### DIFF
--- a/pkg/git/codestorage/provider.go
+++ b/pkg/git/codestorage/provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	codestorage "github.com/pierrecomputer/sdk/packages/code-storage-go"
@@ -235,6 +236,91 @@ func (p *Provider) Head(ctx context.Context, repoID, ref string) (string, error)
 	}
 
 	return commit.Commit.SHA, nil
+}
+
+func (p *Provider) ListBranches(ctx context.Context, repoID, prefix string) ([]string, error) {
+	repo, err := p.repo(repoID)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	cursor := ""
+	for {
+		result, err := repo.ListBranches(ctx, codestorage.ListBranchesOptions{
+			Cursor: cursor,
+			Limit:  100,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, branch := range result.Branches {
+			if prefix == "" || strings.HasPrefix(branch.Name, prefix) {
+				names = append(names, branch.Name)
+			}
+		}
+
+		if !result.HasMore {
+			break
+		}
+		cursor = result.NextCursor
+	}
+
+	sort.Strings(names)
+	return names, nil
+}
+
+func (p *Provider) CreateBranch(ctx context.Context, repoID, branch, fromRef string) error {
+	repo, err := p.repo(repoID)
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.CreateBranch(ctx, codestorage.CreateBranchOptions{
+		TargetBranch: strings.TrimSpace(branch),
+		BaseRef:      provider.RefOrDefault(fromRef, p.defaultBranch),
+	})
+	return err
+}
+
+func (p *Provider) MergeBranch(ctx context.Context, repoID, sourceBranch, targetBranch, message string, author provider.CommitAuthor) (string, error) {
+	if err := provider.ValidateCommitMetadata(message, author); err != nil {
+		return "", err
+	}
+
+	repo, err := p.repo(repoID)
+	if err != nil {
+		return "", err
+	}
+
+	result, err := repo.Merge(ctx, codestorage.MergeOptions{
+		SourceBranch:  strings.TrimSpace(sourceBranch),
+		TargetBranch:  provider.RefOrDefault(targetBranch, p.defaultBranch),
+		CommitMessage: strings.TrimSpace(message),
+		Author: &codestorage.CommitSignature{
+			Name:  strings.TrimSpace(author.Name),
+			Email: strings.TrimSpace(author.Email),
+		},
+		Strategy: codestorage.MergeStrategyFFPrefer,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return result.CommitSHA, nil
+}
+
+func (p *Provider) DeleteBranch(ctx context.Context, repoID, branch string) error {
+	repo, err := p.repo(repoID)
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.DeleteBranch(ctx, codestorage.DeleteBranchOptions{
+		Name: strings.TrimSpace(branch),
+	})
+	return err
 }
 
 func (p *Provider) repo(repoID string) (*codestorage.Repo, error) {

--- a/pkg/git/inmemory/branch_test.go
+++ b/pkg/git/inmemory/branch_test.go
@@ -1,0 +1,70 @@
+package inmemory
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/git/provider"
+)
+
+func TestProviderBranchOperations(t *testing.T) {
+	p := NewProvider()
+	ctx := context.Background()
+	repoID := p.GetRepositoryID(provider.RepositoryOptions{
+		OrganizationID: uuid.New(),
+		CanvasID:       uuid.New(),
+	})
+
+	_, err := p.CreateRepository(ctx, repoID)
+	require.NoError(t, err)
+
+	mainHead, err := p.Head(ctx, repoID, "main")
+	require.NoError(t, err)
+
+	draftBranch := "drafts/" + uuid.New().String()
+	require.NoError(t, p.CreateBranch(ctx, repoID, draftBranch, "main"))
+
+	branches, err := p.ListBranches(ctx, repoID, "drafts/")
+	require.NoError(t, err)
+	assert.Contains(t, branches, draftBranch)
+
+	draftHead, err := p.Head(ctx, repoID, draftBranch)
+	require.NoError(t, err)
+	assert.Equal(t, mainHead, draftHead)
+
+	commitSHA, err := p.Commit(ctx, repoID, provider.CommitOptions{
+		Branch:          draftBranch,
+		BaseBranch:      draftBranch,
+		ExpectedHeadSHA: draftHead,
+		Message:         "draft change",
+		Author: provider.CommitAuthor{
+			Name:  "Test",
+			Email: "test@example.com",
+		},
+		Operations: []provider.FileOperation{
+			{Path: "notes.txt", Content: bytes.NewReader([]byte("draft")), SizeBytes: 5},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, commitSHA)
+
+	mergedSHA, err := p.MergeBranch(ctx, repoID, draftBranch, "main", "merge draft", provider.CommitAuthor{
+		Name:  "Test",
+		Email: "test@example.com",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, mergedSHA)
+
+	files, err := p.ListFiles(ctx, repoID, "main")
+	require.NoError(t, err)
+	assert.Contains(t, files, "notes.txt")
+
+	require.NoError(t, p.DeleteBranch(ctx, repoID, draftBranch))
+	branches, err = p.ListBranches(ctx, repoID, "drafts/")
+	require.NoError(t, err)
+	assert.NotContains(t, branches, draftBranch)
+}

--- a/pkg/git/inmemory/provider.go
+++ b/pkg/git/inmemory/provider.go
@@ -157,6 +157,111 @@ func (p *Provider) Head(_ context.Context, repoID, ref string) (string, error) {
 	return repository.resolveRef(ref)
 }
 
+func (p *Provider) ListBranches(_ context.Context, repoID, prefix string) ([]string, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return nil, err
+	}
+
+	branches := slices.Collect(maps.Keys(repository.branches))
+	sort.Strings(branches)
+	if prefix == "" {
+		return branches, nil
+	}
+
+	filtered := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		if strings.HasPrefix(branch, prefix) {
+			filtered = append(filtered, branch)
+		}
+	}
+
+	return filtered, nil
+}
+
+func (p *Provider) CreateBranch(_ context.Context, repoID, branch, fromRef string) error {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return err
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return provider.ErrInvalidRef
+	}
+
+	if _, ok := repository.branches[branch]; ok {
+		return fmt.Errorf("%w: branch %q already exists", provider.ErrInvalidRef, branch)
+	}
+
+	fromSHA, err := repository.resolveRef(fromRef)
+	if err != nil {
+		return err
+	}
+
+	repository.branches[branch] = fromSHA
+	return nil
+}
+
+func (p *Provider) MergeBranch(_ context.Context, repoID, sourceBranch, targetBranch, message string, _ provider.CommitAuthor) (string, error) {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return "", err
+	}
+
+	sourceSHA, err := repository.resolveRef(sourceBranch)
+	if err != nil {
+		return "", err
+	}
+
+	targetSHA, err := repository.resolveRef(targetBranch)
+	if err != nil {
+		return "", err
+	}
+
+	targetFiles, err := repository.filesAtRef(targetSHA)
+	if err != nil {
+		return "", err
+	}
+
+	sourceFiles, err := repository.filesAtRef(sourceSHA)
+	if err != nil {
+		return "", err
+	}
+
+	for path, content := range sourceFiles {
+		targetFiles[path] = append([]byte(nil), content...)
+	}
+
+	newSHA := nextHeadSHA(targetSHA, message)
+	repository.snapshots[newSHA] = targetFiles
+	repository.branches[targetBranch] = newSHA
+	return newSHA, nil
+}
+
+func (p *Provider) DeleteBranch(_ context.Context, repoID, branch string) error {
+	repository, err := p.repository(repoID)
+	if err != nil {
+		return err
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return provider.ErrInvalidRef
+	}
+
+	if branch == repository.defaultBranch {
+		return fmt.Errorf("%w: cannot delete default branch", provider.ErrInvalidRef)
+	}
+
+	if _, ok := repository.branches[branch]; !ok {
+		return provider.ErrInvalidRef
+	}
+
+	delete(repository.branches, branch)
+	return nil
+}
+
 func (p *Provider) repository(repoID string) (*repositoryState, error) {
 	repository, ok := p.repositories[repoID]
 	if !ok {

--- a/pkg/git/provider/provider.go
+++ b/pkg/git/provider/provider.go
@@ -61,6 +61,14 @@ type Provider interface {
 	GetFile(ctx context.Context, repoID, path, ref string) (io.ReadCloser, error)
 	Commit(ctx context.Context, repoID string, options CommitOptions) (string, error)
 	Head(ctx context.Context, repoID, ref string) (string, error)
+
+	//
+	// Branch management methods
+	//
+	ListBranches(ctx context.Context, repoID, prefix string) ([]string, error)
+	CreateBranch(ctx context.Context, repoID, branch, fromRef string) error
+	MergeBranch(ctx context.Context, repoID, sourceBranch, targetBranch, message string, author CommitAuthor) (string, error)
+	DeleteBranch(ctx context.Context, repoID, branch string) error
 }
 
 type RepositoryOptions struct {

--- a/pkg/git/supergit/client.go
+++ b/pkg/git/supergit/client.go
@@ -57,6 +57,29 @@ type GetCommitResponse struct {
 	CommitSHA string `json:"commit_sha"`
 }
 
+type ListBranchesResponse struct {
+	Branches []string `json:"branches"`
+}
+
+type CreateBranchRequest struct {
+	Branch  string `json:"branch"`
+	FromRef string `json:"from_ref"`
+}
+
+type MergeBranchRequest struct {
+	SourceBranch string `json:"source_branch"`
+	TargetBranch string `json:"target_branch"`
+	Message      string `json:"message"`
+	Author       struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"author"`
+}
+
+type MergeBranchResponse struct {
+	CommitSHA string `json:"commit_sha"`
+}
+
 func (c *Client) createRepo(ctx context.Context, req RepoRequest) (*RepoResponse, error) {
 	var resp RepoResponse
 	if err := c.doJSON(ctx, http.MethodPost, "/repos", req, &resp); err != nil {
@@ -143,6 +166,42 @@ func (c *Client) getCommit(ctx context.Context, repoID, sha string) (*GetCommitR
 	}
 
 	return &resp, nil
+}
+
+func (c *Client) listBranches(ctx context.Context, repoID, prefix string) ([]string, error) {
+	query := url.Values{}
+	if prefix != "" {
+		query.Set("prefix", prefix)
+	}
+
+	var resp ListBranchesResponse
+	endpoint := repoPath(repoID) + "/branches"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+
+	if err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Branches, nil
+}
+
+func (c *Client) createBranch(ctx context.Context, repoID string, req CreateBranchRequest) error {
+	return c.doJSON(ctx, http.MethodPost, repoPath(repoID)+"/branches", req, nil)
+}
+
+func (c *Client) mergeBranch(ctx context.Context, repoID string, req MergeBranchRequest) (string, error) {
+	var resp MergeBranchResponse
+	if err := c.doJSON(ctx, http.MethodPost, repoPath(repoID)+"/merge", req, &resp); err != nil {
+		return "", err
+	}
+
+	return resp.CommitSHA, nil
+}
+
+func (c *Client) deleteBranch(ctx context.Context, repoID, branch string) error {
+	return c.doJSON(ctx, http.MethodDelete, repoPath(repoID)+"/branches/"+url.PathEscape(branch), nil, nil)
 }
 
 func (c *Client) doJSON(ctx context.Context, method, endpoint string, payload any, out any) error {

--- a/pkg/git/supergit/provider.go
+++ b/pkg/git/supergit/provider.go
@@ -115,3 +115,34 @@ func (p *Provider) Head(ctx context.Context, repoID, ref string) (string, error)
 
 	return commit.CommitSHA, nil
 }
+
+func (p *Provider) ListBranches(ctx context.Context, repoID, prefix string) ([]string, error) {
+	return p.client.listBranches(ctx, repoID, prefix)
+}
+
+func (p *Provider) CreateBranch(ctx context.Context, repoID, branch, fromRef string) error {
+	return p.client.createBranch(ctx, repoID, CreateBranchRequest{
+		Branch:  strings.TrimSpace(branch),
+		FromRef: provider.RefOrDefault(fromRef, p.defaultBranch),
+	})
+}
+
+func (p *Provider) MergeBranch(ctx context.Context, repoID, sourceBranch, targetBranch, message string, author provider.CommitAuthor) (string, error) {
+	if err := provider.ValidateCommitMetadata(message, author); err != nil {
+		return "", err
+	}
+
+	req := MergeBranchRequest{
+		SourceBranch: strings.TrimSpace(sourceBranch),
+		TargetBranch: provider.RefOrDefault(targetBranch, p.defaultBranch),
+		Message:      strings.TrimSpace(message),
+	}
+	req.Author.Name = strings.TrimSpace(author.Name)
+	req.Author.Email = strings.TrimSpace(author.Email)
+
+	return p.client.mergeBranch(ctx, repoID, req)
+}
+
+func (p *Provider) DeleteBranch(ctx context.Context, repoID, branch string) error {
+	return p.client.deleteBranch(ctx, repoID, strings.TrimSpace(branch))
+}

--- a/pkg/workers/canvas_cleanup_worker_test.go
+++ b/pkg/workers/canvas_cleanup_worker_test.go
@@ -89,6 +89,22 @@ func (p *cleanupGitProvider) Head(context.Context, string, string) (string, erro
 	return "", errors.New("not used")
 }
 
+func (p *cleanupGitProvider) ListBranches(context.Context, string, string) ([]string, error) {
+	return nil, errors.New("not used")
+}
+
+func (p *cleanupGitProvider) CreateBranch(context.Context, string, string, string) error {
+	return errors.New("not used")
+}
+
+func (p *cleanupGitProvider) MergeBranch(context.Context, string, string, string, string, git.CommitAuthor) (string, error) {
+	return "", errors.New("not used")
+}
+
+func (p *cleanupGitProvider) DeleteBranch(context.Context, string, string) error {
+	return errors.New("not used")
+}
+
 func createAgentSessionWithMessage(t *testing.T, organizationID, userID, canvasID uuid.UUID) *models.AgentSession {
 	t.Helper()
 


### PR DESCRIPTION
Adds branch management to the git `Provider` interface — `ListBranches`, `CreateBranch`, `MergeBranch`, `DeleteBranch` — implemented across the in-memory, codestorage, and supergit providers.

This builds on the multi-branch model from the ref-scoped reads PR and is a foundational prerequisite for git-backed canvas draft branches and change-request merges. Purely additive; no existing behavior changes.