### PR TITLE
feat: add Cloudsmith scanPackage, getPackageVulnerabilities and quarantinePackage components

### DIFF
--- a/docs/components/Cloudsmith.mdx
+++ b/docs/components/Cloudsmith.mdx
@@ -18,10 +18,13 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 <CardGrid>
   <LinkCard title="Delete Package" href="#delete-package" description="Delete a package from a Cloudsmith repository" />
   <LinkCard title="Get Package" href="#get-package" description="Retrieve metadata for a specific Cloudsmith package" />
+  <LinkCard title="Get Package Vulnerabilities" href="#get-package-vulnerabilities" description="Retrieve the latest vulnerability scan result for a specific Cloudsmith package" />
   <LinkCard title="Get Repository" href="#get-repository" description="Fetch details of a Cloudsmith repository" />
   <LinkCard title="List Packages" href="#list-packages" description="List packages in a Cloudsmith repository with optional filtering by sync status, quarantine, and vulnerability" />
   <LinkCard title="Promote Package" href="#promote-package" description="Copy or move a package from one Cloudsmith repository to another" />
+  <LinkCard title="Quarantine Package" href="#quarantine-package" description="Quarantine or release a Cloudsmith package" />
   <LinkCard title="Resync Package" href="#resync-package" description="Schedule a Cloudsmith package for resynchronization" />
+  <LinkCard title="Scan Package" href="#scan-package" description="Schedule a vulnerability scan for a specific Cloudsmith package" />
   <LinkCard title="Tag Package" href="#tag-package" description="Add, replace, clear, or remove tags for a Cloudsmith package" />
 </CardGrid>
 
@@ -266,6 +269,66 @@ Returns the complete package object including:
 }
 ```
 
+<a id="get-package-vulnerabilities"></a>
+
+## Get Package Vulnerabilities
+
+**Component key:** `cloudsmith.getPackageVulnerabilities`
+
+The Get Package Vulnerabilities component retrieves the most recent vulnerability scan
+result for a specific Cloudsmith package.
+
+### Use Cases
+
+- **Release gating**: Block promotion of packages that have known vulnerabilities
+- **Audit reporting**: Record vulnerability counts and max severity for compliance dashboards
+- **Automated response**: Route critical findings to an on-call team or trigger quarantine
+- **Scan verification**: Confirm a scan has completed and check its outcome after **Scan Package**
+
+### Configuration
+
+- **Repository** (required): The repository containing the package, in the form `owner/repository`.
+- **Package** (required): The unique package identifier (`slug_perm`). Supports expressions — use
+  `{{ $['On Vulnerability Scan Completed'].data.slug_perm }}` to reference an upstream trigger.
+
+### Output
+
+Returns the most recent scan result for the package:
+- **identifier**: Unique ID for this scan result entry
+- **created_at**: When the scan was completed (ISO 8601)
+- **has_vulnerabilities**: Whether any vulnerabilities were detected
+- **num_vulnerabilities**: Total number of vulnerabilities found
+- **max_severity**: Highest severity level detected (e.g. `Critical`, `High`, `Medium`, `Low`)
+- **scan_id**: Internal scan identifier (may be `null`)
+- **package**: Nested object with the scanned package details:
+  - **identifier**: Package `slug_perm`
+  - **name**: Package name
+  - **version**: Package version or digest
+  - **url**: Direct API URL for the package
+
+### Example Output
+
+```json
+{
+  "data": {
+    "created_at": "2026-01-01T02:00:00Z",
+    "has_vulnerabilities": true,
+    "identifier": "example-scan-identifier",
+    "max_severity": "High",
+    "num_vulnerabilities": 1,
+    "package": {
+      "identifier": "EXAMPLE123",
+      "name": "example-app",
+      "url": "https://api.cloudsmith.io/v1/packages/example-owner/example-repo/EXAMPLE123/",
+      "version": "example-version"
+    },
+    "scan_id": null
+  },
+  "timestamp": "2026-01-01T02:05:00Z",
+  "type": "cloudsmith.package.vulnerabilities"
+}
+```
+
 <a id="get-repository"></a>
 
 ## Get Repository
@@ -485,6 +548,76 @@ Returns the promoted package as it appears in the destination repository, includ
 }
 ```
 
+<a id="quarantine-package"></a>
+
+## Quarantine Package
+
+**Component key:** `cloudsmith.quarantinePackage`
+
+The Quarantine Package component quarantines or releases a Cloudsmith package.
+
+### Actions
+
+- **Quarantine**: Makes the package unavailable for download while keeping it in the repository.
+  Useful when a package has known vulnerabilities or should not be consumed.
+- **Release**: Removes the quarantine on a previously quarantined package, making it available
+  for download again once any remediation steps are complete.
+
+### Use Cases
+
+- **Vulnerability response**: Automatically quarantine packages when critical vulnerabilities are detected
+- **Policy enforcement**: Quarantine packages that violate license or security policies
+- **Incident response**: Immediately isolate a compromised package version
+- **Remediation workflow**: Release a package after confirming vulnerabilities have been addressed
+
+### Configuration
+
+- **Repository** (required): The repository containing the package, in the form `owner/repository`.
+- **Package** (required): The unique package identifier (`slug_perm`). Supports expressions — use
+  `{{ $['On Vulnerability Scan Completed'].data.slug_perm }}` to reference an upstream trigger.
+- **Action** (required): Whether to quarantine or release the package.
+
+### Output
+
+Returns the updated Cloudsmith package object reflecting the new quarantine state, including:
+- **name** / **version**: Package identifiers
+- **status** / **status_str**: Updated status — `Quarantined` after quarantine, or the previous
+  status (e.g. `Available`) after release
+- **format**: Package format
+- **cdn_url** / **self_html_url**: Download and web UI URLs
+
+### Example Output
+
+```json
+{
+  "data": {
+    "cdn_url": "https://dl.cloudsmith.io/basic/example-owner/example-repo/docker/manifest.json",
+    "checksum_md5": "00000000000000000000000000000000",
+    "checksum_sha1": "0000000000000000000000000000000000000000",
+    "checksum_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "checksum_sha512": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "description": "Example quarantined package record",
+    "format": "docker",
+    "name": "example-app",
+    "namespace": "example-owner",
+    "repository": "example-repo",
+    "self_html_url": "https://cloudsmith.io/~example-owner/repos/example-repo/packages/detail/docker/example-app/example-version/",
+    "self_url": "https://api.cloudsmith.io/v1/packages/example-owner/example-repo/EXAMPLE123/",
+    "size": 123456,
+    "size_str": "",
+    "slug": "example-app-er5g",
+    "slug_perm": "EXAMPLE123",
+    "status": 7,
+    "status_str": "Quarantined",
+    "summary": "",
+    "uploaded_at": "2026-01-01T01:00:00Z",
+    "version": "example-version-hash"
+  },
+  "timestamp": "2026-01-01T01:05:00Z",
+  "type": "cloudsmith.package.quarantined"
+}
+```
+
 <a id="resync-package"></a>
 
 ## Resync Package
@@ -542,6 +675,44 @@ Emits the package returned by Cloudsmith on the default channel.
   },
   "timestamp": "2026-01-01T00:05:00Z",
   "type": "cloudsmith.package.resynced"
