### PR TITLE
fix: hide waitlist email copy without embed config

### DIFF
--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
@@ -61,20 +61,6 @@ describe("VersionsTabPanel", () => {
     expect(screen.queryByTestId("canvas-create-draft-button")).not.toBeInTheDocument();
   });
 
-  it("renders the git-backed footer with a copy clone command action", () => {
-    render(
-      <VersionsTabPanel
-        liveVersions={[]}
-        canUpdateCanvas={true}
-        canvasDeletedRemotely={false}
-        onUseVersion={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByTestId("versions-sidebar-footer")).toBeInTheDocument();
-    expect(screen.getByTestId("versions-sidebar-copy-clone-command")).toBeInTheDocument();
-  });
-
   it("selects a version when a row is clicked", () => {
     const onUseVersion = vi.fn();
 

--- a/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
+++ b/web_src/src/components/CanvasToolSidebar/VersionsTabPanel.tsx
@@ -1,7 +1,5 @@
 import type { CanvasesCanvasVersion } from "@/api-client";
-import { useCallback } from "react";
-import { Copy, GitBranch, Plus } from "lucide-react";
-import { toast } from "sonner";
+import { Plus } from "lucide-react";
 import type { DraftBranchEditStatus } from "@/pages/app/lib/draft-branch-edit-status";
 import { draftBranchName, draftVersionId } from "@/lib/draftVersion";
 import { cn } from "@/lib/utils";
@@ -112,42 +110,6 @@ export function VersionsTabPanel({
           )}
         </section>
       </div>
-
-      <VersionsFooter />
-    </div>
-  );
-}
-
-// Placeholder until the canvas repository clone URL is wired through the API.
-const PLACEHOLDER_CLONE_COMMAND = "git clone <canvas-repository-url>";
-
-function VersionsFooter() {
-  const handleCopyCloneCommand = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(PLACEHOLDER_CLONE_COMMAND);
-      toast.success("Clone command copied");
-    } catch {
-      toast.error("Failed to copy clone command");
-    }
-  }, []);
-
-  return (
-    <div className="shrink-0 border-t border-slate-200 px-4 py-3" data-testid="versions-sidebar-footer">
-      <div className="flex items-center gap-1.5 text-xs font-medium text-slate-600">
-        <GitBranch className="size-3.5 text-slate-500" aria-hidden />
-        <span>This canvas is git-backed</span>
-      </div>
-      <Button
-        type="button"
-        variant="outline"
-        onClick={handleCopyCloneCommand}
-        className="mt-2 flex h-auto w-full items-center justify-between gap-2 rounded border-slate-200 bg-slate-50 px-2 py-1.5 text-left text-xs font-normal text-slate-700 shadow-none hover:bg-slate-100"
-        data-testid="versions-sidebar-copy-clone-command"
-        title="Copy clone command"
-      >
-        <code className="min-w-0 flex-1 truncate font-mono text-[11px]">{PLACEHOLDER_CLONE_COMMAND}</code>
-        <Copy className="size-3.5 shrink-0 text-slate-500" aria-hidden />
-      </Button>
     </div>
   );
 }

--- a/web_src/src/pages/auth/SignupWaitlist.spec.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { SignupWaitlist } from "./SignupWaitlist";
@@ -25,6 +25,7 @@ describe("SignupWaitlist", () => {
     const { container } = render(<SignupWaitlist />);
 
     expect(container.querySelector(".ml-embedded")).toBeNull();
+    expect(screen.queryByText(/Leave your email/)).toBeNull();
     expect(document.getElementById("mailerlite-universal-script")).toBeNull();
   });
 
@@ -35,6 +36,7 @@ describe("SignupWaitlist", () => {
     const { container } = render(<SignupWaitlist />);
 
     expect(container.querySelector(".ml-embedded")).toHaveAttribute("data-form", "form-1");
+    expect(screen.getByText(/Leave your email/)).toBeInTheDocument();
     await waitFor(() => {
       expect(document.getElementById("mailerlite-universal-script")).toHaveAttribute(
         "src",

--- a/web_src/src/pages/auth/SignupWaitlist.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.tsx
@@ -63,6 +63,7 @@ export const SignupWaitlist: React.FC = () => {
   const mailerLiteConfig = getMailerLiteConfig();
   const mailerLiteAccountID = mailerLiteConfig?.accountID;
   const mailerLiteFormID = mailerLiteConfig?.formID;
+  const hasMailerLiteForm = Boolean(mailerLiteFormID);
 
   useEffect(() => {
     if (!mailerLiteAccountID) {
@@ -77,11 +78,11 @@ export const SignupWaitlist: React.FC = () => {
   return (
     <div className="space-y-4">
       <Text className="text-left text-sm leading-6 text-gray-600">
-        We are opening access gradually while demand is high. Leave your email and we will send an invite as soon as
-        capacity is available.
+        We are opening access gradually while demand is high.
+        {hasMailerLiteForm && " Leave your email and we will send an invite as soon as capacity is available."}
       </Text>
 
-      {mailerLiteFormID && <div className="ml-embedded -mx-5" data-form={mailerLiteFormID} />}
+      {hasMailerLiteForm && <div className="ml-embedded -mx-5" data-form={mailerLiteFormID} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide the waitlist email collection sentence when MailerLite embed config is incomplete
- remove the git-backed versions sidebar footer and placeholder clone command
- update focused UI tests for both behaviors

## Tests
- make format.js
- cd web_src && npm run test:run -- src/pages/auth/SignupWaitlist.spec.tsx src/components/CanvasToolSidebar/VersionsTabPanel.spec.tsx
- cd web_src && npm run build