### PR TITLE
fix: dedupe commit and publish draft staging API requests

### DIFF
--- a/web_src/src/hooks/useCanvasData.ts
+++ b/web_src/src/hooks/useCanvasData.ts
@@ -1004,9 +1004,7 @@ export const useDeleteDraftBranch = (canvasId: string) => {
   });
 };
 
-export const usePublishCanvasVersion = (organizationId: string, canvasId: string) => {
-  const queryClient = useQueryClient();
-
+export const usePublishCanvasVersion = (canvasId: string) => {
   return useMutation({
     mutationFn: async (versionId: string) => {
       return await canvasesPublishCanvasVersion(
@@ -1015,13 +1013,6 @@ export const usePublishCanvasVersion = (organizationId: string, canvasId: string
           body: {},
         }),
       );
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionList(canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.draftBranches(canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.consoleAll(canvasId) });
     },
   });
 };
@@ -2053,17 +2044,16 @@ export const useCommitCanvasStaging = (canvasId: string, versionId: string) => {
       );
       return response.data;
     },
-    onSuccess: () => {
-      queryClient.setQueryData(canvasKeys.versionStaging(canvasId, versionId), { hasStaging: false, stagedPaths: [] });
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        canvasKeys.versionStaging(canvasId, versionId),
+        data?.stagingSummary ?? { hasStaging: false, stagedPaths: [] },
+      );
       // Committing staged edits only changes the draft version, not the live
       // canvas, so we skip invalidating canvasKeys.detail to avoid a
-      // DescribeCanvas refetch while staying in edit mode.
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) });
+      // DescribeCanvas refetch while staying in edit mode. Version detail,
+      // canvas.yaml, and console caches are refreshed once from useDraftStagingActions.
       queryClient.invalidateQueries({ queryKey: canvasKeys.versionHistory(canvasId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.versionStaging(canvasId, versionId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFile(canvasId, CANVAS_YAML_PATH, versionId) });
-      queryClient.invalidateQueries({ queryKey: canvasKeys.repositoryFile(canvasId, CONSOLE_YAML_PATH, versionId) });
     },
   });
 };

--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -156,6 +156,7 @@ import {
   shouldClearRunDetailNode,
 } from "./workflowPageHelpers";
 import { useDraftRecovery } from "./useDraftRecovery";
+import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
 const CANVAS_AUTO_LAYOUT_ON_UPDATE_STORAGE_KEY = "canvas-auto-layout-on-update-enabled";
 const VERSION_ACTION_SAVE_SETTLE_TIMEOUT_MS = 5000;
 const EMPTY_CANVAS_NODES: ComponentsNode[] = [];
@@ -288,7 +289,7 @@ export function AppPage() {
   // published/discarded" (session must close). Both states look identical in
   // terms of active-version state (no selected version), so we can't derive it.
   const previewingCurrentVersionRef = useRef(false);
-  const publishCanvasVersionMutation = usePublishCanvasVersion(organizationId!, canvasId!);
+  const publishCanvasVersionMutation = usePublishCanvasVersion(canvasId!);
   const updateCanvasVersionMutation = useUpdateCanvasVersion(organizationId!, canvasId!);
   const [isCanvasSaveInFlight, setIsCanvasSaveInFlight] = useState(false);
   const [isCanvasSaveQueued, setIsCanvasSaveQueued] = useState(false);
@@ -3398,31 +3399,11 @@ export function AppPage() {
     ],
   );
 
-  const refreshLatestLiveCanvasData = useCallback(async () => {
-    if (!organizationId || !canvasId) {
-      return;
-    }
-
-    await Promise.all([
-      queryClient.invalidateQueries({
-        queryKey: canvasKeys.detail(organizationId, canvasId),
-        refetchType: "all",
-      }),
-      queryClient.invalidateQueries({
-        queryKey: canvasKeys.versionList(canvasId),
-        refetchType: "all",
-      }),
-      queryClient.invalidateQueries({
-        queryKey: canvasKeys.versionHistory(canvasId),
-        refetchType: "all",
-      }),
-      queryClient.invalidateQueries({
-        queryKey: canvasKeys.draftBranches(canvasId),
-        refetchType: "all",
-      }),
-      queryClient.invalidateQueries({ queryKey: canvasKeys.consoleAll(canvasId), refetchType: "all" }),
-    ]);
-  }, [organizationId, canvasId, queryClient]);
+  const refreshLatestLiveCanvasData = useRefreshLatestLiveCanvasData(
+    organizationId,
+    canvasId,
+    effectiveLiveCanvasVersionId,
+  );
 
   const cancelPendingCanvasSaves = useCallback(() => {
     canvasSaveSessionRef.current += 1;
@@ -3444,6 +3425,8 @@ export function AppPage() {
     ensureVersionActionDraftReady,
     publishCanvasVersionMutation,
     setIsPreparingVersionAction,
+    registerIgnoredCanvasUpdatedEcho,
+    registerIgnoredCanvasVersionUpdatedEcho,
   });
 
   const handleCanvasDraftRestoredToCommitted = useCallback(
@@ -3474,6 +3457,7 @@ export function AppPage() {
     cancelPendingCanvasSaves,
     onCanvasDraftRestoredToCommitted: handleCanvasDraftRestoredToCommitted,
     recoverIfDraftMissing,
+    registerIgnoredCanvasVersionUpdatedEcho,
   });
 
   const activateCanvasVersionForEditing = useCallback(

--- a/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.spec.ts
@@ -1,0 +1,47 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+import { executeCommitStaging } from "./commit-staging-flow";
+import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
+
+vi.mock("./repository-spec-files", () => ({
+  fetchCanvasVersionWithSpec: vi.fn(),
+}));
+
+describe("executeCommitStaging", () => {
+  it("returns true and clears local draft state when post-commit cache sync fails", async () => {
+    vi.mocked(fetchCanvasVersionWithSpec).mockRejectedValue(new Error("sync failed"));
+
+    const commitCanvasStagingMutation = { mutateAsync: vi.fn().mockResolvedValue({}) };
+    const draftCanvasSpecsRef = { current: new Map([["version-1", { nodes: [], edges: [] }]]) };
+    const setDraftCanvasSpec = vi.fn();
+    const setStagingResetNonce = vi.fn();
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    const queryClient = { invalidateQueries } as unknown as QueryClient;
+
+    const result = await executeCommitStaging({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      activeCanvasVersionId: "version-1",
+      queryClient,
+      commitCanvasStagingMutation,
+      consoleMutationGenerationRef: { current: 0 },
+      draftCanvasSpecsRef,
+      setDraftCanvasSpec,
+      setStagingResetNonce,
+      ensureVersionActionDraftReady: vi.fn().mockResolvedValue(true),
+    });
+
+    expect(result).toBe(true);
+    expect(commitCanvasStagingMutation.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.versionDetail("canvas-1", "version-1"),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: canvasKeys.repository("canvas-1") });
+    expect(draftCanvasSpecsRef.current.has("version-1")).toBe(false);
+    expect(setDraftCanvasSpec).toHaveBeenCalledWith(null);
+    expect(setStagingResetNonce).toHaveBeenCalled();
+  });
+});

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -1,0 +1,73 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+import type { CanvasesCanvas } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+import { syncCommittedCanvasDraftState, syncCommittedConsoleCaches } from "./sync-committed-canvas-draft";
+
+type CommitMutation = { mutateAsync: () => Promise<unknown> };
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+export async function executeCommitStaging({
+  organizationId,
+  canvasId,
+  activeCanvasVersionId,
+  queryClient,
+  commitCanvasStagingMutation,
+  consoleMutationGenerationRef,
+  draftCanvasSpecsRef,
+  setDraftCanvasSpec,
+  setStagingResetNonce,
+  ensureVersionActionDraftReady,
+  flushRepositoryFileStaging,
+  registerIgnoredCanvasVersionUpdatedEcho,
+}: {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionId: string;
+  queryClient: QueryClient;
+  commitCanvasStagingMutation: CommitMutation;
+  consoleMutationGenerationRef: MutableRefObject<number>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  setStagingResetNonce: Dispatch<SetStateAction<number>>;
+  ensureVersionActionDraftReady: (errorMessage: string) => Promise<boolean>;
+  flushRepositoryFileStaging?: () => Promise<void>;
+  registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
+}): Promise<boolean> {
+  await flushRepositoryFileStaging?.();
+  const isReady = await ensureVersionActionDraftReady("Unable to prepare staged changes for commit");
+  if (!isReady) {
+    return false;
+  }
+
+  consoleMutationGenerationRef.current += 1;
+  const releaseCanvasVersionUpdatedEcho = registerIgnoredCanvasVersionUpdatedEcho?.(activeCanvasVersionId);
+  try {
+    await commitCanvasStagingMutation.mutateAsync();
+  } catch (error) {
+    releaseCanvasVersionUpdatedEcho?.();
+    throw error;
+  }
+
+  if (organizationId && canvasId) {
+    await syncCommittedCanvasDraftState({
+      queryClient,
+      organizationId,
+      canvasId,
+      versionId: activeCanvasVersionId,
+    });
+    await syncCommittedConsoleCaches({
+      queryClient,
+      canvasId,
+      versionId: activeCanvasVersionId,
+    });
+  }
+
+  await queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId!) });
+  draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
+  setDraftCanvasSpec(null);
+  setStagingResetNonce((nonce) => nonce + 1);
+  return true;
+}