+}
+```
+
+<a id="scan-package"></a>
+
+## Scan Package
+
+**Component key:** `cloudsmith.scanPackage`
+
+The Scan Package component schedules a vulnerability scan for a specific Cloudsmith package.
+
+### Use Cases
+
+- **On-demand scanning**: Trigger a fresh scan after a package is uploaded or updated
+- **Pre-promotion checks**: Scan a package before promoting it to a production repository
+- **Scheduled audits**: Periodically re-scan packages to catch newly published CVEs
+
+### Configuration
+
+- **Repository** (required): The repository containing the package, in the form `owner/repository`.
+- **Package** (required): The unique package identifier (`slug_perm`). Supports expressions.
+
+### Output
+
+Emits the repository and package identifiers confirming the scan was scheduled. Scan results
+are asynchronous — use the **On Vulnerability Scan Completed** trigger or the
+**Get Package Vulnerabilities** action to retrieve results once the scan finishes.
+
+### Example Output
+
+```json
+{
+  "data": {
+    "package": "example-package-id",
+    "repository": "example-owner/example-repo"
+  },
+  "timestamp": "2026-01-01T00:00:00Z",
+  "type": "cloudsmith.package.scan_scheduled"
 }
 ```
 

--- a/pkg/integrations/cloudsmith/client.go
+++ b/pkg/integrations/cloudsmith/client.go
@@ -308,6 +308,76 @@ func (c *Client) execPackageRequest(method, requestURL string, body io.Reader) (
 	return &pkg, nil
 }
 
+// VulnerabilityPackageRef is the package reference embedded in a vulnerability scan result.
+type VulnerabilityPackageRef struct {
+	Identifier string `json:"identifier"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	URL        string `json:"url"`
+}
+
+// VulnerabilityScanResult is one entry returned by the /vulnerabilities/ endpoint.
+// Each entry represents a completed scan for a specific package version.
+type VulnerabilityScanResult struct {
+	Identifier         string                   `json:"identifier"`
+	CreatedAt          string                   `json:"created_at"`
+	Package            *VulnerabilityPackageRef `json:"package"`
+	ScanID             *string                  `json:"scan_id"`
+	HasVulnerabilities bool                     `json:"has_vulnerabilities"`
+	NumVulnerabilities int                      `json:"num_vulnerabilities"`
+	MaxSeverity        string                   `json:"max_severity,omitempty"`
+}
+
+// ScanPackage schedules a vulnerability scan for the given package.
+func (c *Client) ScanPackage(owner, repo, identifier string) error {
+	requestURL := fmt.Sprintf("%s/packages/%s/%s/%s/scan/", c.BaseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(identifier))
+	_, err := c.execRequest(http.MethodPost, requestURL, nil)
+	return err
+}
+
+// PackageQuarantineRequest is the request body for the quarantine endpoint.
+type PackageQuarantineRequest struct {
+	Release bool `json:"release"`
+}
+
+// QuarantinePackage quarantines or releases a package.
+// Set release=true to release a previously quarantined package.
+func (c *Client) QuarantinePackage(owner, repo, identifier string, release bool) (*Package, error) {
+	requestURL := fmt.Sprintf("%s/packages/%s/%s/%s/quarantine/", c.BaseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(identifier))
+	body, err := json.Marshal(PackageQuarantineRequest{Release: release})
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling request: %v", err)
+	}
+	responseBody, err := c.execRequest(http.MethodPost, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	var pkg Package
+	if err := json.Unmarshal(responseBody, &pkg); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+	return &pkg, nil
+}
+
+// GetPackageVulnerabilities fetches vulnerability scan results for a package.
+// Uses the /vulnerabilities/{owner}/{repo}/{package}/ endpoint, which is a separate
+// top-level resource from the /packages/ sub-resource tree.
+// Returns the full list of scan results (most recent first).
+func (c *Client) GetPackageVulnerabilities(owner, repo, identifier string) ([]VulnerabilityScanResult, error) {
+	requestURL := fmt.Sprintf("%s/vulnerabilities/%s/%s/%s/", c.BaseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(identifier))
+	responseBody, err := c.execRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []VulnerabilityScanResult
+	if err := json.Unmarshal(responseBody, &results); err != nil {
+		return nil, fmt.Errorf("error parsing response: %v", err)
+	}
+
+	return results, nil
+}
+
 const packagePageSize = 100
 
 // ListPackages returns all packages in the given repository, following pagination.

--- a/pkg/integrations/cloudsmith/cloudsmith.go
+++ b/pkg/integrations/cloudsmith/cloudsmith.go
@@ -78,6 +78,9 @@ func (c *Cloudsmith) Actions() []core.Action {
 		&DeletePackage{},
 		&ListPackages{},
 		&PromotePackage{},
+		&ScanPackage{},
+		&QuarantinePackage{},
+		&GetPackageVulnerabilities{},
 	}
 }
 

--- a/pkg/integrations/cloudsmith/example.go
+++ b/pkg/integrations/cloudsmith/example.go
@@ -22,6 +22,15 @@ var exampleOutputTagPackageBytes []byte
 //go:embed example_output_delete_package.json
 var exampleOutputDeletePackageBytes []byte
 
+//go:embed example_output_scan_package.json
+var exampleOutputScanPackageBytes []byte
+
+//go:embed example_output_quarantine_package.json
+var exampleOutputQuarantinePackageBytes []byte
+
+//go:embed example_output_get_package_vulnerabilities.json
+var exampleOutputGetPackageVulnerabilitiesBytes []byte
+
 //go:embed example_data_on_security_scan_completed.json
 var exampleDataOnSecurityScanCompletedBytes []byte
 
@@ -38,6 +47,12 @@ var exampleOutputTagPackageOnce sync.Once
 var exampleOutputTagPackage map[string]any
 var exampleOutputDeletePackageOnce sync.Once
 var exampleOutputDeletePackage map[string]any
+var exampleOutputScanPackageOnce sync.Once
+var exampleOutputScanPackage map[string]any
+var exampleOutputQuarantinePackageOnce sync.Once
+var exampleOutputQuarantinePackage map[string]any
+var exampleOutputGetPackageVulnerabilitiesOnce sync.Once
+var exampleOutputGetPackageVulnerabilities map[string]any
 var exampleDataOnSecurityScanCompletedOnce sync.Once
 var exampleDataOnSecurityScanCompleted map[string]any
 var exampleDataOnPackageCreatedOnce sync.Once
@@ -81,6 +96,18 @@ func (t *TagPackage) ExampleOutput() map[string]any {
 
 func (d *DeletePackage) ExampleOutput() map[string]any {
 	return utils.UnmarshalEmbeddedJSON(&exampleOutputDeletePackageOnce, exampleOutputDeletePackageBytes, &exampleOutputDeletePackage)
+}
+
+func (s *ScanPackage) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputScanPackageOnce, exampleOutputScanPackageBytes, &exampleOutputScanPackage)
+}
+
+func (q *QuarantinePackage) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputQuarantinePackageOnce, exampleOutputQuarantinePackageBytes, &exampleOutputQuarantinePackage)
+}
+
+func (g *GetPackageVulnerabilities) ExampleOutput() map[string]any {
+	return utils.UnmarshalEmbeddedJSON(&exampleOutputGetPackageVulnerabilitiesOnce, exampleOutputGetPackageVulnerabilitiesBytes, &exampleOutputGetPackageVulnerabilities)
 }
 
 func onSecurityScanCompletedExampleData() map[string]any {

--- a/pkg/integrations/cloudsmith/example_output_get_package_vulnerabilities.json
+++ b/pkg/integrations/cloudsmith/example_output_get_package_vulnerabilities.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "created_at": "2026-01-01T02:00:00Z",
+    "has_vulnerabilities": true,
+    "identifier": "example-scan-identifier",
+    "max_severity": "High",
+    "num_vulnerabilities": 1,
+    "package": {
+      "identifier": "EXAMPLE123",
+      "name": "example-app",
+      "url": "https://api.cloudsmith.io/v1/packages/example-owner/example-repo/EXAMPLE123/",
+      "version": "example-version"
+    },
+    "scan_id": null
+  },
+  "timestamp": "2026-01-01T02:05:00Z",
+  "type": "cloudsmith.package.vulnerabilities"
+}

--- a/pkg/integrations/cloudsmith/example_output_quarantine_package.json
+++ b/pkg/integrations/cloudsmith/example_output_quarantine_package.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "cdn_url": "https://dl.cloudsmith.io/basic/example-owner/example-repo/docker/manifest.json",
+    "checksum_md5": "00000000000000000000000000000000",
+    "checksum_sha1": "0000000000000000000000000000000000000000",
+    "checksum_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "checksum_sha512": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "description": "Example quarantined package record",
+    "format": "docker",
+    "name": "example-app",
+    "namespace": "example-owner",
+    "repository": "example-repo",
+    "self_html_url": "https://cloudsmith.io/~example-owner/repos/example-repo/packages/detail/docker/example-app/example-version/",
+    "self_url": "https://api.cloudsmith.io/v1/packages/example-owner/example-repo/EXAMPLE123/",
+    "size": 123456,
+    "size_str": "",
+    "slug": "example-app-er5g",
+    "slug_perm": "EXAMPLE123",
+    "status": 7,
+    "status_str": "Quarantined",
+    "summary": "",
+    "uploaded_at": "2026-01-01T01:00:00Z",
+    "version": "example-version-hash"
+  },
+  "timestamp": "2026-01-01T01:05:00Z",
+  "type": "cloudsmith.package.quarantined"
+}

