### PR TITLE
feat: split login signup onboarding flows

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -39,6 +39,7 @@ const (
 	magicCodeRateLimit         = 5
 	magicCodeRateWindow        = 10 * time.Minute
 	magicCodeMaxVerifyAttempts = 3
+	authSignupStatePrefix      = "signup:"
 )
 
 type Handler struct {
@@ -139,18 +140,18 @@ func (a *Handler) RegisterRoutes(router *mux.Router) {
 func (a *Handler) handleAuth(w http.ResponseWriter, r *http.Request) {
 	gothUser, err := gothic.CompleteUserAuth(w, r)
 	if err == nil {
-		a.handleSuccessfulAuth(w, r, gothUser)
+		a.handleSuccessfulAuth(w, r, gothUser, false)
 		return
 	}
 
-	redirectParam := r.URL.Query().Get("redirect")
-	if redirectParam != "" {
+	authState := getAuthState(r)
+	if authState != "" {
 		r2 := new(http.Request)
 		*r2 = *r
 		r2.URL = new(url.URL)
 		*r2.URL = *r.URL
 		q := r2.URL.Query()
-		q.Set("state", redirectParam)
+		q.Set("state", authState)
 		r2.URL.RawQuery = q.Encode()
 		r = r2
 	}
@@ -176,11 +177,11 @@ func (a *Handler) handleDevAuth(w http.ResponseWriter, r *http.Request) {
 		AccessToken: "dev-token-" + provider,
 	}
 
-	account, err := a.findOrCreateAccountForProvider(mockUser, allowSignupFromRequest(r))
+	account, wasCreated, err := a.findOrCreateAccountForProvider(mockUser, a.allowSignupFromRequest(r))
 
 	if err != nil {
-		if err.Error() == SignupDisabledError {
-			http.Error(w, SignupDisabledError, http.StatusForbidden)
+		if errorStatusForAccountError(err) == http.StatusForbidden {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 
@@ -201,7 +202,7 @@ func (a *Handler) handleDevAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.handleSuccessfulAuth(w, r, mockUser)
+	a.handleSuccessfulAuth(w, r, mockUser, wasCreated)
 }
 
 func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -211,10 +212,10 @@ func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account, err := a.findOrCreateAccountForProvider(gothUser, allowSignupFromRequest(r))
+	account, wasCreated, err := a.findOrCreateAccountForProvider(gothUser, a.allowSignupFromRequest(r))
 	if err != nil {
-		if err.Error() == SignupDisabledError {
-			http.Error(w, SignupDisabledError, http.StatusForbidden)
+		if errorStatusForAccountError(err) == http.StatusForbidden {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		log.Errorf("Error finding/creating account for %s: %v", gothUser.Email, err)
@@ -236,7 +237,7 @@ func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.handleSuccessfulAuth(w, r, gothUser)
+	a.handleSuccessfulAuth(w, r, gothUser, wasCreated)
 }
 
 func (a *Handler) acceptPendingInvitations(account *models.Account) error {
@@ -280,7 +281,7 @@ func (a *Handler) acceptInvitation(invitation models.OrganizationInvitation, acc
 	})
 }
 
-func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, gothUser goth.User) {
+func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, gothUser goth.User, wasCreated bool) {
 	account, err := models.FindAccountByEmail(gothUser.Email)
 	if err != nil {
 		http.Error(w, "Account not found", http.StatusNotFound)
@@ -292,7 +293,7 @@ func (a *Handler) handleSuccessfulAuth(w http.ResponseWriter, r *http.Request, g
 		return
 	}
 
-	redirectURL := getRedirectURL(r)
+	redirectURL := a.getPostAuthRedirectURL(r, wasCreated)
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
@@ -479,7 +480,7 @@ func (a *Handler) handlePasswordSignup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	redirectURL := getRedirectURL(r)
+	redirectURL := a.getPostAuthRedirectURL(r, true)
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }
 
@@ -547,7 +548,7 @@ func (a *Handler) handleMagicCodeRequest(w http.ResponseWriter, r *http.Request)
 	}
 
 	redirectURL := strings.TrimSpace(r.FormValue("redirect"))
-	msg := messages.NewMagicCodeRequestedMessage(email, code, magicLinkToken, redirectURL)
+	msg := messages.NewMagicCodeRequestedMessage(email, code, magicLinkToken, redirectURL, isSignupIntentFromRequest(r))
 	if err := msg.Publish(); err != nil {
 		log.Errorf("Failed to publish magic code email request for %s: %v", email, err)
 	}
@@ -599,13 +600,13 @@ func (a *Handler) handleMagicCodeVerify(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// 4. Find or create the account (policy already verified above).
-	account, err := a.findOrCreateAccountForMagicCode(email, r)
+	account, wasCreated, err := a.findOrCreateAccountForMagicCode(email, r)
 	if err != nil {
 		http.Error(w, err.Error(), errorStatusForAccountError(err))
 		return
 	}
 
-	a.issueSessionAndRedirect(w, r, account)
+	a.issueSessionAndRedirect(w, r, account, wasCreated)
 }
 
 func (a *Handler) parseMagicCodeInput(r *http.Request) (string, string, error) {
@@ -683,6 +684,7 @@ func errorStatusForCodeError(err error) int {
 }
 
 var errSignupDisabled = fmt.Errorf(SignupDisabledError)
+var errSignupRequired = fmt.Errorf("signup must be started from the signup page")
 var errInviteLinkInvalid = fmt.Errorf("invite link not found or disabled")
 var errAccountError = fmt.Errorf("Internal server error")
 
@@ -699,18 +701,16 @@ func (a *Handler) checkSignupPolicy(email string, r *http.Request) error {
 		return errAccountError
 	}
 
-	if !a.blockSignup {
+	if allowSignupFromInvite(r) {
 		return nil
 	}
 
-	inviteToken := strings.TrimSpace(r.FormValue("invite_token"))
-	if inviteToken == "" {
-		return errSignupDisabled
+	if !isSignupIntentFromRequest(r) {
+		return errSignupRequired
 	}
 
-	inviteLink, findErr := models.FindInviteLinkByToken(inviteToken)
-	if findErr != nil || !inviteLink.Enabled {
-		return errInviteLinkInvalid
+	if a.blockSignup {
+		return errSignupDisabled
 	}
 
 	return nil
@@ -718,14 +718,14 @@ func (a *Handler) checkSignupPolicy(email string, r *http.Request) error {
 
 // findOrCreateAccountForMagicCode returns the existing account or creates a
 // new one. Signup policy must already be verified by checkSignupPolicy.
-func (a *Handler) findOrCreateAccountForMagicCode(email string, r *http.Request) (*models.Account, error) {
+func (a *Handler) findOrCreateAccountForMagicCode(email string, r *http.Request) (*models.Account, bool, error) {
 	account, err := models.FindAccountByEmail(email)
 	if err == nil {
-		return account, nil
+		return account, false, nil
 	}
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		log.Errorf("Error finding account for %s: %v", email, err)
-		return nil, errAccountError
+		return nil, false, errAccountError
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
@@ -738,23 +738,24 @@ func (a *Handler) findOrCreateAccountForMagicCode(email string, r *http.Request)
 		account, err = models.FindAccountByEmail(email)
 		if err != nil {
 			log.Errorf("Failed to create or find account for %s: %v", email, err)
-			return nil, errAccountError
+			return nil, false, errAccountError
 		}
+		return account, false, nil
 	}
 
-	return account, nil
+	return account, true, nil
 }
 
 func errorStatusForAccountError(err error) int {
 	switch err {
-	case errSignupDisabled, errInviteLinkInvalid:
+	case errSignupDisabled, errSignupRequired, errInviteLinkInvalid:
 		return http.StatusForbidden
 	default:
 		return http.StatusInternalServerError
 	}
 }
 
-func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request, account *models.Account) {
+func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request, account *models.Account, wasCreated bool) {
 	if err := a.acceptPendingInvitations(account); err != nil {
 		log.Errorf("Error accepting pending invitations for %s: %v", account.Email, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -767,8 +768,21 @@ func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	redirectURL := getRedirectURL(r)
+	redirectURL := a.getPostAuthRedirectURL(r, wasCreated)
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+}
+
+func (a *Handler) getPostAuthRedirectURL(r *http.Request, wasCreated bool) string {
+	redirectURL := getRedirectURL(r)
+	if !wasCreated || !a.magicCodeEnabled {
+		return redirectURL
+	}
+
+	if redirectURL == "/" {
+		return "/welcome"
+	}
+
+	return fmt.Sprintf("/welcome?redirect=%s", url.QueryEscape(redirectURL))
 }
 
 func generateMagicCode() (string, error) {
@@ -788,12 +802,20 @@ func (a *Handler) handleMagicLinkRedirect(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	redirectURL := fmt.Sprintf("/login?magic_link_token=%s", url.QueryEscape(token))
+	authPath := "/login"
+	if isSignupIntentFromRequest(r) {
+		authPath = "/signup"
+	}
+
+	redirectURL := fmt.Sprintf("%s?magic_link_token=%s", authPath, url.QueryEscape(token))
 
 	// Preserve the redirect parameter so invite context survives the
 	// magic-link round-trip through email.
 	if redirect := r.URL.Query().Get("redirect"); redirect != "" {
 		redirectURL += "&redirect=" + url.QueryEscape(redirect)
+	}
+	if isSignupIntentFromRequest(r) {
+		redirectURL += "&signup=true"
 	}
 
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
@@ -843,10 +865,11 @@ func (a *Handler) parseMagicLinkToken(tokenString string) (email string, code st
 }
 
 func (a *Handler) FindOrCreateAccountForProvider(gothUser goth.User) (*models.Account, error) {
-	return a.findOrCreateAccountForProvider(gothUser, false)
+	account, _, err := a.findOrCreateAccountForProvider(gothUser, !a.blockSignup)
+	return account, err
 }
 
-func (a *Handler) findOrCreateAccountForProvider(gothUser goth.User, allowSignup bool) (*models.Account, error) {
+func (a *Handler) findOrCreateAccountForProvider(gothUser goth.User, allowSignup bool) (*models.Account, bool, error) {
 	account, err := models.FindAccountByProvider(gothUser.Provider, gothUser.UserID)
 
 	if err == nil {
@@ -856,35 +879,43 @@ func (a *Handler) findOrCreateAccountForProvider(gothUser goth.User, allowSignup
 
 			if err != nil {
 				log.Errorf("Failed to update account email: %v", err)
-				return nil, fmt.Errorf("failed to update account email: %w", err)
+				return nil, false, fmt.Errorf("failed to update account email: %w", err)
 			}
 		}
-		return account, nil
+		return account, false, nil
 	}
 
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, err
+		return nil, false, err
 	}
 
 	account, err = models.FindAccountByEmail(gothUser.Email)
 	if err == nil {
-		return account, nil
+		return account, false, nil
 	}
 
-	if a.blockSignup && !allowSignup {
+	if !allowSignup {
 		log.Warnf("Signup blocked for email: %s", gothUser.Email)
-		return nil, fmt.Errorf(SignupDisabledError)
+		return nil, false, errSignupRequired
 	}
 
 	account, err = models.CreateAccount(gothUser.Name, gothUser.Email)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return account, nil
+	return account, true, nil
 }
 
-func allowSignupFromRequest(r *http.Request) bool {
+func (a *Handler) allowSignupFromRequest(r *http.Request) bool {
+	if allowSignupFromInvite(r) {
+		return true
+	}
+
+	return !a.blockSignup && isSignupIntentFromRequest(r)
+}
+
+func allowSignupFromInvite(r *http.Request) bool {
 	redirectURL := getRedirectURL(r)
 	if !strings.HasPrefix(redirectURL, "/invite/") {
 		return false
@@ -906,6 +937,28 @@ func allowSignupFromRequest(r *http.Request) bool {
 	}
 
 	return true
+}
+
+func isSignupIntentFromRequest(r *http.Request) bool {
+	signupValue := strings.ToLower(strings.TrimSpace(r.FormValue("signup")))
+	if signupValue == "true" || signupValue == "1" || signupValue == "yes" {
+		return true
+	}
+
+	return strings.HasPrefix(r.URL.Query().Get("state"), authSignupStatePrefix)
+}
+
+func getAuthState(r *http.Request) string {
+	redirectURL := getRedirectURL(r)
+	if isSignupIntentFromRequest(r) {
+		return authSignupStatePrefix + url.QueryEscape(redirectURL)
+	}
+
+	if redirectURL == "/" {
+		return ""
+	}
+
+	return redirectURL
 }
 
 func updateAccountProviders(encryptor crypto.Encryptor, account *models.Account, gothUser goth.User) error {
@@ -961,6 +1014,13 @@ func getRedirectURL(r *http.Request) string {
 
 	if redirectParam == "" {
 		return "/"
+	}
+
+	if strings.HasPrefix(redirectParam, authSignupStatePrefix) {
+		redirectParam = strings.TrimPrefix(redirectParam, authSignupStatePrefix)
+		if redirectParam == "" {
+			return "/"
+		}
 	}
 
 	decodedURL, err := url.QueryUnescape(redirectParam)

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -40,6 +40,7 @@ const (
 	magicCodeRateWindow        = 10 * time.Minute
 	magicCodeMaxVerifyAttempts = 3
 	authSignupStatePrefix      = "signup:"
+	authSignupResultParam      = "auth_signup_result"
 )
 
 type Handler struct {
@@ -774,8 +775,16 @@ func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request
 
 func (a *Handler) getPostAuthRedirectURL(r *http.Request, wasCreated bool) string {
 	redirectURL := getRedirectURL(r)
-	if !wasCreated || !a.magicCodeEnabled {
+	if !wasCreated {
+		if isSignupIntentFromRequest(r) {
+			return addAuthSignupResult(redirectURL, "existing")
+		}
+
 		return redirectURL
+	}
+
+	if !a.magicCodeEnabled {
+		return addAuthSignupResult(redirectURL, "created")
 	}
 
 	if redirectURL == "/" {
@@ -783,6 +792,18 @@ func (a *Handler) getPostAuthRedirectURL(r *http.Request, wasCreated bool) strin
 	}
 
 	return fmt.Sprintf("/welcome?redirect=%s", url.QueryEscape(redirectURL))
+}
+
+func addAuthSignupResult(redirectURL string, result string) string {
+	parsedURL, err := url.Parse(redirectURL)
+	if err != nil {
+		return redirectURL
+	}
+
+	params := parsedURL.Query()
+	params.Set(authSignupResultParam, result)
+	parsedURL.RawQuery = params.Encode()
+	return parsedURL.String()
 }
 
 func generateMagicCode() (string, error) {

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -279,7 +279,25 @@ func TestHandler_getPostAuthRedirectURL(t *testing.T) {
 
 		redirectURL := handler.getPostAuthRedirectURL(req, true)
 
-		assert.Equal(t, "/invite/abc", redirectURL)
+		assert.Equal(t, "/invite/abc?auth_signup_result=created", redirectURL)
+	})
+
+	t.Run("should mark existing user when signup intent resolves to login", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, true)
+		req, _ := http.NewRequest("GET", "/callback?state=signup%3A%252Fcanvases", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, false)
+
+		assert.Equal(t, "/canvases?auth_signup_result=existing", redirectURL)
+	})
+
+	t.Run("should mark new users when welcome is disabled", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, false)
+		req, _ := http.NewRequest("GET", "/callback?state=signup%3A%252Fcanvases%253Fview%253Dlist", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, true)
+
+		assert.Equal(t, "/canvases?auth_signup_result=created&view=list", redirectURL)
 	})
 
 	t.Run("should route new cloud users through welcome with original redirect", func(t *testing.T) {

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -2,6 +2,9 @@ package authentication
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/markbates/goth"
@@ -69,10 +72,11 @@ func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
 		err = database.Conn().Create(otherProvider).Error
 		require.NoError(t, err)
 
-		resultAccount, err := handler.FindOrCreateAccountForProvider(gothUser)
+		resultAccount, wasCreated, err := handler.findOrCreateAccountForProvider(gothUser, false)
 		require.NoError(t, err)
 
 		assert.Equal(t, account.ID, resultAccount.ID)
+		assert.False(t, wasCreated)
 		assert.Equal(t, newEmail, resultAccount.Email)
 
 		var accountFromDB models.Account
@@ -110,10 +114,11 @@ func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
 			Provider: "google",
 		}
 
-		resultAccount, err := handler.FindOrCreateAccountForProvider(gothUser)
+		resultAccount, wasCreated, err := handler.findOrCreateAccountForProvider(gothUser, false)
 		require.NoError(t, err)
 
 		assert.Equal(t, account.ID, resultAccount.ID)
+		assert.False(t, wasCreated)
 		assert.Equal(t, email, resultAccount.Email)
 	})
 
@@ -127,10 +132,11 @@ func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
 			Provider: "github",
 		}
 
-		resultAccount, err := handler.FindOrCreateAccountForProvider(gothUser)
+		resultAccount, wasCreated, err := handler.findOrCreateAccountForProvider(gothUser, true)
 		require.NoError(t, err)
 
 		assert.NotNil(t, resultAccount)
+		assert.True(t, wasCreated)
 		assert.Equal(t, gothUser.Email, resultAccount.Email)
 		assert.Equal(t, gothUser.Name, resultAccount.Name)
 
@@ -140,7 +146,7 @@ func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
 		assert.Equal(t, gothUser.Email, accountFromDB.Email)
 	})
 
-	t.Run("should return error when signup blocked and account not found", func(t *testing.T) {
+	t.Run("should return error when signup intent is missing and account not found", func(t *testing.T) {
 		handler, _ := setupAuthHandler(t, true)
 
 		gothUser := goth.User{
@@ -150,10 +156,11 @@ func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
 			Provider: "github",
 		}
 
-		resultAccount, err := handler.FindOrCreateAccountForProvider(gothUser)
+		resultAccount, wasCreated, err := handler.findOrCreateAccountForProvider(gothUser, false)
 		require.Error(t, err)
-		assert.Equal(t, SignupDisabledError, err.Error())
+		assert.Equal(t, errSignupRequired.Error(), err.Error())
 		assert.Nil(t, resultAccount)
+		assert.False(t, wasCreated)
 	})
 }
 
@@ -182,6 +189,14 @@ func TestGetRedirectURL(t *testing.T) {
 		assert.Equal(t, "/canvases/123", redirectURL)
 	})
 
+	t.Run("should return redirect URL from signup state parameter", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/callback?state=signup%3A%252Fcanvases%252F123", nil)
+
+		redirectURL := getRedirectURL(req)
+
+		assert.Equal(t, "/canvases/123", redirectURL)
+	})
+
 	t.Run("should reject absolute URLs", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/login?redirect=http%3A//evil.com", nil)
 
@@ -196,5 +211,116 @@ func TestGetRedirectURL(t *testing.T) {
 		redirectURL := getRedirectURL(req)
 
 		assert.Equal(t, "/", redirectURL)
+	})
+}
+
+func TestHandler_checkSignupPolicy(t *testing.T) {
+	t.Run("should reject new magic-code account from login flow", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		req, _ := http.NewRequest("POST", "/auth/magic-code/verify", nil)
+
+		err := handler.checkSignupPolicy("new-magic-code-login@example.com", req)
+
+		assert.Equal(t, errSignupRequired, err)
+	})
+
+	t.Run("should allow new magic-code account from signup flow", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		req, _ := http.NewRequest("POST", "/auth/magic-code/verify?signup=true", nil)
+
+		err := handler.checkSignupPolicy("new-magic-code-signup@example.com", req)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("should allow existing account from login flow", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		account, err := models.CreateAccount("Existing User", "existing-magic-code@example.com")
+		require.NoError(t, err)
+		req, _ := http.NewRequest("POST", "/auth/magic-code/verify", nil)
+
+		err = handler.checkSignupPolicy(account.Email, req)
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetAuthState(t *testing.T) {
+	t.Run("should preserve signup intent and redirect", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/github?signup=true&redirect=%2Finvite%2Fabc", nil)
+
+		state := getAuthState(req)
+
+		assert.Equal(t, "signup:%2Finvite%2Fabc", state)
+	})
+
+	t.Run("should preserve login redirect without signup intent", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/github?redirect=%2Finvite%2Fabc", nil)
+
+		state := getAuthState(req)
+
+		assert.Equal(t, "/invite/abc", state)
+	})
+}
+
+func TestHandler_getPostAuthRedirectURL(t *testing.T) {
+	t.Run("should keep redirect for existing users", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, true)
+		req, _ := http.NewRequest("GET", "/login?redirect=%2Finvite%2Fabc", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, false)
+
+		assert.Equal(t, "/invite/abc", redirectURL)
+	})
+
+	t.Run("should keep redirect when magic code auth is disabled", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, false)
+		req, _ := http.NewRequest("GET", "/login?redirect=%2Finvite%2Fabc", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, true)
+
+		assert.Equal(t, "/invite/abc", redirectURL)
+	})
+
+	t.Run("should route new cloud users through welcome with original redirect", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, true)
+		req, _ := http.NewRequest("GET", "/login?redirect=%2Finvite%2Fabc", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, true)
+
+		assert.Equal(t, "/welcome?redirect=%2Finvite%2Fabc", redirectURL)
+	})
+
+	t.Run("should route new cloud users through welcome without empty redirect", func(t *testing.T) {
+		handler := NewHandler(nil, nil, nil, "test", "/templates", false, false, true)
+		req, _ := http.NewRequest("GET", "/login", nil)
+
+		redirectURL := handler.getPostAuthRedirectURL(req, true)
+
+		assert.Equal(t, "/welcome", redirectURL)
+	})
+}
+
+func TestHandler_handlePasswordSignup(t *testing.T) {
+	t.Run("should route new cloud users through welcome with original redirect", func(t *testing.T) {
+		r := support.Setup(t)
+		t.Cleanup(func() { r.Close() })
+
+		signer := jwt.NewSigner("test-secret")
+		handler := NewHandler(signer, r.Encryptor, r.AuthService, "test", "/templates", false, true, true)
+
+		form := url.Values{}
+		form.Set("name", "New User")
+		form.Set("email", "new-password-user@example.com")
+		form.Set("password", "password123")
+
+		req := httptest.NewRequest(http.MethodPost, "/signup?redirect=%2Fcanvases", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		recorder := httptest.NewRecorder()
+
+		handler.handlePasswordSignup(recorder, req)
+
+		assert.Equal(t, http.StatusSeeOther, recorder.Code)
+		assert.Equal(t, "/welcome?redirect=%2Fcanvases", recorder.Header().Get("Location"))
 	})
 }

--- a/pkg/grpc/actions/messages/magic_code_requested.go
+++ b/pkg/grpc/actions/messages/magic_code_requested.go
@@ -9,14 +9,16 @@ type MagicCodeRequestedMessage struct {
 	Code           string `json:"code"`
 	MagicLinkToken string `json:"magic_link_token"`
 	RedirectURL    string `json:"redirect_url,omitempty"`
+	SignupIntent   bool   `json:"signup_intent,omitempty"`
 }
 
-func NewMagicCodeRequestedMessage(email, code, magicLinkToken, redirectURL string) MagicCodeRequestedMessage {
+func NewMagicCodeRequestedMessage(email, code, magicLinkToken, redirectURL string, signupIntent bool) MagicCodeRequestedMessage {
 	return MagicCodeRequestedMessage{
 		Email:          email,
 		Code:           code,
 		MagicLinkToken: magicLinkToken,
 		RedirectURL:    redirectURL,
+		SignupIntent:   signupIntent,
 	}
 }
 

--- a/pkg/public/server_auth_test.go
+++ b/pkg/public/server_auth_test.go
@@ -166,7 +166,7 @@ func TestServer_AuthIntegration(t *testing.T) {
 
 		resultAccount, err := handler.FindOrCreateAccountForProvider(gothUser)
 		require.Error(t, err)
-		assert.Equal(t, "signup is currently disabled", err.Error())
+		assert.Equal(t, "signup must be started from the signup page", err.Error())
 		assert.Nil(t, resultAccount)
 	})
 

--- a/pkg/workers/magic_code_email_consumer.go
+++ b/pkg/workers/magic_code_email_consumer.go
@@ -89,6 +89,9 @@ func (c *MagicCodeEmailConsumer) Consume(delivery tackle.Delivery) error {
 		if data.RedirectURL != "" {
 			magicLink += "&redirect=" + url.QueryEscape(data.RedirectURL)
 		}
+		if data.SignupIntent {
+			magicLink += "&signup=true"
+		}
 	}
 
 	readableCode := formatReadableCode(data.Code)

--- a/web_src/src/App.tsx
+++ b/web_src/src/App.tsx
@@ -17,6 +17,7 @@ import { Login } from "./pages/auth/Login";
 import OrganizationCreate from "./pages/auth/OrganizationCreate";
 import OrganizationSelect from "./pages/auth/OrganizationSelect";
 import OwnerSetup from "./pages/auth/OwnerSetup";
+import WelcomeSurvey from "./pages/auth/WelcomeSurvey";
 import { CanvasSettingsPage } from "./pages/canvas/settings";
 import { HomePage } from "./pages/home";
 import { NewAppPage } from "./pages/home/NewAppPage";
@@ -83,6 +84,8 @@ function AppRouter() {
             <Routes>
               {/* public routes */}
               <Route path="login" element={<Login />} />
+              <Route path="signup" element={<Login mode="signup" />} />
+              <Route path="welcome" element={withAuthOnly(WelcomeSurvey)} />
               <Route path="create" element={<OrganizationCreate />} />
               <Route path="setup" element={<OwnerSetup />} />
 

--- a/web_src/src/contexts/AccountProvider.tsx
+++ b/web_src/src/contexts/AccountProvider.tsx
@@ -35,6 +35,7 @@ export function AccountProvider({ children }: AccountProviderProps) {
             const signupPreference = consumePendingSignupAnalyticsPreference({
               accountEmail: accountData.email,
               currentPath: window.location.pathname,
+              signupResult: getSignupAnalyticsResult(window.location.search),
             });
 
             const accountProperties = {
@@ -72,4 +73,13 @@ export function AccountProvider({ children }: AccountProviderProps) {
   }, []);
 
   return <AccountContext.Provider value={{ account, loading, setupRequired }}>{children}</AccountContext.Provider>;
+}
+
+function getSignupAnalyticsResult(search: string) {
+  const value = new URLSearchParams(search).get("auth_signup_result");
+  if (value === "created" || value === "existing") {
+    return value;
+  }
+
+  return null;
 }

--- a/web_src/src/contexts/AccountProvider.tsx
+++ b/web_src/src/contexts/AccountProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { posthog } from "@/posthog";
+import { consumePendingSignupAnalyticsPreference } from "@/lib/signupAnalytics";
 
 import { AccountContext, type AccountContextType } from "./accountContextState";
 
@@ -31,11 +32,32 @@ export function AccountProvider({ children }: AccountProviderProps) {
           setAccount(accountData);
 
           if (!accountData.impersonation?.active) {
-            posthog.identify(accountData.id, {
+            const signupPreference = consumePendingSignupAnalyticsPreference({
+              accountEmail: accountData.email,
+              currentPath: window.location.pathname,
+            });
+
+            const accountProperties = {
               email: accountData.email,
               name: accountData.name,
               installation_admin: accountData.installation_admin,
-            });
+              ...(signupPreference
+                ? {
+                    product_updates_opt_in: signupPreference.productUpdatesOptIn,
+                  }
+                : {}),
+            };
+
+            posthog.identify(accountData.id, accountProperties);
+
+            if (signupPreference) {
+              posthog.capture("auth:signup", {
+                product_updates_opt_in: signupPreference.productUpdatesOptIn,
+                $set: {
+                  product_updates_opt_in: signupPreference.productUpdatesOptIn,
+                },
+              });
+            }
           }
         }
         // If response is not 200 (e.g., 307 redirect, 401, etc.), user is not authenticated

--- a/web_src/src/lib/signupAnalytics.spec.ts
+++ b/web_src/src/lib/signupAnalytics.spec.ts
@@ -57,6 +57,26 @@ describe("signup analytics preference", () => {
     expect(consumePendingSignupAnalyticsPreference({ currentPath: "/org-123" })).toBeNull();
   });
 
+  it("consumes an unconfirmed signup preference when signup result is created", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: false,
+    });
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/org-123", signupResult: "created" })).toEqual({
+      email: undefined,
+      productUpdatesOptIn: false,
+    });
+  });
+
+  it("clears an unconfirmed signup preference when signup result is existing", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/org-123", signupResult: "existing" })).toBeNull();
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/welcome" })).toBeNull();
+  });
+
   it("does not consume a signup preference for a different account email", () => {
     confirmSignupAnalyticsPreference({
       email: "new-user@example.com",

--- a/web_src/src/lib/signupAnalytics.spec.ts
+++ b/web_src/src/lib/signupAnalytics.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPendingSignupAnalyticsPreference,
+  confirmSignupAnalyticsPreference,
+  consumePendingSignupAnalyticsPreference,
+  savePendingSignupAnalyticsPreference,
+} from "./signupAnalytics";
+
+describe("signup analytics preference", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-18T12:00:00Z"));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("consumes a confirmed signup preference outside welcome", () => {
+    confirmSignupAnalyticsPreference({
+      email: "new-user@example.com",
+      productUpdatesOptIn: false,
+    });
+
+    const preference = consumePendingSignupAnalyticsPreference({
+      accountEmail: "new-user@example.com",
+      currentPath: "/org-123",
+    });
+
+    expect(preference).toEqual({
+      email: "new-user@example.com",
+      productUpdatesOptIn: false,
+    });
+    expect(
+      consumePendingSignupAnalyticsPreference({ accountEmail: "new-user@example.com", currentPath: "/org-123" }),
+    ).toBeNull();
+  });
+
+  it("consumes an unconfirmed signup preference on welcome", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/welcome" })).toEqual({
+      email: undefined,
+      productUpdatesOptIn: true,
+    });
+  });
+
+  it("does not consume an unconfirmed signup preference outside welcome", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/org-123" })).toBeNull();
+  });
+
+  it("does not consume a signup preference for a different account email", () => {
+    confirmSignupAnalyticsPreference({
+      email: "new-user@example.com",
+      productUpdatesOptIn: true,
+    });
+
+    expect(
+      consumePendingSignupAnalyticsPreference({
+        accountEmail: "other-user@example.com",
+        currentPath: "/welcome",
+      }),
+    ).toBeNull();
+  });
+
+  it("clears expired signup preferences", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+    vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/welcome" })).toBeNull();
+  });
+
+  it("clears pending signup preferences", () => {
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    clearPendingSignupAnalyticsPreference();
+
+    expect(consumePendingSignupAnalyticsPreference({ currentPath: "/welcome" })).toBeNull();
+  });
+});

