### PR TITLE
fix: stop stale execution events downgrading finished nodes

### DIFF
--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -190,9 +190,16 @@ export function executionToRef(execution: CanvasesCanvasNodeExecution): Canvases
   };
 }
 
-function shouldAcceptExecutionRefUpdate(
-  existing: CanvasesCanvasNodeExecutionRef,
-  incoming: CanvasesCanvasNodeExecutionRef,
+// Execution state only ever moves forward (pending -> started -> finished), but
+// the backend broadcasts each transition through an independent consumer (since
+// the dedicated executions exchange landed), so the websocket can deliver them
+// out of order. A late "created"/"started" event must never overwrite a newer
+// state we already applied, otherwise a finished node gets stuck showing
+// "running" until the page is reloaded. Accept an update only when it is at
+// least as recent as what we have.
+export function shouldAcceptExecutionUpdate(
+  existing: { state?: string; updatedAt?: string },
+  incoming: { state?: string; updatedAt?: string },
 ): boolean {
   const existingUpdatedAt = parseTimestamp(existing.updatedAt);
   const incomingUpdatedAt = parseTimestamp(incoming.updatedAt);
@@ -208,6 +215,13 @@ function shouldAcceptExecutionRefUpdate(
   const existingState = EXECUTION_STATE_ORDER[existing.state ?? "STATE_UNKNOWN"] ?? 0;
   const incomingState = EXECUTION_STATE_ORDER[incoming.state ?? "STATE_UNKNOWN"] ?? 0;
   return incomingState >= existingState;
+}
+
+function shouldAcceptExecutionRefUpdate(
+  existing: CanvasesCanvasNodeExecutionRef,
+  incoming: CanvasesCanvasNodeExecutionRef,
+): boolean {
+  return shouldAcceptExecutionUpdate(existing, incoming);
 }
 
 export function upsertExecutionRef(

--- a/web_src/src/hooks/canvasInfiniteCache.ts
+++ b/web_src/src/hooks/canvasInfiniteCache.ts
@@ -190,13 +190,9 @@ export function executionToRef(execution: CanvasesCanvasNodeExecution): Canvases
   };
 }
 
-// Execution state only ever moves forward (pending -> started -> finished), but
-// the backend broadcasts each transition through an independent consumer (since
-// the dedicated executions exchange landed), so the websocket can deliver them
-// out of order. A late "created"/"started" event must never overwrite a newer
-// state we already applied, otherwise a finished node gets stuck showing
-// "running" until the page is reloaded. Accept an update only when it is at
-// least as recent as what we have.
+// Execution events can arrive out of order, so only accept an update that is at
+// least as recent as what we have — otherwise a finished node gets stuck
+// "running" until reload.
 export function shouldAcceptExecutionUpdate(
   existing: { state?: string; updatedAt?: string },
   incoming: { state?: string; updatedAt?: string },

--- a/web_src/src/stores/nodeExecutionStore.spec.ts
+++ b/web_src/src/stores/nodeExecutionStore.spec.ts
@@ -27,10 +27,7 @@ describe("nodeExecutionStore.updateNodeExecution", () => {
 
     // Late "started" event for the same execution (older updatedAt) must not
     // downgrade the node back to a running state.
-    store.updateNodeExecution(
-      nodeId,
-      execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }),
-    );
+    store.updateNodeExecution(nodeId, execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }));
 
     const data = useNodeExecutionStore.getState().getNodeData(nodeId);
     expect(data.executions).toHaveLength(1);
@@ -40,10 +37,7 @@ describe("nodeExecutionStore.updateNodeExecution", () => {
   it("applies a newer state update", () => {
     const store = useNodeExecutionStore.getState();
 
-    store.updateNodeExecution(
-      nodeId,
-      execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }),
-    );
+    store.updateNodeExecution(nodeId, execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }));
     store.updateNodeExecution(
       nodeId,
       execution({ state: "STATE_FINISHED", result: "RESULT_PASSED", updatedAt: "2026-06-01T12:00:01.000Z" }),

--- a/web_src/src/stores/nodeExecutionStore.spec.ts
+++ b/web_src/src/stores/nodeExecutionStore.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { CanvasesCanvasNodeExecution } from "@/api-client";
+import { useNodeExecutionStore } from "./nodeExecutionStore";
+
+const nodeId = "node-1";
+
+function execution(overrides: Partial<CanvasesCanvasNodeExecution>): CanvasesCanvasNodeExecution {
+  return {
+    id: "execution-1",
+    nodeId,
+    ...overrides,
+  };
+}
+
+describe("nodeExecutionStore.updateNodeExecution", () => {
+  beforeEach(() => {
+    useNodeExecutionStore.getState().clear();
+  });
+
+  it("keeps the finished state when a stale started event arrives out of order", () => {
+    const store = useNodeExecutionStore.getState();
+
+    store.updateNodeExecution(
+      nodeId,
+      execution({ state: "STATE_FINISHED", result: "RESULT_PASSED", updatedAt: "2026-06-01T12:00:01.000Z" }),
+    );
+
+    // Late "started" event for the same execution (older updatedAt) must not
+    // downgrade the node back to a running state.
+    store.updateNodeExecution(
+      nodeId,
+      execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }),
+    );
+
+    const data = useNodeExecutionStore.getState().getNodeData(nodeId);
+    expect(data.executions).toHaveLength(1);
+    expect(data.executions[0].state).toBe("STATE_FINISHED");
+  });
+
+  it("applies a newer state update", () => {
+    const store = useNodeExecutionStore.getState();
+
+    store.updateNodeExecution(
+      nodeId,
+      execution({ state: "STATE_STARTED", updatedAt: "2026-06-01T12:00:00.000Z" }),
+    );
+    store.updateNodeExecution(
+      nodeId,
+      execution({ state: "STATE_FINISHED", result: "RESULT_PASSED", updatedAt: "2026-06-01T12:00:01.000Z" }),
+    );
+
+    const data = useNodeExecutionStore.getState().getNodeData(nodeId);
+    expect(data.executions).toHaveLength(1);
+    expect(data.executions[0].state).toBe("STATE_FINISHED");
+  });
+
+  it("prepends a different execution rather than replacing", () => {
+    const store = useNodeExecutionStore.getState();
+
+    store.updateNodeExecution(
+      nodeId,
+      execution({ id: "execution-1", state: "STATE_FINISHED", updatedAt: "2026-06-01T12:00:00.000Z" }),
+    );
+    store.updateNodeExecution(
+      nodeId,
+      execution({ id: "execution-2", state: "STATE_STARTED", updatedAt: "2026-06-01T12:01:00.000Z" }),
+    );
+
+    const data = useNodeExecutionStore.getState().getNodeData(nodeId);
+    expect(data.executions.map((e) => e.id)).toEqual(["execution-2", "execution-1"]);
+  });
+});