--- a/pkg/integrations/cloudsmith/example_output_scan_package.json
+++ b/pkg/integrations/cloudsmith/example_output_scan_package.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "package": "example-package-id",
+    "repository": "example-owner/example-repo"
+  },
+  "timestamp": "2026-01-01T00:00:00Z",
+  "type": "cloudsmith.package.scan_scheduled"
+}

--- a/pkg/integrations/cloudsmith/get_package_vulnerabilities.go
+++ b/pkg/integrations/cloudsmith/get_package_vulnerabilities.go
@@ -1,0 +1,191 @@
+package cloudsmith
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type GetPackageVulnerabilities struct{}
+
+type GetPackageVulnerabilitiesSpec struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	Package    string `json:"package" mapstructure:"package"`
+}
+
+func (g *GetPackageVulnerabilities) Name() string {
+	return "cloudsmith.getPackageVulnerabilities"
+}
+
+func (g *GetPackageVulnerabilities) Label() string {
+	return "Get Package Vulnerabilities"
+}
+
+func (g *GetPackageVulnerabilities) Description() string {
+	return "Retrieve the latest vulnerability scan result for a specific Cloudsmith package"
+}
+
+func (g *GetPackageVulnerabilities) Documentation() string {
+	return `The Get Package Vulnerabilities component retrieves the most recent vulnerability scan
+result for a specific Cloudsmith package.
+
+## Use Cases
+
+- **Release gating**: Block promotion of packages that have known vulnerabilities
+- **Audit reporting**: Record vulnerability counts and max severity for compliance dashboards
+- **Automated response**: Route critical findings to an on-call team or trigger quarantine
+- **Scan verification**: Confirm a scan has completed and check its outcome after **Scan Package**
+
+## Configuration
+
+- **Repository** (required): The repository containing the package, in the form ` + "`owner/repository`" + `.
+- **Package** (required): The unique package identifier (` + "`slug_perm`" + `). Supports expressions — use
+  ` + "`{{ $['On Vulnerability Scan Completed'].data.slug_perm }}`" + ` to reference an upstream trigger.
+
+## Output
+
+Returns the most recent scan result for the package:
+- **identifier**: Unique ID for this scan result entry
+- **created_at**: When the scan was completed (ISO 8601)
+- **has_vulnerabilities**: Whether any vulnerabilities were detected
+- **num_vulnerabilities**: Total number of vulnerabilities found
+- **max_severity**: Highest severity level detected (e.g. ` + "`Critical`" + `, ` + "`High`" + `, ` + "`Medium`" + `, ` + "`Low`" + `)
+- **scan_id**: Internal scan identifier (may be ` + "`null`" + `)
+- **package**: Nested object with the scanned package details:
+  - **identifier**: Package ` + "`slug_perm`" + `
+  - **name**: Package name
+  - **version**: Package version or digest
+  - **url**: Direct API URL for the package`
+}
+
+func (g *GetPackageVulnerabilities) Icon() string {
+	return "shield-alert"
+}
+
+func (g *GetPackageVulnerabilities) Color() string {
+	return "gray"
+}
+
+func (g *GetPackageVulnerabilities) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (g *GetPackageVulnerabilities) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "repository",
+			Label:       "Repository",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The repository containing the package",
+			Placeholder: "Select repository",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: false,
+				},
+			},
+		},
+		{
+			Name:        "package",
+			Label:       "Package",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Placeholder: "Select package",
+			Description: "The package to retrieve vulnerability results for",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "package",
+					UseNameAsValue: false,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "repository",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "repository"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (g *GetPackageVulnerabilities) Setup(ctx core.SetupContext) error {
+	spec := GetPackageVulnerabilitiesSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Repository == "" {
+		return errors.New("repository is required")
+	}
+
+	if spec.Package == "" {
+		return errors.New("package is required")
+	}
+
+	return resolvePackageMetadata(ctx, spec.Repository, spec.Package)
+}
+
+func (g *GetPackageVulnerabilities) Execute(ctx core.ExecutionContext) error {
+	spec := GetPackageVulnerabilitiesSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	owner, repo, err := parseRepositoryID(spec.Repository)
+	if err != nil {
+		return fmt.Errorf("invalid repository %q: %w", spec.Repository, err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	results, err := client.GetPackageVulnerabilities(owner, repo, spec.Package)
+	if err != nil {
+		return fmt.Errorf("failed to get package vulnerabilities: %v", err)
+	}
+
+	// An empty list means no scan has run yet — a completed scan with no findings
+	// still returns an entry (with has_vulnerabilities false). Fail loudly rather
+	// than emitting an empty result that downstream steps would read as "clean".
+	if len(results) == 0 {
+		return fmt.Errorf("no vulnerability scan results found for package %q; the package may not have been scanned yet", spec.Package)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudsmith.package.vulnerabilities",
+		[]any{results[0]},
+	)
+}
+
+func (g *GetPackageVulnerabilities) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (g *GetPackageVulnerabilities) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (g *GetPackageVulnerabilities) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (g *GetPackageVulnerabilities) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (g *GetPackageVulnerabilities) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (g *GetPackageVulnerabilities) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudsmith/get_package_vulnerabilities_test.go
+++ b/pkg/integrations/cloudsmith/get_package_vulnerabilities_test.go
@@ -1,0 +1,179 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__GetPackageVulnerabilities__Setup(t *testing.T) {
+	component := &GetPackageVulnerabilities{}
+
+	t.Run("missing repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("missing package returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+			},
+			Metadata: &contexts.MetadataContext{},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+		})
+
+		require.ErrorContains(t, err, "package is required")
+	})
+
+	t.Run("valid configuration resolves package metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+					okResponse(`{"slug":"my-package-1-0-0","slug_perm":"perm123","name":"my-package","version":"1.0.0"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(PackageNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+		assert.Equal(t, "my-package 1.0.0", metadata.PackageName)
+	})
+}
+
+func Test__GetPackageVulnerabilities__Execute(t *testing.T) {
+	component := &GetPackageVulnerabilities{}
+
+	scanResultsJSON := `[
+		{
+			"identifier": "1ceRAXarsZ93o5b7",
+			"created_at": "2026-06-18T07:08:34.479287Z",
+			"package": {
+				"identifier": "YFf7Vw1SnOnK",
+				"name": "hello-go-app",
+				"version": "cd8e0196c8cfe78b87690ec03900b775c7823d32f09ec8f87f760411059de7e2",
+				"url": "https://api.cloudsmith.io/v1/packages/acme/production/YFf7Vw1SnOnK/"
+			},
+			"scan_id": null,
+			"has_vulnerabilities": true,
+			"num_vulnerabilities": 27,
+			"max_severity": "Critical"
+		}
+	]`
+
+	t.Run("successful fetch returns most recent scan result", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "YFf7Vw1SnOnK",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(scanResultsJSON)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "cloudsmith.package.vulnerabilities", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped, ok := executionState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		result, ok := wrapped["data"].(VulnerabilityScanResult)
+		require.True(t, ok)
+		assert.Equal(t, "1ceRAXarsZ93o5b7", result.Identifier)
+		assert.True(t, result.HasVulnerabilities)
+		assert.Equal(t, 27, result.NumVulnerabilities)
+		assert.Equal(t, "Critical", result.MaxSeverity)
+		require.NotNil(t, result.Package)
+		assert.Equal(t, "YFf7Vw1SnOnK", result.Package.Identifier)
+		assert.Equal(t, "hello-go-app", result.Package.Name)
+	})
+
+	t.Run("no scan results returns error instead of a clean-looking result", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "YFf7Vw1SnOnK",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`[]`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no vulnerability scan results found")
+		assert.False(t, executionState.Passed)
+		assert.Empty(t, executionState.Payloads)
+	})
+
+	t.Run("invalid repository format returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "no-namespace",
+				"package":    "perm123",
+			},
+			HTTP:           &contexts.HTTPContext{},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid repository")
+	})
+}

