### PR TITLE
chore: remove dead canvas unsaved-state and manual save UI

### DIFF
--- a/web_src/src/hooks/useCanvasDraftResync.ts
+++ b/web_src/src/hooks/useCanvasDraftResync.ts
@@ -18,8 +18,6 @@ interface UseCanvasDraftResyncOptions {
   setDraftCanvasSpec: Dispatch<SetStateAction<CanvasSpec>>;
   setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
-  setHasUnsavedChanges: Dispatch<SetStateAction<boolean>>;
-  setHasNonPositionalUnsavedChanges: Dispatch<SetStateAction<boolean>>;
   setStagingResetNonce: Dispatch<SetStateAction<number>>;
 }
 
@@ -44,8 +42,6 @@ export function useCanvasDraftResync(options: UseCanvasDraftResyncOptions): Canv
     setDraftCanvasSpec,
     setActiveCanvasVersion,
     setLastSavedWorkflowSnapshot,
-    setHasUnsavedChanges,
-    setHasNonPositionalUnsavedChanges,
     setStagingResetNonce,
   } = options;
   const queryClient = useQueryClient();
@@ -73,8 +69,6 @@ export function useCanvasDraftResync(options: UseCanvasDraftResyncOptions): Canv
       if (restored) {
         setLastSavedWorkflowSnapshot(restored);
       }
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
     },
     [
       organizationId,
@@ -84,8 +78,6 @@ export function useCanvasDraftResync(options: UseCanvasDraftResyncOptions): Canv
       setDraftCanvasSpec,
       setActiveCanvasVersion,
       setLastSavedWorkflowSnapshot,
-      setHasUnsavedChanges,
-      setHasNonPositionalUnsavedChanges,
     ],
   );
 

--- a/web_src/src/pages/app/confirmDeleteDraftBranch.ts
+++ b/web_src/src/pages/app/confirmDeleteDraftBranch.ts
@@ -25,8 +25,6 @@ type ConfirmDeleteDraftBranchOptions = {
   setSearchParams: SetURLSearchParams;
   setActiveCanvasVersion: (value: CanvasesCanvasVersion | null) => void;
   setDraftCanvasSpec: (value: CanvasesCanvas["spec"] | null) => void;
-  setHasUnsavedChanges: (value: boolean) => void;
-  setHasNonPositionalUnsavedChanges: (value: boolean) => void;
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
 };
 
