### PR TITLE
fix: update preview-env-digitalocean manifest entry

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -2,26 +2,38 @@
   {
     "repo": "github.com/superplanehq/app_preview-env-digitalocean",
     "icon": "digitalocean",
-    "title": "Preview Environments (GitHub + DigitalOcean)",
+    "title": "Preview Environments on DigitalOcean",
     "description": "Spin up a live preview environment for every pull request. Comment /start on a PR, get a running app in ~2 minutes using DigitalOcean Droplets.",
-    "integrations": ["github", "digitalocean"],
-    "tags": ["CI/CD", "Preview"],
+    "integrations": [
+      "github",
+      "digitalocean"
+    ],
+    "tags": [
+      "CI/CD",
+      "Preview"
+    ],
     "requirements": [
       "GitHub integration with Deployments permission",
       "DigitalOcean integration",
-      "SSH key added to both DigitalOcean and SuperPlane",
-      "A setup script at scripts/preview-setup.sh in your repo"
+      "An SSH key registered on DigitalOcean",
+      "A SuperPlane secret with the matching private key"
     ],
-    "agentInstructions": "The user just installed the Preview Environments app. This canvas creates ephemeral preview environments for pull requests using GitHub and DigitalOcean. Setup usually involves: 1) Connecting their GitHub integration (needs Deployments permission), 2) Connecting their DigitalOcean integration, 3) Adding an SSH key as a secret, 4) Updating the repository name and setup script URL in the canvas nodes to match their project.",
-    "agentInitialMessage": "Welcome! This canvas is a full preview environment pipeline for **examplehq/example** - it spins up DigitalOcean droplets for pull requests, runs your setup script, posts preview URLs as PR comments, and tears everything down when PRs close or after the 24h TTL.\n\nThe canvas is structurally wired, but it still uses template defaults. Here's the full setup checklist:\n\n---\n\n**What needs to be done:**\n\n**1. Connect GitHub** - [GitHub](integration:github)\nAlmost every trigger and action in this canvas uses GitHub. It needs the **Deployments** permission to create deployment statuses, in addition to standard PR and issue permissions.\n\n**2. Connect DigitalOcean** - [DigitalOcean](integration:digitalocean)\nUsed to create and delete droplets on demand.\n\n**3. Add your SSH private key as a secret**\nThe [Setup App](node:setup-app) node SSHs into new droplets using a secret named `preview-digital-ocean-ssh-key` with key `private_key`. Add the private key that matches the SSH key configured in DigitalOcean.\n\n**4. Update the repo and setup script URL**\nThe template uses example placeholders. We'll need to update:\n- GitHub repository fields from `examplehq/example` to your repo\n- The repo/app values in [Save Environment](node:save-env) from `example-app` to your app name\n- The setup script URL in [Setup App](node:setup-app) (for example, `https://raw.githubusercontent.com/examplehq/example/main/scripts/preview-setup.sh` to your repo's URL)\n- The SSH key name in [Create Droplet](node:create-droplet), if your DigitalOcean SSH key uses a different name\n\n---\n\nLet's start at the top. Connect the integrations, then come back and tell me:\n\n:::survey\nWhat is your GitHub repository? (e.g. `my-org/my-repo`)\n- [input]\n\nWhat is the full URL to your setup script?\n- [input]\n\nDoes the secret `preview-digital-ocean-ssh-key` already exist in your org, or do you need to create it?\n- I need to create it\n- It already exists\n:::\n\nOnce you've shared those details, I'll update the canvas nodes and get the preview environment pipeline wired up."
+    "agentInstructions": "The user just installed the Preview Environments app. This canvas creates ephemeral preview environments for pull requests using GitHub and DigitalOcean. If the user completed the install wizard, the repository, SSH secret, SSH key, region, size, and image are already configured. The main remaining task is customizing scripts/preview-setup.sh in the Files tab to match their application. If the user skipped the wizard, setup involves: 1) Connecting GitHub and DigitalOcean integrations, 2) Creating an SSH key secret, 3) Updating the repository name, SSH secret, and SSH key on the canvas nodes.",
+    "agentInitialMessage": "Welcome! This canvas manages the full lifecycle of preview environments for pull requests \u2014 provisioning DigitalOcean droplets, deploying your app via SSH, posting preview URLs, and tearing everything down when PRs close or after the TTL expires.\n\n---\n\n**If you used the install wizard**, your repository, SSH credentials, and droplet settings are already configured. Here's what you need to do next:\n\n**1. Customize the setup script**\nOpen `scripts/preview-setup.sh` in the **Files** tab. The default script sets up a Node.js app with nginx. Update it to install your runtime, build your app, and start your services.\n\nThe script receives two environment variables:\n- `PR_NUMBER` \u2014 the pull request number\n- `REPO_URL` \u2014 the full clone URL of your repository\n\n**2. Test it**\nOpen a PR on your repository and comment `/start`. The workflow will create a droplet, run your setup script, and post the preview URL as a PR comment.\n\n---\n\n**If you skipped the wizard**, here's the full setup checklist:\n\n**1. Connect GitHub** - [GitHub](integration:github)\nNeeds the **Deployments** permission for deployment statuses.\n\n**2. Connect DigitalOcean** - [DigitalOcean](integration:digitalocean)\nUsed to create and delete droplets.\n\n**3. Add your SSH private key as a secret**\nThe [Setup App](node:setup-app) node SSHs into droplets using a secret with key `private_key`. Create a secret containing the private key that matches your DigitalOcean SSH key.\n\n**4. Update the canvas nodes**\n- Set the repository name on all GitHub trigger and action nodes\n- Set your SSH secret on the [Setup App](node:setup-app) node\n- Set your DigitalOcean SSH key on the [Create Droplet](node:create-droplet) node\n\n**5. Customize the setup script**\nEdit `scripts/preview-setup.sh` in the **Files** tab to match your application.\n\n---\n\nLet me know if you need help with any of these steps!"
   },
   {
     "repo": "github.com/superplanehq/app_preview-env-github-aws",
     "icon": "aws",
     "title": "Preview Environments (GitHub + AWS)",
     "description": "Spin up a live preview environment for every pull request. Comment /start on a PR, get a running app in ~2 minutes using AWS EC2 instances.",
-    "integrations": ["github", "aws"],
-    "tags": ["CI/CD", "Preview"],
+    "integrations": [
+      "github",
+      "aws"
+    ],
+    "tags": [
+      "CI/CD",
+      "Preview"
+    ],
     "requirements": [
       "GitHub integration with Deployments permission",
       "AWS integration",
@@ -36,8 +48,16 @@
     "icon": "hetzner",
     "title": "Cluster Autoscaler (Hetzner + Grafana + Slack)",
     "description": "Autoscale a Hetzner Cloud worker fleet from Grafana CPU alerts. The canvas provisions workers, bootstraps a Docker workload over SSH, tracks active nodes in memory, scales down quiet clusters, and posts Slack notifications.",
-    "integrations": ["grafana", "hetzner", "slack"],
-    "tags": ["Infrastructure", "Autoscaling", "Alerts"],
+    "integrations": [
+      "grafana",
+      "hetzner",
+      "slack"
+    ],
+    "tags": [
+      "Infrastructure",
+      "Autoscaling",
+      "Alerts"
+    ],
     "requirements": [
       "Grafana integration with a HighCPU alert and a Prometheus data source named prometheus",
       "Hetzner Cloud integration with permission to create and delete servers",


### PR DESCRIPTION
Updates the manifest.json entry for Preview Environments on DigitalOcean to match the current parameterized install flow.

**Changes:**
- Title: 'Preview Environments on DigitalOcean' (matches canvas name)
- Requirements: SSH key on DO + secret in SuperPlane (removed 'setup script in your repo')
- Agent instructions: accounts for both wizard and skip-wizard paths
- Agent initial message: two paths — post-wizard (customize script, test) and skipped-wizard (full manual setup). Removed references to `examplehq/example`, `preview-digital-ocean-ssh-key`, and external setup script URLs.