### PR TITLE
fix: rewind recreated agent sessions

### DIFF
--- a/db/migrations/20260617203101_add-agent-session-tool-schema-revision.up.sql
+++ b/db/migrations/20260617203101_add-agent-session-tool-schema-revision.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE agent_sessions
+    ADD COLUMN agent_tool_schema_revision TEXT NOT NULL DEFAULT '',
+    ADD COLUMN context_replayed_at TIMESTAMPTZ NULL;
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -133,7 +133,9 @@ CREATE TABLE public.agent_sessions (
     last_active_at timestamp with time zone,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    heartbeat_at timestamp with time zone
+    heartbeat_at timestamp with time zone,
+    agent_tool_schema_revision text DEFAULT ''::text NOT NULL,
+    context_replayed_at timestamp with time zone
 );
 
 
@@ -2016,7 +2018,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260617143500	f
+20260617203101	f
 \.
 
 

--- a/pkg/agents/agent_tools/registry.go
+++ b/pkg/agents/agent_tools/registry.go
@@ -3,6 +3,7 @@ package agenttools
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -57,6 +58,8 @@ type toolCall struct {
 }
 
 type factory func(Dependencies) tool
+
+const toolContractRevision = "agent-tools-v1"
 
 var registeredTools = struct {
 	sync.RWMutex
@@ -126,6 +129,25 @@ func DefinitionMaps() []map[string]any {
 		})
 	}
 	return tools
