### PR TITLE
fix: keep canvas header above runs sidebar

### DIFF
--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -1390,7 +1390,7 @@ function CanvasPage(props: CanvasPageProps) {
       )}
     >
       {/* Header at the top spanning full width */}
-      <div className="relative z-30">
+      <div className="relative z-40">
         <CanvasContentHeader
           state={state}
           canvasName={props.title ?? ""}


### PR DESCRIPTION
## Summary
- raise the canvas page header stacking context above the runs sidebar
- keeps the organization navigation menu visible when the runs sidebar is open

## Tests
- make format.js
- make check.build.ui