### PR TITLE
fix: always refetch usage settings page

### DIFF
--- a/web_src/src/hooks/useOrganizationData.ts
+++ b/web_src/src/hooks/useOrganizationData.ts
@@ -191,7 +191,18 @@ export const useOrganizationInviteLink = (organizationId: string, enabled = true
   });
 };
 
-export const useOrganizationUsage = (organizationId: string, enabled = true) => {
+type OrganizationUsageQueryOptions = {
+  staleTime?: number;
+  gcTime?: number;
+  refetchOnMount?: boolean | "always";
+  refetchOnWindowFocus?: boolean | "always";
+};
+
+export const useOrganizationUsage = (
+  organizationId: string,
+  enabled = true,
+  options: OrganizationUsageQueryOptions = {},
+) => {
   return useQuery({
     queryKey: organizationKeys.usage(organizationId),
     queryFn: async () => {
@@ -202,9 +213,10 @@ export const useOrganizationUsage = (organizationId: string, enabled = true) => 
       );
       return response.data || null;
     },
-    staleTime: 30 * 1000,
-    gcTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    staleTime: options.staleTime ?? 30 * 1000,
+    gcTime: options.gcTime ?? 5 * 60 * 1000,
+    refetchOnMount: options.refetchOnMount,
+    refetchOnWindowFocus: options.refetchOnWindowFocus ?? false,
     enabled: !!organizationId && enabled,
   });
 };

--- a/web_src/src/pages/organization/settings/Usage.tsx
+++ b/web_src/src/pages/organization/settings/Usage.tsx
@@ -25,14 +25,20 @@ const UNLIMITED_VALUE = "-1";
 export function Usage({ organizationId }: UsageProps) {
   usePageTitle(["Usage"]);
 
-  const { data, isLoading, error } = useOrganizationUsage(organizationId);
+  // Usage can change right before the user opens this page, so force a fetch and hide stale cached data while it runs.
+  const { data, isLoading, isFetching, error } = useOrganizationUsage(organizationId, true, {
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: "always",
+  });
   const forceUsagePage = isUsagePageForced();
+  const isUsageLoading = isLoading || isFetching;
 
-  useReportPageReady(!isLoading, {
+  useReportPageReady(!isUsageLoading, {
     failed: !!error,
   });
 
-  if (isLoading) {
+  if (isUsageLoading) {
     return (
       <div className="pt-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-800 p-6">


### PR DESCRIPTION
## Summary
- let useOrganizationUsage accept per-call query cache options
- make the Usage settings page use an isolated no-cache query scope
- force a fresh usage fetch whenever the Usage page mounts

## Tests
- make format.js
- cd web_src && npx eslint src/hooks/useOrganizationData.ts src/pages/organization/settings/Usage.tsx --quiet
- git diff --check

## Notes
- make check.build.ui is currently blocked on main by missing generated API export ComponentsEdge in @/api-client, referenced by existing app/canvas files.