### PR TITLE
fix: avoid blocking agent stream completion on usage

### DIFF
--- a/pkg/agents/anthropic/anthropic_test.go
+++ b/pkg/agents/anthropic/anthropic_test.go
@@ -838,7 +838,7 @@ func TestStreamEvents_MapsTokenUsageOnCompletedTurn(t *testing.T) {
 	assert.Equal(t, int64(20), received[0].Usage.TotalTokens)
 }
 
-func TestStreamEvents_FetchesSessionUsageWhenIdleEventHasNoUsage(t *testing.T) {
+func TestStreamEvents_DoesNotFetchSessionUsageWhenIdleEventHasNoUsage(t *testing.T) {
 	var sessionFetched bool
 	const sse = "data: {\"type\":\"session.status_idle\",\"model\":\"claude-sonnet-4-5\",\"stop_reason\":{\"type\":\"end_turn\"}}\n\n"
 
@@ -863,15 +863,30 @@ func TestStreamEvents_FetchesSessionUsageWhenIdleEventHasNoUsage(t *testing.T) {
 		return nil
 	}))
 
-	require.True(t, sessionFetched)
+	require.False(t, sessionFetched)
 	require.Len(t, received, 1)
 	assert.Equal(t, agents.ProviderEventTurnCompleted, received[0].Type)
