### PR TITLE
fix: route magic-code signups through welcome survey

### DIFF
--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -41,6 +41,8 @@ const (
 	magicCodeMaxVerifyAttempts = 3
 	authSignupStatePrefix      = "signup:"
 	authSignupResultParam      = "auth_signup_result"
+	authErrorParam             = "auth_error"
+	authErrorSignupRequired    = "signup_required"
 	jsonContentType            = "application/json"
 )
 
@@ -182,6 +184,11 @@ func (a *Handler) handleDevAuth(w http.ResponseWriter, r *http.Request) {
 	account, wasCreated, err := a.findOrCreateAccountForProvider(mockUser, a.allowSignupFromRequest(r))
 
 	if err != nil {
+		if errors.Is(err, errSignupRequired) {
+			http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
+			return
+		}
+
 		if errorStatusForAccountError(err) == http.StatusForbidden {
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
@@ -216,6 +223,11 @@ func (a *Handler) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 
 	account, wasCreated, err := a.findOrCreateAccountForProvider(gothUser, a.allowSignupFromRequest(r))
 	if err != nil {
+		if errors.Is(err, errSignupRequired) {
+			http.Redirect(w, r, getSignupRequiredRedirectURL(r), http.StatusSeeOther)
+			return
+		}
+
 		if errorStatusForAccountError(err) == http.StatusForbidden {
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
@@ -819,6 +831,18 @@ func addAuthSignupResult(redirectURL string, result string) string {
 	params.Set(authSignupResultParam, result)
 	parsedURL.RawQuery = params.Encode()
 	return parsedURL.String()
+}
+
+func getSignupRequiredRedirectURL(r *http.Request) string {
+	params := url.Values{}
+	params.Set(authErrorParam, authErrorSignupRequired)
+
+	redirectURL := getRedirectURL(r)
+	if redirectURL != "/" {
+		params.Set("redirect", redirectURL)
+	}
+
+	return fmt.Sprintf("/signup?%s", params.Encode())
 }
 
 func generateMagicCode() (string, error) {

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -41,6 +41,7 @@ const (
 	magicCodeMaxVerifyAttempts = 3
 	authSignupStatePrefix      = "signup:"
 	authSignupResultParam      = "auth_signup_result"
+	jsonContentType            = "application/json"
 )
 
 type Handler struct {
@@ -770,6 +771,20 @@ func (a *Handler) issueSessionAndRedirect(w http.ResponseWriter, r *http.Request
 	}
 
 	redirectURL := a.getPostAuthRedirectURL(r, wasCreated)
+	writePostAuthRedirect(w, r, redirectURL)
+}
+
+func writePostAuthRedirect(w http.ResponseWriter, r *http.Request, redirectURL string) {
+	if strings.Contains(r.Header.Get("Accept"), jsonContentType) {
+		w.Header().Set("Content-Type", jsonContentType)
+		if err := json.NewEncoder(w).Encode(map[string]string{"redirectUrl": redirectURL}); err != nil {
+			log.Errorf("Error encoding auth redirect response: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		}
+
+		return
+	}
+
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }
 

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -319,6 +319,30 @@ func TestHandler_getPostAuthRedirectURL(t *testing.T) {
 	})
 }
 
+func TestWritePostAuthRedirect(t *testing.T) {
+	t.Run("should return JSON redirect when requested", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/verify", nil)
+		req.Header.Set("Accept", "application/json")
+		recorder := httptest.NewRecorder()
+
+		writePostAuthRedirect(recorder, req, "/welcome?redirect=%2Fcanvases")
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+		assert.JSONEq(t, `{"redirectUrl":"/welcome?redirect=%2Fcanvases"}`, recorder.Body.String())
+	})
+
+	t.Run("should keep browser redirects by default", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/magic-code/verify", nil)
+		recorder := httptest.NewRecorder()
+
+		writePostAuthRedirect(recorder, req, "/welcome")
+
+		assert.Equal(t, http.StatusSeeOther, recorder.Code)
+		assert.Equal(t, "/welcome", recorder.Header().Get("Location"))
+	})
+}
+
 func TestHandler_handlePasswordSignup(t *testing.T) {
 	t.Run("should route new cloud users through welcome with original redirect", func(t *testing.T) {
 		r := support.Setup(t)

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -214,6 +214,24 @@ func TestGetRedirectURL(t *testing.T) {
 	})
 }
 
+func TestGetSignupRequiredRedirectURL(t *testing.T) {
+	t.Run("should redirect to signup with an auth error", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/github/callback", nil)
+
+		redirectURL := getSignupRequiredRedirectURL(req)
+
+		assert.Equal(t, "/signup?auth_error=signup_required", redirectURL)
+	})
+
+	t.Run("should preserve the original OAuth redirect", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/github/callback?state=%2Finvite%2Fabc", nil)
+
+		redirectURL := getSignupRequiredRedirectURL(req)
+
+		assert.Equal(t, "/signup?auth_error=signup_required&redirect=%2Finvite%2Fabc", redirectURL)
+	})
+}
+
 func TestHandler_checkSignupPolicy(t *testing.T) {
 	t.Run("should reject new magic-code account from login flow", func(t *testing.T) {
 		handler, _ := setupAuthHandler(t, false)

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -81,6 +81,14 @@ interface LoginProps {
   mode?: AuthMode;
 }
 
+const getAuthErrorMessage = (authError: string | null) => {
+  if (authError === "signup_required") {
+    return "No account exists for that provider yet. Create an account to continue.";
+  }
+
+  return null;
+};
+
 const LastUsedHint: React.FC<{ label: string }> = ({ label }) => (
   <p className="mt-2 text-center text-xs text-gray-500">You used {label} to log in last time</p>
 );
@@ -259,6 +267,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
   const magicLinkToken = searchParams.get("magic_link_token");
   const redirectTarget = safeRedirect || "";
+  const authErrorMessage = getAuthErrorMessage(searchParams.get("auth_error"));
 
   const handleRedirectAfterAuth = useCallback(
     async (response: Response, authRedirectURL?: string) => {
@@ -412,6 +421,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
   const showStandaloneProductUpdatesOptIn =
     isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
+  const visibleFormError = formError ?? authErrorMessage;
 
   const handleMagicCodeRequest = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -652,9 +662,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             <p className="text-sm text-gray-500">No login methods are configured.</p>
           )}
 
-          {!configLoading && formError && (
+          {!configLoading && visibleFormError && (
             <div className="mb-4 rounded-md border border-red-300 bg-white px-3 py-1 text-sm text-red-500">
-              {formError}
+              {visibleFormError}
             </div>
           )}
 

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -19,6 +19,7 @@ import {
   savePendingSignupAnalyticsPreference,
 } from "@/lib/signupAnalytics";
 import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
+import { getAuthRedirectURL, getWelcomeRedirectPath } from "./authRedirect";
 
 type AuthConfig = {
   providers: string[];
@@ -71,15 +72,6 @@ const providerAuthPath = (provider: string, redirectQuery: string, isSignupMode:
 
   const query = params.toString();
   return query ? `/auth/${provider}?${query}` : `/auth/${provider}`;
-};
-
-const isWelcomeRedirect = (response: Response) => {
-  try {
-    const parsedURL = new URL(response.url || "/", window.location.origin);
-    return parsedURL.origin === window.location.origin && parsedURL.pathname === "/welcome";
-  } catch {
-    return false;
-  }
 };
 
 type MagicCodeStep = "email" | "code";
@@ -269,21 +261,12 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const redirectTarget = safeRedirect || "";
 
   const handleRedirectAfterAuth = useCallback(
-    async (response: Response) => {
-      const finalURL = response.url || "/";
-
-      try {
-        const parsedURL = new URL(finalURL, window.location.origin);
-        if (parsedURL.origin === window.location.origin && parsedURL.pathname === "/welcome") {
-          if (!parsedURL.searchParams.has("redirect") && redirectTarget) {
-            parsedURL.searchParams.set("redirect", redirectTarget);
-          }
-
-          window.location.href = `${parsedURL.pathname}${parsedURL.search}`;
-          return;
-        }
-      } catch {
-        // fall through to existing redirect behavior
+    async (response: Response, authRedirectURL?: string) => {
+      const finalURL = authRedirectURL ?? response.url ?? "/";
+      const welcomeRedirectPath = getWelcomeRedirectPath(finalURL, redirectTarget);
+      if (welcomeRedirectPath) {
+        window.location.href = welcomeRedirectPath;
+        return;
       }
 
       if (redirectTarget) {
@@ -345,7 +328,10 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
         const response = await fetch(url, {
           method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
           credentials: "include",
           body,
         });
@@ -356,11 +342,12 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           return;
         }
 
-        if (mode === "signup" && !isWelcomeRedirect(response)) {
+        const authRedirectURL = await getAuthRedirectURL(response);
+        if (mode === "signup" && !getWelcomeRedirectPath(authRedirectURL, redirectTarget)) {
           clearPendingSignupAnalyticsPreference();
         }
 
-        await handleRedirectAfterAuth(response);
+        await handleRedirectAfterAuth(response, authRedirectURL);
       } catch {
         setFormError("Network error occurred");
         setSubmitLoading(false);
@@ -480,7 +467,10 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
       const response = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
         credentials: "include",
         body: buildMagicCodeVerifyBody(magicCodeEmail, magicCode, isSignupMode, inviteToken),
       });
@@ -492,8 +482,9 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
         return;
       }
 
+      const authRedirectURL = await getAuthRedirectURL(response);
       if (isSignupMode) {
-        if (isWelcomeRedirect(response)) {
+        if (getWelcomeRedirectPath(authRedirectURL, redirectTarget)) {
           confirmSignupAnalyticsPreference({
             email: magicCodeEmail.trim(),
             productUpdatesOptIn: signupProductUpdatesOptIn,
@@ -503,7 +494,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
         }
       }
 
-      await handleRedirectAfterAuth(response);
+      await handleRedirectAfterAuth(response, authRedirectURL);
     } catch {
       clearSignupPreference(isSignupMode);
       setFormError("Network error occurred");
@@ -621,6 +612,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   };
 
   const hasAnyFormMethod = canLoginWithPassword || canSignupWithPassword || showProviderButtons || useMagicCodePrimary;
+  const providerButtonsNeedTopSpacing = useMagicCodePrimary && magicCodeStep === "email";
 
   const getHeading = () => {
     if (useMagicCodePrimary && magicCodeStep === "code") return "Check your email";
@@ -908,7 +900,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
           )}
 
           {!configLoading && showProviderButtons && (!useMagicCodePrimary || magicCodeStep === "email") && (
-            <div className="space-y-3">
+            <div className={providerButtonsNeedTopSpacing ? "mt-4 space-y-3" : "space-y-3"}>
               {activeProviders.map((provider) => (
                 <div key={provider}>
                   <Button variant="outline" className="w-full justify-center gap-2" asChild>

--- a/web_src/src/pages/auth/PostHogSurveyForm.tsx
+++ b/web_src/src/pages/auth/PostHogSurveyForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { analytics } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -63,23 +64,27 @@ interface SurveyChoiceButtonsProps {
 }
 
 const SurveyChoiceButtons: React.FC<SurveyChoiceButtonsProps> = ({ choices, onSelect }) => (
-  <div className="space-y-2">
+  <div className="-mx-2 divide-y divide-gray-200 border-y border-gray-200">
     {choices.map((choice) => {
       const { title, subtitle } = parseChoiceLabel(choice);
 
       return (
-        <Button
+        <button
           key={choice}
           type="button"
-          variant="outline"
-          className="h-auto w-full justify-start whitespace-normal py-3 text-left"
+          className="group flex w-full items-start justify-between gap-4 px-2 py-4 text-left transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2 dark:hover:bg-gray-800"
           onClick={() => onSelect(choice)}
         >
-          <span className="flex flex-col items-start">
-            <span className="font-medium">{title}</span>
-            {subtitle && <span className="text-xs font-normal text-gray-500 dark:text-gray-400">{subtitle}</span>}
+          <span className="min-w-0">
+            <span className="block text-sm font-medium leading-5 text-gray-900 dark:text-white">{title}</span>
+            {subtitle && (
+              <span className="mt-1 block text-sm font-normal leading-5 text-gray-500 dark:text-gray-400">
+                {subtitle}
+              </span>
+            )}
           </span>
-        </Button>
+          <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition-colors group-hover:text-gray-900 dark:group-hover:text-white" />
+        </button>
       );
     })}
   </div>
@@ -94,7 +99,7 @@ interface SurveyMultiChoiceProps {
 
 const SurveyMultiChoice: React.FC<SurveyMultiChoiceProps> = ({ choices, selectedChoices, onToggle, onSubmit }) => (
   <div className="space-y-4">
-    <div className="space-y-2">
+    <div className="-mx-2 divide-y divide-gray-200 border-y border-gray-200">
       {choices.map((choice) => {
         const isChecked = selectedChoices.includes(choice);
         const { title, subtitle } = parseChoiceLabel(choice);
@@ -102,16 +107,18 @@ const SurveyMultiChoice: React.FC<SurveyMultiChoiceProps> = ({ choices, selected
         return (
           <label
             key={choice}
-            className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 px-3 py-2 text-left"
+            className="flex cursor-pointer items-start gap-3 px-2 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
           >
             <Checkbox
               checked={isChecked}
               onCheckedChange={(checked) => onToggle(choice, checked === true)}
-              className="mt-0.5"
+              className="mt-0.5 shrink-0"
             />
-            <span className="flex flex-col text-sm text-gray-800 dark:text-gray-200">
-              <span className="font-medium">{title}</span>
-              {subtitle && <span className="text-xs font-normal text-gray-500 dark:text-gray-400">{subtitle}</span>}
+            <span className="min-w-0 text-sm text-gray-800 dark:text-gray-200">
+              <span className="block font-medium leading-5">{title}</span>
+              {subtitle && (
+                <span className="mt-1 block font-normal leading-5 text-gray-500 dark:text-gray-400">{subtitle}</span>
+              )}
             </span>
           </label>
         );
@@ -136,6 +143,7 @@ const SurveyTextQuestion: React.FC<SurveyTextQuestionProps> = ({ placeholder, te
       placeholder={placeholder ?? "Type your answer"}
       value={textAnswer}
       onChange={(event) => onTextChange(event.target.value)}
+      className="min-h-32 resize-none rounded-md"
     />
     <Button type="button" className="w-full" onClick={onSubmit} disabled={!textAnswer.trim()}>
       Continue
@@ -150,13 +158,13 @@ interface SurveyProgressProps {
 }
 
 const SurveyProgress: React.FC<SurveyProgressProps> = ({ questionCount, currentQuestionIndex, onSkip }) => (
-  <div className="flex flex-col items-center gap-3">
-    <div className="flex gap-1.5">
+  <div className="flex items-center justify-between gap-4">
+    <div className="flex gap-1.5" aria-label={`Question ${currentQuestionIndex + 1} of ${questionCount}`}>
       {Array.from({ length: questionCount }).map((_, i) => (
         <div
           key={i}
-          className={`h-1.5 rounded-full transition-all duration-300 ${
-            i === currentQuestionIndex ? "w-4 bg-gray-900 dark:bg-white" : "w-1.5 bg-gray-300 dark:bg-gray-600"
+          className={`h-1 transition-all duration-300 ${
+            i === currentQuestionIndex ? "w-8 bg-gray-900 dark:bg-white" : "w-4 bg-gray-300 dark:bg-gray-600"
           }`}
         />
       ))}
@@ -166,7 +174,7 @@ const SurveyProgress: React.FC<SurveyProgressProps> = ({ questionCount, currentQ
       className="text-xs text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
       onClick={onSkip}
     >
-      Skip this question
+      Skip
     </button>
   </div>
 );
@@ -191,6 +199,20 @@ const buildSurveyResponseProps = (survey: PostHogSurvey, responses: SurveyRespon
 
   return responseProps;
 };
+
+const SurveyQuestionHeader: React.FC<{ question: string | undefined }> = ({ question }) => (
+  <div className="space-y-5">
+    <img src={superplaneLogo} alt="SuperPlane logo" className="h-8 w-8" />
+    <div className="space-y-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Welcome to SuperPlane
+      </p>
+      <h4 className="text-balance text-2xl font-semibold leading-8 text-gray-950 dark:text-white">
+        {question ?? "Question"}
+      </h4>
+    </div>
+  </div>
+);
 
 const PostHogSurveyForm: React.FC<PostHogSurveyFormProps> = ({ survey, redirectTo, onComplete }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -294,13 +316,8 @@ const PostHogSurveyForm: React.FC<PostHogSurveyFormProps> = ({ survey, redirectT
   }
 
   return (
-    <div className="space-y-6">
-      <div className="text-center">
-        <img src={superplaneLogo} alt="SuperPlane logo" className="mx-auto mb-4 h-8 w-8" />
-        <h4 className="text-lg font-semibold text-gray-900 dark:text-white">
-          {currentQuestion.question ?? "Question"}
-        </h4>
-      </div>
+    <div className="space-y-7">
+      <SurveyQuestionHeader question={currentQuestion.question} />
 
       {currentType === "single_choice" && (
         <SurveyChoiceButtons choices={currentChoices} onSelect={handleSingleChoice} />

--- a/web_src/src/pages/auth/WelcomeSurvey.tsx
+++ b/web_src/src/pages/auth/WelcomeSurvey.tsx
@@ -80,7 +80,7 @@ const WelcomeSurvey: React.FC = () => {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-400 px-4 py-10">
-      <div className="w-full max-w-sm rounded-3xl bg-white p-8 shadow-sm outline outline-gray-950/10 dark:bg-gray-900">
+      <div className="w-full max-w-xl rounded-lg bg-white px-8 py-9 shadow-sm outline outline-gray-950/10 dark:bg-gray-900 sm:px-10">
         <PostHogSurveyForm survey={survey} redirectTo={redirectTo} onComplete={handleSurveyComplete} />
       </div>
     </div>

--- a/web_src/src/pages/auth/authRedirect.spec.ts
+++ b/web_src/src/pages/auth/authRedirect.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getAuthRedirectURL, getWelcomeRedirectPath } from "./authRedirect";
+
+describe("auth redirect helpers", () => {
+  it("reads explicit JSON redirect URLs", async () => {
+    const response = new Response(JSON.stringify({ redirectUrl: "/welcome" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(await getAuthRedirectURL(response)).toBe("/welcome");
+  });
+
+  it("falls back to the response URL when no JSON redirect is present", async () => {
+    const response = new Response("", {
+      headers: { "Content-Type": "text/html" },
+    });
+
+    Object.defineProperty(response, "url", {
+      value: "http://localhost/canvases",
+    });
+
+    expect(await getAuthRedirectURL(response)).toBe("http://localhost/canvases");
+  });
+
+  it("builds same-origin welcome redirect paths", () => {
+    expect(getWelcomeRedirectPath("/welcome", "/invite/token-123")).toBe("/welcome?redirect=%2Finvite%2Ftoken-123");
+  });
+
+  it("rejects non-welcome redirect paths", () => {
+    expect(getWelcomeRedirectPath("/org-123", "")).toBeNull();
+  });
+});

--- a/web_src/src/pages/auth/authRedirect.ts
+++ b/web_src/src/pages/auth/authRedirect.ts
@@ -1,0 +1,38 @@
+type AuthRedirectResponse = {
+  redirectUrl?: unknown;
+};
+
+export const getAuthRedirectURL = async (response: Response) => {
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return response.url || "/";
+  }
+
+  try {
+    const body = (await response.clone().json()) as AuthRedirectResponse;
+    if (typeof body.redirectUrl === "string" && body.redirectUrl.trim()) {
+      return body.redirectUrl;
+    }
+  } catch {
+    return response.url || "/";
+  }
+
+  return response.url || "/";
+};
+
+export const getWelcomeRedirectPath = (redirectURL: string, redirectTarget: string) => {
+  try {
+    const parsedURL = new URL(redirectURL || "/", window.location.origin);
+    if (parsedURL.origin !== window.location.origin || parsedURL.pathname !== "/welcome") {
+      return null;
+    }
+
+    if (!parsedURL.searchParams.has("redirect") && redirectTarget) {
+      parsedURL.searchParams.set("redirect", redirectTarget);
+    }
+
+    return `${parsedURL.pathname}${parsedURL.search}`;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- return explicit JSON redirect targets for magic-code auth requests that ask for JSON
- use that redirect target in the signup UI so direct email/code signups land on /welcome
- add spacing between the primary email signup button and OAuth provider buttons

## Tests
- make test PKG_TEST_PACKAGES=./pkg/authentication
- npm run test -- src/pages/auth/authRedirect.spec.ts src/pages/auth/magicLinkVerifyRequest.spec.ts
- make format.go
- make format.js
- make check.lint.ui
- make check.build.ui
- make lint && make check.build.app