### PR TITLE
fix: keep notes visible while viewing canvas runs

### DIFF
--- a/web_src/src/ui/CanvasPage/Block.spec.tsx
+++ b/web_src/src/ui/CanvasPage/Block.spec.tsx
@@ -335,4 +335,28 @@ describe("Block fallback rendering", () => {
     expect(screen.queryByText("Ready to run...")).not.toBeInTheDocument();
     expect(container.firstChild).not.toHaveClass("opacity-30");
   });
+
+  it("keeps note content visible during runs-style participant dimming", () => {
+    const { container } = render(
+      <Block
+        canvasMode="live"
+        data={{
+          label: "Run Context Note",
+          state: "pending",
+          type: "annotation",
+          _hasHighlightedNodes: true,
+          _isHighlighted: false,
+          _dimBodyBelowHeader: true,
+          annotation: {
+            title: "Run Context Note",
+            annotationText: "Important context for this workflow",
+            annotationColor: "yellow",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Important context for this workflow")).toBeInTheDocument();
+    expect(container.firstChild).not.toHaveClass("opacity-30");
+  });
 });

--- a/web_src/src/ui/CanvasPage/Block/index.tsx
+++ b/web_src/src/ui/CanvasPage/Block/index.tsx
@@ -69,9 +69,10 @@ export const Block = React.memo(function Block(props: BlockProps) {
   const data = props.data;
   const isHighlighted = data._isHighlighted || false;
   const hasHighlightedNodes = data._hasHighlightedNodes || false;
-  const shouldFade = hasHighlightedNodes && !isHighlighted;
+  const isAnnotation = data.type === "annotation";
+  const shouldFade = !isAnnotation && hasHighlightedNodes && !isHighlighted;
   const isRemoved = data._draftDiffStatus === "removed";
-  const shouldBlankBody = data._dimBodyBelowHeader || isRemoved;
+  const shouldBlankBody = !isAnnotation && (data._dimBodyBelowHeader || isRemoved);
   const isConnectionInteractive = props.canvasMode !== "live" && !isRemoved;
 
   return (


### PR DESCRIPTION
## Summary
- Exclude annotation (note) nodes from run-inspection dimming so they no longer get grayed out or body-blanked when viewing a run
- Workflow nodes that did not participate in the run still dim as before
- Add a unit test covering note visibility during runs-style participant dimming

Fixes #5688

## Test plan
- [x] `npm run test:run -- src/ui/CanvasPage/Block.spec.tsx`
- [ ] Open a canvas with notes and workflow nodes, run the canvas, and inspect a run — notes should stay fully visible with their normal colors and content
- [ ] Confirm non-participating workflow nodes are still dimmed during run inspection


Made with [Cursor](https://cursor.com)