--- a/web_src/src/stores/nodeExecutionStore.ts
+++ b/web_src/src/stores/nodeExecutionStore.ts
@@ -15,6 +15,7 @@ import {
   nodeQueueItemsQueryOptions,
   nodeEventsQueryOptions,
 } from "@/hooks/useCanvasData";
+import { shouldAcceptExecutionUpdate } from "@/hooks/canvasInfiniteCache";
 
 interface NodeExecutionData {
   executions: CanvasesCanvasNodeExecution[];
@@ -251,6 +252,15 @@ export const useNodeExecutionStore = create<NodeExecutionStore>((set, get) => ({
       const newData = new Map(state.data);
       const existing = newData.get(nodeId) || emptyNodeData;
       const existingIndex = existing.executions.findIndex((e) => e.id === execution.id);
+
+      // Out-of-order websocket delivery can land a stale "created"/"started"
+      // event after the "finished" one for the same execution. Ignore it so the
+      // node doesn't get downgraded back to a running state (which would only
+      // recover on a page reload).
+      if (existingIndex >= 0 && !shouldAcceptExecutionUpdate(existing.executions[existingIndex], execution)) {
+        return state;
+      }
+
       const updatedExecutions =
         existingIndex >= 0
           ? existing.executions.map((e, i) => (i === existingIndex ? execution : e))

--- a/web_src/src/stores/nodeExecutionStore.ts
+++ b/web_src/src/stores/nodeExecutionStore.ts
@@ -253,10 +253,8 @@ export const useNodeExecutionStore = create<NodeExecutionStore>((set, get) => ({
       const existing = newData.get(nodeId) || emptyNodeData;
       const existingIndex = existing.executions.findIndex((e) => e.id === execution.id);
 
-      // Out-of-order websocket delivery can land a stale "created"/"started"
-      // event after the "finished" one for the same execution. Ignore it so the
-      // node doesn't get downgraded back to a running state (which would only
-      // recover on a page reload).
+      // Ignore stale out-of-order updates so a finished node isn't downgraded
+      // back to running.
       if (existingIndex >= 0 && !shouldAcceptExecutionUpdate(existing.executions[existingIndex], execution)) {
         return state;
       }


### PR DESCRIPTION
## Problem

Execution nodes on the canvas get stuck showing **"running" forever** even after the execution has finished. Reloading the page fixes it (the final state is re-fetched from the API), but it comes back on the next run.

## Root cause

Canvas nodes derive their on-canvas running/finished state from `nodeExecutionStore`, which `useCanvasWebsocket` updates on every `execution_created` / `execution_started` / `execution_finished` event. `updateNodeExecution` replaced an execution **by id with no ordering guard** — it blindly overwrote whatever was there.

This regressed after **#5507 ("use dedicated executions exchange")**. Before that PR, all execution state changes were published under a single routing key and consumed by a single consumer, so events reached the browser in order. After #5507:

- each transition is published under its own routing key (`execution.pending` / `execution.started` / `execution.finished`)
- they are consumed by **separate, concurrent goroutines** in the event distributer (`pkg/workers/event_distributer.go`)
- publishing is split across the queue worker (pending) and the executor (finished)

There is no longer any cross-state ordering guarantee, so the browser can receive a stale `created`/`started` event **after** `finished`. When that happened, the blind replace downgraded the finished execution back to `STATE_STARTED`/`STATE_PENDING`, and the node mapper renders `PENDING || STARTED` as "running" → stuck until reload.

The runs cache already guarded against this exact race (`shouldAcceptExecutionRefUpdate` in `canvasInfiniteCache.ts`), but the **node store never got the same protection**.

## Fix

- Extract a shared, exported `shouldAcceptExecutionUpdate(existing, incoming)` helper (`updatedAt` comparison + state-rank tiebreak); the existing ref guard now delegates to it.
- `updateNodeExecution` rejects stale/out-of-order updates for the same execution id, so an execution can never roll backward.
- Add `nodeExecutionStore.spec.ts` covering the out-of-order case (plus newer-update and distinct-execution cases).

Defensive fix on the receiving side, which is the correct layer — even if the backend can't guarantee cross-consumer ordering, the UI must never roll an execution backward.
