### PR TITLE
feat: add the SuperPlane webhook payload size limit to tasks

### DIFF
--- a/pkg/components/runner/broker.go
+++ b/pkg/components/runner/broker.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 )
 
@@ -72,6 +73,7 @@ func NewBrokerClient(httpClient core.HTTPContext) (*BrokerClient, error) {
 //   "commands": ["echo \"Hello, World!\""],
 //   "environment": [{"name": "APP_ENV", "value": "production"}],
 //   "webhook_url": "https://example.com/webhook",
+//   "webhook_payload_size_limit": 65536,
 //   "execution_mode": "host",
 //   "docker_image": "debian:bookworm-slim",
 //   "execution_timeout_seconds": 600
@@ -92,6 +94,7 @@ type brokerCreateTaskRequest struct {
 	SetupCommands           []string                    `json:"setup_commands,omitempty"`
 	Environment             []BrokerEnvironmentVariable `json:"environment,omitempty"`
 	WebhookURL              string                      `json:"webhook_url"`
+	WebhookPayloadSizeLimit int                         `json:"webhook_payload_size_limit"`
 	ExecutionMode           string                      `json:"execution_mode,omitempty"`
 	DockerImage             string                      `json:"docker_image,omitempty"`
 	ExecutionTimeoutSeconds *int                        `json:"execution_timeout_seconds,omitempty"`
@@ -111,17 +114,18 @@ const (
 
 // CreateTaskParams is forwarded to the task broker POST /v1/tasks.
 type CreateTaskParams struct {
-	MachineType    string
-	RunMode        string
-	Script         string
-	MessageChain   json.RawMessage
-	Commands       []string
-	SetupCommands  []string
-	WebhookURL     string
-	Environment    []BrokerEnvironmentVariable
-	ExecutionMode  string
-	DockerImage    string
-	TimeoutSeconds int // 0 = DefaultExecutionTimeoutSeconds
+	MachineType             string
+	RunMode                 string
+	Script                  string
+	MessageChain            json.RawMessage
+	Commands                []string
+	SetupCommands           []string
+	WebhookURL              string
+	WebhookPayloadSizeLimit int
+	Environment             []BrokerEnvironmentVariable
+	ExecutionMode           string
+	DockerImage             string
+	TimeoutSeconds          int // 0 = DefaultExecutionTimeoutSeconds
 }
 
 type brokerCreateTaskResponse struct {
@@ -134,22 +138,28 @@ func (b *BrokerClient) CreateTask(p CreateTaskParams) (string, error) {
 		mode = ExecutionModeHost
 	}
 
+	webhookPayloadSizeLimit := p.WebhookPayloadSizeLimit
+	if webhookPayloadSizeLimit <= 0 {
+		webhookPayloadSizeLimit = config.MaxWebhookPayloadSize
+	}
+
 	fleetID, err := requireMachineType(p.MachineType)
 	if err != nil {
 		return "", err
 	}
 
 	req := brokerCreateTaskRequest{
-		FleetID:       fleetID,
-		RunMode:       strings.TrimSpace(p.RunMode),
-		Script:        strings.TrimSpace(p.Script),
-		MessageChain:  p.MessageChain,
-		Commands:      p.Commands,
-		SetupCommands: p.SetupCommands,
-		Environment:   p.Environment,
-		WebhookURL:    p.WebhookURL,
-		ExecutionMode: mode,
-		DockerImage:   strings.TrimSpace(p.DockerImage),
+		FleetID:                 fleetID,
+		RunMode:                 strings.TrimSpace(p.RunMode),
+		Script:                  strings.TrimSpace(p.Script),
+		MessageChain:            p.MessageChain,
+		Commands:                p.Commands,
+		SetupCommands:           p.SetupCommands,
+		Environment:             p.Environment,
+		WebhookURL:              p.WebhookURL,
+		WebhookPayloadSizeLimit: webhookPayloadSizeLimit,
+		ExecutionMode:           mode,
+		DockerImage:             strings.TrimSpace(p.DockerImage),
 	}
 	timeout := p.TimeoutSeconds
 	if timeout <= 0 {

--- a/pkg/components/runner/run_bash_test.go
+++ b/pkg/components/runner/run_bash_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -52,6 +53,7 @@ printf '{"pr":%s}\n' "$num" > "$SUPERPLANE_RESULT_FILE"`,
 
 	assert.Equal(t, testRunnerMachineType, req.FleetID)
 	assert.Equal(t, RunModeBash, req.RunMode)
+	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 	assert.Contains(t, req.Script, "jq")
 	assert.Contains(t, req.Script, "SUPERPLANE_PAYLOAD_FILE")
 	assert.Contains(t, req.Script, "SUPERPLANE_RESULT_FILE")

--- a/pkg/components/runner/run_commands_test.go
+++ b/pkg/components/runner/run_commands_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/configuration"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
@@ -446,6 +447,7 @@ func TestRunnerExecuteSendsEnvironmentToBroker(t *testing.T) {
 
 	assert.Equal(t, testRunnerMachineType, req.FleetID)
 	assert.Equal(t, []string{"echo hello"}, req.Commands)
+	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 }
 
 func TestRunnerExecuteUsesConfiguredMachineType(t *testing.T) {

--- a/pkg/components/runner/run_javascript_test.go
+++ b/pkg/components/runner/run_javascript_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -66,6 +67,7 @@ func TestRunJSExecuteSendsJavaScriptPayloadToBroker(t *testing.T) {
 
 	assert.Equal(t, testRunnerMachineType, req.FleetID)
 	assert.Equal(t, RunModeJavaScript, req.RunMode)
+	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 	assert.Contains(t, req.Script, "function main()")
 	assert.NotContains(t, string(body), `"commands"`)
 	assert.Empty(t, req.SetupCommands)

--- a/pkg/components/runner/run_python_test.go
+++ b/pkg/components/runner/run_python_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/test/support/contexts"
 )
@@ -52,6 +53,7 @@ func TestRunPythonExecuteSendsPythonPayloadToBroker(t *testing.T) {
 
 	assert.Equal(t, testRunnerMachineType, req.FleetID)
 	assert.Equal(t, RunModePython, req.RunMode)
+	assert.Equal(t, config.MaxWebhookPayloadSize, req.WebhookPayloadSizeLimit)
 	assert.Contains(t, req.Script, "def main(payload)")
 	assert.NotContains(t, string(body), `"commands"`)
 	assert.Empty(t, req.SetupCommands)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 )
 
+const MaxWebhookPayloadSize = 64 * 1024
+
 func RabbitMQURL() (string, error) {
 	URL := os.Getenv("RABBITMQ_URL")
 	if URL == "" {

--- a/pkg/public/server.go
+++ b/pkg/public/server.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/superplanehq/superplane/pkg/authentication"
 	"github.com/superplanehq/superplane/pkg/authorization"
+	"github.com/superplanehq/superplane/pkg/config"
 	"github.com/superplanehq/superplane/pkg/core"
 	"github.com/superplanehq/superplane/pkg/database"
 	git "github.com/superplanehq/superplane/pkg/git/provider"
@@ -65,7 +66,7 @@ import (
 
 const (
 	// Event payload can be up to 64k in size
-	MaxEventSize = 64 * 1024
+	MaxEventSize = config.MaxWebhookPayloadSize
 
 	// The size of the stage execution outputs can be up to 4k
 	MaxExecutionOutputsSize = 4 * 1024


### PR DESCRIPTION
This PR resolves https://github.com/superplanehq/superplane/issues/5228 on the SuperPlane size.

The only change is that we now send the payload limit with the task so the runners can enforce the limit on their side.