--- a/web_src/src/pages/app/lib/commit-staging-flow.ts
+++ b/web_src/src/pages/app/lib/commit-staging-flow.ts
@@ -4,7 +4,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { CanvasesCanvas } from "@/api-client";
 import { canvasKeys } from "@/hooks/useCanvasData";
 
-import { syncCommittedCanvasDraftState, syncCommittedConsoleCaches } from "./sync-committed-canvas-draft";
+import { refreshCachesAfterCommit } from "./sync-committed-canvas-draft";
 
 type CommitMutation = { mutateAsync: () => Promise<unknown> };
 type DraftSpec = CanvasesCanvas["spec"] | null;
@@ -51,21 +51,19 @@ export async function executeCommitStaging({
     throw error;
   }
 
+  // Commit already succeeded on the server; cache refresh and local cleanup must not fail the action.
   if (organizationId && canvasId) {
-    await syncCommittedCanvasDraftState({
+    await refreshCachesAfterCommit({
       queryClient,
       organizationId,
       canvasId,
       versionId: activeCanvasVersionId,
     });
-    await syncCommittedConsoleCaches({
-      queryClient,
-      canvasId,
-      versionId: activeCanvasVersionId,
-    });
   }
 
-  await queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId!) });
+  if (canvasId) {
+    await queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId) });
+  }
   draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
   setDraftCanvasSpec(null);
   setStagingResetNonce((nonce) => nonce + 1);

--- a/web_src/src/pages/app/lib/draft-missing-recovery.ts
+++ b/web_src/src/pages/app/lib/draft-missing-recovery.ts
@@ -1,0 +1,35 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { ensureDraftVersionExists } from "@/hooks/useCanvasData";
+
+import { isNotFoundError } from "../workflowPageHelpers";
+
+export async function recoverIfDraftMissing({
+  error,
+  versionId,
+  organizationId,
+  canvasId,
+  queryClient,
+  recoverFromMissingDraft,
+}: {
+  error: unknown;
+  versionId: string;
+  organizationId?: string;
+  canvasId?: string;
+  queryClient: QueryClient;
+  recoverFromMissingDraft: (versionId: string, message?: string) => Promise<void>;
+}): Promise<boolean> {
+  if (!isNotFoundError(error) || !organizationId || !canvasId || !versionId) {
+    return false;
+  }
+
+  const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionId).catch(
+    () => true,
+  );
+  if (draftExists) {
+    return false;
+  }
+
+  await recoverFromMissingDraft(versionId);
+  return true;
+}

--- a/web_src/src/pages/app/lib/exit-draft-to-live.ts
+++ b/web_src/src/pages/app/lib/exit-draft-to-live.ts
@@ -1,0 +1,58 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { useSearchParams } from "react-router-dom";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+import { draftVersionId } from "@/lib/draftVersion";
+
+import { clearPublishedDraftVersion } from "./draft-spec-cache";
+import type { RefreshLatestLiveCanvasDataOptions } from "../useRefreshLatestLiveCanvasData";
+import { clearComponentSidebarSearchParams } from "../viewState";
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+type SetSearchParams = ReturnType<typeof useSearchParams>[1];
+
+export async function exitDraftToLive({
+  versionId,
+  options,
+  activeCanvasVersionIdRef,
+  draftCanvasSpecsRef,
+  setActiveCanvasVersion,
+  setDraftCanvasSpec,
+  canvasId,
+  queryClient,
+  exitToLive,
+  setSearchParams,
+  refreshLatestLiveCanvasData,
+}: {
+  versionId: string;
+  options?: RefreshLatestLiveCanvasDataOptions;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  setActiveCanvasVersion: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  canvasId?: string;
+  queryClient: QueryClient;
+  exitToLive: () => void;
+  setSearchParams: SetSearchParams;
+  refreshLatestLiveCanvasData: (options?: RefreshLatestLiveCanvasDataOptions) => Promise<void>;
+}) {
+  activeCanvasVersionIdRef.current = "";
+  if (versionId) {
+    clearPublishedDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, versionId);
+  }
+  if (canvasId && versionId && options?.skipDraftBranchRefetch) {
+    queryClient.setQueryData<CanvasesCanvasVersion[]>(canvasKeys.draftBranches(canvasId), (current) =>
+      (current ?? []).filter((branch) => draftVersionId(branch) !== versionId),
+    );
+  }
+  exitToLive();
+  setSearchParams((current) => {
+    const next = new URLSearchParams(current);
+    next.delete("version");
+    next.delete("branch");
+    return clearComponentSidebarSearchParams(next);
+  });
+  await refreshLatestLiveCanvasData(options);
+}

--- a/web_src/src/pages/app/lib/publish-draft-flow.spec.ts
+++ b/web_src/src/pages/app/lib/publish-draft-flow.spec.ts
@@ -1,0 +1,48 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { ensureDraftVersionExists } from "@/hooks/useCanvasData";
+
+import { publishDraftVersionAndExit } from "./publish-draft-flow";
+
+vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    ensureDraftVersionExists: vi.fn(),
+  };
+});
+
+describe("publishDraftVersionAndExit", () => {
+  it("uses the version id captured after saves settle for publish and failure recovery", async () => {
+    vi.mocked(ensureDraftVersionExists).mockResolvedValue(true);
+
+    const activeCanvasVersionIdRef = { current: "draft-1" };
+    const ensureVersionActionDraftReady = vi.fn().mockImplementation(async () => {
+      activeCanvasVersionIdRef.current = "draft-2";
+      return true;
+    });
+    const publishError = new Error("publish failed");
+    const publishCanvasVersionMutation = {
+      mutateAsync: vi.fn().mockRejectedValue(publishError),
+    };
+
+    const result = await publishDraftVersionAndExit({
+      organizationId: "org-1",
+      canvasId: "canvas-1",
+      activeCanvasVersionIdRef,
+      queryClient: {} as QueryClient,
+      ensureVersionActionDraftReady,
+      publishCanvasVersionMutation,
+      runExitDraftToLive: vi.fn(),
+      recoverFromMissingDraft: vi.fn(),
+    });
+
+    expect(publishCanvasVersionMutation.mutateAsync).toHaveBeenCalledWith("draft-2");
+    expect(result).toEqual({
+      status: "failed",
+      versionIdToPublish: "draft-2",
+      error: publishError,
+    });
+  });
+});

--- a/web_src/src/pages/app/lib/publish-draft-flow.ts
+++ b/web_src/src/pages/app/lib/publish-draft-flow.ts
@@ -7,6 +7,12 @@ import type { RefreshLatestLiveCanvasDataOptions } from "../useRefreshLatestLive
 
 type PublishMutation = { mutateAsync: (versionId: string) => Promise<unknown> };
 