+}
+
+// SchemaRevision identifies the provider-facing custom tool contract. The
+// hash changes when tool names, descriptions, or input schemas change; bump
+// toolContractRevision for behavior changes that keep the JSON schema stable.
+func SchemaRevision() string {
+	payload := struct {
+		Contract string           `json:"contract"`
+		Tools    []map[string]any `json:"tools"`
+	}{
+		Contract: toolContractRevision,
+		Tools:    DefinitionMaps(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(fmt.Sprintf("agent tool schema revision: %v", err))
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%s:%x", toolContractRevision, sum[:])
 }
 
 // Definitions returns the registered custom tool definitions in stable name

--- a/pkg/agents/agent_tools/registry_test.go
+++ b/pkg/agents/agent_tools/registry_test.go
@@ -22,6 +22,14 @@ func TestRegistryDefinitions_ReturnsRegisteredToolsInStableOrder(t *testing.T) {
 	assert.NotEmpty(t, definitions[0].InputSchema())
 }
 
+func TestSchemaRevision_IsStableForRegisteredDefinitions(t *testing.T) {
+	first := SchemaRevision()
+	second := SchemaRevision()
+
+	assert.Equal(t, first, second)
+	assert.Contains(t, first, "agent-tools-v1:")
+}
+
 func TestRegistryExecuteCustomTool_DispatchesByToolName(t *testing.T) {
 	registry := NewRegistry(Dependencies{})
 

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -510,6 +510,50 @@ func TestDeleteSession_PropagatesAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "409")
 }
 
+func TestArchiveSession_SendsCorrectRequest(t *testing.T) {
+	var capturedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/sessions/sesn_abc/archive", r.URL.Path)
+		capturedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	require.NoError(t, p.ArchiveSession(context.Background(), "sesn_abc"))
+	assert.Equal(t, "test-key", capturedHeaders.Get("x-api-key"))
+	assert.Equal(t, managedAgentsBeta, capturedHeaders.Get("anthropic-beta"))
+}
+
+func TestArchiveSession_MapsUnavailableProviderSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"session has been archived"}}`))
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	err := p.ArchiveSession(context.Background(), "sesn_abc")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, agents.ErrProviderSessionUnavailable)
+}
+
+func TestToolSchemaRevision_ReturnsStableRevision(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("schema revision must not call provider API")
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	first := p.ToolSchemaRevision()
+	second := p.ToolSchemaRevision()
+
+	assert.Equal(t, first, second)
+	assert.Contains(t, first, "agent-tools-v1:")
+}
+
 func TestStreamEvents_MapsKnownTypes(t *testing.T) {
 	const sse = "data: {\"id\":\"e1\",\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}]}\n\n" +
 		"data: {\"id\":\"e2\",\"type\":\"agent.tool_use\",\"name\":\"bash\",\"input\":{\"command\":\"ls -la\"}}\n\n" +

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/agents"
+	agenttools "github.com/superplanehq/superplane/pkg/agents/agent_tools"
 )
 
 const ProviderName = "anthropic"
@@ -46,6 +47,10 @@ func New(cfg Config) (*Provider, error) {
 }
 
 func (p *Provider) Name() string { return ProviderName }
+
+func (p *Provider) ToolSchemaRevision() string {
+	return agenttools.SchemaRevision()
+}
 
 func (p *Provider) CreateSession(ctx context.Context, opts agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
 	body := map[string]any{
@@ -259,6 +264,21 @@ func (p *Provider) DeleteSession(ctx context.Context, providerSessionID string) 
 
 	if _, err := p.client.executeHTTP(ctx, http.MethodDelete, "/sessions/"+url.PathEscape(providerSessionID), nil); err != nil {
 		return fmt.Errorf("anthropic: delete session: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Provider) ArchiveSession(ctx context.Context, providerSessionID string) error {
+	if providerSessionID == "" {
+		return fmt.Errorf("anthropic: provider session id is required")
+	}
+
+	if _, err := p.client.executeHTTP(ctx, http.MethodPost, "/sessions/"+url.PathEscape(providerSessionID)+"/archive", nil); err != nil {
+		if isProviderSessionUnavailable(err) {
+			return fmt.Errorf("%w: %w", agents.ErrProviderSessionUnavailable, err)
+		}
+		return fmt.Errorf("anthropic: archive session: %w", err)
 	}
 
 	return nil

--- a/pkg/agents/conversation_rewind.go
+++ b/pkg/agents/conversation_rewind.go
@@ -1,0 +1,114 @@
+package agents
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/superplanehq/superplane/pkg/models"
+)
+
+const (
+	rewindMessageLimit  = 30
+	rewindMaxChars      = 20_000
+	rewindEntryMaxChars = 2_000
+	rewindToolMaxChars  = 800
+)
+
+func (s *Service) messageWithRewind(session *models.AgentSession, content string) (string, bool, error) {
+	if session.ContextReplayedAt != nil {
+		return content, false, nil
+	}
+
+	rewind, err := buildConversationRewind(session.ID)
+	if err != nil {
+		return "", false, fmt.Errorf("build conversation rewind: %w", err)
+	}
+	if rewind == "" {
+		return content, true, nil
+	}
+
+	return rewind + "\n\n[Current user request]\n" + content, true, nil
+}
+
+func buildConversationRewind(sessionID uuid.UUID) (string, error) {
+	rows, err := models.ListAgentSessionMessagesPage(sessionID, nil, rewindMessageLimit)
+	if err != nil {
+		return "", err
+	}
+
+	entries := make([]string, 0, len(rows))
+	remaining := rewindMaxChars
+	for i := len(rows) - 1; i >= 0; i-- {
+		entry := formatRewindEntry(rows[i])
+		if entry == "" {
+			continue
+		}
+		if len(entry) > remaining && len(entries) > 0 {
+			break
+		}
+		if len(entry) > remaining {
+			entry = truncateText(entry, remaining)
+		}
+		entries = append(entries, entry)
+		remaining -= len(entry)
+	}
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	return "[SuperPlane conversation rewind]\n" +
+		"The provider session was recreated. Treat this as prior conversation context, not as a new request. Do not answer or summarize the rewind; answer only the current user request that follows.\n\n" +
+		"Recent conversation:\n" +
+		strings.Join(entries, "\n\n"), nil
+}
+
+func formatRewindEntry(message models.AgentSessionMessage) string {
+	content := strings.TrimSpace(message.Content)
+	switch message.Role {
+	case models.AgentMessageRoleUser:
+		return "User: " + truncateText(content, rewindEntryMaxChars)
+	case models.AgentMessageRoleAssistant:
+		return "Assistant: " + truncateText(content, rewindEntryMaxChars)
+	case models.AgentMessageRoleSystem:
+		return "System note: " + truncateText(strings.TrimPrefix(content, "@@system: "), rewindEntryMaxChars)
+	case models.AgentMessageRoleTool:
+		return formatToolRewindEntry(message, content)
+	default:
+		return ""
+	}
+}
+
+func formatToolRewindEntry(message models.AgentSessionMessage, content string) string {
+	name := strings.TrimSpace(message.ToolName)
+	if name == "" {
+		name = "tool"
+	}
+	status := strings.TrimSpace(message.ToolStatus)
+	if status == "" {
+		status = "finished"
+	}
+	if content == "" {
+		return fmt.Sprintf("Tool %s %s.", name, status)
+	}
+	return fmt.Sprintf("Tool %s %s: %s", name, status, truncateText(content, rewindToolMaxChars))
+}
+
+func truncateText(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	text = strings.TrimSpace(text)
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	if limit <= 3 {
+		return string(runes[:limit])
+	}
+	return strings.TrimSpace(string(runes[:limit-3])) + "..."
+}

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -165,6 +165,16 @@ type ProviderSessionCleaner interface {
 	DeleteSession(ctx context.Context, providerSessionID string) error
 }
 
+type ProviderSessionArchiver interface {
+	Name() string
+	ArchiveSession(ctx context.Context, providerSessionID string) error
+}
+
+type ProviderToolSchemaRevisioner interface {
+	Name() string
+	ToolSchemaRevision() string
+}
+
 var ErrSessionAlreadyTerminated = errors.New("agent session already terminated")
 var ErrSessionBusy = errors.New("agent session is still processing")
 var ErrProviderSessionUnavailable = errors.New("provider session is unavailable")

--- a/pkg/agents/service.go
+++ b/pkg/agents/service.go
@@ -46,7 +46,11 @@ func (s *Service) EnsureSession(ctx context.Context, organizationID, userID, can
 		return nil, err
 	}
 	if existing != nil {
-		return existing, nil
+		refreshed, err := s.refreshStaleProviderSession(ctx, existing)
+		if errors.Is(err, ErrSessionBusy) {
+			return existing, nil
+		}
+		return refreshed, err
 	}
 	return s.provisionSession(ctx, organizationID, userID, canvasID)
 }
@@ -73,13 +77,16 @@ func (s *Service) provisionSession(ctx context.Context, organizationID, userID, 
 			return fmt.Errorf("create provider session: %w", err)
 		}
 
+		now := time.Now()
 		session = &models.AgentSession{
-			OrganizationID:    organizationID,
-			UserID:            userID,
-			CanvasID:          canvasID,
-			Provider:          s.provider.Name(),
-			ProviderSessionID: upstream.ProviderSessionID,
-			Status:            models.AgentSessionStatusIdle,
+			OrganizationID:          organizationID,
+			UserID:                  userID,
+			CanvasID:                canvasID,
+			Provider:                s.provider.Name(),
+			ProviderSessionID:       upstream.ProviderSessionID,
+			AgentToolSchemaRevision: s.currentToolSchemaRevision(),
+			Status:                  models.AgentSessionStatusIdle,
+			ContextReplayedAt:       &now,
 		}
 		return models.CreateAgentSessionInTransaction(tx, session)
 	})
@@ -182,14 +189,16 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 		return s.handleBusySession(sessionID, organizationID, userID)
 	}
 
-	preamble := s.buildPreamble(session, ModeBuilder)
+	session, err = s.refreshStaleProviderSession(ctx, session)
+	if err != nil {
+		if errors.Is(err, ErrSessionBusy) {
+			return s.handleBusySession(sessionID, organizationID, userID)
+		}
+		return err
+	}
 
-	if err := s.provider.DefineOutcome(ctx, session.ProviderSessionID, DefineOutcomeOptions{
-		Description:     description,
-		Rubric:          rubric,
-		MaxIterations:   maxIterations,
-		ContextPreamble: preamble,
-	}); err != nil {
+	contextReplayed, err := s.defineOutcomeOnProvider(ctx, session, description, rubric, maxIterations)
+	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return s.handleBusySession(sessionID, organizationID, userID)
 		}
@@ -201,12 +210,8 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 				}
 				return recoverErr
 			}
-			if err := s.provider.DefineOutcome(ctx, recovered.ProviderSessionID, DefineOutcomeOptions{
-				Description:     description,
-				Rubric:          rubric,
-				MaxIterations:   maxIterations,
-				ContextPreamble: preamble,
-			}); err != nil {
+			contextReplayed, err = s.defineOutcomeOnProvider(ctx, recovered, description, rubric, maxIterations)
+			if err != nil {
 				if errors.Is(err, ErrSessionBusy) {
 					return s.handleBusySession(sessionID, organizationID, userID)
 				}
@@ -214,6 +219,12 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 			}
 		} else {
 			return fmt.Errorf("define outcome: %w", err)
+		}
+	}
+
+	if contextReplayed {
+		if err := models.MarkAgentSessionContextReplayed(sessionID); err != nil {
+			log.WithError(err).WithField("session_id", sessionID).Warn("failed to mark recovered agent context replayed")
 		}
 	}
 
@@ -225,6 +236,21 @@ func (s *Service) DefineOutcome(ctx context.Context, organizationID, userID, ses
 		log.WithError(err).Warn("failed to enqueue stream after define outcome")
 	}
 	return nil
+}
+
+func (s *Service) defineOutcomeOnProvider(ctx context.Context, session *models.AgentSession, description, rubric string, maxIterations int) (bool, error) {
+	description, contextReplayed, err := s.messageWithRewind(session, description)
+	if err != nil {
+		return false, err
+	}
+
+	err = s.provider.DefineOutcome(ctx, session.ProviderSessionID, DefineOutcomeOptions{
+		Description:     description,
+		Rubric:          rubric,
+		MaxIterations:   maxIterations,
+		ContextPreamble: s.buildPreamble(session, ModeBuilder),
+	})
+	return contextReplayed, err
 }
 
 func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessionID uuid.UUID, content string, mode ...string) (*models.AgentSessionMessage, error) {
@@ -242,9 +268,16 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		agentMode = NormalizeMode(mode[0])
 	}
 
-	preamble := s.buildPreamble(session, agentMode)
+	session, err = s.refreshStaleProviderSession(ctx, session)
+	if err != nil {
+		if errors.Is(err, ErrSessionBusy) {
+			return nil, s.handleBusySession(sessionID, organizationID, userID)
+		}
+		return nil, err
+	}
 
-	if err := s.provider.SendMessage(ctx, session.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
+	contextReplayed, err := s.sendMessageToProvider(ctx, session, content, agentMode)
+	if err != nil {
 		if errors.Is(err, ErrSessionBusy) {
 			return nil, s.handleBusySession(sessionID, organizationID, userID)
 		}
@@ -256,7 +289,8 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 				}
 				return nil, recoverErr
 			}
-			if err := s.provider.SendMessage(ctx, recovered.ProviderSessionID, content, SendMessageOptions{ContextPreamble: preamble}); err != nil {
+			contextReplayed, err = s.sendMessageToProvider(ctx, recovered, content, agentMode)
+			if err != nil {
 				if errors.Is(err, ErrSessionBusy) {
 					return nil, s.handleBusySession(sessionID, organizationID, userID)
 				}
@@ -281,6 +315,12 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		return nil, fmt.Errorf("persist user message: %w", err)
 	}
 
+	if contextReplayed {
+		if err := models.MarkAgentSessionContextReplayed(sessionID); err != nil {
+			log.WithError(err).WithField("session_id", sessionID).Warn("failed to mark recovered agent context replayed")
+		}
+	}
+
 	if err := models.UpdateAgentSessionStatus(sessionID, models.AgentSessionStatusStreaming); err != nil {
 		log.WithError(err).Warn("failed to mark agent session as streaming")
 	}
@@ -289,6 +329,18 @@ func (s *Service) SendMessage(ctx context.Context, organizationID, userID, sessi
 		return nil, err
 	}
 	return persisted, nil
+}
+
+func (s *Service) sendMessageToProvider(ctx context.Context, session *models.AgentSession, content string, mode Mode) (bool, error) {
+	message, contextReplayed, err := s.messageWithRewind(session, content)
+	if err != nil {
+		return false, err
+	}
+
+	err = s.provider.SendMessage(ctx, session.ProviderSessionID, message, SendMessageOptions{
+		ContextPreamble: s.buildPreamble(session, mode),
+	})
+	return contextReplayed, err
 }
 
 func (s *Service) handleBusySession(sessionID, organizationID, userID uuid.UUID) error {
@@ -305,40 +357,68 @@ func (s *Service) enqueueStreamAfterBusySession(sessionID, organizationID, userI
 	return s.enqueueStream(sessionID, organizationID, userID)
 }
 
+func (s *Service) refreshStaleProviderSession(ctx context.Context, session *models.AgentSession) (*models.AgentSession, error) {
+	if !s.needsToolSchemaRefresh(session) {
+		return session, nil
+	}
+	if session.Status == models.AgentSessionStatusStreaming {
+		return session, nil
+	}
+
+	recovered, oldProviderSessionID, replaced, err := s.replaceProviderSession(ctx, session, true)
+	if err != nil {
+		return nil, fmt.Errorf("refresh stale provider session: %w", err)
+	}
+	if replaced {
+		s.archiveProviderSession(ctx, oldProviderSessionID)
+	}
+	return recovered, nil
+}
+
 func (s *Service) recoverProviderSession(ctx context.Context, stale *models.AgentSession) (*models.AgentSession, error) {
-	target, err := s.providerSessionRecoveryTarget(stale)
+	recovered, _, _, err := s.replaceProviderSession(ctx, stale, false)
 	if err != nil {
 		return nil, fmt.Errorf("recover provider session: %w", err)
 	}
+	return recovered, nil
+}
+
+type providerSessionRecoveryTarget struct {
+	organizationID       uuid.UUID
+	canvasID             uuid.UUID
+	oldProviderSessionID string
+	recovered            *models.AgentSession
+}
+
+func (s *Service) replaceProviderSession(ctx context.Context, stale *models.AgentSession, requireStaleToolSchema bool) (*models.AgentSession, string, bool, error) {
+	target, err := s.providerSessionRecoveryTarget(stale, requireStaleToolSchema)
+	if err != nil {
+		return nil, "", false, err
+	}
 	if target.recovered != nil {
-		return target.recovered, nil
+		return target.recovered, "", false, nil
 	}
 
 	upstream, err := s.provider.CreateSession(ctx, CreateSessionOptions{
 		Title: sessionTitle(target.organizationID, target.canvasID),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("recover provider session: create provider session: %w", err)
+		return nil, "", false, fmt.Errorf("create provider session: %w", err)
 	}
 
-	recovered, err := s.installRecoveredProviderSession(stale, upstream.ProviderSessionID)
+	recovered, err := s.installRecoveredProviderSession(stale, upstream.ProviderSessionID, requireStaleToolSchema)
 	if err != nil {
 		s.cleanupProviderSession(ctx, upstream.ProviderSessionID)
-		return nil, fmt.Errorf("recover provider session: %w", err)
+		return nil, "", false, err
 	}
 	if recovered.ProviderSessionID != upstream.ProviderSessionID {
 		s.cleanupProviderSession(ctx, upstream.ProviderSessionID)
+		return recovered, "", false, nil
 	}
-	return recovered, nil
+	return recovered, target.oldProviderSessionID, true, nil
 }
 
-type providerSessionRecoveryTarget struct {
-	organizationID uuid.UUID
-	canvasID       uuid.UUID
-	recovered      *models.AgentSession
-}
-
-func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession) (*providerSessionRecoveryTarget, error) {
+func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession, requireStaleToolSchema bool) (*providerSessionRecoveryTarget, error) {
 	target := &providerSessionRecoveryTarget{}
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		locked, err := models.LockAgentSessionInTransaction(tx, stale.ID)
@@ -352,9 +432,14 @@ func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession) (*pr
 			target.recovered = locked
 			return nil
 		}
+		if requireStaleToolSchema && !s.needsToolSchemaRefresh(locked) {
+			target.recovered = locked
+			return nil
+		}
 
 		target.organizationID = locked.OrganizationID
 		target.canvasID = locked.CanvasID
+		target.oldProviderSessionID = locked.ProviderSessionID
 		return nil
 	})
 	if err != nil {
@@ -363,7 +448,7 @@ func (s *Service) providerSessionRecoveryTarget(stale *models.AgentSession) (*pr
 	return target, nil
 }
 
-func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, providerSessionID string) (*models.AgentSession, error) {
+func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, providerSessionID string, requireStaleToolSchema bool) (*models.AgentSession, error) {
 	var recovered *models.AgentSession
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
 		locked, err := models.LockAgentSessionInTransaction(tx, stale.ID)
@@ -377,16 +462,23 @@ func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, pr
 			recovered = locked
 			return nil
 		}
+		if requireStaleToolSchema && !s.needsToolSchemaRefresh(locked) {
+			recovered = locked
+			return nil
+		}
 
 		if err := models.UpdateAgentSessionProviderSessionInTransaction(
 			tx,
 			locked.ID,
 			providerSessionID,
+			s.currentToolSchemaRevision(),
 			models.AgentSessionStatusIdle,
 		); err != nil {
 			return err
 		}
 		locked.ProviderSessionID = providerSessionID
+		locked.AgentToolSchemaRevision = s.currentToolSchemaRevision()
+		locked.ContextReplayedAt = nil
 		locked.Status = models.AgentSessionStatusIdle
 		recovered = locked
 		return nil
@@ -397,6 +489,22 @@ func (s *Service) installRecoveredProviderSession(stale *models.AgentSession, pr
 	return recovered, nil
 }
 
+func (s *Service) needsToolSchemaRefresh(session *models.AgentSession) bool {
+	return session.AgentToolSchemaRevision != s.currentToolSchemaRevision()
+}
+
+func (s *Service) currentToolSchemaRevision() string {
+	revisioner, ok := s.provider.(ProviderToolSchemaRevisioner)
+	if !ok {
+		return s.provider.Name()
+	}
+	revision := strings.TrimSpace(revisioner.ToolSchemaRevision())
+	if revision == "" {
+		return s.provider.Name()
+	}
+	return revision
+}
+
 func (s *Service) cleanupProviderSession(ctx context.Context, providerSessionID string) {
 	cleaner, ok := s.provider.(ProviderSessionCleaner)
 	if !ok {
@@ -404,6 +512,19 @@ func (s *Service) cleanupProviderSession(ctx context.Context, providerSessionID 
 	}
 	if err := cleaner.DeleteSession(ctx, providerSessionID); err != nil {
 		log.WithError(err).WithField("provider_session_id", providerSessionID).Warn("failed to clean up unused recovered provider session")
+	}
+}
+
+func (s *Service) archiveProviderSession(ctx context.Context, providerSessionID string) {
+	if strings.TrimSpace(providerSessionID) == "" {
+		return
+	}
+	archiver, ok := s.provider.(ProviderSessionArchiver)
+	if !ok {
+		return
+	}
+	if err := archiver.ArchiveSession(ctx, providerSessionID); err != nil && !errors.Is(err, ErrProviderSessionUnavailable) {
+		log.WithError(err).WithField("provider_session_id", providerSessionID).Warn("failed to archive stale provider session")
 	}
 }
 

--- a/pkg/agents/service_test.go
+++ b/pkg/agents/service_test.go
@@ -3,6 +3,7 @@ package agents_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -48,25 +49,41 @@ func (b *blockingProvider) StreamEvents(context.Context, string, func(agents.Pro
 const testProviderName = "test"
 
 type fakeProvider struct {
-	mu                  sync.Mutex
-	createCalled        int
-	sendCalled          int
-	interruptCalled     int
-	interruptedSessions []string
-	sentSessions        []string
-	defineSessions      []string
-	lastPreamble        string
-	lastOutcomeOpts     agents.DefineOutcomeOptions
-	createSessionErr    error
-	createHook          func() error
-	sendErr             error
-	sendErrs            []error
-	interruptErr        error
-	defineOutcomeErr    error
-	defineErrs          []error
+	mu                   sync.Mutex
+	createCalled         int
+	sendCalled           int
+	interruptCalled      int
+	interruptedSessions  []string
+	sentSessions         []string
+	sentMessages         []string
+	defineSessions       []string
+	defineDescriptions   []string
+	archivedSessions     []string
+	lastPreamble         string
+	lastOutcomeOpts      agents.DefineOutcomeOptions
+	toolSchemaRevision   string
+	onToolSchemaRevision func()
+	createSessionErr     error
+	createHook           func() error
+	sendErr              error
+	sendErrs             []error
+	interruptErr         error
+	archiveErr           error
+	defineOutcomeErr     error
+	defineErrs           []error
 }
 
 func (f *fakeProvider) Name() string { return testProviderName }
+
+func (f *fakeProvider) ToolSchemaRevision() string {
+	if f.onToolSchemaRevision != nil {
+		f.onToolSchemaRevision()
+	}
+	if f.toolSchemaRevision == "" {
+		return "test-revision"
+	}
+	return f.toolSchemaRevision
+}
 
 func (f *fakeProvider) CreateSession(_ context.Context, _ agents.CreateSessionOptions) (*agents.CreateSessionResult, error) {
 	f.mu.Lock()
@@ -83,11 +100,12 @@ func (f *fakeProvider) CreateSession(_ context.Context, _ agents.CreateSessionOp
 	return &agents.CreateSessionResult{ProviderSessionID: "provider-session-" + uuid.NewString()}, nil
 }
 
-func (f *fakeProvider) SendMessage(_ context.Context, providerSessionID string, _ string, opts agents.SendMessageOptions) error {
+func (f *fakeProvider) SendMessage(_ context.Context, providerSessionID string, message string, opts agents.SendMessageOptions) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sendCalled++
 	f.sentSessions = append(f.sentSessions, providerSessionID)
+	f.sentMessages = append(f.sentMessages, message)
 	f.lastPreamble = opts.ContextPreamble
 	if len(f.sendErrs) > 0 {
 		err := f.sendErrs[0]
@@ -109,6 +127,7 @@ func (f *fakeProvider) DefineOutcome(_ context.Context, providerSessionID string
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.defineSessions = append(f.defineSessions, providerSessionID)
+	f.defineDescriptions = append(f.defineDescriptions, opts.Description)
 	if len(f.defineErrs) > 0 {
 		err := f.defineErrs[0]
 		f.defineErrs = f.defineErrs[1:]
@@ -123,6 +142,13 @@ func (f *fakeProvider) DefineOutcome(_ context.Context, providerSessionID string
 
 func (f *fakeProvider) StreamEvents(_ context.Context, _ string, _ func(agents.ProviderEvent) error) error {
 	return nil
+}
+
+func (f *fakeProvider) ArchiveSession(_ context.Context, providerSessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.archivedSessions = append(f.archivedSessions, providerSessionID)
+	return f.archiveErr
 }
 
 func newService(t *testing.T, r *support.ResourceRegistry, provider agents.Provider) *agents.Service {
@@ -209,6 +235,59 @@ func TestService_EnsureSession_IsIdempotent(t *testing.T) {
 
 	assert.Equal(t, first.ID, second.ID)
 	assert.Equal(t, 1, provider.createCalled, "second call must not provision a new upstream session")
+}
+
+func TestService_EnsureSession_ReplacesIdleSessionWhenToolSchemaRevisionChanges(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	first, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	originalProviderSessionID := first.ProviderSessionID
+
+	provider.toolSchemaRevision = "revision-2"
+	refreshed, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, refreshed.ID)
+	assert.Equal(t, "revision-2", refreshed.AgentToolSchemaRevision)
+	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
+	assert.Nil(t, refreshed.ContextReplayedAt)
+	assert.Equal(t, []string{originalProviderSessionID}, provider.archivedSessions)
+	assert.Equal(t, 2, provider.createCalled)
+}
+
+func TestService_EnsureSession_ReturnsExistingSessionWhenStaleRefreshRacesWithStreamingTurn(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	var revisionChecks atomic.Int32
+	provider.toolSchemaRevision = "revision-2"
+	provider.onToolSchemaRevision = func() {
+		if revisionChecks.Add(1) != 1 {
+			return
+		}
+		require.NoError(t, models.UpdateAgentSessionStatus(session.ID, models.AgentSessionStatusStreaming))
+	}
+
+	refreshed, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, session.ID, refreshed.ID)
+	assert.Equal(t, session.ProviderSessionID, refreshed.ProviderSessionID)
+	assert.Equal(t, 1, provider.createCalled, "busy refresh race must not create a replacement provider session")
+	assert.Empty(t, provider.archivedSessions)
 }
 
 func TestService_EnsureSession_FailsWhenProviderErrors(t *testing.T) {
@@ -346,6 +425,97 @@ func TestService_SendMessage_RecreatesUnavailableProviderSession(t *testing.T) {
 	assert.Equal(t, refreshed.ProviderSessionID, provider.sentSessions[1])
 	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
 	assert.Equal(t, models.AgentSessionStatusStreaming, refreshed.Status)
+}
+
+func TestService_SendMessage_RewindsPriorMessagesAfterProviderSessionRecovery(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{
+		sendErrs: []error{agents.ErrProviderSessionUnavailable, nil},
+	}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	require.NoError(t, models.AppendAgentSessionMessage(&models.AgentSessionMessage{
+		SessionID: session.ID,
+		Role:      models.AgentMessageRoleUser,
+		Content:   "what changed last time?",
+	}))
+	require.NoError(t, models.AppendAgentSessionMessage(&models.AgentSessionMessage{
+		SessionID: session.ID,
+		Role:      models.AgentMessageRoleAssistant,
+		Content:   "We inspected the draft and found a missing approval node.",
+	}))
+	require.NoError(t, models.AppendAgentSessionMessage(&models.AgentSessionMessage{
+		SessionID:  session.ID,
+		Role:       models.AgentMessageRoleTool,
+		ToolName:   "superplane_app",
+		ToolStatus: models.AgentToolStatusFinished,
+		Content:    `{"canvas_yaml":"very large details are compacted"}`,
+	}))
+
+	persisted, err := svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "continue from there")
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+
+	require.Len(t, provider.sentMessages, 2)
+	assert.Equal(t, "continue from there", provider.sentMessages[0])
+	retryMessage := provider.sentMessages[1]
+	assert.Contains(t, retryMessage, "[SuperPlane conversation rewind]")
+	assert.Contains(t, retryMessage, "User: what changed last time?")
+	assert.Contains(t, retryMessage, "Assistant: We inspected the draft")
+	assert.Contains(t, retryMessage, "Tool superplane_app finished")
+	assert.Contains(t, retryMessage, "[Current user request]\ncontinue from there")
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, refreshed.ContextReplayedAt)
+
+	stored, err := models.ListAgentSessionMessagesPage(session.ID, nil, 10)
+	require.NoError(t, err)
+	require.Len(t, stored, 4)
+	assert.Equal(t, "continue from there", stored[3].Content)
+	assert.NotContains(t, stored[3].Content, "conversation rewind")
+}
+
+func TestService_SendMessage_RewindsAfterToolSchemaRefreshAndTrimsOldMessages(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	canvas := setupCanvasForUser(t, r)
+	provider := &fakeProvider{toolSchemaRevision: "revision-1"}
+	svc := newService(t, r, provider)
+
+	session, err := svc.EnsureSession(context.Background(), r.Organization.ID, r.User, canvas.ID)
+	require.NoError(t, err)
+	originalProviderSessionID := session.ProviderSessionID
+	for i := 0; i < 35; i++ {
+		require.NoError(t, models.AppendAgentSessionMessage(&models.AgentSessionMessage{
+			SessionID: session.ID,
+			Role:      models.AgentMessageRoleUser,
+			Content:   fmt.Sprintf("prior-message-%02d", i),
+		}))
+	}
+
+	provider.toolSchemaRevision = "revision-2"
+	_, err = svc.SendMessage(context.Background(), r.Organization.ID, r.User, session.ID, "new work")
+	require.NoError(t, err)
+
+	require.Len(t, provider.sentMessages, 1)
+	assert.Contains(t, provider.sentMessages[0], "[SuperPlane conversation rewind]")
+	assert.NotContains(t, provider.sentMessages[0], "prior-message-00")
+	assert.Contains(t, provider.sentMessages[0], "prior-message-34")
+	assert.Contains(t, provider.sentMessages[0], "[Current user request]\nnew work")
+	assert.Equal(t, []string{originalProviderSessionID}, provider.archivedSessions)
+
+	refreshed, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "revision-2", refreshed.AgentToolSchemaRevision)
+	assert.NotNil(t, refreshed.ContextReplayedAt)
+	assert.NotEqual(t, originalProviderSessionID, refreshed.ProviderSessionID)
 }
 
 func TestService_SendMessage_ReturnsBusyWhenRecoveredProviderSessionIsBusy(t *testing.T) {

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -18,17 +18,19 @@ const (
 )
 
 type AgentSession struct {
-	ID                uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
-	OrganizationID    uuid.UUID
-	UserID            uuid.UUID
-	CanvasID          uuid.UUID
-	Provider          string
-	ProviderSessionID string
-	Status            string
-	LastActiveAt      *time.Time
-	HeartbeatAt       *time.Time
-	CreatedAt         *time.Time
-	UpdatedAt         *time.Time
+	ID                      uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
+	OrganizationID          uuid.UUID
+	UserID                  uuid.UUID
+	CanvasID                uuid.UUID
+	Provider                string
+	ProviderSessionID       string
+	AgentToolSchemaRevision string
+	Status                  string
+	LastActiveAt            *time.Time
+	HeartbeatAt             *time.Time
+	ContextReplayedAt       *time.Time
+	CreatedAt               *time.Time
+	UpdatedAt               *time.Time
 }
 
 func (AgentSession) TableName() string { return "agent_sessions" }
@@ -150,18 +152,30 @@ func TouchAgentSessionHeartbeat(sessionID uuid.UUID) error {
 		Error
 }
 
-func UpdateAgentSessionProviderSessionInTransaction(tx *gorm.DB, sessionID uuid.UUID, providerSessionID, status string) error {
+func MarkAgentSessionContextReplayed(sessionID uuid.UUID) error {
+	now := time.Now()
+	return database.Conn().Model(&AgentSession{}).
+		Where("id = ?", sessionID).
+		Updates(map[string]any{
+			"context_replayed_at": &now,
+			"updated_at":          &now,
+		}).
+		Error
+}
+
+func UpdateAgentSessionProviderSessionInTransaction(tx *gorm.DB, sessionID uuid.UUID, providerSessionID, toolSchemaRevision, status string) error {
 	now := time.Now()
 	return tx.Model(&AgentSession{}).
 		Where("id = ?", sessionID).
 		Updates(map[string]any{
-			"provider_session_id": providerSessionID,
-			"status":              status,
-			"last_active_at":      &now,
-			"updated_at":          &now,
-			"heartbeat_at":        gorm.Expr("NULL"),
-		}).
-		Error
+			"provider_session_id":        providerSessionID,
+			"agent_tool_schema_revision": toolSchemaRevision,
+			"status":                     status,
+			"last_active_at":             &now,
+			"updated_at":                 &now,
+			"heartbeat_at":               gorm.Expr("NULL"),
+			"context_replayed_at":        gorm.Expr("NULL"),
+		}).Error
 }
 
 func UpdateAgentSessionStatusIfUnchangedInTransaction(tx *gorm.DB, sessionID uuid.UUID, status string, unchangedSince *time.Time) (bool, error) {


### PR DESCRIPTION
## Summary
- add agent session tool-schema revision tracking and replay state columns
- lazily replace stale idle provider sessions, archive old Anthropic sessions, and update rows to the current revision
- prepend a compact DB-backed conversation rewind to the first real user turn after provider session recreation
- add focused service, provider, and agent tool revision tests

Closes #5557

## Validation
- make db.migrate DB_NAME=superplane_test
- make test PKG_TEST_PACKAGES="./pkg/agents ./pkg/agents/agent_tools ./pkg/agents/anthropic ./pkg/models"
- make format.go
- make lint && make check.build.app
- make test