### PR TITLE
fix: harden release image build prerequisites

### DIFF
--- a/release/lib/image-build-prerequisites.sh
+++ b/release/lib/image-build-prerequisites.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+
+  if command -v "${command_name}" >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Error: '${command_name}' is required. ${install_hint}" >&2
+  exit 1
+}
+
+generated_protobuf_missing() {
+  [ ! -f "pkg/protos/me/me.pb.go" ] || [ ! -f "pkg/protos/me/me.pb.gw.go" ]
+}
+
+generated_openapi_spec_missing() {
+  [ ! -f "api/swagger/superplane.swagger.json" ]
+}
+
+generated_frontend_client_missing() {
+  [ ! -f "web_src/src/api-client/index.ts" ] ||
+    [ ! -f "web_src/src/api-client/sdk.gen.ts" ] ||
+    [ ! -f "web_src/src/api-client/types.gen.ts" ]
+}
+
+generated_release_build_inputs_missing() {
+  generated_protobuf_missing ||
+    generated_openapi_spec_missing ||
+    generated_frontend_client_missing
+}
+
+require_docker_buildx() {
+  require_command docker "Install Docker and ensure it is available on PATH."
+
+  if docker buildx version >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Error: Docker Buildx is required. Install the Docker Buildx plugin before running this release build." >&2
+  exit 1
+}
+
+require_generated_artifact_prerequisites() {
+  if ! generated_release_build_inputs_missing; then
+    return
+  fi
+
+  require_command make "Install make/build-essential before generating release build artifacts."
+
+  if docker compose version >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Error: Docker Compose is required because generated release build artifacts are missing and make dev.up must run." >&2
+  exit 1
+}
+
+require_release_image_build_prerequisites() {
+  require_docker_buildx
+  require_generated_artifact_prerequisites
+}

--- a/release/superplane-demo-image/build.sh
+++ b/release/superplane-demo-image/build.sh
@@ -23,13 +23,21 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 SUPERGIT_VERSION="${SUPERGIT_VERSION:-v0.1.1}"
 
+# shellcheck source=../lib/image-build-prerequisites.sh
+source "${REPO_ROOT}/release/lib/image-build-prerequisites.sh"
+
 cd "${REPO_ROOT}"
 
-if [ ! -f "pkg/protos/me/me.pb.go" ] || [ ! -f "pkg/protos/me/me.pb.gw.go" ]; then
-  echo "Generating protobuf files"
+require_release_image_build_prerequisites
+
+if generated_release_build_inputs_missing; then
+  echo "Generating release build artifacts"
   make dev.up
   make pb.gen.models
   make pb.gen.gateway
+  make openapi.spec.gen
+  make dev.setup.npm
+  make openapi.web.client.gen
 fi
 
 bash "${SCRIPT_DIR}/download-supergit.sh" "${SUPERGIT_VERSION}" "${ARCH}"

--- a/release/superplane-image/build.sh
+++ b/release/superplane-image/build.sh
@@ -19,11 +19,24 @@ ARCH="$2"
 IMAGE_REPO="${STANDARD_IMAGE_REPO:-ghcr.io/superplanehq/superplane}"
 DEV_BASE_IMAGE_REPO="${DEV_BASE_IMAGE_REPO:-ghcr.io/superplanehq/superplane-dev-base}"
 
-if [ ! -f "pkg/protos/me/me.pb.go" ] || [ ! -f "pkg/protos/me/me.pb.gw.go" ]; then
-  echo "Generating protobuf files"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=../lib/image-build-prerequisites.sh
+source "${REPO_ROOT}/release/lib/image-build-prerequisites.sh"
+
+cd "${REPO_ROOT}"
+
+require_release_image_build_prerequisites
+
+if generated_release_build_inputs_missing; then
+  echo "Generating release build artifacts"
   make dev.up
   make pb.gen.models
   make pb.gen.gateway
+  make openapi.spec.gen
+  make dev.setup.npm
+  make openapi.web.client.gen
 fi
 
 echo "Building SuperPlane image (${IMAGE_REPO})"


### PR DESCRIPTION
## Summary
- fail fast when release image builds are missing Docker, Docker Buildx, or generated-artifact prerequisites
- generate the full release build input set when missing: protobufs, OpenAPI swagger, npm deps, and the frontend API client
- share prerequisite checks between the standard and demo release image scripts

## Context
The SuperPlane Release app run for `release/v0.0.1` did not make it past `wait-unstable-channel`: the Helm and demo image build nodes emitted `failed`, the merge never received all four `passed` inputs, and the run was later cancelled at the merge.

The latest demo image log also showed the Docker frontend build failing because `web_src/src/api-client` was absent from the clean release clone, producing TypeScript `Cannot find module '@/api-client'` errors. This PR expands the release scripts from protobuf-only generation to all generated artifacts needed by the Dockerfile.

## Validation
- `bash -n release/lib/image-build-prerequisites.sh release/superplane-demo-image/build.sh release/superplane-image/build.sh`
- `git diff --check origin/main...HEAD`