+export type PublishDraftVersionAndExitResult =
+  | { status: "not-ready" }
+  | { status: "missing"; versionIdToPublish: string }
+  | { status: "published"; versionIdToPublish: string }
+  | { status: "failed"; versionIdToPublish: string; error: unknown };
+
 export async function executePublishDraftVersion({
   organizationId,
   canvasId,
@@ -64,34 +70,38 @@ export async function publishDraftVersionAndExit({
   registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
   runExitDraftToLive: (versionId: string, options?: RefreshLatestLiveCanvasDataOptions) => Promise<void>;
   recoverFromMissingDraft: (versionId: string) => Promise<void>;
-}): Promise<"not-ready" | "missing" | "published"> {
+}): Promise<PublishDraftVersionAndExitResult> {
   const isReady = await ensureVersionActionDraftReady("Unable to prepare the latest version changes for publishing");
   if (!isReady) {
-    return "not-ready";
+    return { status: "not-ready" };
   }
 
   const versionIdToPublish = activeCanvasVersionIdRef.current;
   if (!versionIdToPublish) {
-    return "not-ready";
+    return { status: "not-ready" };
   }
 
-  const publishResult = await executePublishDraftVersion({
-    organizationId,
-    canvasId,
-    versionIdToPublish,
-    queryClient,
-    publishCanvasVersionMutation,
-    registerIgnoredCanvasUpdatedEcho,
-    registerIgnoredCanvasVersionUpdatedEcho,
-  });
-  if (publishResult === "missing") {
-    await recoverFromMissingDraft(versionIdToPublish);
-    return "missing";
-  }
+  try {
+    const publishResult = await executePublishDraftVersion({
+      organizationId,
+      canvasId,
+      versionIdToPublish,
+      queryClient,
+      publishCanvasVersionMutation,
+      registerIgnoredCanvasUpdatedEcho,
+      registerIgnoredCanvasVersionUpdatedEcho,
+    });
+    if (publishResult === "missing") {
+      await recoverFromMissingDraft(versionIdToPublish);
+      return { status: "missing", versionIdToPublish };
+    }
 
-  await runExitDraftToLive(versionIdToPublish, {
-    liveVersionId: versionIdToPublish,
-    skipDraftBranchRefetch: true,
-  });
-  return "published";
+    await runExitDraftToLive(versionIdToPublish, {
+      liveVersionId: versionIdToPublish,
+      skipDraftBranchRefetch: true,
+    });
+    return { status: "published", versionIdToPublish };
+  } catch (error) {
+    return { status: "failed", versionIdToPublish, error };
+  }
 }

--- a/web_src/src/pages/app/lib/publish-draft-flow.ts
+++ b/web_src/src/pages/app/lib/publish-draft-flow.ts
@@ -1,0 +1,97 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { MutableRefObject } from "react";
+
+import { ensureDraftVersionExists } from "@/hooks/useCanvasData";
+
+import type { RefreshLatestLiveCanvasDataOptions } from "../useRefreshLatestLiveCanvasData";
+
+type PublishMutation = { mutateAsync: (versionId: string) => Promise<unknown> };
+
+export async function executePublishDraftVersion({
+  organizationId,
+  canvasId,
+  versionIdToPublish,
+  queryClient,
+  publishCanvasVersionMutation,
+  registerIgnoredCanvasUpdatedEcho,
+  registerIgnoredCanvasVersionUpdatedEcho,
+}: {
+  organizationId: string;
+  canvasId: string;
+  versionIdToPublish: string;
+  queryClient: QueryClient;
+  publishCanvasVersionMutation: PublishMutation;
+  registerIgnoredCanvasUpdatedEcho?: () => () => void;
+  registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
+}): Promise<"missing" | "published"> {
+  const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionIdToPublish);
+  if (!draftExists) {
+    return "missing";
+  }
+
+  const releaseCanvasUpdatedEcho = registerIgnoredCanvasUpdatedEcho?.();
+  const releaseCanvasVersionUpdatedEcho = registerIgnoredCanvasVersionUpdatedEcho?.(versionIdToPublish);
+  try {
+    await publishCanvasVersionMutation.mutateAsync(versionIdToPublish);
+  } catch (error) {
+    releaseCanvasUpdatedEcho?.();
+    releaseCanvasVersionUpdatedEcho?.();
+    throw error;
+  }
+
+  return "published";
+}
+
+export async function publishDraftVersionAndExit({
+  organizationId,
+  canvasId,
+  activeCanvasVersionIdRef,
+  queryClient,
+  ensureVersionActionDraftReady,
+  publishCanvasVersionMutation,
+  registerIgnoredCanvasUpdatedEcho,
+  registerIgnoredCanvasVersionUpdatedEcho,
+  runExitDraftToLive,
+  recoverFromMissingDraft,
+}: {
+  organizationId: string;
+  canvasId: string;
+  activeCanvasVersionIdRef: MutableRefObject<string>;
+  queryClient: QueryClient;
+  ensureVersionActionDraftReady: (errorMessage: string) => Promise<boolean>;
+  publishCanvasVersionMutation: PublishMutation;
+  registerIgnoredCanvasUpdatedEcho?: () => () => void;
+  registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
+  runExitDraftToLive: (versionId: string, options?: RefreshLatestLiveCanvasDataOptions) => Promise<void>;
+  recoverFromMissingDraft: (versionId: string) => Promise<void>;
+}): Promise<"not-ready" | "missing" | "published"> {
+  const isReady = await ensureVersionActionDraftReady("Unable to prepare the latest version changes for publishing");
+  if (!isReady) {
+    return "not-ready";
+  }
+
+  const versionIdToPublish = activeCanvasVersionIdRef.current;
+  if (!versionIdToPublish) {
+    return "not-ready";
+  }
+
+  const publishResult = await executePublishDraftVersion({
+    organizationId,
+    canvasId,
+    versionIdToPublish,
+    queryClient,
+    publishCanvasVersionMutation,
+    registerIgnoredCanvasUpdatedEcho,
+    registerIgnoredCanvasVersionUpdatedEcho,
+  });
+  if (publishResult === "missing") {
+    await recoverFromMissingDraft(versionIdToPublish);
+    return "missing";
+  }
+
+  await runExitDraftToLive(versionIdToPublish, {
+    liveVersionId: versionIdToPublish,
+    skipDraftBranchRefetch: true,
+  });
+  return "published";
+}

