### PR TITLE
fix: avoid DescribeCanvas requests in canvas edit mode

### DIFF
--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -880,7 +880,7 @@ export const ensureDraftVersionExists = async (
   return branches.some((branch) => draftVersionId(branch) === versionId);
 };
 
-export const useCreateDraftBranch = (organizationId: string, canvasId: string) => {
+export const useCreateDraftBranch = (canvasId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -893,7 +893,9 @@ export const useCreateDraftBranch = (organizationId: string, canvasId: string) =
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+      // Creating a draft does not change the live canvas, so we intentionally do
+      // not invalidate canvasKeys.detail here — doing so would trigger a
+      // DescribeCanvas refetch while entering/staying in edit mode.
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.draftBranches(canvasId) });
@@ -1958,7 +1960,7 @@ export const useStageCanvasSpecFiles = (canvasId: string, versionId: string) => 
 
 // useCommitCanvasStaging parses staged spec files into the draft version row and
 // clears staging.
-export const useCommitCanvasStaging = (organizationId: string, canvasId: string, versionId: string) => {
+export const useCommitCanvasStaging = (canvasId: string, versionId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async () => {
@@ -1972,7 +1974,9 @@ export const useCommitCanvasStaging = (organizationId: string, canvasId: string,
     },
     onSuccess: () => {
       queryClient.setQueryData(canvasKeys.versionStaging(canvasId, versionId), { hasStaging: false, stagedPaths: [] });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+      // Committing staged edits only changes the draft version, not the live
+      // canvas, so we skip invalidating canvasKeys.detail to avoid a
+      // DescribeCanvas refetch while staying in edit mode.
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
@@ -1985,7 +1989,7 @@ export const useCommitCanvasStaging = (organizationId: string, canvasId: string,
 
 // useDiscardCanvasStaging deletes staging rows for a draft version. Pass paths
 // to revert specific files; omit to discard everything.
-export const useDiscardCanvasStaging = (organizationId: string, canvasId: string, versionId: string) => {
+export const useDiscardCanvasStaging = (canvasId: string, versionId: string) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (paths?: string[]) => {
@@ -2003,7 +2007,8 @@ export const useDiscardCanvasStaging = (organizationId: string, canvasId: string
         canvasKeys.versionStaging(canvasId, versionId),
         stagingSummary ?? { hasStaging: false, stagedPaths: [] },
       );
-      queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
+      // Discarding staging reverts draft files but stays in the draft, so the
+      // live canvas is unchanged; skip canvasKeys.detail to avoid DescribeCanvas.
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) });
       queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId) });

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -356,7 +356,7 @@ export function AppPage() {
     setSearchParams,
   });
   const [isCreatingDraftBranch, setIsCreatingDraftBranch] = useState(false);
-  const createDraftBranchMutation = useCreateDraftBranch(organizationId!, canvasId!);
+  const createDraftBranchMutation = useCreateDraftBranch(canvasId!);
   const deleteDraftBranchMutation = useDeleteDraftBranch(organizationId!, canvasId!);
   const { data: canvasVersions = [] } = useCanvasVersions(organizationId!, canvasId!);
   const canvasLiveVersionsQuery = useInfiniteCanvasLiveVersions(organizationId!, canvasId!, true);
@@ -483,33 +483,27 @@ export function AppPage() {
   ]);
 
   const canvas = useMemo(() => {
-    if (!liveCanvas) {
-      return liveCanvas;
-    }
-
-    // Draft editing uses the local query cache as source of truth so
-    // optimistic/local edits are not overwritten by slower version fetches.
+    // Edit mode is self-contained: spec + name/description come from the draft
+    // version's repository files (canvas.yaml), so it renders without the
+    // DescribeCanvas response. `liveCanvas` is only reused opportunistically.
     if (isViewingDraftVersion) {
-      if (draftSpecToRender) {
-        return {
-          ...liveCanvas,
-          spec: draftSpecToRender,
-        };
-      }
-
-      return null;
+      if (!draftSpecToRender) return null;
+      return {
+        ...(liveCanvas ?? {}),
+        metadata: {
+          ...(liveCanvas?.metadata ?? {}),
+          id: liveCanvas?.metadata?.id ?? canvasId,
+          name: selectedCanvasVersion?.metadata?.name || liveCanvas?.metadata?.name || "Canvas",
+          description: selectedCanvasVersion?.metadata?.description ?? liveCanvas?.metadata?.description ?? "",
+        },
+        spec: draftSpecToRender,
+      };
     }
-
+    if (!liveCanvas) return liveCanvas;
     const versionSpec = selectedCanvasVersion?.spec;
-    if (!versionSpec) {
-      return liveCanvas;
-    }
-
-    return {
-      ...liveCanvas,
-      spec: versionSpec,
-    };
-  }, [liveCanvas, selectedCanvasVersion, isViewingDraftVersion, draftSpecToRender]);
+    if (!versionSpec) return liveCanvas;
+    return { ...liveCanvas, spec: versionSpec };
+  }, [liveCanvas, selectedCanvasVersion, isViewingDraftVersion, draftSpecToRender, canvasId]);
   const isEditing = !!activeCanvasVersionId && isViewingDraftVersion;
   const hasEditableVersion = !!activeCanvasVersionId && isViewingDraftVersion;
   // Editing a draft always implies an active edit session; previewing the