@@ -48,8 +46,6 @@ export async function confirmDeleteDraftBranch({
   setSearchParams,
   setActiveCanvasVersion,
   setDraftCanvasSpec,
-  setHasUnsavedChanges,
-  setHasNonPositionalUnsavedChanges,
   setLastSavedWorkflowSnapshot,
 }: ConfirmDeleteDraftBranchOptions): Promise<void> {
   const branch = draftBranches.find((item) => draftVersionId(item) === versionId);
@@ -67,8 +63,6 @@ export async function confirmDeleteDraftBranch({
     await deleteDraftBranch(versionId);
 
     if (isActiveDraft) {
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
       setLastSavedWorkflowSnapshot(null);
       exitToLive();
 

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -685,15 +685,11 @@ export function AppPage() {
   const runsViewportRef = useRef<{ x: number; y: number; zoom: number } | undefined>(undefined);
   const lastRunsViewportKeyRef = useRef<string | null>(null);
 
-  // Track unsaved changes on the canvas
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  const [hasNonPositionalUnsavedChanges, setHasNonPositionalUnsavedChanges] = useState(false);
   const [isPositionAutoSaveQueued, setIsPositionAutoSaveQueued] = useState(false);
   const [isAnnotationAutoSaveQueued, setIsAnnotationAutoSaveQueued] = useState(false);
 
   const isAutoSaveQueued = isPositionAutoSaveQueued || isAnnotationAutoSaveQueued;
   const hasLocalSaveActivity = isCanvasSaveInFlight || isCanvasSaveQueued || isAutoSaveQueued;
-  const hasPendingLocalCanvasState = hasUnsavedChanges || hasLocalSaveActivity;
   const [isAutoLayoutOnUpdateEnabled, setIsAutoLayoutOnUpdateEnabled] = useState(() =>
     readStoredBoolean(CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY),
   );
@@ -835,8 +831,6 @@ export function AppPage() {
     }
 
     hasTrackedCanvasView.current = false;
-    setHasUnsavedChanges(false);
-    setHasNonPositionalUnsavedChanges(false);
     setActiveCanvasVersion(null);
     hasSyncedVersionFromURLRef.current = false;
     setLastSavedWorkflowSnapshot(null);
@@ -925,7 +919,7 @@ export function AppPage() {
       !canvasId ||
       !activeCanvasVersionId ||
       !loadedCanvasVersion?.spec ||
-      hasPendingLocalCanvasState
+      hasLocalSaveActivity
     ) {
       return;
     }
@@ -952,12 +946,12 @@ export function AppPage() {
     });
 
     lastAppliedVersionSnapshotRef.current = snapshotKey;
-  }, [organizationId, canvasId, activeCanvasVersionId, loadedCanvasVersion, queryClient, hasPendingLocalCanvasState]);
+  }, [organizationId, canvasId, activeCanvasVersionId, loadedCanvasVersion, queryClient, hasLocalSaveActivity]);
 
   useEffect(() => {
     if (
       !remoteCanvasUpdatePending ||
-      hasPendingLocalCanvasState ||
+      hasLocalSaveActivity ||
       canvasDeletedRemotely ||
       !organizationId ||
       !canvasId
@@ -977,7 +971,7 @@ export function AppPage() {
     setRemoteCanvasUpdatePending(false);
   }, [
     remoteCanvasUpdatePending,
-    hasPendingLocalCanvasState,
+    hasLocalSaveActivity,
     canvasDeletedRemotely,
     organizationId,
     canvasId,
@@ -1286,15 +1280,6 @@ export function AppPage() {
       return;
     }
 
-    if (hasEditableVersion && hasUnsavedChanges) {
-      const shouldCreate = window.confirm(
-        "You have unsaved changes in the current draft. Create a new draft from live anyway?",
-      );
-      if (!shouldCreate) {
-        return;
-      }
-    }
-
     setIsCreatingDraftBranch(true);
     try {
       const session = ++draftCreationSessionRef.current;
@@ -1332,8 +1317,6 @@ export function AppPage() {
         }
         return [loadedVersion, ...current];
       });
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
       setLastSavedWorkflowSnapshot(null);
       if (session !== draftCreationSessionRef.current) {
         return;
@@ -1376,8 +1359,6 @@ export function AppPage() {
     organizationId,
     canvasId,
     canUpdateCanvas,
-    hasEditableVersion,
-    hasUnsavedChanges,
     createDraftBranchMutation,
     activateBranch,
     queryClient,
@@ -1442,7 +1423,6 @@ export function AppPage() {
             canvasId,
             pendingPositionUpdatesRef,
             isReadOnly,
-            hasNonPositionalUnsavedChanges,
             canvasRef,
             queryClient,
             activeCanvasVersionIdRef,
@@ -1460,7 +1440,6 @@ export function AppPage() {
       canvasId,
       activeCanvasVersionId,
       queryClient,
-      hasNonPositionalUnsavedChanges,
       isReadOnly,
       enqueueCanvasSave,
       applyLocalWorkflowUpdate,
@@ -1509,7 +1488,7 @@ export function AppPage() {
   // Warn user before leaving page with unsaved changes
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (hasPendingLocalCanvasState) {
+      if (hasLocalSaveActivity) {
         e.preventDefault();
         e.returnValue = "Your work isn't saved, unsaved changes will be lost. Are you sure you want to leave?";
       }
@@ -1517,7 +1496,7 @@ export function AppPage() {
 
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [hasPendingLocalCanvasState]);
+  }, [hasLocalSaveActivity]);
 
   // Merge triggers and components from applications into the main arrays
   const allTriggers = useMemo(() => {
@@ -1939,8 +1918,6 @@ export function AppPage() {
     setDraftCanvasSpec,
     setActiveCanvasVersion,
     setLastSavedWorkflowSnapshot,
-    setHasUnsavedChanges,
-    setHasNonPositionalUnsavedChanges,
     setStagingResetNonce,
   });
 
@@ -1972,7 +1949,7 @@ export function AppPage() {
           return true;
         }
 
-        if (payload.versionId === activeCanvasVersionId && hasPendingLocalCanvasState) {
+        if (payload.versionId === activeCanvasVersionId && hasLocalSaveActivity) {
           setRemoteCanvasUpdatePending(true);
           return true;
         }
@@ -1986,7 +1963,7 @@ export function AppPage() {
         return true;
       }
 
-      if (hasPendingLocalCanvasState) {
+      if (hasLocalSaveActivity) {
         setRemoteCanvasUpdatePending(true);
         return true;
       }
@@ -1999,15 +1976,15 @@ export function AppPage() {
       canvasId,
       consumeIgnoredCanvasUpdatedEcho,
       consumeIgnoredCanvasVersionUpdatedEcho,
-      hasPendingLocalCanvasState,
+      hasLocalSaveActivity,
       invalidateCanvasVersionData,
       resyncDraftToCommitted,
     ],
   );
 
   const shouldApplyCanvasUpdate = useCallback(
-    () => isViewingLiveVersion && !hasPendingLocalCanvasState && !canvasDeletedRemotely,
-    [isViewingLiveVersion, hasPendingLocalCanvasState, canvasDeletedRemotely],
+    () => isViewingLiveVersion && !hasLocalSaveActivity && !canvasDeletedRemotely,
+    [isViewingLiveVersion, hasLocalSaveActivity, canvasDeletedRemotely],
   );
 
   const handleCanvasStagingEvent = useCallback(
@@ -2025,7 +2002,7 @@ export function AppPage() {
       // Defer when this tab has its own unsaved canvas edits to avoid clobbering
       // them; the deferred-apply effect refreshes once they settle. The console
       // and files staged caches still refresh through the websocket hook.
-      if (payload.versionId === activeCanvasVersionId && hasPendingLocalCanvasState) {
+      if (payload.versionId === activeCanvasVersionId && hasLocalSaveActivity) {
         setRemoteCanvasUpdatePending(true);
         return true;
       }
@@ -2033,7 +2010,7 @@ export function AppPage() {
       void resyncDraftToStaged(payload.versionId);
       return true;
     },
-    [canvasId, activeCanvasVersionId, hasPendingLocalCanvasState, resyncDraftToStaged],
+    [canvasId, activeCanvasVersionId, hasLocalSaveActivity, resyncDraftToStaged],
   );
 
   useCanvasWebsocket(
@@ -2265,11 +2242,6 @@ export function AppPage() {
           showSuccessToast("Canvas changes saved");
         }
         setLastSavedWorkflowSnapshot(targetWorkflow);
-
-        if (result.matchesCurrentCanvas && !result.hasQueuedFollowUp) {
-          setHasUnsavedChanges(false);
-          setHasNonPositionalUnsavedChanges(false);
-        }
 
         return result;
       } catch (error: any) {
@@ -2594,10 +2566,6 @@ export function AppPage() {
             return;
           }
 
-          if (hasNonPositionalUnsavedChanges) {
-            return;
-          }
-
           const latestWorkflow = queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId));
 
           if (!latestWorkflow?.spec?.nodes) return;
@@ -2641,7 +2609,7 @@ export function AppPage() {
         },
         isReadOnly ? 2000 : 100,
       ),
-    [organizationId, canvasId, queryClient, handleSaveWorkflow, hasNonPositionalUnsavedChanges, isReadOnly],
+    [organizationId, canvasId, queryClient, handleSaveWorkflow, isReadOnly],
   );
 
   const handleAnnotationBlur = useCallback(() => {
@@ -2686,11 +2654,11 @@ export function AppPage() {
     const currentWorkflow = getCurrentWorkflowSnapshot();
 
     if (!currentWorkflow || !lastSavedWorkflowSignatureRef.current) {
-      return hasUnsavedChanges;
+      return false;
     }
 
     return getWorkflowSaveSignature(currentWorkflow) !== lastSavedWorkflowSignatureRef.current;
-  }, [getCurrentWorkflowSnapshot, hasUnsavedChanges]);
+  }, [getCurrentWorkflowSnapshot]);
 
   const waitForLocalCanvasChangesToSettle = useCallback(async () => {
     debouncedAutoSave.flush();
@@ -3040,8 +3008,6 @@ export function AppPage() {
         setLastSavedWorkflowSnapshot(
           queryClient.getQueryData<CanvasesCanvas>(canvasKeys.detail(organizationId, canvasId)) ?? null,
         );
-        setHasUnsavedChanges(false);
-        setHasNonPositionalUnsavedChanges(false);
       } catch (error) {
         releaseCanvasUpdatedEcho();
         releaseCanvasVersionUpdatedEcho();
@@ -3655,67 +3621,6 @@ export function AppPage() {
     ],
   );
 
-  const handleSave = useCallback(
-    async (canvasNodes: CanvasNode[]) => {
-      if (!canvas || !organizationId || !canvasId) return;
-      if (!activeCanvasVersionId) {
-        showErrorToast("Enable edit mode before saving changes");
-        return;
-      }
-
-      // Map canvas nodes back to ComponentsNode format with updated positions
-      const updatedNodes = canvas.spec?.nodes?.map((node) => {
-        const canvasNode = canvasNodes.find((cn) => cn.id === node.id);
-        const componentType = (canvasNode?.data?.type as string) || "";
-        if (canvasNode) {
-          return {
-            ...node,
-            position: {
-              x: Math.round(canvasNode.position.x),
-              y: Math.round(canvasNode.position.y),
-            },
-            isCollapsed: (canvasNode.data[componentType] as { collapsed: boolean })?.collapsed || false,
-          };
-        }
-        return node;
-      });
-
-      const updatedWorkflow = {
-        ...canvas,
-        spec: {
-          ...canvas.spec,
-          nodes: updatedNodes,
-        },
-      };
-
-      try {
-        const savingVersionID = activeCanvasVersionId || undefined;
-        const result = await enqueueCanvasSave(updatedWorkflow, savingVersionID);
-        if (result.status !== "saved") {
-          return;
-        }
-        if (result.response?.data?.version && savingVersionID && activeCanvasVersionIdRef.current === savingVersionID) {
-          setActiveCanvasVersion(result.response.data.version);
-        }
-        if (activeCanvasVersionIdRef.current !== (savingVersionID || "")) {
-          return;
-        }
-
-        showSuccessToast("Canvas changes saved");
-        setLastSavedWorkflowSnapshot(updatedWorkflow);
-
-        if (result.matchesCurrentCanvas && !result.hasQueuedFollowUp) {
-          setHasUnsavedChanges(false);
-          setHasNonPositionalUnsavedChanges(false);
-        }
-      } catch (error) {
-        const errorMessage = getApiErrorMessage(error, "Failed to save changes to the canvas");
-        showErrorToast(errorMessage);
-      }
-    },
-    [canvas, organizationId, canvasId, activeCanvasVersionId, enqueueCanvasSave, setLastSavedWorkflowSnapshot],
-  );
-
   const refreshLatestLiveCanvasData = useCallback(async () => {
     if (!organizationId || !canvasId) {
       return;
@@ -3772,8 +3677,6 @@ export function AppPage() {
       if (restoredWorkflow) {
         setLastSavedWorkflowSnapshot(restoredWorkflow);
       }
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
     },
     [canvasId, organizationId, queryClient, setLastSavedWorkflowSnapshot],
   );
@@ -3841,8 +3744,6 @@ export function AppPage() {
       }
 
       lastAppliedVersionSnapshotRef.current = "";
-      setHasUnsavedChanges(false);
-      setHasNonPositionalUnsavedChanges(false);
       setLastSavedWorkflowSnapshot(null);
 
       const branchName = resolveBranchNameForVersion(versionID, version, draftBranches);
@@ -3933,7 +3834,7 @@ export function AppPage() {
 
   const handleUseVersionFromVersionPanel = useCallback(
     (versionID: string) => {
-      if (hasEditableVersion && hasPendingLocalCanvasState && versionID !== activeCanvasVersionIdRef.current) {
+      if (hasEditableVersion && hasLocalSaveActivity && versionID !== activeCanvasVersionIdRef.current) {
         const shouldSwitch = window.confirm(
           "You have unsaved changes in the current draft. Switch versions and discard those unsaved changes?",
         );
@@ -3954,7 +3855,7 @@ export function AppPage() {
     [
       handleUseVersion,
       hasEditableVersion,
-      hasPendingLocalCanvasState,
+      hasLocalSaveActivity,
       effectiveLiveCanvasVersionId,
       liveCanvasVersionId,
     ],
@@ -3974,7 +3875,7 @@ export function AppPage() {
     isRunInspectionMode: urlViewFlags.isRunInspectionMode,
     selectableVersionsById,
     hasEditableVersion,
-    hasPendingLocalCanvasState,
+    hasLocalSaveActivity,
     activeCanvasVersionIdRef,
     activateCanvasVersionForEditing,
     setSuppressUnpublishedDraftDiscard,
@@ -4010,8 +3911,6 @@ export function AppPage() {
     setSearchParams,
     setActiveCanvasVersion,
     setDraftCanvasSpec,
-    setHasUnsavedChanges,
-    setHasNonPositionalUnsavedChanges,
     setLastSavedWorkflowSnapshot,
   });
 
@@ -4568,8 +4467,6 @@ export function AppPage() {
     }
 
     clearPendingAutoSaveWork();
-    setHasUnsavedChanges(false);
-    setHasNonPositionalUnsavedChanges(false);
     setRemoteCanvasUpdatePending(false);
     setLastSavedWorkflowSnapshot(null);
 
@@ -4585,7 +4482,6 @@ export function AppPage() {
     }
   };
 
-  const hasRunBlockingChanges = hasUnsavedChanges && hasNonPositionalUnsavedChanges;
   const backToAppId = searchParams.get("appId") ?? undefined;
   const appBanner = backToAppId ? (
     <div className="bg-blue-50 border-b border-blue-200 px-4 py-2 flex items-center gap-2">
@@ -4624,15 +4520,6 @@ export function AppPage() {
   ].join(":");
   const headerBanners = [appBanner, remoteUpdateBanner].filter(Boolean);
   const headerBanner = headerBanners.length > 0 ? <div className="flex flex-col">{headerBanners}</div> : null;
-  const saveDisabled = !canUpdateCanvas || !hasEditableVersion;
-  const saveDisabledTooltip = !canUpdateCanvas
-    ? "You don't have permission to edit this canvas."
-    : !hasEditableVersion
-      ? "Enable edit mode to save changes."
-      : undefined;
-  const saveButtonHidden =
-    !canUpdateCanvas || !hasEditableVersion || !hasUnsavedChanges || (!isReadOnly && isAutoSaveQueued);
-  const saveIsPrimary = hasUnsavedChanges && !isReadOnly && !isAutoSaveQueued;
   const enterEditModeDisabled = !canUpdateCanvas || canvasDeletedRemotely;
   const enterEditModeDisabledTooltip = !canUpdateCanvas
     ? "You don't have permission to edit this canvas."
@@ -4671,7 +4558,6 @@ export function AppPage() {
     hasEditableVersion,
   });
   const { disabled: runDisabled, tooltip: runDisabledTooltip } = getRunActionState({
-    hasRunBlockingChanges,
     ...canvasAccess,
     isViewingDraftVersion,
     isViewingCurrentLiveVersion,
@@ -4844,7 +4730,6 @@ export function AppPage() {
           configurationSaveMode={isReadOnly ? "manual" : "auto"}
           onAnnotationUpdate={!isReadOnly ? handleAnnotationUpdate : undefined}
           onAnnotationBlur={!isReadOnly ? handleAnnotationBlur : undefined}
-          onSave={handleSave}
           onEdgeCreate={!isReadOnly ? handleEdgeCreate : undefined}
           onNodeDelete={!isReadOnly ? handleNodeDelete : undefined}
           onNodesDelete={!isReadOnly ? handleNodesDelete : undefined}
@@ -4896,10 +4781,6 @@ export function AppPage() {
           onRunNodeDetailNavigate={handleRunNodeDetailSelection}
           runNodeDetailPaneHeight={runNodeDetailPaneHeight}
           onRunNodeDetailPaneHeightChange={setRunNodeDetailPaneHeight}
-          saveIsPrimary={saveIsPrimary}
-          saveButtonHidden={saveButtonHidden}
-          saveDisabled={saveDisabled}
-          saveDisabledTooltip={saveDisabledTooltip}
           onShowDiff={onShowDiff}
           {...canvasConsoleVersionDiff.consoleDiffHeaderProps}
           visualDiffEnabled={draftVisualDiff.visualDiffEnabled}

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -914,13 +914,7 @@ export function AppPage() {
   ]);
 
   useEffect(() => {
-    if (
-      !organizationId ||
-      !canvasId ||
-      !activeCanvasVersionId ||
-      !loadedCanvasVersion?.spec ||
-      hasLocalSaveActivity
-    ) {
+    if (!organizationId || !canvasId || !activeCanvasVersionId || !loadedCanvasVersion?.spec || hasLocalSaveActivity) {
       return;
     }
 
@@ -949,13 +943,7 @@ export function AppPage() {
   }, [organizationId, canvasId, activeCanvasVersionId, loadedCanvasVersion, queryClient, hasLocalSaveActivity]);
 
   useEffect(() => {
-    if (
-      !remoteCanvasUpdatePending ||
-      hasLocalSaveActivity ||
-      canvasDeletedRemotely ||
-      !organizationId ||
-      !canvasId
-    ) {
+    if (!remoteCanvasUpdatePending || hasLocalSaveActivity || canvasDeletedRemotely || !organizationId || !canvasId) {
       return;
     }
 
@@ -3852,13 +3840,7 @@ export function AppPage() {
 
       handleUseVersion(versionID);
     },
-    [
-      handleUseVersion,
-      hasEditableVersion,
-      hasLocalSaveActivity,
-      effectiveLiveCanvasVersionId,
-      liveCanvasVersionId,
-    ],
+    [handleUseVersion, hasEditableVersion, hasLocalSaveActivity, effectiveLiveCanvasVersionId, liveCanvasVersionId],
   );
 
   const { headerMode, canvasStateMode, showBottomStatusControls, hideAddControls, readOnlyViewModes } =

--- a/web_src/src/pages/app/runPositionAutoSave.ts
+++ b/web_src/src/pages/app/runPositionAutoSave.ts
@@ -46,7 +46,6 @@ export type RunPositionAutoSaveOptions = {
   canvasId?: string;
   pendingPositionUpdatesRef: MutableRefObject<Map<string, { x: number; y: number }>>;
   isReadOnly: boolean;
-  hasNonPositionalUnsavedChanges: boolean;
   canvasRef: MutableRefObject<CanvasesCanvas | null>;
   queryClient: QueryClient;
   activeCanvasVersionIdRef: MutableRefObject<string>;
@@ -64,7 +63,6 @@ export async function runPositionAutoSave({
   canvasId,
   pendingPositionUpdatesRef,
   isReadOnly,
-  hasNonPositionalUnsavedChanges,
   canvasRef,
   queryClient,
   activeCanvasVersionIdRef,
@@ -83,7 +81,7 @@ export async function runPositionAutoSave({
   const focusedNoteId = getActiveNoteId();
 
   try {
-    if (isReadOnly || hasNonPositionalUnsavedChanges) {
+    if (isReadOnly) {
       return;
     }
 

--- a/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
+++ b/web_src/src/pages/app/useAgentDraftEditor.spec.tsx
@@ -54,7 +54,7 @@ function setupHook({
   headerMode = "version-live",
   isRunInspectionMode = false,
   hasEditableVersion = false,
-  hasPendingLocalCanvasState = false,
+  hasLocalSaveActivity = false,
   activeCanvasVersionId = "live-version",
   activateCanvasVersionForEditing = vi.fn(() => true),
   selectableVersionsById = new Map<string, CanvasesCanvasVersion>([[versionId, makeDraftVersion(versionId)]]),
@@ -64,7 +64,7 @@ function setupHook({
   headerMode?: CanvasPageHeaderMode;
   isRunInspectionMode?: boolean;
   hasEditableVersion?: boolean;
-  hasPendingLocalCanvasState?: boolean;
+  hasLocalSaveActivity?: boolean;
   activeCanvasVersionId?: string;
   activateCanvasVersionForEditing?: (versionId: string, version: CanvasesCanvasVersion) => boolean;
   selectableVersionsById?: Map<string, CanvasesCanvasVersion>;
@@ -83,7 +83,7 @@ function setupHook({
     isRunInspectionMode,
     selectableVersionsById,
     hasEditableVersion,
-    hasPendingLocalCanvasState,
+    hasLocalSaveActivity,
     activeCanvasVersionIdRef,
     activateCanvasVersionForEditing,
     setSuppressUnpublishedDraftDiscard,
@@ -158,7 +158,7 @@ describe("useAgentDraftEditor", () => {
       canvasId: "canvas-retry-conflict-clear",
       versionId,
       hasEditableVersion: true,
-      hasPendingLocalCanvasState: true,
+      hasLocalSaveActivity: true,
       activeCanvasVersionId: "other-draft",
     });
 
@@ -167,7 +167,7 @@ describe("useAgentDraftEditor", () => {
     await act(async () => undefined);
     expect(hook.activateCanvasVersionForEditing).not.toHaveBeenCalled();
 
-    hook.updateProps({ hasPendingLocalCanvasState: false });
+    hook.updateProps({ hasLocalSaveActivity: false });
 
     await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
     expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledWith(
@@ -207,7 +207,7 @@ describe("useAgentDraftEditor", () => {
     await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(1));
 
     activateCanvasVersionForEditing.mockReturnValue(true);
-    hook.updateProps({ hasPendingLocalCanvasState: true });
+    hook.updateProps({ hasLocalSaveActivity: true });
 
     await waitFor(() => expect(hook.activateCanvasVersionForEditing).toHaveBeenCalledTimes(2));
   });

--- a/web_src/src/pages/app/useAgentDraftEditor.ts
+++ b/web_src/src/pages/app/useAgentDraftEditor.ts
@@ -29,7 +29,7 @@ type UseAgentDraftEditorArgs = {
   isRunInspectionMode: boolean;
   selectableVersionsById: Map<string, CanvasesCanvasVersion>;
   hasEditableVersion: boolean;
-  hasPendingLocalCanvasState: boolean;
+  hasLocalSaveActivity: boolean;
   activeCanvasVersionIdRef: { current: string };
   activateCanvasVersionForEditing: (versionId: string, version: CanvasesCanvasVersion) => boolean;
   setSuppressUnpublishedDraftDiscard: (value: boolean) => void;
@@ -164,7 +164,7 @@ export function useAgentDraftEditor({
   isRunInspectionMode,
   selectableVersionsById,
   hasEditableVersion,
-  hasPendingLocalCanvasState,
+  hasLocalSaveActivity,
   activeCanvasVersionIdRef,
   activateCanvasVersionForEditing,
   setSuppressUnpublishedDraftDiscard,
@@ -208,7 +208,7 @@ export function useAgentDraftEditor({
         return "opened";
       }
 
-      if (hasEditableVersion && hasPendingLocalCanvasState && activeCanvasVersionIdRef.current !== versionId) {
+      if (hasEditableVersion && hasLocalSaveActivity && activeCanvasVersionIdRef.current !== versionId) {
         if (source === "auto") {
           return "skipped";
         }
@@ -241,7 +241,7 @@ export function useAgentDraftEditor({
       activeCanvasVersionIdRef,
       handleMissingDraft,
       hasEditableVersion,
-      hasPendingLocalCanvasState,
+      hasLocalSaveActivity,
       headerMode,
       isRunInspectionMode,
       loadAgentDraftVersion,

--- a/web_src/src/pages/app/useCanvasDraftBranchActions.ts
+++ b/web_src/src/pages/app/useCanvasDraftBranchActions.ts
@@ -32,8 +32,6 @@ type UseCanvasDraftBranchActionsOptions = {
   setSearchParams: SetURLSearchParams;
   setActiveCanvasVersion: (value: CanvasesCanvasVersion | null) => void;
   setDraftCanvasSpec: (value: CanvasesCanvas["spec"] | null) => void;
-  setHasUnsavedChanges: (value: boolean) => void;
-  setHasNonPositionalUnsavedChanges: (value: boolean) => void;
   setLastSavedWorkflowSnapshot: (workflow: CanvasesCanvas | null) => void;
 };
 
@@ -57,8 +55,6 @@ export function useCanvasDraftBranchActions({
   setSearchParams,
   setActiveCanvasVersion,
   setDraftCanvasSpec,
-  setHasUnsavedChanges,
-  setHasNonPositionalUnsavedChanges,
   setLastSavedWorkflowSnapshot,
 }: UseCanvasDraftBranchActionsOptions) {
   const [draftVersionToDelete, setDraftVersionToDelete] = useState<string | null>(null);
@@ -133,8 +129,6 @@ export function useCanvasDraftBranchActions({
         setSearchParams,
         setActiveCanvasVersion,
         setDraftCanvasSpec,
-        setHasUnsavedChanges,
-        setHasNonPositionalUnsavedChanges,
         setLastSavedWorkflowSnapshot,
       });
       setDraftVersionToDelete(null);
@@ -160,8 +154,6 @@ export function useCanvasDraftBranchActions({
     setLastSavedWorkflowSnapshot,
     setActiveCanvasVersion,
     setDraftCanvasSpec,
-    setHasUnsavedChanges,
-    setHasNonPositionalUnsavedChanges,
   ]);
 
   const requestDeleteActiveDraft = useCallback(() => {

--- a/web_src/src/pages/app/viewState.ts
+++ b/web_src/src/pages/app/viewState.ts
@@ -232,24 +232,17 @@ export function getExitEditModeDisabledTooltip({
 }
 
 export function getRunActionState({
-  hasRunBlockingChanges,
   canUpdateCanvas,
   canvasDeletedRemotely,
   isViewingDraftVersion,
   isViewingCurrentLiveVersion,
 }: {
-  hasRunBlockingChanges: boolean;
   canUpdateCanvas: boolean;
   canvasDeletedRemotely: boolean;
   isViewingDraftVersion: boolean;
   isViewingCurrentLiveVersion: boolean;
 }): { disabled: boolean; tooltip?: string } {
-  const disabled =
-    hasRunBlockingChanges ||
-    !canUpdateCanvas ||
-    canvasDeletedRemotely ||
-    isViewingDraftVersion ||
-    !isViewingCurrentLiveVersion;
+  const disabled = !canUpdateCanvas || canvasDeletedRemotely || isViewingDraftVersion || !isViewingCurrentLiveVersion;
 
   if (canvasDeletedRemotely) {
     return { disabled, tooltip: "This canvas was deleted in another session." };
@@ -265,10 +258,6 @@ export function getRunActionState({
 
   if (!canUpdateCanvas) {
     return { disabled, tooltip: "You don't have permission to emit events on this canvas." };
-  }
-
-  if (hasRunBlockingChanges) {
-    return { disabled, tooltip: "Save canvas changes before running" };
   }
 
   return { disabled, tooltip: undefined };

--- a/web_src/src/ui/CanvasPage/Header.tsx
+++ b/web_src/src/ui/CanvasPage/Header.tsx
@@ -23,7 +23,6 @@ export type HeaderMode =
 export interface HeaderProps {
   /** Shown centered in the top bar (canvas or template display name). May be undefined while the canvas is still loading. */
   canvasName?: string;
-  onSave?: () => void;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
@@ -43,10 +42,6 @@ export interface HeaderProps {
     diffCounts: { added: number; updated: number; removed: number };
   };
   organizationId?: string;
-  saveIsPrimary?: boolean;
-  saveButtonHidden?: boolean;
-  saveDisabled?: boolean;
-  saveDisabledTooltip?: string;
   publishVersionDisabled?: boolean;
   publishVersionDisabledTooltip?: string;
   discardVersionDisabled?: boolean;

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.tsx
@@ -2,18 +2,12 @@ import { Button as UIButton } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { X } from "lucide-react";
-import { Button } from "../button";
 import { DiffSummaryHoverCard } from "./components/DiffSummaryHoverCard";
 import type { HeaderProps } from "./Header";
 
 export function SecondaryHeaderActions({
   mode,
   isEditing = false,
-  onSave,
-  saveButtonHidden,
-  saveDisabled,
-  saveDisabledTooltip,
-  saveIsPrimary,
   hasUnpublishedDraftChanges,
   hasUnpublishedConsoleDraftChanges,
   hasUncommittedCanvasDraftChanges,
@@ -42,15 +36,6 @@ export function SecondaryHeaderActions({
 
   return (
     <div className="relative z-10 ml-auto flex shrink-0 items-center gap-1.5">
-      {mode === "default" && onSave && !saveButtonHidden ? (
-        <SaveButton
-          onSave={onSave}
-          saveDisabled={saveDisabled}
-          saveDisabledTooltip={saveDisabledTooltip}
-          saveIsPrimary={saveIsPrimary}
-        />
-      ) : null}
-
       <FilesHeaderActionsSlot isEditing={isEditing} mode={mode} slotId={filesHeaderActionsSlotId} />
 
       {isEditing ? (
@@ -345,51 +330,6 @@ function ExitEditButton({
   }
 
   return button;
-}
-
-function SaveButton({
-  onSave,
-  saveDisabled,
-  saveDisabledTooltip,
-  saveIsPrimary,
-}: {
-  onSave: () => void;
-  saveDisabled?: boolean;
-  saveDisabledTooltip?: string;
-  saveIsPrimary?: boolean;
-}) {
-  if (saveDisabled && saveDisabledTooltip) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="inline-flex">
-            <Button
-              onClick={onSave}
-              size="sm"
-              variant={saveIsPrimary ? "default" : "outline"}
-              data-testid="save-canvas-button"
-              disabled={saveDisabled}
-            >
-              Save
-            </Button>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="top">{saveDisabledTooltip}</TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Button
-      onClick={onSave}
-      size="sm"
-      variant={saveIsPrimary ? "default" : "outline"}
-      data-testid="save-canvas-button"
-      disabled={saveDisabled}
-    >
-      Save
-    </Button>
-  );
 }
 
 function DiscardDraftButton({

--- a/web_src/src/ui/CanvasPage/index.tsx
+++ b/web_src/src/ui/CanvasPage/index.tsx
@@ -166,10 +166,6 @@ export interface CanvasPageProps {
   headerBanner?: React.ReactNode;
   organizationId?: string;
   canvasId?: string;
-  saveIsPrimary?: boolean;
-  saveButtonHidden?: boolean;
-  saveDisabled?: boolean;
-  saveDisabledTooltip?: string;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
@@ -279,7 +275,6 @@ export interface CanvasPageProps {
   onAnnotationBlur?: () => void;
   getCustomField?: (nodeId: string, integration?: OrganizationsIntegration) => (() => React.ReactNode) | null;
   onNodeClick?: (nodeId: string) => void;
-  onSave?: (nodes: CanvasNode[]) => void;
   integrations?: OrganizationsIntegration[];
   onEdgeCreate?: (sourceId: string, targetId: string, sourceHandle?: string | null) => void;
   onNodeDelete?: (nodeId: string) => void;
@@ -1392,14 +1387,8 @@ function CanvasPage(props: CanvasPageProps) {
       {/* Header at the top spanning full width */}
       <div className="relative z-30">
         <CanvasContentHeader
-          state={state}
           canvasName={props.title ?? ""}
-          onSave={props.onSave}
           organizationId={props.organizationId}
-          saveIsPrimary={props.saveIsPrimary}
-          saveButtonHidden={props.saveButtonHidden}
-          saveDisabled={props.saveDisabled}
-          saveDisabledTooltip={props.saveDisabledTooltip}
           onPublishVersion={props.onPublishVersion}
           onDiscardVersion={props.onDiscardVersion}
           onShowDiff={props.onShowDiff}
@@ -1911,14 +1900,8 @@ function Sidebar({
 }
 
 function CanvasContentHeader({
-  state,
   canvasName,
-  onSave,
   organizationId,
-  saveIsPrimary,
-  saveButtonHidden,
-  saveDisabled,
-  saveDisabledTooltip,
   onPublishVersion,
   onDiscardVersion,
   onShowDiff,
@@ -1970,14 +1953,8 @@ function CanvasContentHeader({
   runsSidebarState,
   versionsSidebarState,
 }: {
-  state: CanvasPageState;
   canvasName: string;
-  onSave?: (nodes: CanvasNode[]) => void;
   organizationId?: string;
-  saveIsPrimary?: boolean;
-  saveButtonHidden?: boolean;
-  saveDisabled?: boolean;
-  saveDisabledTooltip?: string;
   onPublishVersion?: () => void;
   onDiscardVersion?: () => void;
   onShowDiff?: () => void;
@@ -2039,24 +2016,10 @@ function CanvasContentHeader({
   runsSidebarState: CanvasRunsSidebarState;
   versionsSidebarState: CanvasVersionsSidebarState;
 }) {
-  const stateRef = useRef(state);
-  stateRef.current = state;
-
-  const handleSave = useCallback(() => {
-    if (onSave) {
-      onSave(stateRef.current.nodes);
-    }
-  }, [onSave]);
-
   return (
     <Header
       canvasName={canvasName}
-      onSave={onSave ? handleSave : undefined}
       organizationId={organizationId}
-      saveIsPrimary={saveIsPrimary}
-      saveButtonHidden={saveButtonHidden}
-      saveDisabled={saveDisabled}
-      saveDisabledTooltip={saveDisabledTooltip}
       onPublishVersion={onPublishVersion}
       onDiscardVersion={onDiscardVersion}
       onShowDiff={onShowDiff}


### PR DESCRIPTION
- Remove `hasUnsavedChanges` and `hasNonPositionalUnsavedChanges`, which were never set to `true` after `markUnsavedChange` was removed — all dirty tracking now lives in autosave (`handleSaveWorkflow` / `enqueueCanvasSave`) and save signatures
- Drop the dead `hasRunBlockingChanges` run guard and its “Save canvas changes before running” tooltip (always false)
- Remove the manual header Save button path (`onSave`, `saveButtonHidden`, `saveIsPrimary`, `saveDisabled`, etc.) from `CanvasPage` and header components
- Use `hasLocalSaveActivity` directly instead of the redundant `hasPendingLocalCanvasState` alias

## Context

The app autosaves canvas edits; the old boolean dirty flags and header Save button were leftover plumbing with no effect on runtime behavior. Save signature logic (`getWorkflowSaveSignature` / `setLastSavedWorkflowSnapshot`) is unchanged — still used for save conflict detection and commit settle.