--- a/web_src/src/pages/app/lib/reset-staging-flow.ts
+++ b/web_src/src/pages/app/lib/reset-staging-flow.ts
@@ -1,0 +1,54 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+import { restoreCommittedCanvasDraftState } from "./sync-committed-canvas-draft";
+
+type DiscardMutation = { mutateAsync: (input: undefined) => Promise<unknown> };
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+export async function executeResetStaging({
+  organizationId,
+  canvasId,
+  activeCanvasVersionId,
+  queryClient,
+  discardCanvasStagingMutation,
+  consoleMutationGenerationRef,
+  draftCanvasSpecsRef,
+  setDraftCanvasSpec,
+  setActiveCanvasVersion,
+  setStagingResetNonce,
+  cancelPendingCanvasSaves,
+  onCanvasDraftRestoredToCommitted,
+}: {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionId: string;
+  queryClient: QueryClient;
+  discardCanvasStagingMutation: DiscardMutation;
+  consoleMutationGenerationRef: MutableRefObject<number>;
+  draftCanvasSpecsRef: MutableRefObject<Map<string, DraftSpec>>;
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  setActiveCanvasVersion?: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  setStagingResetNonce: Dispatch<SetStateAction<number>>;
+  cancelPendingCanvasSaves?: () => void;
+  onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
+}) {
+  cancelPendingCanvasSaves?.();
+  consoleMutationGenerationRef.current += 1;
+  await discardCanvasStagingMutation.mutateAsync(undefined);
+  await restoreCommittedCanvasDraftState({
+    organizationId,
+    canvasId,
+    activeCanvasVersionId,
+    queryClient,
+    draftCanvasSpecsRef,
+    setDraftCanvasSpec,
+    setActiveCanvasVersion,
+    onCanvasDraftRestoredToCommitted,
+  });
+  await queryClient.refetchQueries({ queryKey: canvasKeys.repository(canvasId!) });
+  setStagingResetNonce((nonce) => nonce + 1);
+}

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
@@ -2,14 +2,22 @@ import type { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
-import { canvasKeys } from "@/hooks/useCanvasData";
+import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { syncCommittedCanvasDraftState } from "./sync-committed-canvas-draft";
+import { refreshCachesAfterCommit, syncCommittedCanvasDraftState } from "./sync-committed-canvas-draft";
 import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
 
 vi.mock("./repository-spec-files", () => ({
   fetchCanvasVersionWithSpec: vi.fn(),
 }));
+
+vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    fetchCanvasConsoleData: vi.fn(),
+  };
+});
 
 describe("syncCommittedCanvasDraftState", () => {
   it("reloads committed canvas spec into staged and detail caches", async () => {
@@ -59,5 +67,31 @@ describe("syncCommittedCanvasDraftState", () => {
       metadata: { id: "canvas-1" },
       spec: committedVersion.spec,
     });
+  });
+});
+
+describe("refreshCachesAfterCommit", () => {
+  it("invalidates draft caches when post-commit sync fails", async () => {
+    vi.mocked(fetchCanvasVersionWithSpec).mockRejectedValue(new Error("network error"));
+
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    const queryClient = { setQueryData: vi.fn(), invalidateQueries } as unknown as QueryClient;
+
+    await expect(
+      refreshCachesAfterCommit({
+        queryClient,
+        organizationId: "org-1",
+        canvasId: "canvas-1",
+        versionId: "version-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.versionDetail("canvas-1", "version-1"),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.consoleStaged("canvas-1", "version-1"),
+    });
+    expect(fetchCanvasConsoleData).not.toHaveBeenCalled();
   });
 });

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.spec.ts
@@ -1,10 +1,14 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
-import { refreshCachesAfterCommit, syncCommittedCanvasDraftState } from "./sync-committed-canvas-draft";
+import {
+  refreshCachesAfterCommit,
+  syncCommittedCanvasDraftState,
+  syncCommittedConsoleCaches,
+} from "./sync-committed-canvas-draft";
 import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
 
 vi.mock("./repository-spec-files", () => ({
@@ -17,6 +21,10 @@ vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
     ...(actual as Record<string, unknown>),
     fetchCanvasConsoleData: vi.fn(),
   };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 describe("syncCommittedCanvasDraftState", () => {
@@ -67,6 +75,31 @@ describe("syncCommittedCanvasDraftState", () => {
       metadata: { id: "canvas-1" },
       spec: committedVersion.spec,
     });
+  });
+});
+
+describe("syncCommittedConsoleCaches", () => {
+  it("invalidates console caches when committed console.yaml is missing or unparsable", async () => {
+    vi.mocked(fetchCanvasConsoleData).mockResolvedValue(undefined);
+
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    const setQueryData = vi.fn();
+    const queryClient = { invalidateQueries, setQueryData } as unknown as QueryClient;
+
+    await syncCommittedConsoleCaches({
+      queryClient,
+      canvasId: "canvas-1",
+      versionId: "version-1",
+    });
+
+    expect(fetchCanvasConsoleData).toHaveBeenCalledWith("canvas-1", "version-1", false);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.console("canvas-1", "version-1"),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.consoleStaged("canvas-1", "version-1"),
+    });
+    expect(setQueryData).not.toHaveBeenCalled();
   });
 });
 

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
@@ -1,9 +1,29 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, SetStateAction } from "react";
 
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
-import { canvasKeys } from "@/hooks/useCanvasData";
+import { canvasKeys, fetchCanvasConsoleData } from "@/hooks/useCanvasData";
 
 import { fetchCanvasVersionWithSpec } from "./repository-spec-files";
+
+export async function syncCommittedConsoleCaches({
+  queryClient,
+  canvasId,
+  versionId,
+}: {
+  queryClient: QueryClient;
+  canvasId: string;
+  versionId: string;
+}): Promise<void> {
+  const consoleData = await fetchCanvasConsoleData(canvasId, versionId, false);
+  if (!consoleData) {
+    return;
+  }
+
+  queryClient.setQueryData(canvasKeys.console(canvasId, versionId), consoleData);
+  // After commit, staging is cleared — mirror the committed console in the staged cache.
+  queryClient.setQueryData(canvasKeys.consoleStaged(canvasId, versionId), consoleData);
+}
 
 export async function syncCommittedCanvasDraftState({
   queryClient,
@@ -46,4 +66,52 @@ export async function syncCommittedCanvasDraftState({
   }
 
   return committedVersion;
+}
+
+type DraftSpec = CanvasesCanvas["spec"] | null;
+
+export async function restoreCommittedCanvasDraftState({
+  organizationId,
+  canvasId,
+  activeCanvasVersionId,
+  queryClient,
+  draftCanvasSpecsRef,
+  setDraftCanvasSpec,
+  setActiveCanvasVersion,
+  onCanvasDraftRestoredToCommitted,
+}: {
+  organizationId?: string;
+  canvasId?: string;
+  activeCanvasVersionId: string;
+  queryClient: QueryClient;
+  draftCanvasSpecsRef: { current: Map<string, DraftSpec> };
+  setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
+  setActiveCanvasVersion?: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
+  onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
+}) {
+  if (!organizationId || !canvasId) {
+    draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
+    setDraftCanvasSpec(null);
+    return;
+  }
+
+  const committedVersion = await syncCommittedCanvasDraftState({
+    queryClient,
+    organizationId,
+    canvasId,
+    versionId: activeCanvasVersionId,
+  });
+
+  if (!committedVersion?.spec) {
+    draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
+    setDraftCanvasSpec(null);
+    return;
+  }
+
+  draftCanvasSpecsRef.current.set(activeCanvasVersionId, committedVersion.spec);
+  setDraftCanvasSpec(committedVersion.spec);
+  setActiveCanvasVersion?.((current) =>
+    current?.metadata?.id === activeCanvasVersionId ? { ...current, spec: committedVersion.spec } : current,
+  );
+  onCanvasDraftRestoredToCommitted?.(committedVersion);
 }

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
@@ -17,6 +17,10 @@ export async function syncCommittedConsoleCaches({
 }): Promise<void> {
   const consoleData = await fetchCanvasConsoleData(canvasId, versionId, false);
   if (!consoleData) {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) }),
+      queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) }),
+    ]);
     return;
   }
 

--- a/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
+++ b/web_src/src/pages/app/lib/sync-committed-canvas-draft.ts
@@ -68,6 +68,40 @@ export async function syncCommittedCanvasDraftState({
   return committedVersion;
 }
 
+export async function refreshCachesAfterCommit({
+  queryClient,
+  organizationId,
+  canvasId,
+  versionId,
+}: {
+  queryClient: QueryClient;
+  organizationId: string;
+  canvasId: string;
+  versionId: string;
+}): Promise<void> {
+  try {
+    await syncCommittedCanvasDraftState({
+      queryClient,
+      organizationId,
+      canvasId,
+      versionId,
+    });
+    await syncCommittedConsoleCaches({
+      queryClient,
+      canvasId,
+      versionId,
+    });
+  } catch {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: canvasKeys.versionDetail(canvasId, versionId) }),
+      queryClient.invalidateQueries({ queryKey: canvasKeys.versionStagedDetail(canvasId, versionId) }),
+      queryClient.invalidateQueries({ queryKey: canvasKeys.console(canvasId, versionId) }),
+      queryClient.invalidateQueries({ queryKey: canvasKeys.consoleStaged(canvasId, versionId) }),
+      queryClient.invalidateQueries({ queryKey: canvasKeys.detail(organizationId, canvasId) }),
+    ]);
+  }
+}
+
 type DraftSpec = CanvasesCanvas["spec"] | null;
 
 export async function restoreCommittedCanvasDraftState({

--- a/web_src/src/pages/app/useDraftRecovery.spec.tsx
+++ b/web_src/src/pages/app/useDraftRecovery.spec.tsx
@@ -9,8 +9,16 @@ const { ensureDraftVersionExists } = vi.hoisted(() => ({
   ensureDraftVersionExists: vi.fn(),
 }));
 
+const { recoverIfDraftMissing } = vi.hoisted(() => ({
+  recoverIfDraftMissing: vi.fn(),
+}));
+
 const { showSuccessToast } = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
+}));
+
+vi.mock("./lib/draft-missing-recovery", () => ({
+  recoverIfDraftMissing,
 }));
 
 vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
