### PR TITLE
fix: track managed agent session usage

### DIFF
--- a/db/migrations/20260624035629_add-agent-session-token-usage-watermark.up.sql
+++ b/db/migrations/20260624035629_add-agent-session-token-usage-watermark.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE agent_sessions
+    ADD COLUMN tracked_usage_input_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tracked_usage_output_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tracked_usage_cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tracked_usage_cache_write_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tracked_usage_total_tokens BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN tracked_usage_initialized BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE agent_sessions
+    ALTER COLUMN tracked_usage_initialized SET DEFAULT TRUE;
+
+COMMIT;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -136,7 +136,13 @@ CREATE TABLE public.agent_sessions (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     heartbeat_at timestamp with time zone,
     agent_tool_schema_revision text DEFAULT ''::text NOT NULL,
-    context_replayed_at timestamp with time zone
+    context_replayed_at timestamp with time zone,
+    tracked_usage_input_tokens bigint DEFAULT 0 NOT NULL,
+    tracked_usage_output_tokens bigint DEFAULT 0 NOT NULL,
+    tracked_usage_cache_read_tokens bigint DEFAULT 0 NOT NULL,
+    tracked_usage_cache_write_tokens bigint DEFAULT 0 NOT NULL,
+    tracked_usage_total_tokens bigint DEFAULT 0 NOT NULL,
+    tracked_usage_initialized boolean DEFAULT true NOT NULL
 );
 
 
@@ -2062,7 +2068,7 @@ SET row_security = off;
 --
 
 COPY public.schema_migrations (version, dirty) FROM stdin;
-20260618234242	f
+20260624035629	f
 \.
 
 

