### PR TITLE
feat: add useNameAsValue for integration-resource install params

### DIFF
--- a/pkg/installation/params.go
+++ b/pkg/installation/params.go
@@ -33,8 +33,9 @@ type InstallParam struct {
 	Required    bool   `json:"required"`
 
 	// For type "integration-resource"
-	Integration  string `json:"integration,omitempty"`  // integration type name (e.g. "digitalocean")
-	ResourceType string `json:"resourceType,omitempty"` // resource type (e.g. "region", "size", "image")
+	Integration    string `json:"integration,omitempty"`    // integration type name (e.g. "digitalocean")
+	ResourceType   string `json:"resourceType,omitempty"`   // resource type (e.g. "region", "size", "image")
+	UseNameAsValue bool   `json:"useNameAsValue,omitempty"` // when true, substitute the resource name instead of the ID
 }
 
 // ParamsFile is the structure of params.json in the app repo.

--- a/web_src/src/pages/home/InstallProgressPanel.tsx
+++ b/web_src/src/pages/home/InstallProgressPanel.tsx
@@ -308,7 +308,7 @@ function ParamsSection({
                   type: "integration-resource",
                   placeholder: param.placeholder,
                   required: param.required,
-                  typeOptions: { resource: { type: param.resourceType } },
+                  typeOptions: { resource: { type: param.resourceType, useNameAsValue: param.useNameAsValue } },
                 }}
                 value={values[param.name]}
                 onChange={(val) => onChange((prev) => ({ ...prev, [param.name]: normalizeResourceValue(val) }))}

--- a/web_src/src/pages/install/types.ts
+++ b/web_src/src/pages/install/types.ts
@@ -14,6 +14,7 @@ export interface InstallParam {
   // For type "integration-resource"
   integration?: string; // integration type name (e.g. "digitalocean")
   resourceType?: string; // resource type (e.g. "region", "size", "image")
+  useNameAsValue?: boolean; // when true, substitute the resource name instead of the ID
 }
 
 export interface InstallPreview {


### PR DESCRIPTION
Adds `useNameAsValue` option to the `integration-resource` install param type.

**Problem:** GitHub `repository` resources return a numeric ID (e.g. `1165844309`) but GitHub component nodes expect the repo name (e.g. `storejs`). When an app template uses `integration-resource` for the repository param, the install substitutes the ID, breaking every node.

**Fix:** When `useNameAsValue: true` is set in `params.json`, the resource picker submits the display name instead of the ID. This uses the existing `useNameAsValue` support in `IntegrationResourceFieldRenderer`.

**Changes:**
- `pkg/installation/params.go` — add `UseNameAsValue` field to `InstallParam`
- `web_src/src/pages/install/types.ts` — add `useNameAsValue` to TS interface
- `web_src/src/pages/home/InstallProgressPanel.tsx` — pass `useNameAsValue` to field renderer

**Usage in params.json:**
```json
{
  "name": "repository",
  "type": "integration-resource",
  "integration": "github",
  "resourceType": "repository",
  "useNameAsValue": true
}
```