### PR TITLE
fix: publish agent token usage events

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -805,6 +805,32 @@ func TestStreamEvents_EndTurnStopReasonCompletesTurn(t *testing.T) {
 	assert.Equal(t, agents.ProviderEventTurnCompleted, received[0].Type)
 }
 
+func TestStreamEvents_MapsTokenUsageOnCompletedTurn(t *testing.T) {
+	const sse = "data: {\"type\":\"session.status_idle\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":3,\"cache_creation_input_tokens\":2}}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.Len(t, received, 1)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[0].Type)
+	assert.Equal(t, "claude-sonnet-4-5", received[0].Model)
+	require.NotNil(t, received[0].Usage)
+	assert.Equal(t, int64(10), received[0].Usage.InputTokens)
+	assert.Equal(t, int64(5), received[0].Usage.OutputTokens)
+	assert.Equal(t, int64(3), received[0].Usage.CacheReadTokens)
+	assert.Equal(t, int64(2), received[0].Usage.CacheWriteTokens)
+	assert.Equal(t, int64(20), received[0].Usage.TotalTokens)
+}
+
 func TestStreamEvents_FallsBackToEventIDWhenToolUseIDMissing(t *testing.T) {
 	const sse = "data: {\"id\":\"evt_fallback\",\"type\":\"agent.tool_use\",\"name\":\"search\"}\n\n" +
 		"data: {\"type\":\"session.status_idle\"}\n\n"

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -11,12 +11,14 @@ import (
 type anthropicEvent struct {
 	ID         string                  `json:"id"`
 	Type       string                  `json:"type"`
+	Model      string                  `json:"model,omitempty"`
 	Name       string                  `json:"name"`
 	ToolName   string                  `json:"tool_name,omitempty"`
 	ToolUseID  string                  `json:"tool_use_id,omitempty"`
 	Input      json.RawMessage         `json:"input,omitempty"`
 	Content    []anthropicContentBlock `json:"content"`
 	StopReason *anthropicStopReason    `json:"stop_reason,omitempty"`
+	Usage      *anthropicUsage         `json:"usage,omitempty"`
 	Error      *struct {
 		Message string `json:"message"`
 	} `json:"error"`
@@ -44,6 +46,18 @@ type anthropicContentBlock struct {
 type anthropicStopReason struct {
 	Type     string   `json:"type"`
 	EventIDs []string `json:"event_ids"`
+}
+
+type anthropicUsage struct {
+	InputTokens              int64  `json:"input_tokens,omitempty"`
+	OutputTokens             int64  `json:"output_tokens,omitempty"`
+	TotalTokens              int64  `json:"total_tokens,omitempty"`
+	CacheReadTokens          int64  `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens         int64  `json:"cache_write_tokens,omitempty"`
+	CacheReadInputTokens     int64  `json:"cache_read_input_tokens,omitempty"`
+	CacheCreationInputTokens int64  `json:"cache_creation_input_tokens,omitempty"`
+	ServerToolUseInputTokens int64  `json:"server_tool_use_input_tokens,omitempty"`
+	ServiceTier              string `json:"service_tier,omitempty"`
 }
 
 func mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
@@ -114,7 +128,11 @@ func customToolUseEvent(raw anthropicEvent) agents.ProviderEvent {
 
 func idleEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
 	if raw.StopReason == nil || raw.StopReason.Type == "" || raw.StopReason.Type == "end_turn" {
-		return agents.ProviderEvent{Type: agents.ProviderEventTurnCompleted}, true
+		return agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: raw.Model,
+			Usage: tokenUsage(raw.Usage),
+		}, true
 	}
 
 	if raw.StopReason.Type == "requires_action" {
@@ -124,7 +142,41 @@ func idleEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
 		}, true
 	}
 
-	return agents.ProviderEvent{Type: agents.ProviderEventTurnCompleted}, true
+	return agents.ProviderEvent{
+		Type:  agents.ProviderEventTurnCompleted,
+		Model: raw.Model,
+		Usage: tokenUsage(raw.Usage),
+	}, true
+}
+
+func tokenUsage(raw *anthropicUsage) *agents.TokenUsage {
+	if raw == nil {
+		return nil
+	}
+
+	usage := &agents.TokenUsage{
+		InputTokens:      raw.InputTokens,
+		OutputTokens:     raw.OutputTokens,
+		TotalTokens:      raw.TotalTokens,
+		CacheReadTokens:  firstNonZero(raw.CacheReadTokens, raw.CacheReadInputTokens),
+		CacheWriteTokens: firstNonZero(raw.CacheWriteTokens, raw.CacheCreationInputTokens),
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheWriteTokens + raw.ServerToolUseInputTokens
+	}
+	if usage.TotalTokens == 0 {
+		return nil
+	}
+	return usage
+}
+
+func firstNonZero(values ...int64) int64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 func sessionFailedEvent(raw anthropicEvent) agents.ProviderEvent {

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -30,6 +30,7 @@ type ProviderEvent struct {
 	ProviderEventID string
 	Type            ProviderEventType
 	Text            string
+	Model           string
 	ToolName        string
 	ToolCallID      string
 	// ToolInput is a human-readable rendering of the tool's invocation
@@ -43,6 +44,20 @@ type ProviderEvent struct {
 	// Multi-agent thread fields
 	AgentName string
 	ThreadID  string
+
+	Usage *TokenUsage
+}
+
+type TokenUsage struct {
+	InputTokens      int64
+	OutputTokens     int64
+	TotalTokens      int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+}
+
+func (u TokenUsage) HasUsage() bool {
+	return u.TotalTokens > 0
 }
 
 type CustomToolUse struct {

--- a/pkg/grpc/actions/messages/agent_usage.go
+++ b/pkg/grpc/actions/messages/agent_usage.go
@@ -1,0 +1,35 @@
+package messages
+
+import (
+	pb "github.com/superplanehq/superplane/pkg/protos/agents"
+)
+
+const AgentsExchange = "superplane.agents-exchange"
+
+const AgentRunFinishedRoutingKey = "agent.run.finished"
+
+type AgentRunFinishedMessage struct {
+	message *pb.AgentRunFinishedMessage
+}
+
+func NewAgentRunFinishedMessage(
+	organizationID, chatID, model string,
+	inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens int64,
+) AgentRunFinishedMessage {
+	return AgentRunFinishedMessage{
+		message: &pb.AgentRunFinishedMessage{
+			OrganizationId:   organizationID,
+			ChatId:           chatID,
+			Model:            model,
+			InputTokens:      inputTokens,
+			OutputTokens:     outputTokens,
+			TotalTokens:      totalTokens,
+			CacheReadTokens:  cacheReadTokens,
+			CacheWriteTokens: cacheWriteTokens,
+		},
+	}
+}
+
+func (m AgentRunFinishedMessage) Publish() error {
+	return Publish(AgentsExchange, AgentRunFinishedRoutingKey, toBytes(m.message))
+}

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -406,7 +406,7 @@ func (w *AgentStreamWorker) streamProviderTurn(
 	for {
 		customTools.clearRequirement()
 		err := w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
-			return handleProviderEvent(session.ID, evt, publish, &streamErr, customTools)
+			return handleProviderEvent(session, evt, publish, &streamErr, customTools)
 		})
 
 		if errors.Is(err, errCustomToolResultsRequired) {
@@ -429,7 +429,7 @@ func (w *AgentStreamWorker) streamProviderTurn(
 }
 
 func handleProviderEvent(
-	sessionID uuid.UUID,
+	session *models.AgentSession,
 	evt agents.ProviderEvent,
 	publish func(messages.AgentSessionEventMessage),
 	streamErr *error,
@@ -438,41 +438,42 @@ func handleProviderEvent(
 	// Drop late events from a turn the user has already stopped — closes
 	// the race between InterruptSession's commit and provider SSE bytes
 	// already in flight.
-	streaming, err := models.IsAgentSessionStreaming(sessionID)
+	streaming, err := models.IsAgentSessionStreaming(session.ID)
 	if err != nil {
-		log.WithError(err).WithField("session_id", sessionID).Warn("agent stream: status check failed; processing event anyway")
+		log.WithError(err).WithField("session_id", session.ID).Warn("agent stream: status check failed; processing event anyway")
 	} else if !streaming {
 		return errSessionAlreadyReset
 	}
 
 	switch evt.Type {
 	case agents.ProviderEventAssistantMessage:
-		return persistAssistantEvent(sessionID, evt, publish)
+		return persistAssistantEvent(session.ID, evt, publish)
 	case agents.ProviderEventToolUseStarted:
-		return persistToolEvent(sessionID, evt, models.AgentToolStatusStarted, evt.ToolInput, "tool_started", publish)
+		return persistToolEvent(session.ID, evt, models.AgentToolStatusStarted, evt.ToolInput, "tool_started", publish)
 	case agents.ProviderEventToolUseFinished:
-		return persistToolEvent(sessionID, evt, models.AgentToolStatusFinished, "", "tool_finished", publish)
+		return persistToolEvent(session.ID, evt, models.AgentToolStatusFinished, "", "tool_finished", publish)
 	case agents.ProviderEventCustomToolUseStarted:
 		customTools.remember(evt)
-		return persistToolEvent(sessionID, evt, models.AgentToolStatusStarted, evt.ToolInput, "tool_started", publish)
+		return persistToolEvent(session.ID, evt, models.AgentToolStatusStarted, evt.ToolInput, "tool_started", publish)
 	case agents.ProviderEventCustomToolResultsRequired:
 		customTools.require(evt.CustomToolEventIDs)
-		if err := customTools.resolvePersisted(sessionID); err != nil {
+		if err := customTools.resolvePersisted(session.ID); err != nil {
 			return err
 		}
 		if customTools.resultsRequired {
 			return errCustomToolResultsRequired
 		}
 	case agents.ProviderEventTurnCompleted:
+		publishAgentTokenUsage(session, evt)
 		publish(messages.AgentSessionEventMessage{Event: "turn_completed", Status: models.AgentSessionStatusIdle})
 	case agents.ProviderEventOutcomeEvaluationStart:
 		publishOutcomeEvaluationStart(evt, publish)
 	case agents.ProviderEventOutcomeEvaluation:
 		publishOutcomeEvaluationEnd(evt, publish)
 	case agents.ProviderEventThreadMessageSent:
-		return persistSubagentEvent(sessionID, evt, models.AgentToolStatusStarted, "tool_started", publish)
+		return persistSubagentEvent(session.ID, evt, models.AgentToolStatusStarted, "tool_started", publish)
 	case agents.ProviderEventThreadMessageReceived:
-		return persistSubagentEvent(sessionID, evt, models.AgentToolStatusFinished, "tool_finished", publish)
+		return persistSubagentEvent(session.ID, evt, models.AgentToolStatusFinished, "tool_finished", publish)
 	case agents.ProviderEventSessionNotice:
 		// Ephemeral notice: no status change, no DB row, stream continues.
 		publish(messages.AgentSessionEventMessage{Event: "session_notice", Error: evt.ErrorMessage})
@@ -482,6 +483,29 @@ func handleProviderEvent(
 		*streamErr = fmt.Errorf("provider reported session failed: %s", evt.ErrorMessage)
 	}
 	return nil
+}
+
+func publishAgentTokenUsage(session *models.AgentSession, evt agents.ProviderEvent) {
+	if evt.Usage == nil || !evt.Usage.HasUsage() {
+		return
+	}
+
+	err := messages.NewAgentRunFinishedMessage(
+		session.OrganizationID.String(),
+		session.ID.String(),
+		evt.Model,
+		evt.Usage.InputTokens,
+		evt.Usage.OutputTokens,
+		evt.Usage.TotalTokens,
+		evt.Usage.CacheReadTokens,
+		evt.Usage.CacheWriteTokens,
+	).Publish()
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"session_id":      session.ID,
+			"organization_id": session.OrganizationID,
+		}).Warn("agent stream: failed to publish agent token usage")
+	}
 }
 
 func (w *AgentStreamWorker) executeAndSendCustomToolResults(

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -39,6 +39,19 @@ var errCustomToolResultsRequired = errors.New("custom tool results required")
 var errAgentStreamAlreadyLocked = errors.New("agent stream already in progress")
 var errSessionAlreadyReset = errors.New("agent session no longer streaming")
 
+var publishAgentRunFinished = func(session *models.AgentSession, evt agents.ProviderEvent) error {
+	return messages.NewAgentRunFinishedMessage(
+		session.OrganizationID.String(),
+		session.ID.String(),
+		evt.Model,
+		evt.Usage.InputTokens,
+		evt.Usage.OutputTokens,
+		evt.Usage.TotalTokens,
+		evt.Usage.CacheReadTokens,
+		evt.Usage.CacheWriteTokens,
+	).Publish()
+}
+
 // AgentStreamWorker is stateless and safe to run as competing consumers.
 type AgentStreamWorker struct {
 	provider           agents.Provider
@@ -435,6 +448,10 @@ func handleProviderEvent(
 	streamErr *error,
 	customTools *customToolTurnState,
 ) error {
+	if evt.Type == agents.ProviderEventTurnCompleted {
+		publishAgentTokenUsage(session, evt)
+	}
+
 	// Drop late events from a turn the user has already stopped — closes
 	// the race between InterruptSession's commit and provider SSE bytes
 	// already in flight.
@@ -464,7 +481,6 @@ func handleProviderEvent(
 			return errCustomToolResultsRequired
 		}
 	case agents.ProviderEventTurnCompleted:
-		publishAgentTokenUsage(session, evt)
 		publish(messages.AgentSessionEventMessage{Event: "turn_completed", Status: models.AgentSessionStatusIdle})
 	case agents.ProviderEventOutcomeEvaluationStart:
 		publishOutcomeEvaluationStart(evt, publish)
@@ -490,17 +506,7 @@ func publishAgentTokenUsage(session *models.AgentSession, evt agents.ProviderEve
 		return
 	}
 
-	err := messages.NewAgentRunFinishedMessage(
-		session.OrganizationID.String(),
-		session.ID.String(),
-		evt.Model,
-		evt.Usage.InputTokens,
-		evt.Usage.OutputTokens,
-		evt.Usage.TotalTokens,
-		evt.Usage.CacheReadTokens,
-		evt.Usage.CacheWriteTokens,
-	).Publish()
-	if err != nil {
+	if err := publishAgentRunFinished(session, evt); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"session_id":      session.ID,
 			"organization_id": session.OrganizationID,

--- a/pkg/workers/agent_stream_worker_internal_test.go
+++ b/pkg/workers/agent_stream_worker_internal_test.go
@@ -1,0 +1,61 @@
+package workers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/agents"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/test/support"
+)
+
+func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:    r.Organization.ID,
+		UserID:            r.User,
+		CanvasID:          canvas.ID,
+		Provider:          "test",
+		ProviderSessionID: "upstream-session",
+		Status:            models.AgentSessionStatusIdle,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	published := 0
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(gotSession *models.AgentSession, evt agents.ProviderEvent) error {
+		published++
+		assert.Equal(t, session.ID, gotSession.ID)
+		assert.Equal(t, "claude-sonnet-4-5", evt.Model)
+		require.NotNil(t, evt.Usage)
+		assert.Equal(t, int64(42), evt.Usage.TotalTokens)
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{TotalTokens: 42},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	assert.True(t, errors.Is(err, errSessionAlreadyReset))
+	assert.Equal(t, 1, published)
+	assert.NoError(t, streamErr)
+}

--- a/protos/agents.proto
+++ b/protos/agents.proto
@@ -167,3 +167,14 @@ message AgentChatMessage {
   google.protobuf.Timestamp created_at = 7;
   repeated AgentChatImage images = 8;
 }
+
+message AgentRunFinishedMessage {
+  string organization_id = 1;
+  string chat_id = 2;
+  string model = 3;
+  int64 input_tokens = 4;
+  int64 output_tokens = 5;
+  int64 total_tokens = 6;
+  int64 cache_read_tokens = 7;
+  int64 cache_write_tokens = 8;
+}

--- a/web_src/src/pages/organization/settings/Usage.tsx
+++ b/web_src/src/pages/organization/settings/Usage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Navigate } from "react-router-dom";
-import { Activity, Gauge } from "lucide-react";
+import { Activity, Bot, Gauge, type LucideIcon } from "lucide-react";
 import type { OrganizationsDescribeUsageResponse, OrganizationsOrganizationLimits } from "@/api-client/types.gen";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useReportPageReady } from "@/hooks/useReportPageReady";
@@ -16,7 +16,7 @@ interface UsageProps {
 type LimitCard = {
   label: string;
   value: string;
-  icon: typeof Activity;
+  icon: LucideIcon;
   description: string;
 };
 
@@ -78,6 +78,7 @@ export function Usage({ organizationId }: UsageProps) {
 function UsageContent({ data, isPreviewMode }: { data: OrganizationsDescribeUsageResponse; isPreviewMode: boolean }) {
   const usageCards = useMemo(() => buildLimitCards(data.limits), [data.limits]);
   const eventUsage = useMemo(() => buildEventUsage(data), [data]);
+  const agentTokenUsage = useMemo(() => buildAgentTokenUsage(data), [data]);
 
   return (
     <div className="pt-6 space-y-6">
@@ -91,13 +92,20 @@ function UsageContent({ data, isPreviewMode }: { data: OrganizationsDescribeUsag
         </AlertDescription>
       </Alert>
 
-      <div className="grid gap-4">
+      <div className="grid gap-4 sm:grid-cols-2">
         <UsageMetricCard
           title="Event Budget"
           value={eventUsage.value}
           subtitle={eventUsage.subtitle}
           progress={eventUsage.progress}
           icon={Activity}
+        />
+        <UsageMetricCard
+          title="Agent Tokens"
+          value={agentTokenUsage.value}
+          subtitle={agentTokenUsage.subtitle}
+          progress={agentTokenUsage.progress}
+          icon={Bot}
         />
       </div>
 
@@ -138,7 +146,7 @@ function UsageMetricCard({
   value: string;
   subtitle: string;
   progress: number | null;
-  icon: typeof Gauge;
+  icon: LucideIcon;
 }) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-800 p-6">
@@ -194,6 +202,16 @@ function buildEventUsage(data: OrganizationsDescribeUsageResponse | null | undef
   );
 }
 
+function buildAgentTokenUsage(data: OrganizationsDescribeUsageResponse | null | undefined) {
+  return buildBucketUsage(
+    data?.usage?.agentTokenBucketLevel ?? 0,
+    data?.usage?.agentTokenBucketCapacity,
+    data?.usage?.agentTokenBucketLastUpdatedAt,
+    data?.usage?.nextAgentTokenBucketDecreaseAt,
+    "Rolling agent token usage for the current 30-day window.",
+  );
+}
+
 function buildLimitCards(limits: OrganizationsOrganizationLimits | undefined): LimitCard[] {
   return [
     {
@@ -207,6 +225,12 @@ function buildLimitCards(limits: OrganizationsOrganizationLimits | undefined): L
       value: formatStringLimit(limits?.maxEventsPerMonth),
       icon: Gauge,
       description: "Rolling 30-day event allowance.",
+    },
+    {
+      label: "Agent tokens per month",
+      value: formatStringLimit(limits?.maxAgentTokensPerMonth),
+      icon: Bot,
+      description: "Rolling 30-day agent token allowance.",
     },
   ];
 }


### PR DESCRIPTION
## Summary
- add an agent token usage RabbitMQ message on `superplane.agents-exchange` with routing key `agent.run.finished`
- map Anthropic completed-turn token usage into provider events
- publish token usage from the agent stream worker when a completed turn reports positive total tokens

## Validation
- `make pb.gen`
- `make format.go`
- `make test PKG_TEST_PACKAGES="./pkg/agents/anthropic ./pkg/workers"`
- `make lint && make check.build.app`