--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -593,9 +593,16 @@ func TestStreamEvents_MapsKnownTypes(t *testing.T) {
 		"data: {\"type\":\"agent.message\",\"content\":[{\"type\":\"text\",\"text\":\"after idle\"}]}\n\n"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/sessions/sesn_abc/events/stream", r.URL.Path)
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, sse)
+		switch r.URL.Path {
+		case "/sessions/sesn_abc/events/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, sse)
+		case "/sessions/sesn_abc":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"sesn_abc","status":"idle"}`)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
 	}))
 	defer server.Close()
 
@@ -829,6 +836,42 @@ func TestStreamEvents_MapsTokenUsageOnCompletedTurn(t *testing.T) {
 	assert.Equal(t, int64(3), received[0].Usage.CacheReadTokens)
 	assert.Equal(t, int64(2), received[0].Usage.CacheWriteTokens)
 	assert.Equal(t, int64(20), received[0].Usage.TotalTokens)
+}
+
+func TestStreamEvents_FetchesSessionUsageWhenIdleEventHasNoUsage(t *testing.T) {
+	var sessionFetched bool
+	const sse = "data: {\"type\":\"session.status_idle\",\"model\":\"claude-sonnet-4-5\",\"stop_reason\":{\"type\":\"end_turn\"}}\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/sesn_abc/events/stream":
+			_, _ = io.WriteString(w, sse)
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/sesn_abc":
+			sessionFetched = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"sesn_abc","status":"idle","usage":{"input_tokens":6,"output_tokens":6,"cache_read_input_tokens":3,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":7}}}`)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	var received []agents.ProviderEvent
+	require.NoError(t, p.StreamEvents(context.Background(), "sesn_abc", func(e agents.ProviderEvent) error {
+		received = append(received, e)
+		return nil
+	}))
+
+	require.True(t, sessionFetched)
+	require.Len(t, received, 1)
+	assert.Equal(t, agents.ProviderEventTurnCompleted, received[0].Type)
+	require.NotNil(t, received[0].Usage)
+	assert.Equal(t, int64(6), received[0].Usage.InputTokens)
+	assert.Equal(t, int64(6), received[0].Usage.OutputTokens)
+	assert.Equal(t, int64(3), received[0].Usage.CacheReadTokens)
+	assert.Equal(t, int64(27), received[0].Usage.CacheWriteTokens)
+	assert.Equal(t, int64(42), received[0].Usage.TotalTokens)
 }
 
 func TestStreamEvents_FallsBackToEventIDWhenToolUseIDMissing(t *testing.T) {

--- a/pkg/agents/anthropic/events.go
+++ b/pkg/agents/anthropic/events.go
@@ -58,6 +58,10 @@ type anthropicUsage struct {
 	CacheCreationInputTokens int64  `json:"cache_creation_input_tokens,omitempty"`
 	ServerToolUseInputTokens int64  `json:"server_tool_use_input_tokens,omitempty"`
 	ServiceTier              string `json:"service_tier,omitempty"`
+	CacheCreation            struct {
+		Ephemeral5mInputTokens int64 `json:"ephemeral_5m_input_tokens,omitempty"`
+		Ephemeral1hInputTokens int64 `json:"ephemeral_1h_input_tokens,omitempty"`
+	} `json:"cache_creation,omitempty"`
 }
 
 func mapEvent(raw anthropicEvent) (agents.ProviderEvent, bool) {
@@ -159,7 +163,7 @@ func tokenUsage(raw *anthropicUsage) *agents.TokenUsage {
 		OutputTokens:     raw.OutputTokens,
 		TotalTokens:      raw.TotalTokens,
 		CacheReadTokens:  firstNonZero(raw.CacheReadTokens, raw.CacheReadInputTokens),
-		CacheWriteTokens: firstNonZero(raw.CacheWriteTokens, raw.CacheCreationInputTokens),
+		CacheWriteTokens: cacheCreationTokens(raw),
 	}
 	if usage.TotalTokens == 0 {
 		usage.TotalTokens = usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheWriteTokens + raw.ServerToolUseInputTokens
@@ -168,6 +172,14 @@ func tokenUsage(raw *anthropicUsage) *agents.TokenUsage {
 		return nil
 	}
 	return usage
+}
+
+func cacheCreationTokens(raw *anthropicUsage) int64 {
+	return firstNonZero(
+		raw.CacheWriteTokens,
+		raw.CacheCreationInputTokens,
+		raw.CacheCreation.Ephemeral5mInputTokens+raw.CacheCreation.Ephemeral1hInputTokens,
+	)
 }
 
 func firstNonZero(values ...int64) int64 {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -268,7 +268,17 @@ func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, o
 		return fmt.Errorf("anthropic: open stream: %w", err)
 	}
 	defer body.Close()
-	return forwardSSE(ctx, body, onEvent)
+	return forwardSSE(ctx, body, func(event agents.ProviderEvent) error {
+		if event.Type == agents.ProviderEventTurnCompleted && event.Usage == nil {
+			usage, err := p.retrieveSessionUsage(ctx, providerSessionID)
+			if err != nil {
+				log.WithError(err).WithField("provider_session_id", providerSessionID).Warn("anthropic: failed to retrieve completed session usage")
+			} else {
+				event.Usage = usage
+			}
+		}
+		return onEvent(event)
+	})
 }
 
 func (p *Provider) DeleteSession(ctx context.Context, providerSessionID string) error {
@@ -311,6 +321,22 @@ func withPreamble(message, preamble string) string {
 		return message
 	}
 	return preamble + "\n\n" + message
+}
+
+func (p *Provider) retrieveSessionUsage(ctx context.Context, providerSessionID string) (*agents.TokenUsage, error) {
+	data, err := p.client.executeHTTP(ctx, http.MethodGet, "/sessions/"+url.PathEscape(providerSessionID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var session struct {
+		Usage *anthropicUsage `json:"usage,omitempty"`
+	}
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("decode session usage: %w", err)
+	}
+
+	return tokenUsage(session.Usage), nil
 }
 
 func forwardSSE(ctx context.Context, body io.Reader, onEvent func(agents.ProviderEvent) error) error {

--- a/pkg/models/agent_session.go
+++ b/pkg/models/agent_session.go
@@ -18,26 +18,45 @@ const (
 )
 
 type AgentSession struct {
-	ID                      uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
-	OrganizationID          uuid.UUID
-	UserID                  uuid.UUID
-	CanvasID                uuid.UUID
-	Provider                string
-	ProviderSessionID       string
-	AgentToolSchemaRevision string
-	Status                  string
-	LastActiveAt            *time.Time
-	HeartbeatAt             *time.Time
-	ContextReplayedAt       *time.Time
-	CreatedAt               *time.Time
-	UpdatedAt               *time.Time
+	ID                           uuid.UUID `gorm:"primaryKey;default:uuid_generate_v4()"`
+	OrganizationID               uuid.UUID
+	UserID                       uuid.UUID
+	CanvasID                     uuid.UUID
+	Provider                     string
+	ProviderSessionID            string
+	AgentToolSchemaRevision      string
+	TrackedUsageInputTokens      int64
+	TrackedUsageOutputTokens     int64
+	TrackedUsageCacheReadTokens  int64
+	TrackedUsageCacheWriteTokens int64
+	TrackedUsageTotalTokens      int64
+	TrackedUsageInitialized      bool `gorm:"default:true"`
+	Status                       string
+	LastActiveAt                 *time.Time
+	HeartbeatAt                  *time.Time
+	ContextReplayedAt            *time.Time
+	CreatedAt                    *time.Time
+	UpdatedAt                    *time.Time
 }
 
 func (AgentSession) TableName() string { return "agent_sessions" }
 
 var ErrAgentSessionNotFound = errors.New("agent session not found")
 
+type AgentSessionTokenUsage struct {
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	TotalTokens      int64
+}
+
+func (u AgentSessionTokenUsage) HasUsage() bool {
+	return u.TotalTokens > 0
+}
+
 func CreateAgentSessionInTransaction(tx *gorm.DB, session *AgentSession) error {
+	session.TrackedUsageInitialized = true
 	return tx.Create(session).Error
 }
 
@@ -168,13 +187,19 @@ func UpdateAgentSessionProviderSessionInTransaction(tx *gorm.DB, sessionID uuid.
 	return tx.Model(&AgentSession{}).
 		Where("id = ?", sessionID).
 		Updates(map[string]any{
-			"provider_session_id":        providerSessionID,
-			"agent_tool_schema_revision": toolSchemaRevision,
-			"status":                     status,
-			"last_active_at":             &now,
-			"updated_at":                 &now,
-			"heartbeat_at":               gorm.Expr("NULL"),
-			"context_replayed_at":        gorm.Expr("NULL"),
+			"provider_session_id":              providerSessionID,
+			"agent_tool_schema_revision":       toolSchemaRevision,
+			"tracked_usage_input_tokens":       0,
+			"tracked_usage_output_tokens":      0,
+			"tracked_usage_cache_read_tokens":  0,
+			"tracked_usage_cache_write_tokens": 0,
+			"tracked_usage_total_tokens":       0,
+			"tracked_usage_initialized":        true,
+			"status":                           status,
+			"last_active_at":                   &now,
+			"updated_at":                       &now,
+			"heartbeat_at":                     gorm.Expr("NULL"),
+			"context_replayed_at":              gorm.Expr("NULL"),
 		}).Error
 }
 
@@ -227,6 +252,38 @@ func LockAgentSessionInTransaction(tx *gorm.DB, sessionID uuid.UUID) (*AgentSess
 	return &session, nil
 }
 
+func CalculateAgentSessionTokenUsageDelta(sessionID uuid.UUID, usage AgentSessionTokenUsage) (AgentSessionTokenUsage, bool, error) {
+	session, err := FindAgentSession(sessionID)
+	if err != nil {
+		return AgentSessionTokenUsage{}, false, err
+	}
+	if !session.TrackedUsageInitialized {
+		return AgentSessionTokenUsage{}, false, nil
+	}
+
+	return agentSessionTokenUsageDelta(session, usage), true, nil
+}
+
+func MarkAgentSessionTokenUsageTracked(sessionID uuid.UUID, usage AgentSessionTokenUsage) error {
+	return database.Conn().Transaction(func(tx *gorm.DB) error {
+		session, err := LockAgentSessionInTransaction(tx, sessionID)
+		if err != nil {
+			return err
+		}
+
+		return tx.Model(&AgentSession{}).
+			Where("id = ?", sessionID).
+			Updates(map[string]any{
+				"tracked_usage_input_tokens":       maxInt64(session.TrackedUsageInputTokens, usage.InputTokens),
+				"tracked_usage_output_tokens":      maxInt64(session.TrackedUsageOutputTokens, usage.OutputTokens),
+				"tracked_usage_cache_read_tokens":  maxInt64(session.TrackedUsageCacheReadTokens, usage.CacheReadTokens),
+				"tracked_usage_cache_write_tokens": maxInt64(session.TrackedUsageCacheWriteTokens, usage.CacheWriteTokens),
+				"tracked_usage_total_tokens":       maxInt64(session.TrackedUsageTotalTokens, usage.TotalTokens),
+				"tracked_usage_initialized":        true,
+			}).Error
+	})
+}
+
 // FailStuckStreamingSessions flags leaked streaming rows. Heartbeated rows
 // use heartbeatCutoff (tight); rows with no heartbeat yet — pre-heartbeat
 // binaries, or new turns before the worker's first tick — fall back to
@@ -260,4 +317,35 @@ func FailStuckStreamingSessions(heartbeatCutoff, legacyCutoff time.Time) ([]Agen
 		return nil, err
 	}
 	return stuck, nil
+}
+
+func agentSessionTokenUsageDelta(session *AgentSession, usage AgentSessionTokenUsage) AgentSessionTokenUsage {
+	delta := AgentSessionTokenUsage{
+		InputTokens:      nonNegativeDelta(usage.InputTokens, session.TrackedUsageInputTokens),
+		OutputTokens:     nonNegativeDelta(usage.OutputTokens, session.TrackedUsageOutputTokens),
+		CacheReadTokens:  nonNegativeDelta(usage.CacheReadTokens, session.TrackedUsageCacheReadTokens),
+		CacheWriteTokens: nonNegativeDelta(usage.CacheWriteTokens, session.TrackedUsageCacheWriteTokens),
+		TotalTokens:      nonNegativeDelta(usage.TotalTokens, session.TrackedUsageTotalTokens),
+	}
+	if delta.TotalTokens == 0 {
+		delta.TotalTokens = delta.InputTokens + delta.OutputTokens + delta.CacheReadTokens + delta.CacheWriteTokens
+	}
+
+	return delta
+}
+
+func nonNegativeDelta(current, tracked int64) int64 {
+	if current <= tracked {
+		return 0
+	}
+
+	return current - tracked
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+
+	return b
 }

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -520,6 +520,28 @@ func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, ses
 		return
 	}
 
+	cumulativeUsage := agentSessionTokenUsage(evt.Usage)
+	deltaUsage, initialized, err := models.CalculateAgentSessionTokenUsageDelta(session.ID, cumulativeUsage)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"session_id":      session.ID,
+			"organization_id": session.OrganizationID,
+		}).Warn("agent stream: failed to calculate agent token usage delta")
+		return
+	}
+	if !initialized {
+		if err := models.MarkAgentSessionTokenUsageTracked(session.ID, cumulativeUsage); err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"session_id":      session.ID,
+				"organization_id": session.OrganizationID,
+			}).Warn("agent stream: failed to initialize agent token usage watermark")
+		}
+		return
+	}
+	if !deltaUsage.HasUsage() {
+		return
+	}
+
 	if err := syncAgentTokenUsageOrganization(ctx, usageService, session.OrganizationID.String()); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"session_id":      session.ID,
