### PR TITLE
fix: submit waitlist emails with native form

### DIFF
--- a/web_src/src/lib/hubspotForms.ts
+++ b/web_src/src/lib/hubspotForms.ts
@@ -1,0 +1,53 @@
+import type { SignupWaitlistConfig } from "@/lib/signupWaitlistConfig";
+
+type HubSpotSubmissionContext = {
+  hutk?: string;
+  pageName?: string;
+  pageUri?: string;
+};
+
+type HubSpotSubmissionPayload = {
+  fields: Array<{
+    name: string;
+    value: string;
+  }>;
+  context?: HubSpotSubmissionContext;
+};
+
+const hubSpotSubmissionURL = ({ portalID, formID }: SignupWaitlistConfig) =>
+  `https://api.hsforms.com/submissions/v3/integration/submit/${encodeURIComponent(portalID)}/${encodeURIComponent(formID)}`;
+
+const getCookieValue = (name: string) => {
+  const prefix = `${name}=`;
+  const cookie = document.cookie.split("; ").find((part) => part.startsWith(prefix));
+  return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : undefined;
+};
+
+const getSubmissionContext = (): HubSpotSubmissionContext => {
+  const hutk = getCookieValue("hubspotutk");
+
+  return {
+    ...(hutk ? { hutk } : {}),
+    pageName: document.title || undefined,
+    pageUri: window.location.href,
+  };
+};
+
+export const submitSignupWaitlistEmail = async (config: SignupWaitlistConfig, email: string) => {
+  const payload: HubSpotSubmissionPayload = {
+    fields: [{ name: "email", value: email }],
+    context: getSubmissionContext(),
+  };
+
+  const response = await fetch(hubSpotSubmissionURL(config), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HubSpot form submission failed with status ${response.status}`);
+  }
+};

--- a/web_src/src/lib/hubspotForms.ts
+++ b/web_src/src/lib/hubspotForms.ts
@@ -14,8 +14,18 @@ type HubSpotSubmissionPayload = {
   context?: HubSpotSubmissionContext;
 };
 
-const hubSpotSubmissionURL = ({ portalID, formID }: SignupWaitlistConfig) =>
-  `https://api.hsforms.com/submissions/v3/integration/submit/${encodeURIComponent(portalID)}/${encodeURIComponent(formID)}`;
+const defaultHubSpotFormsHost = "api.hsforms.com";
+
+const getHubSpotFormsHost = (region?: string) => {
+  if (!region || region === "na1") {
+    return defaultHubSpotFormsHost;
+  }
+
+  return `api-${region}.hsforms.com`;
+};
+
+const hubSpotSubmissionURL = ({ portalID, formID, region }: SignupWaitlistConfig) =>
+  `https://${getHubSpotFormsHost(region)}/submissions/v3/integration/submit/${encodeURIComponent(portalID)}/${encodeURIComponent(formID)}`;
 
 const getCookieValue = (name: string) => {
   const prefix = `${name}=`;

--- a/web_src/src/pages/auth/SignupWaitlist.spec.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.spec.tsx
@@ -37,6 +37,7 @@ describe("SignupWaitlist", () => {
     document.cookie = "hubspotutk=visitor-1; path=/";
     waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID = "portal-1";
     waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID = "form-1";
+    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_REGION = "eu1";
 
     render(<SignupWaitlist />);
 
@@ -48,7 +49,7 @@ describe("SignupWaitlist", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.hsforms.com/submissions/v3/integration/submit/portal-1/form-1",
+      "https://api-eu1.hsforms.com/submissions/v3/integration/submit/portal-1/form-1",
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/web_src/src/pages/auth/SignupWaitlist.spec.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SignupWaitlist } from "./SignupWaitlist";
@@ -7,11 +8,6 @@ type SignupWaitlistWindow = Window & {
   SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID?: string;
   SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID?: string;
   SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_REGION?: string;
-  hbspt?: {
-    forms?: {
-      create: ReturnType<typeof vi.fn>;
-    };
-  };
 };
 
 const waitlistWindow = window as SignupWaitlistWindow;
@@ -20,51 +16,67 @@ afterEach(() => {
   delete waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID;
   delete waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID;
   delete waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_REGION;
-  delete waitlistWindow.hbspt;
-  document.getElementById("hubspot-forms-script")?.remove();
+  document.cookie = "hubspotutk=; Max-Age=0; path=/";
+  vi.unstubAllGlobals();
 });
 
 describe("SignupWaitlist", () => {
-  it("does not render the HubSpot form without complete config", () => {
+  it("does not render the notify form without complete HubSpot config", () => {
     waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID = "portal-1";
 
-    const { container } = render(<SignupWaitlist />);
+    render(<SignupWaitlist />);
 
-    expect(container.querySelector("#signup-waitlist-hubspot-form")).toBeNull();
+    expect(screen.queryByLabelText("Email")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Notify me" })).toBeNull();
     expect(screen.queryByText(/Leave your email/)).toBeNull();
-    expect(document.getElementById("hubspot-forms-script")).toBeNull();
   });
 
-  it("renders the HubSpot form when portal and form IDs are configured", async () => {
-    const createForm = vi.fn();
-    waitlistWindow.hbspt = { forms: { create: createForm } };
-    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID = "portal-1";
-    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID = "form-1";
-    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_REGION = "eu1";
-
-    const { container } = render(<SignupWaitlist />);
-
-    expect(container.querySelector("#signup-waitlist-hubspot-form")).toBeInTheDocument();
-    expect(screen.getByText(/Leave your email/)).toBeInTheDocument();
-    await waitFor(() => {
-      expect(createForm).toHaveBeenCalledWith({
-        portalId: "portal-1",
-        formId: "form-1",
-        target: "#signup-waitlist-hubspot-form",
-        region: "eu1",
-      });
-    });
-  });
-
-  it("loads the HubSpot script when the forms client is not ready", () => {
+  it("submits the native notify form to HubSpot", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    document.cookie = "hubspotutk=visitor-1; path=/";
     waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID = "portal-1";
     waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID = "form-1";
 
     render(<SignupWaitlist />);
 
-    expect(document.getElementById("hubspot-forms-script")).toHaveAttribute(
-      "src",
-      "https://js.hsforms.net/forms/embed/v2.js",
+    await userEvent.type(screen.getByLabelText("Email"), " person@example.com ");
+    await userEvent.click(screen.getByRole("button", { name: "Notify me" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("You are on the waitlist");
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.hsforms.com/submissions/v3/integration/submit/portal-1/form-1",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
     );
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.fields).toEqual([{ name: "email", value: "person@example.com" }]);
+    expect(body.context).toEqual(
+      expect.objectContaining({
+        hutk: "visitor-1",
+        pageUri: expect.any(String),
+      }),
+    );
+  });
+
+  it("shows a retryable error when HubSpot rejects the submission", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })));
+    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_PORTAL_ID = "portal-1";
+    waitlistWindow.SUPERPLANE_SIGNUP_WAITLIST_HUBSPOT_FORM_ID = "form-1";
+
+    render(<SignupWaitlist />);
+
+    await userEvent.type(screen.getByLabelText("Email"), "person@example.com");
+    await userEvent.click(screen.getByRole("button", { name: "Notify me" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("We could not save your email");
+    });
   });
 });

--- a/web_src/src/pages/auth/SignupWaitlist.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.tsx
@@ -8,10 +8,12 @@ import { submitSignupWaitlistEmail } from "@/lib/hubspotForms";
 import { Text } from "@/components/Text/text";
 import { getSignupWaitlistConfig } from "@/lib/signupWaitlistConfig";
 
+type SignupWaitlistStatus = "idle" | "submitting" | "submitted" | "failed";
+
 export const SignupWaitlist: React.FC = () => {
   const hubSpotConfig = getSignupWaitlistConfig();
   const [email, setEmail] = useState("");
-  const [status, setStatus] = useState<"idle" | "submitting" | "submitted" | "failed">("idle");
+  const [status, setStatus] = useState<SignupWaitlistStatus>("idle");
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/web_src/src/pages/auth/SignupWaitlist.tsx
+++ b/web_src/src/pages/auth/SignupWaitlist.tsx
@@ -1,85 +1,87 @@
 import type React from "react";
-import { useEffect } from "react";
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { submitSignupWaitlistEmail } from "@/lib/hubspotForms";
 import { Text } from "@/components/Text/text";
 import { getSignupWaitlistConfig } from "@/lib/signupWaitlistConfig";
 
-const hubSpotScriptID = "hubspot-forms-script";
-const hubSpotFormTargetID = "signup-waitlist-hubspot-form";
-
-type HubSpotFormOptions = {
-  portalId: string;
-  formId: string;
-  target: string;
-  region?: string;
-};
-
-type HubSpotWindow = Window & {
-  hbspt?: {
-    forms?: {
-      create: (options: HubSpotFormOptions) => void;
-    };
-  };
-};
-
-const loadHubSpotScript = () => {
-  const existingScript = document.getElementById(hubSpotScriptID) as HTMLScriptElement | null;
-  if (existingScript) {
-    return existingScript;
-  }
-
-  const script = document.createElement("script");
-  script.id = hubSpotScriptID;
-  script.async = true;
-  script.src = "https://js.hsforms.net/forms/embed/v2.js";
-  document.head.appendChild(script);
-  return script;
-};
-
 export const SignupWaitlist: React.FC = () => {
   const hubSpotConfig = getSignupWaitlistConfig();
-  const hubSpotPortalID = hubSpotConfig?.portalID;
-  const hubSpotFormID = hubSpotConfig?.formID;
-  const hubSpotRegion = hubSpotConfig?.region;
-  const hasHubSpotForm = Boolean(hubSpotPortalID && hubSpotFormID);
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "submitted" | "failed">("idle");
 
-  useEffect(() => {
-    if (!hubSpotPortalID || !hubSpotFormID) {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+    if (!hubSpotConfig || !trimmedEmail || status === "submitting") {
       return;
     }
 
-    const renderForm = () => {
-      const forms = (window as HubSpotWindow).hbspt?.forms;
-      if (!forms) {
-        return;
-      }
-
-      forms.create({
-        portalId: hubSpotPortalID,
-        formId: hubSpotFormID,
-        target: `#${hubSpotFormTargetID}`,
-        ...(hubSpotRegion ? { region: hubSpotRegion } : {}),
-      });
-    };
-
-    if ((window as HubSpotWindow).hbspt?.forms) {
-      renderForm();
-      return;
+    setStatus("submitting");
+    try {
+      await submitSignupWaitlistEmail(hubSpotConfig, trimmedEmail);
+      setEmail("");
+      setStatus("submitted");
+    } catch {
+      setStatus("failed");
     }
-
-    const script = loadHubSpotScript();
-    script.addEventListener("load", renderForm);
-
-    return () => script.removeEventListener("load", renderForm);
-  }, [hubSpotFormID, hubSpotPortalID, hubSpotRegion]);
+  };
 
   return (
     <div className="space-y-4">
       <Text className="text-left text-sm leading-6 text-gray-600">
         We are opening access gradually while demand is high.
-        {hasHubSpotForm && " Leave your email and we will send an invite as soon as capacity is available."}
+        {hubSpotConfig && " Leave your email and we will send an invite as capacity opens."}
       </Text>
 
-      {hasHubSpotForm && <div id={hubSpotFormTargetID} className="-mx-5" />}
+      {hubSpotConfig && (
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="signup-waitlist-email">Email</Label>
+            <Input
+              id="signup-waitlist-email"
+              type="email"
+              value={email}
+              onChange={(event) => {
+                setEmail(event.target.value);
+                if (status !== "submitting") {
+                  setStatus("idle");
+                }
+              }}
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+              data-1p-ignore
+            />
+          </div>
+
+          <LoadingButton
+            type="submit"
+            className="w-full"
+            loading={status === "submitting"}
+            loadingText="Saving..."
+            disabled={!email.trim()}
+          >
+            Notify me
+          </LoadingButton>
+
+          {status === "submitted" && (
+            <p className="text-left text-sm leading-6 text-gray-700" role="status">
+              You are on the waitlist. We will email you when access opens.
+            </p>
+          )}
+
+          {status === "failed" && (
+            <p className="text-left text-sm leading-6 text-red-600" role="alert">
+              We could not save your email. Please try again.
+            </p>
+          )}
+        </form>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- keep the SuperPlane /signup waitlist email UI instead of rendering the HubSpot embedded form
- submit the native email field to HubSpot Forms API using the configured portal and form IDs
- include page context and the HubSpot visitor cookie when present
- cover configured, unconfigured, success, and failure states in the waitlist tests

## Setup note
- the configured HubSpot form must include an `email` field because HubSpot validates submitted fields against the form definition

## Tests
- cd web_src && npm run test:run -- src/pages/auth/SignupWaitlist.spec.tsx
- make format.js
- make check.lint.ui
- make check.build.ui