### PR TITLE
chore: move CanvasChangeset from proto to internal changesets package

### DIFF
--- a/pkg/cli/commands/apps/canvas/models/canvas.go
+++ b/pkg/cli/commands/apps/canvas/models/canvas.go
@@ -73,7 +73,7 @@ func CreateCanvasRequestFromCanvas(resource Canvas) openapi_client.CanvasesCreat
 func EmptyCanvasSpec() *openapi_client.CanvasesCanvasSpec {
 	return &openapi_client.CanvasesCanvasSpec{
 		Nodes: []openapi_client.SuperplaneComponentsNode{},
-		Edges: []openapi_client.SuperplaneComponentsEdge{},
+		Edges: []openapi_client.ComponentsEdge{},
 	}
 }
 

--- a/pkg/grpc/actions/canvases/changesets/builder.go
+++ b/pkg/grpc/actions/canvases/changesets/builder.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/superplanehq/superplane/pkg/models"
-	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -32,8 +31,8 @@ func NewChangesetBuilder(currentNodes []models.Node, currentEdges []models.Edge,
 	}
 }
 
-func (b *ChangesetBuilder) Build() (*pb.CanvasChangeset, error) {
-	allChanges := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) Build() (*CanvasChangeset, error) {
+	allChanges := []*Change{}
 	allChanges = append(allChanges, b.computeDeleteNodeChanges()...)
 	changes, err := b.computeAddNodeChanges()
 	if err != nil {
@@ -50,11 +49,11 @@ func (b *ChangesetBuilder) Build() (*pb.CanvasChangeset, error) {
 	allChanges = append(allChanges, changes...)
 	allChanges = append(allChanges, b.computeDisconnectNodeChanges()...)
 	allChanges = append(allChanges, b.computeConnectNodeChanges()...)
-	return &pb.CanvasChangeset{Changes: allChanges}, nil
+	return &CanvasChangeset{Changes: allChanges}, nil
 }
 
-func (b *ChangesetBuilder) computeAddNodeChanges() ([]*pb.CanvasChangeset_Change, error) {
-	changes := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) computeAddNodeChanges() ([]*Change, error) {
+	changes := []*Change{}
 
 	//
 	// If a node exists in the proposed, but not in the current,
@@ -70,8 +69,8 @@ func (b *ChangesetBuilder) computeAddNodeChanges() ([]*pb.CanvasChangeset_Change
 			return nil, err
 		}
 
-		changes = append(changes, &pb.CanvasChangeset_Change{
-			Type: pb.CanvasChangeset_Change_ADD_NODE,
+		changes = append(changes, &Change{
+			Type: ChangeTypeAddNode,
 			Node: node,
 		})
 	}
@@ -79,8 +78,8 @@ func (b *ChangesetBuilder) computeAddNodeChanges() ([]*pb.CanvasChangeset_Change
 	return changes, nil
 }
 
-func (b *ChangesetBuilder) computeDeleteNodeChanges() []*pb.CanvasChangeset_Change {
-	changes := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) computeDeleteNodeChanges() []*Change {
+	changes := []*Change{}
 
 	//
 	// If a node exists in the current, but not in the proposed,
@@ -91,10 +90,10 @@ func (b *ChangesetBuilder) computeDeleteNodeChanges() []*pb.CanvasChangeset_Chan
 			continue
 		}
 
-		changes = append(changes, &pb.CanvasChangeset_Change{
-			Type: pb.CanvasChangeset_Change_DELETE_NODE,
-			Node: &pb.CanvasChangeset_Change_Node{
-				Id: nodeID,
+		changes = append(changes, &Change{
+			Type: ChangeTypeDeleteNode,
+			Node: &ChangeNode{
+				ID: nodeID,
 			},
 		})
 	}
@@ -102,8 +101,8 @@ func (b *ChangesetBuilder) computeDeleteNodeChanges() []*pb.CanvasChangeset_Chan
 	return changes
 }
 
-func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*pb.CanvasChangeset_Change, error) {
-	changes := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*Change, error) {
+	changes := []*Change{}
 
 	//
 	// If a node exists in both the current and the proposed,
@@ -124,8 +123,8 @@ func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*pb.CanvasChangeset_Cha
 			return nil, err
 		}
 
-		changes = append(changes, &pb.CanvasChangeset_Change{
-			Type: pb.CanvasChangeset_Change_UPDATE_NODE,
+		changes = append(changes, &Change{
+			Type: ChangeTypeUpdateNode,
 			Node: n,
 		})
 	}
@@ -133,8 +132,8 @@ func (b *ChangesetBuilder) computeUpdateNodeChanges() ([]*pb.CanvasChangeset_Cha
 	return changes, nil
 }
 
-func (b *ChangesetBuilder) computeDisconnectNodeChanges() []*pb.CanvasChangeset_Change {
-	changes := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) computeDisconnectNodeChanges() []*Change {
+	changes := []*Change{}
 
 	//
 	// If an edge exists in the current, but not in the proposed,
@@ -145,11 +144,11 @@ func (b *ChangesetBuilder) computeDisconnectNodeChanges() []*pb.CanvasChangeset_
 			continue
 		}
 
-		changes = append(changes, &pb.CanvasChangeset_Change{
-			Type: pb.CanvasChangeset_Change_DELETE_EDGE,
-			Edge: &pb.CanvasChangeset_Change_Edge{
-				SourceId: edge.SourceID,
-				TargetId: edge.TargetID,
+		changes = append(changes, &Change{
+			Type: ChangeTypeDeleteEdge,
+			Edge: &ChangeEdge{
+				SourceID: edge.SourceID,
+				TargetID: edge.TargetID,
 				Channel:  edge.Channel,
 			},
 		})
@@ -158,8 +157,8 @@ func (b *ChangesetBuilder) computeDisconnectNodeChanges() []*pb.CanvasChangeset_
 	return changes
 }
 
-func (b *ChangesetBuilder) computeConnectNodeChanges() []*pb.CanvasChangeset_Change {
-	changes := []*pb.CanvasChangeset_Change{}
+func (b *ChangesetBuilder) computeConnectNodeChanges() []*Change {
+	changes := []*Change{}
 
 	//
 	// If an edge exists in the proposed but not in the current,
@@ -170,11 +169,11 @@ func (b *ChangesetBuilder) computeConnectNodeChanges() []*pb.CanvasChangeset_Cha
 			continue
 		}
 
-		changes = append(changes, &pb.CanvasChangeset_Change{
-			Type: pb.CanvasChangeset_Change_ADD_EDGE,
-			Edge: &pb.CanvasChangeset_Change_Edge{
-				SourceId: edge.SourceID,
-				TargetId: edge.TargetID,
+		changes = append(changes, &Change{
+			Type: ChangeTypeAddEdge,
+			Edge: &ChangeEdge{
+				SourceID: edge.SourceID,
+				TargetID: edge.TargetID,
 				Channel:  edge.Channel,
 			},
 		})
@@ -199,9 +198,9 @@ func blockNameFromNode(node models.Node) string {
 	return ""
 }
 
-func changeNodeRefForAdd(proposedNode models.Node) (*pb.CanvasChangeset_Change_Node, error) {
-	n := &pb.CanvasChangeset_Change_Node{
-		Id:          proposedNode.ID,
+func changeNodeRefForAdd(proposedNode models.Node) (*ChangeNode, error) {
+	n := &ChangeNode{
+		ID:          proposedNode.ID,
 		Name:        proposedNode.Name,
 		Block:       blockNameFromNode(proposedNode),
 		IsCollapsed: proto.Bool(proposedNode.IsCollapsed),
@@ -212,7 +211,7 @@ func changeNodeRefForAdd(proposedNode models.Node) (*pb.CanvasChangeset_Change_N
 	}
 
 	if proposedNode.IntegrationID != nil {
-		n.IntegrationId = *proposedNode.IntegrationID
+		n.IntegrationID = *proposedNode.IntegrationID
 	}
 
 	if proposedNode.Configuration != nil {
@@ -227,9 +226,9 @@ func changeNodeRefForAdd(proposedNode models.Node) (*pb.CanvasChangeset_Change_N
 	return n, nil
 }
 
-func changeNodeRefForUpdate(currentNode models.Node, proposedNode models.Node) (*pb.CanvasChangeset_Change_Node, error) {
-	n := &pb.CanvasChangeset_Change_Node{
-		Id:    proposedNode.ID,
+func changeNodeRefForUpdate(currentNode models.Node, proposedNode models.Node) (*ChangeNode, error) {
+	n := &ChangeNode{
+		ID:    proposedNode.ID,
 		Name:  proposedNode.Name,
 		Block: blockNameFromNode(proposedNode),
 	}

--- a/pkg/grpc/actions/canvases/changesets/builder_test.go
+++ b/pkg/grpc/actions/canvases/changesets/builder_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/superplanehq/superplane/pkg/models"
-	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/test/support"
 )
 
@@ -202,15 +201,15 @@ func Test__ChangesetBuilder(t *testing.T) {
 		steps.assertNoError()
 		steps.assertOperationCount(1)
 
-		op := steps.findNodeOperation(pb.CanvasChangeset_Change_ADD_NODE, "node-a")
+		op := steps.findNodeOperation(ChangeTypeAddNode, "node-a")
 		require.NotNil(t, op)
-		require.Equal(t, integrationID, op.GetNode().GetIntegrationId())
+		require.Equal(t, integrationID, op.Node.IntegrationID)
 	})
 }
 
 type ChangesetBuilderSteps struct {
 	t         *testing.T
-	changeset *pb.CanvasChangeset
+	changeset *CanvasChangeset
 	err       error
 }
 
@@ -235,48 +234,48 @@ func (s *ChangesetBuilderSteps) assertOperationCount(count int) {
 }
 
 func (s *ChangesetBuilderSteps) assertHasDeleteNode(nodeID string) {
-	op := s.findNodeOperation(pb.CanvasChangeset_Change_DELETE_NODE, nodeID)
+	op := s.findNodeOperation(ChangeTypeDeleteNode, nodeID)
 	require.NotNil(s.t, op, "expected DELETE_NODE operation for %s", nodeID)
 }
 
 func (s *ChangesetBuilderSteps) assertHasAddNode(nodeID string, name string, block string, configuration map[string]any) {
-	op := s.findNodeOperation(pb.CanvasChangeset_Change_ADD_NODE, nodeID)
+	op := s.findNodeOperation(ChangeTypeAddNode, nodeID)
 	require.NotNil(s.t, op, "expected ADD_NODE operation for %s", nodeID)
-	require.Equal(s.t, name, op.GetNode().GetName())
-	require.Equal(s.t, block, op.GetNode().GetBlock())
-	require.Equal(s.t, configuration, op.GetNode().GetConfiguration().AsMap())
+	require.Equal(s.t, name, op.Node.Name)
+	require.Equal(s.t, block, op.Node.Block)
+	require.Equal(s.t, configuration, op.Node.Configuration.AsMap())
 }
 
 func (s *ChangesetBuilderSteps) assertHasUpdateNode(nodeID string, name string, block string, configuration map[string]any) {
-	op := s.findNodeOperation(pb.CanvasChangeset_Change_UPDATE_NODE, nodeID)
+	op := s.findNodeOperation(ChangeTypeUpdateNode, nodeID)
 	require.NotNil(s.t, op, "expected UPDATE_NODE operation for %s", nodeID)
-	require.Equal(s.t, name, op.GetNode().GetName())
-	require.Equal(s.t, block, op.GetNode().GetBlock())
-	require.Equal(s.t, configuration, op.GetNode().GetConfiguration().AsMap())
+	require.Equal(s.t, name, op.Node.Name)
+	require.Equal(s.t, block, op.Node.Block)
+	require.Equal(s.t, configuration, op.Node.Configuration.AsMap())
 }
 
 func (s *ChangesetBuilderSteps) assertHasDisconnect(sourceID string, targetID string, channel string) {
-	op := s.findEdgeOperation(pb.CanvasChangeset_Change_DELETE_EDGE, sourceID, targetID, channel)
+	op := s.findEdgeOperation(ChangeTypeDeleteEdge, sourceID, targetID, channel)
 	require.NotNil(s.t, op, "expected DISCONNECT_NODES from %s to %s on channel %s", sourceID, targetID, channel)
 }
 
 func (s *ChangesetBuilderSteps) assertHasConnect(sourceID string, targetID string, channel string) {
-	op := s.findEdgeOperation(pb.CanvasChangeset_Change_ADD_EDGE, sourceID, targetID, channel)
+	op := s.findEdgeOperation(ChangeTypeAddEdge, sourceID, targetID, channel)
 	require.NotNil(s.t, op, "expected CONNECT_NODES from %s to %s on channel %s", sourceID, targetID, channel)
 }
 
-func (s *ChangesetBuilderSteps) findNodeOperation(operationType pb.CanvasChangeset_Change_Type, nodeID string) *pb.CanvasChangeset_Change {
+func (s *ChangesetBuilderSteps) findNodeOperation(operationType ChangeType, nodeID string) *Change {
 	for _, change := range s.changeset.Changes {
-		if change.GetType() != operationType {
+		if change.Type != operationType {
 			continue
 		}
 
-		node := change.GetNode()
+		node := change.Node
 		if node == nil {
 			continue
 		}
 
-		if node.GetId() == nodeID {
+		if node.ID == nodeID {
 			return change
 		}
 	}
@@ -284,26 +283,26 @@ func (s *ChangesetBuilderSteps) findNodeOperation(operationType pb.CanvasChanges
 	return nil
 }
 
-func (s *ChangesetBuilderSteps) findEdgeOperation(operationType pb.CanvasChangeset_Change_Type, sourceID string, targetID string, channel string) *pb.CanvasChangeset_Change {
+func (s *ChangesetBuilderSteps) findEdgeOperation(operationType ChangeType, sourceID string, targetID string, channel string) *Change {
 	for _, change := range s.changeset.Changes {
-		if change.GetType() != operationType {
+		if change.Type != operationType {
 			continue
 		}
 
-		edge := change.GetEdge()
+		edge := change.Edge
 		if edge == nil {
 			continue
 		}
 
-		if edge.GetSourceId() != sourceID {
+		if edge.SourceID != sourceID {
 			continue
 		}
 
-		if edge.GetTargetId() != targetID {
+		if edge.TargetID != targetID {
 			continue
 		}
 
-		if edge.GetChannel() != channel {
+		if edge.Channel != channel {
 			continue
 		}
 

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher.go
@@ -109,7 +109,7 @@ func (p *CanvasPatcher) buildFinalVersion(autoLayout *pb.CanvasAutoLayout) (*mod
 	return v, nil
 }
 
-func (p *CanvasPatcher) ApplyChangeset(changeset *pb.CanvasChangeset, autoLayout *pb.CanvasAutoLayout) error {
+func (p *CanvasPatcher) ApplyChangeset(changeset *CanvasChangeset, autoLayout *pb.CanvasAutoLayout) error {
 	if changeset == nil || len(changeset.Changes) == 0 {
 		return fmt.Errorf("changeset is required")
 	}
@@ -129,43 +129,43 @@ func (p *CanvasPatcher) ApplyChangeset(changeset *pb.CanvasChangeset, autoLayout
 	return CheckForCycles(p.finalVersion.Nodes, p.finalVersion.Edges)
 }
 
-func (p *CanvasPatcher) handleChange(change *pb.CanvasChangeset_Change) error {
+func (p *CanvasPatcher) handleChange(change *Change) error {
 	if change == nil {
 		return fmt.Errorf("change is required")
 	}
 
 	switch change.Type {
-	case pb.CanvasChangeset_Change_ADD_NODE:
+	case ChangeTypeAddNode:
 		return p.addNode(change)
-	case pb.CanvasChangeset_Change_DELETE_NODE:
+	case ChangeTypeDeleteNode:
 		return p.deleteNode(change)
-	case pb.CanvasChangeset_Change_UPDATE_NODE:
+	case ChangeTypeUpdateNode:
 		return p.updateNode(change)
-	case pb.CanvasChangeset_Change_ADD_EDGE:
+	case ChangeTypeAddEdge:
 		return p.addEdge(change)
-	case pb.CanvasChangeset_Change_DELETE_EDGE:
+	case ChangeTypeDeleteEdge:
 		return p.deleteEdge(change)
 	}
 
 	return fmt.Errorf("unknown change type: %s", change.Type)
 }
 
-func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
+func (p *CanvasPatcher) addNode(change *Change) error {
 	//
 	// These initial checks are hard checks.
 	// If they fail, we should return an error immediately.
 	//
-	node := change.GetNode()
+	node := change.Node
 	if node == nil {
 		return fmt.Errorf("node is required for %s", change.Type)
 	}
 
-	nodeID := node.GetId()
+	nodeID := node.ID
 	if nodeID == "" {
 		return fmt.Errorf("target node id is required for %s", change.Type)
 	}
 
-	if node.GetName() == "" {
+	if node.Name == "" {
 		return fmt.Errorf("target node name is required for %s", change.Type)
 	}
 
@@ -174,9 +174,11 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 	}
 
 	newNode := models.Node{
-		ID:          nodeID,
-		Name:        node.GetName(),
-		IsCollapsed: node.GetIsCollapsed(),
+		ID:   nodeID,
+		Name: node.Name,
+	}
+	if node.IsCollapsed != nil {
+		newNode.IsCollapsed = *node.IsCollapsed
 	}
 
 	nodeType, nodeRef, err := p.findBlock(node)
@@ -187,9 +189,9 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 	newNode.Type = nodeType
 	newNode.Ref = *nodeRef
 
-	if node.GetPosition() != nil {
-		newNode.Position.X = int(node.GetPosition().GetX())
-		newNode.Position.Y = int(node.GetPosition().GetY())
+	if node.Position != nil {
+		newNode.Position.X = int(node.Position.X)
+		newNode.Position.Y = int(node.Position.Y)
 	}
 
 	//
@@ -217,8 +219,8 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 	}
 
 	var nodeConfiguration map[string]any
-	if node.GetConfiguration() != nil {
-		nodeConfiguration = node.GetConfiguration().AsMap()
+	if node.Configuration != nil {
+		nodeConfiguration = node.Configuration.AsMap()
 	}
 
 	err = configuration.ValidateConfiguration(schema, nodeConfiguration)
@@ -235,16 +237,16 @@ func (p *CanvasPatcher) addNode(change *pb.CanvasChangeset_Change) error {
 	return nil
 }
 
-func (p *CanvasPatcher) validateIntegration(node *pb.CanvasChangeset_Change_Node) (*string, error) {
-	if p.registry.IsCoreBlock(node.GetBlock()) {
+func (p *CanvasPatcher) validateIntegration(node *ChangeNode) (*string, error) {
+	if p.registry.IsCoreBlock(node.Block) {
 		return nil, nil
 	}
 
-	if node.GetIntegrationId() == "" {
-		return nil, fmt.Errorf("integration is required for %s", node.GetBlock())
+	if node.IntegrationID == "" {
+		return nil, fmt.Errorf("integration is required for %s", node.Block)
 	}
 
-	id := node.GetIntegrationId()
+	id := node.IntegrationID
 	integrationID, err := uuid.Parse(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid integration id: %v", err)
@@ -255,20 +257,20 @@ func (p *CanvasPatcher) validateIntegration(node *pb.CanvasChangeset_Change_Node
 		return nil, fmt.Errorf("integration %s not found", id)
 	}
 
-	if !integration.HasCapabilityEnabled(node.GetBlock()) {
-		return nil, fmt.Errorf("%s is not enabled for integration %s", node.GetBlock(), integration.InstallationName)
+	if !integration.HasCapabilityEnabled(node.Block) {
+		return nil, fmt.Errorf("%s is not enabled for integration %s", node.Block, integration.InstallationName)
 	}
 
 	return &id, nil
 }
 
-func (p *CanvasPatcher) deleteNode(change *pb.CanvasChangeset_Change) error {
-	node := change.GetNode()
+func (p *CanvasPatcher) deleteNode(change *Change) error {
+	node := change.Node
 	if node == nil {
 		return fmt.Errorf("target is required for %s", change.Type)
 	}
 
-	nodeID := node.GetId()
+	nodeID := node.ID
 	if nodeID == "" {
 		return fmt.Errorf("target node id is required for %s", change.Type)
 	}
@@ -289,18 +291,18 @@ func (p *CanvasPatcher) deleteNode(change *pb.CanvasChangeset_Change) error {
 	return nil
 }
 
-func (p *CanvasPatcher) updateNode(change *pb.CanvasChangeset_Change) error {
+func (p *CanvasPatcher) updateNode(change *Change) error {
 
 	//
 	// These initial checks are hard checks.
 	// If they fail, we should return an error immediately.
 	//
-	node := change.GetNode()
+	node := change.Node
 	if node == nil {
 		return fmt.Errorf("node is required for %s", change.Type)
 	}
 
-	nodeID := node.GetId()
+	nodeID := node.ID
 	if nodeID == "" {
 		return fmt.Errorf("node id is required for %s", change.Type)
 	}
@@ -310,17 +312,17 @@ func (p *CanvasPatcher) updateNode(change *pb.CanvasChangeset_Change) error {
 		return fmt.Errorf("node %s not found", nodeID)
 	}
 
-	if node.GetName() != "" {
-		currentNode.Name = node.GetName()
+	if node.Name != "" {
+		currentNode.Name = node.Name
 	}
 
-	if node.GetPosition() != nil {
-		currentNode.Position.X = int(node.GetPosition().GetX())
-		currentNode.Position.Y = int(node.GetPosition().GetY())
+	if node.Position != nil {
+		currentNode.Position.X = int(node.Position.X)
+		currentNode.Position.Y = int(node.Position.Y)
 	}
 
 	if node.IsCollapsed != nil {
-		currentNode.IsCollapsed = node.GetIsCollapsed()
+		currentNode.IsCollapsed = *node.IsCollapsed
 	}
 
 	//
@@ -330,26 +332,26 @@ func (p *CanvasPatcher) updateNode(change *pb.CanvasChangeset_Change) error {
 	// node will be in an error state.
 	//
 
-	if node.GetConfiguration() != nil {
+	if node.Configuration != nil {
 		schema, err := p.findConfigurationSchemaForNode(currentNode.Type, currentNode.Ref)
 		if err != nil {
 			errorMessage := err.Error()
 			currentNode.ErrorMessage = &errorMessage
-			currentNode.Configuration = node.GetConfiguration().AsMap()
+			currentNode.Configuration = node.Configuration.AsMap()
 			p.nodes[nodeID] = currentNode
 			return nil
 		}
 
-		err = configuration.ValidateConfiguration(schema, node.GetConfiguration().AsMap())
+		err = configuration.ValidateConfiguration(schema, node.Configuration.AsMap())
 		if err != nil {
 			errorMessage := err.Error()
 			currentNode.ErrorMessage = &errorMessage
-			currentNode.Configuration = node.GetConfiguration().AsMap()
+			currentNode.Configuration = node.Configuration.AsMap()
 			p.nodes[nodeID] = currentNode
 			return nil
 		}
 
-		currentNode.Configuration = node.GetConfiguration().AsMap()
+		currentNode.Configuration = node.Configuration.AsMap()
 		currentNode.ErrorMessage = nil
 	}
 
@@ -388,77 +390,77 @@ func (p *CanvasPatcher) findConfigurationSchemaForNode(nodeType string, nodeRef 
 	}
 }
 
-func (p *CanvasPatcher) addEdge(change *pb.CanvasChangeset_Change) error {
-	edge := change.GetEdge()
+func (p *CanvasPatcher) addEdge(change *Change) error {
+	edge := change.Edge
 	if edge == nil {
 		return fmt.Errorf("edge is required for %s", change.Type)
 	}
 
-	if edge.GetSourceId() == "" {
+	if edge.SourceID == "" {
 		return fmt.Errorf("source id is required for %s", change.Type)
 	}
 
-	if edge.GetTargetId() == "" {
+	if edge.TargetID == "" {
 		return fmt.Errorf("target id is required for %s", change.Type)
 	}
 
-	if edge.GetChannel() == "" {
+	if edge.Channel == "" {
 		return fmt.Errorf("channel is required for %s", change.Type)
 	}
 
-	if edge.GetSourceId() == edge.GetTargetId() {
+	if edge.SourceID == edge.TargetID {
 		return fmt.Errorf("self-loop edges are not allowed")
 	}
 
-	if _, exists := p.nodes[edge.GetSourceId()]; !exists {
-		return fmt.Errorf("source node %s not found", edge.GetSourceId())
+	if _, exists := p.nodes[edge.SourceID]; !exists {
+		return fmt.Errorf("source node %s not found", edge.SourceID)
 	}
 
-	if _, exists := p.nodes[edge.GetTargetId()]; !exists {
-		return fmt.Errorf("target node %s not found", edge.GetTargetId())
+	if _, exists := p.nodes[edge.TargetID]; !exists {
+		return fmt.Errorf("target node %s not found", edge.TargetID)
 	}
 
 	if err := ValidateSourceNodeOutputChannel(
 		p.registry,
-		p.nodes[edge.GetSourceId()],
-		edge.GetChannel(),
+		p.nodes[edge.SourceID],
+		edge.Channel,
 	); err != nil {
 		return err
 	}
 
-	edgeKey := p.edgeKey(edge.GetSourceId(), edge.GetTargetId(), edge.GetChannel())
+	edgeKey := p.edgeKey(edge.SourceID, edge.TargetID, edge.Channel)
 	if _, exists := p.edges[edgeKey]; exists {
 		return nil
 	}
 
 	p.edges[edgeKey] = models.Edge{
-		SourceID: edge.GetSourceId(),
-		TargetID: edge.GetTargetId(),
-		Channel:  edge.GetChannel(),
+		SourceID: edge.SourceID,
+		TargetID: edge.TargetID,
+		Channel:  edge.Channel,
 	}
 
 	return nil
 }
 
-func (p *CanvasPatcher) deleteEdge(change *pb.CanvasChangeset_Change) error {
-	edge := change.GetEdge()
+func (p *CanvasPatcher) deleteEdge(change *Change) error {
+	edge := change.Edge
 	if edge == nil {
 		return fmt.Errorf("edge is required for %s", change.Type)
 	}
 
-	if edge.GetSourceId() == "" {
+	if edge.SourceID == "" {
 		return fmt.Errorf("source id is required for %s", change.Type)
 	}
 
-	if edge.GetTargetId() == "" {
+	if edge.TargetID == "" {
 		return fmt.Errorf("target id is required for %s", change.Type)
 	}
 
-	if edge.GetChannel() == "" {
+	if edge.Channel == "" {
 		return fmt.Errorf("channel is required for %s", change.Type)
 	}
 
-	edgeKey := p.edgeKey(edge.GetSourceId(), edge.GetTargetId(), edge.GetChannel())
+	edgeKey := p.edgeKey(edge.SourceID, edge.TargetID, edge.Channel)
 	if _, exists := p.edges[edgeKey]; !exists {
 		return nil
 	}
@@ -467,43 +469,43 @@ func (p *CanvasPatcher) deleteEdge(change *pb.CanvasChangeset_Change) error {
 	return nil
 }
 
-func (p *CanvasPatcher) findBlock(node *pb.CanvasChangeset_Change_Node) (string, *models.NodeRef, error) {
-	if node.GetBlock() == "" {
+func (p *CanvasPatcher) findBlock(node *ChangeNode) (string, *models.NodeRef, error) {
+	if node.Block == "" {
 		return "", nil, fmt.Errorf("block is required")
 	}
 
 	//
 	// Check if the block is an action
 	//
-	_, err := p.registry.GetAction(node.GetBlock())
+	_, err := p.registry.GetAction(node.Block)
 	if err == nil {
 		return models.NodeTypeComponent, &models.NodeRef{
-			Component: &models.ComponentRef{Name: node.GetBlock()},
+			Component: &models.ComponentRef{Name: node.Block},
 		}, nil
 	}
 
 	//
 	// Otherwise, check if the block is a trigger
 	//
-	_, err = p.registry.GetTrigger(node.GetBlock())
+	_, err = p.registry.GetTrigger(node.Block)
 	if err == nil {
 		return models.NodeTypeTrigger, &models.NodeRef{
-			Trigger: &models.TriggerRef{Name: node.GetBlock()},
+			Trigger: &models.TriggerRef{Name: node.Block},
 		}, nil
 	}
 
 	//
 	// Otherwise, check if the block is a widget
 	//
-	_, err = p.registry.GetWidget(node.GetBlock())
+	_, err = p.registry.GetWidget(node.Block)
 	if err == nil {
 		return models.NodeTypeWidget, &models.NodeRef{
-			Widget: &models.WidgetRef{Name: node.GetBlock()},
+			Widget: &models.WidgetRef{Name: node.Block},
 		}, nil
 	}
 
 	//
 	// If the block is not any of the above, return an error
 	//
-	return "", nil, fmt.Errorf("block %s not found in registry", node.GetBlock())
+	return "", nil, fmt.Errorf("block %s not found in registry", node.Block)
 }

--- a/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_patcher_test.go
@@ -46,36 +46,36 @@ func Test__CanvasPatcher(t *testing.T) {
 			[]models.Edge{{SourceID: "node-a", TargetID: "node-b", Channel: "true"}},
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-c",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-c",
 						Name:          "Node C",
 						Block:         "noop",
 						Configuration: structFromMap(t, map[string]any{}),
 					},
 				},
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A Updated",
 						Configuration: structFromMap(t, map[string]any{"expression": "false"}),
 					},
 				},
 				{
-					Type: pb.CanvasChangeset_Change_ADD_EDGE,
-					Edge: &pb.CanvasChangeset_Change_Edge{
-						SourceId: "node-a",
-						TargetId: "node-c",
+					Type: ChangeTypeAddEdge,
+					Edge: &ChangeEdge{
+						SourceID: "node-a",
+						TargetID: "node-c",
 						Channel:  "true",
 					},
 				},
 				{
-					Type: pb.CanvasChangeset_Change_DELETE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{Id: "node-b"},
+					Type: ChangeTypeDeleteNode,
+					Node: &ChangeNode{ID: "node-b"},
 				},
 			},
 		}, nil)
@@ -106,12 +106,12 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:   "node-a",
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{
+						ID:   "node-a",
 						Name: "Node A Updated",
 					},
 				},
@@ -143,12 +143,12 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:   "node-a",
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{
+						ID:   "node-a",
 						Name: "Node A Updated",
 					},
 				},
@@ -188,13 +188,13 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_EDGE,
-					Edge: &pb.CanvasChangeset_Change_Edge{
-						SourceId: "node-a",
-						TargetId: "node-b",
+					Type: ChangeTypeAddEdge,
+					Edge: &ChangeEdge{
+						SourceID: "node-a",
+						TargetID: "node-b",
 						Channel:  "default",
 					},
 				},
@@ -237,13 +237,13 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_EDGE,
-					Edge: &pb.CanvasChangeset_Change_Edge{
-						SourceId: "http-1",
-						TargetId: "if-1",
+					Type: ChangeTypeAddEdge,
+					Edge: &ChangeEdge{
+						SourceID: "http-1",
+						TargetID: "if-1",
 						Channel:  "default",
 					},
 				},
@@ -257,7 +257,7 @@ func Test__CanvasPatcher(t *testing.T) {
 	t.Run("returns error when change object is misconfigured", func(t *testing.T) {
 		testCases := []struct {
 			name            string
-			changeset       *pb.CanvasChangeset
+			changeset       *CanvasChangeset
 			expectedMessage string
 		}{
 			{
@@ -267,32 +267,32 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name:            "changeset has no changes",
-				changeset:       &pb.CanvasChangeset{},
+				changeset:       &CanvasChangeset{},
 				expectedMessage: "changeset is required",
 			},
 			{
 				name: "changeset has nil change",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{nil},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{nil},
 				},
 				expectedMessage: "change is required",
 			},
 			{
 				name: "add node change has no node payload",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
-						{Type: pb.CanvasChangeset_Change_ADD_NODE},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
+						{Type: ChangeTypeAddNode},
 					},
 				},
 				expectedMessage: "node is required for ADD_NODE",
 			},
 			{
 				name: "add node change has empty id",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_ADD_NODE,
-							Node: &pb.CanvasChangeset_Change_Node{Name: "Node A", Block: "noop"},
+							Type: ChangeTypeAddNode,
+							Node: &ChangeNode{Name: "Node A", Block: "noop"},
 						},
 					},
 				},
@@ -300,11 +300,11 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name: "add node change has empty name",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_ADD_NODE,
-							Node: &pb.CanvasChangeset_Change_Node{Id: "node-a", Block: "noop"},
+							Type: ChangeTypeAddNode,
+							Node: &ChangeNode{ID: "node-a", Block: "noop"},
 						},
 					},
 				},
@@ -312,20 +312,20 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name: "update node change has no node payload",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
-						{Type: pb.CanvasChangeset_Change_UPDATE_NODE},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
+						{Type: ChangeTypeUpdateNode},
 					},
 				},
 				expectedMessage: "node is required for UPDATE_NODE",
 			},
 			{
 				name: "update node change has empty id",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-							Node: &pb.CanvasChangeset_Change_Node{Name: "Node A"},
+							Type: ChangeTypeUpdateNode,
+							Node: &ChangeNode{Name: "Node A"},
 						},
 					},
 				},
@@ -333,20 +333,20 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name: "delete node change has no node payload",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
-						{Type: pb.CanvasChangeset_Change_DELETE_NODE},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
+						{Type: ChangeTypeDeleteNode},
 					},
 				},
 				expectedMessage: "target is required for DELETE_NODE",
 			},
 			{
 				name: "delete node change has empty id",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_DELETE_NODE,
-							Node: &pb.CanvasChangeset_Change_Node{},
+							Type: ChangeTypeDeleteNode,
+							Node: &ChangeNode{},
 						},
 					},
 				},
@@ -354,20 +354,20 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name: "add edge change has no edge payload",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
-						{Type: pb.CanvasChangeset_Change_ADD_EDGE},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
+						{Type: ChangeTypeAddEdge},
 					},
 				},
 				expectedMessage: "edge is required for ADD_EDGE",
 			},
 			{
 				name: "add edge change has empty source id",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_ADD_EDGE,
-							Edge: &pb.CanvasChangeset_Change_Edge{TargetId: "node-b", Channel: "default"},
+							Type: ChangeTypeAddEdge,
+							Edge: &ChangeEdge{TargetID: "node-b", Channel: "default"},
 						},
 					},
 				},
@@ -375,20 +375,20 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 			{
 				name: "delete edge change has no edge payload",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
-						{Type: pb.CanvasChangeset_Change_DELETE_EDGE},
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
+						{Type: ChangeTypeDeleteEdge},
 					},
 				},
 				expectedMessage: "edge is required for DELETE_EDGE",
 			},
 			{
 				name: "delete edge change has empty channel",
-				changeset: &pb.CanvasChangeset{
-					Changes: []*pb.CanvasChangeset_Change{
+				changeset: &CanvasChangeset{
+					Changes: []*Change{
 						{
-							Type: pb.CanvasChangeset_Change_DELETE_EDGE,
-							Edge: &pb.CanvasChangeset_Change_Edge{SourceId: "node-a", TargetId: "node-b"},
+							Type: ChangeTypeDeleteEdge,
+							Edge: &ChangeEdge{SourceID: "node-a", TargetID: "node-b"},
 						},
 					},
 				},
@@ -425,11 +425,11 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{Id: "node-a", Name: "Node A Updated"},
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{ID: "node-a", Name: "Node A Updated"},
 				},
 			},
 		}, nil)
@@ -454,11 +454,11 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{Id: "node-a", Name: "Node A Updated"},
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{ID: "node-a", Name: "Node A Updated"},
 				},
 			},
 		}, nil)
@@ -483,12 +483,12 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:          "node-a",
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{
+						ID:          "node-a",
 						Name:        "Node A Updated",
 						IsCollapsed: proto.Bool(false),
 					},
@@ -517,12 +517,12 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UPDATE_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeUpdateNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Configuration: structFromMap(t, map[string]any{"expression": nil}),
 					},
@@ -542,13 +542,13 @@ func Test__CanvasPatcher(t *testing.T) {
 			nil,
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_EDGE,
-					Edge: &pb.CanvasChangeset_Change_Edge{
-						SourceId: "node-a",
-						TargetId: "node-a",
+					Type: ChangeTypeAddEdge,
+					Edge: &ChangeEdge{
+						SourceID: "node-a",
+						TargetID: "node-a",
 						Channel:  "default",
 					},
 				},
@@ -562,12 +562,12 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:    "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:    "node-a",
 						Name:  "Node A",
 						Block: "core.hello",
 					},
@@ -583,10 +583,10 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_UNSPECIFIED,
+					Type: ChangeTypeUnspecified,
 				},
 			},
 		}, nil)
@@ -606,13 +606,13 @@ func Test__CanvasPatcher(t *testing.T) {
 			},
 		)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_EDGE,
-					Edge: &pb.CanvasChangeset_Change_Edge{
-						SourceId: "node-b",
-						TargetId: "node-a",
+					Type: ChangeTypeAddEdge,
+					Edge: &ChangeEdge{
+						SourceID: "node-b",
+						TargetID: "node-a",
 						Channel:  "default",
 					},
 				},
@@ -625,12 +625,12 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:    "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:    "node-a",
 						Name:  "Node A",
 						Block: "if",
 					},
@@ -649,12 +649,12 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:    "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:    "node-a",
 						Name:  "Node A",
 						Block: "schedule",
 					},
@@ -673,12 +673,12 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:    "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:    "node-a",
 						Name:  "Node A",
 						Block: "annotation",
 					},
@@ -696,12 +696,12 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry, orgID: r.Organization.ID}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:    "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:    "node-a",
 						Name:  "Node A",
 						Block: "github.getIssue",
 						Configuration: structFromMap(t, map[string]any{
@@ -724,15 +724,15 @@ func Test__CanvasPatcher(t *testing.T) {
 		steps := &CanvasPatcherSteps{t: t, registry: r.Registry, orgID: r.Organization.ID}
 		steps.givenCanvasVersion(nil, nil)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Block:         "github.getIssue",
-						IntegrationId: "not-a-uuid",
+						IntegrationID: "not-a-uuid",
 						Configuration: structFromMap(t, map[string]any{
 							"repository":  "superplanehq/superplane",
 							"issueNumber": "1",
@@ -755,15 +755,15 @@ func Test__CanvasPatcher(t *testing.T) {
 
 		missingIntegrationID := uuid.New().String()
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Block:         "github.getIssue",
-						IntegrationId: missingIntegrationID,
+						IntegrationID: missingIntegrationID,
 						Configuration: structFromMap(t, map[string]any{
 							"repository":  "superplanehq/superplane",
 							"issueNumber": "1",
@@ -793,15 +793,15 @@ func Test__CanvasPatcher(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Block:         "github.getIssue",
-						IntegrationId: integration.ID.String(),
+						IntegrationID: integration.ID.String(),
 						Configuration: structFromMap(t, map[string]any{
 							"repository":  "superplanehq/superplane",
 							"issueNumber": "1",
@@ -829,15 +829,15 @@ func Test__CanvasPatcher(t *testing.T) {
 			{Name: "github.getIssue", State: core.IntegrationCapabilityStateEnabled},
 		})
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Block:         "github.getIssue",
-						IntegrationId: integration.ID.String(),
+						IntegrationID: integration.ID.String(),
 						Configuration: structFromMap(t, map[string]any{
 							"repository":  "superplanehq/superplane",
 							"issueNumber": "1",
@@ -865,15 +865,15 @@ func Test__CanvasPatcher(t *testing.T) {
 			{Name: "github.getIssue", State: core.IntegrationCapabilityStateDisabled},
 		})
 
-		steps.whenHandling(&pb.CanvasChangeset{
-			Changes: []*pb.CanvasChangeset_Change{
+		steps.whenHandling(&CanvasChangeset{
+			Changes: []*Change{
 				{
-					Type: pb.CanvasChangeset_Change_ADD_NODE,
-					Node: &pb.CanvasChangeset_Change_Node{
-						Id:            "node-a",
+					Type: ChangeTypeAddNode,
+					Node: &ChangeNode{
+						ID:            "node-a",
 						Name:          "Node A",
 						Block:         "github.getIssue",
-						IntegrationId: integration.ID.String(),
+						IntegrationID: integration.ID.String(),
 						Configuration: structFromMap(t, map[string]any{
 							"repository":  "superplanehq/superplane",
 							"issueNumber": "1",
@@ -910,7 +910,7 @@ func (s *CanvasPatcherSteps) givenCanvasVersion(nodes []models.Node, edges []mod
 	})
 }
 
-func (s *CanvasPatcherSteps) whenHandling(operations *pb.CanvasChangeset, autoLayout *pb.CanvasAutoLayout) {
+func (s *CanvasPatcherSteps) whenHandling(operations *CanvasChangeset, autoLayout *pb.CanvasAutoLayout) {
 	s.err = s.patcher.ApplyChangeset(operations, autoLayout)
 	s.finalVersion = s.patcher.GetVersion()
 }

--- a/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
+++ b/pkg/grpc/actions/canvases/changesets/canvas_publisher.go
@@ -14,7 +14,6 @@ import (
 	gitprovider "github.com/superplanehq/superplane/pkg/git/provider"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
-	pb "github.com/superplanehq/superplane/pkg/protos/canvases"
 	"github.com/superplanehq/superplane/pkg/registry"
 	"github.com/superplanehq/superplane/pkg/workers/contexts"
 	"gorm.io/datatypes"
@@ -39,7 +38,7 @@ type CanvasPublisher struct {
 	options    CanvasPublisherOptions
 	live       *models.CanvasVersion
 	draft      *models.CanvasVersion
-	changeset  *pb.CanvasChangeset
+	changeset  *CanvasChangeset
 	finalNodes map[string]models.Node
 	renamedIDs map[string]string
 
@@ -94,7 +93,7 @@ func NewCanvasPublisher(tx *gorm.DB, draft *models.CanvasVersion, liveVersion *m
 	if err != nil {
 		return nil, err
 	}
-	if len(changeset.GetChanges()) == 0 {
+	if len(changeset.Changes) == 0 {
 		return nil, errNoChangesToPublish
 	}
 
@@ -189,21 +188,21 @@ func (p *CanvasPublisher) filterEdgesForExistingNodes(edges []models.Edge) []mod
 	return filteredEdges
 }
 
-func (p *CanvasPublisher) processChange(ctx context.Context, change *pb.CanvasChangeset_Change) error {
+func (p *CanvasPublisher) processChange(ctx context.Context, change *Change) error {
 	switch change.Type {
-	case pb.CanvasChangeset_Change_ADD_NODE:
+	case ChangeTypeAddNode:
 		return p.addNode(ctx, change)
-	case pb.CanvasChangeset_Change_DELETE_NODE:
+	case ChangeTypeDeleteNode:
 		return p.deleteNode(change)
-	case pb.CanvasChangeset_Change_UPDATE_NODE:
+	case ChangeTypeUpdateNode:
 		return p.updateNode(ctx, change)
 	}
 
 	return nil
 }
 
-func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangeset_Change) error {
-	node := p.finalNodes[change.GetNode().GetId()]
+func (p *CanvasPublisher) addNode(ctx context.Context, change *Change) error {
+	node := p.finalNodes[change.Node.ID]
 	nodeID := p.ensureNewNodeID(node)
 	node.ID = nodeID
 
@@ -285,8 +284,8 @@ func (p *CanvasPublisher) addNode(ctx context.Context, change *pb.CanvasChangese
 	return p.tx.Save(&newNode).Error
 }
 
-func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChangeset_Change) error {
-	updatedNode := p.finalNodes[change.GetNode().GetId()]
+func (p *CanvasPublisher) updateNode(ctx context.Context, change *Change) error {
+	updatedNode := p.finalNodes[change.Node.ID]
 
 	//
 	// Widgets are not saved as workflow_nodes records in the database.
@@ -357,8 +356,8 @@ func (p *CanvasPublisher) updateNode(ctx context.Context, change *pb.CanvasChang
 	return p.tx.Save(&existingNode).Error
 }
 
-func (p *CanvasPublisher) deleteNode(change *pb.CanvasChangeset_Change) error {
-	existingNode, exists := p.allNodes[change.GetNode().GetId()]
+func (p *CanvasPublisher) deleteNode(change *Change) error {
+	existingNode, exists := p.allNodes[change.Node.ID]
 	if !exists {
 		return nil
 	}

--- a/pkg/grpc/actions/canvases/changesets/changeset.go
+++ b/pkg/grpc/actions/canvases/changesets/changeset.go
@@ -1,0 +1,60 @@
+package changesets
+
+import (
+	componentpb "github.com/superplanehq/superplane/pkg/protos/components"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type ChangeType int
+
+const (
+	ChangeTypeUnspecified ChangeType = iota
+	ChangeTypeAddNode
+	ChangeTypeDeleteNode
+	ChangeTypeUpdateNode
+	ChangeTypeAddEdge
+	ChangeTypeDeleteEdge
+)
+
+func (t ChangeType) String() string {
+	switch t {
+	case ChangeTypeAddNode:
+		return "ADD_NODE"
+	case ChangeTypeDeleteNode:
+		return "DELETE_NODE"
+	case ChangeTypeUpdateNode:
+		return "UPDATE_NODE"
+	case ChangeTypeAddEdge:
+		return "ADD_EDGE"
+	case ChangeTypeDeleteEdge:
+		return "DELETE_EDGE"
+	default:
+		return "UNSPECIFIED"
+	}
+}
+
+type CanvasChangeset struct {
+	Changes []*Change
+}
+
+type Change struct {
+	Type ChangeType
+	Node *ChangeNode
+	Edge *ChangeEdge
+}
+
+type ChangeNode struct {
+	ID            string
+	Name          string
+	Block         string
+	Configuration *structpb.Struct
+	IntegrationID string
+	Position      *componentpb.Position
+	IsCollapsed   *bool
+}
+
+type ChangeEdge struct {
+	SourceID string
+	TargetID string
+	Channel  string
+}

--- a/pkg/grpc/actions/canvases/common.go
+++ b/pkg/grpc/actions/canvases/common.go
@@ -146,7 +146,7 @@ func publishCanvasVersionInTransaction(
 		return err
 	}
 
-	if len(changeset.GetChanges()) == 0 {
+	if len(changeset.Changes) == 0 {
 		return mapCanvasNameUniqueConstraintError(
 			models.PromoteToLiveInTransaction(tx, nextVersion, nextVersion.Nodes, nextVersion.Edges),
 		)

--- a/protos/canvases.proto
+++ b/protos/canvases.proto
@@ -991,52 +991,6 @@ message ResolveExecutionErrorsRequest {
 message ResolveExecutionErrorsResponse {}
 
 //
-// CanvasChangeset describes a unit of change for a canvas version.
-//
-message CanvasChangeset {
-  message Change {
-    enum Type {
-      UNSPECIFIED = 0;
-      ADD_NODE = 1;
-      DELETE_NODE = 2;
-      UPDATE_NODE = 3;
-      ADD_EDGE = 4;
-      DELETE_EDGE = 5;
-    }
-
-    message Node {
-      string id = 1;
-      string name = 2;
-      string block = 3;
-      google.protobuf.Struct configuration = 4;
-      string integration_id = 5;
-      Components.Position position = 6;
-      optional bool is_collapsed = 7;
-    }
-
-    message Edge {
-      string source_id = 1;
-      string target_id = 2;
-      string channel = 3;
-    }
-
-    Type type = 1;
-
-    //
-    // Required for ADD_NODE, UPDATE_NODE, DELETE_NODE
-    //
-    Node node = 2;
-
-    //
-    // Required for ADD_EDGE and DELETE_EDGE
-    //
-    Edge edge = 3;
-  }
-
-  repeated Change changes = 1;
-}
-
-//
 // Standalone messages
 //
 

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -14,7 +14,7 @@ import type {
   CanvasesCanvasRun,
   CanvasesCanvasVersion,
   ActionsAction,
-  SuperplaneComponentsEdge as ComponentsEdge,
+  ComponentsEdge,
   ComponentsIntegrationRef,
   SuperplaneComponentsNode as ComponentsNode,
   OrganizationsIntegration,

--- a/web_src/src/pages/app/lib/canvas-node-preparation.ts
+++ b/web_src/src/pages/app/lib/canvas-node-preparation.ts
@@ -7,7 +7,7 @@ import {
   type CanvasesCanvasNodeExecution,
   type CanvasesCanvasNodeQueueItem,
   type ActionsAction,
-  type SuperplaneComponentsEdge as ComponentsEdge,
+  type ComponentsEdge,
   type SuperplaneComponentsNode as ComponentsNode,
   type TriggersTrigger,
 } from "@/api-client";

--- a/web_src/src/pages/app/lib/canvas-yaml-staging.ts
+++ b/web_src/src/pages/app/lib/canvas-yaml-staging.ts
@@ -1,9 +1,6 @@
 import * as yaml from "js-yaml";
 import type { CanvasesCanvas } from "@/api-client";
-import type {
-  SuperplaneComponentsEdge as ComponentsEdge,
-  SuperplaneComponentsNode as ComponentsNode,
-} from "@/api-client";
+import type { ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
 
 type ParsedCanvasYaml = {
   apiVersion?: string;

--- a/web_src/src/pages/app/useCanvasYaml.ts
+++ b/web_src/src/pages/app/useCanvasYaml.ts
@@ -1,9 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type {
-  CanvasesCanvas,
-  SuperplaneComponentsEdge as ComponentsEdge,
-  SuperplaneComponentsNode as ComponentsNode,
-} from "@/api-client";
+import type { CanvasesCanvas, ComponentsEdge, SuperplaneComponentsNode as ComponentsNode } from "@/api-client";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { analytics } from "@/lib/analytics";
 import type { CanvasNode } from "@/ui/CanvasPage";

--- a/web_src/src/pages/app/useDraftVisualDiff.ts
+++ b/web_src/src/pages/app/useDraftVisualDiff.ts
@@ -2,7 +2,7 @@ import type {
   CanvasesCanvas,
   CanvasesCanvasVersion,
   ActionsAction,
-  SuperplaneComponentsEdge as ComponentsEdge,
+  ComponentsEdge,
   SuperplaneComponentsNode as ComponentsNode,
   TriggersTrigger,
 } from "@/api-client";

--- a/web_src/src/pages/app/workflowPageHelpers.ts
+++ b/web_src/src/pages/app/workflowPageHelpers.ts
@@ -3,7 +3,7 @@ import type {
   CanvasesCanvasEvent,
   CanvasesCanvasNodeExecution,
   CanvasesCanvasNodeQueueItem,
-  SuperplaneComponentsEdge as ComponentsEdge,
+  ComponentsEdge,
   SuperplaneComponentsNode as ComponentsNode,
   IntegrationsIntegrationDefinition,
   ActionsAction,

--- a/web_src/src/pages/home/CanvasCardsGrid.tsx
+++ b/web_src/src/pages/home/CanvasCardsGrid.tsx
@@ -1,5 +1,5 @@
 import { Heading } from "@/components/Heading/heading";
-import type { SuperplaneComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
+import type { ComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
 import { Link } from "react-router-dom";
 import { appPath } from "@/lib/appPaths";
 import { CanvasActionsMenu } from "./CanvasActionsMenu";
@@ -122,7 +122,7 @@ function CanvasCard({
 
 interface CanvasMiniMapProps {
   nodes?: SuperplaneComponentsNode[];
-  edges?: SuperplaneComponentsEdge[];
+  edges?: ComponentsEdge[];
 }
 
 function CanvasMiniMap({ nodes = [], edges = [] }: CanvasMiniMapProps) {

--- a/web_src/src/pages/home/types.ts
+++ b/web_src/src/pages/home/types.ts
@@ -1,4 +1,4 @@
-import type { SuperplaneComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
+import type { ComponentsEdge, SuperplaneComponentsNode } from "@/api-client";
 import type { CanvasFolderColor } from "@/hooks/useCanvasData";
 
 export interface CanvasCardData {
@@ -9,7 +9,7 @@ export interface CanvasCardData {
   canvasFolderId?: string;
   createdBy: { name: string };
   nodes?: SuperplaneComponentsNode[];
-  edges?: SuperplaneComponentsEdge[];
+  edges?: ComponentsEdge[];
 }
 
 export interface CanvasFolderData {

--- a/web_src/src/test/factories.ts
+++ b/web_src/src/test/factories.ts
@@ -1,6 +1,6 @@
 import type {
   CanvasesCanvas,
-  SuperplaneComponentsEdge as ComponentsEdge,
+  ComponentsEdge,
   SuperplaneComponentsNode as ComponentsNode,
   OrganizationsIntegration,
 } from "@/api-client";


### PR DESCRIPTION
Now that we no longer have changeset endpoints - see https://github.com/superplanehq/superplane/pull/5657 - there's no need to expose the changeset type in the API definitions, since it's only used internally now. Here, we move it to pkg/grpc/actions/canvases/changesets package.