### PR TITLE
fix: keep commit button disabled until staging action fully completes

### DIFF
--- a/web_src/src/pages/app/index.tsx
+++ b/web_src/src/pages/app/index.tsx
@@ -3439,26 +3439,28 @@ export function AppPage() {
     [canvasId, organizationId, queryClient, setLastSavedWorkflowSnapshot],
   );
 
-  const { handleCommitStaging, handleResetStaging, resetStagingPending } = useDraftStagingActions({
-    organizationId,
-    canvasId,
-    activeCanvasVersionId,
-    hasEditableVersion,
-    ensureVersionActionDraftReady,
-    commitCanvasStagingMutation,
-    discardCanvasStagingMutation,
-    draftCanvasSpecsRef,
-    setDraftCanvasSpec,
-    setActiveCanvasVersion,
-    setStagingResetNonce,
-    consoleMutationGenerationRef,
-    setIsPreparingVersionAction,
-    flushRepositoryFileStaging,
-    cancelPendingCanvasSaves,
-    onCanvasDraftRestoredToCommitted: handleCanvasDraftRestoredToCommitted,
-    recoverIfDraftMissing,
-    registerIgnoredCanvasVersionUpdatedEcho,
-  });
+  const { handleCommitStaging, handleResetStaging, commitStagingPending, resetStagingPending } = useDraftStagingActions(
+    {
+      organizationId,
+      canvasId,
+      activeCanvasVersionId,
+      hasEditableVersion,
+      ensureVersionActionDraftReady,
+      commitCanvasStagingMutation,
+      discardCanvasStagingMutation,
+      draftCanvasSpecsRef,
+      setDraftCanvasSpec,
+      setActiveCanvasVersion,
+      setStagingResetNonce,
+      consoleMutationGenerationRef,
+      setIsPreparingVersionAction,
+      flushRepositoryFileStaging,
+      cancelPendingCanvasSaves,
+      onCanvasDraftRestoredToCommitted: handleCanvasDraftRestoredToCommitted,
+      recoverIfDraftMissing,
+      registerIgnoredCanvasVersionUpdatedEcho,
+    },
+  );
 
   const activateCanvasVersionForEditing = useCallback(
     (versionID: string, version: CanvasesCanvasVersion) => {
@@ -4558,7 +4560,7 @@ export function AppPage() {
           hasCommittedConsoleDraftChanges={hasCommittedConsoleDraftChanges}
           hasFilesStagingChanges={isEditing && hasFilesStagingChanges}
           onCommitStaging={handleCommitStaging}
-          commitStagingPending={commitCanvasStagingMutation.isPending}
+          commitStagingPending={commitStagingPending}
           resetStagingPending={resetStagingPending}
           onResetStaging={handleResetStaging}
           autoLayoutOnUpdateDisabled={isReadOnly}

--- a/web_src/src/pages/app/useDraftStagingActions.ts
+++ b/web_src/src/pages/app/useDraftStagingActions.ts
@@ -11,6 +11,21 @@ import { executeResetStaging } from "./lib/reset-staging-flow";
 type CommitMutation = { mutateAsync: () => Promise<unknown> };
 type DiscardMutation = { mutateAsync: (input: undefined) => Promise<unknown> };
 
+async function runDraftStagingAction(
+  setActionPending: Dispatch<SetStateAction<boolean>>,
+  setIsPreparingVersionAction: Dispatch<SetStateAction<boolean>>,
+  action: () => Promise<void>,
+): Promise<void> {
+  setActionPending(true);
+  setIsPreparingVersionAction(true);
+  try {
+    await action();
+  } finally {
+    setActionPending(false);
+    setIsPreparingVersionAction(false);
+  }
+}
+
 type UseDraftStagingActionsOptions = {
   organizationId?: string;
   canvasId?: string;
@@ -54,6 +69,7 @@ export function useDraftStagingActions(options: UseDraftStagingActionsOptions) {
     registerIgnoredCanvasVersionUpdatedEcho,
   } = options;
   const queryClient = useQueryClient();
+  const [commitStagingPending, setCommitStagingPending] = useState(false);
   const [resetStagingPending, setResetStagingPending] = useState(false);
 
   const handleCommitStaging = useCallback(async () => {
@@ -61,31 +77,30 @@ export function useDraftStagingActions(options: UseDraftStagingActionsOptions) {
       return;
     }
 
-    setIsPreparingVersionAction(true);
     try {
-      const committed = await executeCommitStaging({
-        organizationId,
-        canvasId,
-        activeCanvasVersionId,
-        queryClient,
-        commitCanvasStagingMutation,
-        consoleMutationGenerationRef,
-        draftCanvasSpecsRef,
-        setDraftCanvasSpec,
-        setStagingResetNonce,
-        ensureVersionActionDraftReady,
-        flushRepositoryFileStaging,
-        registerIgnoredCanvasVersionUpdatedEcho,
+      await runDraftStagingAction(setCommitStagingPending, setIsPreparingVersionAction, async () => {
+        const committed = await executeCommitStaging({
+          organizationId,
+          canvasId,
+          activeCanvasVersionId,
+          queryClient,
+          commitCanvasStagingMutation,
+          consoleMutationGenerationRef,
+          draftCanvasSpecsRef,
+          setDraftCanvasSpec,
+          setStagingResetNonce,
+          ensureVersionActionDraftReady,
+          flushRepositoryFileStaging,
+          registerIgnoredCanvasVersionUpdatedEcho,
+        });
+        if (committed) {
+          showSuccessToast("Changes committed");
+        }
       });
-      if (committed) {
-        showSuccessToast("Changes committed");
-      }
     } catch (error) {
       if (!(await recoverIfDraftMissingOption?.(error, activeCanvasVersionId))) {
         showErrorToast(getApiErrorMessage(error, "Failed to commit changes"));
       }
-    } finally {
-      setIsPreparingVersionAction(false);
     }
   }, [
     activeCanvasVersionId,
@@ -110,31 +125,28 @@ export function useDraftStagingActions(options: UseDraftStagingActionsOptions) {
       return;
     }
 
-    setResetStagingPending(true);
-    setIsPreparingVersionAction(true);
     try {
-      await executeResetStaging({
-        organizationId,
-        canvasId,
-        activeCanvasVersionId,
-        queryClient,
-        discardCanvasStagingMutation,
-        consoleMutationGenerationRef,
-        draftCanvasSpecsRef,
-        setDraftCanvasSpec,
-        setActiveCanvasVersion,
-        setStagingResetNonce,
-        cancelPendingCanvasSaves,
-        onCanvasDraftRestoredToCommitted,
+      await runDraftStagingAction(setResetStagingPending, setIsPreparingVersionAction, async () => {
+        await executeResetStaging({
+          organizationId,
+          canvasId,
+          activeCanvasVersionId,
+          queryClient,
+          discardCanvasStagingMutation,
+          consoleMutationGenerationRef,
+          draftCanvasSpecsRef,
+          setDraftCanvasSpec,
+          setActiveCanvasVersion,
+          setStagingResetNonce,
+          cancelPendingCanvasSaves,
+          onCanvasDraftRestoredToCommitted,
+        });
+        showSuccessToast("Reverted to last commit");
       });
-      showSuccessToast("Reverted to last commit");
     } catch (error) {
       if (!(await recoverIfDraftMissingOption?.(error, activeCanvasVersionId))) {
         showErrorToast(getApiErrorMessage(error, "Failed to reset staged changes"));
       }
-    } finally {
-      setResetStagingPending(false);
-      setIsPreparingVersionAction(false);
     }
   }, [
     activeCanvasVersionId,
@@ -154,5 +166,5 @@ export function useDraftStagingActions(options: UseDraftStagingActionsOptions) {
     setStagingResetNonce,
   ]);
 
-  return { handleCommitStaging, handleResetStaging, resetStagingPending };
+  return { handleCommitStaging, handleResetStaging, commitStagingPending, resetStagingPending };
 }

--- a/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
+++ b/web_src/src/ui/CanvasPage/HeaderSecondaryActions.spec.tsx
@@ -68,6 +68,28 @@ describe("SecondaryHeaderActions", () => {
     expect(screen.getByText("+1")).toBeInTheDocument();
   });
 
+  it("keeps the commit controls pending while staging indicators still show changes", () => {
+    render(
+      <SecondaryHeaderActions
+        canvasName="Canvas"
+        mode="version-live"
+        isEditing
+        hasStagingChanges
+        commitStagingPending
+        onCommitStaging={vi.fn()}
+        onResetStaging={vi.fn()}
+        onPublishVersion={vi.fn()}
+        toolSidebarState={{} as CanvasToolSidebarState}
+        runsSidebarState={runsSidebarState}
+        versionsSidebarState={versionsSidebarState}
+      />,
+    );
+
+    expect(screen.getByTestId("canvas-commit-staging-button")).toBeDisabled();
+    expect(screen.getByTestId("canvas-reset-staging-button")).toBeDisabled();
+    expect(screen.queryByTestId("canvas-publish-version-button")).not.toBeInTheDocument();
+  });
+
   it("keeps the commit controls pending while a commit settles after staging clears", () => {
     render(
       <SecondaryHeaderActions


### PR DESCRIPTION
- Fix a brief flicker where the Commit button re-enabled after the API call finished but before Publish appeared.
- Track `commitStagingPending` for the full commit handler lifecycle (cache refresh, baseline reset), matching how Reset already works.