-	require.NotNil(t, received[0].Usage)
-	assert.Equal(t, int64(6), received[0].Usage.InputTokens)
-	assert.Equal(t, int64(6), received[0].Usage.OutputTokens)
-	assert.Equal(t, int64(3), received[0].Usage.CacheReadTokens)
-	assert.Equal(t, int64(27), received[0].Usage.CacheWriteTokens)
-	assert.Equal(t, int64(42), received[0].Usage.TotalTokens)
+	assert.Nil(t, received[0].Usage)
+}
+
+func TestRetrieveSessionUsage_MapsCompletedSessionUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/sessions/sesn_abc", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"sesn_abc","status":"idle","usage":{"input_tokens":6,"output_tokens":6,"cache_read_input_tokens":3,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":7}}}`)
+	}))
+	defer server.Close()
+
+	p := newTestProvider(t, server)
+	usage, err := p.RetrieveSessionUsage(context.Background(), "sesn_abc")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, int64(6), usage.InputTokens)
+	assert.Equal(t, int64(6), usage.OutputTokens)
+	assert.Equal(t, int64(3), usage.CacheReadTokens)
+	assert.Equal(t, int64(27), usage.CacheWriteTokens)
+	assert.Equal(t, int64(42), usage.TotalTokens)
 }
 
 func TestStreamEvents_FallsBackToEventIDWhenToolUseIDMissing(t *testing.T) {

--- a/pkg/agents/anthropic/provider.go
+++ b/pkg/agents/anthropic/provider.go
@@ -268,17 +268,7 @@ func (p *Provider) StreamEvents(ctx context.Context, providerSessionID string, o
 		return fmt.Errorf("anthropic: open stream: %w", err)
 	}
 	defer body.Close()
-	return forwardSSE(ctx, body, func(event agents.ProviderEvent) error {
-		if event.Type == agents.ProviderEventTurnCompleted && event.Usage == nil {
-			usage, err := p.retrieveSessionUsage(ctx, providerSessionID)
-			if err != nil {
-				log.WithError(err).WithField("provider_session_id", providerSessionID).Warn("anthropic: failed to retrieve completed session usage")
-			} else {
-				event.Usage = usage
-			}
-		}
-		return onEvent(event)
-	})
+	return forwardSSE(ctx, body, onEvent)
 }
 
 func (p *Provider) DeleteSession(ctx context.Context, providerSessionID string) error {
@@ -323,7 +313,7 @@ func withPreamble(message, preamble string) string {
 	return preamble + "\n\n" + message
 }
 
-func (p *Provider) retrieveSessionUsage(ctx context.Context, providerSessionID string) (*agents.TokenUsage, error) {
+func (p *Provider) RetrieveSessionUsage(ctx context.Context, providerSessionID string) (*agents.TokenUsage, error) {
 	data, err := p.client.executeHTTP(ctx, http.MethodGet, "/sessions/"+url.PathEscape(providerSessionID), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/agents/provider.go
+++ b/pkg/agents/provider.go
@@ -191,6 +191,10 @@ type ProviderSessionArchiver interface {
 	ArchiveSession(ctx context.Context, providerSessionID string) error
 }
 
+type ProviderSessionUsageRetriever interface {
+	RetrieveSessionUsage(ctx context.Context, providerSessionID string) (*TokenUsage, error)
+}
+
 type ProviderToolSchemaRevisioner interface {
 	Name() string
 	ToolSchemaRevision() string

--- a/pkg/workers/agent_stream_worker.go
+++ b/pkg/workers/agent_stream_worker.go
@@ -29,6 +29,7 @@ const (
 	maxLockedStreamReschedules = 10
 	agentStreamService         = "superplane.agent-stream-worker"
 	streamHeartbeatInterval    = 30 * time.Second
+	agentTokenUsagePublishWait = 30 * time.Second
 	stuckHeartbeatGrace        = 5 * time.Minute
 	// Must stay above agentStreamTimeout so long-but-healthy turns
 	// without a heartbeat yet aren't force-failed mid-flight.
@@ -51,6 +52,14 @@ var publishAgentRunFinished = func(session *models.AgentSession, evt agents.Prov
 		evt.Usage.CacheReadTokens,
 		evt.Usage.CacheWriteTokens,
 	).Publish()
+}
+
+var publishAgentTokenUsageAsync = func(ctx context.Context, usageService usage.Service, session *models.AgentSession, evt agents.ProviderEvent) {
+	go func() {
+		publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), agentTokenUsagePublishWait)
+		defer cancel()
+		publishPreparedAgentTokenUsage(publishCtx, usageService, session, evt)
+	}()
 }
 
 // AgentStreamWorker is stateless and safe to run as competing consumers.
@@ -427,11 +436,12 @@ func (w *AgentStreamWorker) streamProviderTurn(
 
 	var streamErr error
 	customTools := newCustomToolTurnState()
+	usageRetriever, _ := w.provider.(agents.ProviderSessionUsageRetriever)
 
 	for {
 		customTools.clearRequirement()
 		err := w.provider.StreamEvents(ctx, session.ProviderSessionID, func(evt agents.ProviderEvent) error {
-			return handleProviderEvent(ctx, w.usageService, session, evt, publish, &streamErr, customTools)
+			return handleProviderEvent(ctx, w.usageService, usageRetriever, session, evt, publish, &streamErr, customTools)
 		})
 
 		if errors.Is(err, errCustomToolResultsRequired) {
@@ -456,16 +466,13 @@ func (w *AgentStreamWorker) streamProviderTurn(
 func handleProviderEvent(
 	ctx context.Context,
 	usageService usage.Service,
+	usageRetriever agents.ProviderSessionUsageRetriever,
 	session *models.AgentSession,
 	evt agents.ProviderEvent,
 	publish func(messages.AgentSessionEventMessage),
 	streamErr *error,
 	customTools *customToolTurnState,
 ) error {
-	if evt.Type == agents.ProviderEventTurnCompleted {
-		publishAgentTokenUsage(ctx, usageService, session, evt)
-	}
-
 	// Drop late events from a turn the user has already stopped — closes
 	// the race between InterruptSession's commit and provider SSE bytes
 	// already in flight.
@@ -473,6 +480,9 @@ func handleProviderEvent(
 	if err != nil {
 		log.WithError(err).WithField("session_id", session.ID).Warn("agent stream: status check failed; processing event anyway")
 	} else if !streaming {
+		if evt.Type == agents.ProviderEventTurnCompleted {
+			publishAgentTokenUsage(ctx, usageService, usageRetriever, session, evt)
+		}
 		return errSessionAlreadyReset
 	}
 
@@ -496,6 +506,7 @@ func handleProviderEvent(
 		}
 	case agents.ProviderEventTurnCompleted:
 		publish(messages.AgentSessionEventMessage{Event: "turn_completed", Status: models.AgentSessionStatusIdle})
+		publishAgentTokenUsage(ctx, usageService, usageRetriever, session, evt)
 	case agents.ProviderEventOutcomeEvaluationStart:
 		publishOutcomeEvaluationStart(evt, publish)
 	case agents.ProviderEventOutcomeEvaluation:
@@ -515,8 +526,19 @@ func handleProviderEvent(
 	return nil
 }
 
-func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, session *models.AgentSession, evt agents.ProviderEvent) {
-	if evt.Usage == nil || !evt.Usage.HasUsage() {
+func publishAgentTokenUsage(
+	ctx context.Context,
+	usageService usage.Service,
+	usageRetriever agents.ProviderSessionUsageRetriever,
+	session *models.AgentSession,
+	evt agents.ProviderEvent,
+) {
+	if evt.Usage == nil {
+		retrieveAndPublishAgentTokenUsage(ctx, usageService, usageRetriever, session, evt)
+		return
+	}
+
+	if !evt.Usage.HasUsage() {
 		return
 	}
 
@@ -542,13 +564,6 @@ func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, ses
 		return
 	}
 
-	if err := syncAgentTokenUsageOrganization(ctx, usageService, session.OrganizationID.String()); err != nil {
-		log.WithError(err).WithFields(log.Fields{
-			"session_id":      session.ID,
-			"organization_id": session.OrganizationID,
-		}).Warn("agent stream: failed to sync organization before publishing agent token usage")
-	}
-
 	if err := models.MarkAgentSessionTokenUsageTracked(session.ID, cumulativeUsage); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"session_id":      session.ID,
@@ -559,20 +574,59 @@ func publishAgentTokenUsage(ctx context.Context, usageService usage.Service, ses
 
 	publishEvent := evt
 	publishEvent.Usage = providerTokenUsage(deltaUsage)
+	publishAgentTokenUsageAsync(ctx, usageService, session, publishEvent)
+}
+
+func retrieveAndPublishAgentTokenUsage(
+	ctx context.Context,
+	usageService usage.Service,
+	usageRetriever agents.ProviderSessionUsageRetriever,
+	session *models.AgentSession,
+	evt agents.ProviderEvent,
+) {
+	if usageRetriever == nil {
+		return
+	}
+
+	go func() {
+		retrieveCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), agentTokenUsagePublishWait)
+		defer cancel()
+
+		usage, err := usageRetriever.RetrieveSessionUsage(retrieveCtx, session.ProviderSessionID)
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"session_id":          session.ID,
+				"organization_id":     session.OrganizationID,
+				"provider_session_id": session.ProviderSessionID,
+			}).Warn("agent stream: failed to retrieve completed session usage")
+			return
+		}
+
+		evt.Usage = usage
+		publishAgentTokenUsage(retrieveCtx, usageService, nil, session, evt)
+	}()
+}
+
+func publishPreparedAgentTokenUsage(ctx context.Context, usageService usage.Service, session *models.AgentSession, evt agents.ProviderEvent) {
+	if err := syncAgentTokenUsageOrganization(ctx, usageService, session.OrganizationID.String()); err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"session_id":      session.ID,
+			"organization_id": session.OrganizationID,
+		}).Warn("agent stream: failed to sync organization before publishing agent token usage")
+	}
 
 	log.WithFields(log.Fields{
-		"session_id":              session.ID,
-		"organization_id":         session.OrganizationID,
-		"model":                   evt.Model,
-		"input_tokens":            deltaUsage.InputTokens,
-		"output_tokens":           deltaUsage.OutputTokens,
-		"total_tokens":            deltaUsage.TotalTokens,
-		"cache_read_tokens":       deltaUsage.CacheReadTokens,
-		"cache_write_tokens":      deltaUsage.CacheWriteTokens,
-		"cumulative_total_tokens": cumulativeUsage.TotalTokens,
+		"session_id":         session.ID,
+		"organization_id":    session.OrganizationID,
+		"model":              evt.Model,
+		"input_tokens":       evt.Usage.InputTokens,
+		"output_tokens":      evt.Usage.OutputTokens,
+		"total_tokens":       evt.Usage.TotalTokens,
+		"cache_read_tokens":  evt.Usage.CacheReadTokens,
+		"cache_write_tokens": evt.Usage.CacheWriteTokens,
 	}).Info("agent stream: publishing agent token usage")
 
-	if err := publishAgentRunFinished(session, publishEvent); err != nil {
+	if err := publishAgentRunFinished(session, evt); err != nil {
 		log.WithError(err).WithFields(log.Fields{
 			"session_id":      session.ID,
 			"organization_id": session.OrganizationID,

--- a/pkg/workers/agent_stream_worker_internal_test.go
+++ b/pkg/workers/agent_stream_worker_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,31 @@ func (s *fakeAgentTokenUsageService) CheckOrganizationLimits(
 
 var _ usage.Service = (*fakeAgentTokenUsageService)(nil)
 
+type fakeProviderSessionUsageRetriever struct {
+	usage *agents.TokenUsage
+	err   error
+	calls []string
+}
+
+func (r *fakeProviderSessionUsageRetriever) RetrieveSessionUsage(_ context.Context, providerSessionID string) (*agents.TokenUsage, error) {
+	r.calls = append(r.calls, providerSessionID)
+	return r.usage, r.err
+}
+
+func publishAgentTokenUsageSynchronously(t *testing.T) {
+	t.Helper()
+	originalPublisher := publishAgentTokenUsageAsync
+	publishAgentTokenUsageAsync = func(ctx context.Context, usageService usage.Service, session *models.AgentSession, evt agents.ProviderEvent) {
+		publishPreparedAgentTokenUsage(ctx, usageService, session, evt)
+	}
+	t.Cleanup(func() {
+		publishAgentTokenUsageAsync = originalPublisher
+	})
+}
+
 func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -106,6 +131,7 @@ func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testin
 	err := handleProviderEvent(
 		context.Background(),
 		nil,
+		nil,
 		session,
 		agents.ProviderEvent{
 			Type:  agents.ProviderEventTurnCompleted,
@@ -123,6 +149,8 @@ func TestHandleProviderEvent_PublishesTurnUsageWhenSessionAlreadyReset(t *testin
 }
 
 func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -157,6 +185,7 @@ func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *test
 	err := handleProviderEvent(
 		context.Background(),
 		usageService,
+		nil,
 		session,
 		agents.ProviderEvent{
 			Type:  agents.ProviderEventTurnCompleted,
@@ -177,7 +206,129 @@ func TestHandleProviderEvent_SyncsOrganizationBeforePublishingTokenUsage(t *test
 	assert.Equal(t, r.Account.ID.String(), usageService.setupOrganizationCalls[0][1])
 }
 
+func TestHandleProviderEvent_PublishesTurnCompletedBeforeTokenUsage(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:          r.Organization.ID,
+		UserID:                  r.User,
+		CanvasID:                canvas.ID,
+		Provider:                "test",
+		ProviderSessionID:       "upstream-session",
+		TrackedUsageInitialized: true,
+		Status:                  models.AgentSessionStatusStreaming,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	usagePublicationStarted := make(chan struct{})
+	releaseUsagePublication := make(chan struct{})
+	originalPublisher := publishAgentTokenUsageAsync
+	publishAgentTokenUsageAsync = func(context.Context, usage.Service, *models.AgentSession, agents.ProviderEvent) {
+		close(usagePublicationStarted)
+		<-releaseUsagePublication
+	}
+	t.Cleanup(func() {
+		publishAgentTokenUsageAsync = originalPublisher
+		close(releaseUsagePublication)
+	})
+
+	var published []messages.AgentSessionEventMessage
+	var streamErr error
+	done := make(chan error, 1)
+	go func() {
+		done <- handleProviderEvent(
+			context.Background(),
+			nil,
+			nil,
+			session,
+			agents.ProviderEvent{
+				Type:  agents.ProviderEventTurnCompleted,
+				Model: "claude-sonnet-4-5",
+				Usage: &agents.TokenUsage{TotalTokens: 42},
+			},
+			func(message messages.AgentSessionEventMessage) {
+				published = append(published, message)
+			},
+			&streamErr,
+			newCustomToolTurnState(),
+		)
+	}()
+
+	<-usagePublicationStarted
+	require.Len(t, published, 1)
+	assert.Equal(t, "turn_completed", published[0].Event)
+	assert.Equal(t, models.AgentSessionStatusIdle, published[0].Status)
+
+	releaseUsagePublication <- struct{}{}
+	require.NoError(t, <-done)
+	assert.NoError(t, streamErr)
+}
+
+func TestHandleProviderEvent_RetrievesUsageWhenCompletedTurnHasNoUsage(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
+	r := support.Setup(t)
+	defer r.Close()
+	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
+
+	session := &models.AgentSession{
+		OrganizationID:          r.Organization.ID,
+		UserID:                  r.User,
+		CanvasID:                canvas.ID,
+		Provider:                "test",
+		ProviderSessionID:       "upstream-session",
+		TrackedUsageInitialized: true,
+		Status:                  models.AgentSessionStatusStreaming,
+	}
+	require.NoError(t, database.Conn().Create(session).Error)
+
+	retriever := &fakeProviderSessionUsageRetriever{
+		usage: &agents.TokenUsage{TotalTokens: 42},
+	}
+
+	published := make(chan agents.ProviderEvent, 1)
+	originalPublisher := publishAgentRunFinished
+	publishAgentRunFinished = func(_ *models.AgentSession, evt agents.ProviderEvent) error {
+		published <- evt
+		return nil
+	}
+	t.Cleanup(func() {
+		publishAgentRunFinished = originalPublisher
+	})
+
+	var streamErr error
+	err := handleProviderEvent(
+		context.Background(),
+		nil,
+		retriever,
+		session,
+		agents.ProviderEvent{
+			Type:  agents.ProviderEventTurnCompleted,
+			Model: "claude-sonnet-4-5",
+		},
+		func(messages.AgentSessionEventMessage) {},
+		&streamErr,
+		newCustomToolTurnState(),
+	)
+
+	require.NoError(t, err)
+	assert.NoError(t, streamErr)
+
+	select {
+	case evt := <-published:
+		require.NotNil(t, evt.Usage)
+		assert.Equal(t, int64(42), evt.Usage.TotalTokens)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for retrieved usage to publish")
+	}
+	assert.Equal(t, []string{"upstream-session"}, retriever.calls)
+}
+
 func TestHandleProviderEvent_PublishesOnlyNewCumulativeTokenUsage(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -219,6 +370,7 @@ func TestHandleProviderEvent_PublishesOnlyNewCumulativeTokenUsage(t *testing.T) 
 	err := handleProviderEvent(
 		context.Background(),
 		nil,
+		nil,
 		session,
 		agents.ProviderEvent{
 			Type:  agents.ProviderEventTurnCompleted,
@@ -250,6 +402,8 @@ func TestHandleProviderEvent_PublishesOnlyNewCumulativeTokenUsage(t *testing.T) 
 }
 
 func TestHandleProviderEvent_PublishesComponentTokenDeltaWhenTotalIsAlreadyTracked(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -291,6 +445,7 @@ func TestHandleProviderEvent_PublishesComponentTokenDeltaWhenTotalIsAlreadyTrack
 	err := handleProviderEvent(
 		context.Background(),
 		nil,
+		nil,
 		session,
 		agents.ProviderEvent{
 			Type:  agents.ProviderEventTurnCompleted,
@@ -314,6 +469,8 @@ func TestHandleProviderEvent_PublishesComponentTokenDeltaWhenTotalIsAlreadyTrack
 }
 
 func TestHandleProviderEvent_MarksCumulativeTokenUsageBeforePublishing(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -340,6 +497,7 @@ func TestHandleProviderEvent_MarksCumulativeTokenUsageBeforePublishing(t *testin
 	var streamErr error
 	err := handleProviderEvent(
 		context.Background(),
+		nil,
 		nil,
 		session,
 		agents.ProviderEvent{
@@ -371,6 +529,8 @@ func TestHandleProviderEvent_MarksCumulativeTokenUsageBeforePublishing(t *testin
 }
 
 func TestHandleProviderEvent_BaselinesUninitializedCumulativeTokenUsageWithoutPublishing(t *testing.T) {
+	publishAgentTokenUsageSynchronously(t)
+
 	r := support.Setup(t)
 	defer r.Close()
 	canvas, _ := support.CreateCanvas(t, r.Organization.ID, r.User, nil, nil)
@@ -404,6 +564,7 @@ func TestHandleProviderEvent_BaselinesUninitializedCumulativeTokenUsageWithoutPu
 	var streamErr error
 	err := handleProviderEvent(
 		context.Background(),
+		nil,
 		nil,
 		session,
 		agents.ProviderEvent{


### PR DESCRIPTION
## Summary
- stop fetching Anthropic session usage inside the SSE stream before forwarding turn completion
- retrieve missing completed-session usage through an optional provider capability in the worker billing path
- publish websocket turn completion before token usage sync/Rabbit publishing can block

## Tests
- make test PKG_TEST_PACKAGES="./pkg/agents/anthropic ./pkg/workers ./pkg/models"
- make lint
- docker compose -f docker-compose.dev.yml exec app go build ./pkg/agents ./pkg/agents/anthropic ./pkg/workers ./pkg/models
- git diff --check