### PR TITLE
fix: publish execution state after webhook-finalized executions

### DIFF
--- a/pkg/public/handle_webhook_execution_test.go
+++ b/pkg/public/handle_webhook_execution_test.go
@@ -1,0 +1,134 @@
+package public
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superplanehq/superplane/pkg/config"
+	"github.com/superplanehq/superplane/pkg/core"
+	"github.com/superplanehq/superplane/pkg/database"
+	"github.com/superplanehq/superplane/pkg/grpc/actions/messages"
+	"github.com/superplanehq/superplane/pkg/jwt"
+	"github.com/superplanehq/superplane/pkg/models"
+	testconsumer "github.com/superplanehq/superplane/test/consumer"
+	"github.com/superplanehq/superplane/test/support"
+	"github.com/superplanehq/superplane/test/support/impl"
+	"gorm.io/datatypes"
+)
+
+// A webhook can finalize an execution from inside the handler (e.g. the runner
+// completing via a broker callback). The handler must broadcast the resulting
+// execution state change, otherwise the node stays stuck "running" in the UI.
+func Test__HandleWebhook_PublishesExecutionStateForFinalizedExecution(t *testing.T) {
+	r := support.Setup(t)
+	defer r.Close()
+
+	const actionName = "dummy-webhook-action"
+	const taskID = "task-123"
+
+	r.Registry.Actions[actionName] = impl.NewDummyAction(impl.DummyActionOptions{
+		Name: actionName,
+		HandleWebhookFunc: func(ctx core.WebhookRequestContext) (int, *core.WebhookResponseBody, error) {
+			execCtx, err := ctx.FindExecutionByKV("task_id", taskID)
+			if err != nil {
+				return http.StatusNotFound, nil, nil
+			}
+
+			if err := execCtx.ExecutionState.Pass(); err != nil {
+				return http.StatusInternalServerError, nil, err
+			}
+
+			return http.StatusOK, nil, nil
+		},
+	})
+
+	signer := jwt.NewSigner("test")
+	server, err := NewServer(
+		r.Encryptor,
+		r.Registry,
+		signer,
+		support.NewOIDCProvider(),
+		r.GitProvider,
+		"",
+		"http://localhost",
+		"http://localhost",
+		"test",
+		"/app/templates",
+		r.AuthService,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+
+	webhookID := uuid.New()
+	require.NoError(t, database.Conn().Create(&models.Webhook{
+		ID:     webhookID,
+		State:  models.WebhookStateReady,
+		Secret: []byte("secret"),
+	}).Error)
+
+	nodeID := "action-1"
+	canvas, _ := support.CreateCanvas(
+		t,
+		r.Organization.ID,
+		r.User,
+		[]models.CanvasNode{
+			{
+				NodeID: nodeID,
+				Type:   models.NodeTypeComponent,
+				Ref:    datatypes.NewJSONType(models.NodeRef{Component: &models.ComponentRef{Name: actionName}}),
+			},
+		},
+		[]models.Edge{},
+	)
+	require.NoError(t, database.Conn().
+		Model(&models.CanvasNode{}).
+		Where("workflow_id = ?", canvas.ID).
+		Where("node_id = ?", nodeID).
+		Update("webhook_id", webhookID).
+		Error)
+
+	rootEvent := &models.CanvasEvent{
+		WorkflowID: canvas.ID,
+		NodeID:     nodeID,
+		Channel:    "default",
+		Data:       models.JSONValue{},
+		State:      models.CanvasEventStatePending,
+	}
+	require.NoError(t, database.Conn().Create(rootEvent).Error)
+
+	execution := &models.CanvasNodeExecution{
+		WorkflowID:  canvas.ID,
+		NodeID:      nodeID,
+		RootEventID: rootEvent.ID,
+		EventID:     rootEvent.ID,
+		State:       models.CanvasNodeExecutionStateStarted,
+	}
+	require.NoError(t, database.Conn().Create(execution).Error)
+
+	tx := database.Conn()
+	require.NoError(t, models.CreateNodeExecutionKVInTransaction(tx, canvas.ID, nodeID, execution.ID, "task_id", taskID))
+
+	amqpURL, _ := config.RabbitMQURL()
+	finishedConsumer := testconsumer.NewExecutions(amqpURL, messages.ExecutionFinishedRoutingKey)
+	finishedConsumer.Start()
+	defer finishedConsumer.Stop()
+
+	response := execRequest(server, requestParams{
+		method: "POST",
+		path:   "/webhooks/" + webhookID.String(),
+		body:   []byte(`{"ok": true}`),
+	})
+	require.Equal(t, http.StatusOK, response.Code)
+
+	// The execution is finished in the DB...
+	updated, err := models.FindNodeExecution(canvas.ID, execution.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.CanvasNodeExecutionStateFinished, updated.State)
+
+	// ...and the execution.finished event is broadcast so the UI updates without a reload.
+	assert.True(t, finishedConsumer.HasReceivedMessage())
+}

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -1175,9 +1175,6 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		newEvents = append(newEvents, events...)
 	}
 
-	// Async actions (e.g. the runner) finalize their execution from inside the
-	// webhook handler, so we must broadcast the resulting execution state change
-	// ourselves - otherwise the node stays "running" in the UI until reload.
 	touchedExecutions := map[uuid.UUID]uuid.UUID{}
 	recordExecution := func(workflowID, executionID uuid.UUID) {
 		touchedExecutions[executionID] = workflowID

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -1175,10 +1175,18 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		newEvents = append(newEvents, events...)
 	}
 
