### PR TITLE
feat: add admin signup access control

### DIFF
--- a/.models-tx-debt-baseline.json
+++ b/.models-tx-debt-baseline.json
@@ -1,6 +1,6 @@
 {
-  "maxAllowedInTransactionDefinitions": 191,
-  "maxAllowedDatabaseConnCalls": 220,
+  "maxAllowedInTransactionDefinitions": 187,
+  "maxAllowedDatabaseConnCalls": 217,
   "inTransactionDefinitionKeys": [
     "pkg/models/account.go:40:MarkPasswordChangedInTransaction",
     "pkg/models/account.go:70:CreateAccountInTransaction",
@@ -124,10 +124,6 @@
     "pkg/models/email_settings.go:32:UpsertEmailSettingsInTransaction",
     "pkg/models/email_settings.go:43:FindEmailSettingsInTransaction",
     "pkg/models/email_settings.go:60:DeleteEmailSettingsInTransaction",
-    "pkg/models/installation_metadata.go:31:GetInstallationMetadataInTransaction",
-    "pkg/models/installation_metadata.go:35:GetInstallationIDInTransaction",
-    "pkg/models/installation_metadata.go:48:UpdateInstallationMetadataInTransaction",
-    "pkg/models/installation_metadata.go:62:findOrCreateInstallationMetadataInTransaction",
     "pkg/models/integration.go:86:ListIntegrationSecretsInTransaction",
     "pkg/models/integration.go:136:CountIntegrationsByOrganizationInTransaction",
     "pkg/models/integration.go:220:FindUnscopedIntegrationInTransaction",
@@ -308,9 +304,6 @@
     "pkg/models/email_settings.go:29:database.Conn()",
     "pkg/models/email_settings.go:40:database.Conn()",
     "pkg/models/email_settings.go:57:database.Conn()",
-    "pkg/models/installation_metadata.go:24:database.Conn()",
-    "pkg/models/installation_metadata.go:28:database.Conn()",
-    "pkg/models/installation_metadata.go:45:database.Conn()",
     "pkg/models/integration.go:83:database.Conn()",
     "pkg/models/integration.go:115:database.Conn()",
     "pkg/models/integration.go:125:database.Conn()",
@@ -416,5 +409,5 @@
     "pkg/models/workflow_staging.go:71:database.Conn()",
     "pkg/models/workflow_staging.go:75:database.Conn()"
   ],
-  "updatedAt": "2026-06-18T14:18:06Z"
+  "updatedAt": "2026-06-18T17:32:24Z"
 }

--- a/db/migrations/20260618170412_add-installation-signups-enabled.up.sql
+++ b/db/migrations/20260618170412_add-installation-signups-enabled.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.installation_metadata
+    ADD COLUMN signups_enabled boolean DEFAULT true NOT NULL;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -333,6 +333,7 @@ CREATE TABLE public.installation_metadata (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     allow_private_network_access boolean DEFAULT false NOT NULL,
+    signups_enabled boolean DEFAULT true NOT NULL,
     CONSTRAINT installation_metadata_singleton CHECK ((id = 1))
 );
 
@@ -2018,7 +2019,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260617203101	f
+20260618170412	f
 \.
 
 

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -328,15 +328,17 @@ func (a *Handler) handleAuthConfig(w http.ResponseWriter, r *http.Request) {
 	sort.Strings(providerNames)
 
 	response := struct {
-		Providers            []string `json:"providers"`
-		PasswordLoginEnabled bool     `json:"passwordLoginEnabled"`
-		SignupEnabled        bool     `json:"signupEnabled"`
-		MagicCodeEnabled     bool     `json:"magicCodeEnabled"`
+		Providers                   []string `json:"providers"`
+		PasswordLoginEnabled        bool     `json:"passwordLoginEnabled"`
+		SignupEnabled               bool     `json:"signupEnabled"`
+		SignupsBlockedByEnvironment bool     `json:"signupsBlockedByEnvironment"`
+		MagicCodeEnabled            bool     `json:"magicCodeEnabled"`
 	}{
-		Providers:            providerNames,
-		PasswordLoginEnabled: a.passwordLoginEnabled,
-		SignupEnabled:        !a.blockSignup,
-		MagicCodeEnabled:     a.magicCodeEnabled,
+		Providers:                   providerNames,
+		PasswordLoginEnabled:        a.passwordLoginEnabled,
+		SignupEnabled:               a.SignupsEnabled(),
+		SignupsBlockedByEnvironment: a.SignupsBlockedByEnvironment(),
+		MagicCodeEnabled:            a.magicCodeEnabled,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -430,7 +432,7 @@ func (a *Handler) handlePasswordSignup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if a.blockSignup && inviteToken == "" {
+	if !a.SignupsEnabled() && inviteToken == "" {
 		http.Error(w, SignupDisabledError, http.StatusForbidden)
 		return
 	}
@@ -723,7 +725,7 @@ func (a *Handler) checkSignupPolicy(email string, r *http.Request) error {
 		return errSignupRequired
 	}
 
-	if a.blockSignup {
+	if !a.SignupsEnabled() {
 		return errSignupDisabled
 	}
 
@@ -925,7 +927,7 @@ func (a *Handler) parseMagicLinkToken(tokenString string) (email string, code st
 }
 
 func (a *Handler) FindOrCreateAccountForProvider(gothUser goth.User) (*models.Account, error) {
-	account, _, err := a.findOrCreateAccountForProvider(gothUser, !a.blockSignup)
+	account, _, err := a.findOrCreateAccountForProvider(gothUser, a.SignupsEnabled())
 	return account, err
 }
 
@@ -972,7 +974,29 @@ func (a *Handler) allowSignupFromRequest(r *http.Request) bool {
 		return true
 	}
 
-	return !a.blockSignup && isSignupIntentFromRequest(r)
+	return a.SignupsEnabled() && isSignupIntentFromRequest(r)
+}
+
+func (a *Handler) SignupsEnabled() bool {
+	if a.blockSignup {
+		return false
+	}
+
+	metadata, err := models.GetInstallationMetadata(database.Conn())
+	return signupsEnabledFromMetadata(metadata, err)
+}
+
+func signupsEnabledFromMetadata(metadata *models.InstallationMetadata, err error) bool {
+	if err != nil {
+		log.Errorf("Error loading installation metadata for signup policy: %v", err)
+		return true
+	}
+
+	return metadata.SignupsEnabled
+}
+
+func (a *Handler) SignupsBlockedByEnvironment() bool {
+	return a.blockSignup
 }
 
 func allowSignupFromInvite(r *http.Request) bool {

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -1,11 +1,13 @@
 package authentication
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/markbates/goth"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +18,11 @@ import (
 	"github.com/superplanehq/superplane/test/support"
 )
 
+type authConfigResponse struct {
+	SignupEnabled               bool `json:"signupEnabled"`
+	SignupsBlockedByEnvironment bool `json:"signupsBlockedByEnvironment"`
+}
+
 func setupAuthHandler(t *testing.T, blockSignup bool) (*Handler, *support.ResourceRegistry) {
 	r := support.Setup(t)
 	t.Cleanup(func() { r.Close() })
@@ -23,6 +30,49 @@ func setupAuthHandler(t *testing.T, blockSignup bool) (*Handler, *support.Resour
 	signer := jwt.NewSigner("test-secret")
 	handler := NewHandler(signer, r.Encryptor, r.AuthService, "test", "/templates", blockSignup, false, false)
 	return handler, r
+}
+
+func TestHandler_handleAuthConfig(t *testing.T) {
+	t.Run("reports environment signup block separately from effective signup status", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, true)
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/auth/config", nil)
+
+		handler.handleAuthConfig(recorder, request)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+
+		var response authConfigResponse
+		require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+		assert.False(t, response.SignupEnabled)
+		assert.True(t, response.SignupsBlockedByEnvironment)
+	})
+
+	t.Run("reports admin signup state when environment allows signups", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/auth/config", nil)
+
+		handler.handleAuthConfig(recorder, request)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+
+		var response authConfigResponse
+		require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+		assert.True(t, response.SignupEnabled)
+		assert.False(t, response.SignupsBlockedByEnvironment)
+	})
+}
+
+func TestSignupsEnabledFromMetadata(t *testing.T) {
+	t.Run("defaults to enabled when metadata cannot be loaded", func(t *testing.T) {
+		assert.True(t, signupsEnabledFromMetadata(nil, assert.AnError))
+	})
+
+	t.Run("uses stored installation setting", func(t *testing.T) {
+		assert.True(t, signupsEnabledFromMetadata(&models.InstallationMetadata{SignupsEnabled: true}, nil))
+		assert.False(t, signupsEnabledFromMetadata(&models.InstallationMetadata{SignupsEnabled: false}, nil))
+	})
 }
 
 func TestHandler_findOrCreateAccountForProvider(t *testing.T) {
@@ -260,6 +310,21 @@ func TestHandler_checkSignupPolicy(t *testing.T) {
 		err = handler.checkSignupPolicy(account.Email, req)
 
 		assert.NoError(t, err)
+	})
+
+	t.Run("should reject new account when installation signups are disabled", func(t *testing.T) {
+		handler, _ := setupAuthHandler(t, false)
+		metadata, err := models.GetInstallationMetadata(database.Conn())
+		require.NoError(t, err)
+		metadata.SignupsEnabled = false
+		metadata.UpdatedAt = time.Now()
+		require.NoError(t, models.UpdateInstallationMetadata(database.Conn(), metadata))
+
+		req, _ := http.NewRequest("POST", "/auth/magic-code/verify?signup=true", nil)
+
+		err = handler.checkSignupPolicy("disabled-signup@example.com", req)
+
+		assert.Equal(t, errSignupDisabled, err)
 	})
 }
 

