### PR TITLE
fix: use draft ref as save source in edit mode; reset signature after commit

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -2742,8 +2742,18 @@ export function AppPage() {
       return canvasRef.current;
     }
 
+    // When editing a draft, prefer the in-memory draft ref over the live canvas
+    // cache. After an explicit commit, `canvasKeys.detail` is invalidated and
+    // refetches the live version spec — which does NOT contain the draft's
+    // committed changes. Using it as the save source would stage the live version
+    // and overwrite the correctly-committed draft row when publish auto-commits.
+    // See: github.com/superplanehq/superplane/issues/5611
+    if (activeCanvasVersionIdRef.current) {
+      return canvasRef.current || queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
+    }
+
     return queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) || canvasRef.current;
-  }, [organizationId, canvasId, queryClient]);
+  }, [organizationId, canvasId, queryClient, activeCanvasVersionIdRef]);
 
   const hasPendingLocalDraftChanges = useCallback(() => {
     if (!activeCanvasVersionIdRef.current) {
@@ -3889,6 +3899,7 @@ export function AppPage() {
     setIsPreparingVersionAction,
     flushRepositoryFileStaging,
     cancelPendingCanvasSaves,
+    setLastSavedWorkflowSnapshot,
     onCanvasDraftRestoredToCommitted: handleCanvasDraftRestoredToCommitted,
     recoverIfDraftMissing,
   });

--- a/web_src/src/pages/app/useDraftRecovery.ts
+++ b/web_src/src/pages/app/useDraftRecovery.ts
@@ -147,6 +147,12 @@ export function useDraftRecovery({
         return;
       }
 
+      // Cancel any pending auto-saves (e.g. debounced position updates triggered
+      // by a post-commit re-render) before the publish-time staging commit.
+      // Without this, a rogue staging write can overwrite the correctly-committed
+      // version row with stale local state. See: github.com/superplanehq/superplane/issues/5611
+      cancelPendingCanvasSaves?.();
+
       // Flush staged edits into the committed row before promoting it to live.
       consoleMutationGenerationRef.current += 1;
       await commitCanvasStagingMutation.mutateAsync();
@@ -167,6 +173,7 @@ export function useDraftRecovery({
     canvasId,
     activeCanvasVersionId,
     activeCanvasVersionIdRef,
+    cancelPendingCanvasSaves,
     ensureVersionActionDraftReady,
     queryClient,
     consoleMutationGenerationRef,

--- a/web_src/src/pages/app/useDraftStagingActions.ts
+++ b/web_src/src/pages/app/useDraftStagingActions.ts
@@ -27,6 +27,7 @@ type UseDraftStagingActionsOptions = {
   setIsPreparingVersionAction: Dispatch<SetStateAction<boolean>>;
   flushRepositoryFileStaging?: () => Promise<void>;
   cancelPendingCanvasSaves?: () => void;
+  setLastSavedWorkflowSnapshot?: (workflow: CanvasesCanvas | null) => void;
   onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
   // Recovers from a deleted draft when a mutation fails; returns whether it
   // handled the error (only true when the draft is confirmed gone).
@@ -95,6 +96,7 @@ export function useDraftStagingActions({
   setIsPreparingVersionAction,
   flushRepositoryFileStaging,
   cancelPendingCanvasSaves,
+  setLastSavedWorkflowSnapshot,
   onCanvasDraftRestoredToCommitted,
   recoverIfDraftMissing,
 }: UseDraftStagingActionsOptions) {
@@ -124,6 +126,12 @@ export function useDraftStagingActions({
       draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
       setDraftCanvasSpec(null);
       setStagingResetNonce((nonce) => nonce + 1);
+      // Reset the save-signature baseline to null after commit so
+      // hasPendingLocalDraftChanges() returns false until the next user edit.
+      // Without this, the post-commit cache invalidation can refresh the live
+      // canvas spec into canvasRef, making the signature differ from the committed
+      // draft and triggering a spurious staging write. See: #5611
+      setLastSavedWorkflowSnapshot?.(null);
       showSuccessToast("Changes committed");
     } catch (error) {
       if (await recoverIfDraftMissing?.(error, activeCanvasVersionId)) {
@@ -147,6 +155,7 @@ export function useDraftStagingActions({
     queryClient,
     setDraftCanvasSpec,
     setIsPreparingVersionAction,
+    setLastSavedWorkflowSnapshot,
     setStagingResetNonce,
   ]);
 

--- a/web_src/src/pages/app/useDraftStagingActions.ts
+++ b/web_src/src/pages/app/useDraftStagingActions.ts
@@ -106,6 +106,11 @@ export function useDraftStagingActions({
     }
 
     try {
+      // Cancel any pending auto-saves (e.g. debounced position updates) before
+      // flushing staging. Without this, a save that fires concurrently with the
+      // commit can overwrite the committed version row with stale local state
+      // when publish subsequently runs its own auto-commit.
+      cancelPendingCanvasSaves?.();
       await flushRepositoryFileStaging?.();
       const isReady = await ensureVersionActionDraftReady("Unable to prepare staged changes for commit");
       if (!isReady) {
@@ -131,6 +136,7 @@ export function useDraftStagingActions({
   }, [
     activeCanvasVersionId,
     canvasId,
+    cancelPendingCanvasSaves,
     commitCanvasStagingMutation,
     consoleMutationGenerationRef,
     draftCanvasSpecsRef,


### PR DESCRIPTION
## Root cause

After an explicit commit, `canvasKeys.detail` is invalidated and refetches from `GET /canvases/{id}` — which returns the **live version's spec** (no draft changes). `getCurrentWorkflowSnapshot()` reads from this cache, so any auto-save triggered after commit stages the live version and overwrites the correctly-committed draft when publish auto-commits.

Confirmed via HAR analysis: a rogue `POST staging/files` fires between explicit commit and publish, staging the live canvas. The publish-time `staging/commit` then applies it, discarding the user's changes. See #5611.

## Fix

**1. `getCurrentWorkflowSnapshot()` — prefer draft ref in edit mode**

When `activeCanvasVersionId` is set (user is editing a draft), return `canvasRef.current` instead of the live canvas query cache. `canvasRef.current` only updates from user edits and staging write responses, never from live canvas refetches.

**2. `handleCommitStaging` — reset signature baseline after commit**

Call `setLastSavedWorkflowSnapshot(null)` after commit so `hasPendingLocalDraftChanges()` returns false until the next user edit. This prevents `ensureVersionActionDraftReady` from detecting a spurious diff and generating a rogue staging write.

Also retains `cancelPendingCanvasSaves()` calls in both `handleCommitStaging` and `handlePublishVersion` as defensive guards against concurrent debounced position saves.

Closes #5611