+	// Async actions (e.g. the runner) finalize their execution from inside the
+	// webhook handler, so we must broadcast the resulting execution state change
+	// ourselves - otherwise the node stays "running" in the UI until reload.
+	touchedExecutions := map[uuid.UUID]uuid.UUID{}
+	recordExecution := func(workflowID, executionID uuid.UUID) {
+		touchedExecutions[executionID] = workflowID
+	}
+
 	var firstResponse *core.WebhookResponseBody
 
 	for _, node := range nodes {
-		code, response, err := s.executeWebhookNode(r.Context(), body, r.Header, node, onNewEvents)
+		code, response, err := s.executeWebhookNode(r.Context(), body, r.Header, node, onNewEvents, recordExecution)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error handling webhook: %v", err), code)
 			return
@@ -1193,6 +1201,12 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		messages.PublishCanvasEventCreatedMessage(&event)
 	}
 
+	for executionID, workflowID := range touchedExecutions {
+		if err := messages.PublishCanvasExecutionByID(workflowID, executionID); err != nil {
+			log.Errorf("error publishing execution state for %s: %v", executionID, err)
+		}
+	}
+
 	if firstResponse != nil {
 		if firstResponse.ContentType != "" {
 			w.Header().Set("Content-Type", firstResponse.ContentType)
@@ -1204,12 +1218,12 @@ func (s *Server) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) executeWebhookNode(ctx context.Context, body []byte, headers http.Header, node models.CanvasNode, onNewEvents func([]models.CanvasEvent)) (int, *core.WebhookResponseBody, error) {
+func (s *Server) executeWebhookNode(ctx context.Context, body []byte, headers http.Header, node models.CanvasNode, onNewEvents func([]models.CanvasEvent), recordExecution func(workflowID, executionID uuid.UUID)) (int, *core.WebhookResponseBody, error) {
 	if node.Type == models.NodeTypeTrigger {
 		return s.executeTriggerNode(ctx, body, headers, node, onNewEvents)
 	}
 
-	return s.executeActionNode(ctx, body, headers, node, onNewEvents)
+	return s.executeActionNode(ctx, body, headers, node, onNewEvents, recordExecution)
 }
 
 func (s *Server) executeTriggerNode(ctx context.Context, body []byte, headers http.Header, node models.CanvasNode, onNewEvents func([]models.CanvasEvent)) (int, *core.WebhookResponseBody, error) {
@@ -1247,7 +1261,7 @@ func (s *Server) executeTriggerNode(ctx context.Context, body []byte, headers ht
 	})
 }
 
-func (s *Server) executeActionNode(ctx context.Context, body []byte, headers http.Header, node models.CanvasNode, onNewEvents func([]models.CanvasEvent)) (int, *core.WebhookResponseBody, error) {
+func (s *Server) executeActionNode(ctx context.Context, body []byte, headers http.Header, node models.CanvasNode, onNewEvents func([]models.CanvasEvent), recordExecution func(workflowID, executionID uuid.UUID)) (int, *core.WebhookResponseBody, error) {
 	ref := node.Ref.Data()
 	action, err := s.registry.GetAction(ref.Component.Name)
 	if err != nil {
@@ -1283,6 +1297,10 @@ func (s *Server) executeActionNode(ctx context.Context, body []byte, headers htt
 			execution, err := models.FirstNodeExecutionByKVInTransaction(tx, node.WorkflowID, node.NodeID, key, value)
 			if err != nil {
 				return nil, err
+			}
+
+			if recordExecution != nil {
+				recordExecution(execution.WorkflowID, execution.ID)
 			}
 
 			return &core.ExecutionContext{


### PR DESCRIPTION
## Problem

Async-finalized nodes (e.g. the **runner**) stay stuck showing **"running"** in the UI even after they finish. A reload fixes it (the final state is re-fetched from the API), but it comes back on the next run.

The websocket stream for such a node shows:

```
execution_created  (STATE_PENDING)
execution_started  (STATE_STARTED)
event_created      (the node's output, e.g. runnerBash.finished)
run_finished
```

…with **no `execution_finished`** — so the frontend never learns the execution finished.

## Root cause

Async actions finalize their execution **from inside the webhook handler**:

`HandleWebhook` → `executeActionNode` → `action.HandleWebhook` → (runner) `handleBrokerWebhook` → `processBrokerTaskStatus` → `ExecutionState.Emit` → `PassInTransaction` (sets the execution to `finished` and produces the output events).

`HandleWebhook` then publishes the new **output events** (`PublishCanvasEventCreatedMessage`) but **never publishes the execution state change**, unlike the in-app hook path (`invoke_node_execution_hook.go`, which calls `PublishCanvasExecutionByID`). So `execution_finished` is never broadcast.

(This was the actual cause behind #5696. That PR added a defensive out-of-order guard in the UI store, which is still correct, but the event was missing entirely — not arriving out of order.)

## Fix

Capture the executions touched during webhook processing and publish their state after the transaction commits, mirroring `invoke_node_execution_hook`. The `ExecutionState` context is only ever created inside the `FindExecutionByKV` closure, so recording the execution there covers **every** async webhook-finalized action, not just the runner.

## Testing

- `go build ./pkg/public/...` and `go vet ./pkg/public/...` clean
- `go test ./pkg/components/runner/...` passes (other `pkg/public` tests require a live DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)