--- a/web_src/src/pages/app/lib/canvas-yaml-staging.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.ts
@@ -9,6 +9,7 @@ type ParsedCanvasYaml = {
   apiVersion?: string;
   kind?: string;
   metadata?: {
+    id?: string;
     name?: string;
     description?: string;
   };
@@ -18,7 +19,16 @@ type ParsedCanvasYaml = {
   };
 };
 
-export function parseCanvasYamlToSpec(text: string): CanvasesCanvas["spec"] | null {
+export type ParsedCanvasYamlMetadata = {
+  id?: string;
+  name?: string;
+  description?: string;
+};
+
+// loadCanvasYamlDocument parses and validates that the text is a Canvas YAML
+// document, returning the parsed object or null. Shared by the spec and metadata
+// readers to keep their individual complexity low.
+function loadCanvasYamlDocument(text: string): ParsedCanvasYaml | null {
   const trimmed = text.trim();
   if (!trimmed) {
     return null;
@@ -36,6 +46,32 @@ export function parseCanvasYamlToSpec(text: string): CanvasesCanvas["spec"] | nu
   }
 
   if (parsed.kind && parsed.kind !== "Canvas") {
+    return null;
+  }
+
+  return parsed;
+}
+
+// parseCanvasYamlMetadata extracts the canvas-level metadata (id/name/description)
+// from a canvas.yaml document. Used so edit mode can source the canvas name from
+// the repository file instead of the DescribeCanvas response.
+export function parseCanvasYamlMetadata(text: string): ParsedCanvasYamlMetadata | null {
+  const parsed = loadCanvasYamlDocument(text);
+  const metadata = parsed?.metadata;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+
+  return {
+    ...(typeof metadata.id === "string" ? { id: metadata.id } : {}),
+    ...(typeof metadata.name === "string" ? { name: metadata.name } : {}),
+    ...(typeof metadata.description === "string" ? { description: metadata.description } : {}),
+  };
+}
+
+export function parseCanvasYamlToSpec(text: string): CanvasesCanvas["spec"] | null {
+  const parsed = loadCanvasYamlDocument(text);
+  if (!parsed) {
     return null;
   }
 

--- a/web_src/src/pages/app/lib/repository-spec-files.ts
+++ b/web_src/src/pages/app/lib/repository-spec-files.ts
@@ -1,7 +1,7 @@
 import { canvasesDescribeCanvasVersion, type CanvasesCanvasVersion, type CanvasesStagingSummary } from "@/api-client";
 import { withOrganizationHeader } from "@/lib/withOrganizationHeader";
 
-import { dematerializeCanvasSpec, dematerializeConsoleSpec } from "./workflow-spec-files";
+import { dematerializeCanvasMetadata, dematerializeCanvasSpec, dematerializeConsoleSpec } from "./workflow-spec-files";
 import { CANVAS_YAML_PATH, CONSOLE_YAML_PATH } from "./workflow-spec-paths";
 import { isNotFoundError } from "../workflowPageHelpers";
 
@@ -79,7 +79,19 @@ export function canvasVersionWithSpecFromYaml(
     return version;
   }
 
-  return { ...version, spec };
+  // Carry the canvas-level name/description from canvas.yaml onto the version
+  // metadata so edit mode can render the canvas without the DescribeCanvas
+  // response. Only override when the file actually provides a value.
+  const yamlMetadata = dematerializeCanvasMetadata(canvasYaml);
+  const metadata = version.metadata
+    ? {
+        ...version.metadata,
+        ...(yamlMetadata?.name ? { name: yamlMetadata.name } : {}),
+        ...(yamlMetadata?.description !== undefined ? { description: yamlMetadata.description } : {}),
+      }
+    : version.metadata;
+
+  return { ...version, metadata, spec };
 }
 
 export async function fetchCanvasVersionWithSpec(

--- a/web_src/src/pages/app/lib/workflow-spec-files.spec.ts
+++ b/web_src/src/pages/app/lib/workflow-spec-files.spec.ts
@@ -6,6 +6,7 @@ import { buildAppFiles } from "../files/lib/app-files";
 
 import {
   buildCanvasYamlExportPayload,
+  dematerializeCanvasMetadata,
   dematerializeCanvasSpec,
   materializeCanvasSpec,
   parseCanvasYamlForImport,
@@ -64,5 +65,19 @@ describe("workflow-spec-files", () => {
   it("parses canvas yaml for import with validation errors", () => {
     expect(parseCanvasYamlForImport("")).toEqual({ ok: false, error: "Please provide a YAML definition." });
     expect(parseCanvasYamlForImport("kind: Workflow\nspec:\n  nodes: []").ok).toBe(false);
+  });
+
+  it("dematerializes canvas-level metadata from canvas.yaml", () => {
+    const yamlText = materializeCanvasSpec(sampleWorkflow);
+    expect(dematerializeCanvasMetadata(yamlText)).toEqual({
+      id: "canvas-abc",
+      name: "My Workflow",
+      description: "",
+    });
+  });
+
+  it("returns null canvas metadata for empty or non-canvas yaml", () => {
+    expect(dematerializeCanvasMetadata("")).toBeNull();
+    expect(dematerializeCanvasMetadata("kind: Workflow\nmetadata:\n  name: Nope")).toBeNull();
   });
 });

--- a/web_src/src/pages/app/lib/workflow-spec-files.ts
+++ b/web_src/src/pages/app/lib/workflow-spec-files.ts
@@ -4,7 +4,12 @@ import type { CanvasNode } from "@/ui/CanvasPage";
 
 import { consoleToYaml, parseConsoleYaml } from "../console/consoleYaml";
 
-import { buildCanvasYamlFromWorkflow, parseCanvasYamlToSpec } from "./canvas-yaml-staging";
+import {
+  buildCanvasYamlFromWorkflow,
+  parseCanvasYamlMetadata,
+  parseCanvasYamlToSpec,
+  type ParsedCanvasYamlMetadata,
+} from "./canvas-yaml-staging";
 
 export function applyRenderedNodePositions(workflow: CanvasesCanvas, canvasNodes?: CanvasNode[]): CanvasesCanvas {
   if (!canvasNodes?.length) {
@@ -44,6 +49,10 @@ export function materializeCanvasSpec(workflow: CanvasesCanvas, canvasNodes?: Ca
 
 export function dematerializeCanvasSpec(yamlText: string): CanvasesCanvas["spec"] | null {
   return parseCanvasYamlToSpec(yamlText);
+}
+
+export function dematerializeCanvasMetadata(yamlText: string): ParsedCanvasYamlMetadata | null {
+  return parseCanvasYamlMetadata(yamlText);
 }
 
 export function materializeConsoleSpec(input: {

--- a/web_src/src/pages/app/useAppDraftStagingData.ts
+++ b/web_src/src/pages/app/useAppDraftStagingData.ts
@@ -68,8 +68,8 @@ export function useAppDraftStagingData({
     latestDraftVersion,
     committedBaselines,
   });
-  const commitCanvasStagingMutation = useCommitCanvasStaging(organizationId, canvasId, activeCanvasVersionId);
-  const discardCanvasStagingMutation = useDiscardCanvasStaging(organizationId, canvasId, activeCanvasVersionId);
+  const commitCanvasStagingMutation = useCommitCanvasStaging(canvasId, activeCanvasVersionId);
+  const discardCanvasStagingMutation = useDiscardCanvasStaging(canvasId, activeCanvasVersionId);
 
   const canvasConsoleVersionDiff = useCanvasConsoleVersionDiff({
     canvasId,


### PR DESCRIPTION
## Summary

- Edit mode renders entirely from the draft version's repository files (`canvas.yaml`/`console.yaml`), sourcing the canvas name/description from the YAML metadata instead of the `DescribeCanvas` response.
- The live-canvas detail query is disabled while editing, and draft-scoped mutations (create draft, commit staging, discard staging) no longer invalidate it — so entering edit mode, committing, or creating a draft no longer triggers a `DescribeCanvas` refetch.

## Test plan

- [x] In edit mode, confirm no `DescribeCanvas` requests fire on draft creation or after commit (Network tab).
- [x] Verify the canvas name/description still render correctly while editing.
- [x] Confirm returning to the live canvas refetches the latest data.