--- a/pkg/integrations/cloudsmith/quarantine_package.go
+++ b/pkg/integrations/cloudsmith/quarantine_package.go
@@ -188,6 +188,9 @@ func (q *QuarantinePackage) Execute(ctx core.ExecutionContext) error {
 	release := spec.Action == QuarantineActionRelease
 	pkg, err := client.QuarantinePackage(owner, repo, spec.Package, release)
 	if err != nil {
+		if release {
+			return fmt.Errorf("failed to release package: %v", err)
+		}
 		return fmt.Errorf("failed to quarantine package: %v", err)
 	}
 

--- a/pkg/integrations/cloudsmith/quarantine_package.go
+++ b/pkg/integrations/cloudsmith/quarantine_package.go
@@ -1,0 +1,228 @@
+package cloudsmith
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+const (
+	QuarantineActionQuarantine = "Quarantine"
+	QuarantineActionRelease    = "Release"
+)
+
+type QuarantinePackage struct{}
+
+type QuarantinePackageSpec struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	Package    string `json:"package" mapstructure:"package"`
+	Action     string `json:"action" mapstructure:"action"`
+}
+
+func (q *QuarantinePackage) Name() string {
+	return "cloudsmith.quarantinePackage"
+}
+
+func (q *QuarantinePackage) Label() string {
+	return "Quarantine Package"
+}
+
+func (q *QuarantinePackage) Description() string {
+	return "Quarantine or release a Cloudsmith package"
+}
+
+func (q *QuarantinePackage) Documentation() string {
+	return `The Quarantine Package component quarantines or releases a Cloudsmith package.
+
+## Actions
+
+- **Quarantine**: Makes the package unavailable for download while keeping it in the repository.
+  Useful when a package has known vulnerabilities or should not be consumed.
+- **Release**: Removes the quarantine on a previously quarantined package, making it available
+  for download again once any remediation steps are complete.
+
+## Use Cases
+
+- **Vulnerability response**: Automatically quarantine packages when critical vulnerabilities are detected
+- **Policy enforcement**: Quarantine packages that violate license or security policies
+- **Incident response**: Immediately isolate a compromised package version
+- **Remediation workflow**: Release a package after confirming vulnerabilities have been addressed
+
+## Configuration
+
+- **Repository** (required): The repository containing the package, in the form ` + "`owner/repository`" + `.
+- **Package** (required): The unique package identifier (` + "`slug_perm`" + `). Supports expressions — use
+  ` + "`{{ $['On Vulnerability Scan Completed'].data.slug_perm }}`" + ` to reference an upstream trigger.
+- **Action** (required): Whether to quarantine or release the package.
+
+## Output
+
+Returns the updated Cloudsmith package object reflecting the new quarantine state, including:
+- **name** / **version**: Package identifiers
+- **status** / **status_str**: Updated status — ` + "`Quarantined`" + ` after quarantine, or the previous
+  status (e.g. ` + "`Available`" + `) after release
+- **format**: Package format
+- **cdn_url** / **self_html_url**: Download and web UI URLs`
+}
+
+func (q *QuarantinePackage) Icon() string {
+	return "shield-off"
+}
+
+func (q *QuarantinePackage) Color() string {
+	return "gray"
+}
+
+func (q *QuarantinePackage) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (q *QuarantinePackage) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "repository",
+			Label:       "Repository",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The repository containing the package",
+			Placeholder: "Select repository",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: false,
+				},
+			},
+		},
+		{
+			Name:        "package",
+			Label:       "Package",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Placeholder: "Select package",
+			Description: "The package to quarantine or release",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "package",
+					UseNameAsValue: false,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "repository",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "repository"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "action",
+			Label:       "Action",
+			Type:        configuration.FieldTypeSelect,
+			Required:    true,
+			Default:     QuarantineActionQuarantine,
+			Description: "Whether to quarantine or release the package",
+			TypeOptions: &configuration.TypeOptions{
+				Select: &configuration.SelectTypeOptions{
+					Options: []configuration.FieldOption{
+						{
+							Value:       QuarantineActionQuarantine,
+							Label:       "Quarantine",
+							Description: "Make the package unavailable for download",
+						},
+						{
+							Value:       QuarantineActionRelease,
+							Label:       "Release",
+							Description: "Remove quarantine and make the package available again",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (q *QuarantinePackage) Setup(ctx core.SetupContext) error {
+	spec := QuarantinePackageSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Repository == "" {
+		return errors.New("repository is required")
+	}
+
+	if spec.Package == "" {
+		return errors.New("package is required")
+	}
+
+	// An empty action falls back to the field default (Quarantine), since field
+	// defaults are not merged into saved configuration server-side. Only reject
+	// an explicitly set value that is neither valid option.
+	if spec.Action != "" && spec.Action != QuarantineActionQuarantine && spec.Action != QuarantineActionRelease {
+		return fmt.Errorf("action must be %q or %q", QuarantineActionQuarantine, QuarantineActionRelease)
+	}
+
+	return resolvePackageMetadata(ctx, spec.Repository, spec.Package)
+}
+
+func (q *QuarantinePackage) Execute(ctx core.ExecutionContext) error {
+	spec := QuarantinePackageSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	owner, repo, err := parseRepositoryID(spec.Repository)
+	if err != nil {
+		return fmt.Errorf("invalid repository %q: %w", spec.Repository, err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	release := spec.Action == QuarantineActionRelease
+	pkg, err := client.QuarantinePackage(owner, repo, spec.Package, release)
+	if err != nil {
+		return fmt.Errorf("failed to quarantine package: %v", err)
+	}
+
+	eventType := "cloudsmith.package.quarantined"
+	if release {
+		eventType = "cloudsmith.package.released"
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		eventType,
+		[]any{pkg},
+	)
+}
+
+func (q *QuarantinePackage) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (q *QuarantinePackage) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (q *QuarantinePackage) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (q *QuarantinePackage) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (q *QuarantinePackage) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (q *QuarantinePackage) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudsmith/quarantine_package_test.go
+++ b/pkg/integrations/cloudsmith/quarantine_package_test.go
@@ -1,0 +1,313 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__QuarantinePackage__Setup(t *testing.T) {
+	component := &QuarantinePackage{}
+
+	t.Run("missing repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("missing package returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"action":     QuarantineActionQuarantine,
+			},
+			Metadata: &contexts.MetadataContext{},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+		})
+
+		require.ErrorContains(t, err, "package is required")
+	})
+
+	t.Run("invalid action returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     "Delete",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "action must be")
+	})
+
+	t.Run("omitted action defaults to quarantine and resolves metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+					okResponse(`{"slug":"my-package-1-0-0","slug_perm":"perm123","name":"my-package","version":"1.0.0"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(PackageNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+	})
+
+	t.Run("valid quarantine configuration resolves package metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionQuarantine,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+					okResponse(`{"slug":"my-package-1-0-0","slug_perm":"perm123","name":"my-package","version":"1.0.0"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(PackageNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+		assert.Equal(t, "my-package 1.0.0", metadata.PackageName)
+	})
+
+	t.Run("valid release configuration resolves package metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionRelease,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+					okResponse(`{"slug":"my-package-1-0-0","slug_perm":"perm123","name":"my-package","version":"1.0.0"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(PackageNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+	})
+}
+
+func Test__QuarantinePackage__Execute(t *testing.T) {
+	component := &QuarantinePackage{}
+
+	quarantinedPackageJSON := `{
+		"slug": "my-package-1-0-0",
+		"slug_perm": "perm123",
+		"name": "my-package",
+		"version": "1.0.0",
+		"format": "python",
+		"status": 8,
+		"status_str": "Quarantined",
+		"repository": "production",
+		"namespace": "acme",
+		"cdn_url": "https://dl.cloudsmith.io/public/acme/production/python/my-package-1.0.0.tar.gz",
+		"self_html_url": "https://cloudsmith.io/~acme/repos/production/packages/detail/python/my-package/1.0.0/"
+	}`
+
+	releasedPackageJSON := `{
+		"slug": "my-package-1-0-0",
+		"slug_perm": "perm123",
+		"name": "my-package",
+		"version": "1.0.0",
+		"format": "python",
+		"status": 2,
+		"status_str": "Available",
+		"repository": "production",
+		"namespace": "acme",
+		"cdn_url": "https://dl.cloudsmith.io/public/acme/production/python/my-package-1.0.0.tar.gz"
+	}`
+
+	t.Run("quarantine action emits quarantined package", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionQuarantine,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(quarantinedPackageJSON)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "cloudsmith.package.quarantined", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped, ok := executionState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		pkg, ok := wrapped["data"].(*Package)
+		require.True(t, ok)
+		assert.Equal(t, "my-package", pkg.Name)
+		assert.Equal(t, "Quarantined", pkg.StatusStr)
+	})
+
+	t.Run("omitted action defaults to quarantine", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(quarantinedPackageJSON)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "cloudsmith.package.quarantined", executionState.Type)
+	})
+
+	t.Run("release action emits released package", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionRelease,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(releasedPackageJSON)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "cloudsmith.package.released", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped, ok := executionState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		pkg, ok := wrapped["data"].(*Package)
+		require.True(t, ok)
+		assert.Equal(t, "Available", pkg.StatusStr)
+	})
+
+	t.Run("invalid repository format returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "no-namespace",
+				"package":    "perm123",
+				"action":     QuarantineActionQuarantine,
+			},
+			HTTP:           &contexts.HTTPContext{},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid repository")
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionQuarantine,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Body:       io.NopCloser(strings.NewReader(`{"detail":"Permission denied."}`)),
+					},
+				},
+			},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to quarantine package")
+	})
+}