@@ -527,22 +549,55 @@ func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, ses
 		}).Warn("agent stream: failed to sync organization before publishing agent token usage")
 	}
 
+	if err := models.MarkAgentSessionTokenUsageTracked(session.ID, cumulativeUsage); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"session_id":      session.ID,
+			"organization_id": session.OrganizationID,
+		}).Warn("agent stream: failed to mark agent token usage tracked")
+		return
+	}
+
+	publishEvent := evt
+	publishEvent.Usage = providerTokenUsage(deltaUsage)
+
 	log.WithFields(log.Fields{
-		"session_id":         session.ID,
-		"organization_id":    session.OrganizationID,
-		"model":              evt.Model,
-		"input_tokens":       evt.Usage.InputTokens,
-		"output_tokens":      evt.Usage.OutputTokens,
-		"total_tokens":       evt.Usage.TotalTokens,
-		"cache_read_tokens":  evt.Usage.CacheReadTokens,
-		"cache_write_tokens": evt.Usage.CacheWriteTokens,
+		"session_id":              session.ID,
+		"organization_id":         session.OrganizationID,
+		"model":                   evt.Model,
+		"input_tokens":            deltaUsage.InputTokens,
+		"output_tokens":           deltaUsage.OutputTokens,
+		"total_tokens":            deltaUsage.TotalTokens,
+		"cache_read_tokens":       deltaUsage.CacheReadTokens,
+		"cache_write_tokens":      deltaUsage.CacheWriteTokens,
+		"cumulative_total_tokens": cumulativeUsage.TotalTokens,
 	}).Info("agent stream: publishing agent token usage")
 
