### PR TITLE
fix: stop staged spec reads for published canvas versions

### DIFF
--- a/pkg/grpc/actions/canvases/repository_spec_files.go
+++ b/pkg/grpc/actions/canvases/repository_spec_files.go
@@ -99,10 +99,14 @@ func readRepositorySpecFile(
 	}
 
 	if stage {
-		if err := ensureStagedReadAllowed(ctx, version); err != nil {
+		if version.State != models.CanvasVersionStateDraft {
+			stage = false
+		} else if err := ensureStagedReadAllowed(ctx, version); err != nil {
 			return "", err
 		}
+	}
 
+	if stage {
 		_, rows, stagingErr := stagingSummaryForVersion(version.ID)
 		if stagingErr != nil {
 			return "", stagingErr

--- a/pkg/grpc/actions/canvases/workflow_staging.go
+++ b/pkg/grpc/actions/canvases/workflow_staging.go
@@ -232,6 +232,10 @@ func ReadStagedRepositoryFile(
 		return "", false, false, err
 	}
 
+	if version.State != models.CanvasVersionStateDraft {
+		return "", false, false, nil
+	}
+
 	if err := ensureStagedReadAllowed(ctx, version); err != nil {
 		return "", false, false, err
 	}

--- a/pkg/grpc/actions/canvases/workflow_staging_handlers_test.go
+++ b/pkg/grpc/actions/canvases/workflow_staging_handlers_test.go
@@ -205,3 +205,28 @@ func TestStagedReadRequiresDraftOwner(t *testing.T) {
 	_, err = ReadRepositorySpecFileStaged(otherCtx, orgID, canvasID, versionID, CanvasYAMLRepositoryPath)
 	require.Error(t, err)
 }
+
+func TestReadRepositorySpecFileStagedPublishedVersionReturnsCommitted(t *testing.T) {
+	r, ctx, canvasID, versionID := setupStagingDraft(t)
+	orgID := r.Organization.ID.String()
+
+	committed, err := ReadRepositorySpecFile(ctx, orgID, canvasID, versionID, CanvasYAMLRepositoryPath)
+	require.NoError(t, err)
+
+	_, err = PublishCanvasVersion(
+		ctx,
+		r.Encryptor,
+		r.Registry,
+		r.GitProvider,
+		orgID,
+		canvasID,
+		versionID,
+		testWebhookBaseURL,
+		r.AuthService,
+	)
+	require.NoError(t, err)
+
+	stagedRead, err := ReadRepositorySpecFileStaged(ctx, orgID, canvasID, versionID, CanvasYAMLRepositoryPath)
+	require.NoError(t, err)
+	assert.Equal(t, committed, stagedRead)
+}

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -55,7 +55,7 @@ import { withOrganizationHeader } from "../lib/withOrganizationHeader";
 import { registerLocalStagingWrite } from "../lib/canvasStagingEcho";
 import { draftVersionId } from "../lib/draftVersion";
 import { analytics } from "../lib/analytics";
-import { isPublishedVersion } from "../pages/app/lib/canvas-versions";
+import { isDraftVersion, isPublishedVersion } from "../pages/app/lib/canvas-versions";
 import {
   canvasVersionWithSpecFromYaml,
   fetchCanvasVersionWithSpec,
@@ -402,18 +402,27 @@ export const useInfiniteCanvasLiveVersions = (
   });
 };
 
+function resolveCanvasVersionStage(stage: boolean | CanvasesCanvasVersion | null | undefined): boolean {
+  if (typeof stage === "boolean") {
+    return stage;
+  }
+
+  return !!stage && isDraftVersion(stage);
+}
+
 export const useCanvasVersion = (
   organizationId: string,
   canvasId: string,
   versionId: string,
   enabled = true,
-  stage = false,
+  stage: boolean | CanvasesCanvasVersion | null = false,
 ) => {
+  const readStaged = resolveCanvasVersionStage(stage);
   return useQuery({
-    queryKey: stage
+    queryKey: readStaged
       ? canvasKeys.versionStagedDetail(canvasId, versionId)
       : canvasKeys.versionDetail(canvasId, versionId),
-    queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId, stage),
+    queryFn: async () => fetchCanvasVersionWithSpec(canvasId, versionId, readStaged),
     enabled: !!organizationId && !!canvasId && !!versionId && enabled,
   });
 };

--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -239,8 +239,8 @@ export const canvasKeys = {
   consoleAll: (canvasId: string) => [...canvasKeys.all, "console", canvasId] as const,
   repository: (canvasId: string) => [...canvasKeys.all, "repository", canvasId] as const,
   repositoryFiles: (canvasId: string) => [...canvasKeys.repository(canvasId), "files"] as const,
-  repositoryFile: (canvasId: string, path: string, versionId?: string) =>
-    [...canvasKeys.repository(canvasId), "file", path, versionId ?? "live"] as const,
+  repositoryFile: (canvasId: string, path: string, versionId?: string, stage = false) =>
+    [...canvasKeys.repository(canvasId), "file", path, versionId ?? "live", stage ? "staged" : "committed"] as const,
   // Raw repository-file content keyed per stage so cached reads can be reused
   // and deduped (e.g. the Files diff and committed-baseline lookups). It
   // prefix-extends `repositoryFile`, so any invalidation of a file (or the
@@ -1787,10 +1787,13 @@ export const useUpdateCanvasConsole = (
 export type CanvasConsoleQueryResult = ReturnType<typeof useCanvasConsole>;
 export type UpdateCanvasConsoleMutationResult = ReturnType<typeof useUpdateCanvasConsole>;
 
-async function fetchRepositoryFileContent(canvasId: string, path: string, versionId?: string): Promise<string> {
-  // Draft file reads (versionId present) return effective staged content so the
-  // Files tab reflects uncommitted edits.
-  return fetchRepositorySpecFileContent(canvasId, path, versionId, !!versionId);
+async function fetchRepositoryFileContent(
+  canvasId: string,
+  path: string,
+  versionId?: string,
+  stage = false,
+): Promise<string> {
+  return fetchRepositorySpecFileContent(canvasId, path, versionId, stage);
 }
 
 // fetchRepositoryFileContentCached reads raw repository-file content through the
@@ -1853,12 +1856,13 @@ export const useCanvasRepositoryFile = (
   path: string | null,
   enabled: boolean = true,
   versionId?: string,
+  stage = false,
 ) => {
   const normalizedPath = path ?? "";
   return useQuery({
-    queryKey: canvasKeys.repositoryFile(canvasId, normalizedPath, versionId),
+    queryKey: canvasKeys.repositoryFile(canvasId, normalizedPath, versionId, stage),
     queryFn: async () => {
-      const content = await fetchRepositoryFileContent(canvasId, normalizedPath, versionId);
+      const content = await fetchRepositoryFileContent(canvasId, normalizedPath, versionId, stage);
       return {
         path: normalizedPath,
         content,

--- a/web_src/src/hooks/useCanvasWebsocket.spec.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.spec.ts
@@ -342,7 +342,9 @@ describe("useCanvasWebsocket", () => {
     expect(stagedPredicate).toBeDefined();
     expect(stagedPredicate({ queryKey: canvasKeys.versionStagedDetail(testCanvasId, "version-1") })).toBe(true);
     expect(stagedPredicate({ queryKey: canvasKeys.consoleStaged(testCanvasId, "version-1") })).toBe(true);
-    expect(stagedPredicate({ queryKey: canvasKeys.repositoryFile(testCanvasId, "README.md", "version-1") })).toBe(true);
+    expect(stagedPredicate({ queryKey: canvasKeys.repositoryFile(testCanvasId, "README.md", "version-1", true) })).toBe(
+      true,
+    );
     expect(
       stagedPredicate({ queryKey: canvasKeys.repositoryFileContent(testCanvasId, "README.md", "version-1", true) }),
     ).toBe(true);

--- a/web_src/src/hooks/useCanvasWebsocket.ts
+++ b/web_src/src/hooks/useCanvasWebsocket.ts
@@ -61,11 +61,13 @@ function queryKeyStartsWith(queryKey: readonly unknown[], prefix: readonly unkno
 
 function isDraftRepositoryFileQuery(queryKey: readonly unknown[], canvasId: string, versionId: string): boolean {
   const repositoryPrefix = canvasKeys.repository(canvasId);
+  const fileSegmentIndex = repositoryPrefix.length;
   return (
     queryKeyStartsWith(queryKey, repositoryPrefix) &&
-    queryKey.length === repositoryPrefix.length + 3 &&
-    queryKey[repositoryPrefix.length] === "file" &&
-    queryKey[repositoryPrefix.length + 2] === versionId
+    queryKey.length === repositoryPrefix.length + 4 &&
+    queryKey[fileSegmentIndex] === "file" &&
+    queryKey[fileSegmentIndex + 2] === versionId &&
+    queryKey[fileSegmentIndex + 3] === "staged"
   );
 }
 

--- a/web_src/src/pages/app/files/useCatalog.ts
+++ b/web_src/src/pages/app/files/useCatalog.ts
@@ -83,6 +83,7 @@ export function useRepositorySelectedFileQuery(
   repositoryPathSet: Set<string>,
   generatedFilesByPath: Map<string, AppFile>,
   versionId?: string,
+  stage = false,
 ) {
   const selectedGeneratedFile = selectedPath ? generatedFilesByPath.get(selectedPath) : undefined;
   const selectedPathExistsInRepository = selectedPath ? repositoryPathSet.has(selectedPath) : false;
@@ -91,6 +92,7 @@ export function useRepositorySelectedFileQuery(
     selectedPath,
     !!selectedPath && selectedPathExistsInRepository && !selectedGeneratedFile,
     versionId,
+    stage,
   );
 
   return { selectedGeneratedFile, selectedPathExistsInRepository, selectedFileQuery };

--- a/web_src/src/pages/app/files/useCatalog.ts
+++ b/web_src/src/pages/app/files/useCatalog.ts
@@ -77,14 +77,23 @@ export function useRepositoryPathLists(
   return { allPaths, visiblePaths, finalRepositoryPaths, commitPathError };
 }
 
-export function useRepositorySelectedFileQuery(
-  canvasId: string | undefined,
-  selectedPath: string | null,
-  repositoryPathSet: Set<string>,
-  generatedFilesByPath: Map<string, AppFile>,
-  versionId?: string,
+type UseRepositorySelectedFileQueryOptions = {
+  canvasId?: string;
+  selectedPath: string | null;
+  repositoryPathSet: Set<string>;
+  generatedFilesByPath: Map<string, AppFile>;
+  versionId?: string;
+  stage?: boolean;
+};
+
+export function useRepositorySelectedFileQuery({
+  canvasId,
+  selectedPath,
+  repositoryPathSet,
+  generatedFilesByPath,
+  versionId,
   stage = false,
-) {
+}: UseRepositorySelectedFileQueryOptions) {
   const selectedGeneratedFile = selectedPath ? generatedFilesByPath.get(selectedPath) : undefined;
   const selectedPathExistsInRepository = selectedPath ? repositoryPathSet.has(selectedPath) : false;
   const selectedFileQuery = useCanvasRepositoryFile(

--- a/web_src/src/pages/app/files/useEditor.ts
+++ b/web_src/src/pages/app/files/useEditor.ts
@@ -100,6 +100,7 @@ export function useEditor({
     effectiveRepositoryPathSet,
     catalog.generatedFilesByPath,
     versionId,
+    isEditing,
   );
 
   useEditorLifecycle({

--- a/web_src/src/pages/app/files/useEditor.ts
+++ b/web_src/src/pages/app/files/useEditor.ts
@@ -94,14 +94,14 @@ export function useEditor({
   const tabs = useFilesTabState(pathLists.allPaths, catalog.generatedPaths, catalog.filesQuery.isLoading);
   openFileRef.current = tabs.openFile;
 
-  const selection = useRepositorySelectedFileQuery(
+  const selection = useRepositorySelectedFileQuery({
     canvasId,
-    tabs.selectedPath,
-    effectiveRepositoryPathSet,
-    catalog.generatedFilesByPath,
+    selectedPath: tabs.selectedPath,
+    repositoryPathSet: effectiveRepositoryPathSet,
+    generatedFilesByPath: catalog.generatedFilesByPath,
     versionId,
-    isEditing,
-  );
+    stage: isEditing,
+  });
 
   useEditorLifecycle({
     canvasId,

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -411,11 +411,18 @@ export function AppPage() {
     return canvasVersions.find(isPublishedVersion)?.metadata?.id;
   }, [liveCanvasVersionId, paginatedVersions, canvasVersions]);
   const activeCanvasVersionId = activeCanvasVersion?.metadata?.id || "";
+  const shouldStageActiveVersionRead = !!activeCanvasVersion && isDraftVersion(activeCanvasVersion);
   const {
     data: loadedCanvasVersion,
     isLoading: loadedCanvasVersionLoading,
     isFetching: loadedCanvasVersionFetching,
-  } = useCanvasVersion(organizationId!, canvasId!, activeCanvasVersionId, !!activeCanvasVersionId, true);
+  } = useCanvasVersion(
+    organizationId!,
+    canvasId!,
+    activeCanvasVersionId,
+    !!activeCanvasVersionId,
+    shouldStageActiveVersionRead,
+  );
   const selectedCanvasVersion = activeCanvasVersionId ? loadedCanvasVersion || activeCanvasVersion : null;
   const latestDraftVersion = draftVersions[0];
   const isViewingDraftVersion = !!selectedCanvasVersion && isDraftVersion(selectedCanvasVersion);

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -411,18 +411,11 @@ export function AppPage() {
     return canvasVersions.find(isPublishedVersion)?.metadata?.id;
   }, [liveCanvasVersionId, paginatedVersions, canvasVersions]);
   const activeCanvasVersionId = activeCanvasVersion?.metadata?.id || "";
-  const shouldStageActiveVersionRead = !!activeCanvasVersion && isDraftVersion(activeCanvasVersion);
   const {
     data: loadedCanvasVersion,
     isLoading: loadedCanvasVersionLoading,
     isFetching: loadedCanvasVersionFetching,
-  } = useCanvasVersion(
-    organizationId!,
-    canvasId!,
-    activeCanvasVersionId,
-    !!activeCanvasVersionId,
-    shouldStageActiveVersionRead,
-  );
+  } = useCanvasVersion(organizationId!, canvasId!, activeCanvasVersionId, !!activeCanvasVersionId, activeCanvasVersion);
   const selectedCanvasVersion = activeCanvasVersionId ? loadedCanvasVersion || activeCanvasVersion : null;
   const latestDraftVersion = draftVersions[0];
   const isViewingDraftVersion = !!selectedCanvasVersion && isDraftVersion(selectedCanvasVersion);

--- a/web_src/src/pages/app/useAppDraftStagingData.ts
+++ b/web_src/src/pages/app/useAppDraftStagingData.ts
@@ -81,6 +81,7 @@ export function useAppDraftStagingData({
     hasDraftGraphDiffVersusLive,
     suppressUnpublishedDraftDiscard,
     enabled: true,
+    stageActiveConsole: hasEditableVersion,
     registerIgnoredCanvasVersionUpdatedEcho,
     getConsoleMutationGeneration,
   });

--- a/web_src/src/pages/app/useCanvasConsoleVersionDiff.ts
+++ b/web_src/src/pages/app/useCanvasConsoleVersionDiff.ts
@@ -45,6 +45,7 @@ type UseCanvasConsoleVersionDiffArgs = {
   hasDraftGraphDiffVersusLive: boolean;
   suppressUnpublishedDraftDiscard: boolean;
   enabled: boolean;
+  stageActiveConsole: boolean;
   registerIgnoredCanvasVersionUpdatedEcho?: (savingVersionId?: string) => () => void;
   getConsoleMutationGeneration?: () => number;
 };
@@ -55,13 +56,13 @@ export function useCanvasConsoleVersionDiff({
   hasDraftGraphDiffVersusLive,
   suppressUnpublishedDraftDiscard,
   enabled,
+  stageActiveConsole,
   registerIgnoredCanvasVersionUpdatedEcho,
   getConsoleMutationGeneration,
 }: UseCanvasConsoleVersionDiffArgs) {
-  // The active console drives the editor, so it is fetched with stage=true and
-  // therefore carries the effective draft: committed changes plus the
-  // uncommitted staged edits the editor is showing.
-  const consoleQuery = useCanvasConsole(canvasId, versionIds.active || undefined, enabled, true);
+  // The active console drives the editor. Staged reads (stage=true) apply only
+  // while editing a draft; published version previews use committed content.
+  const consoleQuery = useCanvasConsole(canvasId, versionIds.active || undefined, enabled, stageActiveConsole);
   const draftDiffVersionId = versionIds.active || versionIds.draft;
   // Committed draft console (stage=false) is the publish basis: only committed
   // changes get promoted to live, so the publishable indicators below diff this


### PR DESCRIPTION
## Summary
- Only send `stage=true` for canvas.yaml/console.yaml reads while editing a draft, not when previewing historical published versions
- Fall back to committed content on the server when a staged read targets a published version

Fixes #5532

## Test plan
- [x] Preview historical published versions in edit mode — no 500s on spec file reads
- [x] Draft editing still loads staged canvas.yaml/console.yaml content
- [x] Backend test for staged read on published version