### PR TITLE
feat: support Lucide icons in app catalog

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -88,7 +88,7 @@
   },
   {
     "repo": "github.com/superplanehq/app_tls_monitor",
-    "icon": "discord",
+    "icon": "shield-check",
     "title": "TLS Monitor",
     "description": "Monitor TLS certificate expiry for HTTPS endpoints. Add hostnames, check certificates on a schedule, and get Discord notifications when certificates are expiring.",
     "integrations": [

--- a/web_src/src/pages/home/AppDetailModal.tsx
+++ b/web_src/src/pages/home/AppDetailModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getIntegrationIconSrc } from "@/ui/componentSidebar/integrationIconMaps";
+import { resolveLucideIcon } from "@/lib/iconRegistry";
 import { ArrowLeft, ArrowRight, ExternalLink, Plus } from "lucide-react";
 
 export interface AppEntry {
@@ -115,8 +116,9 @@ export function LeadIcon({
   const cls = size === "lg" ? "h-8 w-8" : "h-5 w-5";
   if (!iconName) return <Plus className={`${cls} text-slate-400`} />;
   const iconSrc = getIntegrationIconSrc(iconName.toLowerCase());
-  if (!iconSrc) return <Plus className={`${cls} text-slate-400`} />;
-  return <img src={iconSrc} alt={iconName} className={cls} />;
+  if (iconSrc) return <img src={iconSrc} alt={iconName} className={cls} />;
+  const FallbackIcon = resolveLucideIcon(iconName);
+  return <FallbackIcon className={`${cls} text-slate-500`} />;
 }
 
 export function IntegrationIcons({ integrations }: { integrations: string[] }) {


### PR DESCRIPTION
The app catalog `LeadIcon` now falls back to the Lucide icon registry when no integration icon matches. This lets apps use any icon from the existing `iconRegistry.ts` (150+ icons).

**Changes:**
- `AppDetailModal.tsx`: `LeadIcon` tries integration icon first, then `resolveLucideIcon`, then Plus placeholder
- `manifest.json`: TLS Monitor icon changed from `discord` to `shield-check`

**Before:** Apps without a matching integration icon always showed the Plus placeholder.
**After:** Apps can use Lucide icon slugs like `shield`, `shield-check`, `lock`, `globe`, `server`, etc.