-	if err := publishAgentRunFinished(session, evt); err != nil {
+	if err := publishAgentRunFinished(session, publishEvent); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"session_id":      session.ID,
 			"organization_id": session.OrganizationID,
 		}).Warn("agent stream: failed to publish agent token usage")
+		return
+	}
+}
+
+func agentSessionTokenUsage(usage *agents.TokenUsage) models.AgentSessionTokenUsage {
+	return models.AgentSessionTokenUsage{
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+		TotalTokens:      usage.TotalTokens,
+	}
+}
+
+func providerTokenUsage(usage models.AgentSessionTokenUsage) *agents.TokenUsage {
+	return &agents.TokenUsage{
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+		TotalTokens:      usage.TotalTokens,
 	}
 }
 

--- a/pkg/workers/agent_stream_worker_internal_test.go
+++ b/pkg/workers/agent_stream_worker_internal_test.go
@@ -78,12 +78,13 @@ func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testin
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
 
 	session := &models.AgentSession{
-		OrganizationID:    r.Organization.ID,
-		UserID:            r.User,
-		CanvasID:          canvas.ID,
-		Provider:          "test",
-		ProviderSessionID: "upstream-session",
-		Status:            models.AgentSessionStatusIdle,
+		OrganizationID:          r.Organization.ID,
+		UserID:                  r.User,
+		CanvasID:                canvas.ID,
+		Provider:                "test",
+		ProviderSessionID:       "upstream-session",
+		TrackedUsageInitialized: true,
+		Status:                  models.AgentSessionStatusIdle,
 	}
 	require.NoError(t, database.Conn().Create(session).Error)
 
