### PR TITLE
feat: substitute install params in seed files

### DIFF
--- a/pkg/installation/install.go
+++ b/pkg/installation/install.go
@@ -77,7 +77,7 @@ func (s *Service) Install(ctx context.Context, req InstallRequest) (*InstallResu
 		return nil, err
 	}
 
-	canvas, err := s.prepareCanvasForInstall(repo, name, req.InstallParams, req.Integrations, req.OrganizationID)
+	canvas, resolvedParams, err := s.prepareCanvasForInstall(repo, name, req.InstallParams, req.Integrations, req.OrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (s *Service) Install(ctx context.Context, req InstallRequest) (*InstallResu
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	seedFiles, err := fetchSeedFiles(repo)
+	seedFiles, err := fetchSeedFiles(repo, resolvedParams)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -143,27 +143,27 @@ func (s *Service) prepareCanvasForInstall(
 	userParams map[string]string,
 	integrations map[string]IntegrationMapping,
 	organizationID uuid.UUID,
-) (*pb.Canvas, error) {
-	canvasBody, err := fetchAndSubstituteParams(repo, userParams, organizationID)
+) (*pb.Canvas, map[string]string, error) {
+	canvasBody, resolvedParams, err := fetchAndSubstituteParams(repo, userParams, organizationID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	canvas, err := parseCanvasYAML(canvasBody)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	canvas.Metadata.Name = name
 	wireIntegrations(canvas, integrations, s.Registry)
 
-	return canvas, nil
+	return canvas, resolvedParams, nil
 }
 
-func fetchAndSubstituteParams(repo *Repository, userParams map[string]string, organizationID uuid.UUID) ([]byte, error) {
+func fetchAndSubstituteParams(repo *Repository, userParams map[string]string, organizationID uuid.UUID) ([]byte, map[string]string, error) {
 	canvasBody, _, err := fetchRawCanvasFile(repo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	params, err := FetchParams(repo, repo.Ref)
@@ -172,7 +172,7 @@ func fetchAndSubstituteParams(repo *Repository, userParams map[string]string, or
 	}
 
 	if params == nil || len(params.InstallParams) == 0 {
-		return canvasBody, nil
+		return canvasBody, nil, nil
 	}
 
 	// A nil userParams map means the install bypassed the params wizard
@@ -181,7 +181,7 @@ func fetchAndSubstituteParams(repo *Repository, userParams map[string]string, or
 	// values; otherwise required params without defaults would always fail.
 	if userParams != nil {
 		if err := ValidateInstallParams(params.InstallParams, userParams); err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 	}
 
@@ -191,11 +191,11 @@ func fetchAndSubstituteParams(repo *Repository, userParams map[string]string, or
 	// secret names, so validating those would reject optional pickers left
 	// empty.
 	if err := ValidateSecretPickerParams(params.InstallParams, userParams, organizationID); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	resolved := ResolveInstallParams(params.InstallParams, userParams)
-	return SubstituteInstallParams(canvasBody, resolved), nil
+	return SubstituteInstallParams(canvasBody, resolved), resolved, nil
 }
 
 func (s *Service) createCanvas(
@@ -249,9 +249,12 @@ func translateInstallError(err error) error {
 // fetchSeedFiles downloads every file in the app repository except the spec
 // files (canvas.yaml/console.yaml) and params.json, converting them into
 // model rows ready to be persisted alongside the pending canvas repository.
+// When resolvedParams is non-nil, {{ install_params.xxx }} placeholders in
+// file contents are replaced with the resolved values, matching the
+// substitution applied to canvas.yaml.
 // Failures are surfaced as InvalidArgument so the install request returns a
 // useful 400 instead of leaving a half-installed canvas behind.
-func fetchSeedFiles(repo *Repository) ([]models.RepositorySeedFile, error) {
+func fetchSeedFiles(repo *Repository, resolvedParams map[string]string) ([]models.RepositorySeedFile, error) {
 	files, err := FetchRepositoryFiles(repo, repo.Ref)
 	if err != nil {
 		return nil, fmt.Errorf("fetch repository files: %w", err)
@@ -263,9 +266,14 @@ func fetchSeedFiles(repo *Repository) ([]models.RepositorySeedFile, error) {
 
 	seedFiles := make([]models.RepositorySeedFile, 0, len(files))
 	for _, file := range files {
+		content := file.Content
+		if len(resolvedParams) > 0 {
+			content = SubstituteInstallParams(content, resolvedParams)
+		}
+
 		seedFiles = append(seedFiles, models.RepositorySeedFile{
 			Path:    file.Path,
-			Content: file.Content,
+			Content: content,
 		})
 	}
 


### PR DESCRIPTION
Apply `{{ install_params.xxx }}` substitution to all seed files (scripts, READMEs, etc.) during app install, not just `canvas.yaml`.

**Why:** App templates can now use install parameters in helper scripts. For example, a preview environment setup script can reference `{{ install_params.repo_url }}` and it gets resolved at install time.

**Changes:**
- `fetchSeedFiles` now accepts `resolvedParams` and calls `SubstituteInstallParams` on each file's content
- Added `resolveInstallParamsForRepo` helper to load and resolve params independently
- All existing tests pass