### PR TITLE
fix: preserve multiline runner setup commands

### DIFF
--- a/pkg/components/runner/commands.go
+++ b/pkg/components/runner/commands.go
@@ -12,21 +12,52 @@ import (
 const (
 	EnvironmentValueSourceLiteral = "literal"
 	EnvironmentValueSourceSecret  = "secret"
+
+	shellTokenIf              = "if"
+	shellTokenCase            = "case"
+	shellTokenFor             = "for"
+	shellTokenSelect          = "select"
+	shellTokenWhile           = "while"
+	shellTokenUntil           = "until"
+	shellTokenFunction        = "function"
+	shellTokenFi              = "fi"
+	shellTokenDone            = "done"
+	shellTokenEsac            = "esac"
+	shellTokenOpenBrace       = "{"
+	shellTokenCloseBrace      = "}"
+	shellTokenHeredoc         = "<<"
+	shellTokenIndentedHeredoc = "<<-"
+	shellTokenHereString      = "<<<"
+	commandLineSeparator      = "\n"
 )
 
 var environmentVariableNameRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+var shellBlockOpeners = map[string]struct{}{
+	shellTokenIf:        {},
+	shellTokenCase:      {},
+	shellTokenFor:       {},
+	shellTokenSelect:    {},
+	shellTokenWhile:     {},
+	shellTokenUntil:     {},
+	shellTokenOpenBrace: {},
+}
+
+var shellBlockClosers = map[string]struct{}{
+	shellTokenFi:         {},
+	shellTokenDone:       {},
+	shellTokenEsac:       {},
+	shellTokenCloseBrace: {},
+}
+
 func normalizeCommands(commands string) []string {
-	lines := strings.Split(commands, "\n")
-	out := make([]string, 0, len(lines))
-	for _, l := range lines {
-		l = strings.TrimSpace(l)
-		if l == "" {
-			continue
-		}
-		out = append(out, l)
+	lines := strings.Split(commands, commandLineSeparator)
+	normalizer := newCommandNormalizer(len(lines))
+	for _, line := range lines {
+		normalizer.add(line)
 	}
-	return out
+
+	return normalizer.result()
 }
 
 func validateCommands(commands string) error {
@@ -35,6 +66,349 @@ func validateCommands(commands string) error {
 		return errors.New("at least one command is required")
 	}
 	return nil
+}
+
+type commandNormalizer struct {
+	normalized        []string
+	blockLines        []string
+	blockDepth        int
+	heredocDelimiters []string
+}
+
+func newCommandNormalizer(commandCount int) *commandNormalizer {
+	return &commandNormalizer{
+		normalized:        make([]string, 0, commandCount),
+		blockLines:        []string{},
+		heredocDelimiters: []string{},
+	}
+}
+
+func (n *commandNormalizer) add(rawLine string) {
+	if n.inHeredoc() {
+		n.addBlockLine(rawLine)
+		n.closeHeredocIfDelimiter(strings.TrimSpace(rawLine))
+		n.flushBlockIfComplete()
+		return
+	}
+
+	line := strings.TrimSpace(rawLine)
+	if line == "" {
+		return
+	}
+
+	structure := inspectShellLine(line)
+	if !n.inBlock() && !structure.startsBlock() {
+		n.normalized = append(n.normalized, line)
+		return
+	}
+
+	n.addBlockLine(line)
+	n.blockDepth += structure.openBlocks
+	n.blockDepth -= min(structure.closeBlocks, n.blockDepth)
+	n.heredocDelimiters = append(n.heredocDelimiters, structure.heredocDelimiters...)
+	n.flushBlockIfComplete()
+}
+
+func (n *commandNormalizer) result() []string {
+	if len(n.blockLines) > 0 {
+		if n.inBlock() {
+			n.normalized = append(n.normalized, separateCommands(n.blockLines)...)
+			return n.normalized
+		}
+
+		n.normalized = append(n.normalized, strings.Join(n.blockLines, commandLineSeparator))
+	}
+
+	return n.normalized
+}
+
+func separateCommands(lines []string) []string {
+	commands := make([]string, 0, len(lines))
+	for _, line := range lines {
+		command := strings.TrimSpace(line)
+		if command != "" {
+			commands = append(commands, command)
+		}
+	}
+
+	return commands
+}
+
+func (n *commandNormalizer) addBlockLine(line string) {
+	n.blockLines = append(n.blockLines, line)
+}
+
+func (n *commandNormalizer) inBlock() bool {
+	return n.blockDepth > 0 || n.inHeredoc()
+}
+
+func (n *commandNormalizer) inHeredoc() bool {
+	return len(n.heredocDelimiters) > 0
+}
+
+func (n *commandNormalizer) closeHeredocIfDelimiter(line string) {
+	if line == n.heredocDelimiters[0] {
+		n.heredocDelimiters = n.heredocDelimiters[1:]
+	}
+}
+
+func (n *commandNormalizer) flushBlockIfComplete() {
+	if n.blockDepth > 0 || n.inHeredoc() {
+		return
+	}
+
+	n.normalized = append(n.normalized, strings.Join(n.blockLines, commandLineSeparator))
+	n.blockLines = n.blockLines[:0]
+}
+
+type shellLineInspection struct {
+	openBlocks        int
+	closeBlocks       int
+	heredocDelimiters []string
+}
+
+func (s shellLineInspection) startsBlock() bool {
+	return s.openBlocks > 0 || len(s.heredocDelimiters) > 0
+}
+
+func inspectShellLine(line string) shellLineInspection {
+	words := shellWords(line)
+	if len(words) == 0 {
+		return shellLineInspection{}
+	}
+
+	inspection := shellLineInspection{}
+	functionBlock := false
+	for _, word := range words {
+		if word.quoted || !word.commandPosition {
+			continue
+		}
+
+		if word.value == shellTokenFunction {
+			functionBlock = true
+			continue
+		}
+
+		if _, ok := shellBlockOpeners[word.value]; ok {
+			inspection.openBlocks++
+			continue
+		}
+
+		if _, ok := shellBlockClosers[word.value]; ok {
+			inspection.closeBlocks++
+		}
+	}
+
+	if functionBlock &&
+		hasUnquotedWord(words, shellTokenOpenBrace) &&
+		!hasUnquotedCommandPositionWord(words, shellTokenOpenBrace) {
+		inspection.openBlocks++
+	}
+
+	inspection.heredocDelimiters = heredocDelimiters(words)
+	return inspection
+}
+
+func hasUnquotedWord(words []shellWord, value string) bool {
+	for _, word := range words {
+		if !word.quoted && word.value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasUnquotedCommandPositionWord(words []shellWord, value string) bool {
+	for _, word := range words {
+		if !word.quoted && word.commandPosition && word.value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+type shellWord struct {
+	value           string
+	quoted          bool
+	startedQuoted   bool
+	commandPosition bool
+}
+
+type shellLineScanner struct {
+	words           []shellWord
+	word            strings.Builder
+	quote           rune
+	escaped         bool
+	quoted          bool
+	startedQuoted   bool
+	commandPosition bool
+}
+
+func newShellLineScanner() *shellLineScanner {
+	return &shellLineScanner{
+		words:           []shellWord{},
+		commandPosition: true,
+	}
+}
+
+func shellWords(line string) []shellWord {
+	scanner := newShellLineScanner()
+
+	for _, r := range line {
+		if scanner.scan(r) {
+			break
+		}
+	}
+
+	return scanner.result()
+}
+
+func (s *shellLineScanner) scan(r rune) bool {
+	switch {
+	case s.escaped:
+		s.writeEscaped(r)
+	case r == '\\':
+		s.escaped = true
+	case s.inQuote():
+		s.scanQuoted(r)
+	default:
+		return s.scanUnquoted(r)
+	}
+
+	return false
+}
+
+func (s *shellLineScanner) result() []shellWord {
+	s.flushWord()
+	return s.words
+}
+
+func (s *shellLineScanner) writeEscaped(r rune) {
+	s.word.WriteRune(r)
+	s.escaped = false
+}
+
+func (s *shellLineScanner) inQuote() bool {
+	return s.quote != 0
+}
+
+func (s *shellLineScanner) scanQuoted(r rune) {
+	if r == s.quote {
+		s.quote = 0
+		return
+	}
+
+	s.word.WriteRune(r)
+}
+
+func (s *shellLineScanner) scanUnquoted(r rune) bool {
+	switch {
+	case isShellQuote(r):
+		if s.word.Len() == 0 {
+			s.startedQuoted = true
+		}
+		s.quote = r
+		s.quoted = true
+	case r == '#':
+		s.flushWord()
+		return true
+	case isShellWhitespace(r):
+		s.flushWord()
+	case isShellCommandSeparator(r):
+		s.flushWord()
+		s.commandPosition = true
+	case isShellBrace(r):
+		s.addBraceWord(r)
+	default:
+		s.word.WriteRune(r)
+	}
+
+	return false
+}
+
+func (s *shellLineScanner) flushWord() {
+	if s.word.Len() == 0 {
+		s.quoted = false
+		s.startedQuoted = false
+		return
+	}
+
+	s.words = append(s.words, shellWord{
+		value:           s.word.String(),
+		quoted:          s.quoted,
+		startedQuoted:   s.startedQuoted,
+		commandPosition: s.commandPosition,
+	})
+	s.word.Reset()
+	s.quoted = false
+	s.startedQuoted = false
+	s.commandPosition = false
+}
+
+func (s *shellLineScanner) addBraceWord(r rune) {
+	s.flushWord()
+	s.words = append(s.words, shellWord{
+		value:           string(r),
+		commandPosition: s.commandPosition,
+	})
+	s.commandPosition = false
+}
+
+func isShellQuote(r rune) bool {
+	return r == '\'' || r == '"' || r == '`'
+}
+
+func isShellWhitespace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func isShellCommandSeparator(r rune) bool {
+	return r == ';' || r == '&' || r == '|' || r == '(' || r == ')'
+}
+
+func isShellBrace(r rune) bool {
+	return r == '{' || r == '}'
+}
+
+func heredocDelimiters(words []shellWord) []string {
+	delimiters := []string{}
+	for i := range words {
+		delimiter := heredocDelimiter(words, i)
+		if delimiter != "" {
+			delimiters = append(delimiters, delimiter)
+		}
+	}
+
+	return delimiters
+}
+
+func heredocDelimiter(words []shellWord, index int) string {
+	if words[index].startedQuoted {
+		return ""
+	}
+
+	value := words[index].value
+	switch {
+	case value == shellTokenHeredoc || value == shellTokenIndentedHeredoc:
+		if index+1 >= len(words) {
+			return ""
+		}
+		return cleanHeredocDelimiter(words[index+1].value)
+	case strings.HasPrefix(value, shellTokenHereString):
+		return ""
+	case strings.HasPrefix(value, shellTokenIndentedHeredoc):
+		return cleanHeredocDelimiter(strings.TrimPrefix(value, shellTokenIndentedHeredoc))
+	case strings.HasPrefix(value, shellTokenHeredoc):
+		return cleanHeredocDelimiter(strings.TrimPrefix(value, shellTokenHeredoc))
+	default:
+		return ""
+	}
+}
+
+func cleanHeredocDelimiter(delimiter string) string {
+	return strings.Trim(delimiter, `"'`)
 }
 
 func validateEnvironment(environment []EnvironmentVariable) error {

--- a/pkg/components/runner/run_bash_test.go
+++ b/pkg/components/runner/run_bash_test.go
@@ -72,11 +72,17 @@ func TestRunBashExecuteSendsSetupCommandsWhenEnabled(t *testing.T) {
 	}
 
 	component := &RunBash{}
+	setupCommands := `if ! command -v aws >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y awscli
+fi
+echo ready`
+
 	err := component.Execute(core.ExecutionContext{
 		Configuration: map[string]any{
 			"machine_type":          testRunnerMachineType,
 			"enable_setup_commands": true,
-			"setup_commands":        "apt-get update\necho ready",
+			"setup_commands":        setupCommands,
 			"script":                `echo '{"ok":true}' > "$SUPERPLANE_RESULT_FILE"`,
 		},
 		HTTP:           httpContext,
@@ -94,7 +100,10 @@ func TestRunBashExecuteSendsSetupCommandsWhenEnabled(t *testing.T) {
 	var req brokerCreateTaskRequest
 	require.NoError(t, json.Unmarshal(body, &req))
 
-	assert.Equal(t, []string{"apt-get update", "echo ready"}, req.SetupCommands)
+	assert.Equal(t, []string{`if ! command -v aws >/dev/null 2>&1; then
+apt-get update
+apt-get install -y awscli
+fi`, "echo ready"}, req.SetupCommands)
 }
 
 func TestValidateRunBashSpecRequiresSetupCommandsWhenEnabled(t *testing.T) {

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -31,6 +31,288 @@ func TestNormalizeCommands(t *testing.T) {
 	}
 }
 
+func TestNormalizeCommandsPreservesShellBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+echo before
+if ! command -v aws >/dev/null 2>&1; then
+  apt-get update
+  for package in curl unzip; do
+    apt-get install -y "$package"
+  done
+fi
+echo ready
+`
+	want := []string{
+		"echo before",
+		`if ! command -v aws >/dev/null 2>&1; then
+apt-get update
+for package in curl unzip; do
+apt-get install -y "$package"
+done
+fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsIgnoresQuotedShellClosers(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  echo "; fi"
+  echo "}"
+fi
+echo ready
+`
+	want := []string{
+		`if true; then
+echo "; fi"
+echo "}"
+fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsIgnoresHeredocBodyShellWords(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  cat <<'EOF'
+fi
+done
+  indented
+
+EOF
+fi
+echo ready
+`
+	want := []string{
+		`if true; then
+cat <<'EOF'
+fi
+done
+  indented
+
+EOF
+fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsPreservesIndentedHeredocs(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		"",
+		"if true; then",
+		"  cat <<-EOF",
+		"\tfi",
+		"\tEOF",
+		"fi",
+		"echo ready",
+		"",
+	}, "\n")
+	want := []string{
+		"if true; then\ncat <<-EOF\n\tfi\n\tEOF\nfi",
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsIgnoresQuotedHeredocOperators(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  grep '<<' pattern
+fi
+echo ready
+`
+	want := []string{
+		"if true; then\ngrep '<<' pattern\nfi",
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsDoesNotTreatHereStringAsHeredoc(t *testing.T) {
+	t.Parallel()
+
+	input := `
+cat <<< "foo"
+echo ready
+`
+	want := []string{
+		`cat <<< "foo"`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsIgnoresArgumentShellClosers(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  echo fi
+  apt-get install -y done
+fi
+echo ready
+`
+	want := []string{
+		`if true; then
+echo fi
+apt-get install -y done
+fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsCountsMultipleCommandPositionClosers(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  for package in curl; do
+    echo "$package"
+  done; fi
+echo ready
+`
+	want := []string{
+		`if true; then
+for package in curl; do
+echo "$package"
+done; fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsPreservesChainedShellBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+command -v aws >/dev/null 2>&1 || if true; then
+  echo install
+fi
+echo ready
+`
+	want := []string{
+		`command -v aws >/dev/null 2>&1 || if true; then
+echo install
+fi`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsSeparatesUnclosedShellBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  echo install
+echo ready
+`
+	want := []string{
+		"if true; then",
+		"echo install",
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsIgnoresBacktickCommandSubstitution(t *testing.T) {
+	t.Parallel()
+
+	input := `
+if true; then
+  echo ` + "`echo fi`" + `
+fi
+echo ready
+`
+	want := []string{
+		"if true; then\necho `echo fi`\nfi",
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsPreservesFunctionBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+function install_tools {
+  echo install
+}
+echo ready
+`
+	want := []string{
+		`function install_tools {
+echo install
+}`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsPreservesFunctionParenBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+function install_tools() {
+  echo install
+}
+echo ready
+`
+	want := []string{
+		`function install_tools() {
+echo install
+}`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
+func TestNormalizeCommandsPreservesPosixFunctionBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := `
+install_tools() {
+  echo install
+}
+echo ready
+`
+	want := []string{
+		`install_tools() {
+echo install
+}`,
+		"echo ready",
+	}
+
+	assert.Equal(t, want, normalizeCommands(input))
+}
+
 func TestValidateEnvironment(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- group shell compound blocks when normalizing runner command text, so `if/fi`, `for/done`, `while/done`, `case/esac`, and nested blocks are sent to the broker as one command
- keep ordinary lines as separate broker commands for existing command-list/setup behavior
- add regression coverage for the setup failure shape that produced a standalone `d0.sh` with only `if ... then`

## Context
This was triggered by a release cleanup runner failure where a multiline setup command was split into separate broker commands. The first generated shell file contained only the block opener, causing Bash to fail with:

```text
bash: /tmp/runner-sh-2037593179/d0.sh: line 2: syntax error: unexpected end of file
```

The cleanup setup started with `if ! command -v aws >/dev/null 2>&1; then`, so splitting line-by-line produced an incomplete shell script before the matching `fi` was included.

