### PR TITLE
chore: use lateral joins for latest per-node canvas status queries

### DIFF
--- a/pkg/models/canvas_event.go
+++ b/pkg/models/canvas_event.go
@@ -422,21 +422,24 @@ func (e *CanvasEvent) RoutedInTransaction(tx *gorm.DB) error {
 	return tx.Save(e).Error
 }
 
-// FindLastEventPerNode finds the most recent event for each node in a workflow
-// using DISTINCT ON to get one event per node_id, ordered by created_at DESC
-// Only returns events for nodes that have not been deleted
+// FindLastEventPerNode finds the most recent event for each node in a workflow.
+// Only returns events for nodes that have not been deleted.
 func FindLastEventPerNode(tx *gorm.DB, canvasID uuid.UUID) ([]CanvasEvent, error) {
 	var events []CanvasEvent
 	err := tx.
 		Raw(`
-			SELECT DISTINCT ON (we.node_id) we.*
-			FROM workflow_events we
-			INNER JOIN workflow_nodes wn
-				ON we.workflow_id = wn.workflow_id
-				AND we.node_id = wn.node_id
-			WHERE we.workflow_id = ?
-			AND wn.deleted_at IS NULL
-			ORDER BY we.node_id, we.created_at DESC
+			SELECT we.*
+			FROM workflow_nodes wn
+			INNER JOIN LATERAL (
+				SELECT *
+				FROM workflow_events
+				WHERE workflow_id = wn.workflow_id
+				  AND node_id = wn.node_id
+				ORDER BY created_at DESC
+				LIMIT 1
+			) we ON true
+			WHERE wn.workflow_id = ?
+			  AND wn.deleted_at IS NULL
 		`, canvasID).
 		Scan(&events).
 		Error

--- a/pkg/models/canvas_node_execution.go
+++ b/pkg/models/canvas_node_execution.go
@@ -652,21 +652,24 @@ func (e *CanvasNodeExecution) CreateRequest(tx *gorm.DB, reqType string, spec No
 	}).Error
 }
 
-// FindLastExecutionPerNode finds the most recent execution for each node in a workflow
-// using DISTINCT ON to get one execution per node_id, ordered by created_at DESC
-// Only returns executions for nodes that have not been deleted
+// FindLastExecutionPerNode finds the most recent execution for each node in a workflow.
+// Only returns executions for nodes that have not been deleted.
 func FindLastExecutionPerNode(tx *gorm.DB, workflowID uuid.UUID) ([]CanvasNodeExecution, error) {
 	var executions []CanvasNodeExecution
 	err := tx.
 		Raw(`
-			SELECT DISTINCT ON (wne.node_id) wne.*
-			FROM workflow_node_executions wne
-			INNER JOIN workflow_nodes wn
-				ON wne.workflow_id = wn.workflow_id
-				AND wne.node_id = wn.node_id
-			WHERE wne.workflow_id = ?
-			AND wn.deleted_at IS NULL
-			ORDER BY wne.node_id, wne.created_at DESC
+			SELECT wne.*
+			FROM workflow_nodes wn
+			INNER JOIN LATERAL (
+				SELECT *
+				FROM workflow_node_executions
+				WHERE workflow_id = wn.workflow_id
+				  AND node_id = wn.node_id
+				ORDER BY created_at DESC
+				LIMIT 1
+			) wne ON true
+			WHERE wn.workflow_id = ?
+			  AND wn.deleted_at IS NULL
 		`, workflowID).
 		Scan(&executions).
 		Error


### PR DESCRIPTION
## Summary
- Rewrites `FindLastExecutionPerNode` and `FindLastEventPerNode` to use `LATERAL ... ORDER BY created_at DESC LIMIT 1` instead of `DISTINCT ON` over full canvas history
- Speeds up `canvases.load_status` in `DescribeCanvas` by scaling with node count rather than total execution/event history

## Test plan
- [x] `make test PKG_TEST_PACKAGES=./pkg/grpc/actions/canvases/...`
- [ ] Run `EXPLAIN ANALYZE` on prod for a slow canvas and confirm per-node index lookups replace full-history sort
- [ ] Verify `DescribeCanvas` returns the same last execution/event per node in the UI


Made with [Cursor](https://cursor.com)