--- a/web_src/src/lib/signupAnalytics.ts
+++ b/web_src/src/lib/signupAnalytics.ts
@@ -1,0 +1,97 @@
+const pendingSignupAnalyticsPreferenceKey = "superplane:pending_signup_analytics_preference";
+const pendingSignupAnalyticsPreferenceMaxAgeMs = 24 * 60 * 60 * 1000;
+
+export type SignupAnalyticsPreference = {
+  email?: string;
+  productUpdatesOptIn: boolean;
+};
+
+type StoredSignupAnalyticsPreference = SignupAnalyticsPreference & {
+  createdAt: number;
+  confirmed: boolean;
+};
+
+type ConsumeSignupAnalyticsPreferenceOptions = {
+  accountEmail?: string;
+  currentPath: string;
+};
+
+export function savePendingSignupAnalyticsPreference(preference: SignupAnalyticsPreference) {
+  writeSignupAnalyticsPreference({
+    ...preference,
+    createdAt: Date.now(),
+    confirmed: false,
+  });
+}
+
+export function confirmSignupAnalyticsPreference(preference: SignupAnalyticsPreference) {
+  writeSignupAnalyticsPreference({
+    ...preference,
+    createdAt: Date.now(),
+    confirmed: true,
+  });
+}
+
+export function clearPendingSignupAnalyticsPreference() {
+  localStorage.removeItem(pendingSignupAnalyticsPreferenceKey);
+}
+
+export function consumePendingSignupAnalyticsPreference({
+  accountEmail,
+  currentPath,
+}: ConsumeSignupAnalyticsPreferenceOptions): SignupAnalyticsPreference | null {
+  const preference = readSignupAnalyticsPreference();
+  if (!preference) {
+    return null;
+  }
+
+  if (isExpired(preference)) {
+    clearPendingSignupAnalyticsPreference();
+    return null;
+  }
+
+  if (preference.email && accountEmail && preference.email.toLowerCase() !== accountEmail.toLowerCase()) {
+    return null;
+  }
+
+  if (!preference.confirmed && currentPath !== "/welcome") {
+    return null;
+  }
+
+  clearPendingSignupAnalyticsPreference();
+  return {
+    email: preference.email,
+    productUpdatesOptIn: preference.productUpdatesOptIn,
+  };
+}
+
+function readSignupAnalyticsPreference(): StoredSignupAnalyticsPreference | null {
+  const rawPreference = localStorage.getItem(pendingSignupAnalyticsPreferenceKey);
+  if (!rawPreference) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawPreference) as Partial<StoredSignupAnalyticsPreference>;
+    if (typeof parsed.productUpdatesOptIn !== "boolean" || typeof parsed.createdAt !== "number") {
+      return null;
+    }
+
+    return {
+      email: typeof parsed.email === "string" ? parsed.email : undefined,
+      productUpdatesOptIn: parsed.productUpdatesOptIn,
+      createdAt: parsed.createdAt,
+      confirmed: parsed.confirmed === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeSignupAnalyticsPreference(preference: StoredSignupAnalyticsPreference) {
+  localStorage.setItem(pendingSignupAnalyticsPreferenceKey, JSON.stringify(preference));
+}
+
+function isExpired(preference: StoredSignupAnalyticsPreference) {
+  return Date.now() - preference.createdAt > pendingSignupAnalyticsPreferenceMaxAgeMs;
+}

--- a/web_src/src/lib/signupAnalytics.ts
+++ b/web_src/src/lib/signupAnalytics.ts
@@ -6,6 +6,8 @@ export type SignupAnalyticsPreference = {
   productUpdatesOptIn: boolean;
 };
 
+export type SignupAnalyticsResult = "created" | "existing" | null;
+
 type StoredSignupAnalyticsPreference = SignupAnalyticsPreference & {
   createdAt: number;
   confirmed: boolean;
@@ -14,6 +16,7 @@ type StoredSignupAnalyticsPreference = SignupAnalyticsPreference & {
 type ConsumeSignupAnalyticsPreferenceOptions = {
   accountEmail?: string;
   currentPath: string;
+  signupResult?: SignupAnalyticsResult;
 };
 
 export function savePendingSignupAnalyticsPreference(preference: SignupAnalyticsPreference) {
@@ -39,9 +42,15 @@ export function clearPendingSignupAnalyticsPreference() {
 export function consumePendingSignupAnalyticsPreference({
   accountEmail,
   currentPath,
+  signupResult = null,
 }: ConsumeSignupAnalyticsPreferenceOptions): SignupAnalyticsPreference | null {
   const preference = readSignupAnalyticsPreference();
   if (!preference) {
+    return null;
+  }
+
+  if (signupResult === "existing") {
+    clearPendingSignupAnalyticsPreference();
     return null;
   }
 
@@ -51,10 +60,14 @@ export function consumePendingSignupAnalyticsPreference({
   }
 
   if (preference.email && accountEmail && preference.email.toLowerCase() !== accountEmail.toLowerCase()) {
+    if (signupResult === "created") {
+      clearPendingSignupAnalyticsPreference();
+    }
+
     return null;
   }
 
-  if (!preference.confirmed && currentPath !== "/welcome") {
+  if (!preference.confirmed && currentPath !== "/welcome" && signupResult !== "created") {
     return null;
   }
 

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -97,10 +97,7 @@ const ProductUpdatesOptIn: React.FC<{
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
 }> = ({ checked, onCheckedChange }) => (
-  <label
-    htmlFor="signup-product-updates"
-    className="mb-4 flex cursor-pointer items-start gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
-  >
+  <label htmlFor="signup-product-updates" className="flex cursor-pointer items-start gap-2 text-sm text-gray-700">
     <Checkbox
       id="signup-product-updates"
       checked={checked}
@@ -312,6 +309,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showProviderButtons = hasProviders && (!isSignupMode || canSignup);
   const canUseMagicCode = authConfig.magicCodeEnabled && (!isSignupMode || canSignup);
   const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
+  const showStandaloneProductUpdatesOptIn =
+    isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -611,10 +610,6 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </div>
           )}
 
-          {!configLoading && isSignupMode && canSignup && magicCodeStep === "email" && (
-            <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
-          )}
-
           {!configLoading && useMagicCodePrimary && magicCodeStep === "email" && (
             <form onSubmit={handleMagicCodeRequest} className="space-y-4">
               <div className="space-y-2">
@@ -629,6 +624,13 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setMagicCodeEmail(e.target.value)}
                 />
               </div>
+
+              {isSignupMode && (
+                <ProductUpdatesOptIn
+                  checked={signupProductUpdatesOptIn}
+                  onCheckedChange={setSignupProductUpdatesOptIn}
+                />
+              )}
 
               <LoadingButton type="submit" loading={submitLoading} loadingText="Sending code..." className="w-full">
                 Continue with email
@@ -777,6 +779,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                 />
               </div>
 
+              <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
+
               <LoadingButton
                 type="submit"
                 disabled={!canSignup}
@@ -840,6 +844,12 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                 <div className="h-px flex-1 bg-gray-300" />
               </div>
             )}
+
+          {!configLoading && showStandaloneProductUpdatesOptIn && (
+            <div className="mb-4">
+              <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
+            </div>
+          )}
 
           {!configLoading && showProviderButtons && (!useMagicCodePrimary || magicCodeStep === "email") && (
             <div className="space-y-3">

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -108,6 +108,120 @@ const ProductUpdatesOptIn: React.FC<{
   </label>
 );
 
+const saveSignupPreference = (enabled: boolean, productUpdatesOptIn: boolean, email?: string) => {
+  if (!enabled) {
+    return;
+  }
+
+  savePendingSignupAnalyticsPreference({
+    email: email?.trim() || undefined,
+    productUpdatesOptIn,
+  });
+};
+
+const clearSignupPreference = (enabled: boolean) => {
+  if (enabled) {
+    clearPendingSignupAnalyticsPreference();
+  }
+};
+
+const buildMagicCodeRequestBody = (email: string, signup: boolean, redirectTarget: string) => {
+  const formData = new URLSearchParams();
+  formData.append("email", email.trim());
+  if (signup) {
+    formData.append("signup", "true");
+  }
+  if (redirectTarget) {
+    formData.append("redirect", redirectTarget);
+  }
+
+  return formData.toString();
+};
+
+const buildMagicCodeVerifyBody = (email: string, code: string, signup: boolean, inviteToken: string) => {
+  const formData = new URLSearchParams();
+  formData.append("email", email.trim());
+  formData.append("code", code.trim());
+  if (signup) {
+    formData.append("signup", "true");
+  }
+  if (inviteToken) {
+    formData.append("invite_token", inviteToken);
+  }
+
+  return formData.toString();
+};
+
+const buildSignupBody = (name: string, email: string, password: string, inviteToken: string) => {
+  const formData = new URLSearchParams();
+  formData.append("name", name);
+  formData.append("email", email.trim());
+  formData.append("password", password);
+  if (inviteToken) {
+    formData.append("invite_token", inviteToken);
+  }
+
+  return formData.toString();
+};
+
+const getMagicCodeVerifyError = async (response: Response) => {
+  if (response.status === 401) {
+    return "Invalid or expired code. Please try again.";
+  }
+
+  if (response.status === 403) {
+    const errorText = await response.text();
+    return errorText || "Sign-up is not allowed.";
+  }
+
+  return "Verification failed. Please try again.";
+};
+
+const getSignupError = async (response: Response) => {
+  if (response.status === 409) {
+    return "Account already exists. Please sign in.";
+  }
+
+  const errorText = await response.text();
+  return errorText || "Signup failed. Please try again.";
+};
+
+type SignupValidationFields = {
+  canSignup: boolean;
+  firstName: string;
+  lastName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+const getSignupValidationError = ({
+  canSignup,
+  firstName,
+  lastName,
+  email,
+  password,
+  confirmPassword,
+}: SignupValidationFields) => {
+  if (!canSignup) {
+    return "Signups are currently disabled.";
+  }
+
+  if (!firstName.trim() || !lastName.trim()) {
+    return "First and last names are required";
+  }
+
+  if (!email.trim() || !password || !confirmPassword) {
+    return "Email and password are required";
+  }
+
+  if (password !== confirmPassword) {
+    return "Passwords do not match";
+  }
+
+  return null;
+};
+
 export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const [authConfig, setAuthConfig] = useState<AuthConfig>({
     providers: [],
@@ -297,7 +411,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const allowedProviders = ["google", "github"];
   const activeProviders = allowedProviders.filter((provider) => providers.includes(provider));
   const hasProviders = activeProviders.length > 0;
-  const canSignup = authConfig.signupEnabled || inviteToken;
+  const canSignup = authConfig.signupEnabled || Boolean(inviteToken);
 
   useReportPageReady(!configLoading && !accountLoading, {
     failed: !!configError,
@@ -321,35 +435,19 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       return;
     }
 
-    if (isSignupMode) {
-      savePendingSignupAnalyticsPreference({
-        email: magicCodeEmail.trim(),
-        productUpdatesOptIn: signupProductUpdatesOptIn,
-      });
-    }
+    saveSignupPreference(isSignupMode, signupProductUpdatesOptIn, magicCodeEmail);
 
     setSubmitLoading(true);
 
     try {
-      const formData = new URLSearchParams();
-      formData.append("email", magicCodeEmail.trim());
-      if (isSignupMode) {
-        formData.append("signup", "true");
-      }
-      if (redirectTarget) {
-        formData.append("redirect", redirectTarget);
-      }
-
       const response = await fetch("/auth/magic-code/request", {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: formData.toString(),
+        body: buildMagicCodeRequestBody(magicCodeEmail, isSignupMode, redirectTarget),
       });
 
       if (!response.ok) {
-        if (isSignupMode) {
-          clearPendingSignupAnalyticsPreference();
-        }
+        clearSignupPreference(isSignupMode);
         setFormError("Failed to send code. Please try again.");
         setSubmitLoading(false);
         return;
@@ -358,9 +456,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       setMagicCodeStep("code");
       setSubmitLoading(false);
     } catch {
-      if (isSignupMode) {
-        clearPendingSignupAnalyticsPreference();
-      }
+      clearSignupPreference(isSignupMode);
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
@@ -378,16 +474,6 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
     setSubmitLoading(true);
 
     try {
-      const formData = new URLSearchParams();
-      formData.append("email", magicCodeEmail.trim());
-      formData.append("code", magicCode.trim());
-      if (isSignupMode) {
-        formData.append("signup", "true");
-      }
-      if (inviteToken) {
-        formData.append("invite_token", inviteToken);
-      }
-
       const url = redirectTarget
         ? `/auth/magic-code/verify?redirect=${encodeURIComponent(redirectTarget)}`
         : "/auth/magic-code/verify";
@@ -396,21 +482,12 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         credentials: "include",
-        body: formData.toString(),
+        body: buildMagicCodeVerifyBody(magicCodeEmail, magicCode, isSignupMode, inviteToken),
       });
 
       if (!response.ok) {
-        if (isSignupMode) {
-          clearPendingSignupAnalyticsPreference();
-        }
-        if (response.status === 401) {
-          setFormError("Invalid or expired code. Please try again.");
-        } else if (response.status === 403) {
-          const errorText = await response.text();
-          setFormError(errorText || "Sign-up is not allowed.");
-        } else {
-          setFormError("Verification failed. Please try again.");
-        }
+        clearSignupPreference(isSignupMode);
+        setFormError(await getMagicCodeVerifyError(response));
         setSubmitLoading(false);
         return;
       }
@@ -422,15 +499,13 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             productUpdatesOptIn: signupProductUpdatesOptIn,
           });
         } else {
-          clearPendingSignupAnalyticsPreference();
+          clearSignupPreference(true);
         }
       }
 
       await handleRedirectAfterAuth(response);
     } catch {
-      if (isSignupMode) {
-        clearPendingSignupAnalyticsPreference();
-      }
+      clearSignupPreference(isSignupMode);
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
@@ -490,37 +565,22 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
     e.preventDefault();
     setFormError(null);
 
-    if (!canSignup) {
-      setFormError("Signups are currently disabled.");
-      return;
-    }
-
-    if (!signupFirstName.trim() || !signupLastName.trim()) {
-      setFormError("First and last names are required");
-      return;
-    }
-
-    if (!signupEmail.trim() || !signupPassword || !signupConfirmPassword) {
-      setFormError("Email and password are required");
-      return;
-    }
-
-    if (signupPassword !== signupConfirmPassword) {
-      setFormError("Passwords do not match");
+    const validationError = getSignupValidationError({
+      canSignup,
+      firstName: signupFirstName,
+      lastName: signupLastName,
+      email: signupEmail,
+      password: signupPassword,
+      confirmPassword: signupConfirmPassword,
+    });
+    if (validationError) {
+      setFormError(validationError);
       return;
     }
 
     setSubmitLoading(true);
 
     try {
-      const formData = new URLSearchParams();
-      formData.append("name", `${signupFirstName.trim()} ${signupLastName.trim()}`);
-      formData.append("email", signupEmail.trim());
-      formData.append("password", signupPassword);
-      if (inviteToken) {
-        formData.append("invite_token", inviteToken);
-      }
-
       const url = redirectTarget ? `/signup?redirect=${encodeURIComponent(redirectTarget)}` : "/signup";
       const response = await fetch(url, {
         method: "POST",
@@ -528,16 +588,16 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           "Content-Type": "application/x-www-form-urlencoded",
         },
         credentials: "include",
-        body: formData.toString(),
+        body: buildSignupBody(
+          `${signupFirstName.trim()} ${signupLastName.trim()}`,
+          signupEmail,
+          signupPassword,
+          inviteToken,
+        ),
       });
 
       if (!response.ok) {
-        if (response.status === 409) {
-          setFormError("Account already exists. Please sign in.");
-        } else {
-          const errorText = await response.text();
-          setFormError(errorText || "Signup failed. Please try again.");
-        }
+        setFormError(await getSignupError(response));
         setSubmitLoading(false);
         return;
       }
@@ -555,11 +615,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   };
 
   const handleProviderClick = (provider: string) => {
-    if (isSignupMode) {
-      savePendingSignupAnalyticsPreference({
-        productUpdatesOptIn: signupProductUpdatesOptIn,
-      });
-    }
+    saveSignupPreference(isSignupMode, signupProductUpdatesOptIn);
 
     recordLastUsedLoginMethod(provider as LastUsedLoginMethod);
   };

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -712,7 +712,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
               </div>
 
               <LoadingButton type="submit" loading={submitLoading} loadingText="Verifying..." className="w-full">
-                Continue
+                {isSignupMode ? "Create account" : "Sign in"}
               </LoadingButton>
 
               <div className="text-center">

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import superplaneLogo from "@/assets/superplane.svg";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
@@ -12,6 +12,7 @@ import {
   recordLastUsedLoginMethod,
   type LastUsedLoginMethod,
 } from "@/lib/lastUsedLoginMethod";
+import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
 
 type AuthConfig = {
   providers: string[];
@@ -56,13 +57,28 @@ const getProviderLabel = (provider: string) => {
   }
 };
 
+const providerAuthPath = (provider: string, redirectQuery: string, isSignupMode: boolean) => {
+  const params = new URLSearchParams(redirectQuery ? redirectQuery.slice(1) : "");
+  if (isSignupMode) {
+    params.set("signup", "true");
+  }
+
+  const query = params.toString();
+  return query ? `/auth/${provider}?${query}` : `/auth/${provider}`;
+};
+
 type MagicCodeStep = "email" | "code";
+type AuthMode = "login" | "signup";
+
+interface LoginProps {
+  mode?: AuthMode;
+}
 
 const LastUsedHint: React.FC<{ label: string }> = ({ label }) => (
   <p className="mt-2 text-center text-xs text-gray-500">You used {label} to log in last time</p>
 );
 
-export const Login: React.FC = () => {
+export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const [authConfig, setAuthConfig] = useState<AuthConfig>({
     providers: [],
     passwordLoginEnabled: false,
@@ -73,7 +89,7 @@ export const Login: React.FC = () => {
   const [configError, setConfigError] = useState<string | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [submitLoading, setSubmitLoading] = useState(false);
-  const [isSignupMode, setIsSignupMode] = useState(false);
+  const [isSignupMode, setIsSignupMode] = useState(mode === "signup");
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
   const [signupFirstName, setSignupFirstName] = useState("");
@@ -109,6 +125,22 @@ export const Login: React.FC = () => {
 
   const handleRedirectAfterAuth = useCallback(
     async (response: Response) => {
+      const finalURL = response.url || "/";
+
+      try {
+        const parsedURL = new URL(finalURL, window.location.origin);
+        if (parsedURL.origin === window.location.origin && parsedURL.pathname === "/welcome") {
+          if (!parsedURL.searchParams.has("redirect") && redirectTarget) {
+            parsedURL.searchParams.set("redirect", redirectTarget);
+          }
+
+          window.location.href = `${parsedURL.pathname}${parsedURL.search}`;
+          return;
+        }
+      } catch {
+        // fall through to existing redirect behavior
+      }
+
       if (redirectTarget) {
         window.location.href = redirectTarget;
         return;
@@ -130,7 +162,6 @@ export const Login: React.FC = () => {
         // fall through to default redirect
       }
 
-      const finalURL = response.url || "/";
       window.location.href = finalURL;
     },
     [redirectTarget],
@@ -147,22 +178,31 @@ export const Login: React.FC = () => {
   }, [account, accountLoading, safeRedirect]);
 
   useEffect(() => {
+    setIsSignupMode(mode === "signup");
+    setFormError(null);
+    setMagicCodeStep("email");
+    setMagicCode("");
+    setShowPasswordLogin(false);
+  }, [mode]);
+
+  useEffect(() => {
     if (!magicLinkToken) return;
 
     const verifyMagicLink = async () => {
       setSubmitLoading(true);
       try {
-        const formData = new URLSearchParams();
-        formData.append("token", magicLinkToken);
-        if (inviteToken) {
-          formData.append("invite_token", inviteToken);
-        }
+        const { url, body } = buildMagicLinkVerifyRequest({
+          token: magicLinkToken,
+          inviteToken,
+          redirectTarget,
+          signupIntent: mode === "signup",
+        });
 
-        const response = await fetch("/auth/magic-code/verify", {
+        const response = await fetch(url, {
           method: "POST",
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           credentials: "include",
-          body: formData.toString(),
+          body,
         });
 
         if (!response.ok) {
@@ -179,7 +219,7 @@ export const Login: React.FC = () => {
     };
 
     verifyMagicLink();
-  }, [magicLinkToken, inviteToken, handleRedirectAfterAuth]);
+  }, [magicLinkToken, inviteToken, redirectTarget, mode, handleRedirectAfterAuth]);
 
   useEffect(() => {
     let canceled = false;
@@ -232,19 +272,8 @@ export const Login: React.FC = () => {
   const canLoginWithPassword = authConfig.passwordLoginEnabled;
   const redirectQuery = safeRedirect ? `?redirect=${encodeURIComponent(safeRedirect)}` : "";
   const showProviderButtons = hasProviders && (!isSignupMode || canSignup);
-  const useMagicCodePrimary = authConfig.magicCodeEnabled && !showPasswordLogin;
-
-  useEffect(() => {
-    if (!canSignup && isSignupMode) {
-      setIsSignupMode(false);
-      setFormError(null);
-    }
-  }, [canSignup, isSignupMode]);
-
-  const handleToggleMode = (nextMode: "login" | "signup") => {
-    setIsSignupMode(nextMode === "signup");
-    setFormError(null);
-  };
+  const canUseMagicCode = authConfig.magicCodeEnabled && (!isSignupMode || canSignup);
+  const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -260,6 +289,9 @@ export const Login: React.FC = () => {
     try {
       const formData = new URLSearchParams();
       formData.append("email", magicCodeEmail.trim());
+      if (isSignupMode) {
+        formData.append("signup", "true");
+      }
       if (redirectTarget) {
         formData.append("redirect", redirectTarget);
       }
@@ -299,6 +331,9 @@ export const Login: React.FC = () => {
       const formData = new URLSearchParams();
       formData.append("email", magicCodeEmail.trim());
       formData.append("code", magicCode.trim());
+      if (isSignupMode) {
+        formData.append("signup", "true");
+      }
       if (inviteToken) {
         formData.append("invite_token", inviteToken);
       }
@@ -450,8 +485,8 @@ export const Login: React.FC = () => {
   const hasAnyFormMethod = canLoginWithPassword || canSignupWithPassword || showProviderButtons || useMagicCodePrimary;
 
   const getHeading = () => {
-    if (isSignupMode) return "Create your account";
     if (useMagicCodePrimary && magicCodeStep === "code") return "Check your email";
+    if (isSignupMode) return "Create your account";
     return "Welcome to SuperPlane";
   };
 
@@ -493,7 +528,7 @@ export const Login: React.FC = () => {
             </div>
           )}
 
-          {!configLoading && !isSignupMode && useMagicCodePrimary && magicCodeStep === "email" && (
+          {!configLoading && useMagicCodePrimary && magicCodeStep === "email" && (
             <form onSubmit={handleMagicCodeRequest} className="space-y-4">
               <div className="space-y-2">
                 <Label>Email</Label>
@@ -514,7 +549,7 @@ export const Login: React.FC = () => {
             </form>
           )}
 
-          {!configLoading && !isSignupMode && useMagicCodePrimary && magicCodeStep === "code" && (
+          {!configLoading && useMagicCodePrimary && magicCodeStep === "code" && (
             <form onSubmit={handleMagicCodeVerify} className="space-y-4">
               <div className="space-y-2">
                 <Label>Code</Label>
@@ -532,7 +567,7 @@ export const Login: React.FC = () => {
               </div>
 
               <LoadingButton type="submit" loading={submitLoading} loadingText="Verifying..." className="w-full">
-                Sign in
+                Continue
               </LoadingButton>
 
               <div className="text-center">
@@ -725,7 +760,7 @@ export const Login: React.FC = () => {
                 <div key={provider}>
                   <Button variant="outline" className="w-full justify-center gap-2" asChild>
                     <a
-                      href={`/auth/${provider}${redirectQuery}`}
+                      href={providerAuthPath(provider, redirectQuery, isSignupMode)}
                       onClick={() => recordLastUsedLoginMethod(provider as LastUsedLoginMethod)}
                     >
                       {provider === "github" && (
@@ -765,26 +800,27 @@ export const Login: React.FC = () => {
           {!configLoading && !isSignupMode && canSignup && !useMagicCodePrimary && (
             <div className="mt-6 text-sm text-gray-500">
               {"Don't have an account? "}
-              <button
-                type="button"
-                onClick={() => handleToggleMode("signup")}
-                className="font-medium text-gray-900 underline underline-offset-2"
-              >
+              <Link to={`/signup${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
                 Create an account
-              </button>
+              </Link>
             </div>
           )}
 
           {!configLoading && isSignupMode && (
             <div className="mt-6 text-sm text-gray-500">
               Already have an account?{" "}
-              <button
-                type="button"
-                onClick={() => handleToggleMode("login")}
-                className="font-medium text-gray-900 underline underline-offset-2"
-              >
+              <Link to={`/login${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
                 Sign in
-              </button>
+              </Link>
+            </div>
+          )}
+
+          {!configLoading && useMagicCodePrimary && magicCodeStep === "email" && !isSignupMode && canSignup && (
+            <div className="mt-6 text-center text-sm text-gray-500">
+              {"Don't have an account? "}
+              <Link to={`/signup${redirectQuery}`} className="font-medium text-gray-900 underline underline-offset-2">
+                Sign up
+              </Link>
             </div>
           )}
         </div>

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import superplaneLogo from "@/assets/superplane.svg";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -12,6 +13,11 @@ import {
   recordLastUsedLoginMethod,
   type LastUsedLoginMethod,
 } from "@/lib/lastUsedLoginMethod";
+import {
+  clearPendingSignupAnalyticsPreference,
+  confirmSignupAnalyticsPreference,
+  savePendingSignupAnalyticsPreference,
+} from "@/lib/signupAnalytics";
 import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
 
 type AuthConfig = {
@@ -67,6 +73,15 @@ const providerAuthPath = (provider: string, redirectQuery: string, isSignupMode:
   return query ? `/auth/${provider}?${query}` : `/auth/${provider}`;
 };
 
+const isWelcomeRedirect = (response: Response) => {
+  try {
+    const parsedURL = new URL(response.url || "/", window.location.origin);
+    return parsedURL.origin === window.location.origin && parsedURL.pathname === "/welcome";
+  } catch {
+    return false;
+  }
+};
+
 type MagicCodeStep = "email" | "code";
 type AuthMode = "login" | "signup";
 
@@ -76,6 +91,24 @@ interface LoginProps {
 
 const LastUsedHint: React.FC<{ label: string }> = ({ label }) => (
   <p className="mt-2 text-center text-xs text-gray-500">You used {label} to log in last time</p>
+);
+
+const ProductUpdatesOptIn: React.FC<{
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}> = ({ checked, onCheckedChange }) => (
+  <label
+    htmlFor="signup-product-updates"
+    className="mb-4 flex cursor-pointer items-start gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"
+  >
+    <Checkbox
+      id="signup-product-updates"
+      checked={checked}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => onCheckedChange(e.target.checked)}
+      className="mt-0.5"
+    />
+    <span>I want to receive product updates</span>
+  </label>
 );
 
 export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
@@ -97,6 +130,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const [signupEmail, setSignupEmail] = useState("");
   const [signupPassword, setSignupPassword] = useState("");
   const [signupConfirmPassword, setSignupConfirmPassword] = useState("");
+  const [signupProductUpdatesOptIn, setSignupProductUpdatesOptIn] = useState(true);
 
   const [magicCodeStep, setMagicCodeStep] = useState<MagicCodeStep>("email");
   const [magicCodeEmail, setMagicCodeEmail] = useState("");
@@ -211,6 +245,10 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           return;
         }
 
+        if (mode === "signup" && !isWelcomeRedirect(response)) {
+          clearPendingSignupAnalyticsPreference();
+        }
+
         await handleRedirectAfterAuth(response);
       } catch {
         setFormError("Network error occurred");
@@ -284,6 +322,13 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       return;
     }
 
+    if (isSignupMode) {
+      savePendingSignupAnalyticsPreference({
+        email: magicCodeEmail.trim(),
+        productUpdatesOptIn: signupProductUpdatesOptIn,
+      });
+    }
+
     setSubmitLoading(true);
 
     try {
@@ -303,6 +348,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       });
 
       if (!response.ok) {
+        if (isSignupMode) {
+          clearPendingSignupAnalyticsPreference();
+        }
         setFormError("Failed to send code. Please try again.");
         setSubmitLoading(false);
         return;
@@ -311,6 +359,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       setMagicCodeStep("code");
       setSubmitLoading(false);
     } catch {
+      if (isSignupMode) {
+        clearPendingSignupAnalyticsPreference();
+      }
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
@@ -350,6 +401,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
       });
 
       if (!response.ok) {
+        if (isSignupMode) {
+          clearPendingSignupAnalyticsPreference();
+        }
         if (response.status === 401) {
           setFormError("Invalid or expired code. Please try again.");
         } else if (response.status === 403) {
@@ -362,8 +416,22 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
         return;
       }
 
+      if (isSignupMode) {
+        if (isWelcomeRedirect(response)) {
+          confirmSignupAnalyticsPreference({
+            email: magicCodeEmail.trim(),
+            productUpdatesOptIn: signupProductUpdatesOptIn,
+          });
+        } else {
+          clearPendingSignupAnalyticsPreference();
+        }
+      }
+
       await handleRedirectAfterAuth(response);
     } catch {
+      if (isSignupMode) {
+        clearPendingSignupAnalyticsPreference();
+      }
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
@@ -475,11 +543,26 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
         return;
       }
 
+      confirmSignupAnalyticsPreference({
+        email: signupEmail.trim(),
+        productUpdatesOptIn: signupProductUpdatesOptIn,
+      });
+
       await handleRedirectAfterAuth(response);
     } catch {
       setFormError("Network error occurred");
       setSubmitLoading(false);
     }
+  };
+
+  const handleProviderClick = (provider: string) => {
+    if (isSignupMode) {
+      savePendingSignupAnalyticsPreference({
+        productUpdatesOptIn: signupProductUpdatesOptIn,
+      });
+    }
+
+    recordLastUsedLoginMethod(provider as LastUsedLoginMethod);
   };
 
   const hasAnyFormMethod = canLoginWithPassword || canSignupWithPassword || showProviderButtons || useMagicCodePrimary;
@@ -526,6 +609,10 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500">
               {formError}
             </div>
+          )}
+
+          {!configLoading && isSignupMode && canSignup && magicCodeStep === "email" && (
+            <ProductUpdatesOptIn checked={signupProductUpdatesOptIn} onCheckedChange={setSignupProductUpdatesOptIn} />
           )}
 
           {!configLoading && useMagicCodePrimary && magicCodeStep === "email" && (
@@ -761,7 +848,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
                   <Button variant="outline" className="w-full justify-center gap-2" asChild>
                     <a
                       href={providerAuthPath(provider, redirectQuery, isSignupMode)}
-                      onClick={() => recordLastUsedLoginMethod(provider as LastUsedLoginMethod)}
+                      onClick={() => handleProviderClick(provider)}
                     >
                       {provider === "github" && (
                         <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>

--- a/web_src/src/pages/auth/OwnerSetup.tsx
+++ b/web_src/src/pages/auth/OwnerSetup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { posthog, isPostHogEnabled } from "@/posthog";
-import OwnerSetupSurvey, { type PostHogSurvey } from "./OwnerSetupSurvey";
+import PostHogSurveyForm, { type PostHogSurvey } from "./PostHogSurveyForm";
 import { OwnerStep } from "./ownerSetup/OwnerStep";
 import { PrivateNetworkStep } from "./ownerSetup/PrivateNetworkStep";
 import { SmtpPromptStep } from "./ownerSetup/SmtpPromptStep";
@@ -274,7 +274,7 @@ const OwnerSetup: React.FC = () => {
         )}
 
         {step === "survey" && activeSurvey && pendingOrganizationId && (
-          <OwnerSetupSurvey survey={activeSurvey} organizationId={pendingOrganizationId} />
+          <PostHogSurveyForm survey={activeSurvey} redirectTo={`/${pendingOrganizationId}`} />
         )}
 
         {step === "smtpConfig" && (

--- a/web_src/src/pages/auth/PostHogSurveyForm.tsx
+++ b/web_src/src/pages/auth/PostHogSurveyForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { analytics } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -22,9 +22,10 @@ export interface PostHogSurvey {
   questions: SurveyQuestion[];
 }
 
-interface OwnerSetupSurveyProps {
+interface PostHogSurveyFormProps {
   survey: PostHogSurvey;
-  organizationId: string;
+  redirectTo: string;
+  onComplete?: () => void;
 }
 
 type SurveyAnswer = string | string[];
@@ -36,6 +37,7 @@ const parseChoiceLabel = (choice: string): { title: string; subtitle: string | n
   if (!match) {
     return { title: choice, subtitle: null };
   }
+
   return { title: match[1].trim(), subtitle: match[2].trim() };
 };
 
@@ -64,12 +66,13 @@ const SurveyChoiceButtons: React.FC<SurveyChoiceButtonsProps> = ({ choices, onSe
   <div className="space-y-2">
     {choices.map((choice) => {
       const { title, subtitle } = parseChoiceLabel(choice);
+
       return (
         <Button
           key={choice}
           type="button"
           variant="outline"
-          className="w-full justify-start whitespace-normal h-auto py-3 text-left"
+          className="h-auto w-full justify-start whitespace-normal py-3 text-left"
           onClick={() => onSelect(choice)}
         >
           <span className="flex flex-col items-start">
@@ -95,10 +98,11 @@ const SurveyMultiChoice: React.FC<SurveyMultiChoiceProps> = ({ choices, selected
       {choices.map((choice) => {
         const isChecked = selectedChoices.includes(choice);
         const { title, subtitle } = parseChoiceLabel(choice);
+
         return (
           <label
             key={choice}
-            className="flex items-start gap-3 rounded-md border border-gray-200 px-3 py-2 text-left cursor-pointer"
+            className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 px-3 py-2 text-left"
           >
             <Checkbox
               checked={isChecked}
@@ -159,7 +163,7 @@ const SurveyProgress: React.FC<SurveyProgressProps> = ({ questionCount, currentQ
     </div>
     <button
       type="button"
-      className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
       onClick={onSkip}
     >
       Skip this question
@@ -167,7 +171,28 @@ const SurveyProgress: React.FC<SurveyProgressProps> = ({ questionCount, currentQ
   </div>
 );
 
-const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizationId }) => {
+const buildSurveyResponseProps = (survey: PostHogSurvey, responses: SurveyResponses) => {
+  const responseProps: Record<string, string | string[]> = {};
+
+  survey.questions.forEach((question, index) => {
+    const answer = responses[index];
+    if (answer === undefined) {
+      return;
+    }
+
+    const key = question.id
+      ? `$survey_response_${question.id}`
+      : index === 0
+        ? "$survey_response"
+        : `$survey_response_${index}`;
+
+    responseProps[key] = answer;
+  });
+
+  return responseProps;
+};
+
+const PostHogSurveyForm: React.FC<PostHogSurveyFormProps> = ({ survey, redirectTo, onComplete }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [surveyResponses, setSurveyResponses] = useState<SurveyResponses>({});
   const [textAnswer, setTextAnswer] = useState("");
@@ -180,25 +205,23 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
   );
   const currentType = currentQuestion ? getQuestionType(currentQuestion, currentChoices.length > 0) : "text";
 
+  const handleComplete = useCallback(() => {
+    if (onComplete) {
+      onComplete();
+      return;
+    }
+
+    window.location.href = redirectTo;
+  }, [onComplete, redirectTo]);
+
   const finishSurvey = (responses: SurveyResponses) => {
     if (Object.keys(responses).length === 0) {
       analytics.surveyDismissed(survey.id);
     } else {
-      const responseProps: Record<string, string | string[]> = {};
-      survey.questions.forEach((question, index) => {
-        const answer = responses[index];
-        if (answer === undefined) return;
-        if (question.id) {
-          responseProps[`$survey_response_${question.id}`] = answer;
-        } else if (index === 0) {
-          responseProps["$survey_response"] = answer;
-        } else {
-          responseProps[`$survey_response_${index}`] = answer;
-        }
-      });
-      analytics.surveySent(survey.id, survey.name, responseProps);
+      analytics.surveySent(survey.id, survey.name, buildSurveyResponseProps(survey, responses));
     }
-    window.location.href = `/${organizationId}`;
+
+    handleComplete();
   };
 
   const advanceOrFinish = (responses: SurveyResponses) => {
@@ -209,6 +232,7 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
       setMultiAnswer([]);
       return;
     }
+
     finishSurvey(responses);
   };
 
@@ -219,7 +243,10 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
 
   const handleSubmitTextAnswer = () => {
     const answer = textAnswer.trim();
-    if (!answer) return;
+    if (!answer) {
+      return;
+    }
+
     const newResponses = { ...surveyResponses, [currentQuestionIndex]: answer };
     advanceOrFinish(newResponses);
   };
@@ -229,11 +256,15 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
       setMultiAnswer((previous) => [...previous, choice]);
       return;
     }
+
     setMultiAnswer((previous) => previous.filter((item) => item !== choice));
   };
 
   const handleSubmitMultiChoice = () => {
-    if (multiAnswer.length === 0) return;
+    if (multiAnswer.length === 0) {
+      return;
+    }
+
     const newResponses = { ...surveyResponses, [currentQuestionIndex]: multiAnswer };
     advanceOrFinish(newResponses);
   };
@@ -243,20 +274,24 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
       setCurrentQuestionIndex(currentQuestionIndex + 1);
       setTextAnswer("");
       setMultiAnswer([]);
-    } else {
-      finishSurvey(surveyResponses);
+      return;
     }
+
+    finishSurvey(surveyResponses);
   };
 
   useEffect(() => {
     if (currentQuestion) {
       return;
     }
-    analytics.surveyDismissed(survey.id);
-    window.location.href = `/${organizationId}`;
-  }, [currentQuestion, organizationId, survey.id]);
 
-  if (!currentQuestion) return null;
+    analytics.surveyDismissed(survey.id);
+    handleComplete();
+  }, [currentQuestion, handleComplete, survey.id]);
+
+  if (!currentQuestion) {
+    return null;
+  }
 
   return (
     <div className="space-y-6">
@@ -298,4 +333,4 @@ const OwnerSetupSurvey: React.FC<OwnerSetupSurveyProps> = ({ survey, organizatio
   );
 };
 
-export default OwnerSetupSurvey;
+export default PostHogSurveyForm;

--- a/web_src/src/pages/auth/WelcomeSurvey.spec.ts
+++ b/web_src/src/pages/auth/WelcomeSurvey.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getWelcomeSurveyRedirectPath } from "./WelcomeSurvey";
+import { getWelcomeSurveyRedirectPath } from "./welcomeSurveyRedirect";
 
 describe("getWelcomeSurveyRedirectPath", () => {
   it("returns a safe internal redirect", () => {

--- a/web_src/src/pages/auth/WelcomeSurvey.spec.ts
+++ b/web_src/src/pages/auth/WelcomeSurvey.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getWelcomeSurveyRedirectPath } from "./WelcomeSurvey";
+
+describe("getWelcomeSurveyRedirectPath", () => {
+  it("returns a safe internal redirect", () => {
+    expect(getWelcomeSurveyRedirectPath("/invite/token-123")).toBe("/invite/token-123");
+  });
+
+  it("returns home when redirect is missing", () => {
+    expect(getWelcomeSurveyRedirectPath(null)).toBe("/");
+  });
+
+  it("rejects external redirects", () => {
+    expect(getWelcomeSurveyRedirectPath("https://example.com")).toBe("/");
+  });
+
+  it("rejects protocol-relative redirects", () => {
+    expect(getWelcomeSurveyRedirectPath("//example.com")).toBe("/");
+  });
+
+  it("rejects welcome redirects", () => {
+    expect(getWelcomeSurveyRedirectPath("/welcome?redirect=/invite/token-123")).toBe("/");
+  });
+});

--- a/web_src/src/pages/auth/WelcomeSurvey.tsx
+++ b/web_src/src/pages/auth/WelcomeSurvey.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
+import { posthog, isPostHogEnabled } from "@/posthog";
+import PostHogSurveyForm, { type PostHogSurvey } from "./PostHogSurveyForm";
+
+const NEW_USER_ONBOARDING_SURVEY_NAME = "New User Onboarding Survey";
+const SURVEY_LOAD_FALLBACK_MS = 3000;
+
+const isValidRedirectPath = (path: string | null): path is string => {
+  if (!path || path[0] !== "/") {
+    return false;
+  }
+
+  if (path.length > 1 && path[1] === "/") {
+    return false;
+  }
+
+  return !path.startsWith("/welcome");
+};
+
+export const getWelcomeSurveyRedirectPath = (rawRedirect: string | null): string => {
+  if (!rawRedirect) {
+    return "/";
+  }
+
+  try {
+    const decoded = decodeURIComponent(rawRedirect);
+    return isValidRedirectPath(decoded) ? decoded : "/";
+  } catch {
+    return "/";
+  }
+};
+
+const findNewUserSurvey = (surveys: PostHogSurvey[]) =>
+  surveys.find(
+    (survey) =>
+      survey.name === NEW_USER_ONBOARDING_SURVEY_NAME && Array.isArray(survey.questions) && survey.questions.length > 0,
+  ) ?? null;
+
+const WelcomeSurvey: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [survey, setSurvey] = useState<PostHogSurvey | null>(null);
+  const [shouldRedirect, setShouldRedirect] = useState(!isPostHogEnabled);
+
+  const redirectTo = useMemo(() => getWelcomeSurveyRedirectPath(searchParams.get("redirect")), [searchParams]);
+
+  const handleSurveyComplete = useCallback(() => {
+    navigate(redirectTo, { replace: true });
+  }, [navigate, redirectTo]);
+
+  useEffect(() => {
+    if (!isPostHogEnabled) {
+      return;
+    }
+
+    let canceled = false;
+    let surveyLoadFinished = false;
+    let fallbackTimer: number;
+
+    const loadMatchingSurveys = () => {
+      posthog.getActiveMatchingSurveys((surveys) => {
+        if (canceled) {
+          return;
+        }
+
+        const matchingSurvey = findNewUserSurvey(surveys as PostHogSurvey[]);
+        surveyLoadFinished = true;
+        window.clearTimeout(fallbackTimer);
+
+        if (!matchingSurvey) {
+          setShouldRedirect(true);
+          return;
+        }
+
+        setSurvey(matchingSurvey);
+      }, true);
+    };
+
+    fallbackTimer = window.setTimeout(() => {
+      if (!canceled && !surveyLoadFinished) {
+        setShouldRedirect(true);
+      }
+    }, SURVEY_LOAD_FALLBACK_MS);
+
+    const unsubscribe = posthog.onSurveysLoaded(loadMatchingSurveys);
+    loadMatchingSurveys();
+
+    return () => {
+      canceled = true;
+      window.clearTimeout(fallbackTimer);
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
+    };
+  }, []);
+
+  if (shouldRedirect) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  if (!survey) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-400 px-4 py-10">
+      <div className="w-full max-w-sm rounded-3xl bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900">
+        <PostHogSurveyForm survey={survey} redirectTo={redirectTo} onComplete={handleSurveyComplete} />
+      </div>
+    </div>
+  );
+};
+
+export default WelcomeSurvey;

--- a/web_src/src/pages/auth/WelcomeSurvey.tsx
+++ b/web_src/src/pages/auth/WelcomeSurvey.tsx
@@ -2,34 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import { posthog, isPostHogEnabled } from "@/posthog";
 import PostHogSurveyForm, { type PostHogSurvey } from "./PostHogSurveyForm";
+import { getWelcomeSurveyRedirectPath } from "./welcomeSurveyRedirect";
 
 const NEW_USER_ONBOARDING_SURVEY_NAME = "New User Onboarding Survey";
 const SURVEY_LOAD_FALLBACK_MS = 3000;
-
-const isValidRedirectPath = (path: string | null): path is string => {
-  if (!path || path[0] !== "/") {
-    return false;
-  }
-
-  if (path.length > 1 && path[1] === "/") {
-    return false;
-  }
-
-  return !path.startsWith("/welcome");
-};
-
-export const getWelcomeSurveyRedirectPath = (rawRedirect: string | null): string => {
-  if (!rawRedirect) {
-    return "/";
-  }
-
-  try {
-    const decoded = decodeURIComponent(rawRedirect);
-    return isValidRedirectPath(decoded) ? decoded : "/";
-  } catch {
-    return "/";
-  }
-};
 
 const findNewUserSurvey = (surveys: PostHogSurvey[]) =>
   surveys.find(
@@ -56,7 +32,12 @@ const WelcomeSurvey: React.FC = () => {
 
     let canceled = false;
     let surveyLoadFinished = false;
-    let fallbackTimer: number;
+
+    const fallbackTimer = window.setTimeout(() => {
+      if (!canceled && !surveyLoadFinished) {
+        setShouldRedirect(true);
+      }
+    }, SURVEY_LOAD_FALLBACK_MS);
 
     const loadMatchingSurveys = () => {
       posthog.getActiveMatchingSurveys((surveys) => {
@@ -76,12 +57,6 @@ const WelcomeSurvey: React.FC = () => {
         setSurvey(matchingSurvey);
       }, true);
     };
-
-    fallbackTimer = window.setTimeout(() => {
-      if (!canceled && !surveyLoadFinished) {
-        setShouldRedirect(true);
-      }
-    }, SURVEY_LOAD_FALLBACK_MS);
 
     const unsubscribe = posthog.onSurveysLoaded(loadMatchingSurveys);
     loadMatchingSurveys();

--- a/web_src/src/pages/auth/magicLinkVerifyRequest.spec.ts
+++ b/web_src/src/pages/auth/magicLinkVerifyRequest.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
+
+describe("buildMagicLinkVerifyRequest", () => {
+  it("includes signup intent for signup magic links", () => {
+    const request = buildMagicLinkVerifyRequest({
+      token: "token-123",
+      inviteToken: "",
+      redirectTarget: "/invite/abc",
+      signupIntent: true,
+    });
+
+    expect(request.url).toBe("/auth/magic-code/verify?redirect=%2Finvite%2Fabc");
+    expect(new URLSearchParams(request.body).get("token")).toBe("token-123");
+    expect(new URLSearchParams(request.body).get("signup")).toBe("true");
+  });
+
+  it("does not include signup intent for login magic links", () => {
+    const request = buildMagicLinkVerifyRequest({
+      token: "token-123",
+      inviteToken: "",
+      redirectTarget: "",
+      signupIntent: false,
+    });
+
+    expect(request.url).toBe("/auth/magic-code/verify");
+    expect(new URLSearchParams(request.body).get("signup")).toBeNull();
+  });
+
+  it("includes invite token when present", () => {
+    const request = buildMagicLinkVerifyRequest({
+      token: "token-123",
+      inviteToken: "invite-123",
+      redirectTarget: "/invite/invite-123",
+      signupIntent: false,
+    });
+
+    expect(new URLSearchParams(request.body).get("invite_token")).toBe("invite-123");
+  });
+});

--- a/web_src/src/pages/auth/magicLinkVerifyRequest.ts
+++ b/web_src/src/pages/auth/magicLinkVerifyRequest.ts
@@ -1,0 +1,33 @@
+interface MagicLinkVerifyRequestInput {
+  token: string;
+  inviteToken: string;
+  redirectTarget: string;
+  signupIntent: boolean;
+}
+
+export function buildMagicLinkVerifyRequest({
+  token,
+  inviteToken,
+  redirectTarget,
+  signupIntent,
+}: MagicLinkVerifyRequestInput) {
+  const formData = new URLSearchParams();
+  formData.append("token", token);
+
+  if (signupIntent) {
+    formData.append("signup", "true");
+  }
+
+  if (inviteToken) {
+    formData.append("invite_token", inviteToken);
+  }
+
+  const url = redirectTarget
+    ? `/auth/magic-code/verify?redirect=${encodeURIComponent(redirectTarget)}`
+    : "/auth/magic-code/verify";
+
+  return {
+    url,
+    body: formData.toString(),
+  };
+}

--- a/web_src/src/pages/auth/welcomeSurveyRedirect.ts
+++ b/web_src/src/pages/auth/welcomeSurveyRedirect.ts
@@ -1,0 +1,24 @@
+const isValidRedirectPath = (path: string | null): path is string => {
+  if (!path || path[0] !== "/") {
+    return false;
+  }
+
+  if (path.length > 1 && path[1] === "/") {
+    return false;
+  }
+
+  return !path.startsWith("/welcome");
+};
+
+export const getWelcomeSurveyRedirectPath = (rawRedirect: string | null): string => {
+  if (!rawRedirect) {
+    return "/";
+  }
+
+  try {
+    const decoded = decodeURIComponent(rawRedirect);
+    return isValidRedirectPath(decoded) ? decoded : "/";
+  } catch {
+    return "/";
+  }
+};

--- a/web_src/src/posthog.spec.tsx
+++ b/web_src/src/posthog.spec.tsx
@@ -34,6 +34,7 @@ vi.mock("@/lib/env", () => ({
 
 import { AccountProvider } from "@/contexts/AccountProvider";
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
+import { confirmSignupAnalyticsPreference } from "@/lib/signupAnalytics";
 
 const mockAccount = {
   id: "user-123",
@@ -77,10 +78,13 @@ describe("posthog init", () => {
 describe("account identification", () => {
   beforeEach(() => {
     identify.mockClear();
+    capture.mockClear();
+    localStorage.clear();
     stubFetch(mockAccount);
   });
 
   afterEach(() => {
+    localStorage.clear();
     vi.unstubAllGlobals();
   });
 
@@ -108,6 +112,35 @@ describe("account identification", () => {
     );
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     expect(identify).not.toHaveBeenCalled();
+  });
+
+  it("captures signup product update preference on account load", async () => {
+    confirmSignupAnalyticsPreference({
+      email: mockAccount.email,
+      productUpdatesOptIn: false,
+    });
+
+    render(
+      <AccountProvider>
+        <div />
+      </AccountProvider>,
+    );
+
+    await waitFor(() => {
+      expect(identify).toHaveBeenCalledWith("user-123", {
+        email: "john@example.com",
+        name: "John Doe",
+        installation_admin: false,
+        product_updates_opt_in: false,
+      });
+    });
+
+    expect(capture).toHaveBeenCalledWith("auth:signup", {
+      product_updates_opt_in: false,
+      $set: {
+        product_updates_opt_in: false,
+      },
+    });
   });
 });
 

--- a/web_src/src/posthog.spec.tsx
+++ b/web_src/src/posthog.spec.tsx
@@ -34,7 +34,7 @@ vi.mock("@/lib/env", () => ({
 
 import { AccountProvider } from "@/contexts/AccountProvider";
 import { OrganizationMenuButton } from "@/components/OrganizationMenuButton";
-import { confirmSignupAnalyticsPreference } from "@/lib/signupAnalytics";
+import { confirmSignupAnalyticsPreference, savePendingSignupAnalyticsPreference } from "@/lib/signupAnalytics";
 
 const mockAccount = {
   id: "user-123",
@@ -85,6 +85,7 @@ describe("account identification", () => {
 
   afterEach(() => {
     localStorage.clear();
+    window.history.replaceState({}, "", "/");
     vi.unstubAllGlobals();
   });
 
@@ -141,6 +142,51 @@ describe("account identification", () => {
         product_updates_opt_in: false,
       },
     });
+  });
+
+  it("captures unconfirmed signup preference when redirect marks account as created", async () => {
+    window.history.replaceState({}, "", "/org-123?auth_signup_result=created");
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    render(
+      <AccountProvider>
+        <div />
+      </AccountProvider>,
+    );
+
+    await waitFor(() => {
+      expect(capture).toHaveBeenCalledWith("auth:signup", {
+        product_updates_opt_in: true,
+        $set: {
+          product_updates_opt_in: true,
+        },
+      });
+    });
+  });
+
+  it("clears unconfirmed signup preference when redirect marks account as existing", async () => {
+    window.history.replaceState({}, "", "/org-123?auth_signup_result=existing");
+    savePendingSignupAnalyticsPreference({
+      productUpdatesOptIn: true,
+    });
+
+    render(
+      <AccountProvider>
+        <div />
+      </AccountProvider>,
+    );
+
+    await waitFor(() => {
+      expect(identify).toHaveBeenCalledWith("user-123", {
+        email: "john@example.com",
+        name: "John Doe",
+        installation_admin: false,
+      });
+    });
+
+    expect(capture).not.toHaveBeenCalledWith("auth:signup", expect.anything());
   });
 });
 


### PR DESCRIPTION
## Summary
- Split login and signup intent across password, magic-code, and OAuth auth flows, including provider links and magic-link verification.
- Require explicit signup intent or invite context before creating new accounts from magic-code or provider auth.
- Route newly created cloud users through /welcome to collect the PostHog onboarding survey while preserving the original redirect.
- Reuse the PostHog survey form for owner setup and add a welcome survey route with safe fallback behavior.

## Test plan
- [x] make format.go
- [x] make format.js
- [x] make test PKG_TEST_PACKAGES='./pkg/authentication ./pkg/public ./pkg/workers'
- [x] cd web_src && npm run test:run -- src/pages/auth/magicLinkVerifyRequest.spec.ts src/pages/auth/WelcomeSurvey.spec.ts
- [x] make lint && make check.build.app
- [x] make check.build.ui