### PR TITLE
fix: preserve signup UTM attribution

### DIFF
--- a/web_src/src/lib/analytics.spec.ts
+++ b/web_src/src/lib/analytics.spec.ts
@@ -16,12 +16,41 @@ import { analytics } from "@/lib/analytics";
 describe("analytics", () => {
   beforeEach(() => {
     capture.mockClear();
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
   });
 
   it("captures org create", () => {
     analytics.orgCreate("org-123");
     expect(capture).toHaveBeenCalledWith("auth:org_create", {
       organization_id: "org-123",
+    });
+  });
+
+  it("captures org create with stored UTM attribution", () => {
+    localStorage.setItem(
+      "superplane.initial_utm",
+      JSON.stringify({
+        utm_source: "youtube",
+        utm_medium: "influencer",
+        utm_campaign: "erictech_beta",
+        utm_content: "video",
+      }),
+    );
+
+    analytics.orgCreate("org-123");
+
+    expect(capture).toHaveBeenCalledWith("auth:org_create", {
+      organization_id: "org-123",
+      utm_source: "youtube",
+      utm_medium: "influencer",
+      utm_campaign: "erictech_beta",
+      utm_content: "video",
     });
   });
 

--- a/web_src/src/lib/analytics.ts
+++ b/web_src/src/lib/analytics.ts
@@ -3,6 +3,7 @@ export type IntegrationSource = "node_configuration" | "integrations_page" | "in
 import { useEffect, useRef } from "react";
 import { posthog } from "@/posthog";
 import type { OrganizationsIntegration } from "@/api-client";
+import { getUtmEventProperties } from "@/lib/utmAttribution";
 // Tracks when a connect form was opened so duration_s can be computed on submit.
 // Keyed by integration name; last-write-wins for the same integration.
 const integrationConnectStartTimes = new Map<string, number>();
@@ -165,7 +166,10 @@ export const analytics = {
   },
 
   orgCreate: (organizationId: string) => {
-    posthog.capture("auth:org_create", { organization_id: organizationId });
+    posthog.capture("auth:org_create", {
+      organization_id: organizationId,
+      ...getUtmEventProperties(),
+    });
   },
 
   canvasRunItemOpen: (nodeRef: string | undefined, executionStatus: string, organizationId: string) => {

--- a/web_src/src/lib/utmAttribution.spec.ts
+++ b/web_src/src/lib/utmAttribution.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getStoredUtmAttribution,
+  getUtmAttributionFromSearch,
+  getUtmCookieDomain,
+  getUtmEventProperties,
+  initializeUtmAttribution,
+} from "@/lib/utmAttribution";
+
+const setOnce = vi.fn();
+const posthog = {
+  people: {
+    set_once: setOnce,
+  },
+};
+
+describe("utmAttribution", () => {
+  beforeEach(() => {
+    setOnce.mockClear();
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("extracts supported UTM values from search params", () => {
+    expect(
+      getUtmAttributionFromSearch(
+        "?utm_source=youtube&utm_medium=influencer&utm_campaign=erictech_beta&utm_content=video&ignored=value",
+      ),
+    ).toEqual({
+      utm_source: "youtube",
+      utm_medium: "influencer",
+      utm_campaign: "erictech_beta",
+      utm_content: "video",
+    });
+  });
+
+  it("stores first-touch UTM values and sets PostHog person properties once", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/signup?utm_source=linkedin&utm_medium=influencer&utm_campaign=erictech_beta&utm_content=linkedin",
+    );
+
+    initializeUtmAttribution(posthog);
+
+    expect(getStoredUtmAttribution()).toEqual({
+      utm_source: "linkedin",
+      utm_medium: "influencer",
+      utm_campaign: "erictech_beta",
+      utm_content: "linkedin",
+    });
+    expect(setOnce).toHaveBeenCalledWith({
+      $initial_utm_source: "linkedin",
+      $initial_utm_medium: "influencer",
+      $initial_utm_campaign: "erictech_beta",
+      $initial_utm_content: "linkedin",
+    });
+  });
+
+  it("does not overwrite first-touch UTM values with later campaign params", () => {
+    window.history.replaceState({}, "", "/?utm_source=youtube&utm_campaign=erictech_beta");
+    initializeUtmAttribution(posthog);
+
+    window.history.replaceState({}, "", "/?utm_source=linkedin&utm_campaign=later_campaign");
+    initializeUtmAttribution(posthog);
+
+    expect(getUtmEventProperties()).toEqual({
+      utm_source: "youtube",
+      utm_campaign: "erictech_beta",
+    });
+  });
+
+  it("uses a shared parent-domain cookie on SuperPlane production domains", () => {
+    expect(getUtmCookieDomain("superplane.com")).toBe(".superplane.com");
+    expect(getUtmCookieDomain("app.superplane.com")).toBe(".superplane.com");
+    expect(getUtmCookieDomain("localhost")).toBeUndefined();
+  });
+});

--- a/web_src/src/lib/utmAttribution.ts
+++ b/web_src/src/lib/utmAttribution.ts
@@ -1,0 +1,158 @@
+const UTM_STORAGE_KEY = "superplane.initial_utm";
+const UTM_COOKIE_NAME = "superplane_initial_utm";
+const UTM_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
+
+const UTM_KEYS = ["utm_source", "utm_campaign", "utm_medium", "utm_content"] as const;
+
+export type UTMKey = (typeof UTM_KEYS)[number];
+export type UTMAttribution = Partial<Record<UTMKey, string>>;
+
+type PostHogPeopleClient = {
+  people?: {
+    set_once?: (properties: Record<string, string>) => void;
+  };
+};
+
+export const getUtmAttributionFromSearch = (search: string): UTMAttribution => {
+  const params = new URLSearchParams(search);
+  return UTM_KEYS.reduce<UTMAttribution>((values, key) => {
+    const value = params.get(key)?.trim();
+    if (value) {
+      values[key] = value;
+    }
+
+    return values;
+  }, {});
+};
+
+export const getStoredUtmAttribution = (): UTMAttribution => {
+  const fromLocalStorage = readLocalStorageAttribution();
+  if (hasUtmAttribution(fromLocalStorage)) {
+    return fromLocalStorage;
+  }
+
+  const fromCookie = readCookieAttribution();
+  if (hasUtmAttribution(fromCookie)) {
+    writeLocalStorageAttribution(fromCookie);
+    return fromCookie;
+  }
+
+  return {};
+};
+
+export const initializeUtmAttribution = (posthog: PostHogPeopleClient) => {
+  const currentAttribution = getUtmAttributionFromSearch(window.location.search);
+  const storedAttribution = getStoredUtmAttribution();
+  const attribution = hasUtmAttribution(storedAttribution) ? storedAttribution : currentAttribution;
+
+  if (!hasUtmAttribution(attribution)) {
+    return;
+  }
+
+  writeLocalStorageAttribution(attribution);
+  writeCookieAttribution(attribution);
+  posthog.people?.set_once?.(toInitialUtmPersonProperties(attribution));
+};
+
+export const getUtmEventProperties = (): UTMAttribution => getStoredUtmAttribution();
+
+export const getUtmCookieDomain = (hostname: string) => {
+  if (hostname === "superplane.com" || hostname.endsWith(".superplane.com")) {
+    return ".superplane.com";
+  }
+
+  if (hostname === "superplane.io" || hostname.endsWith(".superplane.io")) {
+    return ".superplane.io";
+  }
+
+  return undefined;
+};
+
+const toInitialUtmPersonProperties = (attribution: UTMAttribution) =>
+  UTM_KEYS.reduce<Record<string, string>>((properties, key) => {
+    const value = attribution[key];
+    if (value) {
+      properties[`$initial_${key}`] = value;
+    }
+
+    return properties;
+  }, {});
+
+const hasUtmAttribution = (attribution: UTMAttribution) => Object.keys(attribution).length > 0;
+
+const readLocalStorageAttribution = (): UTMAttribution => {
+  try {
+    const rawValue = window.localStorage.getItem(UTM_STORAGE_KEY);
+    return parseAttribution(rawValue);
+  } catch {
+    return {};
+  }
+};
+
+const writeLocalStorageAttribution = (attribution: UTMAttribution) => {
+  try {
+    window.localStorage.setItem(UTM_STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Attribution is best effort; blocked storage should not affect auth.
+  }
+};
+
+const readCookieAttribution = (): UTMAttribution => {
+  const prefix = `${UTM_COOKIE_NAME}=`;
+  const rawValue = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .find((cookie) => cookie.startsWith(prefix))
+    ?.slice(prefix.length);
+
+  if (!rawValue) {
+    return {};
+  }
+
+  try {
+    return parseAttribution(decodeURIComponent(rawValue));
+  } catch {
+    return {};
+  }
+};
+
+const writeCookieAttribution = (attribution: UTMAttribution) => {
+  const encodedValue = encodeURIComponent(JSON.stringify(attribution));
+  const cookieParts = [
+    `${UTM_COOKIE_NAME}=${encodedValue}`,
+    "Path=/",
+    `Max-Age=${UTM_COOKIE_MAX_AGE_SECONDS}`,
+    "SameSite=Lax",
+  ];
+
+  const domain = getUtmCookieDomain(window.location.hostname);
+  if (domain) {
+    cookieParts.push(`Domain=${domain}`);
+  }
+
+  if (window.location.protocol === "https:") {
+    cookieParts.push("Secure");
+  }
+
+  document.cookie = cookieParts.join("; ");
+};
+
+const parseAttribution = (rawValue: string | null | undefined): UTMAttribution => {
+  if (!rawValue) {
+    return {};
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as Record<string, unknown>;
+    return UTM_KEYS.reduce<UTMAttribution>((values, key) => {
+      const value = parsedValue[key];
+      if (typeof value === "string" && value.trim()) {
+        values[key] = value.trim();
+      }
+
+      return values;
+    }, {});
+  } catch {
+    return {};
+  }
+};

--- a/web_src/src/posthog.spec.tsx
+++ b/web_src/src/posthog.spec.tsx
@@ -3,15 +3,16 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { init, identify, capture, reset } = vi.hoisted(() => ({
+const { init, identify, capture, reset, setOnce } = vi.hoisted(() => ({
   init: vi.fn(),
   identify: vi.fn(),
   capture: vi.fn(),
   reset: vi.fn(),
+  setOnce: vi.fn(),
 }));
 
 vi.mock("posthog-js", () => ({
-  default: { init, identify, capture, reset },
+  default: { init, identify, capture, reset, people: { set_once: setOnce } },
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -56,7 +57,17 @@ const stubFetch = (data: object, status = 200) => {
 describe("posthog init", () => {
   beforeEach(() => {
     init.mockClear();
+    setOnce.mockClear();
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete (window as Window & { SUPERPLANE_POSTHOG_KEY?: string }).SUPERPLANE_POSTHOG_KEY;
+    localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
+    window.history.replaceState({}, "", "/");
   });
 
   it("calls init when SUPERPLANE_POSTHOG_KEY is set", async () => {
@@ -64,7 +75,7 @@ describe("posthog init", () => {
     await import("@/posthog");
     expect(init).toHaveBeenCalledWith(
       "test-key",
-      expect.objectContaining({ autocapture: false, capture_pageview: false }),
+      expect.objectContaining({ autocapture: false, capture_pageview: false, person_profiles: "always" }),
     );
   });
 
@@ -73,6 +84,18 @@ describe("posthog init", () => {
     await import("@/posthog");
     expect(init).not.toHaveBeenCalled();
   });
+
+  it("sets initial UTM person properties when PostHog initializes", async () => {
+    (window as Window & { SUPERPLANE_POSTHOG_KEY?: string }).SUPERPLANE_POSTHOG_KEY = "test-key";
+    window.history.replaceState({}, "", "/signup?utm_source=youtube&utm_campaign=erictech_beta");
+
+    await import("@/posthog");
+
+    expect(setOnce).toHaveBeenCalledWith({
+      $initial_utm_source: "youtube",
+      $initial_utm_campaign: "erictech_beta",
+    });
+  });
 });
 
 describe("account identification", () => {
@@ -80,12 +103,15 @@ describe("account identification", () => {
     identify.mockClear();
     capture.mockClear();
     localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
     stubFetch(mockAccount);
   });
 
   afterEach(() => {
     localStorage.clear();
+    document.cookie = "superplane_initial_utm=; Max-Age=0; Path=/";
     window.history.replaceState({}, "", "/");
+    delete (window as Window & { SUPERPLANE_POSTHOG_KEY?: string }).SUPERPLANE_POSTHOG_KEY;
     vi.unstubAllGlobals();
   });
 

--- a/web_src/src/posthog.ts
+++ b/web_src/src/posthog.ts
@@ -1,4 +1,5 @@
 import posthog from "posthog-js";
+import { initializeUtmAttribution } from "@/lib/utmAttribution";
 
 interface PostHogWindow extends Window {
   SUPERPLANE_POSTHOG_KEY?: string;
@@ -11,7 +12,9 @@ if (key) {
     api_host: "https://us.i.posthog.com",
     autocapture: false,
     capture_pageview: false,
+    person_profiles: "always",
   });
+  initializeUtmAttribution(posthog);
 }
 
 export { posthog };


### PR DESCRIPTION
## Summary
- persist first-touch UTM attribution from signup URLs in localStorage and a shared SuperPlane cookie
- set initial UTM person properties through PostHog when the app initializes
- include stored UTM fields on auth:org_create

## Tests
- npm run test -- src/lib/utmAttribution.spec.ts src/lib/analytics.spec.ts src/posthog.spec.tsx
- make format.js
- make check.lint.ui
- make check.build.ui