@@ -127,12 +128,13 @@ func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *test
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
 
 	session := &models.AgentSession{
-		OrganizationID:    r.Organization.ID,
-		UserID:            r.User,
-		CanvasID:          canvas.ID,
-		Provider:          "test",
-		ProviderSessionID: "upstream-session",
-		Status:            models.AgentSessionStatusStreaming,
+		OrganizationID:          r.Organization.ID,
+		UserID:                  r.User,
+		CanvasID:                canvas.ID,
+		Provider:                "test",
+		ProviderSessionID:       "upstream-session",
+		TrackedUsageInitialized: true,
+		Status:                  models.AgentSessionStatusStreaming,
 	}
 	require.NoError(t, database.Conn().Create(session).Error)
 
@@ -173,4 +175,263 @@ func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *test
 	require.Len(t, usageService.setupOrganizationCalls, 1)
 	assert.Equal(t, r.Organization.ID.String(), usageService.setupOrganizationCalls[0][0])
 	assert.Equal(t, r.Account.ID.String(), usageService.setupOrganizationCalls[0][1])
+}
+
+func TestHandleProviderEvent_PublishesOnlyNewCumulativeTokenUsage(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:               r.Organization.ID,
+		UserID:                       r.User,
+		CanvasID:                     canvas.ID,
+		Provider:                     "test",
+		ProviderSessionID:            "upstream-session",
+		Status:                       models.AgentSessionStatusStreaming,
+		TrackedUsageInputTokens:      10,
+		TrackedUsageOutputTokens:     5,
+		TrackedUsageCacheReadTokens:  20,
+		TrackedUsageCacheWriteTokens: 5,
+		TrackedUsageTotalTokens:      40,
+		TrackedUsageInitialized:      true,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	published := 0
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(gotSession *models.AgentSession, evt agents.ProviderEvent) error {
+		published++
+		assert.Equal(t, session.ID, gotSession.ID)
+		require.NotNil(t, evt.Usage)
+		assert.Equal(t, int64(2), evt.Usage.InputTokens)
+		assert.Equal(t, int64(3), evt.Usage.OutputTokens)
+		assert.Equal(t, int64(4), evt.Usage.CacheReadTokens)
+		assert.Equal(t, int64(6), evt.Usage.CacheWriteTokens)
+		assert.Equal(t, int64(15), evt.Usage.TotalTokens)
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		nil,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{
+				InputTokens:      12,
+				OutputTokens:     8,
+				CacheReadTokens:  24,
+				CacheWriteTokens: 11,
+				TotalTokens:      55,
+			},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+	assert.Equal(t, 1, published)
+
+	updated, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), updated.TrackedUsageInputTokens)
+	assert.Equal(t, int64(8), updated.TrackedUsageOutputTokens)
+	assert.Equal(t, int64(24), updated.TrackedUsageCacheReadTokens)
+	assert.Equal(t, int64(11), updated.TrackedUsageCacheWriteTokens)
+	assert.Equal(t, int64(55), updated.TrackedUsageTotalTokens)
+}
+
+func TestHandleProviderEvent_PublishesComponentTokenDeltaWhenTotalIsAlreadyTracked(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:               r.Organization.ID,
+		UserID:                       r.User,
+		CanvasID:                     canvas.ID,
+		Provider:                     "test",
+		ProviderSessionID:            "upstream-session",
+		Status:                       models.AgentSessionStatusStreaming,
+		TrackedUsageInputTokens:      10,
+		TrackedUsageOutputTokens:     5,
+		TrackedUsageCacheReadTokens:  20,
+		TrackedUsageCacheWriteTokens: 5,
+		TrackedUsageTotalTokens:      55,
+		TrackedUsageInitialized:      true,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	published := 0
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(gotSession *models.AgentSession, evt agents.ProviderEvent) error {
+		published++
+		assert.Equal(t, session.ID, gotSession.ID)
+		require.NotNil(t, evt.Usage)
+		assert.Equal(t, int64(2), evt.Usage.InputTokens)
+		assert.Equal(t, int64(3), evt.Usage.OutputTokens)
+		assert.Equal(t, int64(4), evt.Usage.CacheReadTokens)
+		assert.Equal(t, int64(6), evt.Usage.CacheWriteTokens)
+		assert.Equal(t, int64(15), evt.Usage.TotalTokens)
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		nil,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{
+				InputTokens:      12,
+				OutputTokens:     8,
+				CacheReadTokens:  24,
+				CacheWriteTokens: 11,
+				TotalTokens:      55,
+			},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+	assert.Equal(t, 1, published)
+}
+
+func TestHandleProviderEvent_MarksCumulativeTokenUsageBeforePublishing(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:          r.Organization.ID,
+		UserID:                  r.User,
+		CanvasID:                canvas.ID,
+		Provider:                "test",
+		ProviderSessionID:       "upstream-session",
+		TrackedUsageInitialized: true,
+		Status:                  models.AgentSessionStatusStreaming,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(*models.AgentSession, agents.ProviderEvent) error {
+		return errors.New("publish failed")
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		nil,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{
+				InputTokens:      12,
+				OutputTokens:     8,
+				CacheReadTokens:  24,
+				CacheWriteTokens: 11,
+				TotalTokens:      55,
+			},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+
+	updated, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), updated.TrackedUsageInputTokens)
+	assert.Equal(t, int64(8), updated.TrackedUsageOutputTokens)
+	assert.Equal(t, int64(24), updated.TrackedUsageCacheReadTokens)
+	assert.Equal(t, int64(11), updated.TrackedUsageCacheWriteTokens)
+	assert.Equal(t, int64(55), updated.TrackedUsageTotalTokens)
+}
+
+func TestHandleProviderEvent_BaselinesUninitializedCumulativeTokenUsageWithoutPublishing(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:    r.Organization.ID,
+		UserID:            r.User,
+		CanvasID:          canvas.ID,
+		Provider:          "test",
+		ProviderSessionID: "upstream-session",
+		Status:            models.AgentSessionStatusStreaming,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+	require.NoError(t, database.Conn().
+		Model(&models.AgentSession{}).
+		Where("id = ?", session.ID).
+		Update("tracked_usage_initialized", false).
+		Error,
+	)
+
+	published := 0
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(*models.AgentSession, agents.ProviderEvent) error {
+		published++
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		nil,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+			Usage: &agents.TokenUsage{
+				InputTokens:      12,
+				OutputTokens:     8,
+				CacheReadTokens:  24,
+				CacheWriteTokens: 11,
+				TotalTokens:      55,
+			},
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+	assert.Equal(t, 0, published)
+
+	updated, err := models.FindAgentSession(session.ID)
+	require.NoError(t, err)
+	assert.True(t, updated.TrackedUsageInitialized)
+	assert.Equal(t, int64(12), updated.TrackedUsageInputTokens)
+	assert.Equal(t, int64(8), updated.TrackedUsageOutputTokens)
+	assert.Equal(t, int64(24), updated.TrackedUsageCacheReadTokens)
+	assert.Equal(t, int64(11), updated.TrackedUsageCacheWriteTokens)
+	assert.Equal(t, int64(55), updated.TrackedUsageTotalTokens)
 }


### PR DESCRIPTION
## Summary
- fetch Managed Agents session usage after idle turns because Anthropic does not include usage on the idle SSE event
- parse the current nested cache_creation usage shape
- store per-session cumulative usage watermarks so resumed turns publish only the new token delta

## Verification
- Live Anthropic probe confirmed session.status_idle stream events have no usage while GET /sessions/{id} returns usage
- make test PKG_TEST_PACKAGES="./pkg/agents/anthropic ./pkg/workers ./pkg/models"
- make lint
- docker compose -f docker-compose.dev.yml exec app go build ./pkg/agents/anthropic ./pkg/workers ./pkg/models

## Known unrelated failure
- make check.build.app currently fails on main with CanvasService missing ApplyCanvasVersionChangeset from the generated canvases service interface