@@ -141,5 +149,49 @@ describe("useDraftRecovery", () => {
     expect(publishCanvasVersionMutation.mutateAsync).not.toHaveBeenCalled();
     expect(showSuccessToast).not.toHaveBeenCalled();
     expect(setIsPreparingVersionAction).toHaveBeenLastCalledWith(false);
+  });
+
+  it("recovers from publish failures using the version id captured after saves settle", async () => {
+    const activeCanvasVersionIdRef = { current: "draft-1" };
+    const ensureVersionActionDraftReady = vi.fn().mockImplementation(async () => {
+      activeCanvasVersionIdRef.current = "draft-2";
+      return true;
+    });
+    const publishError = new Error("not found");
+    const publishCanvasVersionMutation = { mutateAsync: vi.fn().mockRejectedValue(publishError) };
+    recoverIfDraftMissing.mockResolvedValue(true);
+
+    const { result } = renderHook(
+      () =>
+        useDraftRecovery({
+          organizationId: "org-1",
+          canvasId: "canvas-1",
+          activeCanvasVersionId: "draft-1",
+          activeCanvasVersionIdRef,
+          draftCanvasSpecsRef: { current: new Map([["draft-2", { nodes: [], edges: [] }]]) },
+          setActiveCanvasVersion: vi.fn(),
+          setDraftCanvasSpec: vi.fn(),
+          exitToLive: vi.fn(),
+          setSearchParams: vi.fn(),
+          refreshLatestLiveCanvasData: vi.fn(),
+          cancelPendingCanvasSaves: vi.fn(),
+          ensureVersionActionDraftReady,
+          publishCanvasVersionMutation,
+          setIsPreparingVersionAction: vi.fn(),
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.handlePublishVersion();
+    });
+
+    expect(publishCanvasVersionMutation.mutateAsync).toHaveBeenCalledWith("draft-2");
+    expect(recoverIfDraftMissing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: publishError,
+        versionId: "draft-2",
+      }),
+    );
   });
 });

--- a/web_src/src/pages/app/useDraftRecovery.spec.tsx
+++ b/web_src/src/pages/app/useDraftRecovery.spec.tsx
@@ -13,9 +13,13 @@ const { showSuccessToast } = vi.hoisted(() => ({
   showSuccessToast: vi.fn(),
 }));
 