--- a/pkg/integrations/cloudsmith/quarantine_package_test.go
+++ b/pkg/integrations/cloudsmith/quarantine_package_test.go
@@ -286,7 +286,7 @@ func Test__QuarantinePackage__Execute(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid repository")
 	})
 
-	t.Run("API error returns error", func(t *testing.T) {
+	t.Run("quarantine API error returns quarantine error", func(t *testing.T) {
 		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
 
 		err := component.Execute(core.ExecutionContext{
@@ -309,5 +309,31 @@ func Test__QuarantinePackage__Execute(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to quarantine package")
+	})
+
+	t.Run("release API error returns release error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+				"action":     QuarantineActionRelease,
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusForbidden,
+						Body:       io.NopCloser(strings.NewReader(`{"detail":"Permission denied."}`)),
+					},
+				},
+			},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to release package")
+		assert.NotContains(t, err.Error(), "failed to quarantine package")
 	})
 }

--- a/pkg/integrations/cloudsmith/scan_package.go
+++ b/pkg/integrations/cloudsmith/scan_package.go
@@ -1,0 +1,179 @@
+package cloudsmith
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/superplanehq/superplane/pkg/configuration"
+	"github.com/superplanehq/superplane/pkg/core"
+)
+
+type ScanPackage struct{}
+
+type ScanPackageSpec struct {
+	Repository string `json:"repository" mapstructure:"repository"`
+	Package    string `json:"package" mapstructure:"package"`
+}
+
+type ScanPackageResult struct {
+	Repository string `json:"repository"`
+	Package    string `json:"package"`
+}
+
+func (s *ScanPackage) Name() string {
+	return "cloudsmith.scanPackage"
+}
+
+func (s *ScanPackage) Label() string {
+	return "Scan Package"
+}
+
+func (s *ScanPackage) Description() string {
+	return "Schedule a vulnerability scan for a specific Cloudsmith package"
+}
+
+func (s *ScanPackage) Documentation() string {
+	return `The Scan Package component schedules a vulnerability scan for a specific Cloudsmith package.
+
+## Use Cases
+
+- **On-demand scanning**: Trigger a fresh scan after a package is uploaded or updated
+- **Pre-promotion checks**: Scan a package before promoting it to a production repository
+- **Scheduled audits**: Periodically re-scan packages to catch newly published CVEs
+
+## Configuration
+
+- **Repository** (required): The repository containing the package, in the form ` + "`owner/repository`" + `.
+- **Package** (required): The unique package identifier (` + "`slug_perm`" + `). Supports expressions.
+
+## Output
+
+Emits the repository and package identifiers confirming the scan was scheduled. Scan results
+are asynchronous — use the **On Vulnerability Scan Completed** trigger or the
+**Get Package Vulnerabilities** action to retrieve results once the scan finishes.`
+}
+
+func (s *ScanPackage) Icon() string {
+	return "scan"
+}
+
+func (s *ScanPackage) Color() string {
+	return "gray"
+}
+
+func (s *ScanPackage) OutputChannels(configuration any) []core.OutputChannel {
+	return []core.OutputChannel{core.DefaultOutputChannel}
+}
+
+func (s *ScanPackage) Configuration() []configuration.Field {
+	return []configuration.Field{
+		{
+			Name:        "repository",
+			Label:       "Repository",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Description: "The repository containing the package",
+			Placeholder: "Select repository",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "repository",
+					UseNameAsValue: false,
+				},
+			},
+		},
+		{
+			Name:        "package",
+			Label:       "Package",
+			Type:        configuration.FieldTypeIntegrationResource,
+			Required:    true,
+			Placeholder: "Select package",
+			Description: "The package to scan",
+			TypeOptions: &configuration.TypeOptions{
+				Resource: &configuration.ResourceTypeOptions{
+					Type:           "package",
+					UseNameAsValue: false,
+					Parameters: []configuration.ParameterRef{
+						{
+							Name:      "repository",
+							ValueFrom: &configuration.ParameterValueFrom{Field: "repository"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *ScanPackage) Setup(ctx core.SetupContext) error {
+	spec := ScanPackageSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	if spec.Repository == "" {
+		return errors.New("repository is required")
+	}
+
+	if spec.Package == "" {
+		return errors.New("package is required")
+	}
+
+	return resolvePackageMetadata(ctx, spec.Repository, spec.Package)
+}
+
+func (s *ScanPackage) Execute(ctx core.ExecutionContext) error {
+	spec := ScanPackageSpec{}
+	if err := mapstructure.Decode(ctx.Configuration, &spec); err != nil {
+		return fmt.Errorf("error decoding configuration: %v", err)
+	}
+
+	owner, repo, err := parseRepositoryID(spec.Repository)
+	if err != nil {
+		return fmt.Errorf("invalid repository %q: %w", spec.Repository, err)
+	}
+
+	client, err := NewClient(ctx.HTTP, ctx.Integration)
+	if err != nil {
+		return fmt.Errorf("error creating client: %v", err)
+	}
+
+	if err := client.ScanPackage(owner, repo, spec.Package); err != nil {
+		return fmt.Errorf("failed to schedule scan: %v", err)
+	}
+
+	return ctx.ExecutionState.Emit(
+		core.DefaultOutputChannel.Name,
+		"cloudsmith.package.scan_scheduled",
+		[]any{ScanPackageResult{
+			Repository: spec.Repository,
+			Package:    spec.Package,
+		}},
+	)
+}
+
+func (s *ScanPackage) Cancel(ctx core.ExecutionContext) error {
+	return nil
+}
+
+func (s *ScanPackage) ProcessQueueItem(ctx core.ProcessQueueContext) (*uuid.UUID, error) {
+	return ctx.DefaultProcessing()
+}
+
+func (s *ScanPackage) HandleWebhook(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+	return http.StatusOK, nil, nil
+}
+
+func (s *ScanPackage) Cleanup(ctx core.SetupContext) error {
+	return nil
+}
+
+func (s *ScanPackage) Hooks() []core.Hook {
+	return []core.Hook{}
+}
+
+func (s *ScanPackage) HandleHook(ctx core.ActionHookContext) error {
+	return nil
+}

--- a/pkg/integrations/cloudsmith/scan_package_test.go
+++ b/pkg/integrations/cloudsmith/scan_package_test.go
@@ -1,0 +1,168 @@
+package cloudsmith
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/test/support/contexts"
+)
+
+func Test__ScanPackage__Setup(t *testing.T) {
+	component := &ScanPackage{}
+
+	t.Run("missing repository returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{},
+			Metadata:      &contexts.MetadataContext{},
+		})
+
+		require.ErrorContains(t, err, "repository is required")
+	})
+
+	t.Run("missing package returns error", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+			},
+			Metadata: &contexts.MetadataContext{},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+		})
+
+		require.ErrorContains(t, err, "package is required")
+	})
+
+	t.Run("expression repository and package passes without API call", func(t *testing.T) {
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "{{ $.trigger.data.repository }}",
+				"package":    "{{ $.trigger.data.package }}",
+			},
+			Metadata: &contexts.MetadataContext{},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("valid configuration resolves package metadata", func(t *testing.T) {
+		metadataCtx := &contexts.MetadataContext{}
+
+		err := component.Setup(core.SetupContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					okResponse(`{"name":"Production","slug":"production","namespace":"acme"}`),
+					okResponse(`{"slug":"my-package-1-0-0","slug_perm":"perm123","name":"my-package","version":"1.0.0"}`),
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			Metadata: metadataCtx,
+		})
+
+		require.NoError(t, err)
+		metadata, ok := metadataCtx.Metadata.(PackageNodeMetadata)
+		require.True(t, ok)
+		assert.Equal(t, "Production", metadata.RepositoryName)
+		assert.Equal(t, "my-package 1.0.0", metadata.PackageName)
+		assert.Equal(t, "perm123", metadata.PackageID)
+	})
+}
+
+func Test__ScanPackage__Execute(t *testing.T) {
+	component := &ScanPackage{}
+
+	t.Run("successful scan schedules scan and emits confirmation", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{}`)),
+					},
+				},
+			},
+			Integration: &contexts.IntegrationContext{
+				Configuration: map[string]any{"apiKey": "test-key"},
+			},
+			ExecutionState: executionState,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, executionState.Passed)
+		assert.Equal(t, "default", executionState.Channel)
+		assert.Equal(t, "cloudsmith.package.scan_scheduled", executionState.Type)
+		require.Len(t, executionState.Payloads, 1)
+
+		wrapped, ok := executionState.Payloads[0].(map[string]any)
+		require.True(t, ok)
+		result, ok := wrapped["data"].(ScanPackageResult)
+		require.True(t, ok)
+		assert.Equal(t, "acme/production", result.Repository)
+		assert.Equal(t, "perm123", result.Package)
+	})
+
+	t.Run("invalid repository format returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "no-namespace",
+				"package":    "perm123",
+			},
+			HTTP:           &contexts.HTTPContext{},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid repository")
+		assert.False(t, executionState.Passed)
+	})
+
+	t.Run("API error returns error", func(t *testing.T) {
+		executionState := &contexts.ExecutionStateContext{KVs: map[string]string{}}
+
+		err := component.Execute(core.ExecutionContext{
+			Configuration: map[string]any{
+				"repository": "acme/production",
+				"package":    "perm123",
+			},
+			HTTP: &contexts.HTTPContext{
+				Responses: []*http.Response{
+					{
+						StatusCode: http.StatusBadRequest,
+						Body:       io.NopCloser(strings.NewReader(`{"detail":"Package not found."}`)),
+					},
+				},
+			},
+			Integration:    &contexts.IntegrationContext{Configuration: map[string]any{"apiKey": "test-key"}},
+			ExecutionState: executionState,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to schedule scan")
+		assert.False(t, executionState.Passed)
+	})
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/get_package_vulnerabilities.spec.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_package_vulnerabilities.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { getPackageVulnerabilitiesMapper } from "./get_package_vulnerabilities";
+import { buildDetailsCtx, buildPackageOutput } from "./test_helpers";
+import type { VulnerabilityScanResult } from "./types";
+
+function buildScanResult(overrides?: Partial<VulnerabilityScanResult>): VulnerabilityScanResult {
+  return {
+    identifier: "1ceRAXarsZ93o5b7",
+    created_at: "2026-06-18T07:08:34.479287Z",
+    package: {
+      identifier: "YFf7Vw1SnOnK",
+      name: "hello-go-app",
+      version: "cd8e0196c8cfe78b87690ec03900b775c7823d32f09ec8f87f760411059de7e2",
+      url: "https://api.cloudsmith.io/v1/packages/acme/production/YFf7Vw1SnOnK/",
+    },
+    scan_id: null,
+    has_vulnerabilities: true,
+    num_vulnerabilities: 27,
+    max_severity: "Critical",
+    ...overrides,
+  };
+}
+
+describe("getPackageVulnerabilitiesMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => getPackageVulnerabilitiesMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => getPackageVulnerabilitiesMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns only Executed At when scan result has no identifier", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildPackageOutput({})] } },
+    });
+    const details = getPackageVulnerabilitiesMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Vulnerabilities Found"]).toBeUndefined();
+  });
+
+  it("shows vulnerabilities found, total, max severity and scanned at", () => {
+    const result = buildScanResult();
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildPackageOutput(result)] } } });
+    const details = getPackageVulnerabilitiesMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Vulnerabilities Found"]).toBe("Yes");
+    expect(details["Total"]).toBe("27");
+    expect(details["Max Severity"]).toBe("Critical");
+    expect(details["Scanned At"]).toBeDefined();
+  });
+
+  it("shows no vulnerabilities when scan is clean", () => {
+    const result = buildScanResult({
+      has_vulnerabilities: false,
+      num_vulnerabilities: 0,
+      max_severity: undefined,
+    });
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildPackageOutput(result)] } } });
+    const details = getPackageVulnerabilitiesMapper.getExecutionDetails(ctx);
+    expect(details["Vulnerabilities Found"]).toBe("No");
+    expect(details["Total"]).toBe("0");
+    expect(details["Max Severity"]).toBeUndefined();
+  });
+
+  it("omits Max Severity when not present", () => {
+    const result = buildScanResult({ max_severity: undefined });
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [buildPackageOutput(result)] } } });
+    const details = getPackageVulnerabilitiesMapper.getExecutionDetails(ctx);
+    expect(details["Max Severity"]).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/app/mappers/cloudsmith/get_package_vulnerabilities.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/get_package_vulnerabilities.ts
@@ -1,0 +1,99 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudsmithIcon from "@/assets/icons/integrations/cloudsmith.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import type { GetPackageVulnerabilitiesConfiguration, PackageNodeMetadata, VulnerabilityScanResult } from "./types";
+
+export const getPackageVulnerabilitiesMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudsmith";
+
+    return {
+      iconSrc: cloudsmithIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? buildEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: buildMetadata(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as VulnerabilityScanResult | undefined;
+    if (!result || !result.identifier) return details;
+
+    details["Vulnerabilities Found"] = result.has_vulnerabilities ? "Yes" : "No";
+    if (result.num_vulnerabilities != null) details["Total"] = String(result.num_vulnerabilities);
+    if (result.max_severity) details["Max Severity"] = result.max_severity;
+    if (result.created_at) details["Scanned At"] = new Date(result.created_at).toLocaleString();
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function buildMetadata(node: NodeInfo): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as PackageNodeMetadata | undefined;
+  const configuration = node.configuration as GetPackageVulnerabilitiesConfiguration | undefined;
+
+  if (nodeMetadata?.repositoryName) {
+    items.push({ icon: "package", label: nodeMetadata.repositoryName });
+  } else if (configuration?.repository) {
+    items.push({ icon: "package", label: configuration.repository });
+  }
+
+  if (nodeMetadata?.packageName) {
+    items.push({ icon: "archive", label: nodeMetadata.packageName });
+  } else if (configuration?.package) {
+    items.push({ icon: "archive", label: configuration.package });
+  }
+
+  return items;
+}
+
+function buildEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  if (!execution.rootEvent || !execution.createdAt || !execution.rootEvent.id) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/index.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/index.ts
@@ -4,6 +4,9 @@ import { getRepositoryMapper } from "./get_repository";
 import { getPackageMapper } from "./get_package";
 import { listPackagesMapper } from "./list_packages";
 import { promotePackageMapper, promotePackageEventStateRegistry } from "./promote_package";
+import { scanPackageMapper } from "./scan_package";
+import { quarantinePackageMapper, QUARANTINE_PACKAGE_STATE_REGISTRY } from "./quarantine_package";
+import { getPackageVulnerabilitiesMapper } from "./get_package_vulnerabilities";
 import { onSecurityScanCompletedTriggerRenderer } from "./on_security_scan_completed";
 import { onPackageCreatedTriggerRenderer } from "./on_package_created";
 import { resyncPackageMapper } from "./resync_package";
@@ -18,6 +21,9 @@ export const componentMappers: Record<string, ComponentBaseMapper> = {
   deletePackage: deletePackageMapper,
   listPackages: listPackagesMapper,
   promotePackage: promotePackageMapper,
+  scanPackage: scanPackageMapper,
+  quarantinePackage: quarantinePackageMapper,
+  getPackageVulnerabilities: getPackageVulnerabilitiesMapper,
 };
 
 export const triggerRenderers: Record<string, TriggerRenderer> = {
@@ -35,4 +41,7 @@ export const eventStateRegistry: Record<string, EventStateRegistry> = {
   resyncPackage: buildActionStateRegistry("resynced"),
   tagPackage: buildActionStateRegistry("tagged"),
   deletePackage: buildActionStateRegistry("deleted"),
+  scanPackage: buildActionStateRegistry("scheduled"),
+  quarantinePackage: QUARANTINE_PACKAGE_STATE_REGISTRY,
+  getPackageVulnerabilities: buildActionStateRegistry("fetched"),
 };

--- a/web_src/src/pages/app/mappers/cloudsmith/quarantine_package.spec.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/quarantine_package.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { quarantinePackageMapper, QUARANTINE_PACKAGE_STATE_REGISTRY } from "./quarantine_package";
+import { buildDetailsCtx, buildExecution, buildPackageData, buildPackageOutput } from "./test_helpers";
+
+describe("quarantinePackageMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => quarantinePackageMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => quarantinePackageMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns Executed At without package fields when data is missing", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildPackageOutput(undefined)] } },
+    });
+    const details = quarantinePackageMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Name"]).toBeUndefined();
+  });
+
+  it("extracts package details without URL", () => {
+    const pkg = buildPackageData({ status_str: "Quarantined" });
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildPackageOutput(pkg)] } },
+    });
+    const details = quarantinePackageMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+    expect(details["Name"]).toBe("my-package");
+    expect(details["Version"]).toBe("1.0.0");
+    expect(details["Format"]).toBe("python");
+    expect(details["Status"]).toBe("Quarantined");
+    expect(details["URL"]).toBeUndefined();
+  });
+});
+
+describe("QUARANTINE_PACKAGE_STATE_REGISTRY", () => {
+  it("returns quarantined event type when quarantine output is present", () => {
+    const execution = buildExecution({
+      result: "RESULT_PASSED",
+      outputs: {
+        default: [buildPackageOutput(buildPackageData(), "cloudsmith.package.quarantined")],
+      },
+    });
+    const state = QUARANTINE_PACKAGE_STATE_REGISTRY.getState(execution);
+    expect(state).toBe("cloudsmith.package.quarantined");
+  });
+
+  it("returns released event type when release output is present", () => {
+    const execution = buildExecution({
+      result: "RESULT_PASSED",
+      outputs: {
+        default: [buildPackageOutput(buildPackageData({ status_str: "Available" }), "cloudsmith.package.released")],
+      },
+    });
+    const state = QUARANTINE_PACKAGE_STATE_REGISTRY.getState(execution);
+    expect(state).toBe("cloudsmith.package.released");
+  });
+
+  it("returns failed state on failed execution", () => {
+    const execution = buildExecution({ result: "RESULT_FAILED" });
+    const state = QUARANTINE_PACKAGE_STATE_REGISTRY.getState(execution);
+    expect(state).toBe("failed");
+  });
+});

--- a/web_src/src/pages/app/mappers/cloudsmith/quarantine_package.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/quarantine_package.ts
@@ -1,0 +1,149 @@
+import type { ComponentBaseProps, EventSection, EventStateMap } from "@/ui/componentBase";
+import { DEFAULT_EVENT_STATE_MAP } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  EventStateRegistry,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  OutputPayload,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudsmithIcon from "@/assets/icons/integrations/cloudsmith.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import { defaultStateFunction } from "../stateRegistry";
+import type { PackageData, PackageNodeMetadata, QuarantinePackageConfiguration } from "./types";
+
+export const quarantineStateMap: EventStateMap = {
+  ...DEFAULT_EVENT_STATE_MAP,
+  "cloudsmith.package.quarantined": {
+    icon: "shield-off",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-orange-100",
+    badgeColor: "bg-orange-500",
+    label: "QUARANTINED",
+  },
+  "cloudsmith.package.released": {
+    icon: "shield-check",
+    textColor: "text-gray-800",
+    backgroundColor: "bg-green-100",
+    badgeColor: "bg-emerald-500",
+    label: "RELEASED",
+  },
+};
+
+export const QUARANTINE_PACKAGE_STATE_REGISTRY: EventStateRegistry = {
+  stateMap: quarantineStateMap,
+  getState: (execution: ExecutionInfo) => {
+    const state = defaultStateFunction(execution);
+    if (state !== "success") return state;
+
+    const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+    const event = outputs?.default?.find(
+      (o) => o.type === "cloudsmith.package.quarantined" || o.type === "cloudsmith.package.released",
+    );
+    if (event?.type && quarantineStateMap[event.type]) {
+      return event.type;
+    }
+
+    return "success";
+  },
+};
+
+export const quarantinePackageMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudsmith";
+
+    return {
+      iconSrc: cloudsmithIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? buildEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: buildMetadata(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: quarantineStateMap,
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const pkg = outputs?.default?.[0]?.data as PackageData | undefined;
+    if (!pkg) return details;
+
+    if (pkg.name) details["Name"] = pkg.name;
+    if (pkg.version) details["Version"] = pkg.version;
+    if (pkg.format) details["Format"] = pkg.format;
+    if (pkg.status_str) details["Status"] = pkg.status_str;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function buildMetadata(node: NodeInfo): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as PackageNodeMetadata | undefined;
+  const configuration = node.configuration as QuarantinePackageConfiguration | undefined;
+
+  if (nodeMetadata?.repositoryName) {
+    items.push({ icon: "package", label: nodeMetadata.repositoryName });
+  } else if (configuration?.repository) {
+    items.push({ icon: "package", label: configuration.repository });
+  }
+
+  if (nodeMetadata?.packageName) {
+    items.push({ icon: "archive", label: nodeMetadata.packageName });
+  } else if (configuration?.package) {
+    items.push({ icon: "archive", label: configuration.package });
+  }
+
+  if (configuration?.action) {
+    const icon = configuration.action === "Release" ? "shield-check" : "shield-off";
+    items.push({ icon, label: configuration.action });
+  }
+
+  return items;
+}
+
+function buildEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  if (!execution.rootEvent || !execution.createdAt || !execution.rootEvent.id) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  const outputs = execution.outputs as { default?: OutputPayload[] } | undefined;
+  const event = outputs?.default?.find(
+    (o) => o.type === "cloudsmith.package.quarantined" || o.type === "cloudsmith.package.released",
+  );
+  const eventState = event?.type && quarantineStateMap[event.type] ? event.type : getState(componentName)(execution);
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState,
+      eventId: execution.rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/scan_package.spec.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/scan_package.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { scanPackageMapper } from "./scan_package";
+import { buildDetailsCtx, buildOutput } from "./test_helpers";
+
+describe("scanPackageMapper.getExecutionDetails", () => {
+  it("does not throw when outputs is undefined", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: undefined } });
+    expect(() => scanPackageMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("does not throw when default array is empty", () => {
+    const ctx = buildDetailsCtx({ execution: { outputs: { default: [] } } });
+    expect(() => scanPackageMapper.getExecutionDetails(ctx)).not.toThrow();
+  });
+
+  it("returns Executed At", () => {
+    const ctx = buildDetailsCtx();
+    const details = scanPackageMapper.getExecutionDetails(ctx);
+    expect(details["Executed At"]).toBeDefined();
+  });
+
+  it("shows Repository and Package when present in payload", () => {
+    const result = { repository: "acme/production", package: "perm123" };
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput(result)] } },
+    });
+    const details = scanPackageMapper.getExecutionDetails(ctx);
+    expect(details["Repository"]).toBe("acme/production");
+    expect(details["Package"]).toBe("perm123");
+  });
+
+  it("omits Repository and Package when missing from payload", () => {
+    const ctx = buildDetailsCtx({
+      execution: { outputs: { default: [buildOutput({})] } },
+    });
+    const details = scanPackageMapper.getExecutionDetails(ctx);
+    expect(details["Repository"]).toBeUndefined();
+    expect(details["Package"]).toBeUndefined();
+  });
+});

--- a/web_src/src/pages/app/mappers/cloudsmith/scan_package.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/scan_package.ts
@@ -1,0 +1,100 @@
+import type { ComponentBaseProps, EventSection } from "@/ui/componentBase";
+import type React from "react";
+import { getBackgroundColorClass } from "@/lib/colors";
+import { getState, getStateMap, getTriggerRenderer } from "..";
+import type {
+  ComponentBaseContext,
+  ComponentBaseMapper,
+  ExecutionDetailsContext,
+  ExecutionInfo,
+  NodeInfo,
+  SubtitleContext,
+} from "../types";
+import type { MetadataItem } from "@/ui/metadataList";
+import cloudsmithIcon from "@/assets/icons/integrations/cloudsmith.svg";
+import { renderTimeAgo } from "@/components/TimeAgo";
+import type { OutputPayload } from "../types";
+import type { PackageNodeMetadata, ScanPackageConfiguration } from "./types";
+
+interface ScanPackageResult {
+  repository?: string;
+  package?: string;
+}
+
+export const scanPackageMapper: ComponentBaseMapper = {
+  props(context: ComponentBaseContext): ComponentBaseProps {
+    const lastExecution = context.lastExecutions.length > 0 ? context.lastExecutions[0] : null;
+    const componentName = context.componentDefinition.name ?? "cloudsmith";
+
+    return {
+      iconSrc: cloudsmithIcon,
+      collapsedBackground: getBackgroundColorClass(context.componentDefinition.color),
+      collapsed: context.node.isCollapsed,
+      title: context.node.name || context.componentDefinition.label || "Unnamed component",
+      eventSections: lastExecution ? buildEventSections(context.nodes, lastExecution, componentName) : undefined,
+      metadata: buildMetadata(context.node),
+      includeEmptyState: !lastExecution,
+      eventStateMap: getStateMap(componentName),
+    };
+  },
+
+  getExecutionDetails(context: ExecutionDetailsContext): Record<string, unknown> {
+    const details: Record<string, string> = {};
+
+    if (context.execution.createdAt) {
+      details["Executed At"] = new Date(context.execution.createdAt).toLocaleString();
+    }
+
+    const outputs = context.execution.outputs as { default?: OutputPayload[] } | undefined;
+    const result = outputs?.default?.[0]?.data as ScanPackageResult | undefined;
+    if (result?.repository) details["Repository"] = result.repository;
+    if (result?.package) details["Package"] = result.package;
+
+    return details;
+  },
+
+  subtitle(context: SubtitleContext): string | React.ReactNode {
+    if (!context.execution.createdAt) return "";
+    return renderTimeAgo(new Date(context.execution.createdAt));
+  },
+};
+
+function buildMetadata(node: NodeInfo): MetadataItem[] {
+  const items: MetadataItem[] = [];
+  const nodeMetadata = node.metadata as PackageNodeMetadata | undefined;
+  const configuration = node.configuration as ScanPackageConfiguration | undefined;
+
+  if (nodeMetadata?.repositoryName) {
+    items.push({ icon: "package", label: nodeMetadata.repositoryName });
+  } else if (configuration?.repository) {
+    items.push({ icon: "package", label: configuration.repository });
+  }
+
+  if (nodeMetadata?.packageName) {
+    items.push({ icon: "archive", label: nodeMetadata.packageName });
+  } else if (configuration?.package) {
+    items.push({ icon: "archive", label: configuration.package });
+  }
+
+  return items;
+}
+
+function buildEventSections(nodes: NodeInfo[], execution: ExecutionInfo, componentName: string): EventSection[] {
+  if (!execution.rootEvent || !execution.createdAt || !execution.rootEvent.id) {
+    return [];
+  }
+
+  const rootTriggerNode = nodes.find((n) => n.id === execution.rootEvent?.nodeId);
+  const rootTriggerRenderer = getTriggerRenderer(rootTriggerNode?.componentName ?? "");
+  const { title } = rootTriggerRenderer.getTitleAndSubtitle({ event: execution.rootEvent });
+
+  return [
+    {
+      receivedAt: new Date(execution.createdAt),
+      eventTitle: title,
+      eventSubtitle: renderTimeAgo(new Date(execution.createdAt)),
+      eventState: getState(componentName)(execution),
+      eventId: execution.rootEvent.id,
+    },
+  ];
+}

--- a/web_src/src/pages/app/mappers/cloudsmith/types.ts
+++ b/web_src/src/pages/app/mappers/cloudsmith/types.ts
@@ -187,3 +187,36 @@ export interface PromotePackageResult {
   self_webapp_url?: string;
   slug_perm?: string;
 }
+
+export interface ScanPackageConfiguration {
+  repository?: string;
+  package?: string;
+}
+
+export interface QuarantinePackageConfiguration {
+  repository?: string;
+  package?: string;
+  action?: string;
+}
+
+export interface GetPackageVulnerabilitiesConfiguration {
+  repository?: string;
+  package?: string;
+}
+
+export interface VulnerabilityPackageRef {
+  identifier?: string;
+  name?: string;
+  version?: string;
+  url?: string;
+}
+
+export interface VulnerabilityScanResult {
+  identifier?: string;
+  created_at?: string;
+  package?: VulnerabilityPackageRef;
+  scan_id?: string | null;
+  has_vulnerabilities?: boolean;
+  num_vulnerabilities?: number;
+  max_severity?: string;
+}


### PR DESCRIPTION
## What changed
Extended the Cloudsmith integration with three new action components, built on top of the existing `getPackage` / `resyncPackage` / `tagPackage` / `deletePackage` actions:

- **Scan Package** (`cloudsmith.scanPackage`) — schedules a vulnerability scan for a package.
- **Quarantine Package** (`cloudsmith.quarantinePackage`) — quarantines or releases a package.
- **Get Package Vulnerabilities** (`cloudsmith.getPackageVulnerabilities`) — fetches the latest vulnerability scan result for a package.

## Why
To automate security workflows around Cloudsmith packages — trigger an on-demand scan after upload or before promotion, gate releases on vulnerability findings, and quarantine (or later release) packages that violate security/license policy. Scan results are asynchronous, so `scanPackage` schedules the scan while `getPackageVulnerabilities` retrieves the outcome once it completes.

## How
### Backend
Extended `pkg/integrations/cloudsmith/` with:
- `scan_package.go` — `cloudsmith.scanPackage` action; calls the package `/scan/` endpoint and emits the repository/package identifiers confirming the scan was scheduled.
- `quarantine_package.go` — `cloudsmith.quarantinePackage` action with a Quarantine/Release select; calls the `/quarantine/` endpoint and emits the updated package object.
- `get_package_vulnerabilities.go` — `cloudsmith.getPackageVulnerabilities` action; reads the top-level `/vulnerabilities/` endpoint and emits the most recent scan result (severity, counts, package ref).
- `client.go` — added `ScanPackage`, `QuarantinePackage` (+ `PackageQuarantineRequest`), and `GetPackageVulnerabilities` (+ `VulnerabilityScanResult` / `VulnerabilityPackageRef`) client methods/types.
- `cloudsmith.go` — registered the three new actions.
- `example.go` + example output JSON files for each component.
- All three actions support expressions in the `repository` and `package` fields for dynamic runtime values, and reuse the existing `resolvePackageMetadata` / `parseRepositoryID` helpers.
- Added backend tests for each component (setup validation, metadata resolution, execute, API errors).

### Frontend
Added `web_src/src/pages/app/mappers/cloudsmith/`:
- `scan_package.ts`, `quarantine_package.ts`, `get_package_vulnerabilities.ts` — node mappers with subtitles and execution-details rendering.
- `index.ts` — registered the three mappers and their event-state entries (`quarantinePackage` uses a custom state registry for quarantine vs. release).
- `types.ts` — added `ScanPackageConfiguration`, `QuarantinePackageConfiguration`, `GetPackageVulnerabilitiesConfiguration`, `VulnerabilityScanResult`, and `VulnerabilityPackageRef`.
- Added frontend spec tests for each mapper.
