### PR TITLE
feat: Cache AWS SNS certs

### DIFF
--- a/pkg/integrations/aws/sns/on_topic_message.go
+++ b/pkg/integrations/aws/sns/on_topic_message.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -32,7 +33,20 @@ type OnTopicMessageMetadata struct {
 	TopicArn string `json:"topicArn" mapstructure:"topicArn"`
 }
 
-type OnTopicMessage struct{}
+// signingCertCacheTTL bounds how long a fetched SNS signing certificate is reused
+// before being re-fetched. AWS does not document a rotation cadence for these
+// certificates, so this is a conservative refresh window rather than a value tied
+// to any known rotation schedule.
+const signingCertCacheTTL = time.Hour
+
+type cachedCert struct {
+	cert      *x509.Certificate
+	fetchedAt time.Time
+}
+
+type OnTopicMessage struct {
+	certCache sync.Map
+}
 
 func (t *OnTopicMessage) Name() string {
 	return "aws.sns.onTopicMessage"
@@ -297,9 +311,6 @@ func (t *OnTopicMessage) verifyMessageSignature(ctx core.WebhookRequestContext, 
 		return fmt.Errorf("failed to build string to sign: %w", err)
 	}
 
-	//
-	// TODO: it would be good to not fetch the certificate every time.
-	//
 	cert, err := t.fetchSigningCertificate(ctx, message.SigningCertURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch signing certificate: %w", err)
@@ -403,6 +414,13 @@ func (t *OnTopicMessage) fetchSigningCertificate(ctx core.WebhookRequestContext,
 		return nil, fmt.Errorf("SigningCertURL host must be an AWS SNS domain")
 	}
 
+	if rawCachedCertEntry, ok := t.certCache.Load(signingCertURL); ok {
+		cachedCertEntry := rawCachedCertEntry.(cachedCert)
+		if time.Since(cachedCertEntry.fetchedAt) < signingCertCacheTTL {
+			return cachedCertEntry.cert, nil
+		}
+	}
+
 	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create certificate request: %w", err)
@@ -453,6 +471,8 @@ func (t *OnTopicMessage) fetchSigningCertificate(ctx core.WebhookRequestContext,
 	if now.Before(cert.NotBefore) || now.After(cert.NotAfter) {
 		return nil, fmt.Errorf("signing certificate is not currently valid")
 	}
+
+	t.certCache.Store(signingCertURL, cachedCert{cert: cert, fetchedAt: now})
 
 	return cert, nil
 }

--- a/pkg/integrations/aws/sns/on_topic_message_test.go
+++ b/pkg/integrations/aws/sns/on_topic_message_test.go
@@ -116,9 +116,8 @@ func Test__OnTopicMessage__Setup(t *testing.T) {
 }
 
 func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
-	trigger := &OnTopicMessage{}
-
 	t.Run("notification for configured topic -> emits event", func(t *testing.T) {
+		trigger := &OnTopicMessage{}
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "Notification",
@@ -167,6 +166,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	})
 
 	t.Run("subscription confirmation for different topic -> ignored", func(t *testing.T) {
+		trigger := &OnTopicMessage{}
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "SubscriptionConfirmation",
@@ -206,6 +206,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	})
 
 	t.Run("confirmation for configured topic -> confirms subscription", func(t *testing.T) {
+		trigger := &OnTopicMessage{}
 		privateKey, certPEM := createTestSigningCert(t)
 		message := signTestMessage(t, trigger, SubscriptionMessage{
 			Type:             "SubscriptionConfirmation",
@@ -251,6 +252,7 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 	})
 
 	t.Run("unsupported message type -> bad request", func(t *testing.T) {
+		trigger := &OnTopicMessage{}
 		status, _, err := trigger.HandleWebhook(core.WebhookRequestContext{
 			Body: []byte(`{
 				"Type": "UnknownType",
@@ -267,6 +269,64 @@ func Test__OnTopicMessage__HandleWebhook(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, http.StatusBadRequest, status)
 	})
+}
+
+func Test__OnTopicMessage__fetchSigningCertificate__cachesByURL(t *testing.T) {
+	trigger := &OnTopicMessage{}
+	_, certPEM := createTestSigningCert(t)
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(certPEM)),
+		}},
+	}
+
+	ctx := core.WebhookRequestContext{HTTP: httpContext, Logger: log.NewEntry(log.New())}
+
+	cert1, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 1, "first call should fetch the certificate over HTTP")
+
+	cert2, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 1, "second call should be served from cache, not a new HTTP request")
+	assert.Same(t, cert1, cert2)
+}
+
+func Test__OnTopicMessage__fetchSigningCertificate__refetchesAfterTTL(t *testing.T) {
+	trigger := &OnTopicMessage{}
+	_, certPEM := createTestSigningCert(t)
+
+	httpContext := &contexts.HTTPContext{
+		Responses: []*http.Response{
+			{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM))},
+			{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(certPEM))},
+		},
+	}
+
+	ctx := core.WebhookRequestContext{HTTP: httpContext, Logger: log.NewEntry(log.New())}
+
+	_, err := trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 1)
+
+	trigger.certCache.Store(testSigningCertURL, cachedCert{
+		cert:      mustLoadCachedCert(t, trigger, testSigningCertURL),
+		fetchedAt: time.Now().Add(-signingCertCacheTTL - time.Minute),
+	})
+
+	_, err = trigger.fetchSigningCertificate(ctx, testSigningCertURL)
+	require.NoError(t, err)
+	require.Len(t, httpContext.Requests, 2, "expired cache entry should trigger a re-fetch")
+}
+
+func mustLoadCachedCert(t *testing.T, trigger *OnTopicMessage, url string) *x509.Certificate {
+	t.Helper()
+
+	raw, ok := trigger.certCache.Load(url)
+	require.True(t, ok)
+	return raw.(cachedCert).cert
 }
 
 const testSigningCertURL = "https://sns.us-east-1.amazonaws.com/test.pem"


### PR DESCRIPTION
Resolving a TODO for caching AWS SNS message certs

AWS does not document a rotation cadence for these certificates, so I've implemented a conservative refresh window rather than a value tied to any known rotation schedule.