-vi.mock("@/hooks/useCanvasData", () => ({
-  ensureDraftVersionExists,
-}));
+vi.mock("@/hooks/useCanvasData", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    ensureDraftVersionExists,
+  };
+});
 
 vi.mock("@/lib/toast", () => ({
   showErrorToast: vi.fn(),
@@ -56,6 +60,8 @@ describe("useDraftRecovery", () => {
     const setIsPreparingVersionAction = vi.fn();
     const setSearchParams = vi.fn();
     const refreshLatestLiveCanvasData = vi.fn().mockResolvedValue(undefined);
+    const registerIgnoredCanvasUpdatedEcho = vi.fn(() => vi.fn());
+    const registerIgnoredCanvasVersionUpdatedEcho = vi.fn(() => vi.fn());
     const activeCanvasVersionIdRef = { current: "draft-1" };
 
     const { result } = renderHook(
@@ -75,6 +81,8 @@ describe("useDraftRecovery", () => {
           ensureVersionActionDraftReady,
           publishCanvasVersionMutation,
           setIsPreparingVersionAction,
+          registerIgnoredCanvasUpdatedEcho,
+          registerIgnoredCanvasVersionUpdatedEcho,
         }),
       { wrapper: createWrapper() },
     );
@@ -87,8 +95,13 @@ describe("useDraftRecovery", () => {
       "Unable to prepare the latest version changes for publishing",
     );
     expect(ensureDraftVersionExists).toHaveBeenCalledWith(expect.any(QueryClient), "org-1", "canvas-1", "draft-1");
+    expect(registerIgnoredCanvasUpdatedEcho).toHaveBeenCalledTimes(1);
+    expect(registerIgnoredCanvasVersionUpdatedEcho).toHaveBeenCalledWith("draft-1");
     expect(publishCanvasVersionMutation.mutateAsync).toHaveBeenCalledWith("draft-1");
-    expect(refreshLatestLiveCanvasData).toHaveBeenCalledTimes(1);
+    expect(refreshLatestLiveCanvasData).toHaveBeenCalledWith({
+      liveVersionId: "draft-1",
+      skipDraftBranchRefetch: true,
+    });
     expect(showSuccessToast).toHaveBeenCalledWith("Version published");
     expect(setIsPreparingVersionAction).toHaveBeenNthCalledWith(1, true);
     expect(setIsPreparingVersionAction).toHaveBeenLastCalledWith(false);

--- a/web_src/src/pages/app/useDraftRecovery.ts
+++ b/web_src/src/pages/app/useDraftRecovery.ts
@@ -6,11 +6,11 @@ import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { showErrorToast, showInfoToast, showSuccessToast } from "@/lib/toast";
 import { getApiErrorMessage } from "@/lib/errors";
 import { getUsageLimitToastMessage } from "@/lib/usageLimits";
-import { ensureDraftVersionExists } from "@/hooks/useCanvasData";
 
-import { clearPublishedDraftVersion } from "./lib/draft-spec-cache";
-import { clearComponentSidebarSearchParams } from "./viewState";
-import { isNotFoundError } from "./workflowPageHelpers";
+import { recoverIfDraftMissing as resolveMissingDraftRecovery } from "./lib/draft-missing-recovery";
+import { exitDraftToLive } from "./lib/exit-draft-to-live";
+import { publishDraftVersionAndExit } from "./lib/publish-draft-flow";
+import type { RefreshLatestLiveCanvasDataOptions } from "./useRefreshLatestLiveCanvasData";
 
 type DraftSpec = CanvasesCanvas["spec"] | null;
 type SetSearchParams = ReturnType<typeof useSearchParams>[1];
@@ -26,16 +26,15 @@ type UseDraftRecoveryOptions = {
   setDraftCanvasSpec: Dispatch<SetStateAction<DraftSpec>>;
   exitToLive: () => void;
   setSearchParams: SetSearchParams;
-  refreshLatestLiveCanvasData: () => Promise<void>;
+  refreshLatestLiveCanvasData: (options?: RefreshLatestLiveCanvasDataOptions) => Promise<void>;
   cancelPendingCanvasSaves?: () => void;
   ensureVersionActionDraftReady: (errorMessage: string) => Promise<boolean>;
   publishCanvasVersionMutation: PublishMutation;
   setIsPreparingVersionAction: Dispatch<SetStateAction<boolean>>;
+  registerIgnoredCanvasUpdatedEcho?: () => () => void;
+  registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
 };
 
-// Owns the draft publish + exit-to-live + recovery lifecycle, guarding publish
-// against a draft that was deleted out from under it so a stale id can't strand
-// the UI on a "version not found" error.
 export function useDraftRecovery({
   organizationId,
   canvasId,
@@ -51,29 +50,32 @@ export function useDraftRecovery({
   ensureVersionActionDraftReady,
   publishCanvasVersionMutation,
   setIsPreparingVersionAction,
+  registerIgnoredCanvasUpdatedEcho,
+  registerIgnoredCanvasVersionUpdatedEcho,
 }: UseDraftRecoveryOptions) {
   const queryClient = useQueryClient();
 
-  // Shared by publish-success and missing-draft recovery so both end identically.
-  const exitDraftToLive = useCallback(
-    async (versionId: string) => {
-      activeCanvasVersionIdRef.current = "";
-      if (versionId) {
-        clearPublishedDraftVersion(draftCanvasSpecsRef.current, setActiveCanvasVersion, setDraftCanvasSpec, versionId);
-      }
-      exitToLive();
-      setSearchParams((current) => {
-        const next = new URLSearchParams(current);
-        next.delete("version");
-        next.delete("branch");
-        return clearComponentSidebarSearchParams(next);
-      });
-      await refreshLatestLiveCanvasData();
-    },
+  const runExitDraftToLive = useCallback(
+    (versionId: string, options?: RefreshLatestLiveCanvasDataOptions) =>
+      exitDraftToLive({
+        versionId,
+        options,
+        activeCanvasVersionIdRef,
+        draftCanvasSpecsRef,
+        setActiveCanvasVersion,
+        setDraftCanvasSpec,
+        canvasId,
+        queryClient,
+        exitToLive,
+        setSearchParams,
+        refreshLatestLiveCanvasData,
+      }),
     [
       activeCanvasVersionIdRef,
+      canvasId,
       draftCanvasSpecsRef,
       exitToLive,
+      queryClient,
       refreshLatestLiveCanvasData,
       setActiveCanvasVersion,
       setDraftCanvasSpec,
@@ -81,36 +83,25 @@ export function useDraftRecovery({
     ],
   );
 
-  // Recoverable state, not a fatal error: return to live with an info toast.
   const recoverFromMissingDraft = useCallback(
     async (versionId: string, message = "This draft no longer exists. Returned to the live canvas.") => {
       cancelPendingCanvasSaves?.();
-      await exitDraftToLive(versionId);
-      // Informational, not a hard failure — the user was cleanly returned to live.
+      await runExitDraftToLive(versionId);
       showInfoToast(message);
     },
-    [cancelPendingCanvasSaves, exitDraftToLive],
+    [cancelPendingCanvasSaves, runExitDraftToLive],
   );
 
-  // A NOT_FOUND can also come from unrelated resources (e.g. repository not
-  // found) while the draft still exists, so only recover once the draft itself
-  // is confirmed gone. Returns whether the error was handled as a missing draft.
   const recoverIfDraftMissing = useCallback(
-    async (error: unknown, versionId: string): Promise<boolean> => {
-      if (!isNotFoundError(error) || !organizationId || !canvasId || !versionId) {
-        return false;
-      }
-      // On a failed existence check, treat the draft as present so the caller
-      // surfaces its normal error instead of an unhandled rejection.
-      const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionId).catch(
-        () => true,
-      );
-      if (draftExists) {
-        return false;
-      }
-      await recoverFromMissingDraft(versionId);
-      return true;
-    },
+    (error: unknown, versionId: string) =>
+      resolveMissingDraftRecovery({
+        error,
+        versionId,
+        organizationId,
+        canvasId,
+        queryClient,
+        recoverFromMissingDraft,
+      }),
     [organizationId, canvasId, queryClient, recoverFromMissingDraft],
   );
 
@@ -119,34 +110,25 @@ export function useDraftRecovery({
       return;
     }
 
-    let versionIdToPublish = "";
+    const versionIdToPublish = activeCanvasVersionIdRef.current;
     setIsPreparingVersionAction(true);
     try {
-      const isReady = await ensureVersionActionDraftReady(
-        "Unable to prepare the latest version changes for publishing",
-      );
-      if (!isReady) {
-        return;
+      const result = await publishDraftVersionAndExit({
+        organizationId,
+        canvasId,
+        activeCanvasVersionIdRef,
+        queryClient,
+        ensureVersionActionDraftReady,
+        publishCanvasVersionMutation,
+        registerIgnoredCanvasUpdatedEcho,
+        registerIgnoredCanvasVersionUpdatedEcho,
+        runExitDraftToLive,
+        recoverFromMissingDraft,
+      });
+      if (result === "published") {
+        showSuccessToast("Version published");
       }
-
-      // Read the ref only after prepare settles — the user may have left draft
-      // mode while saves were still being flushed.
-      versionIdToPublish = activeCanvasVersionIdRef.current;
-      if (!versionIdToPublish) {
-        return;
-      }
-
-      const draftExists = await ensureDraftVersionExists(queryClient, organizationId, canvasId, versionIdToPublish);
-      if (!draftExists) {
-        await recoverFromMissingDraft(versionIdToPublish);
-        return;
-      }
-
-      await publishCanvasVersionMutation.mutateAsync(versionIdToPublish);
-      await exitDraftToLive(versionIdToPublish);
-      showSuccessToast("Version published");
     } catch (error) {
-      // The draft can be deleted between the pre-check and the mutation.
       if (await recoverIfDraftMissing(error, versionIdToPublish)) {
         return;
       }
@@ -163,7 +145,9 @@ export function useDraftRecovery({
     ensureVersionActionDraftReady,
     publishCanvasVersionMutation,
     setIsPreparingVersionAction,
-    exitDraftToLive,
+    registerIgnoredCanvasUpdatedEcho,
+    registerIgnoredCanvasVersionUpdatedEcho,
+    runExitDraftToLive,
     recoverFromMissingDraft,
     recoverIfDraftMissing,
   ]);

--- a/web_src/src/pages/app/useDraftRecovery.ts
+++ b/web_src/src/pages/app/useDraftRecovery.ts
@@ -110,7 +110,6 @@ export function useDraftRecovery({
       return;
     }
 
-    const versionIdToPublish = activeCanvasVersionIdRef.current;
     setIsPreparingVersionAction(true);
     try {
       const result = await publishDraftVersionAndExit({
@@ -125,14 +124,18 @@ export function useDraftRecovery({
         runExitDraftToLive,
         recoverFromMissingDraft,
       });
-      if (result === "published") {
+      if (result.status === "published") {
         showSuccessToast("Version published");
-      }
-    } catch (error) {
-      if (await recoverIfDraftMissing(error, versionIdToPublish)) {
         return;
       }
-      showErrorToast(getUsageLimitToastMessage(error, getApiErrorMessage(error, "Failed to publish version")));
+      if (result.status === "failed") {
+        if (await recoverIfDraftMissing(result.error, result.versionIdToPublish)) {
+          return;
+        }
+        showErrorToast(
+          getUsageLimitToastMessage(result.error, getApiErrorMessage(result.error, "Failed to publish version")),
+        );
+      }
     } finally {
       setIsPreparingVersionAction(false);
     }

--- a/web_src/src/pages/app/useDraftStagingActions.ts
+++ b/web_src/src/pages/app/useDraftStagingActions.ts
@@ -4,9 +4,9 @@ import { useCallback, useState, type Dispatch, type MutableRefObject, type SetSt
 import type { CanvasesCanvas, CanvasesCanvasVersion } from "@/api-client";
 import { showErrorToast, showSuccessToast } from "@/lib/toast";
 import { getApiErrorMessage } from "@/lib/errors";
-import { canvasKeys } from "@/hooks/useCanvasData";
 
-import { syncCommittedCanvasDraftState } from "./lib/sync-committed-canvas-draft";
+import { executeCommitStaging } from "./lib/commit-staging-flow";
+import { executeResetStaging } from "./lib/reset-staging-flow";
 
 type CommitMutation = { mutateAsync: () => Promise<unknown> };
 type DiscardMutation = { mutateAsync: (input: undefined) => Promise<unknown> };
@@ -28,76 +28,31 @@ type UseDraftStagingActionsOptions = {
   flushRepositoryFileStaging?: () => Promise<void>;
   cancelPendingCanvasSaves?: () => void;
   onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
-  // Recovers from a deleted draft when a mutation fails; returns whether it
-  // handled the error (only true when the draft is confirmed gone).
   recoverIfDraftMissing?: (error: unknown, versionId: string) => Promise<boolean>;
+  registerIgnoredCanvasVersionUpdatedEcho?: (versionId?: string) => () => void;
 };
 
-async function restoreCommittedCanvasDraftState({
-  organizationId,
-  canvasId,
-  activeCanvasVersionId,
-  queryClient,
-  draftCanvasSpecsRef,
-  setDraftCanvasSpec,
-  setActiveCanvasVersion,
-  onCanvasDraftRestoredToCommitted,
-}: {
-  organizationId?: string;
-  canvasId?: string;
-  activeCanvasVersionId: string;
-  queryClient: ReturnType<typeof useQueryClient>;
-  draftCanvasSpecsRef: MutableRefObject<Map<string, CanvasesCanvas["spec"] | null>>;
-  setDraftCanvasSpec: Dispatch<SetStateAction<CanvasesCanvas["spec"] | null>>;
-  setActiveCanvasVersion?: Dispatch<SetStateAction<CanvasesCanvasVersion | null>>;
-  onCanvasDraftRestoredToCommitted?: (version: CanvasesCanvasVersion) => void;
-}) {
-  if (!organizationId || !canvasId) {
-    draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-    setDraftCanvasSpec(null);
-    return;
-  }
-
-  const committedVersion = await syncCommittedCanvasDraftState({
-    queryClient,
+export function useDraftStagingActions(options: UseDraftStagingActionsOptions) {
+  const {
     organizationId,
     canvasId,
-    versionId: activeCanvasVersionId,
-  });
-
-  if (!committedVersion?.spec) {
-    draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-    setDraftCanvasSpec(null);
-    return;
-  }
-
-  draftCanvasSpecsRef.current.set(activeCanvasVersionId, committedVersion.spec);
-  setDraftCanvasSpec(committedVersion.spec);
-  setActiveCanvasVersion?.((current) =>
-    current?.metadata?.id === activeCanvasVersionId ? { ...current, spec: committedVersion.spec } : current,
-  );
-  onCanvasDraftRestoredToCommitted?.(committedVersion);
-}
-
-export function useDraftStagingActions({
-  organizationId,
-  canvasId,
-  activeCanvasVersionId,
-  hasEditableVersion,
-  ensureVersionActionDraftReady,
-  commitCanvasStagingMutation,
-  discardCanvasStagingMutation,
-  draftCanvasSpecsRef,
-  setDraftCanvasSpec,
-  setActiveCanvasVersion,
-  setStagingResetNonce,
-  consoleMutationGenerationRef,
-  setIsPreparingVersionAction,
-  flushRepositoryFileStaging,
-  cancelPendingCanvasSaves,
-  onCanvasDraftRestoredToCommitted,
-  recoverIfDraftMissing,
-}: UseDraftStagingActionsOptions) {
+    activeCanvasVersionId,
+    hasEditableVersion,
+    ensureVersionActionDraftReady,
+    commitCanvasStagingMutation,
+    discardCanvasStagingMutation,
+    draftCanvasSpecsRef,
+    setDraftCanvasSpec,
+    setActiveCanvasVersion,
+    setStagingResetNonce,
+    consoleMutationGenerationRef,
+    setIsPreparingVersionAction,
+    flushRepositoryFileStaging,
+    cancelPendingCanvasSaves,
+    onCanvasDraftRestoredToCommitted,
+    recoverIfDraftMissing: recoverIfDraftMissingOption,
+    registerIgnoredCanvasVersionUpdatedEcho,
+  } = options;
   const queryClient = useQueryClient();
   const [resetStagingPending, setResetStagingPending] = useState(false);
 
@@ -106,26 +61,29 @@ export function useDraftStagingActions({
       return;
     }
 
+    setIsPreparingVersionAction(true);
     try {
-      await flushRepositoryFileStaging?.();
-      const isReady = await ensureVersionActionDraftReady("Unable to prepare staged changes for commit");
-      if (!isReady) {
-        return;
+      const committed = await executeCommitStaging({
+        organizationId,
+        canvasId,
+        activeCanvasVersionId,
+        queryClient,
+        commitCanvasStagingMutation,
+        consoleMutationGenerationRef,
+        draftCanvasSpecsRef,
+        setDraftCanvasSpec,
+        setStagingResetNonce,
+        ensureVersionActionDraftReady,
+        flushRepositoryFileStaging,
+        registerIgnoredCanvasVersionUpdatedEcho,
+      });
+      if (committed) {
+        showSuccessToast("Changes committed");
       }
-
-      setIsPreparingVersionAction(true);
-      consoleMutationGenerationRef.current += 1;
-      await commitCanvasStagingMutation.mutateAsync();
-      await queryClient.invalidateQueries({ queryKey: canvasKeys.repository(canvasId!) });
-      draftCanvasSpecsRef.current.delete(activeCanvasVersionId);
-      setDraftCanvasSpec(null);
-      setStagingResetNonce((nonce) => nonce + 1);
-      showSuccessToast("Changes committed");
     } catch (error) {
-      if (await recoverIfDraftMissing?.(error, activeCanvasVersionId)) {
-        return;
+      if (!(await recoverIfDraftMissingOption?.(error, activeCanvasVersionId))) {
+        showErrorToast(getApiErrorMessage(error, "Failed to commit changes"));
       }
-      showErrorToast(getApiErrorMessage(error, "Failed to commit changes"));
     } finally {
       setIsPreparingVersionAction(false);
     }
@@ -138,8 +96,10 @@ export function useDraftStagingActions({
     ensureVersionActionDraftReady,
     flushRepositoryFileStaging,
     hasEditableVersion,
-    recoverIfDraftMissing,
+    organizationId,
     queryClient,
+    recoverIfDraftMissingOption,
+    registerIgnoredCanvasVersionUpdatedEcho,
     setDraftCanvasSpec,
     setIsPreparingVersionAction,
     setStagingResetNonce,
@@ -153,27 +113,25 @@ export function useDraftStagingActions({
     setResetStagingPending(true);
     setIsPreparingVersionAction(true);
     try {
-      cancelPendingCanvasSaves?.();
-      consoleMutationGenerationRef.current += 1;
-      await discardCanvasStagingMutation.mutateAsync(undefined);
-      await restoreCommittedCanvasDraftState({
+      await executeResetStaging({
         organizationId,
         canvasId,
         activeCanvasVersionId,
         queryClient,
+        discardCanvasStagingMutation,
+        consoleMutationGenerationRef,
         draftCanvasSpecsRef,
         setDraftCanvasSpec,
         setActiveCanvasVersion,
+        setStagingResetNonce,
+        cancelPendingCanvasSaves,
         onCanvasDraftRestoredToCommitted,
       });
-      await queryClient.refetchQueries({ queryKey: canvasKeys.repository(canvasId!) });
-      setStagingResetNonce((nonce) => nonce + 1);
       showSuccessToast("Reverted to last commit");
     } catch (error) {
-      if (await recoverIfDraftMissing?.(error, activeCanvasVersionId)) {
-        return;
+      if (!(await recoverIfDraftMissingOption?.(error, activeCanvasVersionId))) {
+        showErrorToast(getApiErrorMessage(error, "Failed to reset staged changes"));
       }
-      showErrorToast(getApiErrorMessage(error, "Failed to reset staged changes"));
     } finally {
       setResetStagingPending(false);
       setIsPreparingVersionAction(false);
@@ -187,9 +145,9 @@ export function useDraftStagingActions({
     draftCanvasSpecsRef,
     hasEditableVersion,
     onCanvasDraftRestoredToCommitted,
-    recoverIfDraftMissing,
     organizationId,
     queryClient,
+    recoverIfDraftMissingOption,
     setActiveCanvasVersion,
     setDraftCanvasSpec,
     setIsPreparingVersionAction,

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
@@ -94,8 +94,8 @@ describe("useRefreshLatestLiveCanvasData", () => {
     expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", undefined), { exact: true });
 
     const consoleInvalidations = invalidateQueries.mock.calls
-      .map(([args]) => args.queryKey)
-      .filter((key) => Array.isArray(key) && key.includes("console"));
+      .map(([args]) => args?.queryKey)
+      .filter((key): key is ReturnType<typeof canvasKeys.console> => Array.isArray(key) && key.includes("console"));
     expect(consoleInvalidations).toEqual([canvasKeys.console("canvas-1", undefined)]);
   });
 

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
@@ -13,10 +13,94 @@ function createWrapper(queryClient: QueryClient) {
   };
 }
 
+function createInvalidateSpy() {
+  const queryClient = new QueryClient();
+  const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+  return { queryClient, invalidateQueries };
+}
+
+function expectInvalidation(
+  invalidateQueries: ReturnType<typeof vi.spyOn>,
+  queryKey: readonly unknown[],
+  extra?: Record<string, unknown>,
+) {
+  expect(invalidateQueries).toHaveBeenCalledWith({
+    queryKey,
+    refetchType: "all",
+    ...extra,
+  });
+}
+
 describe("useRefreshLatestLiveCanvasData", () => {
-  it("invalidates both the version-specific and live console cache keys after publish", async () => {
-    const queryClient = new QueryClient();
-    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+  it("invalidates live canvas queries by default, including draft branches", async () => {
+    const { queryClient, invalidateQueries } = createInvalidateSpy();
+
+    const { result } = renderHook(() => useRefreshLatestLiveCanvasData("org-1", "canvas-1", "live-version-1"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.versionList("canvas-1"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.draftBranches("canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "live-version-1"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", undefined), { exact: true });
+  });
+
+  it("does nothing when organization or canvas id is missing", async () => {
+    const { queryClient, invalidateQueries } = createInvalidateSpy();
+
+    const { result: missingOrg } = renderHook(
+      () => useRefreshLatestLiveCanvasData(undefined, "canvas-1", "live-version-1"),
+      {
+        wrapper: createWrapper(queryClient),
+      },
+    );
+    await act(async () => {
+      await missingOrg.current();
+    });
+    expect(invalidateQueries).not.toHaveBeenCalled();
+
+    const missingCanvasQueryClient = new QueryClient();
+    const missingCanvasInvalidate = vi
+      .spyOn(missingCanvasQueryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+    const { result: missingCanvas } = renderHook(
+      () => useRefreshLatestLiveCanvasData("org-1", undefined, "live-version-1"),
+      { wrapper: createWrapper(missingCanvasQueryClient) },
+    );
+    await act(async () => {
+      await missingCanvas.current();
+    });
+    expect(missingCanvasInvalidate).not.toHaveBeenCalled();
+  });
+
+  it("skips version-specific console invalidation when no live version id is available", async () => {
+    const { queryClient, invalidateQueries } = createInvalidateSpy();
+
+    const { result } = renderHook(() => useRefreshLatestLiveCanvasData("org-1", "canvas-1", undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", undefined), { exact: true });
+
+    const consoleInvalidations = invalidateQueries.mock.calls
+      .map(([args]) => args.queryKey)
+      .filter((key) => Array.isArray(key) && key.includes("console"));
+    expect(consoleInvalidations).toEqual([canvasKeys.console("canvas-1", undefined)]);
+  });
+
+  it("invalidates publish console caches and skips draft branches when requested", async () => {
+    const { queryClient, invalidateQueries } = createInvalidateSpy();
 
     const { result } = renderHook(() => useRefreshLatestLiveCanvasData("org-1", "canvas-1", "old-live-version"), {
       wrapper: createWrapper(queryClient),
@@ -26,15 +110,15 @@ describe("useRefreshLatestLiveCanvasData", () => {
       await result.current({ liveVersionId: "published-version", skipDraftBranchRefetch: true });
     });
 
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.console("canvas-1", "published-version"),
-      exact: true,
-      refetchType: "all",
-    });
-    expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: canvasKeys.console("canvas-1", undefined),
-      exact: true,
-      refetchType: "all",
-    });
+    expectInvalidation(invalidateQueries, canvasKeys.detail("org-1", "canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.versionList("canvas-1"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.versionHistory("canvas-1"));
+    expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", "published-version"), { exact: true });
+    expectInvalidation(invalidateQueries, canvasKeys.console("canvas-1", undefined), { exact: true });
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: canvasKeys.draftBranches("canvas-1"),
+      }),
+    );
   });
 });

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.spec.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+import { useRefreshLatestLiveCanvasData } from "./useRefreshLatestLiveCanvasData";
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe("useRefreshLatestLiveCanvasData", () => {
+  it("invalidates both the version-specific and live console cache keys after publish", async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRefreshLatestLiveCanvasData("org-1", "canvas-1", "old-live-version"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current({ liveVersionId: "published-version", skipDraftBranchRefetch: true });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.console("canvas-1", "published-version"),
+      exact: true,
+      refetchType: "all",
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: canvasKeys.console("canvas-1", undefined),
+      exact: true,
+      refetchType: "all",
+    });
+  });
+});

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
@@ -57,6 +57,16 @@ export function useRefreshLatestLiveCanvasData(
         );
       }
 
+      // Live view reads console.yaml via the version-less "live" cache key while
+      // edit mode uses the draft version id; refresh both after publish/exit.
+      invalidations.push(
+        queryClient.invalidateQueries({
+          queryKey: canvasKeys.console(canvasId, undefined),
+          exact: true,
+          refetchType: "all",
+        }),
+      );
+
       await Promise.all(invalidations);
     },
     [organizationId, canvasId, queryClient, effectiveLiveCanvasVersionId],

--- a/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
+++ b/web_src/src/pages/app/useRefreshLatestLiveCanvasData.ts
@@ -1,0 +1,64 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { canvasKeys } from "@/hooks/useCanvasData";
+
+export type RefreshLatestLiveCanvasDataOptions = {
+  liveVersionId?: string;
+  skipDraftBranchRefetch?: boolean;
+};
+
+export function useRefreshLatestLiveCanvasData(
+  organizationId: string | undefined,
+  canvasId: string | undefined,
+  effectiveLiveCanvasVersionId: string | undefined,
+) {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (options?: RefreshLatestLiveCanvasDataOptions) => {
+      if (!organizationId || !canvasId) {
+        return;
+      }
+
+      const liveVersionId = options?.liveVersionId ?? effectiveLiveCanvasVersionId;
+      const invalidations: Array<Promise<unknown>> = [
+        queryClient.invalidateQueries({
+          queryKey: canvasKeys.detail(organizationId, canvasId),
+          refetchType: "all",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: canvasKeys.versionList(canvasId),
+          exact: true,
+          refetchType: "all",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: canvasKeys.versionHistory(canvasId),
+          refetchType: "all",
+        }),
+      ];
+
+      if (!options?.skipDraftBranchRefetch) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: canvasKeys.draftBranches(canvasId),
+            refetchType: "all",
+          }),
+        );
+      }
+
+      if (liveVersionId) {
+        invalidations.push(
+          queryClient.invalidateQueries({
+            queryKey: canvasKeys.console(canvasId, liveVersionId),
+            exact: true,
+            refetchType: "all",
+          }),
+        );
+      }
+
+      await Promise.all(invalidations);
+    },
+    [organizationId, canvasId, queryClient, effectiveLiveCanvasVersionId],
+  );
+}


### PR DESCRIPTION
Commit and publish were each firing many redundant API requests because the mutation response handler, post-action cache refresh, and same-tab WebSocket lifecycle echoes all invalidated overlapping query keys. This aligns commit/publish with the echo-suppression pattern already used for auto-save and draft creation - see https://github.com/superplanehq/superplane/pull/5680 and https://github.com/superplanehq/superplane/pull/5690 - and narrows post-action cache updates to a single intentional refresh per resource.

## Changes
- **Commit:** Register a `canvas_version_updated` echo guard before staging commit; sync version/canvas/console caches once via `syncCommittedCanvasDraftState` + `syncCommittedConsoleCaches` instead of broad invalidations; trim `useCommitCanvasStaging` `onSuccess` to staging summary + version history only.
- **Publish:** Register `canvas_updated` and `canvas_version_updated` echo guards before publish; remove `usePublishCanvasVersion` `onSuccess` invalidations (refresh is owned by exit-to-live); optimistically drop the published draft from the branches cache; pass the published version id into `refreshLatestLiveCanvasData`.
- **Live refresh:** Use `exact: true` for `versionList` invalidation (avoids double-refetching `versionHistory`); replace `consoleAll` invalidation with a targeted live-console refresh.

## Refactor

Linter started to complain after the changes, so a bit of refactoring was needed:
  - Extracted flow helpers: commit-staging-flow, publish-draft-flow, exit-draft-to-live, reset-staging-flow, draft-missing-recovery
  - Extracted useRefreshLatestLiveCanvasData from index.tsx to keep ESLint budgets green

## Analysis after fix

Using HAR files generated in the browser, we can see the difference in the number of requests.
- Commit: ~30 requests → **5** (0 duplicate URLs)
- Publish: ~46 requests → **9** (1 acceptable cross-cache console fetch during exit-to-live)