### PR TITLE
fix: sync usage before publishing agent tokens

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -259,7 +259,12 @@ func startWorkers(
 			AuthService:       authService,
 			UsageService:      getOptionalWorkerUsageService(),
 		})
-		w := workers.NewAgentStreamWorker(agentProvider, rabbitMQURL, agentToolRegistry)
+		w := workers.NewAgentStreamWorkerWithUsageService(
+			agentProvider,
+			rabbitMQURL,
+			getOptionalWorkerUsageService(),
+			agentToolRegistry,
+		)
 		go w.Start(context.Background())
 	}
 

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/logging"
 	"github.com/superplanehq/superplane/pkg/models"
+	"github.com/superplanehq/superplane/pkg/usage"
 	"gorm.io/gorm"
 )
 
@@ -56,11 +57,21 @@ var publishAgentRunFinished = func(session *models.AgentSession, evt agents.Prov
 type AgentStreamWorker struct {
 	provider           agents.Provider
 	customToolExecutor agents.CustomToolExecutor
+	usageService       usage.Service
 	rabbitMQURL        string
 	slots              chan struct{}
 }
 
 func NewAgentStreamWorker(provider agents.Provider, rabbitMQURL string, customToolExecutor ...agents.CustomToolExecutor) *AgentStreamWorker {
+	return NewAgentStreamWorkerWithUsageService(provider, rabbitMQURL, nil, customToolExecutor...)
+}
+
+func NewAgentStreamWorkerWithUsageService(
+	provider agents.Provider,
+	rabbitMQURL string,
+	usageService usage.Service,
+	customToolExecutor ...agents.CustomToolExecutor,
+) *AgentStreamWorker {
 	executor := agents.CustomToolExecutor(unsupportedCustomToolExecutor{})
 	if len(customToolExecutor) > 0 && customToolExecutor[0] != nil {
 		executor = customToolExecutor[0]
@@ -68,6 +79,7 @@ func NewAgentStreamWorker(provider agents.Provider, rabbitMQURL string, customTo
 	return &AgentStreamWorker{
 		provider:           provider,
 		customToolExecutor: executor,
+		usageService:       usageService,
 		rabbitMQURL:        rabbitMQURL,
 		slots:              make(chan struct{}, maxConcurrentStreams),
 	}
@@ -419,7 +431,7 @@ func (w *AgentStreamWorker) streamProviderTurn(
 	for {
 		customTools.clearRequirement()
 		err := w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
-			return handleProviderEvent(session, evt, publish, &streamErr, customTools)
+			return handleProviderEvent(ctx, w.usageService, session, evt, publish, &streamErr, customTools)
 		})
 
 		if errors.Is(err, errCustomToolResultsRequired) {
@@ -442,6 +454,8 @@ func (w *AgentStreamWorker) streamProviderTurn(
 }
 
 func handleProviderEvent(
+	ctx context.Context,
+	usageService usage.Service,
 	session *models.AgentSession,
 	evt agents.ProviderEvent,
 	publish func(messages.AgentSessionEventMessage),
@@ -449,7 +463,7 @@ func handleProviderEvent(
 	customTools *customToolTurnState,
 ) error {
 	if evt.Type == agents.ProviderEventTurnCompleted {
-		publishAgentTokenUsage(session, evt)
+		publishAgentTokenUsage(ctx, usageService, session, evt)
 	}
 
 	// Drop late events from a turn the user has already stopped — closes
@@ -501,10 +515,28 @@ func handleProviderEvent(
 	return nil
 }
 
-func publishAgentTokenUsage(session *models.AgentSession, evt agents.ProviderEvent) {
+func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, session *models.AgentSession, evt agents.ProviderEvent) {
 	if evt.Usage == nil || !evt.Usage.HasUsage() {
 		return
 	}
+
+	if err := syncAgentTokenUsageOrganization(ctx, usageService, session.OrganizationID.String()); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"session_id":      session.ID,
+			"organization_id": session.OrganizationID,
+		}).Warn("agent stream: failed to sync organization before publishing agent token usage")
+	}
+
+	log.WithFields(log.Fields{
+		"session_id":         session.ID,
+		"organization_id":    session.OrganizationID,
+		"model":              evt.Model,
+		"input_tokens":       evt.Usage.InputTokens,
+		"output_tokens":      evt.Usage.OutputTokens,
+		"total_tokens":       evt.Usage.TotalTokens,
+		"cache_read_tokens":  evt.Usage.CacheReadTokens,
+		"cache_write_tokens": evt.Usage.CacheWriteTokens,
+	}).Info("agent stream: publishing agent token usage")
 
 	if err := publishAgentRunFinished(session, evt); err != nil {
 		log.WithError(err).WithFields(log.Fields{
@@ -512,6 +544,14 @@ func publishAgentTokenUsage(session *models.AgentSession, evt agents.ProviderEve
 			"organization_id": session.OrganizationID,
 		}).Warn("agent stream: failed to publish agent token usage")
 	}
+}
+
+func syncAgentTokenUsageOrganization(ctx context.Context, usageService usage.Service, organizationID string) error {
+	if usageService == nil || !usageService.Enabled() {
+		return nil
+	}
+
+	return usage.SyncOrganization(ctx, usageService, organizationID)
 }
 
 func (w *AgentStreamWorker) executeAndSendCustomToolResults(

--- a/pkg/workers/agent_stream_worker_internal_test.go
+++ b/pkg/workers/agent_stream_worker_internal_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -10,8 +11,66 @@ import (
 	"github.com/superplanehq/superplane/pkg/database"
 	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
 	"github.com/superplanehq/superplane/pkg/models"
+	usagepb "github.com/superplanehq/superplane/pkg/protos/usage"
+	"github.com/superplanehq/superplane/pkg/usage"
 	"github.com/superplanehq/superplane/test/support"
 )
+
+type fakeAgentTokenUsageService struct {
+	enabled bool
+
+	setupAccountCalls      []string
+	setupOrganizationCalls [][2]string
+}
+
+func (s *fakeAgentTokenUsageService) Enabled() bool {
+	return s.enabled
+}
+
+func (s *fakeAgentTokenUsageService) SetupAccount(_ context.Context, accountID string) (*usagepb.SetupAccountResponse, error) {
+	s.setupAccountCalls = append(s.setupAccountCalls, accountID)
+	return &usagepb.SetupAccountResponse{}, nil
+}
+
+func (s *fakeAgentTokenUsageService) SetupOrganization(
+	_ context.Context,
+	organizationID, accountID string,
+	_ usage.SetupOrganizationDetails,
+) (*usagepb.SetupOrganizationResponse, error) {
+	s.setupOrganizationCalls = append(s.setupOrganizationCalls, [2]string{organizationID, accountID})
+	return &usagepb.SetupOrganizationResponse{
+		Limits: &usagepb.OrganizationLimits{RetentionWindowDays: 14},
+	}, nil
+}
+
+func (s *fakeAgentTokenUsageService) DescribeAccountLimits(context.Context, string) (*usagepb.DescribeAccountLimitsResponse, error) {
+	return &usagepb.DescribeAccountLimitsResponse{}, nil
+}
+
+func (s *fakeAgentTokenUsageService) DescribeOrganizationLimits(context.Context, string) (*usagepb.DescribeOrganizationLimitsResponse, error) {
+	return &usagepb.DescribeOrganizationLimitsResponse{
+		Limits: &usagepb.OrganizationLimits{RetentionWindowDays: 14},
+	}, nil
+}
+
+func (s *fakeAgentTokenUsageService) DescribeOrganizationUsage(context.Context, string) (*usagepb.DescribeOrganizationUsageResponse, error) {
+	return &usagepb.DescribeOrganizationUsageResponse{}, nil
+}
+
+func (s *fakeAgentTokenUsageService) CheckAccountLimits(context.Context, string, *usagepb.AccountState) (*usagepb.CheckAccountLimitsResponse, error) {
+	return &usagepb.CheckAccountLimitsResponse{Allowed: true}, nil
+}
+
+func (s *fakeAgentTokenUsageService) CheckOrganizationLimits(
+	context.Context,
+	string,
+	*usagepb.OrganizationState,
+	*usagepb.CanvasState,
+) (*usagepb.CheckOrganizationLimitsResponse, error) {
+	return &usagepb.CheckOrganizationLimitsResponse{Allowed: true}, nil
+}
+
+var _ usage.Service = (*fakeAgentTokenUsageService)(nil)
 
 func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testing.T) {
 	r := support.Setup(t)
@@ -44,6 +103,8 @@ func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testin
 
 	var streamErr error
 	err := handleProviderEvent(
+		context.Background(),
+		nil,
 		session,
 		agents.ProviderEvent{
 			Type:  agents.ProviderEventTurnCompleted,
@@ -58,4 +119,58 @@ func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testin
 	assert.True(t, errors.Is(err, errSessionAlreadyReset))
 	assert.Equal(t, 1, published)
 	assert.NoError(t, streamErr)
+}
+
+func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:    r.Organization.ID,
+		UserID:            r.User,
+		CanvasID:          canvas.ID,
+		Provider:          "test",
+		ProviderSessionID: "upstream-session",
+		Status:            models.AgentSessionStatusStreaming,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	usageService := &fakeAgentTokenUsageService{enabled: true}
+
+	published := 0
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(gotSession *models.AgentSession, evt agents.ProviderEvent) error {
+		published++
+		assert.Equal(t, session.ID, gotSession.ID)
+		require.NotNil(t, evt.Usage)
+		assert.Equal(t, int64(42), evt.Usage.TotalTokens)
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		usageService,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{TotalTokens: 42},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+	assert.Equal(t, 1, published)
+	assert.Equal(t, []string{r.Account.ID.String()}, usageService.setupAccountCalls)
+	require.Len(t, usageService.setupOrganizationCalls, 1)
+	assert.Equal(t, r.Organization.ID.String(), usageService.setupOrganizationCalls[0][0])
+	assert.Equal(t, r.Account.ID.String(), usageService.setupOrganizationCalls[0][1])
 }


### PR DESCRIPTION
## Summary
- Give the agent stream worker an optional usage service dependency
- Sync/setup the organization with SaaS before publishing completed-turn token usage
- Add regression coverage that token usage publishing attempts org usage setup first

## Tests
- make format.go
- make test PKG_TEST_PACKAGES="./pkg/workers"
- make lint
- docker compose -f docker-compose.dev.yml exec app go build ./pkg/workers
- git diff --check

## Note
- make check.build.app currently fails on main with an unrelated generated proto/server mismatch: CanvasService is missing ApplyCanvasVersionChangeset.