--- a/pkg/models/installation_metadata.go
+++ b/pkg/models/installation_metadata.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/superplanehq/superplane/pkg/database"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -16,24 +15,17 @@ type InstallationMetadata struct {
 	ID                        int    `gorm:"primary_key"`
 	InstallationID            string `gorm:"type:varchar(64)"`
 	AllowPrivateNetworkAccess bool
+	SignupsEnabled            bool
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
 }
 
-func GetInstallationMetadata() (*InstallationMetadata, error) {
-	return GetInstallationMetadataInTransaction(database.Conn())
+func GetInstallationMetadata(tx *gorm.DB) (*InstallationMetadata, error) {
+	return findOrCreateInstallationMetadata(tx)
 }
 
-func GetInstallationID() (string, error) {
-	return GetInstallationIDInTransaction(database.Conn())
-}
-
-func GetInstallationMetadataInTransaction(tx *gorm.DB) (*InstallationMetadata, error) {
-	return findOrCreateInstallationMetadataInTransaction(tx)
-}
-
-func GetInstallationIDInTransaction(tx *gorm.DB) (string, error) {
-	metadata, err := findOrCreateInstallationMetadataInTransaction(tx)
+func GetInstallationID(tx *gorm.DB) (string, error) {
+	metadata, err := findOrCreateInstallationMetadata(tx)
 	if err != nil {
 		return "", err
 	}
@@ -41,12 +33,8 @@ func GetInstallationIDInTransaction(tx *gorm.DB) (string, error) {
 	return metadata.InstallationID, nil
 }
 
-func UpdateInstallationMetadata(metadata *InstallationMetadata) error {
-	return UpdateInstallationMetadataInTransaction(database.Conn(), metadata)
-}
-
-func UpdateInstallationMetadataInTransaction(tx *gorm.DB, metadata *InstallationMetadata) error {
-	if _, err := findOrCreateInstallationMetadataInTransaction(tx); err != nil {
+func UpdateInstallationMetadata(tx *gorm.DB, metadata *InstallationMetadata) error {
+	if _, err := findOrCreateInstallationMetadata(tx); err != nil {
 		return err
 	}
 
@@ -54,12 +42,13 @@ func UpdateInstallationMetadataInTransaction(tx *gorm.DB, metadata *Installation
 		Where("id = ?", installationMetadataID).
 		Updates(map[string]any{
 			"allow_private_network_access": metadata.AllowPrivateNetworkAccess,
+			"signups_enabled":              metadata.SignupsEnabled,
 			"updated_at":                   metadata.UpdatedAt,
 		}).
 		Error
 }
 
-func findOrCreateInstallationMetadataInTransaction(tx *gorm.DB) (*InstallationMetadata, error) {
+func findOrCreateInstallationMetadata(tx *gorm.DB) (*InstallationMetadata, error) {
 	var metadata InstallationMetadata
 	err := tx.Where("id = ?", installationMetadataID).First(&metadata).Error
 	if err == nil {
@@ -72,6 +61,7 @@ func findOrCreateInstallationMetadataInTransaction(tx *gorm.DB) (*InstallationMe
 	metadata = InstallationMetadata{
 		ID:             installationMetadataID,
 		InstallationID: uuid.NewString(),
+		SignupsEnabled: true,
 	}
 
 	if err := tx.Clauses(clause.OnConflict{

--- a/pkg/models/installation_metadata_test.go
+++ b/pkg/models/installation_metadata_test.go
@@ -12,27 +12,30 @@ import (
 func TestGetInstallationMetadata(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 
-	metadata, err := GetInstallationMetadata()
+	metadata, err := GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 	require.NotNil(t, metadata)
 	assert.Equal(t, installationMetadataID, metadata.ID)
 	assert.NotEmpty(t, metadata.InstallationID)
 	assert.False(t, metadata.AllowPrivateNetworkAccess)
+	assert.True(t, metadata.SignupsEnabled)
 }
 
 func TestUpdateInstallationMetadata(t *testing.T) {
 	require.NoError(t, database.TruncateTables())
 
-	metadata, err := GetInstallationMetadata()
+	metadata, err := GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 
 	metadata.AllowPrivateNetworkAccess = true
+	metadata.SignupsEnabled = false
 	metadata.UpdatedAt = time.Now()
 
-	require.NoError(t, UpdateInstallationMetadata(metadata))
+	require.NoError(t, UpdateInstallationMetadata(database.Conn(), metadata))
 
-	updated, err := GetInstallationMetadata()
+	updated, err := GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 	assert.True(t, updated.AllowPrivateNetworkAccess)
+	assert.False(t, updated.SignupsEnabled)
 	assert.Equal(t, metadata.InstallationID, updated.InstallationID)
 }

--- a/pkg/networkpolicy/http.go
+++ b/pkg/networkpolicy/http.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 	"gorm.io/gorm"
 )
@@ -52,9 +53,9 @@ func ResolveHTTPPolicyInTransaction(tx *gorm.DB) (*HTTPPolicy, error) {
 	var metadata *models.InstallationMetadata
 	var err error
 	if tx == nil {
-		metadata, err = models.GetInstallationMetadata()
+		metadata, err = models.GetInstallationMetadata(database.Conn())
 	} else {
-		metadata, err = models.GetInstallationMetadataInTransaction(tx)
+		metadata, err = models.GetInstallationMetadata(tx)
 	}
 
 	if err != nil {

--- a/pkg/networkpolicy/http_test.go
+++ b/pkg/networkpolicy/http_test.go
@@ -72,12 +72,12 @@ func TestResolveHTTPPolicyInTransaction(t *testing.T) {
 
 	errRollback := errors.New("rollback")
 	err := database.Conn().Transaction(func(tx *gorm.DB) error {
-		metadata, err := models.GetInstallationMetadataInTransaction(tx)
+		metadata, err := models.GetInstallationMetadata(tx)
 		require.NoError(t, err)
 
 		metadata.AllowPrivateNetworkAccess = true
 		metadata.UpdatedAt = time.Now()
-		require.NoError(t, models.UpdateInstallationMetadataInTransaction(tx, metadata))
+		require.NoError(t, models.UpdateInstallationMetadata(tx, metadata))
 
 		policy, err := ResolveHTTPPolicyInTransaction(tx)
 		require.NoError(t, err)

--- a/pkg/public/admin.go
+++ b/pkg/public/admin.go
@@ -35,6 +35,8 @@ type paginatedResponse struct {
 
 type installationSettingsResponse struct {
 	AllowPrivateNetworkAccess  bool     `json:"allow_private_network_access"`
+	SignupsEnabled             bool     `json:"signups_enabled"`
+	SignupsBlockedByEnv        bool     `json:"signups_blocked_by_environment"`
 	EffectiveBlockedHTTPHosts  []string `json:"effective_blocked_http_hosts"`
 	EffectivePrivateIPRanges   []string `json:"effective_private_ip_ranges"`
 	BlockedHTTPHostsOverridden bool     `json:"blocked_http_hosts_overridden"`
@@ -51,6 +53,7 @@ type installationSettingsResponse struct {
 
 type installationSettingsRequest struct {
 	AllowPrivateNetworkAccess *bool   `json:"allow_private_network_access"`
+	SignupsEnabled            *bool   `json:"signups_enabled"`
 	SMTPEnabled               *bool   `json:"smtp_enabled"`
 	SMTPHost                  *string `json:"smtp_host"`
 	SMTPPort                  *int    `json:"smtp_port"`
@@ -132,16 +135,23 @@ var errInvalidInstallationSettingsRequest = errors.New("invalid installation set
 
 func (s *Server) updateInstallationSettings(ctx context.Context, req installationSettingsRequest) error {
 	return database.Conn().Transaction(func(tx *gorm.DB) error {
-		if req.AllowPrivateNetworkAccess != nil {
-			metadata, err := models.GetInstallationMetadataInTransaction(tx)
+		if req.AllowPrivateNetworkAccess != nil || req.SignupsEnabled != nil {
+			metadata, err := models.GetInstallationMetadata(tx)
 			if err != nil {
 				return err
 			}
 
-			metadata.AllowPrivateNetworkAccess = *req.AllowPrivateNetworkAccess
+			if req.AllowPrivateNetworkAccess != nil {
+				metadata.AllowPrivateNetworkAccess = *req.AllowPrivateNetworkAccess
+			}
+
+			if req.SignupsEnabled != nil {
+				metadata.SignupsEnabled = *req.SignupsEnabled
+			}
+
 			metadata.UpdatedAt = time.Now()
 
-			if err := models.UpdateInstallationMetadataInTransaction(tx, metadata); err != nil {
+			if err := models.UpdateInstallationMetadata(tx, metadata); err != nil {
 				return err
 			}
 		}
@@ -155,6 +165,11 @@ func (s *Server) updateInstallationSettings(ctx context.Context, req installatio
 }
 
 func (s *Server) buildInstallationSettingsResponse() (installationSettingsResponse, error) {
+	metadata, err := models.GetInstallationMetadata(database.Conn())
+	if err != nil {
+		return installationSettingsResponse{}, err
+	}
+
 	policy, err := networkpolicy.ResolveHTTPPolicy()
 	if err != nil {
 		return installationSettingsResponse{}, err
@@ -162,6 +177,8 @@ func (s *Server) buildInstallationSettingsResponse() (installationSettingsRespon
 
 	response := installationSettingsResponse{
 		AllowPrivateNetworkAccess:  policy.AllowPrivateNetworkAccess,
+		SignupsEnabled:             metadata.SignupsEnabled,
+		SignupsBlockedByEnv:        s.authHandler.SignupsBlockedByEnvironment(),
 		EffectiveBlockedHTTPHosts:  policy.BlockedHosts,
 		EffectivePrivateIPRanges:   policy.PrivateIPRanges,
 		BlockedHTTPHostsOverridden: policy.BlockedHostsOverridden,

--- a/pkg/public/admin_test.go
+++ b/pkg/public/admin_test.go
@@ -146,6 +146,7 @@ func TestAdminInstallationNetworkSettings(t *testing.T) {
 		err := json.Unmarshal(response.Body.Bytes(), &result)
 		require.NoError(t, err)
 		assert.False(t, result.AllowPrivateNetworkAccess)
+		assert.True(t, result.SignupsEnabled)
 		assert.NotEmpty(t, result.EffectiveBlockedHTTPHosts)
 		assert.NotEmpty(t, result.EffectivePrivateIPRanges)
 		assert.False(t, result.SMTPEnabled)
@@ -167,7 +168,7 @@ func TestAdminInstallationNetworkSettings(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, response.Code)
 
-		metadata, err := models.GetInstallationMetadata()
+		metadata, err := models.GetInstallationMetadata(database.Conn())
 		require.NoError(t, err)
 		assert.True(t, metadata.AllowPrivateNetworkAccess)
 
@@ -177,6 +178,32 @@ func TestAdminInstallationNetworkSettings(t *testing.T) {
 		assert.True(t, result.AllowPrivateNetworkAccess)
 		assert.Empty(t, result.EffectiveBlockedHTTPHosts)
 		assert.Empty(t, result.EffectivePrivateIPRanges)
+	})
+
+	t.Run("admin can disable signups through installation settings", func(t *testing.T) {
+		body, err := json.Marshal(map[string]bool{
+			"signups_enabled": false,
+		})
+		require.NoError(t, err)
+
+		response := execRequest(server, requestParams{
+			method:      "PATCH",
+			path:        "/admin/api/installation/network-settings",
+			body:        body,
+			authCookie:  token,
+			contentType: "application/json",
+		})
+
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		metadata, err := models.GetInstallationMetadata(database.Conn())
+		require.NoError(t, err)
+		assert.False(t, metadata.SignupsEnabled)
+
+		var result installationSettingsResponse
+		err = json.Unmarshal(response.Body.Bytes(), &result)
+		require.NoError(t, err)
+		assert.False(t, result.SignupsEnabled)
 	})
 
 	t.Run("admin can read existing smtp settings", func(t *testing.T) {
@@ -278,14 +305,16 @@ func TestAdminInstallationNetworkSettings(t *testing.T) {
 	t.Run("admin installation settings updates are atomic", func(t *testing.T) {
 		require.NoError(t, models.DeleteEmailSettings(models.EmailProviderSMTP))
 
-		metadata, err := models.GetInstallationMetadata()
+		metadata, err := models.GetInstallationMetadata(database.Conn())
 		require.NoError(t, err)
 		metadata.AllowPrivateNetworkAccess = false
+		metadata.SignupsEnabled = true
 		metadata.UpdatedAt = time.Now()
-		require.NoError(t, models.UpdateInstallationMetadata(metadata))
+		require.NoError(t, models.UpdateInstallationMetadata(database.Conn(), metadata))
 
 		body, err := json.Marshal(map[string]any{
 			"allow_private_network_access": true,
+			"signups_enabled":              false,
 			"smtp_enabled":                 true,
 			"smtp_host":                    "smtp.internal",
 			"smtp_port":                    2525,
@@ -306,9 +335,10 @@ func TestAdminInstallationNetworkSettings(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, response.Code)
 
-		metadata, err = models.GetInstallationMetadata()
+		metadata, err = models.GetInstallationMetadata(database.Conn())
 		require.NoError(t, err)
 		assert.False(t, metadata.AllowPrivateNetworkAccess)
+		assert.True(t, metadata.SignupsEnabled)
 
 		_, err = models.FindEmailSettings(models.EmailProviderSMTP)
 		require.Error(t, err)

--- a/pkg/public/setup_owner.go
+++ b/pkg/public/setup_owner.go
@@ -154,7 +154,7 @@ func (s *Server) setupOwner(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		installationMetadata, err := models.GetInstallationMetadataInTransaction(tx)
+		installationMetadata, err := models.GetInstallationMetadata(tx)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func (s *Server) setupOwner(w http.ResponseWriter, r *http.Request) {
 		installationMetadata.AllowPrivateNetworkAccess = req.AllowPrivateNetworkAccess
 		installationMetadata.UpdatedAt = time.Now()
 
-		return models.UpdateInstallationMetadataInTransaction(tx, installationMetadata)
+		return models.UpdateInstallationMetadata(tx, installationMetadata)
 	})
 
 	if err != nil {

--- a/pkg/public/setup_owner_test.go
+++ b/pkg/public/setup_owner_test.go
@@ -57,7 +57,7 @@ func TestSetupOwnerPersistsInstallationNetworkSettings(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	metadata, err := models.GetInstallationMetadata()
+	metadata, err := models.GetInstallationMetadata(database.Conn())
 	require.NoError(t, err)
 	assert.True(t, metadata.AllowPrivateNetworkAccess)
 }

--- a/pkg/telemetry/beacon.go
+++ b/pkg/telemetry/beacon.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/models"
 )
 
@@ -52,7 +53,7 @@ func sendBeacon() {
 		return
 	}
 
-	installationID, err := models.GetInstallationID()
+	installationID, err := models.GetInstallationID(database.Conn())
 	if err != nil {
 		log.WithError(err).Warn("Failed to load installation ID")
 		return

--- a/test/e2e/admin_test.go
+++ b/test/e2e/admin_test.go
@@ -184,7 +184,7 @@ func (s *adminSteps) saveInstallationSettings() {
 }
 
 func (s *adminSteps) assertPrivateNetworkAccessEnabled() {
-	metadata, err := models.GetInstallationMetadata()
+	metadata, err := models.GetInstallationMetadata(database.Conn())
 	require.NoError(s.t, err)
 	assert.True(s.t, metadata.AllowPrivateNetworkAccess)
 }

--- a/test/e2e/owner_setup_test.go
+++ b/test/e2e/owner_setup_test.go
@@ -244,7 +244,7 @@ func (s *ownerSetupSteps) assertOwnerSetupIsNoLongerRequired() {
 }
 
 func (s *ownerSetupSteps) assertPrivateNetworkAccessEnabled() {
-	metadata, err := models.GetInstallationMetadata()
+	metadata, err := models.GetInstallationMetadata(database.Conn())
 	assert.NoError(s.t, err, "load installation metadata")
 	assert.True(s.t, metadata.AllowPrivateNetworkAccess, "expected private network access to be enabled")
 }

--- a/web_src/src/pages/admin/InstallationSettings.tsx
+++ b/web_src/src/pages/admin/InstallationSettings.tsx
@@ -9,6 +9,8 @@ import React, { useCallback, useEffect, useState } from "react";
 
 type InstallationSettingsResponse = {
   allow_private_network_access: boolean;
+  signups_enabled: boolean;
+  signups_blocked_by_environment: boolean;
   effective_blocked_http_hosts: string[];
   effective_private_ip_ranges: string[];
   blocked_http_hosts_overridden: boolean;
@@ -38,7 +40,17 @@ type DerivedState = {
   blockedHosts: string[];
   privateRanges: string[];
   hasNetworkChanges: boolean;
+  hasSignupChanges: boolean;
   hasSMTPChanges: boolean;
+};
+
+type SignupAccessSectionProps = {
+  enabled: boolean;
+  blockedByEnvironment: boolean;
+  hasChanges: boolean;
+  saving: boolean;
+  onChange: (checked: boolean) => void;
+  onSave: () => void;
 };
 
 type NetworkPolicySectionProps = {
@@ -66,6 +78,13 @@ type SMTPFieldsProps = {
   form: SMTPFormState;
   passwordConfigured: boolean;
   onFieldChange: (field: keyof SMTPFormState, value: boolean | string) => void;
+};
+
+type PolicyListProps = {
+  title: string;
+  items: string[];
+  overridden: boolean;
+  emptyMessage: string;
 };
 
 const emptySMTPForm: SMTPFormState = {
@@ -110,6 +129,7 @@ const toSMTPFormState = (data: InstallationSettingsResponse): SMTPFormState => (
 const getDerivedState = (
   settings: InstallationSettingsResponse | null,
   allowPrivateNetworkAccess: boolean,
+  signupsEnabled: boolean,
   form: SMTPFormState,
 ): DerivedState => {
   const hasSMTPSettings = settings?.smtp_enabled ?? false;
@@ -118,6 +138,7 @@ const getDerivedState = (
     blockedHosts: settings?.effective_blocked_http_hosts ?? [],
     privateRanges: settings?.effective_private_ip_ranges ?? [],
     hasNetworkChanges: settings != null && allowPrivateNetworkAccess !== settings.allow_private_network_access,
+    hasSignupChanges: settings != null && signupsEnabled !== settings.signups_enabled,
     hasSMTPChanges:
       settings != null &&
       (form.enabled !== settings.smtp_enabled ||
@@ -129,6 +150,18 @@ const getDerivedState = (
         ((form.enabled || hasSMTPSettings) && form.useTLS !== settings.smtp_use_tls) ||
         form.password !== ""),
   };
+};
+
+const getSignupAccessDescription = (enabled: boolean, blockedByEnvironment: boolean) => {
+  if (enabled && !blockedByEnvironment) {
+    return "New users can create accounts.";
+  }
+
+  if (blockedByEnvironment) {
+    return "The signup page shows the closed-signup notice.";
+  }
+
+  return "The signup page shows the waitlist.";
 };
 
 const buildSMTPRequestBody = (form: SMTPFormState) => {
@@ -154,6 +187,79 @@ const buildSMTPRequestBody = (form: SMTPFormState) => {
   return body;
 };
 
+const SignupAccessSection = ({
+  enabled,
+  blockedByEnvironment,
+  hasChanges,
+  saving,
+  onChange,
+  onSave,
+}: SignupAccessSectionProps) => {
+  const effectiveEnabled = enabled && !blockedByEnvironment;
+
+  return (
+    <section className="border-t border-slate-200 py-6">
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Signup access</p>
+          <h2 className="mt-1 text-base font-semibold text-gray-900">Public signups</h2>
+          <Text className="mt-2 text-sm text-gray-600">
+            Control whether visitors can create new accounts from the signup page. Invite links can still create
+            accounts while public signups are closed.
+          </Text>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 lg:justify-end">
+          <div className="space-y-1 lg:text-right">
+            <p className="text-sm font-medium text-gray-900">{effectiveEnabled ? "Signups open" : "Signups closed"}</p>
+            <Text className="text-xs text-gray-500">{getSignupAccessDescription(enabled, blockedByEnvironment)}</Text>
+          </div>
+          <Switch
+            data-testid="installation-signups-switch"
+            checked={enabled}
+            disabled={blockedByEnvironment}
+            onCheckedChange={onChange}
+          />
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          data-testid="installation-signups-save"
+          onClick={onSave}
+          disabled={saving || !hasChanges || blockedByEnvironment}
+        >
+          {saving ? "Saving..." : "Save signup settings"}
+        </Button>
+        <Text className="text-xs text-gray-500">
+          {blockedByEnvironment
+            ? "`BLOCK_SIGNUP` is active, so public signups remain closed until the environment override is removed."
+            : "When closed, /signup collects waitlist emails instead of creating accounts."}
+        </Text>
+      </div>
+    </section>
+  );
+};
+
+const PolicyList = ({ title, items, overridden, emptyMessage }: PolicyListProps) => (
+  <div className="min-w-0">
+    <h3 className="text-sm font-medium text-gray-900">{title}</h3>
+    <Text className="mt-1 text-xs text-gray-500">
+      {overridden ? "Overridden by environment." : "Resolved from installation settings."}
+    </Text>
+    {items.length === 0 ? (
+      <Text className="mt-3 text-sm text-gray-500">{emptyMessage}</Text>
+    ) : (
+      <ul className="mt-3 max-h-40 space-y-1 overflow-auto font-mono text-xs text-gray-700">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
 const NetworkPolicySection = ({
   allowPrivateNetworkAccess,
   blockedHosts,
@@ -165,94 +271,50 @@ const NetworkPolicySection = ({
   onChange,
   onSave,
 }: NetworkPolicySectionProps) => (
-  <div className="rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-6 shadow-sm">
-    <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+  <section className="border-t border-slate-200 py-6">
+    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
       <div className="max-w-2xl">
-        <div className="inline-flex rounded-full bg-slate-900 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white">
-          Network Policy
-        </div>
-        <h2 className="mt-4 text-lg font-semibold text-gray-900">Private network access</h2>
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Network policy</p>
+        <h2 className="mt-1 text-base font-semibold text-gray-900">Private network access</h2>
         <Text className="mt-2 text-sm text-gray-600">
           Control whether integrations, components, and triggers can reach internal Kubernetes DNS names or private IP
           ranges.
         </Text>
       </div>
 
-      <div
-        className={`rounded-2xl border px-4 py-3 shadow-sm ${
-          allowPrivateNetworkAccess ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50"
-        }`}
-      >
-        <div className="flex items-center gap-4">
-          <div
-            className={`flex h-11 w-11 items-center justify-center rounded-full ${
-              allowPrivateNetworkAccess ? "bg-emerald-500/15" : "bg-amber-500/15"
-            }`}
-          >
-            <span className={`h-3 w-3 rounded-full ${allowPrivateNetworkAccess ? "bg-emerald-600" : "bg-amber-600"}`} />
-          </div>
-
-          <div>
-            <p className="text-sm font-semibold text-gray-900">
-              {allowPrivateNetworkAccess ? "Enabled for private targets" : "Blocked for private targets"}
-            </p>
-            <Text className="mt-1 text-xs text-gray-600">
-              {allowPrivateNetworkAccess
-                ? "SuperPlane can reach internal hosts and private IPs."
-                : "SSRF safeguards remain active for internal hosts and private IPs."}
-            </Text>
-          </div>
-
-          <Switch
-            data-testid="installation-network-switch"
-            checked={allowPrivateNetworkAccess}
-            onCheckedChange={onChange}
-          />
+      <div className="flex items-center justify-between gap-4 lg:justify-end">
+        <div className="space-y-1 lg:text-right">
+          <p className="text-sm font-medium text-gray-900">
+            {allowPrivateNetworkAccess ? "Private access enabled" : "Private access blocked"}
+          </p>
+          <Text className="text-xs text-gray-500">
+            {allowPrivateNetworkAccess ? "Internal hosts can be reached." : "SSRF safeguards remain active."}
+          </Text>
         </div>
+        <Switch
+          data-testid="installation-network-switch"
+          checked={allowPrivateNetworkAccess}
+          onCheckedChange={onChange}
+        />
       </div>
     </div>
 
-    <div className="mt-6">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="min-w-0 flex-1">
-          <h2 className="text-base font-medium text-gray-900">Effective blocked hosts</h2>
-          <Text className="mt-1 text-sm text-gray-500">
-            {blockedHTTPHostsOverridden ? "Overridden by env var." : "Resolved from installation settings."}
-          </Text>
-          <div className="mt-4 rounded-xl border border-slate-200/80 p-4 bg-slate-100">
-            {blockedHosts.length === 0 ? (
-              <Text className="text-sm text-gray-500">No blocked hosts.</Text>
-            ) : (
-              <ul className="space-y-1 font-mono text-xs text-gray-700">
-                {blockedHosts.map((host) => (
-                  <li key={host}>{host}</li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <h2 className="text-base font-medium text-gray-900">Effective blocked private IP ranges</h2>
-          <Text className="mt-1 text-sm text-gray-500">
-            {privateIPRangesOverridden ? "Overridden by env var." : "Resolved from installation settings."}
-          </Text>
-          <div className="mt-4 rounded-xl border border-slate-200/80 p-4 bg-slate-100">
-            {privateRanges.length === 0 ? (
-              <Text className="text-sm text-gray-500">No blocked private IP ranges.</Text>
-            ) : (
-              <ul className="space-y-1 font-mono text-xs text-gray-700">
-                {privateRanges.map((range) => (
-                  <li key={range}>{range}</li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </div>
-      </div>
+    <div className="mt-6 grid gap-6 lg:grid-cols-2">
+      <PolicyList
+        title="Effective blocked hosts"
+        items={blockedHosts}
+        overridden={blockedHTTPHostsOverridden}
+        emptyMessage="No blocked hosts."
+      />
+      <PolicyList
+        title="Effective blocked private IP ranges"
+        items={privateRanges}
+        overridden={privateIPRangesOverridden}
+        emptyMessage="No blocked private IP ranges."
+      />
     </div>
 
-    <div className="mt-6 flex flex-wrap items-center gap-3 border-t border-slate-200 pt-6">
+    <div className="mt-6 flex flex-wrap items-center gap-3">
       <Button type="button" data-testid="installation-network-save" onClick={onSave} disabled={saving || !hasChanges}>
         {saving ? "Saving..." : "Save network settings"}
       </Button>
@@ -267,7 +329,7 @@ const NetworkPolicySection = ({
         </Text>
       )}
     </div>
-  </div>
+  </section>
 );
 
 const SMTPFields = ({ form, passwordConfigured, onFieldChange }: SMTPFieldsProps) => (
@@ -343,63 +405,54 @@ const SMTPFields = ({ form, passwordConfigured, onFieldChange }: SMTPFieldsProps
       </div>
     </div>
 
-    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-      <div className="flex items-center justify-between gap-4">
-        <div>
-          <p className="text-sm font-medium text-gray-900">Use TLS (STARTTLS)</p>
-          <Text className="mt-1 text-xs text-gray-600">
-            Enable transport encryption when connecting to the SMTP server.
-          </Text>
-        </div>
-        <Switch
-          data-testid="installation-smtp-tls-switch"
-          checked={form.useTLS}
-          onCheckedChange={(checked) => onFieldChange("useTLS", checked)}
-        />
+    <div className="flex items-center justify-between gap-4 pt-2">
+      <div>
+        <p className="text-sm font-medium text-gray-900">Use TLS (STARTTLS)</p>
+        <Text className="mt-1 text-xs text-gray-500">
+          Enable transport encryption when connecting to the SMTP server.
+        </Text>
       </div>
+      <Switch
+        data-testid="installation-smtp-tls-switch"
+        checked={form.useTLS}
+        onCheckedChange={(checked) => onFieldChange("useTLS", checked)}
+      />
     </div>
   </div>
 );
 
 const SMTPSection = ({ form, hasChanges, passwordConfigured, saving, onFieldChange, onSave }: SMTPSectionProps) => (
-  <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-    <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+  <section className="border-t border-slate-200 py-6">
+    <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start">
       <div className="max-w-2xl">
-        <div className="inline-flex rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-700">
-          Email Delivery
-        </div>
-        <h2 className="mt-4 text-lg font-semibold text-gray-900">SMTP configuration</h2>
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Email delivery</p>
+        <h2 className="mt-1 text-base font-semibold text-gray-900">SMTP configuration</h2>
         <Text className="mt-2 text-sm text-gray-600">
           Manage the SMTP credentials used for installation-wide notifications and emails.
         </Text>
       </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 shadow-sm">
-        <div className="flex items-center gap-4">
-          <div className="space-y-1">
-            <p className="text-sm font-semibold text-gray-900">{form.enabled ? "SMTP enabled" : "SMTP disabled"}</p>
-            <Text className="text-xs text-gray-600">
-              {form.enabled ? "Emails can be sent from this instance." : "Notification email delivery is turned off."}
-            </Text>
-          </div>
-
-          <Switch
-            data-testid="installation-smtp-switch"
-            checked={form.enabled}
-            onCheckedChange={(checked) => onFieldChange("enabled", checked)}
-          />
+      <div className="flex items-center justify-between gap-4 lg:justify-end">
+        <div className="space-y-1 lg:text-right">
+          <p className="text-sm font-medium text-gray-900">{form.enabled ? "SMTP enabled" : "SMTP disabled"}</p>
+          <Text className="text-xs text-gray-500">
+            {form.enabled ? "Emails can be sent from this instance." : "Notification email delivery is off."}
+          </Text>
         </div>
+        <Switch
+          data-testid="installation-smtp-switch"
+          checked={form.enabled}
+          onCheckedChange={(checked) => onFieldChange("enabled", checked)}
+        />
       </div>
     </div>
 
     {form.enabled ? (
       <SMTPFields form={form} passwordConfigured={passwordConfigured} onFieldChange={onFieldChange} />
     ) : (
-      <div className="mt-6 rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6">
-        <Text className="text-sm text-gray-600">
-          Enable SMTP to configure the installation-wide email provider used by SuperPlane notifications.
-        </Text>
-      </div>
+      <Text className="mt-5 text-sm text-gray-500">
+        Enable SMTP to configure the installation-wide email provider used by SuperPlane notifications.
+      </Text>
     )}
 
     <div className="mt-6 flex items-center gap-3">
@@ -408,7 +461,7 @@ const SMTPSection = ({ form, hasChanges, passwordConfigured, saving, onFieldChan
       </Button>
       <Text className="text-xs text-gray-500">SMTP changes apply to installation-wide email delivery.</Text>
     </div>
-  </div>
+  </section>
 );
 
 const useInstallationSettingsState = () => {
@@ -416,12 +469,15 @@ const useInstallationSettingsState = () => {
   const [loading, setLoading] = useState(true);
   const [allowPrivateNetworkAccess, setAllowPrivateNetworkAccess] = useState(false);
   const [savingNetwork, setSavingNetwork] = useState(false);
+  const [signupsEnabled, setSignupsEnabled] = useState(true);
+  const [savingSignups, setSavingSignups] = useState(false);
   const [smtpForm, setSMTPForm] = useState<SMTPFormState>(emptySMTPForm);
   const [savingSMTP, setSavingSMTP] = useState(false);
 
   const applySettings = useCallback((data: InstallationSettingsResponse) => {
     setSettings(data);
     setAllowPrivateNetworkAccess(data.allow_private_network_access);
+    setSignupsEnabled(data.signups_enabled);
     setSMTPForm(toSMTPFormState(data));
   }, []);
 
@@ -481,6 +537,21 @@ const useInstallationSettingsState = () => {
     }
   }, [allowPrivateNetworkAccess, patchSettings]);
 
+  const saveSignupSettings = useCallback(async () => {
+    setSavingSignups(true);
+    try {
+      await patchSettings(
+        { signups_enabled: signupsEnabled },
+        "Signup settings updated",
+        "Failed to update signup settings",
+      );
+    } catch (error) {
+      showErrorToast(error instanceof Error ? error.message : "Failed to update signup settings");
+    } finally {
+      setSavingSignups(false);
+    }
+  }, [patchSettings, signupsEnabled]);
+
   const saveSMTPSettings = useCallback(async () => {
     setSavingSMTP(true);
     try {
@@ -504,11 +575,15 @@ const useInstallationSettingsState = () => {
     loading,
     allowPrivateNetworkAccess,
     savingNetwork,
+    signupsEnabled,
+    savingSignups,
     smtpForm,
     savingSMTP,
     setAllowPrivateNetworkAccess,
+    setSignupsEnabled,
     setSMTPField,
     saveNetworkSettings,
+    saveSignupSettings,
     saveSMTPSettings,
   };
 };
@@ -519,11 +594,15 @@ const InstallationSettings: React.FC = () => {
     loading,
     allowPrivateNetworkAccess,
     savingNetwork,
+    signupsEnabled,
+    savingSignups,
     smtpForm,
     savingSMTP,
     setAllowPrivateNetworkAccess,
+    setSignupsEnabled,
     setSMTPField,
     saveNetworkSettings,
+    saveSignupSettings,
     saveSMTPSettings,
   } = useInstallationSettingsState();
 
@@ -538,37 +617,48 @@ const InstallationSettings: React.FC = () => {
     );
   }
 
-  const derivedState = getDerivedState(settings, allowPrivateNetworkAccess, smtpForm);
+  const derivedState = getDerivedState(settings, allowPrivateNetworkAccess, signupsEnabled, smtpForm);
 
   return (
-    <div className="space-y-6">
-      <div>
+    <div>
+      <div className="pb-2">
         <h1 className="text-xl font-semibold text-gray-900">Installation Settings</h1>
         <Text className="mt-1 text-sm text-gray-500">
           Configure installation-wide network policy and email delivery for this SuperPlane instance.
         </Text>
       </div>
 
-      <NetworkPolicySection
-        allowPrivateNetworkAccess={allowPrivateNetworkAccess}
-        blockedHosts={derivedState.blockedHosts}
-        blockedHTTPHostsOverridden={settings?.blocked_http_hosts_overridden ?? false}
-        hasChanges={derivedState.hasNetworkChanges}
-        privateRanges={derivedState.privateRanges}
-        privateIPRangesOverridden={settings?.private_ip_ranges_overridden ?? false}
-        saving={savingNetwork}
-        onChange={setAllowPrivateNetworkAccess}
-        onSave={saveNetworkSettings}
-      />
+      <div className="mt-5 bg-white px-6">
+        <SignupAccessSection
+          enabled={signupsEnabled}
+          blockedByEnvironment={settings?.signups_blocked_by_environment ?? false}
+          hasChanges={derivedState.hasSignupChanges}
+          saving={savingSignups}
+          onChange={setSignupsEnabled}
+          onSave={saveSignupSettings}
+        />
 
-      <SMTPSection
-        form={smtpForm}
-        hasChanges={derivedState.hasSMTPChanges}
-        passwordConfigured={settings?.smtp_password_configured ?? false}
-        saving={savingSMTP}
-        onFieldChange={setSMTPField}
-        onSave={saveSMTPSettings}
-      />
+        <NetworkPolicySection
+          allowPrivateNetworkAccess={allowPrivateNetworkAccess}
+          blockedHosts={derivedState.blockedHosts}
+          blockedHTTPHostsOverridden={settings?.blocked_http_hosts_overridden ?? false}
+          hasChanges={derivedState.hasNetworkChanges}
+          privateRanges={derivedState.privateRanges}
+          privateIPRangesOverridden={settings?.private_ip_ranges_overridden ?? false}
+          saving={savingNetwork}
+          onChange={setAllowPrivateNetworkAccess}
+          onSave={saveNetworkSettings}
+        />
+
+        <SMTPSection
+          form={smtpForm}
+          hasChanges={derivedState.hasSMTPChanges}
+          passwordConfigured={settings?.smtp_password_configured ?? false}
+          saving={savingSMTP}
+          onFieldChange={setSMTPField}
+          onSave={saveSMTPSettings}
+        />
+      </div>
     </div>
   );
 };

--- a/web_src/src/pages/auth/Login.tsx
+++ b/web_src/src/pages/auth/Login.tsx
@@ -20,11 +20,13 @@ import {
 } from "@/lib/signupAnalytics";
 import { buildMagicLinkVerifyRequest } from "./magicLinkVerifyRequest";
 import { getAuthRedirectURL, getWelcomeRedirectPath } from "./authRedirect";
+import { SignupWaitlist } from "./SignupWaitlist";
 
 type AuthConfig = {
   providers: string[];
   passwordLoginEnabled: boolean;
   signupEnabled: boolean;
+  signupsBlockedByEnvironment: boolean;
   magicCodeEnabled: boolean;
 };
 
@@ -76,13 +78,22 @@ const providerAuthPath = (provider: string, redirectQuery: string, isSignupMode:
 
 type MagicCodeStep = "email" | "code";
 type AuthMode = "login" | "signup";
+type SignupUnavailableReason = "closed" | "waitlist" | null;
 
 interface LoginProps {
   mode?: AuthMode;
 }
 
-const getAuthErrorMessage = (authError: string | null) => {
+const getAuthErrorMessage = (authError: string | null, signupUnavailableReason: SignupUnavailableReason) => {
   if (authError === "signup_required") {
+    if (signupUnavailableReason === "waitlist") {
+      return "No account exists for that provider yet. Join the waitlist to request access.";
+    }
+
+    if (signupUnavailableReason === "closed") {
+      return "No account exists for that provider yet. Signups are not available right now.";
+    }
+
     return "No account exists for that provider yet. Create an account to continue.";
   }
 
@@ -106,6 +117,13 @@ const ProductUpdatesOptIn: React.FC<{
     />
     <span>I want to receive product updates</span>
   </label>
+);
+
+const SignupClosedNotice: React.FC = () => (
+  <p className="text-left text-sm leading-6 text-gray-600">
+    This installation is not accepting new account signups right now. Contact your SuperPlane administrator if you need
+    access.
+  </p>
 );
 
 const saveSignupPreference = (enabled: boolean, productUpdatesOptIn: boolean, email?: string) => {
@@ -226,7 +244,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const [authConfig, setAuthConfig] = useState<AuthConfig>({
     providers: [],
     passwordLoginEnabled: false,
-    signupEnabled: false,
+    signupEnabled: true,
+    signupsBlockedByEnvironment: false,
     magicCodeEnabled: false,
   });
   const [configLoading, setConfigLoading] = useState(true);
@@ -267,7 +286,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
   const magicLinkToken = searchParams.get("magic_link_token");
   const redirectTarget = safeRedirect || "";
-  const authErrorMessage = getAuthErrorMessage(searchParams.get("auth_error"));
+  const authError = searchParams.get("auth_error");
 
   const handleRedirectAfterAuth = useCallback(
     async (response: Response, authRedirectURL?: string) => {
@@ -382,6 +401,7 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             providers: data.providers || [],
             passwordLoginEnabled: Boolean(data.passwordLoginEnabled),
             signupEnabled: Boolean(data.signupEnabled),
+            signupsBlockedByEnvironment: Boolean(data.signupsBlockedByEnvironment),
             magicCodeEnabled: Boolean(data.magicCodeEnabled),
           });
         }
@@ -419,6 +439,11 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
   const showProviderButtons = hasProviders && (!isSignupMode || canSignup);
   const canUseMagicCode = authConfig.magicCodeEnabled && (!isSignupMode || canSignup);
   const useMagicCodePrimary = canUseMagicCode && !showPasswordLogin;
+  const showSignupUnavailable = !configLoading && isSignupMode && !canSignup;
+  const showSignupWaitlist = showSignupUnavailable && !authConfig.signupsBlockedByEnvironment;
+  const showSignupClosedNotice = showSignupUnavailable && authConfig.signupsBlockedByEnvironment;
+  const signupUnavailableReason = showSignupWaitlist ? "waitlist" : showSignupClosedNotice ? "closed" : null;
+  const authErrorMessage = getAuthErrorMessage(authError, signupUnavailableReason);
   const showStandaloneProductUpdatesOptIn =
     isSignupMode && canSignup && magicCodeStep === "email" && !canSignupWithPassword && !useMagicCodePrimary;
   const visibleFormError = formError ?? authErrorMessage;
@@ -626,11 +651,15 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
 
   const getHeading = () => {
     if (useMagicCodePrimary && magicCodeStep === "code") return "Check your email";
+    if (showSignupClosedNotice) return "Signups are closed";
+    if (showSignupWaitlist) return "SuperPlane Cloud";
     if (isSignupMode) return "Create your account";
     return "Welcome to SuperPlane";
   };
 
   const getSubheading = () => {
+    if (showSignupClosedNotice) return "New accounts are not available.";
+    if (showSignupWaitlist) return "Join the waitlist for access.";
     if (isSignupMode) return "Set up your account.";
     if (useMagicCodePrimary && magicCodeStep === "code") return `We sent a code to ${magicCodeEmail}`;
     return "Log in to continue";
@@ -654,9 +683,8 @@ export const Login: React.FC<LoginProps> = ({ mode = "login" }) => {
             </div>
           )}
 
-          {!configLoading && isSignupMode && !canSignup && (
-            <p className="text-sm text-gray-500">Signups are currently disabled.</p>
-          )}
+          {!configLoading && showSignupWaitlist && <SignupWaitlist />}
+          {!configLoading && showSignupClosedNotice && <SignupClosedNotice />}
 
           {!configLoading && !isSignupMode && !hasAnyFormMethod && (
             <p className="text-sm text-gray-500">No login methods are configured.</p>

--- a/web_src/src/pages/auth/SignupWaitlist.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.tsx
@@ -1,0 +1,61 @@
+import type React from "react";
+import { useEffect } from "react";
+import { Text } from "@/components/Text/text";
+
+const mailerLiteScriptID = "mailerlite-universal-script";
+const mailerLiteAccountID = "1905484";
+
+type MailerLiteClient = {
+  (...args: unknown[]): void;
+  q?: unknown[][];
+};
+
+type MailerLiteWindow = Window & {
+  ml?: MailerLiteClient;
+};
+
+const ensureMailerLiteClient = () => {
+  const win = window as MailerLiteWindow;
+  if (win.ml) {
+    return win.ml;
+  }
+
+  const queuedClient: MailerLiteClient = (...args: unknown[]) => {
+    queuedClient.q = queuedClient.q || [];
+    queuedClient.q.push(args);
+  };
+
+  win.ml = queuedClient;
+  return queuedClient;
+};
+
+const loadMailerLiteScript = () => {
+  if (document.getElementById(mailerLiteScriptID)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.id = mailerLiteScriptID;
+  script.async = true;
+  script.src = "https://assets.mailerlite.com/js/universal.js";
+  document.head.appendChild(script);
+};
+
+export const SignupWaitlist: React.FC = () => {
+  useEffect(() => {
+    const ml = ensureMailerLiteClient();
+    loadMailerLiteScript();
+    ml("account", mailerLiteAccountID);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <Text className="text-left text-sm leading-6 text-gray-600">
+        We are opening access gradually while demand is high. Leave your email and we will send an invite as soon as
+        capacity is available.
+      </Text>
+
+      <div className="ml-embedded -mx-5" data-form="BwOnd2" />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a persisted installation-level signups_enabled setting with migration and admin API support
- expose a Signup Access section in Installation Settings to close public signups
- show the MailerLite waitlist form on /signup when public signups are closed

## Tests
- make format.go
- make format.js
- make db.migrate.all
- make test PKG_TEST_PACKAGES='./pkg/models ./pkg/authentication ./pkg/public'
- make check.lint.ui
- make check.build.ui
- make lint && make check.build.app
- make check.db.structure